### PR TITLE
Refactor: Drop worktree pinning, fix stale branch detection

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -99,61 +99,6 @@ extension AppState {
         }
     }
 
-    /// Toggle pin state for a worktree.
-    func setWorktreePin(id: UUID, pinned: Bool) async {
-        // Optimistic local update
-        for repoID in worktrees.keys {
-            if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == id }) {
-                worktrees[repoID]?[idx].pinnedAt = pinned ? Date() : nil
-            }
-        }
-
-        if pinned {
-            // Add to selection if not already there
-            if !selectedWorktreeIDs.contains(id) {
-                selectedWorktreeIDs.insert(id)
-            }
-        }
-        // Rebuild order: pinned first (by pinnedAt), then unpinned in existing order
-        rebuildSelectionOrder()
-
-        do {
-            try await daemonClient.setWorktreePin(id: id, pinned: pinned)
-        } catch {
-            logger.error("Failed to set pin: \(error)")
-            handleConnectionError(error)
-        }
-    }
-
-    /// Rebuild selectionOrder from selectedWorktreeIDs, putting pinned items first (by pinnedAt).
-    func rebuildSelectionOrder() {
-        let allWts = worktrees.values.flatMap { $0 }
-        let wtMap = Dictionary(uniqueKeysWithValues: allWts.map { ($0.id, $0) })
-
-        let selected = selectedWorktreeIDs
-        var pinned: [(UUID, Date)] = []
-        var unpinned: [UUID] = []
-
-        for id in selectionOrder where selected.contains(id) {
-            if let wt = wtMap[id], let pinnedAt = wt.pinnedAt {
-                pinned.append((id, pinnedAt))
-            } else {
-                unpinned.append(id)
-            }
-        }
-        // Add any selected IDs not yet in selectionOrder
-        for id in selected where !selectionOrder.contains(id) {
-            if let wt = wtMap[id], let pinnedAt = wt.pinnedAt {
-                pinned.append((id, pinnedAt))
-            } else {
-                unpinned.append(id)
-            }
-        }
-
-        pinned.sort { $0.1 < $1.1 }
-        selectionOrder = pinned.map(\.0) + unpinned
-    }
-
     // MARK: - Keyboard Shortcut Actions
 
     /// All worktrees in sidebar order (sorted by repo, then by creation date).

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -21,8 +21,7 @@ final class AppState: ObservableObject {
             }
         }
     }
-    /// Tracks the order of selected worktrees for split view rendering.
-    /// Pinned worktrees come first (sorted by pinnedAt), then cmd+clicked ones in click order.
+    /// Tracks the order of selected worktrees for split view rendering (cmd+click order).
     @Published var selectionOrder: [UUID] = []
 
     /// All pinned terminals across all worktrees, sorted by pinnedAt.
