### PR TITLE
Feat: Let users create Claude sessions and notes from the tab bar

### DIFF
--- a/Sources/TBDApp/AppState+Notes.swift
+++ b/Sources/TBDApp/AppState+Notes.swift
@@ -50,36 +50,4 @@ extension AppState {
         }
     }
 
-    /// Fork a Claude terminal by resuming from an existing session ID.
-    func forkClaudeTerminal(worktreeID: UUID, sessionID: String) async {
-        do {
-            let terminal = try await daemonClient.createTerminal(
-                worktreeID: worktreeID,
-                resumeSessionID: sessionID
-            )
-            terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
-            tabs[worktreeID, default: []].append(tab)
-        } catch {
-            logger.error("Failed to fork Claude terminal: \(error)")
-            handleConnectionError(error)
-        }
-    }
-
-    /// Create a Claude terminal in a worktree and add a new tab for it.
-    func createClaudeTerminal(worktreeID: UUID) async {
-        do {
-            let terminal = try await daemonClient.createTerminal(
-                worktreeID: worktreeID,
-                cmd: nil,
-                type: .claude
-            )
-            terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
-            tabs[worktreeID, default: []].append(tab)
-        } catch {
-            logger.error("Failed to create Claude terminal: \(error)")
-            handleConnectionError(error)
-        }
-    }
 }

--- a/Sources/TBDApp/AppState+Notes.swift
+++ b/Sources/TBDApp/AppState+Notes.swift
@@ -50,6 +50,22 @@ extension AppState {
         }
     }
 
