### PR TITLE
Fix: Pinned terminals vanish from dock when switching tabs in their home worktree

### DIFF
--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -3,17 +3,99 @@ import TBDShared
 
 /// A vertical dock showing pinned terminals from worktrees not currently visible.
 /// Each pinned terminal gets a cell with a header (pin icon + worktree name) and the terminal view.
+/// When multiple terminals are docked, draggable dividers between cells allow vertical resizing.
 struct PinnedTerminalDock: View {
     let terminals: [Terminal]
     @EnvironmentObject var appState: AppState
+    @State private var ratios: [CGFloat] = []
 
     var body: some View {
-        VStack(spacing: 1) {
-            ForEach(terminals) { terminal in
-                PinnedTerminalCell(terminal: terminal)
+        let count = terminals.count
+        let activeRatios = ratios.count == count ? ratios : Array(repeating: 1.0 / CGFloat(count), count: count)
+
+        GeometryReader { geometry in
+            let totalHeight = geometry.size.height
+            let dividerThickness: CGFloat = 4
+            let totalDividerSpace = dividerThickness * CGFloat(max(count - 1, 0))
+            let available = max(totalHeight - totalDividerSpace, 0)
+
+            VStack(spacing: 0) {
+                ForEach(Array(terminals.enumerated()), id: \.element.id) { index, terminal in
+                    PinnedTerminalCell(terminal: terminal)
+                        .frame(height: activeRatios[index] * available)
+
+                    if index < count - 1 {
+                        DockCellDivider(
+                            index: index,
+                            ratios: Binding(
+                                get: { activeRatios },
+                                set: { ratios = $0 }
+                            ),
+                            availableSpace: available
+                        )
+                        .frame(height: dividerThickness)
+                    }
+                }
             }
         }
-        .background(Color(nsColor: .separatorColor))
+        .onChange(of: terminals.map(\.id)) { _, newIDs in
+            let count = newIDs.count
+            ratios = Array(repeating: 1.0 / CGFloat(count), count: count)
+        }
+    }
+}
+
+/// Draggable vertical divider between dock cells.
+/// Uses deferred resize: shows indicator line during drag, commits on release.
+private struct DockCellDivider: View {
+    let index: Int
+    @Binding var ratios: [CGFloat]
+    let availableSpace: CGFloat
+
+    @State private var dragStartRatios: [CGFloat] = []
+    @State private var dragOffset: CGFloat = 0
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.gray.opacity(0.3))
+            .contentShape(Rectangle())
+            .cursor(.resizeUpDown)
+            .overlay(alignment: .top) {
+                if dragOffset != 0 {
+                    Rectangle()
+                        .fill(Color.accentColor.opacity(0.6))
+                        .frame(height: 2)
+                        .offset(y: dragOffset)
+                        .allowsHitTesting(false)
+                }
+            }
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        if dragStartRatios.isEmpty {
+                            dragStartRatios = ratios
+                        }
+                        guard availableSpace > 0 else { return }
+                        let minRatio: CGFloat = 0.1
+                        let maxDown = (dragStartRatios[index + 1] - minRatio) * availableSpace
+                        let maxUp = -(dragStartRatios[index] - minRatio) * availableSpace
+                        dragOffset = max(maxUp, min(maxDown, value.translation.height))
+                    }
+                    .onEnded { _ in
+                        guard availableSpace > 0 else {
+                            dragOffset = 0
+                            dragStartRatios = []
+                            return
+                        }
+                        let delta = dragOffset / availableSpace
+                        var newRatios = dragStartRatios
+                        newRatios[index] = dragStartRatios[index] + delta
+                        newRatios[index + 1] = dragStartRatios[index + 1] - delta
+                        ratios = newRatios
+                        dragOffset = 0
+                        dragStartRatios = []
+                    }
+            )
     }
 }
 

