### PR TITLE
Fix: Prevent Cmd+C from hijacking into another worktree's Claude session

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -190,25 +190,16 @@ public struct WorktreeLifecycle: Sendable {
     /// If the command is already the user's shell, returns it unchanged.
     private func shellWrapped(_ command: String) -> String {
         if command == defaultShell { return command }
-        return "\(command); exec \(defaultShell)"
+        let escaped = command.replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'; exec \(defaultShell)"
     }
 
-    /// Completes the creation flow after the git worktree has been added.
-    private func finishCreate(
-        repo: Repo, name: String, branch: String,
-        worktreePath: String, skipClaude: Bool
-    ) async throws -> Worktree {
-        let tmuxServer = TmuxManager.serverName(forRepoID: repo.id)
-
-        // Insert worktree into db
-        let worktree = try await db.worktrees.create(
-            repoID: repo.id,
-            name: name,
-            branch: branch,
-            path: worktreePath,
-            tmuxServer: tmuxServer
-        )
-
+    /// Sets up tmux windows and terminal records for a worktree.
+    /// Shared by `finishCreate` and `reviveWorktree`.
+    private func setupTerminals(
+        worktreeID: UUID, repoPath: String,
+        tmuxServer: String, worktreePath: String, skipClaude: Bool
+    ) async throws {
         // Ensure tmux server exists — capture initial window ID to kill later
         let initialWindowID = try await tmux.ensureServer(
             server: tmuxServer,
@@ -230,7 +221,7 @@ public struct WorktreeLifecycle: Sendable {
             shellCommand: claudeCommand
         )
         _ = try await db.terminals.create(
-            worktreeID: worktree.id,
+            worktreeID: worktreeID,
             tmuxWindowID: window1.windowID,
             tmuxPaneID: window1.paneID,
             label: skipClaude ? "shell" : "claude"
@@ -239,7 +230,7 @@ public struct WorktreeLifecycle: Sendable {
         // Create terminal 2: setup hook
         let setupHookPath = hooks.resolve(
             event: .setup,
-            repoPath: repo.path,
+            repoPath: repoPath,
             appHookPath: nil
         )
         let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
@@ -250,7 +241,7 @@ public struct WorktreeLifecycle: Sendable {
             shellCommand: setupCommand
         )
         _ = try await db.terminals.create(
-            worktreeID: worktree.id,
+            worktreeID: worktreeID,
             tmuxWindowID: window2.windowID,
             tmuxPaneID: window2.paneID,
             label: "setup"
@@ -260,6 +251,29 @@ public struct WorktreeLifecycle: Sendable {
         if let windowID = initialWindowID {
             try? await tmux.killWindow(server: tmuxServer, windowID: windowID)
         }
+    }
+
+    /// Completes the creation flow after the git worktree has been added.
+    private func finishCreate(
+        repo: Repo, name: String, branch: String,
+        worktreePath: String, skipClaude: Bool
+    ) async throws -> Worktree {
+        let tmuxServer = TmuxManager.serverName(forRepoID: repo.id)
+
+        // Insert worktree into db
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id,
+            name: name,
+            branch: branch,
+            path: worktreePath,
+            tmuxServer: tmuxServer
+        )
+
+        try await setupTerminals(
+            worktreeID: worktree.id, repoPath: repo.path,
+            tmuxServer: tmuxServer, worktreePath: worktreePath,
+            skipClaude: skipClaude
+        )
 
         return worktree
     }
@@ -367,52 +381,11 @@ public struct WorktreeLifecycle: Sendable {
             branch: worktree.branch
         )
 
-        // Ensure tmux server — capture initial window ID to kill later
-        let initialWindowID = try await tmux.ensureServer(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path
+        try await setupTerminals(
+            worktreeID: worktree.id, repoPath: repo.path,
+            tmuxServer: worktree.tmuxServer, worktreePath: worktree.path,
+            skipClaude: skipClaude
         )
-
-        // Create terminal 1: claude (or shell)
-        let claudeCommand = skipClaude ? defaultShell : shellWrapped("claude --dangerously-skip-permissions")
-        let window1 = try await tmux.createWindow(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path,
-            shellCommand: claudeCommand
-        )
-        _ = try await db.terminals.create(
-            worktreeID: worktree.id,
-            tmuxWindowID: window1.windowID,
-            tmuxPaneID: window1.paneID,
-            label: skipClaude ? "shell" : "claude"
-        )
-
-        // Create terminal 2: setup hook
-        let setupHookPath = hooks.resolve(
-            event: .setup,
-            repoPath: repo.path,
-            appHookPath: nil
-        )
-        let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
-        let window2 = try await tmux.createWindow(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path,
-            shellCommand: setupCommand
-        )
-        _ = try await db.terminals.create(
-            worktreeID: worktree.id,
-            tmuxWindowID: window2.windowID,
-            tmuxPaneID: window2.paneID,
-            label: "setup"
-        )
-
-        // Kill the untracked initial window that new-session created
-        if let windowID = initialWindowID {
-            try? await tmux.killWindow(server: worktree.tmuxServer, windowID: windowID)
-        }
 
         // Update status to active
         try await db.worktrees.revive(id: worktreeID)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -185,6 +185,14 @@ public struct WorktreeLifecycle: Sendable {
         )
     }
 
+    /// Wraps a command so the user's shell takes over when it exits,
+    /// preventing tmux from destroying the window and jumping to another.
+    /// If the command is already the user's shell, returns it unchanged.
+    private func shellWrapped(_ command: String) -> String {
+        if command == defaultShell { return command }
+        return "\(command); exec \(defaultShell)"
+    }
+
     /// Completes the creation flow after the git worktree has been added.
     private func finishCreate(
         repo: Repo, name: String, branch: String,
@@ -201,8 +209,8 @@ public struct WorktreeLifecycle: Sendable {
             tmuxServer: tmuxServer
         )
 
-        // Ensure tmux server exists
-        try await tmux.ensureServer(
+        // Ensure tmux server exists — capture initial window ID to kill later
+        let initialWindowID = try await tmux.ensureServer(
             server: tmuxServer,
             session: "main",
             cwd: worktreePath
@@ -213,7 +221,7 @@ public struct WorktreeLifecycle: Sendable {
         if skipClaude {
             claudeCommand = defaultShell
         } else {
-            claudeCommand = "claude --dangerously-skip-permissions"
+            claudeCommand = shellWrapped("claude --dangerously-skip-permissions")
         }
         let window1 = try await tmux.createWindow(
             server: tmuxServer,
@@ -234,7 +242,7 @@ public struct WorktreeLifecycle: Sendable {
             repoPath: repo.path,
             appHookPath: nil
         )
-        let setupCommand = setupHookPath ?? defaultShell
+        let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
         let window2 = try await tmux.createWindow(
             server: tmuxServer,
             session: "main",
@@ -247,6 +255,11 @@ public struct WorktreeLifecycle: Sendable {
             tmuxPaneID: window2.paneID,
             label: "setup"
         )
+
+        // Kill the untracked initial window that new-session created
+        if let windowID = initialWindowID {
+            try? await tmux.killWindow(server: tmuxServer, windowID: windowID)
+        }
 
         return worktree
     }
@@ -354,15 +367,15 @@ public struct WorktreeLifecycle: Sendable {
             branch: worktree.branch
         )
 
-        // Ensure tmux server
-        try await tmux.ensureServer(
+        // Ensure tmux server — capture initial window ID to kill later
+        let initialWindowID = try await tmux.ensureServer(
             server: worktree.tmuxServer,
             session: "main",
             cwd: worktree.path
         )
 
         // Create terminal 1: claude (or shell)
-        let claudeCommand = skipClaude ? defaultShell : "claude --dangerously-skip-permissions"
+        let claudeCommand = skipClaude ? defaultShell : shellWrapped("claude --dangerously-skip-permissions")
         let window1 = try await tmux.createWindow(
             server: worktree.tmuxServer,
             session: "main",
@@ -382,7 +395,7 @@ public struct WorktreeLifecycle: Sendable {
             repoPath: repo.path,
             appHookPath: nil
         )
-        let setupCommand = setupHookPath ?? defaultShell
+        let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
         let window2 = try await tmux.createWindow(
             server: worktree.tmuxServer,
             session: "main",
@@ -395,6 +408,11 @@ public struct WorktreeLifecycle: Sendable {
             tmuxPaneID: window2.paneID,
             label: "setup"
         )
+
+        // Kill the untracked initial window that new-session created
+        if let windowID = initialWindowID {
+            try? await tmux.killWindow(server: worktree.tmuxServer, windowID: windowID)
+        }
 
         // Update status to active
         try await db.worktrees.revive(id: worktreeID)
@@ -654,9 +672,15 @@ public struct WorktreeLifecycle: Sendable {
         let gitPaths = Set(gitWorktrees.map(\.path))
         let dbPaths = Set(dbWorktrees.map(\.path))
 
-        // Mark missing worktrees as archived
+        // Mark missing worktrees as archived — also kill their tmux windows
         for wt in dbWorktrees where !gitPaths.contains(wt.path) {
-            // Clean up terminals
+            let terminals = try await db.terminals.list(worktreeID: wt.id)
+            for terminal in terminals {
+                try? await tmux.killWindow(
+                    server: wt.tmuxServer,
+                    windowID: terminal.tmuxWindowID
+                )
+            }
             try await db.terminals.deleteForWorktree(worktreeID: wt.id)
             try await db.worktrees.archive(id: wt.id)
         }
@@ -677,6 +701,30 @@ public struct WorktreeLifecycle: Sendable {
                 path: gitWt.path,
                 tmuxServer: tmuxServer
             )
+        }
+
+        // Clean up orphaned tmux windows — windows not tracked by any active terminal
+        let tmuxServer = TmuxManager.serverName(forRepoID: repoID)
+        let activeWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
+        if activeWorktrees.isEmpty {
+            // No active worktrees — kill the entire tmux server
+            try? await tmux.killServer(server: tmuxServer)
+        } else {
+            // Collect all tracked window IDs
+            var trackedWindowIDs: Set<String> = []
+            for wt in activeWorktrees {
+                let terminals = try await db.terminals.list(worktreeID: wt.id)
+                for t in terminals {
+                    trackedWindowIDs.insert(t.tmuxWindowID)
+                }
+            }
+
+            // List actual tmux windows and kill any that aren't tracked
+            if let tmuxWindows = try? await tmux.listWindows(server: tmuxServer, session: "main") {
+                for window in tmuxWindows where !trackedWindowIDs.contains(window.windowID) {
+                    try? await tmux.killWindow(server: tmuxServer, windowID: window.windowID)
+                }
+            }
         }
     }
 }

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -56,23 +56,35 @@ public struct TmuxManager: Sendable {
 
     // MARK: - Instance Execution Methods
 
-    public func ensureServer(server: String, session: String, cwd: String) async throws {
-        if dryRun { return }
+    /// Ensures a tmux server and session exist.
+    /// - Returns: The initial window ID if a new session was created (caller should kill it after
+    ///   creating real windows), or `nil` if the session already existed.
+    @discardableResult
+    public func ensureServer(server: String, session: String, cwd: String) async throws -> String? {
+        if dryRun { return nil }
         // Check if the session already exists before creating
         let hasSessionArgs = Self.hasSessionCommand(server: server, session: session)
         do {
             try await runTmux(hasSessionArgs)
             // Session already exists, nothing to do
+            return nil
         } catch {
-            // Session does not exist, create it
-            let args = Self.newServerCommand(server: server, session: session, cwd: cwd)
-            try await runTmux(args)
+            // Session does not exist, create it — capture the initial window ID
+            let args = ["-L", server, "new-session", "-d", "-s", session, "-c", cwd, "-PF", "#{window_id}"]
+            let output = try await runTmux(args)
             // Hide tmux chrome globally — TBD app provides its own UI
             try? await runTmux(["-L", server, "set", "-g", "status", "off"])
             try? await runTmux(["-L", server, "set", "-g", "pane-border-style", "fg=black"])
             // Enable mouse so scroll wheel enters copy-mode and scrolls history
             try? await runTmux(["-L", server, "set", "-g", "mouse", "on"])
+            return output.trimmingCharacters(in: .whitespacesAndNewlines)
         }
+    }
+
+    /// Kills an entire tmux server and all its sessions.
+    public func killServer(server: String) async throws {
+        if dryRun { return }
+        try await runTmux(["-L", server, "kill-server"])
     }
 
     public func createWindow(server: String, session: String, cwd: String, shellCommand: String) async throws -> (windowID: String, paneID: String) {

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -31,7 +31,7 @@ public struct TmuxManager: Sendable {
     }
 
     public static func newServerCommand(server: String, session: String, cwd: String) -> [String] {
-        ["-L", server, "new-session", "-d", "-s", session, "-c", cwd]
+        ["-L", server, "new-session", "-d", "-s", session, "-c", cwd, "-PF", "#{window_id}"]
     }
 
     public static func hasSessionCommand(server: String, session: String) -> [String] {
@@ -70,7 +70,7 @@ public struct TmuxManager: Sendable {
             return nil
         } catch {
             // Session does not exist, create it — capture the initial window ID
-            let args = ["-L", server, "new-session", "-d", "-s", session, "-c", cwd, "-PF", "#{window_id}"]
+            let args = Self.newServerCommand(server: server, session: session, cwd: cwd)
             let output = try await runTmux(args)
             // Hide tmux chrome globally — TBD app provides its own UI
             try? await runTmux(["-L", server, "set", "-g", "status", "off"])

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -29,6 +29,8 @@ import Testing
     #expect(args.contains("main"))
     #expect(args.contains("-c"))
     #expect(args.contains("/tmp/repo"))
+    #expect(args.contains("-PF"))
+    #expect(args.contains("#{window_id}"))
 }
 
 @Test func testHasSessionCommand() {


### PR DESCRIPTION
## Summary
- When exiting Claude (Cmd+C) in a terminal panel, tmux would destroy the window and auto-switch to another worktree's Claude session — now the user's shell takes over instead, keeping you in the same window
- Kill the untracked initial window that `tmux new-session` creates, preventing orphaned window @0 from accumulating across worktree creates
- Reconciliation now kills tmux windows for worktrees that no longer exist on disk, cleans up orphaned windows not tracked by any terminal record, and kills the entire tmux server when no active worktrees remain

## Test plan
- [ ] Create a new worktree, Cmd+C out of Claude — should drop to shell prompt, not jump to another session
- [ ] Verify `tmux -L tbd-<server> list-windows -t main` shows no orphan windows after creating a worktree
- [ ] Archive all worktrees for a repo, verify the tmux server is cleaned up
- [ ] `swift test` passes (92/92 non-GitManager tests)