### PR TITLE
Feat: Add conductor pattern for meta-agent orchestration of Claude terminals

### DIFF
--- a/.claude/skills/tbd-project/references/architecture.md
+++ b/.claude/skills/tbd-project/references/architecture.md
@@ -39,15 +39,19 @@ Stateless. Connects to daemon socket, sends RPC, prints result, exits.
 
 ## Data Model (SQLite)
 
-Four tables: `repo`, `worktree`, `terminal`, `notification`. See `Sources/TBDShared/Models.swift` for struct definitions and `Sources/TBDDaemon/Database/` for GRDB record types.
+Five tables: `repo`, `worktree`, `terminal`, `notification`, `conductor`. See `Sources/TBDShared/Models.swift` and `Sources/TBDShared/ConductorModels.swift` for struct definitions and `Sources/TBDDaemon/Database/` + `Sources/TBDDaemon/Conductor/` for GRDB record types.
 
 ### Migrations
 - **v1** — initial schema: repo, worktree, terminal, notification tables
 - **v2** — adds `gitStatus` column to worktree (defaults to "current")
 - **v3** — adds `hasConflicts` bool column to worktree (defaults to false), replacing the gitStatus enum
+- **v4-v8** — adds pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, archivedClaudeSessions columns
+- **v9** — adds `conductor` table + synthetic "Conductors" pseudo-repo (well-known UUID)
 
 ### Key model types
-- `WorktreeStatus`: `.active`, `.archived`, `.main`, `.creating`
+- `WorktreeStatus`: `.active`, `.archived`, `.main`, `.creating`, `.conductor`
+- `Conductor`: meta-agent session with scoped repos, permissions (`.observe`/`.observeAndInteract`), heartbeat config
+- `ConductorPermission`: enum — `.observe` (read-only) or `.observeAndInteract` (can send to terminals)
 - `Worktree.hasConflicts`: bool indicating merge-tree conflict detection against main
 - `PRStatus`: open/merged/closed state + `PRMergeableState` (mergeable/conflicting/unknown)
 - `PaneContent`: `.terminal(terminalID:)`, `.webview(url:)`, `.codeViewer(filePath:)`
@@ -126,4 +130,4 @@ Environment variables: `TBD_REPO_PATH`, `TBD_WORKTREE_PATH`, `TBD_WORKTREE_NAME`
 
 JSON-RPC style over Unix socket (newline-delimited) and HTTP POST `/rpc`.
 
-Methods: `repo.add`, `repo.remove`, `repo.list`, `worktree.create`, `worktree.list`, `worktree.archive`, `worktree.revive`, `worktree.rename`, `terminal.create`, `terminal.list`, `terminal.send`, `terminal.delete`, `notify`, `daemon.status`, `state.subscribe`, `resolve.path`, `notifications.list`, `notifications.markRead`, `pr.list`, `pr.refresh`, `cleanup`
+Methods: `repo.add`, `repo.remove`, `repo.list`, `worktree.create`, `worktree.list`, `worktree.archive`, `worktree.revive`, `worktree.rename`, `terminal.create`, `terminal.list`, `terminal.send`, `terminal.delete`, `terminal.output`, `notify`, `daemon.status`, `state.subscribe`, `resolve.path`, `notifications.list`, `notifications.markRead`, `pr.list`, `pr.refresh`, `cleanup`, `conductor.setup`, `conductor.start`, `conductor.stop`, `conductor.teardown`, `conductor.list`, `conductor.status`

--- a/.claude/skills/tbd-project/references/file-map.md
+++ b/.claude/skills/tbd-project/references/file-map.md
@@ -6,7 +6,8 @@ Key source files and what they do.
 - `Package.swift` — SPM manifest. Targets: TBDShared, TBDDaemonLib, TBDDaemon, TBDCLI, TBDApp
 
 ## Sources/TBDShared/
-- `Constants.swift` — paths (~/.tbd/), version string, socket path
+- `Constants.swift` — paths (~/.tbd/), version string, socket path, conductor constants
+- `ConductorModels.swift` — Conductor struct, ConductorPermission enum
 - `Models.swift` — Repo, Worktree (with hasConflicts bool), Terminal, TBDNotification, NotificationType, WorktreeStatus (.active/.archived/.main/.creating), PRStatus, PRMergeableState
 - `RPCProtocol.swift` — RPCRequest/Response, all param/result structs, RPCMethod constants
 - `NameGenerator.swift` — YYYYMMDD-adjective-animal name generation
@@ -16,8 +17,12 @@ Key source files and what they do.
 
 ## Sources/TBDDaemon/ (TBDDaemonLib target)
 
+### Conductor/
+- `ConductorStore.swift` — GRDB store for conductor table (CRUD, updateTerminalID, updateWorktreeID)
+- `ConductorManager.swift` — Conductor lifecycle: setup (directory + synthetic worktree + DB + CLAUDE.md), start (tmux window), stop, teardown. Name validation, interact conflict check, template generation.
+
 ### Database/
-- `Database.swift` — TBDDatabase class, GRDB setup, WAL mode, migrations (v1: schema, v2: gitStatus column, v3: hasConflicts bool replacing gitStatus)
+- `Database.swift` — TBDDatabase class, GRDB setup, WAL mode, migrations (v1: schema, v2: gitStatus column, v3: hasConflicts bool replacing gitStatus, ..., v9: conductor table + synthetic repo)
 - `RepoStore.swift` — Repo CRUD
 - `WorktreeStore.swift` — Worktree CRUD (archive, revive, rename, findByPath, updateHasConflicts, updateTmuxServer)
 - `TerminalStore.swift` — Terminal CRUD (list supports optional worktreeID filter for batch fetching)
@@ -48,7 +53,8 @@ Key source files and what they do.
 - `RPCRouter.swift` — maps RPC method names to handler functions (dispatch switch)
 - `RPCRouter+RepoHandlers.swift` — repo.add, repo.remove, repo.list handlers
 - `RPCRouter+WorktreeHandlers.swift` — worktree.create, worktree.list, worktree.archive, worktree.revive, worktree.rename handlers
-- `RPCRouter+TerminalHandlers.swift` — terminal.create, terminal.list, terminal.send, terminal.delete, notify, notifications.list, notifications.markRead, cleanup, daemon.status, resolve.path, pr.refresh handlers
+- `RPCRouter+TerminalHandlers.swift` — terminal.create, terminal.list, terminal.send, terminal.delete, terminal.output, notify, notifications.list, notifications.markRead, cleanup, daemon.status, resolve.path, pr.refresh handlers
+- `RPCRouter+ConductorHandlers.swift` — conductor.setup, conductor.start, conductor.stop, conductor.teardown, conductor.list, conductor.status handlers
 - `SocketServer.swift` — Unix domain socket server (NIO)
 - `HTTPServer.swift` — HTTP server on localhost (NIO + NIOHTTP1)
 - `StateSubscription.swift` — StateDelta events (worktreeConflictsChanged, etc.) + StateSubscriptionManager for streaming deltas to clients
@@ -65,7 +71,8 @@ Key source files and what they do.
 - `Utilities.swift` — printJSON, resolvePath helpers
 - `Commands/RepoCommands.swift` — tbd repo add/remove/list
 - `Commands/WorktreeCommands.swift` — tbd worktree create/list/archive/revive/rename
-- `Commands/TerminalCommands.swift` — tbd terminal create/list/send
+- `Commands/TerminalCommands.swift` — tbd terminal create/list/send/output
+- `Commands/ConductorCommands.swift` — tbd conductor setup/start/stop/teardown/list/status
 - `Commands/NotifyCommand.swift` — tbd notify (auto-resolves worktree from PWD)
 - `Commands/DaemonCommands.swift` — tbd daemon status
 - `Commands/SetupHooksCommand.swift` — tbd setup-hooks --global/--repo
@@ -118,6 +125,8 @@ Key source files and what they do.
 - `Tests/TBDDaemonTests/SSHAgentResolverTests.swift` — SSH agent resolution tests
 - `Tests/TBDDaemonTests/TmuxManagerTests.swift` — tmux manager tests
 - `Tests/TBDDaemonTests/WorktreeLifecycleTests.swift` — lifecycle orchestration tests
+- `Tests/TBDDaemonTests/ConductorStoreTests.swift` — conductor DB store tests
+- `Tests/TBDDaemonTests/ConductorManagerTests.swift` — conductor lifecycle tests
 - `Tests/TBDAppTests/LayoutNodeTests.swift` — layout node tree tests
 - `Tests/TBDAppTests/PaneContentTests.swift` — pane content encoding/decoding tests
 - `Tests/TBDAppTests/PlaceholderTests.swift` — placeholder

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
                 "TBDDaemonLib",
             ],
             path: "Sources/TBDDaemon",
-            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Daemon.swift", "PIDFile.swift"],
+            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Conductor", "Daemon.swift", "PIDFile.swift"],
             sources: ["main.swift"]
         ),
         .executableTarget(

--- a/Sources/TBDCLI/Commands/ConductorCommands.swift
+++ b/Sources/TBDCLI/Commands/ConductorCommands.swift
@@ -1,0 +1,228 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct ConductorCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "conductor",
+        abstract: "Manage conductors",
+        subcommands: [
+            ConductorSetup.self,
+            ConductorStart.self,
+            ConductorStop.self,
+            ConductorTeardown.self,
+            ConductorListCmd.self,
+            ConductorStatusCmd.self,
+        ]
+    )
+}
+
+// MARK: - conductor setup
+
+struct ConductorSetup: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "setup",
+        abstract: "Create a new conductor"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    @Option(name: .long, help: "Comma-separated repo IDs (default: all)")
+    var repos: String?
+
+    @Option(name: .long, help: "Comma-separated worktree name patterns")
+    var worktrees: String?
+
+    @Option(name: .long, help: "Comma-separated terminal labels to monitor")
+    var terminalLabels: String?
+
+    @Option(name: .long, help: "Heartbeat interval in minutes (default: 10, 0 = disabled)")
+    var heartbeat: Int?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let reposList = repos?.split(separator: ",").map(String.init)
+        let worktreesList = worktrees?.split(separator: ",").map(String.init)
+        let labelsList = terminalLabels?.split(separator: ",").map(String.init)
+
+        let conductor: Conductor = try client.call(
+            method: RPCMethod.conductorSetup,
+            params: ConductorSetupParams(
+                name: name,
+                repos: reposList,
+                worktrees: worktreesList,
+                terminalLabels: labelsList,
+                heartbeatIntervalMinutes: heartbeat
+            ),
+            resultType: Conductor.self
+        )
+
+        if json {
+            printJSON(conductor)
+        } else {
+            print("Created conductor: \(conductor.name)")
+            print("  ID:          \(conductor.id)")
+            print("  Repos:       \(conductor.repos.joined(separator: ", "))")
+            print("  Heartbeat:   \(conductor.heartbeatIntervalMinutes)m")
+        }
+    }
+}
+
+// MARK: - conductor start
+
+struct ConductorStart: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "start",
+        abstract: "Start a conductor session"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let terminal: Terminal = try client.call(
+            method: RPCMethod.conductorStart,
+            params: ConductorNameParams(name: name),
+            resultType: Terminal.self
+        )
+
+        if json {
+            printJSON(terminal)
+        } else {
+            print("Started conductor: \(name)")
+            print("  Terminal: \(terminal.id)")
+            print("  Window:   \(terminal.tmuxWindowID)")
+        }
+    }
+}
+
+// MARK: - conductor stop
+
+struct ConductorStop: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "stop",
+        abstract: "Stop a conductor session"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.conductorStop,
+            params: ConductorNameParams(name: name)
+        )
+        print("Stopped conductor: \(name)")
+    }
+}
+
+// MARK: - conductor teardown
+
+struct ConductorTeardown: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "teardown",
+        abstract: "Remove a conductor completely"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.conductorTeardown,
+            params: ConductorNameParams(name: name)
+        )
+        print("Removed conductor: \(name)")
+    }
+}
+
+// MARK: - conductor list
+
+struct ConductorListCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List all conductors"
+    )
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let result: ConductorListResult = try client.call(
+            method: RPCMethod.conductorList,
+            params: EmptyParams(),
+            resultType: ConductorListResult.self
+        )
+
+        if json {
+            printJSON(result.conductors)
+        } else {
+            if result.conductors.isEmpty {
+                print("No conductors configured.")
+                return
+            }
+            let header = String(format: "%-20s  %-20s  %s", "NAME", "REPOS", "HEARTBEAT")
+            print(header)
+            print(String(repeating: "-", count: 55))
+            for c in result.conductors {
+                let reposStr = c.repos.contains("*") ? "*" : c.repos.joined(separator: ",")
+                let line = String(format: "%-20s  %-20s  %dm",
+                    c.name as NSString,
+                    String(reposStr.prefix(20)) as NSString,
+                    c.heartbeatIntervalMinutes)
+                print(line)
+            }
+        }
+    }
+}
+
+// MARK: - conductor status
+
+struct ConductorStatusCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show conductor status"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let result: ConductorStatusResult = try client.call(
+            method: RPCMethod.conductorStatus,
+            params: ConductorNameParams(name: name),
+            resultType: ConductorStatusResult.self
+        )
+
+        if json {
+            printJSON(result)
+        } else {
+            let c = result.conductor
+            print("Conductor: \(c.name)")
+            print("  ID:          \(c.id)")
+            print("  Running:     \(result.isRunning)")
+            print("  Repos:       \(c.repos.joined(separator: ", "))")
+            print("  Heartbeat:   \(c.heartbeatIntervalMinutes)m")
+            if let wt = c.worktrees { print("  Worktrees:   \(wt.joined(separator: ", "))") }
+            if let labels = c.terminalLabels { print("  Labels:      \(labels.joined(separator: ", "))") }
+        }
+    }
+}
+
+// Empty params for list endpoints
+private struct EmptyParams: Codable {}

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -6,7 +6,7 @@ struct TerminalCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "terminal",
         abstract: "Manage terminals",
-        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self]
+        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalOutput.self, TerminalConversation.self]
     )
 }
 
