### PR TITLE
Fix: Eliminate duplicate filename row in code viewer tabs

### DIFF
--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -9,7 +9,7 @@ struct CodeViewerPaneView: View {
     let worktreePath: String
 
     @State private var selectedFiles: [String] = []
-    @State private var showSidebar = false
+    @AppStorage("codeViewer.showSidebar") private var showSidebar = false
 
     var body: some View {
         HStack(spacing: 0) {
@@ -27,50 +27,16 @@ struct CodeViewerPaneView: View {
             }
 
             // Code preview
-            VStack(spacing: 0) {
-                // Tab header bar
-                HStack(spacing: 6) {
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.15)) {
-                            showSidebar.toggle()
-                        }
-                    } label: {
-                        Image(systemName: "sidebar.left")
-                            .font(.system(size: 11))
-                            .foregroundStyle(showSidebar ? .primary : .secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Toggle file tree")
-
-                    if let firstName = selectedFiles.first {
-                        Image(systemName: "doc")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                        Text(URL(fileURLWithPath: firstName).lastPathComponent)
-                            .font(.system(size: 11))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
-
-                    Spacer()
-                }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 5)
-                .background(Color(nsColor: .controlBackgroundColor))
-
-                Divider()
-
-                if selectedFiles.isEmpty {
-                    emptyState
-                } else {
-                    ScrollView {
-                        LazyVStack(alignment: .leading, spacing: 0) {
-                            ForEach(selectedFiles, id: \.self) { filePath in
-                                if selectedFiles.count > 1 {
-                                    fileHeader(filePath)
-                                }
-                                FilePreviewView(filePath: filePath)
+            if selectedFiles.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(selectedFiles, id: \.self) { filePath in
+                            if selectedFiles.count > 1 {
+                                fileHeader(filePath)
                             }
+                            FilePreviewView(filePath: filePath)
                         }
                     }
                 }

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -63,9 +63,15 @@ private struct TabBarItem: View {
 
     @State private var isHovering = false
     @State private var isHoveringClose = false
+    @AppStorage("codeViewer.showSidebar") private var showSidebar = false
 
     private var showClose: Bool {
         isSelected || isHovering
+    }
+
+    private var isCodeViewer: Bool {
+        if case .codeViewer = tab.content { return true }
+        return false
     }
 
     var body: some View {
@@ -87,6 +93,23 @@ private struct TabBarItem: View {
             .buttonStyle(.plain)
             .opacity(showClose ? 1 : 0)
             .animation(.easeInOut(duration: 0.12), value: showClose)
+
+            // Sidebar toggle for code viewer tabs
+            if isCodeViewer {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        showSidebar.toggle()
+                    }
+                } label: {
+                    Image(systemName: "sidebar.left")
+                        .font(.system(size: 10))
+                        .foregroundStyle(showSidebar ? .primary : .tertiary)
+                        .frame(width: 16, height: 16)
+                }
+                .buttonStyle(.plain)
+                .help("Toggle file tree")
+                .padding(.trailing, 2)
+            }
 
             // Type icon
             Image(systemName: tabIcon)


### PR DESCRIPTION
## Summary
- Code viewer tabs showed the filename twice — once in the tab bar and again in a redundant inner header bar, wasting vertical space
- Merged the sidebar toggle button into the tab bar item for code viewer tabs, then removed the inner header entirely
- Sidebar toggle state uses `@AppStorage` so it persists across sessions and stays in sync between TabBar and CodeViewerPaneView

## Test plan
- [ ] Open a file from the git changes panel — verify only ONE row shows the filename (the tab bar), not two
- [ ] Verify the sidebar toggle icon appears in the tab bar for code viewer tabs but not for terminal/webview tabs
- [ ] Click the sidebar toggle — verify the file tree slides in/out correctly
- [ ] Switch between terminal and code viewer tabs — verify layout is clean with no extra header rows