### PR TITLE
Feat: Enable Shift+Enter in embedded terminal via Kitty keyboard protocol

### DIFF
--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -143,6 +143,9 @@ struct PanePlaceholder: View {
                 onFilePathClicked: { path in
                     let newContent = PaneContent.codeViewer(id: UUID(), path: path)
                     layout = layout.splitPane(id: terminalID, direction: .horizontal, newContent: newContent)
+                },
+                onTerminalNotification: { title, body in
+                    debugLog("OSC 777: \(title) — \(body)")
                 }
             )
             .id(terminalID)

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -8,6 +8,7 @@ class TBDTerminalView: TerminalView {
     var naturalTextEditing: Bool = true
     var onFilePathClicked: ((String) -> Void)?
     var worktreePath: String = ""
+    var onNotification: ((String, String) -> Void)?
 
     // MARK: - Mouse click pass-through
     // Track mouseDown position to distinguish clicks from drags.
@@ -215,6 +216,15 @@ class TBDTerminalView: TerminalView {
         }
 
         return false
+    }
+
+    func notify(source: Terminal, title: String, body: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            // Only notify when this terminal is not focused
+            guard self.window?.isKeyWindow != true else { return }
+            self.onNotification?(title, body)
+        }
     }
 
 }

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -27,6 +27,7 @@ struct TerminalPanelView: NSViewRepresentable {
     let tmuxBridge: TmuxBridge
     var worktreePath: String = ""
     var onFilePathClicked: ((String) -> Void)?
+    var onTerminalNotification: ((String, String) -> Void)?
 
     func makeNSView(context: Context) -> TBDTerminalView {
         let tv = TBDTerminalView(
@@ -45,6 +46,7 @@ struct TerminalPanelView: NSViewRepresentable {
         // Wire up Cmd+Click file path detection
         tv.worktreePath = worktreePath
         tv.onFilePathClicked = onFilePathClicked
+        tv.onNotification = onTerminalNotification
 
         // Set delegate for terminal events
         tv.terminalDelegate = context.coordinator

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -95,6 +95,9 @@ public struct TmuxManager: Sendable {
             try? await runTmux(["-L", server, "set", "-g", "mouse", "on"])
             // Enable extended key sequences so Shift+Arrow etc. pass through to applications
             try? await runTmux(["-L", server, "set", "-g", "xterm-keys", "on"])
+            // Enable Kitty keyboard protocol so apps can distinguish Shift+Enter from Enter
+            try? await runTmux(["-L", server, "set", "-g", "extended-keys", "on"])
+            try? await runTmux(["-L", server, "set", "-g", "extended-keys-format", "kitty"])
             // Set SSH_AUTH_SOCK to stable symlink so shells get a resilient path
             try? await runTmux(["-L", server, "setenv", "-g", "SSH_AUTH_SOCK", SSHAgentResolver.defaultSymlinkPath])
             return output.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/docs/superpowers/plans/2026-03-27-terminal-enhancements.md
+++ b/docs/superpowers/plans/2026-03-27-terminal-enhancements.md
@@ -1,0 +1,118 @@
+# Terminal Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable Kitty keyboard protocol (fixes Shift+Enter in Claude Code) and OSC 777 terminal notifications in TBD's embedded terminal.
+
+**Architecture:** One tmux option added to server setup enables the Kitty keyboard protocol end-to-end. One `TerminalDelegate` method override in `TBDTerminalView` routes OSC 777 notifications into TBD's notification system via callback. OSC 9 progress already works via SwiftTerm's built-in progress bar — no changes needed.
+
+**Tech Stack:** Swift, SwiftTerm, tmux, AppKit
+
+---
+
+### Task 1: Enable Kitty keyboard protocol in tmux server setup
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Tmux/TmuxManager.swift:91-97`
+
+- [ ] **Step 1: Add `extended-keys-format kitty` to `ensureServer()`**
+
+In `TmuxManager.swift`, add two lines after line 95 (the `mouse on` setting) and before line 97 (the `SSH_AUTH_SOCK` line):
+
+```swift
+// Enable Kitty keyboard protocol so apps can distinguish Shift+Enter from Enter
+try? await runTmux(["-L", server, "set", "-g", "extended-keys", "on"])
+try? await runTmux(["-L", server, "set", "-g", "extended-keys-format", "kitty"])
+```
+
+We set both `extended-keys on` (in case the user's tmux.conf doesn't have it) and `extended-keys-format kitty` (to use CSI u encoding instead of the default xterm format).
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: `Build complete!`
+
+- [ ] **Step 3: Run tests**
+
+Run: `swift test 2>&1 | tail -10`
+Expected: All tests pass. The `ensureServer` test uses `dryRun: true` which skips `runTmux` calls, so our new lines are not exercised in tests (by design — they're runtime tmux commands).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDDaemon/Tmux/TmuxManager.swift
+git commit -m "feat: enable Kitty keyboard protocol in tmux (fixes Shift+Enter)"
+```
+
+---
+
+### Task 2: Wire up OSC 777 notifications in TBDTerminalView
+
+**Files:**
+- Modify: `Sources/TBDApp/Terminal/TBDTerminalView.swift`
+- Modify: `Sources/TBDApp/Terminal/TerminalPanelView.swift`
+- Modify: `Sources/TBDApp/Panes/PanePlaceholder.swift`
+
+- [ ] **Step 1: Add notification callback and override to TBDTerminalView**
+
+In `Sources/TBDApp/Terminal/TBDTerminalView.swift`, add a callback property and override the `notify` method from `TerminalDelegate`. Add these after the `worktreePath` property (line 10) and before the `extractFilePath` method (line 12):
+
+```swift
+var onNotification: ((String, String) -> Void)?
+```
+
+Then add this override after the `handleNaturalTextEditing` method (after line 124, before the closing brace of the class):
+
+```swift
+override func notify(source: Terminal, title: String, body: String) {
+    DispatchQueue.main.async { [weak self] in
+        guard let self else { return }
+        // Only notify when this terminal is not focused
+        guard self.window?.isKeyWindow != true else { return }
+        self.onNotification?(title, body)
+    }
+}
+```
+
+Note: `notify(source: Terminal, ...)` is a `TerminalDelegate` method with a default empty implementation. `TerminalView` (an `open class`) conforms to `TerminalDelegate`. Our subclass `TBDTerminalView` can override it. The `Terminal` type is from `import SwiftTerm`.
+
+- [ ] **Step 2: Add notification callback to TerminalPanelView**
+
+In `Sources/TBDApp/Terminal/TerminalPanelView.swift`, add a callback property after the `onFilePathClicked` property (line 29):
+
+```swift
+var onTerminalNotification: ((String, String) -> Void)?
+```
+
+Then in `makeNSView(context:)`, wire it up. Add after line 47 (`tv.onFilePathClicked = onFilePathClicked`):
+
+```swift
+tv.onNotification = onTerminalNotification
+```
+
+- [ ] **Step 3: Pass notification callback from PanePlaceholder**
+
+In `Sources/TBDApp/Panes/PanePlaceholder.swift`, add the `onTerminalNotification` parameter where `TerminalPanelView` is constructed (after the `onFilePathClicked` closure, around line 146). The exact wiring depends on how the notification system is accessed from this view. For now, log the notification so the callback is exercised:
+
+```swift
+onTerminalNotification: { title, body in
+    debugLog("OSC 777: \(title) — \(body)")
+}
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: `Build complete!`
+
+- [ ] **Step 5: Run tests**
+
+Run: `swift test 2>&1 | tail -10`
+Expected: All tests pass (no test changes — this is UI-layer code in `TBDApp` target which has no unit tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDApp/Terminal/TBDTerminalView.swift Sources/TBDApp/Terminal/TerminalPanelView.swift Sources/TBDApp/Panes/PanePlaceholder.swift
+git commit -m "feat: wire up OSC 777 terminal notifications"
+```

--- a/docs/superpowers/specs/2026-03-27-terminal-enhancements-design.md
+++ b/docs/superpowers/specs/2026-03-27-terminal-enhancements-design.md
@@ -1,0 +1,93 @@
+# Terminal Enhancements: Kitty Keyboard Protocol, OSC 777, OSC 9
+
+## Problem
+
+TBD's embedded terminal (SwiftTerm → tmux → shell) doesn't send distinct escape sequences for Shift+Enter, so Claude Code can't distinguish it from plain Enter. Users can't use Shift+Enter for multi-line input. Additionally, SwiftTerm already parses OSC 777 (notifications) and OSC 9 (progress) sequences but TBD doesn't handle them.
+
+## Solution
+
+Three changes, ordered by impact:
+
+1. **Enable Kitty keyboard protocol in tmux** — fixes Shift+Enter and all modifier+key combos
+2. **Wire up OSC 777 notifications** — route terminal notifications into TBD's existing notification system
+3. **Wire up OSC 9 progress** — surface progress state in the worktree UI
+
+## Architecture
+
+### Data Flow
+
+```
+Claude Code (inner app)
+    ↕ CSI u sequences, OSC 777, OSC 9
+tmux (middleman, -L tbd-<hash>)
+    ↕ passthrough
+SwiftTerm (outer terminal emulator)
+    ↕ delegate callbacks
+TerminalPanelView.Coordinator
+    ↕ callbacks / published state
+TBD UI (worktree rows, notifications)
+```
+
+### 1. Kitty Keyboard Protocol via tmux
+
+**What:** Add `set -g extended-keys-format kitty` to TBD's tmux server configuration.
+
+**Where:** `TmuxManager.swift`, in `ensureServer()` (lines 92-97), alongside the existing `set -g status off` / `set -g mouse on` options.
+
+**Why this works:**
+- tmux 3.6a supports the Kitty keyboard protocol
+- `extended-keys on` is already set (user's global tmux.conf)
+- SwiftTerm has full Kitty keyboard protocol support (KittyKeyboardProtocol.swift, KittyKeyboardEncoder.swift)
+- When Claude Code sends `CSI = 1 u` to request the protocol, tmux negotiates with the outer terminal (SwiftTerm), and key events flow back encoded as `CSI key;modifier u`
+
+**Change:** One line added to `ensureServer()`:
+```swift
+try? await runTmux(["-L", server, "set", "-g", "extended-keys-format", "kitty"])
+```
+
+**No changes needed in:**
+- SwiftTerm (already supports the protocol)
+- TBDTerminalView (handleNaturalTextEditing only fires for Cmd/Opt combos, not Shift+Enter)
+- TerminalPanelView (passthrough works automatically)
+
+### 2. OSC 777 Notifications
+
+**What:** Override SwiftTerm's default (no-op) handling of `notify(source:title:body:)` on the `TerminalDelegate` protocol, and route notifications into TBD's existing notification system.
+
+**Important detail:** `notify` is on `TerminalDelegate` (the low-level Terminal protocol), **not** on `TerminalViewDelegate` (the view-level protocol the Coordinator conforms to). `MacTerminalView` does not handle or forward this — it falls through to a default empty implementation. We need to subclass or otherwise intercept this.
+
+**Approach:** Override `notify` in `TBDTerminalView` (our existing `TerminalView` subclass). `TerminalView` conforms to `TerminalDelegate`, so we can override the method there and forward via a callback.
+
+**Where:** `TBDTerminalView.swift` — add the override and a callback property.
+
+**Interface:**
+```swift
+// On TBDTerminalView
+var onNotification: ((String, String) -> Void)?  // (title, body)
+
+// Override in TBDTerminalView (TerminalDelegate method)
+// Note: need to verify this is overridable — check if it's open/public in MacTerminalView
+```
+
+**Filtering:** Only fire if the terminal window is not key (not focused). Check `window?.isKeyWindow != true`.
+
+### 3. OSC 9 Progress Reporting
+
+**What:** SwiftTerm's `MacTerminalView` **already handles OSC 9 internally** — it has a built-in `TerminalProgressBarView` that renders a progress bar directly in the terminal view, with a 15-second auto-hide timer.
+
+**No code changes needed.** This works out of the box.
+
+**Optional future enhancement:** If we want to also surface progress in the worktree sidebar row (outside the terminal view), we could override `progressReport` in `TBDTerminalView` (same approach as notify), call `super`, and forward the state via a callback. But this is unnecessary for now — the built-in progress bar is sufficient.
+
+## What This Does NOT Change
+
+- No changes to SwiftTerm library code
+- No changes to the TBDTerminalView key handling (handleNaturalTextEditing is unaffected)
+- No changes to the existing notification hook system (notify.sh continues to work)
+- No new dependencies
+
+## Testing
+
+- **Shift+Enter:** Launch Claude Code in TBD, press Shift+Enter — should insert newline instead of submitting
+- **OSC 777:** Run `printf '\033]777;notify;Test Title;Test Body\007'` in a TBD terminal — should create a TBD notification (verify via DB or notification UI)
+- **OSC 9:** Run `printf '\033]9;4;1;50\007'` in a TBD terminal — SwiftTerm's built-in progress bar should appear at top of terminal view (already works, just verify)


### PR DESCRIPTION
## Summary
- **Fixes Shift+Enter** in TBD's embedded terminal by enabling the Kitty keyboard protocol in tmux (`extended-keys-format kitty`). SwiftTerm already supports the protocol — tmux just needed to use the right encoding format.
- **Wires up OSC 777 notifications** so terminal apps can send desktop-style notifications through the terminal. Currently logs via `debugLog`; ready to integrate with TBD's notification system.
- **OSC 9 progress** already works out of the box via SwiftTerm's built-in progress bar view — no changes needed.

## Test plan
- [ ] Restart a TBD worktree (so tmux server recreates with new options), open Claude Code, press Shift+Enter — should insert newline instead of submitting
- [ ] Run `printf '\033]777;notify;Test Title;Test Body\007'` in a TBD terminal — check `/tmp/tbd-bridge.log` for `OSC 777: Test Title — Test Body`
- [ ] Run `printf '\033]9;4;1;50\007'` in a TBD terminal — SwiftTerm's built-in progress bar should appear at top of terminal view