### PR TITLE
Compound: Capture software intent as recipes so the why survives rewrites

### DIFF
--- a/.github/workflows/recipe-check.yml
+++ b/.github/workflows/recipe-check.yml
@@ -1,0 +1,21 @@
+name: Recipe Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'recipe/**'
+      - 'scripts/recipe-check.sh'
+
+concurrency:
+  group: recipe-check-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Recipe mechanical checks
+        run: scripts/recipe-check.sh

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Recipe files require review from someone who understands architectural intent.
 # Recipes have more leverage than code — they guide all future generation.
-/recipe/ @chang
+/recipe/ @cheapsteak

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Recipe files require review from someone who understands architectural intent.
+# Recipes have more leverage than code — they guide all future generation.
+/recipe/ @chang

--- a/docs/superpowers/plans/2026-03-28-recipe-format-implementation.md
+++ b/docs/superpowers/plans/2026-03-28-recipe-format-implementation.md
@@ -1,0 +1,867 @@
+# Recipe Format Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construct the `recipe/` directory for TBD by mining existing design specs and git history, then add mechanical checks and review gating.
+
+**Architecture:** Pure markdown files in `recipe/`, one bash script for mechanical validation, one CODEOWNERS file. No code changes to the Swift project. All content is distilled from the 9 existing design specs in `docs/superpowers/specs/` and the git history.
+
+**Tech Stack:** Markdown, Bash, GitHub CODEOWNERS
+
+**Spec:** `docs/superpowers/specs/2026-03-28-recipe-format-design.md`
+
+---
+
+### Task 1: Create recipe.md (The Dish)
+
+**Files:**
+- Create: `recipe/recipe.md`
+
+- [ ] **Step 1: Create the recipe directory and root file**
+
+```markdown
+---
+format: recipe/v1
+last-audit: 2026-03-28
+---
+
+# TBD
+
+A macOS native worktree and terminal manager for multi-agent Claude Code workflows.
+
+## Why it exists
+
+Managing multiple AI coding agents on the same repo requires juggling git worktrees, terminal sessions, and status monitoring — creating worktrees, spawning terminals, checking PR status, resuming context after a crash. TBD makes this invisible. Agents get isolated workspaces with their own branches and terminals. Humans get a single window to see what every agent is doing.
+
+## Jobs
+
+- [Set up a multi-agent coding session](jobs/setup-session.md)
+- [Monitor agent progress without context-switching](jobs/monitor-agents.md)
+- [Resume work across sessions without losing state](jobs/resume-sessions.md)
+- [Review and integrate agent work](jobs/review-integrate.md)
+
+## Constraints
+
+- [Daemon owns all state](constraints/daemon-owns-state.md) — Invariant
+- [Crash resilience](constraints/crash-resilience.md) — Invariant
+- [No agent cooperation required](constraints/no-agent-cooperation.md) — Strong
+- [Agents are first-class users](constraints/agents-first-class.md) — Strong
+
+## Key Techniques
+
+- [Grouped tmux sessions](techniques/grouped-tmux.md) (Make)
+- [One tmux server per repo](techniques/tmux-per-repo.md) (Make)
+- [Daemon-UI-CLI split](techniques/daemon-ui-cli.md) (Make)
+- [SQLite with WAL mode](techniques/sqlite-wal.md) (Buy: GRDB)
+- [Terminal emulation behind a protocol](techniques/terminal-protocol.md) (Wrap: SwiftTerm)
+- [Unix domain socket + HTTP RPC](techniques/unix-socket-rpc.md) (Make)
+- [YYYYMMDD-adjective-animal naming](techniques/adjective-animal-naming.md) (Make)
+- [Stable SSH agent symlink](techniques/ssh-agent-symlink.md) (Make)
+```
+
+- [ ] **Step 2: Create directory structure**
+
+Run: `mkdir -p recipe/constraints recipe/jobs recipe/techniques`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add recipe/recipe.md
+git commit -m "feat: add recipe.md — the dish-level recipe for TBD"
+```
+
+---
+
+### Task 2: Create constraint files
+
+**Files:**
+- Create: `recipe/constraints/daemon-owns-state.md`
+- Create: `recipe/constraints/crash-resilience.md`
+- Create: `recipe/constraints/no-agent-cooperation.md`
+- Create: `recipe/constraints/agents-first-class.md`
+
+- [ ] **Step 1: Create daemon-owns-state.md**
+
+Mine from: `docs/superpowers/specs/2026-03-21-tbd-design.md` lines 9-11 (Core Philosophy), lines 29-47 (Components — daemon owns state), lines 424 (Architecture decision).
+
+```markdown
+# Daemon owns all state
+
+**Weight: Invariant**
+
+The UI is a stateless client. All persistent state lives in the daemon process (`tbdd`). If the app crashes, no user-visible data is lost — agents keep working in their tmux sessions, the database retains all worktree metadata, and terminals continue running. If the daemon crashes, it recovers from the SQLite database on restart and reconnects to surviving tmux servers.
+
+## Why this matters
+
+- Agents work in terminals independent of the UI — they don't know or care whether the app is open
+- The UI can be restarted, crashed, or closed without interrupting any agent's work
+- The CLI tool (`tbd`) works without the app running, talking directly to the daemon
+- Multiple UIs could theoretically connect to the same daemon
+
+## What this constrains
+
+- The app process must never be the source of truth for anything persistent — it only owns window layout (split positions, tab order) in UserDefaults
+- All state mutations go through the daemon's RPC interface (Unix socket or HTTP)
+- The database schema is the daemon's responsibility, not the app's
+- State reconciliation on launch: the daemon reconciles its ledger against `git worktree list` — git is authoritative for what exists on disk, the ledger adds metadata
+```
+
+- [ ] **Step 2: Create crash-resilience.md**
+
+Mine from: `docs/superpowers/specs/2026-03-21-tbd-design.md` lines 119-121 (Session Persistence), lines 393-399 (Crash recovery).
+
+```markdown
+# Crash resilience
+
+**Weight: Invariant**
+
+No user-visible data loss when any component crashes. The system is designed so that the failure of any single component (app, daemon, or tmux server) does not cascade into data loss or require manual recovery.
+
+## Why this matters
+
+- AI agents run for extended periods — losing their terminal state mid-task is expensive
+- Users expect a native app to survive crashes gracefully
+- The daemon may be kept alive by launchd across system restarts
+
+## What this constrains
+
+- Tmux servers are independent processes — they survive both app and daemon crashes
+- The daemon uses PID file checking on startup to detect stale state and clean up
+- The daemon reconciles its database against git worktree list on every startup
+- The app reattaches to existing tmux sessions on relaunch — scrollback is preserved by tmux
+- SQLite WAL mode ensures the database survives process crashes without corruption
+```
+
+- [ ] **Step 3: Create no-agent-cooperation.md**
+
+Mine from: `docs/superpowers/specs/2026-03-21-tbd-design.md` lines 9-11 (agents don't need to know about TBD), `docs/superpowers/specs/2026-03-23-worktree-pr-status-design.md` (status is inferred from git artifacts, not agent reporting).
+
+```markdown
+# No agent cooperation required
+
+**Weight: Strong**
+
+TBD observes agents through their git artifacts (branches, commits, PRs) and terminal output — it never requires agents to know about TBD, install plugins, or report their status. Agents are unmodified Claude Code sessions.
+
+## Why this matters
+
+- Agents should work the same way inside and outside TBD
+- Requiring agent-side integration creates a fragile dependency — agent updates could break TBD
+- Users can adopt TBD without changing their agent configuration
+
+## What this constrains
+
+- Status monitoring must infer state from git (branches, merge status, PRs), not from agent APIs
+- The notification hook (`tbd notify`) is opt-in and self-filtering — it's a no-op outside TBD-managed worktrees
+- Terminal output parsing for status is a trap — use git artifacts as the signal
+```
+
+- [ ] **Step 4: Create agents-first-class.md**
+
+Mine from: `docs/superpowers/specs/2026-03-21-tbd-design.md` lines 9-11 (Core Philosophy: "Everything the app can do must be accessible to coding agents").
+
+```markdown
+# Agents are first-class users
+
+**Weight: Strong**
+
+Everything the app can do must also be accessible to coding agents via the CLI or RPC interface. The UI is one client of the daemon — not a privileged one.
+
+## Why this matters
+
+- The primary workflow involves AI agents creating worktrees, spawning terminals, and managing their own workspace
+- If a feature only works through the GUI, agents can't use it, which defeats the purpose of the tool
+- The CLI must be the full-powered interface, not a subset
+
+## What this constrains
+
+- Every new feature needs both a UI surface and a CLI/RPC method
+- The daemon's RPC protocol is the canonical API — the app and CLI are both clients
+- All commands support `--json` output for machine-readable consumption
+- `tbd worktree create` blocks until the directory exists and terminals are spawned, so scripts can rely on the output
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add recipe/constraints/
+git commit -m "feat: add recipe constraints — daemon-owns-state, crash-resilience, no-agent-cooperation, agents-first-class"
+```
+
+---
+
+### Task 3: Create job files
+
+**Files:**
+- Create: `recipe/jobs/setup-session.md`
+- Create: `recipe/jobs/monitor-agents.md`
+- Create: `recipe/jobs/resume-sessions.md`
+- Create: `recipe/jobs/review-integrate.md`
+
+- [ ] **Step 1: Create setup-session.md**
+
+Mine from: `docs/superpowers/specs/2026-03-21-tbd-design.md` lines 163-177 (Worktree Creation flow), lines 204-237 (Hook System).
+
+```markdown
+# Set up a multi-agent coding session
+
+When starting work on a codebase with multiple AI agents, I need each agent to get its own isolated workspace — a git worktree with a fresh branch, a terminal running Claude Code, and a setup hook that prepares the environment — without manually running git commands, tmux sessions, or configuration scripts.
+
+## Constraints
+
+- Creating a worktree must be a single action (click or CLI command)
+- Each worktree gets an isolated git branch based on the latest remote default branch
+- Setup hooks from existing tools (Conductor, dmux) must be auto-detected and honored
+- The CLI must block until the workspace is ready so scripts can depend on the output
+- [Daemon owns all state](../constraints/daemon-owns-state.md)
+- [Agents are first-class users](../constraints/agents-first-class.md)
+
+## Techniques used
+
+- [Daemon-UI-CLI split](../techniques/daemon-ui-cli.md)
+- [One tmux server per repo](../techniques/tmux-per-repo.md)
+- [YYYYMMDD-adjective-animal naming](../techniques/adjective-animal-naming.md)
+
+## Success looks like
+
+- Clicking "+" on a repo in the sidebar creates a worktree, spawns two terminals (Claude Code + setup hook), and selects it — all in under 5 seconds
+- Running `tbd worktree create --repo .` from any terminal does the same thing and returns the path
+- The setup hook runs visibly in its own terminal so users can see its output
+- Multiple agents can be set up in rapid succession without conflicts
+
+## Traps
+
+- Don't require network for worktree creation — fall back to local `origin/main` if fetch fails
+- Don't chain hooks — first match wins, or you'll double-execute when dmux hooks call conductor scripts internally
+- Don't block on the setup hook — let Claude Code start immediately in terminal 1 while the hook runs in terminal 2
+```
+
+- [ ] **Step 2: Create monitor-agents.md**
+
+Mine from: `docs/superpowers/specs/2026-03-23-worktree-git-status-design.md` (git status indicators), `docs/superpowers/specs/2026-03-23-worktree-pr-status-design.md` (PR status), `docs/superpowers/specs/2026-03-27-terminal-enhancements-design.md` (OSC 777 notifications).
+
+```markdown
+# Monitor agent progress without context-switching
+
+When managing multiple coding agents on the same repo, I need to see what each is doing, whether they're blocked, and what PRs they've opened — without leaving my current context or switching windows.
+
+## Constraints
+
+- Agents work independently; can't require them to report in
+- Status must be fresh (< 60s for git, ~30s for PRs) without manual refresh
+- Must work even if the UI crashes mid-session
+- [Daemon owns all state](../constraints/daemon-owns-state.md)
+- [No agent cooperation required](../constraints/no-agent-cooperation.md)
+
+## Techniques used
+
+- [Grouped tmux sessions](../techniques/grouped-tmux.md)
+- [Daemon-UI-CLI split](../techniques/daemon-ui-cli.md)
+
+## Success looks like
+
+- Glancing at the sidebar tells me which agents are active, which have PRs open, and whether any branches have conflicts with main
+- PR status icons update automatically — green means mergeable, orange means open, purple means merged
+- Git status icons show when a branch is behind main or has merge conflicts
+- Pinning 2-3 worktrees gives me a persistent split view across sessions
+- Terminal notifications (OSC 777) from agents surface as TBD notification badges
+
+## Traps
+
+- Don't poll GitHub too aggressively — rate limits will cut you off. One bulk GraphQL query for all PRs is better than per-worktree REST calls.
+- Don't try to infer agent status from terminal output parsing — use git artifacts (branches, PRs) as the signal
+- Don't compute git status on a timer — make it event-driven (after fetch, after merge, on startup)
+```
+
+- [ ] **Step 3: Create resume-sessions.md**
+
+Mine from: `docs/superpowers/specs/2026-03-26-worktree-pinning-design.md` (persistent selection), `docs/superpowers/specs/2026-03-27-terminal-pane-pinning-design.md` (terminal dock), `docs/superpowers/specs/2026-03-21-tbd-design.md` lines 119-121 (session persistence), lines 148-161 (split layout model).
+
+```markdown
+# Resume work across sessions without losing state
+
+When I close the app and reopen it — or it crashes — I need to pick up exactly where I left off: the same worktrees visible, the same terminals running, the same split layout, with no manual reconstruction.
+
+## Constraints
+
+- Tmux sessions must survive app crashes and restarts
+- Pinned worktrees must persist across sessions
+- Terminal panes pinned to the dock must persist
+- Split layout (pane positions, ratios) must be restored
+- [Crash resilience](../constraints/crash-resilience.md)
+- [Daemon owns all state](../constraints/daemon-owns-state.md)
+
+## Techniques used
+
+- [Grouped tmux sessions](../techniques/grouped-tmux.md)
+- [One tmux server per repo](../techniques/tmux-per-repo.md)
+- [SQLite with WAL mode](../techniques/sqlite-wal.md)
+- [Stable SSH agent symlink](../techniques/ssh-agent-symlink.md)
+
+## Success looks like
+
+- Closing and reopening the app restores the same worktrees in the sidebar, the same terminals with their output, and the same split layout
+- Pinned worktrees are automatically selected on launch
+- Pinned terminal panes appear in the dock
+- SSH signing works in old terminals after a system restart (no stale agent socket)
+
+## Traps
+
+- Don't store session state in the app process — it dies with the UI
+- Don't use tmux control mode for the connection model — use grouped sessions so each panel gets independent current-window and size
+- The SSH agent socket path goes stale after WindowServer crashes — use a stable symlink that's refreshed periodically
+```
+
+- [ ] **Step 4: Create review-integrate.md**
+
+Mine from: `docs/superpowers/specs/2026-03-23-worktree-git-status-design.md` (conflict detection, merge status), `docs/superpowers/specs/2026-03-24-multiformat-panes-design.md` (webview for PRs, code viewer for diffs).
+
+```markdown
+# Review and integrate agent work
+
+When agents have completed work on their branches, I need to see diffs, review PRs, spot merge conflicts, and understand what changed — all within the same app, without switching to a browser or running git commands manually.
+
+## Constraints
+
+- Must detect merge conflicts before they become a problem
+- PR review should be possible without leaving TBD
+- File changes should be viewable with syntax highlighting
+- [No agent cooperation required](../constraints/no-agent-cooperation.md)
+
+## Techniques used
+
+- [Daemon-UI-CLI split](../techniques/daemon-ui-cli.md)
+- [Terminal emulation behind a protocol](../techniques/terminal-protocol.md)
+
+## Success looks like
+
+- Conflict icons appear on worktree rows when a branch would conflict with main
+- Clicking a PR status icon opens the GitHub PR in an embedded webview tab
+- Cmd+clicking a file path in a terminal opens a syntax-highlighted code viewer alongside the terminal
+- The file viewer shows changes since the branch's merge-base with main
+
+## Traps
+
+- Don't try to detect squash merges done outside TBD (e.g., via GitHub PR merge button) — only track merges TBD performs itself
+- Don't build a full code review tool — embedded webview to GitHub is sufficient for PR review
+- File path detection from terminal text is a heuristic — accept that it won't always work and fail silently
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add recipe/jobs/
+git commit -m "feat: add recipe jobs — setup-session, monitor-agents, resume-sessions, review-integrate"
+```
+
+---
+
+### Task 4: Create technique files
+
+**Files:**
+- Create: `recipe/techniques/grouped-tmux.md`
+- Create: `recipe/techniques/tmux-per-repo.md`
+- Create: `recipe/techniques/daemon-ui-cli.md`
+- Create: `recipe/techniques/sqlite-wal.md`
+- Create: `recipe/techniques/terminal-protocol.md`
+- Create: `recipe/techniques/unix-socket-rpc.md`
+- Create: `recipe/techniques/adjective-animal-naming.md`
+- Create: `recipe/techniques/ssh-agent-symlink.md`
+
+- [ ] **Step 1: Create grouped-tmux.md**
+
+Mine from: `docs/superpowers/specs/2026-03-21-tbd-design.md` lines 101-147 (Tmux Architecture), `docs/superpowers/specs/2026-03-26-tmux-input-passthrough-design.md`.
+
+```markdown
+# Grouped tmux sessions for independent panel views
+
+## Posture: Make
+
+This is a tmux configuration pattern, not a library dependency. The technique is a handful of tmux commands. No library models this specific multi-panel use case.
+
+## The problem
+
+Multiple UI panels need independent views of the same set of terminal sessions — different current windows, different sizes, different scroll positions. A single tmux connection forces all panels to share state.
+
+## The technique
+
+Use tmux grouped sessions. Each repo gets one tmux server (via `-L` socket name). Each UI panel attaches its own session grouped to a shared server. Panels can navigate independently — switching windows in one panel doesn't affect another.
+
+Each terminal is a tmux window with exactly one pane. No tmux pane splits are used — all spatial layout is managed by the host UI (SwiftUI). This keeps the tmux topology flat and predictable.
+
+Key configuration applied to each server:
+- `set -g mouse on` — enables mouse click passthrough for agent team pane switching
+- `set -g status off` — TBD owns the tab bar, not tmux
+- `set -g xterm-keys on` — passes through extended key sequences (Shift+Arrow)
+- `set -g extended-keys-format kitty` — enables Kitty keyboard protocol for Shift+Enter and modifier combos
+
+## Why not alternatives
+
+- **Tmux control mode (`-CC`):** Single controller, shared state, size conflicts between panels. iTerm2 uses this but dedicates ~3000 lines to working around its constraints.
+- **Multiple independent servers:** Can't share sessions across panels. Each panel would need its own copy of every terminal.
+- **No tmux (direct PTY):** Loses session persistence across app crashes. Tmux's independent process model is the key to crash resilience.
+
+## Where this applies
+
+Any multi-panel terminal UI that needs independent navigation of shared sessions with crash-resilient persistence.
+```
+
+- [ ] **Step 2: Create tmux-per-repo.md**
+
+```markdown
+# One tmux server per repo
+
+## Posture: Make
+
+A naming convention and process isolation pattern. No dependencies.
+
+## The problem
+
+Multiple repos managed in one app need terminal isolation. A crash or misconfiguration in one repo's terminal sessions shouldn't affect another repo.
+
+## The technique
+
+Each repo gets its own tmux server, named `tbd-<hash>` where hash is derived from the repo's stable identifier. Selected via `tmux -L tbd-<hash>`. Each server has one session named `main`. Windows within the session correspond to individual terminal panels.
+
+## Why not alternatives
+
+- **Single shared server:** A crash takes down all repos. Window name collisions. No isolation.
+- **Per-worktree servers:** Too many servers. Harder to share sessions between panels viewing the same repo.
+
+## Where this applies
+
+Any tool managing terminals across multiple independent projects in a single UI.
+```
+
+- [ ] **Step 3: Create daemon-ui-cli.md**
+
+Mine from: `docs/superpowers/specs/2026-03-21-tbd-design.md` lines 29-47 (Components), line 424 (Architecture decision).
+
+```markdown
+# Daemon-UI-CLI three-process split
+
+## Posture: Make
+
+Architectural pattern. Three SPM targets in one Swift package.
+
+## The problem
+
+A macOS app that manages long-running terminal sessions needs to survive its own UI crashes. It also needs to be scriptable by AI agents that work in terminals, not GUIs.
+
+## The technique
+
+Split into three processes:
+- **Daemon (`tbdd`):** Long-running headless process that owns all state (database, tmux servers, git operations, hooks). Communicates via Unix socket and HTTP.
+- **App (`TBD.app`):** SwiftUI client that subscribes to the daemon's state stream. Owns only window layout. Stateless — can be killed and restarted without data loss.
+- **CLI (`tbd`):** Stateless tool that sends a command to the daemon socket, prints the response, exits. Auto-resolves repo and worktree from `$PWD`.
+
+The daemon is the brain. The app and CLI are views.
+
+## Why not alternatives
+
+- **Monolithic app:** UI crash kills everything. Agents can't interact when app is closed.
+- **App + CLI (no daemon):** State lives in the app process. CLI can't work when app is closed. App crash loses state.
+- **Electron/web approach:** Heavy runtime, poor macOS integration, no native terminal performance.
+
+## Where this applies
+
+Any developer tool that needs to survive crashes and be accessible to both humans (GUI) and machines (CLI/API).
+```
+
+- [ ] **Step 4: Create sqlite-wal.md**
+
+```markdown
+# SQLite with WAL mode for persistent state
+
+## Posture: Buy (currently GRDB)
+
+Embedded SQLite via a Swift ORM. Don't hand-roll SQL query builders or migration systems. The migration framework and Codable integration aren't worth reimplementing.
+
+## The problem
+
+The daemon needs persistent state (worktree metadata, display names, notification history, pin timestamps) that survives crashes and supports concurrent readers (the daemon writes while the database is being read for state broadcasts).
+
+## The technique
+
+SQLite database at `~/.tbd/state.db` in WAL (Write-Ahead Logging) mode. Only the daemon writes — CLI and UI go through the daemon's RPC, so there are no concurrent writer conflicts. GRDB provides the Swift ORM layer with Codable record types and a sequential migration system (`DatabaseMigrator` with named migrations: v1, v2, v3...).
+
+Key rule: never modify an existing migration. Always add a new one. New columns must have `.defaults(to:)` values, and the corresponding Codable model must make new fields optional or provide defaults.
+
+## Why not alternatives
+
+- **UserDefaults / plist:** No relational queries, no migrations, doesn't scale to the worktree/terminal/notification model.
+- **Core Data:** Heavy, complex, designed for app processes not daemons, poor CLI ergonomics.
+- **Raw SQLite (no ORM):** Works but GRDB's Codable integration and migration system save significant boilerplate.
+
+## Where this applies
+
+Any Swift daemon or CLI tool needing structured persistent storage with crash safety and migration support.
+```
+
+- [ ] **Step 5: Create terminal-protocol.md**
+
+```markdown
+# Terminal emulation behind a swappable protocol
+
+## Posture: Wrap (currently SwiftTerm)
+
+We need terminal rendering but must isolate the app from API changes. The terminal adapter layer exists so the underlying library can be swapped.
+
+## The problem
+
+Terminal emulation is complex and the library landscape shifts. Committing to one library's API throughout the codebase creates expensive lock-in if a better option emerges (e.g., Ghostty's renderer).
+
+## The technique
+
+Abstract the terminal emulator behind a protocol (`TerminalRenderer`). The app talks to the protocol; the concrete implementation wraps SwiftTerm. The bridge between tmux control mode output and the terminal emulator is the highest-complexity component — the protocol should be designed with this bridging in mind.
+
+## Why not alternatives
+
+- **Direct SwiftTerm integration (no protocol):** Tightly couples the entire app to one library. Expensive to swap.
+- **Building a custom terminal emulator:** Years of work. SwiftTerm and Ghostty exist for a reason.
+
+## Where this applies
+
+Any app embedding a terminal emulator where the library choice may change.
+```
+
+- [ ] **Step 6: Create unix-socket-rpc.md**
+
+```markdown
+# Unix domain socket + HTTP RPC
+
+## Posture: Make
+
+Standard Unix IPC pattern. SwiftNIO provides the transport layer.
+
+## The problem
+
+The daemon, app, and CLI need to communicate. The protocol must be fast (for real-time state streaming), secure (user-scoped), and debuggable (for development).
+
+## The technique
+
+Dual transport: Unix domain socket at `~/.tbd/sock` (primary, user-scoped permissions) and HTTP on localhost (port stored in `~/.tbd/port`, for debugging with curl). Both use the same JSON-RPC style protocol with newline-delimited messages.
+
+The `state.subscribe` method returns a persistent streaming connection that pushes state deltas as they occur — the app uses this for reactive UI updates.
+
+## Why not alternatives
+
+- **HTTP only:** No Unix socket means no user-scoped permissions out of the box. Localhost HTTP is fine for debugging but shouldn't be the primary transport.
+- **gRPC:** Heavy dependency for a single-machine IPC use case. JSON-RPC is simpler and curl-debuggable.
+- **XPC:** macOS-only, requires entitlements, harder to debug, no good Swift async story.
+
+## Where this applies
+
+Any daemon + client architecture on a single machine where both performance and debuggability matter.
+```
+
+- [ ] **Step 7: Create adjective-animal-naming.md**
+
+```markdown
+# YYYYMMDD-adjective-animal naming for worktrees
+
+## Posture: Make
+
+A naming convention. ~20 lines of code with word lists.
+
+## The problem
+
+Worktrees need unique, human-friendly names that don't collide and are easy to type in a terminal. Branch names derived from ticket numbers or descriptions are either cryptic or conflict-prone.
+
+## The technique
+
+Auto-generate names as `YYYYMMDD-adjective-animal` (e.g., `20260321-fuzzy-penguin`). The date prefix groups worktrees chronologically. The adjective-animal suffix is drawn from large randomized word pools, making collisions vanishingly unlikely. The git branch is `tbd/<name>`.
+
+Users can rename the display name in the sidebar without changing the branch or directory name.
+
+## Why not alternatives
+
+- **Sequential numbers:** `worktree-1`, `worktree-2` — no semantic meaning, confusing across repos.
+- **Ticket-based names:** Requires ticket system integration, names are ugly in terminals.
+- **UUID-based:** Impossible to type or remember.
+
+## Where this applies
+
+Any system that auto-generates human-facing identifiers where uniqueness and typability both matter.
+```
+
+- [ ] **Step 8: Create ssh-agent-symlink.md**
+
+Mine from: `docs/superpowers/specs/2026-03-23-ssh-agent-resolver-design.md`.
+
+```markdown
+# Stable SSH agent symlink
+
+## Posture: Make
+
+A background task and symlink management. ~100 lines of code.
+
+## The problem
+
+The daemon inherits `SSH_AUTH_SOCK` from its launch environment. When macOS's WindowServer crashes or restarts, launchd creates a new SSH agent at a new socket path. The daemon (and its tmux sessions) retain the old, stale path. Git commit signing breaks in all TBD-managed terminals.
+
+## The technique
+
+Maintain a stable symlink (`~/.ssh/tbd-agent.sock`) that always points to the live SSH agent socket. Set `SSH_AUTH_SOCK` to this symlink path in all tmux sessions. A background task probes every 60 seconds: fast-path checks if the current symlink is reachable via `connect(2)`, slow-path probes launchd socket candidates if not. Symlink updates are atomic via `rename(2)`.
+
+The symlink indirection is the key insight: existing shells don't need to be restarted when the agent socket moves — the symlink resolves at connect time.
+
+## Why not alternatives
+
+- **Restart terminals on SSH agent change:** Destructive, loses agent context.
+- **Set env per-command:** Complex, fragile, doesn't work for all git operations.
+- **Rely on user to restart:** Happens several times per week on macOS. Not acceptable.
+
+## Where this applies
+
+Any long-running process on macOS that needs SSH agent access across WindowServer restarts.
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add recipe/techniques/
+git commit -m "feat: add recipe techniques — grouped-tmux, tmux-per-repo, daemon-ui-cli, sqlite-wal, terminal-protocol, unix-socket-rpc, adjective-animal-naming, ssh-agent-symlink"
+```
+
+---
+
+### Task 5: Create evolution.md from git history
+
+**Files:**
+- Create: `recipe/evolution.md`
+
+- [ ] **Step 1: Create evolution.md**
+
+Mine from git log — identify reasoning shifts visible in the commit history and PR titles.
+
+```markdown
+# Evolution
+
+Reasoning shifts in TBD's recipe, distilled from git history. Newest first.
+
+# 2026-03-27 | Terminal pane pinning adds a dock model
+Originally, pinned terminals were just part of the worktree's own layout. Users actually want to reference a terminal from one worktree while working in another. Terminal pinning creates a persistent dock alongside the main content, filtered to hide terminals whose home worktree is already visible.
+
+# 2026-03-26 | Worktree pinning replaces tab-based workflow
+Originally, switching between agents meant clicking sidebar items like tabs. Users actually want 2-3 agents visible simultaneously. Pinning with persistent split view replaces the single-select tab model. Selection order is preserved for split layout.
+
+# 2026-03-26 | Kitty keyboard protocol for modifier key passthrough
+The original xterm-keys approach handled Shift+Arrow but not Shift+Enter. Claude Code needs Shift+Enter for multi-line input. Enabling Kitty keyboard protocol in tmux (`extended-keys-format kitty`) solved the full modifier key space in one configuration change.
+
+# 2026-03-26 | Mouse clicks forwarded to tmux for agent team pane switching
+Claude Code's agent teams feature spawns tmux split panes. Users couldn't switch between panes because SwiftTerm intercepted all clicks for text selection. Click-vs-drag detection now forwards simple clicks to tmux while preserving drag-select for text.
+
+# 2026-03-24 | Multi-format panes generalize beyond terminals
+The layout system originally assumed every leaf was a terminal. Adding webview (for GitHub PRs) and code viewer (for file diffs) required generalizing to a PaneContent enum. The terminal tab system became a generic tab system with mixed pane types.
+
+# 2026-03-23 | PR status is a monitoring job, not a review job
+Initially grouped PR display under "reviewing agent work." Realized users check PR status for monitoring (is the agent still working?) not reviewing (is the code good?). PR status polling was moved to background bulk GraphQL queries, not on-demand per-worktree lookups.
+
+# 2026-03-23 | Git status is event-driven, not periodic
+The original design polled git status on a timer. Changed to event-driven triggers: after fetch, after merge, on startup. Avoids unnecessary git operations and makes status appear faster when it matters.
+
+# 2026-03-23 | Stable symlink solves SSH agent socket rotation
+SSH agent sockets go stale several times per week on macOS. The initial approach was to update tmux env vars periodically, but existing shells would still have the old path. A stable symlink that resolves at connect time means existing sessions self-heal without restart.
+
+# 2026-03-21 | Grouped tmux sessions over control mode
+The original design used tmux control mode (-CC) for the app-to-tmux connection. Control mode forces a single controller with shared window state and size. Grouped sessions give each panel independent current-window and size. iTerm2 uses control mode and dedicates ~3000 lines to working around its constraints.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add recipe/evolution.md
+git commit -m "feat: add recipe evolution.md — reasoning history distilled from git log"
+```
+
+---
+
+### Task 6: Create mechanical check script
+
+**Files:**
+- Create: `scripts/recipe-check.sh`
+
+- [ ] **Step 1: Create the validation script**
+
+```bash
+#!/usr/bin/env bash
+# recipe-check.sh — mechanical checks for recipe/ directory integrity
+# Validates internal links and detects orphaned files.
+# Exit 0 = all checks pass, Exit 1 = issues found.
+
+set -euo pipefail
+
+RECIPE_DIR="$(git rev-parse --show-toplevel)/recipe"
+ERRORS=0
+
+if [ ! -d "$RECIPE_DIR" ]; then
+    echo "ERROR: recipe/ directory not found"
+    exit 1
+fi
+
+echo "=== Recipe Mechanical Checks ==="
+echo ""
+
+# --- Check 1: Broken internal links ---
+echo "Checking internal links..."
+
+while IFS= read -r file; do
+    dir="$(dirname "$file")"
+    # Extract markdown links: [text](relative/path.md)
+    grep -oE '\[([^]]+)\]\(([^)]+\.md)\)' "$file" | while IFS= read -r match; do
+        target="$(echo "$match" | sed 's/.*](\(.*\))/\1/')"
+        # Skip external URLs
+        if [[ "$target" == http* ]]; then
+            continue
+        fi
+        resolved="$(cd "$dir" && realpath -q "$target" 2>/dev/null || echo "")"
+        if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then
+            echo "  BROKEN LINK: $file -> $target"
+            ERRORS=$((ERRORS + 1))
+        fi
+    done
+done < <(find "$RECIPE_DIR" -name '*.md' -type f)
+
+# --- Check 2: Orphaned techniques (referenced by zero jobs) ---
+echo "Checking for orphaned techniques..."
+
+if [ -d "$RECIPE_DIR/techniques" ]; then
+    for technique in "$RECIPE_DIR/techniques"/*.md; do
+        [ -f "$technique" ] || continue
+        basename="$(basename "$technique")"
+        # Search for references in jobs/ and recipe.md
+        refs=$(grep -rl "techniques/$basename" "$RECIPE_DIR/jobs/" "$RECIPE_DIR/recipe.md" 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$refs" -eq 0 ]; then
+            echo "  ORPHAN TECHNIQUE: techniques/$basename (referenced by 0 jobs)"
+            ERRORS=$((ERRORS + 1))
+        fi
+    done
+fi
+
+# --- Check 3: Orphaned constraints (referenced by zero jobs) ---
+echo "Checking for orphaned constraints..."
+
+if [ -d "$RECIPE_DIR/constraints" ]; then
+    for constraint in "$RECIPE_DIR/constraints"/*.md; do
+        [ -f "$constraint" ] || continue
+        basename="$(basename "$constraint")"
+        refs=$(grep -rl "constraints/$basename" "$RECIPE_DIR/jobs/" "$RECIPE_DIR/recipe.md" 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$refs" -eq 0 ]; then
+            echo "  ORPHAN CONSTRAINT: constraints/$basename (referenced by 0 jobs)"
+            ERRORS=$((ERRORS + 1))
+        fi
+    done
+fi
+
+# --- Check 4: Audit staleness ---
+echo "Checking audit freshness..."
+
+last_audit=$(grep -m1 'last-audit:' "$RECIPE_DIR/recipe.md" 2>/dev/null | sed 's/.*last-audit: *//' | tr -d ' ')
+if [ -n "$last_audit" ]; then
+    audit_epoch=$(date -j -f "%Y-%m-%d" "$last_audit" "+%s" 2>/dev/null || echo "0")
+    now_epoch=$(date "+%s")
+    days_ago=$(( (now_epoch - audit_epoch) / 86400 ))
+    if [ "$days_ago" -gt 14 ]; then
+        echo "  STALE AUDIT: last audit was $days_ago days ago ($last_audit)"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "  Audit is fresh ($days_ago days ago)"
+    fi
+else
+    echo "  WARNING: No last-audit timestamp found in recipe.md"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+    echo "FAILED: $ERRORS issue(s) found"
+    exit 1
+else
+    echo "PASSED: All checks clean"
+    exit 0
+fi
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x scripts/recipe-check.sh`
+
+- [ ] **Step 3: Run the check to verify it passes**
+
+Run: `scripts/recipe-check.sh`
+
+Expected: PASSED (all links resolve, no orphans, audit is fresh)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/recipe-check.sh
+git commit -m "feat: add recipe mechanical checks — link validation, orphan detection, audit staleness"
+```
+
+---
+
+### Task 7: Add CODEOWNERS for review gating
+
+**Files:**
+- Create: `CODEOWNERS`
+
+- [ ] **Step 1: Create CODEOWNERS file**
+
+```
+# Recipe files require review from someone who understands architectural intent.
+# Recipes have more leverage than code — they guide all future generation.
+/recipe/ @chang
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CODEOWNERS
+git commit -m "feat: add CODEOWNERS — recipe changes require architectural review"
+```
+
+---
+
+### Task 8: Final validation
+
+- [ ] **Step 1: Run the mechanical check script**
+
+Run: `scripts/recipe-check.sh`
+
+Expected: `PASSED: All checks clean`
+
+- [ ] **Step 2: Verify the complete directory structure**
+
+Run: `find recipe/ -type f | sort`
+
+Expected output:
+```
+recipe/constraints/agents-first-class.md
+recipe/constraints/crash-resilience.md
+recipe/constraints/daemon-owns-state.md
+recipe/constraints/no-agent-cooperation.md
+recipe/evolution.md
+recipe/jobs/monitor-agents.md
+recipe/jobs/resume-sessions.md
+recipe/jobs/review-integrate.md
+recipe/jobs/setup-session.md
+recipe/recipe.md
+recipe/techniques/adjective-animal-naming.md
+recipe/techniques/daemon-ui-cli.md
+recipe/techniques/grouped-tmux.md
+recipe/techniques/sqlite-wal.md
+recipe/techniques/ssh-agent-symlink.md
+recipe/techniques/terminal-protocol.md
+recipe/techniques/tmux-per-repo.md
+recipe/techniques/unix-socket-rpc.md
+```
+
+- [ ] **Step 3: Verify recipe.md links match actual files**
+
+Spot-check: every link in `recipe/recipe.md` should resolve to an actual file in the recipe directory.
+
+- [ ] **Step 4: Read through recipe.md as a first-time reader**
+
+Quick sanity check: does the top-level recipe tell a coherent story? Do the job names make sense? Do the constraint weights feel right?

