### PR TITLE
Feat: Hide file tree by default and auto-reveal opened file location like VS Code

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "TBD",
     platforms: [
-        .macOS(.v14)
+        .macOS(.v15)
     ],
     dependencies: [
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -314,7 +314,10 @@ struct CodeViewerSidebar: View {
     var revealPath: String = ""
     @State private var expandedDirs: Set<String> = []
     @State private var entries: [FileEntry] = []
-    @State private var scrollRevision: Int = 0
+    @State private var scrollPosition = ScrollPosition(edge: .top)
+
+    /// Each row is 11pt font (~16pt line height) + 6pt vertical padding = ~22pt.
+    private static let rowHeight: CGFloat = 22
 
     var body: some View {
         VStack(spacing: 0) {
@@ -330,27 +333,20 @@ struct CodeViewerSidebar: View {
 
             Divider()
 
-            ScrollViewReader { proxy in
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 0) {
-                        ForEach(entries, id: \.path) { entry in
-                            FileEntryRow(
-                                entry: entry,
-                                isExpanded: expandedDirs.contains(entry.path),
-                                isSelected: selectedFiles.contains(entry.path),
-                                onToggleDir: { toggleDir(entry.path) },
-                                onSelectFile: { selectFile(entry.path, event: NSApp.currentEvent) }
-                            )
-                            .id(entry.path)
-                        }
-                    }
-                }
-                .onChange(of: scrollRevision) {
-                    Task { @MainActor in
-                        scrollToRevealedFile(proxy: proxy)
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(entries, id: \.path) { entry in
+                        FileEntryRow(
+                            entry: entry,
+                            isExpanded: expandedDirs.contains(entry.path),
+                            isSelected: selectedFiles.contains(entry.path),
+                            onToggleDir: { toggleDir(entry.path) },
+                            onSelectFile: { selectFile(entry.path, event: NSApp.currentEvent) }
+                        )
                     }
                 }
             }
+            .scrollPosition($scrollPosition)
         }
         .background(Color(nsColor: .controlBackgroundColor))
         .task(id: worktreePath) {
@@ -367,7 +363,8 @@ struct CodeViewerSidebar: View {
         entries = listDirectory(worktreePath, depth: 0)
     }
 
-    /// Expand all ancestor directories so `revealPath` is visible in the tree.
+    /// Expand all ancestor directories so `revealPath` is visible in the tree,
+    /// then scroll to it by computed offset (works with LazyVStack).
     private func revealFile() {
         guard !revealPath.isEmpty,
               revealPath.hasPrefix(worktreePath + "/") else { return }
@@ -387,12 +384,14 @@ struct CodeViewerSidebar: View {
                 }
             }
         }
-        scrollRevision += 1
-    }
 
-    private func scrollToRevealedFile(proxy: ScrollViewProxy) {
-        guard !revealPath.isEmpty, entries.contains(where: { $0.path == revealPath }) else { return }
-        proxy.scrollTo(revealPath, anchor: .center)
+        // Scroll by offset — works even when LazyVStack hasn't rendered the target row
+        if let index = entries.firstIndex(where: { $0.path == revealPath }) {
+            let offset = CGFloat(index) * Self.rowHeight
+            Task { @MainActor in
+                scrollPosition.scrollTo(y: offset)
+            }
+        }
     }
 
     private func toggleDir(_ path: String) {

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -9,29 +9,66 @@ struct CodeViewerPaneView: View {
     let worktreePath: String
 
     @State private var selectedFiles: [String] = []
+    @State private var showSidebar = false
 
     var body: some View {
         HStack(spacing: 0) {
-            // File sidebar
-            CodeViewerSidebar(
-                worktreePath: worktreePath,
-                selectedFiles: $selectedFiles
-            )
-            .frame(width: 200)
+            if showSidebar {
+                CodeViewerSidebar(
+                    worktreePath: worktreePath,
+                    selectedFiles: $selectedFiles,
+                    revealPath: path
+                )
+                .frame(width: 200)
 
-            Divider()
+                Divider()
+            }
 
             // Code preview
-            if selectedFiles.isEmpty {
-                emptyState
-            } else {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(selectedFiles, id: \.self) { filePath in
-                            if selectedFiles.count > 1 {
-                                fileHeader(filePath)
+            VStack(spacing: 0) {
+                // Tab header bar
+                HStack(spacing: 6) {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.15)) {
+                            showSidebar.toggle()
+                        }
+                    } label: {
+                        Image(systemName: "sidebar.left")
+                            .font(.system(size: 11))
+                            .foregroundStyle(showSidebar ? .primary : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Toggle file tree")
+
+                    if let firstName = selectedFiles.first {
+                        Image(systemName: "doc")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text(URL(fileURLWithPath: firstName).lastPathComponent)
+                            .font(.system(size: 11))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+
+                    Spacer()
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .background(Color(nsColor: .controlBackgroundColor))
+
+                Divider()
+
+                if selectedFiles.isEmpty {
+                    emptyState
+                } else {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(selectedFiles, id: \.self) { filePath in
+                                if selectedFiles.count > 1 {
+                                    fileHeader(filePath)
+                                }
+                                FilePreviewView(filePath: filePath)
                             }
-                            FilePreviewView(filePath: filePath)
                         }
                     }
                 }
@@ -273,6 +310,7 @@ private func languageForFilename(_ filename: String) -> String? {
 struct CodeViewerSidebar: View {
     let worktreePath: String
     @Binding var selectedFiles: [String]
+    var revealPath: String = ""
     @State private var expandedDirs: Set<String> = []
     @State private var entries: [FileEntry] = []
 
@@ -290,29 +328,63 @@ struct CodeViewerSidebar: View {
 
             Divider()
 
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(entries, id: \.path) { entry in
-                        FileEntryRow(
-                            entry: entry,
-                            isExpanded: expandedDirs.contains(entry.path),
-                            isSelected: selectedFiles.contains(entry.path),
-                            onToggleDir: { toggleDir(entry.path) },
-                            onSelectFile: { selectFile(entry.path, event: NSApp.currentEvent) }
-                        )
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(entries, id: \.path) { entry in
+                            FileEntryRow(
+                                entry: entry,
+                                isExpanded: expandedDirs.contains(entry.path),
+                                isSelected: selectedFiles.contains(entry.path),
+                                onToggleDir: { toggleDir(entry.path) },
+                                onSelectFile: { selectFile(entry.path, event: NSApp.currentEvent) }
+                            )
+                            .id(entry.path)
+                        }
                     }
+                }
+                .onChange(of: entries.count) {
+                    scrollToRevealedFile(proxy: proxy)
                 }
             }
         }
         .background(Color(nsColor: .controlBackgroundColor))
         .task(id: worktreePath) {
             loadTopLevel()
+            revealFile()
         }
     }
 
     private func loadTopLevel() {
         guard !worktreePath.isEmpty else { return }
         entries = listDirectory(worktreePath, depth: 0)
+    }
+
+    /// Expand all ancestor directories so `revealPath` is visible in the tree.
+    private func revealFile() {
+        guard !revealPath.isEmpty,
+              revealPath.hasPrefix(worktreePath + "/") else { return }
+
+        let relative = revealPath.replacingOccurrences(of: worktreePath + "/", with: "")
+        let components = relative.components(separatedBy: "/")
+        // Expand each ancestor directory (all but the last component which is the file)
+        var currentPath = worktreePath
+        for component in components.dropLast() {
+            currentPath += "/" + component
+            if !expandedDirs.contains(currentPath) {
+                expandedDirs.insert(currentPath)
+                let depth = depthOf(currentPath)
+                let children = listDirectory(currentPath, depth: depth + 1)
+                if let idx = entries.firstIndex(where: { $0.path == currentPath }) {
+                    entries.insert(contentsOf: children, at: idx + 1)
+                }
+            }
+        }
+    }
+
+    private func scrollToRevealedFile(proxy: ScrollViewProxy) {
+        guard !revealPath.isEmpty, entries.contains(where: { $0.path == revealPath }) else { return }
+        proxy.scrollTo(revealPath, anchor: .center)
     }
 
     private func toggleDir(_ path: String) {

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -20,6 +20,7 @@ struct CodeViewerPaneView: View {
                     revealPath: path
                 )
                 .frame(width: 200)
+                .transition(.move(edge: .leading))
 
                 Divider()
             }
@@ -331,7 +332,7 @@ struct CodeViewerSidebar: View {
 
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
+                    VStack(alignment: .leading, spacing: 0) {
                         ForEach(entries, id: \.path) { entry in
                             FileEntryRow(
                                 entry: entry,

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -313,6 +313,7 @@ struct CodeViewerSidebar: View {
     var revealPath: String = ""
     @State private var expandedDirs: Set<String> = []
     @State private var entries: [FileEntry] = []
+    @State private var scrollRevision: Int = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -343,8 +344,10 @@ struct CodeViewerSidebar: View {
                         }
                     }
                 }
-                .onChange(of: entries.count) {
-                    scrollToRevealedFile(proxy: proxy)
+                .onChange(of: scrollRevision) {
+                    Task { @MainActor in
+                        scrollToRevealedFile(proxy: proxy)
+                    }
                 }
             }
         }
@@ -383,6 +386,7 @@ struct CodeViewerSidebar: View {
                 }
             }
         }
+        scrollRevision += 1
     }
 
     private func scrollToRevealedFile(proxy: ScrollViewProxy) {

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -23,6 +23,7 @@ struct CodeViewerPaneView: View {
                 .transition(.move(edge: .leading))
 
                 Divider()
+                    .transition(.move(edge: .leading))
             }
 
             // Code preview
@@ -314,10 +315,7 @@ struct CodeViewerSidebar: View {
     var revealPath: String = ""
     @State private var expandedDirs: Set<String> = []
     @State private var entries: [FileEntry] = []
-    @State private var scrollPosition = ScrollPosition(edge: .top)
-
-    /// Each row is 11pt font (~16pt line height) + 6pt vertical padding = ~22pt.
-    private static let rowHeight: CGFloat = 22
+    @State private var scrollTargetID: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -343,10 +341,12 @@ struct CodeViewerSidebar: View {
                             onToggleDir: { toggleDir(entry.path) },
                             onSelectFile: { selectFile(entry.path, event: NSApp.currentEvent) }
                         )
+                        .id(entry.path)
                     }
                 }
+                .scrollTargetLayout()
             }
-            .scrollPosition($scrollPosition)
+            .scrollPosition(id: $scrollTargetID, anchor: .center)
         }
         .background(Color(nsColor: .controlBackgroundColor))
         .task(id: worktreePath) {
@@ -364,7 +364,7 @@ struct CodeViewerSidebar: View {
     }
 
     /// Expand all ancestor directories so `revealPath` is visible in the tree,
-    /// then scroll to it by computed offset (works with LazyVStack).
+    /// then scroll to it via `scrollPosition(id:)` binding.
     private func revealFile() {
         guard !revealPath.isEmpty,
               revealPath.hasPrefix(worktreePath + "/") else { return }
@@ -385,12 +385,9 @@ struct CodeViewerSidebar: View {
             }
         }
 
-        // Scroll by offset — works even when LazyVStack hasn't rendered the target row
-        if let index = entries.firstIndex(where: { $0.path == revealPath }) {
-            let offset = CGFloat(index) * Self.rowHeight
-            Task { @MainActor in
-                scrollPosition.scrollTo(y: offset)
-            }
+        // Defer to next run loop so SwiftUI processes the entries mutation first
+        Task { @MainActor in
+            scrollTargetID = revealPath
         }
     }
 

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -353,6 +353,9 @@ struct CodeViewerSidebar: View {
             loadTopLevel()
             revealFile()
         }
+        .onChange(of: revealPath) {
+            revealFile()
+        }
     }
 
     private func loadTopLevel() {


### PR DESCRIPTION
## Summary
- File tree sidebar is now hidden by default — a sidebar toggle icon in the tab header bar shows/hides it, keeping the code viewer uncluttered
- When the sidebar is open, it auto-expands ancestor directories to reveal the currently opened file and scrolls it into view, matching VS Code's "reveal in explorer" behavior
- Navigating to a different file within the same worktree correctly re-expands the tree to the new location
- Bumps minimum deployment target from macOS 14 → macOS 15 for `ScrollPosition` / `scrollTargetLayout` APIs

## Test plan
- [ ] Open a file from the git changes panel — verify the code viewer shows the file with the sidebar hidden and the filename visible in the header
- [ ] Click the sidebar toggle icon — verify the file tree appears with the opened file's parent directories expanded and the file scrolled into view
- [ ] Click a different file in the tree — verify it opens in the preview
- [ ] Navigate to a file in a deeply nested directory — verify all ancestors expand automatically
- [ ] Toggle the sidebar off and on — verify it animates smoothly (sidebar and divider slide together)
- [ ] Open a top-level file — verify the tree still scrolls to it