### PR TITLE
Fix: Route Cmd+Arrow to the clicked terminal, not the previously focused one

### DIFF
--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -94,6 +94,7 @@ struct TerminalPanelView: NSViewRepresentable {
         private var localProcess: LocalProcess?
         private var scrollMonitor: Any?
         private var clickMonitor: Any?
+        private var focusMonitor: Any?
 
         func startTmuxClient(
             terminalView: TerminalView,
@@ -216,6 +217,20 @@ struct TerminalPanelView: NSViewRepresentable {
                 }
                 return consumed ? nil : event
             }
+
+            // Claim first responder on click so Cmd+Arrow and other key
+            // equivalents route to the focused terminal, not the previously
+            // focused one (e.g. main panel vs pinned dock).
+            focusMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                let location = event.locationInWindow
+                MainActor.assumeIsolated {
+                    guard let tv = ref.view else { return }
+                    let point = tv.convert(location, from: nil)
+                    guard tv.bounds.contains(point) else { return }
+                    tv.window?.makeFirstResponder(tv)
+                }
+                return event // always pass through
+            }
         }
 
         func cleanup() {
@@ -228,6 +243,10 @@ struct TerminalPanelView: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
                 clickMonitor = nil
             }
+            if let monitor = focusMonitor {
+                NSEvent.removeMonitor(monitor)
+                focusMonitor = nil
+            }
             tmuxBridge?.cleanupSession(panelID: panelID, server: tmuxServer)
         }
 
@@ -237,6 +256,9 @@ struct TerminalPanelView: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
             }
             if let monitor = clickMonitor {
+                NSEvent.removeMonitor(monitor)
+            }
+            if let monitor = focusMonitor {
                 NSEvent.removeMonitor(monitor)
             }
         }

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -94,7 +94,6 @@ struct TerminalPanelView: NSViewRepresentable {
         private var localProcess: LocalProcess?
         private var scrollMonitor: Any?
         private var clickMonitor: Any?
-        private var focusMonitor: Any?
 
         func startTmuxClient(
             terminalView: TerminalView,
@@ -185,12 +184,21 @@ struct TerminalPanelView: NSViewRepresentable {
                 return consumed ? nil : event
             }
 
-            // Intercept Cmd+Click to detect file paths in the terminal buffer.
+            // Intercept clicks: claim first responder on any click (so Cmd+Arrow
+            // routes to the focused terminal), and handle Cmd+Click for file paths.
             clickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
+                let location = event.locationInWindow
+
+                // Claim first responder so key equivalents route to this terminal
+                MainActor.assumeIsolated {
+                    guard let tv = ref.view else { return }
+                    let point = tv.convert(location, from: nil)
+                    guard tv.bounds.contains(point) else { return }
+                    tv.window?.makeFirstResponder(tv)
+                }
+
                 guard event.modifierFlags.contains(.command) else { return event }
 
-                // Capture event properties before entering the MainActor closure
-                let location = event.locationInWindow
                 let consumed = MainActor.assumeIsolated { () -> Bool in
                     guard let tv = ref.view as? TBDTerminalView else { return false }
                     let point = tv.convert(location, from: nil)
@@ -217,20 +225,6 @@ struct TerminalPanelView: NSViewRepresentable {
                 }
                 return consumed ? nil : event
             }
-
-            // Claim first responder on click so Cmd+Arrow and other key
-            // equivalents route to the focused terminal, not the previously
-            // focused one (e.g. main panel vs pinned dock).
-            focusMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
-                let location = event.locationInWindow
-                MainActor.assumeIsolated {
-                    guard let tv = ref.view else { return }
-                    let point = tv.convert(location, from: nil)
-                    guard tv.bounds.contains(point) else { return }
-                    tv.window?.makeFirstResponder(tv)
-                }
-                return event // always pass through
-            }
         }
 
         func cleanup() {
@@ -243,10 +237,6 @@ struct TerminalPanelView: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
                 clickMonitor = nil
             }
-            if let monitor = focusMonitor {
-                NSEvent.removeMonitor(monitor)
-                focusMonitor = nil
-            }
             tmuxBridge?.cleanupSession(panelID: panelID, server: tmuxServer)
         }
 
@@ -256,9 +246,6 @@ struct TerminalPanelView: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
             }
             if let monitor = clickMonitor {
-                NSEvent.removeMonitor(monitor)
-            }
-            if let monitor = focusMonitor {
                 NSEvent.removeMonitor(monitor)
             }
         }


### PR DESCRIPTION
## Summary
- Clicking a pinned dock terminal didn't transfer first responder because SwiftTerm's `mouseDown` isn't `open` (can't override)
- Added a focus monitor that calls `makeFirstResponder` when a click lands inside a terminal view's bounds
- Fixes Cmd+Left/Right going to the main panel instead of the focused pinned terminal

## Test plan
- [ ] Pin a terminal, click into the pinned dock terminal, press Cmd+Left → cursor moves to line start in the pinned terminal (not the main panel)
- [ ] Click back into the main panel terminal, press Cmd+Right → cursor moves to line end in the main panel
- [ ] Verify text selection still works (click-drag in terminals)
- [ ] Verify Cmd+Click on file paths still opens code viewer