+    /// Fork a Claude terminal by resuming from an existing session ID.
+    func forkClaudeTerminal(worktreeID: UUID, sessionID: String) async {
+        do {
+            let terminal = try await daemonClient.createTerminal(
+                worktreeID: worktreeID,
+                resumeSessionID: sessionID
+            )
+            terminals[worktreeID, default: []].append(terminal)
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            tabs[worktreeID, default: []].append(tab)
+        } catch {
+            logger.error("Failed to fork Claude terminal: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
     /// Create a Claude terminal in a worktree and add a new tab for it.
     func createClaudeTerminal(worktreeID: UUID) async {
         do {

--- a/Sources/TBDApp/AppState+Notes.swift
+++ b/Sources/TBDApp/AppState+Notes.swift
@@ -56,7 +56,7 @@ extension AppState {
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
                 cmd: nil,
-                type: "claude"
+                type: .claude
             )
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))

--- a/Sources/TBDApp/AppState+Notes.swift
+++ b/Sources/TBDApp/AppState+Notes.swift
@@ -1,0 +1,69 @@
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "AppState+Notes")
+
+extension AppState {
+    // MARK: - Note Actions
+
+    /// Create a note in a worktree and add a new tab for it.
+    func createNote(worktreeID: UUID) async {
+        do {
+            let note = try await daemonClient.createNote(worktreeID: worktreeID)
+            notes[worktreeID, default: []].append(note)
+            let tab = Tab(id: note.id, content: .note(noteID: note.id), label: note.title)
+            tabs[worktreeID, default: []].append(tab)
+        } catch {
+            logger.error("Failed to create note: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
+    /// Update a note's title and/or content.
+    func updateNote(noteID: UUID, worktreeID: UUID, title: String? = nil, content: String? = nil) async {
+        do {
+            let updated = try await daemonClient.updateNote(noteID: noteID, title: title, content: content)
+            if let idx = notes[worktreeID]?.firstIndex(where: { $0.id == noteID }) {
+                notes[worktreeID]?[idx] = updated
+            }
+            // Update tab label if title changed
+            if let newTitle = title {
+                if let tabIdx = tabs[worktreeID]?.firstIndex(where: { $0.id == noteID }) {
+                    tabs[worktreeID]?[tabIdx].label = newTitle
+                }
+            }
+        } catch {
+            logger.error("Failed to update note: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
+    /// Delete a note.
+    func deleteNote(noteID: UUID, worktreeID: UUID) async {
+        do {
+            try await daemonClient.deleteNote(noteID: noteID)
+            notes[worktreeID]?.removeAll { $0.id == noteID }
+        } catch {
+            logger.error("Failed to delete note: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
+    /// Create a Claude terminal in a worktree and add a new tab for it.
+    func createClaudeTerminal(worktreeID: UUID) async {
+        do {
+            let terminal = try await daemonClient.createTerminal(
+                worktreeID: worktreeID,
+                cmd: nil,
+                type: "claude"
+            )
+            terminals[worktreeID, default: []].append(terminal)
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            tabs[worktreeID, default: []].append(tab)
+        } catch {
+            logger.error("Failed to create Claude terminal: \(error)")
+            handleConnectionError(error)
+        }
+    }
+}

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -76,6 +76,39 @@ extension AppState {
         }
     }
 
+    /// Create a Claude terminal in a worktree and add a new tab for it.
+    func createClaudeTerminal(worktreeID: UUID) async {
+        do {
+            let terminal = try await daemonClient.createTerminal(
+                worktreeID: worktreeID,
+                cmd: nil,
+                type: .claude
+            )
+            terminals[worktreeID, default: []].append(terminal)
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            tabs[worktreeID, default: []].append(tab)
+        } catch {
+            logger.error("Failed to create Claude terminal: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
+    /// Fork a Claude terminal by resuming from an existing session ID.
+    func forkClaudeTerminal(worktreeID: UUID, sessionID: String) async {
+        do {
+            let terminal = try await daemonClient.createTerminal(
+                worktreeID: worktreeID,
+                resumeSessionID: sessionID
+            )
+            terminals[worktreeID, default: []].append(terminal)
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            tabs[worktreeID, default: []].append(tab)
+        } catch {
+            logger.error("Failed to fork Claude terminal: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
     /// Toggle pin state for a terminal.
     func setTerminalPin(id: UUID, pinned: Bool) async {
         // Optimistic local update

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -10,6 +10,7 @@ final class AppState: ObservableObject {
     @Published var repos: [Repo] = []
     @Published var worktrees: [UUID: [Worktree]] = [:]
     @Published var terminals: [UUID: [Terminal]] = [:]
+    @Published var notes: [UUID: [Note]] = [:]
     @Published var notifications: [UUID: NotificationType?] = [:]
     @Published var selectedWorktreeIDs: Set<UUID> = [] {
         didSet {
@@ -306,6 +307,18 @@ final class AppState: ObservableObject {
                     reconcileTabs(worktreeID: wtID, terminals: fetched)
                 }
             }
+
+            // Fetch all notes, group client-side
+            let allNotes = try await daemonClient.listNotes()
+            let notesByWorktree = Dictionary(grouping: allNotes, by: { $0.worktreeID })
+            for wtID in visibleWorktreeIDs {
+                let fetched = notesByWorktree[wtID] ?? []
+                let existing = notes[wtID] ?? []
+                if fetched != existing {
+                    notes[wtID] = fetched
+                    reconcileNoteTabs(worktreeID: wtID, notes: fetched)
+                }
+            }
         } catch {
             logger.error("Failed to list worktrees: \(error)")
             handleConnectionError(error)
@@ -364,6 +377,33 @@ final class AppState: ObservableObject {
         // 3. Add tabs for terminals not already in any surviving layout.
         for terminal in terminals where !terminalIDsInLayouts.contains(terminal.id) {
             currentTabs.append(Tab(id: terminal.id, content: .terminal(terminalID: terminal.id)))
+        }
+
+        tabs[worktreeID] = currentTabs
+    }
+
+    /// Reconcile note tabs — remove tabs whose note no longer exists,
+    /// add tabs for notes not already represented.
+    private func reconcileNoteTabs(worktreeID: UUID, notes: [Note]) {
+        var currentTabs = tabs[worktreeID] ?? []
+        let noteIDs = Set(notes.map(\.id))
+
+        // Collect note IDs already in tabs
+        var noteIDsInTabs = Set<UUID>()
+        currentTabs.removeAll { tab in
+            if case .note(let id) = tab.content {
+                if !noteIDs.contains(id) {
+                    layouts.removeValue(forKey: tab.id)
+                    return true
+                }
+                noteIDsInTabs.insert(id)
+            }
+            return false
+        }
+
+        // Add tabs for notes not already represented
+        for note in notes where !noteIDsInTabs.contains(note.id) {
+            currentTabs.append(Tab(id: note.id, content: .note(noteID: note.id), label: note.title))
         }
 
         tabs[worktreeID] = currentTabs

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -351,7 +351,7 @@ actor DaemonClient {
     }
 
     /// Create a terminal in a worktree.
-    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: String? = nil) throws -> Terminal {
+    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil) throws -> Terminal {
         return try call(
             method: RPCMethod.terminalCreate,
             params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type),

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -351,10 +351,10 @@ actor DaemonClient {
     }
 
     /// Create a terminal in a worktree.
-    func createTerminal(worktreeID: UUID, cmd: String? = nil) throws -> Terminal {
+    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: String? = nil) throws -> Terminal {
         return try call(
             method: RPCMethod.terminalCreate,
-            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd),
+            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type),
             resultType: Terminal.self
         )
     }
@@ -484,5 +484,51 @@ actor DaemonClient {
             resultType: PRRefreshResult.self
         )
         return result.status
+    }
+
+    // MARK: - Notes
+
+    /// Create a new note in a worktree.
+    func createNote(worktreeID: UUID) throws -> Note {
+        return try call(
+            method: RPCMethod.noteCreate,
+            params: NoteCreateParams(worktreeID: worktreeID),
+            resultType: Note.self
+        )
+    }
+
+    /// Get a note by ID.
+    func getNote(noteID: UUID) throws -> Note {
+        return try call(
+            method: RPCMethod.noteGet,
+            params: NoteGetParams(noteID: noteID),
+            resultType: Note.self
+        )
+    }
+
+    /// Update a note's title and/or content.
+    func updateNote(noteID: UUID, title: String? = nil, content: String? = nil) throws -> Note {
+        return try call(
+            method: RPCMethod.noteUpdate,
+            params: NoteUpdateParams(noteID: noteID, title: title, content: content),
+            resultType: Note.self
+        )
+    }
+
+    /// Delete a note.
+    func deleteNote(noteID: UUID) throws {
+        try callVoid(
+            method: RPCMethod.noteDelete,
+            params: NoteDeleteParams(noteID: noteID)
+        )
+    }
+
+    /// List notes, optionally filtered by worktree.
+    func listNotes(worktreeID: UUID? = nil) throws -> [Note] {
+        return try call(
+            method: RPCMethod.noteList,
+            params: NoteListParams(worktreeID: worktreeID),
+            resultType: [Note].self
+        )
     }
 }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -351,10 +351,10 @@ actor DaemonClient {
     }
 
     /// Create a terminal in a worktree.
-    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil) throws -> Terminal {
+    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil) throws -> Terminal {
         return try call(
             method: RPCMethod.terminalCreate,
-            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type),
+            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, resumeSessionID: resumeSessionID),
             resultType: Terminal.self
         )
     }

--- a/Sources/TBDApp/Panes/NotePaneView.swift
+++ b/Sources/TBDApp/Panes/NotePaneView.swift
@@ -39,6 +39,12 @@ struct NotePaneView: View {
             .onDisappear {
                 saveTask?.cancel()
                 saveTask = nil
+                // Flush an immediate save so content isn't lost on tab switch.
+                // If the note was deleted, updateNote gets "Note not found"
+                // which handleConnectionError already absorbs silently.
+                if loaded {
+                    Task { await appState.updateNote(noteID: noteID, worktreeID: worktreeID, content: text) }
+                }
             }
     }
 

--- a/Sources/TBDApp/Panes/NotePaneView.swift
+++ b/Sources/TBDApp/Panes/NotePaneView.swift
@@ -17,17 +17,24 @@ struct NotePaneView: View {
     var body: some View {
         TextEditor(text: $text)
             .font(.system(.body, design: .monospaced))
+            .padding(12)
             .scrollContentBackground(.hidden)
             .background(Color(nsColor: .textBackgroundColor))
             .onChange(of: text) { _, newValue in
                 guard loaded else { return }
                 debounceSave(content: newValue)
             }
+            .onChange(of: note?.content) { _, newContent in
+                // Load content when note data arrives from polling
+                guard !loaded, let newContent else { return }
+                text = newContent
+                loaded = true
+            }
             .task(id: noteID) {
                 if let note {
                     text = note.content
+                    loaded = true
                 }
-                loaded = true
             }
     }
 

--- a/Sources/TBDApp/Panes/NotePaneView.swift
+++ b/Sources/TBDApp/Panes/NotePaneView.swift
@@ -36,6 +36,10 @@ struct NotePaneView: View {
                     loaded = true
                 }
             }
+            .onDisappear {
+                saveTask?.cancel()
+                saveTask = nil
+            }
     }
 
     private func debounceSave(content: String) {

--- a/Sources/TBDApp/Panes/NotePaneView.swift
+++ b/Sources/TBDApp/Panes/NotePaneView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import TBDShared
+
+/// A simple text editor pane for freeform notes.
+struct NotePaneView: View {
+    let noteID: UUID
+    let worktreeID: UUID
+    @EnvironmentObject var appState: AppState
+    @State private var text: String = ""
+    @State private var loaded = false
+    @State private var saveTask: Task<Void, Never>?
+
+    private var note: Note? {
+        appState.notes[worktreeID]?.first { $0.id == noteID }
+    }
+
+    var body: some View {
+        TextEditor(text: $text)
+            .font(.system(.body, design: .monospaced))
+            .scrollContentBackground(.hidden)
+            .background(Color(nsColor: .textBackgroundColor))
+            .onChange(of: text) { _, newValue in
+                guard loaded else { return }
+                debounceSave(content: newValue)
+            }
+            .task(id: noteID) {
+                if let note {
+                    text = note.content
+                }
+                loaded = true
+            }
+    }
+
+    private func debounceSave(content: String) {
+        saveTask?.cancel()
+        saveTask = Task {
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            await appState.updateNote(noteID: noteID, worktreeID: worktreeID, content: content)
+        }
+    }
+}

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -73,6 +73,16 @@ struct PanePlaceholder: View {
         }
     }
 
+    /// Find the Note model matching a note ID across all worktree notes.
+    private func note(for id: UUID) -> Note? {
+        for (_, noteList) in appState.notes {
+            if let n = noteList.first(where: { $0.id == id }) {
+                return n
+            }
+        }
+        return nil
+    }
+
     @ViewBuilder
     private var paneLabel: some View {
         switch content {
@@ -102,6 +112,8 @@ struct PanePlaceholder: View {
             Text(url.host ?? url.absoluteString)
         case .codeViewer(_, let path):
             Text(URL(fileURLWithPath: path).lastPathComponent)
+        case .note(let noteID):
+            EditableNoteTitle(noteID: noteID, worktreeID: worktree.id)
         }
     }
 
@@ -154,6 +166,9 @@ struct PanePlaceholder: View {
                 .buttonStyle(.borderless)
                 .help(showSourceCode ? "Show rendered view" : "Show source code")
             }
+
+        case .note:
+            EmptyView()
         }
     }
 
@@ -168,6 +183,8 @@ struct PanePlaceholder: View {
             WebviewPaneView(url: url)
         case .codeViewer(_, let path):
             CodeViewerPaneView(path: path, worktreePath: worktree.path, showSourceCode: showSourceCode)
+        case .note(let noteID):
+            NotePaneView(noteID: noteID, worktreeID: worktree.id)
         }
     }
 
@@ -230,6 +247,11 @@ struct PanePlaceholder: View {
     // MARK: - Close
 
     private func closePane() {
+        // Delete the underlying resource for note panes
+        if case .note(let noteID) = content {
+            Task { await appState.deleteNote(noteID: noteID, worktreeID: worktree.id) }
+        }
+
         if let newLayout = layout.removePane(id: content.paneID) {
             layout = newLayout
         } else {
@@ -266,6 +288,53 @@ struct PanePlaceholder: View {
             direction: direction,
             newContent: .terminal(terminalID: newTerminal.id)
         )
+    }
+}
+
+// MARK: - EditableNoteTitle
+
+/// An inline-editable title for note panes. Displays as text, becomes
+/// a text field on click. Commits on Enter or focus loss.
+struct EditableNoteTitle: View {
+    let noteID: UUID
+    let worktreeID: UUID
+    @EnvironmentObject var appState: AppState
+    @State private var isEditing = false
+    @State private var editText = ""
+    @FocusState private var isFocused: Bool
+
+    private var note: Note? {
+        appState.notes[worktreeID]?.first { $0.id == noteID }
+    }
+
+    var body: some View {
+        if isEditing {
+            TextField("Title", text: $editText, onCommit: {
+                commitEdit()
+            })
+            .textFieldStyle(.plain)
+            .font(.caption)
+            .focused($isFocused)
+            .onAppear { isFocused = true }
+            .onChange(of: isFocused) { _, focused in
+                if !focused { commitEdit() }
+            }
+        } else {
+            Text(note?.title ?? "Note")
+                .onTapGesture {
+                    editText = note?.title ?? ""
+                    isEditing = true
+                }
+        }
+    }
+
+    private func commitEdit() {
+        isEditing = false
+        let trimmed = editText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != note?.title else { return }
+        Task {
+            await appState.updateNote(noteID: noteID, worktreeID: worktreeID, title: trimmed)
+        }
     }
 }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -73,16 +73,6 @@ struct PanePlaceholder: View {
         }
     }
 
-    /// Find the Note model matching a note ID across all worktree notes.
-    private func note(for id: UUID) -> Note? {
-        for (_, noteList) in appState.notes {
-            if let n = noteList.first(where: { $0.id == id }) {
-                return n
-            }
-        }
-        return nil
-    }
-
     @ViewBuilder
     private var paneLabel: some View {
         switch content {

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -8,7 +8,9 @@ import TBDShared
 struct TabBar: View {
     let tabs: [Tab]
     @Binding var activeTabIndex: Int
-    var onAddTab: () -> Void
+    var onAddShell: () -> Void = {}
+    var onAddClaude: () -> Void = {}
+    var onAddNote: () -> Void = {}
     var onCloseTab: (Int) -> Void
     var terminalForTab: (UUID) -> Terminal? = { _ in nil }
     var onSuspendTab: (UUID) -> Void = { _ in }
@@ -41,15 +43,28 @@ struct TabBar: View {
                 .fill(Color.primary.opacity(0.08))
                 .frame(width: 1, height: 18)
 
-            Button(action: onAddTab) {
+            Menu {
+                Button(action: onAddShell) {
+                    Label("Shell", systemImage: "terminal")
+                }
+                Button(action: onAddClaude) {
+                    Label("Claude", systemImage: "sparkle")
+                }
+                Divider()
+                Button(action: onAddNote) {
+                    Label("Note", systemImage: "note.text")
+                }
+            } label: {
                 Image(systemName: "plus")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
                     .frame(width: 34, height: 28)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .help("New Terminal Tab")
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .frame(width: 34, height: 28)
+            .help("New Tab")
 
             Spacer()
         }
@@ -194,6 +209,7 @@ private struct TabBarItem: View {
             return isSuspended ? "moon.zzz" : "terminal"
         case .webview: return "globe"
         case .codeViewer: return "doc.text"
+        case .note: return "note.text"
         }
     }
 
@@ -208,6 +224,8 @@ private struct TabBarItem: View {
             return url.host ?? "Web"
         case .codeViewer(_, let path):
             return URL(fileURLWithPath: path).lastPathComponent
+        case .note:
+            return "Note \(index + 1)"
         }
     }
 }

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -174,37 +174,40 @@ private struct TabBarItem: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            // Sidebar toggle for code viewer tabs
-            if isCodeViewer {
-                Button {
-                    withAnimation(.easeInOut(duration: 0.15)) {
-                        showSidebar.toggle()
+            // Clickable tab content area
+            Button(action: onSelect) {
+                HStack(spacing: 0) {
+                    // Sidebar toggle for code viewer tabs
+                    if isCodeViewer {
+                        Image(systemName: "sidebar.left")
+                            .font(.system(size: 10))
+                            .foregroundStyle(showSidebar ? .primary : .tertiary)
+                            .frame(width: 16, height: 16)
+                            .padding(.trailing, 2)
+                            .onTapGesture {
+                                withAnimation(.easeInOut(duration: 0.15)) {
+                                    showSidebar.toggle()
+                                }
+                            }
                     }
-                } label: {
-                    Image(systemName: "sidebar.left")
+
+                    // Type icon
+                    Image(systemName: tabIcon)
                         .font(.system(size: 10))
-                        .foregroundStyle(showSidebar ? .primary : .tertiary)
-                        .frame(width: 16, height: 16)
+                        .foregroundStyle(isSelected ? .primary : .tertiary)
+                        .frame(width: 14)
+                        .padding(.trailing, 3)
+
+                    Text(tabLabel)
+                        .font(.system(size: 11))
+                        .lineLimit(1)
+                        .fixedSize()
+                        .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))
                 }
-                .buttonStyle(.plain)
-                .help("Toggle file tree")
-                .padding(.trailing, 2)
             }
+            .buttonStyle(.plain)
 
-            // Type icon
-            Image(systemName: tabIcon)
-                .font(.system(size: 10))
-                .foregroundStyle(isSelected ? .primary : .tertiary)
-                .frame(width: 14)
-                .padding(.trailing, 3)
-
-            Text(tabLabel)
-                .font(.system(size: 11))
-                .lineLimit(1)
-                .fixedSize()
-                .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))
-
-            // Close button — right side, flush to edge
+            // Close button — right side
             Button(action: onClose) {
                 Image(systemName: "xmark")
                     .font(.system(size: 8, weight: .bold))
@@ -232,29 +235,31 @@ private struct TabBarItem: View {
                 : (isHovering ? Color.primary.opacity(0.04) : Color.clear)
         )
         .animation(.easeInOut(duration: 0.1), value: isHovering)
+        .contextMenu { contextMenuContent }
         .onHover { hovering in
             isHovering = hovering
         }
-        .onTapGesture {
-            onSelect()
+    }
+
+    @ViewBuilder
+    private var contextMenuContent: some View {
+        if isClaudeTerminal {
+            Button(action: onFork) {
+                Label("Fork Session", systemImage: "arrow.triangle.branch")
+            }
+
+            Button(action: isSuspended ? onResume : onSuspend) {
+                Label(
+                    isSuspended ? "Resume Claude" : "Suspend Claude",
+                    systemImage: isSuspended ? "play.circle" : "pause.circle"
+                )
+            }
+
+            Divider()
         }
-        .contentShape(Rectangle())
-        .contextMenu {
-            if isClaudeTerminal {
-                Button(action: onFork) {
-                    Label("Fork Session", systemImage: "arrow.triangle.branch")
-                }
-                Button(action: isSuspended ? onResume : onSuspend) {
-                    Label(
-                        isSuspended ? "Resume Claude" : "Suspend Claude",
-                        systemImage: isSuspended ? "play.circle" : "pause.circle"
-                    )
-                }
-                Divider()
-            }
-            Button(action: onClose) {
-                Label("Close Tab", systemImage: "xmark")
-            }
+
+        Button(action: onClose) {
+            Label("Close Tab", systemImage: "xmark")
         }
     }
 
@@ -285,3 +290,4 @@ private struct TabBarItem: View {
         }
     }
 }
+

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -43,35 +43,97 @@ struct TabBar: View {
                 .fill(Color.primary.opacity(0.08))
                 .frame(width: 1, height: 18)
 
-            Menu {
-                Button(action: onAddShell) {
-                    Label("Shell", systemImage: "terminal")
-                }
-                Button(action: onAddClaude) {
-                    Label("Claude", systemImage: "sparkle")
-                }
-                Divider()
-                Button(action: onAddNote) {
-                    Label("Note", systemImage: "note.text")
-                }
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 34, height: 28)
-                    .contentShape(Rectangle())
-            }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .frame(width: 34, height: 28)
-            .help("New Tab")
-
+            AddTabButton(
+                onAddShell: onAddShell,
+                onAddClaude: onAddClaude,
+                onAddNote: onAddNote
+            )
             Spacer()
         }
         .padding(.horizontal, 0)
         .frame(height: 30)
         .background(Color(nsColor: .windowBackgroundColor))
     }
+}
+
+// MARK: - AddTabButton
+
+/// Plain Button that shows an NSMenu on click. SwiftUI's Menu + borderlessButton
+/// swallows hover events, making custom hover styling impossible. Using NSMenu
+/// directly sidesteps this entirely.
+private struct AddTabButton: View {
+    let onAddShell: () -> Void
+    let onAddClaude: () -> Void
+    let onAddNote: () -> Void
+    @State private var isHovering = false
+
+    var body: some View {
+        Image(systemName: "plus")
+            .font(.caption)
+            .foregroundStyle(isHovering ? .primary : .secondary)
+            .frame(width: 20, height: 20)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isHovering ? Color.primary.opacity(0.08) : Color.clear)
+            )
+            .padding(6)
+            .contentShape(Rectangle())
+            .onHover { hovering in isHovering = hovering }
+            .onTapGesture { showMenu() }
+            .help("New Tab")
+    }
+
+    private func showMenu() {
+        let menu = NSMenu()
+
+        let shellItem = NSMenuItem(title: "Shell", action: nil, keyEquivalent: "")
+        shellItem.image = NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
+        shellItem.target = nil
+        menu.addItem(shellItem)
+
+        let claudeItem = NSMenuItem(title: "Claude", action: nil, keyEquivalent: "")
+        claudeItem.image = NSImage(systemSymbolName: "sparkle", accessibilityDescription: nil)
+        menu.addItem(claudeItem)
+
+        menu.addItem(.separator())
+
+        let noteItem = NSMenuItem(title: "Note", action: nil, keyEquivalent: "")
+        noteItem.image = NSImage(systemSymbolName: "note.text", accessibilityDescription: nil)
+        menu.addItem(noteItem)
+
+        // Use a coordinator to handle menu item actions via closures
+        let coordinator = MenuCoordinator(
+            onShell: onAddShell, onClaude: onAddClaude, onNote: onAddNote
+        )
+        shellItem.target = coordinator
+        shellItem.action = #selector(MenuCoordinator.addShell)
+        claudeItem.target = coordinator
+        claudeItem.action = #selector(MenuCoordinator.addClaude)
+        noteItem.target = coordinator
+        noteItem.action = #selector(MenuCoordinator.addNote)
+
+        // Keep coordinator alive for the duration of the menu
+        objc_setAssociatedObject(menu, "coordinator", coordinator, .OBJC_ASSOCIATION_RETAIN)
+
+        let location = NSEvent.mouseLocation
+        menu.popUp(positioning: nil, at: location, in: nil)
+    }
+}
+
+private class MenuCoordinator: NSObject {
+    let onShell: () -> Void
+    let onClaude: () -> Void
+    let onNote: () -> Void
+
+    init(onShell: @escaping () -> Void, onClaude: @escaping () -> Void, onNote: @escaping () -> Void) {
+        self.onShell = onShell
+        self.onClaude = onClaude
+        self.onNote = onNote
+    }
+
+    @objc func addShell() { onShell() }
+    @objc func addClaude() { onClaude() }
+    @objc func addNote() { onNote() }
 }
 
 // MARK: - TabBarItem
@@ -88,7 +150,6 @@ private struct TabBarItem: View {
 
     @State private var isHovering = false
     @State private var isHoveringClose = false
-    @State private var isHoveringSuspend = false
     @AppStorage("codeViewer.showSidebar") private var showSidebar = false
 
     private var showClose: Bool {
@@ -101,8 +162,7 @@ private struct TabBarItem: View {
     }
 
     private var isClaudeTerminal: Bool {
-        guard let terminal else { return false }
-        return terminal.label?.hasPrefix("claude") == true
+        terminal?.claudeSessionID != nil
     }
 
     private var isSuspended: Bool {
@@ -111,24 +171,6 @@ private struct TabBarItem: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            // Close button area — always takes space, visibility changes via opacity
-            Button(action: onClose) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 8, weight: .bold))
-                    .foregroundStyle(isHoveringClose ? .primary : .secondary)
-                    .frame(width: 16, height: 16)
-                    .background(
-                        Circle()
-                            .fill(Color.primary.opacity(isHoveringClose ? 0.12 : 0))
-                    )
-                    .onHover { hovering in
-                        isHoveringClose = hovering
-                    }
-            }
-            .buttonStyle(.plain)
-            .opacity(showClose ? 1 : 0)
-            .animation(.easeInOut(duration: 0.12), value: showClose)
-
             // Sidebar toggle for code viewer tabs
             if isCodeViewer {
                 Button {
@@ -146,28 +188,6 @@ private struct TabBarItem: View {
                 .padding(.trailing, 2)
             }
 
-            // Suspend/resume button for Claude terminals
-            if isClaudeTerminal {
-                Button(action: isSuspended ? onResume : onSuspend) {
-                    Image(systemName: isSuspended ? "play.circle" : "pause.circle")
-                        .font(.system(size: 10))
-                        .foregroundStyle(isHoveringSuspend ? .primary : .secondary)
-                        .frame(width: 16, height: 16)
-                        .background(
-                            Circle()
-                                .fill(Color.primary.opacity(isHoveringSuspend ? 0.12 : 0))
-                        )
-                        .onHover { hovering in
-                            isHoveringSuspend = hovering
-                        }
-                }
-                .buttonStyle(.plain)
-                .opacity((isSuspended || showClose) ? 1 : 0)
-                .animation(.easeInOut(duration: 0.12), value: isSuspended || showClose)
-                .help(isSuspended ? "Resume Claude" : "Suspend Claude")
-                .padding(.trailing, 2)
-            }
-
             // Type icon
             Image(systemName: tabIcon)
                 .font(.system(size: 10))
@@ -178,16 +198,31 @@ private struct TabBarItem: View {
             Text(tabLabel)
                 .font(.system(size: 11))
                 .lineLimit(1)
+                .fixedSize()
                 .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))
-                .frame(maxWidth: .infinity)
 
-            // Invisible spacer matching close button width for centering
-            Color.clear
-                .frame(width: 16, height: 16)
+            // Close button — right side, flush to edge
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(isHoveringClose ? .primary : .secondary)
+                    .frame(width: 18, height: 18)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color.primary.opacity(isHoveringClose ? 0.08 : 0))
+                    )
+                    .onHover { hovering in
+                        isHoveringClose = hovering
+                    }
+            }
+            .buttonStyle(.plain)
+            .padding(.leading, 2)
+            .padding(.trailing, 2)
+            .opacity(showClose ? 1 : 0)
+            .animation(.easeInOut(duration: 0.12), value: showClose)
         }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 2)
-        .frame(minWidth: 80, maxWidth: 180, minHeight: 28)
+        .padding(.leading, 8)
+        .frame(minHeight: 28)
         .background(
             isSelected
                 ? Color(nsColor: .controlBackgroundColor)
@@ -201,11 +236,27 @@ private struct TabBarItem: View {
             onSelect()
         }
         .contentShape(Rectangle())
+        .contextMenu {
+            if isClaudeTerminal {
+                Button(action: isSuspended ? onResume : onSuspend) {
+                    Label(
+                        isSuspended ? "Resume Claude" : "Suspend Claude",
+                        systemImage: isSuspended ? "play.circle" : "pause.circle"
+                    )
+                }
+            }
+            Button(action: onClose) {
+                Label("Close Tab", systemImage: "xmark")
+            }
+        }
     }
 
     private var tabIcon: String {
         switch tab.content {
         case .terminal:
+            if isClaudeTerminal {
+                return isSuspended ? "moon.zzz" : "alien.headphones"
+            }
             return isSuspended ? "moon.zzz" : "terminal"
         case .webview: return "globe"
         case .codeViewer: return "doc.text"

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -15,6 +15,7 @@ struct TabBar: View {
     var terminalForTab: (UUID) -> Terminal? = { _ in nil }
     var onSuspendTab: (UUID) -> Void = { _ in }
     var onResumeTab: (UUID) -> Void = { _ in }
+    var onForkTab: (UUID) -> Void = { _ in }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -34,7 +35,8 @@ struct TabBar: View {
                     onSelect: { activeTabIndex = index },
                     onClose: { onCloseTab(index) },
                     onSuspend: { onSuspendTab(tab.id) },
-                    onResume: { onResumeTab(tab.id) }
+                    onResume: { onResumeTab(tab.id) },
+                    onFork: { onForkTab(tab.id) }
                 )
             }
 
@@ -88,11 +90,10 @@ private struct AddTabButton: View {
 
         let shellItem = NSMenuItem(title: "Shell", action: nil, keyEquivalent: "")
         shellItem.image = NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
-        shellItem.target = nil
         menu.addItem(shellItem)
 
         let claudeItem = NSMenuItem(title: "Claude", action: nil, keyEquivalent: "")
-        claudeItem.image = NSImage(systemSymbolName: "sparkle", accessibilityDescription: nil)
+        claudeItem.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: nil)
         menu.addItem(claudeItem)
 
         menu.addItem(.separator())
@@ -118,6 +119,7 @@ private struct AddTabButton: View {
         let location = NSEvent.mouseLocation
         menu.popUp(positioning: nil, at: location, in: nil)
     }
+
 }
 
 private class MenuCoordinator: NSObject {
@@ -147,6 +149,7 @@ private struct TabBarItem: View {
     let onClose: () -> Void
     let onSuspend: () -> Void
     let onResume: () -> Void
+    let onFork: () -> Void
 
     @State private var isHovering = false
     @State private var isHoveringClose = false
@@ -238,12 +241,16 @@ private struct TabBarItem: View {
         .contentShape(Rectangle())
         .contextMenu {
             if isClaudeTerminal {
+                Button(action: onFork) {
+                    Label("Fork Session", systemImage: "arrow.triangle.branch")
+                }
                 Button(action: isSuspended ? onResume : onSuspend) {
                     Label(
                         isSuspended ? "Resume Claude" : "Suspend Claude",
                         systemImage: isSuspended ? "play.circle" : "pause.circle"
                     )
                 }
+                Divider()
             }
             Button(action: onClose) {
                 Label("Close Tab", systemImage: "xmark")
@@ -254,10 +261,8 @@ private struct TabBarItem: View {
     private var tabIcon: String {
         switch tab.content {
         case .terminal:
-            if isClaudeTerminal {
-                return isSuspended ? "moon.zzz" : "alien.headphones"
-            }
-            return isSuspended ? "moon.zzz" : "terminal"
+            if isSuspended { return "moon.zzz" }
+            return isClaudeTerminal ? "sparkles" : "terminal"
         case .webview: return "globe"
         case .codeViewer: return "doc.text"
         case .note: return "note.text"

--- a/Sources/TBDApp/Terminal/PaneContent.swift
+++ b/Sources/TBDApp/Terminal/PaneContent.swift
@@ -6,12 +6,14 @@ enum PaneContent: Codable, Equatable, Sendable {
     case terminal(terminalID: UUID)
     case webview(id: UUID, url: URL)
     case codeViewer(id: UUID, path: String)
+    case note(noteID: UUID)
 
     var paneID: UUID {
         switch self {
         case .terminal(let id): return id
         case .webview(let id, _): return id
         case .codeViewer(let id, _): return id
+        case .note(let id): return id
         }
     }
 }

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -102,14 +102,22 @@ private struct SingleWorktreeView: View {
                             get: { activeTabIndex },
                             set: { activeTabIndex = $0 }
                         ),
-                        onAddTab: {
+                        onAddShell: {
                             Task {
                                 await appState.createTerminal(worktreeID: worktreeID)
-                                // Select the newly added tab
-                                let newCount = appState.tabs[worktreeID]?.count ?? 0
-                                if newCount > 0 {
-                                    activeTabIndex = newCount - 1
-                                }
+                                selectLastTab()
+                            }
+                        },
+                        onAddClaude: {
+                            Task {
+                                await appState.createClaudeTerminal(worktreeID: worktreeID)
+                                selectLastTab()
+                            }
+                        },
+                        onAddNote: {
+                            Task {
+                                await appState.createNote(worktreeID: worktreeID)
+                                selectLastTab()
                             }
                         },
                         onCloseTab: { index in
@@ -186,6 +194,13 @@ private struct SingleWorktreeView: View {
         }
     }
 
+    private func selectLastTab() {
+        let newCount = appState.tabs[worktreeID]?.count ?? 0
+        if newCount > 0 {
+            activeTabIndex = newCount - 1
+        }
+    }
+
     private var activeTab: Tab? {
         let tabs = worktreeTabs
         guard !tabs.isEmpty else { return nil }
@@ -211,6 +226,13 @@ private struct SingleWorktreeView: View {
         for terminalID in terminalIDsInTab {
             Task {
                 await appState.deleteTerminal(terminalID: terminalID, worktreeID: worktreeID)
+            }
+        }
+
+        // Delete note if this is a note tab
+        if case .note(let noteID) = tab.content {
+            Task {
+                await appState.deleteNote(noteID: noteID, worktreeID: worktreeID)
             }
         }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -140,6 +140,15 @@ private struct SingleWorktreeView: View {
                                 try? await appState.daemonClient.terminalResume(terminalID: terminalID)
                                 await appState.refreshTerminals(worktreeID: worktreeID)
                             }
+                        },
+                        onForkTab: { tabID in
+                            guard let terminalID = terminalID(for: tabID) else { return }
+                            let terminal = appState.terminals[worktreeID]?.first { $0.id == terminalID }
+                            guard let sessionID = terminal?.claudeSessionID else { return }
+                            Task {
+                                await appState.forkClaudeTerminal(worktreeID: worktreeID, sessionID: sessionID)
+                                selectLastTab()
+                            }
                         }
                     )
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -142,8 +142,8 @@ private struct SingleWorktreeView: View {
                             }
                         },
                         onForkTab: { tabID in
-                            guard let terminalID = terminalID(for: tabID) else { return }
-                            let terminal = appState.terminals[worktreeID]?.first { $0.id == terminalID }
+                            guard let tID = terminalID(for: tabID) else { return }
+                            let terminal = appState.terminals[worktreeID]?.first { $0.id == tID }
                             guard let sessionID = terminal?.claudeSessionID else { return }
                             Task {
                                 await appState.forkClaudeTerminal(worktreeID: worktreeID, sessionID: sessionID)

--- a/Sources/TBDDaemon/CLAUDE.md
+++ b/Sources/TBDDaemon/CLAUDE.md
@@ -1,0 +1,5 @@
+# TBDDaemon
+
+After changing daemon or shared code (`Sources/TBDDaemon/`, `Sources/TBDShared/`), always use `scripts/restart.sh` (full restart), NOT `scripts/restart.sh --app`.
+
+The app-only restart leaves the daemon running the old binary. New RPC fields will silently decode as nil, causing features to appear broken while the code is correct.

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -10,6 +10,7 @@ public final class TBDDatabase: Sendable {
     public let worktrees: WorktreeStore
     public let terminals: TerminalStore
     public let notifications: NotificationStore
+    public let notes: NoteStore
 
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
     public init(path: String) throws {
@@ -25,6 +26,7 @@ public final class TBDDatabase: Sendable {
         self.worktrees = WorktreeStore(writer: pool)
         self.terminals = TerminalStore(writer: pool)
         self.notifications = NotificationStore(writer: pool)
+        self.notes = NoteStore(writer: pool)
         try Self.migrate(writer: pool)
     }
 
@@ -37,6 +39,7 @@ public final class TBDDatabase: Sendable {
         self.worktrees = WorktreeStore(writer: queue)
         self.terminals = TerminalStore(writer: queue)
         self.notifications = NotificationStore(writer: queue)
+        self.notes = NoteStore(writer: queue)
         try Self.migrate(writer: queue)
     }
 
@@ -130,6 +133,18 @@ public final class TBDDatabase: Sendable {
         migrator.registerMigration("v8") { db in
             try db.alter(table: "worktree") { t in
                 t.add(column: "archivedClaudeSessions", .text)
+            }
+        }
+
+        migrator.registerMigration("v9") { db in
+            try db.create(table: "note") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("worktreeID", .text).notNull()
+                    .references("worktree", onDelete: .cascade)
+                t.column("title", .text).notNull()
+                t.column("content", .text).notNull().defaults(to: "")
+                t.column("createdAt", .datetime).notNull()
+                t.column("updatedAt", .datetime).notNull()
             }
         }
 

--- a/Sources/TBDDaemon/Database/NoteStore.swift
+++ b/Sources/TBDDaemon/Database/NoteStore.swift
@@ -42,15 +42,18 @@ public struct NoteStore: Sendable {
         self.writer = writer
     }
 
-    /// Create a new note with an auto-assigned title ("Note 1", "Note 2", etc.).
+    /// Create a new note with a monotonically increasing title ("Note 1", "Note 2", etc.).
     public func create(worktreeID: UUID) async throws -> Note {
         try await writer.write { db in
-            let count = try NoteRecord
-                .filter(Column("worktreeID") == worktreeID.uuidString)
-                .fetchCount(db)
+            // Use MAX to avoid duplicate titles after deletions
+            let maxNum = try Int.fetchOne(db, sql: """
+                SELECT MAX(CAST(SUBSTR(title, 6) AS INTEGER))
+                FROM note
+                WHERE worktreeID = ? AND title LIKE 'Note %'
+                """, arguments: [worktreeID.uuidString]) ?? 0
             let note = Note(
                 worktreeID: worktreeID,
-                title: "Note \(count + 1)"
+                title: "Note \(maxNum + 1)"
             )
             let record = NoteRecord(from: note)
             try record.insert(db)

--- a/Sources/TBDDaemon/Database/NoteStore.swift
+++ b/Sources/TBDDaemon/Database/NoteStore.swift
@@ -1,0 +1,108 @@
+import Foundation
+import GRDB
+import TBDShared
+
+/// GRDB Record type for the `note` table.
+struct NoteRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "note"
+
+    var id: String
+    var worktreeID: String
+    var title: String
+    var content: String
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(from note: Note) {
+        self.id = note.id.uuidString
+        self.worktreeID = note.worktreeID.uuidString
+        self.title = note.title
+        self.content = note.content
+        self.createdAt = note.createdAt
+        self.updatedAt = note.updatedAt
+    }
+
+    func toModel() -> Note {
+        Note(
+            id: UUID(uuidString: id)!,
+            worktreeID: UUID(uuidString: worktreeID)!,
+            title: title,
+            content: content,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+    }
+}
+
+/// Provides CRUD operations for notes.
+public struct NoteStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Create a new note with an auto-assigned title ("Note 1", "Note 2", etc.).
+    public func create(worktreeID: UUID) async throws -> Note {
+        try await writer.write { db in
+            let count = try NoteRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .fetchCount(db)
+            let note = Note(
+                worktreeID: worktreeID,
+                title: "Note \(count + 1)"
+            )
+            let record = NoteRecord(from: note)
+            try record.insert(db)
+            return note
+        }
+    }
+
+    /// Get a note by ID.
+    public func get(id: UUID) async throws -> Note? {
+        try await writer.read { db in
+            try NoteRecord.fetchOne(db, key: id.uuidString)?.toModel()
+        }
+    }
+
+    /// List notes, optionally filtered by worktree.
+    public func list(worktreeID: UUID? = nil) async throws -> [Note] {
+        try await writer.read { db in
+            var request = NoteRecord.all()
+            if let worktreeID {
+                request = request.filter(Column("worktreeID") == worktreeID.uuidString)
+            }
+            return try request.fetchAll(db).map { $0.toModel() }
+        }
+    }
+
+    /// Update a note's title and/or content.
+    public func update(id: UUID, title: String? = nil, content: String? = nil) async throws -> Note {
+        try await writer.write { db in
+            guard var record = try NoteRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Note not found")
+            }
+            if let title { record.title = title }
+            if let content { record.content = content }
+            record.updatedAt = Date()
+            try record.update(db)
+            return record.toModel()
+        }
+    }
+
+    /// Delete a note by ID.
+    public func delete(id: UUID) async throws {
+        _ = try await writer.write { db in
+            try NoteRecord.deleteOne(db, key: id.uuidString)
+        }
+    }
+
+    /// Delete all notes for a worktree.
+    public func deleteForWorktree(worktreeID: UUID) async throws {
+        _ = try await writer.write { db in
+            try NoteRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .deleteAll(db)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
@@ -29,6 +29,10 @@ extension RPCRouter {
     func handleNoteUpdate(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(NoteUpdateParams.self, from: paramsData)
 
+        guard try await db.notes.get(id: params.noteID) != nil else {
+            return RPCResponse(error: "Note not found: \(params.noteID)")
+        }
+
         let note = try await db.notes.update(
             id: params.noteID,
             title: params.title,

--- a/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
@@ -1,0 +1,51 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+
+    // MARK: - Note Handlers
+
+    func handleNoteCreate(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NoteCreateParams.self, from: paramsData)
+
+        guard try await db.worktrees.get(id: params.worktreeID) != nil else {
+            return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
+        }
+
+        let note = try await db.notes.create(worktreeID: params.worktreeID)
+        return try RPCResponse(result: note)
+    }
+
+    func handleNoteGet(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NoteGetParams.self, from: paramsData)
+
+        guard let note = try await db.notes.get(id: params.noteID) else {
+            return RPCResponse(error: "Note not found: \(params.noteID)")
+        }
+
+        return try RPCResponse(result: note)
+    }
+
+    func handleNoteUpdate(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NoteUpdateParams.self, from: paramsData)
+
+        let note = try await db.notes.update(
+            id: params.noteID,
+            title: params.title,
+            content: params.content
+        )
+        return try RPCResponse(result: note)
+    }
+
+    func handleNoteDelete(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NoteDeleteParams.self, from: paramsData)
+        try await db.notes.delete(id: params.noteID)
+        return .ok()
+    }
+
+    func handleNoteList(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NoteListParams.self, from: paramsData)
+        let notes = try await db.notes.list(worktreeID: params.worktreeID)
+        return try RPCResponse(result: notes)
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -20,18 +20,27 @@ extension RPCRouter {
             cwd: worktree.path
         )
 
-        let isClaudeType = params.type == .claude
-        let claudeSessionID: String? = isClaudeType ? UUID().uuidString : nil
+        let isClaudeType = params.type == .claude || params.resumeSessionID != nil
+        let claudeSessionID: String?
         let shellCommand: String
         let label: String?
 
-        if isClaudeType, let sessionID = claudeSessionID {
+        if let resumeID = params.resumeSessionID {
+            // Fork: resume from an existing session (creates a new session that shares context)
+            claudeSessionID = resumeID
+            shellCommand = "claude --resume \(resumeID) --dangerously-skip-permissions"
+            label = "claude"
+        } else if isClaudeType {
+            let sessionID = UUID().uuidString
+            claudeSessionID = sessionID
             shellCommand = "claude --session-id \(sessionID) --dangerously-skip-permissions"
             label = "claude"
         } else if let cmd = params.cmd {
+            claudeSessionID = nil
             shellCommand = cmd
             label = cmd
         } else {
+            claudeSessionID = nil
             shellCommand = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
             label = nil
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -20,7 +20,26 @@ extension RPCRouter {
             cwd: worktree.path
         )
 
-        let shellCommand = params.cmd ?? (ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh")
+        let isClaudeType = params.type == "claude"
+        let claudeSessionID = isClaudeType ? UUID().uuidString : nil
+        let shellCommand: String
+        let label: String?
+
+        if isClaudeType {
+            if let sessionID = claudeSessionID {
+                shellCommand = "claude --session-id \(sessionID) --dangerously-skip-permissions"
+            } else {
+                shellCommand = "claude --dangerously-skip-permissions"
+            }
+            label = "claude"
+        } else if let cmd = params.cmd {
+            shellCommand = cmd
+            label = cmd
+        } else {
+            shellCommand = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+            label = nil
+        }
+
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
             session: "main",
@@ -32,7 +51,8 @@ extension RPCRouter {
             worktreeID: params.worktreeID,
             tmuxWindowID: window.windowID,
             tmuxPaneID: window.paneID,
-            label: params.cmd
+            label: label,
+            claudeSessionID: claudeSessionID
         )
 
         subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -20,7 +20,7 @@ extension RPCRouter {
             cwd: worktree.path
         )
 
-        let isClaudeType = params.type == "claude"
+        let isClaudeType = params.type == .claude
         let claudeSessionID: String? = isClaudeType ? UUID().uuidString : nil
         let shellCommand: String
         let label: String?

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -21,16 +21,12 @@ extension RPCRouter {
         )
 
         let isClaudeType = params.type == "claude"
-        let claudeSessionID = isClaudeType ? UUID().uuidString : nil
+        let claudeSessionID: String? = isClaudeType ? UUID().uuidString : nil
         let shellCommand: String
         let label: String?
 
-        if isClaudeType {
-            if let sessionID = claudeSessionID {
-                shellCommand = "claude --session-id \(sessionID) --dangerously-skip-permissions"
-            } else {
-                shellCommand = "claude --dangerously-skip-permissions"
-            }
+        if isClaudeType, let sessionID = claudeSessionID {
+            shellCommand = "claude --session-id \(sessionID) --dangerously-skip-permissions"
             label = "claude"
         } else if let cmd = params.cmd {
             shellCommand = cmd

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -104,6 +104,16 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeResume(request.paramsData)
             case RPCMethod.terminalRecreateWindow:
                 return try await handleTerminalRecreateWindow(request.paramsData)
+            case RPCMethod.noteCreate:
+                return try await handleNoteCreate(request.paramsData)
+            case RPCMethod.noteGet:
+                return try await handleNoteGet(request.paramsData)
+            case RPCMethod.noteUpdate:
+                return try await handleNoteUpdate(request.paramsData)
+            case RPCMethod.noteDelete:
+                return try await handleNoteDelete(request.paramsData)
+            case RPCMethod.noteList:
+                return try await handleNoteList(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/CLAUDE.md
+++ b/Sources/TBDShared/CLAUDE.md
@@ -1,0 +1,3 @@
+# TBDShared
+
+Models and RPC types shared by daemon, app, and CLI. After changing anything here, use `scripts/restart.sh` (full restart) — the daemon must be restarted to pick up new fields.

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -116,6 +116,25 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
+public struct Note: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var worktreeID: UUID
+    public var title: String
+    public var content: String
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(id: UUID = UUID(), worktreeID: UUID, title: String,
+                content: String = "", createdAt: Date = Date(), updatedAt: Date = Date()) {
+        self.id = id
+        self.worktreeID = worktreeID
+        self.title = title
+        self.content = content
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
 public enum NotificationType: String, Codable, Sendable {
     case responseComplete = "response_complete"
     case error

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -195,8 +195,10 @@ public struct TerminalCreateParams: Codable, Sendable {
     public let worktreeID: UUID
     public let cmd: String?
     public let type: TerminalCreateType?
-    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil) {
-        self.worktreeID = worktreeID; self.cmd = cmd; self.type = type
+    /// Session ID to resume from (for forking a Claude session).
+    public let resumeSessionID: String?
+    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil) {
+        self.worktreeID = worktreeID; self.cmd = cmd; self.type = type; self.resumeSessionID = resumeSessionID
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -104,6 +104,11 @@ public enum RPCMethod {
     public static let worktreeSuspend = "worktree.suspend"
     public static let worktreeResume = "worktree.resume"
     public static let terminalRecreateWindow = "terminal.recreateWindow"
+    public static let noteCreate = "note.create"
+    public static let noteGet = "note.get"
+    public static let noteUpdate = "note.update"
+    public static let noteDelete = "note.delete"
+    public static let noteList = "note.list"
 }
 
 public struct NotificationsListResult: Codable, Sendable {
@@ -184,8 +189,10 @@ public struct WorktreeRenameParams: Codable, Sendable {
 public struct TerminalCreateParams: Codable, Sendable {
     public let worktreeID: UUID
     public let cmd: String?
-    public init(worktreeID: UUID, cmd: String? = nil) {
-        self.worktreeID = worktreeID; self.cmd = cmd
+    /// "shell" (default) or "claude"
+    public let type: String?
+    public init(worktreeID: UUID, cmd: String? = nil, type: String? = nil) {
+        self.worktreeID = worktreeID; self.cmd = cmd; self.type = type
     }
 }
 
@@ -263,6 +270,35 @@ public struct WorktreeResumeParams: Codable, Sendable {
 public struct TerminalRecreateWindowParams: Codable, Sendable {
     public let terminalID: UUID
     public init(terminalID: UUID) { self.terminalID = terminalID }
+}
+
+public struct NoteCreateParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public init(worktreeID: UUID) { self.worktreeID = worktreeID }
+}
+
+public struct NoteGetParams: Codable, Sendable {
+    public let noteID: UUID
+    public init(noteID: UUID) { self.noteID = noteID }
+}
+
+public struct NoteUpdateParams: Codable, Sendable {
+    public let noteID: UUID
+    public let title: String?
+    public let content: String?
+    public init(noteID: UUID, title: String? = nil, content: String? = nil) {
+        self.noteID = noteID; self.title = title; self.content = content
+    }
+}
+
+public struct NoteDeleteParams: Codable, Sendable {
+    public let noteID: UUID
+    public init(noteID: UUID) { self.noteID = noteID }
+}
+
+public struct NoteListParams: Codable, Sendable {
+    public let worktreeID: UUID?
+    public init(worktreeID: UUID? = nil) { self.worktreeID = worktreeID }
 }
 
 // MARK: - Result Structs

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -186,12 +186,16 @@ public struct WorktreeRenameParams: Codable, Sendable {
     }
 }
 
+public enum TerminalCreateType: String, Codable, Sendable {
+    case shell
+    case claude
+}
+
 public struct TerminalCreateParams: Codable, Sendable {
     public let worktreeID: UUID
     public let cmd: String?
-    /// "shell" (default) or "claude"
-    public let type: String?
-    public init(worktreeID: UUID, cmd: String? = nil, type: String? = nil) {
+    public let type: TerminalCreateType?
+    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil) {
         self.worktreeID = worktreeID; self.cmd = cmd; self.type = type
     }
 }

--- a/Tests/TBDDaemonTests/DatabaseTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseTests.swift
@@ -351,4 +351,76 @@ struct DatabaseTests {
         let highest = try await db.notifications.highestSeverity(worktreeID: wt.id)
         #expect(highest == nil)
     }
+
+    // MARK: - Note Tests
+
+    @Test func createAndListNotes() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+            path: "/tmp/test/.tbd/worktrees/test-wt", tmuxServer: "tbd-a1b2c3d4"
+        )
+
+        let note1 = try await db.notes.create(worktreeID: wt.id)
+        #expect(note1.title == "Note 1")
+        #expect(note1.content == "")
+
+        let note2 = try await db.notes.create(worktreeID: wt.id)
+        #expect(note2.title == "Note 2")
+
+        let notes = try await db.notes.list(worktreeID: wt.id)
+        #expect(notes.count == 2)
+    }
+
+    @Test func updateNoteContent() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+            path: "/tmp/test/.tbd/worktrees/test-wt", tmuxServer: "tbd-a1b2c3d4"
+        )
+
+        let note = try await db.notes.create(worktreeID: wt.id)
+        let updated = try await db.notes.update(id: note.id, title: "My Note", content: "Hello world")
+        #expect(updated.title == "My Note")
+        #expect(updated.content == "Hello world")
+
+        let fetched = try await db.notes.get(id: note.id)
+        #expect(fetched?.title == "My Note")
+        #expect(fetched?.content == "Hello world")
+    }
+
+    @Test func deleteNote() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+            path: "/tmp/test/.tbd/worktrees/test-wt", tmuxServer: "tbd-a1b2c3d4"
+        )
+
+        let note = try await db.notes.create(worktreeID: wt.id)
+        try await db.notes.delete(id: note.id)
+        let notes = try await db.notes.list(worktreeID: wt.id)
+        #expect(notes.isEmpty)
+    }
+
+    @Test func noteTitleMonotonicAfterDeletion() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+            path: "/tmp/test/.tbd/worktrees/test-wt", tmuxServer: "tbd-a1b2c3d4"
+        )
+
+        let note1 = try await db.notes.create(worktreeID: wt.id)
+        #expect(note1.title == "Note 1")
+        let note2 = try await db.notes.create(worktreeID: wt.id)
+        #expect(note2.title == "Note 2")
+
+        // Delete Note 1, create another — should be Note 3, not Note 2
+        try await db.notes.delete(id: note1.id)
+        let note3 = try await db.notes.create(worktreeID: wt.id)
+        #expect(note3.title == "Note 3")
+    }
 }

--- a/Tests/TBDDaemonTests/RPCRouterTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTests.swift
@@ -437,6 +437,85 @@ struct RPCRouterTests {
         #expect(result.status == nil)
     }
 
+    // MARK: - Claude Terminal Creation
+
+    @Test("terminal.create with type claude sets label and sessionID")
+    func terminalCreateClaude() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+
+        let createReq = try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        )
+        let createResp = await router.handle(createReq)
+        #expect(createResp.success)
+
+        let terminal = try createResp.decodeResult(Terminal.self)
+        #expect(terminal.label == "claude")
+        #expect(terminal.claudeSessionID != nil)
+    }
+
+    // MARK: - Note RPC Tests
+
+    @Test("note.create and note.list work together")
+    func noteCreateAndList() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+
+        let createReq = try RPCRequest(
+            method: RPCMethod.noteCreate,
+            params: NoteCreateParams(worktreeID: wt.id)
+        )
+        let createResp = await router.handle(createReq)
+        #expect(createResp.success)
+
+        let note = try createResp.decodeResult(Note.self)
+        #expect(note.title == "Note 1")
+        #expect(note.worktreeID == wt.id)
+
+        let listReq = try RPCRequest(
+            method: RPCMethod.noteList,
+            params: NoteListParams(worktreeID: wt.id)
+        )
+        let listResp = await router.handle(listReq)
+        #expect(listResp.success)
+
+        let notes = try listResp.decodeResult([Note].self)
+        #expect(notes.count == 1)
+    }
+
+    @Test("note.update returns error for missing note")
+    func noteUpdateMissing() async throws {
+        let updateReq = try RPCRequest(
+            method: RPCMethod.noteUpdate,
+            params: NoteUpdateParams(noteID: UUID(), title: "x")
+        )
+        let resp = await router.handle(updateReq)
+        #expect(!resp.success)
+        #expect(resp.error?.contains("Note not found") == true)
+    }
+
     // MARK: - Unknown Method
 
     @Test("unknown method returns error")


### PR DESCRIPTION
## Summary
- Replace the single `+` button with a menu offering three pane types: Shell (same as before), Claude (managed session with suspend/resume), and Note (freeform text editor with auto-save)
- Claude terminals created this way get proper labels and session IDs, so they automatically integrate with the existing suspend/resume coordinator — no coordinator changes needed
- Notes are a new entity (DB table, CRUD RPC, `NoteStore`) with debounced auto-save, inline-renameable titles, and daemon-side persistence

## Test plan
- [ ] Click `+` in tab bar → menu shows Shell, Claude, Note
- [ ] Create Shell → behaves exactly as before
- [ ] Create Claude → label shows "claude", suspend/resume button appears on tab, coordinator manages it on worktree switch
- [ ] Create Note → text editor appears with "Note 1" title, typing auto-saves after 500ms
- [ ] Click note title in pane header → inline edit, commit on Enter/blur
- [ ] Close note tab → note deleted from DB
- [ ] Create Note 1, Note 2, delete Note 1, create new → titled "Note 3" (not duplicate "Note 2")
- [ ] `swift test` → 180 tests pass