### PR TITLE
Fix: Sidebar shows stale branch name after switching branches inside a worktree

### DIFF
--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -198,6 +198,17 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// Update the branch name for a worktree.
+    public func updateBranch(id: UUID, branch: String) async throws {
+        try await writer.write { db in
+            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Worktree not found")
+            }
+            record.branch = branch
+            try record.update(db)
+        }
+    }
+
     /// Update the tmux server name for a worktree.
     public func updateTmuxServer(id: UUID, tmuxServer: String) async throws {
         try await writer.write { db in

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -5,10 +5,23 @@ extension WorktreeLifecycle {
     // MARK: - Git Status
 
     /// Recompute conflict status for all active worktrees in a repo.
+    /// Also detects branch name changes (e.g., `git checkout -b` inside a worktree).
     /// Runs git checks concurrently and updates the DB + broadcasts deltas.
     public func refreshGitStatuses(repoID: UUID) async {
         guard let repo = try? await db.repos.get(id: repoID) else { return }
-        let worktrees = (try? await db.worktrees.list(repoID: repoID, status: .active)) ?? []
+        var worktrees = (try? await db.worktrees.list(repoID: repoID, status: .active)) ?? []
+
+        // Sync branch names: one `git worktree list` call gives us
+        // the current branch for every worktree — update DB if changed.
+        if let gitWorktrees = try? await git.worktreeList(repoPath: repo.path) {
+            let branchByPath = Dictionary(gitWorktrees.map { ($0.path, $0.branch) }, uniquingKeysWith: { _, b in b })
+            for (i, wt) in worktrees.enumerated() {
+                if let gitBranch = branchByPath[wt.path], gitBranch != wt.branch {
+                    try? await db.worktrees.updateBranch(id: wt.id, branch: gitBranch)
+                    worktrees[i].branch = gitBranch  // use updated branch for conflict check below
+                }
+            }
+        }
 
         await withTaskGroup(of: Void.self) { group in
             for wt in worktrees {


### PR DESCRIPTION
## Summary

The sidebar kept showing the original branch name from when a worktree was created, even after `git checkout -b` changed it. This also caused the PR status to track the wrong PR (matched by the stale branch name).

**Root cause:** Branch name was written to the DB at worktree creation and never updated. No periodic check existed to detect changes.

**Fix:** Piggyback on the existing `refreshGitStatuses` cycle — call `git worktree list` once per repo (already a cheap porcelain command), compare each worktree's DB branch to the git-reported branch, and update the DB if they differ. Zero new RPC calls; the app's existing poll picks up the change automatically.

## Test plan
- [ ] Run `git checkout -b new-branch` inside a TBD-managed worktree → sidebar updates branch name within one poll cycle (~30s)
- [ ] PR status re-resolves to the correct PR for the new branch on next PR poll
- [ ] Conflict status uses the updated branch for its check (no stale branch in the merge-base calculation)
- [ ] 143 tests pass (`swift test`)