--- a/Sources/TBDApp/Terminal/SplitLayoutView.swift
+++ b/Sources/TBDApp/Terminal/SplitLayoutView.swift
@@ -151,6 +151,7 @@ struct SplitContainer: View {
 // MARK: - SplitDivider
 
 /// A draggable divider between split children.
+/// Uses deferred resize: tracks drag offset for an indicator overlay, commits on release.
 struct SplitDivider: View {
     let direction: SplitDirection
     let thickness: CGFloat
@@ -160,6 +161,8 @@ struct SplitDivider: View {
     let onDragEnd: () -> Void
 
     @State private var dragStartRatios: [CGFloat] = []
+    /// Pixel offset from the divider's resting position during drag.
+    @State private var dragOffset: CGFloat = 0
 
     var body: some View {
         Rectangle()
@@ -170,6 +173,21 @@ struct SplitDivider: View {
             )
             .contentShape(Rectangle())
             .cursor(direction == .horizontal ? .resizeLeftRight : .resizeUpDown)
+            .overlay(alignment: direction == .horizontal ? .leading : .top) {
+                if dragOffset != 0 {
+                    Rectangle()
+                        .fill(Color.accentColor.opacity(0.6))
+                        .frame(
+                            width: direction == .horizontal ? 2 : nil,
+                            height: direction == .vertical ? 2 : nil
+                        )
+                        .offset(
+                            x: direction == .horizontal ? dragOffset : 0,
+                            y: direction == .vertical ? dragOffset : 0
+                        )
+                        .allowsHitTesting(false)
+                }
+            }
             .gesture(
                 DragGesture()
                     .onChanged { value in
@@ -178,34 +196,29 @@ struct SplitDivider: View {
                         }
                         guard availableSpace > 0 else { return }
 
-                        let delta: CGFloat
-                        if direction == .horizontal {
-                            delta = value.translation.width / availableSpace
-                        } else {
-                            delta = value.translation.height / availableSpace
-                        }
+                        let translation: CGFloat = direction == .horizontal
+                            ? value.translation.width
+                            : value.translation.height
 
-                        var newRatios = dragStartRatios
+                        // Clamp the drag offset to respect min ratios
                         let minRatio: CGFloat = 0.1
-
-                        newRatios[index] = dragStartRatios[index] + delta
-                        newRatios[index + 1] = dragStartRatios[index + 1] - delta
-
-                        // Clamp both ratios
-                        if newRatios[index] < minRatio {
-                            let correction = minRatio - newRatios[index]
-                            newRatios[index] = minRatio
-                            newRatios[index + 1] -= correction
-                        }
-                        if newRatios[index + 1] < minRatio {
-                            let correction = minRatio - newRatios[index + 1]
-                            newRatios[index + 1] = minRatio
-                            newRatios[index] -= correction
-                        }
-
-                        ratios = newRatios
+                        let maxForward = (dragStartRatios[index + 1] - minRatio) * availableSpace
+                        let maxBackward = -(dragStartRatios[index] - minRatio) * availableSpace
+                        dragOffset = max(maxBackward, min(maxForward, translation))
                     }
                     .onEnded { _ in
+                        guard availableSpace > 0 else {
+                            dragOffset = 0
+                            dragStartRatios = []
+                            return
+                        }
+                        let delta = dragOffset / availableSpace
+                        var newRatios = dragStartRatios
+                        newRatios[index] = dragStartRatios[index] + delta
+                        newRatios[index + 1] = dragStartRatios[index + 1] - delta
+                        ratios = newRatios
+
+                        dragOffset = 0
                         dragStartRatios = []
                         onDragEnd()
                     }
@@ -215,7 +228,7 @@ struct SplitDivider: View {
 
 // MARK: - Cursor helper
 
-private extension View {
+extension View {
     func cursor(_ cursor: NSCursor) -> some View {
         self.onHover { hovering in
             if hovering {

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -12,10 +12,26 @@ import TBDShared
 struct TerminalContainerView: View {
     @EnvironmentObject var appState: AppState
 
+    /// Terminal IDs currently visible in the active tab layouts of selected worktrees.
+    private var visibleTerminalIDs: Set<UUID> {
+        var ids = Set<UUID>()
+        for worktreeID in appState.selectedWorktreeIDs {
+            let tabs = appState.tabs[worktreeID] ?? []
+            guard !tabs.isEmpty else { continue }
+            let activeIndex = appState.activeTabIndices[worktreeID] ?? 0
+            let tab = tabs[min(activeIndex, tabs.count - 1)]
+            let layout = appState.layouts[tab.id] ?? .pane(tab.content)
+            for id in layout.allTerminalIDs() {
+                ids.insert(id)
+            }
+        }
+        return ids
+    }
+
     var body: some View {
-        let visibleWorktreeIDs = appState.selectedWorktreeIDs
+        let visible = visibleTerminalIDs
         let dockTerminals = appState.pinnedTerminals.filter { terminal in
-            !visibleWorktreeIDs.contains(terminal.worktreeID)
+            !visible.contains(terminal.id)
         }
 
         let mainContent = Group {
@@ -240,8 +256,19 @@ private struct MultiWorktreeCell: View {
         return nil
     }
 
+    /// The terminal shown in this cell — derived from the active tab's layout
+    /// so it stays consistent with the dock's visibleTerminalIDs filter.
     private var primaryTerminal: Terminal? {
-        appState.terminals[worktreeID]?.first
+        let tabs = appState.tabs[worktreeID] ?? []
+        guard !tabs.isEmpty else { return appState.terminals[worktreeID]?.first }
+        let activeIndex = appState.activeTabIndices[worktreeID] ?? 0
+        let tab = tabs[min(activeIndex, tabs.count - 1)]
+        let layout = appState.layouts[tab.id] ?? .pane(tab.content)
+        // Use the first terminal in the active tab's layout tree
+        guard let firstID = layout.allTerminalIDs().first else {
+            return appState.terminals[worktreeID]?.first
+        }
+        return appState.terminals[worktreeID]?.first { $0.id == firstID }
     }
 
     var body: some View {
@@ -302,13 +329,15 @@ private struct MultiWorktreeCell: View {
 // MARK: - DockSplitView
 
 /// A horizontal split between main content (left) and pinned terminal dock (right).
-/// The divider is draggable to resize the dock.
+/// Uses deferred resize: shows an indicator line during drag, only commits on release.
 private struct DockSplitView<Main: View, Dock: View>: View {
     @Binding var dockRatio: CGFloat
     @ViewBuilder let mainContent: () -> Main
     @ViewBuilder let dockContent: () -> Dock
 
     @State private var dragStartRatio: CGFloat?
+    /// Preview ratio shown as indicator line during drag; nil when not dragging.
+    @State private var previewRatio: CGFloat?
 
     var body: some View {
         GeometryReader { geometry in
@@ -326,11 +355,15 @@ private struct DockSplitView<Main: View, Dock: View>: View {
                     .fill(Color.gray.opacity(0.3))
                     .frame(width: dividerWidth)
                     .contentShape(Rectangle())
-                    .onHover { hovering in
-                        if hovering {
-                            NSCursor.resizeLeftRight.push()
-                        } else {
-                            NSCursor.pop()
+                    .cursor(.resizeLeftRight)
+                    .overlay {
+                        if let preview = previewRatio {
+                            let offsetX = -(preview - dockRatio) * available
+                            Rectangle()
+                                .fill(Color.accentColor.opacity(0.6))
+                                .frame(width: 2)
+                                .offset(x: offsetX)
+                                .allowsHitTesting(false)
                         }
                     }
                     .gesture(
@@ -341,10 +374,13 @@ private struct DockSplitView<Main: View, Dock: View>: View {
                                 }
                                 guard let startRatio = dragStartRatio, available > 0 else { return }
                                 let delta = -value.translation.width / available
-                                let newRatio = max(0.1, min(0.6, startRatio + delta))
-                                dockRatio = newRatio
+                                previewRatio = max(0.1, min(0.6, startRatio + delta))
                             }
                             .onEnded { _ in
+                                if let preview = previewRatio {
+                                    dockRatio = preview
+                                }
+                                previewRatio = nil
                                 dragStartRatio = nil
                             }
                     )


### PR DESCRIPTION
## Summary
- **Dock visibility bug**: Pinned terminals disappeared from the dock when switching to a different tab in their home worktree. The filter checked if the worktree was selected, not whether the terminal was actually visible in the active tab's layout tree. Fixed by walking the active tab's layout to determine which terminals are currently on-screen.
- **Multi-select grid consistency**: `MultiWorktreeCell` hardcoded `.first` terminal regardless of active tab, causing a pinned terminal to appear in both the grid and dock simultaneously. Now derives the displayed terminal from the active tab's layout, consistent with the dock filter.
- **Janky resize**: Dragging split dividers live-resized terminal panels on every mouse move, causing visible lag as terminals struggled to keep up with PTY resize signals. All dividers now show an indicator line during drag and only commit the resize on release.
- **Dock cell resize**: Vertically stacked dock cells had no way to resize between them. Added draggable dividers with the same deferred-resize pattern.

## Test plan
- [ ] Pin a terminal, switch to a different tab in that worktree → verify it appears in the dock
- [ ] Switch back to the tab containing the pinned terminal → verify it disappears from the dock (visible in-place)
- [ ] Multi-select worktrees where one has a pinned terminal on a non-active tab → verify no duplication between grid and dock
- [ ] Drag a split divider in any terminal split → verify indicator line shows during drag, panels resize only on release
- [ ] Drag the dock horizontal divider → same deferred behavior
- [ ] Pin 2+ terminals → verify vertical dividers between dock cells are draggable