### PR TITLE
Fix: Cmd+click on relative file paths opens code viewer instead of crashing

### DIFF
--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -272,7 +272,32 @@ struct TerminalPanelView: NSViewRepresentable {
         func scrolled(source: TerminalView, position: Double) {}
 
         func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {
-            if let url = URL(string: link) { NSWorkspace.shared.open(url) }
+            MainActor.assumeIsolated {
+                // Check if this is a file path (relative or absolute) that we can open in a split pane
+                if let tv = source as? TBDTerminalView, !tv.worktreePath.isEmpty {
+                    let resolvedPath: String
+                    if link.hasPrefix("/") {
+                        resolvedPath = link
+                    } else if link.hasPrefix("file://") {
+                        resolvedPath = URL(string: link)?.path ?? link
+                    } else if !link.contains("://") {
+                        // Relative path — resolve against worktree
+                        resolvedPath = URL(fileURLWithPath: tv.worktreePath).appendingPathComponent(link).path
+                    } else {
+                        // Regular URL — open externally
+                        if let url = URL(string: link) { NSWorkspace.shared.open(url) }
+                        return
+                    }
+
+                    if FileManager.default.fileExists(atPath: resolvedPath) {
+                        tv.onFilePathClicked?(resolvedPath)
+                        return
+                    }
+                }
+
+                // Fallback: open as URL
+                if let url = URL(string: link) { NSWorkspace.shared.open(url) }
+            }
         }
 
         func bell(source: TerminalView) { NSSound.beep() }


### PR DESCRIPTION
## Summary
- Cmd+clicking OSC 8 hyperlinks with relative paths (e.g. Claude Code file output like `docs/specs/design.md`) failed with "The application can't be opened. -50" because `requestOpenLink` passed the raw relative path to `NSWorkspace`
- Now resolves relative paths against the worktree directory and opens them as a code viewer split pane, matching the existing custom cmd+click file extractor behavior
- Absolute paths, `file://` URLs, and regular `https://` URLs still work as before

## Test plan
- [ ] In a terminal pane, have Claude Code output a relative file path (it renders as an OSC 8 hyperlink)
- [ ] Cmd+click the link → should open as a code viewer split pane on the right
- [ ] Cmd+click an absolute path in terminal output → should also open as code viewer
- [ ] Cmd+click a regular URL (https) → should open in browser as before