### PR TITLE
Fix: Stop showing unread badge on worktrees the user is already looking at

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -31,6 +31,17 @@ final class AppState: ObservableObject {
             .sorted { ($0.pinnedAt ?? .distantPast) < ($1.pinnedAt ?? .distantPast) }
     }
 
+    /// Worktree IDs that have at least one terminal currently visible on screen.
+    /// Includes selected worktrees (active tab visible) and worktrees with pinned terminals
+    /// (always visible in either the active tab or the pinned dock).
+    var visibleWorktreeIDs: Set<UUID> {
+        var ids = selectedWorktreeIDs
+        for terminal in pinnedTerminals {
+            ids.insert(terminal.worktreeID)
+        }
+        return ids
+    }
+
     @Published var dockRatio: CGFloat = 0.3 {
         didSet { UserDefaults.standard.set(Double(dockRatio), forKey: Self.dockRatioKey) }
     }
@@ -375,12 +386,27 @@ final class AppState: ObservableObject {
     }
 
     /// Refresh unread notifications from the daemon.
+    /// Notifications for currently visible worktrees (selected or pinned) are
+    /// automatically marked as read so the badge never appears while the user
+    /// is looking at the terminal.
     func refreshNotifications() async {
         do {
             let fetched = try await daemonClient.listNotifications()
-            if fetched != notifications.compactMapValues({ $0 }) {
+
+            // Auto-mark-as-read for worktrees the user is currently looking at
+            let visible = visibleWorktreeIDs
+            let toMarkRead = fetched.keys.filter { visible.contains($0) }
+            for worktreeID in toMarkRead {
+                Task {
+                    try? await daemonClient.markNotificationsRead(worktreeID: worktreeID)
+                }
+            }
+
+            // Only include notifications for non-visible worktrees in UI state
+            let filtered = fetched.filter { !visible.contains($0.key) }
+            if filtered != notifications.compactMapValues({ $0 }) {
                 var updated: [UUID: NotificationType?] = [:]
-                for (id, type) in fetched {
+                for (id, type) in filtered {
                     updated[id] = type
                 }
                 notifications = updated

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -397,8 +397,10 @@ final class AppState: ObservableObject {
             let visible = visibleWorktreeIDs
             let toMarkRead = fetched.keys.filter { visible.contains($0) }
             for worktreeID in toMarkRead {
-                Task {
-                    try? await daemonClient.markNotificationsRead(worktreeID: worktreeID)
+                do {
+                    try await daemonClient.markNotificationsRead(worktreeID: worktreeID)
+                } catch {
+                    logger.warning("Failed to auto-mark-read for \(worktreeID): \(error)")
                 }
             }
 


### PR DESCRIPTION
## Summary
- Unread notification badges appeared on worktrees even when their terminal was currently visible on screen (selected worktree's active tab, or pinned terminal in the dock)
- Root cause: `refreshNotifications()` blindly applied all unread notifications from the daemon, and the mark-as-read logic only fired on selection *change* — not for notifications arriving while already selected
- Adds `visibleWorktreeIDs` (selected + pinned worktree IDs) and filters them out during notification refresh, auto-marking them as read on the daemon

## Test plan
- [ ] Select a worktree with a Claude terminal, wait for response to complete — verify no blue badge appears
- [ ] Switch away, wait for original worktree's Claude to finish — verify badge **does** appear
- [ ] Pin a terminal from worktree B, select worktree A, wait for B's notification — verify no badge on B (visible in dock)
- [ ] Unpin B's terminal, trigger another notification — verify badge now appears on B