@@ -126,6 +126,92 @@ struct TerminalSend: AsyncParsableCommand {
             printJSON(["status": "sent"])
         } else {
             print("Text sent.")
+        }
+    }
+}
+
+// MARK: - terminal output
+
+struct TerminalOutput: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "output",
+        abstract: "Capture terminal output"
+    )
+
+    @Argument(help: "Terminal ID")
+    var terminal: String
+
+    @Option(name: .long, help: "Number of lines to capture (default 50)")
+    var lines: Int?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        guard let terminalID = UUID(uuidString: terminal) else {
+            throw CLIError.invalidArgument("Invalid terminal ID: \(terminal)")
+        }
+
+        let client = SocketClient()
+        let result: TerminalOutputResult = try client.call(
+            method: RPCMethod.terminalOutput,
+            params: TerminalOutputParams(terminalID: terminalID, lines: lines),
+            resultType: TerminalOutputResult.self
+        )
+
+        if json {
+            printJSON(result)
+        } else {
+            print(result.output)
+        }
+    }
+}
+
+// MARK: - terminal conversation
+
+struct TerminalConversation: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "conversation",
+        abstract: "Read Claude conversation messages from a terminal"
+    )
+
+    @Argument(help: "Terminal ID")
+    var terminal: String
+
+    @Option(name: .long, help: "Number of messages to return (default 1)")
+    var messages: Int?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        guard let terminalID = UUID(uuidString: terminal) else {
+            throw CLIError.invalidArgument("Invalid terminal ID: \(terminal)")
+        }
+
+        let client = SocketClient()
+        let result: TerminalConversationResult = try client.call(
+            method: RPCMethod.terminalConversation,
+            params: TerminalConversationParams(terminalID: terminalID, messages: messages),
+            resultType: TerminalConversationResult.self
+        )
+
+        if json {
+            printJSON(result)
+        } else {
+            if let sid = result.sessionID {
+                print("Session: \(sid)")
+                print()
+            }
+            if result.messages.isEmpty {
+                print("No messages found.")
+            } else {
+                for msg in result.messages {
+                    print("[\(msg.role)]")
+                    print(msg.content)
+                    print()
+                }
+            }
         }
     }
 }

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -11,6 +11,7 @@ struct TBDCommand: AsyncParsableCommand {
             RepoCommand.self,
             WorktreeCommand.self,
             TerminalCommand.self,
+            ConductorCommand.self,
             NotifyCommand.self,
             DaemonCommand.self,
             SetupHooksCommand.self,

--- a/Sources/TBDDaemon/Conductor/ConductorManager.swift
+++ b/Sources/TBDDaemon/Conductor/ConductorManager.swift
@@ -1,0 +1,320 @@
+import Foundation
+import TBDShared
+
+public final class ConductorManager: Sendable {
+    let db: TBDDatabase
+    let tmux: TmuxManager
+
+    public init(db: TBDDatabase, tmux: TmuxManager) {
+        self.db = db
+        self.tmux = tmux
+    }
+
+    // MARK: - Setup
+
+    nonisolated(unsafe) static let nameRegex = try! Regex(#"^[a-zA-Z0-9][a-zA-Z0-9_-]*$"#)
+
+    public func setup(
+        name: String,
+        repos: [String] = ["*"],
+        worktrees: [String]? = nil,
+        terminalLabels: [String]? = nil,
+        heartbeatIntervalMinutes: Int = 10
+    ) async throws -> Conductor {
+        // Validate name: alphanumeric start, then alphanumeric/underscore/hyphen, max 64 chars
+        guard !name.isEmpty, name.count <= 64, (try? Self.nameRegex.wholeMatch(in: name)) != nil else {
+            throw ConductorError.invalidName(name)
+        }
+
+        // Create config directory + synthetic worktree — clean up directory if worktree creation fails
+        let conductorDir = TBDConstants.conductorsDir.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: conductorDir, withIntermediateDirectories: true)
+
+        let syntheticWorktree: Worktree
+        do {
+            syntheticWorktree = try await db.worktrees.create(
+                repoID: TBDConstants.conductorsRepoID,
+                name: "conductor-\(name)",
+                branch: "conductor",
+                path: conductorDir.path,
+                tmuxServer: TBDConstants.conductorsTmuxServer,
+                status: .conductor
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: conductorDir)
+            throw error
+        }
+
+        // Create conductor DB row — if this fails (e.g. duplicate name), clean up
+        let conductor: Conductor
+        do {
+            var c = try await db.conductors.create(
+                name: name,
+                repos: repos,
+                worktrees: worktrees,
+                terminalLabels: terminalLabels,
+                heartbeatIntervalMinutes: heartbeatIntervalMinutes
+            )
+            c.worktreeID = syntheticWorktree.id
+            try await db.conductors.updateWorktreeID(conductorID: c.id, worktreeID: syntheticWorktree.id)
+            conductor = c
+        } catch {
+            // Rollback: remove synthetic worktree and directory
+            try? await db.worktrees.delete(id: syntheticWorktree.id)
+            try? FileManager.default.removeItem(at: conductorDir)
+            throw error
+        }
+
+        // Write CLAUDE.md template — rollback on failure
+        do {
+            let template = Self.generateTemplate(name: name, repos: repos)
+            let claudePath = conductorDir.appendingPathComponent("CLAUDE.md")
+            try template.write(to: claudePath, atomically: true, encoding: .utf8)
+        } catch {
+            try? await db.conductors.delete(id: conductor.id)
+            if let wid = conductor.worktreeID { try? await db.worktrees.delete(id: wid) }
+            try? FileManager.default.removeItem(at: conductorDir)
+            throw error
+        }
+
+        return conductor
+    }
+
+    // MARK: - Start
+
+    public func start(name: String) async throws -> Terminal {
+        guard let conductor = try await db.conductors.get(name: name) else {
+            throw ConductorError.notFound(name: name)
+        }
+        guard let worktreeID = conductor.worktreeID else {
+            throw ConductorError.noWorktree(name: name)
+        }
+
+        // Guard against double-start: if terminalID is set, check if it's actually alive
+        if let existingTerminalID = conductor.terminalID,
+           let existingTerminal = try await db.terminals.get(id: existingTerminalID) {
+            let alive = await tmux.windowExists(
+                server: TBDConstants.conductorsTmuxServer,
+                windowID: existingTerminal.tmuxWindowID
+            )
+            if alive {
+                throw ConductorError.alreadyRunning(name: name)
+            }
+            // Window is dead — clean up stale terminal record
+            try await db.terminals.delete(id: existingTerminalID)
+            try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: nil)
+        }
+
+        let conductorDir = TBDConstants.conductorsDir.appendingPathComponent(name)
+        let shellCommand = "claude --dangerously-skip-permissions"
+
+        try await tmux.ensureServer(
+            server: TBDConstants.conductorsTmuxServer,
+            session: "main",
+            cwd: conductorDir.path
+        )
+
+        let window = try await tmux.createWindow(
+            server: TBDConstants.conductorsTmuxServer,
+            session: "main",
+            cwd: conductorDir.path,
+            shellCommand: shellCommand
+        )
+
+        let terminal = try await db.terminals.create(
+            worktreeID: worktreeID,
+            tmuxWindowID: window.windowID,
+            tmuxPaneID: window.paneID,
+            label: "conductor:\(name)"
+        )
+
+        try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: terminal.id)
+
+        return terminal
+    }
+
+    // MARK: - Stop
+
+    public func stop(name: String) async throws {
+        guard let conductor = try await db.conductors.get(name: name) else {
+            throw ConductorError.notFound(name: name)
+        }
+
+        if let terminalID = conductor.terminalID,
+           let terminal = try await db.terminals.get(id: terminalID) {
+            try? await tmux.killWindow(
+                server: TBDConstants.conductorsTmuxServer,
+                windowID: terminal.tmuxWindowID
+            )
+            try await db.terminals.delete(id: terminalID)
+        }
+
+        try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: nil)
+    }
+
+    // MARK: - Teardown
+
+    public func teardown(name: String) async throws {
+        // Stop first (kills window + deletes terminal)
+        try await stop(name: name)
+
+        guard let conductor = try await db.conductors.get(name: name) else {
+            throw ConductorError.notFound(name: name)
+        }
+
+        // Delete synthetic worktree
+        if let worktreeID = conductor.worktreeID {
+            try await db.worktrees.delete(id: worktreeID)
+        }
+
+        // Delete conductor DB row
+        try await db.conductors.delete(id: conductor.id)
+
+        // Remove directory
+        let conductorDir = TBDConstants.conductorsDir.appendingPathComponent(name)
+        try? FileManager.default.removeItem(at: conductorDir)
+    }
+
+    // MARK: - Template
+
+    public static func generateTemplate(
+        name: String,
+        repos: [String],
+        worktrees: [String]? = nil,
+        terminalLabels: [String]? = nil
+    ) -> String {
+        let repoDisplay = repos.contains("*") ? "All repos" : repos.joined(separator: ", ")
+        let worktreeDisplay = worktrees?.joined(separator: ", ") ?? "All worktrees"
+        let labelDisplay = terminalLabels?.joined(separator: ", ") ?? "All terminals"
+
+        return """
+        # Conductor: \(name)
+
+        You are a conductor — a persistent Claude Code session that monitors and
+        orchestrates other Claude terminals managed by TBD.
+
+        ## Your Scope
+        - Repos: \(repoDisplay)
+        - Worktrees: \(worktreeDisplay)
+        - Terminal labels: \(labelDisplay)
+
+        ## Startup Checklist
+
+        Run this when you first start, after a restart, or after context compaction:
+        1. Read `./state.json` if it exists (restore context from previous session)
+        2. Run `tbd worktree list --json` to see active worktrees
+        3. Run `tbd terminal list --json` to discover terminal IDs
+        4. Run `tbd conductor status \(name) --json` to verify your scope
+        5. Log startup in `./task-log.md`
+        6. Output: "Conductor \(name) online. N terminals found across M worktrees."
+
+        ## How You Work (Manual Polling)
+
+        You must actively poll terminals to check on them:
+
+        1. Run `tbd worktree list --json` to get worktree names/IDs
+        2. For each worktree, run `tbd terminal list <worktree-name> --json` to get terminal IDs
+        3. For each terminal of interest, run `tbd terminal output <id> --lines 50`
+        4. Review the output — is the agent waiting for input?
+        5. If waiting: decide to auto-respond or escalate
+        6. If running: leave it alone
+
+        ## Core Rules
+
+        1. **Never send to running terminals.** Only respond to terminals that are
+           waiting for input (look for the ❯ prompt with no "esc to interrupt" indicator).
+        2. **When unsure, escalate.** The cost of a false escalation (user gets a notification)
+           is much lower than a wrong auto-response (agent goes off track).
+        3. **Log everything.** Every action goes in `./task-log.md`.
+        4. **Keep responses SHORT.** Status updates: 1-3 sentences. Use bullet points.
+        5. **Don't poll in a loop.** Check when asked or when relevant. If no terminals are
+           active, say so and wait.
+
+        ## CLI Commands
+
+        | Command | Description |
+        |---------|-------------|
+        | `tbd worktree list --json` | List all worktrees with IDs |
+        | `tbd terminal list <worktree> --json` | List terminals in a worktree |
+        | `tbd terminal output <id> --lines 50` | Read last 50 lines of terminal output |
+        | `tbd terminal send --terminal <id> --text "message"` | Send message to a terminal |
+        | `tbd conductor list --json` | List all conductors |
+        | `tbd conductor status \(name) --json` | Your own scope and config |
+        | `tbd notify --type attention_needed "message"` | Escalate to user via macOS notification |
+
+        Terminal IDs are UUIDs. Use the full ID from `tbd terminal list` output.
+
+        ## Terminal States
+
+        When reading terminal output, look for these indicators:
+        - **Waiting for input:** ❯ prompt visible, status bar shows "⏵⏵" or "? for shortcuts"
+        - **Running/busy:** Status bar shows "esc to interrupt" or "to stop agents"
+        - **Idle (no Claude):** Shell prompt (zsh/bash), no Claude process running
+        - **Unknown:** Can't determine — terminal may be dead. Escalate if persistent.
+
+        ## Auto-Response Guidelines
+
+        ### Safe to Auto-Respond
+        - "Should I proceed?" / "Should I continue?" → Yes, if the plan looks reasonable
+        - "Tests passed. What's next?" → Direct to the next logical step
+        - Compilation/lint errors with obvious fixes → Suggest the fix
+        - Questions about project conventions → Answer from context
+
+        ### Always Escalate
+        - Destructive actions (delete, force-push, drop table)
+        - Security issues
+        - Design decisions with multiple valid approaches
+        - Requests for credentials or API keys
+        - "I'm stuck and don't know how to proceed"
+        - Anything you're unsure about
+
+        ## Handling Send Rejections
+
+        If `tbd terminal send` returns an error, the terminal may have transitioned
+        since you last checked. Do NOT retry immediately. Re-read the terminal output
+        to see its current state, then decide what to do.
+
+        ## Escalation
+
+        When escalating, notify the user:
+        ```
+        tbd notify --type attention_needed "worktree-name: brief description"
+        ```
+
+        ## State Management
+
+        Maintain `./state.json` for context across context compactions:
+        ```json
+        {
+          "terminals": {},
+          "last_checked": null,
+          "auto_responses_today": 0,
+          "escalations_today": 0
+        }
+        ```
+
+        Read state.json at the start of each interaction. Update it after taking action.
+
+        ## Task Log
+
+        Append every action to `./task-log.md` with timestamps.
+        """
+    }
+}
+
+public enum ConductorError: Error, LocalizedError {
+    case invalidName(String)
+    case notFound(name: String)
+    case noWorktree(name: String)
+    case alreadyRunning(name: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidName(let name):
+            "Invalid conductor name '\(name)': must start with alphanumeric, contain only [a-zA-Z0-9_-], max 64 chars"
+        case .notFound(let name): "Conductor not found: \(name)"
+        case .alreadyRunning(let name): "Conductor '\(name)' is already running. Stop it first with `tbd conductor stop \(name)`"
+        case .noWorktree(let name): "Conductor has no worktree: \(name)"
+        }
+    }
+}

