### PR TITLE
Feat: Bring back Claude conversations when reviving archived worktrees

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -65,9 +65,15 @@ extension AppState {
 
     /// Revive an archived worktree.
     func reviveWorktree(id: UUID) async {
+        // Find the repo before reviving so we can refresh the archived list
+        let repoID = archivedWorktrees.first(where: { $0.value.contains { $0.id == id } })?.key
         do {
             try await daemonClient.reviveWorktree(id: id)
             await refreshWorktrees()
+            selectedWorktreeIDs = [id]
+            if let repoID {
+                await refreshArchivedWorktrees(repoID: repoID)
+            }
         } catch {
             logger.error("Failed to revive worktree: \(error)")
             handleConnectionError(error)
@@ -96,6 +102,25 @@ extension AppState {
         } catch {
             logger.error("Failed to rename worktree: \(error)")
             handleConnectionError(error)
+        }
+    }
+
+    // MARK: - Archived Worktrees
+
+    /// Select a repo to show its archived worktrees in the content pane.
+    func selectRepo(id: UUID) {
+        selectedWorktreeIDs = []
+        selectedRepoID = id
+        Task { await refreshArchivedWorktrees(repoID: id) }
+    }
+
+    /// Fetch archived worktrees for a repo.
+    func refreshArchivedWorktrees(repoID: UUID) async {
+        do {
+            let archived = try await daemonClient.listWorktrees(repoID: repoID, status: .archived)
+            archivedWorktrees[repoID] = archived
+        } catch {
+            logger.error("Failed to list archived worktrees: \(error)")
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -19,10 +19,18 @@ final class AppState: ObservableObject {
             for id in selectedWorktreeIDs where !selectionOrder.contains(id) {
                 selectionOrder.append(id)
             }
+            // Clear repo selection when a worktree is selected
+            if !selectedWorktreeIDs.isEmpty {
+                selectedRepoID = nil
+            }
         }
     }
     /// Tracks the order of selected worktrees for split view rendering (cmd+click order).
     @Published var selectionOrder: [UUID] = []
+    /// Selected repo ID — set when a repo header is clicked, shows archived worktrees in content pane.
+    @Published var selectedRepoID: UUID? = nil
+    /// Archived worktrees keyed by repo ID, fetched on demand.
+    @Published var archivedWorktrees: [UUID: [Worktree]] = [:]
 
     /// All pinned terminals across all worktrees, sorted by pinnedAt.
     var pinnedTerminals: [Terminal] {

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+import TBDShared
+
+struct ArchivedWorktreesView: View {
+    let repoID: UUID
+    @EnvironmentObject var appState: AppState
+
+    private var repo: Repo? {
+        appState.repos.first { $0.id == repoID }
+    }
+
+    private var archived: [Worktree] {
+        (appState.archivedWorktrees[repoID] ?? [])
+            .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+    }
+
+    var body: some View {
+        if archived.isEmpty {
+            VStack(spacing: 12) {
+                Image(systemName: "archivebox")
+                    .font(.system(size: 36))
+                    .foregroundStyle(.secondary)
+                Text("No Archived Worktrees")
+                    .font(.title3)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            VStack(spacing: 0) {
+                // Header
+                HStack {
+                    Text("Archived Worktrees")
+                        .font(.title3)
+                        .fontWeight(.medium)
+                    Spacer()
+                    Text("\(archived.count) worktree\(archived.count == 1 ? "" : "s")")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+
+                Divider()
+
+                // List
+                ScrollView {
+                    LazyVStack(spacing: 1) {
+                        ForEach(archived) { worktree in
+                            ArchivedWorktreeRow(worktree: worktree)
+                        }
+                    }
+                    .padding(.vertical, 8)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+private struct ArchivedWorktreeRow: View {
+    let worktree: Worktree
+    @EnvironmentObject var appState: AppState
+    @State private var isReviving = false
+
+    private var hasClaudeSessions: Bool {
+        worktree.archivedClaudeSessions?.isEmpty == false
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(worktree.displayName)
+                        .fontWeight(.medium)
+                    if hasClaudeSessions {
+                        let count = worktree.archivedClaudeSessions?.count ?? 0
+                        Text("\(count) Claude session\(count == 1 ? "" : "s")")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(.orange.opacity(0.1), in: Capsule())
+                    }
+                }
+                HStack(spacing: 8) {
+                    Label(worktree.branch, systemImage: "arrow.triangle.branch")
+                    if let archivedAt = worktree.archivedAt {
+                        Text("archived \(archivedAt, format: .relative(presentation: .named))")
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                isReviving = true
+                Task {
+                    await appState.reviveWorktree(id: worktree.id)
+                    isReviving = false
+                }
+            } label: {
+                if isReviving {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 60)
+                } else {
+                    Text("Revive")
+                        .frame(width: 60)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .disabled(isReviving)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .background(Color.primary.opacity(0.03))
+        .cornerRadius(6)
+        .padding(.horizontal, 12)
+    }
+}

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -22,6 +22,8 @@ struct ContentView: View {
                     disconnectedView
                 } else if appState.repos.isEmpty {
                     emptyStateView
+                } else if let repoID = appState.selectedRepoID {
+                    ArchivedWorktreesView(repoID: repoID)
                 } else if appState.selectedWorktreeIDs.isEmpty {
                     Text("Select a worktree or click + to create one")
                         .foregroundStyle(.secondary)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -51,7 +51,10 @@ struct RepoSectionView: View {
 
             Text(repo.displayName)
                 .font(.headline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(appState.selectedRepoID == repo.id ? .primary : .secondary)
+                .onTapGesture {
+                    appState.selectRepo(id: repo.id)
+                }
 
             Spacer()
 

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -127,6 +127,12 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v8") { db in
+            try db.alter(table: "worktree") { t in
+                t.add(column: "archivedClaudeSessions", .text)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -157,8 +157,9 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Archive a worktree (set status to archived and record the timestamp).
+    /// Optionally saves Claude session IDs in the same transaction so they survive terminal deletion.
     /// Refuses to archive worktrees with `.main` status.
-    public func archive(id: UUID) async throws {
+    public func archive(id: UUID, claudeSessionIDs: [String]? = nil) async throws {
         try await writer.write { db in
             guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Worktree not found")
@@ -171,6 +172,10 @@ public struct WorktreeStore: Sendable {
             }
             record.status = WorktreeStatus.archived.rawValue
             record.archivedAt = Date()
+            if let sessions = claudeSessionIDs, !sessions.isEmpty {
+                record.archivedClaudeSessions = try String(
+                    data: JSONEncoder().encode(sessions), encoding: .utf8)
+            }
             try record.update(db)
         }
     }
@@ -184,18 +189,6 @@ public struct WorktreeStore: Sendable {
             record.status = WorktreeStatus.active.rawValue
             record.archivedAt = nil
             record.archivedClaudeSessions = nil
-            try record.update(db)
-        }
-    }
-
-    /// Save Claude session IDs from terminals before they are deleted during archive.
-    public func saveArchivedClaudeSessions(id: UUID, sessionIDs: [String]) async throws {
-        try await writer.write { db in
-            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
-                throw DatabaseError(message: "Worktree not found")
-            }
-            record.archivedClaudeSessions = try String(
-                data: JSONEncoder().encode(sessionIDs), encoding: .utf8)
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -180,15 +180,19 @@ public struct WorktreeStore: Sendable {
         }
     }
 
-    /// Revive an archived worktree (set status back to active, clear archivedAt and archivedClaudeSessions).
-    public func revive(id: UUID) async throws {
+    /// Revive an archived worktree (set status back to active, clear archivedAt).
+    /// When `clearSessions` is true (default), also clears archivedClaudeSessions.
+    /// Pass false to preserve sessions when Claude wasn't restored (e.g. skipClaude).
+    public func revive(id: UUID, clearSessions: Bool = true) async throws {
         try await writer.write { db in
             guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Worktree not found")
             }
             record.status = WorktreeStatus.active.rawValue
             record.archivedAt = nil
-            record.archivedClaudeSessions = nil
+            if clearSessions {
+                record.archivedClaudeSessions = nil
+            }
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -17,6 +17,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var createdAt: Date
     var archivedAt: Date?
     var tmuxServer: String
+    var archivedClaudeSessions: String?
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -30,10 +31,19 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.createdAt = wt.createdAt
         self.archivedAt = wt.archivedAt
         self.tmuxServer = wt.tmuxServer
+        if let sessions = wt.archivedClaudeSessions {
+            self.archivedClaudeSessions = try? String(
+                data: JSONEncoder().encode(sessions), encoding: .utf8)
+        }
     }
 
     func toModel() -> Worktree {
-        Worktree(
+        var sessions: [String]?
+        if let json = archivedClaudeSessions,
+           let data = json.data(using: .utf8) {
+            sessions = try? JSONDecoder().decode([String].self, from: data)
+        }
+        return Worktree(
             id: UUID(uuidString: id)!,
             repoID: UUID(uuidString: repoID)!,
             name: name,
@@ -44,7 +54,8 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             hasConflicts: hasConflicts,
             createdAt: createdAt,
             archivedAt: archivedAt,
-            tmuxServer: tmuxServer
+            tmuxServer: tmuxServer,
+            archivedClaudeSessions: sessions
         )
     }
 }
@@ -164,7 +175,7 @@ public struct WorktreeStore: Sendable {
         }
     }
 
-    /// Revive an archived worktree (set status back to active, clear archivedAt).
+    /// Revive an archived worktree (set status back to active, clear archivedAt and archivedClaudeSessions).
     public func revive(id: UUID) async throws {
         try await writer.write { db in
             guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
@@ -172,6 +183,19 @@ public struct WorktreeStore: Sendable {
             }
             record.status = WorktreeStatus.active.rawValue
             record.archivedAt = nil
+            record.archivedClaudeSessions = nil
+            try record.update(db)
+        }
+    }
+
+    /// Save Claude session IDs from terminals before they are deleted during archive.
+    public func saveArchivedClaudeSessions(id: UUID, sessionIDs: [String]) async throws {
+        try await writer.write { db in
+            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Worktree not found")
+            }
+            record.archivedClaudeSessions = try String(
+                data: JSONEncoder().encode(sessionIDs), encoding: .utf8)
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -128,8 +128,10 @@ extension WorktreeLifecycle {
             archivedClaudeSessions: worktree.archivedClaudeSessions
         )
 
-        // Update status to active (also clears archivedClaudeSessions)
-        try await db.worktrees.revive(id: worktreeID)
+        // Update status to active.
+        // Only clear archivedClaudeSessions if Claude was actually restored —
+        // otherwise preserve them so a subsequent revive (without skipClaude) can use them.
+        try await db.worktrees.revive(id: worktreeID, clearSessions: !skipClaude)
 
         // Return updated worktree
         guard let revived = try await db.worktrees.get(id: worktreeID) else {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -27,8 +27,15 @@ extension WorktreeLifecycle {
         // Update DB status immediately
         try await db.worktrees.archive(id: worktreeID)
 
-        // Kill all tmux windows for this worktree
+        // Save Claude session IDs before deleting terminals so revive can restore conversations
         let terminals = try await db.terminals.list(worktreeID: worktreeID)
+        let claudeSessionIDs = terminals.compactMap { $0.claudeSessionID }
+        if !claudeSessionIDs.isEmpty {
+            try await db.worktrees.saveArchivedClaudeSessions(
+                id: worktreeID, sessionIDs: claudeSessionIDs)
+        }
+
+        // Kill all tmux windows for this worktree
         for terminal in terminals {
             try? await tmux.killWindow(
                 server: worktree.tmuxServer,
@@ -119,10 +126,11 @@ extension WorktreeLifecycle {
         try await setupTerminals(
             worktreeID: worktree.id, repoPath: repo.path,
             tmuxServer: worktree.tmuxServer, worktreePath: worktree.path,
-            skipClaude: skipClaude
+            skipClaude: skipClaude,
+            archivedClaudeSessions: worktree.archivedClaudeSessions
         )
 
-        // Update status to active
+        // Update status to active (also clears archivedClaudeSessions)
         try await db.worktrees.revive(id: worktreeID)
 
         // Return updated worktree

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -24,16 +24,14 @@ extension WorktreeLifecycle {
             throw WorktreeLifecycleError.repoNotFound(worktree.repoID)
         }
 
-        // Update DB status immediately
-        try await db.worktrees.archive(id: worktreeID)
-
-        // Save Claude session IDs before deleting terminals so revive can restore conversations
+        // Collect Claude session IDs before archiving so they survive terminal deletion
         let terminals = try await db.terminals.list(worktreeID: worktreeID)
-        let claudeSessionIDs = terminals.compactMap { $0.claudeSessionID }
-        if !claudeSessionIDs.isEmpty {
-            try await db.worktrees.saveArchivedClaudeSessions(
-                id: worktreeID, sessionIDs: claudeSessionIDs)
-        }
+        let claudeSessionIDs = terminals
+            .sorted(by: { $0.createdAt < $1.createdAt })
+            .compactMap { $0.claudeSessionID }
+
+        // Update DB status and save sessions in one transaction
+        try await db.worktrees.archive(id: worktreeID, claudeSessionIDs: claudeSessionIDs)
 
         // Kill all tmux windows for this worktree
         for terminal in terminals {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -231,7 +231,7 @@ extension WorktreeLifecycle {
         )
 
         // Restore additional archived Claude sessions (beyond the first which was used above)
-        if let sessions = archivedClaudeSessions, sessions.count > 1 {
+        if !skipClaude, let sessions = archivedClaudeSessions, sessions.count > 1 {
             for sessionID in sessions.dropFirst() {
                 let cmd = "claude --dangerously-skip-permissions --session-id \(sessionID)"
                 let window = try await tmux.createWindow(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -169,9 +169,14 @@ extension WorktreeLifecycle {
 
     /// Sets up tmux windows and terminal records for a worktree.
     /// Shared by `finishCreate` and `reviveWorktree`.
+    ///
+    /// When `archivedClaudeSessions` is provided (revive path), the first session ID
+    /// is reused for the main Claude terminal to restore the conversation, and any
+    /// additional sessions get their own terminal windows.
     func setupTerminals(
         worktreeID: UUID, repoPath: String,
-        tmuxServer: String, worktreePath: String, skipClaude: Bool
+        tmuxServer: String, worktreePath: String, skipClaude: Bool,
+        archivedClaudeSessions: [String]? = nil
     ) async throws {
         // Ensure tmux server exists — capture initial window ID to kill later
         let initialWindowID = try await tmux.ensureServer(
@@ -187,7 +192,7 @@ extension WorktreeLifecycle {
             claudeCommand = defaultShell
             claudeSessionID = nil
         } else {
-            let sessionUUID = UUID().uuidString
+            let sessionUUID = archivedClaudeSessions?.first ?? UUID().uuidString
             claudeCommand = "claude --dangerously-skip-permissions --session-id \(sessionUUID)"
             claudeSessionID = sessionUUID
         }
@@ -224,6 +229,26 @@ extension WorktreeLifecycle {
             tmuxPaneID: window2.paneID,
             label: "setup"
         )
+
+        // Restore additional archived Claude sessions (beyond the first which was used above)
+        if let sessions = archivedClaudeSessions, sessions.count > 1 {
+            for sessionID in sessions.dropFirst() {
+                let cmd = "claude --dangerously-skip-permissions --session-id \(sessionID)"
+                let window = try await tmux.createWindow(
+                    server: tmuxServer,
+                    session: "main",
+                    cwd: worktreePath,
+                    shellCommand: cmd
+                )
+                _ = try await db.terminals.create(
+                    worktreeID: worktreeID,
+                    tmuxWindowID: window.windowID,
+                    tmuxPaneID: window.paneID,
+                    label: "claude",
+                    claudeSessionID: sessionID
+                )
+            }
+        }
 
         // Kill the untracked initial window that new-session created
         if let windowID = initialWindowID {

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -35,11 +35,13 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public var createdAt: Date
     public var archivedAt: Date?
     public var tmuxServer: String
+    public var archivedClaudeSessions: [String]?
 
     public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
                 hasConflicts: Bool = false,
-                createdAt: Date = Date(), archivedAt: Date? = nil, tmuxServer: String) {
+                createdAt: Date = Date(), archivedAt: Date? = nil, tmuxServer: String,
+                archivedClaudeSessions: [String]? = nil) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -51,6 +53,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.createdAt = createdAt
         self.archivedAt = archivedAt
         self.tmuxServer = tmuxServer
+        self.archivedClaudeSessions = archivedClaudeSessions
     }
 
     public init(from decoder: Decoder) throws {
@@ -66,6 +69,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         createdAt = try c.decode(Date.self, forKey: .createdAt)
         archivedAt = try c.decodeIfPresent(Date.self, forKey: .archivedAt)
         tmuxServer = try c.decode(String.self, forKey: .tmuxServer)
+        archivedClaudeSessions = try c.decodeIfPresent([String].self, forKey: .archivedClaudeSessions)
     }
 }
 

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -180,6 +180,74 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
     }
 }
 
+@Test func testArchivePreservesClaudeSessions() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    // Create worktree with Claude (skipClaude: false creates a session ID)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+    let terminalsBeforeArchive = try await db.terminals.list(worktreeID: wt.id)
+    let originalSessionIDs = terminalsBeforeArchive.compactMap { $0.claudeSessionID }
+    #expect(!originalSessionIDs.isEmpty, "Should have at least one Claude session")
+
+    // Archive — should save session IDs
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+    let archived = try await db.worktrees.get(id: wt.id)
+    #expect(archived?.archivedClaudeSessions == originalSessionIDs)
+
+    // Terminals should be deleted
+    let terminalsAfterArchive = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminalsAfterArchive.isEmpty)
+
+    // Revive — should restore the same Claude session ID
+    let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: false)
+    let terminalsAfterRevive = try await db.terminals.list(worktreeID: revived.id)
+    let revivedSessionIDs = terminalsAfterRevive.compactMap { $0.claudeSessionID }
+    #expect(revivedSessionIDs.contains(originalSessionIDs[0]),
+            "Revived terminal should reuse the original Claude session ID")
+
+    // archivedClaudeSessions should be cleared after revive
+    let revivedWt = try await db.worktrees.get(id: wt.id)
+    #expect(revivedWt?.archivedClaudeSessions == nil)
+}
+
+@Test func testArchiveWithoutClaudeSessionsDoesNotSaveEmpty() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    // Create worktree without Claude
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    let archived = try await db.worktrees.get(id: wt.id)
+    #expect(archived?.archivedClaudeSessions == nil,
+            "Should not save empty session list")
+}
+
 @Test func testWorktreePathStructure() async throws {
     let (tempDir, repoDir) = try await createTestRepo()
     defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -248,6 +248,88 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
             "Should not save empty session list")
 }
 
+@Test func testReviveWithSkipClaudePreservesSessions() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    // Create with Claude, archive, then revive with skipClaude
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+    let originalSessions = try await db.terminals.list(worktreeID: wt.id)
+        .compactMap { $0.claudeSessionID }
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    _ = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
+
+    // Sessions should be preserved since Claude wasn't restored
+    let revivedWt = try await db.worktrees.get(id: wt.id)
+    #expect(revivedWt?.archivedClaudeSessions == originalSessions,
+            "skipClaude revive should preserve sessions for later recovery")
+}
+
+@Test func testReviveRestoresMultipleClaudeSessions() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    // Create worktree with Claude
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+
+    // Simulate a second Claude terminal added by the user
+    let secondSessionID = UUID().uuidString
+    let window = try await lifecycle.tmux.createWindow(
+        server: wt.tmuxServer, session: "main",
+        cwd: wt.path, shellCommand: "echo test"
+    )
+    _ = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: window.windowID,
+        tmuxPaneID: window.paneID,
+        label: "claude",
+        claudeSessionID: secondSessionID
+    )
+
+    let allSessions = try await db.terminals.list(worktreeID: wt.id)
+        .compactMap { $0.claudeSessionID }
+    #expect(allSessions.count == 2)
+
+    // Archive and revive
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+    let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: false)
+
+    // Should have 2 setup + 2 claude = but setup only creates once, so:
+    // 1 claude (from first session) + 1 setup + 1 extra claude (from second session) = 3
+    let terminals = try await db.terminals.list(worktreeID: revived.id)
+    let claudeTerminals = terminals.filter { $0.claudeSessionID != nil }
+    #expect(claudeTerminals.count == 2,
+            "Both Claude sessions should be restored")
+
+    let restoredSessionIDs = Set(claudeTerminals.compactMap { $0.claudeSessionID })
+    #expect(restoredSessionIDs.count == 2)
+}
+
 @Test func testWorktreePathStructure() async throws {
     let (tempDir, repoDir) = try await createTestRepo()
     defer { try? FileManager.default.removeItem(at: tempDir) }


### PR DESCRIPTION
## Summary
- When archiving a worktree, Claude session IDs were lost because terminal records (which store `claudeSessionID`) were deleted. Reviving created fresh terminals with new sessions, so old conversations were gone forever.
- Now the archive flow saves Claude session IDs to the worktree record before deleting terminals. On revive, those session IDs are passed back to `setupTerminals` so Claude resumes the original conversation via `--session-id`.
- Multiple Claude sessions per worktree are supported — the first restores the main terminal, additional sessions each get their own window.

## Test plan
- [x] `swift build` compiles clean
- [x] `swift test` — 178 tests pass (2 new)
- [ ] Create a worktree, have a Claude conversation, archive it, revive it — verify Claude resumes the old conversation
- [ ] Archive a worktree with no Claude terminals — verify no crash and `archivedClaudeSessions` stays nil
- [ ] Archive a worktree with multiple Claude terminals — verify all sessions restore on revive