### PR TITLE
Fix: PR status stuck on old closed PR when a newer one exists for the same branch

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -32,15 +32,17 @@ public actor PRStatusManager {
             return
         }
 
-        // Build branch → PRNode lookup, preferring the most relevant PR
-        // when multiple PRs exist for the same branch (e.g., one closed, one open).
-        // Priority: OPEN > MERGED > CLOSED. Within the same state, newer (earlier
-        // in the DESC-ordered list) wins because it's inserted first.
+        // Build branch → PRNode lookup. When multiple PRs share a branch,
+        // pick the best one: sort by state priority (OPEN > MERGED > CLOSED),
+        // then by createdAt descending (newest first within the same state).
         var byBranch: [String: PRNode] = [:]
         for node in nodes {
             if let existing = byBranch[node.headRefName] {
-                // Only replace if the new node has higher priority
-                if Self.prPriority(node.state) > Self.prPriority(existing.state) {
+                let nodePriority = Self.prPriority(node.state)
+                let existingPriority = Self.prPriority(existing.state)
+                if nodePriority > existingPriority {
+                    byBranch[node.headRefName] = node
+                } else if nodePriority == existingPriority && node.createdAt > existing.createdAt {
                     byBranch[node.headRefName] = node
                 }
             } else {
@@ -122,6 +124,7 @@ public actor PRStatusManager {
         public let mergeStateStatus: String
         public let reviewDecision: String   // "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", or ""
         public let headRefName: String
+        public let createdAt: String        // ISO 8601, e.g. "2026-03-24T15:58:27Z"
     }
 
     public static func parsePRNodes(from data: Data) throws -> [PRNode] {
@@ -139,13 +142,14 @@ public actor PRStatusManager {
                   let state = node["state"] as? String,
                   let mergeStateStatus = node["mergeStateStatus"] as? String,
                   let headRefName = node["headRefName"] as? String,
+                  let createdAt = node["createdAt"] as? String,
                   headRefName.hasPrefix("tbd/") else { return nil }
-            // reviewDecision can be null in JSON (no reviews yet)
             let reviewDecision = node["reviewDecision"] as? String ?? ""
             return PRNode(number: number, url: url, state: state,
                           mergeStateStatus: mergeStateStatus,
                           reviewDecision: reviewDecision,
-                          headRefName: headRefName)
+                          headRefName: headRefName,
+                          createdAt: createdAt)
         }
     }
 
@@ -158,7 +162,7 @@ public actor PRStatusManager {
             pullRequests(first: 100, states: [OPEN, MERGED, CLOSED],
                          orderBy: {field: CREATED_AT, direction: DESC}) {
               nodes {
-                number url state mergeStateStatus reviewDecision headRefName
+                number url state mergeStateStatus reviewDecision headRefName createdAt
               }
             }
           }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -32,10 +32,20 @@ public actor PRStatusManager {
             return
         }
 
-        // Build branch → PRNode lookup
+        // Build branch → PRNode lookup, preferring the most relevant PR
+        // when multiple PRs exist for the same branch (e.g., one closed, one open).
+        // Priority: OPEN > MERGED > CLOSED. Within the same state, newer (earlier
+        // in the DESC-ordered list) wins because it's inserted first.
         var byBranch: [String: PRNode] = [:]
         for node in nodes {
-            byBranch[node.headRefName] = node
+            if let existing = byBranch[node.headRefName] {
+                // Only replace if the new node has higher priority
+                if Self.prPriority(node.state) > Self.prPriority(existing.state) {
+                    byBranch[node.headRefName] = node
+                }
+            } else {
+                byBranch[node.headRefName] = node
+            }
         }
 
         // Update cache — clear entries for worktrees with no matching PR
@@ -89,6 +99,17 @@ public actor PRStatusManager {
         default:
             if reviewDecision == "CHANGES_REQUESTED" { return .changesRequested }
             return mergeStateStatus == "CLEAN" ? .mergeable : .open
+        }
+    }
+
+    /// Priority for choosing between multiple PRs on the same branch.
+    /// Higher value = preferred.
+    private static func prPriority(_ ghState: String) -> Int {
+        switch ghState {
+        case "OPEN": return 3
+        case "MERGED": return 2
+        case "CLOSED": return 1
+        default: return 0
         }
     }
 

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -66,7 +66,8 @@ struct PRStatusManagerTests {
                     "state": "OPEN",
                     "mergeStateStatus": "CLEAN",
                     "reviewDecision": null,
-                    "headRefName": "tbd/cool-feature"
+                    "headRefName": "tbd/cool-feature",
+                    "createdAt": "2026-03-24T10:00:00Z"
                   },
                   {
                     "number": 7,
@@ -74,7 +75,8 @@ struct PRStatusManagerTests {
                     "state": "MERGED",
                     "mergeStateStatus": "UNKNOWN",
                     "reviewDecision": null,
-                    "headRefName": "tbd/old-feature"
+                    "headRefName": "tbd/old-feature",
+                    "createdAt": "2026-03-20T10:00:00Z"
                   },
                   {
                     "number": 99,
@@ -82,7 +84,8 @@ struct PRStatusManagerTests {
                     "state": "OPEN",
                     "mergeStateStatus": "CLEAN",
                     "reviewDecision": null,
-                    "headRefName": "feature/not-tbd"
+                    "headRefName": "feature/not-tbd",
+                    "createdAt": "2026-03-24T12:00:00Z"
                   }
                 ]
               }


### PR DESCRIPTION
## Summary

The toolbar was showing PR #17 (closed) instead of PR #23 (the current one) for this worktree's branch.

**Root cause:** `fetchAll` queries `viewer.pullRequests` ordered by `CREATED_AT DESC` and builds a `branch → PR` dictionary. When multiple PRs exist for the same branch (e.g., #17 closed, #23 open), the dictionary key gets overwritten — newer PRs appear first in the list but older ones overwrite them, leaving the stale PR cached.

**Fix:** When multiple PRs match the same branch, pick the most relevant one by state priority: OPEN > MERGED > CLOSED. Within the same state, the first one encountered (newest, since the query is DESC) wins.

## Test plan
- [ ] Open a worktree that has had multiple PRs on its branch → toolbar shows the most recent/relevant PR number
- [ ] Close a PR and open a new one on the same branch → status updates to the new PR on next poll
- [ ] 10 PRStatusManager tests pass