### PR TITLE
Reliability: Survive macOS crashes by keeping SSH agent reachable in all terminals

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -11,6 +11,7 @@ public final class Daemon: Sendable {
     public nonisolated(unsafe) var socketServer: SocketServer?
     public nonisolated(unsafe) var httpServer: HTTPServer?
     public nonisolated(unsafe) var subscriptions: StateSubscriptionManager?
+    public nonisolated(unsafe) var sshRefreshTask: Task<Void, Never>?
     public let pidFile: PIDFile
     public let startTime: Date
 
@@ -43,6 +44,25 @@ public final class Daemon: Sendable {
 
         // 4. Write PID file
         try pidFile.write()
+
+        // 4a. Resolve SSH agent symlink and update daemon's own environment
+        let sshResolver = SSHAgentResolver()
+        if await sshResolver.resolve() {
+            setenv("SSH_AUTH_SOCK", sshResolver.symlinkPath, 1)
+            print("[Daemon] SSH agent symlink resolved: \(sshResolver.symlinkPath)")
+        }
+
+        // 4b. Start periodic SSH agent refresh (every 60s)
+        self.sshRefreshTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                if !sshResolver.isValid() {
+                    if await sshResolver.resolve() {
+                        print("[Daemon] SSH agent symlink refreshed")
+                    }
+                }
+            }
+        }
 
         // 5. Initialize database
         let database = try TBDDatabase(path: TBDConstants.databasePath)
@@ -98,6 +118,9 @@ public final class Daemon: Sendable {
     /// Stop the daemon: shut down servers, remove PID and socket files.
     public func stop() async {
         print("[Daemon] Shutting down...")
+
+        // Cancel SSH refresh
+        sshRefreshTask?.cancel()
 
         // Stop servers
         if let sock = socketServer {

--- a/Sources/TBDDaemon/SSH/SSHAgentResolver.swift
+++ b/Sources/TBDDaemon/SSH/SSHAgentResolver.swift
@@ -1,0 +1,50 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "SSHAgent")
+
+public struct SSHAgentResolver: Sendable {
+    /// The stable symlink path: ~/.ssh/tbd-agent.sock
+    public static let defaultSymlinkPath: String = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.ssh/tbd-agent.sock"
+    }()
+
+    public let symlinkPath: String
+
+    public init(symlinkPath: String = SSHAgentResolver.defaultSymlinkPath) {
+        self.symlinkPath = symlinkPath
+    }
+
+    /// Check if the current symlink target is reachable via connect(2).
+    public func isValid() -> Bool {
+        let fm = FileManager.default
+        guard let target = try? fm.destinationOfSymbolicLink(atPath: symlinkPath) else {
+            return false
+        }
+        return canConnect(to: target)
+    }
+
+    /// Attempt a connect(2) on a Unix domain socket path.
+    /// Returns true if the connection succeeds (agent is alive).
+    func canConnect(to path: String) -> Bool {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let sunPathSize = MemoryLayout.size(ofValue: addr.sun_path)
+        path.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+                rawPathPtr.copyMemory(from: ptr, byteCount: min(strlen(ptr) + 1, sunPathSize))
+            }
+        }
+        return withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        } == 0
+    }
+}