--- a/docs/superpowers/specs/2026-03-28-recipe-format-brainstorm-ingredients.md
+++ b/docs/superpowers/specs/2026-03-28-recipe-format-brainstorm-ingredients.md
@@ -1,0 +1,136 @@
+# Recipe Format — Brainstorm Ingredients
+
+Raw ingredients from the brainstorming conversation that produced the manifesto and format design. Preserved so the manifesto can be revisited and distilled later.
+
+---
+
+## The Core Observation
+
+- "Code" has always been a form of rasterization/reification, but agentic coding has made it more obvious
+- Something is lost in the transformation, and the valuable thing to capture isn't the pixels
+- The metaphor: code is rendered pixels; intent is the vector source
+
+## The Cooking Metaphor
+
+- A lot of software will be more like "dishes"
+- "Recipes" will exist of the important parts (ideas, techniques)
+- Recipes should ideally be composable
+- People should be able to tweak recipes to cater to their own needs and tastes
+- You can swap out ingredients (other sub-recipes, or libraries)
+- Some things might never make sense to DIY — you probably always want to buy soy sauce rather than ferment your own
+- But many things will make much more sense to DIY
+- Especially if there exists a rich and vibrant library of other recipes to reference and build upon
+- "Like npm, but for recipes"
+
+## What Recipes Should Contain
+
+- Primarily composed of "why" — user stories / jobs to be done
+- Without the tedious "As a {x}" repetition
+- Occasionally include techniques of the "how" for non-obvious things
+- Architecture might be a sub-recipe that carries its own user story — architecture doesn't exist for its own sake but to solve real problems
+- The "user" might not be human but machine
+- Code is allowed when pragmatic — when it IS the technique. Extremism/purism is not pragmatic.
+
+## Key Design Decisions Made During Brainstorm
+
+### Audience: Universal
+The manifesto is short enough to be universal — states the observation and implication, lets each audience (toolmakers, practitioners) draw their own conclusions.
+
+### TBD is the first test case, not the product
+The format is project-agnostic. TBD proves it out by retroactive construction.
+
+### Two scales of recipe
+A project recipe composes fragment recipes. The "dish" is the composed whole; "techniques" circulate independently.
+
+### JTBD over other organizational models
+- Story Maps: good for organizing but not framing
+- Epics: arbitrary Jira buckets, no semantic meaning
+- Capability Maps: niche, enterprise-oriented
+- JTBD: captures the "why" — jobs are durable, features are ephemeral
+- Industry consensus: JTBD has "won" the framing layer
+- Tickets and epics are for implementation planning, not for distilling intent — they're rasterized too
+
+### Granularity: Workflow-oriented, cross-cutting
+- Per-architecture-decision is wrong granularity
+- Per-feature is too fine for most things
+- Per-workflow that cross-cuts capabilities and features is better for larger groupings
+- Per-capability for medium/small granularities
+- Jobs can fragment — that's expected, not a problem
+
+### Drift is the primary fear
+- Recipe drift (code evolves, recipe doesn't) is the killer — it creates false confidence
+- Recipe bloat is easier to rectify — overcapture first, condense later (2 phases)
+- Recipe absence is less worrying if generation is automated
+
+### Existing specs are raw material
+- Design specs in docs/specs/ are implementation-oriented
+- Recipes are the transferable essence — what matters and why regardless of tech stack
+- Both coexist: specs are for this dish, recipes are transferable knowledge
+
+## Approach Selection
+
+Three approaches were proposed and evaluated by two independent agents:
+
+### A: Git-native (markdown in repo, no tooling)
+- Lowest friction to create and consume
+- No dependency management story
+- Ship today
+
+### B: npm-style (registry, semver, dependency resolution)
+- Heavy infrastructure, premature
+- Semver is wrong model for intent
+- Registry becomes bottleneck
+
+### C: Hybrid (markdown + recipe.yaml manifest + light CLI)
+- Both agents independently recommended this
+- But consensus was: start with A, grow into C when needed
+
+**Decision: Start with A, option to evolve to C.**
+
+## Constructive Review — Key Additions
+
+1. `constraints/` directory for system-wide invariants that cross-cut jobs
+2. `## Success looks like` and `## Traps` sections on job template
+3. Buy/Make/Wrap posture on technique files
+4. Evolution.md heuristic: "would a future reader wonder why not the obvious alternative?"
+5. One evolution.md at recipe root, not per-directory
+6. Skip deterministic drift detection → go straight to periodic AI audit
+7. Format version marker (`recipe/v1`)
+8. Document relationship between recipes and CLAUDE.md
+
+## Adversarial Review — Key Challenges
+
+1. "Code is rasterized intent" breaks down for performance-critical code, emergent/accidental knowledge, and code-as-specification (parsers, state machines) — the code IS the valuable artifact in these cases
+2. JTBD fragmentation: jobs split on sprint timescales, not evolutionary ones — format must handle this gracefully
+3. Drift detection is fundamentally a judgment problem — automation catches structural drift, semantic drift requires AI/human review
+4. Two levels (jobs + techniques) is a simplification — constraints, aesthetic decisions, architectural invariants, NFRs, and job relationships don't fit neatly
+5. The cooking metaphor is technically wrong (sequential/imperative vs declarative/incomplete) — but communicates the spirit better than "pattern language" to a general audience
+6. Christopher Alexander's pattern language and 40 years of design rationale research (QOC, IBIS, DRL) are closer prior art worth studying
+
+## Resolutions to Adversarial Challenges
+
+- Accidental knowledge: partially captured by AI audit (reads code, surfaces undocumented edge cases)
+- Job fragmentation: expected workflow — split files, update index, add evolution entry
+- Inline comment drift comparison: "a thing of the past because it required human diligence; LLM diligence can solve for that already"
+- Constraints directory addresses the "two levels" gap
+
+## Recipe Lifecycle (integrating prose skills)
+
+1. Brainstorm (conversation)
+2. Synthesize (prose-synthesize) → draft recipe
+3. Overcapture (live with it)
+4. Distill (prose-distill) → tighten
+5. AI audit → catch drift
+
+## Sources and Prior Art Identified
+
+- Jeff Patton — Story Maps
+- Clayton Christensen, Anthony Ulwick, Alan Klement — Jobs To Be Done
+- Michael Nygard — Architecture Decision Records
+- Christopher Alexander — Pattern Language
+- QOC, IBIS, DRL — Design rationale frameworks
+- Nix Flakes, Terraform modules, Homebrew formulas — composition/distribution models
+- Schema.org Recipe format — metadata about recipes
+- Spec-Driven Development — specs as executable artifacts
+- Rustdoc doctests, Python doctests — executable documentation
+- Storybook — shared component documentation preventing drift

--- a/docs/superpowers/specs/2026-03-28-recipe-format-design.md
+++ b/docs/superpowers/specs/2026-03-28-recipe-format-design.md
@@ -1,0 +1,363 @@
+# Recipe Format Design
+
+## Manifesto: Code Is Rasterized Intent
+
+Code has always been a lossy transformation. An idea becomes a design, a design becomes implementation, and at each step something is lost — the reasoning, the tradeoffs, the alternatives considered and rejected. We've always known this, but it was tolerable when code was expensive to write and cheap to read.
+
+Agentic coding inverts this. Code is now cheap to write and cheap to read — for machines. What's expensive is the *intent* that produced it. An agent can generate a thousand lines in seconds, but it can't recover why those lines exist, what jobs they serve, or which constraints shaped the decisions.
+
+We've been preserving the pixels and discarding the vectors.
+
+Software should be captured as **recipes**, not as code. A recipe describes the jobs the software does, the constraints it operates under, and the techniques worth knowing — the transferable, composable essence that survives a rewrite, a new language, a different team.
+
+Code is a dish. Recipes are how dishes travel.
+
+**Principles:**
+
+1. **Capture why, not what.** A recipe is organized around jobs to be done, not features implemented. Features are ephemeral; jobs are durable.
+2. **Techniques over implementation.** When the "how" matters, capture it as a reusable technique — a solution to a recurring constraint, not a description of specific code.
+3. **Composability over completeness.** Recipes reference other recipes. You don't explain braising every time you use it. Some techniques you always "buy" (use a library); others you "make" (implement yourself). Both are valid.
+4. **Living documents, geological history.** A recipe evolves as understanding deepens, but the evolution is preserved — not as changelog noise, but as a record of how reasoning changed.
+5. **Automation keeps recipes honest.** Drift between recipe and code is the silent killer. Recipes must be wired into the development workflow so that forgetting to update them is harder than updating them.
+
+---
+
+## Format
+
+### Directory Structure
+
+```
+recipe/
+  recipe.md                # The dish — what, why, jobs index
+  constraints/
+    invariant-name.md      # System-wide invariants
+  jobs/
+    job-name.md            # Jobs to be done
+  techniques/
+    technique-name.md      # Reusable solutions to recurring problems
+  evolution.md             # AI-generated reasoning history (current)
+  evolution-archive.md     # Archived entries after compaction (created on first compact)
+```
+
+Flat by default. Optional subdirectory grouping within `jobs/` and `techniques/` when a directory exceeds ~15 items. `recipe.md` is always the authoritative index regardless of nesting.
+
+### recipe.md — The Dish
+
+Frontmatter:
+
+```yaml
+---
+format: recipe/v1
+---
+```
+
+Body: what this software is, why it exists, and a structured index of its jobs, constraints, and techniques. This is what someone reads first. Keep it short — it's a map, not the territory.
+
+Example:
+
+```markdown
+---
+format: recipe/v1
+last-audit: 2026-03-28
+---
+
+# TBD
+
+A macOS native worktree and terminal manager for multi-agent
+Claude Code workflows.
+
+## Why it exists
+Managing multiple AI coding agents on the same repo requires
+juggling git worktrees, terminal sessions, and status monitoring.
+TBD makes this invisible — agents get isolated workspaces,
+humans get a single pane of glass.
+
+## Jobs
+- [Set up a multi-agent session](jobs/setup-session.md)
+- [Monitor agent progress without context-switching](jobs/monitor-agents.md)
+- [Resume work across sessions](jobs/resume-sessions.md)
+- [Review and integrate agent work](jobs/review-integrate.md)
+
+## Constraints
+- [Daemon owns all state](constraints/daemon-owns-state.md) — Invariant
+- [Crash resilience](constraints/crash-resilience.md) — Invariant
+- [No agent cooperation required](constraints/no-agent-cooperation.md) — Strong
+
+## Key Techniques
+- [Grouped tmux sessions](techniques/grouped-tmux.md)
+- [One tmux server per repo](techniques/tmux-per-repo.md)
+- [SQLite with WAL mode](techniques/sqlite-wal.md) (Buy: GRDB)
+```
+
+**Minimum viable recipe:** `recipe.md` and 2-3 job files is a valid starting point. Add constraints and techniques as they emerge. When two or more jobs share the same constraint, extract it to a constraint file.
+
+### constraints/*.md — System-Wide Invariants
+
+Cross-cutting rules that constrain all jobs. Constraints have an ordinal **weight** indicating how firm they are:
+
+- **Invariant** — violating this is a bug. Non-negotiable. ("Daemon owns all state.")
+- **Strong** — bends only under significant pressure, and bending must be recorded in evolution.md. ("Status must be fresh within 60s.")
+- **Preference** — the default direction; acceptable to trade off against other constraints. ("Minimize external API calls.")
+
+When constraints conflict, higher-weight constraints win. If two constraints at the same weight conflict, the resolution belongs in the job file that encounters the tension, and warrants an evolution.md entry.
+
+```markdown
+# Daemon owns all state
+
+**Weight: Invariant**
+
+The UI is a stateless client. All persistent state lives in the daemon
+process. If the app crashes, no user-visible data is lost. If the daemon
+crashes, it recovers from the database on restart.
+
+## Why this matters
+- Agents work in terminals independent of the UI
+- The UI can be restarted without interrupting agent work
+- Multiple UIs could theoretically connect to the same daemon
+
+## What this constrains
+- The app process must never be the source of truth for anything
+- All state mutations go through the daemon's RPC interface
+- The database schema is the daemon's responsibility, not the app's
+```
+
+Jobs and techniques link to constraints they depend on. The distinction: techniques are *how* you solve a problem; constraints are *what you cannot violate*. The weight in the constraint file is authoritative; weights shown in `recipe.md`'s index are convenience summaries.
+
+### jobs/*.md — Jobs To Be Done
+
+One file per job. Framed around the situation and need, not "As a ___."
+
+```markdown
+# Monitor agent progress without context-switching
+
+When managing multiple coding agents on the same repo,
+I need to see what each is doing, whether they're blocked,
+and what PRs they've opened — without leaving my current context.
+
+## Constraints
+- Agents work independently; can't require them to report in
+- Status must be fresh (< 60s) without manual refresh
+- Must work even if the UI crashes mid-session
+- [Daemon owns all state](../constraints/daemon-owns-state.md)
+- [No agent cooperation required](../constraints/no-agent-cooperation.md)
+
+## Techniques used
+- [Background git fetch cycle](../techniques/background-fetch.md)
+- [PR status polling](../techniques/pr-status-polling.md)
+
+## Success looks like
+- Glancing at the app tells me which agents are active, blocked, or done
+- I never have to manually refresh or switch windows to check status
+- If an agent opens a PR, I see it within one polling cycle
+
+## Traps
+- Don't poll GitHub too aggressively — rate limits will cut you off
+- Don't try to infer agent status from terminal output parsing; use git artifacts (branches, PRs) as the signal
+```
+
+Inline constraints in job files are job-scoped context and don't carry weights. Only constraints extracted to `constraints/` files participate in the weight system.
+
+**Job fragmentation is expected.** When a job splits as the product matures, split the file, update `recipe.md` index, add an `evolution.md` entry explaining the split. This is normal evolution, not a problem.
+
+**System-facing jobs are fine.** The "When..." clause names the actual actor. "When the SwiftUI app reconnects after a crash..." — the reader understands the daemon is serving the app. No taxonomy of "system jobs" vs "user jobs" needed.
+
+### techniques/*.md — Reusable Techniques
+
+One file per technique. Each describes a problem, its solution, why alternatives were rejected, and where it applies beyond this project.
+
+```markdown
+# Grouped tmux sessions for independent panel views
+
+## Posture: Make
+This is a tmux configuration pattern, not a library dependency.
+The technique is 10 lines of tmux commands. No library models
+this specific multi-panel use case.
+
+## The problem
+Multiple UI panels need independent views of the same terminal
+session set — different current windows, different sizes.
+
+## The technique
+Use tmux grouped sessions (not control mode). Each panel
+gets its own session grouped to a shared server. Panels can
+navigate independently without affecting each other.
+
+## Why not alternatives
+- Control mode: single controller, shared state, size conflicts
+- Multiple servers: can't share sessions across panels
+
+## Where this applies
+Any multi-panel terminal UI that needs independent navigation.
+```
+
+**Posture** has three values:
+
+- **Buy** — use an existing library/service. Name the category, not the specific product. Optionally name a current recommendation. ("Buy: Embedded SQLite via a Swift ORM. Currently GRDB.")
+- **Make** — implement yourself. Explain why a dependency isn't worth it.
+- **Wrap** — use a library behind your own interface, because you need to be able to swap it. ("Wrap: Terminal emulation. Currently SwiftTerm, behind an adapter protocol.")
+
+The posture is about the decision, not the product. "Use GRDB" is an implementation detail. "Buy your embedded database layer" is a technique.
+
+### evolution.md — AI-Generated Reasoning History
+
+One file at the recipe root. Newest entries first. Records changes in reasoning, not changes in text.
+
+**evolution.md is generated by the AI audit, not hand-written.** The audit reads git history (commits, PR descriptions, code changes) and distills reasoning shifts into evolution entries. This eliminates the double-ledger problem — git is the source of truth, evolution.md is a curated view of it. Humans can hand-edit entries to correct or enrich them, but the generation is automated.
+
+**When the audit adds an entry:** When git history shows a change that shifted the reasoning behind a job, technique, or constraint — and a future reader looking at the current recipe state would wonder "why not the obvious alternative?"
+
+**When entries are skipped:** Self-evident changes (typos, additions that don't replace anything, refactors that don't change intent).
+
+| Git change | Evolution entry? |
+|--------|--------------|
+| New constraint added to a job | No — the constraint is self-evident in the file |
+| Polling replaced by WebSocket | Yes — why was polling insufficient? |
+| Two jobs merged into one | Yes — why were they the same job? |
+| A job split into sub-jobs | Yes — what fragmentation drove the split? |
+| A firm constraint relaxed | Yes — what changed to make it flexible? |
+
+Format:
+
+```markdown
+# 2026-03-26 | Pinning replaces tab-based workflow
+Originally, switching between agents meant clicking sidebar items
+like tabs. Users actually want 2-3 agents visible simultaneously.
+Pinning with split view replaces the tab model.
+
+# 2026-03-23 | PR status is a monitoring job, not a review job
+Initially grouped PR display under "reviewing agent work."
+Realized users check PR status for monitoring (is the agent
+still working?) not reviewing (is the code good?).
+```
+
+---
+
+## Drift Detection
+
+Two layers: cheap mechanical checks that run always, and expensive semantic audits that run periodically.
+
+### Mechanical checks (CI / pre-commit)
+
+These are deterministic, quiet, and cheap:
+
+- **Broken link validation** — all internal markdown links in `recipe/` resolve to existing files
+- **Orphan detection** — technique or constraint files referenced by zero jobs
+- **Audit staleness signal** — a visible timestamp ("last audit: 12 days ago") in recipe.md frontmatter or CI dashboard, so the team knows when the audit hasn't run
+
+These catch structural rot without the noise problems of semantic hooks.
+
+### Semantic audit (periodic AI)
+
+An AI agent reads all recipe files against the current codebase and git history:
+
+1. Flags semantic drift: jobs whose success criteria no longer match reality, techniques that have been replaced, constraints that are no longer enforced
+2. Catches accidental knowledge — bug fixes and edge cases encoded in code that no recipe mentions, which may warrant a new trap or technique
+3. Generates evolution.md entries from git history (see evolution.md section)
+4. Proposes recipe file updates as diffs for human review
+
+The audit runs on a schedule (weekly) or is triggered manually.
+
+### Review gating
+
+Recipe changes have more leverage than code changes — they guide all future generation and agent behavior. Recipe changes (in `recipe/`) should receive at least the same review rigor as code. Consider a CODEOWNERS-equivalent for the `recipe/` directory requiring review from someone who understands architectural intent.
+
+### Audit failure modes
+
+The system depends on the AI audit for semantic integrity. When the audit is wrong or absent:
+
+- **Bad output:** All audit-generated changes (evolution.md entries, recipe update proposals) go through the same review gating as any recipe change. The audit proposes; humans approve. A hallucinated evolution entry or incorrect drift flag is caught at review time.
+- **Missed drift (false negative):** The mechanical checks catch structural rot (broken links, orphans) even when the semantic audit misses something. For semantic drift, the `last-audit` timestamp in recipe.md makes silence visible — the team can see that the audit hasn't run, rather than assuming health from absence of warnings.
+- **Audit stops running:** The staleness signal is the defense. If `last-audit` shows a date more than 2 weeks old, the recipe's integrity is unverified. This is a passive signal, not a blocker — but it's visible in the file that every recipe consumer reads first.
+
+---
+
+## Recipe Lifecycle
+
+Recipes integrate with existing prose skills:
+
+1. **Brainstorm** — conversation, design sessions, scattered thinking
+2. **Synthesize** (`prose-synthesize`) — structure the thinking into draft recipe files (jobs, techniques, constraints)
+3. **Overcapture** — err toward too much detail. Live with it as the code evolves.
+4. **Distill** (`prose-distill`) — periodically tighten recipes. Lossless compression: remove redundancy, sharpen language, preserve all meaning.
+5. **AI audit** — catch drift, generate evolution.md entries, propose recipe updates. (See [Drift Detection](#drift-detection) for details.)
+6. **Compact** — fold accumulated evolution.md entries back into recipe files. The audit proposes updates to jobs, techniques, and constraints that reflect the reasoning shifts recorded in evolution.md. Folded entries are archived to `evolution-archive.md`. Recipe files become the current truth; evolution.md resets to only unfolded entries. This is like git squash for reasoning.
+
+Phase 3→4 is the expected steady state. Overcapture first, condense when the recipe stabilizes. The compact step runs when evolution.md accumulates enough entries that the recipe files and evolution have visibly diverged — typically alongside a distill pass.
+
+---
+
+## Relationship to Other Artifacts
+
+| Artifact | Purpose | Audience | Durability |
+|----------|---------|----------|------------|
+| Recipes | Why the software exists and what jobs it does | Anyone — current team, future team, competitors, agents | Survives a rewrite |
+| CLAUDE.md | Operational rules for agents working on this codebase | AI coding agents | Tied to current implementation |
+| Design specs (`docs/specs/`) | How a specific feature is implemented | Current developers | Tied to current implementation |
+| Code | The implementation itself | Machines and developers | Ephemeral — can be regenerated from recipes + specs |
+
+Recipes capture *why*. CLAUDE.md captures *what to do*. Specs capture *how it's built*. Code captures *what was built*. Each layer has different durability and different audiences.
+
+**Recipes are not consulted during ongoing iteration** — CLAUDE.md is the operational layer that agents and developers reference while working. Recipes are the durable layer consulted when starting new work, onboarding, making architectural decisions, or regenerating from intent. CLAUDE.md may restate recipe knowledge in operational form ("never delete state.db") without needing to stay in sync — it's a downstream artifact, not a mirror.
+
+---
+
+## Distribution
+
+Git-native. Recipes live in the repo's `recipe/` directory and are distributed via GitHub. No manifest, no registry, no tooling on day one.
+
+When cross-repo composition becomes a real need (recipes referencing recipes in other repos), add a `recipe.yaml` manifest with git URL + ref references. Not before. Semver is the wrong model for intent — recipes are pinned by git ref if needed.
+
+---
+
+## How Recipes Differ From Existing Formats
+
+- **vs. ADRs (Architecture Decision Records):** ADRs capture individual decisions. Recipes capture the living whole — jobs, constraints, techniques, and how they relate. An ADR is a snapshot; a recipe is a fractal, living document that evolves and self-compacts via the audit cycle. ADR history is close to what evolution.md captures, but evolution.md is generated from git, not hand-written.
+- **vs. RFCs / PEPs / Design Docs:** These are proposals for specific changes, frozen at acceptance. Recipes are living documents that track the current state of intent. A design doc quickly becomes stale after implementation; a recipe stays current through the audit-compact cycle.
+- **vs. README / Documentation:** READMEs describe how to use the software. Recipes describe why the software exists and what jobs it does — transferable knowledge that survives a rewrite.
+- **vs. Pattern Languages (Christopher Alexander):** The closest prior art. Recipes borrow the composable, multi-scale structure of pattern languages but add the JTBD framing (organized by jobs, not by spatial/structural patterns) and the automated drift detection cycle. Pattern languages are static catalogs; recipes are living and self-auditing.
+- **vs. User Stories / Epics:** Implementation scheduling artifacts. Recipes are the durable intent that stories are derived from, not the other way around.
+
+Recipes are fractal — a technique can contain sub-techniques, a job can reference sub-jobs, and the same structure works at every scale from a single utility to an entire platform.
+
+---
+
+## What Recipes Explicitly Exclude
+
+- **Tickets, epics, sprint planning** — these are implementation scheduling, not intent
+- **Code** — unless the code IS the technique (a non-obvious algorithm, a critical pattern)
+- **Implementation specs** — those live in `docs/specs/` as a separate, implementation-tied layer
+- **Metrics and KPIs** — recipes describe behavioral success criteria, not numbers
+
+---
+
+## Open Questions
+
+- **Cross-repo composition mechanics:** When `recipe.yaml` becomes necessary, what's the minimal schema? Git URL + ref + path? How are transitive dependencies handled?
+- **Recipe quality criteria:** How do you know a recipe is good? Complete? At the right altitude? This may emerge from practice rather than being prescribed upfront.
+- **Automation specifics:** What does the AI audit prompt look like? How does it map code to recipes without explicit annotations? This needs prototyping.
+
+---
+
+## Applying to TBD: Retroactive Construction
+
+TBD (the macOS worktree + terminal manager for multi-agent Claude Code workflows) is the first test case. The existing design specs in `docs/superpowers/specs/` are the raw material — they'll be mined for jobs, constraints, and techniques.
+
+Preliminary job candidates (to be refined during construction):
+- Set up a multi-agent coding session without manual tmux/git choreography
+- Monitor agent progress without context-switching
+- Resume work across sessions without losing layout or state
+- Review and integrate agent work (diffs, PRs, conflicts)
+
+Preliminary constraint candidates:
+- Daemon owns all state (UI is stateless)
+- Crash resilience (no data loss on app crash)
+- No agent cooperation required (agents don't know about TBD)
+
+Preliminary technique candidates:
+- Grouped tmux sessions for independent panel views
+- One tmux server per repo for isolation
+- YYYYMMDD-adjective-animal naming for uniqueness without conflicts
+- SQLite with WAL mode for concurrent readers (Buy: GRDB)
+- Unix domain socket + HTTP RPC for daemon communication
+
+These will be extracted from the existing specs and codebase in the implementation phase.

--- a/recipe/constraints/agents-first-class.md
+++ b/recipe/constraints/agents-first-class.md
@@ -1,0 +1,18 @@
+# Agents are first-class users
+
+**Weight: Strong**
+
+Everything the app can do must also be accessible to coding agents via the CLI or RPC interface. The UI is one client of the daemon — not a privileged one.
+
+## Why this matters
+
+- The primary workflow involves AI agents creating worktrees, spawning terminals, and managing their own workspace
+- If a feature only works through the GUI, agents can't use it, which defeats the purpose of the tool
+- The CLI must be the full-powered interface, not a subset
+
+## What this constrains
+
+- Every new feature needs both a UI surface and a CLI/RPC method
+- The daemon's RPC protocol is the canonical API — the app and CLI are both clients
+- All commands support `--json` output for machine-readable consumption
+- `tbd worktree create` blocks until the directory exists and terminals are spawned, so scripts can rely on the output

--- a/recipe/constraints/crash-resilience.md
+++ b/recipe/constraints/crash-resilience.md
@@ -1,0 +1,19 @@
+# Crash resilience
+
+**Weight: Invariant**
+
+No user-visible data loss when any component crashes. The system is designed so that the failure of any single component (app, daemon, or tmux server) does not cascade into data loss or require manual recovery.
+
+## Why this matters
+
+- AI agents run for extended periods — losing their terminal state mid-task is expensive
+- Users expect a native app to survive crashes gracefully
+- The daemon may be kept alive by launchd across system restarts
+
+## What this constrains
+
+- Tmux servers are independent processes — they survive both app and daemon crashes
+- The daemon uses PID file checking on startup to detect stale state and clean up
+- The daemon reconciles its database against git worktree list on every startup
+- The app reattaches to existing tmux sessions on relaunch — scrollback is preserved by tmux
+- SQLite WAL mode ensures the database survives process crashes without corruption

--- a/recipe/constraints/daemon-owns-state.md
+++ b/recipe/constraints/daemon-owns-state.md
@@ -1,0 +1,19 @@
+# Daemon owns all state
+
+**Weight: Invariant**
+
+The UI is a stateless client. All persistent state lives in the daemon process (`tbdd`). If the app crashes, no user-visible data is lost — agents keep working in their tmux sessions, the database retains all worktree metadata, and terminals continue running. If the daemon crashes, it recovers from the SQLite database on restart and reconnects to surviving tmux servers.
+
+## Why this matters
+
+- Agents work in terminals independent of the UI — they don't know or care whether the app is open
+- The UI can be restarted, crashed, or closed without interrupting any agent's work
+- The CLI tool (`tbd`) works without the app running, talking directly to the daemon
+- Multiple UIs could theoretically connect to the same daemon
+
+## What this constrains
+
+- The app process must never be the source of truth for anything persistent — it only owns window layout (split positions, tab order) in UserDefaults
+- All state mutations go through the daemon's RPC interface (Unix socket or HTTP)
+- The database schema is the daemon's responsibility, not the app's
+- State reconciliation on launch: the daemon reconciles its ledger against `git worktree list` — git is authoritative for what exists on disk, the ledger adds metadata

--- a/recipe/constraints/no-agent-cooperation.md
+++ b/recipe/constraints/no-agent-cooperation.md
@@ -1,0 +1,17 @@
+# No agent cooperation required
+
+**Weight: Strong**
+
+TBD observes agents through their git artifacts (branches, commits, PRs) and terminal output — it never requires agents to know about TBD, install plugins, or report their status. Agents are unmodified Claude Code sessions.
+
+## Why this matters
+
+- Agents should work the same way inside and outside TBD
+- Requiring agent-side integration creates a fragile dependency — agent updates could break TBD
+- Users can adopt TBD without changing their agent configuration
+
+## What this constrains
+
+- Status monitoring must infer state from git (branches, merge status, PRs), not from agent APIs
+- The notification hook (`tbd notify`) is opt-in and self-filtering — it's a no-op outside TBD-managed worktrees
+- Terminal output parsing for status is a trap — use git artifacts as the signal

--- a/recipe/evolution.md
+++ b/recipe/evolution.md
@@ -1,0 +1,30 @@
+# Evolution
+
+Reasoning shifts in TBD's recipe, distilled from git history. Newest first.
+
+# 2026-03-27 | Terminal pane pinning adds a dock model
+Originally, pinned terminals were just part of the worktree's own layout. Users actually want to reference a terminal from one worktree while working in another. Terminal pinning creates a persistent dock alongside the main content, filtered to hide terminals whose home worktree is already visible.
+
+# 2026-03-26 | Worktree pinning replaces tab-based workflow
+Originally, switching between agents meant clicking sidebar items like tabs. Users actually want 2-3 agents visible simultaneously. Pinning with persistent split view replaces the single-select tab model. Selection order is preserved for split layout.
+
+# 2026-03-26 | Kitty keyboard protocol for modifier key passthrough
+The original xterm-keys approach handled Shift+Arrow but not Shift+Enter. Claude Code needs Shift+Enter for multi-line input. Enabling Kitty keyboard protocol in tmux (`extended-keys-format kitty`) solved the full modifier key space in one configuration change.
+
+# 2026-03-26 | Mouse clicks forwarded to tmux for agent team pane switching
+Claude Code's agent teams feature spawns tmux split panes. Users couldn't switch between panes because SwiftTerm intercepted all clicks for text selection. Click-vs-drag detection now forwards simple clicks to tmux while preserving drag-select for text.
+
+# 2026-03-24 | Multi-format panes generalize beyond terminals
+The layout system originally assumed every leaf was a terminal. Adding webview (for GitHub PRs) and code viewer (for file diffs) required generalizing to a PaneContent enum. The terminal tab system became a generic tab system with mixed pane types.
+
+# 2026-03-23 | PR status is a monitoring job, not a review job
+Initially grouped PR display under "reviewing agent work." Realized users check PR status for monitoring (is the agent still working?) not reviewing (is the code good?). PR status polling was moved to background bulk GraphQL queries, not on-demand per-worktree lookups.
+
+# 2026-03-23 | Git status is event-driven, not periodic
+The original design polled git status on a timer. Changed to event-driven triggers: after fetch, after merge, on startup. Avoids unnecessary git operations and makes status appear faster when it matters.
+
+# 2026-03-23 | Stable symlink solves SSH agent socket rotation
+SSH agent sockets go stale several times per week on macOS. The initial approach was to update tmux env vars periodically, but existing shells would still have the old path. A stable symlink that resolves at connect time means existing sessions self-heal without restart.
+
+# 2026-03-21 | Grouped tmux sessions over control mode
+The original design used tmux control mode (-CC) for the app-to-tmux connection. Control mode forces a single controller with shared window state and size. Grouped sessions give each panel independent current-window and size. iTerm2 uses control mode and dedicates ~3000 lines to working around its constraints.

--- a/recipe/jobs/monitor-agents.md
+++ b/recipe/jobs/monitor-agents.md
@@ -1,0 +1,30 @@
+# Monitor agent progress without context-switching
+
+When managing multiple coding agents on the same repo, I need to see what each is doing, whether they're blocked, and what PRs they've opened — without leaving my current context or switching windows.
+
+## Constraints
+
+- Agents work independently; can't require them to report in
+- Status must be fresh (< 60s for git, ~30s for PRs) without manual refresh
+- Must work even if the UI crashes mid-session
+- [Daemon owns all state](../constraints/daemon-owns-state.md)
+- [No agent cooperation required](../constraints/no-agent-cooperation.md)
+
+## Techniques used
+
+- [Grouped tmux sessions](../techniques/grouped-tmux.md)
+- [Daemon-UI-CLI split](../techniques/daemon-ui-cli.md)
+
+## Success looks like
+
+- Glancing at the sidebar tells me which agents are active, which have PRs open, and whether any branches have conflicts with main
+- PR status icons update automatically — green means mergeable, orange means open, purple means merged
+- Git status icons show when a branch is behind main or has merge conflicts
+- Pinning 2-3 worktrees gives me a persistent split view across sessions
+- Terminal notifications (OSC 777) from agents surface as TBD notification badges
+
+## Traps
+
+- Don't poll GitHub too aggressively — rate limits will cut you off. One bulk GraphQL query for all PRs is better than per-worktree REST calls.
+- Don't try to infer agent status from terminal output parsing — use git artifacts (branches, PRs) as the signal
+- Don't compute git status on a timer — make it event-driven (after fetch, after merge, on startup)

--- a/recipe/jobs/resume-sessions.md
+++ b/recipe/jobs/resume-sessions.md
@@ -1,0 +1,32 @@
+# Resume work across sessions without losing state
+
+When I close the app and reopen it — or it crashes — I need to pick up exactly where I left off: the same worktrees visible, the same terminals running, the same split layout, with no manual reconstruction.
+
+## Constraints
+
+- Tmux sessions must survive app crashes and restarts
+- Pinned worktrees must persist across sessions
+- Terminal panes pinned to the dock must persist
+- Split layout (pane positions, ratios) must be restored
+- [Crash resilience](../constraints/crash-resilience.md)
+- [Daemon owns all state](../constraints/daemon-owns-state.md)
+
+## Techniques used
+
+- [Grouped tmux sessions](../techniques/grouped-tmux.md)
+- [One tmux server per repo](../techniques/tmux-per-repo.md)
+- [SQLite with WAL mode](../techniques/sqlite-wal.md)
+- [Stable SSH agent symlink](../techniques/ssh-agent-symlink.md)
+
+## Success looks like
+
+- Closing and reopening the app restores the same worktrees in the sidebar, the same terminals with their output, and the same split layout
+- Pinned worktrees are automatically selected on launch
+- Pinned terminal panes appear in the dock
+- SSH signing works in old terminals after a system restart (no stale agent socket)
+
+## Traps
+
+- Don't store session state in the app process — it dies with the UI
+- Don't use tmux control mode for the connection model — use grouped sessions so each panel gets independent current-window and size
+- The SSH agent socket path goes stale after WindowServer crashes — use a stable symlink that's refreshed periodically

--- a/recipe/jobs/review-integrate.md
+++ b/recipe/jobs/review-integrate.md
@@ -1,0 +1,28 @@
+# Review and integrate agent work
+
+When agents have completed work on their branches, I need to see diffs, review PRs, spot merge conflicts, and understand what changed — all within the same app, without switching to a browser or running git commands manually.
+
+## Constraints
+
+- Must detect merge conflicts before they become a problem
+- PR review should be possible without leaving TBD
+- File changes should be viewable with syntax highlighting
+- [No agent cooperation required](../constraints/no-agent-cooperation.md)
+
+## Techniques used
+
+- [Daemon-UI-CLI split](../techniques/daemon-ui-cli.md)
+- [Terminal emulation behind a protocol](../techniques/terminal-protocol.md)
+
+## Success looks like
+
+- Conflict icons appear on worktree rows when a branch would conflict with main
+- Clicking a PR status icon opens the GitHub PR in an embedded webview tab
+- Cmd+clicking a file path in a terminal opens a syntax-highlighted code viewer alongside the terminal
+- The file viewer shows changes since the branch's merge-base with main
+
+## Traps
+
+- Don't try to detect squash merges done outside TBD (e.g., via GitHub PR merge button) — only track merges TBD performs itself
+- Don't build a full code review tool — embedded webview to GitHub is sufficient for PR review
+- File path detection from terminal text is a heuristic — accept that it won't always work and fail silently

--- a/recipe/jobs/setup-session.md
+++ b/recipe/jobs/setup-session.md
@@ -1,0 +1,31 @@
+# Set up a multi-agent coding session
+
+When starting work on a codebase with multiple AI agents, I need each agent to get its own isolated workspace — a git worktree with a fresh branch, a terminal running Claude Code, and a setup hook that prepares the environment — without manually running git commands, tmux sessions, or configuration scripts.
+
+## Constraints
+
+- Creating a worktree must be a single action (click or CLI command)
+- Each worktree gets an isolated git branch based on the latest remote default branch
+- Setup hooks from existing tools (Conductor, dmux) must be auto-detected and honored
+- The CLI must block until the workspace is ready so scripts can depend on the output
+- [Daemon owns all state](../constraints/daemon-owns-state.md)
+- [Agents are first-class users](../constraints/agents-first-class.md)
+
+## Techniques used
+
+- [Daemon-UI-CLI split](../techniques/daemon-ui-cli.md)
+- [One tmux server per repo](../techniques/tmux-per-repo.md)
+- [YYYYMMDD-adjective-animal naming](../techniques/adjective-animal-naming.md)
+
+## Success looks like
+
+- Clicking "+" on a repo in the sidebar creates a worktree, spawns two terminals (Claude Code + setup hook), and selects it — all in under 5 seconds
+- Running `tbd worktree create --repo .` from any terminal does the same thing and returns the path
+- The setup hook runs visibly in its own terminal so users can see its output
+- Multiple agents can be set up in rapid succession without conflicts
+
+## Traps
+
+- Don't require network for worktree creation — fall back to local `origin/main` if fetch fails
+- Don't chain hooks — first match wins, or you'll double-execute when dmux hooks call conductor scripts internally
+- Don't block on the setup hook — let Claude Code start immediately in terminal 1 while the hook runs in terminal 2

--- a/recipe/recipe.md
+++ b/recipe/recipe.md
@@ -1,0 +1,37 @@
+---
+format: recipe/v1
+last-audit: 2026-03-28
+---
+
+# TBD
+
+A macOS native worktree and terminal manager for multi-agent Claude Code workflows.
+
+## Why it exists
+
+Managing multiple AI coding agents on the same repo requires juggling git worktrees, terminal sessions, and status monitoring — creating worktrees, spawning terminals, checking PR status, resuming context after a crash. TBD makes this invisible. Agents get isolated workspaces with their own branches and terminals. Humans get a single window to see what every agent is doing.
+
+## Jobs
+
+- [Set up a multi-agent coding session](jobs/setup-session.md)
+- [Monitor agent progress without context-switching](jobs/monitor-agents.md)
+- [Resume work across sessions without losing state](jobs/resume-sessions.md)
+- [Review and integrate agent work](jobs/review-integrate.md)
+
+## Constraints
+
+- [Daemon owns all state](constraints/daemon-owns-state.md) — Invariant
+- [Crash resilience](constraints/crash-resilience.md) — Invariant
+- [No agent cooperation required](constraints/no-agent-cooperation.md) — Strong
+- [Agents are first-class users](constraints/agents-first-class.md) — Strong
+
+## Key Techniques
+
+- [Grouped tmux sessions](techniques/grouped-tmux.md) (Make)
+- [One tmux server per repo](techniques/tmux-per-repo.md) (Make)
+- [Daemon-UI-CLI split](techniques/daemon-ui-cli.md) (Make)
+- [SQLite with WAL mode](techniques/sqlite-wal.md) (Buy: GRDB)
+- [Terminal emulation behind a protocol](techniques/terminal-protocol.md) (Wrap: SwiftTerm)
+- [Unix domain socket + HTTP RPC](techniques/unix-socket-rpc.md) (Make)
+- [YYYYMMDD-adjective-animal naming](techniques/adjective-animal-naming.md) (Make)
+- [Stable SSH agent symlink](techniques/ssh-agent-symlink.md) (Make)

--- a/recipe/recipe.md
+++ b/recipe/recipe.md
@@ -35,3 +35,7 @@ Managing multiple AI coding agents on the same repo requires juggling git worktr
 - [Unix domain socket + HTTP RPC](techniques/unix-socket-rpc.md) (Make)
 - [YYYYMMDD-adjective-animal naming](techniques/adjective-animal-naming.md) (Make)
 - [Stable SSH agent symlink](techniques/ssh-agent-symlink.md) (Make)
+
+## Evolution
+
+- [Reasoning history](evolution.md) — how and why the recipe changed over time

--- a/recipe/techniques/adjective-animal-naming.md
+++ b/recipe/techniques/adjective-animal-naming.md
@@ -1,0 +1,25 @@
+# YYYYMMDD-adjective-animal naming for worktrees
+
+## Posture: Make
+
+A naming convention. ~20 lines of code with word lists.
+
+## The problem
+
+Worktrees need unique, human-friendly names that don't collide and are easy to type in a terminal. Branch names derived from ticket numbers or descriptions are either cryptic or conflict-prone.
+
+## The technique
+
+Auto-generate names as `YYYYMMDD-adjective-animal` (e.g., `20260321-fuzzy-penguin`). The date prefix groups worktrees chronologically. The adjective-animal suffix is drawn from large randomized word pools, making collisions vanishingly unlikely. The git branch is `tbd/<name>`.
+
+Users can rename the display name in the sidebar without changing the branch or directory name.
+
+## Why not alternatives
+
+- **Sequential numbers:** `worktree-1`, `worktree-2` — no semantic meaning, confusing across repos.
+- **Ticket-based names:** Requires ticket system integration, names are ugly in terminals.
+- **UUID-based:** Impossible to type or remember.
+
+## Where this applies
+
+Any system that auto-generates human-facing identifiers where uniqueness and typability both matter.

--- a/recipe/techniques/daemon-ui-cli.md
+++ b/recipe/techniques/daemon-ui-cli.md
@@ -1,0 +1,28 @@
+# Daemon-UI-CLI three-process split
+
+## Posture: Make
+
+Architectural pattern. Three SPM targets in one Swift package.
+
+## The problem
+
+A macOS app that manages long-running terminal sessions needs to survive its own UI crashes. It also needs to be scriptable by AI agents that work in terminals, not GUIs.
+
+## The technique
+
+Split into three processes:
+- **Daemon (`tbdd`):** Long-running headless process that owns all state (database, tmux servers, git operations, hooks). Communicates via Unix socket and HTTP.
+- **App (`TBD.app`):** SwiftUI client that subscribes to the daemon's state stream. Owns only window layout. Stateless — can be killed and restarted without data loss.
+- **CLI (`tbd`):** Stateless tool that sends a command to the daemon socket, prints the response, exits. Auto-resolves repo and worktree from `$PWD`.
+
+The daemon is the brain. The app and CLI are views.
+
+## Why not alternatives
+
+- **Monolithic app:** UI crash kills everything. Agents can't interact when app is closed.
+- **App + CLI (no daemon):** State lives in the app process. CLI can't work when app is closed. App crash loses state.
+- **Electron/web approach:** Heavy runtime, poor macOS integration, no native terminal performance.
+
+## Where this applies
+
+Any developer tool that needs to survive crashes and be accessible to both humans (GUI) and machines (CLI/API).

--- a/recipe/techniques/grouped-tmux.md
+++ b/recipe/techniques/grouped-tmux.md
@@ -1,0 +1,31 @@
+# Grouped tmux sessions for independent panel views
+
+## Posture: Make
+
+This is a tmux configuration pattern, not a library dependency. The technique is a handful of tmux commands. No library models this specific multi-panel use case.
+
+## The problem
+
+Multiple UI panels need independent views of the same set of terminal sessions — different current windows, different sizes, different scroll positions. A single tmux connection forces all panels to share state.
+
+## The technique
+
+Use tmux grouped sessions. Each repo gets one tmux server (via `-L` socket name). Each UI panel attaches its own session grouped to a shared server. Panels can navigate independently — switching windows in one panel doesn't affect another.
+
+Each terminal is a tmux window with exactly one pane. No tmux pane splits are used — all spatial layout is managed by the host UI (SwiftUI). This keeps the tmux topology flat and predictable.
+
+Key configuration applied to each server:
+- `set -g mouse on` — enables mouse click passthrough for agent team pane switching
+- `set -g status off` — TBD owns the tab bar, not tmux
+- `set -g xterm-keys on` — passes through extended key sequences (Shift+Arrow)
+- `set -g extended-keys-format kitty` — enables Kitty keyboard protocol for Shift+Enter and modifier combos
+
+## Why not alternatives
+
+- **Tmux control mode (`-CC`):** Single controller, shared state, size conflicts between panels. iTerm2 uses this but dedicates ~3000 lines to working around its constraints.
+- **Multiple independent servers:** Can't share sessions across panels. Each panel would need its own copy of every terminal.
+- **No tmux (direct PTY):** Loses session persistence across app crashes. Tmux's independent process model is the key to crash resilience.
+
+## Where this applies
+
+Any multi-panel terminal UI that needs independent navigation of shared sessions with crash-resilient persistence.

--- a/recipe/techniques/sqlite-wal.md
+++ b/recipe/techniques/sqlite-wal.md
@@ -1,0 +1,25 @@
+# SQLite with WAL mode for persistent state
+
+## Posture: Buy (currently GRDB)
+
+Embedded SQLite via a Swift ORM. Don't hand-roll SQL query builders or migration systems. The migration framework and Codable integration aren't worth reimplementing.
+
+## The problem
+
+The daemon needs persistent state (worktree metadata, display names, notification history, pin timestamps) that survives crashes and supports concurrent readers (the daemon writes while the database is being read for state broadcasts).
+
+## The technique
+
+SQLite database at `~/.tbd/state.db` in WAL (Write-Ahead Logging) mode. Only the daemon writes — CLI and UI go through the daemon's RPC, so there are no concurrent writer conflicts. GRDB provides the Swift ORM layer with Codable record types and a sequential migration system (`DatabaseMigrator` with named migrations: v1, v2, v3...).
+
+Key rule: never modify an existing migration. Always add a new one. New columns must have `.defaults(to:)` values, and the corresponding Codable model must make new fields optional or provide defaults.
+
+## Why not alternatives
+
+- **UserDefaults / plist:** No relational queries, no migrations, doesn't scale to the worktree/terminal/notification model.
+- **Core Data:** Heavy, complex, designed for app processes not daemons, poor CLI ergonomics.
+- **Raw SQLite (no ORM):** Works but GRDB's Codable integration and migration system save significant boilerplate.
+
+## Where this applies
+
+Any Swift daemon or CLI tool needing structured persistent storage with crash safety and migration support.

--- a/recipe/techniques/ssh-agent-symlink.md
+++ b/recipe/techniques/ssh-agent-symlink.md
@@ -1,0 +1,25 @@
+# Stable SSH agent symlink
+
+## Posture: Make
+
+A background task and symlink management. ~100 lines of code.
+
+## The problem
+
+The daemon inherits `SSH_AUTH_SOCK` from its launch environment. When macOS's WindowServer crashes or restarts, launchd creates a new SSH agent at a new socket path. The daemon (and its tmux sessions) retain the old, stale path. Git commit signing breaks in all TBD-managed terminals.
+
+## The technique
+
+Maintain a stable symlink (`~/.ssh/tbd-agent.sock`) that always points to the live SSH agent socket. Set `SSH_AUTH_SOCK` to this symlink path in all tmux sessions. A background task probes every 60 seconds: fast-path checks if the current symlink is reachable via `connect(2)`, slow-path probes launchd socket candidates if not. Symlink updates are atomic via `rename(2)`.
+
+The symlink indirection is the key insight: existing shells don't need to be restarted when the agent socket moves — the symlink resolves at connect time.
+
+## Why not alternatives
+
+- **Restart terminals on SSH agent change:** Destructive, loses agent context.
+- **Set env per-command:** Complex, fragile, doesn't work for all git operations.
+- **Rely on user to restart:** Happens several times per week on macOS. Not acceptable.
+
+## Where this applies
+
+Any long-running process on macOS that needs SSH agent access across WindowServer restarts.

--- a/recipe/techniques/terminal-protocol.md
+++ b/recipe/techniques/terminal-protocol.md
@@ -1,0 +1,22 @@
+# Terminal emulation behind a swappable protocol
+
+## Posture: Wrap (currently SwiftTerm)
+
+We need terminal rendering but must isolate the app from API changes. The terminal adapter layer exists so the underlying library can be swapped.
+
+## The problem
+
+Terminal emulation is complex and the library landscape shifts. Committing to one library's API throughout the codebase creates expensive lock-in if a better option emerges (e.g., Ghostty's renderer).
+
+## The technique
+
+Abstract the terminal emulator behind a protocol (`TerminalRenderer`). The app talks to the protocol; the concrete implementation wraps SwiftTerm. The bridge between tmux control mode output and the terminal emulator is the highest-complexity component — the protocol should be designed with this bridging in mind.
+
+## Why not alternatives
+
+- **Direct SwiftTerm integration (no protocol):** Tightly couples the entire app to one library. Expensive to swap.
+- **Building a custom terminal emulator:** Years of work. SwiftTerm and Ghostty exist for a reason.
+
+## Where this applies
+
+Any app embedding a terminal emulator where the library choice may change.

--- a/recipe/techniques/terminal-protocol.md
+++ b/recipe/techniques/terminal-protocol.md
@@ -10,7 +10,7 @@ Terminal emulation is complex and the library landscape shifts. Committing to on
 
 ## The technique
 
-Abstract the terminal emulator behind a protocol (`TerminalRenderer`). The app talks to the protocol; the concrete implementation wraps SwiftTerm. The bridge between tmux control mode output and the terminal emulator is the highest-complexity component — the protocol should be designed with this bridging in mind.
+Abstract the terminal emulator behind a protocol (`TerminalRenderer`). The app talks to the protocol; the concrete implementation wraps SwiftTerm. The bridge between tmux terminal output (escape sequences tmux emits to attached sessions) and the terminal emulator is the highest-complexity component — the protocol should be designed with this bridging in mind.
 
 ## Why not alternatives
 

--- a/recipe/techniques/tmux-per-repo.md
+++ b/recipe/techniques/tmux-per-repo.md
@@ -1,0 +1,22 @@
+# One tmux server per repo
+
+## Posture: Make
+
+A naming convention and process isolation pattern. No dependencies.
+
+## The problem
+
+Multiple repos managed in one app need terminal isolation. A crash or misconfiguration in one repo's terminal sessions shouldn't affect another repo.
+
+## The technique
+
+Each repo gets its own tmux server, named `tbd-<hash>` where hash is derived from the repo's stable identifier. Selected via `tmux -L tbd-<hash>`. Each server has one session named `main`. Windows within the session correspond to individual terminal panels.
+
+## Why not alternatives
+
+- **Single shared server:** A crash takes down all repos. Window name collisions. No isolation.
+- **Per-worktree servers:** Too many servers. Harder to share sessions between panels viewing the same repo.
+
+## Where this applies
+
+Any tool managing terminals across multiple independent projects in a single UI.

--- a/recipe/techniques/unix-socket-rpc.md
+++ b/recipe/techniques/unix-socket-rpc.md
@@ -1,0 +1,25 @@
+# Unix domain socket + HTTP RPC
+
+## Posture: Make
+
+Standard Unix IPC pattern. SwiftNIO provides the transport layer.
+
+## The problem
+
+The daemon, app, and CLI need to communicate. The protocol must be fast (for real-time state streaming), secure (user-scoped), and debuggable (for development).
+
+## The technique
+
+Dual transport: Unix domain socket at `~/.tbd/sock` (primary, user-scoped permissions) and HTTP on localhost (port stored in `~/.tbd/port`, for debugging with curl). Both use the same JSON-RPC style protocol with newline-delimited messages.
+
+The `state.subscribe` method returns a persistent streaming connection that pushes state deltas as they occur — the app uses this for reactive UI updates.
+
+## Why not alternatives
+
+- **HTTP only:** No Unix socket means no user-scoped permissions out of the box. Localhost HTTP is fine for debugging but shouldn't be the primary transport.
+- **gRPC:** Heavy dependency for a single-machine IPC use case. JSON-RPC is simpler and curl-debuggable.
+- **XPC:** macOS-only, requires entitlements, harder to debug, no good Swift async story.
+
+## Where this applies
+
+Any daemon + client architecture on a single machine where both performance and debuggability matter.

--- a/scripts/recipe-check.sh
+++ b/scripts/recipe-check.sh
@@ -17,10 +17,10 @@ echo ""
 # --- Check 1: Broken internal links ---
 echo "Checking internal links..."
 
-for file in $(find "$RECIPE_DIR" -name '*.md' -type f); do
+while IFS= read -r -d '' file; do
     dir="$(dirname "$file")"
-    # Extract markdown link targets: [text](relative/path.md)
-    targets=$(grep -oE '\]\([^)]+\.md\)' "$file" 2>/dev/null | sed 's/^](\(.*\))$/\1/' || true)
+    # Extract markdown link targets: [text](relative/path.md) — strip #anchor fragments
+    targets=$(grep -oE '\]\([^)]+\.md[^)]*\)' "$file" 2>/dev/null | sed 's/^](\(.*\))$/\1/' | sed 's/#.*//' || true)
     for target in $targets; do
         # Skip external URLs
         case "$target" in http*) continue ;; esac
@@ -31,7 +31,7 @@ for file in $(find "$RECIPE_DIR" -name '*.md' -type f); do
             ERRORS=$((ERRORS + 1))
         fi
     done
-done
+done < <(find "$RECIPE_DIR" -name '*.md' -type f -print0)
 
 # --- Check 2: Orphaned techniques (referenced by zero jobs) ---
 echo "Checking for orphaned techniques..."
@@ -68,7 +68,14 @@ echo "Checking audit freshness..."
 
 last_audit=$(grep -m1 'last-audit:' "$RECIPE_DIR/recipe.md" 2>/dev/null | sed 's/.*last-audit: *//' | tr -d ' ')
 if [ -n "$last_audit" ]; then
-    audit_epoch=$(date -j -f "%Y-%m-%d" "$last_audit" "+%s" 2>/dev/null || echo "0")
+    # Portable date arithmetic — parse YYYY-MM-DD without platform-specific date flags
+    if date -j -f "%Y-%m-%d" "$last_audit" "+%s" >/dev/null 2>&1; then
+        audit_epoch=$(date -j -f "%Y-%m-%d" "$last_audit" "+%s")
+    elif date -d "$last_audit" "+%s" >/dev/null 2>&1; then
+        audit_epoch=$(date -d "$last_audit" "+%s")
+    else
+        audit_epoch=0
+    fi
     now_epoch=$(date "+%s")
     days_ago=$(( (now_epoch - audit_epoch) / 86400 ))
     if [ "$days_ago" -gt 14 ]; then

--- a/scripts/recipe-check.sh
+++ b/scripts/recipe-check.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# recipe-check.sh — mechanical checks for recipe/ directory integrity
+# Validates internal links and detects orphaned files.
+# Exit 0 = all checks pass, Exit 1 = issues found.
+
+RECIPE_DIR="$(git rev-parse --show-toplevel)/recipe"
+ERRORS=0
+
+if [ ! -d "$RECIPE_DIR" ]; then
+    echo "ERROR: recipe/ directory not found"
+    exit 1
+fi
+
+echo "=== Recipe Mechanical Checks ==="
+echo ""
+
+# --- Check 1: Broken internal links ---
+echo "Checking internal links..."
+
+for file in $(find "$RECIPE_DIR" -name '*.md' -type f); do
+    dir="$(dirname "$file")"
+    # Extract markdown link targets: [text](relative/path.md)
+    targets=$(grep -oE '\]\([^)]+\.md\)' "$file" 2>/dev/null | sed 's/^](\(.*\))$/\1/' || true)
+    for target in $targets; do
+        # Skip external URLs
+        case "$target" in http*) continue ;; esac
+        resolved="$(cd "$dir" && realpath "$target" 2>/dev/null || echo "")"
+        if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then
+            rel="${file#$RECIPE_DIR/}"
+            echo "  BROKEN LINK: $rel -> $target"
+            ERRORS=$((ERRORS + 1))
+        fi
+    done
+done
+
+# --- Check 2: Orphaned techniques (referenced by zero jobs) ---
+echo "Checking for orphaned techniques..."
+
+if [ -d "$RECIPE_DIR/techniques" ]; then
+    for technique in "$RECIPE_DIR/techniques"/*.md; do
+        [ -f "$technique" ] || continue
+        bname="$(basename "$technique")"
+        refs=$(grep -rl "techniques/$bname" "$RECIPE_DIR/jobs/" "$RECIPE_DIR/recipe.md" 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$refs" -eq 0 ]; then
+            echo "  ORPHAN TECHNIQUE: techniques/$bname (referenced by 0 jobs or recipe.md)"
+            ERRORS=$((ERRORS + 1))
+        fi
+    done
+fi
+
+# --- Check 3: Orphaned constraints (referenced by zero jobs) ---
+echo "Checking for orphaned constraints..."
+
+if [ -d "$RECIPE_DIR/constraints" ]; then
+    for constraint in "$RECIPE_DIR/constraints"/*.md; do
+        [ -f "$constraint" ] || continue
+        bname="$(basename "$constraint")"
+        refs=$(grep -rl "constraints/$bname" "$RECIPE_DIR/jobs/" "$RECIPE_DIR/recipe.md" 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$refs" -eq 0 ]; then
+            echo "  ORPHAN CONSTRAINT: constraints/$bname (referenced by 0 jobs or recipe.md)"
+            ERRORS=$((ERRORS + 1))
+        fi
+    done
+fi
+
+# --- Check 4: Audit staleness ---
+echo "Checking audit freshness..."
+
+last_audit=$(grep -m1 'last-audit:' "$RECIPE_DIR/recipe.md" 2>/dev/null | sed 's/.*last-audit: *//' | tr -d ' ')
+if [ -n "$last_audit" ]; then
+    audit_epoch=$(date -j -f "%Y-%m-%d" "$last_audit" "+%s" 2>/dev/null || echo "0")
+    now_epoch=$(date "+%s")
+    days_ago=$(( (now_epoch - audit_epoch) / 86400 ))
+    if [ "$days_ago" -gt 14 ]; then
+        echo "  STALE AUDIT: last audit was $days_ago days ago ($last_audit)"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "  Audit is fresh ($days_ago days ago)"
+    fi
+else
+    echo "  WARNING: No last-audit timestamp found in recipe.md"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+    echo "FAILED: $ERRORS issue(s) found"
+    exit 1
+else
+    echo "PASSED: All checks clean"
+    exit 0
+fi

--- a/scripts/recipe-check.sh
+++ b/scripts/recipe-check.sh
@@ -74,8 +74,11 @@ if [ -n "$last_audit" ]; then
     elif date -d "$last_audit" "+%s" >/dev/null 2>&1; then
         audit_epoch=$(date -d "$last_audit" "+%s")
     else
-        audit_epoch=0
+        echo "  WARNING: Could not parse last-audit date '$last_audit' — neither BSD nor GNU date worked"
+        ERRORS=$((ERRORS + 1))
+        audit_epoch=""
     fi
+    if [ -n "$audit_epoch" ]; then
     now_epoch=$(date "+%s")
     days_ago=$(( (now_epoch - audit_epoch) / 86400 ))
     if [ "$days_ago" -gt 14 ]; then
@@ -83,6 +86,7 @@ if [ -n "$last_audit" ]; then
         ERRORS=$((ERRORS + 1))
     else
         echo "  Audit is fresh ($days_ago days ago)"
+    fi
     fi
 else
     echo "  WARNING: No last-audit timestamp found in recipe.md"

--- a/scripts/recipe-check.sh
+++ b/scripts/recipe-check.sh
@@ -20,8 +20,8 @@ echo "Checking internal links..."
 while IFS= read -r -d '' file; do
     dir="$(dirname "$file")"
     # Extract markdown link targets: [text](relative/path.md) — strip #anchor fragments
-    targets=$(grep -oE '\]\([^)]+\.md[^)]*\)' "$file" 2>/dev/null | sed 's/^](\(.*\))$/\1/' | sed 's/#.*//' || true)
-    for target in $targets; do
+    while IFS= read -r target; do
+        [ -z "$target" ] && continue
         # Skip external URLs
         case "$target" in http*) continue ;; esac
         resolved="$(cd "$dir" && realpath "$target" 2>/dev/null || echo "")"
