### PR TITLE
Feat: Show frozen terminal snapshot instead of blank screen during session restore

### DIFF
--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -157,7 +157,8 @@ struct PanePlaceholder: View {
 
     @ViewBuilder
     private func terminalContent(terminalID: UUID) -> some View {
-        if let terminal = terminal(for: terminalID),
+        let term = terminal(for: terminalID)
+        if let terminal = term,
            terminal.suspendedAt != nil,
            let snapshot = terminal.suspendedSnapshot {
             ZStack(alignment: .bottomTrailing) {
@@ -166,7 +167,7 @@ struct PanePlaceholder: View {
                     .padding(12)
             }
             .id("\(terminal.id)-snapshot")
-        } else if let terminal = terminal(for: terminalID) {
+        } else if let terminal = term {
             TerminalPanelView(
                 terminalID: terminalID,
                 tmuxServer: worktree.tmuxServer,

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -160,8 +160,12 @@ struct PanePlaceholder: View {
         if let terminal = terminal(for: terminalID),
            terminal.suspendedAt != nil,
            let snapshot = terminal.suspendedSnapshot {
-            SnapshotTerminalView(snapshot: snapshot)
-                .id("\(terminal.id)-snapshot")
+            ZStack(alignment: .bottomTrailing) {
+                SnapshotTerminalView(snapshot: snapshot)
+                RestoringIndicator()
+                    .padding(12)
+            }
+            .id("\(terminal.id)-snapshot")
         } else if let terminal = terminal(for: terminalID) {
             TerminalPanelView(
                 terminalID: terminalID,
@@ -238,5 +242,30 @@ struct PanePlaceholder: View {
             direction: direction,
             newContent: .terminal(terminalID: newTerminal.id)
         )
+    }
+}
+
+// MARK: - RestoringIndicator
+
+/// Subtle bottom-right pill shown over a snapshot while Claude resumes.
+private struct RestoringIndicator: View {
+    @State private var opacity: Double = 0.6
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Restoring session…")
+                .font(.caption)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 6))
+        .opacity(opacity)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                opacity = 1.0
+            }
+        }
     }
 }

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -157,7 +157,12 @@ struct PanePlaceholder: View {
 
     @ViewBuilder
     private func terminalContent(terminalID: UUID) -> some View {
-        if let terminal = terminal(for: terminalID) {
+        if let terminal = terminal(for: terminalID),
+           terminal.suspendedAt != nil,
+           let snapshot = terminal.suspendedSnapshot {
+            SnapshotTerminalView(snapshot: snapshot)
+                .id("\(terminal.id)-snapshot")
+        } else if let terminal = terminal(for: terminalID) {
             TerminalPanelView(
                 terminalID: terminalID,
                 tmuxServer: worktree.tmuxServer,

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -167,7 +167,7 @@ struct PanePlaceholder: View {
                     .padding(12)
             }
             .id("\(terminal.id)-snapshot")
-        } else if let terminal = term {
+        } else if let terminal = term, terminal.suspendedAt == nil {
             TerminalPanelView(
                 terminalID: terminalID,
                 tmuxServer: worktree.tmuxServer,
@@ -185,20 +185,27 @@ struct PanePlaceholder: View {
             )
             .id("\(terminal.id)-\(terminal.tmuxWindowID)")
         } else {
-            // Fallback when terminal data hasn't loaded yet
-            ZStack {
-                Color(nsColor: .black)
+            // Fallback: terminal data not loaded, or suspended without snapshot
+            ZStack(alignment: .bottomTrailing) {
+                ZStack {
+                    Color(nsColor: .black)
 
-                VStack(spacing: 8) {
-                    Image(systemName: "terminal")
-                        .font(.largeTitle)
-                        .foregroundStyle(.secondary)
-                    Text(worktree.displayName)
-                        .font(.headline)
-                        .foregroundStyle(.secondary)
-                    Text(worktree.branch)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
+                    VStack(spacing: 8) {
+                        Image(systemName: "terminal")
+                            .font(.largeTitle)
+                            .foregroundStyle(.secondary)
+                        Text(worktree.displayName)
+                            .font(.headline)
+                            .foregroundStyle(.secondary)
+                        Text(worktree.branch)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+
+                if term?.suspendedAt != nil {
+                    RestoringIndicator()
+                        .padding(12)
                 }
             }
         }

--- a/Sources/TBDApp/Terminal/SnapshotTerminalView.swift
+++ b/Sources/TBDApp/Terminal/SnapshotTerminalView.swift
@@ -4,22 +4,30 @@ import AppKit
 
 /// Displays a read-only snapshot of a terminal's last state before suspend.
 /// Uses SwiftTerm's TerminalView to render ANSI escape sequences with full color.
+/// Defers feeding content until after first layout so the terminal geometry
+/// matches the actual view size, preventing incorrect line wrapping.
 struct SnapshotTerminalView: NSViewRepresentable {
     let snapshot: String
 
     func makeNSView(context: Context) -> TerminalView {
-        let tv = TerminalView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let tv = TerminalView(frame: .zero)
         tv.nativeBackgroundColor = NSColor.black
         tv.nativeForegroundColor = NSColor(white: 0.85, alpha: 1.0)
         tv.allowMouseReporting = false
-
-        // Feed the captured ANSI snapshot into the terminal emulator
-        tv.feed(text: snapshot)
-
         return tv
     }
 
     func updateNSView(_ nsView: TerminalView, context: Context) {
-        // Static snapshot — no updates needed
+        // Feed snapshot once the view has real dimensions from layout
+        if nsView.bounds.width > 0 && !context.coordinator.hasFed {
+            context.coordinator.hasFed = true
+            nsView.feed(text: snapshot)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        var hasFed = false
     }
 }

--- a/Sources/TBDApp/Terminal/SnapshotTerminalView.swift
+++ b/Sources/TBDApp/Terminal/SnapshotTerminalView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import SwiftTerm
+import AppKit
+
+/// Displays a read-only snapshot of a terminal's last state before suspend.
+/// Uses SwiftTerm's TerminalView to render ANSI escape sequences with full color.
+struct SnapshotTerminalView: NSViewRepresentable {
+    let snapshot: String
+
+    func makeNSView(context: Context) -> TerminalView {
+        let tv = TerminalView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        tv.nativeBackgroundColor = NSColor.black
+        tv.nativeForegroundColor = NSColor(white: 0.85, alpha: 1.0)
+        tv.allowMouseReporting = false
+
+        // Feed the captured ANSI snapshot into the terminal emulator
+        tv.feed(text: snapshot)
+
+        return tv
+    }
+
+    func updateNSView(_ nsView: TerminalView, context: Context) {
+        // Static snapshot — no updates needed
+    }
+}

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -121,6 +121,12 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v7") { db in
+            try db.alter(table: "terminal") { t in
+                t.add(column: "suspendedSnapshot", .text)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -15,6 +15,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var pinnedAt: Date?
     var claudeSessionID: String?
     var suspendedAt: Date?
+    var suspendedSnapshot: String?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -26,6 +27,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.pinnedAt = terminal.pinnedAt
         self.claudeSessionID = terminal.claudeSessionID
         self.suspendedAt = terminal.suspendedAt
+        self.suspendedSnapshot = terminal.suspendedSnapshot
     }
 
     func toModel() -> Terminal {
@@ -38,7 +40,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             createdAt: createdAt,
             pinnedAt: pinnedAt,
             claudeSessionID: claudeSessionID,
-            suspendedAt: suspendedAt
+            suspendedAt: suspendedAt,
+            suspendedSnapshot: suspendedSnapshot
         )
     }
 }
@@ -118,14 +121,15 @@ public struct TerminalStore: Sendable {
         }
     }
 
-    /// Mark a terminal as suspended, recording the session ID and current timestamp.
-    public func setSuspended(id: UUID, sessionID: String, at date: Date = Date()) async throws {
+    /// Mark a terminal as suspended, recording the session ID, snapshot, and current timestamp.
+    public func setSuspended(id: UUID, sessionID: String, snapshot: String? = nil, at date: Date = Date()) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.claudeSessionID = sessionID
             record.suspendedAt = date
+            record.suspendedSnapshot = snapshot
             try record.update(db)
         }
     }
@@ -137,6 +141,7 @@ public struct TerminalStore: Sendable {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.suspendedAt = nil
+            record.suspendedSnapshot = nil
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -195,15 +195,32 @@ public actor SuspendResumeCoordinator {
             try await db.terminals.updateTmuxIDs(
                 id: terminal.id, windowID: window.windowID, paneID: window.paneID
             )
-            try await db.terminals.clearSuspended(id: terminal.id)
             logger.info("Resumed terminal \(terminal.id) in window \(window.windowID)")
 
-            // Re-capture session ID after ~5s, and re-seed idle flag
+            // Wait for Claude to start before clearing the snapshot, so the
+            // app's polling loop has time to observe the suspended state and
+            // show SnapshotTerminalView instead of a blank pane.
             let termID = terminal.id
             let worktreeID = terminal.worktreeID
             let paneID = window.paneID
             Task {
-                try? await Task.sleep(for: .seconds(5))
+                // Poll for Claude process to appear (up to 10s)
+                var claudeDetected = false
+                for _ in 0..<50 {
+                    try? await Task.sleep(for: .milliseconds(200))
+                    if let cmd = try? await self.tmux.paneCurrentCommand(server: server, paneID: paneID),
+                       ClaudeStateDetector.isClaudeProcess(cmd) {
+                        claudeDetected = true
+                        break
+                    }
+                }
+                suspendLog("Clearing suspended for \(termID.uuidString.prefix(8)): claudeDetected=\(claudeDetected)")
+                try? await self.db.terminals.clearSuspended(id: termID)
+
+                // Re-capture session ID after Claude has settled
+                if claudeDetected {
+                    try? await Task.sleep(for: .seconds(3))
+                }
                 if let newID = await self.detector.captureSessionID(server: server, paneID: paneID) {
                     try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
                     suspendLog("Re-captured session ID for \(termID.uuidString.prefix(8)): \(newID)")

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -98,6 +98,17 @@ public actor SuspendResumeCoordinator {
             return
         }
 
+        // Capture terminal snapshot with ANSI colors before exit
+        let snapshot: String?
+        do {
+            let captured = try await tmux.capturePaneWithAnsi(server: server, paneID: terminal.tmuxPaneID)
+            snapshot = captured.isEmpty ? nil : captured
+            suspendLog("Captured snapshot for \(terminal.id.uuidString.prefix(8)): \(captured.count) chars")
+        } catch {
+            snapshot = nil
+            suspendLog("Failed to capture snapshot for \(terminal.id.uuidString.prefix(8)): \(error)")
+        }
+
         // POINT OF NO RETURN — send /exit
         suspendLog("SUSPENDING \(terminal.id.uuidString.prefix(8)): sending /exit")
         do {
@@ -118,7 +129,7 @@ public actor SuspendResumeCoordinator {
 
         // Always mark suspended after point of no return
         do {
-            try await db.terminals.setSuspended(id: terminal.id, sessionID: terminal.claudeSessionID!)
+            try await db.terminals.setSuspended(id: terminal.id, sessionID: terminal.claudeSessionID!, snapshot: snapshot)
             worktreeIdleFromHook.remove(terminal.worktreeID)
             logger.info("Suspended terminal \(terminal.id)")
         } catch {

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -4,10 +4,22 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "SuspendResume")
 
+/// Thread-safe ISO8601 timestamp formatter for debug logging.
+private final class SuspendLogFormatter: @unchecked Sendable {
+    private let lock = NSLock()
+    private let formatter = ISO8601DateFormatter()
+
+    func timestamp() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return formatter.string(from: Date())
+    }
+}
+
 /// File-based debug log for suspend/resume diagnostics (os_log not reliably captured)
-nonisolated(unsafe) private let suspendLogDateFormatter = ISO8601DateFormatter()
+private let suspendLogFormatter = SuspendLogFormatter()
 private func suspendLog(_ msg: String) {
-    let line = "[SR \(suspendLogDateFormatter.string(from: Date()))] \(msg)\n"
+    let line = "[SR \(suspendLogFormatter.timestamp())] \(msg)\n"
     if let data = line.data(using: .utf8) {
         if let fh = FileHandle(forWritingAtPath: "/tmp/tbd-suspend.log") {
             fh.seekToEndOfFile()

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -5,8 +5,9 @@ import os
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "SuspendResume")
 
 /// File-based debug log for suspend/resume diagnostics (os_log not reliably captured)
+nonisolated(unsafe) private let suspendLogDateFormatter = ISO8601DateFormatter()
 private func suspendLog(_ msg: String) {
-    let line = "[SR \(ISO8601DateFormatter().string(from: Date()))] \(msg)\n"
+    let line = "[SR \(suspendLogDateFormatter.string(from: Date()))] \(msg)\n"
     if let data = line.data(using: .utf8) {
         if let fh = FileHandle(forWritingAtPath: "/tmp/tbd-suspend.log") {
             fh.seekToEndOfFile()
@@ -203,17 +204,22 @@ public actor SuspendResumeCoordinator {
             let termID = terminal.id
             let worktreeID = terminal.worktreeID
             let paneID = window.paneID
-            Task {
+            // Track the post-resume task in inFlight so a rapid re-suspend
+            // can cancel it — otherwise stale clearSuspended/updateSessionID
+            // calls could race with the new suspend cycle.
+            inFlight[termID] = Task {
                 // Poll for Claude process to appear (up to 10s)
                 var claudeDetected = false
                 for _ in 0..<50 {
                     try? await Task.sleep(for: .milliseconds(200))
+                    guard !Task.isCancelled else { return }
                     if let cmd = try? await self.tmux.paneCurrentCommand(server: server, paneID: paneID),
                        ClaudeStateDetector.isClaudeProcess(cmd) {
                         claudeDetected = true
                         break
                     }
                 }
+                guard !Task.isCancelled else { return }
                 suspendLog("Clearing suspended for \(termID.uuidString.prefix(8)): claudeDetected=\(claudeDetected)")
                 try? await self.db.terminals.clearSuspended(id: termID)
 
@@ -221,6 +227,7 @@ public actor SuspendResumeCoordinator {
                 if claudeDetected {
                     try? await Task.sleep(for: .seconds(3))
                 }
+                guard !Task.isCancelled else { return }
                 if let newID = await self.detector.captureSessionID(server: server, paneID: paneID) {
                     try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
                     suspendLog("Re-captured session ID for \(termID.uuidString.prefix(8)): \(newID)")
@@ -234,12 +241,12 @@ public actor SuspendResumeCoordinator {
                     self.worktreeIdleFromHook.insert(worktreeID)
                     suspendLog("Re-seeded idle hook for worktree \(worktreeID.uuidString.prefix(8)) after resume")
                 }
+                self.inFlight[termID] = nil
             }
         } catch {
             logger.warning("Failed to resume terminal \(terminal.id): \(error)")
+            inFlight[terminal.id] = nil
         }
-
-        inFlight[terminal.id] = nil
     }
 
     // MARK: - Startup Reconciliation

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -76,7 +76,7 @@ public struct TmuxManager: Sendable {
 
     /// Capture pane content with ANSI escape sequences and joined wrapped lines preserved.
     public static func capturePaneWithAnsiCommand(server: String, paneID: String) -> [String] {
-        ["-L", server, "capture-pane", "-p", "-e", "-t", paneID]
+        ["-L", server, "capture-pane", "-p", "-e", "-J", "-t", paneID]
     }
 
     public static func paneCurrentCommandQuery(server: String, paneID: String) -> [String] {

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -74,6 +74,11 @@ public struct TmuxManager: Sendable {
         ["-L", server, "capture-pane", "-p", "-t", paneID]
     }
 
+    /// Capture pane content with ANSI escape sequences and joined wrapped lines preserved.
+    public static func capturePaneWithAnsiCommand(server: String, paneID: String) -> [String] {
+        ["-L", server, "capture-pane", "-p", "-e", "-J", "-t", paneID]
+    }
+
     public static func paneCurrentCommandQuery(server: String, paneID: String) -> [String] {
         ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_current_command}"]
     }
@@ -158,6 +163,13 @@ public struct TmuxManager: Sendable {
     public func capturePaneOutput(server: String, paneID: String) async throws -> String {
         if dryRun { return "" }
         let args = Self.capturePaneCommand(server: server, paneID: paneID)
+        return try await runTmux(args)
+    }
+
+    /// Capture pane content with ANSI escape sequences preserved for snapshot display.
+    public func capturePaneWithAnsi(server: String, paneID: String) async throws -> String {
+        if dryRun { return "" }
+        let args = Self.capturePaneWithAnsiCommand(server: server, paneID: paneID)
         return try await runTmux(args)
     }
 

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -76,7 +76,7 @@ public struct TmuxManager: Sendable {
 
     /// Capture pane content with ANSI escape sequences and joined wrapped lines preserved.
     public static func capturePaneWithAnsiCommand(server: String, paneID: String) -> [String] {
-        ["-L", server, "capture-pane", "-p", "-e", "-J", "-t", paneID]
+        ["-L", server, "capture-pane", "-p", "-e", "-t", paneID]
     }
 
     public static func paneCurrentCommandQuery(server: String, paneID: String) -> [String] {

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -79,11 +79,12 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public var pinnedAt: Date?
     public var claudeSessionID: String?
     public var suspendedAt: Date?
+    public var suspendedSnapshot: String?
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
                 pinnedAt: Date? = nil, claudeSessionID: String? = nil,
-                suspendedAt: Date? = nil) {
+                suspendedAt: Date? = nil, suspendedSnapshot: String? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -93,6 +94,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.pinnedAt = pinnedAt
         self.claudeSessionID = claudeSessionID
         self.suspendedAt = suspendedAt
+        self.suspendedSnapshot = suspendedSnapshot
     }
 
     public init(from decoder: Decoder) throws {
@@ -106,6 +108,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
         claudeSessionID = try c.decodeIfPresent(String.self, forKey: .claudeSessionID)
         suspendedAt = try c.decodeIfPresent(Date.self, forKey: .suspendedAt)
+        suspendedSnapshot = try c.decodeIfPresent(String.self, forKey: .suspendedSnapshot)
     }
 }
 


### PR DESCRIPTION
## Summary
- When switching to a worktree with a suspended Claude terminal, users previously saw a blank/dead pane while Claude restarted. Now the terminal buffer is captured with ANSI colors before suspend and displayed as a read-only snapshot with a "Restoring session…" indicator until the live terminal takes over.
- Snapshot is stored in SQLite via a new `suspendedSnapshot` column (migration v7) and cleared once Claude is detected running in the new pane.
- The suspended state is held until Claude actually starts (polling up to 10s), ensuring the app's 2s polling loop has time to observe and display the snapshot.

## Test plan
- [ ] Switch away from a worktree with an idle Claude terminal — verify it suspends and the snapshot is captured (check `/tmp/tbd-suspend.log`)
- [ ] Switch back to the worktree — verify the frozen snapshot is displayed with "Restoring session…" pill, then transitions to the live terminal once Claude resumes
- [ ] Verify colors/formatting in the snapshot match the original terminal output
- [ ] Test with a pinned terminal — should not be suspended
- [ ] Test rapid switching between worktrees — snapshot should appear even on quick round-trips