### PR TITLE
Fix: Stop file panel from showing stale worktree data after switching selection

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -15,6 +15,7 @@ final class AppState: ObservableObject {
     @Published var isConnected: Bool = false
     @Published var layouts: [UUID: LayoutNode] = [:]
     @Published var tabs: [UUID: [Tab]] = [:]
+    @Published var activeTabIndices: [UUID: Int] = [:]
     @Published var repoFilter: UUID? = nil
     @Published var pendingWorktreeIDs: Set<UUID> = []
     @Published var editingWorktreeID: UUID? = nil

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -34,6 +34,7 @@ struct ContentView: View {
                             ))
                             FileViewerPanel(worktree: worktree)
                                 .frame(width: CGFloat(filePanelWidth))
+                                .id(worktree.id)
                         }
                     }
                 }

--- a/Sources/TBDApp/FileViewer/FileViewerPanel.swift
+++ b/Sources/TBDApp/FileViewer/FileViewerPanel.swift
@@ -135,21 +135,25 @@ struct FileViewerPanel: View {
     private func handleFileClick(_ relativePath: String, cmdClick: Bool) {
         let fullPath = URL(fileURLWithPath: worktree.path).appendingPathComponent(relativePath).path
         var tabs = appState.tabs[worktree.id, default: []]
+        let fileName = URL(fileURLWithPath: relativePath).lastPathComponent
 
         if !cmdClick, let existingIndex = tabs.firstIndex(where: {
             if case .codeViewer = $0.content { return true }
             return false
         }) {
-            // Replace existing code viewer tab content
+            // Replace existing code viewer tab content and clear stale layout
             let newID = UUID()
+            appState.layouts.removeValue(forKey: tabs[existingIndex].id)
             tabs[existingIndex].content = .codeViewer(id: newID, path: fullPath)
-            tabs[existingIndex].label = URL(fileURLWithPath: relativePath).lastPathComponent
+            tabs[existingIndex].label = fileName
             appState.tabs[worktree.id] = tabs
+            appState.activeTabIndices[worktree.id] = existingIndex
         } else {
             // Create new code viewer tab
             let newID = UUID()
-            let tab = Tab(id: UUID(), content: .codeViewer(id: newID, path: fullPath), label: URL(fileURLWithPath: relativePath).lastPathComponent)
+            let tab = Tab(id: UUID(), content: .codeViewer(id: newID, path: fullPath), label: fileName)
             appState.tabs[worktree.id, default: []].append(tab)
+            appState.activeTabIndices[worktree.id] = (appState.tabs[worktree.id]?.count ?? 1) - 1
         }
     }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -31,7 +31,11 @@ struct TerminalContainerView: View {
 private struct SingleWorktreeView: View {
     let worktreeID: UUID
     @EnvironmentObject var appState: AppState
-    @State private var activeTabIndex: Int = 0
+
+    private var activeTabIndex: Int {
+        get { appState.activeTabIndices[worktreeID] ?? 0 }
+        nonmutating set { appState.activeTabIndices[worktreeID] = newValue }
+    }
 
     private var worktree: Worktree? {
         for wts in appState.worktrees.values {
@@ -53,7 +57,10 @@ private struct SingleWorktreeView: View {
                 if !worktreeTabs.isEmpty {
                     TabBar(
                         tabs: worktreeTabs,
-                        activeTabIndex: $activeTabIndex,
+                        activeTabIndex: Binding(
+                            get: { activeTabIndex },
+                            set: { activeTabIndex = $0 }
+                        ),
                         onAddTab: {
                             Task {
                                 await appState.createTerminal(worktreeID: worktreeID)


### PR DESCRIPTION
## Summary
- **File panel showed stale git status** — switching worktrees in the sidebar left the file panel displaying the previous worktree's changes because SwiftUI reused the view identity and `@State` persisted across prop changes
- **Clicking a file didn't focus its code viewer tab** — `activeTabIndex` was `@State` local to `SingleWorktreeView`, invisible to `FileViewerPanel`. Moved to `AppState.activeTabIndices` (per-worktree) so file clicks can switch the tab bar.
- **Code viewer showed old file after clicking a new one** — `handleFileClick` replaced `tab.content` but the stale `LayoutNode` in `appState.layouts[tab.id]` took precedence over the new content. Now clears the layout entry on content change.

## Test plan
- [ ] Select worktree A (with changes), then switch to worktree B — file panel should refresh immediately
- [ ] Click a file in the file viewer — tab bar should switch to the code viewer tab showing that file
- [ ] Click a different file — code viewer tab should update to the new file's content
- [ ] Cmd-click a file — should open in a new tab (not replace existing code viewer)