--- a/Sources/TBDDaemon/Conductor/ConductorStore.swift
+++ b/Sources/TBDDaemon/Conductor/ConductorStore.swift
@@ -1,0 +1,136 @@
+import Foundation
+import GRDB
+import TBDShared
+
+struct ConductorRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "conductor"
+
+    var id: String
+    var name: String
+    var repos: String           // JSON array
+    var worktrees: String?      // JSON array
+    var terminalLabels: String? // JSON array
+    var heartbeatIntervalMinutes: Int
+    var terminalID: String?
+    var worktreeID: String?
+    var createdAt: Date
+
+    init(from conductor: Conductor) {
+        self.id = conductor.id.uuidString
+        self.name = conductor.name
+        self.repos = (try? String(data: JSONEncoder().encode(conductor.repos), encoding: .utf8)) ?? "[\"*\"]"
+        if let wt = conductor.worktrees {
+            self.worktrees = try? String(data: JSONEncoder().encode(wt), encoding: .utf8)
+        }
+        if let labels = conductor.terminalLabels {
+            self.terminalLabels = try? String(data: JSONEncoder().encode(labels), encoding: .utf8)
+        }
+        self.heartbeatIntervalMinutes = conductor.heartbeatIntervalMinutes
+        self.terminalID = conductor.terminalID?.uuidString
+        self.worktreeID = conductor.worktreeID?.uuidString
+        self.createdAt = conductor.createdAt
+    }
+
+    func toModel() -> Conductor {
+        let reposList: [String] = {
+            guard let data = repos.data(using: .utf8) else { return ["*"] }
+            return (try? JSONDecoder().decode([String].self, from: data)) ?? ["*"]
+        }()
+        let worktreesList: [String]? = {
+            guard let json = worktrees, let data = json.data(using: .utf8) else { return nil }
+            return try? JSONDecoder().decode([String].self, from: data)
+        }()
+        let labelsList: [String]? = {
+            guard let json = terminalLabels, let data = json.data(using: .utf8) else { return nil }
+            return try? JSONDecoder().decode([String].self, from: data)
+        }()
+        return Conductor(
+            id: UUID(uuidString: id)!,
+            name: name,
+            repos: reposList,
+            worktrees: worktreesList,
+            terminalLabels: labelsList,
+            heartbeatIntervalMinutes: heartbeatIntervalMinutes,
+            terminalID: terminalID.flatMap { UUID(uuidString: $0) },
+            worktreeID: worktreeID.flatMap { UUID(uuidString: $0) },
+            createdAt: createdAt
+        )
+    }
+}
+
+public struct ConductorStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    public func create(
+        name: String,
+        repos: [String],
+        worktrees: [String]? = nil,
+        terminalLabels: [String]? = nil,
+        heartbeatIntervalMinutes: Int
+    ) async throws -> Conductor {
+        let conductor = Conductor(
+            name: name,
+            repos: repos,
+            worktrees: worktrees,
+            terminalLabels: terminalLabels,
+            heartbeatIntervalMinutes: heartbeatIntervalMinutes
+        )
+        let record = ConductorRecord(from: conductor)
+
+        try await writer.write { db in
+            try record.insert(db)
+        }
+        return conductor
+    }
+
+    public func list() async throws -> [Conductor] {
+        try await writer.read { db in
+            try ConductorRecord.fetchAll(db).map { $0.toModel() }
+        }
+    }
+
+    public func get(name: String) async throws -> Conductor? {
+        try await writer.read { db in
+            try ConductorRecord
+                .filter(Column("name") == name)
+                .fetchOne(db)?
+                .toModel()
+        }
+    }
+
+    public func get(id: UUID) async throws -> Conductor? {
+        try await writer.read { db in
+            try ConductorRecord.fetchOne(db, key: id.uuidString)?.toModel()
+        }
+    }
+
+    public func delete(id: UUID) async throws {
+        _ = try await writer.write { db in
+            try ConductorRecord.deleteOne(db, key: id.uuidString)
+        }
+    }
+
+    public func updateTerminalID(conductorID: UUID, terminalID: UUID?) async throws {
+        try await writer.write { db in
+            guard var record = try ConductorRecord.fetchOne(db, key: conductorID.uuidString) else {
+                throw DatabaseError(message: "Conductor not found")
+            }
+            record.terminalID = terminalID?.uuidString
+            try record.update(db)
+        }
+    }
+
+    public func updateWorktreeID(conductorID: UUID, worktreeID: UUID?) async throws {
+        try await writer.write { db in
+            guard var record = try ConductorRecord.fetchOne(db, key: conductorID.uuidString) else {
+                throw DatabaseError(message: "Conductor not found")
+            }
+            record.worktreeID = worktreeID?.uuidString
+            try record.update(db)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -11,6 +11,7 @@ public final class TBDDatabase: Sendable {
     public let terminals: TerminalStore
     public let notifications: NotificationStore
     public let notes: NoteStore
+    public let conductors: ConductorStore
 
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
     public init(path: String) throws {
@@ -27,6 +28,7 @@ public final class TBDDatabase: Sendable {
         self.terminals = TerminalStore(writer: pool)
         self.notifications = NotificationStore(writer: pool)
         self.notes = NoteStore(writer: pool)
+        self.conductors = ConductorStore(writer: pool)
         try Self.migrate(writer: pool)
     }
 
@@ -40,6 +42,7 @@ public final class TBDDatabase: Sendable {
         self.terminals = TerminalStore(writer: queue)
         self.notifications = NotificationStore(writer: queue)
         self.notes = NoteStore(writer: queue)
+        self.conductors = ConductorStore(writer: queue)
         try Self.migrate(writer: queue)
     }
 
@@ -146,6 +149,36 @@ public final class TBDDatabase: Sendable {
                 t.column("createdAt", .datetime).notNull()
                 t.column("updatedAt", .datetime).notNull()
             }
+        }
+
+        migrator.registerMigration("v10") { db in
+            // Conductor table
+            try db.create(table: "conductor") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("name", .text).notNull().unique()
+                t.column("repos", .text).notNull().defaults(to: "[\"*\"]")
+                t.column("worktrees", .text)
+                t.column("terminalLabels", .text)
+                t.column("heartbeatIntervalMinutes", .integer).notNull().defaults(to: 10)
+                t.column("terminalID", .text)
+                    .references("terminal", onDelete: .setNull)
+                t.column("worktreeID", .text)
+                    .references("worktree", onDelete: .setNull)
+                t.column("createdAt", .datetime).notNull()
+            }
+
+            // Synthetic "conductors" pseudo-repo
+            try db.execute(
+                sql: """
+                INSERT OR IGNORE INTO repo (id, path, displayName, defaultBranch, createdAt)
+                VALUES (?, ?, 'Conductors', 'main', ?)
+                """,
+                arguments: [
+                    TBDConstants.conductorsRepoID.uuidString,
+                    TBDConstants.conductorsDir.path,
+                    Date()
+                ]
+            )
         }
 
         try migrator.migrate(writer)

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -62,10 +62,13 @@ public struct RepoStore: Sendable {
         return repo
     }
 
-    /// List all repos.
+    /// List all repos, excluding the synthetic conductors pseudo-repo.
     public func list() async throws -> [Repo] {
         try await writer.read { db in
-            try RepoRecord.fetchAll(db).map { $0.toModel() }
+            try RepoRecord
+                .filter(Column("id") != TBDConstants.conductorsRepoID.uuidString)
+                .fetchAll(db)
+                .map { $0.toModel() }
         }
     }
 

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -144,6 +144,9 @@ public struct WorktreeStore: Sendable {
             }
             if let status {
                 request = request.filter(Column("status") == status.rawValue)
+            } else {
+                // Exclude conductor worktrees from default listing
+                request = request.filter(Column("status") != WorktreeStatus.conductor.rawValue)
             }
             return try request.fetchAll(db).map { $0.toModel() }
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift
@@ -1,0 +1,55 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+    func handleConductorSetup(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorSetupParams.self, from: paramsData)
+        let conductor = try await conductorManager.setup(
+            name: params.name,
+            repos: params.repos ?? ["*"],
+            worktrees: params.worktrees,
+            terminalLabels: params.terminalLabels,
+            heartbeatIntervalMinutes: params.heartbeatIntervalMinutes ?? 10
+        )
+        return try RPCResponse(result: conductor)
+    }
+
+    func handleConductorStart(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+        let terminal = try await conductorManager.start(name: params.name)
+        return try RPCResponse(result: terminal)
+    }
+
+    func handleConductorStop(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+        try await conductorManager.stop(name: params.name)
+        return .ok()
+    }
+
+    func handleConductorTeardown(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+        try await conductorManager.teardown(name: params.name)
+        return .ok()
+    }
+
+    func handleConductorList() async throws -> RPCResponse {
+        let conductors = try await db.conductors.list()
+        return try RPCResponse(result: ConductorListResult(conductors: conductors))
+    }
+
+    func handleConductorStatus(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+        guard let conductor = try await db.conductors.get(name: params.name) else {
+            return RPCResponse(error: "Conductor not found: \(params.name)")
+        }
+        var isRunning = false
+        if let terminalID = conductor.terminalID,
+           let terminal = try await db.terminals.get(id: terminalID) {
+            isRunning = await tmux.windowExists(
+                server: TBDConstants.conductorsTmuxServer,
+                windowID: terminal.tmuxWindowID
+            )
+        }
+        return try RPCResponse(result: ConductorStatusResult(conductor: conductor, isRunning: isRunning))
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -153,6 +153,116 @@ extension RPCRouter {
         return try RPCResponse(result: updated)
     }
 
+    func handleTerminalOutput(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalOutputParams.self, from: paramsData)
+
+        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+            return RPCResponse(error: "Terminal not found: \(params.terminalID)")
+        }
+
+        guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+            return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
+        }
+
+        let rawOutput = try await tmux.capturePaneOutput(
+            server: worktree.tmuxServer,
+            paneID: terminal.tmuxPaneID
+        )
+
+        let lines = params.lines ?? 50
+        let outputLines = rawOutput.split(separator: "\n", omittingEmptySubsequences: false)
+        let trimmed = outputLines.suffix(lines).joined(separator: "\n")
+
+        return try RPCResponse(result: TerminalOutputResult(output: trimmed))
+    }
+
+    func handleTerminalConversation(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalConversationParams.self, from: paramsData)
+
+        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+            return RPCResponse(error: "Terminal not found: \(params.terminalID)")
+        }
+
+        guard let sessionID = terminal.claudeSessionID else {
+            return RPCResponse(error: "No Claude session ID for terminal \(params.terminalID)")
+        }
+
+        let count = params.messages ?? 1
+        let messages = Self.readSessionMessages(sessionID: sessionID, count: count)
+        return try RPCResponse(result: TerminalConversationResult(messages: messages, sessionID: sessionID))
+    }
+
+    // MARK: - Session JSONL Parsing (Codable)
+
+    private struct SessionEntry: Decodable {
+        let type: String
+        let message: SessionMessage?
+    }
+
+    private struct SessionMessage: Decodable {
+        let role: String?
+        let content: [ContentBlock]?
+    }
+
+    private struct ContentBlock: Decodable {
+        let type: String
+        let text: String?
+    }
+
+    /// Search `~/.claude/projects/` for a session JSONL file matching the given session ID,
+    /// parse it, and return the last N assistant messages with text content.
+    static func readSessionMessages(sessionID: String, count: Int) -> [ConversationMessage] {
+        let claudeDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/projects")
+
+        let fm = FileManager.default
+        guard let projectDirs = try? fm.contentsOfDirectory(atPath: claudeDir.path) else {
+            return []
+        }
+
+        var sessionPath: URL?
+        for dir in projectDirs {
+            let candidate = claudeDir
+                .appendingPathComponent(dir)
+                .appendingPathComponent("\(sessionID).jsonl")
+            if fm.fileExists(atPath: candidate.path) {
+                sessionPath = candidate
+                break
+            }
+        }
+
+        guard let path = sessionPath,
+              let data = fm.contents(atPath: path.path),
+              let content = String(data: data, encoding: .utf8) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        var allMessages: [ConversationMessage] = []
+
+        for line in content.components(separatedBy: "\n") where !line.isEmpty {
+            guard let lineData = line.data(using: .utf8),
+                  let entry = try? decoder.decode(SessionEntry.self, from: lineData) else {
+                continue
+            }
+
+            guard entry.type == "assistant" || entry.type == "user",
+                  let blocks = entry.message?.content else {
+                continue
+            }
+
+            let textParts = blocks.compactMap { $0.type == "text" ? $0.text : nil }
+            if !textParts.isEmpty {
+                allMessages.append(ConversationMessage(
+                    role: entry.type,
+                    content: textParts.joined(separator: "\n")
+                ))
+            }
+        }
+
+        return Array(allMessages.suffix(count))
+    }
+
     func handleTerminalSend(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSendParams.self, from: paramsData)
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -12,6 +12,7 @@ public final class RPCRouter: Sendable {
     public let subscriptions: StateSubscriptionManager
     public let prManager: PRStatusManager
     public let suspendResumeCoordinator: SuspendResumeCoordinator
+    public let conductorManager: ConductorManager
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -23,7 +24,8 @@ public final class RPCRouter: Sendable {
         git: GitManager = GitManager(),
         startTime: Date = Date(),
         subscriptions: StateSubscriptionManager = StateSubscriptionManager(),
-        prManager: PRStatusManager = PRStatusManager()
+        prManager: PRStatusManager = PRStatusManager(),
+        conductorManager: ConductorManager? = nil
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -33,6 +35,7 @@ public final class RPCRouter: Sendable {
         self.subscriptions = subscriptions
         self.prManager = prManager
         self.suspendResumeCoordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
+        self.conductorManager = conductorManager ?? ConductorManager(db: db, tmux: tmux)
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.
@@ -114,6 +117,22 @@ public final class RPCRouter: Sendable {
                 return try await handleNoteDelete(request.paramsData)
             case RPCMethod.noteList:
                 return try await handleNoteList(request.paramsData)
+            case RPCMethod.terminalOutput:
+                return try await handleTerminalOutput(request.paramsData)
+            case RPCMethod.terminalConversation:
+                return try await handleTerminalConversation(request.paramsData)
+            case RPCMethod.conductorSetup:
+                return try await handleConductorSetup(request.paramsData)
+            case RPCMethod.conductorStart:
+                return try await handleConductorStart(request.paramsData)
+            case RPCMethod.conductorStop:
+                return try await handleConductorStop(request.paramsData)
+            case RPCMethod.conductorTeardown:
+                return try await handleConductorTeardown(request.paramsData)
+            case RPCMethod.conductorList:
+                return try await handleConductorList()
+            case RPCMethod.conductorStatus:
+                return try await handleConductorStatus(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDDaemon/Server/StateSubscription.swift
+++ b/Sources/TBDDaemon/Server/StateSubscription.swift
@@ -24,9 +24,10 @@ public struct WorktreeDelta: Codable, Sendable {
     public let repoID: UUID
     public let name: String
     public let path: String
-    public init(worktreeID: UUID, repoID: UUID, name: String, path: String) {
+    public let status: WorktreeStatus?
+    public init(worktreeID: UUID, repoID: UUID, name: String, path: String, status: WorktreeStatus? = nil) {
         self.worktreeID = worktreeID; self.repoID = repoID
-        self.name = name; self.path = path
+        self.name = name; self.path = path; self.status = status
     }
 }
 
@@ -154,6 +155,18 @@ public final class StateSubscriptionManager: @unchecked Sendable {
     /// Encodes the delta as JSON and sends it to each subscriber callback.
     /// Failed encodings are silently ignored.
     public func broadcast(delta: StateDelta) {
+        // Suppress deltas for conductor worktrees/terminals — app doesn't display them
+        switch delta {
+        case .worktreeCreated(let d), .worktreeRevived(let d):
+            if d.status == .conductor { return }
+        case .terminalCreated(let d):
+            if d.label?.hasPrefix("conductor:") == true { return }
+        case .terminalRemoved:
+            break // Can't cheaply check — terminal already deleted. Low impact.
+        default:
+            break
+        }
+
         guard let data = try? JSONEncoder().encode(delta) else { return }
 
         lock.lock()

--- a/Sources/TBDShared/ConductorModels.swift
+++ b/Sources/TBDShared/ConductorModels.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct Conductor: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var name: String
+    public var repos: [String]             // repo IDs or ["*"]
+    public var worktrees: [String]?        // worktree name patterns, nil = all
+    public var terminalLabels: [String]?   // terminal labels to monitor, nil = all
+    public var heartbeatIntervalMinutes: Int
+    public var terminalID: UUID?           // FK to terminal (conductor's own terminal)
+    public var worktreeID: UUID?           // FK to synthetic worktree
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        repos: [String] = ["*"],
+        worktrees: [String]? = nil,
+        terminalLabels: [String]? = nil,
+        heartbeatIntervalMinutes: Int = 10,
+        terminalID: UUID? = nil,
+        worktreeID: UUID? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.repos = repos
+        self.worktrees = worktrees
+        self.terminalLabels = terminalLabels
+        self.heartbeatIntervalMinutes = heartbeatIntervalMinutes
+        self.terminalID = terminalID
+        self.worktreeID = worktreeID
+        self.createdAt = createdAt
+    }
+}

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -8,4 +8,9 @@ public enum TBDConstants {
     public static let databasePath = configDir.appendingPathComponent("state.db").path
     public static let pidFilePath = configDir.appendingPathComponent("tbdd.pid").path
     public static let portFilePath = configDir.appendingPathComponent("port").path
+    public static let conductorsDir = configDir.appendingPathComponent("conductors")
+    public static let conductorsTmuxServer = "tbd-conductor"
+    /// Well-known UUID for the synthetic "conductors" pseudo-repo.
+    /// Inserted by migration v9. Used as repoID for all conductor worktrees.
+    public static let conductorsRepoID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -20,7 +20,7 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
 }
 
 public enum WorktreeStatus: String, Codable, Sendable {
-    case active, archived, main, creating
+    case active, archived, main, creating, conductor
 }
 
 public struct Worktree: Codable, Sendable, Identifiable, Equatable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -109,6 +109,14 @@ public enum RPCMethod {
     public static let noteUpdate = "note.update"
     public static let noteDelete = "note.delete"
     public static let noteList = "note.list"
+    public static let terminalOutput = "terminal.output"
+    public static let conductorSetup = "conductor.setup"
+    public static let conductorStart = "conductor.start"
+    public static let conductorStop = "conductor.stop"
+    public static let conductorTeardown = "conductor.teardown"
+    public static let conductorList = "conductor.list"
+    public static let conductorStatus = "conductor.status"
+    public static let terminalConversation = "terminal.conversation"
 }
 
 public struct NotificationsListResult: Codable, Sendable {
@@ -334,5 +342,81 @@ public struct CleanupResult: Codable, Sendable {
         self.reposProcessed = reposProcessed
         self.worktreesReconciled = worktreesReconciled
         self.errors = errors
+    }
+}
+
+// MARK: - Terminal Output
+
+public struct TerminalOutputParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let lines: Int?
+    public init(terminalID: UUID, lines: Int? = nil) {
+        self.terminalID = terminalID; self.lines = lines
+    }
+}
+
+public struct TerminalOutputResult: Codable, Sendable {
+    public let output: String
+    public init(output: String) { self.output = output }
+}
+
+// MARK: - Conductor
+
+public struct ConductorSetupParams: Codable, Sendable {
+    public let name: String
+    public let repos: [String]?
+    public let worktrees: [String]?
+    public let terminalLabels: [String]?
+    public let heartbeatIntervalMinutes: Int?
+    public init(name: String, repos: [String]? = nil, worktrees: [String]? = nil,
+                terminalLabels: [String]? = nil,
+                heartbeatIntervalMinutes: Int? = nil) {
+        self.name = name; self.repos = repos; self.worktrees = worktrees
+        self.terminalLabels = terminalLabels
+        self.heartbeatIntervalMinutes = heartbeatIntervalMinutes
+    }
+}
+
+public struct ConductorNameParams: Codable, Sendable {
+    public let name: String
+    public init(name: String) { self.name = name }
+}
+
+public struct ConductorListResult: Codable, Sendable {
+    public let conductors: [Conductor]
+    public init(conductors: [Conductor]) { self.conductors = conductors }
+}
+
+public struct ConductorStatusResult: Codable, Sendable {
+    public let conductor: Conductor
+    public let isRunning: Bool
+    public init(conductor: Conductor, isRunning: Bool) {
+        self.conductor = conductor; self.isRunning = isRunning
+    }
+}
+
+// MARK: - Terminal Conversation
+
+public struct TerminalConversationParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let messages: Int?  // number of assistant messages to return, default 1
+    public init(terminalID: UUID, messages: Int? = nil) {
+        self.terminalID = terminalID; self.messages = messages
+    }
+}
+
+public struct TerminalConversationResult: Codable, Sendable {
+    public let messages: [ConversationMessage]
+    public let sessionID: String?
+    public init(messages: [ConversationMessage], sessionID: String? = nil) {
+        self.messages = messages; self.sessionID = sessionID
+    }
+}
+
+public struct ConversationMessage: Codable, Sendable {
+    public let role: String  // "assistant" or "user"
+    public let content: String
+    public init(role: String, content: String) {
+        self.role = role; self.content = content
     }
 }

--- a/Tests/TBDDaemonTests/ConductorManagerTests.swift
+++ b/Tests/TBDDaemonTests/ConductorManagerTests.swift
@@ -1,0 +1,118 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct ConductorManagerTests {
+    func makeDB() throws -> TBDDatabase {
+        try TBDDatabase(inMemory: true)
+    }
+
+    @Test func setupCreatesDirectoryAndDBRow() async throws {
+        let db = try makeDB()
+        let tmux = TmuxManager(dryRun: true)
+        let manager = ConductorManager(db: db, tmux: tmux)
+
+        let conductor = try await manager.setup(
+            name: "test",
+            repos: ["*"],
+            heartbeatIntervalMinutes: 10
+        )
+        #expect(conductor.name == "test")
+
+        // Verify DB row
+        let found = try await db.conductors.get(name: "test")
+        #expect(found != nil)
+
+        // Verify synthetic worktree
+        #expect(conductor.worktreeID != nil)
+        let wt = try await db.worktrees.get(id: conductor.worktreeID!)
+        #expect(wt?.status == .conductor)
+        #expect(wt?.branch == "conductor")
+
+        // Verify directory exists
+        let dirPath = TBDConstants.conductorsDir.appendingPathComponent("test").path
+        #expect(FileManager.default.fileExists(atPath: dirPath))
+
+        // Verify CLAUDE.md exists
+        let claudePath = TBDConstants.conductorsDir
+            .appendingPathComponent("test")
+            .appendingPathComponent("CLAUDE.md").path
+        #expect(FileManager.default.fileExists(atPath: claudePath))
+
+        // Cleanup
+        try? FileManager.default.removeItem(atPath: dirPath)
+    }
+
+    @Test func teardownRemovesEverything() async throws {
+        let db = try makeDB()
+        let tmux = TmuxManager(dryRun: true)
+        let manager = ConductorManager(db: db, tmux: tmux)
+
+        let conductor = try await manager.setup(name: "doomed", repos: ["*"], heartbeatIntervalMinutes: 10)
+        try await manager.teardown(name: "doomed")
+
+        let found = try await db.conductors.get(name: "doomed")
+        #expect(found == nil)
+
+        // Synthetic worktree should be gone
+        let wt = try await db.worktrees.get(id: conductor.worktreeID!)
+        #expect(wt == nil)
+
+        // Directory should be gone
+        let dirPath = TBDConstants.conductorsDir.appendingPathComponent("doomed").path
+        #expect(!FileManager.default.fileExists(atPath: dirPath))
+    }
+
+    @Test func templateContainsConductorName() async throws {
+        let template = ConductorManager.generateTemplate(
+            name: "my-conductor",
+            repos: ["*"]
+        )
+        #expect(template.contains("Conductor: my-conductor"))
+        #expect(template.contains("tbd terminal output"))
+    }
+
+    @Test func invalidNameRejected() async throws {
+        let db = try makeDB()
+        let tmux = TmuxManager(dryRun: true)
+        let manager = ConductorManager(db: db, tmux: tmux)
+
+        // Empty name
+        do {
+            _ = try await manager.setup(name: "")
+            Issue.record("Expected invalid name error")
+        } catch {
+            #expect(error.localizedDescription.contains("Invalid conductor name"))
+        }
+
+        // Name starting with hyphen
+        do {
+            _ = try await manager.setup(name: "-bad")
+            Issue.record("Expected invalid name error")
+        } catch {
+            #expect(error.localizedDescription.contains("Invalid conductor name"))
+        }
+
+        // Name with slash (path traversal)
+        do {
+            _ = try await manager.setup(name: "../escape")
+            Issue.record("Expected invalid name error")
+        } catch {
+            #expect(error.localizedDescription.contains("Invalid conductor name"))
+        }
+
+        // Name too long
+        do {
+            _ = try await manager.setup(name: String(repeating: "a", count: 65))
+            Issue.record("Expected invalid name error")
+        } catch {
+            #expect(error.localizedDescription.contains("Invalid conductor name"))
+        }
+
+        // Valid name should work
+        let conductor = try await manager.setup(name: "valid-Name_123")
+        #expect(conductor.name == "valid-Name_123")
+        try? FileManager.default.removeItem(at: TBDConstants.conductorsDir.appendingPathComponent("valid-Name_123"))
+    }
+}

--- a/Tests/TBDDaemonTests/ConductorStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConductorStoreTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct ConductorStoreTests {
+    func makeDB() throws -> TBDDatabase {
+        try TBDDatabase(inMemory: true)
+    }
+
+    @Test func createAndList() async throws {
+        let db = try makeDB()
+        let conductor = try await db.conductors.create(
+            name: "test",
+            repos: ["*"],
+            heartbeatIntervalMinutes: 10
+        )
+        #expect(conductor.name == "test")
+        #expect(conductor.repos == ["*"])
+
+        let all = try await db.conductors.list()
+        #expect(all.count == 1)
+        #expect(all[0].name == "test")
+    }
+
+    @Test func getByName() async throws {
+        let db = try makeDB()
+        _ = try await db.conductors.create(name: "alpha", repos: ["*"], heartbeatIntervalMinutes: 10)
+        let found = try await db.conductors.get(name: "alpha")
+        #expect(found != nil)
+        #expect(found?.name == "alpha")
+
+        let notFound = try await db.conductors.get(name: "nope")
+        #expect(notFound == nil)
+    }
+
+    @Test func delete() async throws {
+        let db = try makeDB()
+        let conductor = try await db.conductors.create(name: "doomed", repos: ["*"], heartbeatIntervalMinutes: 10)
+        try await db.conductors.delete(id: conductor.id)
+        let all = try await db.conductors.list()
+        #expect(all.isEmpty)
+    }
+
+    @Test func duplicateNameFails() async throws {
+        let db = try makeDB()
+        _ = try await db.conductors.create(name: "unique", repos: ["*"], heartbeatIntervalMinutes: 10)
+        do {
+            _ = try await db.conductors.create(name: "unique", repos: ["*"], heartbeatIntervalMinutes: 10)
+            Issue.record("Expected duplicate name to fail")
+        } catch {
+            // Expected — UNIQUE constraint on name
+        }
+    }
+
+    @Test func syntheticRepoExists() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.get(id: TBDConstants.conductorsRepoID)
+        #expect(repo != nil)
+        #expect(repo?.displayName == "Conductors")
+    }
+
+    @Test func updateTerminalID() async throws {
+        let db = try makeDB()
+
+        // Create a repo and worktree so we can create a real terminal record
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0"
+        )
+
+        let conductor = try await db.conductors.create(name: "test", repos: ["*"], heartbeatIntervalMinutes: 10)
+        try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: terminal.id)
+        let updated = try await db.conductors.get(name: "test")
+        #expect(updated?.terminalID == terminal.id)
+    }
+}

--- a/Tests/TBDDaemonTests/DatabaseTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseTests.swift
@@ -11,12 +11,14 @@ struct DatabaseTests {
 
     @Test func createAndListRepos() async throws {
         let db = try TBDDatabase(inMemory: true)
+        // v9 migration inserts the synthetic "Conductors" pseudo-repo
+        let baseCount = try await db.repos.list().count
         let repo = try await db.repos.create(path: "/tmp/test-repo", displayName: "test", defaultBranch: "main")
         #expect(repo.displayName == "test")
 
         let repos = try await db.repos.list()
-        #expect(repos.count == 1)
-        #expect(repos[0].id == repo.id)
+        #expect(repos.count == baseCount + 1)
+        #expect(repos.contains(where: { $0.id == repo.id }))
     }
 
     @Test func removeRepo() async throws {
@@ -24,7 +26,8 @@ struct DatabaseTests {
         let repo = try await db.repos.create(path: "/tmp/test", displayName: "test", defaultBranch: "main")
         try await db.repos.remove(id: repo.id)
         let repos = try await db.repos.list()
-        #expect(repos.isEmpty)
+        // Synthetic conductor repo is filtered from list, so only real repos remain
+        #expect(!repos.contains(where: { $0.id == repo.id }))
     }
 
     @Test func findRepoByPath() async throws {
@@ -339,6 +342,50 @@ struct DatabaseTests {
 
         let highest = try await db.notifications.highestSeverity(worktreeID: wt.id)
         #expect(highest == .error)
+    }
+
+    // MARK: - Conductor Filtering Tests
+
+    @Test func worktreeListExcludesConductorByDefault() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let repo = try await db.repos.create(path: "/tmp/test-repo-cond", displayName: "Test", defaultBranch: "main")
+
+        // Create a normal worktree
+        _ = try await db.worktrees.create(
+            repoID: repo.id, name: "normal", branch: "main",
+            path: "/tmp/normal", tmuxServer: "test"
+        )
+
+        // Create a conductor worktree
+        _ = try await db.worktrees.create(
+            repoID: TBDConstants.conductorsRepoID,
+            name: "conductor-test", branch: "conductor",
+            path: "/tmp/conductor", tmuxServer: "tbd-conductor",
+            status: .conductor
+        )
+
+        // Default list should exclude conductor
+        let defaultList = try await db.worktrees.list()
+        #expect(defaultList.count == 1)
+        #expect(defaultList[0].name == "normal")
+
+        // Explicit conductor list
+        let conductorList = try await db.worktrees.list(status: .conductor)
+        #expect(conductorList.count == 1)
+        #expect(conductorList[0].name == "conductor-test")
+    }
+
+    @Test func repoListExcludesSyntheticConductorsRepo() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        // Create a real repo
+        let repo = try await db.repos.create(path: "/tmp/real-repo", displayName: "Real", defaultBranch: "main")
+
+        // Default list should only show real repos, not the synthetic conductors repo
+        let all = try await db.repos.list()
+        #expect(all.count == 1)
+        #expect(all[0].displayName == "Real")
     }
 
     @Test func highestSeverityReturnsNilWhenNoUnread() async throws {

--- a/Tests/TBDDaemonTests/RPCRouterTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTests.swift
@@ -516,6 +516,17 @@ struct RPCRouterTests {
         #expect(resp.error?.contains("Note not found") == true)
     }
 
+    // MARK: - Terminal Output
+
+    @Test("terminal.output returns error when terminal not found")
+    func terminalOutputReturnsError_whenTerminalNotFound() async throws {
+        let params = TerminalOutputParams(terminalID: UUID())
+        let request = try RPCRequest(method: RPCMethod.terminalOutput, params: params)
+        let response = await router.handle(request)
+        #expect(!response.success)
+        #expect(response.error?.contains("Terminal not found") == true)
+    }
+
     // MARK: - Unknown Method
 
     @Test("unknown method returns error")

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -199,6 +199,27 @@ import Testing
     #expect(decoded.connectedClients == 2)
 }
 
+@Test func conductorStatusRoundTrips() throws {
+    let status = WorktreeStatus.conductor
+    let data = try JSONEncoder().encode(status)
+    let decoded = try JSONDecoder().decode(WorktreeStatus.self, from: data)
+    #expect(decoded == .conductor)
+}
+
+@Test func conductorModelRoundTrips() throws {
+    let conductor = Conductor(
+        id: UUID(),
+        name: "test-conductor",
+        repos: ["*"],
+        heartbeatIntervalMinutes: 10,
+        createdAt: Date()
+    )
+    let data = try JSONEncoder().encode(conductor)
+    let decoded = try JSONDecoder().decode(Conductor.self, from: data)
+    #expect(decoded.name == "test-conductor")
+    #expect(decoded.repos == ["*"])
+}
+
 @Test func testResolvedPathResultRoundTrip() throws {
     let repoID = UUID()
     let result = ResolvedPathResult(repoID: repoID, worktreeID: nil)

--- a/docs/superpowers/plans/2026-04-02-conductor-phase-1a.md
+++ b/docs/superpowers/plans/2026-04-02-conductor-phase-1a.md
@@ -1,0 +1,1728 @@
+# Conductor Phase 1a Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a minimal viable conductor — a Claude Code session that can manually poll and interact with other terminals via `tbd` CLI commands.
+
+**Architecture:** Add `.conductor` WorktreeStatus, a `conductor` DB table, a synthetic "conductors" pseudo-repo, `terminal.output` RPC, conductor lifecycle management (setup/start/stop/teardown), CLI commands, and a CLAUDE.md template. Conductors run in a dedicated `tbd-conductor` tmux server.
+
+**Tech Stack:** Swift 6, GRDB, ArgumentParser, tmux
+
+**Spec:** `docs/superpowers/specs/2026-04-02-conductor-pattern-design.md`
+
+---
+
+### File Map
+
+**Create:**
+- `Sources/TBDShared/ConductorModels.swift` — Conductor model struct + ConductorConfig
+- `Sources/TBDDaemon/Conductor/ConductorStore.swift` — GRDB store for conductor table
+- `Sources/TBDDaemon/Conductor/ConductorManager.swift` — Lifecycle: setup, start, stop, teardown, template generation
+- `Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift` — RPC handlers for conductor.* and terminal.output
+- `Sources/TBDCLI/Commands/ConductorCommands.swift` — CLI commands
+- `Tests/TBDDaemonTests/ConductorStoreTests.swift` — DB store tests
+- `Tests/TBDDaemonTests/ConductorManagerTests.swift` — Lifecycle tests
+
+**Modify:**
+- `Sources/TBDShared/Models.swift` — Add `.conductor` to WorktreeStatus
+- `Sources/TBDShared/RPCProtocol.swift` — Add RPC method constants + param/result structs
+- `Sources/TBDShared/Constants.swift` — Add conductorsDir path
+- `Sources/TBDDaemon/Database/Database.swift` — Add v9 migration (conductor table + synthetic repo)
+- `Sources/TBDDaemon/Server/RPCRouter.swift` — Wire conductor handlers + add ConductorManager dependency
+- `Sources/TBDDaemon/Server/StateSubscription.swift` — Suppress conductor worktree deltas
+- `Sources/TBDDaemon/Daemon.swift` — Initialize ConductorManager
+- `Sources/TBDCLI/TBD.swift` — Register ConductorCommand
+- `Sources/TBDDaemon/Database/WorktreeStore.swift` — Add list filter to exclude .conductor by default
+
+---
+
+### Task 1: Add WorktreeStatus.conductor + Conductor Model
+
+**Files:**
+- Modify: `Sources/TBDShared/Models.swift:22-24`
+- Create: `Sources/TBDShared/ConductorModels.swift`
+- Modify: `Sources/TBDShared/Constants.swift`
+- Test: `Tests/TBDSharedTests/ModelsTests.swift`
+
+- [ ] **Step 1: Write test for new WorktreeStatus case**
+
+```swift
+// In Tests/TBDSharedTests/ModelsTests.swift, add:
+
+@Test func conductorStatusRoundTrips() throws {
+    let status = WorktreeStatus.conductor
+    let data = try JSONEncoder().encode(status)
+    let decoded = try JSONDecoder().decode(WorktreeStatus.self, from: data)
+    #expect(decoded == .conductor)
+}
+
+@Test func conductorModelRoundTrips() throws {
+    let conductor = Conductor(
+        id: UUID(),
+        name: "test-conductor",
+        repos: ["*"],
+        permissions: "observe",
+        heartbeatIntervalMinutes: 10,
+        createdAt: Date()
+    )
+    let data = try JSONEncoder().encode(conductor)
+    let decoded = try JSONDecoder().decode(Conductor.self, from: data)
+    #expect(decoded.name == "test-conductor")
+    #expect(decoded.repos == ["*"])
+    #expect(decoded.permissions == "observe")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --filter conductorStatusRoundTrips 2>&1 | tail -5`
+Expected: Compilation error — `.conductor` not defined
+
+- [ ] **Step 3: Add WorktreeStatus.conductor**
+
+In `Sources/TBDShared/Models.swift:22-24`, change:
+
+```swift
+public enum WorktreeStatus: String, Codable, Sendable {
+    case active, archived, main, creating, conductor
+}
+```
+
+- [ ] **Step 4: Create Conductor model**
+
+Create `Sources/TBDShared/ConductorModels.swift`:
+
+```swift
+import Foundation
+
+public struct Conductor: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var name: String
+    public var repos: [String]             // repo IDs or ["*"]
+    public var worktrees: [String]?        // worktree name patterns, nil = all
+    public var terminalLabels: [String]?   // terminal labels to monitor, nil = all
+    public var permissions: String          // "observe" or "observe+interact"
+    public var heartbeatIntervalMinutes: Int
+    public var terminalID: UUID?           // FK to terminal (conductor's own terminal)
+    public var worktreeID: UUID?           // FK to synthetic worktree
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        repos: [String] = ["*"],
+        worktrees: [String]? = nil,
+        terminalLabels: [String]? = nil,
+        permissions: String = "observe",
+        heartbeatIntervalMinutes: Int = 10,
+        terminalID: UUID? = nil,
+        worktreeID: UUID? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.repos = repos
+        self.worktrees = worktrees
+        self.terminalLabels = terminalLabels
+        self.permissions = permissions
+        self.heartbeatIntervalMinutes = heartbeatIntervalMinutes
+        self.terminalID = terminalID
+        self.worktreeID = worktreeID
+        self.createdAt = createdAt
+    }
+}
+```
+
+- [ ] **Step 5: Add conductorsDir to Constants**
+
+In `Sources/TBDShared/Constants.swift`, add:
+
+```swift
+public static let conductorsDir = configDir.appendingPathComponent("conductors")
+public static let conductorsTmuxServer = "tbd-conductor"
+/// Well-known UUID for the synthetic "conductors" pseudo-repo.
+/// Inserted by migration v9. Used as repoID for all conductor worktrees.
+public static let conductorsRepoID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `swift test --filter "conductorStatusRoundTrips|conductorModelRoundTrips" 2>&1 | tail -5`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/TBDShared/ Tests/TBDSharedTests/
+git commit -m "feat: add WorktreeStatus.conductor and Conductor model"
+```
+
+---
+
+### Task 2: DB Migration v9 — Conductor Table + Synthetic Repo
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Database/Database.swift:134-137`
+- Create: `Sources/TBDDaemon/Conductor/ConductorStore.swift`
+- Test: `Tests/TBDDaemonTests/ConductorStoreTests.swift`
+
+- [ ] **Step 1: Write ConductorStore tests**
+
+Create `Tests/TBDDaemonTests/ConductorStoreTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct ConductorStoreTests {
+    func makeDB() throws -> TBDDatabase {
+        try TBDDatabase(inMemory: true)
+    }
+
+    @Test func createAndList() async throws {
+        let db = try makeDB()
+        let conductor = try await db.conductors.create(
+            name: "test",
+            repos: ["*"],
+            permissions: "observe",
+            heartbeatIntervalMinutes: 10
+        )
+        #expect(conductor.name == "test")
+        #expect(conductor.repos == ["*"])
+
+        let all = try await db.conductors.list()
+        #expect(all.count == 1)
+        #expect(all[0].name == "test")
+    }
+
+    @Test func getByName() async throws {
+        let db = try makeDB()
+        _ = try await db.conductors.create(name: "alpha", repos: ["*"], permissions: "observe", heartbeatIntervalMinutes: 10)
+        let found = try await db.conductors.get(name: "alpha")
+        #expect(found != nil)
+        #expect(found?.name == "alpha")
+
+        let notFound = try await db.conductors.get(name: "nope")
+        #expect(notFound == nil)
+    }
+
+    @Test func delete() async throws {
+        let db = try makeDB()
+        let conductor = try await db.conductors.create(name: "doomed", repos: ["*"], permissions: "observe", heartbeatIntervalMinutes: 10)
+        try await db.conductors.delete(id: conductor.id)
+        let all = try await db.conductors.list()
+        #expect(all.isEmpty)
+    }
+
+    @Test func duplicateNameFails() async throws {
+        let db = try makeDB()
+        _ = try await db.conductors.create(name: "unique", repos: ["*"], permissions: "observe", heartbeatIntervalMinutes: 10)
+        do {
+            _ = try await db.conductors.create(name: "unique", repos: ["*"], permissions: "observe", heartbeatIntervalMinutes: 10)
+            Issue.record("Expected duplicate name to fail")
+        } catch {
+            // Expected — UNIQUE constraint on name
+        }
+    }
+
+    @Test func syntheticRepoExists() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.get(id: TBDConstants.conductorsRepoID)
+        #expect(repo != nil)
+        #expect(repo?.displayName == "Conductors")
+    }
+
+    @Test func updateTerminalID() async throws {
+        let db = try makeDB()
+        let conductor = try await db.conductors.create(name: "test", repos: ["*"], permissions: "observe", heartbeatIntervalMinutes: 10)
+        let termID = UUID()
+        try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: termID)
+        let updated = try await db.conductors.get(name: "test")
+        #expect(updated?.terminalID == termID)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `swift test --filter ConductorStoreTests 2>&1 | tail -5`
+Expected: Compilation error — `db.conductors` doesn't exist
+
+- [ ] **Step 3: Add v9 migration**
+
+In `Sources/TBDDaemon/Database/Database.swift`, before `try migrator.migrate(writer)`:
+
+```swift
+migrator.registerMigration("v9") { db in
+    // Conductor table
+    try db.create(table: "conductor") { t in
+        t.primaryKey("id", .text).notNull()
+        t.column("name", .text).notNull().unique()
+        t.column("repos", .text).notNull().defaults(to: "[\"*\"]")
+        t.column("worktrees", .text)
+        t.column("terminalLabels", .text)
+        t.column("permissions", .text).notNull().defaults(to: "observe")
+        t.column("heartbeatIntervalMinutes", .integer).notNull().defaults(to: 10)
+        t.column("terminalID", .text)
+            .references("terminal", onDelete: .setNull)
+        t.column("worktreeID", .text)
+            .references("worktree", onDelete: .setNull)
+        t.column("createdAt", .datetime).notNull()
+    }
+
+    // Synthetic "conductors" pseudo-repo
+    try db.execute(
+        sql: """
+        INSERT OR IGNORE INTO repo (id, path, displayName, defaultBranch, createdAt)
+        VALUES (?, ?, 'Conductors', 'main', ?)
+        """,
+        arguments: [
+            TBDConstants.conductorsRepoID.uuidString,
+            TBDConstants.conductorsDir.path,
+            Date()
+        ]
+    )
+}
+```
+
+- [ ] **Step 4: Add `conductors` store to TBDDatabase**
+
+In `Sources/TBDDaemon/Database/Database.swift`, add property:
+
+```swift
+public let conductors: ConductorStore
+```
+
+And initialize in both `init(path:)` and `init(inMemory:)`:
+
+```swift
+self.conductors = ConductorStore(writer: pool)  // or queue for inMemory
+```
+
+- [ ] **Step 5: Create ConductorStore**
+
+Create `Sources/TBDDaemon/Conductor/ConductorStore.swift`:
+
+```swift
+import Foundation
+import GRDB
+import TBDShared
+
+struct ConductorRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "conductor"
+
+    var id: String
+    var name: String
+    var repos: String           // JSON array
+    var worktrees: String?      // JSON array
+    var terminalLabels: String? // JSON array
+    var permissions: String
+    var heartbeatIntervalMinutes: Int
+    var terminalID: String?
+    var worktreeID: String?
+    var createdAt: Date
+
+    init(from conductor: Conductor) {
+        self.id = conductor.id.uuidString
+        self.name = conductor.name
+        self.repos = (try? String(data: JSONEncoder().encode(conductor.repos), encoding: .utf8)) ?? "[\"*\"]"
+        if let wt = conductor.worktrees {
+            self.worktrees = try? String(data: JSONEncoder().encode(wt), encoding: .utf8)
+        }
+        if let labels = conductor.terminalLabels {
+            self.terminalLabels = try? String(data: JSONEncoder().encode(labels), encoding: .utf8)
+        }
+        self.permissions = conductor.permissions
+        self.heartbeatIntervalMinutes = conductor.heartbeatIntervalMinutes
+        self.terminalID = conductor.terminalID?.uuidString
+        self.worktreeID = conductor.worktreeID?.uuidString
+        self.createdAt = conductor.createdAt
+    }
+
+    func toModel() -> Conductor {
+        let reposList: [String] = {
+            guard let data = repos.data(using: .utf8) else { return ["*"] }
+            return (try? JSONDecoder().decode([String].self, from: data)) ?? ["*"]
+        }()
+        let worktreesList: [String]? = {
+            guard let json = worktrees, let data = json.data(using: .utf8) else { return nil }
+            return try? JSONDecoder().decode([String].self, from: data)
+        }()
+        let labelsList: [String]? = {
+            guard let json = terminalLabels, let data = json.data(using: .utf8) else { return nil }
+            return try? JSONDecoder().decode([String].self, from: data)
+        }()
+        return Conductor(
+            id: UUID(uuidString: id)!,
+            name: name,
+            repos: reposList,
+            worktrees: worktreesList,
+            terminalLabels: labelsList,
+            permissions: permissions,
+            heartbeatIntervalMinutes: heartbeatIntervalMinutes,
+            terminalID: terminalID.flatMap { UUID(uuidString: $0) },
+            worktreeID: worktreeID.flatMap { UUID(uuidString: $0) },
+            createdAt: createdAt
+        )
+    }
+}
+
+public struct ConductorStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    public func create(
+        name: String,
+        repos: [String],
+        worktrees: [String]? = nil,
+        terminalLabels: [String]? = nil,
+        permissions: String,
+        heartbeatIntervalMinutes: Int
+    ) async throws -> Conductor {
+        let conductor = Conductor(
+            name: name,
+            repos: repos,
+            worktrees: worktrees,
+            terminalLabels: terminalLabels,
+            permissions: permissions,
+            heartbeatIntervalMinutes: heartbeatIntervalMinutes
+        )
+        let record = ConductorRecord(from: conductor)
+        try await writer.write { db in
+            try record.insert(db)
+        }
+        return conductor
+    }
+
+    public func list() async throws -> [Conductor] {
+        try await writer.read { db in
+            try ConductorRecord.fetchAll(db).map { $0.toModel() }
+        }
+    }
+
+    public func get(name: String) async throws -> Conductor? {
+        try await writer.read { db in
+            try ConductorRecord
+                .filter(Column("name") == name)
+                .fetchOne(db)?
+                .toModel()
+        }
+    }
+
+    public func get(id: UUID) async throws -> Conductor? {
+        try await writer.read { db in
+            try ConductorRecord.fetchOne(db, key: id.uuidString)?.toModel()
+        }
+    }
+
+    public func delete(id: UUID) async throws {
+        _ = try await writer.write { db in
+            try ConductorRecord.deleteOne(db, key: id.uuidString)
+        }
+    }
+
+    public func updateTerminalID(conductorID: UUID, terminalID: UUID?) async throws {
+        try await writer.write { db in
+            guard var record = try ConductorRecord.fetchOne(db, key: conductorID.uuidString) else {
+                throw DatabaseError(message: "Conductor not found")
+            }
+            record.terminalID = terminalID?.uuidString
+            try record.update(db)
+        }
+    }
+
+    public func updateWorktreeID(conductorID: UUID, worktreeID: UUID?) async throws {
+        try await writer.write { db in
+            guard var record = try ConductorRecord.fetchOne(db, key: conductorID.uuidString) else {
+                throw DatabaseError(message: "Conductor not found")
+            }
+            record.worktreeID = worktreeID?.uuidString
+            try record.update(db)
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `swift test --filter ConductorStoreTests 2>&1 | tail -10`
+Expected: All 6 tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/TBDDaemon/Database/Database.swift Sources/TBDDaemon/Conductor/
+git add Tests/TBDDaemonTests/ConductorStoreTests.swift
+git commit -m "feat: add conductor DB table, store, and v9 migration"
+```
+
+---
+
+### Task 3: terminal.output RPC + CLI Command
+
+**Files:**
+- Modify: `Sources/TBDShared/RPCProtocol.swift`
+- Modify: `Sources/TBDDaemon/Server/RPCRouter.swift`
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`
+- Modify: `Sources/TBDCLI/Commands/TerminalCommands.swift`
+- Test: `Tests/TBDDaemonTests/RPCRouterTests.swift`
+
+- [ ] **Step 1: Write test for terminal.output handler**
+
+Add to `Tests/TBDDaemonTests/RPCRouterTests.swift`:
+
+```swift
+@Test func terminalOutputReturnsError_whenTerminalNotFound() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let tmux = TmuxManager(dryRun: true)
+    let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+    let router = RPCRouter(db: db, lifecycle: lifecycle, tmux: tmux)
+
+    let params = TerminalOutputParams(terminalID: UUID())
+    let request = try RPCRequest(method: RPCMethod.terminalOutput, params: params)
+    let response = await router.handle(request)
+    #expect(!response.success)
+    #expect(response.error?.contains("Terminal not found") == true)
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `swift test --filter terminalOutputReturnsError 2>&1 | tail -5`
+Expected: Compilation error — `TerminalOutputParams` and `RPCMethod.terminalOutput` don't exist
+
+- [ ] **Step 3: Add RPC protocol types**
+
+In `Sources/TBDShared/RPCProtocol.swift`, add to `RPCMethod`:
+
+```swift
+public static let terminalOutput = "terminal.output"
+public static let conductorSetup = "conductor.setup"
+public static let conductorStart = "conductor.start"
+public static let conductorStop = "conductor.stop"
+public static let conductorTeardown = "conductor.teardown"
+public static let conductorList = "conductor.list"
+public static let conductorStatus = "conductor.status"
+```
+
+Add param/result structs at the end of the file:
+
+```swift
+// MARK: - Terminal Output
+
+public struct TerminalOutputParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let lines: Int?
+    public init(terminalID: UUID, lines: Int? = nil) {
+        self.terminalID = terminalID; self.lines = lines
+    }
+}
+
+public struct TerminalOutputResult: Codable, Sendable {
+    public let output: String
+    public init(output: String) { self.output = output }
+}
+
+// MARK: - Conductor
+
+public struct ConductorSetupParams: Codable, Sendable {
+    public let name: String
+    public let repos: [String]?
+    public let worktrees: [String]?
+    public let terminalLabels: [String]?
+    public let interact: Bool?
+    public let heartbeatIntervalMinutes: Int?
+    public init(name: String, repos: [String]? = nil, worktrees: [String]? = nil,
+                terminalLabels: [String]? = nil, interact: Bool? = nil,
+                heartbeatIntervalMinutes: Int? = nil) {
+        self.name = name; self.repos = repos; self.worktrees = worktrees
+        self.terminalLabels = terminalLabels; self.interact = interact
+        self.heartbeatIntervalMinutes = heartbeatIntervalMinutes
+    }
+}
+
+public struct ConductorNameParams: Codable, Sendable {
+    public let name: String
+    public init(name: String) { self.name = name }
+}
+
+public struct ConductorListResult: Codable, Sendable {
+    public let conductors: [Conductor]
+    public init(conductors: [Conductor]) { self.conductors = conductors }
+}
+
+public struct ConductorStatusResult: Codable, Sendable {
+    public let conductor: Conductor
+    public let isRunning: Bool
+    public init(conductor: Conductor, isRunning: Bool) {
+        self.conductor = conductor; self.isRunning = isRunning
+    }
+}
+```
+
+- [ ] **Step 4: Add terminal.output handler**
+
+In `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`, add:
+
+```swift
+func handleTerminalOutput(_ paramsData: Data) async throws -> RPCResponse {
+    let params = try decoder.decode(TerminalOutputParams.self, from: paramsData)
+
+    guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+        return RPCResponse(error: "Terminal not found: \(params.terminalID)")
+    }
+
+    guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+        return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
+    }
+
+    let rawOutput = try await tmux.capturePaneOutput(
+        server: worktree.tmuxServer,
+        paneID: terminal.tmuxPaneID
+    )
+
+    let lines = params.lines ?? 50
+    let outputLines = rawOutput.split(separator: "\n", omittingEmptySubsequences: false)
+    let trimmed = outputLines.suffix(lines).joined(separator: "\n")
+
+    return try RPCResponse(result: TerminalOutputResult(output: trimmed))
+}
+```
+
+- [ ] **Step 5: Add CLI command**
+
+In `Sources/TBDCLI/Commands/TerminalCommands.swift`, add `TerminalOutput` to subcommands:
+
+```swift
+static let configuration = CommandConfiguration(
+    commandName: "terminal",
+    abstract: "Manage terminals",
+    subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalOutput.self]
+)
+```
+
+Add the command:
+
+```swift
+// MARK: - terminal output
+
+struct TerminalOutput: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "output",
+        abstract: "Capture terminal output"
+    )
+
+    @Argument(help: "Terminal ID")
+    var terminal: String
+
+    @Option(name: .long, help: "Number of lines to capture (default 50)")
+    var lines: Int?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        guard let terminalID = UUID(uuidString: terminal) else {
+            throw CLIError.invalidArgument("Invalid terminal ID: \(terminal)")
+        }
+
+        let client = SocketClient()
+        let result: TerminalOutputResult = try client.call(
+            method: RPCMethod.terminalOutput,
+            params: TerminalOutputParams(terminalID: terminalID, lines: lines),
+            resultType: TerminalOutputResult.self
+        )
+
+        if json {
+            printJSON(result)
+        } else {
+            print(result.output)
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `swift test --filter terminalOutputReturnsError 2>&1 | tail -5`
+Expected: PASS (the handler is wired in Task 5, but the test should compile now)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/TBDShared/RPCProtocol.swift Sources/TBDDaemon/Server/
+git add Sources/TBDCLI/Commands/TerminalCommands.swift
+git commit -m "feat: add terminal.output RPC and CLI command"
+```
+
+---
+
+### Task 4: ConductorManager — Lifecycle + CLAUDE.md Template
+
+**Files:**
+- Create: `Sources/TBDDaemon/Conductor/ConductorManager.swift`
+- Test: `Tests/TBDDaemonTests/ConductorManagerTests.swift`
+
+- [ ] **Step 1: Write tests**
+
+Create `Tests/TBDDaemonTests/ConductorManagerTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct ConductorManagerTests {
+    func makeDB() throws -> TBDDatabase {
+        try TBDDatabase(inMemory: true)
+    }
+
+    @Test func setupCreatesDirectoryAndDBRow() async throws {
+        let db = try makeDB()
+        let tmux = TmuxManager(dryRun: true)
+        let manager = ConductorManager(db: db, tmux: tmux)
+
+        let conductor = try await manager.setup(
+            name: "test",
+            repos: ["*"],
+            interact: false,
+            heartbeatIntervalMinutes: 10
+        )
+        #expect(conductor.name == "test")
+        #expect(conductor.permissions == "observe")
+
+        // Verify DB row
+        let found = try await db.conductors.get(name: "test")
+        #expect(found != nil)
+
+        // Verify synthetic worktree
+        #expect(conductor.worktreeID != nil)
+        let wt = try await db.worktrees.get(id: conductor.worktreeID!)
+        #expect(wt?.status == .conductor)
+        #expect(wt?.branch == "conductor")
+
+        // Verify directory exists
+        let dirPath = TBDConstants.conductorsDir.appendingPathComponent("test").path
+        #expect(FileManager.default.fileExists(atPath: dirPath))
+
+        // Verify CLAUDE.md exists
+        let claudePath = TBDConstants.conductorsDir
+            .appendingPathComponent("test")
+            .appendingPathComponent("CLAUDE.md").path
+        #expect(FileManager.default.fileExists(atPath: claudePath))
+
+        // Cleanup
+        try? FileManager.default.removeItem(atPath: dirPath)
+    }
+
+    @Test func setupInteractConflictFails() async throws {
+        let db = try makeDB()
+        let tmux = TmuxManager(dryRun: true)
+        let manager = ConductorManager(db: db, tmux: tmux)
+
+        _ = try await manager.setup(name: "first", repos: ["*"], interact: true, heartbeatIntervalMinutes: 10)
+        do {
+            _ = try await manager.setup(name: "second", repos: ["*"], interact: true, heartbeatIntervalMinutes: 10)
+            Issue.record("Expected interact conflict")
+        } catch {
+            #expect("\(error)".contains("interact"))
+        }
+
+        // Cleanup
+        let dir1 = TBDConstants.conductorsDir.appendingPathComponent("first").path
+        let dir2 = TBDConstants.conductorsDir.appendingPathComponent("second").path
+        try? FileManager.default.removeItem(atPath: dir1)
+        try? FileManager.default.removeItem(atPath: dir2)
+    }
+
+    @Test func teardownRemovesEverything() async throws {
+        let db = try makeDB()
+        let tmux = TmuxManager(dryRun: true)
+        let manager = ConductorManager(db: db, tmux: tmux)
+
+        let conductor = try await manager.setup(name: "doomed", repos: ["*"], interact: false, heartbeatIntervalMinutes: 10)
+        try await manager.teardown(name: "doomed")
+
+        let found = try await db.conductors.get(name: "doomed")
+        #expect(found == nil)
+
+        // Synthetic worktree should be gone
+        let wt = try await db.worktrees.get(id: conductor.worktreeID!)
+        #expect(wt == nil)
+
+        // Directory should be gone
+        let dirPath = TBDConstants.conductorsDir.appendingPathComponent("doomed").path
+        #expect(!FileManager.default.fileExists(atPath: dirPath))
+    }
+
+    @Test func templateContainsConductorName() async throws {
+        let template = ConductorManager.generateTemplate(
+            name: "my-conductor",
+            repos: ["*"],
+            permissions: "observe+interact"
+        )
+        #expect(template.contains("Conductor: my-conductor"))
+        #expect(template.contains("observe+interact"))
+        #expect(template.contains("tbd terminal output"))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `swift test --filter ConductorManagerTests 2>&1 | tail -5`
+Expected: Compilation error — `ConductorManager` doesn't exist
+
+- [ ] **Step 3: Implement ConductorManager**
+
+Create `Sources/TBDDaemon/Conductor/ConductorManager.swift`:
+
+```swift
+import Foundation
+import TBDShared
+
+public final class ConductorManager: Sendable {
+    let db: TBDDatabase
+    let tmux: TmuxManager
+
+    public init(db: TBDDatabase, tmux: TmuxManager) {
+        self.db = db
+        self.tmux = tmux
+    }
+
+    // MARK: - Setup
+
+    public func setup(
+        name: String,
+        repos: [String] = ["*"],
+        worktrees: [String]? = nil,
+        terminalLabels: [String]? = nil,
+        interact: Bool = false,
+        heartbeatIntervalMinutes: Int = 10
+    ) async throws -> Conductor {
+        let permissions = interact ? "observe+interact" : "observe"
+
+        // Check interact conflict
+        if interact {
+            let existing = try await db.conductors.list()
+            for c in existing where c.permissions == "observe+interact" {
+                let overlap = repos.contains("*") || c.repos.contains("*") ||
+                    !Set(repos).intersection(Set(c.repos)).isEmpty
+                if overlap {
+                    throw ConductorError.interactConflict(existingName: c.name)
+                }
+            }
+        }
+
+        // Create config directory
+        let conductorDir = TBDConstants.conductorsDir.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: conductorDir, withIntermediateDirectories: true)
+
+        // Create synthetic worktree
+        let syntheticWorktree = Worktree(
+            repoID: TBDConstants.conductorsRepoID,
+            name: "conductor-\(name)",
+            displayName: "conductor-\(name)",
+            branch: "conductor",
+            path: conductorDir.path,
+            status: .conductor,
+            tmuxServer: TBDConstants.conductorsTmuxServer
+        )
+        try await db.worktrees.create(syntheticWorktree)
+
+        // Create DB row
+        var conductor = try await db.conductors.create(
+            name: name,
+            repos: repos,
+            worktrees: worktrees,
+            terminalLabels: terminalLabels,
+            permissions: permissions,
+            heartbeatIntervalMinutes: heartbeatIntervalMinutes
+        )
+        conductor.worktreeID = syntheticWorktree.id
+        try await db.conductors.updateWorktreeID(conductorID: conductor.id, worktreeID: syntheticWorktree.id)
+
+        // Write CLAUDE.md
+        let repoDisplay = repos.contains("*") ? "All repos" : repos.joined(separator: ", ")
+        let template = Self.generateTemplate(name: name, repos: repos, permissions: permissions)
+        let claudePath = conductorDir.appendingPathComponent("CLAUDE.md")
+        try template.write(to: claudePath, atomically: true, encoding: .utf8)
+
+        return conductor
+    }
+
+    // MARK: - Start
+
+    public func start(name: String) async throws -> Terminal {
+        guard let conductor = try await db.conductors.get(name: name) else {
+            throw ConductorError.notFound(name: name)
+        }
+        guard let worktreeID = conductor.worktreeID else {
+            throw ConductorError.noWorktree(name: name)
+        }
+
+        let conductorDir = TBDConstants.conductorsDir.appendingPathComponent(name)
+        let shellCommand = "claude --dangerously-skip-permissions"
+
+        try await tmux.ensureServer(
+            server: TBDConstants.conductorsTmuxServer,
+            session: "main",
+            cwd: conductorDir.path
+        )
+
+        let window = try await tmux.createWindow(
+            server: TBDConstants.conductorsTmuxServer,
+            session: "main",
+            cwd: conductorDir.path,
+            shellCommand: shellCommand
+        )
+
+        let terminal = try await db.terminals.create(
+            worktreeID: worktreeID,
+            tmuxWindowID: window.windowID,
+            tmuxPaneID: window.paneID,
+            label: "conductor:\(name)"
+        )
+
+        try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: terminal.id)
+
+        return terminal
+    }
+
+    // MARK: - Stop
+
+    public func stop(name: String) async throws {
+        guard let conductor = try await db.conductors.get(name: name) else {
+            throw ConductorError.notFound(name: name)
+        }
+
+        if let terminalID = conductor.terminalID,
+           let terminal = try await db.terminals.get(id: terminalID) {
+            try? await tmux.killWindow(
+                server: TBDConstants.conductorsTmuxServer,
+                windowID: terminal.tmuxWindowID
+            )
+            try await db.terminals.delete(id: terminalID)
+        }
+
+        try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: nil)
+    }
+
+    // MARK: - Teardown
+
+    public func teardown(name: String) async throws {
+        try await stop(name: name)
+
+        guard let conductor = try await db.conductors.get(name: name) else {
+            throw ConductorError.notFound(name: name)
+        }
+
+        // Delete synthetic worktree (cascades terminal records)
+        if let worktreeID = conductor.worktreeID {
+            try await db.worktrees.delete(id: worktreeID)
+        }
+
+        // Delete conductor DB row
+        try await db.conductors.delete(id: conductor.id)
+
+        // Remove directory
+        let conductorDir = TBDConstants.conductorsDir.appendingPathComponent(name)
+        try? FileManager.default.removeItem(at: conductorDir)
+    }
+
+    // MARK: - Template
+
+    public static func generateTemplate(
+        name: String,
+        repos: [String],
+        worktrees: [String]? = nil,
+        terminalLabels: [String]? = nil,
+        permissions: String = "observe"
+    ) -> String {
+        let repoDisplay = repos.contains("*") ? "All repos" : repos.joined(separator: ", ")
+        let worktreeDisplay = worktrees?.joined(separator: ", ") ?? "All worktrees"
+        let labelDisplay = terminalLabels?.joined(separator: ", ") ?? "All terminals"
+
+        return """
+        # Conductor: \(name)
+
+        You are a conductor — a persistent Claude Code session that monitors and
+        orchestrates other Claude terminals managed by TBD.
+
+        ## Your Scope
+        - Repos: \(repoDisplay)
+        - Worktrees: \(worktreeDisplay)
+        - Terminal labels: \(labelDisplay)
+        - Permissions: \(permissions)
+
+        ## Startup Checklist
+
+        Run this when you first start, after a restart, or after context compaction:
+        1. Read `./state.json` if it exists (restore context from previous session)
+        2. Run `tbd worktree list --json` to see active worktrees
+        3. Run `tbd terminal list --json` to discover terminal IDs
+        4. Run `tbd conductor status \(name) --json` to verify your scope
+        5. Log startup in `./task-log.md`
+        6. Output: "Conductor \(name) online. N terminals found across M worktrees."
+
+        ## How You Work (Manual Polling)
+
+        You must actively poll terminals to check on them:
+
+        1. Run `tbd worktree list --json` to get worktree names/IDs
+        2. For each worktree, run `tbd terminal list <worktree-name> --json` to get terminal IDs
+        3. For each terminal of interest, run `tbd terminal output <id> --lines 50`
+        4. Review the output — is the agent waiting for input?
+        5. If waiting: decide to auto-respond or escalate
+        6. If running: leave it alone
+
+        ## Core Rules
+
+        1. **Never send to running terminals.** Only respond to terminals that are
+           waiting for input (look for the ❯ prompt with no "esc to interrupt" indicator).
+        2. **When unsure, escalate.** The cost of a false escalation (user gets a notification)
+           is much lower than a wrong auto-response (agent goes off track).
+        3. **Log everything.** Every action goes in `./task-log.md`.
+        4. **Keep responses SHORT.** Status updates: 1-3 sentences. Use bullet points.
+        5. **Don't poll in a loop.** Check when asked or when relevant. If no terminals are
+           active, say so and wait.
+
+        ## CLI Commands
+
+        | Command | Description |
+        |---------|-------------|
+        | `tbd worktree list --json` | List all worktrees with IDs |
+        | `tbd terminal list <worktree> --json` | List terminals in a worktree |
+        | `tbd terminal output <id> --lines 50` | Read last 50 lines of terminal output |
+        | `tbd terminal send --terminal <id> --text "message"` | Send message to a terminal |
+        | `tbd conductor list --json` | List all conductors |
+        | `tbd conductor status \(name) --json` | Your own scope and config |
+        | `tbd notify --type attention_needed "message"` | Escalate to user via macOS notification |
+
+        Terminal IDs are UUIDs. Use the full ID from `tbd terminal list` output.
+
+        ## Terminal States
+
+        When reading terminal output, look for these indicators:
+        - **Waiting for input:** ❯ prompt visible, status bar shows "⏵⏵" or "? for shortcuts"
+        - **Running/busy:** Status bar shows "esc to interrupt" or "to stop agents"
+        - **Idle (no Claude):** Shell prompt (zsh/bash), no Claude process running
+        - **Unknown:** Can't determine — terminal may be dead. Escalate if persistent.
+
+        ## Auto-Response Guidelines
+
+        ### Safe to Auto-Respond
+        - "Should I proceed?" / "Should I continue?" → Yes, if the plan looks reasonable
+        - "Tests passed. What's next?" → Direct to the next logical step
+        - Compilation/lint errors with obvious fixes → Suggest the fix
+        - Questions about project conventions → Answer from context
+
+        ### Always Escalate
+        - Destructive actions (delete, force-push, drop table)
+        - Security issues
+        - Design decisions with multiple valid approaches
+        - Requests for credentials or API keys
+        - "I'm stuck and don't know how to proceed"
+        - Anything you're unsure about
+
+        ## Handling Send Rejections
+
+        If `tbd terminal send` returns an error, the terminal may have transitioned
+        since you last checked. Do NOT retry immediately. Re-read the terminal output
+        to see its current state, then decide what to do.
+
+        ## Escalation
+
+        When escalating, notify the user:
+        ```
+        tbd notify --type attention_needed "worktree-name: brief description"
+        ```
+
+        ## State Management
+
+        Maintain `./state.json` for context across context compactions:
+        ```json
+        {
+          "terminals": {},
+          "last_checked": null,
+          "auto_responses_today": 0,
+          "escalations_today": 0
+        }
+        ```
+
+        Read state.json at the start of each interaction. Update it after taking action.
+
+        ## Task Log
+
+        Append every action to `./task-log.md` with timestamps.
+        """
+    }
+}
+
+public enum ConductorError: Error, LocalizedError {
+    case notFound(name: String)
+    case noWorktree(name: String)
+    case interactConflict(existingName: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notFound(let name): "Conductor not found: \(name)"
+        case .noWorktree(let name): "Conductor has no worktree: \(name)"
+        case .interactConflict(let existing):
+            "Cannot grant interact permission: conductor '\(existing)' already has interact on overlapping repos"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add WorktreeStore.create and delete methods if missing**
+
+Check `Sources/TBDDaemon/Database/WorktreeStore.swift` — it should already have create/delete. If `create` takes a `Worktree` directly, it works as-is. If not, add a convenience method. Also add a `delete(id:)` method if missing.
+
+- [ ] **Step 5: Run tests**
+
+Run: `swift test --filter ConductorManagerTests 2>&1 | tail -10`
+Expected: All 4 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDDaemon/Conductor/ConductorManager.swift
+git add Tests/TBDDaemonTests/ConductorManagerTests.swift
+git commit -m "feat: add ConductorManager with lifecycle and CLAUDE.md template"
+```
+
+---
+
+### Task 5: RPC Handlers + Router Wiring
+
+**Files:**
+- Create: `Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift`
+- Modify: `Sources/TBDDaemon/Server/RPCRouter.swift`
+- Modify: `Sources/TBDDaemon/Daemon.swift`
+
+- [ ] **Step 1: Create conductor RPC handlers**
+
+Create `Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift`:
+
+```swift
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+    func handleConductorSetup(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorSetupParams.self, from: paramsData)
+        let conductor = try await conductorManager.setup(
+            name: params.name,
+            repos: params.repos ?? ["*"],
+            worktrees: params.worktrees,
+            terminalLabels: params.terminalLabels,
+            interact: params.interact ?? false,
+            heartbeatIntervalMinutes: params.heartbeatIntervalMinutes ?? 10
+        )
+        return try RPCResponse(result: conductor)
+    }
+
+    func handleConductorStart(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+        let terminal = try await conductorManager.start(name: params.name)
+        return try RPCResponse(result: terminal)
+    }
+
+    func handleConductorStop(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+        try await conductorManager.stop(name: params.name)
+        return .ok()
+    }
+
+    func handleConductorTeardown(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+        try await conductorManager.teardown(name: params.name)
+        return .ok()
+    }
+
+    func handleConductorList() async throws -> RPCResponse {
+        let conductors = try await db.conductors.list()
+        return try RPCResponse(result: ConductorListResult(conductors: conductors))
+    }
+
+    func handleConductorStatus(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+        guard let conductor = try await db.conductors.get(name: params.name) else {
+            return RPCResponse(error: "Conductor not found: \(params.name)")
+        }
+        var isRunning = false
+        if let terminalID = conductor.terminalID,
+           let terminal = try await db.terminals.get(id: terminalID) {
+            isRunning = await tmux.windowExists(
+                server: TBDConstants.conductorsTmuxServer,
+                windowID: terminal.tmuxWindowID
+            )
+        }
+        return try RPCResponse(result: ConductorStatusResult(conductor: conductor, isRunning: isRunning))
+    }
+}
+```
+
+- [ ] **Step 2: Add ConductorManager to RPCRouter**
+
+In `Sources/TBDDaemon/Server/RPCRouter.swift`, add property:
+
+```swift
+public let conductorManager: ConductorManager
+```
+
+Update `init` to accept and store it:
+
+```swift
+public init(
+    db: TBDDatabase,
+    lifecycle: WorktreeLifecycle,
+    tmux: TmuxManager,
+    git: GitManager = GitManager(),
+    startTime: Date = Date(),
+    subscriptions: StateSubscriptionManager = StateSubscriptionManager(),
+    prManager: PRStatusManager = PRStatusManager(),
+    conductorManager: ConductorManager? = nil
+) {
+    self.db = db
+    self.lifecycle = lifecycle
+    self.tmux = tmux
+    self.git = git
+    self.startTime = startTime
+    self.subscriptions = subscriptions
+    self.prManager = prManager
+    self.suspendResumeCoordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
+    self.conductorManager = conductorManager ?? ConductorManager(db: db, tmux: tmux)
+}
+```
+
+Add cases to the `handle` switch:
+
+```swift
+case RPCMethod.terminalOutput:
+    return try await handleTerminalOutput(request.paramsData)
+case RPCMethod.conductorSetup:
+    return try await handleConductorSetup(request.paramsData)
+case RPCMethod.conductorStart:
+    return try await handleConductorStart(request.paramsData)
+case RPCMethod.conductorStop:
+    return try await handleConductorStop(request.paramsData)
+case RPCMethod.conductorTeardown:
+    return try await handleConductorTeardown(request.paramsData)
+case RPCMethod.conductorList:
+    return try await handleConductorList()
+case RPCMethod.conductorStatus:
+    return try await handleConductorStatus(request.paramsData)
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift
+git add Sources/TBDDaemon/Server/RPCRouter.swift Sources/TBDDaemon/Daemon.swift
+git commit -m "feat: wire conductor RPC handlers into router"
+```
+
+---
+
+### Task 6: CLI Commands
+
+**Files:**
+- Create: `Sources/TBDCLI/Commands/ConductorCommands.swift`
+- Modify: `Sources/TBDCLI/TBD.swift`
+
+- [ ] **Step 1: Create ConductorCommands**
+
+Create `Sources/TBDCLI/Commands/ConductorCommands.swift`:
+
+```swift
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct ConductorCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "conductor",
+        abstract: "Manage conductors",
+        subcommands: [
+            ConductorSetup.self,
+            ConductorStart.self,
+            ConductorStop.self,
+            ConductorTeardown.self,
+            ConductorListCmd.self,
+            ConductorStatusCmd.self,
+        ]
+    )
+}
+
+// MARK: - conductor setup
+
+struct ConductorSetup: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "setup",
+        abstract: "Create a new conductor"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    @Option(name: .long, help: "Comma-separated repo IDs (default: all)")
+    var repos: String?
+
+    @Option(name: .long, help: "Comma-separated worktree name patterns")
+    var worktrees: String?
+
+    @Option(name: .long, help: "Comma-separated terminal labels to monitor")
+    var terminalLabels: String?
+
+    @Flag(name: .long, help: "Grant interact permission (can send to terminals)")
+    var interact = false
+
+    @Option(name: .long, help: "Heartbeat interval in minutes (default: 10, 0 = disabled)")
+    var heartbeat: Int?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let reposList = repos?.split(separator: ",").map(String.init)
+        let worktreesList = worktrees?.split(separator: ",").map(String.init)
+        let labelsList = terminalLabels?.split(separator: ",").map(String.init)
+
+        let conductor: Conductor = try client.call(
+            method: RPCMethod.conductorSetup,
+            params: ConductorSetupParams(
+                name: name,
+                repos: reposList,
+                worktrees: worktreesList,
+                terminalLabels: labelsList,
+                interact: interact,
+                heartbeatIntervalMinutes: heartbeat
+            ),
+            resultType: Conductor.self
+        )
+
+        if json {
+            printJSON(conductor)
+        } else {
+            print("Created conductor: \(conductor.name)")
+            print("  ID:          \(conductor.id)")
+            print("  Repos:       \(conductor.repos.joined(separator: ", "))")
+            print("  Permissions: \(conductor.permissions)")
+            print("  Heartbeat:   \(conductor.heartbeatIntervalMinutes)m")
+        }
+    }
+}
+
+// MARK: - conductor start
+
+struct ConductorStart: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "start",
+        abstract: "Start a conductor session"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let terminal: Terminal = try client.call(
+            method: RPCMethod.conductorStart,
+            params: ConductorNameParams(name: name),
+            resultType: Terminal.self
+        )
+
+        if json {
+            printJSON(terminal)
+        } else {
+            print("Started conductor: \(name)")
+            print("  Terminal: \(terminal.id)")
+            print("  Window:   \(terminal.tmuxWindowID)")
+        }
+    }
+}
+
+// MARK: - conductor stop
+
+struct ConductorStop: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "stop",
+        abstract: "Stop a conductor session"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.conductorStop,
+            params: ConductorNameParams(name: name)
+        )
+        print("Stopped conductor: \(name)")
+    }
+}
+
+// MARK: - conductor teardown
+
+struct ConductorTeardown: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "teardown",
+        abstract: "Remove a conductor completely"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.conductorTeardown,
+            params: ConductorNameParams(name: name)
+        )
+        print("Removed conductor: \(name)")
+    }
+}
+
+// MARK: - conductor list
+
+struct ConductorListCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List all conductors"
+    )
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let result: ConductorListResult = try client.call(
+            method: RPCMethod.conductorList,
+            params: EmptyParams(),
+            resultType: ConductorListResult.self
+        )
+
+        if json {
+            printJSON(result.conductors)
+        } else {
+            if result.conductors.isEmpty {
+                print("No conductors configured.")
+                return
+            }
+            let header = String(format: "%-20s  %-20s  %-18s  %s", "NAME", "REPOS", "PERMISSIONS", "HEARTBEAT")
+            print(header)
+            print(String(repeating: "-", count: 75))
+            for c in result.conductors {
+                let reposStr = c.repos.contains("*") ? "*" : c.repos.joined(separator: ",")
+                let line = String(format: "%-20s  %-20s  %-18s  %dm",
+                    c.name as NSString,
+                    String(reposStr.prefix(20)) as NSString,
+                    c.permissions as NSString,
+                    c.heartbeatIntervalMinutes)
+                print(line)
+            }
+        }
+    }
+}
+
+// MARK: - conductor status
+
+struct ConductorStatusCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show conductor status"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let result: ConductorStatusResult = try client.call(
+            method: RPCMethod.conductorStatus,
+            params: ConductorNameParams(name: name),
+            resultType: ConductorStatusResult.self
+        )
+
+        if json {
+            printJSON(result)
+        } else {
+            let c = result.conductor
+            print("Conductor: \(c.name)")
+            print("  ID:          \(c.id)")
+            print("  Running:     \(result.isRunning)")
+            print("  Repos:       \(c.repos.joined(separator: ", "))")
+            print("  Permissions: \(c.permissions)")
+            print("  Heartbeat:   \(c.heartbeatIntervalMinutes)m")
+            if let wt = c.worktrees { print("  Worktrees:   \(wt.joined(separator: ", "))") }
+            if let labels = c.terminalLabels { print("  Labels:      \(labels.joined(separator: ", "))") }
+        }
+    }
+}
+
+// Empty params for list endpoints
+private struct EmptyParams: Codable {}
+```
+
+- [ ] **Step 2: Register ConductorCommand**
+
+In `Sources/TBDCLI/TBD.swift`, add to subcommands:
+
+```swift
+subcommands: [
+    RepoCommand.self,
+    WorktreeCommand.self,
+    TerminalCommand.self,
+    ConductorCommand.self,
+    NotifyCommand.self,
+    DaemonCommand.self,
+    SetupHooksCommand.self,
+    CleanupCommand.self,
+]
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDCLI/Commands/ConductorCommands.swift Sources/TBDCLI/TBD.swift
+git commit -m "feat: add conductor CLI commands"
+```
+
+---
+
+### Task 7: StateDelta Suppression + Worktree List Filtering
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Server/StateSubscription.swift`
+- Modify: `Sources/TBDDaemon/Database/WorktreeStore.swift`
+- Test: `Tests/TBDDaemonTests/DatabaseTests.swift`
+
+- [ ] **Step 1: Write test for worktree list filtering**
+
+Add to `Tests/TBDDaemonTests/DatabaseTests.swift`:
+
+```swift
+@Test func worktreeListExcludesConductorByDefault() async throws {
+    let db = try TBDDatabase(inMemory: true)
+
+    // The synthetic conductors repo is already inserted by v9 migration
+    let repo = try await db.repos.create(path: "/tmp/test-repo", displayName: "Test")
+
+    // Create a normal worktree
+    let normal = Worktree(repoID: repo.id, name: "normal", displayName: "normal",
+                          branch: "main", path: "/tmp/normal", status: .active,
+                          tmuxServer: "test")
+    try await db.worktrees.create(normal)
+
+    // Create a conductor worktree
+    let conductor = Worktree(repoID: TBDConstants.conductorsRepoID,
+                             name: "conductor-test", displayName: "conductor-test",
+                             branch: "conductor", path: "/tmp/conductor",
+                             status: .conductor, tmuxServer: "tbd-conductor")
+    try await db.worktrees.create(conductor)
+
+    // Default list should exclude conductor
+    let defaultList = try await db.worktrees.list()
+    #expect(defaultList.count == 1)
+    #expect(defaultList[0].name == "normal")
+
+    // Explicit conductor list
+    let conductorList = try await db.worktrees.list(status: .conductor)
+    #expect(conductorList.count == 1)
+    #expect(conductorList[0].name == "conductor-test")
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `swift test --filter worktreeListExcludesConductorByDefault 2>&1 | tail -5`
+Expected: FAIL — conductor worktrees not filtered
+
+- [ ] **Step 3: Update WorktreeStore.list to exclude .conductor by default**
+
+In `Sources/TBDDaemon/Database/WorktreeStore.swift`, find the `list` method and update it to exclude `.conductor` when no status filter is specified:
+
+```swift
+public func list(repoID: UUID? = nil, status: WorktreeStatus? = nil) async throws -> [Worktree] {
+    try await writer.read { db in
+        var request = WorktreeRecord.all()
+        if let repoID {
+            request = request.filter(Column("repoID") == repoID.uuidString)
+        }
+        if let status {
+            request = request.filter(Column("status") == status.rawValue)
+        } else {
+            // Exclude conductor worktrees from default listing
+            request = request.filter(Column("status") != WorktreeStatus.conductor.rawValue)
+        }
+        return try request.fetchAll(db).map { $0.toModel() }
+    }
+}
+```
+
+- [ ] **Step 4: Suppress conductor deltas in StateSubscriptionManager**
+
+In `Sources/TBDDaemon/Server/StateSubscription.swift`, update `broadcast`:
+
+```swift
+public func broadcast(delta: StateDelta) {
+    // Suppress deltas for conductor worktrees — app can't display them yet
+    switch delta {
+    case .worktreeCreated(let d):
+        if d.name.hasPrefix("conductor-") { return }
+    case .worktreeArchived, .worktreeRevived:
+        break // These don't carry name; conductor worktrees are rarely archived/revived
+    default:
+        break
+    }
+
+    guard let data = try? JSONEncoder().encode(delta) else { return }
+
+    lock.lock()
+    let currentSubscribers = subscribers
+    lock.unlock()
+
+    for (_, callback) in currentSubscribers {
+        callback(data)
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `swift test --filter worktreeListExcludesConductorByDefault 2>&1 | tail -5`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `swift test 2>&1 | tail -20`
+Expected: All tests pass (existing + new)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/TBDDaemon/Database/WorktreeStore.swift
+git add Sources/TBDDaemon/Server/StateSubscription.swift
+git add Tests/TBDDaemonTests/DatabaseTests.swift
+git commit -m "feat: filter conductor worktrees from listings and suppress deltas"
+```
+
+---
+
+### Task 8: Filter Synthetic Repo from repo.list
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Database/RepoStore.swift`
+- Test: `Tests/TBDDaemonTests/DatabaseTests.swift`
+
+- [ ] **Step 1: Write test**
+
+Add to `Tests/TBDDaemonTests/DatabaseTests.swift`:
+
+```swift
+@Test func repoListExcludesSyntheticConductorsRepo() async throws {
+    let db = try TBDDatabase(inMemory: true)
+
+    // Create a real repo
+    let repo = try await db.repos.create(path: "/tmp/real-repo", displayName: "Real")
+
+    // Default list should only show real repos, not the synthetic conductors repo
+    let all = try await db.repos.list()
+    #expect(all.count == 1)
+    #expect(all[0].displayName == "Real")
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `swift test --filter repoListExcludesSyntheticConductorsRepo 2>&1 | tail -5`
+Expected: FAIL — synthetic repo appears in list
+
+- [ ] **Step 3: Update RepoStore.list**
+
+In `Sources/TBDDaemon/Database/RepoStore.swift`, filter out the synthetic repo:
+
+```swift
+public func list() async throws -> [Repo] {
+    try await writer.read { db in
+        try RepoRecord
+            .filter(Column("id") != TBDConstants.conductorsRepoID.uuidString)
+            .fetchAll(db)
+            .map { $0.toModel() }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `swift test --filter repoListExcludesSyntheticConductorsRepo 2>&1 | tail -5`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `swift test 2>&1 | tail -20`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDDaemon/Database/RepoStore.swift Tests/TBDDaemonTests/DatabaseTests.swift
+git commit -m "feat: filter synthetic conductors repo from repo.list"
+```
+
+---
+
+### Task 9: Final Integration — Build + Smoke Test
+
+- [ ] **Step 1: Full build**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 2: Full test suite**
+
+Run: `swift test 2>&1 | tail -20`
+Expected: All tests pass
+
+- [ ] **Step 3: Verify CLI help**
+
+Run: `swift run tbd conductor --help 2>&1`
+Expected: Shows subcommands: setup, start, stop, teardown, list, status
+
+Run: `swift run tbd terminal output --help 2>&1`
+Expected: Shows terminal output usage
+
+- [ ] **Step 4: Commit any final fixups**
+
+If any compilation issues were found and fixed, commit them:
+
+```bash
+git add -A
+git commit -m "fix: resolve Phase 1a integration issues"
+```

--- a/docs/superpowers/specs/2026-04-02-conductor-pattern-design.md
+++ b/docs/superpowers/specs/2026-04-02-conductor-pattern-design.md
@@ -1,0 +1,624 @@
+# Conductor Pattern Design
+
+A meta-agent orchestration layer for TBD. Conductors are persistent Claude Code sessions that monitor and coordinate other Claude terminals across worktrees and repos.
+
+## Problem
+
+When running multiple Claude agents across worktrees, agents frequently block waiting for human input — "Should I proceed?", "Which approach?", "Tests passed, what next?". The user must manually check each terminal, context-switch, and respond. With 5+ active worktrees across multiple repos, this becomes a bottleneck.
+
+## Solution
+
+A **conductor** is a Claude Code session with special instructions that:
+1. Receives real-time notifications when any terminal in its scope transitions to "waiting"
+2. Reads the agent's last conversation message (via Claude session JSONL) to understand what the agent needs
+3. Auto-responds when confident (routine questions, obvious next steps)
+4. Escalates to the user when unsure (design decisions, destructive actions, ambiguity)
+
+The TBD daemon serves as the API/medium — the conductor is a consumer of existing daemon capabilities, augmented with a few new ones.
+
+## Design Principles
+
+- **Daemon as API, conductor as consumer.** The conductor uses `tbd` CLI commands. No special privileges.
+- **Event-driven with heartbeat fallback.** Real-time notifications on state transitions, periodic summaries as a safety net.
+- **Interaction locks as safety mechanism.** Any conductor can respond to waiting terminals. The daemon enforces one-at-a-time interaction per worktree via advisory locks — no permission tiers needed.
+- **Decouple detection from action.** Terminal state tracking is independent of both suspend/resume and conductor systems.
+- **Flexible scoping.** Conductors choose their repos, worktrees, and terminal labels. Multiple conductors can observe the same worktree. Only one can interact with a given worktree at a time (enforced by interaction locks).
+- **Server-side safety.** The daemon enforces invariants (don't send to non-waiting terminals) rather than trusting the conductor's view of state.
+
+## Architecture
+
+### Component Overview
+
+```
+┌─────────────┐     ┌──────────────────┐     ┌─────────────┐
+│  Conductor  │────▶│      tbdd        │◀────│  tbd CLI    │
+│  (Claude)   │ RPC │                  │ RPC │             │
+└─────────────┘     │  TerminalState   │     └─────────────┘
+                    │  Tracker         │
+┌─────────────┐     │       │          │     ┌─────────────┐
+│  Conductor  │────▶│       ▼          │◀────│  TBDApp     │
+│  (Claude)   │ RPC │  ConductorRouter │ RPC │  SwiftUI    │
+└─────────────┘     │       │          │     └─────────────┘
+                    │       ▼          │
+                    │  Notification    │
+                    │  Delivery        │
+                    └──────────────────┘
+```
+
+### New Components
+
+#### 1. TerminalStateTracker (Deferred — Phase 1b)
+
+Extracted from `SuspendResumeCoordinator`. Owns all terminal state detection logic, independent of what consumers do with the information. See `2026-04-02-conductor-phase-1b-deferred.md` for full details. Retained here for architectural context.
+
+**Inputs:**
+- `response_complete` notifications (already broadcast as StateDelta from the notify RPC)
+- `ClaudeStateDetector.isIdle()` polling (tmux capture-pane heuristic)
+- Terminal process status (is Claude process running in the pane?)
+
+**State model per terminal:**
+
+| State | Meaning | Detection |
+|-------|---------|-----------|
+| `running` | Claude is actively processing | `ClaudeStateDetector.busyIndicators` present in pane |
+| `waiting` | Claude finished, needs input | `response_complete` hook fired AND `isIdle()` confirms prompt visible |
+| `idle` | Shell prompt, no Claude running | `paneCurrentCommand` is not a Claude process |
+| `unknown` | Can't determine | tmux capture-pane failed, window dead, or detection error |
+
+The `unknown` state is produced when `capturePaneOutput` or `paneCurrentCommand` throws. `ClaudeStateDetector.isIdle()` currently swallows errors and returns `false` (appearing as `running`). The tracker must distinguish "confirmed busy" from "can't tell" by catching errors explicitly.
+
+**API:**
+```swift
+public actor TerminalStateTracker {
+    /// Current state of a terminal
+    func state(terminalID: UUID) async -> TerminalState
+    
+    /// All terminals in a given state
+    func terminals(in state: TerminalState) async -> [TerminalStateEntry]
+    
+    /// Called when response_complete notification arrives
+    func responseCompleted(terminalID: UUID, worktreeID: UUID)
+    
+    /// Clear idle tracking for a worktree (called by SuspendResumeCoordinator
+    /// on suspend/resume to prevent immediate re-eligibility)
+    func clearIdleFlag(worktreeID: UUID)
+    
+    /// Subscribe to state transitions
+    func onTransition(_ handler: @Sendable (TerminalStateTransition) -> Void)
+}
+
+public struct TerminalStateEntry: Sendable {
+    let terminalID: UUID
+    let worktreeID: UUID
+    let repoID: UUID
+    let state: TerminalState
+    let since: Date              // when it entered this state
+    let terminalLabel: String?   // e.g. "claude", "setup"
+    let lastAssistantMessage: String?  // last assistant message from Claude session JSONL
+}
+
+public struct TerminalStateTransition: Sendable {
+    let terminalID: UUID
+    let worktreeID: UUID
+    let repoID: UUID
+    let worktreeName: String
+    let branchName: String
+    let terminalLabel: String?
+    let from: TerminalState
+    let to: TerminalState
+    let timestamp: Date
+}
+```
+
+**Polling cadence:** Running terminals are polled more frequently than idle ones (e.g., ~10s vs ~60s). Exact intervals are implementation details — the invariant is that the tracker detects running→waiting transitions within a reasonable window. Event-driven via `response_complete` hook provides near-instant detection for the common case; polling is the safety net.
+
+**Relationship to SuspendResumeCoordinator:** The coordinator becomes a consumer of `TerminalStateTracker` instead of managing its own `worktreeIdleFromHook` set. It subscribes to transitions and triggers suspend/resume logic when appropriate. The coordinator-specific 30-second re-eligibility delay after resume stays in the coordinator, not the tracker. The tracker exposes `clearIdleFlag(worktreeID:)` so the coordinator can reset idle tracking on suspend/resume (preserving the existing `worktreeIdleFromHook.remove()` semantics at SuspendResumeCoordinator.swift lines 158, 300).
+
+#### 2. Conversation Reader
+
+Reads Claude's structured conversation history for a terminal, providing the conductor with reliable access to what agents said — independent of terminal viewport size.
+
+**How it works:** Each Claude terminal stores a `claudeSessionID` (already captured by `ClaudeStateDetector.captureSessionID()`). Claude writes conversation history to `~/.claude/projects/<project-path>/sessions/<session-id>.jsonl`. The daemon reads this file to extract the last N assistant messages.
+
+**Why not capture-pane:** tmux capture-pane only returns the visible viewport (~24-50 lines). Claude responses routinely exceed one screenful. The JSONL contains the complete, structured conversation.
+
+**API:**
+- `terminal.conversation` RPC — returns last N assistant messages for a terminal's Claude session
+- Used by ConductorRouter when formatting [TERMINAL WAITING] notifications
+- Used by conductor CLI for manual polling
+- `terminal.output` remains available as a debug tool for raw terminal state
+
+#### 3. ConductorRouter (Deferred — Phase 1b)
+
+Routes terminal state transitions to the appropriate conductor(s) based on scope configuration. See `2026-04-02-conductor-phase-1b-deferred.md` for full details. Retained here for architectural context.
+
+**Responsibilities:**
+- Loads conductor configs from the `conductor` DB table
+- On each `TerminalStateTransition`, determines which conductors should be notified
+- Manages interaction locks (one conductor at a time per worktree)
+- Formats and delivers messages to conductor terminals
+- Detects conductor terminal death and releases interaction locks
+
+**Routing rules:**
+1. When a terminal transitions to `waiting`: notify all conductors whose scope includes that terminal's repo (filtered by worktree and terminal_label if configured)
+2. When a conductor wants to send a message to a terminal: the `terminal.send` RPC handler verifies the target terminal is currently in `waiting` state before dispatching `sendKeys`. This is a server-side invariant — if the terminal transitioned to `running` between the conductor's decision and the send, the RPC returns an error.
+
+#### 4. Conductor Storage
+
+**Database table (new `conductor` table):** Queryable metadata lives in SQLite for consistency with the rest of TBD's data model.
+
+```sql
+CREATE TABLE conductor (
+    id TEXT PRIMARY KEY,           -- UUID
+    name TEXT UNIQUE NOT NULL,     -- human-readable name
+    repos TEXT NOT NULL DEFAULT '*', -- JSON array of repo IDs or ["*"]
+    worktrees TEXT,                -- JSON array of worktree name patterns, null = all
+    terminalLabels TEXT,           -- JSON array of terminal labels to monitor, null = all
+    heartbeatIntervalMinutes INTEGER NOT NULL DEFAULT 10,
+    terminalID TEXT,               -- FK to terminal table (the conductor's own terminal)
+    createdAt TEXT NOT NULL,
+    FOREIGN KEY (terminalID) REFERENCES terminal(id) ON DELETE SET NULL
+);
+```
+
+**Filesystem (for Claude's CWD):** The conductor's CLAUDE.md, state.json, and task-log.md live at `~/.tbd/conductors/<name>/`. This directory is the conductor's CWD so Claude reads CLAUDE.md on startup.
+
+```
+~/.tbd/conductors/
+├── my-conductor/
+│   ├── CLAUDE.md            # Instructions for the conductor Claude session
+│   ├── state.json           # Conductor's persistent state (managed by Claude)
+│   └── task-log.md          # Action log (managed by Claude)
+└── ops-conductor/
+    ├── CLAUDE.md
+    ├── state.json
+    └── task-log.md
+```
+
+**Scope fields:**
+- `repos`: `["*"]` for all repos, or specific repo IDs
+- `worktrees`: `null` for all worktrees, or name patterns like `["fix-*", "feature-*"]`
+- `terminalLabels`: `null` for all terminals, or specific labels like `["claude"]` (excludes "setup" terminals)
+
+#### 5. Conductor Terminal Model
+
+The conductor needs a terminal record in the DB (for tmux window tracking, state detection, etc.). Rather than making `worktreeID` nullable (which would require a migration + audit of every query), the conductor gets a **synthetic worktree** record:
+
+```
+Worktree {
+    id: UUID,
+    repoID: <conductors-pseudo-repo-id>,  // synthetic repo inserted by migration
+    name: "conductor-<name>",
+    path: "~/.tbd/conductors/<name>",
+    branch: "conductor",                  // sentinel value (column is NOT NULL)
+    status: .conductor,                   // new WorktreeStatus case
+    ...
+}
+```
+
+**Synthetic "conductors" repo:** The DB migration inserts a pseudo-repo with a well-known UUID and path `~/.tbd/conductors`. All conductor worktrees reference this repo. This avoids FK cascade issues — if a real repo is removed, conductor worktrees are unaffected. The pseudo-repo is filtered from `repo.list` results (by checking a `synthetic` bool column or the well-known UUID).
+
+**WorktreeStatus.conductor and StateDelta:** Adding `.conductor` to the `WorktreeStatus` enum must ship in `TBDShared` (used by both daemon and app). The `StateSubscriptionManager` must suppress `worktreeCreated`/`worktreeArchived` deltas for `.conductor`-status worktrees to prevent the app from displaying or failing to decode them before UI support exists.
+
+This new `.conductor` status is filtered out of normal worktree listings (sidebar, `tbd worktree list`) but visible via `tbd conductor list`. The terminal record uses this synthetic worktreeID normally — no NULL handling needed.
+
+The conductor runs in a dedicated tmux server named `tbd-conductor` (shared by all conductors, separate from any repo's server). Each conductor gets its own tmux window in this server. **Known limitation:** one conductor crashing tmux takes down all conductors. Acceptable for Phase 1; per-conductor servers can be added in Phase 2 if users run 3+ conductors.
+
+#### 6. Interaction Locking
+
+Any conductor can send messages to waiting terminals. When a conductor sends a message (via `terminal.send`), the daemon records an **advisory interaction lock** on that worktree. The lock:
+- Is recorded in memory (not DB — it's transient)
+- Auto-expires after 5 minutes
+- Prevents other conductors from sending to the same worktree simultaneously
+- Does NOT prevent the user from interacting directly (user always wins)
+- Is released when the terminal transitions back to `running` (the agent started processing)
+- Is released immediately if the conductor's terminal dies (daemon detects pane gone / process exited via TerminalStateTracker's periodic polling)
+
+```swift
+public struct InteractionLock: Sendable {
+    let worktreeID: UUID
+    let conductorName: String
+    let acquiredAt: Date
+    let expiresAt: Date
+}
+```
+
+#### 7. Server-Side Send Guard (Deferred — Phase 1b)
+
+The `terminal.send` RPC handler (RPCRouter+TerminalHandlers.swift) gains a state check. See `2026-04-02-conductor-phase-1b-deferred.md` for full details. Retained here for architectural context.
+
+```
+terminal.send received (from conductor)
+  → Look up terminal in TerminalStateTracker
+  → If state != .waiting: return error "terminal is not waiting for input (current state: running)"
+  → If interaction lock held by another conductor: return error "locked by conductor X"
+  → Acquire interaction lock, send keys, return success
+```
+
+No permission check — any conductor can interact. The guard enforces two invariants: the terminal must be waiting, and no other conductor can be mid-interaction with the same worktree. This prevents the stale-notification race: even if a conductor acts on an outdated `[TERMINAL WAITING]` notification, the send is rejected server-side if the terminal has already transitioned.
+
+### Conductor Lifecycle
+
+#### Setup
+
+```bash
+tbd conductor setup my-conductor                                    # defaults: all repos
+tbd conductor setup my-conductor --repos repo-id-1,repo-id-2       # specific repos
+tbd conductor setup my-conductor --worktrees "fix-*,feature-*"     # worktree name patterns
+tbd conductor setup my-conductor --terminal-labels claude           # only monitor claude terminals
+tbd conductor setup my-conductor --heartbeat 5                      # 5-minute heartbeat interval
+```
+
+Creates the directory structure, generates a default `CLAUDE.md` from a template, inserts a row in the `conductor` table, and creates a synthetic worktree record.
+
+#### Start
+
+```bash
+tbd conductor start my-conductor
+```
+
+Creates a tmux window in `tbd-conductor` server running `claude --dangerously-skip-permissions` with the conductor's directory as CWD. Registers a terminal in the DB linked to the synthetic worktree.
+
+#### Stop / Teardown
+
+```bash
+tbd conductor stop my-conductor     # kills tmux window, keeps config + DB row
+tbd conductor teardown my-conductor # stop + remove DB row + remove directory
+```
+
+#### List
+
+```bash
+tbd conductor list                  # all conductors with status
+tbd conductor list --json           # machine-readable
+```
+
+### Message Delivery to Conductor
+
+When a terminal transitions to `waiting`, the `ConductorRouter` formats a notification:
+
+```
+[TERMINAL WAITING] id: <terminal-uuid>
+repo: my-app | worktree: fix-auth (tbd/fix-auth) | terminal: claude
+Waiting for 0s. Running for 4m since last input.
+Last message:
+---
+I've updated the authentication middleware to use JWT tokens instead of session cookies.
+Should I also update the test fixtures to use the new token format?
+---
+```
+
+Includes terminal UUID (so conductor can immediately `tbd terminal send <id>`), branch name, terminal label, time waiting, and time running since last input. Last assistant message from the Claude session JSONL.
+
+This is sent to the conductor terminal via `TmuxManager.sendKeys()` (same mechanism as `tbd terminal send`).
+
+### Escalation
+
+When the conductor decides to escalate (rather than auto-respond), it uses a structured format and fires a notification:
+
+```bash
+tbd notify --type attention_needed "fix-auth waiting 12m: asking whether to run integration tests against staging or prod"
+```
+
+This creates a macOS notification visible to the user. The conductor's CLAUDE.md defines a structured `[ESCALATION]` output format:
+
+```
+[ESCALATION] fix-auth @ my-app
+Agent is asking: "Should I run integration tests against staging or prod?"
+Context: Working on JWT migration, tests need a live database.
+```
+
+Phase 2: A bridge (Telegram/Slack) can parse `[ESCALATION]` lines from conductor output and forward them. The daemon-side notification hook exists in Phase 1, giving the bridge something to consume.
+
+### Heartbeat Delivery
+
+The daemon runs a single heartbeat timer in `Daemon.swift` (alongside existing periodic timers). The timer fires at the minimum interval across all active conductors and tracks per-conductor cadence — each conductor receives heartbeats at its own configured interval.
+
+```
+[HEARTBEAT] 5 terminals across 2 repos.
+  waiting (3m): fix-auth @ my-app [claude] — "Should I also update the test fixtures?" (from session JSONL)
+  waiting (12m): add-export @ my-app [claude] — "Which CSV library should I use?" (from session JSONL)
+  running: refactor-db @ api-server [claude]
+  running: add-metrics @ api-server [claude]
+  idle (1h): setup-ci @ my-app [setup]
+```
+
+The conductor replies with a structured format:
+
+```
+[STATUS] Auto-responded to 1 terminal. 1 needs your attention.
+
+AUTO: fix-auth — told it to proceed with updating test fixtures
+NEED: add-export — asking about CSV library preference, escalating
+```
+
+The daemon builds the heartbeat from `TerminalStateTracker` data — no CLI round-trips needed.
+
+### RPC Methods
+
+New methods added to the daemon:
+
+| Method | Params | Result | Description |
+|--------|--------|--------|-------------|
+| `conductor.setup` | name, repos?, worktrees?, terminalLabels?, heartbeat? | Conductor | Create conductor config + directory + DB row |
+| `conductor.start` | name | Terminal | Start conductor session |
+| `conductor.stop` | name | void | Stop conductor session |
+| `conductor.teardown` | name | void | Stop + remove conductor |
+| `conductor.list` | (none) | Conductor[] | List all conductors with status |
+| `conductor.status` | name | ConductorStatus | Detailed status of one conductor |
+| `terminal.state` | terminalID | TerminalStateEntry | Get current terminal state *(deferred — Phase 1b)* |
+| `terminal.states` | repoID? | TerminalStateEntry[] | Get all terminal states, optionally filtered by repo *(deferred — Phase 1b)* |
+| `terminal.conversation` | terminalID, messages? | string[] | Last N assistant messages from Claude session JSONL (default 1) |
+| `terminal.output` | terminalID, lines? | string | Debug: capture visible terminal viewport (default 50 lines) |
+
+### CLI Commands
+
+```bash
+# Conductor management
+tbd conductor setup <name> [--repos id,...] [--worktrees pattern,...] [--terminal-labels label,...] [--heartbeat N]
+tbd conductor start <name>
+tbd conductor stop <name>
+tbd conductor teardown <name>
+tbd conductor list [--json]
+tbd conductor status <name> [--json]
+
+# Terminal state (useful for conductors and debugging)
+tbd terminal state [--repo <id>] [--json]     # list terminal states (deferred — Phase 1b)
+tbd terminal conversation <id> [--messages N]  # last N assistant messages from session JSONL
+tbd terminal output <id> [--lines N]           # debug: capture raw terminal viewport
+```
+
+### Conductor CLAUDE.md Template
+
+#### Phase 1a Template (Manual Polling)
+
+```markdown
+# Conductor: {NAME}
+
+You are a conductor — a persistent Claude Code session that monitors and
+orchestrates other Claude terminals managed by TBD.
+
+## Your Scope
+- Repos: {REPO_LIST}
+- Worktrees: {WORKTREE_PATTERNS}
+- Terminal labels: {TERMINAL_LABELS}
+
+## Startup Checklist
+
+Run this when you first start, after a restart, or after context compaction:
+1. Read `./state.json` if it exists (restore context from previous session)
+2. Run `tbd worktree list --json` to see active worktrees
+3. Run `tbd terminal list --json` to discover terminal IDs
+4. Run `tbd conductor status {NAME} --json` to verify your scope
+5. Log startup in `./task-log.md`
+6. Output: "Conductor {NAME} online. N terminals found across M worktrees."
+
+This output is a self-log confirmation, not a message to anyone.
+
+## How You Work (Manual Polling)
+
+In this version, you do NOT receive automatic notifications. You must actively
+poll terminals to check on them. When asked to check status, or periodically:
+
+1. Run `tbd terminal list --json` to get terminal IDs
+2. For each terminal of interest, run `tbd terminal conversation <id>` to read the last assistant message
+3. Review the message — is the agent waiting for input?
+4. If waiting: decide to auto-respond or escalate
+5. If running: leave it alone
+
+## Core Rules
+
+1. **Never send to running terminals.** Only respond to terminals that are
+   waiting for input (you can tell from the terminal output — look for the ❯ prompt).
+2. **When unsure, escalate.** The cost of a false escalation (user gets a notification)
+   is much lower than a wrong auto-response (agent goes off track).
+3. **Log everything.** Every action goes in `./task-log.md`.
+4. **Keep responses SHORT.** Status updates: 1-3 sentences. Use bullet points for lists.
+5. **Don't poll in a loop.** Check when asked or when relevant. If no terminals are
+   active, say so and wait.
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `tbd worktree list --json` | List all worktrees with IDs |
+| `tbd terminal list --json` | List all terminals with IDs and worktree mapping |
+| `tbd terminal conversation <id>` | Read last assistant message from Claude session |
+| `tbd terminal conversation <id> --messages N` | Read last N assistant messages |
+| `tbd terminal output <id> --lines 50` | Debug: raw terminal viewport (last 50 lines) |
+| `tbd terminal send <id> "message"` | Send message to a terminal |
+| `tbd conductor list --json` | List all conductors |
+| `tbd conductor status {NAME} --json` | Your own scope and config |
+| `tbd notify --type attention_needed "message"` | Escalate to user via macOS notification |
+
+Terminal IDs are UUIDs. Use the full ID from `tbd terminal list` output.
+
+## Terminal States
+
+When reading terminal output, look for these indicators:
+- **Waiting for input:** ❯ prompt visible, status bar shows "⏵⏵" or "? for shortcuts"
+- **Running/busy:** Status bar shows "esc to interrupt" or "to stop agents"
+- **Idle (no Claude):** Shell prompt (zsh/bash), no Claude process
+- **Unknown:** Can't determine — terminal may be dead or restarting. Escalate if persistent.
+
+## Auto-Response Guidelines
+
+### Safe to Auto-Respond
+- "Should I proceed?" / "Should I continue?" → Yes, if the plan looks reasonable
+- "Tests passed. What's next?" → Direct to the next logical step
+- Compilation/lint errors with obvious fixes → Suggest the fix
+- Questions about project conventions → Answer from context
+
+### Always Escalate
+- Destructive actions (delete, force-push, drop table)
+- Security issues
+- Design decisions with multiple valid approaches
+- Requests for credentials or API keys
+- "I'm stuck and don't know how to proceed"
+- Anything you're unsure about
+
+## Handling Send Rejections
+
+If `tbd terminal send` returns an error (e.g., "terminal is not waiting for input"),
+the terminal transitioned since you last checked. Do NOT retry immediately. Re-read
+the terminal output to see its current state, then decide what to do.
+
+### Escalation
+When escalating, notify the user:
+```bash
+tbd notify --type attention_needed "worktree-name: brief description of what needs attention"
+```
+
+## State Management
+
+Maintain `./state.json` for context across context compactions:
+```json
+{
+  "terminals": {
+    "terminal-uuid": {
+      "worktree": "fix-auth",
+      "repo": "my-app",
+      "summary": "Migrating auth from sessions to JWT tokens",
+      "last_auto_response": "2026-04-02T10:30:00Z",
+      "escalated": false
+    }
+  },
+  "last_checked": "2026-04-02T10:30:00Z",
+  "auto_responses_today": 5,
+  "escalations_today": 2
+}
+```
+
+Read state.json at the start of each interaction. Update it after taking action.
+Keep terminal summaries current based on what you observe in their conversation messages.
+
+## Task Log
+
+Append every action to `./task-log.md`:
+```markdown
+## 2026-04-02 10:30 - Status Check
+- Scanned 5 terminals (2 waiting, 3 running)
+- Auto-responded to fix-auth: "Proceed with updating test fixtures"
+- Escalated add-export: needs decision on CSV library
+
+## 2026-04-02 10:15 - Terminal Check
+- fix-auth asking: "Should I update test fixtures?"
+- Auto-responded: "Yes, update the test fixtures to use JWT tokens"
+```
+```
+
+### App UI (Phase 2, not in this spec)
+
+Future work: conductor section in sidebar, status indicators showing which worktrees are conductor-managed, scope editor in settings. Not designed here — this spec covers the daemon + CLI + CLAUDE.md layer only.
+
+**UI model note:** The conductor is envisioned as a repo-level feature in the sidebar — users start and configure conductors from the repo section, not primarily via CLI. The CLI exists as the backend the app calls. Phase 1 builds the CLI/daemon layer; Phase 2 wraps it in the app UI.
+
+## Data Flow
+
+### Conductor checks terminals (Phase 1a — manual polling)
+
+```
+Conductor (Claude) decides to check on terminals
+  → Runs: tbd terminal list --json (gets terminal IDs)
+  → Runs: tbd terminal conversation <id> (reads last assistant message from session JSONL)
+  → Reviews the message — is the agent waiting for input?
+  → If waiting: decides to auto-respond or escalate
+  → If running: leaves it alone
+```
+
+### Conductor auto-responds (Phase 1a)
+
+```
+Conductor (Claude) reads terminal conversation, decides to auto-respond
+  → Runs: tbd terminal send <terminal-id> "Yes, proceed with updating the tests"
+  → Daemon receives terminal.send RPC
+  → Message sent to terminal via TmuxManager.sendKeys()
+  → Terminal's Claude processes the message (transitions to running)
+```
+
+### Conductor escalates (Phase 1a)
+
+```
+Conductor (Claude) reads terminal conversation, decides to escalate
+  → Runs: tbd notify --type attention_needed "fix-auth: asking whether to delete the old migration files"
+  → User receives macOS notification
+  → Logs escalation in task-log.md and updates state.json
+```
+
+### Event-driven data flows (Deferred — Phase 1b)
+
+See `2026-04-02-conductor-phase-1b-deferred.md` for the event-driven flows: automatic `[TERMINAL WAITING]` notifications, server-side send guard with interaction locks, and daemon-driven heartbeats.
+
+## Phasing
+
+### Phase 1a: Minimal Viable Conductor
+
+The smallest slice that delivers value — a conductor can run and manually poll terminals.
+
+1. **terminal.conversation RPC** — Read last N assistant messages from Claude session JSONL via the terminal's `claudeSessionID`. Primary content-reading mechanism for conductors. **terminal.output RPC** remains as a debug tool (raw terminal viewport via tmux capture-pane).
+2. **Conductor DB table + synthetic repo + config directory** — `conductor.setup` / `conductor.teardown` / `conductor.list`. DB migration adds `conductor` table + synthetic "conductors" pseudo-repo + `.conductor` WorktreeStatus. StateDelta suppression for conductor worktrees.
+3. **Conductor lifecycle** — `conductor.start` / `conductor.stop` (synthetic worktree, tmux window in `tbd-conductor` server, terminal record)
+4. **Phase 1a CLAUDE.md template** — Uses only pre-existing + Phase 1a commands. Startup checklist uses `tbd worktree list --json` + `tbd terminal list --json` (both exist today). Does NOT reference `[TERMINAL WAITING]` or `[HEARTBEAT]` messages (those are deferred — see `2026-04-02-conductor-phase-1b-deferred.md`). Includes manual polling workflow using `tbd terminal conversation`.
+5. **CLI commands** — `tbd conductor setup/start/stop/teardown/list/status`, `tbd terminal conversation`, `tbd terminal output` (debug)
+
+At this point, the conductor can run and manually check on terminals via `tbd worktree list`, `tbd terminal list`, and `tbd terminal conversation <id>` (reading session JSONL). `tbd terminal output <id>` is available as a debug tool for raw terminal viewport. It can escalate via `tbd notify --type attention_needed`. No automatic routing yet.
+
+### Phase 1b: Event-Driven Routing (Deferred)
+
+Deferred to a separate document: `2026-04-02-conductor-phase-1b-deferred.md`. 
+Event-driven notifications would push terminal state transitions to conductors automatically, 
+but the token cost (~3-5k per notification, ~1-2k per heartbeat) may not justify the benefit 
+over manual polling. Agent Deck's conductor operates without this and works well. 
+Phase 2 (app UI) does not depend on Phase 1b.
+
+### Phase 2: Polish (future)
+
+- App UI: conductor section in sidebar (requires new `StateDelta` case for terminal state transitions)
+- Per-conductor tmux servers (blast radius isolation)
+- Bridge integration (Telegram/Slack forwarding of escalations via `[ESCALATION]` parsing)
+- Conductor metrics/analytics (auto-response success rate, escalation frequency)
+- Conductor-to-conductor communication
+
+## Testing Strategy
+
+### Phase 1a Tests
+
+- **Conductor lifecycle tests:** Setup creates correct directory structure + DB row + synthetic worktree, start creates terminal record in tbd-conductor tmux server, teardown cleans up everything
+- **CLI integration tests:** Verify `tbd conductor setup/list` produce correct output
+- **End-to-end:** Manual test with a real conductor session monitoring a worktree
+
+### Phase 1b Tests (Deferred)
+
+See `2026-04-02-conductor-phase-1b-deferred.md` for TerminalStateTracker, ConductorRouter, server-side send guard, and SuspendResumeCoordinator regression tests.
+
+## Migration
+
+- **DB migration (v9):**
+  - New `conductor` table (schema in Conductor Storage section — no permissions column, just scope fields and heartbeat config).
+  - Synthetic "conductors" pseudo-repo inserted with well-known UUID.
+  - New `.conductor` case for `WorktreeStatus` in `TBDShared/Models.swift`. Must ship in TBDShared so both daemon and app can decode it. The `Worktree.branch` column is NOT NULL, so conductor worktrees use the sentinel value `"conductor"`.
+- **StateDelta suppression:** `StateSubscriptionManager` filters out `worktreeCreated`/`worktreeArchived` deltas for `.conductor`-status worktrees. This prevents the app from receiving deltas it can't display yet.
+- **SuspendResumeCoordinator refactor (deferred, Phase 1b):** Extract idle detection into `TerminalStateTracker`. See `2026-04-02-conductor-phase-1b-deferred.md` for details.
+- New RPC methods are additive (no breaking changes to existing RPCs).
+- `WorktreeStatus.conductor` is filtered out of `worktree.list` results by default.
+
+## Risks & Mitigations
+
+### Phase 1a Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Conductor auto-responds incorrectly | CLAUDE.md template is conservative ("when unsure, escalate"). Cost asymmetry: false escalation < wrong auto-response. |
+| Shared tbd-conductor tmux server blast radius | One conductor crashing tmux affects all conductors. Acceptable for Phase 1. Per-conductor servers in Phase 2 if needed. |
+| NULL worktreeID for conductor terminals breaks queries | Avoided: synthetic worktree with status `.conductor` instead. Filtered from normal worktree listings. |
+
+### Phase 1b Risks (Deferred)
+
+| Risk | Mitigation |
+|------|------------|
+| Stale notification race (terminal transitions running->waiting->running before conductor acts) | Server-side send guard: `terminal.send` checks TerminalStateTracker state before dispatching. Rejects sends to non-waiting terminals. |
+| Conductor sends conflicting message while user is typing | Interaction lock prevents simultaneous sends. User input always takes priority (conductor can't send to a `running` terminal). |
+| tmux capture-pane failure masks terminal state | TerminalStateTracker produces `unknown` state on detection errors instead of silently reporting `running`. Conductors can flag persistent `unknown` states. |
+| Conductor crashes with held interaction lock | Daemon detects conductor terminal death via TerminalStateTracker periodic polling. Immediately releases all locks held by dead conductor. |
+| TerminalStateTracker polling adds overhead | 10s polling only for `running` terminals. Most detection is event-driven via hooks. Polling is a safety net. |
+| Refactoring SuspendResumeCoordinator breaks suspend/resume | Tracker exposes `clearIdleFlag()` preserving existing semantics. 30s resume delay stays in coordinator. Existing tests serve as regression suite. |

--- a/docs/superpowers/specs/2026-04-02-conductor-phase-1b-deferred.md
+++ b/docs/superpowers/specs/2026-04-02-conductor-phase-1b-deferred.md
@@ -1,0 +1,233 @@
+# Conductor Phase 1b: Event-Driven Routing (Deferred)
+
+Extracted from the [Conductor Pattern Design](2026-04-02-conductor-pattern-design.md). This is a potential future enhancement, not a planned phase.
+
+## Why Deferred
+
+- **Event-driven notifications burn tokens.** The conductor is a Claude session — every `[TERMINAL WAITING]` notification costs ~3-5k tokens to process (message parsing, state.json read, decision logic, response or escalation). With 5+ active terminals, this adds up fast.
+- **Heartbeats cost tokens even when nothing changed.** Each heartbeat cycle costs ~1-2k tokens for the conductor to read and respond to, regardless of whether any terminal state actually changed.
+- **Agent Deck's conductor works without event-driven push.** It uses timer-based polling (launchd heartbeat) and that's sufficient. The polling model is proven in production.
+- **Phase 1a with manual polling + `terminal.conversation` delivers the core value.** The conductor can read agent output, auto-respond to waiting terminals, and escalate — all without the daemon pushing notifications.
+- **Phase 1b is not required for Phase 2 (app UI).** The sidebar only needs the conductor DB, lifecycle, and terminal state from Phase 1a. Event-driven routing is orthogonal to the UI layer.
+- **Can revisit if a lightweight heartbeat proves worthwhile.** A launchd timer that only fires when terminals are in `waiting` state would avoid the always-on token cost. This is worth exploring if manual polling feels too slow in practice.
+
+## What This Would Add
+
+### TerminalStateTracker
+
+Extracted from `SuspendResumeCoordinator`. Owns all terminal state detection logic, independent of what consumers do with the information.
+
+**Inputs:**
+- `response_complete` notifications (already broadcast as StateDelta from the notify RPC)
+- `ClaudeStateDetector.isIdle()` polling (tmux capture-pane heuristic)
+- Terminal process status (is Claude process running in the pane?)
+
+**State model per terminal:**
+
+| State | Meaning | Detection |
+|-------|---------|-----------|
+| `running` | Claude is actively processing | `ClaudeStateDetector.busyIndicators` present in pane |
+| `waiting` | Claude finished, needs input | `response_complete` hook fired AND `isIdle()` confirms prompt visible |
+| `idle` | Shell prompt, no Claude running | `paneCurrentCommand` is not a Claude process |
+| `unknown` | Can't determine | tmux capture-pane failed, window dead, or detection error |
+
+The `unknown` state is produced when `capturePaneOutput` or `paneCurrentCommand` throws. `ClaudeStateDetector.isIdle()` currently swallows errors and returns `false` (appearing as `running`). The tracker must distinguish "confirmed busy" from "can't tell" by catching errors explicitly.
+
+**API:**
+```swift
+public actor TerminalStateTracker {
+    /// Current state of a terminal
+    func state(terminalID: UUID) async -> TerminalState
+    
+    /// All terminals in a given state
+    func terminals(in state: TerminalState) async -> [TerminalStateEntry]
+    
+    /// Called when response_complete notification arrives
+    func responseCompleted(terminalID: UUID, worktreeID: UUID)
+    
+    /// Clear idle tracking for a worktree (called by SuspendResumeCoordinator
+    /// on suspend/resume to prevent immediate re-eligibility)
+    func clearIdleFlag(worktreeID: UUID)
+    
+    /// Subscribe to state transitions
+    func onTransition(_ handler: @Sendable (TerminalStateTransition) -> Void)
+}
+
+public struct TerminalStateEntry: Sendable {
+    let terminalID: UUID
+    let worktreeID: UUID
+    let repoID: UUID
+    let state: TerminalState
+    let since: Date              // when it entered this state
+    let terminalLabel: String?   // e.g. "claude", "setup"
+    let lastAssistantMessage: String?  // last assistant message from Claude session JSONL
+}
+
+public struct TerminalStateTransition: Sendable {
+    let terminalID: UUID
+    let worktreeID: UUID
+    let repoID: UUID
+    let worktreeName: String
+    let branchName: String
+    let terminalLabel: String?
+    let from: TerminalState
+    let to: TerminalState
+    let timestamp: Date
+}
+```
+
+**Polling cadence:** Running terminals are polled more frequently than idle ones (e.g., ~10s vs ~60s). Exact intervals are implementation details — the invariant is that the tracker detects running->waiting transitions within a reasonable window. Event-driven via `response_complete` hook provides near-instant detection for the common case; polling is the safety net.
+
+**Relationship to SuspendResumeCoordinator:** The coordinator becomes a consumer of `TerminalStateTracker` instead of managing its own `worktreeIdleFromHook` set. It subscribes to transitions and triggers suspend/resume logic when appropriate. The coordinator-specific 30-second re-eligibility delay after resume stays in the coordinator, not the tracker. The tracker exposes `clearIdleFlag(worktreeID:)` so the coordinator can reset idle tracking on suspend/resume (preserving the existing `worktreeIdleFromHook.remove()` semantics at SuspendResumeCoordinator.swift lines 158, 300).
+
+### ConductorRouter
+
+Routes terminal state transitions to the appropriate conductor(s) based on scope configuration.
+
+**Responsibilities:**
+- Loads conductor configs from the `conductor` DB table
+- On each `TerminalStateTransition`, determines which conductors should be notified
+- Manages interaction locks (one conductor at a time per worktree)
+- Formats and delivers messages to conductor terminals
+- Detects conductor terminal death and releases interaction locks
+
+**Routing rules:**
+1. When a terminal transitions to `waiting`: notify all conductors whose scope includes that terminal's repo (filtered by worktree and terminal_label if configured)
+2. When a conductor wants to send a message to a terminal: the `terminal.send` RPC handler verifies the target terminal is currently in `waiting` state before dispatching `sendKeys`. This is a server-side invariant — if the terminal transitioned to `running` between the conductor's decision and the send, the RPC returns an error.
+
+### Server-Side Send Guard
+
+The `terminal.send` RPC handler (RPCRouter+TerminalHandlers.swift) gains a state check:
+
+```
+terminal.send received (from conductor)
+  -> Look up terminal in TerminalStateTracker
+  -> If state != .waiting: return error "terminal is not waiting for input (current state: running)"
+  -> If interaction lock held by another conductor: return error "locked by conductor X"
+  -> Acquire interaction lock, send keys, return success
+```
+
+No permission check — any conductor can interact. The guard enforces two invariants: the terminal must be waiting, and no other conductor can be mid-interaction with the same worktree. This prevents the stale-notification race: even if a conductor acts on an outdated `[TERMINAL WAITING]` notification, the send is rejected server-side if the terminal has already transitioned.
+
+### Heartbeat Delivery
+
+The daemon runs a single heartbeat timer in `Daemon.swift` (alongside existing periodic timers). The timer fires at the minimum interval across all active conductors and tracks per-conductor cadence — each conductor receives heartbeats at its own configured interval.
+
+```
+[HEARTBEAT] 5 terminals across 2 repos.
+  waiting (3m): fix-auth @ my-app [claude] — "Should I also update the test fixtures?" (from session JSONL)
+  waiting (12m): add-export @ my-app [claude] — "Which CSV library should I use?" (from session JSONL)
+  running: refactor-db @ api-server [claude]
+  running: add-metrics @ api-server [claude]
+  idle (1h): setup-ci @ my-app [setup]
+```
+
+### Full CLAUDE.md Template
+
+Replaces the Phase 1a template. Adds sections for `[TERMINAL WAITING]`, `[HEARTBEAT]`, `tbd terminal state`, structured response formats, and quick commands. Key additions over Phase 1a:
+
+```markdown
+## How You Receive Information
+
+The TBD daemon sends you two types of messages automatically:
+
+1. **[TERMINAL WAITING]** — Real-time notification when a terminal needs input.
+   Includes terminal ID, repo, worktree, branch, duration, and last assistant message from session JSONL.
+   Decide: auto-respond or escalate.
+
+2. **[HEARTBEAT]** — Periodic summary of all terminal states.
+   Review for stuck agents, long waits, or patterns needing attention.
+   Reply with a [STATUS] report (see Response Formats below).
+
+## Additional CLI Commands (Phase 1b)
+
+| Command | Description |
+|---------|-------------|
+| `tbd terminal state --json` | List all terminal states with running/waiting/idle/unknown |
+
+## Response Formats
+
+### Heartbeat Response
+[STATUS] All clear.
+
+or:
+
+[STATUS] Auto-responded to 1 terminal. 1 needs your attention.
+
+AUTO: fix-auth — told it to proceed with updating test fixtures
+NEED: add-export — asking about CSV library preference
+
+### Quick Commands
+
+Self-invokable procedures for common tasks:
+
+| Command | What to Do |
+|---------|------------|
+| "check status" | Run `tbd terminal state --json`, summarize |
+| "check <worktree>" | Find terminal, run `tbd terminal conversation <id>`, summarize |
+| "list sessions" | Run `tbd terminal state --json`, format as table |
+
+## Unknown/Error States
+
+If a terminal shows `unknown` state for more than 2 consecutive heartbeats,
+escalate to the user. The terminal may be dead or its tmux window may need
+recreation.
+
+## Idle Terminals
+
+Terminals in `idle` state have no Claude process running (just a shell prompt).
+Do not send messages to idle terminals. Note them in status reports but take
+no action unless the user asks.
+```
+
+### Additional RPC Methods
+
+| Method | Params | Result | Description |
+|--------|--------|--------|-------------|
+| `terminal.state` | terminalID | TerminalStateEntry | Get current terminal state |
+| `terminal.states` | repoID? | TerminalStateEntry[] | Get all terminal states, optionally filtered by repo |
+
+### Additional CLI Commands
+
+```bash
+tbd terminal state [--repo <id>] [--json]     # list terminal states
+```
+
+## Data Flows
+
+### Terminal transitions to "waiting" (event-driven)
+
+```
+Claude finishes response
+  -> PostToolUse hook fires `tbd notify --type response_complete`
+  -> Daemon receives notification via RPC
+  -> TerminalStateTracker.responseCompleted() called
+  -> ClaudeStateDetector.isIdle() confirms (debounced)
+  -> TerminalStateTracker emits transition(running -> waiting)
+  -> ConductorRouter receives transition
+  -> Router checks scope: which conductors cover this repo/worktree/label?
+  -> Router formats [TERMINAL WAITING] message with context
+  -> Router sends to each scoped conductor via TmuxManager.sendKeys()
+  -> SuspendResumeCoordinator also receives transition (if enabled)
+```
+
+### Heartbeat
+
+```
+Daemon heartbeat timer fires (every N minutes, in Daemon.swift)
+  -> TerminalStateTracker.terminals(in:) queried for all states
+  -> Filtered by conductor scope (repos, worktrees, terminal labels)
+  -> Formatted as [HEARTBEAT] message
+  -> Sent to conductor terminal
+```
+
+## Testing (Phase 1b-specific)
+
+- **TerminalStateTracker tests:** Mock TmuxManager in dryRun mode + mockable `ClaudeStateDetector` interface. Verify state transitions fire correctly, test response_complete -> waiting transition, test capture-pane failure -> unknown state, test clearIdleFlag semantics
+- **ConductorRouter tests:** Verify scope filtering (repo match, wildcard, worktree patterns, terminal labels), verify interaction lock acquire/release/expiry, verify lock conflict between two conductors, verify message formatting, verify conductor death releases locks
+- **Server-side send guard tests:** Verify terminal.send rejects when terminal is running, verify it succeeds when waiting, verify lock conflict returns error
+- **SuspendResumeCoordinator regression tests:** Existing tests still pass after TerminalStateTracker extraction
+
+## Migration Notes
+
+- **SuspendResumeCoordinator refactor:** Extract idle detection into `TerminalStateTracker`. Coordinator subscribes to tracker transitions. `clearIdleFlag()` replaces direct `worktreeIdleFromHook.remove()` calls. The coordinator-specific 30-second re-eligibility delay after resume stays in the coordinator (not the tracker). Public API unchanged.


### PR DESCRIPTION
## Summary
- Adds a **conductor** system — persistent Claude Code sessions that monitor and coordinate other Claude terminals across worktrees and repos. Conductors can read agent conversation history via session JSONL, auto-respond to waiting agents, and escalate to the user via macOS notifications.
- Implements Phase 1a (minimal viable conductor): `WorktreeStatus.conductor`, DB migration v9 (conductor table + synthetic repo), `terminal.output` RPC (debug), `terminal.conversation` RPC (reads Claude session JSONL), `ConductorManager` lifecycle (setup/start/stop/teardown), CLI commands (`tbd conductor setup/start/stop/teardown/list/status`), and a CLAUDE.md template that teaches Claude how to be a conductor.
- Includes design spec for the full conductor pattern (Phase 1a + deferred Phase 1b + Phase 2) with flexible scoping (per-repo, per-worktree, per-terminal-label) and interaction locking.

## Test plan
- [ ] `swift build` succeeds
- [ ] `swift test` — all 195 tests pass (new: ConductorStore, ConductorManager, terminal.output, worktree/repo filtering)
- [ ] `tbd conductor setup test-conductor` creates directory at `~/.tbd/conductors/test-conductor/` with CLAUDE.md
- [ ] `tbd conductor list --json` shows the conductor
- [ ] `tbd conductor start test-conductor` creates tmux window in `tbd-conductor` server
- [ ] `tbd conductor stop test-conductor` kills the window
- [ ] `tbd conductor teardown test-conductor` removes everything
- [ ] `tbd terminal output <id>` captures terminal viewport (debug)
- [ ] `tbd terminal conversation <id>` reads Claude session JSONL
- [ ] Conductor worktrees don't appear in `tbd worktree list`
- [ ] Synthetic conductors repo doesn't appear in `tbd repo list`