### PR TITLE
Fix: Sidebar never shows bold/badge notifications for worktrees

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -227,7 +227,6 @@ final class AppState: ObservableObject {
         do {
             let fetched = try await daemonClient.listNotifications()
             if fetched != notifications.compactMapValues({ $0 }) {
-                // Merge: keep nil entries for worktrees we've locally dismissed
                 var updated: [UUID: NotificationType?] = [:]
                 for (id, type) in fetched {
                     updated[id] = type
@@ -236,6 +235,7 @@ final class AppState: ObservableObject {
             }
         } catch {
             logger.error("Failed to list notifications: \(error)")
+            handleConnectionError(error)
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -143,6 +143,7 @@ final class AppState: ObservableObject {
     func refreshAll() async {
         await refreshRepos()
         await refreshWorktrees()
+        await refreshNotifications()
     }
 
     /// Refresh the repo list. Only updates if data changed.
@@ -218,6 +219,23 @@ final class AppState: ObservableObject {
         } catch {
             logger.error("Failed to list terminals for worktree \(worktreeID): \(error)")
             handleConnectionError(error)
+        }
+    }
+
+    /// Refresh unread notifications from the daemon.
+    func refreshNotifications() async {
+        do {
+            let fetched = try await daemonClient.listNotifications()
+            if fetched != notifications.compactMapValues({ $0 }) {
+                // Merge: keep nil entries for worktrees we've locally dismissed
+                var updated: [UUID: NotificationType?] = [:]
+                for (id, type) in fetched {
+                    updated[id] = type
+                }
+                notifications = updated
+            }
+        } catch {
+            logger.error("Failed to list notifications: \(error)")
         }
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -402,6 +402,12 @@ actor DaemonClient {
         )
     }
 
+    /// List unread notifications grouped by worktree (highest severity per worktree).
+    func listNotifications() throws -> [UUID: NotificationType] {
+        let result = try callNoParams(method: RPCMethod.notificationsList, resultType: NotificationsListResult.self)
+        return result.notifications
+    }
+
     /// Mark notifications as read for a worktree.
     func markNotificationsRead(worktreeID: UUID) throws {
         try callVoid(

--- a/Sources/TBDDaemon/Database/NotificationStore.swift
+++ b/Sources/TBDDaemon/Database/NotificationStore.swift
@@ -89,4 +89,25 @@ public struct NotificationStore: Sendable {
             .map(\.type)
             .max(by: { $0.severity < $1.severity })
     }
+
+    /// Get the highest severity unread notification type for all worktrees.
+    public func allUnreadByWorktree() async throws -> [UUID: NotificationType] {
+        let records = try await writer.read { db in
+            try NotificationRecord
+                .filter(Column("read") == false)
+                .fetchAll(db)
+        }
+        var result: [UUID: NotificationType] = [:]
+        for record in records {
+            let model = record.toModel()
+            if let existing = result[model.worktreeID] {
+                if model.type.severity > existing.severity {
+                    result[model.worktreeID] = model.type
+                }
+            } else {
+                result[model.worktreeID] = model.type
+            }
+        }
+        return result
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -77,6 +77,8 @@ public final class RPCRouter: Sendable {
                 return try handleDaemonStatus()
             case RPCMethod.resolvePath:
                 return try await handleResolvePath(request.paramsData)
+            case RPCMethod.notificationsList:
+                return try await handleNotificationsList()
             case RPCMethod.notificationsMarkRead:
                 return try await handleNotificationsMarkRead(request.paramsData)
             case RPCMethod.cleanup:
@@ -353,6 +355,13 @@ public final class RPCRouter: Sendable {
         )))
 
         return try RPCResponse(result: notification)
+    }
+
+    // MARK: - Notifications List
+
+    private func handleNotificationsList() async throws -> RPCResponse {
+        let notifications = try await db.notifications.allUnreadByWorktree()
+        return try RPCResponse(result: NotificationsListResult(notifications: notifications))
     }
 
     // MARK: - Notifications Mark Read

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -91,10 +91,16 @@ public enum RPCMethod {
     public static let daemonStatus = "daemon.status"
     public static let stateSubscribe = "state.subscribe"
     public static let resolvePath = "resolve.path"
+    public static let notificationsList = "notifications.list"
     public static let notificationsMarkRead = "notifications.markRead"
     public static let worktreeMerge = "worktree.merge"
     public static let worktreeMergeStatus = "worktree.mergeStatus"
     public static let cleanup = "cleanup"
+}
+
+public struct NotificationsListResult: Codable, Sendable {
+    public let notifications: [UUID: NotificationType]
+    public init(notifications: [UUID: NotificationType]) { self.notifications = notifications }
 }
 
 public struct NotificationsMarkReadParams: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Worktree sidebar items never showed bold text or colored badges when Claude finished responding, because the app never fetched notification state from the daemon
- The `notifications` dictionary in `AppState` was only ever cleared (set to nil) — never populated
- Added a `notifications.list` RPC method that returns the highest-severity unread notification per worktree, and poll it every 2s alongside repos/worktrees

## Test plan
- [ ] Run `tbd setup-hooks --global` to install the Claude Code Stop hook
- [ ] Start a Claude session in a TBD worktree, let it respond, then switch focus away — the worktree row should show bold text with a blue dot
- [ ] Click the worktree to select it — bold/badge should clear