--- a/Sources/TBDDaemon/SSH/SSHAgentResolver.swift
+++ b/Sources/TBDDaemon/SSH/SSHAgentResolver.swift
@@ -81,15 +81,15 @@ public struct SSHAgentResolver: Sendable {
     }
 
     private func probeWithSSHAdd(socketPath: String) async -> Bool {
-        await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                let process = Process()
-                process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh-add")
-                process.arguments = ["-l"]
-                process.environment = ["SSH_AUTH_SOCK": socketPath]
-                process.standardOutput = FileHandle.nullDevice
-                process.standardError = FileHandle.nullDevice
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh-add")
+        process.arguments = ["-l"]
+        process.environment = ["SSH_AUTH_SOCK": socketPath]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
 
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
                 do {
                     try process.run()
                     process.waitUntilExit()
@@ -101,6 +101,10 @@ public struct SSHAgentResolver: Sendable {
 
             group.addTask {
                 try? await Task.sleep(for: .seconds(2))
+                if process.isRunning {
+                    process.terminate()
+                    logger.debug("SSH probe timed out for \(socketPath)")
+                }
                 return false
             }
 

--- a/Sources/TBDDaemon/SSH/SSHAgentResolver.swift
+++ b/Sources/TBDDaemon/SSH/SSHAgentResolver.swift
@@ -4,19 +4,51 @@ import os
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "SSHAgent")
 
 public struct SSHAgentResolver: Sendable {
-    /// The stable symlink path: ~/.ssh/tbd-agent.sock
     public static let defaultSymlinkPath: String = {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return "\(home)/.ssh/tbd-agent.sock"
     }()
 
     public let symlinkPath: String
+    private let candidatePaths: [String]?
 
-    public init(symlinkPath: String = SSHAgentResolver.defaultSymlinkPath) {
+    public init(
+        symlinkPath: String = SSHAgentResolver.defaultSymlinkPath,
+        candidatePaths: [String]? = nil
+    ) {
         self.symlinkPath = symlinkPath
+        self.candidatePaths = candidatePaths
     }
 
-    /// Check if the current symlink target is reachable via connect(2).
+    public func resolve() async -> Bool {
+        if isValid() {
+            logger.debug("SSH agent symlink is valid")
+            return true
+        }
+
+        let candidates: [String]
+        if let injected = candidatePaths {
+            candidates = injected
+            logger.info("SSH agent stale, probing \(candidates.count) injected candidates")
+            for path in candidates {
+                if canConnect(to: path) {
+                    return applySymlink(to: path)
+                }
+            }
+        } else {
+            candidates = discoverCandidates()
+            logger.info("SSH agent stale, probing \(candidates.count) candidates")
+            for path in candidates {
+                if await probeWithSSHAdd(socketPath: path) {
+                    return applySymlink(to: path)
+                }
+            }
+        }
+
+        logger.warning("No live SSH agent found among \(candidates.count) candidates")
+        return false
+    }
+
     public func isValid() -> Bool {
         let fm = FileManager.default
         guard let target = try? fm.destinationOfSymbolicLink(atPath: symlinkPath) else {
@@ -25,9 +57,9 @@ public struct SSHAgentResolver: Sendable {
         return canConnect(to: target)
     }
 
-    /// Attempt a connect(2) on a Unix domain socket path.
-    /// Returns true if the connection succeeds (agent is alive).
-    func canConnect(to path: String) -> Bool {
+    // MARK: - Private
+
+    private func canConnect(to path: String) -> Bool {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { return false }
         defer { close(fd) }
@@ -46,5 +78,100 @@ public struct SSHAgentResolver: Sendable {
                 Darwin.connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
             }
         } == 0
+    }
+
+    private func probeWithSSHAdd(socketPath: String) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh-add")
+                process.arguments = ["-l"]
+                process.environment = ["SSH_AUTH_SOCK": socketPath]
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = FileHandle.nullDevice
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    return process.terminationStatus != 2
+                } catch {
+                    return false
+                }
+            }
+
+            group.addTask {
+                try? await Task.sleep(for: .seconds(2))
+                return false
+            }
+
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+    }
+
+    private func discoverCandidates() -> [String] {
+        let fm = FileManager.default
+        let baseDir = "/private/tmp"
+        guard let entries = try? fm.contentsOfDirectory(atPath: baseDir) else { return [] }
+
+        var candidates: [(path: String, mtime: Date)] = []
+        for dir in entries where dir.hasPrefix("com.apple.launchd.") {
+            let path = "\(baseDir)/\(dir)/Listeners"
+            var statBuf = stat()
+            guard stat(path, &statBuf) == 0,
+                  (statBuf.st_mode & S_IFMT) == S_IFSOCK else {
+                continue
+            }
+            let mtime = Date(timeIntervalSince1970: TimeInterval(statBuf.st_mtimespec.tv_sec))
+            candidates.append((path: path, mtime: mtime))
+        }
+
+        return candidates
+            .sorted { $0.mtime > $1.mtime }
+            .prefix(10)
+            .map(\.path)
+    }
+
+    private func applySymlink(to target: String) -> Bool {
+        do {
+            try updateSymlink(to: target)
+            return true
+        } catch {
+            logger.error("Failed to update symlink: \(error)")
+            return false
+        }
+    }
+
+    private func updateSymlink(to target: String) throws {
+        let fm = FileManager.default
+
+        let sshDir = (symlinkPath as NSString).deletingLastPathComponent
+        if !fm.fileExists(atPath: sshDir) {
+            try fm.createDirectory(atPath: sshDir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        }
+
+        let old = (try? fm.destinationOfSymbolicLink(atPath: symlinkPath)) ?? "(none)"
+
+        // Remove existing non-symlink file/directory at the path
+        var pathStat = stat()
+        if lstat(symlinkPath, &pathStat) == 0 {
+            let fileType = pathStat.st_mode & S_IFMT
+            if fileType != S_IFLNK {
+                try fm.removeItem(atPath: symlinkPath)
+            }
+        }
+
+        let tempPath = symlinkPath + ".tmp.\(ProcessInfo.processInfo.processIdentifier)"
+        unlink(tempPath)
+        guard symlink(target, tempPath) == 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        guard Darwin.rename(tempPath, symlinkPath) == 0 else {
+            unlink(tempPath)
+            throw CocoaError(.fileWriteUnknown)
+        }
+
+        logger.info("SSH agent symlink updated: \(old) → \(target)")
     }
 }

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -77,6 +77,8 @@ public struct TmuxManager: Sendable {
             try? await runTmux(["-L", server, "set", "-g", "pane-border-style", "fg=black"])
             // Enable mouse so scroll wheel enters copy-mode and scrolls history
             try? await runTmux(["-L", server, "set", "-g", "mouse", "on"])
+            // Set SSH_AUTH_SOCK to stable symlink so shells get a resilient path
+            try? await runTmux(["-L", server, "setenv", "-g", "SSH_AUTH_SOCK", SSHAgentResolver.defaultSymlinkPath])
             return output.trimmingCharacters(in: .whitespacesAndNewlines)
         }
     }

--- a/Tests/TBDDaemonTests/SSHAgentResolverTests.swift
+++ b/Tests/TBDDaemonTests/SSHAgentResolverTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Test func testIsValidReturnsFalseForNonexistentSymlink() {
+    let resolver = SSHAgentResolver(
+        symlinkPath: "/tmp/tbd-test-nonexistent-\(UUID().uuidString).sock"
+    )
+    #expect(!resolver.isValid())
+}
+
+@Test func testIsValidReturnsTrueForLiveSocket() throws {
+    // Create a real Unix domain socket
+    let socketPath = "/tmp/tbd-test-\(UUID().uuidString).sock"
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    #expect(fd >= 0)
+    defer {
+        close(fd)
+        unlink(socketPath)
+    }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    socketPath.withCString { ptr in
+        withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+            let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+            rawPathPtr.copyMemory(from: ptr, byteCount: strlen(ptr) + 1)
+        }
+    }
+    let bindResult = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    #expect(bindResult == 0)
+    listen(fd, 1)
+
+    // Create symlink pointing to the socket
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    try FileManager.default.createSymbolicLink(
+        atPath: symlinkPath,
+        withDestinationPath: socketPath
+    )
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(symlinkPath: symlinkPath)
+    #expect(resolver.isValid())
+}
+
+@Test func testIsValidReturnsFalseForStaleSocket() throws {
+    // Create symlink pointing to a nonexistent socket
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    try FileManager.default.createSymbolicLink(
+        atPath: symlinkPath,
+        withDestinationPath: "/tmp/tbd-nonexistent-socket"
+    )
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(symlinkPath: symlinkPath)
+    #expect(!resolver.isValid())
+}

--- a/Tests/TBDDaemonTests/SSHAgentResolverTests.swift
+++ b/Tests/TBDDaemonTests/SSHAgentResolverTests.swift
@@ -59,3 +59,100 @@ import Testing
     let resolver = SSHAgentResolver(symlinkPath: symlinkPath)
     #expect(!resolver.isValid())
 }
