### PR TITLE
Fix: Stop "Restoring session" from getting stuck after suspend/resume (10-17s → 3s)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Use the `tbd-project` skill for architecture, conventions, and file reference.
 - Use conventional commit messages: `feat:`, `fix:`, `docs:`, `refactor:`
 - Verify your changes compile (`swift build`) before committing.
 - Run `swift test` if you changed daemon or shared code.
+- When adding a branching conditional that gates behavior (feature flags, toggles, mode switches), add a test for each branch. Verify the gated behavior is off when the flag is off, and that ungated behavior still works.
 
 ## Critical Rules
 

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -108,14 +108,13 @@ struct ContentView: View {
             for worktreeID in newlySelected {
                 Task { await appState.refreshPRStatus(worktreeID: worktreeID) }
             }
-            if autoSuspendClaude {
-                Task {
-                    try? await appState.daemonClient.worktreeSelectionChanged(
-                        selectedWorktreeIDs: appState.selectedWorktreeIDs
-                    )
-                    for worktreeID in newSelection {
-                        await appState.refreshTerminals(worktreeID: worktreeID)
-                    }
+            Task {
+                try? await appState.daemonClient.worktreeSelectionChanged(
+                    selectedWorktreeIDs: appState.selectedWorktreeIDs,
+                    suspendEnabled: autoSuspendClaude
+                )
+                for worktreeID in newSelection {
+                    await appState.refreshTerminals(worktreeID: worktreeID)
                 }
             }
         }

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -44,10 +44,15 @@ struct ContentView: View {
             .toolbar(removing: .sidebarToggle)
             .toolbar {
                 ToolbarItemGroup(placement: .primaryAction) {
-                    Button(action: addRepo) {
-                        Label("Add Repository", systemImage: "plus.rectangle.on.folder")
+                    Button {
+                        autoSuspendClaude.toggle()
+                    } label: {
+                        Image(systemName: autoSuspendClaude ? "pause.circle.fill" : "pause.circle")
+                            .foregroundStyle(autoSuspendClaude ? .primary : .secondary)
                     }
-                    .help("Add a Git repository")
+                    .help(autoSuspendClaude
+                        ? "Auto-suspend is on — idle Claude instances are suspended when switching worktrees"
+                        : "Auto-suspend is off — Claude instances stay running when switching worktrees")
 
                     Picker("Filter", selection: $appState.repoFilter) {
                         Text("All Repos").tag(UUID?.none)

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -50,6 +50,7 @@ struct ContentView: View {
                         Image(systemName: autoSuspendClaude ? "pause.circle.fill" : "pause.circle")
                             .foregroundStyle(autoSuspendClaude ? .primary : .secondary)
                     }
+                    .accessibilityLabel(autoSuspendClaude ? "Auto-suspend on" : "Auto-suspend off")
                     .help(autoSuspendClaude
                         ? "Auto-suspend is on — idle Claude instances are suspended when switching worktrees"
                         : "Auto-suspend is off — Claude instances stay running when switching worktrees")

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -427,10 +427,10 @@ actor DaemonClient {
     }
 
     /// Notify the daemon which worktrees are currently selected in the app.
-    func worktreeSelectionChanged(selectedWorktreeIDs: Set<UUID>) throws {
+    func worktreeSelectionChanged(selectedWorktreeIDs: Set<UUID>, suspendEnabled: Bool = true) throws {
         try callVoid(
             method: RPCMethod.worktreeSelectionChanged,
-            params: WorktreeSelectionChangedParams(selectedWorktreeIDs: Array(selectedWorktreeIDs))
+            params: WorktreeSelectionChangedParams(selectedWorktreeIDs: Array(selectedWorktreeIDs), suspendEnabled: suspendEnabled)
         )
     }
 

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -56,7 +56,7 @@ struct RepositoriesSettingsTab: View {
                     Spacer()
                     Text("No repositories added yet.")
                         .foregroundStyle(.secondary)
-                    Text("Use the Add Repository button in the main window toolbar.")
+                    Text("Use the + button in the sidebar to add a repository.")
                         .foregroundStyle(.tertiary)
                         .font(.caption)
                     Spacer()

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -219,10 +219,10 @@ public actor SuspendResumeCoordinator {
             // can cancel it — otherwise stale clearSuspended/updateSessionID
             // calls could race with the new suspend cycle.
             inFlight[termID] = Task {
-                // Brief delay so the app's 2s polling loop (AppState.startPolling)
-                // has time to observe the snapshot before we clear it. Must be
-                // longer than the poll interval. Then hand off to the live
-                // terminal — Claude's startup progress is visible there.
+                // AppState.startPolling polls every 2s. Wait 3s so at least one
+                // full cycle observes the snapshot before we clear it. Then hand
+                // off to the live terminal — Claude's startup progress is visible
+                // there. If the poll interval changes, update this to match.
                 try? await Task.sleep(for: .seconds(3))
                 guard !Task.isCancelled else { return }
                 suspendLog("Clearing suspended for \(termID.uuidString.prefix(8))")

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -210,9 +210,6 @@ public actor SuspendResumeCoordinator {
             )
             logger.info("Resumed terminal \(terminal.id) in window \(window.windowID)")
 
-            // Wait for Claude to start before clearing the snapshot, so the
-            // app's polling loop has time to observe the suspended state and
-            // show SnapshotTerminalView instead of a blank pane.
             let termID = terminal.id
             let worktreeID = terminal.worktreeID
             let paneID = window.paneID
@@ -220,25 +217,16 @@ public actor SuspendResumeCoordinator {
             // can cancel it — otherwise stale clearSuspended/updateSessionID
             // calls could race with the new suspend cycle.
             inFlight[termID] = Task {
-                // Poll for Claude process to appear (up to 10s)
-                var claudeDetected = false
-                for _ in 0..<50 {
-                    try? await Task.sleep(for: .milliseconds(200))
-                    guard !Task.isCancelled else { return }
-                    if let cmd = try? await self.tmux.paneCurrentCommand(server: server, paneID: paneID),
-                       ClaudeStateDetector.isClaudeProcess(cmd) {
-                        claudeDetected = true
-                        break
-                    }
-                }
+                // Brief delay so the app's 2s polling loop has time to observe
+                // the snapshot before we clear it. Then hand off to the live
+                // terminal — Claude's startup progress is visible there.
+                try? await Task.sleep(for: .seconds(3))
                 guard !Task.isCancelled else { return }
-                suspendLog("Clearing suspended for \(termID.uuidString.prefix(8)): claudeDetected=\(claudeDetected)")
+                suspendLog("Clearing suspended for \(termID.uuidString.prefix(8))")
                 try? await self.db.terminals.clearSuspended(id: termID)
 
-                // Re-capture session ID after Claude has settled
-                if claudeDetected {
-                    try? await Task.sleep(for: .seconds(3))
-                }
+                // Wait for Claude to settle, then re-capture session ID
+                try? await Task.sleep(for: .seconds(5))
                 guard !Task.isCancelled else { return }
                 if let newID = await self.detector.captureSessionID(server: server, paneID: paneID) {
                     try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -217,8 +217,9 @@ public actor SuspendResumeCoordinator {
             // can cancel it — otherwise stale clearSuspended/updateSessionID
             // calls could race with the new suspend cycle.
             inFlight[termID] = Task {
-                // Brief delay so the app's 2s polling loop has time to observe
-                // the snapshot before we clear it. Then hand off to the live
+                // Brief delay so the app's 2s polling loop (AppState.startPolling)
+                // has time to observe the snapshot before we clear it. Must be
+                // longer than the poll interval. Then hand off to the live
                 // terminal — Claude's startup progress is visible there.
                 try? await Task.sleep(for: .seconds(3))
                 guard !Task.isCancelled else { return }

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -56,14 +56,16 @@ public actor SuspendResumeCoordinator {
         suspendLog("responseCompleted for worktree \(worktreeID.uuidString.prefix(8))")
     }
 
-    public func selectionChanged(to newSelection: Set<UUID>) {
+    public func selectionChanged(to newSelection: Set<UUID>, suspendEnabled: Bool = true) {
         let departing = lastKnownSelection.subtracting(newSelection)
         let arriving = newSelection.subtracting(lastKnownSelection)
-        suspendLog("selectionChanged: departing=\(departing.map { $0.uuidString.prefix(8) }), arriving=\(arriving.map { $0.uuidString.prefix(8) }), idleHook=\(worktreeIdleFromHook.map { $0.uuidString.prefix(8) })")
+        suspendLog("selectionChanged: departing=\(departing.map { $0.uuidString.prefix(8) }), arriving=\(arriving.map { $0.uuidString.prefix(8) }), suspendEnabled=\(suspendEnabled), idleHook=\(worktreeIdleFromHook.map { $0.uuidString.prefix(8) })")
         lastKnownSelection = newSelection
 
-        for worktreeID in departing {
-            scheduleSuspend(worktreeID: worktreeID)
+        if suspendEnabled {
+            for worktreeID in departing {
+                scheduleSuspend(worktreeID: worktreeID)
+            }
         }
         for worktreeID in arriving {
             scheduleResume(worktreeID: worktreeID)

--- a/Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SelectionHandlers.swift
@@ -5,7 +5,8 @@ extension RPCRouter {
     func handleWorktreeSelectionChanged(_ data: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeSelectionChangedParams.self, from: data)
         let newSelection = Set(params.selectedWorktreeIDs)
-        await suspendResumeCoordinator.selectionChanged(to: newSelection)
+        let suspendEnabled = params.suspendEnabled ?? true
+        await suspendResumeCoordinator.selectionChanged(to: newSelection, suspendEnabled: suspendEnabled)
         return .ok()
     }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -226,8 +226,10 @@ public struct ResolvePathParams: Codable, Sendable {
 
 public struct WorktreeSelectionChangedParams: Codable, Sendable {
     public let selectedWorktreeIDs: [UUID]
-    public init(selectedWorktreeIDs: [UUID]) {
+    public var suspendEnabled: Bool?
+    public init(selectedWorktreeIDs: [UUID], suspendEnabled: Bool? = nil) {
         self.selectedWorktreeIDs = selectedWorktreeIDs
+        self.suspendEnabled = suspendEnabled
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -226,7 +226,7 @@ public struct ResolvePathParams: Codable, Sendable {
 
 public struct WorktreeSelectionChangedParams: Codable, Sendable {
     public let selectedWorktreeIDs: [UUID]
-    public var suspendEnabled: Bool?
+    public let suspendEnabled: Bool?
     public init(selectedWorktreeIDs: [UUID], suspendEnabled: Bool? = nil) {
         self.selectedWorktreeIDs = selectedWorktreeIDs
         self.suspendEnabled = suspendEnabled

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -226,6 +226,8 @@ public struct ResolvePathParams: Codable, Sendable {
 
 public struct WorktreeSelectionChangedParams: Codable, Sendable {
     public let selectedWorktreeIDs: [UUID]
+    /// Whether to suspend idle terminals on departure. Nil defaults to true
+    /// for backwards compatibility with older clients that omit this field.
     public let suspendEnabled: Bool?
     public init(selectedWorktreeIDs: [UUID], suspendEnabled: Bool? = nil) {
         self.selectedWorktreeIDs = selectedWorktreeIDs

--- a/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
@@ -1,0 +1,91 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("SuspendResumeCoordinator Tests")
+struct SuspendResumeCoordinatorTests {
+
+    /// Helper: create an in-memory DB with a repo, worktree, and suspended terminal.
+    private func setupSuspendedTerminal() async throws -> (TBDDatabase, UUID, UUID) {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-repo", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt",
+            branch: "main", path: "/tmp/test-repo",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude-1", claudeSessionID: "session-abc"
+        )
+        try await db.terminals.setSuspended(
+            id: terminal.id, sessionID: "session-abc", snapshot: "fake snapshot"
+        )
+        return (db, wt.id, terminal.id)
+    }
+
+    @Test func resumeRunsWhenSuspendDisabled() async throws {
+        let (db, worktreeID, terminalID) = try await setupSuspendedTerminal()
+        let tmux = TmuxManager(dryRun: true)
+        let coordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
+
+        // Verify terminal is suspended
+        let before = try await db.terminals.get(id: terminalID)
+        #expect(before?.suspendedAt != nil)
+        #expect(before?.suspendedSnapshot != nil)
+
+        // Simulate arriving at the worktree with suspend disabled
+        await coordinator.selectionChanged(to: [worktreeID], suspendEnabled: false)
+
+        // Wait for the async resume to complete (3s delay + margin)
+        try await Task.sleep(for: .seconds(5))
+
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.suspendedAt == nil, "Resume should clear suspendedAt even when suspendEnabled is false")
+        #expect(after?.suspendedSnapshot == nil, "Resume should clear snapshot even when suspendEnabled is false")
+    }
+
+    @Test func resumeRunsWhenSuspendEnabled() async throws {
+        let (db, worktreeID, terminalID) = try await setupSuspendedTerminal()
+        let tmux = TmuxManager(dryRun: true)
+        let coordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
+
+        await coordinator.selectionChanged(to: [worktreeID], suspendEnabled: true)
+
+        try await Task.sleep(for: .seconds(5))
+
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.suspendedAt == nil, "Resume should clear suspendedAt when suspendEnabled is true")
+    }
+
+    @Test func suspendSkippedWhenDisabled() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-repo", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt",
+            branch: "main", path: "/tmp/test-repo",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude-1", claudeSessionID: "session-abc"
+        )
+        let tmux = TmuxManager(dryRun: true)
+        let coordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
+
+        // First: arrive at the worktree so it's in lastKnownSelection
+        await coordinator.selectionChanged(to: [wt.id], suspendEnabled: false)
+        // Seed the idle hook so the terminal would be eligible for suspend
+        await coordinator.responseCompleted(worktreeID: wt.id)
+
+        // Now depart with suspend disabled
+        await coordinator.selectionChanged(to: [], suspendEnabled: false)
+
+        // Wait for any async suspend to complete
+        try await Task.sleep(for: .seconds(2))
+
+        let after = try await db.terminals.get(id: terminal.id)
+        #expect(after?.suspendedAt == nil, "Terminal should NOT be suspended when suspendEnabled is false")
+    }
+}


### PR DESCRIPTION
## Summary

The "Restoring session…" snapshot indicator stayed visible for 10-17s (sometimes indefinitely) after Claude had already resumed, requiring users to navigate away and back to see the live terminal.

**Why it happens:** The post-resume task polled tmux 50 times (200ms sleep + tmux round-trip + actor contention per iteration) to detect Claude before clearing the suspended state. Actor scheduling delays inflated the expected 10s to 17s+, and in some cases the view never re-rendered even after clearing.

**What this PR does:**
- Replaces the 50-iteration polling loop with a simple 3s fixed delay before clearing — long enough for the app's 2s poll to observe the snapshot, short enough to not feel stuck
- Adds an auto-suspend toggle button in the toolbar (replaces the add-repo button) so users can quickly disable suspension without opening Settings
- The toggle only gates suspend — resume always runs for already-suspended terminals

## Test plan
- [ ] Suspend a Claude terminal by switching worktrees, then switch back — "Restoring session…" should show for ~3-5s then transition to the live terminal
- [ ] Toggle auto-suspend off via toolbar button — switching worktrees should no longer suspend idle Claude instances
- [ ] Toggle auto-suspend back on — suspension should resume on next worktree switch
- [ ] VoiceOver reads the toggle button label correctly