### PR TITLE
Fix: Scrolling only affects middle teammate pane regardless of cursor position

### DIFF
--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -162,18 +162,21 @@ struct TerminalPanelView: NSViewRepresentable {
                 guard deltaY != 0 else { return event }
 
                 let consumed = MainActor.assumeIsolated {
-                    guard let tv = ref.view else { return false }
+                    guard let tv = ref.view as? TBDTerminalView else { return false }
                     let point = tv.convert(location, from: nil)
                     guard tv.bounds.contains(point) else { return false }
                     guard tv.terminal.mouseMode != .off else { return false }
+
+                    // Use actual scroll position so tmux routes to the correct pane
+                    let cell = tv.cellDimensions()
+                    let col = Int(point.x / cell.width)
+                    let row = Int((tv.bounds.height - point.y) / cell.height)
 
                     let isUp = deltaY > 0
                     let buttonFlags = tv.terminal.encodeButton(
                         button: isUp ? 4 : 5,
                         release: false, shift: false, meta: false, control: false
                     )
-                    let col = tv.terminal.cols / 2
-                    let row = tv.terminal.rows / 2
                     let lines = max(1, Int(abs(deltaY)))
                     for _ in 0..<lines {
                         tv.terminal.sendEvent(buttonFlags: buttonFlags, x: col, y: row)

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -168,9 +168,7 @@ struct TerminalPanelView: NSViewRepresentable {
                     guard tv.terminal.mouseMode != .off else { return false }
 
                     // Use actual scroll position so tmux routes to the correct pane
-                    let cell = tv.cellDimensions()
-                    let col = Int(point.x / cell.width)
-                    let row = Int((tv.bounds.height - point.y) / cell.height)
+                    guard let (col, row) = tv.gridPosition(atWindowLocation: location) else { return false }
 
                     let isUp = deltaY > 0
                     let buttonFlags = tv.terminal.encodeButton(


### PR DESCRIPTION
## Summary
- With Claude Code agent teams in split-pane mode, scrolling always affected the middle teammate's pane no matter where the cursor was hovering
- The scroll wheel monitor was sending events at hardcoded coordinates `(cols/2, rows/2)` — the center of the terminal grid — so tmux always routed them to whatever pane occupied the middle
- Now converts the actual mouse position to grid coordinates so tmux routes scroll events to the pane under the cursor

## Test plan
- [ ] Restart TBD and spawn a Claude Code agent team with 3+ teammates (split-pane mode)
- [ ] Hover over the leftmost pane and scroll — verify it scrolls that pane's history
- [ ] Hover over the rightmost pane and scroll — verify it scrolls that pane's history
- [ ] Verify scrolling still works normally in single-pane terminals (no agent teams)