### PR TITLE
Fix: Detect branch switches so PR status doesn't go stale

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -13,6 +13,7 @@ public final class Daemon: Sendable {
     public nonisolated(unsafe) var subscriptions: StateSubscriptionManager?
     public nonisolated(unsafe) var sshRefreshTask: Task<Void, Never>?
     public nonisolated(unsafe) var gitFetchTask: Task<Void, Never>?
+    public nonisolated(unsafe) var gitStatusTask: Task<Void, Never>?
     public let pidFile: PIDFile
     public let startTime: Date
 
@@ -134,11 +135,15 @@ public final class Daemon: Sendable {
 
         print("[Daemon] Started successfully (PID \(ProcessInfo.processInfo.processIdentifier))")
 
-        // 13. Refresh git statuses for all repos in background (cold recovery)
-        Task {
-            let allRepos = (try? await database.repos.list()) ?? []
-            for repo in allRepos {
-                await lifecycle.refreshGitStatuses(repoID: repo.id)
+        // 13. Periodic git status refresh (branch sync, conflict detection)
+        self.gitStatusTask = Task {
+            // Run once immediately (cold recovery), then every 10s
+            while !Task.isCancelled {
+                let allRepos = (try? await database.repos.list()) ?? []
+                for repo in allRepos {
+                    await lifecycle.refreshGitStatuses(repoID: repo.id)
+                }
+                try? await Task.sleep(for: .seconds(10))
             }
         }
     }
@@ -150,6 +155,7 @@ public final class Daemon: Sendable {
         // Cancel background tasks
         sshRefreshTask?.cancel()
         gitFetchTask?.cancel()
+        gitStatusTask?.cancel()
 
         // Stop servers
         if let sock = socketServer {

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -144,6 +144,7 @@ public final class Daemon: Sendable {
                     await lifecycle.refreshGitStatuses(repoID: repo.id)
                 }
                 try? await Task.sleep(for: .seconds(10))
+                guard !Task.isCancelled else { break }
             }
         }
     }


### PR DESCRIPTION
## Summary
- `refreshGitStatuses` already diffs actual branches (from `git worktree list`) against DB and updates changed ones, but only ran once at daemon startup
- Now runs every 10s as a periodic task, so PR status lookups use the correct branch even after a manual `git checkout` inside a worktree

## Test plan
- [ ] Switch branches inside a TBD worktree (`git checkout other-branch`)
- [ ] Wait ~10s, verify the worktree's branch updates in the sidebar/PR status
- [ ] `swift test` passes (152 tests)