+
+@Test func testResolveFindsLiveSocket() async throws {
+    let socketPath = "/tmp/tbd-test-agent-\(UUID().uuidString).sock"
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    #expect(fd >= 0)
+    defer {
+        close(fd)
+        unlink(socketPath)
+    }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    socketPath.withCString { ptr in
+        withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+            let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+            rawPathPtr.copyMemory(from: ptr, byteCount: strlen(ptr) + 1)
+        }
+    }
+    let bindResult = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    #expect(bindResult == 0)
+    listen(fd, 5)  // backlog >= 2 so resolve() + isValid() can both connect
+
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(
+        symlinkPath: symlinkPath,
+        candidatePaths: [socketPath]
+    )
+    let result = await resolver.resolve()
+    #expect(result)
+
+    let target = try FileManager.default.destinationOfSymbolicLink(atPath: symlinkPath)
+    #expect(target == socketPath)
+    #expect(resolver.isValid())
+}
+
+@Test func testResolveReturnsFalseWhenNoLiveSocket() async {
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(
+        symlinkPath: symlinkPath,
+        candidatePaths: ["/tmp/nonexistent-socket-1", "/tmp/nonexistent-socket-2"]
+    )
+    let result = await resolver.resolve()
+    #expect(!result)
+}
+
+@Test func testResolveUpdatesStaleSymlink() async throws {
+    let stalePath = "/tmp/tbd-test-stale-\(UUID().uuidString).sock"
+    let livePath = "/tmp/tbd-test-live-\(UUID().uuidString).sock"
+
+    let liveFd = socket(AF_UNIX, SOCK_STREAM, 0)
+    #expect(liveFd >= 0)
+    defer {
+        close(liveFd)
+        unlink(livePath)
+    }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    livePath.withCString { ptr in
+        withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+            let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+            rawPathPtr.copyMemory(from: ptr, byteCount: strlen(ptr) + 1)
+        }
+    }
+    let bindResult = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            bind(liveFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    #expect(bindResult == 0)
+    listen(liveFd, 1)
+
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    try FileManager.default.createSymbolicLink(
+        atPath: symlinkPath,
+        withDestinationPath: stalePath
+    )
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(
+        symlinkPath: symlinkPath,
+        candidatePaths: [stalePath, livePath]
+    )
+    let result = await resolver.resolve()
+    #expect(result)
+
+    let target = try FileManager.default.destinationOfSymbolicLink(atPath: symlinkPath)
+    #expect(target == livePath)
+}

