### PR TITLE
Fix: Stop Cmd+Arrow from always targeting the leftmost terminal

### DIFF
--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -285,6 +285,13 @@ class TBDTerminalView: TerminalView {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // Only handle key equivalents if this terminal is the first responder.
+        // performKeyEquivalent walks the entire view hierarchy — without this
+        // guard, the leftmost terminal always wins and steals Cmd+Arrow from
+        // whichever terminal the user actually clicked on.
+        guard window?.firstResponder === self else {
+            return super.performKeyEquivalent(with: event)
+        }
         if naturalTextEditing, event.type == .keyDown, handleNaturalTextEditing(event) {
             return true
         }


### PR DESCRIPTION
## Summary
- Cmd+Left/Right (Home/End) always routes to the leftmost terminal panel, ignoring which terminal the user clicked on
- Root cause: `performKeyEquivalent` walks the entire NSView hierarchy — the first view returning `true` wins, and the leftmost terminal is always first in the tree traversal
- Adds a `window?.firstResponder === self` guard so only the focused terminal handles the key equivalent; non-focused terminals fall through to `super` (returns `false`)

Completes the fix started in #47, which correctly sets first responder on click but didn't prevent the wrong terminal from consuming the event.

## Test plan
- [ ] Open two terminal panels side by side
- [ ] Click on the right terminal
- [ ] Press Cmd+Left — cursor should jump to line start in the right terminal, not the left
- [ ] Press Cmd+Right — cursor should jump to line end in the right terminal
- [ ] Click on the left terminal and verify Cmd+Arrow still works there