### PR TITLE
Feat: Show webviews and syntax-highlighted code alongside terminals in split panes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fd32deb23b6bf59c575e70e460abd086f98997de000b62e737dc7e6fbd892f15",
+  "originHash" : "1c178a984ed4e977efebcbf9ac5113e65824841b35ea06ff71820dff5dd68cef",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
         "version" : "7.10.0"
+      }
+    },
+    {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.65.0"),
         .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.0.0"),
+        .package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
     ],
     targets: [
         .target(
@@ -53,6 +54,7 @@ let package = Package(
             dependencies: [
                 "TBDShared",
                 .product(name: "SwiftTerm", package: "SwiftTerm"),
+                .product(name: "Highlightr", package: "Highlightr"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
             ],

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -12,6 +12,8 @@ extension AppState {
         do {
             let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cmd: cmd)
             terminals[worktreeID, default: []].append(terminal)
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            tabs[worktreeID, default: []].append(tab)
         } catch {
             logger.error("Failed to create terminal: \(error)")
             handleConnectionError(error)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -14,6 +14,7 @@ final class AppState: ObservableObject {
     @Published var selectedWorktreeIDs: Set<UUID> = []
     @Published var isConnected: Bool = false
     @Published var layouts: [UUID: LayoutNode] = [:]
+    @Published var tabs: [UUID: [Tab]] = [:]
     @Published var repoFilter: UUID? = nil
     @Published var pendingWorktreeIDs: Set<UUID> = []
     @Published var editingWorktreeID: UUID? = nil
@@ -205,11 +206,33 @@ final class AppState: ObservableObject {
             let existing = terminals[worktreeID] ?? []
             if fetched != existing {
                 terminals[worktreeID] = fetched
+                reconcileTabs(worktreeID: worktreeID, terminals: fetched)
             }
         } catch {
             logger.error("Failed to list terminals for worktree \(worktreeID): \(error)")
             handleConnectionError(error)
         }
+    }
+
+    /// Reconcile tabs with the current terminal list for a worktree.
+    /// Removes tabs for terminals that no longer exist, adds tabs for new terminals.
+    private func reconcileTabs(worktreeID: UUID, terminals: [Terminal]) {
+        var currentTabs = tabs[worktreeID] ?? []
+        let terminalIDs = Set(terminals.map(\.id))
+        let existingTerminalTabIDs = Set(currentTabs.compactMap { tab -> UUID? in
+            if case .terminal(let id) = tab.content { return id }
+            return nil
+        })
+        // Remove tabs for terminals that no longer exist
+        currentTabs.removeAll { tab in
+            if case .terminal(let id) = tab.content { return !terminalIDs.contains(id) }
+            return false
+        }
+        // Add tabs for new terminals
+        for terminal in terminals where !existingTerminalTabIDs.contains(terminal.id) {
+            currentTabs.append(Tab(id: terminal.id, content: .terminal(terminalID: terminal.id)))
+        }
+        tabs[worktreeID] = currentTabs
     }
 
     /// Poll all cached PR statuses from the daemon (background, every ~30s).

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -62,9 +62,17 @@ struct ContentView: View {
                        let prStatus = appState.prStatuses[worktreeID],
                        let prURL = URL(string: prStatus.url) {
                         Button {
-                            let webviewID = UUID()
-                            let tab = Tab(id: UUID(), content: .webview(id: webviewID, url: prURL), label: "PR #\(prStatus.number)")
-                            appState.tabs[worktreeID, default: []].append(tab)
+                            // Reuse existing PR tab if one exists
+                            let existingTabs = appState.tabs[worktreeID] ?? []
+                            let hasPRTab = existingTabs.contains { tab in
+                                if case .webview(_, let url) = tab.content { return url == prURL }
+                                return false
+                            }
+                            if !hasPRTab {
+                                let webviewID = UUID()
+                                let tab = Tab(id: UUID(), content: .webview(id: webviewID, url: prURL), label: "PR #\(prStatus.number)")
+                                appState.tabs[worktreeID, default: []].append(tab)
+                            }
                         } label: {
                             HStack(spacing: 3) {
                                 Image(systemName: "arrow.triangle.pull")

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -57,6 +57,26 @@ struct ContentView: View {
                     .pickerStyle(.menu)
                     .help("Filter sidebar by repository")
 
+                    if let worktreeID = appState.selectedWorktreeIDs.first,
+                       appState.selectedWorktreeIDs.count == 1,
+                       let prStatus = appState.prStatuses[worktreeID],
+                       let prURL = URL(string: prStatus.url) {
+                        Button {
+                            let webviewID = UUID()
+                            let tab = Tab(id: UUID(), content: .webview(id: webviewID, url: prURL), label: "PR #\(prStatus.number)")
+                            appState.tabs[worktreeID, default: []].append(tab)
+                        } label: {
+                            HStack(spacing: 3) {
+                                Image(systemName: "arrow.triangle.pull")
+                                    .font(.caption)
+                                Text("#\(prStatus.number)")
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                            }
+                        }
+                        .help("Open PR in browser pane")
+                    }
+
                     Button {
                         withAnimation(.easeInOut(duration: 0.2)) { showFilePanel.toggle() }
                     } label: {

--- a/Sources/TBDApp/FileViewer/FileViewerPanel.swift
+++ b/Sources/TBDApp/FileViewer/FileViewerPanel.swift
@@ -71,6 +71,7 @@ private func parseGitStatus(_ output: String) -> [GitFileStatus] {
 
 struct FileViewerPanel: View {
     let worktree: Worktree
+    @EnvironmentObject var appState: AppState
 
     @State private var staged: [GitFileStatus] = []
     @State private var unstaged: [GitFileStatus] = []
@@ -118,16 +119,37 @@ struct FileViewerPanel: View {
                         .padding(.vertical, 20)
                 }
                 if !staged.isEmpty {
-                    FileStatusSection(title: "Staged", files: staged, useIndexStatus: true, worktreePath: worktree.path)
+                    FileStatusSection(title: "Staged", files: staged, useIndexStatus: true, worktreePath: worktree.path, onFileClick: handleFileClick)
                 }
                 if !unstaged.isEmpty {
-                    FileStatusSection(title: "Changes", files: unstaged, useIndexStatus: false, worktreePath: worktree.path)
+                    FileStatusSection(title: "Changes", files: unstaged, useIndexStatus: false, worktreePath: worktree.path, onFileClick: handleFileClick)
                 }
                 if !untracked.isEmpty {
-                    FileStatusSection(title: "Untracked", files: untracked, useIndexStatus: false, worktreePath: worktree.path)
+                    FileStatusSection(title: "Untracked", files: untracked, useIndexStatus: false, worktreePath: worktree.path, onFileClick: handleFileClick)
                 }
             }
             .padding(.vertical, 4)
+        }
+    }
+
+    private func handleFileClick(_ relativePath: String, cmdClick: Bool) {
+        let fullPath = URL(fileURLWithPath: worktree.path).appendingPathComponent(relativePath).path
+        var tabs = appState.tabs[worktree.id, default: []]
+
+        if !cmdClick, let existingIndex = tabs.firstIndex(where: {
+            if case .codeViewer = $0.content { return true }
+            return false
+        }) {
+            // Replace existing code viewer tab content
+            let newID = UUID()
+            tabs[existingIndex].content = .codeViewer(id: newID, path: fullPath)
+            tabs[existingIndex].label = URL(fileURLWithPath: relativePath).lastPathComponent
+            appState.tabs[worktree.id] = tabs
+        } else {
+            // Create new code viewer tab
+            let newID = UUID()
+            let tab = Tab(id: UUID(), content: .codeViewer(id: newID, path: fullPath), label: URL(fileURLWithPath: relativePath).lastPathComponent)
+            appState.tabs[worktree.id, default: []].append(tab)
         }
     }
 
@@ -150,6 +172,7 @@ private struct FileStatusSection: View {
     /// Staged section uses index; Changes/Untracked sections use working tree.
     let useIndexStatus: Bool
     let worktreePath: String
+    var onFileClick: (String, Bool) -> Void = { _, _ in }
     @State private var isExpanded = true
 
     var body: some View {
@@ -179,7 +202,7 @@ private struct FileStatusSection: View {
             if isExpanded {
                 ForEach(files) { file in
                     let statusChar = useIndexStatus ? file.indexStatus : file.workingStatus
-                    GitFileRow(file: file, statusChar: statusChar, worktreePath: worktreePath)
+                    GitFileRow(file: file, statusChar: statusChar, worktreePath: worktreePath, onFileClick: onFileClick)
                 }
             }
         }
@@ -192,12 +215,13 @@ private struct GitFileRow: View {
     let file: GitFileStatus
     let statusChar: Character
     let worktreePath: String
+    var onFileClick: (String, Bool) -> Void = { _, _ in }
     @State private var isHovered = false
 
     var body: some View {
         Button {
-            let url = URL(fileURLWithPath: worktreePath).appendingPathComponent(file.path)
-            NSWorkspace.shared.open(url)
+            let cmdClick = NSEvent.modifierFlags.contains(.command)
+            onFileClick(file.path, cmdClick)
         } label: {
             HStack(spacing: 6) {
                 Text(String(statusChar))

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -1,19 +1,324 @@
 import SwiftUI
+import AppKit
+@preconcurrency import Highlightr
 
-// Temporary stub — will be replaced in Task 7
+// MARK: - CodeViewerPaneView
+
 struct CodeViewerPaneView: View {
     let path: String
     let worktreePath: String
+
+    @State private var selectedFiles: [String] = []
+
     var body: some View {
-        VStack {
+        HStack(spacing: 0) {
+            // File sidebar
+            CodeViewerSidebar(
+                worktreePath: worktreePath,
+                selectedFiles: $selectedFiles
+            )
+            .frame(width: 200)
+
+            Divider()
+
+            // Code preview
+            if selectedFiles.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(selectedFiles, id: \.self) { filePath in
+                            if selectedFiles.count > 1 {
+                                fileHeader(filePath)
+                            }
+                            HighlightedCodeView(filePath: filePath)
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            if !path.isEmpty && FileManager.default.fileExists(atPath: path) {
+                selectedFiles = [path]
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
             Image(systemName: "doc.text")
-                .font(.largeTitle)
-                .foregroundStyle(.secondary)
-            Text(URL(fileURLWithPath: path).lastPathComponent)
-                .font(.caption)
+                .font(.system(size: 40))
+                .foregroundStyle(.tertiary)
+            Text("Select a file to view")
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    private func fileHeader(_ path: String) -> some View {
+        HStack {
+            Image(systemName: "doc.text")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(URL(fileURLWithPath: path).lastPathComponent)
+                .font(.caption)
+                .fontWeight(.medium)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+}
+
+// MARK: - HighlightedCodeView
+
+private struct HighlightedCodeView: View {
+    let filePath: String
+    @State private var attributedContent: NSAttributedString?
+    @State private var loadError: String?
+
+    var body: some View {
+        Group {
+            if let error = loadError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(12)
+            } else if let content = attributedContent {
+                Text(AttributedString(content))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 100)
+            }
+        }
+        .task(id: filePath) {
+            await loadAndHighlight()
+        }
+    }
+
+    private func loadAndHighlight() async {
+        do {
+            let content = try String(contentsOfFile: filePath, encoding: .utf8)
+            let highlighted = highlightCode(content, filename: filePath)
+            attributedContent = highlighted
+        } catch {
+            loadError = "Could not read file"
+        }
+    }
+}
+
+// MARK: - Syntax Highlighting
+
+nonisolated(unsafe) let sharedHighlightr: Highlightr? = {
+    let h = Highlightr()
+    h?.setTheme(to: "atom-one-dark")
+    return h
+}()
+
+private func highlightCode(_ code: String, filename: String) -> NSAttributedString {
+    let lang = languageForFilename(filename)
+    let monoFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+    guard let highlightr = sharedHighlightr,
+          let highlighted = highlightr.highlight(code, as: lang) else {
+        return NSAttributedString(string: code, attributes: [.font: monoFont])
+    }
+
+    let mutable = NSMutableAttributedString(attributedString: highlighted)
+    let fullRange = NSRange(location: 0, length: mutable.length)
+
+    // Override font to consistent monospace
+    mutable.addAttribute(.font, value: monoFont, range: fullRange)
+
+    // Legibility fix: replace too-pale foreground colors
+    mutable.enumerateAttribute(.foregroundColor, in: fullRange) { value, attrRange, _ in
+        if let color = value as? NSColor, colorIsTooPale(color) {
+            mutable.addAttribute(.foregroundColor, value: NSColor.labelColor, range: attrRange)
+        }
+    }
+
+    return mutable
+}
+
+private func colorIsTooPale(_ color: NSColor) -> Bool {
+    guard let rgb = color.usingColorSpace(.sRGB) else { return false }
+    let luminance = 0.2126 * rgb.redComponent + 0.7152 * rgb.greenComponent + 0.0722 * rgb.blueComponent
+    return luminance > 0.6
+}
+
+private func languageForFilename(_ filename: String) -> String? {
+    let ext = (filename as NSString).pathExtension.lowercased()
+    let map: [String: String] = [
+        "swift": "swift", "ts": "typescript", "tsx": "typescript", "js": "javascript",
+        "jsx": "javascript", "py": "python", "rb": "ruby", "go": "go", "rs": "rust",
+        "java": "java", "kt": "kotlin", "cpp": "cpp", "c": "c", "h": "c", "hpp": "cpp",
+        "cs": "csharp", "css": "css", "scss": "scss", "html": "xml", "xml": "xml",
+        "json": "json", "yaml": "yaml", "yml": "yaml", "toml": "ini", "sql": "sql",
+        "sh": "bash", "bash": "bash", "zsh": "bash", "md": "markdown",
+        "graphql": "graphql", "gql": "graphql",
+    ]
+    return map[ext]
+}
+
+// MARK: - CodeViewerSidebar
+
+struct CodeViewerSidebar: View {
+    let worktreePath: String
+    @Binding var selectedFiles: [String]
+    @State private var expandedDirs: Set<String> = []
+    @State private var entries: [FileEntry] = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Files")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+
+            Divider()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(entries, id: \.path) { entry in
+                        FileEntryRow(
+                            entry: entry,
+                            isExpanded: expandedDirs.contains(entry.path),
+                            isSelected: selectedFiles.contains(entry.path),
+                            onToggleDir: { toggleDir(entry.path) },
+                            onSelectFile: { selectFile(entry.path, event: NSApp.currentEvent) }
+                        )
+                    }
+                }
+            }
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+        .task(id: worktreePath) {
+            loadTopLevel()
+        }
+    }
+
+    private func loadTopLevel() {
+        guard !worktreePath.isEmpty else { return }
+        entries = listDirectory(worktreePath, depth: 0)
+    }
+
+    private func toggleDir(_ path: String) {
+        if expandedDirs.contains(path) {
+            expandedDirs.remove(path)
+            entries.removeAll { $0.path.hasPrefix(path + "/") }
+        } else {
+            expandedDirs.insert(path)
+            let children = listDirectory(path, depth: depthOf(path) + 1)
+            if let idx = entries.firstIndex(where: { $0.path == path }) {
+                entries.insert(contentsOf: children, at: idx + 1)
+            }
+        }
+    }
+
+    private func selectFile(_ path: String, event: NSEvent?) {
+        if event?.modifierFlags.contains(.command) == true {
+            if selectedFiles.contains(path) {
+                selectedFiles.removeAll { $0 == path }
+            } else {
+                selectedFiles.append(path)
+            }
+        } else {
+            selectedFiles = [path]
+        }
+    }
+
+    private func depthOf(_ path: String) -> Int {
+        let relative = path.replacingOccurrences(of: worktreePath + "/", with: "")
+        return relative.components(separatedBy: "/").count - 1
+    }
+
+    private func listDirectory(_ dir: String, depth: Int) -> [FileEntry] {
+        let fm = FileManager.default
+        guard let items = try? fm.contentsOfDirectory(atPath: dir) else { return [] }
+        return items
+            .filter { !$0.hasPrefix(".") }
+            .sorted { a, b in
+                let aIsDir = isDirectory(dir + "/" + a)
+                let bIsDir = isDirectory(dir + "/" + b)
+                if aIsDir != bIsDir { return aIsDir }
+                return a.localizedCaseInsensitiveCompare(b) == .orderedAscending
+            }
+            .map { name in
+                let fullPath = dir + "/" + name
+                return FileEntry(path: fullPath, name: name, isDirectory: isDirectory(fullPath), depth: depth)
+            }
+    }
+
+    private func isDirectory(_ path: String) -> Bool {
+        var isDir: ObjCBool = false
+        FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
+        return isDir.boolValue
+    }
+}
+
+struct FileEntry {
+    let path: String
+    let name: String
+    let isDirectory: Bool
+    let depth: Int
+}
+
+private struct FileEntryRow: View {
+    let entry: FileEntry
+    let isExpanded: Bool
+    let isSelected: Bool
+    let onToggleDir: () -> Void
+    let onSelectFile: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            if entry.isDirectory {
+                onToggleDir()
+            } else {
+                onSelectFile()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                if entry.isDirectory {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 8))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 10)
+                } else {
+                    Color.clear.frame(width: 10)
+                }
+
+                Image(systemName: entry.isDirectory ? "folder" : "doc")
+                    .font(.caption2)
+                    .foregroundStyle(entry.isDirectory ? .blue : .secondary)
+
+                Text(entry.name)
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer()
+            }
+            .padding(.leading, CGFloat(entry.depth) * 16 + 8)
+            .padding(.vertical, 3)
+            .background(
+                isSelected ? Color.accentColor.opacity(0.2) :
+                (isHovered ? Color.primary.opacity(0.05) : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
     }
 }

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+// Temporary stub — will be replaced in Task 7
+struct CodeViewerPaneView: View {
+    let path: String
+    let worktreePath: String
+    var body: some View {
+        VStack {
+            Image(systemName: "doc.text")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text(URL(fileURLWithPath: path).lastPathComponent)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+}

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -101,6 +101,13 @@ private struct HighlightedCodeView: View {
     }
 
     private func loadAndHighlight() async {
+        // Guard against large files (>1MB) to prevent memory pressure
+        let fm = FileManager.default
+        if let attrs = try? fm.attributesOfItem(atPath: filePath),
+           let size = attrs[.size] as? UInt64, size > 1_048_576 {
+            loadError = "File too large to preview (\(size / 1024)KB)"
+            return
+        }
         do {
             let content = try String(contentsOfFile: filePath, encoding: .utf8)
             let highlighted = highlightCode(content, filename: filePath)
@@ -113,12 +120,16 @@ private struct HighlightedCodeView: View {
 
 // MARK: - Syntax Highlighting
 
-nonisolated(unsafe) let sharedHighlightr: Highlightr? = {
+/// Shared Highlightr instance — accessed only from @MainActor context
+/// to avoid thread-safety issues (Highlightr is not thread-safe).
+@MainActor
+private let sharedHighlightr: Highlightr? = {
     let h = Highlightr()
     h?.setTheme(to: "atom-one-dark")
     return h
 }()
 
+@MainActor
 private func highlightCode(_ code: String, filename: String) -> NSAttributedString {
     let lang = languageForFilename(filename)
     let monoFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -160,20 +160,26 @@ struct PanePlaceholder: View {
     // MARK: - Split Actions
 
     private func splitRight() {
-        let newID = UUID()
-        layout = layout.splitPane(
-            id: content.paneID,
-            direction: .horizontal,
-            newContent: .terminal(terminalID: newID)
-        )
+        Task {
+            await createTerminalSplit(direction: .horizontal)
+        }
     }
 
     private func splitDown() {
-        let newID = UUID()
+        Task {
+            await createTerminalSplit(direction: .vertical)
+        }
+    }
+
+    /// Creates a real terminal via the daemon, then inserts it as a split pane.
+    private func createTerminalSplit(direction: SplitDirection) async {
+        await appState.createTerminal(worktreeID: worktree.id)
+        // The newly created terminal is the last one appended
+        guard let newTerminal = appState.terminals[worktree.id]?.last else { return }
         layout = layout.splitPane(
             id: content.paneID,
-            direction: .vertical,
-            newContent: .terminal(terminalID: newID)
+            direction: direction,
+            newContent: .terminal(terminalID: newTerminal.id)
         )
     }
 }

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+import TBDShared
+
+// MARK: - PanePlaceholder
+
+/// Universal leaf wrapper that renders the appropriate pane content
+/// based on PaneContent type. Replaces the former TerminalPanelPlaceholder.
+struct PanePlaceholder: View {
+    let content: PaneContent
+    let worktree: Worktree
+    @Binding var layout: LayoutNode
+    @EnvironmentObject var appState: AppState
+
+    /// Find the Terminal model matching a terminal ID across all worktree terminals.
+    private func terminal(for id: UUID) -> Terminal? {
+        for (_, terms) in appState.terminals {
+            if let t = terms.first(where: { $0.id == id }) {
+                return t
+            }
+        }
+        return nil
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Toolbar header
+            toolbar
+
+            Divider()
+
+            // Pane content
+            paneBody
+        }
+    }
+
+    // MARK: - Toolbar
+
+    @ViewBuilder
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            paneLabel
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            Spacer()
+
+            toolbarActions
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    @ViewBuilder
+    private var paneLabel: some View {
+        switch content {
+        case .terminal(let terminalID):
+            Text("Terminal: \(terminalID.uuidString.prefix(8))")
+        case .webview(_, let url):
+            Text(url.host ?? url.absoluteString)
+        case .codeViewer(_, let path):
+            Text(URL(fileURLWithPath: path).lastPathComponent)
+        }
+    }
+
+    @ViewBuilder
+    private var toolbarActions: some View {
+        switch content {
+        case .terminal:
+            Button(action: splitRight) {
+                HStack(spacing: 2) {
+                    Image(systemName: "rectangle.split.1x2")
+                        .rotationEffect(.degrees(90))
+                    Text("Split Right")
+                }
+                .font(.caption)
+            }
+            .buttonStyle(.borderless)
+
+            Button(action: splitDown) {
+                HStack(spacing: 2) {
+                    Image(systemName: "rectangle.split.1x2")
+                    Text("Split Down")
+                }
+                .font(.caption)
+            }
+            .buttonStyle(.borderless)
+
+        case .webview:
+            // Placeholder for back/forward — will be wired in Task 6
+            Button(action: {}) {
+                Image(systemName: "chevron.left")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .disabled(true)
+
+            Button(action: {}) {
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .disabled(true)
+
+        case .codeViewer:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Pane Body
+
+    @ViewBuilder
+    private var paneBody: some View {
+        switch content {
+        case .terminal(let terminalID):
+            terminalContent(terminalID: terminalID)
+        case .webview(_, let url):
+            WebviewPaneView(url: url)
+        case .codeViewer(_, let path):
+            CodeViewerPaneView(path: path, worktreePath: worktree.path)
+        }
+    }
+
+    @ViewBuilder
+    private func terminalContent(terminalID: UUID) -> some View {
+        if let terminal = terminal(for: terminalID) {
+            TerminalPanelView(
+                terminalID: terminalID,
+                tmuxServer: worktree.tmuxServer,
+                tmuxWindowID: terminal.tmuxWindowID,
+                tmuxBridge: appState.tmuxBridge
+            )
+            .id(terminalID)
+        } else {
+            // Fallback when terminal data hasn't loaded yet
+            ZStack {
+                Color(nsColor: .black)
+
+                VStack(spacing: 8) {
+                    Image(systemName: "terminal")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                    Text(worktree.displayName)
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                    Text(worktree.branch)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Split Actions
+
+    private func splitRight() {
+        let newID = UUID()
+        layout = layout.splitPane(
+            id: content.paneID,
+            direction: .horizontal,
+            newContent: .terminal(terminalID: newID)
+        )
+    }
+
+    private func splitDown() {
+        let newID = UUID()
+        layout = layout.splitPane(
+            id: content.paneID,
+            direction: .vertical,
+            newContent: .terminal(terminalID: newID)
+        )
+    }
+}

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -129,7 +129,12 @@ struct PanePlaceholder: View {
                 terminalID: terminalID,
                 tmuxServer: worktree.tmuxServer,
                 tmuxWindowID: terminal.tmuxWindowID,
-                tmuxBridge: appState.tmuxBridge
+                tmuxBridge: appState.tmuxBridge,
+                worktreePath: worktree.path,
+                onFilePathClicked: { path in
+                    let newContent = PaneContent.codeViewer(id: UUID(), path: path)
+                    layout = layout.splitPane(id: terminalID, direction: .horizontal, newContent: newContent)
+                }
             )
             .id(terminalID)
         } else {

--- a/Sources/TBDApp/Panes/WebviewPaneView.swift
+++ b/Sources/TBDApp/Panes/WebviewPaneView.swift
@@ -1,18 +1,23 @@
 import SwiftUI
+import WebKit
 
-// Temporary stub — will be replaced in Task 6
-struct WebviewPaneView: View {
+struct WebviewPaneView: NSViewRepresentable {
     let url: URL
-    var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .font(.largeTitle)
-                .foregroundStyle(.secondary)
-            Text(url.absoluteString)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: .textBackgroundColor))
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .default()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: url))
+        return webView
     }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        // Don't reload on SwiftUI updates — only initial load matters
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {}
 }

--- a/Sources/TBDApp/Panes/WebviewPaneView.swift
+++ b/Sources/TBDApp/Panes/WebviewPaneView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+// Temporary stub — will be replaced in Task 6
+struct WebviewPaneView: View {
+    let url: URL
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text(url.absoluteString)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+}

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -1,17 +1,18 @@
 import SwiftUI
-import TBDShared
 
-// MARK: - TerminalTabBar
+// MARK: - TabBar
 
-struct TerminalTabBar: View {
-    let terminals: [Terminal]
+/// Generic tab bar that renders Tab items with type-appropriate icons and labels.
+/// Replaces the former TerminalTabBar.
+struct TabBar: View {
+    let tabs: [Tab]
     @Binding var activeTabIndex: Int
     var onAddTab: () -> Void
     var onCloseTab: (Int) -> Void
 
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(Array(terminals.enumerated()), id: \.element.id) { index, terminal in
+            ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
                 if index > 0 {
                     // Subtle vertical divider between tabs (iTerm2-style)
                     Rectangle()
@@ -19,8 +20,8 @@ struct TerminalTabBar: View {
                         .frame(width: 1, height: 18)
                 }
 
-                TerminalTabItem(
-                    terminal: terminal,
+                TabBarItem(
+                    tab: tab,
                     index: index,
                     isSelected: index == activeTabIndex,
                     onSelect: { activeTabIndex = index },
@@ -51,10 +52,10 @@ struct TerminalTabBar: View {
     }
 }
 
-// MARK: - TerminalTabItem
+// MARK: - TabBarItem
 
-private struct TerminalTabItem: View {
-    let terminal: Terminal
+private struct TabBarItem: View {
+    let tab: Tab
     let index: Int
     let isSelected: Bool
     let onSelect: () -> Void
@@ -87,6 +88,13 @@ private struct TerminalTabItem: View {
             .opacity(showClose ? 1 : 0)
             .animation(.easeInOut(duration: 0.12), value: showClose)
 
+            // Type icon
+            Image(systemName: tabIcon)
+                .font(.system(size: 10))
+                .foregroundStyle(isSelected ? .primary : .tertiary)
+                .frame(width: 14)
+                .padding(.trailing, 3)
+
             Text(tabLabel)
                 .font(.system(size: 11))
                 .lineLimit(1)
@@ -115,10 +123,25 @@ private struct TerminalTabItem: View {
         .contentShape(Rectangle())
     }
 
+    private var tabIcon: String {
+        switch tab.content {
+        case .terminal: return "terminal"
+        case .webview: return "globe"
+        case .codeViewer: return "doc.text"
+        }
+    }
+
     private var tabLabel: String {
-        if let label = terminal.label, !label.isEmpty {
+        if let label = tab.label, !label.isEmpty {
             return label
         }
-        return "Terminal \(index + 1)"
+        switch tab.content {
+        case .terminal:
+            return "Terminal \(index + 1)"
+        case .webview(_, let url):
+            return url.host ?? "Web"
+        case .codeViewer(_, let path):
+            return URL(fileURLWithPath: path).lastPathComponent
+        }
     }
 }

--- a/Sources/TBDApp/Terminal/LayoutNode.swift
+++ b/Sources/TBDApp/Terminal/LayoutNode.swift
@@ -10,22 +10,22 @@ enum SplitDirection: String, Codable, Sendable {
 // MARK: - LayoutNode
 
 indirect enum LayoutNode: Equatable, Sendable {
-    case terminal(terminalID: UUID)
+    case pane(PaneContent)
     case split(direction: SplitDirection, children: [LayoutNode], ratios: [CGFloat])
 
     // MARK: - Helpers
 
-    /// Finds the terminal node with the given ID and replaces it with a split
-    /// containing the original + new terminal at 50/50 ratio.
-    func splitTerminal(id: UUID, direction: SplitDirection, newTerminalID: UUID) -> LayoutNode {
+    /// Finds the pane with the given ID and replaces it with a split
+    /// containing the original + new pane at 50/50 ratio.
+    func splitPane(id: UUID, direction: SplitDirection, newContent: PaneContent) -> LayoutNode {
         switch self {
-        case .terminal(let terminalID):
-            if terminalID == id {
+        case .pane(let content):
+            if content.paneID == id {
                 return .split(
                     direction: direction,
                     children: [
-                        .terminal(terminalID: terminalID),
-                        .terminal(terminalID: newTerminalID),
+                        .pane(content),
+                        .pane(newContent),
                     ],
                     ratios: [0.5, 0.5]
                 )
@@ -34,18 +34,18 @@ indirect enum LayoutNode: Equatable, Sendable {
 
         case .split(let dir, let children, let ratios):
             let newChildren = children.map { child in
-                child.splitTerminal(id: id, direction: direction, newTerminalID: newTerminalID)
+                child.splitPane(id: id, direction: direction, newContent: newContent)
             }
             return .split(direction: dir, children: newChildren, ratios: ratios)
         }
     }
 
-    /// Removes a terminal, simplifying the tree. If a split has one child left,
-    /// unwrap it. Returns nil if the last terminal is removed.
-    func removeTerminal(id: UUID) -> LayoutNode? {
+    /// Removes a pane, simplifying the tree. If a split has one child left,
+    /// unwrap it. Returns nil if the last pane is removed.
+    func removePane(id: UUID) -> LayoutNode? {
         switch self {
-        case .terminal(let terminalID):
-            if terminalID == id {
+        case .pane(let content):
+            if content.paneID == id {
                 return nil
             }
             return self
@@ -55,7 +55,7 @@ indirect enum LayoutNode: Equatable, Sendable {
             var newRatios: [CGFloat] = []
 
             for (index, child) in children.enumerated() {
-                if let remaining = child.removeTerminal(id: id) {
+                if let remaining = child.removePane(id: id) {
                     newChildren.append(remaining)
                     newRatios.append(ratios[index])
                 }
@@ -79,11 +79,26 @@ indirect enum LayoutNode: Equatable, Sendable {
         }
     }
 
-    /// Flat list of all terminal IDs in the tree.
+    /// Flat list of all pane IDs in the tree.
+    func allPaneIDs() -> [UUID] {
+        switch self {
+        case .pane(let content):
+            return [content.paneID]
+        case .split(_, let children, _):
+            return children.flatMap { $0.allPaneIDs() }
+        }
+    }
+
+    // MARK: - Backward-compatible convenience
+
+    /// Flat list of all terminal IDs in the tree (terminals only).
     func allTerminalIDs() -> [UUID] {
         switch self {
-        case .terminal(let terminalID):
-            return [terminalID]
+        case .pane(let content):
+            if case .terminal(let id) = content {
+                return [id]
+            }
+            return []
         case .split(_, let children, _):
             return children.flatMap { $0.allTerminalIDs() }
         }
@@ -95,14 +110,17 @@ indirect enum LayoutNode: Equatable, Sendable {
 extension LayoutNode: Codable {
     private enum CodingKeys: String, CodingKey {
         case type
-        case terminalID
+        case terminalID    // legacy key for backward compat
+        case paneContent   // new key
         case direction
         case children
         case ratios
     }
 
     private enum NodeType: String, Codable {
-        case terminal, split
+        case terminal  // legacy
+        case pane
+        case split
     }
 
     init(from decoder: Decoder) throws {
@@ -111,8 +129,12 @@ extension LayoutNode: Codable {
 
         switch type {
         case .terminal:
+            // Backward compat: old format {"type":"terminal","terminalID":"..."}
             let terminalID = try container.decode(UUID.self, forKey: .terminalID)
-            self = .terminal(terminalID: terminalID)
+            self = .pane(.terminal(terminalID: terminalID))
+        case .pane:
+            let content = try container.decode(PaneContent.self, forKey: .paneContent)
+            self = .pane(content)
         case .split:
             let direction = try container.decode(SplitDirection.self, forKey: .direction)
             let children = try container.decode([LayoutNode].self, forKey: .children)
@@ -125,9 +147,9 @@ extension LayoutNode: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {
-        case .terminal(let terminalID):
-            try container.encode(NodeType.terminal, forKey: .type)
-            try container.encode(terminalID, forKey: .terminalID)
+        case .pane(let content):
+            try container.encode(NodeType.pane, forKey: .type)
+            try container.encode(content, forKey: .paneContent)
         case .split(let direction, let children, let ratios):
             try container.encode(NodeType.split, forKey: .type)
             try container.encode(direction, forKey: .direction)

--- a/Sources/TBDApp/Terminal/PaneContent.swift
+++ b/Sources/TBDApp/Terminal/PaneContent.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// MARK: - PaneContent
+
+enum PaneContent: Codable, Equatable, Sendable {
+    case terminal(terminalID: UUID)
+    case webview(id: UUID, url: URL)
+    case codeViewer(id: UUID, path: String)
+
+    var paneID: UUID {
+        switch self {
+        case .terminal(let id): return id
+        case .webview(let id, _): return id
+        case .codeViewer(let id, _): return id
+        }
+    }
+}
+
+// MARK: - Tab
+
+struct Tab: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    var content: PaneContent
+    var label: String?
+}

--- a/Sources/TBDApp/Terminal/SplitLayoutView.swift
+++ b/Sources/TBDApp/Terminal/SplitLayoutView.swift
@@ -11,8 +11,8 @@ struct SplitLayoutView: View {
     var body: some View {
         switch node {
         case .pane(let content):
-            TerminalPanelPlaceholder(
-                terminalID: content.paneID,
+            PanePlaceholder(
+                content: content,
                 worktree: worktree,
                 layout: $layout
             )
@@ -224,130 +224,5 @@ private extension View {
                 NSCursor.pop()
             }
         }
-    }
-}
-
-// MARK: - TerminalPanelPlaceholder
-
-/// Terminal panel with split buttons toolbar and real SwiftTerm terminal view.
-/// Looks up the Terminal object from AppState to get tmux server and pane ID.
-struct TerminalPanelPlaceholder: View {
-    let terminalID: UUID
-    let worktree: Worktree
-    @Binding var layout: LayoutNode
-    @EnvironmentObject var appState: AppState
-
-    /// Find the Terminal model matching this terminalID across all worktree terminals.
-    private var terminal: Terminal? {
-        for (_, terms) in appState.terminals {
-            if let t = terms.first(where: { $0.id == terminalID }) {
-                return t
-            }
-        }
-        return nil
-    }
-
-    var body: some View {
-        let _ = debugLogPlaceholder()
-        VStack(spacing: 0) {
-            // Mini toolbar with split buttons
-            HStack(spacing: 8) {
-                Text("Terminal: \(terminalID.uuidString.prefix(8))")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-
-                Spacer()
-
-                Button(action: splitRight) {
-                    HStack(spacing: 2) {
-                        Image(systemName: "rectangle.split.1x2")
-                            .rotationEffect(.degrees(90))
-                        Text("Split Right")
-                    }
-                    .font(.caption)
-                }
-                .buttonStyle(.borderless)
-
-                Button(action: splitDown) {
-                    HStack(spacing: 2) {
-                        Image(systemName: "rectangle.split.1x2")
-                        Text("Split Down")
-                    }
-                    .font(.caption)
-                }
-                .buttonStyle(.borderless)
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(Color(nsColor: .controlBackgroundColor))
-
-            Divider()
-
-            // Real terminal view or fallback placeholder
-            if let terminal = terminal {
-                TerminalPanelView(
-                    terminalID: terminalID,
-                    tmuxServer: worktree.tmuxServer,
-                    tmuxWindowID: terminal.tmuxWindowID,
-                    tmuxBridge: appState.tmuxBridge
-                )
-                .id(terminalID) // Force SwiftUI to create a unique view per terminal
-            } else {
-                // Fallback when terminal data hasn't loaded yet
-                ZStack {
-                    Color(nsColor: .black)
-
-                    VStack(spacing: 8) {
-                        Image(systemName: "terminal")
-                            .font(.largeTitle)
-                            .foregroundStyle(.secondary)
-                        Text(worktree.displayName)
-                            .font(.headline)
-                            .foregroundStyle(.secondary)
-                        Text(worktree.branch)
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
-                }
-            }
-        }
-    }
-
-    // Throttle: only log once per terminal ID
-    private static var loggedTerminals: Set<String> = []
-    private func debugLogPlaceholder() {
-        let key = "\(terminalID.uuidString.prefix(8))-\(terminal != nil)"
-        guard !Self.loggedTerminals.contains(key) else { return }
-        Self.loggedTerminals.insert(key)
-        let allTermIDs = appState.terminals.values.flatMap { $0.map { $0.id.uuidString.prefix(8) } }
-        let msg = "PLACEHOLDER: terminalID=\(terminalID.uuidString.prefix(8)) found=\(terminal != nil) allTermIDs=\(allTermIDs) wtID=\(worktree.id.uuidString.prefix(8))"
-        if let data = "[\(ISO8601DateFormatter().string(from: Date()))] \(msg)\n".data(using: .utf8) {
-            if let fh = FileHandle(forWritingAtPath: "/tmp/tbd-bridge.log") {
-                fh.seekToEndOfFile()
-                fh.write(data)
-                fh.closeFile()
-            } else {
-                FileManager.default.createFile(atPath: "/tmp/tbd-bridge.log", contents: data)
-            }
-        }
-    }
-
-    private func splitRight() {
-        let newID = UUID()
-        layout = layout.splitPane(
-            id: terminalID,
-            direction: .horizontal,
-            newContent: .terminal(terminalID: newID)
-        )
-    }
-
-    private func splitDown() {
-        let newID = UUID()
-        layout = layout.splitPane(
-            id: terminalID,
-            direction: .vertical,
-            newContent: .terminal(terminalID: newID)
-        )
     }
 }

--- a/Sources/TBDApp/Terminal/SplitLayoutView.swift
+++ b/Sources/TBDApp/Terminal/SplitLayoutView.swift
@@ -10,9 +10,9 @@ struct SplitLayoutView: View {
 
     var body: some View {
         switch node {
-        case .terminal(let id):
+        case .pane(let content):
             TerminalPanelPlaceholder(
-                terminalID: id,
+                terminalID: content.paneID,
                 worktree: worktree,
                 layout: $layout
             )
@@ -134,7 +134,7 @@ struct SplitContainer: View {
         newRatios: [CGFloat]
     ) -> LayoutNode {
         switch node {
-        case .terminal:
+        case .pane:
             return node
         case .split(let dir, let nodeChildren, let nodeRatios):
             if nodeChildren == targetChildren {
@@ -335,19 +335,19 @@ struct TerminalPanelPlaceholder: View {
 
     private func splitRight() {
         let newID = UUID()
-        layout = layout.splitTerminal(
+        layout = layout.splitPane(
             id: terminalID,
             direction: .horizontal,
-            newTerminalID: newID
+            newContent: .terminal(terminalID: newID)
         )
     }
 
     private func splitDown() {
         let newID = UUID()
-        layout = layout.splitTerminal(
+        layout = layout.splitPane(
             id: terminalID,
             direction: .vertical,
-            newTerminalID: newID
+            newContent: .terminal(terminalID: newID)
         )
     }
 }

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -14,15 +14,13 @@ class TBDTerminalView: TerminalView {
         let localPoint = convert(windowPoint, from: nil)
         let terminal = getTerminal()
 
-        // Calculate column and row from point
-        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        let charWidth = ("M" as NSString).size(withAttributes: [.font: font]).width
-        let lineHeight = ceil(font.ascender - font.descender + font.leading)
+        // Derive cell dimensions from the terminal's actual grid size and view bounds
+        let charWidth = bounds.width / CGFloat(terminal.cols)
+        let lineHeight = bounds.height / CGFloat(terminal.rows)
 
         let col = Int(localPoint.x / charWidth)
         // Terminal rows are numbered from top, but NSView y is from bottom
-        let viewHeight = bounds.height
-        let row = Int((viewHeight - localPoint.y) / lineHeight)
+        let row = Int((frame.height - localPoint.y) / lineHeight)
 
         guard row >= 0 && row < terminal.rows && col >= 0 && col < terminal.cols else {
             return nil

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -6,6 +6,73 @@ import SwiftTerm
 /// to the escape sequences that shells expect.
 class TBDTerminalView: TerminalView {
     var naturalTextEditing: Bool = true
+    var onFilePathClicked: ((String) -> Void)?
+    var worktreePath: String = ""
+
+    /// Extracts a file path from the terminal buffer at the given window-coordinate point.
+    func extractFilePath(atWindowLocation windowPoint: CGPoint) -> String? {
+        let localPoint = convert(windowPoint, from: nil)
+        let terminal = getTerminal()
+
+        // Calculate column and row from point
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let charWidth = ("M" as NSString).size(withAttributes: [.font: font]).width
+        let lineHeight = ceil(font.ascender - font.descender + font.leading)
+
+        let col = Int(localPoint.x / charWidth)
+        // Terminal rows are numbered from top, but NSView y is from bottom
+        let viewHeight = bounds.height
+        let row = Int((viewHeight - localPoint.y) / lineHeight)
+
+        guard row >= 0 && row < terminal.rows && col >= 0 && col < terminal.cols else {
+            return nil
+        }
+
+        guard let bufferLine = terminal.getLine(row: row) else { return nil }
+        let lineText = bufferLine.translateToString()
+
+        guard col < lineText.count else { return nil }
+
+        // Find word boundaries around click position using path-valid characters
+        let pathChars = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "/._-~"))
+        let chars = Array(lineText.unicodeScalars)
+        var start = col
+        var end = col
+
+        while start > 0 && pathChars.contains(chars[start - 1]) {
+            start -= 1
+        }
+        while end < chars.count - 1 && pathChars.contains(chars[end + 1]) {
+            end += 1
+        }
+
+        guard start <= end else { return nil }
+
+        let startIndex = lineText.index(lineText.startIndex, offsetBy: start)
+        let endIndex = lineText.index(lineText.startIndex, offsetBy: end + 1)
+        var candidate = String(lineText[startIndex..<endIndex])
+
+        // Strip trailing :line:col suffix (e.g., "file.swift:10:5")
+        let colonPattern = try? NSRegularExpression(pattern: ":\\d+(:\\d+)?$")
+        if let match = colonPattern?.firstMatch(in: candidate, range: NSRange(candidate.startIndex..., in: candidate)) {
+            candidate = String(candidate[candidate.startIndex..<candidate.index(candidate.startIndex, offsetBy: match.range.location)])
+        }
+
+        guard !candidate.isEmpty else { return nil }
+
+        // Resolve relative paths against worktreePath
+        let resolvedPath: String
+        if candidate.hasPrefix("/") {
+            resolvedPath = candidate
+        } else {
+            resolvedPath = URL(fileURLWithPath: worktreePath).appendingPathComponent(candidate).path
+        }
+
+        // Validate file exists
+        guard FileManager.default.fileExists(atPath: resolvedPath) else { return nil }
+
+        return resolvedPath
+    }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         if naturalTextEditing, event.type == .keyDown, handleNaturalTextEditing(event) {

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -95,7 +95,7 @@ private struct SingleWorktreeView: View {
             let layoutKey = terminal.id
             let layoutBinding = Binding<LayoutNode>(
                 get: {
-                    appState.layouts[layoutKey] ?? .terminal(terminalID: terminal.id)
+                    appState.layouts[layoutKey] ?? .pane(.terminal(terminalID: terminal.id))
                 },
                 set: { newLayout in
                     appState.layouts[layoutKey] = newLayout
@@ -139,7 +139,7 @@ private struct SingleWorktreeView: View {
 
         // Remove terminal from layout
         if let currentLayout = appState.layouts[worktreeID] {
-            if let newLayout = currentLayout.removeTerminal(id: terminal.id) {
+            if let newLayout = currentLayout.removePane(id: terminal.id) {
                 appState.layouts[worktreeID] = newLayout
             } else {
                 appState.layouts.removeValue(forKey: worktreeID)
@@ -252,7 +252,7 @@ private struct MultiWorktreeCell: View {
                 let layoutBinding = Binding<LayoutNode>(
                     get: {
                         appState.layouts[worktreeID]
-                            ?? .terminal(terminalID: terminal.id)
+                            ?? .pane(.terminal(terminalID: terminal.id))
                     },
                     set: { newLayout in
                         appState.layouts[worktreeID] = newLayout

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -258,8 +258,8 @@ private struct MultiWorktreeCell: View {
                         appState.layouts[worktreeID] = newLayout
                     }
                 )
-                TerminalPanelPlaceholder(
-                    terminalID: terminal.id,
+                PanePlaceholder(
+                    content: .terminal(terminalID: terminal.id),
                     worktree: worktree,
                     layout: layoutBinding
                 )

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -42,23 +42,23 @@ private struct SingleWorktreeView: View {
         return nil
     }
 
-    private var terminals: [Terminal] {
-        appState.terminals[worktreeID] ?? []
+    private var worktreeTabs: [Tab] {
+        appState.tabs[worktreeID] ?? []
     }
 
     var body: some View {
         if let worktree {
             VStack(spacing: 0) {
                 // Tab bar
-                if !terminals.isEmpty {
-                    TerminalTabBar(
-                        terminals: terminals,
+                if !worktreeTabs.isEmpty {
+                    TabBar(
+                        tabs: worktreeTabs,
                         activeTabIndex: $activeTabIndex,
                         onAddTab: {
                             Task {
                                 await appState.createTerminal(worktreeID: worktreeID)
                                 // Select the newly added tab
-                                let newCount = appState.terminals[worktreeID]?.count ?? 0
+                                let newCount = appState.tabs[worktreeID]?.count ?? 0
                                 if newCount > 0 {
                                     activeTabIndex = newCount - 1
                                 }
@@ -78,6 +78,7 @@ private struct SingleWorktreeView: View {
             // TmuxBridge sessions are created on-demand by TerminalPanelView
             .task(id: worktreeID) {
                 // Auto-create a terminal when selecting a main worktree with none
+                let terminals = appState.terminals[worktreeID] ?? []
                 if worktree.status == .main && terminals.isEmpty {
                     await appState.createTerminal(worktreeID: worktreeID)
                 }
@@ -90,16 +91,10 @@ private struct SingleWorktreeView: View {
 
     @ViewBuilder
     private func layoutContent(worktree: Worktree) -> some View {
-        if let terminal = activeTerminal {
-            // Each tab shows one terminal (with optional splits stored per-terminal)
-            let layoutKey = terminal.id
+        if let tab = activeTab {
             let layoutBinding = Binding<LayoutNode>(
-                get: {
-                    appState.layouts[layoutKey] ?? .pane(.terminal(terminalID: terminal.id))
-                },
-                set: { newLayout in
-                    appState.layouts[layoutKey] = newLayout
-                }
+                get: { appState.layouts[tab.id] ?? .pane(tab.content) },
+                set: { appState.layouts[tab.id] = $0 }
             )
 
             SplitLayoutView(
@@ -107,7 +102,7 @@ private struct SingleWorktreeView: View {
                 worktree: worktree,
                 layout: layoutBinding
             )
-            .id(terminal.id) // Force new view hierarchy when switching tabs
+            .id(tab.id) // Force new view hierarchy when switching tabs
         } else {
             VStack(spacing: 12) {
                 Image(systemName: "terminal")
@@ -125,37 +120,31 @@ private struct SingleWorktreeView: View {
         }
     }
 
-    private var activeTerminal: Terminal? {
-        let terms = terminals
-        guard !terms.isEmpty else { return nil }
-        let clampedIndex = min(activeTabIndex, terms.count - 1)
-        return terms[clampedIndex]
+    private var activeTab: Tab? {
+        let tabs = worktreeTabs
+        guard !tabs.isEmpty else { return nil }
+        return tabs[min(activeTabIndex, tabs.count - 1)]
     }
 
     private func closeTab(at index: Int) {
-        let terms = terminals
-        guard index >= 0, index < terms.count else { return }
-        let terminal = terms[index]
+        let tabs = worktreeTabs
+        guard index >= 0, index < tabs.count else { return }
+        let tab = tabs[index]
 
-        // Remove terminal from layout
-        if let currentLayout = appState.layouts[worktreeID] {
-            if let newLayout = currentLayout.removePane(id: terminal.id) {
-                appState.layouts[worktreeID] = newLayout
-            } else {
-                appState.layouts.removeValue(forKey: worktreeID)
-            }
+        // Remove layout
+        appState.layouts.removeValue(forKey: tab.id)
+
+        // Remove tab
+        appState.tabs[worktreeID]?.remove(at: index)
+
+        // For terminal tabs, also remove from terminals
+        if case .terminal(let terminalID) = tab.content {
+            appState.terminals[worktreeID]?.removeAll { $0.id == terminalID }
         }
-
-        // Remove from terminals list
-        appState.terminals[worktreeID]?.removeAll { $0.id == terminal.id }
 
         // Adjust active tab index
-        let remaining = appState.terminals[worktreeID]?.count ?? 0
-        if remaining > 0 {
-            activeTabIndex = min(activeTabIndex, remaining - 1)
-        } else {
-            activeTabIndex = 0
-        }
+        let remaining = appState.tabs[worktreeID]?.count ?? 0
+        activeTabIndex = remaining > 0 ? min(activeTabIndex, remaining - 1) : 0
     }
 }
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -25,6 +25,8 @@ struct TerminalPanelView: NSViewRepresentable {
     let tmuxServer: String
     let tmuxWindowID: String
     let tmuxBridge: TmuxBridge
+    var worktreePath: String = ""
+    var onFilePathClicked: ((String) -> Void)?
 
     func makeNSView(context: Context) -> TBDTerminalView {
         let tv = TBDTerminalView(
@@ -39,6 +41,10 @@ struct TerminalPanelView: NSViewRepresentable {
         // Disable mouse reporting so click-drag selects text locally
         // instead of forwarding mouse events to tmux
         tv.allowMouseReporting = false
+
+        // Wire up Cmd+Click file path detection
+        tv.worktreePath = worktreePath
+        tv.onFilePathClicked = onFilePathClicked
 
         // Set delegate for terminal events
         tv.terminalDelegate = context.coordinator
@@ -86,6 +92,7 @@ struct TerminalPanelView: NSViewRepresentable {
         var initialFrame: NSRect = .zero
         private var localProcess: LocalProcess?
         private var scrollMonitor: Any?
+        private var clickMonitor: Any?
 
         func startTmuxClient(
             terminalView: TerminalView,
@@ -170,6 +177,26 @@ struct TerminalPanelView: NSViewRepresentable {
                 }
                 return consumed ? nil : event
             }
+
+            // Intercept Cmd+Click to detect file paths in the terminal buffer.
+            clickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                guard event.modifierFlags.contains(.command) else { return event }
+
+                // Capture event properties before entering the MainActor closure
+                let location = event.locationInWindow
+                let consumed = MainActor.assumeIsolated { () -> Bool in
+                    guard let tv = ref.view as? TBDTerminalView else { return false }
+                    let point = tv.convert(location, from: nil)
+                    guard tv.bounds.contains(point) else { return false }
+
+                    if let filePath = tv.extractFilePath(atWindowLocation: location) {
+                        tv.onFilePathClicked?(filePath)
+                        return true
+                    }
+                    return false
+                }
+                return consumed ? nil : event
+            }
         }
 
         func cleanup() {
@@ -178,12 +205,19 @@ struct TerminalPanelView: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
                 scrollMonitor = nil
             }
+            if let monitor = clickMonitor {
+                NSEvent.removeMonitor(monitor)
+                clickMonitor = nil
+            }
             tmuxBridge?.cleanupSession(panelID: panelID, server: tmuxServer)
         }
 
         deinit {
             debugLog("PANEL: deinit for \(panelID.uuidString.prefix(8))")
             if let monitor = scrollMonitor {
+                NSEvent.removeMonitor(monitor)
+            }
+            if let monitor = clickMonitor {
                 NSEvent.removeMonitor(monitor)
             }
         }

--- a/Tests/TBDAppTests/LayoutNodeTests.swift
+++ b/Tests/TBDAppTests/LayoutNodeTests.swift
@@ -1,0 +1,252 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+
+@Suite("LayoutNode")
+struct LayoutNodeTests {
+
+    // MARK: - splitPane
+
+    @Test func splitPane_replacesTargetWithSplit() {
+        let id = UUID()
+        let newContent = PaneContent.terminal(terminalID: UUID())
+        let node = LayoutNode.pane(.terminal(terminalID: id))
+
+        let result = node.splitPane(id: id, direction: .horizontal, newContent: newContent)
+
+        if case .split(let dir, let children, let ratios) = result {
+            #expect(dir == .horizontal)
+            #expect(children.count == 2)
+            #expect(ratios == [0.5, 0.5])
+            #expect(children[0] == .pane(.terminal(terminalID: id)))
+            #expect(children[1] == .pane(newContent))
+        } else {
+            Issue.record("Expected split node")
+        }
+    }
+
+    @Test func splitPane_nonMatchingIDUnchanged() {
+        let id = UUID()
+        let otherId = UUID()
+        let node = LayoutNode.pane(.terminal(terminalID: id))
+
+        let result = node.splitPane(id: otherId, direction: .vertical, newContent: .terminal(terminalID: UUID()))
+        #expect(result == node)
+    }
+
+    @Test func splitPane_recursesIntoSplit() {
+        let id1 = UUID()
+        let id2 = UUID()
+        let newContent = PaneContent.webview(id: UUID(), url: URL(string: "https://example.com")!)
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [.pane(.terminal(terminalID: id1)), .pane(.terminal(terminalID: id2))],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = node.splitPane(id: id2, direction: .vertical, newContent: newContent)
+
+        if case .split(_, let children, _) = result {
+            #expect(children[0] == .pane(.terminal(terminalID: id1)))
+            if case .split(let dir, let innerChildren, _) = children[1] {
+                #expect(dir == .vertical)
+                #expect(innerChildren.count == 2)
+            } else {
+                Issue.record("Expected nested split")
+            }
+        } else {
+            Issue.record("Expected split node")
+        }
+    }
+
+    // MARK: - removePane
+
+    @Test func removePane_removesMatchingLeaf() {
+        let id = UUID()
+        let node = LayoutNode.pane(.terminal(terminalID: id))
+        let result = node.removePane(id: id)
+        #expect(result == nil)
+    }
+
+    @Test func removePane_keepsNonMatchingLeaf() {
+        let id = UUID()
+        let node = LayoutNode.pane(.terminal(terminalID: id))
+        let result = node.removePane(id: UUID())
+        #expect(result == node)
+    }
+
+    @Test func removePane_simplifiesSplitToSingleChild() {
+        let id1 = UUID()
+        let id2 = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [.pane(.terminal(terminalID: id1)), .pane(.terminal(terminalID: id2))],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = node.removePane(id: id1)
+        #expect(result == .pane(.terminal(terminalID: id2)))
+    }
+
+    @Test func removePane_renormalizesRatios() {
+        let id1 = UUID()
+        let id2 = UUID()
+        let id3 = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: id1)),
+                .pane(.terminal(terminalID: id2)),
+                .pane(.terminal(terminalID: id3)),
+            ],
+            ratios: [0.25, 0.25, 0.5]
+        )
+
+        let result = node.removePane(id: id1)
+        if case .split(_, let children, let ratios) = result {
+            #expect(children.count == 2)
+            // 0.25/(0.25+0.5) ≈ 0.333, 0.5/(0.25+0.5) ≈ 0.667
+            let sum = ratios.reduce(0, +)
+            #expect(abs(sum - 1.0) < 0.001)
+        } else {
+            Issue.record("Expected split node")
+        }
+    }
+
+    // MARK: - allPaneIDs
+
+    @Test func allPaneIDs_singlePane() {
+        let id = UUID()
+        let node = LayoutNode.pane(.terminal(terminalID: id))
+        #expect(node.allPaneIDs() == [id])
+    }
+
+    @Test func allPaneIDs_mixedTypes() {
+        let termID = UUID()
+        let webID = UUID()
+        let codeID = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: termID)),
+                .split(
+                    direction: .vertical,
+                    children: [
+                        .pane(.webview(id: webID, url: URL(string: "https://example.com")!)),
+                        .pane(.codeViewer(id: codeID, path: "/tmp/file.swift")),
+                    ],
+                    ratios: [0.5, 0.5]
+                ),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let ids = node.allPaneIDs()
+        #expect(ids.count == 3)
+        #expect(ids.contains(termID))
+        #expect(ids.contains(webID))
+        #expect(ids.contains(codeID))
+    }
+
+    @Test func allTerminalIDs_filtersNonTerminals() {
+        let termID = UUID()
+        let webID = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: termID)),
+                .pane(.webview(id: webID, url: URL(string: "https://example.com")!)),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let ids = node.allTerminalIDs()
+        #expect(ids == [termID])
+    }
+
+    // MARK: - Codable backward compat
+
+    @Test func codable_backwardCompat_oldTerminalFormat() throws {
+        // Old format: {"type":"terminal","terminalID":"<uuid>"}
+        let uuid = UUID()
+        let json = """
+        {"type":"terminal","terminalID":"\(uuid.uuidString)"}
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(LayoutNode.self, from: data)
+        #expect(decoded == .pane(.terminal(terminalID: uuid)))
+    }
+
+    @Test func codable_backwardCompat_oldSplitWithTerminals() throws {
+        let id1 = UUID()
+        let id2 = UUID()
+        let json = """
+        {
+            "type": "split",
+            "direction": "horizontal",
+            "children": [
+                {"type": "terminal", "terminalID": "\(id1.uuidString)"},
+                {"type": "terminal", "terminalID": "\(id2.uuidString)"}
+            ],
+            "ratios": [0.5, 0.5]
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(LayoutNode.self, from: data)
+
+        let expected = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: id1)),
+                .pane(.terminal(terminalID: id2)),
+            ],
+            ratios: [0.5, 0.5]
+        )
+        #expect(decoded == expected)
+    }
+
+    // MARK: - Codable roundtrip (new format)
+
+    @Test func codable_roundtrip_paneTerminal() throws {
+        let node = LayoutNode.pane(.terminal(terminalID: UUID()))
+        let data = try JSONEncoder().encode(node)
+        let decoded = try JSONDecoder().decode(LayoutNode.self, from: data)
+        #expect(decoded == node)
+    }
+
+    @Test func codable_roundtrip_paneWebview() throws {
+        let node = LayoutNode.pane(.webview(id: UUID(), url: URL(string: "https://example.com")!))
+        let data = try JSONEncoder().encode(node)
+        let decoded = try JSONDecoder().decode(LayoutNode.self, from: data)
+        #expect(decoded == node)
+    }
+
+    @Test func codable_roundtrip_paneCodeViewer() throws {
+        let node = LayoutNode.pane(.codeViewer(id: UUID(), path: "/tmp/test.swift"))
+        let data = try JSONEncoder().encode(node)
+        let decoded = try JSONDecoder().decode(LayoutNode.self, from: data)
+        #expect(decoded == node)
+    }
+
+    @Test func codable_roundtrip_complexTree() throws {
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: UUID())),
+                .split(
+                    direction: .vertical,
+                    children: [
+                        .pane(.webview(id: UUID(), url: URL(string: "https://example.com")!)),
+                        .pane(.codeViewer(id: UUID(), path: "/tmp/file.swift")),
+                    ],
+                    ratios: [0.4, 0.6]
+                ),
+            ],
+            ratios: [0.3, 0.7]
+        )
+        let data = try JSONEncoder().encode(node)
+        let decoded = try JSONDecoder().decode(LayoutNode.self, from: data)
+        #expect(decoded == node)
+    }
+}

--- a/Tests/TBDAppTests/PaneContentTests.swift
+++ b/Tests/TBDAppTests/PaneContentTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+
+@Suite("PaneContent")
+struct PaneContentTests {
+    @Test func paneID_terminal() {
+        let id = UUID()
+        let content = PaneContent.terminal(terminalID: id)
+        #expect(content.paneID == id)
+    }
+
+    @Test func paneID_webview() {
+        let id = UUID()
+        let content = PaneContent.webview(id: id, url: URL(string: "https://example.com")!)
+        #expect(content.paneID == id)
+    }
+
+    @Test func paneID_codeViewer() {
+        let id = UUID()
+        let content = PaneContent.codeViewer(id: id, path: "/tmp/file.swift")
+        #expect(content.paneID == id)
+    }
+
+    @Test func codable_roundtrip_terminal() throws {
+        let original = PaneContent.terminal(terminalID: UUID())
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PaneContent.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func codable_roundtrip_webview() throws {
+        let original = PaneContent.webview(id: UUID(), url: URL(string: "https://example.com/path")!)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PaneContent.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func codable_roundtrip_codeViewer() throws {
+        let original = PaneContent.codeViewer(id: UUID(), path: "/Users/test/file.swift")
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PaneContent.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func tab_codable_roundtrip() throws {
+        let tab = Tab(
+            id: UUID(),
+            content: .terminal(terminalID: UUID()),
+            label: "Main"
+        )
+        let data = try JSONEncoder().encode(tab)
+        let decoded = try JSONDecoder().decode(Tab.self, from: data)
+        #expect(decoded == tab)
+    }
+
+    @Test func tab_codable_roundtrip_nil_label() throws {
+        let tab = Tab(
+            id: UUID(),
+            content: .webview(id: UUID(), url: URL(string: "https://example.com")!),
+            label: nil
+        )
+        let data = try JSONEncoder().encode(tab)
+        let decoded = try JSONDecoder().decode(Tab.self, from: data)
+        #expect(decoded == tab)
+        #expect(decoded.label == nil)
+    }
+}

--- a/docs/superpowers/plans/2026-03-24-multiformat-panes.md
+++ b/docs/superpowers/plans/2026-03-24-multiformat-panes.md
@@ -1,0 +1,1652 @@
+# Multi-Format Panes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add webview and code viewer panes alongside terminals, all splittable within the same layout tree.
+
+**Architecture:** Generalize `LayoutNode` leaves from terminal-only to a `PaneContent` enum (terminal/webview/codeViewer). Replace the terminal-driven tab system with a `Tab` model as single source of truth. Add `WebviewPaneView` (WKWebView) and `CodeViewerPaneView` (Highlightr) as new pane renderers.
+
+**Tech Stack:** SwiftUI, WebKit (WKWebView), Highlightr (SPM), SwiftTerm
+
+**Spec:** `docs/superpowers/specs/2026-03-24-multiformat-panes-design.md`
+
+---
+
+## File Structure
+
+### New files
+- `Sources/TBDApp/Terminal/PaneContent.swift` — `PaneContent` enum, `Tab` struct
+- `Sources/TBDApp/Panes/PanePlaceholder.swift` — universal pane leaf wrapper (replaces `TerminalPanelPlaceholder`)
+- `Sources/TBDApp/Panes/WebviewPaneView.swift` — WKWebView NSViewRepresentable
+- `Sources/TBDApp/Panes/CodeViewerPaneView.swift` — Highlightr-based code viewer with file sidebar
+- `Sources/TBDApp/TabBar.swift` — generic tab bar (replaces `TerminalTabBar`)
+- `Tests/TBDAppTests/LayoutNodeTests.swift` — tests for PaneContent, LayoutNode migration, tree ops
+- `Tests/TBDAppTests/PaneContentTests.swift` — tests for PaneContent codable, paneID
+
+### Modified files
+- `Package.swift` — add Highlightr dependency
+- `Sources/TBDApp/Terminal/LayoutNode.swift` — `.terminal()` → `.pane(PaneContent)`, rename helpers
+- `Sources/TBDApp/Terminal/SplitLayoutView.swift` — switch on `.pane()`, remove `TerminalPanelPlaceholder`
+- `Sources/TBDApp/Terminal/TerminalContainerView.swift` — read from `appState.tabs`, use `TabBar`
+- `Sources/TBDApp/AppState.swift` — add `tabs: [UUID: [Tab]]` property
+- `Sources/TBDApp/AppState+Terminals.swift` — update `createTerminal` to also append tab
+- `Sources/TBDApp/ContentView.swift` — PR link in toolbar
+- `Sources/TBDApp/FileViewer/FileViewerPanel.swift` — click handler opens code viewer tab
+- `Sources/TBDApp/Terminal/TBDTerminalView.swift` — Cmd+Click file path interception
+
+---
+
+## Task 1: Add Highlightr dependency to Package.swift
+
+**Files:**
+- Modify: `Package.swift:10-14` (dependencies array), `Package.swift:53-58` (TBDApp target)
+
+- [ ] **Step 1: Add Highlightr to package dependencies**
+
+In `Package.swift`, add to the `dependencies` array:
+```swift
+.package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
+```
+
+And add to the TBDApp target's `dependencies`:
+```swift
+.product(name: "Highlightr", package: "Highlightr"),
+```
+
+- [ ] **Step 2: Verify it resolves**
+
+Run: `swift package resolve`
+Expected: resolves without errors
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `swift build`
+Expected: builds successfully
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Package.swift Package.resolved
+git commit -m "feat: add Highlightr dependency for syntax highlighting"
+```
+
+---
+
+## Task 2: PaneContent enum and Tab model
+
+**Files:**
+- Create: `Sources/TBDApp/Terminal/PaneContent.swift`
+- Create: `Tests/TBDAppTests/PaneContentTests.swift`
+
+- [ ] **Step 1: Write tests for PaneContent**
+
+Create `Tests/TBDAppTests/PaneContentTests.swift`:
+```swift
+import Testing
+import Foundation
+@testable import TBDApp
+
+@Suite("PaneContent")
+struct PaneContentTests {
+    @Test("paneID returns correct ID for each variant")
+    func paneID() {
+        let termID = UUID()
+        let webID = UUID()
+        let codeID = UUID()
+
+        #expect(PaneContent.terminal(terminalID: termID).paneID == termID)
+        #expect(PaneContent.webview(id: webID, url: URL(string: "https://github.com")!).paneID == webID)
+        #expect(PaneContent.codeViewer(id: codeID, path: "/tmp/test.swift").paneID == codeID)
+    }
+
+    @Test("PaneContent roundtrips through Codable")
+    func codableRoundtrip() throws {
+        let cases: [PaneContent] = [
+            .terminal(terminalID: UUID()),
+            .webview(id: UUID(), url: URL(string: "https://github.com/foo/bar/pull/42")!),
+            .codeViewer(id: UUID(), path: "/Users/test/project/main.swift"),
+        ]
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        for original in cases {
+            let data = try encoder.encode(original)
+            let decoded = try decoder.decode(PaneContent.self, from: data)
+            #expect(decoded == original)
+        }
+    }
+
+    @Test("Tab model stores PaneContent")
+    func tabModel() {
+        let id = UUID()
+        let content = PaneContent.terminal(terminalID: UUID())
+        let tab = Tab(id: id, content: content, label: "My Tab")
+        #expect(tab.id == id)
+        #expect(tab.content == content)
+        #expect(tab.label == "My Tab")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter PaneContentTests`
+Expected: FAIL — `PaneContent` and `Tab` not defined
+
+- [ ] **Step 3: Implement PaneContent and Tab**
+
+Create `Sources/TBDApp/Terminal/PaneContent.swift`:
+```swift
+import Foundation
+
+// MARK: - PaneContent
+
+enum PaneContent: Codable, Equatable, Sendable {
+    case terminal(terminalID: UUID)
+    case webview(id: UUID, url: URL)
+    case codeViewer(id: UUID, path: String)
+
+    var paneID: UUID {
+        switch self {
+        case .terminal(let id): return id
+        case .webview(let id, _): return id
+        case .codeViewer(let id, _): return id
+        }
+    }
+}
+
+// MARK: - Tab
+
+struct Tab: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    var content: PaneContent
+    var label: String?
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter PaneContentTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDApp/Terminal/PaneContent.swift Tests/TBDAppTests/PaneContentTests.swift
+git commit -m "feat: add PaneContent enum and Tab model"
+```
+
+---
+
+## Task 3: Migrate LayoutNode from .terminal to .pane(PaneContent)
+
+**Files:**
+- Modify: `Sources/TBDApp/Terminal/LayoutNode.swift`
+- Create: `Tests/TBDAppTests/LayoutNodeTests.swift`
+
+- [ ] **Step 1: Write tests for migrated LayoutNode**
+
+Create `Tests/TBDAppTests/LayoutNodeTests.swift`:
+```swift
+import Testing
+import Foundation
+import CoreGraphics
+@testable import TBDApp
+
+@Suite("LayoutNode")
+struct LayoutNodeTests {
+    @Test("splitPane replaces target pane with a split containing original + new")
+    func splitPane() {
+        let id1 = UUID()
+        let id2 = UUID()
+        let node = LayoutNode.pane(.terminal(terminalID: id1))
+        let newContent = PaneContent.codeViewer(id: id2, path: "/tmp/test.swift")
+        let result = node.splitPane(paneID: id1, direction: .horizontal, newContent: newContent)
+
+        if case .split(let dir, let children, let ratios) = result {
+            #expect(dir == .horizontal)
+            #expect(children.count == 2)
+            #expect(ratios == [0.5, 0.5])
+            #expect(children[0] == .pane(.terminal(terminalID: id1)))
+            #expect(children[1] == .pane(newContent))
+        } else {
+            Issue.record("Expected split node")
+        }
+    }
+
+    @Test("removePane removes target and simplifies tree")
+    func removePane() {
+        let id1 = UUID()
+        let id2 = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [.pane(.terminal(terminalID: id1)), .pane(.terminal(terminalID: id2))],
+            ratios: [0.5, 0.5]
+        )
+        let result = node.removePane(paneID: id1)
+        #expect(result == .pane(.terminal(terminalID: id2)))
+    }
+
+    @Test("allPaneIDs returns all leaf IDs")
+    func allPaneIDs() {
+        let id1 = UUID()
+        let id2 = UUID()
+        let id3 = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: id1)),
+                .split(direction: .vertical, children: [
+                    .pane(.webview(id: id2, url: URL(string: "https://github.com")!)),
+                    .pane(.codeViewer(id: id3, path: "/tmp/test.swift")),
+                ], ratios: [0.5, 0.5]),
+            ],
+            ratios: [0.5, 0.5]
+        )
+        let ids = node.allPaneIDs()
+        #expect(Set(ids) == Set([id1, id2, id3]))
+    }
+
+    @Test("Codable backward compat: old terminal format decodes to .pane(.terminal())")
+    func codableBackwardCompat() throws {
+        // Simulates the old on-disk format
+        let termID = UUID()
+        let oldJSON = """
+        {"type":"terminal","terminalID":"\(termID.uuidString)"}
+        """
+        let decoded = try JSONDecoder().decode(LayoutNode.self, from: oldJSON.data(using: .utf8)!)
+        #expect(decoded == .pane(.terminal(terminalID: termID)))
+    }
+
+    @Test("Codable roundtrip for all pane types")
+    func codableRoundtrip() throws {
+        let nodes: [LayoutNode] = [
+            .pane(.terminal(terminalID: UUID())),
+            .pane(.webview(id: UUID(), url: URL(string: "https://github.com")!)),
+            .pane(.codeViewer(id: UUID(), path: "/tmp/test.swift")),
+            .split(direction: .horizontal, children: [
+                .pane(.terminal(terminalID: UUID())),
+                .pane(.webview(id: UUID(), url: URL(string: "https://example.com")!)),
+            ], ratios: [0.5, 0.5]),
+        ]
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        for original in nodes {
+            let data = try encoder.encode(original)
+            let decoded = try decoder.decode(LayoutNode.self, from: data)
+            #expect(decoded == original)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter LayoutNodeTests`
+Expected: FAIL — `.pane()` case doesn't exist, `splitPane` method doesn't exist
+
+- [ ] **Step 3: Rewrite LayoutNode.swift**
+
+Replace the entire contents of `Sources/TBDApp/Terminal/LayoutNode.swift` with:
+
+```swift
+import Foundation
+import CoreGraphics
+
+// MARK: - SplitDirection
+
+enum SplitDirection: String, Codable, Sendable {
+    case horizontal, vertical
+}
+
+// MARK: - LayoutNode
+
+indirect enum LayoutNode: Equatable, Sendable {
+    case pane(PaneContent)
+    case split(direction: SplitDirection, children: [LayoutNode], ratios: [CGFloat])
+
+    // MARK: - Helpers
+
+    /// Finds the pane with the given ID and replaces it with a split
+    /// containing the original + new pane at 50/50 ratio.
+    func splitPane(paneID: UUID, direction: SplitDirection, newContent: PaneContent) -> LayoutNode {
+        switch self {
+        case .pane(let content):
+            if content.paneID == paneID {
+                return .split(
+                    direction: direction,
+                    children: [
+                        .pane(content),
+                        .pane(newContent),
+                    ],
+                    ratios: [0.5, 0.5]
+                )
+            }
+            return self
+
+        case .split(let dir, let children, let ratios):
+            let newChildren = children.map { child in
+                child.splitPane(paneID: paneID, direction: direction, newContent: newContent)
+            }
+            return .split(direction: dir, children: newChildren, ratios: ratios)
+        }
+    }
+
+    /// Removes a pane, simplifying the tree. If a split has one child left,
+    /// unwrap it. Returns nil if the last pane is removed.
+    func removePane(paneID: UUID) -> LayoutNode? {
+        switch self {
+        case .pane(let content):
+            if content.paneID == paneID {
+                return nil
+            }
+            return self
+
+        case .split(let direction, let children, let ratios):
+            var newChildren: [LayoutNode] = []
+            var newRatios: [CGFloat] = []
+
+            for (index, child) in children.enumerated() {
+                if let remaining = child.removePane(paneID: paneID) {
+                    newChildren.append(remaining)
+                    newRatios.append(ratios[index])
+                }
+            }
+
+            if newChildren.isEmpty {
+                return nil
+            }
+
+            if newChildren.count == 1 {
+                return newChildren[0]
+            }
+
+            // Renormalize ratios so they sum to 1.0
+            let total = newRatios.reduce(0, +)
+            if total > 0 {
+                newRatios = newRatios.map { $0 / total }
+            }
+
+            return .split(direction: direction, children: newChildren, ratios: newRatios)
+        }
+    }
+
+    /// Flat list of all pane IDs in the tree.
+    func allPaneIDs() -> [UUID] {
+        switch self {
+        case .pane(let content):
+            return [content.paneID]
+        case .split(_, let children, _):
+            return children.flatMap { $0.allPaneIDs() }
+        }
+    }
+}
+
+// MARK: - Codable (manual conformance for indirect enum)
+
+extension LayoutNode: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case terminalID  // backward compat for old terminal format
+        case paneContent  // new: encoded PaneContent
+        case direction
+        case children
+        case ratios
+    }
+
+    private enum NodeType: String, Codable {
+        case terminal  // backward compat
+        case pane      // new generic pane
+        case split
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(NodeType.self, forKey: .type)
+
+        switch type {
+        case .terminal:
+            // Backward compat: old format had type:"terminal" + terminalID
+            let terminalID = try container.decode(UUID.self, forKey: .terminalID)
+            self = .pane(.terminal(terminalID: terminalID))
+        case .pane:
+            let content = try container.decode(PaneContent.self, forKey: .paneContent)
+            self = .pane(content)
+        case .split:
+            let direction = try container.decode(SplitDirection.self, forKey: .direction)
+            let children = try container.decode([LayoutNode].self, forKey: .children)
+            let ratios = try container.decode([CGFloat].self, forKey: .ratios)
+            self = .split(direction: direction, children: children, ratios: ratios)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .pane(let content):
+            try container.encode(NodeType.pane, forKey: .type)
+            try container.encode(content, forKey: .paneContent)
+        case .split(let direction, let children, let ratios):
+            try container.encode(NodeType.split, forKey: .type)
+            try container.encode(direction, forKey: .direction)
+            try container.encode(children, forKey: .children)
+            try container.encode(ratios, forKey: .ratios)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter LayoutNodeTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDApp/Terminal/LayoutNode.swift Tests/TBDAppTests/LayoutNodeTests.swift
+git commit -m "feat: migrate LayoutNode from .terminal to .pane(PaneContent)"
+```
+
+---
+
+## Task 4: Update SplitLayoutView — extract TerminalPanelPlaceholder, wire PanePlaceholder
+
+**Files:**
+- Create: `Sources/TBDApp/Panes/PanePlaceholder.swift`
+- Modify: `Sources/TBDApp/Terminal/SplitLayoutView.swift`
+
+This task depends on Tasks 2 and 3.
+
+- [ ] **Step 1: Create PanePlaceholder**
+
+Create `Sources/TBDApp/Panes/PanePlaceholder.swift`:
+```swift
+import SwiftUI
+import TBDShared
+
+/// Universal leaf wrapper for the split layout tree.
+/// Renders the appropriate view based on PaneContent type.
+struct PanePlaceholder: View {
+    let content: PaneContent
+    let worktree: Worktree
+    @Binding var layout: LayoutNode
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            paneToolbar
+            Divider()
+            paneContent
+        }
+    }
+
+    @ViewBuilder
+    private var paneToolbar: some View {
+        HStack(spacing: 8) {
+            paneLabel
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            Spacer()
+
+            // Webview: back/forward buttons
+            if case .webview = content {
+                // Note: WebviewToolbarContent needs a reference to the WKWebView.
+                // This will be wired via a @State var in the full implementation.
+                // For now, stub with disabled buttons.
+                Button { } label: {
+                    Image(systemName: "chevron.left").font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .disabled(true)
+
+                Button { } label: {
+                    Image(systemName: "chevron.right").font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .disabled(true)
+            }
+
+            // Split buttons for terminal panes only
+            if case .terminal = content {
+                Button(action: { splitRight() }) {
+                    HStack(spacing: 2) {
+                        Image(systemName: "rectangle.split.1x2")
+                            .rotationEffect(.degrees(90))
+                        Text("Split Right")
+                    }
+                    .font(.caption)
+                }
+                .buttonStyle(.borderless)
+
+                Button(action: { splitDown() }) {
+                    HStack(spacing: 2) {
+                        Image(systemName: "rectangle.split.1x2")
+                        Text("Split Down")
+                    }
+                    .font(.caption)
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    @ViewBuilder
+    private var paneLabel: some View {
+        switch content {
+        case .terminal(let terminalID):
+            Text("Terminal: \(terminalID.uuidString.prefix(8))")
+        case .webview(_, let url):
+            HStack(spacing: 4) {
+                Image(systemName: "globe")
+                Text(url.host ?? url.absoluteString)
+            }
+        case .codeViewer(_, let path):
+            HStack(spacing: 4) {
+                Image(systemName: "doc.text")
+                Text(URL(fileURLWithPath: path).lastPathComponent)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var paneContent: some View {
+        switch content {
+        case .terminal(let terminalID):
+            terminalContent(terminalID: terminalID)
+        case .webview(_, let url):
+            WebviewPaneView(url: url)
+        case .codeViewer(_, let path):
+            CodeViewerPaneView(path: path, worktreePath: worktree.path)
+        }
+    }
+
+    @ViewBuilder
+    private func terminalContent(terminalID: UUID) -> some View {
+        let terminal: Terminal? = {
+            for (_, terms) in appState.terminals {
+                if let t = terms.first(where: { $0.id == terminalID }) {
+                    return t
+                }
+            }
+            return nil
+        }()
+
+        if let terminal {
+            TerminalPanelView(
+                terminalID: terminalID,
+                tmuxServer: worktree.tmuxServer,
+                tmuxWindowID: terminal.tmuxWindowID,
+                tmuxBridge: appState.tmuxBridge
+            )
+            .id(terminalID)
+        } else {
+            ZStack {
+                Color(nsColor: .black)
+                VStack(spacing: 8) {
+                    Image(systemName: "terminal")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                    Text(worktree.displayName)
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                    Text(worktree.branch)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    private func splitRight() {
+        let newContent = PaneContent.terminal(terminalID: UUID())
+        layout = layout.splitPane(paneID: content.paneID, direction: .horizontal, newContent: newContent)
+    }
+
+    private func splitDown() {
+        let newContent = PaneContent.terminal(terminalID: UUID())
+        layout = layout.splitPane(paneID: content.paneID, direction: .vertical, newContent: newContent)
+    }
+}
+```
+
+- [ ] **Step 2: Update SplitLayoutView to use .pane() and PanePlaceholder**
+
+In `Sources/TBDApp/Terminal/SplitLayoutView.swift`:
+- Change `SplitLayoutView.body` switch from `.terminal(let id)` → `.pane(let content)` rendering `PanePlaceholder`
+- Remove `TerminalPanelPlaceholder` entirely (it's replaced by `PanePlaceholder`)
+- Update `updateRatios` switch to use `.pane` instead of `.terminal`
+
+The full `SplitLayoutView` body becomes:
+```swift
+var body: some View {
+    switch node {
+    case .pane(let content):
+        PanePlaceholder(
+            content: content,
+            worktree: worktree,
+            layout: $layout
+        )
+    case .split(let direction, let children, let ratios):
+        SplitContainer(
+            direction: direction,
+            children: children,
+            ratios: ratios,
+            worktree: worktree,
+            layout: $layout
+        )
+    }
+}
+```
+
+In `SplitContainer.updateRatios`, change `case .terminal:` to `case .pane:`.
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `swift build`
+Expected: May have compile errors for `WebviewPaneView` and `CodeViewerPaneView` — add stub implementations:
+
+Create temporary stubs if needed:
+```swift
+// In WebviewPaneView.swift
+import SwiftUI
+struct WebviewPaneView: View {
+    let url: URL
+    var body: some View { Text("Webview: \(url.absoluteString)") }
+}
+
+// In CodeViewerPaneView.swift
+import SwiftUI
+struct CodeViewerPaneView: View {
+    let path: String
+    let worktreePath: String
+    var body: some View { Text("Code: \(path)") }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/Panes/ Sources/TBDApp/Terminal/SplitLayoutView.swift
+git commit -m "feat: add PanePlaceholder, wire SplitLayoutView to .pane(PaneContent)"
+```
+
+---
+
+## Task 5: Generic TabBar and tab system in AppState
+
+**Files:**
+- Create: `Sources/TBDApp/TabBar.swift`
+- Modify: `Sources/TBDApp/AppState.swift:16` (add tabs property)
+- Modify: `Sources/TBDApp/AppState+Terminals.swift` (update createTerminal to also append tab)
+- Modify: `Sources/TBDApp/Terminal/TerminalContainerView.swift` (read from tabs, use TabBar)
+
+- [ ] **Step 1: Create generic TabBar**
+
+Create `Sources/TBDApp/TabBar.swift`:
+```swift
+import SwiftUI
+
+// MARK: - TabBar
+
+struct TabBar: View {
+    let tabs: [Tab]
+    @Binding var activeTabIndex: Int
+    var onAddTab: () -> Void
+    var onCloseTab: (Int) -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
+                if index > 0 {
+                    Rectangle()
+                        .fill(Color.primary.opacity(0.08))
+                        .frame(width: 1, height: 18)
+                }
+
+                TabItem(
+                    tab: tab,
+                    index: index,
+                    isSelected: index == activeTabIndex,
+                    onSelect: { activeTabIndex = index },
+                    onClose: { onCloseTab(index) }
+                )
+            }
+
+            Rectangle()
+                .fill(Color.primary.opacity(0.08))
+                .frame(width: 1, height: 18)
+
+            Button(action: onAddTab) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 34, height: 28)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("New Terminal Tab")
+
+            Spacer()
+        }
+        .padding(.horizontal, 0)
+        .frame(height: 30)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+}
+
+// MARK: - TabItem
+
+private struct TabItem: View {
+    let tab: Tab
+    let index: Int
+    let isSelected: Bool
+    let onSelect: () -> Void
+    let onClose: () -> Void
+
+    @State private var isHovering = false
+    @State private var isHoveringClose = false
+
+    private var showClose: Bool {
+        isSelected || isHovering
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(isHoveringClose ? .primary : .secondary)
+                    .frame(width: 16, height: 16)
+                    .background(
+                        Circle()
+                            .fill(Color.primary.opacity(isHoveringClose ? 0.12 : 0))
+                    )
+                    .onHover { hovering in
+                        isHoveringClose = hovering
+                    }
+            }
+            .buttonStyle(.plain)
+            .opacity(showClose ? 1 : 0)
+            .animation(.easeInOut(duration: 0.12), value: showClose)
+
+            tabIcon
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .padding(.trailing, 3)
+
+            Text(tabLabel)
+                .font(.system(size: 11))
+                .lineLimit(1)
+                .foregroundStyle(isSelected ? .primary : .secondary)
+                .frame(maxWidth: .infinity)
+
+            Color.clear
+                .frame(width: 16, height: 16)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .frame(minWidth: 80, maxWidth: 180, minHeight: 28)
+        .background(
+            isSelected
+                ? Color(nsColor: .controlBackgroundColor)
+                : (isHovering ? Color.primary.opacity(0.04) : Color.clear)
+        )
+        .animation(.easeInOut(duration: 0.1), value: isHovering)
+        .onHover { hovering in
+            isHovering = hovering
+        }
+        .onTapGesture {
+            onSelect()
+        }
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private var tabIcon: some View {
+        switch tab.content {
+        case .terminal:
+            Image(systemName: "terminal")
+        case .webview:
+            Image(systemName: "globe")
+        case .codeViewer:
+            Image(systemName: "doc.text")
+        }
+    }
+
+    private var tabLabel: String {
+        if let label = tab.label, !label.isEmpty {
+            return label
+        }
+        switch tab.content {
+        case .terminal:
+            return "Terminal \(index + 1)"
+        case .webview(_, let url):
+            return url.host ?? "Web"
+        case .codeViewer(_, let path):
+            return URL(fileURLWithPath: path).lastPathComponent
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add `tabs` property to AppState**
+
+In `Sources/TBDApp/AppState.swift`, add after line 16 (`@Published var layouts`):
+```swift
+@Published var tabs: [UUID: [Tab]] = [:]
+```
+
+- [ ] **Step 3: Update createTerminal to also append a Tab**
+
+In `Sources/TBDApp/AppState+Terminals.swift`, update `createTerminal`:
+```swift
+func createTerminal(worktreeID: UUID, cmd: String? = nil) async {
+    do {
+        let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cmd: cmd)
+        terminals[worktreeID, default: []].append(terminal)
+        // Also create a tab for this terminal
+        let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+        tabs[worktreeID, default: []].append(tab)
+    } catch {
+        logger.error("Failed to create terminal: \(error)")
+        handleConnectionError(error)
+    }
+}
+```
+
+- [ ] **Step 4: Update refreshTerminals to reconcile tabs**
+
+In `Sources/TBDApp/AppState.swift`, update `refreshTerminals(worktreeID:)` to reconcile tabs after updating terminals:
+```swift
+func refreshTerminals(worktreeID: UUID) async {
+    do {
+        let fetched = try await daemonClient.listTerminals(worktreeID: worktreeID)
+        let existing = terminals[worktreeID] ?? []
+        if fetched != existing {
+            terminals[worktreeID] = fetched
+            reconcileTabs(worktreeID: worktreeID, terminals: fetched)
+        }
+    } catch {
+        logger.error("Failed to list terminals for worktree \(worktreeID): \(error)")
+        handleConnectionError(error)
+    }
+}
+
+/// Ensure tabs stay in sync with daemon-managed terminals.
+/// Adds tabs for new terminals, removes tabs for deleted terminals.
+/// Preserves non-terminal tabs (webview, code viewer).
+private func reconcileTabs(worktreeID: UUID, terminals: [Terminal]) {
+    var currentTabs = tabs[worktreeID] ?? []
+    let terminalIDs = Set(terminals.map(\.id))
+    let existingTerminalTabIDs = Set(currentTabs.compactMap { tab -> UUID? in
+        if case .terminal(let id) = tab.content { return id }
+        return nil
+    })
+
+    // Remove tabs for terminals that no longer exist
+    currentTabs.removeAll { tab in
+        if case .terminal(let id) = tab.content {
+            return !terminalIDs.contains(id)
+        }
+        return false
+    }
+
+    // Add tabs for new terminals
+    for terminal in terminals where !existingTerminalTabIDs.contains(terminal.id) {
+        currentTabs.append(Tab(id: terminal.id, content: .terminal(terminalID: terminal.id)))
+    }
+
+    tabs[worktreeID] = currentTabs
+}
+```
+
+- [ ] **Step 5: Rewrite TerminalContainerView to use tabs**
+
+Rewrite `Sources/TBDApp/Terminal/TerminalContainerView.swift` `SingleWorktreeView` to read from `appState.tabs[worktreeID]` instead of `appState.terminals[worktreeID]`:
+
+Key changes in `SingleWorktreeView`:
+- Replace `private var terminals: [Terminal]` with `private var tabs: [Tab]`
+- Replace `TerminalTabBar` with `TabBar`
+- `layoutContent` reads layout keyed by `tab.id`
+- Default layout is `.pane(tab.content)`
+- `closeTab` removes from `appState.tabs` (and for terminal tabs, also removes from `appState.terminals`)
+- `activeTerminal` logic replaced with `activeTab`
+- The "+" button still calls `createTerminal()` which now handles both
+
+Similarly update `MultiWorktreeCell` to use `.pane()` for default layout.
+
+- [ ] **Step 6: Delete old TerminalTabBar.swift**
+
+Delete `Sources/TBDApp/Terminal/TerminalTabBar.swift` — replaced by `Sources/TBDApp/TabBar.swift`.
+
+- [ ] **Step 7: Build to verify**
+
+Run: `swift build`
+Expected: builds successfully
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/TBDApp/TabBar.swift Sources/TBDApp/AppState.swift Sources/TBDApp/AppState+Terminals.swift Sources/TBDApp/Terminal/TerminalContainerView.swift
+git rm Sources/TBDApp/Terminal/TerminalTabBar.swift
+git commit -m "feat: generic tab system with Tab model as single source of truth"
+```
+
+---
+
+## Task 6: WebviewPaneView — WKWebView wrapper
+
+**Files:**
+- Create: `Sources/TBDApp/Panes/WebviewPaneView.swift` (replace stub)
+
+- [ ] **Step 1: Implement WebviewPaneView**
+
+Replace the stub `Sources/TBDApp/Panes/WebviewPaneView.swift` with:
+```swift
+import SwiftUI
+import WebKit
+
+/// Wraps WKWebView for displaying web content in a pane.
+/// All instances share WKWebsiteDataStore.default() for persistent cookies.
+struct WebviewPaneView: NSViewRepresentable {
+    let url: URL
+    @State private var currentURL: URL?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .default()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: url))
+        context.coordinator.webView = webView
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        // Only reload if the initial URL changed (not navigation)
+        if webView.url == nil {
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        weak var webView: WKWebView?
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            // URL tracking handled by the webview itself via webView.url
+        }
+    }
+}
+
+/// Toolbar content for a webview pane — back/forward buttons + URL display.
+struct WebviewToolbarContent: View {
+    let webView: WKWebView?
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Button { webView?.goBack() } label: {
+                Image(systemName: "chevron.left")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .disabled(!(webView?.canGoBack ?? false))
+
+            Button { webView?.goForward() } label: {
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .disabled(!(webView?.canGoForward ?? false))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `swift build`
+Expected: builds successfully
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/Panes/WebviewPaneView.swift
+git commit -m "feat: WebviewPaneView with shared cookie store"
+```
+
+---
+
+## Task 7: CodeViewerPaneView — syntax-highlighted code viewer
+
+**Files:**
+- Create: `Sources/TBDApp/Panes/CodeViewerPaneView.swift` (replace stub)
+
+- [ ] **Step 1: Implement CodeViewerPaneView**
+
+Replace the stub `Sources/TBDApp/Panes/CodeViewerPaneView.swift` with a complete implementation:
+
+```swift
+import SwiftUI
+import AppKit
+import Highlightr
+
+// MARK: - CodeViewerPaneView
+
+struct CodeViewerPaneView: View {
+    let path: String
+    let worktreePath: String
+
+    @State private var selectedFiles: [String] = []
+    @State private var fileTree: [FileTreeNode] = []
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // File sidebar
+            CodeViewerSidebar(
+                worktreePath: worktreePath,
+                selectedFiles: $selectedFiles
+            )
+            .frame(width: 200)
+
+            Divider()
+
+            // Code preview
+            if selectedFiles.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(selectedFiles, id: \.self) { filePath in
+                            if selectedFiles.count > 1 {
+                                fileHeader(filePath)
+                            }
+                            HighlightedCodeView(filePath: filePath)
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            if !path.isEmpty && FileManager.default.fileExists(atPath: path) {
+                selectedFiles = [path]
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "doc.text")
+                .font(.system(size: 40))
+                .foregroundStyle(.tertiary)
+            Text("Select a file to view")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func fileHeader(_ path: String) -> some View {
+        HStack {
+            Image(systemName: "doc.text")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(URL(fileURLWithPath: path).lastPathComponent)
+                .font(.caption)
+                .fontWeight(.medium)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+}
+
+// MARK: - HighlightedCodeView
+
+private struct HighlightedCodeView: View {
+    let filePath: String
+    @State private var attributedContent: NSAttributedString?
+    @State private var loadError: String?
+
+    var body: some View {
+        Group {
+            if let error = loadError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(12)
+            } else if let content = attributedContent {
+                Text(AttributedString(content))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 100)
+            }
+        }
+        .task(id: filePath) {
+            await loadAndHighlight()
+        }
+    }
+
+    private func loadAndHighlight() async {
+        do {
+            let content = try String(contentsOfFile: filePath, encoding: .utf8)
+            let highlighted = highlightCode(content, filename: filePath)
+            attributedContent = highlighted
+        } catch {
+            loadError = "Could not read file"
+        }
+    }
+}
+
+// MARK: - Syntax Highlighting
+
+private let sharedHighlightr: Highlightr? = {
+    let h = Highlightr()
+    h?.setTheme(to: "atom-one-dark")
+    return h
+}()
+
+private func highlightCode(_ code: String, filename: String) -> NSAttributedString {
+    let lang = languageForFilename(filename)
+    let monoFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+    guard let highlightr = sharedHighlightr,
+          let highlighted = highlightr.highlight(code, as: lang) else {
+        return NSAttributedString(string: code, attributes: [.font: monoFont])
+    }
+
+    let mutable = NSMutableAttributedString(attributedString: highlighted)
+    let fullRange = NSRange(location: 0, length: mutable.length)
+
+    // Override font to consistent monospace
+    mutable.addAttribute(.font, value: monoFont, range: fullRange)
+
+    // Legibility fix: replace too-pale foreground colors
+    mutable.enumerateAttribute(.foregroundColor, in: fullRange) { value, attrRange, _ in
+        if let color = value as? NSColor, colorIsTooPale(color) {
+            mutable.addAttribute(.foregroundColor, value: NSColor.labelColor, range: attrRange)
+        }
+    }
+
+    return mutable
+}
+
+private func colorIsTooPale(_ color: NSColor) -> Bool {
+    guard let rgb = color.usingColorSpace(.sRGB) else { return false }
+    let luminance = 0.2126 * rgb.redComponent + 0.7152 * rgb.greenComponent + 0.0722 * rgb.blueComponent
+    return luminance > 0.6
+}
+
+private func languageForFilename(_ filename: String) -> String? {
+    let ext = (filename as NSString).pathExtension.lowercased()
+    let map: [String: String] = [
+        "swift": "swift", "ts": "typescript", "tsx": "typescript", "js": "javascript",
+        "jsx": "javascript", "py": "python", "rb": "ruby", "go": "go", "rs": "rust",
+        "java": "java", "kt": "kotlin", "cpp": "cpp", "c": "c", "h": "c", "hpp": "cpp",
+        "cs": "csharp", "css": "css", "scss": "scss", "html": "xml", "xml": "xml",
+        "json": "json", "yaml": "yaml", "yml": "yaml", "toml": "ini", "sql": "sql",
+        "sh": "bash", "bash": "bash", "zsh": "bash", "md": "markdown",
+        "graphql": "graphql", "gql": "graphql",
+    ]
+    return map[ext]
+}
+
+// MARK: - CodeViewerSidebar
+
+struct CodeViewerSidebar: View {
+    let worktreePath: String
+    @Binding var selectedFiles: [String]
+    @State private var expandedDirs: Set<String> = []
+    @State private var entries: [FileEntry] = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Files")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+
+            Divider()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(entries, id: \.path) { entry in
+                        FileEntryRow(
+                            entry: entry,
+                            isExpanded: expandedDirs.contains(entry.path),
+                            isSelected: selectedFiles.contains(entry.path),
+                            onToggleDir: { toggleDir(entry.path) },
+                            onSelectFile: { selectFile(entry.path, event: NSApp.currentEvent) }
+                        )
+                    }
+                }
+            }
+        }
+        .background(Color(nsColor: .controlBackgroundColor))
+        .task(id: worktreePath) {
+            loadTopLevel()
+        }
+    }
+
+    private func loadTopLevel() {
+        guard !worktreePath.isEmpty else { return }
+        entries = listDirectory(worktreePath, depth: 0)
+    }
+
+    private func toggleDir(_ path: String) {
+        if expandedDirs.contains(path) {
+            expandedDirs.remove(path)
+            entries.removeAll { $0.path.hasPrefix(path + "/") }
+        } else {
+            expandedDirs.insert(path)
+            let children = listDirectory(path, depth: depthOf(path) + 1)
+            if let idx = entries.firstIndex(where: { $0.path == path }) {
+                entries.insert(contentsOf: children, at: idx + 1)
+            }
+        }
+    }
+
+    private func selectFile(_ path: String, event: NSEvent?) {
+        if event?.modifierFlags.contains(.command) == true {
+            if selectedFiles.contains(path) {
+                selectedFiles.removeAll { $0 == path }
+            } else {
+                selectedFiles.append(path)
+            }
+        } else {
+            selectedFiles = [path]
+        }
+    }
+
+    private func depthOf(_ path: String) -> Int {
+        let relative = path.replacingOccurrences(of: worktreePath + "/", with: "")
+        return relative.components(separatedBy: "/").count - 1
+    }
+
+    private func listDirectory(_ dir: String, depth: Int) -> [FileEntry] {
+        let fm = FileManager.default
+        guard let items = try? fm.contentsOfDirectory(atPath: dir) else { return [] }
+        return items
+            .filter { !$0.hasPrefix(".") }
+            .sorted { a, b in
+                let aIsDir = isDirectory(dir + "/" + a)
+                let bIsDir = isDirectory(dir + "/" + b)
+                if aIsDir != bIsDir { return aIsDir }
+                return a.localizedCaseInsensitiveCompare(b) == .orderedAscending
+            }
+            .map { name in
+                let fullPath = dir + "/" + name
+                return FileEntry(path: fullPath, name: name, isDirectory: isDirectory(fullPath), depth: depth)
+            }
+    }
+
+    private func isDirectory(_ path: String) -> Bool {
+        var isDir: ObjCBool = false
+        FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
+        return isDir.boolValue
+    }
+}
+
+struct FileEntry {
+    let path: String
+    let name: String
+    let isDirectory: Bool
+    let depth: Int
+}
+
+private struct FileEntryRow: View {
+    let entry: FileEntry
+    let isExpanded: Bool
+    let isSelected: Bool
+    let onToggleDir: () -> Void
+    let onSelectFile: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            if entry.isDirectory {
+                onToggleDir()
+            } else {
+                onSelectFile()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                if entry.isDirectory {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 8))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 10)
+                } else {
+                    Color.clear.frame(width: 10)
+                }
+
+                Image(systemName: entry.isDirectory ? "folder" : "doc")
+                    .font(.caption2)
+                    .foregroundStyle(entry.isDirectory ? .blue : .secondary)
+
+                Text(entry.name)
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer()
+            }
+            .padding(.leading, CGFloat(entry.depth) * 16 + 8)
+            .padding(.vertical, 3)
+            .background(
+                isSelected ? Color.accentColor.opacity(0.2) :
+                (isHovered ? Color.primary.opacity(0.05) : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `swift build`
+Expected: builds successfully
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/Panes/CodeViewerPaneView.swift
+git commit -m "feat: CodeViewerPaneView with Highlightr syntax highlighting and file sidebar"
+```
+
+---
+
+## Task 8: PR link in toolbar → webview tab
+
+**Files:**
+- Modify: `Sources/TBDApp/ContentView.swift:43-67` (toolbar section)
+
+- [ ] **Step 1: Add PR link to toolbar**
+
+In `Sources/TBDApp/ContentView.swift`, in the `ToolbarItemGroup`, add a PR link button. After the filter picker and before the file panel toggle, add:
+
+```swift
+if let worktreeID = appState.selectedWorktreeIDs.first,
+   appState.selectedWorktreeIDs.count == 1,
+   let prStatus = appState.prStatuses[worktreeID],
+   let prURL = URL(string: prStatus.url) {
+    Button {
+        let tab = Tab(id: UUID(), content: .webview(id: UUID(), url: prURL), label: "PR #\(prStatus.number)")
+        appState.tabs[worktreeID, default: []].append(tab)
+    } label: {
+        HStack(spacing: 3) {
+            Image(systemName: "arrow.triangle.pull")
+                .font(.caption)
+            Text("#\(prStatus.number)")
+                .font(.caption)
+                .fontWeight(.medium)
+        }
+    }
+    .help("Open PR in browser pane")
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `swift build`
+Expected: builds successfully
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/ContentView.swift
+git commit -m "feat: PR link in toolbar opens webview tab"
+```
+
+---
+
+## Task 9: FileViewerPanel click → code viewer tab
+
+**Files:**
+- Modify: `Sources/TBDApp/FileViewer/FileViewerPanel.swift:191-222` (GitFileRow)
+
+- [ ] **Step 1: Update GitFileRow to open code viewer tab**
+
+In `Sources/TBDApp/FileViewer/FileViewerPanel.swift`, update `GitFileRow` to open a code viewer tab instead of calling `NSWorkspace.shared.open`. The row needs access to `appState` and `worktreeID`:
+
+Add `@EnvironmentObject var appState: AppState` and a `worktreeID: UUID` parameter to `FileStatusSection` and `GitFileRow`.
+
+Update the button action in `GitFileRow`:
+```swift
+Button {
+    let fullPath = URL(fileURLWithPath: worktreePath).appendingPathComponent(file.path).path
+    openInCodeViewer(fullPath)
+} label: { /* existing label */ }
+```
+
+Add helper:
+```swift
+private func openInCodeViewer(_ path: String) {
+    // Find or create a code viewer tab for this worktree
+    let worktreeID = worktree.id  // passed through from FileViewerPanel
+    var worktreeTabs = appState.tabs[worktreeID] ?? []
+
+    // Look for existing code viewer tab to reuse
+    if let existingIndex = worktreeTabs.firstIndex(where: {
+        if case .codeViewer = $0.content { return true }
+        return false
+    }) {
+        // Check if Cmd is held for multi-select
+        if NSApp.currentEvent?.modifierFlags.contains(.command) == true {
+            // Don't replace — add a new tab
+        } else {
+            // Replace existing code viewer tab's content
+            worktreeTabs[existingIndex] = Tab(
+                id: worktreeTabs[existingIndex].id,
+                content: .codeViewer(id: worktreeTabs[existingIndex].content.paneID, path: path),
+                label: URL(fileURLWithPath: path).lastPathComponent
+            )
+            appState.tabs[worktreeID] = worktreeTabs
+            return
+        }
+    }
+
+    // Create new code viewer tab
+    let tab = Tab(
+        id: UUID(),
+        content: .codeViewer(id: UUID(), path: path),
+        label: URL(fileURLWithPath: path).lastPathComponent
+    )
+    appState.tabs[worktreeID, default: []].append(tab)
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `swift build`
+Expected: builds successfully
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/FileViewer/FileViewerPanel.swift
+git commit -m "feat: FileViewerPanel click opens code viewer tab"
+```
+
+---
+
+## Task 10: Cmd+Click file path in terminal → code viewer split
+
+**Files:**
+- Modify: `Sources/TBDApp/Terminal/TBDTerminalView.swift`
+- Modify: `Sources/TBDApp/Terminal/TerminalPanelView.swift` (pass callback)
+
+- [ ] **Step 1: Add Cmd+Click handler to TBDTerminalView**
+
+In `Sources/TBDApp/Terminal/TBDTerminalView.swift`, add a callback and mouse handler:
+
+```swift
+/// Called when user Cmd+Clicks a file path in the terminal.
+/// The callback receives the resolved absolute file path.
+var onFilePathClicked: ((String) -> Void)?
+
+/// The worktree path for resolving relative file paths.
+var worktreePath: String = ""
+
+override func mouseDown(with event: NSEvent) {
+    // Cmd+Click: try to extract a file path
+    if event.modifierFlags.contains(.command) {
+        if let filePath = extractFilePath(at: event) {
+            onFilePathClicked?(filePath)
+            return
+        }
+    }
+    super.mouseDown(with: event)
+}
+
+private func extractFilePath(at event: NSEvent) -> String? {
+    let localPoint = convert(event.locationInWindow, from: nil)
+    let terminal = getTerminal()
+    let cellWidth = frame.width / CGFloat(terminal.cols)
+    let cellHeight = frame.height / CGFloat(terminal.rows)
+
+    let col = Int(localPoint.x / cellWidth)
+    // Terminal Y is flipped — 0 is top
+    let row = Int((frame.height - localPoint.y) / cellHeight)
+
+    guard row >= 0, row < terminal.rows else { return nil }
+
+    // Get the line text
+    let line = terminal.getLine(row: row)
+    let lineText = line?.translateToString() ?? ""
+    guard !lineText.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+
+    // Extract word around the click position
+    let chars = Array(lineText)
+    guard col >= 0, col < chars.count else { return nil }
+
+    // Expand outward from click position to find path-like text
+    var start = col
+    var end = col
+    let pathChars = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "/._-~"))
+    while start > 0 && chars[start - 1].unicodeScalars.allSatisfy({ pathChars.contains($0) }) {
+        start -= 1
+    }
+    while end < chars.count - 1 && chars[end + 1].unicodeScalars.allSatisfy({ pathChars.contains($0) }) {
+        end += 1
+    }
+
+    var candidate = String(chars[start...end])
+
+    // Strip trailing :line:col suffix (e.g., "file.swift:42:10")
+    if let colonRange = candidate.range(of: #":\d+.*$"#, options: .regularExpression) {
+        candidate = String(candidate[candidate.startIndex..<colonRange.lowerBound])
+    }
+
+    guard !candidate.isEmpty else { return nil }
+
+    // Resolve relative paths against worktree
+    let resolved: String
+    if candidate.hasPrefix("/") || candidate.hasPrefix("~") {
+        resolved = NSString(string: candidate).expandingTildeInPath
+    } else {
+        resolved = URL(fileURLWithPath: worktreePath).appendingPathComponent(candidate).path
+    }
+
+    // Validate it exists
+    if FileManager.default.fileExists(atPath: resolved) {
+        return resolved
+    }
+
+    return nil
+}
+```
+
+- [ ] **Step 2: Wire callback in TerminalPanelView / PanePlaceholder**
+
+In `PanePlaceholder.swift`, when rendering terminal content, set the callback on the `TBDTerminalView` via the coordinator. This requires passing a closure through `TerminalPanelView` that mutates the layout binding to add a code viewer split.
+
+In the `TerminalPanelView` coordinator's `makeNSView`, after creating the `TBDTerminalView`:
+```swift
+tv.worktreePath = worktreePath  // new parameter
+tv.onFilePathClicked = { [weak tv] path in
+    onFilePathClicked?(path)
+}
+```
+
+Add `worktreePath: String` and `onFilePathClicked: ((String) -> Void)?` parameters to `TerminalPanelView`.
+
+In `PanePlaceholder`, when rendering terminal content:
+```swift
+TerminalPanelView(
+    terminalID: terminalID,
+    tmuxServer: worktree.tmuxServer,
+    tmuxWindowID: terminal.tmuxWindowID,
+    tmuxBridge: appState.tmuxBridge,
+    worktreePath: worktree.path,
+    onFilePathClicked: { path in
+        let newContent = PaneContent.codeViewer(id: UUID(), path: path)
+        layout = layout.splitPane(paneID: terminalID, direction: .horizontal, newContent: newContent)
+    }
+)
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `swift build`
+Expected: builds successfully
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/Terminal/TBDTerminalView.swift Sources/TBDApp/Panes/PanePlaceholder.swift Sources/TBDApp/Terminal/TerminalPanelView.swift
+git commit -m "feat: Cmd+Click file path in terminal opens code viewer split"
+```
+
+---
+
+## Task 11: Final integration test and cleanup
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `swift test`
+Expected: all tests pass
+
+- [ ] **Step 2: Run full build**
+
+Run: `swift build`
+Expected: builds with no warnings related to our changes
+
+- [ ] **Step 3: Manual smoke test checklist**
+
+Test with `scripts/restart.sh`:
+1. Terminal tabs work as before (create, close, split)
+2. PR link appears in toolbar when worktree has a PR → clicking opens webview tab
+3. Webview loads GitHub and retains login across tabs
+4. Clicking a file in FileViewerPanel opens code viewer tab with syntax highlighting
+5. Clicking another file replaces content in same code viewer tab
+6. Cmd+Click on a file path in terminal opens code viewer split to the right
+7. Split/resize between terminal and code viewer works
+
+- [ ] **Step 4: Commit any final fixes**
+
+```bash
+git add -A
+git commit -m "fix: final integration fixes for multi-format panes"
+```

--- a/docs/superpowers/specs/2026-03-24-multiformat-panes-design.md
+++ b/docs/superpowers/specs/2026-03-24-multiformat-panes-design.md
@@ -1,0 +1,187 @@
+# Multi-Format Panes
+
+Add support for webview and code viewer panes alongside existing terminal panes, splittable within the same layout tree.
+
+## Background
+
+TBD currently supports only terminal panes. The layout system (`LayoutNode`) is a recursive split tree where every leaf is a terminal. This design generalizes the leaf type so panes can render terminals, web content (particularly GitHub PRs), or syntax-highlighted source code.
+
+## Data Model
+
+### PaneContent enum
+
+Replaces the terminal-only leaf with a discriminated union of pane types:
+
+```swift
+enum PaneContent: Codable, Equatable, Sendable {
+    case terminal(terminalID: UUID)
+    case webview(id: UUID, url: URL)
+    case codeViewer(id: UUID, path: String) // absolute file path
+}
+```
+
+Each variant carries its own `id: UUID` so the layout tree can address any pane uniformly.
+
+### LayoutNode changes
+
+```swift
+indirect enum LayoutNode: Equatable, Sendable {
+    case pane(PaneContent)  // was: .terminal(terminalID: UUID)
+    case split(direction: SplitDirection, children: [LayoutNode], ratios: [CGFloat])
+}
+```
+
+Tree helpers renamed: `splitTerminal` → `splitPane`, `removeTerminal` → `removePane`, `allTerminalIDs` → `allPaneIDs`. Logic is identical — only the leaf type changes.
+
+### Codable migration
+
+The manual `Codable` conformance on `LayoutNode` currently encodes a `NodeType` discriminator (`terminal`, `split`). Add new `NodeType` cases (`webview`, `codeViewer`). The existing `terminal` case decodes to `.pane(.terminal(...))`, so persisted layouts migrate without data changes.
+
+## Tab System
+
+### Single source of truth
+
+Introduce a `Tab` model:
+
+```swift
+struct Tab: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    var content: TabContent
+    var label: String?
+}
+
+enum TabContent: Codable, Equatable, Sendable {
+    case terminal(terminalID: UUID)
+    case webview(id: UUID, url: URL)
+    case codeViewer(id: UUID, path: String)
+}
+```
+
+`appState.tabs: [UUID: [Tab]]` (keyed by worktree ID) is the single source of truth for tab ordering and existence. `appState.terminals: [UUID: [Terminal]]` becomes a passive lookup table for tmux connection info only.
+
+### Tab bar
+
+`TerminalTabBar` becomes a generic `TabBar` displaying icons per type:
+- Terminal: terminal icon + truncated ID
+- Webview: globe icon + domain or page title
+- Code viewer: document icon + filename
+
+The "+" button creates a new terminal tab (calls `createTerminal()` on the daemon, then appends a tab entry).
+
+### Daemon reconciliation
+
+When the daemon creates/deletes terminals (including on reconnect), `appState.tabs` is updated accordingly:
+- New terminal from daemon → append `.terminal(terminalID:)` tab
+- Terminal removed → remove its tab entry
+- On reconnect, reconcile: remove tabs for terminals that no longer exist, add tabs for new ones
+
+### Migration
+
+On first launch after update, if `tabs[worktreeID]` is nil, generate it from `terminals[worktreeID]`.
+
+### Layouts
+
+`appState.layouts: [UUID: LayoutNode]` continues to be keyed by the tab's root pane ID. For terminal tabs that's `terminal.id`, for webview/code viewer tabs it's their respective UUID.
+
+## WebviewPaneView
+
+`NSViewRepresentable` wrapping `WKWebView`.
+
+- **Shared session:** All webview panes share `WKWebsiteDataStore.default()`. Log in to GitHub once, authenticated everywhere. Cookies persist across app restarts.
+- **Chrome:** Minimal — URL display (read-only, shows current page URL), back/forward buttons in the `PanePlaceholder` header. No URL input bar.
+- **Navigation:** `WKNavigationDelegate` updates the displayed URL as the user navigates.
+- **Creation flow:** Programmatic only — no generic "create webview" UI.
+
+## CodeViewerPaneView
+
+Native syntax-highlighted code viewer using [Highlightr](https://github.com/raspu/Highlightr) (Swift wrapper around highlight.js).
+
+### Components
+
+- **File sidebar** (~200px, left): Tree view of the worktree directory. Single-click selects a file and shows it in the preview. Cmd+Click selects multiple files, shown stacked vertically in a scrollable view.
+- **Code preview** (main area, right): Read-only `NSTextView` displaying `NSAttributedString` from Highlightr. Monospace font, text-selectable.
+
+### Syntax highlighting
+
+- Highlightr tokenizes code via highlight.js, produces `NSAttributedString`
+- Override font to consistent monospace (`NSFont.monospacedSystemFont`)
+- **Legibility fix:** Enumerate foreground color attributes; replace any with WCAG relative luminance > 0.6 with `NSColor.labelColor` (same approach as gh-review's `colorIsTooPale()`)
+
+### Language detection
+
+Map file extensions to highlight.js language names (swift, typescript, python, etc.). Fall back to plain text for unknown extensions.
+
+### Dependency
+
+Add `Highlightr` SPM package to `Package.swift`, imported in `TBDApp` target only.
+
+## SplitLayoutView Changes
+
+`SplitLayoutView` switches on the new `LayoutNode`:
+
+```swift
+switch node {
+case .pane(let content):
+    PanePlaceholder(content: content, worktree: worktree, layout: $layout)
+case .split(let direction, let children, let ratios):
+    SplitContainer(/* unchanged */)
+}
+```
+
+### PanePlaceholder
+
+Universal leaf wrapper replacing `TerminalPanelPlaceholder`:
+
+- **Shared header toolbar:** Pane type indicator, close button. Split buttons shown for terminal panes only.
+- **Content switch:** Renders `TerminalPanelView`, `WebviewPaneView`, or `CodeViewerPaneView` based on `PaneContent`.
+
+`SplitContainer` and `SplitDivider` are untouched — they only know about `LayoutNode`, not leaf contents.
+
+## Creation Flows
+
+### PR link → webview tab
+
+- When a single worktree is selected and has a `PRStatus` in `appState.prStatuses[worktreeID]`, show a clickable PR number (e.g., "#42") in the toolbar title area.
+- Clicking it creates a new tab: `.webview(id: UUID(), url: URL(string: prStatus.url)!)`.
+
+### Cmd+Click file path in terminal → code viewer split
+
+- Override `mouseDown(with:)` in `TBDTerminalView` when Cmd is held.
+- Extract the terminal line text via SwiftTerm's buffer API.
+- Parse text around click position for a plausible file path (contiguous non-whitespace, optional `:line` suffix).
+- Resolve relative paths against `worktree.path`.
+- Validate path exists via `FileManager`.
+- If valid: mutate layout to add `.pane(.codeViewer(...))` split to the right of the current terminal.
+- If invalid: silent no-op (replaces current broken Finder open that shows error -50).
+
+> **TODO: Harden file path detection.** The current approach is best-effort heuristic parsing of terminal buffer text. If this proves unreliable in practice, consider: regex-based pattern matching on full line text, OSC 8 hyperlink support, or shell integration escape sequences.
+
+### FileViewerPanel click → code viewer tab
+
+- Clicking a file in the git status FileViewerPanel opens a code viewer tab (or reuses an existing one).
+- Subsequent file clicks replace the displayed file in the same code viewer tab.
+- Cmd+Click adds files to a multi-file selection, shown stacked in the code viewer.
+
+### CLI
+
+`tbd open path/to/file.swift` — programmatic access for opening files in the code viewer.
+
+## Files Changed
+
+### New files
+- `Sources/TBDApp/Panes/PanePlaceholder.swift` — universal pane leaf wrapper
+- `Sources/TBDApp/Panes/WebviewPaneView.swift` — WKWebView wrapper
+- `Sources/TBDApp/Panes/CodeViewerPaneView.swift` — Highlightr-based code viewer
+- `Sources/TBDApp/Panes/CodeViewerSidebar.swift` — file tree sidebar for code viewer
+- `Sources/TBDApp/TabBar.swift` — generalized tab bar (replaces TerminalTabBar)
+
+### Modified files
+- `Sources/TBDApp/Terminal/LayoutNode.swift` — `PaneContent` enum, `.pane()` case, renamed helpers
+- `Sources/TBDApp/Terminal/SplitLayoutView.swift` — switch on `.pane()`, remove `TerminalPanelPlaceholder`
+- `Sources/TBDApp/Terminal/TerminalContainerView.swift` — read tabs from `appState.tabs`, use generic `TabBar`
+- `Sources/TBDApp/Terminal/TBDTerminalView.swift` — Cmd+Click file path interception
+- `Sources/TBDApp/AppState.swift` — add `tabs: [UUID: [Tab]]`, daemon reconciliation updates
+- `Sources/TBDApp/ContentView.swift` — PR link in toolbar
+- `Sources/TBDApp/FileViewer/FileViewerPanel.swift` — click handler to open code viewer tab
+- `Sources/TBDShared/Models.swift` — `Tab`, `TabContent` models (if shared with daemon, otherwise app-only)
+- `Package.swift` — add Highlightr dependency

--- a/docs/superpowers/specs/2026-03-24-multiformat-panes-design.md
+++ b/docs/superpowers/specs/2026-03-24-multiformat-panes-design.md
@@ -10,7 +10,7 @@ TBD currently supports only terminal panes. The layout system (`LayoutNode`) is 
 
 ### PaneContent enum
 
-Replaces the terminal-only leaf with a discriminated union of pane types:
+Single type used in both the layout tree and the tab system (no separate `TabContent` — one type serves both purposes):
 
 ```swift
 enum PaneContent: Codable, Equatable, Sendable {
@@ -20,7 +20,7 @@ enum PaneContent: Codable, Equatable, Sendable {
 }
 ```
 
-Each variant carries its own `id: UUID` so the layout tree can address any pane uniformly.
+Each variant carries its own `id: UUID` so the layout tree can address any pane uniformly. A `PaneContent` has a computed `paneID: UUID` that returns the relevant ID regardless of variant.
 
 ### LayoutNode changes
 
@@ -31,33 +31,34 @@ indirect enum LayoutNode: Equatable, Sendable {
 }
 ```
 
-Tree helpers renamed: `splitTerminal` → `splitPane`, `removeTerminal` → `removePane`, `allTerminalIDs` → `allPaneIDs`. Logic is identical — only the leaf type changes.
+Tree helpers renamed: `splitTerminal` → `splitPane`, `removeTerminal` → `removePane`, `allTerminalIDs` → `allPaneIDs`. `splitPane` takes a `PaneContent` (not just a UUID) so it can insert any pane type. Logic is otherwise identical — only the leaf type changes.
 
 ### Codable migration
 
-The manual `Codable` conformance on `LayoutNode` currently encodes a `NodeType` discriminator (`terminal`, `split`). Add new `NodeType` cases (`webview`, `codeViewer`). The existing `terminal` case decodes to `.pane(.terminal(...))`, so persisted layouts migrate without data changes.
+The manual `Codable` conformance on `LayoutNode` currently encodes a `NodeType` discriminator (`terminal`, `split`) and type-specific keys (`terminalID`). After the change:
+
+- `NodeType` gains new cases: `webview`, `codeViewer`
+- The `terminal` decoder is rewritten to produce `.pane(.terminal(terminalID:))` instead of `.terminal(terminalID:)` — same on-disk format, different in-memory representation
+- New pane types add their own coding keys (`url` for webview, `path` for code viewer)
+- **No data file migration needed** — persisted layouts with `NodeType.terminal` decode correctly through the updated decoder. New pane types simply use new `NodeType` values that old versions won't encounter.
 
 ## Tab System
 
 ### Single source of truth
 
-Introduce a `Tab` model:
+Introduce a `Tab` model that reuses `PaneContent` (no separate `TabContent` type):
 
 ```swift
 struct Tab: Identifiable, Codable, Equatable, Sendable {
     let id: UUID
-    var content: TabContent
+    var content: PaneContent  // same type used in LayoutNode leaves
     var label: String?
-}
-
-enum TabContent: Codable, Equatable, Sendable {
-    case terminal(terminalID: UUID)
-    case webview(id: UUID, url: URL)
-    case codeViewer(id: UUID, path: String)
 }
 ```
 
 `appState.tabs: [UUID: [Tab]]` (keyed by worktree ID) is the single source of truth for tab ordering and existence. `appState.terminals: [UUID: [Terminal]]` becomes a passive lookup table for tmux connection info only.
+
+The "+" button creates a new terminal tab only. There is no generic UI for creating webview or code viewer tabs — those are created exclusively through the contextual flows described in "Creation Flows" below (PR link, Cmd+Click, FileViewerPanel click).
 
 ### Tab bar
 
@@ -81,7 +82,9 @@ On first launch after update, if `tabs[worktreeID]` is nil, generate it from `te
 
 ### Layouts
 
-`appState.layouts: [UUID: LayoutNode]` continues to be keyed by the tab's root pane ID. For terminal tabs that's `terminal.id`, for webview/code viewer tabs it's their respective UUID.
+`appState.layouts: [UUID: LayoutNode]` is keyed by `Tab.id`. Each tab has exactly one layout tree. The default layout for a new tab is `.pane(tab.content)` — a single leaf matching the tab's content type. When the user splits a pane, the layout grows into a `.split(...)` tree. A tab's layout can contain mixed pane types (e.g., a terminal tab with a code viewer split alongside it).
+
+This is a change from the current scheme where layouts are keyed by `terminal.id`. Migration: on first launch, for each terminal, create a `Tab` with `id == terminal.id` so existing layout keys remain valid.
 
 ## WebviewPaneView
 
@@ -162,9 +165,9 @@ Universal leaf wrapper replacing `TerminalPanelPlaceholder`:
 - Subsequent file clicks replace the displayed file in the same code viewer tab.
 - Cmd+Click adds files to a multi-file selection, shown stacked in the code viewer.
 
-### CLI
+### CLI (future scope)
 
-`tbd open path/to/file.swift` — programmatic access for opening files in the code viewer.
+`tbd open path/to/file.swift` — programmatic access for opening files in the code viewer. This requires a new RPC method and daemon-to-app communication channel. Deferred to a follow-up; not part of this implementation.
 
 ## Files Changed
 
@@ -183,5 +186,5 @@ Universal leaf wrapper replacing `TerminalPanelPlaceholder`:
 - `Sources/TBDApp/AppState.swift` — add `tabs: [UUID: [Tab]]`, daemon reconciliation updates
 - `Sources/TBDApp/ContentView.swift` — PR link in toolbar
 - `Sources/TBDApp/FileViewer/FileViewerPanel.swift` — click handler to open code viewer tab
-- `Sources/TBDShared/Models.swift` — `Tab`, `TabContent` models (if shared with daemon, otherwise app-only)
+- `Sources/TBDShared/Models.swift` — `Tab`, `PaneContent` models (if shared with daemon, otherwise app-only)
 - `Package.swift` — add Highlightr dependency


### PR DESCRIPTION
## Summary
- Generalize pane system from terminal-only to support three pane types: terminals, webviews (WKWebView with shared cookie store), and syntax-highlighted code viewers (Highlightr)
- Replace terminal-driven tab bar with a generic `Tab` model as single source of truth, with daemon reconciliation for terminal lifecycle
- Wire contextual creation flows: PR link in toolbar opens GitHub in a webview tab, clicking files in the git status panel opens a code viewer tab, Cmd+Click on file paths in the terminal opens a code viewer split

## Test plan
- [ ] Terminal tabs work as before (create, close, split right/down)
- [ ] PR link appears in toolbar when worktree has a PR — clicking opens webview tab with GitHub
- [ ] Webview retains GitHub login across tabs and app restarts (shared cookie store)
- [ ] Clicking duplicate PR link doesn't create duplicate tabs
- [ ] Clicking a file in the git status FileViewerPanel opens code viewer tab with syntax highlighting
- [ ] Clicking another file replaces content in same code viewer tab
- [ ] Cmd+Click on a file path in terminal opens code viewer split to the right
- [ ] Split/resize between terminal and code viewer panes works correctly
- [ ] Files >1MB show "too large" message instead of loading
- [ ] 145 unit tests pass (`swift test`)