### PR TITLE
Fix: Prevent setup-hooks from writing invalid hook format that silently disables all settings

### DIFF
--- a/Sources/TBDCLI/Commands/SetupHooksCommand.swift
+++ b/Sources/TBDCLI/Commands/SetupHooksCommand.swift
@@ -63,34 +63,36 @@ struct SetupHooksCommand: AsyncParsableCommand {
         // The hook command we want to add
         let tbdNotifyCommand = "tbd notify --type response_complete 2>/dev/null || true"
 
-        // Check if our hook already exists (search inside hooks arrays)
-        let alreadyExists = stopHooks.contains { matcher in
-            guard let innerHooks = matcher["hooks"] as? [[String: Any]] else {
-                // Also check legacy bare format so we can migrate it
-                if let command = matcher["command"] as? String {
-                    return command.contains("tbd notify")
+        let correctEntry: [String: Any] = [
+            "hooks": [
+                [
+                    "type": "command",
+                    "command": tbdNotifyCommand,
+                ] as [String: Any],
+            ],
+        ]
+
+        // Migrate legacy bare-format entries and check if hook already exists
+        var found = false
+        for (i, matcher) in stopHooks.enumerated() {
+            if let innerHooks = matcher["hooks"] as? [[String: Any]] {
+                // Correct format — check if it's ours
+                if innerHooks.contains(where: { ($0["command"] as? String)?.contains("tbd notify") == true }) {
+                    found = true
                 }
-                return false
-            }
-            return innerHooks.contains { hook in
-                guard let command = hook["command"] as? String else { return false }
-                return command.contains("tbd notify")
+            } else if let command = matcher["command"] as? String, command.contains("tbd notify") {
+                // Legacy bare format — migrate in place
+                stopHooks[i] = correctEntry
+                found = true
             }
         }
 
-        if !alreadyExists {
-            let hookEntry: [String: Any] = [
-                "hooks": [
-                    [
-                        "type": "command",
-                        "command": tbdNotifyCommand,
-                    ] as [String: Any],
-                ],
-            ]
-            stopHooks.append(hookEntry)
-            hooks["Stop"] = stopHooks
-            settings["hooks"] = hooks
+        if !found {
+            stopHooks.append(correctEntry)
         }
+
+        hooks["Stop"] = stopHooks
+        settings["hooks"] = hooks
 
         // Write back
         let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])

--- a/Sources/TBDCLI/Commands/SetupHooksCommand.swift
+++ b/Sources/TBDCLI/Commands/SetupHooksCommand.swift
@@ -63,16 +63,29 @@ struct SetupHooksCommand: AsyncParsableCommand {
         // The hook command we want to add
         let tbdNotifyCommand = "tbd notify --type response_complete 2>/dev/null || true"
 
-        // Check if our hook already exists
-        let alreadyExists = stopHooks.contains { hook in
-            guard let command = hook["command"] as? String else { return false }
-            return command.contains("tbd notify")
+        // Check if our hook already exists (search inside hooks arrays)
+        let alreadyExists = stopHooks.contains { matcher in
+            guard let innerHooks = matcher["hooks"] as? [[String: Any]] else {
+                // Also check legacy bare format so we can migrate it
+                if let command = matcher["command"] as? String {
+                    return command.contains("tbd notify")
+                }
+                return false
+            }
+            return innerHooks.contains { hook in
+                guard let command = hook["command"] as? String else { return false }
+                return command.contains("tbd notify")
+            }
         }
 
         if !alreadyExists {
             let hookEntry: [String: Any] = [
-                "type": "command",
-                "command": tbdNotifyCommand,
+                "hooks": [
+                    [
+                        "type": "command",
+                        "command": tbdNotifyCommand,
+                    ] as [String: Any],
+                ],
             ]
             stopHooks.append(hookEntry)
             hooks["Stop"] = stopHooks

--- a/docs/superpowers/specs/2026-03-21-tbd-design.md
+++ b/docs/superpowers/specs/2026-03-21-tbd-design.md
@@ -312,7 +312,10 @@ Users opt in by adding a Claude Code hook. Two approaches:
 {
   "hooks": {
     "Stop": [{
-      "command": "tbd notify --type response_complete 2>/dev/null || true"
+      "hooks": [{
+        "type": "command",
+        "command": "tbd notify --type response_complete 2>/dev/null || true"
+      }]
     }]
   }
 }


### PR DESCRIPTION
## Summary
- `tbd setup-hooks` was writing bare `{type, command}` objects directly into the `Stop` array, but Claude Code expects each entry wrapped in `{hooks: [{type, command}]}`. The malformed entry caused Claude Code to skip the **entire** settings.json file with a validation error — silently disabling all hooks, permissions, and other settings.
- Re-running `setup-hooks` now migrates legacy bare-format entries in-place rather than silently leaving them broken.
- Updated the design spec to document the correct hook structure.

## Test plan
- [ ] Run `tbd setup-hooks --global` on a clean `~/.claude/settings.json` — verify the Stop entry uses `{hooks: [...]}` wrapper
- [ ] Run `tbd setup-hooks --global` on a settings.json with the old bare format — verify it gets migrated in-place
- [ ] Restart Claude Code — verify no hook validation errors in the status line