### PR TITLE
DX: Make Claude PR reviews gate CI with phased feedback and dedup

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,42 +3,124 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+concurrency:
+  group: claude-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.draft != true
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
+      actions: read
+      checks: read
 
     steps:
+      - name: Check for existing Claude review on this commit
+        id: check-existing-review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          EXISTING_REVIEW=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+            --jq "[.[] | select(.user.login == \"claude[bot]\" and .commit_id == \"$HEAD_SHA\" and (.state == \"APPROVED\" or .state == \"CHANGES_REQUESTED\"))] | length")
+
+          if [ "$EXISTING_REVIEW" -gt 0 ] && [ "${{ github.run_attempt }}" -eq 1 ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Claude already reviewed commit $HEAD_SHA — skipping"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout repository
+        if: steps.check-existing-review.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
+        if: steps.check-existing-review.outputs.skip != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
+          use_sticky_comment: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            Additional review instructions:
+
+            First, check for existing Claude PR comments using `gh pr view --json comments`. Do NOT use `gh pr view --comments` (it triggers a GraphQL permissions error). If Claude has already reviewed this PR:
+            - Review the entire PR for context and holistic understanding
+            - Update the summary comment to reflect both the previous review findings and the new changes
+
+            Do not comment on formatting/linting/style issues. These are handled by CI.
+
+            Do not use `mcp__github_inline_comment__create_inline_comment`. Do not leave inline comments. State file path and line numbers in the primary comment.
+
+            Do not read or review changes in generated files like graphql codegen output.
+
+            IMPORTANT: You are to execute in three phases:
+
+            Phase 1: Write out your feedback and comments on the changes in a local txt file in the current working directory (not to GitHub). Use the Write tool to create the file, not shell redirection. Do not write to /tmp/.
+
+            Phase 2: Read each piece of feedback individually, and consider if they're valid. If they are not valid, do not include it in the comment to GitHub. For feedback asking for tests, consider if the test would require too much mocking to be useful, and do not suggest adding tests that would mostly test 3rd party libraries or APIs. Avoid being persnickety. Keep a count of invalid or persnickety feedback filtered out.
+
+            Phase 3: Actually post the comment to GitHub.
+
+            Format:
+            - The verdict (e.g. "✅ Approve", or "🧌 Reject" with changes requested) should be up at the very top. Do not approve PRs with unaddressed Medium or High severity issues.
+            - Consider whether each item should be considered "high", "medium", or "minor" in severity.
+            - High severity should NOT be measured as high relative to other feedback, but should try to use an objective scale.
+            - Minor items should be tucked into an html <details><summary>..</summary> ... </details> section.
+            - Don't spill ink glazing the PR (Strengths and Highlights should be rarely warranted and extremely succinct).
+            - Include a count of invalid feedback not posted.
+
+            DIAGNOSTICS: At the very end of your comment, add a collapsed section:
+            <details><summary>Review diagnostics</summary>
+            List any tool calls that failed or were denied (e.g. "Write to /tmp/ blocked", "gh api denied"). If none failed, say so. This helps us tune the workflow permissions and allowedTools over time.
+            </details>
+
+            VERDICT: After completing your review, you MUST submit a formal GitHub review using `gh pr review`.
+            Do NOT put review text in the -b body — your findings are already in the sticky comment. Use an empty body:
+            - If no unaddressed medium or high priority issues remain: `gh pr review ${{ github.event.pull_request.number }} --approve -b ""`
+            - If unaddressed medium or high priority issues remain: `gh pr review ${{ github.event.pull_request.number }} --request-changes -b ""`
+            Only use --request-changes for meaningful issues (bugs, security, correctness, significant performance problems). Not for style preferences or minor nitpicks.
+            An issue counts as "addressed" if the author has commented explaining why no code change is needed — you don't need to agree, just acknowledge it was considered.
+            Note to PR authors: if you disagree with a request-changes verdict, you can dismiss the review via GitHub's review dismissal feature and re-trigger the workflow.
+            This verdict determines whether the CI check passes or fails, so be judicious.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: |
+            --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),WebSearch,Read,Write,Glob,Grep,Task"
 
+      - name: Check review verdict
+        if: always() && steps.claude-review.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REVIEW_STATE=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+            | jq -r --arg sha "${{ github.event.pull_request.head.sha }}" \
+              '[.[] | select(.user.login == "claude[bot]" and .commit_id == $sha)] | last | .state // empty')
+
+          echo "Review verdict: ${REVIEW_STATE:-none}"
+
+          if [ "$REVIEW_STATE" = "CHANGES_REQUESTED" ]; then
+            echo "::error::Claude requested changes on this PR"
+            exit 1
+          elif [ "$REVIEW_STATE" = "APPROVED" ]; then
+            echo "Claude approved this PR"
+          else
+            echo "::error::Claude did not submit a review verdict for commit ${{ github.event.pull_request.head.sha }}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Overhaul the Claude Code Review workflow to produce higher-signal reviews by running a 3-phase process: draft feedback locally, filter out noise, then post
- Add commit-level dedup so re-runs on the same SHA skip redundant reviews, and concurrency control to cancel stale runs
- Claude now submits a formal `--approve` or `--request-changes` verdict that gates the CI check, making reviews actionable rather than advisory

## Test plan
- [ ] Open a PR and verify the review workflow triggers, posts a sticky comment, and submits a verdict
- [ ] Push a second commit — verify the previous run is cancelled and a new review runs
- [ ] Re-run the workflow on an already-reviewed commit — verify it skips
- [ ] Open a draft PR — verify the workflow does not run