@@ -123,14 +122,6 @@ final class AppState: ObservableObject {
         isConnected = didConnect
         if didConnect {
             await refreshAll()
-            // Auto-select pinned worktrees on launch
-            let pinnedWts = worktrees.values.flatMap { $0 }
-                .filter { $0.pinnedAt != nil }
-                .sorted { ($0.pinnedAt ?? .distantPast) < ($1.pinnedAt ?? .distantPast) }
-            if !pinnedWts.isEmpty {
-                selectedWorktreeIDs = Set(pinnedWts.map(\.id))
-                selectionOrder = pinnedWts.map(\.id)
-            }
             await refreshPRStatuses()
         } else {
             logger.warning("Could not connect to daemon — is tbdd running?")

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -337,14 +337,6 @@ actor DaemonClient {
         )
     }
 
-    /// Set or clear the pin on a worktree.
-    func setWorktreePin(id: UUID, pinned: Bool) throws {
-        try callVoid(
-            method: RPCMethod.worktreeSetPin,
-            params: WorktreeSetPinParams(worktreeID: id, pinned: pinned)
-        )
-    }
-
     /// Set or clear the pin on a terminal.
     func setTerminalPin(id: UUID, pinned: Bool) throws {
         try callVoid(

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -11,16 +11,6 @@ struct SidebarContextMenu: View {
         Group {
             if worktree.status == .main || worktree.status == .creating {
                 // Main / creating worktree: only Finder and Copy Path (no rename/archive)
-                Button(worktree.pinnedAt != nil ? "Unpin" : "Pin") {
-                    let wtID = worktree.id
-                    let shouldPin = worktree.pinnedAt == nil
-                    Task {
-                        await appState.setWorktreePin(id: wtID, pinned: shouldPin)
-                    }
-                }
-
-                Divider()
-
                 if !worktree.path.isEmpty {
                     Button("Open in Finder") {
                         NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.path)
@@ -34,14 +24,6 @@ struct SidebarContextMenu: View {
             } else {
                 Button("Rename...") {
                     onRename()
-                }
-
-                Button(worktree.pinnedAt != nil ? "Unpin" : "Pin") {
-                    let wtID = worktree.id
-                    let shouldPin = worktree.pinnedAt == nil
-                    Task {
-                        await appState.setWorktreePin(id: wtID, pinned: shouldPin)
-                    }
                 }
 
                 Button("Archive", role: .destructive) {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -13,7 +13,6 @@ struct WorktreeRowView: View {
     @State private var emojiSelectedIndex = 0
     @State private var frecency = EmojiFrecency.load()
     @State private var isNameTruncated = false
-    @State private var isHovering = false
 
     private var isPending: Bool {
         worktree.status == .creating
@@ -81,29 +80,6 @@ struct WorktreeRowView: View {
     }
 
     @ViewBuilder
-    private func pinIcon() -> some View {
-        if worktree.pinnedAt != nil {
-            Image(systemName: "pin.fill")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-                .frame(width: 10)
-                .onTapGesture {
-                    Task { await appState.setWorktreePin(id: worktree.id, pinned: false) }
-                }
-        } else if isHovering {
-            Image(systemName: "pin")
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-                .frame(width: 10)
-                .onTapGesture {
-                    Task { await appState.setWorktreePin(id: worktree.id, pinned: true) }
-                }
-        } else {
-            Color.clear.frame(width: 10)
-        }
-    }
-
-    @ViewBuilder
     private func rowIcons() -> some View {
         if isMain {
             Image(systemName: "arrow.triangle.branch")
@@ -130,7 +106,6 @@ struct WorktreeRowView: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            pinIcon()
             rowIcons()
             if isEditing {
                 InlineTextField(
@@ -200,16 +175,10 @@ struct WorktreeRowView: View {
             }
         }
         .contentShape(Rectangle())
-        .onHover { hovering in
-            isHovering = hovering
-        }
         .onTapGesture {
             if NSEvent.modifierFlags.contains(.command) {
                 if appState.selectedWorktreeIDs.contains(worktree.id) {
-                    // Don't allow cmd+click removal of pinned worktrees
-                    if worktree.pinnedAt == nil {
-                        appState.selectedWorktreeIDs.remove(worktree.id)
-                    }
+                    appState.selectedWorktreeIDs.remove(worktree.id)
                 } else {
                     appState.selectedWorktreeIDs.insert(worktree.id)
                 }
@@ -230,7 +199,6 @@ struct WorktreeRowView: View {
             }
         ) {
             HStack(spacing: 6) {
-                pinIcon()
                 rowIcons()
                 Text(worktree.displayName)
                     .fontWeight(hasBoldNotification ? .bold : .regular)

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -16,7 +16,6 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var hasConflicts: Bool
     var createdAt: Date
     var archivedAt: Date?
-    var pinnedAt: Date?
     var tmuxServer: String
 
     init(from wt: Worktree) {
@@ -30,7 +29,6 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.hasConflicts = wt.hasConflicts
         self.createdAt = wt.createdAt
         self.archivedAt = wt.archivedAt
-        self.pinnedAt = wt.pinnedAt
         self.tmuxServer = wt.tmuxServer
     }
 
@@ -46,7 +44,6 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             hasConflicts: hasConflicts,
             createdAt: createdAt,
             archivedAt: archivedAt,
-            pinnedAt: pinnedAt,
             tmuxServer: tmuxServer
         )
     }
@@ -163,7 +160,6 @@ public struct WorktreeStore: Sendable {
             }
             record.status = WorktreeStatus.archived.rawValue
             record.archivedAt = Date()
-            record.pinnedAt = nil
             try record.update(db)
         }
     }
@@ -231,17 +227,6 @@ public struct WorktreeStore: Sendable {
                 .filter(Column("path") == path)
                 .fetchOne(db)?
                 .toModel()
-        }
-    }
-
-    /// Set or clear the pinned timestamp for a worktree.
-    public func setPin(id: UUID, pinned: Bool, at date: Date = Date()) async throws {
-        try await writer.write { db in
-            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
-                throw DatabaseError(message: "Worktree not found")
-            }
-            record.pinnedAt = pinned ? date : nil
-            try record.update(db)
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -83,15 +83,4 @@ extension RPCRouter {
 
         return .ok()
     }
-
-    func handleWorktreeSetPin(_ paramsData: Data) async throws -> RPCResponse {
-        let params = try decoder.decode(WorktreeSetPinParams.self, from: paramsData)
-        let pinnedAt: Date? = params.pinned ? Date() : nil
-        try await db.worktrees.setPin(id: params.worktreeID, pinned: params.pinned, at: pinnedAt ?? Date())
-        subscriptions.broadcast(delta: .worktreePinChanged(WorktreePinDelta(
-            worktreeID: params.worktreeID, pinnedAt: pinnedAt
-        )))
-
-        return .ok()
-    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -64,8 +64,6 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeRevive(request.paramsData)
             case RPCMethod.worktreeRename:
                 return try await handleWorktreeRename(request.paramsData)
-            case RPCMethod.worktreeSetPin:
-                return try await handleWorktreeSetPin(request.paramsData)
             case RPCMethod.terminalCreate:
                 return try await handleTerminalCreate(request.paramsData)
             case RPCMethod.terminalList:

--- a/Sources/TBDDaemon/Server/StateSubscription.swift
+++ b/Sources/TBDDaemon/Server/StateSubscription.swift
@@ -15,7 +15,6 @@ public enum StateDelta: Codable, Sendable {
     case terminalCreated(TerminalDelta)
     case terminalRemoved(TerminalIDDelta)
     case worktreeConflictsChanged(WorktreeConflictDelta)
-    case worktreePinChanged(WorktreePinDelta)
     case terminalPinChanged(TerminalPinDelta)
 }
 
@@ -96,15 +95,6 @@ public struct WorktreeConflictDelta: Codable, Sendable {
     public let hasConflicts: Bool
     public init(worktreeID: UUID, hasConflicts: Bool) {
         self.worktreeID = worktreeID; self.hasConflicts = hasConflicts
-    }
-}
-
-/// Delta payload for worktree pin state change.
-public struct WorktreePinDelta: Codable, Sendable {
-    public let worktreeID: UUID
-    public let pinnedAt: Date?
-    public init(worktreeID: UUID, pinnedAt: Date?) {
-        self.worktreeID = worktreeID; self.pinnedAt = pinnedAt
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -34,13 +34,12 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public var hasConflicts: Bool = false
     public var createdAt: Date
     public var archivedAt: Date?
-    public var pinnedAt: Date?
     public var tmuxServer: String
 
     public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
                 hasConflicts: Bool = false,
-                createdAt: Date = Date(), archivedAt: Date? = nil, pinnedAt: Date? = nil, tmuxServer: String) {
+                createdAt: Date = Date(), archivedAt: Date? = nil, tmuxServer: String) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -51,7 +50,6 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.hasConflicts = hasConflicts
         self.createdAt = createdAt
         self.archivedAt = archivedAt
-        self.pinnedAt = pinnedAt
         self.tmuxServer = tmuxServer
     }
 
@@ -67,7 +65,6 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         hasConflicts = try c.decodeIfPresent(Bool.self, forKey: .hasConflicts) ?? false
         createdAt = try c.decode(Date.self, forKey: .createdAt)
         archivedAt = try c.decodeIfPresent(Date.self, forKey: .archivedAt)
-        pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
         tmuxServer = try c.decode(String.self, forKey: .tmuxServer)
     }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -84,7 +84,6 @@ public enum RPCMethod {
     public static let worktreeArchive = "worktree.archive"
     public static let worktreeRevive = "worktree.revive"
     public static let worktreeRename = "worktree.rename"
-    public static let worktreeSetPin = "worktree.setPin"
     public static let terminalCreate = "terminal.create"
     public static let terminalList = "terminal.list"
     public static let terminalSend = "terminal.send"
@@ -173,14 +172,6 @@ public struct WorktreeRenameParams: Codable, Sendable {
     public let displayName: String
     public init(worktreeID: UUID, displayName: String) {
         self.worktreeID = worktreeID; self.displayName = displayName
-    }
-}
-
-public struct WorktreeSetPinParams: Codable, Sendable {
-    public let worktreeID: UUID
-    public let pinned: Bool
-    public init(worktreeID: UUID, pinned: Bool) {
-        self.worktreeID = worktreeID; self.pinned = pinned
     }
 }
 

--- a/Tests/TBDDaemonTests/DatabaseTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseTests.swift
@@ -149,58 +149,6 @@ struct DatabaseTests {
         #expect(archived.count == 1)
     }
 
-    // MARK: - Pin Tests
-
-    @Test func worktreeSetPinAndUnpin() async throws {
-        let db = try TBDDatabase(inMemory: true)
-        let repo = try await db.repos.create(path: "/tmp/test-pin-repo", displayName: "Test", defaultBranch: "main")
-        let wt = try await db.worktrees.create(
-            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
-            path: "/tmp/test-pin-repo/.tbd/worktrees/test-wt", tmuxServer: "test"
-        )
-
-        // Initially not pinned
-        let initial = try await db.worktrees.get(id: wt.id)
-        #expect(initial?.pinnedAt == nil)
-
-        // Pin it
-        try await db.worktrees.setPin(id: wt.id, pinned: true)
-        let pinned = try await db.worktrees.get(id: wt.id)
-        #expect(pinned?.pinnedAt != nil)
-
-        // Unpin it
-        try await db.worktrees.setPin(id: wt.id, pinned: false)
-        let unpinned = try await db.worktrees.get(id: wt.id)
-        #expect(unpinned?.pinnedAt == nil)
-    }
-
-    @Test func pinnedWorktreesOrderByPinnedAt() async throws {
-        let db = try TBDDatabase(inMemory: true)
-        let repo = try await db.repos.create(path: "/tmp/test-pin-order", displayName: "Test2", defaultBranch: "main")
-
-        let wt1 = try await db.worktrees.create(
-            repoID: repo.id, name: "wt-1", branch: "tbd/wt-1",
-            path: "/tmp/test-pin-order/.tbd/worktrees/wt-1", tmuxServer: "test"
-        )
-        let wt2 = try await db.worktrees.create(
-            repoID: repo.id, name: "wt-2", branch: "tbd/wt-2",
-            path: "/tmp/test-pin-order/.tbd/worktrees/wt-2", tmuxServer: "test"
-        )
-
-        // Pin wt2 first, then wt1
-        try await db.worktrees.setPin(id: wt2.id, pinned: true)
-        try await Task.sleep(for: .milliseconds(10))
-        try await db.worktrees.setPin(id: wt1.id, pinned: true)
-
-        let all = try await db.worktrees.list(repoID: repo.id)
-        let pinned = all.filter { $0.pinnedAt != nil }
-        let sorted = pinned.sorted { ($0.pinnedAt ?? Date.distantPast) < ($1.pinnedAt ?? Date.distantPast) }
-
-        #expect(sorted.count == 2)
-        #expect(sorted[0].id == wt2.id) // pinned first
-        #expect(sorted[1].id == wt1.id) // pinned second
-    }
-
     // MARK: - Terminal Tests
 
     @Test func createAndListTerminals() async throws {


### PR DESCRIPTION
## Summary
- Removes worktree pinning (pin icon, context menu, RPC, auto-select on launch) — terminal pane pinning with the dock already covers the use case
- Fixes stale branch detection: `refreshGitStatuses` now runs every 10s instead of only at startup, so PR status lookups use the correct branch even after a manual `git checkout` inside a worktree
- Keeps `selectionOrder`, terminal pane pinning, and the pinned terminal dock

## Test plan
- [ ] Verify no pin icon or Pin/Unpin in worktree sidebar
- [ ] Verify terminal pane pinning still works
- [ ] Switch branches inside a worktree (`git checkout other-branch`), wait ~10s, verify PR status updates to the new branch
- [ ] `swift test` passes (152 tests)