### PR TITLE
Feat: Add subtle warm glow to icon text so it reads at dock size

### DIFF
--- a/Sources/TBDApp/AppIcon.swift
+++ b/Sources/TBDApp/AppIcon.swift
@@ -189,10 +189,18 @@ private func drawTBDText(ctx: CGContext, size: CGFloat) {
     let x = (size - bounds.width) / 2 - bounds.origin.x
     let y = (size - bounds.height) / 2 - bounds.origin.y
 
-    ctx.setShadow(offset: CGSize(width: 0, height: -size * 0.010),
-                   blur: size * 0.025,
-                   color: CGColor(red: 0, green: 0, blue: 0, alpha: 0.45))
+    // Soft glow: draw text multiple times with zero-offset shadow (= glow)
+    for _ in 0..<3 {
+        ctx.saveGState()
+        ctx.setShadow(offset: .zero,
+                       blur: size * 0.095,
+                       color: CGColor(red: 0.35, green: 0.12, blue: 0.06, alpha: 0.04))
+        ctx.textPosition = CGPoint(x: x, y: y)
+        CTLineDraw(line, ctx)
+        ctx.restoreGState()
+    }
 
+    // Crisp white text on top
     ctx.textPosition = CGPoint(x: x, y: y)
     CTLineDraw(line, ctx)
 


### PR DESCRIPTION
## Summary

- White text on the warm orange/yellow/green panels was hard to read at dock size (~48px)
- Replaces the old black drop shadow with a soft warm glow — 3 stacked passes of zero-offset shadow with dark reddish tint (0.04 alpha, 0.095 blur radius)
- The glow subtly darkens the background around each letter without being visually heavy, then crisp white text draws on top

## Test plan

- [ ] Build and run, verify icon looks good in the dock at normal size
- [ ] Verify text is readable at 32px and 16px sizes
- [ ] Compare with the previous icon (just a black drop shadow) — should be a subtle improvement, not a dramatic change