### PR TITLE
Fix: Resolve hook scripts from worktree, not main repo

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -48,7 +48,7 @@ extension WorktreeLifecycle {
         if !force {
             let archiveHookPath = hooks.resolve(
                 event: .archive,
-                repoPath: repo.path,
+                repoPath: worktree.path,
                 appHookPath: nil
             )
             if let hookPath = archiveHookPath {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -208,7 +208,7 @@ extension WorktreeLifecycle {
         // Create terminal 2: setup hook
         let setupHookPath = hooks.resolve(
             event: .setup,
-            repoPath: repoPath,
+            repoPath: worktreePath,
             appHookPath: nil
         )
         let setupCommand = shellWrapped(setupHookPath ?? defaultShell)


### PR DESCRIPTION
## Summary
- Hook scripts (setup, archive) were resolved by reading `conductor.json` and script paths from the **main repo's working tree** instead of the worktree's. If the worktree's branch had moved/renamed scripts that hadn't landed on the main repo's HEAD yet, the hook would fail with "No such file or directory".
- Changed both `hooks.resolve()` call sites to pass the worktree path, so `conductor.json` and hook scripts come from the worktree's own branch.

## Test plan
- [ ] Create a worktree on a branch where `conductor.json` references a script path that doesn't exist on main — verify the setup hook runs successfully
- [ ] Archive a worktree in the same scenario — verify the archive hook runs from the worktree's copy