### PR TITLE
Feat: Enable Claude Code agent team pane switching inside TBD terminals

### DIFF
--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -77,6 +77,11 @@ class TBDTerminalView: TerminalView {
     private func handleClickPassthrough(at point: CGPoint) {
         // If this was a click (not a drag) and tmux has mouse mode enabled,
         // forward the click to tmux so it can handle pane switching.
+        //
+        // This won't produce duplicate events: allowMouseReporting is set to
+        // false in TerminalPanelView, so SwiftTerm's mouseDown/mouseUp only
+        // handle local text selection — they never forward to the pty.
+        // We are the sole path that sends mouse events to tmux.
         let term = getTerminal()
         guard !didDrag && term.mouseMode != .off else { return }
 

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -24,7 +24,7 @@ class TBDTerminalView: TerminalView {
     private static let dragThreshold: CGFloat = 3.0
     nonisolated(unsafe) private var mouseMonitor: Any?
 
-    func installMouseMonitor() {
+    private func installMouseMonitor() {
         guard mouseMonitor == nil else { return }
         mouseMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp]) { [weak self] event in
             guard let self = self else { return event }
@@ -52,7 +52,7 @@ class TBDTerminalView: TerminalView {
         }
     }
 
-    func removeMouseMonitor() {
+    private func removeMouseMonitor() {
         if let monitor = mouseMonitor {
             NSEvent.removeMonitor(monitor)
             mouseMonitor = nil

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -9,6 +9,95 @@ class TBDTerminalView: TerminalView {
     var onFilePathClicked: ((String) -> Void)?
     var worktreePath: String = ""
 
+    // MARK: - Mouse click pass-through
+    // Track mouseDown position to distinguish clicks from drags.
+    // Single clicks are forwarded to tmux for pane switching;
+    // click-drags are handled locally by SwiftTerm for text selection.
+    //
+    // Because SwiftTerm's TerminalView declares its mouse overrides as
+    // `public` (not `open`), we cannot override them from another module.
+    // Instead we install a local event monitor that observes mouseDown /
+    // mouseDragged / mouseUp and forwards clicks after SwiftTerm has
+    // already processed them.
+    private var mouseDownLocation: CGPoint = .zero
+    private var didDrag: Bool = false
+    private static let dragThreshold: CGFloat = 3.0
+    nonisolated(unsafe) private var mouseMonitor: Any?
+
+    func installMouseMonitor() {
+        guard mouseMonitor == nil else { return }
+        mouseMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp]) { [weak self] event in
+            guard let self = self else { return event }
+            // Only handle events that target this view
+            guard let eventWindow = event.window, eventWindow == self.window else { return event }
+            let locationInSelf = self.convert(event.locationInWindow, from: nil)
+            guard self.bounds.contains(locationInSelf) else { return event }
+
+            switch event.type {
+            case .leftMouseDown:
+                self.mouseDownLocation = locationInSelf
+                self.didDrag = false
+            case .leftMouseDragged:
+                let dx = locationInSelf.x - self.mouseDownLocation.x
+                let dy = locationInSelf.y - self.mouseDownLocation.y
+                if sqrt(dx * dx + dy * dy) > Self.dragThreshold {
+                    self.didDrag = true
+                }
+            case .leftMouseUp:
+                self.handleClickPassthrough(at: locationInSelf)
+            default:
+                break
+            }
+            return event  // always pass the event through
+        }
+    }
+
+    func removeMouseMonitor() {
+        if let monitor = mouseMonitor {
+            NSEvent.removeMonitor(monitor)
+            mouseMonitor = nil
+        }
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            installMouseMonitor()
+        } else {
+            removeMouseMonitor()
+        }
+    }
+
+    deinit {
+        if let monitor = mouseMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+
+    private func handleClickPassthrough(at point: CGPoint) {
+        // If this was a click (not a drag) and tmux has mouse mode enabled,
+        // forward the click to tmux so it can handle pane switching.
+        let term = getTerminal()
+        guard !didDrag && term.mouseMode != .off else { return }
+
+        let charWidth = bounds.width / CGFloat(term.cols)
+        let lineHeight = bounds.height / CGFloat(term.rows)
+        let col = Int(point.x / charWidth)
+        let row = Int((bounds.height - point.y) / lineHeight)
+
+        let pressFlags = term.encodeButton(
+            button: 0, release: false,
+            shift: false, meta: false, control: false
+        )
+        term.sendEvent(buttonFlags: pressFlags, x: col, y: row)
+
+        let releaseFlags = term.encodeButton(
+            button: 0, release: true,
+            shift: false, meta: false, control: false
+        )
+        term.sendEvent(buttonFlags: releaseFlags, x: col, y: row)
+    }
+
     /// Extracts a file path from the terminal buffer at the given window-coordinate point.
     func extractFilePath(atWindowLocation windowPoint: CGPoint) -> String? {
         let localPoint = convert(windowPoint, from: nil)

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -93,6 +93,8 @@ public struct TmuxManager: Sendable {
             try? await runTmux(["-L", server, "set", "-g", "pane-border-style", "fg=black"])
             // Enable mouse so scroll wheel enters copy-mode and scrolls history
             try? await runTmux(["-L", server, "set", "-g", "mouse", "on"])
+            // Enable extended key sequences so Shift+Arrow etc. pass through to applications
+            try? await runTmux(["-L", server, "set", "-g", "xterm-keys", "on"])
             // Set SSH_AUTH_SOCK to stable symlink so shells get a resilient path
             try? await runTmux(["-L", server, "setenv", "-g", "SSH_AUTH_SOCK", SSHAgentResolver.defaultSymlinkPath])
             return output.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/docs/superpowers/plans/2026-03-26-tmux-input-passthrough.md
+++ b/docs/superpowers/plans/2026-03-26-tmux-input-passthrough.md
@@ -1,0 +1,155 @@
+# Tmux Input Pass-Through Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable Claude Code agent team pane switching inside TBD's terminal by forwarding mouse clicks and Shift+Arrow keys through to tmux.
+
+**Architecture:** Two independent changes — (1) override mouse events in TBDTerminalView to forward single clicks to tmux while preserving drag-to-select, (2) add `xterm-keys on` to tmux server config for Shift+Arrow pass-through.
+
+**Tech Stack:** Swift, SwiftTerm (TerminalView subclass), tmux CLI
+
+---
+
+### Task 1: Add xterm-keys to tmux server config
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Tmux/TmuxManager.swift:95` (after `mouse on` line)
+
+- [ ] **Step 1: Add xterm-keys setting**
+
+In `TmuxManager.swift`, inside `ensureServer()`, add this line after the `mouse on` setting (line 95):
+
+```swift
+// Enable extended key sequences so Shift+Arrow etc. pass through to applications
+try? await runTmux(["-L", server, "set", "-g", "xterm-keys", "on"])
+```
+
+The full block (lines 91-98) should read:
+
+```swift
+// Hide tmux chrome globally — TBD app provides its own UI
+try? await runTmux(["-L", server, "set", "-g", "status", "off"])
+try? await runTmux(["-L", server, "set", "-g", "pane-border-style", "fg=black"])
+// Enable mouse so scroll wheel enters copy-mode and scrolls history
+try? await runTmux(["-L", server, "set", "-g", "mouse", "on"])
+// Enable extended key sequences so Shift+Arrow etc. pass through to applications
+try? await runTmux(["-L", server, "set", "-g", "xterm-keys", "on"])
+// Set SSH_AUTH_SOCK to stable symlink so shells get a resilient path
+try? await runTmux(["-L", server, "setenv", "-g", "SSH_AUTH_SOCK", SSHAgentResolver.defaultSymlinkPath])
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run tests**
+
+Run: `swift test --filter TmuxManagerTests 2>&1 | tail -10`
+Expected: All tests pass (dry-run tests don't execute tmux commands, so the new line has no effect on them).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDDaemon/Tmux/TmuxManager.swift
+git commit -m "feat: enable xterm-keys in tmux for Shift+Arrow pass-through"
+```
+
+---
+
+### Task 2: Add mouse click pass-through to TBDTerminalView
+
+**Files:**
+- Modify: `Sources/TBDApp/Terminal/TBDTerminalView.swift` (add mouse overrides after `performKeyEquivalent`)
+
+- [ ] **Step 1: Add drag-tracking state properties**
+
+Add these properties after the existing `worktreePath` property (line 10), before `extractFilePath`:
+
+```swift
+// MARK: - Mouse click pass-through
+// Track mouseDown position to distinguish clicks from drags.
+// Single clicks are forwarded to tmux for pane switching;
+// click-drags are handled locally by SwiftTerm for text selection.
+private var mouseDownLocation: CGPoint = .zero
+private var didDrag: Bool = false
+private static let dragThreshold: CGFloat = 3.0
+```
+
+- [ ] **Step 2: Add mouseDown override**
+
+Add after the closing brace of `handleNaturalTextEditing` (after line 123), before the final class closing brace:
+
+```swift
+override func mouseDown(with event: NSEvent) {
+    mouseDownLocation = convert(event.locationInWindow, from: nil)
+    didDrag = false
+    super.mouseDown(with: event)
+}
+```
+
+- [ ] **Step 3: Add mouseDragged override**
+
+Add immediately after `mouseDown`:
+
+```swift
+override func mouseDragged(with event: NSEvent) {
+    let current = convert(event.locationInWindow, from: nil)
+    let dx = current.x - mouseDownLocation.x
+    let dy = current.y - mouseDownLocation.y
+    if sqrt(dx * dx + dy * dy) > Self.dragThreshold {
+        didDrag = true
+    }
+    super.mouseDragged(with: event)
+}
+```
+
+- [ ] **Step 4: Add mouseUp override**
+
+Add immediately after `mouseDragged`:
+
+```swift
+override func mouseUp(with event: NSEvent) {
+    // If this was a click (not a drag) and tmux has mouse mode enabled,
+    // forward the click to tmux so it can handle pane switching.
+    if !didDrag && terminal.mouseMode != .off {
+        let point = convert(event.locationInWindow, from: nil)
+        let charWidth = bounds.width / CGFloat(terminal.cols)
+        let lineHeight = bounds.height / CGFloat(terminal.rows)
+        let col = Int(point.x / charWidth)
+        let row = Int((bounds.height - point.y) / lineHeight)
+
+        let pressFlags = terminal.encodeButton(
+            button: 0, release: false,
+            shift: false, meta: false, control: false
+        )
+        terminal.sendEvent(buttonFlags: pressFlags, x: col, y: row)
+
+        let releaseFlags = terminal.encodeButton(
+            button: 0, release: true,
+            shift: false, meta: false, control: false
+        )
+        terminal.sendEvent(buttonFlags: releaseFlags, x: col, y: row)
+    }
+    super.mouseUp(with: event)
+}
+```
+
+Key details:
+- `button: 0` is left mouse button in SwiftTerm's encoding
+- `release: false` for press, `release: true` for release
+- Grid position uses the same math as `extractFilePath` — `bounds.width / terminal.cols` for cell width, flipped Y axis via `bounds.height - point.y`
+- `terminal.mouseMode` is set by tmux when `mouse on` is configured (already done in TmuxManager)
+- `super.mouseUp()` is always called so SwiftTerm still handles link detection etc.
+
+- [ ] **Step 5: Build to verify**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDApp/Terminal/TBDTerminalView.swift
+git commit -m "feat: forward single clicks to tmux for pane switching"
+```

--- a/docs/superpowers/specs/2026-03-26-tmux-input-passthrough-design.md
+++ b/docs/superpowers/specs/2026-03-26-tmux-input-passthrough-design.md
@@ -1,0 +1,39 @@
+# Tmux Input Pass-Through for Agent Teams
+
+## Problem
+
+Claude Code's agent teams feature doesn't work properly inside TBD's terminal. When Claude Code spawns split-pane teammates, users can't switch between panes because:
+
+1. **Mouse clicks** don't reach tmux — `allowMouseReporting = false` in SwiftTerm causes all clicks to be handled locally for text selection, so tmux never receives click events to switch pane focus.
+2. **Shift+Arrow keys** are stripped — tmux isn't configured with `xterm-keys on`, so extended key sequences lose their shift modifier before reaching applications.
+
+## Design
+
+### Mouse Click Pass-Through
+
+Override mouse event handling in `TBDTerminalView` to distinguish clicks from drags:
+
+- **Click (no drag):** Forward to tmux as a mouse press+release event so tmux can handle pane switching.
+- **Click-drag:** Let SwiftTerm handle it locally for text selection (existing behavior).
+
+**Implementation:**
+
+1. Override `mouseDown` — record the click position, call `super.mouseDown()`.
+2. Override `mouseDragged` — set a `didDrag` flag when mouse moves beyond a ~3px threshold from the initial click position.
+3. Override `mouseUp` — if `didDrag` is false and `terminal.mouseMode != .off`, compute the grid position and send press+release mouse events to tmux via `terminal.encodeButton()` + `terminal.sendEvent()`. Always call `super.mouseUp()`.
+
+Grid position is computed the same way `extractFilePath` already does: `bounds.width / terminal.cols` for cell width, `bounds.height / terminal.rows` for cell height.
+
+The key SwiftTerm APIs used are all public:
+- `terminal.encodeButton(button:release:shift:meta:control:)` — encodes mouse button flags
+- `terminal.sendEvent(buttonFlags:x:y:)` — sends the escape sequence to the PTY
+- `terminal.mouseMode` — checks if tmux has mouse reporting enabled
+
+### Shift+Arrow Key Pass-Through
+
+Add `set -g xterm-keys on` to the tmux server configuration in `TmuxManager.ensureServer()`, alongside the existing global settings (`mouse on`, `status off`). This tells tmux to pass through extended xterm key sequences including Shift+Up/Down.
+
+## Files Changed
+
+1. **`Sources/TBDApp/Terminal/TBDTerminalView.swift`** — Add `mouseDown`, `mouseUp`, `mouseDragged` overrides.
+2. **`Sources/TBDDaemon/Tmux/TmuxManager.swift`** — Add `set -g xterm-keys on` in `ensureServer()`.


### PR DESCRIPTION
## Summary
- Claude Code agent teams spawn tmux split panes for teammates, but mouse clicks and Shift+Arrow keys weren't reaching tmux — users got stuck in one pane with no way to navigate
- Forward single mouse clicks to tmux for pane switching while preserving click-drag text selection (uses NSEvent monitor since SwiftTerm's mouse methods aren't `open`)
- Enable `xterm-keys on` in tmux server config so Shift+Up/Down pass through for in-process teammate cycling

## Test plan
- [ ] Restart TBD and kill existing tmux servers so new config takes effect
- [ ] Spawn a Claude Code agent team with 2+ teammates in split-pane mode
- [ ] Verify clicking on a teammate's pane switches focus to it
- [ ] Verify click-drag still selects text locally (not forwarded to tmux)
- [ ] Verify Shift+Up/Down cycles between teammates