### PR TITLE
Render markdown in code viewer with source toggle

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e56c0299fff1614532d9698090fd2c7ae4617d49052e1467880ea2c54b39cda1",
+  "originHash" : "c2da7ffd797ffd079b074831df57566bfc15464dcac04fe5da81f867f3fb2577",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
         "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
       }
     },
     {
@@ -38,12 +47,30 @@
       }
     },
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
         .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.0.0"),
         .package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
         .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),
+        .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),
     ],
     targets: [
         .target(
@@ -57,6 +58,7 @@ let package = Package(
                 .product(name: "SwiftTerm", package: "SwiftTerm"),
                 .product(name: "Highlightr", package: "Highlightr"),
                 .product(name: "SwiftUIIntrospect", package: "swiftui-introspect"),
+                .product(name: "MarkdownUI", package: "swift-markdown-ui"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
             ],

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -157,6 +157,8 @@ private struct RenderedContentView: View {
     }
 
     private func loadContent() async {
+        content = nil
+        loadError = nil
         let fm = FileManager.default
         if let attrs = try? fm.attributesOfItem(atPath: filePath),
            let size = attrs[.size] as? UInt64, size > 1_048_576 {

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -5,8 +5,16 @@ import MarkdownUI
 
 // MARK: - CodeViewerPaneView
 
+/// Preference key that child views set to signal renderable content is present.
+struct HasRenderableContentKey: PreferenceKey {
+    static let defaultValue = false
+    static func reduce(value: inout Bool, nextValue: () -> Bool) {
+        value = value || nextValue()
+    }
+}
+
 /// Files that have a rich rendered view in addition to raw source code.
-func isRenderableFile(_ path: String) -> Bool {
+private func isRenderableFile(_ path: String) -> Bool {
     let ext = (path as NSString).pathExtension.lowercased()
     return ["md", "markdown"].contains(ext)
 }
@@ -54,6 +62,7 @@ struct CodeViewerPaneView: View {
             .background(highlightrBackgroundColor)
             .colorScheme(.dark)
         }
+        .preference(key: HasRenderableContentKey.self, value: selectedFiles.contains(where: isRenderableFile))
         .onAppear {
             if !path.isEmpty && FileManager.default.fileExists(atPath: path) {
                 selectedFiles = [path]

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -5,7 +5,7 @@ import MarkdownUI
 
 // MARK: - CodeViewerPaneView
 
-/// Files that can be rendered in a rich view (markdown now; SVG, mermaid, etc. in the future).
+/// Files that have a rich rendered view in addition to raw source code.
 func isRenderableFile(_ path: String) -> Bool {
     let ext = (path as NSString).pathExtension.lowercased()
     return ["md", "markdown"].contains(ext)

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -1,12 +1,20 @@
 import SwiftUI
 import AppKit
 @preconcurrency import Highlightr
+import MarkdownUI
 
 // MARK: - CodeViewerPaneView
+
+/// Files that can be rendered in a rich view (markdown now; SVG, mermaid, etc. in the future).
+func isRenderableFile(_ path: String) -> Bool {
+    let ext = (path as NSString).pathExtension.lowercased()
+    return ["md", "markdown"].contains(ext)
+}
 
 struct CodeViewerPaneView: View {
     let path: String
     let worktreePath: String
+    let showSourceCode: Bool
 
     @State private var selectedFiles: [String] = []
     @AppStorage("codeViewer.showSidebar") private var showSidebar = false
@@ -37,7 +45,7 @@ struct CodeViewerPaneView: View {
                                 if selectedFiles.count > 1 {
                                     fileHeader(filePath)
                                 }
-                                FilePreviewView(filePath: filePath)
+                                FilePreviewView(filePath: filePath, showSourceCode: showSourceCode)
                             }
                         }
                     }
@@ -103,14 +111,62 @@ private func isTextFile(_ path: String) -> Bool {
 /// images → native NSImage, text → syntax-highlighted code, binary → "Open in Finder" fallback.
 private struct FilePreviewView: View {
     let filePath: String
+    let showSourceCode: Bool
 
     var body: some View {
-        if isImageFile(filePath) {
+        if !showSourceCode && isRenderableFile(filePath) {
+            RenderedContentView(filePath: filePath)
+        } else if isImageFile(filePath) {
             ImagePreviewView(filePath: filePath)
         } else if isTextFile(filePath) {
             HighlightedCodeView(filePath: filePath)
         } else {
             BinaryFallbackView(filePath: filePath)
+        }
+    }
+}
+
+// MARK: - RenderedContentView
+
+private struct RenderedContentView: View {
+    let filePath: String
+    @State private var content: String?
+    @State private var loadError: String?
+
+    var body: some View {
+        Group {
+            if let error = loadError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(12)
+            } else if let content {
+                Markdown(content)
+                    .markdownTheme(.gitHub)
+                    .textSelection(.enabled)
+                    .padding(16)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 100)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .task(id: filePath) {
+            await loadContent()
+        }
+    }
+
+    private func loadContent() async {
+        let fm = FileManager.default
+        if let attrs = try? fm.attributesOfItem(atPath: filePath),
+           let size = attrs[.size] as? UInt64, size > 1_048_576 {
+            loadError = "File too large to preview (\(size / 1024)KB)"
+            return
+        }
+        do {
+            content = try String(contentsOfFile: filePath, encoding: .utf8)
+        } catch {
+            loadError = "Could not read file"
         }
     }
 }

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -11,6 +11,7 @@ struct PanePlaceholder: View {
     @Binding var layout: LayoutNode
     @EnvironmentObject var appState: AppState
     @State private var isHeaderHovering = false
+    @State private var showSourceCode = false
 
     /// Find the Terminal model matching a terminal ID across all worktree terminals.
     private func terminal(for id: UUID) -> Terminal? {
@@ -136,8 +137,16 @@ struct PanePlaceholder: View {
             .buttonStyle(.borderless)
             .disabled(true)
 
-        case .codeViewer:
-            EmptyView()
+        case .codeViewer(_, let path):
+            if isRenderableFile(path) {
+                Button(action: { showSourceCode.toggle() }) {
+                    Image(systemName: "chevron.left.forwardslash.chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(showSourceCode ? .primary : .secondary)
+                }
+                .buttonStyle(.borderless)
+                .help(showSourceCode ? "Show rendered view" : "Show source code")
+            }
         }
     }
 
@@ -151,7 +160,7 @@ struct PanePlaceholder: View {
         case .webview(_, let url):
             WebviewPaneView(url: url)
         case .codeViewer(_, let path):
-            CodeViewerPaneView(path: path, worktreePath: worktree.path)
+            CodeViewerPaneView(path: path, worktreePath: worktree.path, showSourceCode: showSourceCode)
         }
     }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -12,6 +12,7 @@ struct PanePlaceholder: View {
     @EnvironmentObject var appState: AppState
     @State private var isHeaderHovering = false
     @State private var showSourceCode = false
+    @State private var hasRenderableContent = false
 
     /// Find the Terminal model matching a terminal ID across all worktree terminals.
     private func terminal(for id: UUID) -> Terminal? {
@@ -33,6 +34,7 @@ struct PanePlaceholder: View {
             // Pane content
             paneBody
         }
+        .onPreferenceChange(HasRenderableContentKey.self) { hasRenderableContent = $0 }
     }
 
     // MARK: - Toolbar
@@ -138,13 +140,15 @@ struct PanePlaceholder: View {
             .disabled(true)
 
         case .codeViewer:
-            Button(action: { showSourceCode.toggle() }) {
-                Image(systemName: "chevron.left.forwardslash.chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(showSourceCode ? .primary : .secondary)
+            if hasRenderableContent {
+                Button(action: { showSourceCode.toggle() }) {
+                    Image(systemName: "chevron.left.forwardslash.chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(showSourceCode ? .primary : .secondary)
+                }
+                .buttonStyle(.borderless)
+                .help(showSourceCode ? "Show rendered view" : "Show source code")
             }
-            .buttonStyle(.borderless)
-            .help(showSourceCode ? "Show rendered view" : "Show source code")
         }
     }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -137,16 +137,14 @@ struct PanePlaceholder: View {
             .buttonStyle(.borderless)
             .disabled(true)
 
-        case .codeViewer(_, let path):
-            if isRenderableFile(path) {
-                Button(action: { showSourceCode.toggle() }) {
-                    Image(systemName: "chevron.left.forwardslash.chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(showSourceCode ? .primary : .secondary)
-                }
-                .buttonStyle(.borderless)
-                .help(showSourceCode ? "Show rendered view" : "Show source code")
+        case .codeViewer:
+            Button(action: { showSourceCode.toggle() }) {
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(showSourceCode ? .primary : .secondary)
             }
+            .buttonStyle(.borderless)
+            .help(showSourceCode ? "Show rendered view" : "Show source code")
         }
     }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -34,7 +34,12 @@ struct PanePlaceholder: View {
             // Pane content
             paneBody
         }
-        .onPreferenceChange(HasRenderableContentKey.self) { hasRenderableContent = $0 }
+        .onPreferenceChange(HasRenderableContentKey.self) { newValue in
+            if newValue && !hasRenderableContent {
+                showSourceCode = false
+            }
+            hasRenderableContent = newValue
+        }
     }
 
     // MARK: - Toolbar


### PR DESCRIPTION
## Summary
- Add **MarkdownUI** dependency for rich markdown rendering in the code viewer pane
- Markdown files (`.md`, `.markdown`) now render as formatted content by default instead of syntax-highlighted source
- A `</>` toggle button in the pane header switches between rendered and raw source views
- Toggle visibility dynamically tracks the current file selection via a `PreferenceKey`, so it only appears when viewing renderable files
- The toggle is designed generically to support future renderable formats (SVG, mermaid diagrams, etc.)

## Test plan
- [ ] Open a `.md` file in the code viewer — should render as formatted markdown
- [ ] Click the `</>` toggle — should switch to raw source code view
- [ ] Click again — should return to rendered markdown
- [ ] Open a `.swift` file — toggle button should not appear
- [ ] With sidebar enabled, navigate from a `.md` to a `.swift` file — toggle should disappear
- [ ] Navigate back to a `.md` file — toggle should reappear
- [ ] Verify dark mode rendering looks correct (light text on dark background)