### PR TITLE
Feat: Pin worktrees and terminal panes for persistent split view across sessions

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -55,4 +55,21 @@ extension AppState {
             handleConnectionError(error)
         }
     }
+
+    /// Toggle pin state for a terminal.
+    func setTerminalPin(id: UUID, pinned: Bool) async {
+        // Optimistic local update
+        for worktreeID in terminals.keys {
+            if let idx = terminals[worktreeID]?.firstIndex(where: { $0.id == id }) {
+                terminals[worktreeID]?[idx].pinnedAt = pinned ? Date() : nil
+            }
+        }
+
+        do {
+            try await daemonClient.setTerminalPin(id: id, pinned: pinned)
+        } catch {
+            logger.error("Failed to set terminal pin: \(error)")
+            handleConnectionError(error)
+        }
+    }
 }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -99,6 +99,61 @@ extension AppState {
         }
     }
 
+    /// Toggle pin state for a worktree.
+    func setWorktreePin(id: UUID, pinned: Bool) async {
+        // Optimistic local update
+        for repoID in worktrees.keys {
+            if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == id }) {
+                worktrees[repoID]?[idx].pinnedAt = pinned ? Date() : nil
+            }
+        }
+
+        if pinned {
+            // Add to selection if not already there
+            if !selectedWorktreeIDs.contains(id) {
+                selectedWorktreeIDs.insert(id)
+            }
+        }
+        // Rebuild order: pinned first (by pinnedAt), then unpinned in existing order
+        rebuildSelectionOrder()
+
+        do {
+            try await daemonClient.setWorktreePin(id: id, pinned: pinned)
+        } catch {
+            logger.error("Failed to set pin: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
+    /// Rebuild selectionOrder from selectedWorktreeIDs, putting pinned items first (by pinnedAt).
+    func rebuildSelectionOrder() {
+        let allWts = worktrees.values.flatMap { $0 }
+        let wtMap = Dictionary(uniqueKeysWithValues: allWts.map { ($0.id, $0) })
+
+        let selected = selectedWorktreeIDs
+        var pinned: [(UUID, Date)] = []
+        var unpinned: [UUID] = []
+
+        for id in selectionOrder where selected.contains(id) {
+            if let wt = wtMap[id], let pinnedAt = wt.pinnedAt {
+                pinned.append((id, pinnedAt))
+            } else {
+                unpinned.append(id)
+            }
+        }
+        // Add any selected IDs not yet in selectionOrder
+        for id in selected where !selectionOrder.contains(id) {
+            if let wt = wtMap[id], let pinnedAt = wt.pinnedAt {
+                pinned.append((id, pinnedAt))
+            } else {
+                unpinned.append(id)
+            }
+        }
+
+        pinned.sort { $0.1 < $1.1 }
+        selectionOrder = pinned.map(\.0) + unpinned
+    }
+
     // MARK: - Keyboard Shortcut Actions
 
     /// All worktrees in sidebar order (sorted by repo, then by creation date).

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -11,7 +11,19 @@ final class AppState: ObservableObject {
     @Published var worktrees: [UUID: [Worktree]] = [:]
     @Published var terminals: [UUID: [Terminal]] = [:]
     @Published var notifications: [UUID: NotificationType?] = [:]
-    @Published var selectedWorktreeIDs: Set<UUID> = []
+    @Published var selectedWorktreeIDs: Set<UUID> = [] {
+        didSet {
+            // Remove deselected items from order
+            selectionOrder.removeAll { !selectedWorktreeIDs.contains($0) }
+            // Append newly selected items (maintains insertion order for cmd+click)
+            for id in selectedWorktreeIDs where !selectionOrder.contains(id) {
+                selectionOrder.append(id)
+            }
+        }
+    }
+    /// Tracks the order of selected worktrees for split view rendering.
+    /// Pinned worktrees come first (sorted by pinnedAt), then cmd+clicked ones in click order.
+    @Published var selectionOrder: [UUID] = []
     @Published var isConnected: Bool = false
     @Published var layouts: [UUID: LayoutNode] = [:] {
         didSet { persistLayouts() }
@@ -96,6 +108,14 @@ final class AppState: ObservableObject {
         isConnected = didConnect
         if didConnect {
             await refreshAll()
+            // Auto-select pinned worktrees on launch
+            let pinnedWts = worktrees.values.flatMap { $0 }
+                .filter { $0.pinnedAt != nil }
+                .sorted { ($0.pinnedAt ?? .distantPast) < ($1.pinnedAt ?? .distantPast) }
+            if !pinnedWts.isEmpty {
+                selectedWorktreeIDs = Set(pinnedWts.map(\.id))
+                selectionOrder = pinnedWts.map(\.id)
+            }
             await refreshPRStatuses()
         } else {
             logger.warning("Could not connect to daemon — is tbdd running?")

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -64,7 +64,7 @@ final class AppState: ObservableObject {
     init() {
         restoreLayouts()
         if let saved = UserDefaults.standard.object(forKey: Self.dockRatioKey) as? Double {
-            dockRatio = CGFloat(saved)
+            dockRatio = max(0.1, min(0.6, CGFloat(saved)))
         }
         Task {
             await connectAndLoadInitialState()

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -24,6 +24,17 @@ final class AppState: ObservableObject {
     /// Tracks the order of selected worktrees for split view rendering.
     /// Pinned worktrees come first (sorted by pinnedAt), then cmd+clicked ones in click order.
     @Published var selectionOrder: [UUID] = []
+
+    /// All pinned terminals across all worktrees, sorted by pinnedAt.
+    var pinnedTerminals: [Terminal] {
+        terminals.values.flatMap { $0 }
+            .filter { $0.pinnedAt != nil }
+            .sorted { ($0.pinnedAt ?? .distantPast) < ($1.pinnedAt ?? .distantPast) }
+    }
+
+    @Published var dockRatio: CGFloat = 0.3 {
+        didSet { UserDefaults.standard.set(Double(dockRatio), forKey: Self.dockRatioKey) }
+    }
     @Published var isConnected: Bool = false
     @Published var layouts: [UUID: LayoutNode] = [:] {
         didSet { persistLayouts() }
@@ -48,9 +59,13 @@ final class AppState: ObservableObject {
     private var pollCycle = 0
 
     private static let layoutsKey = "com.tbd.app.layouts"
+    private static let dockRatioKey = "com.tbd.app.dockRatio"
 
     init() {
         restoreLayouts()
+        if let saved = UserDefaults.standard.object(forKey: Self.dockRatioKey) as? Double {
+            dockRatio = CGFloat(saved)
+        }
         Task {
             await connectAndLoadInitialState()
             startPolling()

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -345,6 +345,14 @@ actor DaemonClient {
         )
     }
 
+    /// Set or clear the pin on a terminal.
+    func setTerminalPin(id: UUID, pinned: Bool) throws {
+        try callVoid(
+            method: RPCMethod.terminalSetPin,
+            params: TerminalSetPinParams(terminalID: id, pinned: pinned)
+        )
+    }
+
     /// Create a terminal in a worktree.
     func createTerminal(worktreeID: UUID, cmd: String? = nil) throws -> Terminal {
         return try call(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -337,6 +337,14 @@ actor DaemonClient {
         )
     }
 
+    /// Set or clear the pin on a worktree.
+    func setWorktreePin(id: UUID, pinned: Bool) throws {
+        try callVoid(
+            method: RPCMethod.worktreeSetPin,
+            params: WorktreeSetPinParams(worktreeID: id, pinned: pinned)
+        )
+    }
+
     /// Create a terminal in a worktree.
     func createTerminal(worktreeID: UUID, cmd: String? = nil) throws -> Terminal {
         return try call(

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -10,6 +10,7 @@ struct PanePlaceholder: View {
     let worktree: Worktree
     @Binding var layout: LayoutNode
     @EnvironmentObject var appState: AppState
+    @State private var isHeaderHovering = false
 
     /// Find the Terminal model matching a terminal ID across all worktree terminals.
     private func terminal(for id: UUID) -> Terminal? {
@@ -59,13 +60,36 @@ struct PanePlaceholder: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Color(nsColor: .controlBackgroundColor))
+        .onHover { hovering in
+            isHeaderHovering = hovering
+        }
     }
 
     @ViewBuilder
     private var paneLabel: some View {
         switch content {
         case .terminal(let terminalID):
-            Text("Terminal: \(terminalID.uuidString.prefix(8))")
+            let term = terminal(for: terminalID)
+            let isPinned = term?.pinnedAt != nil
+            HStack(spacing: 4) {
+                if isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 10)
+                        .onTapGesture {
+                            Task { await appState.setTerminalPin(id: terminalID, pinned: false) }
+                        }
+                } else if isHeaderHovering {
+                    Image(systemName: "pin")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 10)
+                        .onTapGesture {
+                            Task { await appState.setTerminalPin(id: terminalID, pinned: true) }
+                        }
+                }
+            }
         case .webview(_, let url):
             Text(url.host ?? url.absoluteString)
         case .codeViewer(_, let path):

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -11,6 +11,16 @@ struct SidebarContextMenu: View {
         Group {
             if worktree.status == .main || worktree.status == .creating {
                 // Main / creating worktree: only Finder and Copy Path (no rename/archive)
+                Button(worktree.pinnedAt != nil ? "Unpin" : "Pin") {
+                    let wtID = worktree.id
+                    let shouldPin = worktree.pinnedAt == nil
+                    Task {
+                        await appState.setWorktreePin(id: wtID, pinned: shouldPin)
+                    }
+                }
+
+                Divider()
+
                 if !worktree.path.isEmpty {
                     Button("Open in Finder") {
                         NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.path)
@@ -24,6 +34,14 @@ struct SidebarContextMenu: View {
             } else {
                 Button("Rename...") {
                     onRename()
+                }
+
+                Button(worktree.pinnedAt != nil ? "Unpin" : "Pin") {
+                    let wtID = worktree.id
+                    let shouldPin = worktree.pinnedAt == nil
+                    Task {
+                        await appState.setWorktreePin(id: wtID, pinned: shouldPin)
+                    }
                 }
 
                 Button("Archive", role: .destructive) {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -178,7 +178,10 @@ struct WorktreeRowView: View {
         .onTapGesture {
             if NSEvent.modifierFlags.contains(.command) {
                 if appState.selectedWorktreeIDs.contains(worktree.id) {
-                    appState.selectedWorktreeIDs.remove(worktree.id)
+                    // Don't allow cmd+click removal of pinned worktrees
+                    if worktree.pinnedAt == nil {
+                        appState.selectedWorktreeIDs.remove(worktree.id)
+                    }
                 } else {
                     appState.selectedWorktreeIDs.insert(worktree.id)
                 }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -13,6 +13,7 @@ struct WorktreeRowView: View {
     @State private var emojiSelectedIndex = 0
     @State private var frecency = EmojiFrecency.load()
     @State private var isNameTruncated = false
+    @State private var isHovering = false
 
     private var isPending: Bool {
         worktree.status == .creating
@@ -80,6 +81,29 @@ struct WorktreeRowView: View {
     }
 
     @ViewBuilder
+    private func pinIcon() -> some View {
+        if worktree.pinnedAt != nil {
+            Image(systemName: "pin.fill")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .frame(width: 10)
+                .onTapGesture {
+                    Task { await appState.setWorktreePin(id: worktree.id, pinned: false) }
+                }
+        } else if isHovering {
+            Image(systemName: "pin")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .frame(width: 10)
+                .onTapGesture {
+                    Task { await appState.setWorktreePin(id: worktree.id, pinned: true) }
+                }
+        } else {
+            Color.clear.frame(width: 10)
+        }
+    }
+
+    @ViewBuilder
     private func rowIcons() -> some View {
         if isMain {
             Image(systemName: "arrow.triangle.branch")
@@ -106,6 +130,7 @@ struct WorktreeRowView: View {
 
     var body: some View {
         HStack(spacing: 6) {
+            pinIcon()
             rowIcons()
             if isEditing {
                 InlineTextField(
@@ -175,6 +200,9 @@ struct WorktreeRowView: View {
             }
         }
         .contentShape(Rectangle())
+        .onHover { hovering in
+            isHovering = hovering
+        }
         .onTapGesture {
             if NSEvent.modifierFlags.contains(.command) {
                 if appState.selectedWorktreeIDs.contains(worktree.id) {
@@ -202,6 +230,7 @@ struct WorktreeRowView: View {
             }
         ) {
             HStack(spacing: 6) {
+                pinIcon()
                 rowIcons()
                 Text(worktree.displayName)
                     .fontWeight(hasBoldNotification ? .bold : .regular)

--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import TBDShared
+
+/// A vertical dock showing pinned terminals from worktrees not currently visible.
+/// Each pinned terminal gets a cell with a header (pin icon + worktree name) and the terminal view.
+struct PinnedTerminalDock: View {
+    let terminals: [Terminal]
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        VStack(spacing: 1) {
+            ForEach(terminals) { terminal in
+                PinnedTerminalCell(terminal: terminal)
+            }
+        }
+        .background(Color(nsColor: .separatorColor))
+    }
+}
+
+/// A single cell in the pinned terminal dock.
+private struct PinnedTerminalCell: View {
+    let terminal: Terminal
+    @EnvironmentObject var appState: AppState
+
+    private var worktree: Worktree? {
+        for wts in appState.worktrees.values {
+            if let wt = wts.first(where: { $0.id == terminal.worktreeID }) {
+                return wt
+            }
+        }
+        return nil
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header: pin icon + worktree name
+            HStack(spacing: 4) {
+                Image(systemName: "pin.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 10)
+                    .onTapGesture {
+                        Task { await appState.setTerminalPin(id: terminal.id, pinned: false) }
+                    }
+                if let worktree {
+                    Text(worktree.displayName)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color(nsColor: .controlBackgroundColor))
+
+            Divider()
+
+            // Terminal content
+            if let worktree {
+                TerminalPanelView(
+                    terminalID: terminal.id,
+                    tmuxServer: worktree.tmuxServer,
+                    tmuxWindowID: terminal.tmuxWindowID,
+                    tmuxBridge: appState.tmuxBridge,
+                    worktreePath: worktree.path
+                )
+                .id(terminal.id)
+            } else {
+                ZStack {
+                    Color(nsColor: .textBackgroundColor)
+                    Text("Loading...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -17,7 +17,7 @@ struct TerminalContainerView: View {
            let worktreeID = appState.selectedWorktreeIDs.first {
             SingleWorktreeView(worktreeID: worktreeID)
         } else if appState.selectedWorktreeIDs.count > 1 {
-            MultiWorktreeView(worktreeIDs: Array(appState.selectedWorktreeIDs))
+            MultiWorktreeView(worktreeIDs: appState.selectionOrder)
         } else {
             Text("Select a worktree or click + to create one")
                 .foregroundStyle(.secondary)

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -13,14 +13,31 @@ struct TerminalContainerView: View {
     @EnvironmentObject var appState: AppState
 
     var body: some View {
-        if appState.selectedWorktreeIDs.count == 1,
-           let worktreeID = appState.selectedWorktreeIDs.first {
-            SingleWorktreeView(worktreeID: worktreeID)
-        } else if appState.selectedWorktreeIDs.count > 1 {
-            MultiWorktreeView(worktreeIDs: appState.selectionOrder)
+        let visibleWorktreeIDs = appState.selectedWorktreeIDs
+        let dockTerminals = appState.pinnedTerminals.filter { terminal in
+            !visibleWorktreeIDs.contains(terminal.worktreeID)
+        }
+
+        let mainContent = Group {
+            if appState.selectedWorktreeIDs.count == 1,
+               let worktreeID = appState.selectedWorktreeIDs.first {
+                SingleWorktreeView(worktreeID: worktreeID)
+            } else if appState.selectedWorktreeIDs.count > 1 {
+                MultiWorktreeView(worktreeIDs: appState.selectionOrder)
+            } else {
+                Text("Select a worktree or click + to create one")
+                    .foregroundStyle(.secondary)
+            }
+        }
+
+        if dockTerminals.isEmpty {
+            mainContent
         } else {
-            Text("Select a worktree or click + to create one")
-                .foregroundStyle(.secondary)
+            DockSplitView(
+                dockRatio: $appState.dockRatio,
+                mainContent: { mainContent },
+                dockContent: { PinnedTerminalDock(terminals: dockTerminals) }
+            )
         }
     }
 }
@@ -277,6 +294,63 @@ private struct MultiWorktreeCell: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+            }
+        }
+    }
+}
+
+// MARK: - DockSplitView
+
+/// A horizontal split between main content (left) and pinned terminal dock (right).
+/// The divider is draggable to resize the dock.
+private struct DockSplitView<Main: View, Dock: View>: View {
+    @Binding var dockRatio: CGFloat
+    @ViewBuilder let mainContent: () -> Main
+    @ViewBuilder let dockContent: () -> Dock
+
+    @State private var dragStartRatio: CGFloat?
+
+    var body: some View {
+        GeometryReader { geometry in
+            let totalWidth = geometry.size.width
+            let dividerWidth: CGFloat = 4
+            let available = totalWidth - dividerWidth
+            let dockWidth = available * dockRatio
+            let mainWidth = available - dockWidth
+
+            HStack(spacing: 0) {
+                mainContent()
+                    .frame(width: mainWidth)
+
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(width: dividerWidth)
+                    .contentShape(Rectangle())
+                    .onHover { hovering in
+                        if hovering {
+                            NSCursor.resizeLeftRight.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                if dragStartRatio == nil {
+                                    dragStartRatio = dockRatio
+                                }
+                                guard let startRatio = dragStartRatio, available > 0 else { return }
+                                let delta = -value.translation.width / available
+                                let newRatio = max(0.1, min(0.6, startRatio + delta))
+                                dockRatio = newRatio
+                            }
+                            .onEnded { _ in
+                                dragStartRatio = nil
+                            }
+                    )
+
+                dockContent()
+                    .frame(width: dockWidth)
             }
         }
     }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -102,6 +102,12 @@ public final class TBDDatabase: Sendable {
             try db.execute(sql: "UPDATE worktree SET hasConflicts = (gitStatus = 'conflicts')")
         }
 
+        migrator.registerMigration("v4") { db in
+            try db.alter(table: "worktree") { t in
+                t.add(column: "pinnedAt", .datetime)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -108,6 +108,12 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v5") { db in
+            try db.alter(table: "terminal") { t in
+                t.add(column: "pinnedAt", .datetime)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -100,12 +100,12 @@ public struct TerminalStore: Sendable {
     }
 
     /// Set or clear the pinned timestamp for a terminal.
-    public func setPin(id: UUID, pinned: Bool) async throws {
+    public func setPin(id: UUID, pinned: Bool, at date: Date = Date()) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
-            record.pinnedAt = pinned ? Date() : nil
+            record.pinnedAt = pinned ? date : nil
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -12,6 +12,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var tmuxPaneID: String
     var label: String?
     var createdAt: Date
+    var pinnedAt: Date?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -20,6 +21,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.tmuxPaneID = terminal.tmuxPaneID
         self.label = terminal.label
         self.createdAt = terminal.createdAt
+        self.pinnedAt = terminal.pinnedAt
     }
 
     func toModel() -> Terminal {
@@ -29,7 +31,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             tmuxWindowID: tmuxWindowID,
             tmuxPaneID: tmuxPaneID,
             label: label,
-            createdAt: createdAt
+            createdAt: createdAt,
+            pinnedAt: pinnedAt
         )
     }
 }
@@ -93,6 +96,17 @@ public struct TerminalStore: Sendable {
             try TerminalRecord
                 .filter(Column("worktreeID") == worktreeID.uuidString)
                 .deleteAll(db)
+        }
+    }
+
+    /// Set or clear the pinned timestamp for a terminal.
+    public func setPin(id: UUID, pinned: Bool) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.pinnedAt = pinned ? Date() : nil
+            try record.update(db)
         }
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -163,6 +163,7 @@ public struct WorktreeStore: Sendable {
             }
             record.status = WorktreeStatus.archived.rawValue
             record.archivedAt = Date()
+            record.pinnedAt = nil
             try record.update(db)
         }
     }
@@ -234,12 +235,12 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Set or clear the pinned timestamp for a worktree.
-    public func setPin(id: UUID, pinned: Bool) async throws {
+    public func setPin(id: UUID, pinned: Bool, at date: Date = Date()) async throws {
         try await writer.write { db in
             guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Worktree not found")
             }
-            record.pinnedAt = pinned ? Date() : nil
+            record.pinnedAt = pinned ? date : nil
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -16,6 +16,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var hasConflicts: Bool
     var createdAt: Date
     var archivedAt: Date?
+    var pinnedAt: Date?
     var tmuxServer: String
 
     init(from wt: Worktree) {
@@ -29,6 +30,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.hasConflicts = wt.hasConflicts
         self.createdAt = wt.createdAt
         self.archivedAt = wt.archivedAt
+        self.pinnedAt = wt.pinnedAt
         self.tmuxServer = wt.tmuxServer
     }
 
@@ -44,6 +46,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             hasConflicts: hasConflicts,
             createdAt: createdAt,
             archivedAt: archivedAt,
+            pinnedAt: pinnedAt,
             tmuxServer: tmuxServer
         )
     }
@@ -227,6 +230,17 @@ public struct WorktreeStore: Sendable {
                 .filter(Column("path") == path)
                 .fetchOne(db)?
                 .toModel()
+        }
+    }
+
+    /// Set or clear the pinned timestamp for a worktree.
+    public func setPin(id: UUID, pinned: Bool) async throws {
+        try await writer.write { db in
+            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Worktree not found")
+            }
+            record.pinnedAt = pinned ? Date() : nil
+            try record.update(db)
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -74,9 +74,10 @@ extension RPCRouter {
     func handleTerminalSetPin(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSetPinParams.self, from: paramsData)
         try await db.terminals.setPin(id: params.terminalID, pinned: params.pinned)
-        let terminal = try await db.terminals.get(id: params.terminalID)
+
+        let pinnedAt: Date? = params.pinned ? Date() : nil
         subscriptions.broadcast(delta: .terminalPinChanged(TerminalPinDelta(
-            terminalID: params.terminalID, pinnedAt: terminal?.pinnedAt
+            terminalID: params.terminalID, pinnedAt: pinnedAt
         )))
         return .ok()
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -71,6 +71,16 @@ extension RPCRouter {
         return .ok()
     }
 
+    func handleTerminalSetPin(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalSetPinParams.self, from: paramsData)
+        try await db.terminals.setPin(id: params.terminalID, pinned: params.pinned)
+        let terminal = try await db.terminals.get(id: params.terminalID)
+        subscriptions.broadcast(delta: .terminalPinChanged(TerminalPinDelta(
+            terminalID: params.terminalID, pinnedAt: terminal?.pinnedAt
+        )))
+        return .ok()
+    }
+
     func handleTerminalSend(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSendParams.self, from: paramsData)
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -73,9 +73,8 @@ extension RPCRouter {
 
     func handleTerminalSetPin(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSetPinParams.self, from: paramsData)
-        try await db.terminals.setPin(id: params.terminalID, pinned: params.pinned)
-
         let pinnedAt: Date? = params.pinned ? Date() : nil
+        try await db.terminals.setPin(id: params.terminalID, pinned: params.pinned, at: pinnedAt ?? Date())
         subscriptions.broadcast(delta: .terminalPinChanged(TerminalPinDelta(
             terminalID: params.terminalID, pinnedAt: pinnedAt
         )))

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -83,4 +83,16 @@ extension RPCRouter {
 
         return .ok()
     }
+
+    func handleWorktreeSetPin(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeSetPinParams.self, from: paramsData)
+        try await db.worktrees.setPin(id: params.worktreeID, pinned: params.pinned)
+
+        let wt = try await db.worktrees.get(id: params.worktreeID)
+        subscriptions.broadcast(delta: .worktreePinChanged(WorktreePinDelta(
+            worktreeID: params.worktreeID, pinnedAt: wt?.pinnedAt
+        )))
+
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -88,9 +88,9 @@ extension RPCRouter {
         let params = try decoder.decode(WorktreeSetPinParams.self, from: paramsData)
         try await db.worktrees.setPin(id: params.worktreeID, pinned: params.pinned)
 
-        let wt = try await db.worktrees.get(id: params.worktreeID)
+        let pinnedAt: Date? = params.pinned ? Date() : nil
         subscriptions.broadcast(delta: .worktreePinChanged(WorktreePinDelta(
-            worktreeID: params.worktreeID, pinnedAt: wt?.pinnedAt
+            worktreeID: params.worktreeID, pinnedAt: pinnedAt
         )))
 
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -86,9 +86,8 @@ extension RPCRouter {
 
     func handleWorktreeSetPin(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeSetPinParams.self, from: paramsData)
-        try await db.worktrees.setPin(id: params.worktreeID, pinned: params.pinned)
-
         let pinnedAt: Date? = params.pinned ? Date() : nil
+        try await db.worktrees.setPin(id: params.worktreeID, pinned: params.pinned, at: pinnedAt ?? Date())
         subscriptions.broadcast(delta: .worktreePinChanged(WorktreePinDelta(
             worktreeID: params.worktreeID, pinnedAt: pinnedAt
         )))

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -64,6 +64,8 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeRevive(request.paramsData)
             case RPCMethod.worktreeRename:
                 return try await handleWorktreeRename(request.paramsData)
+            case RPCMethod.worktreeSetPin:
+                return try await handleWorktreeSetPin(request.paramsData)
             case RPCMethod.terminalCreate:
                 return try await handleTerminalCreate(request.paramsData)
             case RPCMethod.terminalList:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -74,6 +74,8 @@ public final class RPCRouter: Sendable {
                 return try await handleTerminalSend(request.paramsData)
             case RPCMethod.terminalDelete:
                 return try await handleTerminalDelete(request.paramsData)
+            case RPCMethod.terminalSetPin:
+                return try await handleTerminalSetPin(request.paramsData)
             case RPCMethod.notify:
                 return try await handleNotify(request.paramsData)
             case RPCMethod.daemonStatus:

--- a/Sources/TBDDaemon/Server/StateSubscription.swift
+++ b/Sources/TBDDaemon/Server/StateSubscription.swift
@@ -15,6 +15,7 @@ public enum StateDelta: Codable, Sendable {
     case terminalCreated(TerminalDelta)
     case terminalRemoved(TerminalIDDelta)
     case worktreeConflictsChanged(WorktreeConflictDelta)
+    case worktreePinChanged(WorktreePinDelta)
 }
 
 /// Delta payload for worktree creation/revival.
@@ -94,6 +95,15 @@ public struct WorktreeConflictDelta: Codable, Sendable {
     public let hasConflicts: Bool
     public init(worktreeID: UUID, hasConflicts: Bool) {
         self.worktreeID = worktreeID; self.hasConflicts = hasConflicts
+    }
+}
+
+/// Delta payload for worktree pin state change.
+public struct WorktreePinDelta: Codable, Sendable {
+    public let worktreeID: UUID
+    public let pinnedAt: Date?
+    public init(worktreeID: UUID, pinnedAt: Date?) {
+        self.worktreeID = worktreeID; self.pinnedAt = pinnedAt
     }
 }
 

--- a/Sources/TBDDaemon/Server/StateSubscription.swift
+++ b/Sources/TBDDaemon/Server/StateSubscription.swift
@@ -16,6 +16,7 @@ public enum StateDelta: Codable, Sendable {
     case terminalRemoved(TerminalIDDelta)
     case worktreeConflictsChanged(WorktreeConflictDelta)
     case worktreePinChanged(WorktreePinDelta)
+    case terminalPinChanged(TerminalPinDelta)
 }
 
 /// Delta payload for worktree creation/revival.
@@ -104,6 +105,15 @@ public struct WorktreePinDelta: Codable, Sendable {
     public let pinnedAt: Date?
     public init(worktreeID: UUID, pinnedAt: Date?) {
         self.worktreeID = worktreeID; self.pinnedAt = pinnedAt
+    }
+}
+
+/// Delta payload for terminal pin state change.
+public struct TerminalPinDelta: Codable, Sendable {
+    public let terminalID: UUID
+    public let pinnedAt: Date?
+    public init(terminalID: UUID, pinnedAt: Date?) {
+        self.terminalID = terminalID; self.pinnedAt = pinnedAt
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -34,12 +34,13 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public var hasConflicts: Bool = false
     public var createdAt: Date
     public var archivedAt: Date?
+    public var pinnedAt: Date?
     public var tmuxServer: String
 
     public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
                 hasConflicts: Bool = false,
-                createdAt: Date = Date(), archivedAt: Date? = nil, tmuxServer: String) {
+                createdAt: Date = Date(), archivedAt: Date? = nil, pinnedAt: Date? = nil, tmuxServer: String) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -50,6 +51,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.hasConflicts = hasConflicts
         self.createdAt = createdAt
         self.archivedAt = archivedAt
+        self.pinnedAt = pinnedAt
         self.tmuxServer = tmuxServer
     }
 
@@ -65,6 +67,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         hasConflicts = try c.decodeIfPresent(Bool.self, forKey: .hasConflicts) ?? false
         createdAt = try c.decode(Date.self, forKey: .createdAt)
         archivedAt = try c.decodeIfPresent(Date.self, forKey: .archivedAt)
+        pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
         tmuxServer = try c.decode(String.self, forKey: .tmuxServer)
     }
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -79,15 +79,18 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public var tmuxPaneID: String
     public var label: String?
     public var createdAt: Date
+    public var pinnedAt: Date?
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
-                tmuxPaneID: String, label: String? = nil, createdAt: Date = Date()) {
+                tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
+                pinnedAt: Date? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
         self.tmuxPaneID = tmuxPaneID
         self.label = label
         self.createdAt = createdAt
+        self.pinnedAt = pinnedAt
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -84,6 +84,7 @@ public enum RPCMethod {
     public static let worktreeArchive = "worktree.archive"
     public static let worktreeRevive = "worktree.revive"
     public static let worktreeRename = "worktree.rename"
+    public static let worktreeSetPin = "worktree.setPin"
     public static let terminalCreate = "terminal.create"
     public static let terminalList = "terminal.list"
     public static let terminalSend = "terminal.send"
@@ -171,6 +172,14 @@ public struct WorktreeRenameParams: Codable, Sendable {
     public let displayName: String
     public init(worktreeID: UUID, displayName: String) {
         self.worktreeID = worktreeID; self.displayName = displayName
+    }
+}
+
+public struct WorktreeSetPinParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let pinned: Bool
+    public init(worktreeID: UUID, pinned: Bool) {
+        self.worktreeID = worktreeID; self.pinned = pinned
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -89,6 +89,7 @@ public enum RPCMethod {
     public static let terminalList = "terminal.list"
     public static let terminalSend = "terminal.send"
     public static let terminalDelete = "terminal.delete"
+    public static let terminalSetPin = "terminal.setPin"
     public static let notify = "notify"
     public static let daemonStatus = "daemon.status"
     public static let stateSubscribe = "state.subscribe"
@@ -207,6 +208,14 @@ public struct TerminalSendParams: Codable, Sendable {
 public struct TerminalDeleteParams: Codable, Sendable {
     public let terminalID: UUID
     public init(terminalID: UUID) { self.terminalID = terminalID }
+}
+
+public struct TerminalSetPinParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let pinned: Bool
+    public init(terminalID: UUID, pinned: Bool) {
+        self.terminalID = terminalID; self.pinned = pinned
+    }
 }
 
 public struct NotifyParams: Codable, Sendable {

--- a/Tests/TBDDaemonTests/DatabaseTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseTests.swift
@@ -149,6 +149,58 @@ struct DatabaseTests {
         #expect(archived.count == 1)
     }
 
+    // MARK: - Pin Tests
+
+    @Test func worktreeSetPinAndUnpin() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-pin-repo", displayName: "Test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+            path: "/tmp/test-pin-repo/.tbd/worktrees/test-wt", tmuxServer: "test"
+        )
+
+        // Initially not pinned
+        let initial = try await db.worktrees.get(id: wt.id)
+        #expect(initial?.pinnedAt == nil)
+
+        // Pin it
+        try await db.worktrees.setPin(id: wt.id, pinned: true)
+        let pinned = try await db.worktrees.get(id: wt.id)
+        #expect(pinned?.pinnedAt != nil)
+
+        // Unpin it
+        try await db.worktrees.setPin(id: wt.id, pinned: false)
+        let unpinned = try await db.worktrees.get(id: wt.id)
+        #expect(unpinned?.pinnedAt == nil)
+    }
+
+    @Test func pinnedWorktreesOrderByPinnedAt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-pin-order", displayName: "Test2", defaultBranch: "main")
+
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id, name: "wt-1", branch: "tbd/wt-1",
+            path: "/tmp/test-pin-order/.tbd/worktrees/wt-1", tmuxServer: "test"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id, name: "wt-2", branch: "tbd/wt-2",
+            path: "/tmp/test-pin-order/.tbd/worktrees/wt-2", tmuxServer: "test"
+        )
+
+        // Pin wt2 first, then wt1
+        try await db.worktrees.setPin(id: wt2.id, pinned: true)
+        try await Task.sleep(for: .milliseconds(10))
+        try await db.worktrees.setPin(id: wt1.id, pinned: true)
+
+        let all = try await db.worktrees.list(repoID: repo.id)
+        let pinned = all.filter { $0.pinnedAt != nil }
+        let sorted = pinned.sorted { ($0.pinnedAt ?? Date.distantPast) < ($1.pinnedAt ?? Date.distantPast) }
+
+        #expect(sorted.count == 2)
+        #expect(sorted[0].id == wt2.id) // pinned first
+        #expect(sorted[1].id == wt1.id) // pinned second
+    }
+
     // MARK: - Terminal Tests
 
     @Test func createAndListTerminals() async throws {

--- a/Tests/TBDDaemonTests/DatabaseTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseTests.swift
@@ -248,6 +248,62 @@ struct DatabaseTests {
         #expect(terminals.isEmpty)
     }
 
+    // MARK: - Terminal Pin Tests
+
+    @Test func terminalSetPinAndUnpin() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-term-pin", displayName: "Test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+            path: "/tmp/test-term-pin/.tbd/worktrees/test-wt", tmuxServer: "test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1"
+        )
+
+        // Initially not pinned
+        let initial = try await db.terminals.get(id: terminal.id)
+        #expect(initial?.pinnedAt == nil)
+
+        // Pin it
+        try await db.terminals.setPin(id: terminal.id, pinned: true)
+        let pinned = try await db.terminals.get(id: terminal.id)
+        #expect(pinned?.pinnedAt != nil)
+
+        // Unpin it
+        try await db.terminals.setPin(id: terminal.id, pinned: false)
+        let unpinned = try await db.terminals.get(id: terminal.id)
+        #expect(unpinned?.pinnedAt == nil)
+    }
+
+    @Test func pinnedTerminalsOrderByPinnedAt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-term-pin-order", displayName: "Test2", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt-1", branch: "tbd/wt-1",
+            path: "/tmp/test-term-pin-order/.tbd/worktrees/wt-1", tmuxServer: "test"
+        )
+        let t1 = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1"
+        )
+        let t2 = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@2", tmuxPaneID: "%2"
+        )
+
+        // Pin t2 first, then t1
+        try await db.terminals.setPin(id: t2.id, pinned: true)
+        try await Task.sleep(for: .milliseconds(10))
+        try await db.terminals.setPin(id: t1.id, pinned: true)
+
+        let all = try await db.terminals.list(worktreeID: wt.id)
+        let pinned = all.filter { $0.pinnedAt != nil }
+        let sorted = pinned.sorted { ($0.pinnedAt ?? Date.distantPast) < ($1.pinnedAt ?? Date.distantPast) }
+
+        #expect(sorted.count == 2)
+        #expect(sorted[0].id == t2.id)
+        #expect(sorted[1].id == t1.id)
+    }
+
     // MARK: - Notification Tests
 
     @Test func createAndReadNotifications() async throws {

--- a/Tests/TBDDaemonTests/NameGeneratorTests.swift
+++ b/Tests/TBDDaemonTests/NameGeneratorTests.swift
@@ -12,13 +12,6 @@ import Testing
     #expect(Int(parts[0]) != nil) // numeric date
 }
 
-@Test func testNamesAreUnique() {
-    let names = (0..<100).map { _ in NameGenerator.generate() }
-    let uniqueNames = Set(names)
-    // With 500+ adjectives * 500+ animals, collisions in 100 tries should be near-zero
-    #expect(names.count == uniqueNames.count)
-}
-
 @Test func testDatePrefix() {
     let name = NameGenerator.generate()
     let dateStr = String(name.prefix(8))

--- a/docs/superpowers/plans/2026-03-27-terminal-pane-pinning.md
+++ b/docs/superpowers/plans/2026-03-27-terminal-pane-pinning.md
@@ -1,0 +1,651 @@
+# Terminal Pane Pinning & Dock Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add terminal pane pinning with a persistent right-side dock, so pinned terminals remain visible when navigating between worktrees.
+
+**Architecture:** Database stores `pinnedAt` timestamp per terminal (migration v5). A new `PinnedTerminalDock` view renders pinned terminals from non-visible worktrees in a resizable right-side column. The pane header's terminal ID label is replaced with a pin icon. Dock ratio persists in UserDefaults.
+
+**Tech Stack:** Swift, SwiftUI, GRDB, Unix socket RPC
+
+---
+
+### Task 1: Database Migration + Terminal Model
+
+**Files:**
+- Modify: `Sources/TBDShared/Models.swift:75-91` (add pinnedAt to Terminal)
+- Modify: `Sources/TBDDaemon/Database/Database.swift:105` (add migration v5)
+- Modify: `Sources/TBDDaemon/Database/TerminalStore.swift:6-35` (add pinnedAt to record + conversions)
+
+- [ ] **Step 1: Add `pinnedAt` to the Terminal model**
+
+In `Sources/TBDShared/Models.swift`, add `pinnedAt: Date?` to the `Terminal` struct after `createdAt`:
+
+```swift
+public struct Terminal: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var worktreeID: UUID
+    public var tmuxWindowID: String
+    public var tmuxPaneID: String
+    public var label: String?
+    public var createdAt: Date
+    public var pinnedAt: Date?
+
+    public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
+                tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
+                pinnedAt: Date? = nil) {
+        self.id = id
+        self.worktreeID = worktreeID
+        self.tmuxWindowID = tmuxWindowID
+        self.tmuxPaneID = tmuxPaneID
+        self.label = label
+        self.createdAt = createdAt
+        self.pinnedAt = pinnedAt
+    }
+}
+```
+
+Note: `Terminal` uses synthesized Codable. Since `pinnedAt` is optional, existing JSON without the field decodes as `nil` automatically. No custom decoder needed.
+
+- [ ] **Step 2: Add `pinnedAt` to TerminalRecord**
+
+In `Sources/TBDDaemon/Database/TerminalStore.swift`, add to the record struct after `createdAt`:
+
+```swift
+var pinnedAt: Date?
+```
+
+Update `init(from terminal: Terminal)`:
+```swift
+self.pinnedAt = terminal.pinnedAt
+```
+
+Update `toModel()` to pass `pinnedAt: pinnedAt`.
+
+- [ ] **Step 3: Add database migration v5**
+
+In `Sources/TBDDaemon/Database/Database.swift`, add before `try migrator.migrate(writer)`:
+
+```swift
+migrator.registerMigration("v5") { db in
+    try db.alter(table: "terminal") { t in
+        t.add(column: "pinnedAt", .datetime)
+    }
+}
+```
+
+- [ ] **Step 4: Add `setPin` method to TerminalStore**
+
+In `Sources/TBDDaemon/Database/TerminalStore.swift`, add after `deleteForWorktree`:
+
+```swift
+/// Set or clear the pinned timestamp for a terminal.
+public func setPin(id: UUID, pinned: Bool) async throws {
+    try await writer.write { db in
+        guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+            throw DatabaseError(message: "Terminal not found")
+        }
+        record.pinnedAt = pinned ? Date() : nil
+        try record.update(db)
+    }
+}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDShared/Models.swift Sources/TBDDaemon/Database/Database.swift Sources/TBDDaemon/Database/TerminalStore.swift
+git commit -m "feat: add pinnedAt column to terminal table (migration v5)"
+```
+
+---
+
+### Task 2: RPC Protocol + Daemon Handler
+
+**Files:**
+- Modify: `Sources/TBDShared/RPCProtocol.swift` (add method + params)
+- Modify: `Sources/TBDDaemon/Server/StateSubscription.swift` (add delta case)
+- Modify: `Sources/TBDDaemon/Server/RPCRouter.swift` (add switch case)
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift` (add handler)
+- Modify: `Sources/TBDApp/DaemonClient.swift` (add client method)
+
+- [ ] **Step 1: Add RPC method and params**
+
+In `Sources/TBDShared/RPCProtocol.swift`, add to `RPCMethod` enum after `terminalDelete`:
+
+```swift
+public static let terminalSetPin = "terminal.setPin"
+```
+
+Add params struct after `TerminalDeleteParams`:
+
+```swift
+public struct TerminalSetPinParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let pinned: Bool
+    public init(terminalID: UUID, pinned: Bool) {
+        self.terminalID = terminalID; self.pinned = pinned
+    }
+}
+```
+
+- [ ] **Step 2: Add state delta**
+
+In `Sources/TBDDaemon/Server/StateSubscription.swift`, add to `StateDelta` enum after `worktreePinChanged`:
+
+```swift
+case terminalPinChanged(TerminalPinDelta)
+```
+
+Add the delta struct after `WorktreePinDelta`:
+
+```swift
+/// Delta payload for terminal pin state change.
+public struct TerminalPinDelta: Codable, Sendable {
+    public let terminalID: UUID
+    public let pinnedAt: Date?
+    public init(terminalID: UUID, pinnedAt: Date?) {
+        self.terminalID = terminalID; self.pinnedAt = pinnedAt
+    }
+}
+```
+
+- [ ] **Step 3: Add handler in RPCRouter**
+
+In `Sources/TBDDaemon/Server/RPCRouter.swift`, add case in the switch after `terminalDelete`:
+
+```swift
+case RPCMethod.terminalSetPin:
+    return try await handleTerminalSetPin(request.paramsData)
+```
+
+In `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`, add handler after `handleTerminalSend`:
+
+```swift
+func handleTerminalSetPin(_ paramsData: Data) async throws -> RPCResponse {
+    let params = try decoder.decode(TerminalSetPinParams.self, from: paramsData)
+    try await db.terminals.setPin(id: params.terminalID, pinned: params.pinned)
+
+    let terminal = try await db.terminals.get(id: params.terminalID)
+    subscriptions.broadcast(delta: .terminalPinChanged(TerminalPinDelta(
+        terminalID: params.terminalID, pinnedAt: terminal?.pinnedAt
+    )))
+
+    return .ok()
+}
+```
+
+- [ ] **Step 4: Add client method**
+
+In `Sources/TBDApp/DaemonClient.swift`, add after `setWorktreePin`:
+
+```swift
+/// Set or clear the pin on a terminal.
+func setTerminalPin(id: UUID, pinned: Bool) throws {
+    try callVoid(
+        method: RPCMethod.terminalSetPin,
+        params: TerminalSetPinParams(terminalID: id, pinned: pinned)
+    )
+}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDShared/RPCProtocol.swift Sources/TBDDaemon/Server/StateSubscription.swift Sources/TBDDaemon/Server/RPCRouter.swift Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift Sources/TBDApp/DaemonClient.swift
+git commit -m "feat: add terminal.setPin RPC method and handler"
+```
+
+---
+
+### Task 3: AppState Terminal Pin Support
+
+**Files:**
+- Modify: `Sources/TBDApp/AppState+Terminals.swift` (add setTerminalPin method)
+- Modify: `Sources/TBDApp/AppState.swift` (add pinnedTerminals computed property, dock ratio persistence)
+
+- [ ] **Step 1: Add setTerminalPin to AppState**
+
+Read `Sources/TBDApp/AppState+Terminals.swift` first to understand existing patterns.
+
+Add a new method for toggling terminal pin state:
+
+```swift
+/// Toggle pin state for a terminal.
+func setTerminalPin(id: UUID, pinned: Bool) async {
+    // Optimistic local update
+    for worktreeID in terminals.keys {
+        if let idx = terminals[worktreeID]?.firstIndex(where: { $0.id == id }) {
+            terminals[worktreeID]?[idx].pinnedAt = pinned ? Date() : nil
+        }
+    }
+
+    do {
+        try await daemonClient.setTerminalPin(id: id, pinned: pinned)
+    } catch {
+        logger.error("Failed to set terminal pin: \(error)")
+        handleConnectionError(error)
+    }
+}
+```
+
+- [ ] **Step 2: Add pinnedTerminals computed property and dock ratio to AppState**
+
+In `Sources/TBDApp/AppState.swift`, add the computed property (after `selectionOrder`):
+
+```swift
+/// All pinned terminals across all worktrees, sorted by pinnedAt.
+var pinnedTerminals: [Terminal] {
+    terminals.values.flatMap { $0 }
+        .filter { $0.pinnedAt != nil }
+        .sorted { ($0.pinnedAt ?? .distantPast) < ($1.pinnedAt ?? .distantPast) }
+}
+```
+
+Add dock ratio persistence (near the layouts persistence):
+
+```swift
+private static let dockRatioKey = "com.tbd.app.dockRatio"
+
+@Published var dockRatio: CGFloat = 0.3 {
+    didSet { UserDefaults.standard.set(Double(dockRatio), forKey: Self.dockRatioKey) }
+}
+```
+
+In `init()`, before the `Task` block, add:
+
+```swift
+if let saved = UserDefaults.standard.object(forKey: Self.dockRatioKey) as? Double {
+    dockRatio = CGFloat(saved)
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/AppState.swift Sources/TBDApp/AppState+Terminals.swift
+git commit -m "feat: add terminal pin support and dock ratio persistence to AppState"
+```
+
+---
+
+### Task 4: Pane Header Pin Icon (Replace Terminal ID)
+
+**Files:**
+- Modify: `Sources/TBDApp/Panes/PanePlaceholder.swift:64-74` (replace paneLabel)
+
+- [ ] **Step 1: Replace terminal ID with pin icon in pane header**
+
+In `Sources/TBDApp/Panes/PanePlaceholder.swift`, add a hover state at the top of the struct (after line 12):
+
+```swift
+@State private var isHeaderHovering = false
+```
+
+Replace the `paneLabel` computed property (lines 64-74):
+
+```swift
+@ViewBuilder
+private var paneLabel: some View {
+    switch content {
+    case .terminal(let terminalID):
+        let terminal = terminal(for: terminalID)
+        let isPinned = terminal?.pinnedAt != nil
+        HStack(spacing: 4) {
+            if isPinned {
+                Image(systemName: "pin.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 10)
+                    .onTapGesture {
+                        Task { await appState.setTerminalPin(id: terminalID, pinned: false) }
+                    }
+            } else if isHeaderHovering {
+                Image(systemName: "pin")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 10)
+                    .onTapGesture {
+                        Task { await appState.setTerminalPin(id: terminalID, pinned: true) }
+                    }
+            }
+        }
+    case .webview(_, let url):
+        Text(url.host ?? url.absoluteString)
+    case .codeViewer(_, let path):
+        Text(URL(fileURLWithPath: path).lastPathComponent)
+    }
+}
+```
+
+Add `.onHover` to the toolbar view. In the `toolbar` computed property, add after `.background(Color(nsColor: .controlBackgroundColor))`:
+
+```swift
+.onHover { hovering in
+    isHeaderHovering = hovering
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/Panes/PanePlaceholder.swift
+git commit -m "feat: replace terminal ID in pane header with pin icon"
+```
+
+---
+
+### Task 5: Pinned Terminal Dock View
+
+**Files:**
+- Create: `Sources/TBDApp/Terminal/PinnedTerminalDock.swift`
+
+- [ ] **Step 1: Create the dock view**
+
+Create `Sources/TBDApp/Terminal/PinnedTerminalDock.swift`:
+
+```swift
+import SwiftUI
+import TBDShared
+
+/// A vertical dock showing pinned terminals from worktrees not currently visible.
+/// Each pinned terminal gets a cell with a header (pin icon + worktree name) and the terminal view.
+struct PinnedTerminalDock: View {
+    let terminals: [Terminal]
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        VStack(spacing: 1) {
+            ForEach(terminals) { terminal in
+                PinnedTerminalCell(terminal: terminal)
+            }
+        }
+        .background(Color(nsColor: .separatorColor))
+    }
+}
+
+/// A single cell in the pinned terminal dock.
+private struct PinnedTerminalCell: View {
+    let terminal: Terminal
+    @EnvironmentObject var appState: AppState
+
+    private var worktree: Worktree? {
+        for wts in appState.worktrees.values {
+            if let wt = wts.first(where: { $0.id == terminal.worktreeID }) {
+                return wt
+            }
+        }
+        return nil
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header: pin icon + worktree name
+            HStack(spacing: 4) {
+                Image(systemName: "pin.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 10)
+                    .onTapGesture {
+                        Task { await appState.setTerminalPin(id: terminal.id, pinned: false) }
+                    }
+                if let worktree {
+                    Text(worktree.displayName)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color(nsColor: .controlBackgroundColor))
+
+            Divider()
+
+            // Terminal content
+            if let worktree {
+                TerminalPanelView(
+                    terminalID: terminal.id,
+                    tmuxServer: worktree.tmuxServer,
+                    tmuxWindowID: terminal.tmuxWindowID,
+                    tmuxBridge: appState.tmuxBridge,
+                    worktreePath: worktree.path
+                )
+                .id(terminal.id)
+            } else {
+                ZStack {
+                    Color(nsColor: .textBackgroundColor)
+                    Text("Loading...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+git commit -m "feat: add PinnedTerminalDock view for pinned terminal cells"
+```
+
+---
+
+### Task 6: Integrate Dock into TerminalContainerView
+
+**Files:**
+- Modify: `Sources/TBDApp/Terminal/TerminalContainerView.swift:12-26` (wrap content with dock)
+
+- [ ] **Step 1: Add dock wrapper to TerminalContainerView**
+
+In `Sources/TBDApp/Terminal/TerminalContainerView.swift`, replace the `body` of `TerminalContainerView` (lines 15-25):
+
+```swift
+var body: some View {
+    let visibleWorktreeIDs = appState.selectedWorktreeIDs
+    let dockTerminals = appState.pinnedTerminals.filter { terminal in
+        !visibleWorktreeIDs.contains(terminal.worktreeID)
+    }
+
+    let mainContent = Group {
+        if appState.selectedWorktreeIDs.count == 1,
+           let worktreeID = appState.selectedWorktreeIDs.first {
+            SingleWorktreeView(worktreeID: worktreeID)
+        } else if appState.selectedWorktreeIDs.count > 1 {
+            MultiWorktreeView(worktreeIDs: appState.selectionOrder)
+        } else {
+            Text("Select a worktree or click + to create one")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    if dockTerminals.isEmpty {
+        mainContent
+    } else {
+        DockSplitView(
+            dockRatio: $appState.dockRatio,
+            mainContent: { mainContent },
+            dockContent: { PinnedTerminalDock(terminals: dockTerminals) }
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Add DockSplitView**
+
+Add at the bottom of `TerminalContainerView.swift` (or in a new section):
+
+```swift
+// MARK: - DockSplitView
+
+/// A horizontal split between main content (left) and pinned terminal dock (right).
+/// The divider is draggable to resize the dock.
+private struct DockSplitView<Main: View, Dock: View>: View {
+    @Binding var dockRatio: CGFloat
+    @ViewBuilder let mainContent: () -> Main
+    @ViewBuilder let dockContent: () -> Dock
+
+    @State private var dragStartRatio: CGFloat?
+
+    var body: some View {
+        GeometryReader { geometry in
+            let totalWidth = geometry.size.width
+            let dividerWidth: CGFloat = 4
+            let available = totalWidth - dividerWidth
+            let dockWidth = available * dockRatio
+            let mainWidth = available - dockWidth
+
+            HStack(spacing: 0) {
+                mainContent()
+                    .frame(width: mainWidth)
+
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(width: dividerWidth)
+                    .contentShape(Rectangle())
+                    .onHover { hovering in
+                        if hovering {
+                            NSCursor.resizeLeftRight.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                if dragStartRatio == nil {
+                                    dragStartRatio = dockRatio
+                                }
+                                guard let startRatio = dragStartRatio, available > 0 else { return }
+                                let delta = -value.translation.width / available
+                                let newRatio = max(0.1, min(0.6, startRatio + delta))
+                                dockRatio = newRatio
+                            }
+                            .onEnded { _ in
+                                dragStartRatio = nil
+                            }
+                    )
+
+                dockContent()
+                    .frame(width: dockWidth)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/Terminal/TerminalContainerView.swift
+git commit -m "feat: integrate pinned terminal dock into TerminalContainerView"
+```
+
+---
+
+### Task 7: Tests
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/DatabaseTests.swift` (add terminal pin tests)
+
+- [ ] **Step 1: Add terminal pin tests**
+
+Read `Tests/TBDDaemonTests/DatabaseTests.swift` to check the existing pattern for creating test terminals and repos (look for `createAndListTerminals` or similar).
+
+Add test functions following the existing patterns. The `repos.create` method requires `(path:displayName:defaultBranch:)` and `worktrees.create` requires `(repoID:name:branch:path:tmuxServer:)`. Terminals require `(worktreeID:tmuxWindowID:tmuxPaneID:)`.
+
+```swift
+@Test func terminalSetPinAndUnpin() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let repo = try await db.repos.create(path: "/tmp/test-term-pin", displayName: "Test", defaultBranch: "main")
+    let wt = try await db.worktrees.create(
+        repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+        path: "/tmp/test-term-pin/.tbd/worktrees/test-wt", tmuxServer: "test"
+    )
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1"
+    )
+
+    // Initially not pinned
+    let initial = try await db.terminals.get(id: terminal.id)
+    #expect(initial?.pinnedAt == nil)
+
+    // Pin it
+    try await db.terminals.setPin(id: terminal.id, pinned: true)
+    let pinned = try await db.terminals.get(id: terminal.id)
+    #expect(pinned?.pinnedAt != nil)
+
+    // Unpin it
+    try await db.terminals.setPin(id: terminal.id, pinned: false)
+    let unpinned = try await db.terminals.get(id: terminal.id)
+    #expect(unpinned?.pinnedAt == nil)
+}
+
+@Test func pinnedTerminalsOrderByPinnedAt() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let repo = try await db.repos.create(path: "/tmp/test-term-pin-order", displayName: "Test2", defaultBranch: "main")
+    let wt = try await db.worktrees.create(
+        repoID: repo.id, name: "wt-1", branch: "tbd/wt-1",
+        path: "/tmp/test-term-pin-order/.tbd/worktrees/wt-1", tmuxServer: "test"
+    )
+    let t1 = try await db.terminals.create(
+        worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1"
+    )
+    let t2 = try await db.terminals.create(
+        worktreeID: wt.id, tmuxWindowID: "@2", tmuxPaneID: "%2"
+    )
+
+    // Pin t2 first, then t1
+    try await db.terminals.setPin(id: t2.id, pinned: true)
+    try await Task.sleep(for: .milliseconds(10))
+    try await db.terminals.setPin(id: t1.id, pinned: true)
+
+    let all = try await db.terminals.list(worktreeID: wt.id)
+    let pinned = all.filter { $0.pinnedAt != nil }
+    let sorted = pinned.sorted { ($0.pinnedAt ?? Date.distantPast) < ($1.pinnedAt ?? Date.distantPast) }
+
+    #expect(sorted.count == 2)
+    #expect(sorted[0].id == t2.id) // pinned first
+    #expect(sorted[1].id == t1.id) // pinned second
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift test 2>&1 | tail -30`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/
+git commit -m "test: add terminal pin/unpin database tests"
+```

--- a/docs/superpowers/plans/2026-03-27-worktree-pinning.md
+++ b/docs/superpowers/plans/2026-03-27-worktree-pinning.md
@@ -1,0 +1,582 @@
+# Worktree Pinning & Ordered Split View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add worktree pinning so pinned worktrees auto-select on launch, and split view renders panes in pin/click order instead of arbitrary Set order.
+
+**Architecture:** Database stores `pinnedAt` timestamp per worktree. AppState keeps a `selectionOrder: [UUID]` array alongside the existing `selectedWorktreeIDs: Set<UUID>` (Set required by SwiftUI's `List(selection:)`). Split view uses the ordered array. Pin icon on row left + context menu toggle pin state via RPC.
+
+**Tech Stack:** Swift, SwiftUI, GRDB, Unix socket RPC
+
+---
+
+### Task 1: Database Migration + Shared Model
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Database/Database.swift:104` (add migration v4)
+- Modify: `Sources/TBDDaemon/Database/WorktreeStore.swift:6-50` (add pinnedAt to record + conversions)
+- Modify: `Sources/TBDShared/Models.swift:26-69` (add pinnedAt to Worktree)
+
+- [ ] **Step 1: Add `pinnedAt` to the Worktree model**
+
+In `Sources/TBDShared/Models.swift`, add `pinnedAt: Date?` to the `Worktree` struct:
+
+```swift
+// After line 36 (archivedAt):
+public var pinnedAt: Date?
+```
+
+Update the `init` (line 39-54) to accept `pinnedAt`:
+```swift
+public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
+            branch: String, path: String, status: WorktreeStatus = .active,
+            hasConflicts: Bool = false,
+            createdAt: Date = Date(), archivedAt: Date? = nil,
+            pinnedAt: Date? = nil,
+            tmuxServer: String) {
+    // ... existing assignments ...
+    self.pinnedAt = pinnedAt
+}
+```
+
+Update the custom `init(from decoder:)` (line 56-69):
+```swift
+pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
+```
+
+- [ ] **Step 2: Add `pinnedAt` to WorktreeRecord**
+
+In `Sources/TBDDaemon/Database/WorktreeStore.swift`, add to the record struct (after line 18):
+```swift
+var pinnedAt: Date?
+```
+
+Update `init(from wt: Worktree)` (after line 31):
+```swift
+self.pinnedAt = wt.pinnedAt
+```
+
+Update `toModel()` to pass `pinnedAt: pinnedAt` in the Worktree init call.
+
+- [ ] **Step 3: Add database migration v4**
+
+In `Sources/TBDDaemon/Database/Database.swift`, before `try migrator.migrate(writer)` (line 105):
+```swift
+migrator.registerMigration("v4") { db in
+    try db.alter(table: "worktree") { t in
+        t.add(column: "pinnedAt", .datetime)
+    }
+}
+```
+
+- [ ] **Step 4: Add `setPin` method to WorktreeStore**
+
+In `Sources/TBDDaemon/Database/WorktreeStore.swift`, add after `updateBranch` method:
+```swift
+/// Set or clear the pinned timestamp for a worktree.
+public func setPin(id: UUID, pinned: Bool) async throws {
+    try await writer.write { db in
+        guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
+            throw DatabaseError(message: "Worktree not found")
+        }
+        record.pinnedAt = pinned ? Date() : nil
+        try record.update(db)
+    }
+}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDShared/Models.swift Sources/TBDDaemon/Database/Database.swift Sources/TBDDaemon/Database/WorktreeStore.swift
+git commit -m "feat: add pinnedAt column to worktree table (migration v4)"
+```
+
+---
+
+### Task 2: RPC Protocol + Daemon Handler
+
+**Files:**
+- Modify: `Sources/TBDShared/RPCProtocol.swift:78-100` (add method + params)
+- Modify: `Sources/TBDDaemon/Server/RPCRouter.swift:48-97` (add switch case)
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift:76-86` (add handler)
+- Modify: `Sources/TBDDaemon/Server/StateSubscription.swift:7-17` (add delta case)
+
+- [ ] **Step 1: Add RPC method and params**
+
+In `Sources/TBDShared/RPCProtocol.swift`, add to `RPCMethod` enum (after line 99):
+```swift
+public static let worktreeSetPin = "worktree.setPin"
+```
+
+Add params struct (after `WorktreeRenameParams`, around line 175):
+```swift
+public struct WorktreeSetPinParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let pinned: Bool
+    public init(worktreeID: UUID, pinned: Bool) {
+        self.worktreeID = worktreeID; self.pinned = pinned
+    }
+}
+```
+
+- [ ] **Step 2: Add state delta for pin change**
+
+In `Sources/TBDDaemon/Server/StateSubscription.swift`, add to the `StateDelta` enum (after `worktreeConflictsChanged`):
+```swift
+case worktreePinChanged(WorktreePinDelta)
+```
+
+Add the delta struct (after `WorktreeConflictDelta`):
+```swift
+/// Delta payload for worktree pin state change.
+public struct WorktreePinDelta: Codable, Sendable {
+    public let worktreeID: UUID
+    public let pinnedAt: Date?
+    public init(worktreeID: UUID, pinnedAt: Date?) {
+        self.worktreeID = worktreeID; self.pinnedAt = pinnedAt
+    }
+}
+```
+
+- [ ] **Step 3: Add handler in RPCRouter**
+
+In `Sources/TBDDaemon/Server/RPCRouter.swift`, add case in the switch (after `worktreeRename` case, line 66):
+```swift
+case RPCMethod.worktreeSetPin:
+    return try await handleWorktreeSetPin(request.paramsData)
+```
+
+In `Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift`, add handler (after `handleWorktreeRename`):
+```swift
+func handleWorktreeSetPin(_ paramsData: Data) async throws -> RPCResponse {
+    let params = try decoder.decode(WorktreeSetPinParams.self, from: paramsData)
+    try await db.worktrees.setPin(id: params.worktreeID, pinned: params.pinned)
+
+    // Fetch the updated worktree to get the actual pinnedAt value
+    let wt = try await db.worktrees.get(id: params.worktreeID)
+    subscriptions.broadcast(delta: .worktreePinChanged(WorktreePinDelta(
+        worktreeID: params.worktreeID, pinnedAt: wt?.pinnedAt
+    )))
+
+    return .ok()
+}
+```
+
+- [ ] **Step 4: Add client method in DaemonClient**
+
+In `Sources/TBDApp/DaemonClient.swift`, add after `renameWorktree` method:
+```swift
+/// Set or clear the pin on a worktree.
+func setWorktreePin(id: UUID, pinned: Bool) throws {
+    try callVoid(
+        method: RPCMethod.worktreeSetPin,
+        params: WorktreeSetPinParams(worktreeID: id, pinned: pinned)
+    )
+}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDShared/RPCProtocol.swift Sources/TBDDaemon/Server/RPCRouter.swift Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift Sources/TBDDaemon/Server/StateSubscription.swift Sources/TBDApp/DaemonClient.swift
+git commit -m "feat: add worktree.setPin RPC method and handler"
+```
+
+---
+
+### Task 3: AppState Selection Order + Pin Integration
+
+**Files:**
+- Modify: `Sources/TBDApp/AppState.swift:14,40-46` (add selectionOrder, init pin restore)
+- Modify: `Sources/TBDApp/AppState+Worktrees.swift:50-64,78-100` (sync selectionOrder on mutations)
+- Modify: `Sources/TBDApp/Terminal/TerminalContainerView.swift:19-20` (use selectionOrder)
+
+- [ ] **Step 1: Add selectionOrder and pin methods to AppState**
+
+In `Sources/TBDApp/AppState.swift`, add after `selectedWorktreeIDs` (line 14):
+```swift
+/// Tracks the order of selected worktrees for split view rendering.
+/// Pinned worktrees come first (sorted by pinnedAt), then cmd+clicked ones in click order.
+@Published var selectionOrder: [UUID] = []
+```
+
+- [ ] **Step 2: Add pin action method to AppState+Worktrees**
+
+In `Sources/TBDApp/AppState+Worktrees.swift`, add after `renameWorktree`:
+```swift
+/// Toggle pin state for a worktree.
+func setWorktreePin(id: UUID, pinned: Bool) async {
+    // Optimistic local update
+    for repoID in worktrees.keys {
+        if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == id }) {
+            worktrees[repoID]?[idx].pinnedAt = pinned ? Date() : nil
+        }
+    }
+
+    if pinned {
+        // Add to selection if not already there
+        if !selectedWorktreeIDs.contains(id) {
+            selectedWorktreeIDs.insert(id)
+        }
+        // Rebuild order: pinned first (by pinnedAt), then unpinned in existing order
+        rebuildSelectionOrder()
+    } else {
+        // Just rebuild order — item stays selected but loses pin priority
+        rebuildSelectionOrder()
+    }
+
+    do {
+        try await daemonClient.setWorktreePin(id: id, pinned: pinned)
+    } catch {
+        logger.error("Failed to set pin: \(error)")
+        handleConnectionError(error)
+    }
+}
+
+/// Rebuild selectionOrder from selectedWorktreeIDs, putting pinned items first (by pinnedAt).
+func rebuildSelectionOrder() {
+    let allWts = worktrees.values.flatMap { $0 }
+    let wtMap = Dictionary(uniqueKeysWithValues: allWts.map { ($0.id, $0) })
+
+    let selected = selectedWorktreeIDs
+    var pinned: [(UUID, Date)] = []
+    var unpinned: [UUID] = []
+
+    for id in selectionOrder where selected.contains(id) {
+        if let wt = wtMap[id], let pinnedAt = wt.pinnedAt {
+            pinned.append((id, pinnedAt))
+        } else {
+            unpinned.append(id)
+        }
+    }
+    // Add any selected IDs not yet in selectionOrder
+    for id in selected where !selectionOrder.contains(id) {
+        if let wt = wtMap[id], let pinnedAt = wt.pinnedAt {
+            pinned.append((id, pinnedAt))
+        } else {
+            unpinned.append(id)
+        }
+    }
+
+    pinned.sort { $0.1 < $1.1 }
+    selectionOrder = pinned.map(\.0) + unpinned
+}
+```
+
+- [ ] **Step 3: Sync selectionOrder on selection changes**
+
+In `Sources/TBDApp/AppState.swift`, add a `didSet` observer to `selectedWorktreeIDs` to keep `selectionOrder` in sync. Change line 14 from:
+```swift
+@Published var selectedWorktreeIDs: Set<UUID> = []
+```
+to:
+```swift
+@Published var selectedWorktreeIDs: Set<UUID> = [] {
+    didSet {
+        // Remove deselected items from order
+        selectionOrder.removeAll { !selectedWorktreeIDs.contains($0) }
+        // Append newly selected items (maintains insertion order for cmd+click)
+        for id in selectedWorktreeIDs where !selectionOrder.contains(id) {
+            selectionOrder.append(id)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Restore pinned selection on launch**
+
+In `Sources/TBDApp/AppState.swift`, update `connectAndLoadInitialState` (line 94-103). After `await refreshAll()` and before `await refreshPRStatuses()`:
+```swift
+// Auto-select pinned worktrees on launch
+let pinnedWts = worktrees.values.flatMap { $0 }
+    .filter { $0.pinnedAt != nil }
+    .sorted { ($0.pinnedAt ?? .distantPast) < ($1.pinnedAt ?? .distantPast) }
+if !pinnedWts.isEmpty {
+    selectedWorktreeIDs = Set(pinnedWts.map(\.id))
+    selectionOrder = pinnedWts.map(\.id)
+}
+```
+
+- [ ] **Step 5: Update MultiWorktreeView to use selectionOrder**
+
+In `Sources/TBDApp/Terminal/TerminalContainerView.swift`, change line 19-20 from:
+```swift
+} else if appState.selectedWorktreeIDs.count > 1 {
+    MultiWorktreeView(worktreeIDs: Array(appState.selectedWorktreeIDs))
+```
+to:
+```swift
+} else if appState.selectedWorktreeIDs.count > 1 {
+    MultiWorktreeView(worktreeIDs: appState.selectionOrder)
+```
+
+- [ ] **Step 6: Update cmd+click to protect pinned items**
+
+In `Sources/TBDApp/Sidebar/WorktreeRowView.swift`, update the cmd+click handler (lines 174-179). Replace:
+```swift
+if NSEvent.modifierFlags.contains(.command) {
+    if appState.selectedWorktreeIDs.contains(worktree.id) {
+        appState.selectedWorktreeIDs.remove(worktree.id)
+    } else {
+        appState.selectedWorktreeIDs.insert(worktree.id)
+    }
+```
+with:
+```swift
+if NSEvent.modifierFlags.contains(.command) {
+    if appState.selectedWorktreeIDs.contains(worktree.id) {
+        // Don't allow cmd+click removal of pinned worktrees
+        if worktree.pinnedAt == nil {
+            appState.selectedWorktreeIDs.remove(worktree.id)
+        }
+    } else {
+        appState.selectedWorktreeIDs.insert(worktree.id)
+    }
+```
+
+- [ ] **Step 7: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/TBDApp/AppState.swift Sources/TBDApp/AppState+Worktrees.swift Sources/TBDApp/Terminal/TerminalContainerView.swift Sources/TBDApp/Sidebar/WorktreeRowView.swift
+git commit -m "feat: add selectionOrder for ordered split view and pin-aware selection"
+```
+
+---
+
+### Task 4: Pin Icon in Sidebar Row
+
+**Files:**
+- Modify: `Sources/TBDApp/Sidebar/WorktreeRowView.swift:82-230` (add pin icon to both HStacks)
+
+- [ ] **Step 1: Add hover state and pin icon to the main HStack**
+
+In `Sources/TBDApp/Sidebar/WorktreeRowView.swift`, add a hover state variable (after line 15):
+```swift
+@State private var isHovering = false
+```
+
+In the main `body` HStack (line 83), add the pin icon as the FIRST element (before the `if isMain` check at line 84):
+```swift
+// Pin icon: always visible when pinned, hover-only when unpinned
+if worktree.pinnedAt != nil {
+    Image(systemName: "pin.fill")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .frame(width: 10)
+        .onTapGesture {
+            Task { await appState.setWorktreePin(id: worktree.id, pinned: false) }
+        }
+} else if isHovering {
+    Image(systemName: "pin")
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+        .frame(width: 10)
+        .onTapGesture {
+            Task { await appState.setWorktreePin(id: worktree.id, pinned: true) }
+        }
+} else {
+    Color.clear.frame(width: 10)
+}
+```
+
+Add `.onHover` modifier. Place it right after `.contentShape(Rectangle())` (line 172), before `.onTapGesture`:
+```swift
+.onHover { hovering in
+    isHovering = hovering
+}
+```
+
+- [ ] **Step 2: Add pin icon to the expanding row overlay HStack**
+
+In the expanding row overlay HStack (line 196), add the same pin icon as the first element (before the `if isMain` check at line 197):
+```swift
+if worktree.pinnedAt != nil {
+    Image(systemName: "pin.fill")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .frame(width: 10)
+} else if isHovering {
+    Image(systemName: "pin")
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+        .frame(width: 10)
+} else {
+    Color.clear.frame(width: 10)
+}
+```
+
+Note: The overlay HStack does NOT need tap gesture handlers because the overlay panel has `ignoresMouseEvents = true` — clicks pass through to the underlying SwiftUI view. The click monitor in `ExpandingRowPanel` only fires the `onClick` callback (which triggers rename), then lets the click pass through. So the pin icon tap handler on the main HStack will receive the click.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/Sidebar/WorktreeRowView.swift
+git commit -m "feat: add pin icon to worktree sidebar rows (hover + persistent)"
+```
+
+---
+
+### Task 5: Context Menu Pin/Unpin
+
+**Files:**
+- Modify: `Sources/TBDApp/Sidebar/SidebarContextMenu.swift:24-46` (add Pin/Unpin button)
+
+- [ ] **Step 1: Add Pin/Unpin to context menu**
+
+In `Sources/TBDApp/Sidebar/SidebarContextMenu.swift`, in the `else` branch (active/archived worktrees, line 24), add after "Rename..." button (line 27):
+
+```swift
+Button(worktree.pinnedAt != nil ? "Unpin" : "Pin") {
+    let wtID = worktree.id
+    let shouldPin = worktree.pinnedAt == nil
+    Task {
+        await appState.setWorktreePin(id: wtID, pinned: shouldPin)
+    }
+}
+```
+
+Also add a Pin/Unpin option for main worktrees too — in the `if` branch (line 12-23), add before "Open in Finder":
+
+```swift
+Button(worktree.pinnedAt != nil ? "Unpin" : "Pin") {
+    let wtID = worktree.id
+    let shouldPin = worktree.pinnedAt == nil
+    Task {
+        await appState.setWorktreePin(id: wtID, pinned: shouldPin)
+    }
+}
+
+Divider()
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift build 2>&1 | tail -20`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+git commit -m "feat: add Pin/Unpin to worktree context menu"
+```
+
+---
+
+### Task 6: Tests
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/DatabaseTests.swift` (add pin tests)
+
+- [ ] **Step 1: Write database pin tests**
+
+Add test cases to the existing database test file. Use `@Test` and `#expect` (Swift Testing framework):
+
+```swift
+@Test func worktreeSetPinAndUnpin() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let repo = try await db.repos.create(path: "/tmp/test-repo", displayName: "Test")
+    let wt = try await db.worktrees.create(
+        repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+        path: "/tmp/test-repo/.tbd/worktrees/test-wt", tmuxServer: "test"
+    )
+
+    // Initially not pinned
+    let initial = try await db.worktrees.get(id: wt.id)
+    #expect(initial?.pinnedAt == nil)
+
+    // Pin it
+    try await db.worktrees.setPin(id: wt.id, pinned: true)
+    let pinned = try await db.worktrees.get(id: wt.id)
+    #expect(pinned?.pinnedAt != nil)
+
+    // Unpin it
+    try await db.worktrees.setPin(id: wt.id, pinned: false)
+    let unpinned = try await db.worktrees.get(id: wt.id)
+    #expect(unpinned?.pinnedAt == nil)
+}
+
+@Test func pinnedWorktreesOrderByPinnedAt() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let repo = try await db.repos.create(path: "/tmp/test-repo2", displayName: "Test2")
+
+    let wt1 = try await db.worktrees.create(
+        repoID: repo.id, name: "wt-1", branch: "tbd/wt-1",
+        path: "/tmp/test-repo2/.tbd/worktrees/wt-1", tmuxServer: "test"
+    )
+    let wt2 = try await db.worktrees.create(
+        repoID: repo.id, name: "wt-2", branch: "tbd/wt-2",
+        path: "/tmp/test-repo2/.tbd/worktrees/wt-2", tmuxServer: "test"
+    )
+
+    // Pin wt2 first, then wt1
+    try await db.worktrees.setPin(id: wt2.id, pinned: true)
+    try await Task.sleep(for: .milliseconds(10))
+    try await db.worktrees.setPin(id: wt1.id, pinned: true)
+
+    let all = try await db.worktrees.list(repoID: repo.id)
+    let pinned = all.filter { $0.pinnedAt != nil }
+        .sorted { ($0.pinnedAt ?? .distantPast) < ($1.pinnedAt ?? .distantPast) }
+
+    #expect(pinned.count == 2)
+    #expect(pinned[0].id == wt2.id) // pinned first
+    #expect(pinned[1].id == wt1.id) // pinned second
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /Users/chang/projects/tbd/.tbd/worktrees/20260326-comprehensive-bee && swift test 2>&1 | tail -30`
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/
+git commit -m "test: add worktree pin/unpin database tests"
+```
+
+---
+
+### Task 7: Archive Cleanup — Unpin on Archive
+
+**Files:**
+- Modify: `Sources/TBDApp/AppState+Worktrees.swift:50-64` (remove from selectionOrder on archive)
+
+- [ ] **Step 1: Clean up selection order when archiving**
+
+In `Sources/TBDApp/AppState+Worktrees.swift`, in `archiveWorktree` method (line 50-64), after `selectedWorktreeIDs.remove(id)` (line 57), add:
+```swift
+selectionOrder.removeAll { $0 == id }
+```
+
+This is needed because the `didSet` on `selectedWorktreeIDs` handles this, but it's good to be explicit. Actually — the `didSet` already removes items not in the Set, so this line is redundant. Skip this step.
+
+Actually, let's verify: the `didSet` on `selectedWorktreeIDs` does `selectionOrder.removeAll { !selectedWorktreeIDs.contains($0) }` — this already handles it. No changes needed.
+
+- [ ] **Step 1 (revised): Verify archive behavior is already correct**
+
+No code changes needed. The `didSet` on `selectedWorktreeIDs` automatically removes archived worktrees from `selectionOrder` when they're removed from the Set.
+
+- [ ] **Step 2: Commit** (skip — no changes)

--- a/docs/superpowers/specs/2026-03-26-worktree-pinning-design.md
+++ b/docs/superpowers/specs/2026-03-26-worktree-pinning-design.md
@@ -6,7 +6,9 @@ Multi-selected worktrees in split view render in arbitrary order because selecti
 
 ## Solution
 
-Add worktree pinning (persistent, ordered) and change the selection model from `Set<UUID>` to `[UUID]` so split view respects pin/click order.
+Add worktree pinning (persistent, ordered) and add a `selectionOrder: [UUID]` array alongside the existing `selectedWorktreeIDs: Set<UUID>` so split view respects pin/click order.
+
+**Design constraint:** SwiftUI's `List(selection:)` requires `Binding<Set<UUID>>` for multi-select, so `selectedWorktreeIDs` must remain a `Set<UUID>`. A parallel `selectionOrder: [UUID]` array tracks insertion order for split view rendering.
 
 ## Data Model
 
@@ -20,10 +22,10 @@ Add `pinnedAt: Date?` to the `Worktree` model in `Models.swift`. Optional field,
 
 ### AppState
 
-Change `selectedWorktreeIDs: Set<UUID>` to `selectedWorktreeIDs: [UUID]`. Call sites update accordingly:
-- `.contains()` stays the same (Array has contains)
-- `.insert()` becomes `append()` with a guard against duplicates
-- `.remove()` becomes `.removeAll(where:)`
+Keep `selectedWorktreeIDs: Set<UUID>` (required by SwiftUI List binding). Add `selectionOrder: [UUID]` to track the order in which worktrees were selected/pinned. Both must stay in sync:
+- When inserting: add to both Set and Array
+- When removing: remove from both
+- `selectionOrder` determines split view pane order
 
 ## Selection Behavior
 

--- a/docs/superpowers/specs/2026-03-26-worktree-pinning-design.md
+++ b/docs/superpowers/specs/2026-03-26-worktree-pinning-design.md
@@ -1,0 +1,88 @@
+# Worktree Pinning & Ordered Split View
+
+## Problem
+
+Multi-selected worktrees in split view render in arbitrary order because selection uses an unordered `Set<UUID>`. Users also have no way to persistently keep certain worktrees visible — every session starts with an empty selection.
+
+## Solution
+
+Add worktree pinning (persistent, ordered) and change the selection model from `Set<UUID>` to `[UUID]` so split view respects pin/click order.
+
+## Data Model
+
+### Database Migration
+
+Add a nullable `pinnedAt` column (ISO 8601 timestamp) to the `worktree` table. `NULL` means not pinned; a timestamp means pinned at that time. Sort by `pinnedAt ASC` for pin order.
+
+### Shared Model
+
+Add `pinnedAt: Date?` to the `Worktree` model in `Models.swift`. Optional field, so existing data decodes without issue.
+
+### AppState
+
+Change `selectedWorktreeIDs: Set<UUID>` to `selectedWorktreeIDs: [UUID]`. Call sites update accordingly:
+- `.contains()` stays the same (Array has contains)
+- `.insert()` becomes `append()` with a guard against duplicates
+- `.remove()` becomes `.removeAll(where:)`
+
+## Selection Behavior
+
+### App Launch
+
+Query worktrees where `pinnedAt IS NOT NULL`, sorted by `pinnedAt ASC`. Populate `selectedWorktreeIDs` with these IDs in that order.
+
+### Cmd+Click (Unpinned Worktree)
+
+Append to `selectedWorktreeIDs` if not present; remove if already present.
+
+### Cmd+Click (Pinned Worktree)
+
+No-op. Pinned items cannot be deselected via cmd+click. User must unpin first.
+
+### Regular Click
+
+Replace selection with just that worktree: `selectedWorktreeIDs = [worktree.id]`. Pinned items remain pinned in the DB but aren't forced into the selection during manual single-select. Pins reassert on next app launch.
+
+### Pinning a Worktree
+
+Sets `pinnedAt` to current timestamp. If the worktree is not in `selectedWorktreeIDs`, insert it at the correct position — before any unpinned items, sorted by `pinnedAt` among other pins.
+
+### Unpinning a Worktree
+
+Sets `pinnedAt` to NULL. The worktree stays in `selectedWorktreeIDs` at its current position but loses cmd+click removal protection.
+
+## Split View Ordering
+
+`MultiWorktreeView` uses `selectedWorktreeIDs` directly (no Set-to-Array conversion needed). The array order is:
+
+1. Pinned worktrees, sorted by `pinnedAt ASC`
+2. Manually cmd+clicked worktrees, in click order
+
+Grid layout logic (column count based on total count) is unchanged.
+
+## Pin Icon
+
+### Hover Behavior
+
+- Appears on the very left of the worktree row
+- **Pinned items:** pin icon always visible, filled style
+- **Unpinned items:** pin icon appears on hover only, outline style
+- Click toggles pin state via daemon RPC
+
+### Overlay Integration
+
+The pin icon lives inside the row content (not in the overflow overlay), so it scrolls and clips naturally with the row. Care must be taken to integrate with the existing overlay system for overflowing sidebar items.
+
+## Context Menu
+
+Add "Pin" / "Unpin" item to the existing worktree right-click context menu. Label reflects current pin state.
+
+## RPC
+
+New `setWorktreePin` method with params `{ worktreeID: UUID, pinned: Bool }`. Sets or clears `pinnedAt` and broadcasts a state delta so the app updates immediately.
+
+## Non-Goals
+
+- Drag-to-reorder in split grid
+- Reordering pinned items in the sidebar
+- Persisting non-pin selection state across sessions

--- a/docs/superpowers/specs/2026-03-27-terminal-pane-pinning-design.md
+++ b/docs/superpowers/specs/2026-03-27-terminal-pane-pinning-design.md
@@ -1,0 +1,91 @@
+# Terminal Pane Pinning & Dock
+
+## Problem
+
+Pinned worktrees keep worktrees visible across sessions, but there's no way to keep a specific terminal pane visible when navigating between worktrees. Users working across multiple worktrees often want to reference a terminal from one worktree while working in another.
+
+## Solution
+
+Add terminal pane pinning with a persistent dock. Pinned terminals appear in a right-side dock alongside whatever worktree the user is viewing. The dock hides pinned terminals whose home worktree is already visible (no duplication).
+
+## Data Model
+
+### Database Migration
+
+Add a nullable `pinnedAt` column (ISO 8601 timestamp) to the `terminal` table (migration v5). NULL = not pinned, timestamp = pinned at that time. Sort by `pinnedAt ASC` for ordering within the dock.
+
+### Shared Model
+
+Add `pinnedAt: Date?` to the `Terminal` struct in `Models.swift`. Optional field, so existing data decodes without issue.
+
+### RPC
+
+New `terminal.setPin` method with params `{ terminalID: UUID, pinned: Bool }`. Sets or clears `pinnedAt` and broadcasts a `terminalPinChanged` state delta.
+
+### AppState
+
+Computed property `pinnedTerminals: [Terminal]` — all terminals across all worktrees where `pinnedAt != nil`, sorted by `pinnedAt ASC`. Derived from the existing `appState.terminals[worktreeID]` dictionary; no separate storage needed.
+
+## Layout Behavior
+
+### Single Worktree Selected
+
+The content area splits into two regions when pinned terminals from other worktrees exist:
+
+- **Left:** Normal single-worktree view — tab bar, split layout, full controls. Unchanged.
+- **Right:** Pinned terminal dock — pinned terminals stacked vertically, each with a header.
+
+**Filtering rule:** Pinned terminals whose home worktree IS the currently viewed worktree are excluded from the dock. They are already visible in-place within the worktree's own layout. This means:
+
+- Pinned terminals from only THIS worktree → no dock, full-width worktree view.
+- Pinned terminals from only OTHER worktrees → dock appears on the right.
+- Pinned terminals from BOTH → dock shows only those from other worktrees.
+
+### Multi-Worktree Selected (Cmd+Click / Worktree Pins)
+
+The dock still appears on the right if there are pinned terminals from worktrees NOT in the current grid selection. Same filtering rule: if a pinned terminal's home worktree is visible in the grid, it's excluded from the dock.
+
+- All pinned terminals' home worktrees are in the grid → no dock.
+- Some pinned terminals' home worktrees are NOT in the grid → dock appears.
+
+### No Pinned Terminals
+
+No dock renders. Full width goes to the main content (single-worktree or multi-worktree grid). No empty placeholder.
+
+## Dock Layout
+
+### Structure
+
+A vertical column on the right side of the main content area. Multiple pinned terminals stack vertically within the dock, each getting equal height.
+
+### Header Per Dock Cell
+
+`[pin icon (filled)] [worktree display name]` — left-aligned, compact, same styling as multi-worktree grid headers.
+
+### Sizing
+
+Default 70/30 split between main content and dock. User can drag the divider to resize. The dock/content ratio is persisted in UserDefaults (same pattern as layout persistence).
+
+## Pane Header Changes
+
+### Current
+
+Pane headers display the terminal ID, which is not useful to the user.
+
+### New
+
+Replace the terminal ID with a pin icon:
+
+- **Unpinned terminal:** Pin icon appears on hover only (outline style). Click pins the terminal.
+- **Pinned terminal:** Pin icon always visible (filled style). Click unpins the terminal.
+
+Pin icon appears at the left-most position. When displayed in the dock, the worktree display name appears to the right of the pin icon.
+
+When displayed within the home worktree's own layout, no worktree name is shown (context is obvious).
+
+## Non-Goals
+
+- Configurable dock position (left/right/top/bottom) — start with right only, make configurable later
+- Configurable stacking direction (horizontal/vertical) — start with vertical stacking, make configurable later
+- Drag-to-reorder within the dock
+- Pinning non-terminal pane types (webview, codeViewer)


### PR DESCRIPTION
## Summary
- **Worktree pinning** — pin worktrees so they auto-select on launch and stay visible in split view, with panes rendered in pin/click order instead of arbitrary Set order
- **Terminal pane pinning** — pin individual terminal panes so they persist in a right-side dock when navigating between worktrees; dock hides when viewing the pinned terminal's home worktree (no duplication)
- **Resizable dock** — draggable divider between main content and pinned terminal dock, ratio persisted across sessions
- Pin icon on hover (worktree rows + pane headers) with Pin/Unpin in context menus

## Test plan
- [ ] Pin a worktree via hover icon or context menu → verify it auto-selects on app restart
- [ ] Pin multiple worktrees → verify split view shows them in pin order
- [ ] Cmd+click a pinned worktree → verify it can't be deselected (must unpin first)
- [ ] Pin a terminal pane via the pane header icon → verify dock appears on the right when viewing other worktrees
- [ ] View the pinned terminal's home worktree → verify dock hides (terminal visible in-place)
- [ ] Pin multiple terminals from different worktrees → verify dock stacks them vertically
- [ ] Drag the dock divider → verify ratio persists after app restart
- [ ] Unpin terminal → verify it disappears from the dock
- [ ] `swift test` passes (155 tests including 4 new pin tests)