### PR TITLE
Fix: Stop relative file links from triggering macOS error -50

### DIFF
--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -206,6 +206,32 @@ class TBDTerminalView: TerminalView {
         return resolvedPath
     }
 
+    /// Resolves a string as a file path — handles absolute paths, file:// URLs, and relative paths.
+    /// Returns the resolved path if the file exists, nil otherwise.
+    func resolveAsFilePath(_ link: String) -> String? {
+        let candidate: String
+        if link.hasPrefix("file://") {
+            guard let path = URL(string: link)?.path, !path.isEmpty else { return nil }
+            candidate = path
+        } else if link.hasPrefix("/") {
+            candidate = link
+        } else if !link.contains("://"), !worktreePath.isEmpty {
+            candidate = URL(fileURLWithPath: worktreePath).appendingPathComponent(link).path
+        } else {
+            return nil
+        }
+        // Strip trailing :line:col suffix for existence check
+        let pathOnly: String
+        if let range = candidate.range(of: ":\\d+(:\\d+)?$", options: .regularExpression) {
+            pathOnly = String(candidate[..<range.lowerBound])
+        } else {
+            pathOnly = candidate
+        }
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: pathOnly, isDirectory: &isDir), !isDir.boolValue else { return nil }
+        return pathOnly
+    }
+
     /// Extracts a clickable URL from the terminal buffer at the given window-coordinate point.
     /// Checks for OSC 8 hyperlink payloads first, then falls back to pattern matching
     /// for common link patterns like "PR #123".

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -200,10 +200,17 @@ struct TerminalPanelView: NSViewRepresentable {
                         return true
                     }
                     // Fall back to hyperlink detection (OSC 8 or pattern matching)
-                    if let urlString = tv.extractHyperlinkURL(atWindowLocation: location),
-                       let url = URL(string: urlString) {
-                        NSWorkspace.shared.open(url)
-                        return true
+                    if let urlString = tv.extractHyperlinkURL(atWindowLocation: location) {
+                        // Try to resolve as a file path first (OSC 8 payload may be relative or file:// URL)
+                        if let resolved = tv.resolveAsFilePath(urlString) {
+                            tv.onFilePathClicked?(resolved)
+                            return true
+                        }
+                        // Only open as external URL if it has a real scheme
+                        if urlString.contains("://"), let url = URL(string: urlString) {
+                            NSWorkspace.shared.open(url)
+                            return true
+                        }
                     }
                     return false
                 }
@@ -284,30 +291,17 @@ struct TerminalPanelView: NSViewRepresentable {
 
         func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {
             MainActor.assumeIsolated {
-                // Check if this is a file path (relative or absolute) that we can open in a split pane
-                if let tv = source as? TBDTerminalView, !tv.worktreePath.isEmpty {
-                    let resolvedPath: String
-                    if link.hasPrefix("/") {
-                        resolvedPath = link
-                    } else if link.hasPrefix("file://") {
-                        resolvedPath = URL(string: link)?.path ?? link
-                    } else if !link.contains("://") {
-                        // Relative path — resolve against worktree
-                        resolvedPath = URL(fileURLWithPath: tv.worktreePath).appendingPathComponent(link).path
-                    } else {
-                        // Regular URL — open externally
-                        if let url = URL(string: link) { NSWorkspace.shared.open(url) }
-                        return
-                    }
-
-                    if FileManager.default.fileExists(atPath: resolvedPath) {
-                        tv.onFilePathClicked?(resolvedPath)
-                        return
-                    }
+                // Try to resolve as a file path (absolute, file://, or relative to worktree)
+                if let tv = source as? TBDTerminalView,
+                   let resolved = tv.resolveAsFilePath(link) {
+                    tv.onFilePathClicked?(resolved)
+                    return
                 }
 
-                // Fallback: open as URL
-                if let url = URL(string: link) { NSWorkspace.shared.open(url) }
+                // Only open as external URL if it has a real scheme
+                if link.contains("://"), let url = URL(string: link) {
+                    NSWorkspace.shared.open(url)
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Clicking relative file paths in Claude Code output (e.g. `docs/specs/file.md`) would construct a URL with scheme `"docs"` and pass it to `NSWorkspace.shared.open()`, which macOS rejects with error -50
- Added `resolveAsFilePath()` helper on TBDTerminalView that consolidates resolution of absolute paths, `file://` URLs, and relative paths (against worktreePath) with existence validation
- Both `requestOpenLink` (regular click on OSC 8 links) and the Cmd+Click handler now resolve file paths first, only falling back to external URL opening for links with a real scheme

## Test plan
- [ ] Open a worktree terminal where Claude Code outputs a relative file path
- [ ] Click the relative path link — should open in a code viewer split pane (not error -50)
- [ ] Cmd+Click a relative path — should also open in split pane
- [ ] Click an actual URL (e.g. GitHub PR link) — should still open in browser
- [ ] Click a `file:///absolute/path` link — should open in split pane