### PR TITLE
Perf: Eliminate ~1s blank screen when switching worktrees

### DIFF
--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -11,6 +11,20 @@ class TBDTerminalView: TerminalView {
     var remoteURL: String?
     var onNotification: ((String, String) -> Void)?
 
+    /// Called once when the view has been laid out with non-zero bounds.
+    /// Used to start the tmux client as soon as the terminal has real dimensions.
+    var onReady: (() -> Void)?
+    private var didFireReady = false
+
+    override func layout() {
+        super.layout()
+        if !didFireReady && bounds.width > 0 && bounds.height > 0 {
+            didFireReady = true
+            onReady?()
+            onReady = nil
+        }
+    }
+
     // MARK: - Cell dimension calculation
 
     /// Computes cell dimensions from font metrics, matching SwiftTerm's internal calculation.

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -20,8 +20,9 @@ class TBDTerminalView: TerminalView {
         super.layout()
         if !didFireReady && bounds.width > 0 && bounds.height > 0 {
             didFireReady = true
-            onReady?()
+            let callback = onReady
             onReady = nil
+            DispatchQueue.main.async { callback?() }
         }
     }
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -146,8 +146,8 @@ struct TerminalPanelView: NSViewRepresentable {
                 }
             }
 
-            // Focus
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            // Focus on next run loop iteration (needs main actor for window access)
+            DispatchQueue.main.async {
                 terminalView.window?.makeFirstResponder(terminalView)
             }
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -57,8 +57,8 @@ struct TerminalPanelView: NSViewRepresentable {
         context.coordinator.tmuxServer = tmuxServer
         context.coordinator.panelID = terminalID
 
-        // Delay process start to let SwiftUI lay out the view first
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak tv] in
+        // Start tmux client as soon as the view has real dimensions from layout
+        tv.onReady = { [weak tv] in
             guard let tv else { return }
             context.coordinator.startTmuxClient(
                 terminalView: tv,

--- a/Sources/TBDApp/Terminal/TmuxBridge.swift
+++ b/Sources/TBDApp/Terminal/TmuxBridge.swift
@@ -54,21 +54,24 @@ final class TmuxBridge: @unchecked Sendable {
 
         // Single tmux invocation: create grouped session + select the target window.
         // Global options (status, borders, etc.) are set once by the daemon at server creation.
+        // tmux returns the exit code of the last chained command, so if new-session
+        // fails (session exists) but select-window succeeds, result.success is true.
         let result = runTmux(server: server, args: [
             "new-session", "-d", "-t", "main", "-s", sessionName, ";",
             "select-window", "-t", "\(sessionName):\(windowID)"
         ])
 
         if !result.success {
-            // Either the session couldn't be created or the window is dead.
-            // Try to distinguish: attempt select-window alone in case the session
-            // already existed but the chained command failed on new-session.
+            // Two failure modes:
+            //  (a) session already existed → new-session failed, select-window may still work
+            //  (b) new-session succeeded, select-window failed (window dead)
+            // Retry select-window alone to distinguish. Kill-session is safe in both
+            // cases since session names are UUID-based (no collision risk).
             let selectResult = runTmux(server: server, args: [
                 "select-window", "-t", "\(sessionName):\(windowID)"
             ])
             if !selectResult.success {
                 debugLog("PREPARE: window \(windowID) is dead on server \(server)")
-                // Clean up in case the session was partially created
                 let _ = runTmux(server: server, args: ["kill-session", "-t", sessionName])
                 return nil
             }

--- a/Sources/TBDApp/Terminal/TmuxBridge.swift
+++ b/Sources/TBDApp/Terminal/TmuxBridge.swift
@@ -52,43 +52,26 @@ final class TmuxBridge: @unchecked Sendable {
     func prepareSession(panelID: UUID, server: String, windowID: String) -> [String]? {
         let sessionName = "tbd-view-\(panelID.uuidString.prefix(8).lowercased())"
 
-        // Create a grouped session linked to "main"
-        let createResult = runTmux(server: server, args: [
-            "new-session", "-d", "-t", "main", "-s", sessionName
+        // Single tmux invocation: create grouped session + select the target window.
+        // Global options (status, borders, etc.) are set once by the daemon at server creation.
+        let result = runTmux(server: server, args: [
+            "new-session", "-d", "-t", "main", "-s", sessionName, ";",
+            "select-window", "-t", "\(sessionName):\(windowID)"
         ])
 
-        // Hide ALL tmux chrome — our app provides its own UI
-        // Set globally so it applies to main session and all grouped sessions
-        let _ = runTmux(server: server, args: ["set", "-g", "status", "off"])
-        let _ = runTmux(server: server, args: ["set", "-g", "pane-border-style", "fg=black"])
-        let _ = runTmux(server: server, args: ["set", "-g", "pane-border-indicators", "off"])
-        // Also set default-terminal for proper color support
-        let _ = runTmux(server: server, args: ["set", "-g", "default-terminal", "xterm-256color"])
-
-        if !createResult.success {
-            // Session might already exist, try to use it
-            debugLog("PREPARE: new-session failed (may already exist): \(createResult.output)")
-        }
-
-        // Verify the window still exists before selecting it
-        let checkResult = runTmux(server: server, args: [
-            "list-panes", "-t", windowID
-        ])
-
-        if checkResult.success {
-            // Window exists — select it in the grouped session
+        if !result.success {
+            // Either the session couldn't be created or the window is dead.
+            // Try to distinguish: attempt select-window alone in case the session
+            // already existed but the chained command failed on new-session.
             let selectResult = runTmux(server: server, args: [
                 "select-window", "-t", "\(sessionName):\(windowID)"
             ])
             if !selectResult.success {
-                debugLog("PREPARE: select-window failed: \(selectResult.output)")
+                debugLog("PREPARE: window \(windowID) is dead on server \(server)")
+                // Clean up in case the session was partially created
+                let _ = runTmux(server: server, args: ["kill-session", "-t", sessionName])
+                return nil
             }
-        } else {
-            // Window is dead — return nil so the caller can recreate the terminal
-            debugLog("PREPARE: window \(windowID) is dead on server \(server)")
-            // Clean up the grouped session we just created
-            let _ = runTmux(server: server, args: ["kill-session", "-t", sessionName])
-            return nil
         }
 
         lock.lock()

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -91,6 +91,8 @@ public struct TmuxManager: Sendable {
             // Hide tmux chrome globally — TBD app provides its own UI
             try? await runTmux(["-L", server, "set", "-g", "status", "off"])
             try? await runTmux(["-L", server, "set", "-g", "pane-border-style", "fg=black"])
+            try? await runTmux(["-L", server, "set", "-g", "pane-border-indicators", "off"])
+            try? await runTmux(["-L", server, "set", "-g", "default-terminal", "xterm-256color"])
             // Enable mouse so scroll wheel enters copy-mode and scrolls history
             try? await runTmux(["-L", server, "set", "-g", "mouse", "on"])
             // Enable extended key sequences so Shift+Arrow etc. pass through to applications


### PR DESCRIPTION
## Summary
- Collapsed 7 sequential tmux process spawns into 1 by removing redundant global `set -g` calls (daemon already handles these at server creation) and chaining `new-session` + `select-window` into a single tmux invocation
- Replaced the hardcoded 0.3s layout delay with an `NSView.layout()` callback that fires as soon as the terminal view has real dimensions
- Removed the 0.3s focus delay, using next-run-loop dispatch instead

## Test plan
- [ ] Switch between worktrees — terminal content should appear near-instantly instead of showing a blank cursor for ~1s
- [ ] Create a new terminal tab — should start up without delay
- [ ] Kill a terminal's tmux window externally (`tmux kill-window`), then try to view it — should show "Terminal session expired" message (dead window detection still works)
- [ ] Restart the app from scratch — global tmux options (no status bar, black borders) should still apply (set by daemon's `ensureServer`)