### PR TITLE
Perf: Auto-suspend idle Claude instances on worktree switch to free ~500MB–1GB each

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -151,6 +151,11 @@ final class AppState: ObservableObject {
         if didConnect {
             await refreshAll()
             await refreshPRStatuses()
+            Task {
+                try? await daemonClient.worktreeSelectionChanged(
+                    selectedWorktreeIDs: selectedWorktreeIDs
+                )
+            }
         } else {
             logger.warning("Could not connect to daemon — is tbdd running?")
         }

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -101,6 +101,11 @@ struct ContentView: View {
             for worktreeID in newlySelected {
                 Task { await appState.refreshPRStatus(worktreeID: worktreeID) }
             }
+            Task {
+                try? await appState.daemonClient.worktreeSelectionChanged(
+                    selectedWorktreeIDs: appState.selectedWorktreeIDs
+                )
+            }
         }
         .alert(
             appState.alertIsError ? "Error" : "Success",

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -105,6 +105,12 @@ struct ContentView: View {
                 try? await appState.daemonClient.worktreeSelectionChanged(
                     selectedWorktreeIDs: appState.selectedWorktreeIDs
                 )
+                // Immediately refresh terminals for newly-selected worktrees so the
+                // UI picks up any updated tmuxWindowID (e.g. after a resume) rather
+                // than waiting for the ~2s poll cycle.
+                for worktreeID in newSelection {
+                    await appState.refreshTerminals(worktreeID: worktreeID)
+                }
             }
         }
         .alert(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -426,6 +426,14 @@ actor DaemonClient {
         return result.statuses
     }
 
+    /// Notify the daemon which worktrees are currently selected in the app.
+    func worktreeSelectionChanged(selectedWorktreeIDs: Set<UUID>) throws {
+        try callVoid(
+            method: RPCMethod.worktreeSelectionChanged,
+            params: WorktreeSelectionChangedParams(selectedWorktreeIDs: Array(selectedWorktreeIDs))
+        )
+    }
+
     /// Trigger an immediate PR status refresh for one worktree.
     /// Returns nil if no PR exists for the worktree's branch.
     func refreshPRStatus(worktreeID: UUID) throws -> PRStatus? {

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -173,7 +173,7 @@ struct PanePlaceholder: View {
                     debugLog("OSC 777: \(title) — \(body)")
                 }
             )
-            .id(terminalID)
+            .id("\(terminal.id)-\(terminal.tmuxWindowID)")
         } else {
             // Fallback when terminal data hasn't loaded yet
             ZStack {

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -104,6 +104,7 @@ public final class Daemon: Sendable {
         try await http.start()
 
         // 11. Reconcile worktrees for all known repos
+        await rpcRouter.suspendResumeCoordinator.reconcileOnStartup()
         do {
             let repos = try await database.repos.list()
             for repo in repos {

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -114,6 +114,13 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v6") { db in
+            try db.alter(table: "terminal") { t in
+                t.add(column: "claudeSessionID", .text)
+                t.add(column: "suspendedAt", .datetime)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -13,6 +13,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var label: String?
     var createdAt: Date
     var pinnedAt: Date?
+    var claudeSessionID: String?
+    var suspendedAt: Date?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -22,6 +24,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.label = terminal.label
         self.createdAt = terminal.createdAt
         self.pinnedAt = terminal.pinnedAt
+        self.claudeSessionID = terminal.claudeSessionID
+        self.suspendedAt = terminal.suspendedAt
     }
 
     func toModel() -> Terminal {
@@ -32,7 +36,9 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             tmuxPaneID: tmuxPaneID,
             label: label,
             createdAt: createdAt,
-            pinnedAt: pinnedAt
+            pinnedAt: pinnedAt,
+            claudeSessionID: claudeSessionID,
+            suspendedAt: suspendedAt
         )
     }
 }
@@ -50,13 +56,15 @@ public struct TerminalStore: Sendable {
         worktreeID: UUID,
         tmuxWindowID: String,
         tmuxPaneID: String,
-        label: String? = nil
+        label: String? = nil,
+        claudeSessionID: String? = nil
     ) async throws -> Terminal {
         let terminal = Terminal(
             worktreeID: worktreeID,
             tmuxWindowID: tmuxWindowID,
             tmuxPaneID: tmuxPaneID,
-            label: label
+            label: label,
+            claudeSessionID: claudeSessionID
         )
         let record = TerminalRecord(from: terminal)
         try await writer.write { db in
@@ -106,6 +114,52 @@ public struct TerminalStore: Sendable {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.pinnedAt = pinned ? date : nil
+            try record.update(db)
+        }
+    }
+
+    /// Mark a terminal as suspended, recording the session ID and current timestamp.
+    public func setSuspended(id: UUID, sessionID: String, at date: Date = Date()) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.claudeSessionID = sessionID
+            record.suspendedAt = date
+            try record.update(db)
+        }
+    }
+
+    /// Clear the suspended state of a terminal.
+    public func clearSuspended(id: UUID) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.suspendedAt = nil
+            try record.update(db)
+        }
+    }
+
+    /// Update the Claude session ID for a terminal.
+    public func updateSessionID(id: UUID, sessionID: String) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.claudeSessionID = sessionID
+            try record.update(db)
+        }
+    }
+
+    /// Update the tmux window and pane IDs for a terminal.
+    public func updateTmuxIDs(id: UUID, windowID: String, paneID: String) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.tmuxWindowID = windowID
+            record.tmuxPaneID = paneID
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -1,0 +1,185 @@
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "SuspendResume")
+
+public actor SuspendResumeCoordinator {
+    private let db: TBDDatabase
+    private let tmux: TmuxManager
+    private let detector: ClaudeStateDetector
+    private var inFlight: [UUID: Task<Void, Never>] = [:]
+    private var lastKnownSelection: Set<UUID> = []
+
+    public init(db: TBDDatabase, tmux: TmuxManager) {
+        self.db = db
+        self.tmux = tmux
+        self.detector = ClaudeStateDetector(tmux: tmux)
+    }
+
+    public func selectionChanged(to newSelection: Set<UUID>) {
+        let departing = lastKnownSelection.subtracting(newSelection)
+        let arriving = newSelection.subtracting(lastKnownSelection)
+        lastKnownSelection = newSelection
+
+        for worktreeID in departing {
+            scheduleSuspend(worktreeID: worktreeID)
+        }
+        for worktreeID in arriving {
+            scheduleResume(worktreeID: worktreeID)
+        }
+    }
+
+    // MARK: - Suspend
+
+    private func scheduleSuspend(worktreeID: UUID) {
+        Task {
+            guard let terminals = try? await db.terminals.list(worktreeID: worktreeID) else { return }
+            for terminal in terminals {
+                guard terminal.label?.hasPrefix("claude") == true,
+                      terminal.pinnedAt == nil,
+                      terminal.suspendedAt == nil,
+                      terminal.claudeSessionID != nil else { continue }
+
+                inFlight[terminal.id]?.cancel()
+                let task = Task<Void, Never> { await suspendTerminal(terminal) }
+                inFlight[terminal.id] = task
+            }
+        }
+    }
+
+    private func suspendTerminal(_ terminal: Terminal) async {
+        guard let server = await worktreeServer(for: terminal.worktreeID) else { return }
+
+        // Cancellable phase: idle check with 1s debounce
+        guard await detector.isIdleConfirmed(server: server, paneID: terminal.tmuxPaneID) else { return }
+        guard !Task.isCancelled else { return }
+
+        // POINT OF NO RETURN — send /exit
+        do {
+            try await tmux.sendCommand(server: server, paneID: terminal.tmuxPaneID, command: "/exit")
+        } catch {
+            logger.warning("Failed to send /exit to terminal \(terminal.id): \(error)")
+            return
+        }
+
+        // Verify exit: poll for up to 3s
+        for _ in 0..<15 {
+            try? await Task.sleep(for: .milliseconds(200))
+            if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
+               !ClaudeStateDetector.isClaudeProcess(cmd) {
+                break
+            }
+        }
+
+        // Always mark suspended after point of no return
+        do {
+            try await db.terminals.setSuspended(id: terminal.id, sessionID: terminal.claudeSessionID!)
+            logger.info("Suspended terminal \(terminal.id)")
+        } catch {
+            logger.warning("Failed to mark terminal \(terminal.id) suspended: \(error)")
+        }
+
+        inFlight[terminal.id] = nil
+    }
+
+    // MARK: - Resume
+
+    private func scheduleResume(worktreeID: UUID) {
+        Task {
+            guard let terminals = try? await db.terminals.list(worktreeID: worktreeID) else { return }
+            for terminal in terminals where terminal.suspendedAt != nil {
+                inFlight[terminal.id]?.cancel()
+                let task = Task<Void, Never> { await resumeTerminal(terminal) }
+                inFlight[terminal.id] = task
+            }
+        }
+    }
+
+    private func resumeTerminal(_ terminal: Terminal) async {
+        guard let server = await worktreeServer(for: terminal.worktreeID),
+              let sessionID = terminal.claudeSessionID else { return }
+
+        // Step 1: Check if Claude is still running (pending /exit or user restarted)
+        if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
+           ClaudeStateDetector.isClaudeProcess(cmd) {
+            // Wait up to 5s for queued /exit to process
+            var stillRunning = true
+            for _ in 0..<25 {
+                try? await Task.sleep(for: .milliseconds(200))
+                if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
+                   !ClaudeStateDetector.isClaudeProcess(cmd) {
+                    stillRunning = false
+                    break
+                }
+            }
+            if stillRunning {
+                // User restarted it — clear and re-capture
+                try? await db.terminals.clearSuspended(id: terminal.id)
+                if let newID = await detector.captureSessionID(server: server, paneID: terminal.tmuxPaneID) {
+                    try? await db.terminals.updateSessionID(id: terminal.id, sessionID: newID)
+                }
+                inFlight[terminal.id] = nil
+                return
+            }
+        }
+
+        // Step 2-4: Create new tmux window with resume command
+        guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+            inFlight[terminal.id] = nil
+            return
+        }
+
+        let resumeCommand = "claude --resume \(sessionID) --dangerously-skip-permissions"
+        do {
+            let window = try await tmux.createWindow(
+                server: server, session: "main",
+                cwd: worktree.path, shellCommand: resumeCommand
+            )
+            try await db.terminals.updateTmuxIDs(
+                id: terminal.id, windowID: window.windowID, paneID: window.paneID
+            )
+            try await db.terminals.clearSuspended(id: terminal.id)
+            logger.info("Resumed terminal \(terminal.id) in window \(window.windowID)")
+
+            // Re-capture session ID after ~5s
+            let termID = terminal.id
+            let paneID = window.paneID
+            Task {
+                try? await Task.sleep(for: .seconds(5))
+                if let newID = await self.detector.captureSessionID(server: server, paneID: paneID) {
+                    try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
+                    logger.info("Re-captured session ID for terminal \(termID): \(newID)")
+                } else {
+                    logger.warning("Failed to re-capture session ID for terminal \(termID)")
+                }
+            }
+        } catch {
+            logger.warning("Failed to resume terminal \(terminal.id): \(error)")
+        }
+
+        inFlight[terminal.id] = nil
+    }
+
+    // MARK: - Startup Reconciliation
+
+    public func reconcileOnStartup() async {
+        guard let allTerminals = try? await db.terminals.list() else { return }
+        for terminal in allTerminals where terminal.suspendedAt != nil {
+            guard let server = await worktreeServer(for: terminal.worktreeID) else { continue }
+            let alive = await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID)
+            if alive, let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
+               ClaudeStateDetector.isClaudeProcess(cmd) {
+                try? await db.terminals.clearSuspended(id: terminal.id)
+                logger.info("Startup: cleared suspendedAt for running terminal \(terminal.id)")
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func worktreeServer(for worktreeID: UUID) async -> String? {
+        guard let wt = try? await db.worktrees.get(id: worktreeID) else { return nil }
+        return wt.tmuxServer
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -165,6 +165,7 @@ public actor SuspendResumeCoordinator {
 
     public func reconcileOnStartup() async {
         guard let allTerminals = try? await db.terminals.list() else { return }
+
         for terminal in allTerminals where terminal.suspendedAt != nil {
             guard let server = await worktreeServer(for: terminal.worktreeID) else { continue }
             let alive = await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID)
@@ -172,6 +173,21 @@ public actor SuspendResumeCoordinator {
                ClaudeStateDetector.isClaudeProcess(cmd) {
                 try? await db.terminals.clearSuspended(id: terminal.id)
                 logger.info("Startup: cleared suspendedAt for running terminal \(terminal.id)")
+            }
+        }
+
+        // Backfill session IDs for pre-existing Claude terminals that lack one.
+        // These were created before --session-id was added at terminal creation.
+        for terminal in allTerminals {
+            guard terminal.claudeSessionID == nil,
+                  terminal.label?.hasPrefix("claude") == true,
+                  terminal.suspendedAt == nil else { continue }
+            guard let server = await worktreeServer(for: terminal.worktreeID) else { continue }
+            let alive = await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID)
+            guard alive else { continue }
+            if let sessionID = await detector.captureSessionID(server: server, paneID: terminal.tmuxPaneID) {
+                try? await db.terminals.updateSessionID(id: terminal.id, sessionID: sessionID)
+                logger.info("Startup: backfilled session ID for terminal \(terminal.id): \(sessionID)")
             }
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -182,10 +182,14 @@ extension WorktreeLifecycle {
 
         // Create terminal 1: claude (or shell if skipClaude)
         let claudeCommand: String
+        let claudeSessionID: String?
         if skipClaude {
             claudeCommand = defaultShell
+            claudeSessionID = nil
         } else {
-            claudeCommand = "claude --dangerously-skip-permissions"
+            let sessionUUID = UUID().uuidString
+            claudeCommand = "claude --dangerously-skip-permissions --session-id \(sessionUUID)"
+            claudeSessionID = sessionUUID
         }
         let window1 = try await tmux.createWindow(
             server: tmuxServer,
@@ -197,7 +201,8 @@ extension WorktreeLifecycle {
             worktreeID: worktreeID,
             tmuxWindowID: window1.windowID,
             tmuxPaneID: window1.paneID,
-            label: skipClaude ? "shell" : "claude"
+            label: skipClaude ? "shell" : "claude",
+            claudeSessionID: claudeSessionID
         )
 
         // Create terminal 2: setup hook

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -131,7 +131,7 @@ extension WorktreeLifecycle {
                 let alive = await tmux.windowExists(
                     server: wt.tmuxServer, windowID: terminal.tmuxWindowID
                 )
-                if !alive {
+                if !alive && terminal.suspendedAt == nil {
                     try? await db.terminals.delete(id: terminal.id)
                 }
             }

--- a/Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift
@@ -4,8 +4,8 @@ import TBDShared
 extension RPCRouter {
     func handleWorktreeSelectionChanged(_ data: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeSelectionChangedParams.self, from: data)
-        // TODO: Task 5 will integrate SuspendResumeCoordinator here
-        _ = params
+        let newSelection = Set(params.selectedWorktreeIDs)
+        await suspendResumeCoordinator.selectionChanged(to: newSelection)
         return .ok()
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift
@@ -1,0 +1,11 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+    func handleWorktreeSelectionChanged(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeSelectionChangedParams.self, from: data)
+        // TODO: Task 5 will integrate SuspendResumeCoordinator here
+        _ = params
+        return .ok()
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -90,6 +90,8 @@ public final class RPCRouter: Sendable {
                 return try await handlePRList()
             case RPCMethod.prRefresh:
                 return try await handlePRRefresh(request.paramsData)
+            case RPCMethod.worktreeSelectionChanged:
+                return try await handleWorktreeSelectionChanged(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -11,6 +11,7 @@ public final class RPCRouter: Sendable {
     public let startTime: Date
     public let subscriptions: StateSubscriptionManager
     public let prManager: PRStatusManager
+    public let suspendResumeCoordinator: SuspendResumeCoordinator
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -31,6 +32,7 @@ public final class RPCRouter: Sendable {
         self.startTime = startTime
         self.subscriptions = subscriptions
         self.prManager = prManager
+        self.suspendResumeCoordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.

--- a/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
+++ b/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+public struct ClaudeStateDetector: Sendable {
+    // MARK: - Pattern Constants
+    nonisolated(unsafe) static let claudeProcessRegex = try! Regex(#"^\d+\.\d+\.\d+"#)
+    nonisolated(unsafe) static let promptRegex = try! Regex(#"^❯[\s\u{00a0}]*$"#)
+    static let statusIndicators = ["⏵⏵", "bypass", "auto mode", "? for shortcuts"]
+
+    // MARK: - Pure Static Methods
+
+    public static func isClaudeProcess(_ command: String) -> Bool {
+        command.firstMatch(of: claudeProcessRegex) != nil
+    }
+
+    public static func checkIdle(output: String) -> Bool {
+        let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
+        let lastLines = lines.suffix(5).map(String.init)
+        let text = lastLines.joined(separator: "\n")
+        let hasStatusBar = statusIndicators.contains { text.contains($0) }
+        let hasPrompt = lastLines.contains { $0.firstMatch(of: promptRegex) != nil }
+        return hasStatusBar && hasPrompt
+    }
+
+    public static func parseSessionID(from json: String) -> String? {
+        struct SessionFile: Decodable { let sessionId: String }
+        guard let data = json.data(using: .utf8),
+              let parsed = try? JSONDecoder().decode(SessionFile.self, from: data) else {
+            return nil
+        }
+        return parsed.sessionId
+    }
+
+    // MARK: - Instance Methods (require TmuxManager)
+    private let tmux: TmuxManager
+
+    public init(tmux: TmuxManager) { self.tmux = tmux }
+
+    public func isIdle(server: String, paneID: String) async -> Bool {
+        do {
+            let command = try await tmux.paneCurrentCommand(server: server, paneID: paneID)
+            guard Self.isClaudeProcess(command) else { return false }
+            let output = try await tmux.capturePaneOutput(server: server, paneID: paneID)
+            return Self.checkIdle(output: output)
+        } catch { return false }
+    }
+
+    public func isIdleConfirmed(server: String, paneID: String) async -> Bool {
+        guard await isIdle(server: server, paneID: paneID) else { return false }
+        try? await Task.sleep(for: .seconds(1))
+        guard !Task.isCancelled else { return false }
+        return await isIdle(server: server, paneID: paneID)
+    }
+
+    public func captureSessionID(server: String, paneID: String) async -> String? {
+        do {
+            let pidStr = try await tmux.panePID(server: server, paneID: paneID)
+            guard let shellPID = Int(pidStr) else { return nil }
+
+            let process = Process()
+            let pipe = Pipe()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+            process.arguments = ["-P", String(shellPID), "-x", "claude"]
+            process.standardOutput = pipe
+            process.standardError = FileHandle.nullDevice
+            try process.run()
+            process.waitUntilExit()
+
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let pids = output.trimmingCharacters(in: .whitespacesAndNewlines)
+                .split(separator: "\n").compactMap { Int($0) }
+            guard pids.count == 1, let claudePID = pids.first else { return nil }
+
+            let sessionPath = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".claude/sessions/\(claudePID).json")
+            guard let json = try? String(contentsOf: sessionPath, encoding: .utf8) else { return nil }
+            return Self.parseSessionID(from: json)
+        } catch { return nil }
+    }
+}

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -70,6 +70,23 @@ public struct TmuxManager: Sendable {
         ["-L", server, "list-windows", "-t", session, "-F", "#{window_id} #{pane_id}"]
     }
 
+    public static func capturePaneCommand(server: String, paneID: String) -> [String] {
+        ["-L", server, "capture-pane", "-p", "-t", paneID]
+    }
+
+    public static func paneCurrentCommandQuery(server: String, paneID: String) -> [String] {
+        ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_current_command}"]
+    }
+
+    public static func panePIDQuery(server: String, paneID: String) -> [String] {
+        ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_pid}"]
+    }
+
+    /// send-keys without -l so "Enter" is interpreted as a key name, not literal text.
+    public static func sendCommandArgs(server: String, paneID: String, command: String) -> [String] {
+        ["-L", server, "send-keys", "-t", paneID, command, "Enter"]
+    }
+
     // MARK: - Instance Execution Methods
 
     /// Ensures a tmux server and session exist.
@@ -135,6 +152,30 @@ public struct TmuxManager: Sendable {
     public func sendKeys(server: String, paneID: String, text: String) async throws {
         if dryRun { return }
         let args = Self.sendKeysCommand(server: server, paneID: paneID, text: text)
+        try await runTmux(args)
+    }
+
+    public func capturePaneOutput(server: String, paneID: String) async throws -> String {
+        if dryRun { return "" }
+        let args = Self.capturePaneCommand(server: server, paneID: paneID)
+        return try await runTmux(args)
+    }
+
+    public func paneCurrentCommand(server: String, paneID: String) async throws -> String {
+        if dryRun { return "zsh" }
+        let args = Self.paneCurrentCommandQuery(server: server, paneID: paneID)
+        return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public func panePID(server: String, paneID: String) async throws -> String {
+        if dryRun { return "0" }
+        let args = Self.panePIDQuery(server: server, paneID: paneID)
+        return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public func sendCommand(server: String, paneID: String, command: String) async throws {
+        if dryRun { return }
+        let args = Self.sendCommandArgs(server: server, paneID: paneID, command: command)
         try await runTmux(args)
     }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -77,10 +77,13 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public var label: String?
     public var createdAt: Date
     public var pinnedAt: Date?
+    public var claudeSessionID: String?
+    public var suspendedAt: Date?
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
-                pinnedAt: Date? = nil) {
+                pinnedAt: Date? = nil, claudeSessionID: String? = nil,
+                suspendedAt: Date? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -88,6 +91,21 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.label = label
         self.createdAt = createdAt
         self.pinnedAt = pinnedAt
+        self.claudeSessionID = claudeSessionID
+        self.suspendedAt = suspendedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        worktreeID = try c.decode(UUID.self, forKey: .worktreeID)
+        tmuxWindowID = try c.decode(String.self, forKey: .tmuxWindowID)
+        tmuxPaneID = try c.decode(String.self, forKey: .tmuxPaneID)
+        label = try c.decodeIfPresent(String.self, forKey: .label)
+        createdAt = try c.decode(Date.self, forKey: .createdAt)
+        pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
+        claudeSessionID = try c.decodeIfPresent(String.self, forKey: .claudeSessionID)
+        suspendedAt = try c.decodeIfPresent(Date.self, forKey: .suspendedAt)
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -98,6 +98,7 @@ public enum RPCMethod {
     public static let prList    = "pr.list"
     public static let prRefresh = "pr.refresh"
     public static let cleanup = "cleanup"
+    public static let worktreeSelectionChanged = "worktree.selectionChanged"
 }
 
 public struct NotificationsListResult: Codable, Sendable {
@@ -221,6 +222,13 @@ public struct NotifyParams: Codable, Sendable {
 public struct ResolvePathParams: Codable, Sendable {
     public let path: String
     public init(path: String) { self.path = path }
+}
+
+public struct WorktreeSelectionChangedParams: Codable, Sendable {
+    public let selectedWorktreeIDs: [UUID]
+    public init(selectedWorktreeIDs: [UUID]) {
+        self.selectedWorktreeIDs = selectedWorktreeIDs
+    }
 }
 
 // MARK: - Result Structs

--- a/Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift
@@ -1,0 +1,58 @@
+import Testing
+@testable import TBDDaemonLib
+
+@Test func idleWithBarePromptAndStatusBar() {
+    let lines = "some output above\n\n─────────\n❯\u{00a0}\n─────────\n  ⏵⏵ bypass permissions on (shift+tab to cycle)"
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == true)
+}
+
+@Test func notIdleWithUserInput() {
+    let lines = "─────────\n❯ fix the bug\n─────────\n  ⏵⏵ bypass permissions on (shift+tab to cycle)"
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == false)
+}
+
+@Test func notIdleNoPrompt() {
+    let lines = "⏺ Working on something...\n  Reading file.swift\n─────────\n  ⏵⏵ bypass permissions on (shift+tab to cycle)"
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == false)
+}
+
+@Test func notIdleNoStatusBar() {
+    let lines = "─────────\n❯\u{00a0}\n─────────\nEnter to select · ↑/↓ to navigate · Esc to cancel"
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == false)
+}
+
+@Test func idleWithQuestionForShortcuts() {
+    let lines = "─────────\n❯\n─────────\n  ? for shortcuts"
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == true)
+}
+
+@Test func idleWithAutoMode() {
+    let lines = "─────────\n❯\n─────────\n  ⏵⏵ auto mode (shift+tab to cycle)"
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == true)
+}
+
+@Test func claudeProcessPatternMatchesSemver() {
+    #expect(ClaudeStateDetector.isClaudeProcess("2.1.86") == true)
+    #expect(ClaudeStateDetector.isClaudeProcess("2.1.85") == true)
+    #expect(ClaudeStateDetector.isClaudeProcess("10.0.1") == true)
+    #expect(ClaudeStateDetector.isClaudeProcess("zsh") == false)
+    #expect(ClaudeStateDetector.isClaudeProcess("bash") == false)
+    #expect(ClaudeStateDetector.isClaudeProcess("node") == false)
+    #expect(ClaudeStateDetector.isClaudeProcess("git") == false)
+    #expect(ClaudeStateDetector.isClaudeProcess("") == false)
+}
+
+@Test func parseSessionFile() {
+    let json = """
+    {"pid": 12345, "sessionId": "abc-def-123", "cwd": "/tmp", "startedAt": 1000, "kind": "interactive", "entrypoint": "cli"}
+    """
+    #expect(ClaudeStateDetector.parseSessionID(from: json) == "abc-def-123")
+}
+
+@Test func parseSessionFileBadJSON() {
+    #expect(ClaudeStateDetector.parseSessionID(from: "not json") == nil)
+}
+
+@Test func parseSessionFilePartialJSON() {
+    #expect(ClaudeStateDetector.parseSessionID(from: "{\"pid\": 123") == nil)
+}

--- a/Tests/TBDDaemonTests/DatabaseTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseTests.swift
@@ -252,6 +252,61 @@ struct DatabaseTests {
         #expect(sorted[1].id == t1.id)
     }
 
+    // MARK: - Terminal Suspend Tests
+
+    @Test func terminalSuspendFields() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-repo", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test", branch: "main",
+            path: "/tmp/test-repo/.tbd/worktrees/test", tmuxServer: "tbd-test"
+        )
+
+        // Create terminal with new fields
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude",
+            claudeSessionID: "abc-123"
+        )
+        #expect(terminal.claudeSessionID == "abc-123")
+        #expect(terminal.suspendedAt == nil)
+
+        // Set suspended
+        try await db.terminals.setSuspended(id: terminal.id, sessionID: "abc-123")
+        let updated = try await db.terminals.get(id: terminal.id)
+        #expect(updated?.suspendedAt != nil)
+        #expect(updated?.claudeSessionID == "abc-123")
+
+        // Clear suspended
+        try await db.terminals.clearSuspended(id: terminal.id)
+        let cleared = try await db.terminals.get(id: terminal.id)
+        #expect(cleared?.suspendedAt == nil)
+
+        // Update session ID
+        try await db.terminals.updateSessionID(id: terminal.id, sessionID: "new-456")
+        let refreshed = try await db.terminals.get(id: terminal.id)
+        #expect(refreshed?.claudeSessionID == "new-456")
+    }
+
+    @Test func terminalSuspendedAtPreservesOnReconcile() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-repo2", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test", branch: "main",
+            path: "/tmp/test-repo2/.tbd/worktrees/test", tmuxServer: "tbd-test"
+        )
+        let t = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "abc"
+        )
+        try await db.terminals.setSuspended(id: t.id, sessionID: "abc")
+
+        let suspended = try await db.terminals.list(worktreeID: wt.id)
+            .filter { $0.suspendedAt != nil }
+        #expect(suspended.count == 1)
+    }
+
     // MARK: - Notification Tests
 
     @Test func createAndReadNotifications() async throws {

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -144,3 +144,23 @@ import Testing
     // Should not throw in dry run mode
     try await manager.sendKeys(server: "tbd-test", paneID: "%mock-0", text: "hello")
 }
+
+@Test func capturePaneCommand() {
+    let args = TmuxManager.capturePaneCommand(server: "tbd-test", paneID: "%42")
+    #expect(args == ["-L", "tbd-test", "capture-pane", "-p", "-t", "%42"])
+}
+
+@Test func paneCurrentCommandQuery() {
+    let args = TmuxManager.paneCurrentCommandQuery(server: "tbd-test", paneID: "%42")
+    #expect(args == ["-L", "tbd-test", "list-panes", "-t", "%42", "-F", "#{pane_current_command}"])
+}
+
+@Test func panePIDQuery() {
+    let args = TmuxManager.panePIDQuery(server: "tbd-test", paneID: "%42")
+    #expect(args == ["-L", "tbd-test", "list-panes", "-t", "%42", "-F", "#{pane_pid}"])
+}
+
+@Test func sendCommandWithEnter() {
+    let args = TmuxManager.sendCommandArgs(server: "tbd-test", paneID: "%42", command: "/exit")
+    #expect(args == ["-L", "tbd-test", "send-keys", "-t", "%42", "/exit", "Enter"])
+}

--- a/docs/superpowers/plans/2026-03-29-auto-suspend-claude.md
+++ b/docs/superpowers/plans/2026-03-29-auto-suspend-claude.md
@@ -1,0 +1,1164 @@
+# Auto-suspend/resume Claude Code Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-suspend idle Claude Code instances when switching worktrees and resume them when switching back, freeing 500MB–1GB per idle instance.
+
+**Architecture:** Daemon-driven lifecycle management. App sends selection changes via RPC; daemon detects idle Claude instances, exits them gracefully, and recreates tmux windows on resume. `SuspendResumeCoordinator` actor serializes all operations with cancellation semantics.
+
+**Tech Stack:** Swift, GRDB (SQLite), tmux, SwiftUI (NSViewRepresentable), Swift Testing framework
+
+**Spec:** `docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md`
+
+---
+
+### Task 1: Database migration and model updates
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Database/Database.swift` (add migration v6)
+- Modify: `Sources/TBDDaemon/Database/TerminalStore.swift` (add fields + new methods)
+- Modify: `Sources/TBDShared/Models.swift` (add fields to Terminal)
+- Test: `Tests/TBDDaemonTests/DatabaseTests.swift`
+
+- [ ] **Step 1: Write failing test for new Terminal fields**
+
+```swift
+@Test func terminalSuspendFields() async throws {
+    let db = try TBDDatabase(writer: DatabaseQueue())
+    let repo = try await db.repos.create(path: "/tmp/test-repo")
+    let wt = try await db.worktrees.create(
+        repoID: repo.id, name: "test", branch: "main",
+        path: "/tmp/test-repo/.tbd/worktrees/test", tmuxServer: "tbd-test"
+    )
+
+    // Create terminal with new fields
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@1", tmuxPaneID: "%1",
+        label: "claude",
+        claudeSessionID: "abc-123"
+    )
+    #expect(terminal.claudeSessionID == "abc-123")
+    #expect(terminal.suspendedAt == nil)
+
+    // Set suspended
+    try await db.terminals.setSuspended(id: terminal.id, sessionID: "abc-123")
+    let updated = try await db.terminals.get(id: terminal.id)
+    #expect(updated?.suspendedAt != nil)
+    #expect(updated?.claudeSessionID == "abc-123")
+
+    // Clear suspended
+    try await db.terminals.clearSuspended(id: terminal.id)
+    let cleared = try await db.terminals.get(id: terminal.id)
+    #expect(cleared?.suspendedAt == nil)
+
+    // Update session ID
+    try await db.terminals.updateSessionID(id: terminal.id, sessionID: "new-456")
+    let refreshed = try await db.terminals.get(id: terminal.id)
+    #expect(refreshed?.claudeSessionID == "new-456")
+}
+
+@Test func terminalSuspendedAtPreservesOnReconcile() async throws {
+    // Verify that listing suspended terminals works for reconcile skip logic
+    let db = try TBDDatabase(writer: DatabaseQueue())
+    let repo = try await db.repos.create(path: "/tmp/test-repo")
+    let wt = try await db.worktrees.create(
+        repoID: repo.id, name: "test", branch: "main",
+        path: "/tmp/test-repo/.tbd/worktrees/test", tmuxServer: "tbd-test"
+    )
+    let t = try await db.terminals.create(
+        worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+        label: "claude", claudeSessionID: "abc"
+    )
+    try await db.terminals.setSuspended(id: t.id, sessionID: "abc")
+
+    let suspended = try await db.terminals.list(worktreeID: wt.id)
+        .filter { $0.suspendedAt != nil }
+    #expect(suspended.count == 1)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter terminalSuspendFields 2>&1 | tail -5`
+Expected: Compilation errors — `claudeSessionID` param and methods don't exist yet.
+
+- [ ] **Step 3: Add migration v6 to Database.swift**
+
+In `Sources/TBDDaemon/Database/Database.swift`, after the `v5` migration block, add:
+
+```swift
+migrator.registerMigration("v6") { db in
+    try db.alter(table: "terminal") { t in
+        t.add(column: "claudeSessionID", .text)
+        t.add(column: "suspendedAt", .datetime)
+    }
+}
+```
+
+- [ ] **Step 4: Update Terminal model in Models.swift**
+
+Add fields to `Terminal` struct. Use custom `Codable` for backward compatibility:
+
+```swift
+public struct Terminal: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var worktreeID: UUID
+    public var tmuxWindowID: String
+    public var tmuxPaneID: String
+    public var label: String?
+    public var createdAt: Date
+    public var pinnedAt: Date?
+    public var claudeSessionID: String?
+    public var suspendedAt: Date?
+
+    public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
+                tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
+                pinnedAt: Date? = nil, claudeSessionID: String? = nil,
+                suspendedAt: Date? = nil) {
+        self.id = id
+        self.worktreeID = worktreeID
+        self.tmuxWindowID = tmuxWindowID
+        self.tmuxPaneID = tmuxPaneID
+        self.label = label
+        self.createdAt = createdAt
+        self.pinnedAt = pinnedAt
+        self.claudeSessionID = claudeSessionID
+        self.suspendedAt = suspendedAt
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt,
+             pinnedAt, claudeSessionID, suspendedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        worktreeID = try c.decode(UUID.self, forKey: .worktreeID)
+        tmuxWindowID = try c.decode(String.self, forKey: .tmuxWindowID)
+        tmuxPaneID = try c.decode(String.self, forKey: .tmuxPaneID)
+        label = try c.decodeIfPresent(String.self, forKey: .label)
+        createdAt = try c.decode(Date.self, forKey: .createdAt)
+        pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
+        claudeSessionID = try c.decodeIfPresent(String.self, forKey: .claudeSessionID)
+        suspendedAt = try c.decodeIfPresent(Date.self, forKey: .suspendedAt)
+    }
+}
+```
+
+- [ ] **Step 5: Update TerminalRecord and TerminalStore**
+
+In `TerminalStore.swift`, add fields to `TerminalRecord`:
+
+```swift
+struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "terminal"
+
+    var id: String
+    var worktreeID: String
+    var tmuxWindowID: String
+    var tmuxPaneID: String
+    var label: String?
+    var createdAt: Date
+    var pinnedAt: Date?
+    var claudeSessionID: String?
+    var suspendedAt: Date?
+
+    init(from terminal: Terminal) {
+        self.id = terminal.id.uuidString
+        self.worktreeID = terminal.worktreeID.uuidString
+        self.tmuxWindowID = terminal.tmuxWindowID
+        self.tmuxPaneID = terminal.tmuxPaneID
+        self.label = terminal.label
+        self.createdAt = terminal.createdAt
+        self.pinnedAt = terminal.pinnedAt
+        self.claudeSessionID = terminal.claudeSessionID
+        self.suspendedAt = terminal.suspendedAt
+    }
+
+    func toModel() -> Terminal {
+        Terminal(
+            id: UUID(uuidString: id)!,
+            worktreeID: UUID(uuidString: worktreeID)!,
+            tmuxWindowID: tmuxWindowID,
+            tmuxPaneID: tmuxPaneID,
+            label: label,
+            createdAt: createdAt,
+            pinnedAt: pinnedAt,
+            claudeSessionID: claudeSessionID,
+            suspendedAt: suspendedAt
+        )
+    }
+}
+```
+
+Update `create` to accept `claudeSessionID`:
+
+```swift
+public func create(
+    worktreeID: UUID,
+    tmuxWindowID: String,
+    tmuxPaneID: String,
+    label: String? = nil,
+    claudeSessionID: String? = nil
+) async throws -> Terminal {
+    let terminal = Terminal(
+        worktreeID: worktreeID,
+        tmuxWindowID: tmuxWindowID,
+        tmuxPaneID: tmuxPaneID,
+        label: label,
+        claudeSessionID: claudeSessionID
+    )
+    let record = TerminalRecord(from: terminal)
+    try await writer.write { db in
+        try record.insert(db)
+    }
+    return terminal
+}
+```
+
+Add new methods:
+
+```swift
+/// Mark a terminal as suspended.
+public func setSuspended(id: UUID, sessionID: String) async throws {
+    try await writer.write { db in
+        guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+            throw DatabaseError(message: "Terminal not found")
+        }
+        record.suspendedAt = Date()
+        record.claudeSessionID = sessionID
+        try record.update(db)
+    }
+}
+
+/// Clear the suspended state.
+public func clearSuspended(id: UUID) async throws {
+    try await writer.write { db in
+        guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+            throw DatabaseError(message: "Terminal not found")
+        }
+        record.suspendedAt = nil
+        try record.update(db)
+    }
+}
+
+/// Update the Claude session ID (e.g. after resume generates a new one).
+public func updateSessionID(id: UUID, sessionID: String) async throws {
+    try await writer.write { db in
+        guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+            throw DatabaseError(message: "Terminal not found")
+        }
+        record.claudeSessionID = sessionID
+        try record.update(db)
+    }
+}
+
+/// Update tmux window/pane IDs (e.g. after resume creates a new window).
+public func updateTmuxIDs(id: UUID, windowID: String, paneID: String) async throws {
+    try await writer.write { db in
+        guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+            throw DatabaseError(message: "Terminal not found")
+        }
+        record.tmuxWindowID = windowID
+        record.tmuxPaneID = paneID
+        try record.update(db)
+    }
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `swift test --filter "terminalSuspend" 2>&1 | tail -5`
+Expected: Both tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/TBDShared/Models.swift Sources/TBDDaemon/Database/Database.swift Sources/TBDDaemon/Database/TerminalStore.swift Tests/TBDDaemonTests/DatabaseTests.swift
+git commit -m "feat: add claudeSessionID and suspendedAt to terminal model (migration v6)"
+```
+
+---
+
+### Task 2: TmuxManager helper methods
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Tmux/TmuxManager.swift`
+- Test: `Tests/TBDDaemonTests/TmuxManagerTests.swift`
+
+- [ ] **Step 1: Write tests for new command builders**
+
+```swift
+@Test func capturePaneCommand() {
+    let args = TmuxManager.capturePaneCommand(server: "tbd-test", paneID: "%42")
+    #expect(args == ["-L", "tbd-test", "capture-pane", "-p", "-t", "%42"])
+}
+
+@Test func paneCurrentCommandQuery() {
+    let args = TmuxManager.paneCurrentCommandQuery(server: "tbd-test", paneID: "%42")
+    #expect(args == ["-L", "tbd-test", "list-panes", "-t", "%42", "-F", "#{pane_current_command}"])
+}
+
+@Test func panePIDQuery() {
+    let args = TmuxManager.panePIDQuery(server: "tbd-test", paneID: "%42")
+    #expect(args == ["-L", "tbd-test", "list-panes", "-t", "%42", "-F", "#{pane_pid}"])
+}
+
+@Test func sendCommandWithEnter() {
+    let args = TmuxManager.sendCommandArgs(server: "tbd-test", paneID: "%42", command: "/exit")
+    #expect(args == ["-L", "tbd-test", "send-keys", "-t", "%42", "/exit", "Enter"])
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter "capturePane\|paneCurrentCommand\|panePID\|sendCommand" 2>&1 | tail -5`
+Expected: Compilation errors.
+
+- [ ] **Step 3: Implement command builders and instance methods**
+
+Add to `TmuxManager.swift` in the static command builders section:
+
+```swift
+public static func capturePaneCommand(server: String, paneID: String) -> [String] {
+    ["-L", server, "capture-pane", "-p", "-t", paneID]
+}
+
+public static func paneCurrentCommandQuery(server: String, paneID: String) -> [String] {
+    ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_current_command}"]
+}
+
+public static func panePIDQuery(server: String, paneID: String) -> [String] {
+    ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_pid}"]
+}
+
+/// send-keys without -l so "Enter" is interpreted as a key name, not literal text.
+public static func sendCommandArgs(server: String, paneID: String, command: String) -> [String] {
+    ["-L", server, "send-keys", "-t", paneID, command, "Enter"]
+}
+```
+
+Add instance methods:
+
+```swift
+/// Capture the visible content of a tmux pane.
+public func capturePaneOutput(server: String, paneID: String) async throws -> String {
+    if dryRun { return "" }
+    let args = Self.capturePaneCommand(server: server, paneID: paneID)
+    return try await runTmux(args)
+}
+
+/// Get the current foreground command name for a pane.
+public func paneCurrentCommand(server: String, paneID: String) async throws -> String {
+    if dryRun { return "zsh" }
+    let args = Self.paneCurrentCommandQuery(server: server, paneID: paneID)
+    return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+/// Get the PID of the process running in a pane.
+public func panePID(server: String, paneID: String) async throws -> String {
+    if dryRun { return "0" }
+    let args = Self.panePIDQuery(server: server, paneID: paneID)
+    return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+/// Send a command string followed by Enter to a pane.
+public func sendCommand(server: String, paneID: String, command: String) async throws {
+    if dryRun { return }
+    let args = Self.sendCommandArgs(server: server, paneID: paneID, command: command)
+    try await runTmux(args)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `swift test --filter "TmuxManager" 2>&1 | tail -5`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Tmux/TmuxManager.swift Tests/TBDDaemonTests/TmuxManagerTests.swift
+git commit -m "feat: add tmux capture-pane, pane inspection, and sendCommand helpers"
+```
+
+---
+
+### Task 3: ClaudeStateDetector
+
+**Files:**
+- Create: `Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift`
+- Create: `Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift`
+
+- [ ] **Step 1: Write tests for idle detection**
+
+```swift
+import Testing
+@testable import TBDDaemonLib
+
+@Test func idleWithBarePromptAndStatusBar() {
+    let lines = """
+    some output above
+
+    ─────────────────────────
+    ❯\u{00a0}
+    ─────────────────────────
+      ⏵⏵ bypass permissions on (shift+tab to cycle)
+    """
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == true)
+}
+
+@Test func notIdleWithUserInput() {
+    let lines = """
+    ─────────────────────────
+    ❯ fix the bug
+    ─────────────────────────
+      ⏵⏵ bypass permissions on (shift+tab to cycle)
+    """
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == false)
+}
+
+@Test func notIdleNoPrompt() {
+    let lines = """
+    ⏺ Working on something...
+      Reading file.swift
+    ─────────────────────────
+      ⏵⏵ bypass permissions on (shift+tab to cycle)
+    """
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == false)
+}
+
+@Test func notIdleNoStatusBar() {
+    let lines = """
+    ─────────────────────────
+    ❯\u{00a0}
+    ─────────────────────────
+    Enter to select · ↑/↓ to navigate · Esc to cancel
+    """
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == false)
+}
+
+@Test func idleWithQuestionForShortcuts() {
+    let lines = """
+    ─────────────────────────
+    ❯
+    ─────────────────────────
+      ? for shortcuts
+    """
+    #expect(ClaudeStateDetector.checkIdle(output: lines) == true)
+}
+
+@Test func claudeProcessPatternMatchesSemver() {
+    #expect(ClaudeStateDetector.isClaudeProcess("2.1.86") == true)
+    #expect(ClaudeStateDetector.isClaudeProcess("2.1.85") == true)
+    #expect(ClaudeStateDetector.isClaudeProcess("10.0.1") == true)
+    #expect(ClaudeStateDetector.isClaudeProcess("zsh") == false)
+    #expect(ClaudeStateDetector.isClaudeProcess("bash") == false)
+    #expect(ClaudeStateDetector.isClaudeProcess("node") == false)
+    #expect(ClaudeStateDetector.isClaudeProcess("git") == false)
+}
+
+@Test func parseSessionFile() {
+    let json = """
+    {"pid": 12345, "sessionId": "abc-def-123", "cwd": "/tmp", "startedAt": 1000, "kind": "interactive", "entrypoint": "cli"}
+    """
+    let result = ClaudeStateDetector.parseSessionID(from: json)
+    #expect(result == "abc-def-123")
+}
+
+@Test func parseSessionFileBadJSON() {
+    let result = ClaudeStateDetector.parseSessionID(from: "not json")
+    #expect(result == nil)
+}
+
+@Test func parseSessionFilePartialJSON() {
+    let result = ClaudeStateDetector.parseSessionID(from: "{\"pid\": 123")
+    #expect(result == nil)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter "ClaudeStateDetector" 2>&1 | tail -5`
+Expected: Compilation errors — `ClaudeStateDetector` doesn't exist.
+
+- [ ] **Step 3: Implement ClaudeStateDetector**
+
+Create `Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift`:
+
+```swift
+import Foundation
+
+/// Detects Claude Code idle state and captures session IDs.
+/// Pattern constants are centralized here — Claude Code UI details with no stability contract.
+public struct ClaudeStateDetector: Sendable {
+
+    // MARK: - Pattern Constants
+
+    /// Claude appears as a semver string in tmux's pane_current_command (e.g. "2.1.86").
+    static let claudeProcessRegex = try! Regex(#"^\d+\.\d+\.\d+"#)
+
+    /// The prompt character Claude shows when waiting for input.
+    static let promptRegex = try! Regex(#"^❯[\s\u{00a0}]*$"#)
+
+    /// Status bar indicators that confirm Claude is at its idle prompt.
+    static let statusIndicators = ["⏵⏵", "bypass", "auto mode", "? for shortcuts"]
+
+    // MARK: - Public API
+
+    /// Check if a pane_current_command value looks like a Claude process.
+    public static func isClaudeProcess(_ command: String) -> Bool {
+        command.firstMatch(of: claudeProcessRegex) != nil
+    }
+
+    /// Check if captured pane output shows an idle Claude prompt.
+    /// Requires BOTH a bare prompt line AND a status bar indicator in the last 5 lines.
+    public static func checkIdle(output: String) -> Bool {
+        let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
+        let lastLines = lines.suffix(5).map(String.init)
+        let text = lastLines.joined(separator: "\n")
+
+        let hasStatusBar = statusIndicators.contains { text.contains($0) }
+        let hasPrompt = lastLines.contains { $0.firstMatch(of: promptRegex) != nil }
+
+        return hasStatusBar && hasPrompt
+    }
+
+    /// Parse a session ID from Claude Code's session file JSON.
+    public static func parseSessionID(from json: String) -> String? {
+        struct SessionFile: Decodable {
+            let sessionId: String
+        }
+        guard let data = json.data(using: .utf8),
+              let parsed = try? JSONDecoder().decode(SessionFile.self, from: data) else {
+            return nil
+        }
+        return parsed.sessionId
+    }
+
+    // MARK: - Tmux-dependent methods
+
+    private let tmux: TmuxManager
+
+    public init(tmux: TmuxManager) {
+        self.tmux = tmux
+    }
+
+    /// Full idle check: verify pane_current_command is Claude, then check pane output.
+    public func isIdle(server: String, paneID: String) async -> Bool {
+        do {
+            let command = try await tmux.paneCurrentCommand(server: server, paneID: paneID)
+            guard Self.isClaudeProcess(command) else { return false }
+
+            let output = try await tmux.capturePaneOutput(server: server, paneID: paneID)
+            return Self.checkIdle(output: output)
+        } catch {
+            return false
+        }
+    }
+
+    /// Debounced idle check — calls isIdle twice with a 1s gap.
+    public func isIdleConfirmed(server: String, paneID: String) async -> Bool {
+        guard await isIdle(server: server, paneID: paneID) else { return false }
+        try? await Task.sleep(for: .seconds(1))
+        guard !Task.isCancelled else { return false }
+        return await isIdle(server: server, paneID: paneID)
+    }
+
+    /// Capture the Claude session ID from a running instance's PID file.
+    public func captureSessionID(server: String, paneID: String) async -> String? {
+        do {
+            let pidStr = try await tmux.panePID(server: server, paneID: paneID)
+            guard let shellPID = Int(pidStr) else { return nil }
+
+            // Find the claude child process
+            let process = Process()
+            let pipe = Pipe()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+            process.arguments = ["-P", String(shellPID), "-x", "claude"]
+            process.standardOutput = pipe
+            process.standardError = FileHandle.nullDevice
+            try process.run()
+            process.waitUntilExit()
+
+            let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let pids = output.trimmingCharacters(in: .whitespacesAndNewlines)
+                .split(separator: "\n")
+                .compactMap { Int($0) }
+
+            // Skip if multiple matches (ambiguous)
+            guard pids.count == 1, let claudePID = pids.first else { return nil }
+
+            // Read session file
+            let sessionPath = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".claude/sessions/\(claudePID).json")
+            guard let json = try? String(contentsOf: sessionPath, encoding: .utf8) else { return nil }
+
+            return Self.parseSessionID(from: json)
+        } catch {
+            return nil
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `swift test --filter "ClaudeStateDetector" 2>&1 | tail -5`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift
+git commit -m "feat: add ClaudeStateDetector for idle detection and session ID capture"
+```
+
+---
+
+### Task 4: RPC method and selection tracking
+
+**Files:**
+- Modify: `Sources/TBDShared/RPCProtocol.swift` (add method + param struct)
+- Modify: `Sources/TBDDaemon/Server/RPCRouter.swift` (add handler dispatch)
+- Create: `Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift` (handler)
+- Modify: `Sources/TBDApp/DaemonClient.swift` (add client method)
+- Modify: `Sources/TBDApp/ContentView.swift` (wire onChange)
+- Modify: `Sources/TBDApp/AppState.swift` (send on reconnect)
+
+- [ ] **Step 1: Add RPC method constant and param struct**
+
+In `Sources/TBDShared/RPCProtocol.swift`, add to `RPCMethod`:
+
+```swift
+public static let worktreeSelectionChanged = "worktree.selectionChanged"
+```
+
+Add param struct after the existing ones:
+
+```swift
+public struct WorktreeSelectionChangedParams: Codable, Sendable {
+    public let selectedWorktreeIDs: [UUID]
+    public init(selectedWorktreeIDs: [UUID]) {
+        self.selectedWorktreeIDs = selectedWorktreeIDs
+    }
+}
+```
+
+- [ ] **Step 2: Add handler dispatch in RPCRouter.swift**
+
+In the `handle(_:)` switch, add:
+
+```swift
+case RPCMethod.worktreeSelectionChanged:
+    return try await handleWorktreeSelectionChanged(request.paramsData)
+```
+
+- [ ] **Step 3: Create handler file**
+
+Create `Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift`:
+
+```swift
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+    func handleWorktreeSelectionChanged(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeSelectionChangedParams.self, from: data)
+        let newSelection = Set(params.selectedWorktreeIDs)
+
+        // TODO: Task 5 will add SuspendResumeCoordinator integration here.
+        // For now, just store the selection.
+
+        return .ok()
+    }
+}
+```
+
+- [ ] **Step 4: Add client method in DaemonClient.swift**
+
+Add to `DaemonClient`:
+
+```swift
+func worktreeSelectionChanged(selectedWorktreeIDs: Set<UUID>) async throws {
+    let params = WorktreeSelectionChangedParams(selectedWorktreeIDs: Array(selectedWorktreeIDs))
+    let request = try RPCRequest(method: RPCMethod.worktreeSelectionChanged, params: params)
+    _ = try await send(request)
+}
+```
+
+- [ ] **Step 5: Wire into ContentView.swift onChange**
+
+In the existing `onChange(of: appState.selectedWorktreeIDs)` handler, add the RPC call:
+
+```swift
+Task {
+    try? await appState.daemonClient?.worktreeSelectionChanged(
+        selectedWorktreeIDs: appState.selectedWorktreeIDs
+    )
+}
+```
+
+- [ ] **Step 6: Wire into AppState reconnect path**
+
+In `AppState`'s refresh/reconnect method (where it re-fetches worktrees and terminals after daemon connection), add:
+
+```swift
+// Re-send current selection so daemon has accurate baseline after restart
+Task {
+    try? await daemonClient?.worktreeSelectionChanged(
+        selectedWorktreeIDs: selectedWorktreeIDs
+    )
+}
+```
+
+- [ ] **Step 7: Build and verify**
+
+Run: `swift build 2>&1 | grep -E "error:|Build complete"`
+Expected: Build complete.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/TBDShared/RPCProtocol.swift Sources/TBDDaemon/Server/RPCRouter.swift Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift Sources/TBDApp/DaemonClient.swift Sources/TBDApp/ContentView.swift Sources/TBDApp/AppState.swift
+git commit -m "feat: add worktreeSelectionChanged RPC method"
+```
+
+---
+
+### Task 5: SuspendResumeCoordinator actor
+
+**Files:**
+- Create: `Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift`
+- Modify: `Sources/TBDDaemon/Server/RPCRouter.swift` (add coordinator property)
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift` (integrate)
+
+- [ ] **Step 1: Create the coordinator**
+
+Create `Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift`:
+
+```swift
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "SuspendResume")
+
+/// Serializes suspend/resume operations per terminal.
+/// Handles rapid switching by cancelling in-flight suspends before the point of no return.
+public actor SuspendResumeCoordinator {
+    private let db: TBDDatabase
+    private let tmux: TmuxManager
+    private let detector: ClaudeStateDetector
+    private var inFlight: [UUID: Task<Void, Never>] = [:]
+    private var lastKnownSelection: Set<UUID> = []
+
+    public init(db: TBDDatabase, tmux: TmuxManager) {
+        self.db = db
+        self.tmux = tmux
+        self.detector = ClaudeStateDetector(tmux: tmux)
+    }
+
+    /// Called when app reports a new selection. Diffs against last-known and triggers suspend/resume.
+    public func selectionChanged(to newSelection: Set<UUID>) {
+        let departing = lastKnownSelection.subtracting(newSelection)
+        let arriving = newSelection.subtracting(lastKnownSelection)
+        lastKnownSelection = newSelection
+
+        for worktreeID in departing {
+            scheduleSuspend(worktreeID: worktreeID)
+        }
+        for worktreeID in arriving {
+            scheduleResume(worktreeID: worktreeID)
+        }
+    }
+
+    // MARK: - Suspend
+
+    private func scheduleSuspend(worktreeID: UUID) {
+        Task {
+            let terminals = try? await db.terminals.list(worktreeID: worktreeID)
+            guard let terminals else { return }
+            for terminal in terminals {
+                guard terminal.label?.hasPrefix("claude") == true,
+                      terminal.pinnedAt == nil,
+                      terminal.suspendedAt == nil,
+                      terminal.claudeSessionID != nil else { continue }
+
+                // Cancel any in-flight operation for this terminal
+                inFlight[terminal.id]?.cancel()
+
+                let task = Task<Void, Never> {
+                    await suspendTerminal(terminal)
+                }
+                inFlight[terminal.id] = task
+            }
+        }
+    }
+
+    private func suspendTerminal(_ terminal: Terminal) async {
+        let server = await worktreeServer(for: terminal.worktreeID)
+        guard let server else { return }
+
+        // Steps 1-5: cancellable phase
+        guard await detector.isIdleConfirmed(server: server, paneID: terminal.tmuxPaneID) else {
+            return
+        }
+
+        // Check cancellation before point of no return
+        guard !Task.isCancelled else { return }
+
+        // Step 6: POINT OF NO RETURN — send /exit
+        do {
+            try await tmux.sendCommand(server: server, paneID: terminal.tmuxPaneID, command: "/exit")
+        } catch {
+            logger.warning("Failed to send /exit to \(terminal.id): \(error)")
+            return
+        }
+
+        // Step 7: verify exit (poll for up to 3s)
+        for _ in 0..<15 {
+            try? await Task.sleep(for: .milliseconds(200))
+            if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
+               !ClaudeStateDetector.isClaudeProcess(cmd) {
+                break // Claude exited
+            }
+        }
+
+        // Step 8: mark suspended regardless of whether Claude exited yet
+        do {
+            try await db.terminals.setSuspended(id: terminal.id, sessionID: terminal.claudeSessionID!)
+            logger.info("Suspended terminal \(terminal.id)")
+        } catch {
+            logger.warning("Failed to mark terminal \(terminal.id) suspended: \(error)")
+        }
+
+        inFlight[terminal.id] = nil
+    }
+
+    // MARK: - Resume
+
+    private func scheduleResume(worktreeID: UUID) {
+        Task {
+            let terminals = try? await db.terminals.list(worktreeID: worktreeID)
+            guard let terminals else { return }
+            for terminal in terminals where terminal.suspendedAt != nil {
+                // Cancel any in-flight suspend (only effective if still in cancellable phase)
+                inFlight[terminal.id]?.cancel()
+
+                let task = Task<Void, Never> {
+                    await resumeTerminal(terminal)
+                }
+                inFlight[terminal.id] = task
+            }
+        }
+    }
+
+    private func resumeTerminal(_ terminal: Terminal) async {
+        let server = await worktreeServer(for: terminal.worktreeID)
+        guard let server, let sessionID = terminal.claudeSessionID else { return }
+
+        // Step 1: check if Claude is still/already running (pending /exit or user restarted)
+        if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
+           ClaudeStateDetector.isClaudeProcess(cmd) {
+            // Wait up to 5s for queued /exit to process
+            var stillRunning = true
+            for _ in 0..<25 {
+                try? await Task.sleep(for: .milliseconds(200))
+                if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
+                   !ClaudeStateDetector.isClaudeProcess(cmd) {
+                    stillRunning = false
+                    break
+                }
+            }
+            if stillRunning {
+                // User restarted it — just clear suspended state and re-capture session
+                try? await db.terminals.clearSuspended(id: terminal.id)
+                if let newID = await detector.captureSessionID(server: server, paneID: terminal.tmuxPaneID) {
+                    try? await db.terminals.updateSessionID(id: terminal.id, sessionID: newID)
+                }
+                inFlight[terminal.id] = nil
+                return
+            }
+        }
+
+        // Step 2-4: pane is dead — create new window
+        let worktree = try? await db.worktrees.get(id: terminal.worktreeID)
+        guard let worktree else {
+            inFlight[terminal.id] = nil
+            return
+        }
+
+        let resumeCommand = "claude --resume \(sessionID) --dangerously-skip-permissions"
+        do {
+            let window = try await tmux.createWindow(
+                server: server,
+                session: "main",
+                cwd: worktree.path,
+                shellCommand: resumeCommand
+            )
+            try await db.terminals.updateTmuxIDs(
+                id: terminal.id,
+                windowID: window.windowID,
+                paneID: window.paneID
+            )
+            try await db.terminals.clearSuspended(id: terminal.id)
+            logger.info("Resumed terminal \(terminal.id) in new window \(window.windowID)")
+
+            // Step 7: re-capture session ID after ~5s
+            Task {
+                try? await Task.sleep(for: .seconds(5))
+                if let newID = await detector.captureSessionID(server: server, paneID: window.paneID) {
+                    try? await db.terminals.updateSessionID(id: terminal.id, sessionID: newID)
+                    logger.info("Re-captured session ID for terminal \(terminal.id): \(newID)")
+                } else {
+                    logger.warning("Failed to re-capture session ID for terminal \(terminal.id)")
+                }
+            }
+        } catch {
+            logger.warning("Failed to resume terminal \(terminal.id): \(error)")
+        }
+
+        inFlight[terminal.id] = nil
+    }
+
+    // MARK: - Helpers
+
+    private func worktreeServer(for worktreeID: UUID) async -> String? {
+        guard let wt = try? await db.worktrees.get(id: worktreeID) else { return nil }
+        return wt.tmuxServer
+    }
+
+    /// Reconcile suspended terminals on startup.
+    public func reconcileOnStartup() async {
+        let allTerminals = (try? await db.terminals.list()) ?? []
+        for terminal in allTerminals where terminal.suspendedAt != nil {
+            let server = await worktreeServer(for: terminal.worktreeID)
+            guard let server else { continue }
+
+            let alive = await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID)
+            if alive {
+                if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
+                   ClaudeStateDetector.isClaudeProcess(cmd) {
+                    // Claude is running — clear suspended state
+                    try? await db.terminals.clearSuspended(id: terminal.id)
+                    logger.info("Startup reconcile: cleared suspendedAt for running terminal \(terminal.id)")
+                }
+            }
+            // If pane is dead, leave suspendedAt set — will be resumed on next selection
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add coordinator to RPCRouter**
+
+In `RPCRouter`, add property:
+
+```swift
+public let suspendResumeCoordinator: SuspendResumeCoordinator
+```
+
+Update the `init` to create it:
+
+```swift
+self.suspendResumeCoordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
+```
+
+- [ ] **Step 3: Wire selection handler to coordinator**
+
+Update `RPCRouter+SelectionHandlers.swift`:
+
+```swift
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+    func handleWorktreeSelectionChanged(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeSelectionChangedParams.self, from: data)
+        let newSelection = Set(params.selectedWorktreeIDs)
+        await suspendResumeCoordinator.selectionChanged(to: newSelection)
+        return .ok()
+    }
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `swift build 2>&1 | grep -E "error:|Build complete"`
+Expected: Build complete.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift Sources/TBDDaemon/Server/RPCRouter.swift Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift
+git commit -m "feat: add SuspendResumeCoordinator actor with suspend/resume flows"
+```
+
+---
+
+### Task 6: Reconcile fix, terminal creation, and startup
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift`
+- Modify: `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift`
+- Modify: `Sources/TBDDaemon/Daemon.swift` (startup reconcile)
+
+- [ ] **Step 1: Fix reconcile to skip suspended terminals**
+
+In `WorktreeLifecycle+Reconcile.swift`, in the terminal cleanup loop (around line 130), change:
+
+```swift
+// Before:
+if !alive {
+    try? await db.terminals.delete(id: terminal.id)
+}
+
+// After:
+if !alive && terminal.suspendedAt == nil {
+    try? await db.terminals.delete(id: terminal.id)
+}
+```
+
+- [ ] **Step 2: Add --session-id to terminal creation**
+
+In `WorktreeLifecycle+Create.swift`, where the Claude command is built (around line 188), change:
+
+```swift
+// Before:
+let claudeCommand: String
+if skipClaude {
+    claudeCommand = defaultShell
+} else {
+    claudeCommand = "claude --dangerously-skip-permissions"
+}
+
+// After:
+let claudeCommand: String
+let claudeSessionID: String?
+if skipClaude {
+    claudeCommand = defaultShell
+    claudeSessionID = nil
+} else {
+    let sessionUUID = UUID().uuidString
+    claudeCommand = "claude --dangerously-skip-permissions --session-id \(sessionUUID)"
+    claudeSessionID = sessionUUID
+}
+```
+
+And update the `db.terminals.create` call to pass it:
+
+```swift
+_ = try await db.terminals.create(
+    worktreeID: worktreeID,
+    tmuxWindowID: window1.windowID,
+    tmuxPaneID: window1.paneID,
+    label: skipClaude ? "shell" : "claude",
+    claudeSessionID: claudeSessionID
+)
+```
+
+- [ ] **Step 3: Add startup reconcile to Daemon.swift**
+
+In `Daemon.swift`, after the RPCRouter is created but before (or at the start of) the existing reconcile, add:
+
+```swift
+await router.suspendResumeCoordinator.reconcileOnStartup()
+```
+
+- [ ] **Step 4: Build and run tests**
+
+Run: `swift build 2>&1 | grep -E "error:|Build complete"` then `swift test 2>&1 | tail -5`
+Expected: Build complete, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift Sources/TBDDaemon/Daemon.swift
+git commit -m "feat: reconcile skip for suspended terminals, --session-id at creation, startup sweep"
+```
+
+---
+
+### Task 7: App UI reconnection
+
+**Files:**
+- Modify: `Sources/TBDApp/Panes/PanePlaceholder.swift`
+
+- [ ] **Step 1: Change view identity to include tmuxWindowID**
+
+In `PanePlaceholder.swift`, find the `.id(terminalID)` on the `TerminalPanelView` (around line 176) and change it:
+
+```swift
+// Before:
+.id(terminalID)
+
+// After:
+.id("\(terminal.id)-\(terminal.tmuxWindowID)")
+```
+
+This requires the `terminal` object to be available in scope. The `terminalContent` function already looks up the terminal (line 160: `if let terminal = terminal(for: terminalID)`), so use `terminal.id` and `terminal.tmuxWindowID` directly.
+
+- [ ] **Step 2: Trigger immediate refresh after selection RPC**
+
+In `ContentView.swift`, in the `onChange` handler where we call `worktreeSelectionChanged`, trigger an immediate terminal refresh after the RPC returns:
+
+```swift
+Task {
+    try? await appState.daemonClient?.worktreeSelectionChanged(
+        selectedWorktreeIDs: appState.selectedWorktreeIDs
+    )
+    // Immediate refresh so UI picks up new tmuxWindowID from resume
+    await appState.refreshTerminals()
+}
+```
+
+(If `refreshTerminals` doesn't exist as a standalone method, extract the terminal-refresh logic from the existing poll timer into a callable method.)
+
+- [ ] **Step 3: Build and verify**
+
+Run: `swift build 2>&1 | grep -E "error:|Build complete"`
+Expected: Build complete.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/Panes/PanePlaceholder.swift Sources/TBDApp/ContentView.swift
+git commit -m "feat: composite view identity for UI reconnection on resume"
+```
+
+---
+
+### Task 8: Integration test and final verification
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Build the full project**
+
+Run: `swift build 2>&1 | grep -E "error:|Build complete"`
+Expected: Build complete.
+
+- [ ] **Step 2: Run all tests**
+
+Run: `swift test 2>&1 | tail -10`
+Expected: All tests pass.
+
+- [ ] **Step 3: Manual smoke test**
+
+1. Run `scripts/restart.sh` to rebuild and restart
+2. Open TBD app, create a worktree
+3. Verify the Claude terminal launches with `--session-id` (check `/tmp/tbd-bridge.log` or tmux output)
+4. Wait for Claude to reach idle prompt
+5. Switch to a different worktree
+6. Wait ~2s for the suspend flow
+7. Switch back — verify Claude resumes with the conversation intact
+
+- [ ] **Step 4: Final commit if any fixups needed**
+
+```bash
+git add -A
+git commit -m "fix: integration fixups from smoke testing"
+```

--- a/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
+++ b/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
@@ -12,14 +12,31 @@ Automatically exit idle Claude Code instances when the user switches away from a
 
 ### New terminal fields
 
-Add two optional fields to the `Terminal` model and database:
+Add to the `Terminal` model and database:
 
 | Field | Type | Purpose |
 |-------|------|---------|
+| `claudeSessionID` | `String?` | Claude Code session UUID. Set at launch for TBD-created terminals (via `--session-id`), or lazily captured at suspend time for user-spawned instances. |
 | `suspendedAt` | `Date?` | Timestamp when daemon auto-suspended this terminal. `nil` = not suspended. |
-| `suspendedSessionID` | `String?` | Claude Code session UUID captured before exit. Used for `claude --resume <id>`. |
 
 **Migration**: New migration `v6` adds both columns to the `terminal` table with nil defaults. `Models.swift` gets matching optional fields (both optional, so existing rows decode fine).
+
+### Session ID lifecycle
+
+Two paths for obtaining the session ID:
+
+**Path A — TBD-created terminals**: When the daemon creates a Claude terminal, it generates a UUID and passes `--session-id <uuid>` in the launch command. The UUID is stored as `claudeSessionID` immediately at creation time. This is the reliable, race-free path.
+
+**Path B — User-spawned terminals**: When a user manually runs `claude` in a shell tab, there's no `--session-id`. The session ID is captured lazily at suspend time via PID file lookup:
+
+1. `tmux list-panes -t <paneID> -F "#{pane_pid}"` → shell PID
+2. `pgrep -P <shellPID> -x claude` → Claude process PID (must filter for `claude` specifically — the shell may also have MCP server children, `caffeinate`, etc.)
+3. Read `~/.claude/sessions/<claudePID>.json` → parse `sessionId`
+4. Cache the result as `claudeSessionID` on the terminal record
+
+If lazy capture fails (process already exited, file missing, no `claude` child found), the terminal is skipped for suspension — conservative by default.
+
+**Note**: `~/.claude/sessions/<pid>.json` is an implementation detail of Claude Code, not a documented API. Files are deleted when Claude exits (verified: 59/59 session files on disk belong to live processes, zero orphans). The session ID is stable for the lifetime of the process.
 
 ## Idle detection
 
@@ -27,22 +44,28 @@ Add two optional fields to the `Terminal` model and database:
 
 New file: `Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift`
 
-Takes a `TmuxManager` dependency for running tmux commands. `TmuxManager` will need a new public `capturePaneOutput(server:paneID:)` method (thin wrapper around `runTmux` for `capture-pane -p`), and a `paneProcessID(server:paneID:)` method for `list-panes -F "#{pane_pid}"`.
-
-Provides two methods:
+Takes a `TmuxManager` dependency. `TmuxManager` needs new public methods: `capturePaneOutput(server:paneID:)` (wraps `capture-pane -p`), `paneProcessID(server:paneID:)` (wraps `list-panes -F "#{pane_pid}"`), and `paneCurrentCommand(server:paneID:)` (wraps `list-panes -F "#{pane_current_command}"`).
 
 #### `isIdle(server:paneID:) async -> Bool`
 
 Determines whether a Claude Code instance is idle and safe to suspend.
 
-1. Run `tmux capture-pane -p -t <paneID>` via `TmuxManager.runTmux`
-2. Take the last 5 lines of output
-3. Check for **both** conditions:
-   - **Status bar present**: text contains any of `⏵⏵`, `bypass`, `auto mode`, `? for shortcuts`
-   - **Bare prompt**: a line matching `❯` followed by only whitespace/non-breaking-space to end of line (regex: `^❯[\s\u{00a0}]*$`)
-4. Return `true` only if both conditions are met
+1. **Guard**: check `pane_current_command` — if it's `zsh`, `bash`, or doesn't look like a Claude version string, return `false` (Claude isn't the foreground process)
+2. Run `tmux capture-pane -p -t <paneID>`
+3. Take the last 5 lines of output
+4. Check for **both** conditions:
+   - **Status bar present**: text contains any of the status indicators (see constants below)
+   - **Bare prompt**: a line matching the prompt pattern with no user input after it
+5. Return `true` only if both conditions are met
 
-States that are correctly classified as **not idle**:
+**Pattern constants** (centralized, since these are Claude Code UI details with no stability contract):
+
+```swift
+static let promptPattern = "^❯[\\s\\u{00a0}]*$"  // ❯ followed by only whitespace/nbsp
+static let statusIndicators = ["⏵⏵", "bypass", "auto mode", "? for shortcuts"]
+```
+
+States correctly classified as **not idle**:
 - Claude mid-generation (no prompt visible)
 - User has typed partial input after the prompt (`❯ some text`)
 - Interactive picker/menu visible (no prompt line)
@@ -50,30 +73,33 @@ States that are correctly classified as **not idle**:
 
 #### `captureSessionID(server:paneID:) async -> String?`
 
-Extracts the Claude Code session UUID for a running instance.
+Extracts the Claude Code session UUID for a running instance (used for user-spawned terminals that lack a pre-assigned `claudeSessionID`).
 
-1. Run `tmux list-panes -t <paneID> -F "#{pane_pid}"` to get the shell PID
-2. Run `pgrep -P <shellPID>` to find the claude child process PID
+1. Get shell PID via `paneProcessID(server:paneID:)`
+2. Run `pgrep -P <shellPID> -x claude` to find the Claude child process (not MCP servers or other children)
 3. Read `~/.claude/sessions/<claudePID>.json`
-4. Parse the JSON and return the `sessionId` string
-5. Return `nil` at any step if the lookup fails (process gone, file missing, etc.)
+4. Parse JSON and return `sessionId`
+5. Return `nil` at any step if the lookup fails
 
 ## Suspend flow
 
-Triggered when the app changes worktree selection (the daemon already receives this via RPC state deltas).
+Triggered when the user switches away from a worktree. Requires a new RPC method (see Integration section).
 
 For each terminal in the **departing** worktree:
 
-1. **Skip if not a Claude terminal**: `label` does not start with `"claude"` → skip
-2. **Skip if pinned**: `pinnedAt != nil` → skip
-3. **Skip if already suspended**: `suspendedAt != nil` → skip
+1. **Skip if pinned**: `pinnedAt != nil` → skip
+2. **Skip if already suspended**: `suspendedAt != nil` → skip
+3. **Skip if not Claude**: check `pane_current_command` — if it doesn't look like Claude, skip. (Covers both TBD-created terminals where `label == "claude"` and user-spawned Claude instances.)
 4. **Check idle state**: call `isIdle(server:paneID:)` → skip if `false`
-5. **Capture session ID**: call `captureSessionID(server:paneID:)` → skip if `nil` (can't resume without it)
+5. **Ensure session ID**: if `claudeSessionID` is nil, call `captureSessionID(server:paneID:)` and store it. If still nil → skip (can't resume without it)
 6. **Exit Claude**: `tmux send-keys -t <paneID> "/exit" Enter`
-7. **Update database**: set `suspendedAt = Date()`, `suspendedSessionID = <uuid>`
-8. **Broadcast state delta** so the app UI can show a "suspended" indicator
+7. **Verify exit** (async): poll `pane_current_command` every 200ms for up to 3 seconds. If Claude is still running after timeout, clear `suspendedAt` and log a warning — don't leave the terminal in a bad state.
+8. **Update database**: set `suspendedAt = Date()`
+9. **Broadcast state delta**
 
-Each step that skips leaves the terminal running — the design is conservative. If anything is uncertain, don't suspend.
+Each step that skips leaves the terminal running — conservative by default.
+
+**Race condition note**: Claude could start working between `isIdle()` and the `/exit` send. This is benign — Claude Code queues `/exit` and processes it after the current turn completes. The session ID remains valid.
 
 ## Resume flow
 
@@ -81,20 +107,50 @@ Triggered when a worktree is selected.
 
 For each terminal in the **arriving** worktree where `suspendedAt != nil`:
 
-1. **Wait for shell readiness**: after Claude exits, the shell prompt needs a moment to appear. Poll with `tmux capture-pane` looking for a shell prompt (e.g. `$` or `%` or `❯` from zsh), up to 2 seconds, checking every 200ms. If the shell prompt never appears, skip (don't send blind input).
-2. **Build resume command**: `claude --resume <suspendedSessionID>` + append ` --dangerously-skip-permissions` if the user's `skipPermissions` setting is enabled
-3. **Send command**: `tmux send-keys -t <paneID> "<command>" Enter`
-4. **Clear state**: set `suspendedAt = nil`, `suspendedSessionID = nil`
-5. **Broadcast state delta**
+1. **Check if Claude is already running**: `pane_current_command` shows Claude → clear `suspendedAt`, done (user manually restarted it)
+2. **Check pane is alive**: verify the tmux pane/window still exists. If dead → create a new tmux window in the same session with the resume command (the `zsh -ic` wrapper means the pane dies when Claude exits)
+3. **Build resume command**: `claude --resume <claudeSessionID>` + append ` --dangerously-skip-permissions` if the user's `skipPermissions` setting is enabled
+4. **If pane alive** (shell prompt visible): `tmux send-keys -t <paneID> "<command>" Enter`
+5. **If pane dead**: create new window via `TmuxManager.createWindow(server:session:cwd:shellCommand:)` with the resume command. Update the terminal record's `tmuxWindowID` and `tmuxPaneID` to the new values.
+6. **Clear state**: set `suspendedAt = nil`
+7. **Broadcast state delta**
 
-## Integration point
+**Stale session handling**: if `claude --resume <id>` fails (session file deleted, corrupted), Claude will show an error. This is acceptable — the user sees the error and can start a new session manually.
 
-The suspend/resume logic hooks into the daemon's existing worktree selection handling. When the daemon processes a selection change:
+## Integration
 
-1. Identify departing worktrees (were selected, now aren't)
-2. Identify arriving worktrees (weren't selected, now are)
-3. Run suspend flow for departing worktrees (async, non-blocking — sends `/exit` but does not wait for Claude to actually terminate)
-4. Run resume flow for arriving worktrees (async, independent of suspend — arriving worktrees are different from departing worktrees, so there's no ordering dependency)
+### New RPC: `worktreeSelectionChanged`
+
+The app's worktree selection is local to `AppState.selectedWorktreeIDs`. State deltas only flow daemon→app, not the reverse. A new RPC method is needed:
+
+**Method**: `worktreeSelectionChanged`
+**Params**: `{ selectedWorktreeIDs: [UUID], previousWorktreeIDs: [UUID] }`
+**Result**: `{ success: Bool }`
+
+The app calls this from its `onChange(of: appState.selectedWorktreeIDs)` handler in `ContentView.swift`. The daemon computes departing/arriving sets and runs suspend/resume flows.
+
+### Rapid switch handling
+
+If the user switches A→B→A within seconds:
+- The suspend for A may still be in flight when the resume for A triggers
+- Track in-flight suspend operations per terminal ID (e.g. a `Set<UUID>` of terminals being suspended)
+- If a resume arrives for a terminal being suspended, cancel/await the suspend before proceeding
+- If a suspend arrives for a terminal being resumed, skip it
+
+### Daemon startup reconciliation
+
+On daemon startup, sweep all terminals with `suspendedAt != nil`:
+- Check if the tmux pane is alive and Claude is running → clear `suspendedAt` (user or system restarted it)
+- Check if the pane is dead → leave `suspendedAt` set (will be resumed when worktree is next selected)
+
+## Terminal creation changes
+
+When the daemon creates a Claude terminal (in `WorktreeLifecycle+Create.swift`):
+1. Generate a UUID for the session: `UUID().uuidString`
+2. Store it as `claudeSessionID` on the terminal record
+3. Append `--session-id <uuid>` to the Claude launch command
+
+This ensures TBD-created terminals always have a known session ID from the start, independent of PID file availability.
 
 ## Scope boundaries
 
@@ -102,8 +158,14 @@ The suspend/resume logic hooks into the daemon's existing worktree selection han
 - Auto-suspend idle Claude terminals on worktree switch
 - Auto-resume with correct session on worktree switch back
 - Respect pinned terminals (never suspend)
-- New DB migration for `suspendedAt` and `suspendedSessionID`
+- Deterministic `--session-id` for TBD-created terminals
+- Lazy session ID capture for user-spawned Claude instances
+- New DB migration for `claudeSessionID` and `suspendedAt`
+- New `worktreeSelectionChanged` RPC method
 - `ClaudeStateDetector` for idle detection and session ID capture
+- Pane recreation on resume when original pane is dead
+- Rapid switch protection
+- Daemon startup reconciliation
 
 ### Out of scope
 - UI indicator for suspended state (future enhancement)
@@ -114,7 +176,10 @@ The suspend/resume logic hooks into the daemon's existing worktree selection han
 
 ## Testing
 
-- **ClaudeStateDetector**: unit tests with mocked tmux output covering all states (idle, idle+input, busy, popup, picker menu)
-- **Suspend flow**: verify skip conditions (pinned, non-claude, already suspended, not idle, no session ID)
-- **Resume flow**: verify command construction with and without `--dangerously-skip-permissions`
+- **ClaudeStateDetector**: unit tests with mocked tmux output covering all states (idle, idle+input, busy, popup, picker menu, non-Claude foreground process)
+- **Session ID capture**: test `pgrep` filtering (must find `claude` not MCP servers), test missing session file gracefully returns nil
+- **Suspend flow**: verify skip conditions (pinned, non-claude, already suspended, not idle, no session ID). Verify exit verification with timeout and rollback.
+- **Resume flow**: verify command construction with and without `--dangerously-skip-permissions`. Test pane-alive vs pane-dead paths. Test "Claude already running" detection.
+- **Rapid switch**: verify suspend cancellation when resume arrives for same terminal
 - **DB migration**: verify new columns exist with nil defaults, existing rows still decode
+- **Terminal creation**: verify `--session-id` is passed in launch command and stored on record

--- a/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
+++ b/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
@@ -1,0 +1,120 @@
+# Auto-suspend/resume Claude Code on worktree switch
+
+## Problem
+
+Claude Code processes consume 500MB–1GB+ of memory each. With multiple worktrees open, idle Claude instances accumulate significant memory pressure even when only one worktree is actively in use. Users see system slowdown from swap pressure despite most Claude instances sitting at an idle prompt.
+
+## Solution
+
+Automatically exit idle Claude Code instances when the user switches away from a worktree, and resume them (with full conversation context) when switching back. Pinned terminals are never suspended.
+
+## Data model
+
+### New terminal fields
+
+Add two optional fields to the `Terminal` model and database:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `suspendedAt` | `Date?` | Timestamp when daemon auto-suspended this terminal. `nil` = not suspended. |
+| `suspendedSessionID` | `String?` | Claude Code session UUID captured before exit. Used for `claude --resume <id>`. |
+
+**Migration**: New migration `v6` adds both columns to the `terminal` table with nil defaults. `Models.swift` gets matching optional fields (both optional, so existing rows decode fine).
+
+## Idle detection
+
+### `ClaudeStateDetector`
+
+New file: `Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift`
+
+Takes a `TmuxManager` dependency for running tmux commands. `TmuxManager` will need a new public `capturePaneOutput(server:paneID:)` method (thin wrapper around `runTmux` for `capture-pane -p`), and a `paneProcessID(server:paneID:)` method for `list-panes -F "#{pane_pid}"`.
+
+Provides two methods:
+
+#### `isIdle(server:paneID:) async -> Bool`
+
+Determines whether a Claude Code instance is idle and safe to suspend.
+
+1. Run `tmux capture-pane -p -t <paneID>` via `TmuxManager.runTmux`
+2. Take the last 5 lines of output
+3. Check for **both** conditions:
+   - **Status bar present**: text contains any of `⏵⏵`, `bypass`, `auto mode`, `? for shortcuts`
+   - **Bare prompt**: a line matching `❯` followed by only whitespace/non-breaking-space to end of line (regex: `^❯[\s\u{00a0}]*$`)
+4. Return `true` only if both conditions are met
+
+States that are correctly classified as **not idle**:
+- Claude mid-generation (no prompt visible)
+- User has typed partial input after the prompt (`❯ some text`)
+- Interactive picker/menu visible (no prompt line)
+- Popup/overlay obscuring the prompt (status bar visible but no prompt line)
+
+#### `captureSessionID(server:paneID:) async -> String?`
+
+Extracts the Claude Code session UUID for a running instance.
+
+1. Run `tmux list-panes -t <paneID> -F "#{pane_pid}"` to get the shell PID
+2. Run `pgrep -P <shellPID>` to find the claude child process PID
+3. Read `~/.claude/sessions/<claudePID>.json`
+4. Parse the JSON and return the `sessionId` string
+5. Return `nil` at any step if the lookup fails (process gone, file missing, etc.)
+
+## Suspend flow
+
+Triggered when the app changes worktree selection (the daemon already receives this via RPC state deltas).
+
+For each terminal in the **departing** worktree:
+
+1. **Skip if not a Claude terminal**: `label` does not start with `"claude"` → skip
+2. **Skip if pinned**: `pinnedAt != nil` → skip
+3. **Skip if already suspended**: `suspendedAt != nil` → skip
+4. **Check idle state**: call `isIdle(server:paneID:)` → skip if `false`
+5. **Capture session ID**: call `captureSessionID(server:paneID:)` → skip if `nil` (can't resume without it)
+6. **Exit Claude**: `tmux send-keys -t <paneID> "/exit" Enter`
+7. **Update database**: set `suspendedAt = Date()`, `suspendedSessionID = <uuid>`
+8. **Broadcast state delta** so the app UI can show a "suspended" indicator
+
+Each step that skips leaves the terminal running — the design is conservative. If anything is uncertain, don't suspend.
+
+## Resume flow
+
+Triggered when a worktree is selected.
+
+For each terminal in the **arriving** worktree where `suspendedAt != nil`:
+
+1. **Wait for shell readiness**: after Claude exits, the shell prompt needs a moment to appear. Poll with `tmux capture-pane` looking for a shell prompt (e.g. `$` or `%` or `❯` from zsh), up to 2 seconds, checking every 200ms. If the shell prompt never appears, skip (don't send blind input).
+2. **Build resume command**: `claude --resume <suspendedSessionID>` + append ` --dangerously-skip-permissions` if the user's `skipPermissions` setting is enabled
+3. **Send command**: `tmux send-keys -t <paneID> "<command>" Enter`
+4. **Clear state**: set `suspendedAt = nil`, `suspendedSessionID = nil`
+5. **Broadcast state delta**
+
+## Integration point
+
+The suspend/resume logic hooks into the daemon's existing worktree selection handling. When the daemon processes a selection change:
+
+1. Identify departing worktrees (were selected, now aren't)
+2. Identify arriving worktrees (weren't selected, now are)
+3. Run suspend flow for departing worktrees (async, non-blocking — sends `/exit` but does not wait for Claude to actually terminate)
+4. Run resume flow for arriving worktrees (async, independent of suspend — arriving worktrees are different from departing worktrees, so there's no ordering dependency)
+
+## Scope boundaries
+
+### In scope
+- Auto-suspend idle Claude terminals on worktree switch
+- Auto-resume with correct session on worktree switch back
+- Respect pinned terminals (never suspend)
+- New DB migration for `suspendedAt` and `suspendedSessionID`
+- `ClaudeStateDetector` for idle detection and session ID capture
+
+### Out of scope
+- UI indicator for suspended state (future enhancement)
+- User setting to enable/disable auto-suspend (always on for v1; add setting if users want it)
+- Suspending non-Claude terminals
+- Suspending terminals in the currently selected worktree
+- Timer-based suspension (only on worktree switch)
+
+## Testing
+
+- **ClaudeStateDetector**: unit tests with mocked tmux output covering all states (idle, idle+input, busy, popup, picker menu)
+- **Suspend flow**: verify skip conditions (pinned, non-claude, already suspended, not idle, no session ID)
+- **Resume flow**: verify command construction with and without `--dangerously-skip-permissions`
+- **DB migration**: verify new columns exist with nil defaults, existing rows still decode

--- a/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
+++ b/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
@@ -16,25 +16,32 @@ Add to the `Terminal` model and database:
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `claudeSessionID` | `String?` | Claude Code session UUID. Set at launch for TBD-created terminals (via `--session-id`), or lazily captured at suspend time for user-spawned instances. |
+| `claudeSessionID` | `String?` | Claude Code session UUID. Set at launch for TBD-created terminals (via `--session-id`), or lazily captured at suspend time for user-spawned instances. Mutable — updated after each resume cycle (see Session ID lifecycle). |
 | `suspendedAt` | `Date?` | Timestamp when daemon auto-suspended this terminal. `nil` = not suspended. |
+| `skipPermissions` | `Bool` | Whether this terminal was launched with `--dangerously-skip-permissions`. Set at creation time, read at resume time. Defaults to `false`. |
 
-**Migration**: New migration `v6` adds both columns to the `terminal` table with nil defaults. `Models.swift` gets matching optional fields (both optional, so existing rows decode fine).
+**Migration**: New migration `v6` adds all three columns to the `terminal` table with nil/false defaults. `Models.swift` gets matching fields (optional for `claudeSessionID` and `suspendedAt`, defaulted for `skipPermissions`).
 
 ### Session ID lifecycle
 
+**Important**: `claude --resume <id>` generates a NEW internal session ID (confirmed: GitHub issues #8069, #10806, #12235). The stored `claudeSessionID` goes stale after every resume. The design must account for this.
+
+**Important**: Do NOT use `claude --continue` as an alternative. It resumes the most recent session per cwd, but the user regularly runs multiple Claude sessions in the same worktree directory. `--continue` would resume the wrong session.
+
 Two paths for obtaining the session ID:
 
-**Path A — TBD-created terminals**: When the daemon creates a Claude terminal, it generates a UUID and passes `--session-id <uuid>` in the launch command. The UUID is stored as `claudeSessionID` immediately at creation time. This is the reliable, race-free path.
+**Path A — TBD-created terminals**: When the daemon creates a Claude terminal, it generates a UUID and passes `--session-id <uuid>` in the launch command. The UUID is stored as `claudeSessionID` immediately at creation time. This is the reliable, race-free path for the first suspend cycle.
 
 **Path B — User-spawned terminals**: When a user manually runs `claude` in a shell tab, there's no `--session-id`. The session ID is captured lazily at suspend time via PID file lookup:
 
 1. `tmux list-panes -t <paneID> -F "#{pane_pid}"` → shell PID
-2. `pgrep -P <shellPID> -x claude` → Claude process PID (must filter for `claude` specifically — the shell may also have MCP server children, `caffeinate`, etc.)
-3. Read `~/.claude/sessions/<claudePID>.json` → parse `sessionId`
+2. `pgrep -P <shellPID> -x claude` → Claude process PID (must filter for `claude` specifically — the shell may also have MCP server children, `caffeinate`, etc.). If multiple matches, skip (ambiguous — don't suspend).
+3. Read `~/.claude/sessions/<claudePID>.json` → parse `sessionId` (treat JSON decode errors as nil — file may be partially written)
 4. Cache the result as `claudeSessionID` on the terminal record
 
-If lazy capture fails (process already exited, file missing, no `claude` child found), the terminal is skipped for suspension — conservative by default.
+If lazy capture fails (process already exited, file missing, no `claude` child found, multiple matches), the terminal is skipped for suspension — conservative by default.
+
+**Session ID refresh after resume**: After every resume (both Path A and Path B), the daemon must re-capture the session ID via PID file lookup once the new Claude process has started. This is done as part of the resume flow (see Resume flow step 7). `claudeSessionID` is mutable throughout the terminal's lifetime.
 
 **Note**: `~/.claude/sessions/<pid>.json` is an implementation detail of Claude Code, not a documented API. Files are deleted when Claude exits (verified: 59/59 session files on disk belong to live processes, zero orphans). The session ID is stable for the lifetime of the process.
 
@@ -71,51 +78,76 @@ States correctly classified as **not idle**:
 - Interactive picker/menu visible (no prompt line)
 - Popup/overlay obscuring the prompt (status bar visible but no prompt line)
 
+#### `isIdleConfirmed(server:paneID:) async -> Bool`
+
+Debounced idle check. Calls `isIdle()` twice with a 1-second gap. Returns `true` only if both checks pass. This guards against a transient prompt flash between Claude's multi-step turns — the prompt briefly appears between tool calls for a few hundred milliseconds, but disappears when the next turn starts.
+
+The 1s debounce is conservative. False positives are benign: if Claude starts a new turn between the check and `/exit`, `/exit` is queued and processed after the turn completes. The session is preserved either way.
+
 #### `captureSessionID(server:paneID:) async -> String?`
 
-Extracts the Claude Code session UUID for a running instance (used for user-spawned terminals that lack a pre-assigned `claudeSessionID`).
+Extracts the Claude Code session UUID for a running instance.
 
 1. Get shell PID via `paneProcessID(server:paneID:)`
-2. Run `pgrep -P <shellPID> -x claude` to find the Claude child process (not MCP servers or other children)
+2. Run `pgrep -P <shellPID> -x claude` to find the Claude child process (not MCP servers or other children). If multiple matches, return `nil`.
 3. Read `~/.claude/sessions/<claudePID>.json`
-4. Parse JSON and return `sessionId`
+4. Parse JSON and return `sessionId`. Treat decode errors as `nil` (file may be partially written).
 5. Return `nil` at any step if the lookup fails
 
 ## Suspend flow
 
-Triggered when the user switches away from a worktree. Requires a new RPC method (see Integration section).
+Triggered when the user switches away from a worktree. Requires a new RPC method (see Integration section). Orchestrated by the `SuspendResumeCoordinator` actor (see Concurrency section).
 
 For each terminal in the **departing** worktree:
 
 1. **Skip if pinned**: `pinnedAt != nil` → skip
 2. **Skip if already suspended**: `suspendedAt != nil` → skip
 3. **Skip if not Claude**: check `pane_current_command` — if it doesn't look like Claude, skip. (Covers both TBD-created terminals where `label == "claude"` and user-spawned Claude instances.)
-4. **Check idle state**: call `isIdle(server:paneID:)` → skip if `false`
+4. **Check idle state**: call `isIdleConfirmed(server:paneID:)` → skip if `false` (includes 1s debounce)
 5. **Ensure session ID**: if `claudeSessionID` is nil, call `captureSessionID(server:paneID:)` and store it. If still nil → skip (can't resume without it)
 6. **Exit Claude**: `tmux send-keys -t <paneID> "/exit" Enter`
-7. **Verify exit** (async): poll `pane_current_command` every 200ms for up to 3 seconds. If Claude is still running after timeout, clear `suspendedAt` and log a warning — don't leave the terminal in a bad state.
-8. **Update database**: set `suspendedAt = Date()`
-9. **Broadcast state delta**
+7. **Verify exit**: poll `pane_current_command` every 200ms for up to 3 seconds. If Claude is still running after timeout, log a warning and skip — don't mark as suspended.
+8. **Show suspend message**: after exit confirmed, send `echo '[Session suspended — will resume when you switch back]'` to the pane via `tmux send-keys`. This gives the user a visible indicator if they peek at the terminal.
+9. **Update database**: set `suspendedAt = Date()`
+10. **Broadcast state delta**
 
 Each step that skips leaves the terminal running — conservative by default.
 
-**Race condition note**: Claude could start working between `isIdle()` and the `/exit` send. This is benign — Claude Code queues `/exit` and processes it after the current turn completes. The session ID remains valid.
+**Race condition note**: Claude could start working between `isIdleConfirmed()` and the `/exit` send. This is benign — Claude Code queues `/exit` and processes it after the current turn completes. The session ID remains valid.
 
 ## Resume flow
 
-Triggered when a worktree is selected.
+Triggered when a worktree is selected. Orchestrated by the `SuspendResumeCoordinator` actor.
 
 For each terminal in the **arriving** worktree where `suspendedAt != nil`:
 
-1. **Check if Claude is already running**: `pane_current_command` shows Claude → clear `suspendedAt`, done (user manually restarted it)
-2. **Check pane is alive**: verify the tmux pane/window still exists. If dead → create a new tmux window in the same session with the resume command (the `zsh -ic` wrapper means the pane dies when Claude exits)
-3. **Build resume command**: `claude --resume <claudeSessionID>` + append ` --dangerously-skip-permissions` if the user's `skipPermissions` setting is enabled
+1. **Check if Claude is already running**: `pane_current_command` shows Claude → clear `suspendedAt`, re-capture session ID via PID lookup, done (user manually restarted it)
+2. **Check pane is alive**: verify the tmux pane/window still exists. If dead → create a new tmux window (the `zsh -ic` wrapper means the pane dies when Claude exits)
+3. **Build resume command**: `claude --resume <claudeSessionID>` + append ` --dangerously-skip-permissions` if `skipPermissions == true` on the terminal record
 4. **If pane alive** (shell prompt visible): `tmux send-keys -t <paneID> "<command>" Enter`
 5. **If pane dead**: create new window via `TmuxManager.createWindow(server:session:cwd:shellCommand:)` with the resume command. Update the terminal record's `tmuxWindowID` and `tmuxPaneID` to the new values.
 6. **Clear state**: set `suspendedAt = nil`
-7. **Broadcast state delta**
+7. **Re-capture session ID**: wait ~5s for Claude to start, then call `captureSessionID(server:paneID:)` to get the new session UUID (since `--resume` generates a new ID). Update `claudeSessionID` in the DB. If capture fails, log a warning — the terminal is usable but won't be suspendable next time until the ID is captured.
+8. **Broadcast state delta**
 
 **Stale session handling**: if `claude --resume <id>` fails (session file deleted, corrupted), Claude will show an error. This is acceptable — the user sees the error and can start a new session manually.
+
+## Concurrency
+
+### `SuspendResumeCoordinator` actor
+
+Serializes all suspend/resume operations to prevent data races and handle rapid switching.
+
+```swift
+actor SuspendResumeCoordinator {
+    private var inFlight: [UUID: Task<Void, Never>] = [:]
+
+    func suspend(terminalID: UUID, ...) { ... }
+    func resume(terminalID: UUID, ...) { ... }
+}
+```
+
+When a resume arrives for a terminal with an in-flight suspend, the coordinator cancels the suspend task before starting the resume. When a suspend arrives for a terminal with an in-flight resume, it skips. This naturally handles rapid switching (A→B→A) and serves as the debounce mechanism — no separate timer needed.
 
 ## Integration
 
@@ -127,15 +159,7 @@ The app's worktree selection is local to `AppState.selectedWorktreeIDs`. State d
 **Params**: `{ selectedWorktreeIDs: [UUID], previousWorktreeIDs: [UUID] }`
 **Result**: `{ success: Bool }`
 
-The app calls this from its `onChange(of: appState.selectedWorktreeIDs)` handler in `ContentView.swift`. The daemon computes departing/arriving sets and runs suspend/resume flows.
-
-### Rapid switch handling
-
-If the user switches A→B→A within seconds:
-- The suspend for A may still be in flight when the resume for A triggers
-- Track in-flight suspend operations per terminal ID (e.g. a `Set<UUID>` of terminals being suspended)
-- If a resume arrives for a terminal being suspended, cancel/await the suspend before proceeding
-- If a suspend arrives for a terminal being resumed, skip it
+The app calls this from its `onChange(of: appState.selectedWorktreeIDs)` handler in `ContentView.swift`. The daemon computes departing/arriving sets and runs suspend/resume flows via the `SuspendResumeCoordinator`.
 
 ### Daemon startup reconciliation
 
@@ -148,7 +172,8 @@ On daemon startup, sweep all terminals with `suspendedAt != nil`:
 When the daemon creates a Claude terminal (in `WorktreeLifecycle+Create.swift`):
 1. Generate a UUID for the session: `UUID().uuidString`
 2. Store it as `claudeSessionID` on the terminal record
-3. Append `--session-id <uuid>` to the Claude launch command
+3. Store `skipPermissions` based on the user's current setting
+4. Append `--session-id <uuid>` to the Claude launch command (and `--dangerously-skip-permissions` if applicable, as it already does)
 
 This ensures TBD-created terminals always have a known session ID from the start, independent of PID file availability.
 
@@ -157,29 +182,40 @@ This ensures TBD-created terminals always have a known session ID from the start
 ### In scope
 - Auto-suspend idle Claude terminals on worktree switch
 - Auto-resume with correct session on worktree switch back
+- Session ID re-capture after resume (handles `--resume` generating new IDs)
 - Respect pinned terminals (never suspend)
 - Deterministic `--session-id` for TBD-created terminals
 - Lazy session ID capture for user-spawned Claude instances
-- New DB migration for `claudeSessionID` and `suspendedAt`
+- 1s idle detection debounce
+- Terminal buffer message on suspend
+- `SuspendResumeCoordinator` actor for concurrency and rapid-switch handling
+- New DB migration for `claudeSessionID`, `suspendedAt`, `skipPermissions`
 - New `worktreeSelectionChanged` RPC method
 - `ClaudeStateDetector` for idle detection and session ID capture
 - Pane recreation on resume when original pane is dead
-- Rapid switch protection
 - Daemon startup reconciliation
 
 ### Out of scope
-- UI indicator for suspended state (future enhancement)
+- UI indicator for suspended state beyond the terminal buffer message (future enhancement)
 - User setting to enable/disable auto-suspend (always on for v1; add setting if users want it)
 - Suspending non-Claude terminals
 - Suspending terminals in the currently selected worktree
 - Timer-based suspension (only on worktree switch)
 
+## Known limitations
+
+- `~/.claude/sessions/<pid>.json` is an undocumented implementation detail. If Claude Code changes this format, lazy capture and post-resume refresh will fail silently (terminals won't be suspendable until the code is updated, but nothing breaks).
+- `claude --resume` ignores `CLAUDE_CONFIG_DIR` environment variable (GitHub issue #16103). Users with custom config dirs may see resume failures.
+- Idle detection patterns (`❯` prompt, status bar strings) are Claude Code UI details with no stability contract. Changes to Claude's TUI would cause false negatives (failing to detect idle), not false positives (incorrectly suspending). Patterns are centralized as constants for easy updates.
+
 ## Testing
 
 - **ClaudeStateDetector**: unit tests with mocked tmux output covering all states (idle, idle+input, busy, popup, picker menu, non-Claude foreground process)
-- **Session ID capture**: test `pgrep` filtering (must find `claude` not MCP servers), test missing session file gracefully returns nil
-- **Suspend flow**: verify skip conditions (pinned, non-claude, already suspended, not idle, no session ID). Verify exit verification with timeout and rollback.
+- **Idle debounce**: test that `isIdleConfirmed` returns false when first check passes but second doesn't (simulating inter-turn prompt flash)
+- **Session ID capture**: test `pgrep` filtering (must find `claude` not MCP servers), test multiple matches returns nil, test missing/corrupt session file returns nil
+- **Session ID refresh**: test that `claudeSessionID` is updated after resume via PID lookup
+- **Suspend flow**: verify skip conditions (pinned, non-claude, already suspended, not idle, no session ID). Verify exit verification with timeout and rollback. Verify echo message after exit.
 - **Resume flow**: verify command construction with and without `--dangerously-skip-permissions`. Test pane-alive vs pane-dead paths. Test "Claude already running" detection.
-- **Rapid switch**: verify suspend cancellation when resume arrives for same terminal
-- **DB migration**: verify new columns exist with nil defaults, existing rows still decode
-- **Terminal creation**: verify `--session-id` is passed in launch command and stored on record
+- **Coordinator**: verify suspend cancellation when resume arrives for same terminal. Verify skip when suspend arrives during resume.
+- **DB migration**: verify new columns exist with nil/false defaults, existing rows still decode
+- **Terminal creation**: verify `--session-id` is passed in launch command and stored on record. Verify `skipPermissions` stored.

--- a/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
+++ b/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
@@ -10,6 +10,8 @@ Automatically exit idle Claude Code instances when the user switches away from a
 
 **v1 scope**: Only daemon-created Claude terminals (where `label` starts with `"claude"`). User-spawned Claude instances are not suspended. This eliminates runtime process inspection at suspend time and avoids dependency on undocumented PID files for the suspend path.
 
+**v1 assumes a single TBDApp UI session controls worktree selection.** Daemon selection state is global, not per-client. Multi-client correctness (multiple app windows) would require per-client selection tracking in a future version.
+
 ## Data model
 
 ### New terminal fields
@@ -96,16 +98,23 @@ For each terminal in the **departing** worktree:
 3. **Skip if already suspended**: `suspendedAt != nil` → skip
 4. **Skip if no session ID**: `claudeSessionID == nil` → skip (can't resume without it)
 5. **Check idle state**: call `isIdleConfirmed(server:paneID:)` → skip if `false` (includes 1s debounce)
-6. **Exit Claude**: `tmux send-keys -t <paneID> "/exit" Enter`
-7. **Verify exit**: poll `pane_current_command` every 200ms for up to 3 seconds. If Claude is still running after timeout, log a warning and skip — don't mark as suspended.
+
+**--- Point of no return below ---**
+
+Steps 1–5 are cancellable (the coordinator can cancel the suspend task during any of them). Once step 6 executes, the suspend is committed — `/exit` has been sent and cannot be retracted.
+
+6. **Exit Claude**: send `/exit` followed by Enter to the pane. Note: `TmuxManager.sendKeys` currently uses `-l` (literal text). A new `sendCommand(server:paneID:command:)` method is needed that sends text + Enter key (either via `send-keys` without `-l`, or two calls: `-l` for the text then `Enter` for the key).
+7. **Verify exit**: poll `pane_current_command` every 200ms for up to 3 seconds.
+   - If Claude exits within timeout → proceed to step 8
+   - If Claude is still running after timeout → it may be finishing a turn before processing `/exit`. Mark as suspended anyway (`suspendedAt = Date()`) — Claude will exit eventually and the session is preserved. The pane will die when it does, and resume will create a new window as usual.
 8. **Update database**: set `suspendedAt = Date()`
 9. **Broadcast state delta**
 
-Each step that skips leaves the terminal running — conservative by default.
+Steps 1–5 that skip leave the terminal running — conservative by default.
 
 **No suspend message for v1**: TBD-created panes use `zsh -ic <command>` — the pane dies when Claude exits, so there's no shell to echo into. The user sees the terminal resume when they switch back, which is sufficient feedback.
 
-**Race condition note**: Claude could start working between `isIdleConfirmed()` and the `/exit` send. This is benign — Claude Code queues `/exit` and processes it after the current turn completes. The session ID remains valid.
+**Race condition note**: Claude could start working between `isIdleConfirmed()` and the `/exit` send. This is benign — Claude Code queues `/exit` and processes it after the current turn completes. The session is preserved. Since `/exit` is past the point of no return, the terminal is always marked as suspended once step 6 executes.
 
 ## Resume flow
 
@@ -139,7 +148,9 @@ actor SuspendResumeCoordinator {
 }
 ```
 
-When a resume arrives for a terminal with an in-flight suspend, the coordinator cancels the suspend task before starting the resume. When a suspend arrives for a terminal with an in-flight resume, it skips. This naturally handles rapid switching (A→B→A) and serves as the debounce mechanism — no separate timer needed.
+**Cancellation semantics**: The suspend flow has a point of no return (sending `/exit`). The coordinator can cancel an in-flight suspend only during the pre-exit phase (steps 1–5). The suspend task must check for cancellation via `Task.isCancelled` before step 6, and must NOT check after. Once `/exit` is sent, the suspend runs to completion — the terminal will be marked as suspended regardless of subsequent selection changes.
+
+When a resume arrives for a terminal that is already marked `suspendedAt != nil` (suspend completed), the coordinator runs the normal resume flow. When a resume arrives while a suspend is still in its cancellable phase (steps 1–5), the coordinator cancels the suspend task. When a suspend arrives for a terminal with an in-flight resume, it skips.
 
 ## Integration
 
@@ -151,7 +162,11 @@ The app's worktree selection is local to `AppState.selectedWorktreeIDs`. State d
 **Params**: `{ selectedWorktreeIDs: [UUID] }` (idempotent — daemon diffs against its own last-known selection)
 **Result**: `{ success: Bool }`
 
-The app calls this from its `onChange(of: appState.selectedWorktreeIDs)` handler in `ContentView.swift`. The daemon computes departing/arriving sets and runs suspend/resume flows via the `SuspendResumeCoordinator`.
+The app calls this from:
+1. `onChange(of: appState.selectedWorktreeIDs)` in `ContentView.swift` — on every selection change
+2. The reconnect/refresh path in `AppState` — after daemon restart or reconnect, the app must re-send its current selection so the daemon has an accurate baseline. Without this, a daemon restart while the user stays on the same worktree leaves the daemon with an empty selection cache and no resume trigger.
+
+The daemon diffs against its last-known selection. **Unknown worktree IDs are silently ignored** — the app uses optimistic placeholder UUIDs during worktree creation (before the daemon assigns the real ID), so the daemon will sometimes see IDs it doesn't recognize. These are not errors.
 
 ### Reconcile changes
 
@@ -217,6 +232,7 @@ When the daemon creates a Claude terminal (in `WorktreeLifecycle+Create.swift`):
 - `~/.claude/sessions/<pid>.json` is an undocumented implementation detail, used only for post-resume session ID refresh. If Claude Code changes this format, the first suspend/resume cycle works (uses the creation-time `--session-id`), but subsequent cycles won't until the code is updated.
 - `claude --resume` ignores `CLAUDE_CONFIG_DIR` environment variable (GitHub issue #16103). Users with custom config dirs may see resume failures.
 - Idle detection patterns (`❯` prompt, status bar strings) are Claude Code UI details with no stability contract. Changes to Claude's TUI would cause false negatives (failing to detect idle), not false positives (incorrectly suspending). Patterns are centralized as constants for easy updates.
+- `pane_current_command` reporting Claude as a semver string (e.g. `2.1.86`) is empirically observed behavior, not documented by tmux or Claude Code. If this changes, the `claudeProcessPattern` regex would need updating. Failure mode is false negatives (Claude not detected as foreground process → not suspended), not false positives.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
+++ b/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
@@ -8,6 +8,8 @@ Claude Code processes consume 500MB–1GB+ of memory each. With multiple worktre
 
 Automatically exit idle Claude Code instances when the user switches away from a worktree, and resume them (with full conversation context) when switching back. Pinned terminals are never suspended.
 
+**v1 scope**: Only daemon-created Claude terminals (where `label` starts with `"claude"`). User-spawned Claude instances are not suspended. This eliminates runtime process inspection at suspend time and avoids dependency on undocumented PID files for the suspend path.
+
 ## Data model
 
 ### New terminal fields
@@ -16,11 +18,10 @@ Add to the `Terminal` model and database:
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `claudeSessionID` | `String?` | Claude Code session UUID. Set at launch for TBD-created terminals (via `--session-id`), or lazily captured at suspend time for user-spawned instances. Mutable — updated after each resume cycle (see Session ID lifecycle). |
+| `claudeSessionID` | `String?` | Claude Code session UUID. Set at launch via `--session-id`. Mutable — updated after each resume cycle since `--resume` generates a new ID. |
 | `suspendedAt` | `Date?` | Timestamp when daemon auto-suspended this terminal. `nil` = not suspended. |
-| `skipPermissions` | `Bool` | Whether this terminal was launched with `--dangerously-skip-permissions`. Set at creation time, read at resume time. Defaults to `false`. |
 
-**Migration**: New migration `v6` adds all three columns to the `terminal` table with nil/false defaults. `Models.swift` gets matching fields (optional for `claudeSessionID` and `suspendedAt`, defaulted for `skipPermissions`).
+**Migration**: New migration `v6` adds both columns to the `terminal` table with nil defaults. In `Models.swift`, both fields must use `decodeIfPresent` (synthesized `Codable` does not use property default values for missing keys — a `let foo: String? = nil` still throws `keyNotFound` if the key is absent in JSON). Update `TerminalRecord` in `TerminalStore.swift` with matching GRDB columns.
 
 ### Session ID lifecycle
 
@@ -28,20 +29,9 @@ Add to the `Terminal` model and database:
 
 **Important**: Do NOT use `claude --continue` as an alternative. It resumes the most recent session per cwd, but the user regularly runs multiple Claude sessions in the same worktree directory. `--continue` would resume the wrong session.
 
-Two paths for obtaining the session ID:
+**At terminal creation**: The daemon generates a UUID, passes `--session-id <uuid>` in the launch command, and stores it as `claudeSessionID`. This is the reliable, race-free path for the first suspend cycle.
 
-**Path A — TBD-created terminals**: When the daemon creates a Claude terminal, it generates a UUID and passes `--session-id <uuid>` in the launch command. The UUID is stored as `claudeSessionID` immediately at creation time. This is the reliable, race-free path for the first suspend cycle.
-
-**Path B — User-spawned terminals**: When a user manually runs `claude` in a shell tab, there's no `--session-id`. The session ID is captured lazily at suspend time via PID file lookup:
-
-1. `tmux list-panes -t <paneID> -F "#{pane_pid}"` → shell PID
-2. `pgrep -P <shellPID> -x claude` → Claude process PID (must filter for `claude` specifically — the shell may also have MCP server children, `caffeinate`, etc.). If multiple matches, skip (ambiguous — don't suspend).
-3. Read `~/.claude/sessions/<claudePID>.json` → parse `sessionId` (treat JSON decode errors as nil — file may be partially written)
-4. Cache the result as `claudeSessionID` on the terminal record
-
-If lazy capture fails (process already exited, file missing, no `claude` child found, multiple matches), the terminal is skipped for suspension — conservative by default.
-
-**Session ID refresh after resume**: After every resume (both Path A and Path B), the daemon must re-capture the session ID via PID file lookup once the new Claude process has started. This is done as part of the resume flow (see Resume flow step 7). `claudeSessionID` is mutable throughout the terminal's lifetime.
+**After each resume**: The daemon re-captures the session ID via PID file lookup once the new Claude process has started (see Resume flow step 7). This is the only point where `~/.claude/sessions/<pid>.json` is read. `claudeSessionID` is mutable throughout the terminal's lifetime.
 
 **Note**: `~/.claude/sessions/<pid>.json` is an implementation detail of Claude Code, not a documented API. Files are deleted when Claude exits (verified: 59/59 session files on disk belong to live processes, zero orphans). The session ID is stable for the lifetime of the process.
 
@@ -51,13 +41,13 @@ If lazy capture fails (process already exited, file missing, no `claude` child f
 
 New file: `Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift`
 
-Takes a `TmuxManager` dependency. `TmuxManager` needs new public methods: `capturePaneOutput(server:paneID:)` (wraps `capture-pane -p`), `paneProcessID(server:paneID:)` (wraps `list-panes -F "#{pane_pid}"`), and `paneCurrentCommand(server:paneID:)` (wraps `list-panes -F "#{pane_current_command}"`).
+Takes a `TmuxManager` dependency. `TmuxManager` needs new public methods: `capturePaneOutput(server:paneID:)` (wraps `capture-pane -p`) and `paneCurrentCommand(server:paneID:)` (wraps `list-panes -F "#{pane_current_command}"`).
 
 #### `isIdle(server:paneID:) async -> Bool`
 
 Determines whether a Claude Code instance is idle and safe to suspend.
 
-1. **Guard**: check `pane_current_command` — if it's `zsh`, `bash`, or doesn't look like a Claude version string, return `false` (Claude isn't the foreground process)
+1. **Guard**: check `pane_current_command` — Claude appears as a semver-like string (e.g. `2.1.86`). If the value is `zsh`, `bash`, or doesn't match `\d+\.\d+\.\d+`, return `false`.
 2. Run `tmux capture-pane -p -t <paneID>`
 3. Take the last 5 lines of output
 4. Check for **both** conditions:
@@ -68,7 +58,8 @@ Determines whether a Claude Code instance is idle and safe to suspend.
 **Pattern constants** (centralized, since these are Claude Code UI details with no stability contract):
 
 ```swift
-static let promptPattern = "^❯[\\s\\u{00a0}]*$"  // ❯ followed by only whitespace/nbsp
+static let claudeProcessPattern = #"^\d+\.\d+\.\d+"#  // e.g. "2.1.86"
+static let promptPattern = "^❯[\\s\\u{00a0}]*$"        // ❯ followed by only whitespace/nbsp
 static let statusIndicators = ["⏵⏵", "bypass", "auto mode", "? for shortcuts"]
 ```
 
@@ -86,32 +77,33 @@ The 1s debounce is conservative. False positives are benign: if Claude starts a 
 
 #### `captureSessionID(server:paneID:) async -> String?`
 
-Extracts the Claude Code session UUID for a running instance.
+Extracts the Claude Code session UUID for a running instance. Used only for post-resume session ID refresh.
 
-1. Get shell PID via `paneProcessID(server:paneID:)`
-2. Run `pgrep -P <shellPID> -x claude` to find the Claude child process (not MCP servers or other children). If multiple matches, return `nil`.
+1. Get shell PID via `tmux list-panes -t <paneID> -F "#{pane_pid}"`
+2. Run `pgrep -P <shellPID> -x claude` to find the Claude child process. If multiple matches, return `nil`.
 3. Read `~/.claude/sessions/<claudePID>.json`
-4. Parse JSON and return `sessionId`. Treat decode errors as `nil` (file may be partially written).
+4. Parse JSON and return `sessionId`. Treat decode errors as `nil`.
 5. Return `nil` at any step if the lookup fails
 
 ## Suspend flow
 
-Triggered when the user switches away from a worktree. Requires a new RPC method (see Integration section). Orchestrated by the `SuspendResumeCoordinator` actor (see Concurrency section).
+Triggered when the user switches away from a worktree. Orchestrated by the `SuspendResumeCoordinator` actor (see Concurrency section).
 
 For each terminal in the **departing** worktree:
 
-1. **Skip if pinned**: `pinnedAt != nil` → skip
-2. **Skip if already suspended**: `suspendedAt != nil` → skip
-3. **Skip if not Claude**: check `pane_current_command` — if it doesn't look like Claude, skip. (Covers both TBD-created terminals where `label == "claude"` and user-spawned Claude instances.)
-4. **Check idle state**: call `isIdleConfirmed(server:paneID:)` → skip if `false` (includes 1s debounce)
-5. **Ensure session ID**: if `claudeSessionID` is nil, call `captureSessionID(server:paneID:)` and store it. If still nil → skip (can't resume without it)
+1. **Skip if not daemon-created Claude**: `label` does not start with `"claude"` → skip (v1 scope)
+2. **Skip if pinned**: `pinnedAt != nil` → skip
+3. **Skip if already suspended**: `suspendedAt != nil` → skip
+4. **Skip if no session ID**: `claudeSessionID == nil` → skip (can't resume without it)
+5. **Check idle state**: call `isIdleConfirmed(server:paneID:)` → skip if `false` (includes 1s debounce)
 6. **Exit Claude**: `tmux send-keys -t <paneID> "/exit" Enter`
 7. **Verify exit**: poll `pane_current_command` every 200ms for up to 3 seconds. If Claude is still running after timeout, log a warning and skip — don't mark as suspended.
-8. **Show suspend message**: after exit confirmed, send `echo '[Session suspended — will resume when you switch back]'` to the pane via `tmux send-keys`. This gives the user a visible indicator if they peek at the terminal.
-9. **Update database**: set `suspendedAt = Date()`
-10. **Broadcast state delta**
+8. **Update database**: set `suspendedAt = Date()`
+9. **Broadcast state delta**
 
 Each step that skips leaves the terminal running — conservative by default.
+
+**No suspend message for v1**: TBD-created panes use `zsh -ic <command>` — the pane dies when Claude exits, so there's no shell to echo into. The user sees the terminal resume when they switch back, which is sufficient feedback.
 
 **Race condition note**: Claude could start working between `isIdleConfirmed()` and the `/exit` send. This is benign — Claude Code queues `/exit` and processes it after the current turn completes. The session ID remains valid.
 
@@ -121,13 +113,13 @@ Triggered when a worktree is selected. Orchestrated by the `SuspendResumeCoordin
 
 For each terminal in the **arriving** worktree where `suspendedAt != nil`:
 
-1. **Check if Claude is already running**: `pane_current_command` shows Claude → clear `suspendedAt`, re-capture session ID via PID lookup, done (user manually restarted it)
-2. **Check pane is alive**: verify the tmux pane/window still exists. If dead → create a new tmux window (the `zsh -ic` wrapper means the pane dies when Claude exits)
-3. **Build resume command**: `claude --resume <claudeSessionID>` + append ` --dangerously-skip-permissions` if `skipPermissions == true` on the terminal record
-4. **If pane alive** (shell prompt visible): `tmux send-keys -t <paneID> "<command>" Enter`
-5. **If pane dead**: create new window via `TmuxManager.createWindow(server:session:cwd:shellCommand:)` with the resume command. Update the terminal record's `tmuxWindowID` and `tmuxPaneID` to the new values.
+1. **Check if Claude is already running**: `pane_current_command` matches Claude → clear `suspendedAt`, re-capture session ID, done (user manually restarted it)
+2. **Check pane is alive**: verify the tmux pane/window still exists via `TmuxManager.windowExists()`. The pane will almost always be dead (TBD-created panes use `zsh -ic` — the shell exits when Claude exits).
+3. **Build resume command**: `claude --resume <claudeSessionID> --dangerously-skip-permissions` (daemon always launches managed Claude with this flag today)
+4. **Create new tmux window**: call `TmuxManager.createWindow(server:session:cwd:shellCommand:)` with the resume command. Update the terminal record's `tmuxWindowID` and `tmuxPaneID` to the new values.
+5. **Force app UI reconnection**: the state delta broadcast must cause the app to recreate the `TerminalPanelView` for this terminal. Since `TerminalPanelView` binds tmux in `makeNSView` (which only runs once) and `updateNSView` is a no-op, a changed `tmuxWindowID` won't rebind the view. **Fix**: include `tmuxWindowID` in the view's `.id()` modifier (e.g. `.id("\(terminalID)-\(tmuxWindowID)")`), so SwiftUI destroys and recreates the view when the window ID changes.
 6. **Clear state**: set `suspendedAt = nil`
-7. **Re-capture session ID**: wait ~5s for Claude to start, then call `captureSessionID(server:paneID:)` to get the new session UUID (since `--resume` generates a new ID). Update `claudeSessionID` in the DB. If capture fails, log a warning — the terminal is usable but won't be suspendable next time until the ID is captured.
+7. **Re-capture session ID**: wait ~5s for Claude to start, then call `captureSessionID(server:paneID:)` to get the new session UUID. Update `claudeSessionID` in the DB. If capture fails, log a warning — the terminal is usable but won't be suspendable next time until the ID is captured.
 8. **Broadcast state delta**
 
 **Stale session handling**: if `claude --resume <id>` fails (session file deleted, corrupted), Claude will show an error. This is acceptable — the user sees the error and can start a new session manually.
@@ -156,10 +148,14 @@ When a resume arrives for a terminal with an in-flight suspend, the coordinator 
 The app's worktree selection is local to `AppState.selectedWorktreeIDs`. State deltas only flow daemon→app, not the reverse. A new RPC method is needed:
 
 **Method**: `worktreeSelectionChanged`
-**Params**: `{ selectedWorktreeIDs: [UUID], previousWorktreeIDs: [UUID] }`
+**Params**: `{ selectedWorktreeIDs: [UUID] }` (idempotent — daemon diffs against its own last-known selection)
 **Result**: `{ success: Bool }`
 
 The app calls this from its `onChange(of: appState.selectedWorktreeIDs)` handler in `ContentView.swift`. The daemon computes departing/arriving sets and runs suspend/resume flows via the `SuspendResumeCoordinator`.
+
+### Reconcile changes
+
+The existing reconcile flow (`WorktreeLifecycle+Reconcile.swift`) deletes terminal records whose tmux window is dead. Auto-suspended terminals have dead panes by design. **Reconcile must skip terminals where `suspendedAt != nil`** — they will be recreated on resume.
 
 ### Daemon startup reconciliation
 
@@ -167,55 +163,71 @@ On daemon startup, sweep all terminals with `suspendedAt != nil`:
 - Check if the tmux pane is alive and Claude is running → clear `suspendedAt` (user or system restarted it)
 - Check if the pane is dead → leave `suspendedAt` set (will be resumed when worktree is next selected)
 
+This runs BEFORE the normal reconcile, so suspended terminals are already flagged and reconcile will skip them.
+
+### App UI reconnection
+
+`TerminalPanelView` binds to tmux once in `makeNSView` and never rebinds (`updateNSView` is a no-op). When resume creates a new tmux window, the old view is stale. **Fix**: change the view identity in `PanePlaceholder.swift` to include the tmux window ID:
+
+```swift
+// Before:
+.id(terminalID)
+
+// After:
+.id("\(terminal.id)-\(terminal.tmuxWindowID)")
+```
+
+This forces SwiftUI to destroy and recreate the `TerminalPanelView` when the window ID changes, triggering a fresh `makeNSView` that binds to the new tmux session.
+
 ## Terminal creation changes
 
 When the daemon creates a Claude terminal (in `WorktreeLifecycle+Create.swift`):
 1. Generate a UUID for the session: `UUID().uuidString`
 2. Store it as `claudeSessionID` on the terminal record
-3. Store `skipPermissions` based on the user's current setting
-4. Append `--session-id <uuid>` to the Claude launch command (and `--dangerously-skip-permissions` if applicable, as it already does)
-
-This ensures TBD-created terminals always have a known session ID from the start, independent of PID file availability.
+3. Append `--session-id <uuid>` to the Claude launch command (the daemon already appends `--dangerously-skip-permissions`)
 
 ## Scope boundaries
 
-### In scope
-- Auto-suspend idle Claude terminals on worktree switch
+### In scope (v1)
+- Auto-suspend idle daemon-created Claude terminals on worktree switch
 - Auto-resume with correct session on worktree switch back
 - Session ID re-capture after resume (handles `--resume` generating new IDs)
 - Respect pinned terminals (never suspend)
 - Deterministic `--session-id` for TBD-created terminals
-- Lazy session ID capture for user-spawned Claude instances
 - 1s idle detection debounce
-- Terminal buffer message on suspend
 - `SuspendResumeCoordinator` actor for concurrency and rapid-switch handling
-- New DB migration for `claudeSessionID`, `suspendedAt`, `skipPermissions`
-- New `worktreeSelectionChanged` RPC method
-- `ClaudeStateDetector` for idle detection and session ID capture
-- Pane recreation on resume when original pane is dead
+- New DB migration for `claudeSessionID` and `suspendedAt`
+- New `worktreeSelectionChanged` RPC method (idempotent)
+- `ClaudeStateDetector` for idle detection and post-resume session ID capture
+- Pane recreation on resume (new tmux window)
+- App UI reconnection via composite view identity
+- Reconcile fix (preserve suspended terminals)
 - Daemon startup reconciliation
 
-### Out of scope
-- UI indicator for suspended state beyond the terminal buffer message (future enhancement)
-- User setting to enable/disable auto-suspend (always on for v1; add setting if users want it)
+### Out of scope (v2+)
+- Suspending user-spawned Claude instances (requires lazy PID file capture at suspend time)
+- UI indicator for suspended state (future enhancement)
+- User setting to enable/disable auto-suspend
 - Suspending non-Claude terminals
-- Suspending terminals in the currently selected worktree
 - Timer-based suspension (only on worktree switch)
+- Per-terminal `skipPermissions` toggle (daemon always uses `--dangerously-skip-permissions` today)
 
 ## Known limitations
 
-- `~/.claude/sessions/<pid>.json` is an undocumented implementation detail. If Claude Code changes this format, lazy capture and post-resume refresh will fail silently (terminals won't be suspendable until the code is updated, but nothing breaks).
+- `~/.claude/sessions/<pid>.json` is an undocumented implementation detail, used only for post-resume session ID refresh. If Claude Code changes this format, the first suspend/resume cycle works (uses the creation-time `--session-id`), but subsequent cycles won't until the code is updated.
 - `claude --resume` ignores `CLAUDE_CONFIG_DIR` environment variable (GitHub issue #16103). Users with custom config dirs may see resume failures.
 - Idle detection patterns (`❯` prompt, status bar strings) are Claude Code UI details with no stability contract. Changes to Claude's TUI would cause false negatives (failing to detect idle), not false positives (incorrectly suspending). Patterns are centralized as constants for easy updates.
 
 ## Testing
 
-- **ClaudeStateDetector**: unit tests with mocked tmux output covering all states (idle, idle+input, busy, popup, picker menu, non-Claude foreground process)
-- **Idle debounce**: test that `isIdleConfirmed` returns false when first check passes but second doesn't (simulating inter-turn prompt flash)
-- **Session ID capture**: test `pgrep` filtering (must find `claude` not MCP servers), test multiple matches returns nil, test missing/corrupt session file returns nil
+- **ClaudeStateDetector**: unit tests with mocked tmux output covering all states (idle, idle+input, busy, popup, picker menu, non-Claude foreground process). Test `claudeProcessPattern` regex against real version strings.
+- **Idle debounce**: test that `isIdleConfirmed` returns false when first check passes but second doesn't
+- **Session ID capture**: test missing/corrupt session file returns nil, test multiple `pgrep` matches returns nil
 - **Session ID refresh**: test that `claudeSessionID` is updated after resume via PID lookup
-- **Suspend flow**: verify skip conditions (pinned, non-claude, already suspended, not idle, no session ID). Verify exit verification with timeout and rollback. Verify echo message after exit.
-- **Resume flow**: verify command construction with and without `--dangerously-skip-permissions`. Test pane-alive vs pane-dead paths. Test "Claude already running" detection.
+- **Suspend flow**: verify skip conditions (not-claude-label, pinned, already suspended, no session ID, not idle). Verify exit verification with timeout and skip-on-failure.
+- **Resume flow**: verify command includes `--dangerously-skip-permissions`. Test new window creation and terminal record update. Test "Claude already running" detection.
+- **App UI reconnection**: verify that changing `tmuxWindowID` on a terminal triggers view recreation
+- **Reconcile**: verify terminals with `suspendedAt != nil` are preserved (not deleted as dead windows)
 - **Coordinator**: verify suspend cancellation when resume arrives for same terminal. Verify skip when suspend arrives during resume.
-- **DB migration**: verify new columns exist with nil/false defaults, existing rows still decode
-- **Terminal creation**: verify `--session-id` is passed in launch command and stored on record. Verify `skipPermissions` stored.
+- **DB migration**: verify new columns exist with nil defaults, existing rows decode with `decodeIfPresent`
+- **Terminal creation**: verify `--session-id` is passed in launch command and stored on record

--- a/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
+++ b/docs/superpowers/specs/2026-03-29-auto-suspend-claude-design.md
@@ -122,7 +122,7 @@ Triggered when a worktree is selected. Orchestrated by the `SuspendResumeCoordin
 
 For each terminal in the **arriving** worktree where `suspendedAt != nil`:
 
-1. **Check if Claude is already running**: `pane_current_command` matches Claude → clear `suspendedAt`, re-capture session ID, done (user manually restarted it)
+1. **Check if Claude is already running**: `pane_current_command` matches Claude. This could mean the user manually restarted it, OR a timed-out suspend's `/exit` hasn't been processed yet. **Do not clear `suspendedAt` in this case** — wait for Claude to exit (the queued `/exit` will eventually process). If the terminal is still running after another 5s, then assume the user restarted it intentionally: clear `suspendedAt`, re-capture session ID, done.
 2. **Check pane is alive**: verify the tmux pane/window still exists via `TmuxManager.windowExists()`. The pane will almost always be dead (TBD-created panes use `zsh -ic` — the shell exits when Claude exits).
 3. **Build resume command**: `claude --resume <claudeSessionID> --dangerously-skip-permissions` (daemon always launches managed Claude with this flag today)
 4. **Create new tmux window**: call `TmuxManager.createWindow(server:session:cwd:shellCommand:)` with the resume command. Update the terminal record's `tmuxWindowID` and `tmuxPaneID` to the new values.
@@ -233,6 +233,16 @@ When the daemon creates a Claude terminal (in `WorktreeLifecycle+Create.swift`):
 - `claude --resume` ignores `CLAUDE_CONFIG_DIR` environment variable (GitHub issue #16103). Users with custom config dirs may see resume failures.
 - Idle detection patterns (`❯` prompt, status bar strings) are Claude Code UI details with no stability contract. Changes to Claude's TUI would cause false negatives (failing to detect idle), not false positives (incorrectly suspending). Patterns are centralized as constants for easy updates.
 - `pane_current_command` reporting Claude as a semver string (e.g. `2.1.86`) is empirically observed behavior, not documented by tmux or Claude Code. If this changes, the `claudeProcessPattern` regex would need updating. Failure mode is false negatives (Claude not detected as foreground process → not suspended), not false positives.
+
+## Implementation notes
+
+These are codebase-specific details the implementer should be aware of:
+
+- **Startup ordering**: The daemon currently starts serving RPCs before reconcile runs (`Daemon.swift`). The startup reconciliation sweep (clearing stale `suspendedAt`) must complete before selection RPCs are processed, otherwise a race exists where a selection RPC triggers resume while reconcile is still cleaning up. Either block RPC serving until reconcile finishes, or have the coordinator queue selection changes until reconcile is done.
+- **Reconcile orphan cleanup**: `WorktreeLifecycle+Reconcile.swift` kills tmux windows not present in the DB. Since resume creates new windows, ensure the reconcile snapshot and the resume path don't race (the coordinator serializes this naturally if reconcile uses it).
+- **App state propagation**: The app polls terminals every ~2s (`AppState.swift`). There is no push/subscription path for terminal state deltas. After `worktreeSelectionChanged` RPC returns, the app should trigger an immediate terminal refresh (not wait for the next poll cycle), otherwise the user may briefly see "Terminal session expired" for the old dead window.
+- **Worktree name collision**: `WorktreeLifecycle+Create.swift` may keep stale `name`/`branch`/`path` on retry after name collision. Resume uses the stored worktree cwd. This is a pre-existing bug, not introduced by this feature, but the implementer should be aware it exists.
+- **TmuxManager testability**: `TmuxManager` is a concrete struct with a private `runTmux`. `ClaudeStateDetector` tests need a protocol or injectable command runner to mock tmux output. `TmuxManager` already has `dryRun` mode for command builders; extend this pattern or extract a `TmuxCommandRunner` protocol.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Idle Claude Code instances consume 500MB–1GB+ of memory each. With multiple worktrees, this adds up fast and causes swap pressure even though most instances are sitting at a prompt doing nothing.
- When switching away from a worktree, the daemon detects idle Claude terminals (via `tmux capture-pane` prompt matching), gracefully exits them with `/exit`, and recreates them with `claude --resume <session-id>` when switching back. Full conversation context is preserved.
- v1 scoped to daemon-created Claude terminals only. Pinned terminals are never suspended. User-spawned Claude instances are left alone.

### Key design decisions
- **Session ID tracking**: `--session-id` assigned at terminal creation. Re-captured via PID file lookup after each resume (since `--resume` generates a new internal ID).
- **Idle detection**: Debounced double-check (1s gap) of Claude's `❯` prompt + status bar via `tmux capture-pane`. Conservative — skips if anything is uncertain.
- **Point of no return**: `/exit` is irreversible. Coordinator actor has cancellable pre-exit phase and committed post-exit phase.
- **Dead pane handling**: `zsh -ic` wrapper means pane dies when Claude exits. Resume creates a new tmux window; composite `.id()` on the view forces SwiftUI to recreate the terminal panel.

## Test plan
- [ ] Create a worktree, verify Claude launches with `--session-id` in the command
- [ ] Wait for Claude to reach idle prompt, switch to a different worktree — verify Claude exits within a few seconds
- [ ] Switch back — verify Claude resumes with conversation history intact
- [ ] Pin a terminal, switch away — verify it stays alive (not suspended)
- [ ] Rapid switch (A→B→A quickly) — verify no crashes or stuck state
- [ ] Restart daemon — verify suspended terminals survive and resume on next selection
- [ ] `swift test` — 168 tests pass