### PR TITLE
Fix: Prevent split panes from duplicating tabs, vanishing on restart, and orphaning terminals

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -7,7 +7,7 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "AppState+Termin
 extension AppState {
     // MARK: - Terminal Actions
 
-    /// Create a terminal in a worktree.
+    /// Create a terminal in a worktree and add a new tab for it.
     func createTerminal(worktreeID: UUID, cmd: String? = nil) async {
         do {
             let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cmd: cmd)
@@ -17,6 +17,21 @@ extension AppState {
         } catch {
             logger.error("Failed to create terminal: \(error)")
             handleConnectionError(error)
+        }
+    }
+
+    /// Create a terminal via the daemon without adding a tab.
+    /// Used when splitting an existing tab — the terminal lives inside
+    /// the parent tab's layout tree, not as its own tab.
+    func createTerminalForSplit(worktreeID: UUID) async -> Terminal? {
+        do {
+            let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID)
+            terminals[worktreeID, default: []].append(terminal)
+            return terminal
+        } catch {
+            logger.error("Failed to create terminal for split: \(error)")
+            handleConnectionError(error)
+            return nil
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -240,7 +240,19 @@ final class AppState: ObservableObject {
         var currentTabs = tabs[worktreeID] ?? []
         let terminalIDs = Set(terminals.map(\.id))
 
-        // Collect all terminal IDs that are already in a layout tree
+        // 1. Remove tabs whose root terminal no longer exists,
+        //    and clean up their persisted layouts.
+        currentTabs.removeAll { tab in
+            if case .terminal(let id) = tab.content, !terminalIDs.contains(id) {
+                layouts.removeValue(forKey: tab.id)
+                return true
+            }
+            return false
+        }
+
+        // 2. Now collect terminal IDs from surviving tabs' layouts.
+        //    This must happen AFTER pruning so that dead tabs' children
+        //    don't mask still-alive terminals that need new tabs.
         var terminalIDsInLayouts = Set<UUID>()
         for tab in currentTabs {
             if let layout = layouts[tab.id] {
@@ -248,20 +260,13 @@ final class AppState: ObservableObject {
                     terminalIDsInLayouts.insert(id)
                 }
             } else {
-                // No layout stored — the tab's root content is the only pane
                 if case .terminal(let id) = tab.content {
                     terminalIDsInLayouts.insert(id)
                 }
             }
         }
 
-        // Remove tabs whose root terminal no longer exists
-        currentTabs.removeAll { tab in
-            if case .terminal(let id) = tab.content { return !terminalIDs.contains(id) }
-            return false
-        }
-
-        // Add tabs only for terminals not already in any layout
+        // 3. Add tabs for terminals not already in any surviving layout.
         for terminal in terminals where !terminalIDsInLayouts.contains(terminal.id) {
             currentTabs.append(Tab(id: terminal.id, content: .terminal(terminalID: terminal.id)))
         }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -13,7 +13,9 @@ final class AppState: ObservableObject {
     @Published var notifications: [UUID: NotificationType?] = [:]
     @Published var selectedWorktreeIDs: Set<UUID> = []
     @Published var isConnected: Bool = false
-    @Published var layouts: [UUID: LayoutNode] = [:]
+    @Published var layouts: [UUID: LayoutNode] = [:] {
+        didSet { persistLayouts() }
+    }
     @Published var tabs: [UUID: [Tab]] = [:]
     @Published var repoFilter: UUID? = nil
     @Published var pendingWorktreeIDs: Set<UUID> = []
@@ -29,11 +31,27 @@ final class AppState: ObservableObject {
     private var pollTimer: Timer?
     private var pollCycle = 0
 
+    private static let layoutsKey = "com.tbd.app.layouts"
+
     init() {
+        restoreLayouts()
         Task {
             await connectAndLoadInitialState()
             startPolling()
         }
+    }
+
+    // MARK: - Layout Persistence
+
+    private func persistLayouts() {
+        guard let data = try? JSONEncoder().encode(layouts) else { return }
+        UserDefaults.standard.set(data, forKey: Self.layoutsKey)
+    }
+
+    private func restoreLayouts() {
+        guard let data = UserDefaults.standard.data(forKey: Self.layoutsKey),
+              let restored = try? JSONDecoder().decode([UUID: LayoutNode].self, from: data) else { return }
+        layouts = restored
     }
 
     func stopPolling() {
@@ -215,23 +233,39 @@ final class AppState: ObservableObject {
     }
 
     /// Reconcile tabs with the current terminal list for a worktree.
-    /// Removes tabs for terminals that no longer exist, adds tabs for new terminals.
+    /// Removes tabs whose root terminal no longer exists. Adds tabs for
+    /// terminals that aren't already represented (either as a tab root or
+    /// embedded in another tab's split layout).
     private func reconcileTabs(worktreeID: UUID, terminals: [Terminal]) {
         var currentTabs = tabs[worktreeID] ?? []
         let terminalIDs = Set(terminals.map(\.id))
-        let existingTerminalTabIDs = Set(currentTabs.compactMap { tab -> UUID? in
-            if case .terminal(let id) = tab.content { return id }
-            return nil
-        })
-        // Remove tabs for terminals that no longer exist
+
+        // Collect all terminal IDs that are already in a layout tree
+        var terminalIDsInLayouts = Set<UUID>()
+        for tab in currentTabs {
+            if let layout = layouts[tab.id] {
+                for id in layout.allTerminalIDs() {
+                    terminalIDsInLayouts.insert(id)
+                }
+            } else {
+                // No layout stored — the tab's root content is the only pane
+                if case .terminal(let id) = tab.content {
+                    terminalIDsInLayouts.insert(id)
+                }
+            }
+        }
+
+        // Remove tabs whose root terminal no longer exists
         currentTabs.removeAll { tab in
             if case .terminal(let id) = tab.content { return !terminalIDs.contains(id) }
             return false
         }
-        // Add tabs for new terminals
-        for terminal in terminals where !existingTerminalTabIDs.contains(terminal.id) {
+
+        // Add tabs only for terminals not already in any layout
+        for terminal in terminals where !terminalIDsInLayouts.contains(terminal.id) {
             currentTabs.append(Tab(id: terminal.id, content: .terminal(terminalID: terminal.id)))
         }
+
         tabs[worktreeID] = currentTabs
     }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -196,10 +196,10 @@ struct PanePlaceholder: View {
     }
 
     /// Creates a real terminal via the daemon, then inserts it as a split pane.
+    /// Uses createTerminalForSplit so no extra tab is created — the terminal
+    /// lives inside this tab's layout tree.
     private func createTerminalSplit(direction: SplitDirection) async {
-        await appState.createTerminal(worktreeID: worktree.id)
-        // The newly created terminal is the last one appended
-        guard let newTerminal = appState.terminals[worktree.id]?.last else { return }
+        guard let newTerminal = await appState.createTerminalForSplit(worktreeID: worktree.id) else { return }
         layout = layout.splitPane(
             id: content.paneID,
             direction: direction,

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -131,16 +131,18 @@ private struct SingleWorktreeView: View {
         guard index >= 0, index < tabs.count else { return }
         let tab = tabs[index]
 
+        // Find all terminal IDs in this tab's layout (including splits)
+        let layout = appState.layouts[tab.id] ?? .pane(tab.content)
+        let terminalIDsInTab = Set(layout.allTerminalIDs())
+
         // Remove layout
         appState.layouts.removeValue(forKey: tab.id)
 
         // Remove tab
         appState.tabs[worktreeID]?.remove(at: index)
 
-        // For terminal tabs, also remove from terminals
-        if case .terminal(let terminalID) = tab.content {
-            appState.terminals[worktreeID]?.removeAll { $0.id == terminalID }
-        }
+        // Remove ALL terminals that were in this tab's layout
+        appState.terminals[worktreeID]?.removeAll { terminalIDsInTab.contains($0.id) }
 
         // Adjust active tab index
         let remaining = appState.tabs[worktreeID]?.count ?? 0


### PR DESCRIPTION
## Summary

Splitting a terminal pane had three compounding bugs:

1. **Duplicate tab on split.** Splitting right/down in a terminal created a new daemon terminal AND a new tab — but the terminal should live inside the existing tab's split layout, not spawn its own tab.

2. **Split layout lost on restart.** Layouts were in-memory only. On app restart, the daemon still knows about the split terminal, but the app has no record of which tab it belonged to — so `reconcileTabs` promotes it to a standalone tab, losing the split arrangement.

3. **Closing a tab leaks split terminals.** `closeTab` only removed the tab's root terminal, leaving any split terminals alive on the daemon but invisible in the UI. On the next poll, `reconcileTabs` would re-create them as standalone tabs.

**Root cause:** `createTerminal` unconditionally appended both a terminal and a tab. Layouts weren't persisted. Tab cleanup only looked at the root content, not the full layout tree.

**Fixes:**
- Add `createTerminalForSplit` that creates a daemon terminal without a tab entry
- Persist layouts to UserDefaults (LayoutNode is already Codable) with restore on init
- `reconcileTabs` now scans all layout trees to avoid duplicating embedded terminals
- `closeTab` collects all terminal IDs from the tab's layout tree and removes them all

## Test plan
- [ ] Split a terminal right → new pane appears, NO extra tab in the tab bar
- [ ] Restart the app (`scripts/restart.sh`) → split layout is preserved
- [ ] Close a tab that has splits → all split terminals are cleaned up (no ghost tabs appear on next poll)
- [ ] Create a new terminal tab via "+" → still works as before (creates tab + terminal)
- [ ] 143 tests pass (`swift test`)