### PR TITLE
Fix: PR status disappears after batch poll when PR is older than the 100-result window

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -50,7 +50,10 @@ public actor PRStatusManager {
             }
         }
 
-        // Update cache — clear entries for worktrees with no matching PR
+        // Update cache for worktrees found in the batch.
+        // Do NOT clear entries for missing worktrees — the batch query is
+        // limited to 100 PRs across all repos, so older PRs may not appear.
+        // Those entries may have been populated by a targeted `refresh` call.
         for wt in worktrees {
             if let node = byBranch[wt.branch] {
                 cache[wt.id] = PRStatus(
@@ -58,8 +61,6 @@ public actor PRStatusManager {
                     url: node.url,
                     state: Self.mapState(ghState: node.state, mergeStateStatus: node.mergeStateStatus, reviewDecision: node.reviewDecision)
                 )
-            } else {
-                cache.removeValue(forKey: wt.id)
             }
         }
     }


### PR DESCRIPTION
## Summary

Some worktrees (like "bot comments" in longeye-app) have PRs that don't appear in the batch GraphQL query, which fetches the viewer's 100 most recent PRs across all repos. Clicking the worktree triggers a targeted `gh pr view` that finds the PR correctly — but the next batch poll wipes it from the cache because the batch didn't see it.

**Root cause:** `fetchAll` called `cache.removeValue` for any worktree whose branch wasn't in the batch results. This cleared entries that had been populated by the targeted on-select `refresh`.

**Fix:** `fetchAll` now only updates entries it has data for — it never clears entries for missing branches. The on-select `refresh` (which uses `gh pr view`, repo-scoped, no limit) remains the mechanism for finding PRs outside the batch window, and its results now persist.

## Test plan
- [ ] Select a worktree whose PR is older than your 100th most recent PR → PR icon appears
- [ ] Wait for a batch poll cycle (~30s) → PR icon stays (not wiped)
- [ ] Worktrees whose PRs ARE in the batch still update normally
- [ ] 10 PRStatusManager tests pass