### PR TITLE
Fix: PR toolbar button now focuses existing tab instead of silently doing nothing

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -63,16 +63,19 @@ struct ContentView: View {
                        let prStatus = appState.prStatuses[worktreeID],
                        let prURL = URL(string: prStatus.url) {
                         Button {
-                            // Reuse existing PR tab if one exists
                             let existingTabs = appState.tabs[worktreeID] ?? []
-                            let hasPRTab = existingTabs.contains { tab in
-                                if case .webview(_, let url) = tab.content { return url == prURL }
+                            if let existingIndex = existingTabs.firstIndex(where: {
+                                if case .webview(_, let url) = $0.content { return url == prURL }
                                 return false
-                            }
-                            if !hasPRTab {
+                            }) {
+                                // Focus existing PR tab
+                                appState.activeTabIndices[worktreeID] = existingIndex
+                            } else {
+                                // Create and focus new PR tab
                                 let webviewID = UUID()
                                 let tab = Tab(id: UUID(), content: .webview(id: webviewID, url: prURL), label: "PR #\(prStatus.number)")
                                 appState.tabs[worktreeID, default: []].append(tab)
+                                appState.activeTabIndices[worktreeID] = (appState.tabs[worktreeID]?.count ?? 1) - 1
                             }
                         } label: {
                             HStack(spacing: 3) {

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -78,13 +78,7 @@ struct ContentView: View {
                                 appState.activeTabIndices[worktreeID] = (appState.tabs[worktreeID]?.count ?? 1) - 1
                             }
                         } label: {
-                            HStack(spacing: 3) {
-                                Image(systemName: "arrow.triangle.pull")
-                                    .font(.caption)
-                                Text("#\(prStatus.number)")
-                                    .font(.caption)
-                                    .fontWeight(.medium)
-                            }
+                            PRButtonLabel(prStatus: prStatus)
                         }
                         .help("Open PR in browser pane")
                     }
@@ -198,6 +192,53 @@ struct ContentView: View {
                 await appState.markNotificationsRead(worktreeID: worktreeID)
             }
         }
+    }
+}
+
+// MARK: - PRButtonLabel
+
+private struct PRButtonLabel: View {
+    let prStatus: PRStatus
+
+    private var iconName: String {
+        switch prStatus.state {
+        case .open, .changesRequested, .mergeable: return "git-pull-request"
+        case .merged:                              return "git-merge"
+        case .closed:                              return "git-pull-request-closed"
+        }
+    }
+
+    private var iconColor: Color {
+        switch prStatus.state {
+        case .open:             return .secondary
+        case .changesRequested: return .red
+        case .mergeable:        return .green
+        case .merged:           return .purple
+        case .closed:           return .secondary
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 3) {
+            if let nsImage = loadIcon(iconName) {
+                Image(nsImage: nsImage)
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 12, height: 12)
+                    .foregroundStyle(iconColor)
+            }
+            Text("#\(prStatus.number)")
+                .font(.caption)
+                .fontWeight(.medium)
+        }
+    }
+
+    private func loadIcon(_ name: String) -> NSImage? {
+        guard let url = Bundle.module.url(forResource: name, withExtension: "svg", subdirectory: "Icons"),
+              let image = NSImage(contentsOf: url) else { return nil }
+        image.isTemplate = true
+        return image
     }
 }
 

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -40,30 +40,38 @@ struct WorktreeRowView: View {
 
     private var worktreeIcon: String? {
         guard !isMain else { return nil }
+        let prState = appState.prStatuses[worktree.id]?.state
+        // PR state takes priority over local conflict detection —
+        // a merged PR means the branch is done regardless of local git status.
+        if let prState {
+            switch prState {
+            case .open, .changesRequested, .mergeable: return "git-pull-request"
+            case .merged:                              return "git-merge"
+            case .closed:                              return "git-pull-request-closed"
+            }
+        }
         if worktree.hasConflicts {
             return "git-merge-conflict"
         }
-        guard let status = appState.prStatuses[worktree.id] else { return nil }
-        switch status.state {
-        case .open, .changesRequested, .mergeable: return "git-pull-request"
-        case .merged:                              return "git-merge"
-        case .closed:                              return "git-pull-request-closed"
-        }
+        return nil
     }
 
     private var worktreeIconColor: Color {
         guard !isMain else { return .secondary }
+        let prState = appState.prStatuses[worktree.id]?.state
+        if let prState {
+            switch prState {
+            case .open:             return .secondary
+            case .changesRequested: return .red
+            case .mergeable:        return .green
+            case .merged:           return .purple
+            case .closed:           return .secondary
+            }
+        }
         if worktree.hasConflicts {
             return .orange
         }
-        guard let status = appState.prStatuses[worktree.id] else { return .secondary }
-        switch status.state {
-        case .open:             return .secondary
-        case .changesRequested: return .red
-        case .mergeable:        return .green
-        case .merged:           return .purple
-        case .closed:           return .secondary
-        }
+        return .secondary
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Clicking the PR button in the toolbar when a PR tab already existed did nothing visible — the tab was already created but not focused, so it looked broken
- Now: first click creates and focuses the PR tab, subsequent clicks focus the existing tab

## Test plan
- [ ] Click PR button → PR webview tab opens and is focused
- [ ] Click PR button again → same tab is focused (no duplicate)
- [ ] Switch to a different tab, click PR button → switches back to the PR tab