@@ -30,7 +30,7 @@ while IFS= read -r -d '' file; do
             echo "  BROKEN LINK: $rel -> $target"
             ERRORS=$((ERRORS + 1))
         fi
-    done
+    done < <(grep -oE '\]\([^)]+\.md[^)]*\)' "$file" 2>/dev/null | sed 's/^](\(.*\))$/\1/' | sed 's/#.*//' || true)
 done < <(find "$RECIPE_DIR" -name '*.md' -type f -print0)
 
 # --- Check 2: Orphaned techniques (referenced by zero jobs) ---


### PR DESCRIPTION
## Summary

- Introduces the "Code Is Rasterized Intent" recipe format — a structured way to capture software intent (jobs to be done, constraints, techniques) that survives rewrites, language changes, and team turnover
- Retroactively constructs TBD's recipe from the 9 existing design specs and git history: 4 jobs, 4 constraints, 8 techniques, and an evolution log
- Adds mechanical checks (`scripts/recipe-check.sh` — broken link validation, orphan detection, audit staleness) and CODEOWNERS review gating for recipe changes

## Test plan
- [ ] `scripts/recipe-check.sh` passes (link validation, orphan detection, audit freshness)
- [ ] All internal markdown links in `recipe/` resolve to existing files
- [ ] `recipe/recipe.md` reads coherently as a standalone entry point
- [ ] CODEOWNERS shows `@cheapsteak` for `/recipe/` path