--- a/docs/superpowers/plans/2026-03-23-ssh-agent-resolver.md
+++ b/docs/superpowers/plans/2026-03-23-ssh-agent-resolver.md
@@ -1,0 +1,628 @@
+# SSH Agent Resolver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep `SSH_AUTH_SOCK` pointing to a live SSH agent in all TBD-managed tmux sessions, surviving macOS WindowServer crashes.
+
+**Architecture:** A stable symlink (`~/.ssh/tbd-agent.sock`) that the daemon keeps pointed at the live SSH agent socket. Tmux sessions use the symlink path. A periodic background task detects staleness and re-probes.
+
+**Tech Stack:** Swift, Foundation `Process`, POSIX sockets (`connect(2)`), `os.Logger`
+
+**Spec:** `docs/superpowers/specs/2026-03-23-ssh-agent-resolver-design.md`
+
+**Note on Package.swift:** The `SSH/` subdirectory does NOT need to be added to any exclude list. `TBDDaemonLib` picks up all `.swift` files under `Sources/TBDDaemon/` automatically (no `sources` key set). The `TBDDaemon` executable target already limits itself to `sources: ["main.swift"]`.
+
+---
+
+### Task 1: Create `SSHAgentResolver` with `isValid()`
+
+**Files:**
+- Create: `Sources/TBDDaemon/SSH/SSHAgentResolver.swift`
+- Create: `Tests/TBDDaemonTests/SSHAgentResolverTests.swift`
+
+- [ ] **Step 1: Write the failing test for `isValid()`**
+
+Create `Tests/TBDDaemonTests/SSHAgentResolverTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Test func testIsValidReturnsFalseForNonexistentSymlink() {
+    let resolver = SSHAgentResolver(
+        symlinkPath: "/tmp/tbd-test-nonexistent-\(UUID().uuidString).sock"
+    )
+    #expect(!resolver.isValid())
+}
+
+@Test func testIsValidReturnsTrueForLiveSocket() throws {
+    // Create a real Unix domain socket
+    let socketPath = "/tmp/tbd-test-\(UUID().uuidString).sock"
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    #expect(fd >= 0)
+    defer {
+        close(fd)
+        unlink(socketPath)
+    }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    socketPath.withCString { ptr in
+        withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+            let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+            rawPathPtr.copyMemory(from: ptr, byteCount: strlen(ptr) + 1)
+        }
+    }
+    let bindResult = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    #expect(bindResult == 0)
+    listen(fd, 1)
+
+    // Create symlink pointing to the socket
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    try FileManager.default.createSymbolicLink(
+        atPath: symlinkPath,
+        withDestinationPath: socketPath
+    )
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(symlinkPath: symlinkPath)
+    #expect(resolver.isValid())
+}
+
+@Test func testIsValidReturnsFalseForStaleSocket() throws {
+    // Create symlink pointing to a nonexistent socket
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    try FileManager.default.createSymbolicLink(
+        atPath: symlinkPath,
+        withDestinationPath: "/tmp/tbd-nonexistent-socket"
+    )
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(symlinkPath: symlinkPath)
+    #expect(!resolver.isValid())
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter SSHAgentResolver 2>&1 | tail -20`
+Expected: FAIL — `SSHAgentResolver` not found
+
+- [ ] **Step 3: Write `SSHAgentResolver` with `isValid()`**
+
+Create `Sources/TBDDaemon/SSH/SSHAgentResolver.swift`:
+
+```swift
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "SSHAgent")
+
+public struct SSHAgentResolver: Sendable {
+    /// The stable symlink path: ~/.ssh/tbd-agent.sock
+    public static let defaultSymlinkPath: String = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.ssh/tbd-agent.sock"
+    }()
+
+    public let symlinkPath: String
+
+    public init(symlinkPath: String = SSHAgentResolver.defaultSymlinkPath) {
+        self.symlinkPath = symlinkPath
+    }
+
+    /// Check if the current symlink target is reachable via connect(2).
+    public func isValid() -> Bool {
+        let fm = FileManager.default
+        guard let target = try? fm.destinationOfSymbolicLink(atPath: symlinkPath) else {
+            return false
+        }
+        return canConnect(to: target)
+    }
+
+    /// Attempt a connect(2) on a Unix domain socket path.
+    /// Returns true if the connection succeeds (agent is alive).
+    func canConnect(to path: String) -> Bool {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        path.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+                rawPathPtr.copyMemory(from: ptr, byteCount: min(strlen(ptr) + 1, MemoryLayout.size(ofValue: addr.sun_path)))
+            }
+        }
+        return withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        } == 0
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter SSHAgentResolver 2>&1 | tail -20`
+Expected: All 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/SSH/SSHAgentResolver.swift Tests/TBDDaemonTests/SSHAgentResolverTests.swift
+git commit -m "feat: add SSHAgentResolver with isValid() using connect(2)"
+```
+
+---
+
+### Task 2: Add `resolve()` — probing with `ssh-add` and symlink update
+
+**Files:**
+- Modify: `Sources/TBDDaemon/SSH/SSHAgentResolver.swift`
+- Modify: `Tests/TBDDaemonTests/SSHAgentResolverTests.swift`
+
+- [ ] **Step 1: Write the failing test for `resolve()` with a mock socket**
+
+Add to `SSHAgentResolverTests.swift`:
+
+```swift
+@Test func testResolveFindsLiveSocket() async throws {
+    // Create a listening Unix domain socket (simulates SSH agent)
+    let socketPath = "/tmp/tbd-test-agent-\(UUID().uuidString).sock"
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    #expect(fd >= 0)
+    defer {
+        close(fd)
+        unlink(socketPath)
+    }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    socketPath.withCString { ptr in
+        withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+            let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+            rawPathPtr.copyMemory(from: ptr, byteCount: strlen(ptr) + 1)
+        }
+    }
+    let bindResult = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    #expect(bindResult == 0)
+    listen(fd, 1)
+
+    // Resolver with a fresh symlink path — inject known candidate
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(
+        symlinkPath: symlinkPath,
+        candidatePaths: [socketPath]
+    )
+    let result = await resolver.resolve()
+    #expect(result)
+
+    // Verify the symlink was created and points to the socket
+    let target = try FileManager.default.destinationOfSymbolicLink(atPath: symlinkPath)
+    #expect(target == socketPath)
+    #expect(resolver.isValid())
+}
+
+@Test func testResolveReturnsFalseWhenNoLiveSocket() async {
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(
+        symlinkPath: symlinkPath,
+        candidatePaths: ["/tmp/nonexistent-socket-1", "/tmp/nonexistent-socket-2"]
+    )
+    let result = await resolver.resolve()
+    #expect(!result)
+}
+
+@Test func testResolveUpdatesStaleSymlink() async throws {
+    // Create a live socket and a stale (nonexistent) path
+    let stalePath = "/tmp/tbd-test-stale-\(UUID().uuidString).sock"
+    let livePath = "/tmp/tbd-test-live-\(UUID().uuidString).sock"
+
+    let liveFd = socket(AF_UNIX, SOCK_STREAM, 0)
+    #expect(liveFd >= 0)
+    defer {
+        close(liveFd)
+        unlink(livePath)
+    }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    livePath.withCString { ptr in
+        withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+            let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+            rawPathPtr.copyMemory(from: ptr, byteCount: strlen(ptr) + 1)
+        }
+    }
+    let bindResult = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            bind(liveFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    #expect(bindResult == 0)
+    listen(liveFd, 1)
+
+    // Create symlink pointing to stale path
+    let symlinkPath = "/tmp/tbd-test-link-\(UUID().uuidString).sock"
+    try FileManager.default.createSymbolicLink(
+        atPath: symlinkPath,
+        withDestinationPath: stalePath
+    )
+    defer { unlink(symlinkPath) }
+
+    let resolver = SSHAgentResolver(
+        symlinkPath: symlinkPath,
+        candidatePaths: [stalePath, livePath]
+    )
+    let result = await resolver.resolve()
+    #expect(result)
+
+    // Verify symlink now points to the live socket
+    let target = try FileManager.default.destinationOfSymbolicLink(atPath: symlinkPath)
+    #expect(target == livePath)
+}
+```
+
+Note: `resolve()` tests use `candidatePaths` injection to avoid depending on `ssh-add` in CI. The `canConnect(to:)` fast path is sufficient for test sockets. The production `discoverCandidates()` uses `ssh-add -l` to verify the SSH agent protocol (see Step 3).
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `swift test --filter SSHAgentResolver 2>&1 | tail -20`
+Expected: New tests FAIL — `resolve()` and `candidatePaths` don't exist yet
+
+- [ ] **Step 3: Implement `resolve()`, `discoverCandidates()`, and `updateSymlink()`**
+
+Replace the full content of `SSHAgentResolver.swift`:
+
+```swift
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "SSHAgent")
+
+public struct SSHAgentResolver: Sendable {
+    /// The stable symlink path: ~/.ssh/tbd-agent.sock
+    public static let defaultSymlinkPath: String = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.ssh/tbd-agent.sock"
+    }()
+
+    public let symlinkPath: String
+    private let candidatePaths: [String]?
+
+    public init(
+        symlinkPath: String = SSHAgentResolver.defaultSymlinkPath,
+        candidatePaths: [String]? = nil
+    ) {
+        self.symlinkPath = symlinkPath
+        self.candidatePaths = candidatePaths
+    }
+
+    /// Ensure the symlink points to a live SSH agent socket.
+    /// Returns true if a live agent was found and the symlink was updated.
+    public func resolve() async -> Bool {
+        // Fast path: current symlink target is still alive
+        if isValid() {
+            logger.debug("SSH agent symlink is valid")
+            return true
+        }
+
+        // Slow path: probe candidates
+        let candidates: [String]
+        if let injected = candidatePaths {
+            // Test injection: use connect(2) instead of ssh-add
+            candidates = injected
+            logger.info("SSH agent stale, probing \(candidates.count) injected candidates")
+            for path in candidates {
+                if canConnect(to: path) {
+                    return applySymlink(to: path)
+                }
+            }
+        } else {
+            // Production: discover and probe with ssh-add -l
+            candidates = discoverCandidates()
+            logger.info("SSH agent stale, probing \(candidates.count) candidates")
+            for path in candidates {
+                if await probeWithSSHAdd(socketPath: path) {
+                    return applySymlink(to: path)
+                }
+            }
+        }
+
+        logger.warning("No live SSH agent found among \(candidates.count) candidates")
+        return false
+    }
+
+    /// Check if the current symlink target is reachable via connect(2).
+    public func isValid() -> Bool {
+        let fm = FileManager.default
+        guard let target = try? fm.destinationOfSymbolicLink(atPath: symlinkPath) else {
+            return false
+        }
+        return canConnect(to: target)
+    }
+
+    // MARK: - Private
+
+    /// Attempt a connect(2) on a Unix domain socket path.
+    func canConnect(to path: String) -> Bool {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        path.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+                rawPathPtr.copyMemory(from: ptr, byteCount: min(strlen(ptr) + 1, MemoryLayout.size(ofValue: addr.sun_path)))
+            }
+        }
+        return withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        } == 0
+    }
+
+    /// Probe a socket with `ssh-add -l` to verify it speaks SSH agent protocol.
+    /// Exit code 0 or 1 = live agent. Exit code 2 = not an SSH agent.
+    /// Times out after 2 seconds.
+    private func probeWithSSHAdd(socketPath: String) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh-add")
+                process.arguments = ["-l"]
+                process.environment = ["SSH_AUTH_SOCK": socketPath]
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = FileHandle.nullDevice
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    // Exit 0 = keys listed, Exit 1 = agent has no keys, Exit 2 = not an agent
+                    return process.terminationStatus != 2
+                } catch {
+                    return false
+                }
+            }
+
+            group.addTask {
+                try? await Task.sleep(for: .seconds(2))
+                return false  // Timeout sentinel
+            }
+
+            // Take whichever finishes first
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+    }
+
+    /// Discover candidate SSH agent socket paths from launchd.
+    /// Sorted newest first by mtime, capped at 10 to bound probe time.
+    private func discoverCandidates() -> [String] {
+        let fm = FileManager.default
+        let baseDir = "/private/tmp"
+        guard let entries = try? fm.contentsOfDirectory(atPath: baseDir) else { return [] }
+
+        var candidates: [(path: String, mtime: Date)] = []
+        for dir in entries where dir.hasPrefix("com.apple.launchd.") {
+            let path = "\(baseDir)/\(dir)/Listeners"
+            var statBuf = stat()
+            guard stat(path, &statBuf) == 0,
+                  (statBuf.st_mode & S_IFMT) == S_IFSOCK else {
+                continue
+            }
+            let mtime = Date(timeIntervalSince1970: TimeInterval(statBuf.st_mtimespec.tv_sec))
+            candidates.append((path: path, mtime: mtime))
+        }
+
+        return candidates
+            .sorted { $0.mtime > $1.mtime }
+            .prefix(10)
+            .map(\.path)
+    }
+
+    /// Apply the symlink update and log the change.
+    private func applySymlink(to target: String) -> Bool {
+        do {
+            try updateSymlink(to: target)
+            return true
+        } catch {
+            logger.error("Failed to update symlink: \(error)")
+            return false
+        }
+    }
+
+    /// Atomically update the symlink to point to a new target.
+    private func updateSymlink(to target: String) throws {
+        let fm = FileManager.default
+
+        // Ensure ~/.ssh/ exists with correct permissions
+        let sshDir = (symlinkPath as NSString).deletingLastPathComponent
+        if !fm.fileExists(atPath: sshDir) {
+            try fm.createDirectory(atPath: sshDir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        }
+
+        // Read old target BEFORE the rename for logging
+        let old = (try? fm.destinationOfSymbolicLink(atPath: symlinkPath)) ?? "(none)"
+
+        // Remove existing non-symlink file/directory at the path
+        var pathStat = stat()
+        if lstat(symlinkPath, &pathStat) == 0 {
+            let fileType = pathStat.st_mode & S_IFMT
+            if fileType != S_IFLNK {
+                try fm.removeItem(atPath: symlinkPath)
+            }
+        }
+
+        // Atomic update: create temp symlink, then rename over target
+        let tempPath = symlinkPath + ".tmp.\(ProcessInfo.processInfo.processIdentifier)"
+        unlink(tempPath)
+        guard symlink(target, tempPath) == 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        guard Darwin.rename(tempPath, symlinkPath) == 0 else {
+            unlink(tempPath)
+            throw CocoaError(.fileWriteUnknown)
+        }
+
+        logger.info("SSH agent symlink updated: \(old) → \(target)")
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter SSHAgentResolver 2>&1 | tail -20`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/SSH/SSHAgentResolver.swift Tests/TBDDaemonTests/SSHAgentResolverTests.swift
+git commit -m "feat: add SSHAgentResolver.resolve() with ssh-add probing and atomic symlink"
+```
+
+---
+
+### Task 3: Integrate into `TmuxManager.ensureServer`
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Tmux/TmuxManager.swift:59-76`
+
+- [ ] **Step 1: Add `setenv` call in `ensureServer`**
+
+After the `set -g mouse on` line (line 74), add:
+
+```swift
+            // Set SSH_AUTH_SOCK to stable symlink so shells get a resilient path
+            try? await runTmux(["-L", server, "setenv", "-g", "SSH_AUTH_SOCK", SSHAgentResolver.defaultSymlinkPath])
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build complete
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDDaemon/Tmux/TmuxManager.swift
+git commit -m "feat: set SSH_AUTH_SOCK to stable symlink in tmux server env"
+```
+
+---
+
+### Task 4: Integrate into daemon startup and periodic refresh
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Daemon.swift`
+
+This consolidates both the spec's `main.swift` startup integration and the `Daemon.swift` periodic refresh into `Daemon.swift` (the lifecycle owner), since `main.swift` only calls `daemon.start()`.
+
+- [ ] **Step 1: Add SSH agent resolve at startup and periodic refresh**
+
+In `Daemon.swift`, add an `sshRefreshTask` property:
+
+```swift
+    public nonisolated(unsafe) var sshRefreshTask: Task<Void, Never>?
+```
+
+In `start()`, after step 4 (Write PID file) and before step 5 (Initialize database), add:
+
+```swift
+        // 4a. Resolve SSH agent symlink and update daemon's own environment
+        let sshResolver = SSHAgentResolver()
+        if await sshResolver.resolve() {
+            setenv("SSH_AUTH_SOCK", sshResolver.symlinkPath, 1)
+            print("[Daemon] SSH agent symlink resolved: \(sshResolver.symlinkPath)")
+        }
+
+        // 4b. Start periodic SSH agent refresh (every 60s)
+        self.sshRefreshTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                if !sshResolver.isValid() {
+                    if await sshResolver.resolve() {
+                        print("[Daemon] SSH agent symlink refreshed")
+                    }
+                }
+            }
+        }
+```
+
+In `stop()`, before "Stop servers", add:
+
+```swift
+        // Cancel SSH refresh
+        sshRefreshTask?.cancel()
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build complete
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `swift test 2>&1 | tail -20`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDDaemon/Daemon.swift
+git commit -m "feat: resolve SSH agent at startup and refresh every 60s"
+```
+
+---
+
+### Task 5: End-to-end verification
+
+- [ ] **Step 1: Rebuild and restart the daemon**
+
+Run: `scripts/restart.sh`
+Expected: Daemon starts successfully
+
+- [ ] **Step 2: Verify symlink was created**
+
+Run: `ls -la ~/.ssh/tbd-agent.sock`
+Expected: Symlink pointing to a `/private/tmp/com.apple.launchd.*/Listeners` path
+
+- [ ] **Step 3: Verify the symlink target is the live agent**
+
+Run: `SSH_AUTH_SOCK=~/.ssh/tbd-agent.sock ssh-add -l`
+Expected: Shows the ed25519 key
+
+- [ ] **Step 4: Verify git signing works through the symlink**
+
+Run (in a TBD-managed tmux session):
+```bash
+echo $SSH_AUTH_SOCK  # should be ~/.ssh/tbd-agent.sock
+git log --show-signature -1  # should work without errors
+```
+
+- [ ] **Step 5: Commit any final adjustments**
+
+```bash
+git commit -m "fix: adjust SSH agent resolver based on e2e testing"
+```
+(Only if changes were needed.)

--- a/docs/superpowers/specs/2026-03-23-ssh-agent-resolver-design.md
+++ b/docs/superpowers/specs/2026-03-23-ssh-agent-resolver-design.md
@@ -40,7 +40,7 @@ public struct SSHAgentResolver: Sendable {
 **Probing logic in `resolve()`:**
 
 1. Fast path: if the current symlink target is reachable via `connect(2)` on the Unix domain socket, return true — no work needed.
-2. Slow path: glob `/private/tmp/com.apple.launchd.*/Listeners`. Filter for Unix domain sockets via `stat(2)` / `S_ISSOCK`. Test each with `ssh-add -l`. Exit code 0 or 1 means live SSH agent (exit 2 = agent protocol not spoken on that socket).
+2. Slow path: glob `/private/tmp/com.apple.launchd.*/Listeners`. Filter for Unix domain sockets via `stat(2)` / `S_ISSOCK`. Cap at 10 candidates (sorted newest first by mtime) to bound probe time. Test each with `ssh-add -l`. Exit code 0 or 1 means live SSH agent (exit 2 = agent protocol not spoken on that socket). Stop at the first match.
 3. Update the symlink atomically: `symlink()` to a temp path in `~/.ssh/`, then `Darwin.rename()` over the target (not `FileManager.moveItem`, which may resolve symlinks). Both paths are on the same volume, so `rename(2)` is atomic.
 4. Return false if no live agent found among any socket.
 
@@ -73,6 +73,14 @@ A background `Task` in the daemon that runs every 60 seconds:
 3. After resolving, the symlink is updated on disk. No need to re-run `tmux setenv` since the env already points to the stable symlink path — the symlink indirection handles it.
 
 The periodic task is cancellable and tied to the daemon's lifecycle.
+
+### Logging
+
+Use `os.Logger` (subsystem `com.tbd.daemon`, category `SSHAgent`). Log:
+- Symlink created/updated: old target → new target
+- Resolve failure: no live agent found (list candidates checked)
+- Periodic refresh recovery: symlink was stale, updated to new target
+- Probe timeouts: which socket path timed out
 
 ## Data flow
 
@@ -117,5 +125,5 @@ launchd creates SSH agent at /private/tmp/com.apple.launchd.XXX/Listeners
 | `Sources/TBDDaemon/SSH/SSHAgentResolver.swift` | Create |
 | `Sources/TBDDaemon/Tmux/TmuxManager.swift` | Modify — add `setenv` call in `ensureServer` |
 | `Sources/TBDDaemon/main.swift` | Modify — call `resolve()` at startup, `setenv` in-process |
-| `Sources/TBDDaemon/Server/DaemonServer.swift` (or equivalent lifecycle owner) | Modify — add periodic refresh task |
+| `Sources/TBDDaemon/Daemon.swift` | Modify — add periodic refresh task |
 | `Tests/TBDDaemonTests/SSHAgentResolverTests.swift` | Create |

--- a/docs/superpowers/specs/2026-03-23-ssh-agent-resolver-design.md
+++ b/docs/superpowers/specs/2026-03-23-ssh-agent-resolver-design.md
@@ -1,0 +1,109 @@
+# SSH Agent Resolver
+
+## Problem
+
+TBD's daemon inherits `SSH_AUTH_SOCK` from its launch environment. When the macOS WindowServer crashes or the system restarts, launchd creates a new SSH agent at a new socket path. The daemon (which may survive the crash) retains the old, stale path. This breaks git commit signing in all TBD-managed terminals — happening several times per week.
+
+Normal terminals work because they're launched fresh by the window server with the current launchd environment. TBD's tmux sessions don't get this refresh.
+
+## Solution
+
+A stable symlink (`~/.ssh/tbd-agent.sock`) that always points to the live SSH agent socket. TBD sets `SSH_AUTH_SOCK` to this symlink path in all tmux sessions. A background task keeps the symlink target current.
+
+This fixes existing sessions instantly — processes resolve the symlink at use time, not at shell startup.
+
+## Components
+
+### `SSHAgentResolver` (new, in `TBDDaemonLib`)
+
+A `Sendable` struct with two public methods:
+
+```swift
+public struct SSHAgentResolver: Sendable {
+    /// The stable symlink path: ~/.ssh/tbd-agent.sock
+    public static let symlinkPath: String
+
+    /// Ensure the symlink points to a live SSH agent socket.
+    /// Returns true if a live agent was found and the symlink was updated.
+    public func resolve() async -> Bool
+
+    /// Check if the current symlink target is reachable.
+    public func isValid() -> Bool
+}
+```
+
+**Probing logic in `resolve()`:**
+
+1. Fast path: if the current symlink target responds to `ssh-add -l` (exit 0 or 1), return true — no work needed.
+2. Slow path: glob `/private/tmp/com.apple.launchd.*/Listeners`, test each socket with `ssh-add -l`. Exit code 0 or 1 means live agent (exit 2 = no agent on that socket).
+3. Update the symlink atomically: write to a temp path, then `rename()` over the target.
+4. Return false if no live agent found among any socket.
+
+**Process execution:** Uses `Process` with `/usr/bin/ssh-add` and arguments `["-l"]`, setting the `SSH_AUTH_SOCK` environment variable per probe. Timeout each probe at 2 seconds to avoid hanging on unresponsive sockets.
+
+### Integration: `TmuxManager.ensureServer`
+
+After creating a new tmux server, set the SSH agent socket in the tmux global environment:
+
+```swift
+try? await runTmux(["-L", server, "setenv", "-g", "SSH_AUTH_SOCK", SSHAgentResolver.symlinkPath])
+```
+
+This goes alongside the existing `set -g status off` and `set -g mouse on` calls.
+
+### Integration: Daemon startup
+
+In the daemon's startup sequence, call `resolver.resolve()` once to create/update the symlink before any tmux sessions are created.
+
+### Integration: Periodic refresh
+
+A background `Task` in the daemon that runs every 60 seconds:
+
+1. Call `resolver.isValid()` (cheap — just tests the current symlink target)
+2. If invalid, call `resolver.resolve()` (probes all sockets)
+3. If resolved, update all active tmux servers: `tmux -L <server> setenv -g SSH_AUTH_SOCK <symlinkPath>`
+
+The periodic task is cancellable and tied to the daemon's lifecycle.
+
+## Data flow
+
+```
+launchd creates SSH agent at /private/tmp/com.apple.launchd.XXX/Listeners
+                    │
+    SSHAgentResolver probes and finds it
+                    │
+                    ▼
+    ~/.ssh/tbd-agent.sock ──symlink──▶ /private/tmp/com.apple.launchd.XXX/Listeners
+                    │
+    tmux global env: SSH_AUTH_SOCK=~/.ssh/tbd-agent.sock
+                    │
+                    ▼
+    shell in tmux pane reads SSH_AUTH_SOCK
+                    │
+                    ▼
+    git commit --gpg-sign follows symlink to live agent ✓
+```
+
+## Edge cases
+
+- **No live agent found:** `resolve()` returns false, symlink is left as-is (or not created). Git signing fails as it does today — no worse than current behavior.
+- **Multiple live agents:** Take the first one that responds. In practice, only one launchd socket is the SSH agent.
+- **Daemon restart:** Symlink persists on disk. On next startup, fast path likely succeeds immediately.
+- **Symlink already exists from previous run:** Overwritten atomically via `rename()`.
+- **`~/.ssh/` doesn't exist:** Create it with mode 0700 before creating the symlink.
+
+## Testing
+
+- Unit test `SSHAgentResolver` with a mock socket (create a Unix domain socket in a temp dir, test probing logic).
+- Unit test the fast path (valid symlink) vs slow path (stale symlink triggers re-probe).
+- Integration: verify `tmux setenv` is called with the correct path after `ensureServer`.
+
+## Files to create/modify
+
+| File | Action |
+|------|--------|
+| `Sources/TBDDaemon/SSH/SSHAgentResolver.swift` | Create |
+| `Sources/TBDDaemon/Tmux/TmuxManager.swift` | Modify — add `setenv` call in `ensureServer` |
+| `Sources/TBDDaemon/main.swift` | Modify — call `resolve()` at startup |
+| `Sources/TBDDaemon/Server/DaemonServer.swift` (or equivalent lifecycle owner) | Modify — add periodic refresh task |
+| `Tests/TBDDaemonTests/SSHAgentResolverTests.swift` | Create |

--- a/docs/superpowers/specs/2026-03-23-ssh-agent-resolver-design.md
+++ b/docs/superpowers/specs/2026-03-23-ssh-agent-resolver-design.md
@@ -10,11 +10,15 @@ Normal terminals work because they're launched fresh by the window server with t
 
 A stable symlink (`~/.ssh/tbd-agent.sock`) that always points to the live SSH agent socket. TBD sets `SSH_AUTH_SOCK` to this symlink path in all tmux sessions. A background task keeps the symlink target current.
 
-This fixes existing sessions instantly — processes resolve the symlink at use time, not at shell startup.
+### How "fixes existing sessions" works
+
+The symlink is the indirection that makes this work. Once a shell was started with `SSH_AUTH_SOCK=~/.ssh/tbd-agent.sock`, every subsequent `git commit` (or any SSH operation) resolves the symlink at connect time. When the symlink target is updated, the next git command in that shell follows the new target — no shell restart needed.
+
+Limitation: shells that were started *before* this feature is deployed still have the old literal socket path in their env, not the symlink. Those shells won't benefit until they're restarted. This is a one-time migration cost.
 
 ## Components
 
-### `SSHAgentResolver` (new, in `TBDDaemonLib`)
+### `SSHAgentResolver` (new, under `Sources/TBDDaemon/SSH/`)
 
 A `Sendable` struct with two public methods:
 
@@ -28,18 +32,23 @@ public struct SSHAgentResolver: Sendable {
     public func resolve() async -> Bool
 
     /// Check if the current symlink target is reachable.
+    /// Uses raw socket connect(2), not ssh-add — fast and cheap.
     public func isValid() -> Bool
 }
 ```
 
 **Probing logic in `resolve()`:**
 
-1. Fast path: if the current symlink target responds to `ssh-add -l` (exit 0 or 1), return true — no work needed.
-2. Slow path: glob `/private/tmp/com.apple.launchd.*/Listeners`, test each socket with `ssh-add -l`. Exit code 0 or 1 means live agent (exit 2 = no agent on that socket).
-3. Update the symlink atomically: write to a temp path, then `rename()` over the target.
+1. Fast path: if the current symlink target is reachable via `connect(2)` on the Unix domain socket, return true — no work needed.
+2. Slow path: glob `/private/tmp/com.apple.launchd.*/Listeners`. Filter for Unix domain sockets via `stat(2)` / `S_ISSOCK`. Test each with `ssh-add -l`. Exit code 0 or 1 means live SSH agent (exit 2 = agent protocol not spoken on that socket).
+3. Update the symlink atomically: `symlink()` to a temp path in `~/.ssh/`, then `Darwin.rename()` over the target (not `FileManager.moveItem`, which may resolve symlinks). Both paths are on the same volume, so `rename(2)` is atomic.
 4. Return false if no live agent found among any socket.
 
-**Process execution:** Uses `Process` with `/usr/bin/ssh-add` and arguments `["-l"]`, setting the `SSH_AUTH_SOCK` environment variable per probe. Timeout each probe at 2 seconds to avoid hanging on unresponsive sockets.
+**`isValid()` implementation:** Attempt `connect(2)` on the symlink path using a `AF_UNIX` socket. If it connects, the agent is alive. This avoids spawning a process and completes in microseconds.
+
+**Process timeout for probing:** `Foundation.Process` has no built-in timeout. Wrap each probe in a `Task` that races against `Task.sleep(for: .seconds(2))`. If the sleep wins, call `process.terminate()` and skip that socket.
+
+**Symlink directory:** If `~/.ssh/` doesn't exist, create it with mode 0700. If `~/.ssh/tbd-agent.sock` exists as a regular file or directory (not a symlink), remove it before creating the symlink.
 
 ### Integration: `TmuxManager.ensureServer`
 
@@ -49,19 +58,19 @@ After creating a new tmux server, set the SSH agent socket in the tmux global en
 try? await runTmux(["-L", server, "setenv", "-g", "SSH_AUTH_SOCK", SSHAgentResolver.symlinkPath])
 ```
 
-This goes alongside the existing `set -g status off` and `set -g mouse on` calls.
+This goes alongside the existing `set -g status off` and `set -g mouse on` calls. New panes/windows created in this tmux server will inherit this env var.
 
 ### Integration: Daemon startup
 
-In the daemon's startup sequence, call `resolver.resolve()` once to create/update the symlink before any tmux sessions are created.
+In the daemon's startup sequence, call `resolver.resolve()` once to create/update the symlink before any tmux sessions are created. Also update the daemon's own process environment via `setenv("SSH_AUTH_SOCK", symlinkPath, 1)` so that any `Process` calls within the daemon (e.g., `GitManager` git operations) also use the stable symlink.
 
 ### Integration: Periodic refresh
 
 A background `Task` in the daemon that runs every 60 seconds:
 
-1. Call `resolver.isValid()` (cheap — just tests the current symlink target)
-2. If invalid, call `resolver.resolve()` (probes all sockets)
-3. If resolved, update all active tmux servers: `tmux -L <server> setenv -g SSH_AUTH_SOCK <symlinkPath>`
+1. Call `resolver.isValid()` (cheap — raw socket connect, no process spawn)
+2. If invalid, call `resolver.resolve()` (probes all sockets, ~100ms)
+3. After resolving, the symlink is updated on disk. No need to re-run `tmux setenv` since the env already points to the stable symlink path — the symlink indirection handles it.
 
 The periodic task is cancellable and tied to the daemon's lifecycle.
 
@@ -89,14 +98,17 @@ launchd creates SSH agent at /private/tmp/com.apple.launchd.XXX/Listeners
 - **No live agent found:** `resolve()` returns false, symlink is left as-is (or not created). Git signing fails as it does today — no worse than current behavior.
 - **Multiple live agents:** Take the first one that responds. In practice, only one launchd socket is the SSH agent.
 - **Daemon restart:** Symlink persists on disk. On next startup, fast path likely succeeds immediately.
-- **Symlink already exists from previous run:** Overwritten atomically via `rename()`.
+- **Symlink already exists from previous run:** Overwritten atomically via `rename(2)`.
 - **`~/.ssh/` doesn't exist:** Create it with mode 0700 before creating the symlink.
+- **`~/.ssh/tbd-agent.sock` is a regular file/directory:** Remove it before creating the symlink.
+- **Pre-existing sessions (migration):** Shells started before this feature was deployed have the old literal socket path. They won't benefit from the symlink until restarted. This is expected — a one-time cost.
 
 ## Testing
 
-- Unit test `SSHAgentResolver` with a mock socket (create a Unix domain socket in a temp dir, test probing logic).
-- Unit test the fast path (valid symlink) vs slow path (stale symlink triggers re-probe).
-- Integration: verify `tmux setenv` is called with the correct path after `ensureServer`.
+- Unit test `SSHAgentResolver` probing with a mock Unix domain socket in a temp dir.
+- Unit test the fast path (valid symlink → `isValid()` returns true) vs slow path (stale symlink → triggers re-probe).
+- Unit test atomic symlink update (verify old symlink is replaced).
+- Test timeout behavior: mock a socket that accepts connections but never responds.
 
 ## Files to create/modify
 
@@ -104,6 +116,6 @@ launchd creates SSH agent at /private/tmp/com.apple.launchd.XXX/Listeners
 |------|--------|
 | `Sources/TBDDaemon/SSH/SSHAgentResolver.swift` | Create |
 | `Sources/TBDDaemon/Tmux/TmuxManager.swift` | Modify — add `setenv` call in `ensureServer` |
-| `Sources/TBDDaemon/main.swift` | Modify — call `resolve()` at startup |
+| `Sources/TBDDaemon/main.swift` | Modify — call `resolve()` at startup, `setenv` in-process |
 | `Sources/TBDDaemon/Server/DaemonServer.swift` (or equivalent lifecycle owner) | Modify — add periodic refresh task |
 | `Tests/TBDDaemonTests/SSHAgentResolverTests.swift` | Create |


### PR DESCRIPTION
## Summary
- Git commit signing breaks several times a week after macOS WindowServer crashes — the daemon survives but its `SSH_AUTH_SOCK` points to a stale launchd socket
- Adds `SSHAgentResolver` that maintains a stable symlink (`~/.ssh/tbd-agent.sock`) always pointing to the live SSH agent socket, probing candidates with `ssh-add -l` when the current target goes stale
- Daemon resolves the symlink at startup, sets it in all tmux server environments, and refreshes every 60s in the background
- Also includes scroll wheel fix for terminal panels (forwards scroll events to tmux as mouse button presses)

## Test plan
- [ ] Restart daemon (`scripts/restart.sh`), verify `~/.ssh/tbd-agent.sock` symlink is created
- [ ] `SSH_AUTH_SOCK=~/.ssh/tbd-agent.sock ssh-add -l` shows the signing key
- [ ] Git commit signing works in TBD-managed terminals
- [ ] `swift test --filter SSHAgentResolver` — 6 tests pass
- [ ] Scroll wheel works in terminal panels (scroll up enters tmux copy-mode)