### PR TITLE
Feat: Guake-style conductor overlay with one-click setup and navigation suggestions

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -33,6 +33,12 @@ final class AppState: ObservableObject {
     /// Archived worktrees keyed by repo ID, fetched on demand.
     @Published var archivedWorktrees: [UUID: [Worktree]] = [:]
 
+    /// The first selected worktree, if any.
+    var selectedWorktree: Worktree? {
+        guard let id = selectedWorktreeIDs.first else { return nil }
+        return worktrees.values.flatMap { $0 }.first { $0.id == id }
+    }
+
     /// All pinned terminals across all worktrees, sorted by pinnedAt.
     var pinnedTerminals: [Terminal] {
         terminals.values.flatMap { $0 }
@@ -76,7 +82,7 @@ final class AppState: ObservableObject {
     @Published var showConductor: Bool = false
     /// Conductor overlay height — persisted.
     @Published var conductorHeight: CGFloat = 300 {
-        didSet { UserDefaults.standard.set(Double(conductorHeight), forKey: "com.tbd.app.conductorHeight") }
+        didSet { UserDefaults.standard.set(Double(conductorHeight), forKey: Self.conductorHeightKey) }
     }
     /// Remembers selected tab index per worktree so switching back restores the tab.
     @Published var selectedTabIndex: [UUID: Int] = [:]
@@ -95,6 +101,7 @@ final class AppState: ObservableObject {
 
     private static let layoutsKey = "com.tbd.app.layouts"
     private static let dockRatioKey = "com.tbd.app.dockRatio"
+    private static let conductorHeightKey = "com.tbd.app.conductorHeight"
 
     private var memoryPressureSource: DispatchSourceMemoryPressure?
 
@@ -103,7 +110,7 @@ final class AppState: ObservableObject {
         if let saved = UserDefaults.standard.object(forKey: Self.dockRatioKey) as? Double {
             dockRatio = max(0.1, min(0.6, CGFloat(saved)))
         }
-        if let savedHeight = UserDefaults.standard.object(forKey: "com.tbd.app.conductorHeight") as? Double {
+        if let savedHeight = UserDefaults.standard.object(forKey: Self.conductorHeightKey) as? Double {
             conductorHeight = max(100, min(800, CGFloat(savedHeight)))
         }
         startMemoryPressureMonitor()
@@ -524,21 +531,21 @@ final class AppState: ObservableObject {
 
             // Update suggestion from the conductor matching the current selection
             let newSuggestion: ConductorSuggestion? = {
-                guard let selectedID = selectedWorktreeIDs.first,
-                      let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }),
+                guard let selectedWt = selectedWorktree,
                       let conductor = byRepo[selectedWt.repoID] else { return nil }
                 return conductor.suggestion
             }()
             if newSuggestion != conductorSuggestion { conductorSuggestion = newSuggestion }
         } catch {
-            // Don't log connection errors for conductors — they're not critical
+            if !(error is DaemonClientError) {
+                logger.error("Failed to refresh conductors: \(error)")
+            }
         }
     }
 
     /// The conductor for the repo of the currently selected worktree.
     var currentConductor: Conductor? {
-        guard let selectedID = selectedWorktreeIDs.first,
-              let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }) else { return nil }
+        guard let selectedWt = selectedWorktree else { return nil }
         return conductorsByRepo[selectedWt.repoID]
     }
 
@@ -550,8 +557,7 @@ final class AppState: ObservableObject {
 
     /// The conductor's terminal for the currently selected repo.
     var currentConductorTerminal: Terminal? {
-        guard let selectedID = selectedWorktreeIDs.first,
-              let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }) else { return nil }
+        guard let selectedWt = selectedWorktree else { return nil }
         return conductorTerminalsByRepo[selectedWt.repoID]
     }
 
@@ -568,8 +574,7 @@ final class AppState: ObservableObject {
 
     /// One-click conductor: setup (if needed) + start + show overlay.
     func ensureConductorRunning() async {
-        guard let selectedID = selectedWorktreeIDs.first,
-              let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }) else { return }
+        guard let selectedWt = selectedWorktree else { return }
         let repoID = selectedWt.repoID
 
         do {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -567,8 +567,8 @@ final class AppState: ObservableObject {
         let cleaned = repoName
             .lowercased()
             .replacing(/[^a-z0-9]+/, with: "-")
-            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
         let truncated = String(cleaned.prefix(64))
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
         return truncated.isEmpty ? "conductor" : truncated
     }
 
@@ -590,6 +590,9 @@ final class AppState: ObservableObject {
                 _ = try await daemonClient.conductorSetup(name: name, repos: [repoID.uuidString])
                 _ = try await daemonClient.conductorStart(name: name)
             }
+            // Refresh worktrees first so terminals dict is populated,
+            // then refresh conductors to find the new terminal
+            await refreshWorktrees()
             await refreshConductors()
             showConductor = true
         } catch {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -65,6 +65,19 @@ final class AppState: ObservableObject {
     @Published var editingWorktreeID: UUID? = nil
     @Published var isRenamingWorktree = false
     @Published var prStatuses: [UUID: PRStatus] = [:]
+
+    /// Conductor for each repo (wildcard conductors expanded across all repos).
+    @Published var conductorsByRepo: [UUID: Conductor] = [:]
+    /// The conductor's terminal record, keyed by repo ID.
+    @Published var conductorTerminalsByRepo: [UUID: Terminal] = [:]
+    /// Current navigation suggestion from any conductor.
+    @Published var conductorSuggestion: ConductorSuggestion? = nil
+    /// Whether the conductor overlay is visible.
+    @Published var showConductor: Bool = false
+    /// Conductor overlay height — persisted.
+    @Published var conductorHeight: CGFloat = 300 {
+        didSet { UserDefaults.standard.set(Double(conductorHeight), forKey: "com.tbd.app.conductorHeight") }
+    }
     /// Remembers selected tab index per worktree so switching back restores the tab.
     @Published var selectedTabIndex: [UUID: Int] = [:]
 
@@ -89,6 +102,9 @@ final class AppState: ObservableObject {
         restoreLayouts()
         if let saved = UserDefaults.standard.object(forKey: Self.dockRatioKey) as? Double {
             dockRatio = max(0.1, min(0.6, CGFloat(saved)))
+        }
+        if let savedHeight = UserDefaults.standard.object(forKey: "com.tbd.app.conductorHeight") as? Double {
+            conductorHeight = max(100, min(800, CGFloat(savedHeight)))
         }
         startMemoryPressureMonitor()
         Task {
@@ -249,6 +265,7 @@ final class AppState: ObservableObject {
         await refreshRepos()
         await refreshWorktrees()
         await refreshNotifications()
+        await refreshConductors()
     }
 
     /// Refresh the repo list. Only updates if data changed.
@@ -467,6 +484,111 @@ final class AppState: ObservableObject {
         } catch {
             logger.error("Failed to list notifications: \(error)")
             handleConnectionError(error)
+        }
+    }
+
+    // MARK: - Conductors
+
+    /// Refresh conductor state from the daemon.
+    func refreshConductors() async {
+        do {
+            let conductors = try await daemonClient.listConductors()
+
+            // Build conductorsByRepo: expand ["*"] conductors across all repo IDs
+            var byRepo: [UUID: Conductor] = [:]
+            var termByRepo: [UUID: Terminal] = [:]
+            let repoIDs = repos.map(\.id)
+
+            for conductor in conductors {
+                let matchingRepoIDs: [UUID]
+                if conductor.repos.contains("*") {
+                    matchingRepoIDs = repoIDs
+                } else {
+                    matchingRepoIDs = conductor.repos.compactMap { UUID(uuidString: $0) }
+                }
+                for repoID in matchingRepoIDs {
+                    if byRepo[repoID] == nil {  // first match wins
+                        byRepo[repoID] = conductor
+                        // Find the conductor's terminal in the terminals dict
+                        if let termID = conductor.terminalID,
+                           let wtID = conductor.worktreeID,
+                           let term = terminals[wtID]?.first(where: { $0.id == termID }) {
+                            termByRepo[repoID] = term
+                        }
+                    }
+                }
+            }
+
+            if byRepo != conductorsByRepo { conductorsByRepo = byRepo }
+            if termByRepo != conductorTerminalsByRepo { conductorTerminalsByRepo = termByRepo }
+
+            // Update suggestion from the conductor matching the current selection
+            let newSuggestion: ConductorSuggestion? = {
+                guard let selectedID = selectedWorktreeIDs.first,
+                      let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }),
+                      let conductor = byRepo[selectedWt.repoID] else { return nil }
+                return conductor.suggestion
+            }()
+            if newSuggestion != conductorSuggestion { conductorSuggestion = newSuggestion }
+        } catch {
+            // Don't log connection errors for conductors — they're not critical
+        }
+    }
+
+    /// The conductor for the repo of the currently selected worktree.
+    var currentConductor: Conductor? {
+        guard let selectedID = selectedWorktreeIDs.first,
+              let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }) else { return nil }
+        return conductorsByRepo[selectedWt.repoID]
+    }
+
+    /// Whether a conductor is active (exists and has a terminal) for the current repo.
+    var conductorActive: Bool {
+        guard let conductor = currentConductor else { return false }
+        return conductor.terminalID != nil
+    }
+
+    /// The conductor's terminal for the currently selected repo.
+    var currentConductorTerminal: Terminal? {
+        guard let selectedID = selectedWorktreeIDs.first,
+              let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }) else { return nil }
+        return conductorTerminalsByRepo[selectedWt.repoID]
+    }
+
+    /// Derive a conductor name from a repo's display name.
+    /// Lowercases, replaces non-alphanumeric chars with hyphens, trims leading/trailing hyphens.
+    static func conductorName(from repoName: String) -> String {
+        let cleaned = repoName
+            .lowercased()
+            .replacing(/[^a-z0-9]+/, with: "-")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        let truncated = String(cleaned.prefix(64))
+        return truncated.isEmpty ? "conductor" : truncated
+    }
+
+    /// One-click conductor: setup (if needed) + start + show overlay.
+    func ensureConductorRunning() async {
+        guard let selectedID = selectedWorktreeIDs.first,
+              let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }) else { return }
+        let repoID = selectedWt.repoID
+
+        do {
+            if let existing = conductorsByRepo[repoID] {
+                // Conductor exists — start it if not running
+                if existing.terminalID == nil {
+                    _ = try await daemonClient.conductorStart(name: existing.name)
+                }
+            } else {
+                // No conductor — setup + start
+                guard let repo = repos.first(where: { $0.id == repoID }) else { return }
+                let name = Self.conductorName(from: repo.displayName)
+                _ = try await daemonClient.conductorSetup(name: name, repos: [repoID.uuidString])
+                _ = try await daemonClient.conductorStart(name: name)
+            }
+            await refreshConductors()
+            showConductor = true
+        } catch {
+            showAlert("Conductor error: \(error.localizedDescription)", isError: true)
         }
     }
 }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -80,8 +80,8 @@ final class AppState: ObservableObject {
     @Published var conductorSuggestion: ConductorSuggestion? = nil
     /// Whether the conductor overlay is visible.
     @Published var showConductor: Bool = false
-    /// Conductor overlay height — persisted.
-    @Published var conductorHeight: CGFloat = 300 {
+    /// Conductor overlay height — persisted. 0 means "use default (50% of parent)".
+    @Published var conductorHeight: CGFloat = 0 {
         didSet { UserDefaults.standard.set(Double(conductorHeight), forKey: Self.conductorHeightKey) }
     }
     /// Remembers selected tab index per worktree so switching back restores the tab.
@@ -501,6 +501,11 @@ final class AppState: ObservableObject {
         do {
             let conductors = try await daemonClient.listConductors()
 
+            // Fetch all terminals to find conductor terminals (conductor worktrees
+            // are excluded from worktree.list, so self.terminals doesn't contain them)
+            let allTerminals = try await daemonClient.listTerminals()
+            let terminalsById = Dictionary(allTerminals.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+
             // Build conductorsByRepo: expand ["*"] conductors across all repo IDs
             var byRepo: [UUID: Conductor] = [:]
             var termByRepo: [UUID: Terminal] = [:]
@@ -516,10 +521,8 @@ final class AppState: ObservableObject {
                 for repoID in matchingRepoIDs {
                     if byRepo[repoID] == nil {  // first match wins
                         byRepo[repoID] = conductor
-                        // Find the conductor's terminal in the terminals dict
                         if let termID = conductor.terminalID,
-                           let wtID = conductor.worktreeID,
-                           let term = terminals[wtID]?.first(where: { $0.id == termID }) {
+                           let term = terminalsById[termID] {
                             termByRepo[repoID] = term
                         }
                     }

--- a/Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift
+++ b/Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift
@@ -8,6 +8,7 @@ final class ConductorHotkeyMonitor {
     /// Install the local event monitor. Call once at app startup.
     /// The `toggle` closure is called on the main thread when the hotkey fires.
     func install(toggle: @escaping () -> Void) {
+        guard monitor == nil else { return }
         monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             // Opt+. : modifiers = option, keyCode 47 = period
             if event.modifierFlags.contains(.option),

--- a/Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift
+++ b/Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift
@@ -10,11 +10,11 @@ final class ConductorHotkeyMonitor {
     func install(toggle: @escaping () -> Void) {
         guard monitor == nil else { return }
         monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            // Opt+. : modifiers = option, keyCode 47 = period
+            // Opt+' : modifiers = option, keyCode 39 = apostrophe
             if event.modifierFlags.contains(.option),
                !event.modifierFlags.contains(.command),
                !event.modifierFlags.contains(.control),
-               event.keyCode == 47 {
+               event.keyCode == 39 {
                 toggle()
                 return nil  // consume the event
             }

--- a/Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift
+++ b/Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift
@@ -1,0 +1,34 @@
+import AppKit
+
+/// Monitors local key events for the conductor toggle hotkey (Opt+.).
+/// Only fires when TBD is the active app.
+final class ConductorHotkeyMonitor {
+    private var monitor: Any?
+
+    /// Install the local event monitor. Call once at app startup.
+    /// The `toggle` closure is called on the main thread when the hotkey fires.
+    func install(toggle: @escaping () -> Void) {
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // Opt+. : modifiers = option, keyCode 47 = period
+            if event.modifierFlags.contains(.option),
+               !event.modifierFlags.contains(.command),
+               !event.modifierFlags.contains(.control),
+               event.keyCode == 47 {
+                toggle()
+                return nil  // consume the event
+            }
+            return event
+        }
+    }
+
+    func uninstall() {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+            self.monitor = nil
+        }
+    }
+
+    deinit {
+        uninstall()
+    }
+}

--- a/Sources/TBDApp/Conductor/ConductorOverlayView.swift
+++ b/Sources/TBDApp/Conductor/ConductorOverlayView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import TBDShared
 
@@ -14,6 +15,9 @@ struct ConductorOverlayView: View {
     private let minHeight: CGFloat = 100
 
     private var maxHeight: CGFloat { parentHeight * 0.8 }
+    private var effectiveHeight: CGFloat {
+        appState.conductorHeight > 0 ? appState.conductorHeight : parentHeight * 0.5
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -22,9 +26,10 @@ struct ConductorOverlayView: View {
                 terminalID: terminal.id,
                 tmuxServer: tmuxServer,
                 tmuxWindowID: terminal.tmuxWindowID,
-                tmuxBridge: appState.tmuxBridge
+                tmuxBridge: appState.tmuxBridge,
+                worktreePath: "conductor"
             )
-            .frame(height: appState.conductorHeight)
+            .frame(height: effectiveHeight)
             .clipped()
 
             // Drag handle
@@ -49,10 +54,10 @@ struct ConductorOverlayView: View {
             .gesture(
                 DragGesture(minimumDistance: 1)
                     .onChanged { value in
-                        if dragStartHeight == 0 { dragStartHeight = appState.conductorHeight }
+                        if dragStartHeight == 0 { dragStartHeight = effectiveHeight }
                         let proposed = dragStartHeight + value.translation.height
                         let clamped = max(minHeight, min(maxHeight, proposed))
-                        dragIndicatorOffset = clamped - appState.conductorHeight
+                        dragIndicatorOffset = clamped - effectiveHeight
                     }
                     .onEnded { value in
                         let proposed = dragStartHeight + value.translation.height
@@ -67,10 +72,34 @@ struct ConductorOverlayView: View {
                 ConductorSuggestionBar(suggestion: suggestion)
             }
         }
-        .background(.ultraThinMaterial)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .onChange(of: appState.showConductor) { _, visible in
+            if visible {
+                // Focus the conductor terminal when overlay becomes visible.
+                // Delay slightly to let SwiftUI finish the opacity transition.
+                DispatchQueue.main.async {
+                    if let window = NSApp.keyWindow {
+                        focusConductorTerminal(in: window.contentView)
+                    }
+                }
+            }
+        }
         .onDisappear {
             // Clean up pushed cursor if we disappear while hovering
             if isHoveringHandle { NSCursor.pop() }
+        }
+    }
+
+    /// Walk the view tree to find the conductor's TBDTerminalView and make it first responder.
+    private func focusConductorTerminal(in view: NSView?) {
+        guard let view else { return }
+        if let terminalView = view as? TBDTerminalView,
+           terminalView.worktreePath == "conductor" {
+            view.window?.makeFirstResponder(terminalView)
+            return
+        }
+        for subview in view.subviews {
+            focusConductorTerminal(in: subview)
         }
     }
 }

--- a/Sources/TBDApp/Conductor/ConductorOverlayView.swift
+++ b/Sources/TBDApp/Conductor/ConductorOverlayView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import TBDShared
+
+struct ConductorOverlayView: View {
+    @EnvironmentObject var appState: AppState
+    let terminal: Terminal
+    let tmuxServer: String
+
+    @State private var dragStartHeight: CGFloat = 0
+    @State private var dragIndicatorOffset: CGFloat? = nil
+
+    private let minHeight: CGFloat = 100
+
+    var body: some View {
+        GeometryReader { geometry in
+            let maxHeight = geometry.size.height * 0.8
+
+            VStack(spacing: 0) {
+                // Terminal
+                TerminalPanelView(
+                    terminalID: terminal.id,
+                    tmuxServer: tmuxServer,
+                    tmuxWindowID: terminal.tmuxWindowID,
+                    tmuxBridge: appState.tmuxBridge
+                )
+                .frame(height: appState.conductorHeight)
+                .clipped()
+
+                // Drag handle
+                ZStack {
+                    Rectangle()
+                        .fill(Color(nsColor: .separatorColor))
+                        .frame(height: 1)
+
+                    if let offset = dragIndicatorOffset {
+                        Rectangle()
+                            .fill(Color.accentColor)
+                            .frame(height: 2)
+                            .offset(y: offset)
+                    }
+                }
+                .frame(height: 4)
+                .contentShape(Rectangle())
+                .onHover { hovering in
+                    if hovering { NSCursor.resizeUpDown.push() } else { NSCursor.pop() }
+                }
+                .gesture(
+                    DragGesture(minimumDistance: 1)
+                        .onChanged { value in
+                            if dragStartHeight == 0 { dragStartHeight = appState.conductorHeight }
+                            let proposed = dragStartHeight + value.translation.height
+                            let clamped = max(minHeight, min(maxHeight, proposed))
+                            dragIndicatorOffset = clamped - appState.conductorHeight
+                        }
+                        .onEnded { value in
+                            let proposed = dragStartHeight + value.translation.height
+                            appState.conductorHeight = max(minHeight, min(maxHeight, proposed))
+                            dragStartHeight = 0
+                            dragIndicatorOffset = nil
+                        }
+                )
+
+                // Suggestion bar (conditional)
+                if let suggestion = appState.conductorSuggestion {
+                    ConductorSuggestionBar(suggestion: suggestion)
+                }
+            }
+            .background(.ultraThinMaterial)
+        }
+    }
+}

--- a/Sources/TBDApp/Conductor/ConductorOverlayView.swift
+++ b/Sources/TBDApp/Conductor/ConductorOverlayView.swift
@@ -5,67 +5,72 @@ struct ConductorOverlayView: View {
     @EnvironmentObject var appState: AppState
     let terminal: Terminal
     let tmuxServer: String
+    let parentHeight: CGFloat
 
     @State private var dragStartHeight: CGFloat = 0
     @State private var dragIndicatorOffset: CGFloat? = nil
+    @State private var isHoveringHandle = false
 
     private let minHeight: CGFloat = 100
 
+    private var maxHeight: CGFloat { parentHeight * 0.8 }
+
     var body: some View {
-        GeometryReader { geometry in
-            let maxHeight = geometry.size.height * 0.8
+        VStack(spacing: 0) {
+            // Terminal
+            TerminalPanelView(
+                terminalID: terminal.id,
+                tmuxServer: tmuxServer,
+                tmuxWindowID: terminal.tmuxWindowID,
+                tmuxBridge: appState.tmuxBridge
+            )
+            .frame(height: appState.conductorHeight)
+            .clipped()
 
-            VStack(spacing: 0) {
-                // Terminal
-                TerminalPanelView(
-                    terminalID: terminal.id,
-                    tmuxServer: tmuxServer,
-                    tmuxWindowID: terminal.tmuxWindowID,
-                    tmuxBridge: appState.tmuxBridge
-                )
-                .frame(height: appState.conductorHeight)
-                .clipped()
+            // Drag handle
+            ZStack {
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor))
+                    .frame(height: 1)
 
-                // Drag handle
-                ZStack {
+                if let offset = dragIndicatorOffset {
                     Rectangle()
-                        .fill(Color(nsColor: .separatorColor))
-                        .frame(height: 1)
-
-                    if let offset = dragIndicatorOffset {
-                        Rectangle()
-                            .fill(Color.accentColor)
-                            .frame(height: 2)
-                            .offset(y: offset)
-                    }
-                }
-                .frame(height: 4)
-                .contentShape(Rectangle())
-                .onHover { hovering in
-                    if hovering { NSCursor.resizeUpDown.push() } else { NSCursor.pop() }
-                }
-                .gesture(
-                    DragGesture(minimumDistance: 1)
-                        .onChanged { value in
-                            if dragStartHeight == 0 { dragStartHeight = appState.conductorHeight }
-                            let proposed = dragStartHeight + value.translation.height
-                            let clamped = max(minHeight, min(maxHeight, proposed))
-                            dragIndicatorOffset = clamped - appState.conductorHeight
-                        }
-                        .onEnded { value in
-                            let proposed = dragStartHeight + value.translation.height
-                            appState.conductorHeight = max(minHeight, min(maxHeight, proposed))
-                            dragStartHeight = 0
-                            dragIndicatorOffset = nil
-                        }
-                )
-
-                // Suggestion bar (conditional)
-                if let suggestion = appState.conductorSuggestion {
-                    ConductorSuggestionBar(suggestion: suggestion)
+                        .fill(Color.accentColor)
+                        .frame(height: 2)
+                        .offset(y: offset)
                 }
             }
-            .background(.ultraThinMaterial)
+            .frame(height: 4)
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                isHoveringHandle = hovering
+                if hovering { NSCursor.resizeUpDown.push() } else { NSCursor.pop() }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .onChanged { value in
+                        if dragStartHeight == 0 { dragStartHeight = appState.conductorHeight }
+                        let proposed = dragStartHeight + value.translation.height
+                        let clamped = max(minHeight, min(maxHeight, proposed))
+                        dragIndicatorOffset = clamped - appState.conductorHeight
+                    }
+                    .onEnded { value in
+                        let proposed = dragStartHeight + value.translation.height
+                        appState.conductorHeight = max(minHeight, min(maxHeight, proposed))
+                        dragStartHeight = 0
+                        dragIndicatorOffset = nil
+                    }
+            )
+
+            // Suggestion bar (conditional)
+            if let suggestion = appState.conductorSuggestion {
+                ConductorSuggestionBar(suggestion: suggestion)
+            }
+        }
+        .background(.ultraThinMaterial)
+        .onDisappear {
+            // Clean up pushed cursor if we disappear while hovering
+            if isHoveringHandle { NSCursor.pop() }
         }
     }
 }

--- a/Sources/TBDApp/Conductor/ConductorSuggestionBar.swift
+++ b/Sources/TBDApp/Conductor/ConductorSuggestionBar.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import TBDShared
+
+struct ConductorSuggestionBar: View {
+    @EnvironmentObject var appState: AppState
+    let suggestion: ConductorSuggestion
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.right.circle.fill")
+                .foregroundStyle(.blue)
+                .font(.system(size: 12))
+
+            Text(suggestion.worktreeName)
+                .fontWeight(.medium)
+                .font(.caption)
+
+            if let label = suggestion.label {
+                Text("— \(label)")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Spacer()
+
+            Button("Go") {
+                navigateToSuggestion()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+
+            Button {
+                appState.conductorSuggestion = nil
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .frame(height: 28)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private func navigateToSuggestion() {
+        appState.selectedWorktreeIDs = [suggestion.worktreeID]
+        appState.conductorSuggestion = nil
+    }
+}

--- a/Sources/TBDApp/Conductor/ConductorSuggestionBar.swift
+++ b/Sources/TBDApp/Conductor/ConductorSuggestionBar.swift
@@ -30,7 +30,7 @@ struct ConductorSuggestionBar: View {
             .controlSize(.small)
 
             Button {
-                appState.conductorSuggestion = nil
+                dismissSuggestion()
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 9, weight: .bold))
@@ -46,6 +46,16 @@ struct ConductorSuggestionBar: View {
 
     private func navigateToSuggestion() {
         appState.selectedWorktreeIDs = [suggestion.worktreeID]
+        dismissSuggestion()
+    }
+
+    private func dismissSuggestion() {
         appState.conductorSuggestion = nil
+        // Clear server-side so it doesn't flicker back on next poll
+        if let conductor = appState.currentConductor {
+            Task {
+                try? await appState.daemonClient.conductorClearSuggestion(name: conductor.name)
+            }
+        }
     }
 }

--- a/Sources/TBDApp/Conductor/ConductorSuggestionBar.swift
+++ b/Sources/TBDApp/Conductor/ConductorSuggestionBar.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "ConductorSuggestion")
 
 struct ConductorSuggestionBar: View {
     @EnvironmentObject var appState: AppState
@@ -45,16 +48,23 @@ struct ConductorSuggestionBar: View {
     }
 
     private func navigateToSuggestion() {
+        // Capture conductor name before changing selection (currentConductor depends on selection)
+        let conductorName = appState.currentConductor?.name
         appState.selectedWorktreeIDs = [suggestion.worktreeID]
-        dismissSuggestion()
+        dismissSuggestion(conductorName: conductorName)
     }
 
-    private func dismissSuggestion() {
+    private func dismissSuggestion(conductorName: String? = nil) {
+        let name = conductorName ?? appState.currentConductor?.name
         appState.conductorSuggestion = nil
         // Clear server-side so it doesn't flicker back on next poll
-        if let conductor = appState.currentConductor {
+        if let name {
             Task {
-                try? await appState.daemonClient.conductorClearSuggestion(name: conductor.name)
+                do {
+                    try await appState.daemonClient.conductorClearSuggestion(name: name)
+                } catch {
+                    logger.warning("Failed to clear suggestion server-side: \(error)")
+                }
             }
         }
     }

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
     @AppStorage("filePanel.isVisible") private var showFilePanel = true
     @AppStorage("filePanel.width") private var filePanelWidth: Double = 280
     @AppStorage("autoSuspendClaude") private var autoSuspendClaude: Bool = true
+    @State private var conductorHotkeyMonitor = ConductorHotkeyMonitor()
 
     private var selectedWorktree: Worktree? {
         guard let id = appState.selectedWorktreeIDs.first else { return nil }
@@ -40,6 +41,15 @@ struct ContentView: View {
                                 .id(worktree.id)
                         }
                     }
+                    .overlay(alignment: .top) {
+                        if appState.showConductor,
+                           let terminal = appState.currentConductorTerminal {
+                            ConductorOverlayView(
+                                terminal: terminal,
+                                tmuxServer: TBDConstants.conductorsTmuxServer
+                            )
+                        }
+                    }
                 }
             }
             .navigationSplitViewStyle(.prominentDetail)
@@ -56,6 +66,41 @@ struct ContentView: View {
                     .help(autoSuspendClaude
                         ? "Auto-suspend is on — idle Claude instances are suspended when switching worktrees"
                         : "Auto-suspend is off — Claude instances stay running when switching worktrees")
+
+                    // Conductor toggle
+                    Button {
+                        if appState.conductorActive {
+                            appState.showConductor.toggle()
+                        } else {
+                            Task { await appState.ensureConductorRunning() }
+                        }
+                    } label: {
+                        Image(systemName: appState.conductorActive
+                            ? (appState.showConductor ? "wand.and.stars" : "wand.and.stars.inverse")
+                            : "wand.and.stars.inverse")
+                            .foregroundStyle(appState.showConductor ? .primary : .secondary)
+                    }
+                    .help(appState.conductorActive
+                        ? (appState.showConductor ? "Hide conductor (\u{2325}.)" : "Show conductor (\u{2325}.)")
+                        : "Start conductor (\u{2325}.)")
+                    .contextMenu {
+                        if appState.conductorActive, let conductor = appState.currentConductor {
+                            Button("Stop Conductor") {
+                                Task {
+                                    try? await appState.daemonClient.conductorStop(name: conductor.name)
+                                    appState.showConductor = false
+                                    await appState.refreshConductors()
+                                }
+                            }
+                            Button("Remove Conductor", role: .destructive) {
+                                Task {
+                                    try? await appState.daemonClient.conductorTeardown(name: conductor.name)
+                                    appState.showConductor = false
+                                    await appState.refreshConductors()
+                                }
+                            }
+                        }
+                    }
 
                     Picker("Filter", selection: $appState.repoFilter) {
                         Text("All Repos").tag(UUID?.none)
@@ -130,6 +175,16 @@ struct ContentView: View {
             Button("OK") { appState.alertMessage = nil }
         } message: {
             Text(appState.alertMessage ?? "")
+        }
+        .onAppear {
+            conductorHotkeyMonitor.install { [weak appState] in
+                guard let appState else { return }
+                if appState.conductorActive {
+                    appState.showConductor.toggle()
+                } else {
+                    Task { await appState.ensureConductorRunning() }
+                }
+            }
         }
     }
 

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @AppStorage("filePanel.width") private var filePanelWidth: Double = 280
     @AppStorage("autoSuspendClaude") private var autoSuspendClaude: Bool = true
     @State private var conductorHotkeyMonitor = ConductorHotkeyMonitor()
+    @State private var contentAreaHeight: CGFloat = 600
 
     private var selectedWorktree: Worktree? {
         guard let id = appState.selectedWorktreeIDs.first else { return nil }
@@ -41,12 +42,17 @@ struct ContentView: View {
                                 .id(worktree.id)
                         }
                     }
+                    .background(GeometryReader { geometry in
+                        Color.clear.preference(key: ContentHeightKey.self, value: geometry.size.height)
+                    })
+                    .onPreferenceChange(ContentHeightKey.self) { contentAreaHeight = $0 }
                     .overlay(alignment: .top) {
                         if appState.showConductor,
                            let terminal = appState.currentConductorTerminal {
                             ConductorOverlayView(
                                 terminal: terminal,
-                                tmuxServer: TBDConstants.conductorsTmuxServer
+                                tmuxServer: TBDConstants.conductorsTmuxServer,
+                                parentHeight: contentAreaHeight
                             )
                         }
                     }
@@ -313,6 +319,13 @@ private struct PRButtonLabel: View {
         image.isTemplate = true
         return image
     }
+}
+
+// MARK: - ContentHeightKey
+
+private struct ContentHeightKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: CGFloat = 600
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
 }
 
 // MARK: - FilePanelDivider

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -9,6 +9,8 @@ struct ContentView: View {
     @AppStorage("autoSuspendClaude") private var autoSuspendClaude: Bool = true
     @State private var conductorHotkeyMonitor = ConductorHotkeyMonitor()
     @State private var contentAreaHeight: CGFloat = 600
+    /// Saved first responder to restore when conductor hides.
+    @State private var previousFirstResponder: NSResponder?
 
     private var selectedWorktree: Worktree? {
         guard let id = appState.selectedWorktreeIDs.first else { return nil }
@@ -47,13 +49,14 @@ struct ContentView: View {
                     })
                     .onPreferenceChange(ContentHeightKey.self) { contentAreaHeight = $0 }
                     .overlay(alignment: .top) {
-                        if appState.showConductor,
-                           let terminal = appState.currentConductorTerminal {
+                        if let terminal = appState.currentConductorTerminal {
                             ConductorOverlayView(
                                 terminal: terminal,
                                 tmuxServer: TBDConstants.conductorsTmuxServer,
                                 parentHeight: contentAreaHeight
                             )
+                            .opacity(appState.showConductor ? 1 : 0)
+                            .allowsHitTesting(appState.showConductor)
                         }
                     }
                 }
@@ -75,11 +78,7 @@ struct ContentView: View {
 
                     // Conductor toggle
                     Button {
-                        if appState.conductorActive {
-                            appState.showConductor.toggle()
-                        } else {
-                            Task { await appState.ensureConductorRunning() }
-                        }
+                        toggleConductor()
                     } label: {
                         Image(systemName: appState.conductorActive
                             ? (appState.showConductor ? "wand.and.stars" : "wand.and.stars.inverse")
@@ -87,8 +86,8 @@ struct ContentView: View {
                             .foregroundStyle(appState.showConductor ? .primary : .secondary)
                     }
                     .help(appState.conductorActive
-                        ? (appState.showConductor ? "Hide conductor (\u{2325}.)" : "Show conductor (\u{2325}.)")
-                        : "Start conductor (\u{2325}.)")
+                        ? (appState.showConductor ? "Hide conductor (\u{2325}')" : "Show conductor (\u{2325}')")
+                        : "Start conductor (\u{2325}')")
                     .contextMenu {
                         if appState.conductorActive, let conductor = appState.currentConductor {
                             Button("Stop Conductor") {
@@ -185,12 +184,29 @@ struct ContentView: View {
         .onAppear {
             conductorHotkeyMonitor.install { [weak appState] in
                 guard let appState else { return }
-                if appState.conductorActive {
-                    appState.showConductor.toggle()
-                } else {
-                    Task { await appState.ensureConductorRunning() }
-                }
+                toggleConductor()
             }
+        }
+    }
+
+    // MARK: - Conductor
+
+    private func toggleConductor() {
+        if appState.conductorActive {
+            if appState.showConductor {
+                // Hiding — restore previous focus
+                appState.showConductor = false
+                if let prev = previousFirstResponder {
+                    NSApp.keyWindow?.makeFirstResponder(prev)
+                    previousFirstResponder = nil
+                }
+            } else {
+                // Showing — save current focus
+                previousFirstResponder = NSApp.keyWindow?.firstResponder
+                appState.showConductor = true
+            }
+        } else {
+            Task { await appState.ensureConductorRunning() }
         }
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -531,4 +531,46 @@ actor DaemonClient {
             resultType: [Note].self
         )
     }
+
+    // MARK: - Conductors
+
+    /// List all conductors.
+    func listConductors() throws -> [Conductor] {
+        let result = try callNoParams(method: RPCMethod.conductorList, resultType: ConductorListResult.self)
+        return result.conductors
+    }
+
+    /// Set up a new conductor with defaults.
+    func conductorSetup(name: String, repos: [String] = ["*"]) throws -> Conductor {
+        return try call(
+            method: RPCMethod.conductorSetup,
+            params: ConductorSetupParams(name: name, repos: repos),
+            resultType: Conductor.self
+        )
+    }
+
+    /// Start a conductor.
+    func conductorStart(name: String) throws -> Terminal {
+        return try call(
+            method: RPCMethod.conductorStart,
+            params: ConductorNameParams(name: name),
+            resultType: Terminal.self
+        )
+    }
+
+    /// Stop a conductor.
+    func conductorStop(name: String) throws {
+        try callVoid(
+            method: RPCMethod.conductorStop,
+            params: ConductorNameParams(name: name)
+        )
+    }
+
+    /// Teardown (remove) a conductor.
+    func conductorTeardown(name: String) throws {
+        try callVoid(
+            method: RPCMethod.conductorTeardown,
+            params: ConductorNameParams(name: name)
+        )
+    }
 }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -573,4 +573,12 @@ actor DaemonClient {
             params: ConductorNameParams(name: name)
         )
     }
+
+    /// Clear the navigation suggestion for a conductor.
+    func conductorClearSuggestion(name: String) throws {
+        try callVoid(
+            method: RPCMethod.conductorClearSuggestion,
+            params: ConductorNameParams(name: name)
+        )
+    }
 }

--- a/Sources/TBDCLI/Commands/ConductorCommands.swift
+++ b/Sources/TBDCLI/Commands/ConductorCommands.swift
@@ -13,6 +13,8 @@ struct ConductorCommand: ParsableCommand {
             ConductorTeardown.self,
             ConductorListCmd.self,
             ConductorStatusCmd.self,
+            ConductorSuggestCmd.self,
+            ConductorClearSuggestionCmd.self,
         ]
     )
 }
@@ -221,6 +223,58 @@ struct ConductorStatusCmd: AsyncParsableCommand {
             if let wt = c.worktrees { print("  Worktrees:   \(wt.joined(separator: ", "))") }
             if let labels = c.terminalLabels { print("  Labels:      \(labels.joined(separator: ", "))") }
         }
+    }
+}
+
+// MARK: - conductor suggest
+
+struct ConductorSuggestCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "suggest",
+        abstract: "Set a navigation suggestion for the UI"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    @Option(name: .long, help: "Worktree ID to suggest navigating to")
+    var worktree: String
+
+    @Option(name: .long, help: "Optional label (e.g. 'waiting for input')")
+    var label: String?
+
+    mutating func run() async throws {
+        guard let worktreeID = UUID(uuidString: worktree) else {
+            print("Error: invalid worktree UUID: \(worktree)")
+            throw ExitCode.failure
+        }
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.conductorSuggest,
+            params: ConductorSuggestParams(name: name, worktreeID: worktreeID, label: label)
+        )
+        print("Suggestion set for conductor '\(name)'")
+    }
+}
+
+// MARK: - conductor clear-suggestion
+
+struct ConductorClearSuggestionCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "clear-suggestion",
+        abstract: "Clear the navigation suggestion"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.conductorClearSuggestion,
+            params: ConductorNameParams(name: name)
+        )
+        print("Suggestion cleared for conductor '\(name)'")
     }
 }
 

--- a/Sources/TBDDaemon/Conductor/ConductorManager.swift
+++ b/Sources/TBDDaemon/Conductor/ConductorManager.swift
@@ -1,13 +1,36 @@
 import Foundation
+import os
 import TBDShared
 
 public final class ConductorManager: Sendable {
     let db: TBDDatabase
     let tmux: TmuxManager
+    private let _suggestions = OSAllocatedUnfairLock(initialState: [String: ConductorSuggestion]())
 
     public init(db: TBDDatabase, tmux: TmuxManager) {
         self.db = db
         self.tmux = tmux
+    }
+
+    // MARK: - Suggestions
+
+    public func suggest(name: String, worktreeID: UUID, worktreeName: String, label: String?) async throws {
+        guard let _ = try await db.conductors.get(name: name) else {
+            throw ConductorError.notFound(name: name)
+        }
+        let suggestion = ConductorSuggestion(worktreeID: worktreeID, worktreeName: worktreeName, label: label)
+        _suggestions.withLock { $0[name] = suggestion }
+    }
+
+    public func clearSuggestion(name: String) async throws {
+        guard let _ = try await db.conductors.get(name: name) else {
+            throw ConductorError.notFound(name: name)
+        }
+        _suggestions.withLock { $0.removeValue(forKey: name) }
+    }
+
+    public func suggestion(for name: String) -> ConductorSuggestion? {
+        _suggestions.withLock { $0[name] }
     }
 
     // MARK: - Setup
@@ -241,8 +264,23 @@ public final class ConductorManager: Sendable {
         | `tbd conductor list --json` | List all conductors |
         | `tbd conductor status \(name) --json` | Your own scope and config |
         | `tbd notify --type attention_needed "message"` | Escalate to user via macOS notification |
+        | `tbd conductor suggest \(name) --worktree <id> [--label "text"]` | Show navigation pill in UI |
+        | `tbd conductor clear-suggestion \(name)` | Clear navigation pill |
 
         Terminal IDs are UUIDs. Use the full ID from `tbd terminal list` output.
+
+        ## Navigation Suggestions
+
+        When discussing a specific worktree, help the user navigate to it:
+
+        | Command | Description |
+        |---------|-------------|
+        | `tbd conductor suggest \(name) --worktree <id>` | Show a "Go to" pill in the UI |
+        | `tbd conductor suggest \(name) --worktree <id> --label "waiting for input"` | With context label |
+        | `tbd conductor clear-suggestion \(name)` | Remove the pill |
+
+        Set a suggestion when surfacing info about a worktree. Clear it when moving on
+        to a different topic or when the user has acknowledged it.
 
         ## Terminal States
 

--- a/Sources/TBDDaemon/Conductor/ConductorManager.swift
+++ b/Sources/TBDDaemon/Conductor/ConductorManager.swift
@@ -26,7 +26,7 @@ public final class ConductorManager: Sendable {
         guard let _ = try await db.conductors.get(name: name) else {
             throw ConductorError.notFound(name: name)
         }
-        _suggestions.withLock { $0.removeValue(forKey: name) }
+        _ = _suggestions.withLock { $0.removeValue(forKey: name) }
     }
 
     public func suggestion(for name: String) -> ConductorSuggestion? {

--- a/Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift
@@ -33,7 +33,10 @@ extension RPCRouter {
     }
 
     func handleConductorList() async throws -> RPCResponse {
-        let conductors = try await db.conductors.list()
+        var conductors = try await db.conductors.list()
+        for i in conductors.indices {
+            conductors[i].suggestion = conductorManager.suggestion(for: conductors[i].name)
+        }
         return try RPCResponse(result: ConductorListResult(conductors: conductors))
     }
 
@@ -50,6 +53,32 @@ extension RPCRouter {
                 windowID: terminal.tmuxWindowID
             )
         }
-        return try RPCResponse(result: ConductorStatusResult(conductor: conductor, isRunning: isRunning))
+        var enriched = conductor
+        enriched.suggestion = conductorManager.suggestion(for: conductor.name)
+        return try RPCResponse(result: ConductorStatusResult(conductor: enriched, isRunning: isRunning))
+    }
+
+    func handleConductorSuggest(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorSuggestParams.self, from: paramsData)
+        // Look up worktree name for the suggestion
+        let worktreeName: String
+        if let wt = try await db.worktrees.get(id: params.worktreeID) {
+            worktreeName = wt.displayName
+        } else {
+            return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
+        }
+        try await conductorManager.suggest(
+            name: params.name,
+            worktreeID: params.worktreeID,
+            worktreeName: worktreeName,
+            label: params.label
+        )
+        return .ok()
+    }
+
+    func handleConductorClearSuggestion(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+        try await conductorManager.clearSuggestion(name: params.name)
+        return .ok()
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -133,6 +133,10 @@ public final class RPCRouter: Sendable {
                 return try await handleConductorList()
             case RPCMethod.conductorStatus:
                 return try await handleConductorStatus(request.paramsData)
+            case RPCMethod.conductorSuggest:
+                return try await handleConductorSuggest(request.paramsData)
+            case RPCMethod.conductorClearSuggestion:
+                return try await handleConductorClearSuggestion(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/ConductorModels.swift
+++ b/Sources/TBDShared/ConductorModels.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+public struct ConductorSuggestion: Codable, Sendable, Equatable {
+    public let worktreeID: UUID
+    public let worktreeName: String
+    public let label: String?
+
+    public init(worktreeID: UUID, worktreeName: String, label: String? = nil) {
+        self.worktreeID = worktreeID
+        self.worktreeName = worktreeName
+        self.label = label
+    }
+}
+
 public struct Conductor: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var name: String
@@ -10,6 +22,7 @@ public struct Conductor: Codable, Sendable, Identifiable, Equatable {
     public var terminalID: UUID?           // FK to terminal (conductor's own terminal)
     public var worktreeID: UUID?           // FK to synthetic worktree
     public var createdAt: Date
+    public var suggestion: ConductorSuggestion?
 
     public init(
         id: UUID = UUID(),
@@ -20,7 +33,8 @@ public struct Conductor: Codable, Sendable, Identifiable, Equatable {
         heartbeatIntervalMinutes: Int = 10,
         terminalID: UUID? = nil,
         worktreeID: UUID? = nil,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        suggestion: ConductorSuggestion? = nil
     ) {
         self.id = id
         self.name = name
@@ -31,5 +45,6 @@ public struct Conductor: Codable, Sendable, Identifiable, Equatable {
         self.terminalID = terminalID
         self.worktreeID = worktreeID
         self.createdAt = createdAt
+        self.suggestion = suggestion
     }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -116,6 +116,8 @@ public enum RPCMethod {
     public static let conductorTeardown = "conductor.teardown"
     public static let conductorList = "conductor.list"
     public static let conductorStatus = "conductor.status"
+    public static let conductorSuggest = "conductor.suggest"
+    public static let conductorClearSuggestion = "conductor.clearSuggestion"
     public static let terminalConversation = "terminal.conversation"
 }
 
@@ -392,6 +394,15 @@ public struct ConductorStatusResult: Codable, Sendable {
     public let isRunning: Bool
     public init(conductor: Conductor, isRunning: Bool) {
         self.conductor = conductor; self.isRunning = isRunning
+    }
+}
+
+public struct ConductorSuggestParams: Codable, Sendable {
+    public let name: String
+    public let worktreeID: UUID
+    public let label: String?
+    public init(name: String, worktreeID: UUID, label: String? = nil) {
+        self.name = name; self.worktreeID = worktreeID; self.label = label
     }
 }
 

--- a/Tests/TBDDaemonTests/ConductorManagerTests.swift
+++ b/Tests/TBDDaemonTests/ConductorManagerTests.swift
@@ -80,7 +80,7 @@ import TBDShared
         let tmux = TmuxManager(dryRun: true)
         let manager = ConductorManager(db: db, tmux: tmux)
 
-        let conductor = try await manager.setup(name: "test-suggest", repos: ["*"])
+        _ = try await manager.setup(name: "test-suggest", repos: ["*"])
         defer { try? FileManager.default.removeItem(at: TBDConstants.conductorsDir.appendingPathComponent("test-suggest")) }
 
         // Create a worktree to suggest

--- a/Tests/TBDDaemonTests/ConductorManagerTests.swift
+++ b/Tests/TBDDaemonTests/ConductorManagerTests.swift
@@ -71,6 +71,57 @@ import TBDShared
         )
         #expect(template.contains("Conductor: my-conductor"))
         #expect(template.contains("tbd terminal output"))
+        #expect(template.contains("tbd conductor suggest my-conductor"))
+        #expect(template.contains("tbd conductor clear-suggestion my-conductor"))
+    }
+
+    @Test func suggestAndClearSuggestion() async throws {
+        let db = try makeDB()
+        let tmux = TmuxManager(dryRun: true)
+        let manager = ConductorManager(db: db, tmux: tmux)
+
+        let conductor = try await manager.setup(name: "test-suggest", repos: ["*"])
+        defer { try? FileManager.default.removeItem(at: TBDConstants.conductorsDir.appendingPathComponent("test-suggest")) }
+
+        // Create a worktree to suggest
+        let wt = try await db.worktrees.create(
+            repoID: TBDConstants.conductorsRepoID,
+            name: "fake-wt",
+            branch: "main",
+            path: "/tmp/fake",
+            tmuxServer: "test",
+            status: .active
+        )
+
+        // No suggestion initially
+        #expect(manager.suggestion(for: "test-suggest") == nil)
+
+        // Set suggestion
+        try await manager.suggest(name: "test-suggest", worktreeID: wt.id, worktreeName: "fake-wt", label: "waiting")
+        let s = manager.suggestion(for: "test-suggest")
+        #expect(s?.worktreeID == wt.id)
+        #expect(s?.label == "waiting")
+
+        // Overwrite suggestion
+        try await manager.suggest(name: "test-suggest", worktreeID: wt.id, worktreeName: "fake-wt", label: "new label")
+        #expect(manager.suggestion(for: "test-suggest")?.label == "new label")
+
+        // Clear
+        try await manager.clearSuggestion(name: "test-suggest")
+        #expect(manager.suggestion(for: "test-suggest") == nil)
+    }
+
+    @Test func suggestForNonexistentConductorFails() async throws {
+        let db = try makeDB()
+        let tmux = TmuxManager(dryRun: true)
+        let manager = ConductorManager(db: db, tmux: tmux)
+
+        do {
+            try await manager.suggest(name: "nope", worktreeID: UUID(), worktreeName: "x", label: nil)
+            Issue.record("Expected not found error")
+        } catch {
+            #expect(error.localizedDescription.contains("not found"))
+        }
     }
 
     @Test func invalidNameRejected() async throws {

--- a/docs/superpowers/plans/2026-04-04-conductor-ui.md
+++ b/docs/superpowers/plans/2026-04-04-conductor-ui.md
@@ -1,0 +1,1006 @@
+# Conductor UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Guake-style toggleable conductor terminal overlay to TBDApp with navigation suggestions and hotkey support.
+
+**Architecture:** SwiftUI `.overlay(alignment: .top)` on the main content area renders the conductor's terminal. Conductor lifecycle (setup/start/stop) triggered from a toolbar button. Navigation suggestions flow via polling `conductor.list` (which gains an in-memory `suggestion` field). Local `NSEvent` monitor handles Opt+. hotkey.
+
+**Tech Stack:** SwiftUI, SwiftTerm, NSEvent, TBDShared RPC protocol, GRDB
+
+**Spec:** `docs/superpowers/specs/2026-04-04-conductor-ui-design.md`
+
+---
+
+### Task 1: Add suggestion field to Conductor model + RPC
+
+**Files:**
+- Modify: `Sources/TBDShared/ConductorModels.swift`
+- Modify: `Sources/TBDShared/RPCProtocol.swift:119-120,364-396`
+- Modify: `Sources/TBDDaemon/Conductor/ConductorManager.swift`
+- Modify: `Sources/TBDDaemon/Conductor/ConductorStore.swift:34-58`
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift`
+- Modify: `Sources/TBDDaemon/Server/RPCRouter.swift:136`
+- Test: `Tests/TBDDaemonTests/ConductorManagerTests.swift`
+
+- [ ] **Step 1: Add `ConductorSuggestion` to shared models and optional field to `Conductor`**
+
+In `Sources/TBDShared/ConductorModels.swift`, add the suggestion struct and an optional field:
+
+```swift
+public struct ConductorSuggestion: Codable, Sendable, Equatable {
+    public let worktreeID: UUID
+    public let worktreeName: String
+    public let label: String?
+
+    public init(worktreeID: UUID, worktreeName: String, label: String? = nil) {
+        self.worktreeID = worktreeID
+        self.worktreeName = worktreeName
+        self.label = label
+    }
+}
+```
+
+Add to `Conductor` struct (after `createdAt`):
+
+```swift
+public var suggestion: ConductorSuggestion?
+```
+
+Add the parameter to the `init` with default `nil`:
+
+```swift
+suggestion: ConductorSuggestion? = nil
+```
+
+- [ ] **Step 2: Add RPC method constants and param structs**
+
+In `Sources/TBDShared/RPCProtocol.swift`, add after `conductorStatus` (line 118):
+
+```swift
+public static let conductorSuggest = "conductor.suggest"
+public static let conductorClearSuggestion = "conductor.clearSuggestion"
+```
+
+Add param structs after the existing conductor section (~line 396):
+
+```swift
+public struct ConductorSuggestParams: Codable, Sendable {
+    public let name: String
+    public let worktreeID: UUID
+    public let label: String?
+    public init(name: String, worktreeID: UUID, label: String? = nil) {
+        self.name = name; self.worktreeID = worktreeID; self.label = label
+    }
+}
+```
+
+`conductor.clearSuggestion` reuses existing `ConductorNameParams`.
+
+- [ ] **Step 3: Add in-memory suggestion state to ConductorManager**
+
+In `Sources/TBDDaemon/Conductor/ConductorManager.swift`, add a thread-safe suggestions dict. Since `ConductorManager` is `Sendable` (not an actor), use `OSAllocatedUnfairLock`:
+
+```swift
+import os
+
+// Add as property:
+private let _suggestions = OSAllocatedUnfairLock(initialState: [String: ConductorSuggestion]())
+
+public func suggest(name: String, worktreeID: UUID, worktreeName: String, label: String?) async throws {
+    guard let _ = try await db.conductors.get(name: name) else {
+        throw ConductorError.notFound(name: name)
+    }
+    let suggestion = ConductorSuggestion(worktreeID: worktreeID, worktreeName: worktreeName, label: label)
+    _suggestions.withLock { $0[name] = suggestion }
+}
+
+public func clearSuggestion(name: String) async throws {
+    guard let _ = try await db.conductors.get(name: name) else {
+        throw ConductorError.notFound(name: name)
+    }
+    _suggestions.withLock { $0.removeValue(forKey: name) }
+}
+
+public func suggestion(for name: String) -> ConductorSuggestion? {
+    _suggestions.withLock { $0[name] }
+}
+```
+
+- [ ] **Step 4: Update `handleConductorList` and `handleConductorStatus` to include suggestions**
+
+In `Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift`, modify `handleConductorList`:
+
+```swift
+func handleConductorList() async throws -> RPCResponse {
+    var conductors = try await db.conductors.list()
+    for i in conductors.indices {
+        conductors[i].suggestion = conductorManager.suggestion(for: conductors[i].name)
+    }
+    return try RPCResponse(result: ConductorListResult(conductors: conductors))
+}
+```
+
+Similarly in `handleConductorStatus`, add before the return:
+
+```swift
+var conductor = conductor  // make mutable
+conductor.suggestion = conductorManager.suggestion(for: conductor.name)
+```
+
+- [ ] **Step 5: Add suggest/clearSuggestion RPC handlers**
+
+In `Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift`:
+
+```swift
+func handleConductorSuggest(_ paramsData: Data) async throws -> RPCResponse {
+    let params = try decoder.decode(ConductorSuggestParams.self, from: paramsData)
+    // Look up worktree name for the suggestion
+    let worktreeName: String
+    if let wt = try await db.worktrees.get(id: params.worktreeID) {
+        worktreeName = wt.displayName
+    } else {
+        return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
+    }
+    try await conductorManager.suggest(
+        name: params.name,
+        worktreeID: params.worktreeID,
+        worktreeName: worktreeName,
+        label: params.label
+    )
+    return .ok()
+}
+
+func handleConductorClearSuggestion(_ paramsData: Data) async throws -> RPCResponse {
+    let params = try decoder.decode(ConductorNameParams.self, from: paramsData)
+    try await conductorManager.clearSuggestion(name: params.name)
+    return .ok()
+}
+```
+
+- [ ] **Step 6: Route the new methods in RPCRouter**
+
+In `Sources/TBDDaemon/Server/RPCRouter.swift`, add before the `default:` case (~line 136):
+
+```swift
+case RPCMethod.conductorSuggest:
+    return try await handleConductorSuggest(request.paramsData)
+case RPCMethod.conductorClearSuggestion:
+    return try await handleConductorClearSuggestion(request.paramsData)
+```
+
+- [ ] **Step 7: Update ConductorStore.toModel() to handle the new optional field**
+
+The `suggestion` field is in-memory only (not stored in DB), so `ConductorStore.toModel()` already returns `nil` for it by default (since `Conductor.init` defaults `suggestion` to `nil`). No store changes needed.
+
+- [ ] **Step 8: Write tests**
+
+In `Tests/TBDDaemonTests/ConductorManagerTests.swift`, add:
+
+```swift
+@Test func suggestAndClearSuggestion() async throws {
+    let db = try makeDB()
+    let tmux = TmuxManager(dryRun: true)
+    let manager = ConductorManager(db: db, tmux: tmux)
+
+    let conductor = try await manager.setup(name: "test-suggest", repos: ["*"])
+    defer { try? FileManager.default.removeItem(at: TBDConstants.conductorsDir.appendingPathComponent("test-suggest")) }
+
+    // Create a worktree to suggest
+    let wt = try await db.worktrees.create(
+        repoID: TBDConstants.conductorsRepoID,
+        name: "fake-wt",
+        branch: "main",
+        path: "/tmp/fake",
+        tmuxServer: "test",
+        status: .active
+    )
+
+    // No suggestion initially
+    #expect(manager.suggestion(for: "test-suggest") == nil)
+
+    // Set suggestion
+    try await manager.suggest(name: "test-suggest", worktreeID: wt.id, worktreeName: "fake-wt", label: "waiting")
+    let s = manager.suggestion(for: "test-suggest")
+    #expect(s?.worktreeID == wt.id)
+    #expect(s?.label == "waiting")
+
+    // Overwrite suggestion
+    try await manager.suggest(name: "test-suggest", worktreeID: wt.id, worktreeName: "fake-wt", label: "new label")
+    #expect(manager.suggestion(for: "test-suggest")?.label == "new label")
+
+    // Clear
+    try await manager.clearSuggestion(name: "test-suggest")
+    #expect(manager.suggestion(for: "test-suggest") == nil)
+}
+
+@Test func suggestForNonexistentConductorFails() async throws {
+    let db = try makeDB()
+    let tmux = TmuxManager(dryRun: true)
+    let manager = ConductorManager(db: db, tmux: tmux)
+
+    do {
+        try await manager.suggest(name: "nope", worktreeID: UUID(), worktreeName: "x", label: nil)
+        Issue.record("Expected not found error")
+    } catch {
+        #expect(error.localizedDescription.contains("not found"))
+    }
+}
+```
+
+- [ ] **Step 9: Run tests**
+
+Run: `swift test --filter ConductorManagerTests`
+Expected: All tests pass including the new suggestion tests.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Sources/TBDShared/ConductorModels.swift Sources/TBDShared/RPCProtocol.swift \
+  Sources/TBDDaemon/Conductor/ConductorManager.swift Sources/TBDDaemon/Server/RPCRouter.swift \
+  Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift \
+  Tests/TBDDaemonTests/ConductorManagerTests.swift
+git commit -m "feat: add conductor.suggest/clearSuggestion RPC with in-memory state"
+```
+
+---
+
+### Task 2: Add suggest/clear-suggestion CLI commands
+
+**Files:**
+- Modify: `Sources/TBDCLI/Commands/ConductorCommands.swift`
+
+- [ ] **Step 1: Add ConductorSuggest subcommand**
+
+In `Sources/TBDCLI/Commands/ConductorCommands.swift`, add to the `subcommands` array in `ConductorCommand.configuration`:
+
+```swift
+ConductorSuggestCmd.self,
+ConductorClearSuggestionCmd.self,
+```
+
+Then add the command structs:
+
+```swift
+// MARK: - conductor suggest
+
+struct ConductorSuggestCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "suggest",
+        abstract: "Set a navigation suggestion for the UI"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    @Option(name: .long, help: "Worktree ID to suggest navigating to")
+    var worktree: String
+
+    @Option(name: .long, help: "Optional label (e.g. 'waiting for input')")
+    var label: String?
+
+    mutating func run() async throws {
+        guard let worktreeID = UUID(uuidString: worktree) else {
+            print("Error: invalid worktree UUID: \(worktree)")
+            throw ExitCode.failure
+        }
+        let client = SocketClient()
+        let response = try client.call(RPCRequest(
+            method: RPCMethod.conductorSuggest,
+            params: ConductorSuggestParams(name: name, worktreeID: worktreeID, label: label)
+        ))
+        if !response.success {
+            print("Error: \(response.error ?? "unknown")")
+            throw ExitCode.failure
+        }
+        print("Suggestion set for conductor '\(name)'")
+    }
+}
+
+// MARK: - conductor clear-suggestion
+
+struct ConductorClearSuggestionCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "clear-suggestion",
+        abstract: "Clear the navigation suggestion"
+    )
+
+    @Argument(help: "Conductor name")
+    var name: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let response = try client.call(RPCRequest(
+            method: RPCMethod.conductorClearSuggestion,
+            params: ConductorNameParams(name: name)
+        ))
+        if !response.success {
+            print("Error: \(response.error ?? "unknown")")
+            throw ExitCode.failure
+        }
+        print("Suggestion cleared for conductor '\(name)'")
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `swift build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDCLI/Commands/ConductorCommands.swift
+git commit -m "feat: add conductor suggest/clear-suggestion CLI commands"
+```
+
+---
+
+### Task 3: Add conductor polling to AppState + DaemonClient
+
+**Files:**
+- Modify: `Sources/TBDApp/DaemonClient.swift`
+- Modify: `Sources/TBDApp/AppState.swift`
+
+- [ ] **Step 1: Add `listConductors` to DaemonClient**
+
+In `Sources/TBDApp/DaemonClient.swift`, add after the existing conductor-related methods (or at the end of the MARK sections):
+
+```swift
+// MARK: - Conductors
+
+/// List all conductors.
+func listConductors() throws -> [Conductor] {
+    let result = try callNoParams(method: RPCMethod.conductorList, resultType: ConductorListResult.self)
+    return result.conductors
+}
+
+/// Set up a new conductor with defaults.
+func conductorSetup(name: String, repos: [String] = ["*"]) throws -> Conductor {
+    return try call(
+        method: RPCMethod.conductorSetup,
+        params: ConductorSetupParams(name: name, repos: repos),
+        resultType: Conductor.self
+    )
+}
+
+/// Start a conductor.
+func conductorStart(name: String) throws -> Terminal {
+    return try call(
+        method: RPCMethod.conductorStart,
+        params: ConductorNameParams(name: name),
+        resultType: Terminal.self
+    )
+}
+
+/// Stop a conductor.
+func conductorStop(name: String) throws {
+    try callVoid(
+        method: RPCMethod.conductorStop,
+        params: ConductorNameParams(name: name)
+    )
+}
+
+/// Teardown (remove) a conductor.
+func conductorTeardown(name: String) throws {
+    try callVoid(
+        method: RPCMethod.conductorTeardown,
+        params: ConductorNameParams(name: name)
+    )
+}
+```
+
+- [ ] **Step 2: Add conductor state properties to AppState**
+
+In `Sources/TBDApp/AppState.swift`, add after the `prStatuses` property (~line 67):
+
+```swift
+/// Conductor for each repo (wildcard conductors expanded across all repos).
+@Published var conductorsByRepo: [UUID: Conductor] = [:]
+/// The conductor's terminal record, keyed by repo ID.
+@Published var conductorTerminalsByRepo: [UUID: Terminal] = [:]
+/// Current navigation suggestion from any conductor.
+@Published var conductorSuggestion: ConductorSuggestion? = nil
+/// Whether the conductor overlay is visible.
+@Published var showConductor: Bool = false
+/// Conductor overlay height — persisted.
+@Published var conductorHeight: CGFloat = 300 {
+    didSet { UserDefaults.standard.set(Double(conductorHeight), forKey: "com.tbd.app.conductorHeight") }
+}
+```
+
+Add to `init()` after the dockRatio restoration (~line 91):
+
+```swift
+if let savedHeight = UserDefaults.standard.object(forKey: "com.tbd.app.conductorHeight") as? Double {
+    conductorHeight = max(100, min(800, CGFloat(savedHeight)))
+}
+```
+
+- [ ] **Step 3: Add `refreshConductors()` and wire into poll cycle**
+
+In `Sources/TBDApp/AppState.swift`, add after `refreshNotifications()`:
+
+```swift
+/// Refresh conductor state from the daemon.
+func refreshConductors() async {
+    do {
+        let conductors = try await daemonClient.listConductors()
+
+        // Build conductorsByRepo: expand ["*"] conductors across all repo IDs
+        var byRepo: [UUID: Conductor] = [:]
+        var termByRepo: [UUID: Terminal] = [:]
+        let repoIDs = repos.map(\.id)
+
+        for conductor in conductors {
+            let matchingRepoIDs: [UUID]
+            if conductor.repos.contains("*") {
+                matchingRepoIDs = repoIDs
+            } else {
+                matchingRepoIDs = conductor.repos.compactMap { UUID(uuidString: $0) }
+            }
+            for repoID in matchingRepoIDs {
+                if byRepo[repoID] == nil {  // first match wins
+                    byRepo[repoID] = conductor
+                    // Find the conductor's terminal in the terminals dict
+                    if let termID = conductor.terminalID,
+                       let wtID = conductor.worktreeID,
+                       let term = terminals[wtID]?.first(where: { $0.id == termID }) {
+                        termByRepo[repoID] = term
+                    }
+                }
+            }
+        }
+
+        if byRepo != conductorsByRepo { conductorsByRepo = byRepo }
+        if termByRepo != conductorTerminalsByRepo { conductorTerminalsByRepo = termByRepo }
+
+        // Update suggestion from the conductor matching the current selection
+        let newSuggestion: ConductorSuggestion? = {
+            guard let selectedID = selectedWorktreeIDs.first,
+                  let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }),
+                  let conductor = byRepo[selectedWt.repoID] else { return nil }
+            return conductor.suggestion
+        }()
+        if newSuggestion != conductorSuggestion { conductorSuggestion = newSuggestion }
+    } catch {
+        // Don't log connection errors for conductors — they're not critical
+    }
+}
+```
+
+Add computed properties:
+
+```swift
+/// The conductor for the repo of the currently selected worktree.
+var currentConductor: Conductor? {
+    guard let selectedID = selectedWorktreeIDs.first,
+          let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }) else { return nil }
+    return conductorsByRepo[selectedWt.repoID]
+}
+
+/// Whether a conductor is active (exists and has a terminal) for the current repo.
+var conductorActive: Bool {
+    guard let conductor = currentConductor else { return false }
+    return conductor.terminalID != nil
+}
+
+/// The conductor's terminal for the currently selected repo.
+var currentConductorTerminal: Terminal? {
+    guard let selectedID = selectedWorktreeIDs.first,
+          let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }) else { return nil }
+    return conductorTerminalsByRepo[selectedWt.repoID]
+}
+```
+
+Wire into `refreshAll()`:
+
+```swift
+func refreshAll() async {
+    await refreshRepos()
+    await refreshWorktrees()
+    await refreshNotifications()
+    await refreshConductors()
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `swift build`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDApp/DaemonClient.swift Sources/TBDApp/AppState.swift
+git commit -m "feat: add conductor polling to AppState with repo-scoped lookup"
+```
+
+---
+
+### Task 4: Build ConductorOverlayView + ConductorSuggestionBar
+
+**Files:**
+- Create: `Sources/TBDApp/Conductor/ConductorOverlayView.swift`
+- Create: `Sources/TBDApp/Conductor/ConductorSuggestionBar.swift`
+
+- [ ] **Step 1: Create ConductorOverlayView**
+
+Create `Sources/TBDApp/Conductor/ConductorOverlayView.swift`:
+
+```swift
+import SwiftUI
+import TBDShared
+
+struct ConductorOverlayView: View {
+    @EnvironmentObject var appState: AppState
+    let terminal: Terminal
+    let tmuxServer: String
+
+    @State private var dragStartHeight: CGFloat = 0
+    @State private var dragIndicatorOffset: CGFloat? = nil
+
+    private let minHeight: CGFloat = 100
+
+    var body: some View {
+        GeometryReader { geometry in
+            let maxHeight = geometry.size.height * 0.8
+
+            VStack(spacing: 0) {
+                // Terminal
+                TerminalPanelView(
+                    terminalID: terminal.id,
+                    tmuxServer: tmuxServer,
+                    tmuxWindowID: terminal.tmuxWindowID,
+                    tmuxBridge: appState.tmuxBridge
+                )
+                .frame(height: appState.conductorHeight)
+                .clipped()
+
+                // Drag handle
+                ZStack {
+                    Rectangle()
+                        .fill(Color(nsColor: .separatorColor))
+                        .frame(height: 1)
+
+                    if let offset = dragIndicatorOffset {
+                        Rectangle()
+                            .fill(Color.accentColor)
+                            .frame(height: 2)
+                            .offset(y: offset)
+                    }
+                }
+                .frame(height: 4)
+                .contentShape(Rectangle())
+                .onHover { hovering in
+                    if hovering { NSCursor.resizeUpDown.push() } else { NSCursor.pop() }
+                }
+                .gesture(
+                    DragGesture(minimumDistance: 1)
+                        .onChanged { value in
+                            if dragStartHeight == 0 { dragStartHeight = appState.conductorHeight }
+                            let proposed = dragStartHeight + value.translation.height
+                            let clamped = max(minHeight, min(maxHeight, proposed))
+                            dragIndicatorOffset = clamped - appState.conductorHeight
+                        }
+                        .onEnded { value in
+                            let proposed = dragStartHeight + value.translation.height
+                            appState.conductorHeight = max(minHeight, min(maxHeight, proposed))
+                            dragStartHeight = 0
+                            dragIndicatorOffset = nil
+                        }
+                )
+
+                // Suggestion bar (conditional)
+                if let suggestion = appState.conductorSuggestion {
+                    ConductorSuggestionBar(suggestion: suggestion)
+                }
+            }
+            .background(.ultraThinMaterial)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create ConductorSuggestionBar**
+
+Create `Sources/TBDApp/Conductor/ConductorSuggestionBar.swift`:
+
+```swift
+import SwiftUI
+import TBDShared
+
+struct ConductorSuggestionBar: View {
+    @EnvironmentObject var appState: AppState
+    let suggestion: ConductorSuggestion
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.right.circle.fill")
+                .foregroundStyle(.blue)
+                .font(.system(size: 12))
+
+            Text(suggestion.worktreeName)
+                .fontWeight(.medium)
+                .font(.caption)
+
+            if let label = suggestion.label {
+                Text("— \(label)")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Spacer()
+
+            Button("Go") {
+                navigateToSuggestion()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+
+            Button {
+                appState.conductorSuggestion = nil
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .frame(height: 28)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private func navigateToSuggestion() {
+        appState.selectedWorktreeIDs = [suggestion.worktreeID]
+        appState.conductorSuggestion = nil
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `swift build`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/Conductor/ConductorOverlayView.swift \
+  Sources/TBDApp/Conductor/ConductorSuggestionBar.swift
+git commit -m "feat: add ConductorOverlayView and ConductorSuggestionBar"
+```
+
+---
+
+### Task 5: Add hotkey monitor
+
+**Files:**
+- Create: `Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift`
+
+- [ ] **Step 1: Create the hotkey monitor**
+
+Create `Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift`:
+
+```swift
+import AppKit
+
+/// Monitors local key events for the conductor toggle hotkey (Opt+.).
+/// Only fires when TBD is the active app.
+final class ConductorHotkeyMonitor {
+    private var monitor: Any?
+
+    /// Install the local event monitor. Call once at app startup.
+    /// The `toggle` closure is called on the main thread when the hotkey fires.
+    func install(toggle: @escaping () -> Void) {
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // Opt+. : modifiers = option, keyCode 47 = period
+            if event.modifierFlags.contains(.option),
+               !event.modifierFlags.contains(.command),
+               !event.modifierFlags.contains(.control),
+               event.keyCode == 47 {
+                toggle()
+                return nil  // consume the event
+            }
+            return event
+        }
+    }
+
+    func uninstall() {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+            self.monitor = nil
+        }
+    }
+
+    deinit {
+        uninstall()
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `swift build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift
+git commit -m "feat: add ConductorHotkeyMonitor for Opt+. toggle"
+```
+
+---
+
+### Task 6: Integrate overlay + toggle + hotkey into ContentView
+
+**Files:**
+- Modify: `Sources/TBDApp/ContentView.swift`
+- Modify: `Sources/TBDApp/AppState.swift` (minor — add conductor name derivation helper)
+
+- [ ] **Step 1: Add conductor name derivation helper to AppState**
+
+In `Sources/TBDApp/AppState.swift`, add a helper (e.g., after the computed properties added in Task 3):
+
+```swift
+/// Derive a conductor name from a repo's display name.
+/// Lowercases, replaces non-alphanumeric chars with hyphens, trims leading/trailing hyphens.
+static func conductorName(from repoName: String) -> String {
+    let cleaned = repoName
+        .lowercased()
+        .replacing(/[^a-z0-9]+/, with: "-")
+        .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    let truncated = String(cleaned.prefix(64))
+    return truncated.isEmpty ? "conductor" : truncated
+}
+```
+
+- [ ] **Step 2: Add one-click conductor setup/start method to AppState**
+
+In `Sources/TBDApp/AppState.swift`:
+
+```swift
+/// One-click conductor: setup (if needed) + start + show overlay.
+func ensureConductorRunning() async {
+    guard let selectedID = selectedWorktreeIDs.first,
+          let selectedWt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == selectedID }) else { return }
+    let repoID = selectedWt.repoID
+
+    do {
+        if let existing = conductorsByRepo[repoID] {
+            // Conductor exists — start it if not running
+            if existing.terminalID == nil {
+                _ = try await daemonClient.conductorStart(name: existing.name)
+            }
+        } else {
+            // No conductor — setup + start
+            guard let repo = repos.first(where: { $0.id == repoID }) else { return }
+            let name = Self.conductorName(from: repo.displayName)
+            _ = try await daemonClient.conductorSetup(name: name, repos: [repoID.uuidString])
+            _ = try await daemonClient.conductorStart(name: name)
+        }
+        await refreshConductors()
+        showConductor = true
+    } catch {
+        showAlert("Conductor error: \(error.localizedDescription)", isError: true)
+    }
+}
+```
+
+- [ ] **Step 3: Modify ContentView to add overlay and toolbar button**
+
+In `Sources/TBDApp/ContentView.swift`, add a `@StateObject` for the hotkey monitor and set it up. Then add the overlay to the content branch and the toolbar button.
+
+Add at the top of `ContentView`:
+
+```swift
+@State private var conductorHotkeyMonitor = ConductorHotkeyMonitor()
+```
+
+Wrap the `HStack` content branch (lines 31-42) with the overlay. Replace:
+
+```swift
+HStack(spacing: 0) {
+    TerminalContainerView()
+    if showFilePanel, let worktree = selectedWorktree, !worktree.path.isEmpty {
+        FilePanelDivider(panelWidth: Binding(
+            get: { CGFloat(filePanelWidth) },
+            set: { filePanelWidth = Double($0) }
+        ))
+        FileViewerPanel(worktree: worktree)
+            .frame(width: CGFloat(filePanelWidth))
+            .id(worktree.id)
+    }
+}
+```
+
+With:
+
+```swift
+HStack(spacing: 0) {
+    TerminalContainerView()
+    if showFilePanel, let worktree = selectedWorktree, !worktree.path.isEmpty {
+        FilePanelDivider(panelWidth: Binding(
+            get: { CGFloat(filePanelWidth) },
+            set: { filePanelWidth = Double($0) }
+        ))
+        FileViewerPanel(worktree: worktree)
+            .frame(width: CGFloat(filePanelWidth))
+            .id(worktree.id)
+    }
+}
+.overlay(alignment: .top) {
+    if appState.showConductor,
+       let terminal = appState.currentConductorTerminal {
+        ConductorOverlayView(
+            terminal: terminal,
+            tmuxServer: TBDConstants.conductorsTmuxServer
+        )
+    }
+}
+```
+
+Add the toolbar button in the `ToolbarItemGroup`, after the auto-suspend button (after line 58):
+
+```swift
+// Conductor toggle
+Button {
+    if appState.conductorActive {
+        appState.showConductor.toggle()
+    } else {
+        Task { await appState.ensureConductorRunning() }
+    }
+} label: {
+    Image(systemName: appState.conductorActive
+        ? (appState.showConductor ? "wand.and.stars" : "wand.and.stars.inverse")
+        : "wand.and.stars.inverse")
+        .foregroundStyle(appState.showConductor ? .primary : .secondary)
+}
+.help(appState.conductorActive
+    ? (appState.showConductor ? "Hide conductor (⌥.)" : "Show conductor (⌥.)")
+    : "Start conductor (⌥.)")
+.contextMenu {
+    if appState.conductorActive, let conductor = appState.currentConductor {
+        Button("Stop Conductor") {
+            Task {
+                try? await appState.daemonClient.conductorStop(name: conductor.name)
+                appState.showConductor = false
+                await appState.refreshConductors()
+            }
+        }
+        Button("Remove Conductor", role: .destructive) {
+            Task {
+                try? await appState.daemonClient.conductorTeardown(name: conductor.name)
+                appState.showConductor = false
+                await appState.refreshConductors()
+            }
+        }
+    }
+}
+```
+
+Install the hotkey monitor. Add `.onAppear` to the outermost `VStack` (after `.alert`):
+
+```swift
+.onAppear {
+    conductorHotkeyMonitor.install { [weak appState] in
+        guard let appState else { return }
+        if appState.conductorActive {
+            appState.showConductor.toggle()
+        } else {
+            Task { await appState.ensureConductorRunning() }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add TBDConstants.conductorsTmuxServer to TBDShared if not accessible from app**
+
+Check if `TBDConstants.conductorsTmuxServer` is accessible from the app target. It's in `Sources/TBDShared/Constants.swift`. Verify it's `public`. If not, make it public.
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `swift build`
+Expected: Build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDApp/ContentView.swift Sources/TBDApp/AppState.swift
+git commit -m "feat: integrate conductor overlay, toolbar toggle, and Opt+. hotkey"
+```
+
+---
+
+### Task 7: Update conductor CLAUDE.md template with suggest commands
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Conductor/ConductorManager.swift`
+
+- [ ] **Step 1: Add suggest commands to the template**
+
+In `Sources/TBDDaemon/Conductor/ConductorManager.swift`, in the `generateTemplate` method, add before the `## Terminal States` section:
+
+```swift
+## Navigation Suggestions
+
+When discussing a specific worktree, help the user navigate to it:
+
+| Command | Description |
+|---------|-------------|
+| `tbd conductor suggest \(name) --worktree <id>` | Show a "Go to" pill in the UI |
+| `tbd conductor suggest \(name) --worktree <id> --label "waiting for input"` | With context label |
+| `tbd conductor clear-suggestion \(name)` | Remove the pill |
+
+Set a suggestion when surfacing info about a worktree. Clear it when moving on
+to a different topic or when the user has acknowledged it.
+```
+
+Also add the commands to the CLI table in the template:
+
+```swift
+| `tbd conductor suggest \(name) --worktree <id> [--label "text"]` | Show navigation pill in UI |
+| `tbd conductor clear-suggestion \(name)` | Clear navigation pill |
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `swift build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run existing template test**
+
+Run: `swift test --filter templateContainsConductorName`
+Expected: PASS. Update the test to also check for suggest commands:
+
+In `Tests/TBDDaemonTests/ConductorManagerTests.swift`, modify `templateContainsConductorName`:
+
+```swift
+@Test func templateContainsConductorName() async throws {
+    let template = ConductorManager.generateTemplate(
+        name: "my-conductor",
+        repos: ["*"]
+    )
+    #expect(template.contains("Conductor: my-conductor"))
+    #expect(template.contains("tbd terminal output"))
+    #expect(template.contains("tbd conductor suggest my-conductor"))
+    #expect(template.contains("tbd conductor clear-suggestion my-conductor"))
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `swift test --filter ConductorManagerTests`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Conductor/ConductorManager.swift \
+  Tests/TBDDaemonTests/ConductorManagerTests.swift
+git commit -m "feat: add suggest/clear-suggestion commands to conductor CLAUDE.md template"
+```
+
+---
+
+### Task 8: Final build + test + manual verification
+
+**Files:** None new — verification only.
+
+- [ ] **Step 1: Full build**
+
+Run: `swift build`
+Expected: Build succeeds with no warnings related to conductor code.
+
+- [ ] **Step 2: Run all tests**
+
+Run: `swift test`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit if any fixups were needed**
+
+Only commit if steps 1 or 2 required changes.

--- a/docs/superpowers/specs/2026-04-04-conductor-ui-design.md
+++ b/docs/superpowers/specs/2026-04-04-conductor-ui-design.md
@@ -8,7 +8,7 @@ The conductor (Phase 1a) is a CLI-only experience. Users must manually switch to
 
 ## Solution
 
-A resizable, toggleable terminal overlay that drops from the top of the main content area. One-click setup from the toolbar. Local hotkey (Cmd+.) for instant toggle. Navigation suggestions let the conductor surface clickable "go to worktree" pills without blocking interaction.
+A resizable, toggleable terminal overlay that drops from the top of the main content area. One-click setup from the toolbar. Local hotkey (Opt+.) for instant toggle. Navigation suggestions let the conductor surface clickable "go to worktree" pills without blocking interaction.
 
 ## Design Principles
 
@@ -21,7 +21,9 @@ A resizable, toggleable terminal overlay that drops from the top of the main con
 
 ### Overlay Layout
 
-The conductor overlay is a SwiftUI `.overlay(alignment: .top)` on the detail side of `NavigationSplitView` in `ContentView`. It spans the full main content area — everything right of the sidebar, covering tab content, multi-worktree grid, and pinned dock.
+The conductor overlay is a SwiftUI `.overlay(alignment: .top)` applied inside the `detail:` closure of `NavigationSplitView` in `ContentView`, wrapping the terminal/worktree content branch. It spans the full main content area — everything right of the sidebar, covering tab content, multi-worktree grid, and pinned dock.
+
+The overlay only renders when terminal content is showing — not over the disconnected view, empty state, or archived worktrees view. The `.overlay()` wraps the `HStack` containing `TerminalContainerView` (+ optional `FileViewerPanel`).
 
 ```
 ┌─────────┬──────────────────────────────────────────┐
@@ -54,9 +56,9 @@ ConductorOverlayView
 
 ### Visibility & Terminal Lifecycle
 
-- `appState.showConductor: Bool` controls visibility
-- When hidden: `TerminalPanelView` stays mounted via `.opacity(0).allowsHitTesting(false).frame(height: 0)` — SwiftTerm + tmux grouped session stays alive
-- When shown: restores opacity, hit testing, and configured height
+- `appState.showConductor: Bool` controls visibility (defaults to `false` on app launch, even if a conductor is running — the user toggles it when they want it)
+- When hidden: `TerminalPanelView` stays mounted at its configured height via `.opacity(0).allowsHitTesting(false)` — SwiftTerm + tmux grouped session stays alive. **Do not use `frame(height: 0)`** — a zero-height frame would send 0 rows to the PTY via `TIOCSWINSZ`, breaking the terminal. The view keeps its full frame but is invisible and non-interactive.
+- When shown: restores opacity and hit testing
 
 ### Sizing
 
@@ -75,7 +77,7 @@ Nearly opaque with blur: `.background(.ultraThinMaterial)` or solid dark backgro
 A button in the `ContentView` toolbar, next to the auto-suspend toggle. Shows a conductor icon.
 
 **States:**
-- **No conductor for this repo:** Click runs `conductor.setup` (default name from repo, all worktrees, manual polling) → `conductor.start` → shows overlay. One click, zero config.
+- **No conductor for this repo:** Click runs `conductor.setup` (name auto-derived: `repo.displayName` lowercased, non-alphanumeric chars replaced with hyphens, e.g. "My App" → "my-app"; all worktrees, manual polling) → `conductor.start` → shows overlay. One click, zero config.
 - **Conductor exists but hidden:** Click shows overlay.
 - **Conductor visible:** Click hides overlay.
 
@@ -87,9 +89,11 @@ A button in the `ContentView` toolbar, next to the auto-suspend toggle. Shows a 
 
 The conductor is tied to a repo. When the user selects a worktree in a different repo, the overlay shows/hides the conductor for *that* repo's conductor. If the other repo has no conductor, the overlay is empty and the button shows "no conductor" state. Each repo has at most one conductor (simplification for now).
 
+**Conductor-to-repo matching:** The `Conductor` model has `repos: [String]` which is either `["*"]` (all repos) or specific repo ID strings. To find the conductor for a given repo: check all conductors for one whose `repos` contains the repo's UUID string or `"*"`. A `["*"]` conductor matches every repo. If multiple conductors match (unlikely in practice), use the first one found. The app builds `conductorsByRepo: [UUID: Conductor]` client-side by expanding wildcard conductors across all known repos.
+
 ## Hotkey
 
-**Default:** Cmd+. (period)
+**Default:** Opt+. (Option + period)
 
 Registered via `NSEvent.addLocalMonitorForEvents(matching: .keyDown)` at app startup. Only fires when TBD is the active app. Toggles `appState.showConductor`. The monitor consumes the event (returns `nil`) when matched, preventing propagation to terminals or other responders.
 
@@ -100,7 +104,7 @@ Hotkey is configurable, stored in UserDefaults. Settings UI deferred.
 1. **Conductor appears:** Conductor terminal becomes first responder. User can type immediately.
 2. **Conductor hides:** Previous first responder is restored (stored before showing conductor).
 3. **User clicks a terminal below the overlay:** That terminal becomes first responder. Conductor stays visible but unfocused. Standard NSView first responder chain handles this naturally.
-4. **Re-focus conductor:** Click inside the conductor overlay, or Cmd+. twice (hide/show).
+4. **Re-focus conductor:** Click inside the conductor overlay, or Opt+. twice (hide/show).
 5. **Cmd+G (go to suggestion):** Navigates to suggested worktree, clears suggestion. Conductor stays visible.
 
 No custom focus management needed beyond sequencing `makeFirstResponder` calls on show/hide. SwiftUI hit testing + NSView responder chain handles the rest.
@@ -113,9 +117,12 @@ The conductor can set a navigation target via RPC. The app renders a non-blockin
 
 | Method | Params | Result | Description |
 |--------|--------|--------|-------------|
-| `conductor.suggest` | `conductorName: String, worktreeID: UUID, label: String?` | void | Set navigation suggestion |
-| `conductor.clearSuggestion` | `conductorName: String` | void | Clear navigation suggestion |
-| `conductor.info` | `repoID: UUID` | `Conductor?, Terminal?` | Conductor + terminal for a repo |
+| `conductor.suggest` | `name: String, worktreeID: UUID, label: String?` | void | Set navigation suggestion |
+| `conductor.clearSuggestion` | `name: String` | void | Clear navigation suggestion |
+
+Param structs use `name: String` to match the existing `ConductorNameParams` convention.
+
+**No `conductor.info` RPC needed.** The app already polls `conductor.list` — the suggestion state is included in the polling response by adding an optional `suggestion` field to the `Conductor` model returned by `conductor.list`/`conductor.status`.
 
 ### New CLI Commands
 
@@ -136,22 +143,15 @@ tbd conductor clear-suggestion <name>
 - **Dismiss (✕):** Clears suggestion without navigating.
 - **Cmd+G:** Same as clicking Go — navigates to suggested worktree, clears suggestion. Only active when a suggestion exists and conductor is focused.
 
-### StateDelta
+### Data Flow
 
-```swift
-case conductorSuggestionChanged(ConductorSuggestionDelta)
+Suggestion state is in-memory on `ConductorManager` (not DB — transient UI state).
 
-struct ConductorSuggestionDelta: Codable, Sendable {
-    let conductorName: String
-    let worktreeID: UUID?  // nil = cleared
-    let worktreeName: String?
-    let label: String?
-}
-```
+**Primary mechanism: polling.** The app's existing 2-second poll cycle calls `conductor.list`. The `Conductor` result type gains an optional `suggestion: ConductorSuggestion?` field (worktreeID + worktreeName + label). The app compares against previous poll to detect changes. This means suggestion updates have up to 2s latency — acceptable for a non-blocking pill.
 
-### Daemon Side
+**No StateDelta subscription needed.** The app currently has no live StateDelta subscription (it's poll-only via `refreshAll()`). Adding a persistent socket connection for push updates is out of scope. If subscriptions are added later, a `conductorSuggestionChanged` delta case can be added for lower latency.
 
-Suggestion state is in-memory on `ConductorManager` (not DB — transient UI state). Broadcast to app via `StateDelta.conductorSuggestionChanged`.
+**Polling integration:** Add `refreshConductors()` to `AppState.refreshAll()`. This calls `conductor.list`, populates `conductorsByRepo` (expanding `["*"]` conductors across all repos), `conductorTerminalsByRepo`, and `conductorSuggestion`.
 
 ### CLAUDE.md Template Additions
 
@@ -173,22 +173,18 @@ Set a suggestion when surfacing info about a worktree. Clear it when moving on t
 
 ```swift
 // Conductor state
-@Published var showConductor: Bool = false
+@Published var showConductor: Bool = false  // defaults false, even if conductor is running
 @Published var conductorHeight: CGFloat = 300  // persisted in UserDefaults
-@Published var conductorsByRepo: [UUID: Conductor] = [:]  // from polling
+@Published var conductorsByRepo: [UUID: Conductor] = [:]  // from polling, wildcard-expanded
 @Published var conductorTerminalsByRepo: [UUID: Terminal] = [:]
-@Published var conductorSuggestion: ConductorSuggestion?  // from StateDelta
-
-struct ConductorSuggestion {
-    let worktreeID: UUID
-    let worktreeName: String
-    let label: String?
-}
+@Published var conductorSuggestion: ConductorSuggestion?  // from polling conductor.list
 
 // Derived
 var currentConductor: Conductor?  // conductor for the repo of currently selected worktree
 var conductorActive: Bool  // currentConductor != nil && its terminal exists
 ```
+
+`ConductorSuggestion` is an app-only struct (in AppState or a local types file), derived from the `suggestion` field on the `Conductor` wire type returned by `conductor.list`. It is NOT a shared model in `ConductorModels.swift`.
 
 ## File Changes
 
@@ -199,23 +195,21 @@ var conductorActive: Bool  // currentConductor != nil && its terminal exists
 
 ### Modified Files
 - `Sources/TBDApp/ContentView.swift` — `.overlay()` + toolbar toggle button with context menu
-- `Sources/TBDApp/AppState.swift` — conductor state properties
-- `Sources/TBDShared/RPCProtocol.swift` — `conductor.suggest`, `conductor.clearSuggestion`, `conductor.info` methods + param/result structs
-- `Sources/TBDShared/ConductorModels.swift` — `ConductorSuggestion` model
-- `Sources/TBDShared/Models.swift` — `conductorSuggestionChanged` StateDelta case
-- `Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift` — suggest/clearSuggestion/info handlers
+- `Sources/TBDApp/AppState.swift` — conductor state properties + `refreshConductors()` in poll cycle
+- `Sources/TBDShared/RPCProtocol.swift` — `conductor.suggest`, `conductor.clearSuggestion` methods + param structs
+- `Sources/TBDShared/ConductorModels.swift` — add optional `suggestion` field to `Conductor` model (worktreeID, worktreeName, label)
+- `Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift` — suggest/clearSuggestion handlers
 - `Sources/TBDDaemon/Conductor/ConductorManager.swift` — in-memory suggestion state, CLAUDE.md template update
-- `Sources/TBDDaemon/Server/StateSubscription.swift` — broadcast suggestion deltas
-- `Sources/TBDApp/DaemonClient.swift` — conductor info client method
+- `Sources/TBDApp/DaemonClient.swift` — use existing `conductor.list` for polling conductors
 - `Sources/TBDCLI/Commands/ConductorCommands.swift` — suggest/clear-suggestion subcommands
 
 ### No DB Migration
 
-Suggestions are transient (in-memory). Conductor records already exist from Phase 1a (migration v9). The `conductor.info` RPC queries existing tables.
+Suggestions are transient (in-memory). Conductor records already exist from Phase 1a (migration v9).
 
 ## Testing
 
 - **RPC handler tests:** conductor.suggest sets suggestion, conductor.clearSuggestion clears it, suggest overwrites previous suggestion
-- **StateDelta tests:** encode/decode `conductorSuggestionChanged`
-- **ConductorManager tests:** suggestion state lifecycle (set, overwrite, clear, clear when none exists)
-- **UI:** Manual testing — toggle overlay, resize via drag handle, Cmd+. hotkey, suggestion pill click → navigation, dismiss suggestion, focus flow between conductor and worktree terminals
+- **ConductorManager tests:** suggestion state lifecycle (set, overwrite, clear, clear when none exists); suggestion included in conductor.list/status results
+- **Conductor model tests:** encode/decode `Conductor` with optional `suggestion` field (nil and non-nil)
+- **UI:** Manual testing — toggle overlay, resize via drag handle, Opt+. hotkey, suggestion pill click → navigation, dismiss suggestion, focus flow between conductor and worktree terminals

--- a/docs/superpowers/specs/2026-04-04-conductor-ui-design.md
+++ b/docs/superpowers/specs/2026-04-04-conductor-ui-design.md
@@ -1,0 +1,221 @@
+# Conductor UI Design
+
+A Guake-style toggleable overlay that renders the conductor's terminal session within the TBD app, with navigation suggestions and hotkey support.
+
+## Problem
+
+The conductor (Phase 1a) is a CLI-only experience. Users must manually switch to a conductor terminal, check on it, and switch back. There's no way to keep the conductor visible while working in worktrees, and no UI affordance to start one.
+
+## Solution
+
+A resizable, toggleable terminal overlay that drops from the top of the main content area. One-click setup from the toolbar. Local hotkey (Cmd+.) for instant toggle. Navigation suggestions let the conductor surface clickable "go to worktree" pills without blocking interaction.
+
+## Design Principles
+
+- **Zero reflow.** The overlay covers content — it doesn't push it down. Content underneath retains its layout.
+- **Non-destructive hide.** Hiding the overlay keeps the terminal and tmux session alive. Show/hide is instant.
+- **Non-blocking suggestions.** Navigation pills are informational. The user can ignore them and keep chatting with the conductor.
+- **One-click start.** No configuration dialogs. Click the toolbar button, conductor is running.
+
+## Architecture
+
+### Overlay Layout
+
+The conductor overlay is a SwiftUI `.overlay(alignment: .top)` on the detail side of `NavigationSplitView` in `ContentView`. It spans the full main content area — everything right of the sidebar, covering tab content, multi-worktree grid, and pinned dock.
+
+```
+┌─────────┬──────────────────────────────────────────┐
+│         │ Toolbar: [auto-suspend] [conductor ⚡]    │
+│         ├──────────────────────────────────────────┤
+│         │ ┌──────────────────────────────────────┐ │
+│ Sidebar │ │  Conductor terminal (SwiftTerm)      │ │
+│         │ │                                      │ │
+│         │ ├──────── drag handle ─────────────────┤ │
+│         │ │ 🔗 fix-auth — waiting for input [Go] │ │
+│         │ ├──────────────────────────────────────┤ │
+│         │ │                                      │ │
+│         │ │  Tab content / worktree grid          │ │
+│         │ │  (partially covered by overlay)       │ │
+│         │ │                                      │ │
+│         │ └──────────────────────────────────────┘ │
+└─────────┴──────────────────────────────────────────┘
+```
+
+### ConductorOverlayView Structure
+
+```
+ConductorOverlayView
+├── VStack(spacing: 0) {
+│   ├── TerminalPanelView (conductor's terminal — fills available height)
+│   ├── ConductorDragHandle (4pt, full width, resizeUpDown cursor)
+│   └── ConductorSuggestionBar (conditional — only when suggestion is active, ~28px)
+│   }
+```
+
+### Visibility & Terminal Lifecycle
+
+- `appState.showConductor: Bool` controls visibility
+- When hidden: `TerminalPanelView` stays mounted via `.opacity(0).allowsHitTesting(false).frame(height: 0)` — SwiftTerm + tmux grouped session stays alive
+- When shown: restores opacity, hit testing, and configured height
+
+### Sizing
+
+- `appState.conductorHeight: CGFloat` — persisted in UserDefaults, default 300px
+- Drag handle at bottom edge uses the same deferred-commit pattern as existing `SplitDivider` — shows blue indicator during drag, commits on release
+- Min height: 100px. Max height: 80% of content area.
+
+### Background
+
+Nearly opaque with blur: `.background(.ultraThinMaterial)` or solid dark background with ~0.93 opacity. Matches the user's iTerm2 guake profile aesthetic (transparency 0.065, blur radius ~5).
+
+## Conductor Lifecycle
+
+### Toolbar Toggle
+
+A button in the `ContentView` toolbar, next to the auto-suspend toggle. Shows a conductor icon.
+
+**States:**
+- **No conductor for this repo:** Click runs `conductor.setup` (default name from repo, all worktrees, manual polling) → `conductor.start` → shows overlay. One click, zero config.
+- **Conductor exists but hidden:** Click shows overlay.
+- **Conductor visible:** Click hides overlay.
+
+**Context menu (right-click):**
+- **Stop conductor** — kills tmux window, keeps config/DB row. Button returns to "not running" state. Next click runs `conductor.start` (no re-setup).
+- **Remove conductor** — runs `conductor.teardown` (stop + remove DB row + remove directory). Clean slate. Next click runs full setup.
+
+### Repo Scoping
+
+The conductor is tied to a repo. When the user selects a worktree in a different repo, the overlay shows/hides the conductor for *that* repo's conductor. If the other repo has no conductor, the overlay is empty and the button shows "no conductor" state. Each repo has at most one conductor (simplification for now).
+
+## Hotkey
+
+**Default:** Cmd+. (period)
+
+Registered via `NSEvent.addLocalMonitorForEvents(matching: .keyDown)` at app startup. Only fires when TBD is the active app. Toggles `appState.showConductor`. The monitor consumes the event (returns `nil`) when matched, preventing propagation to terminals or other responders.
+
+Hotkey is configurable, stored in UserDefaults. Settings UI deferred.
+
+## Focus Management
+
+1. **Conductor appears:** Conductor terminal becomes first responder. User can type immediately.
+2. **Conductor hides:** Previous first responder is restored (stored before showing conductor).
+3. **User clicks a terminal below the overlay:** That terminal becomes first responder. Conductor stays visible but unfocused. Standard NSView first responder chain handles this naturally.
+4. **Re-focus conductor:** Click inside the conductor overlay, or Cmd+. twice (hide/show).
+5. **Cmd+G (go to suggestion):** Navigates to suggested worktree, clears suggestion. Conductor stays visible.
+
+No custom focus management needed beyond sequencing `makeFirstResponder` calls on show/hide. SwiftUI hit testing + NSView responder chain handles the rest.
+
+## Navigation Suggestions
+
+The conductor can set a navigation target via RPC. The app renders a non-blocking pill at the bottom of the conductor overlay.
+
+### New RPC Methods
+
+| Method | Params | Result | Description |
+|--------|--------|--------|-------------|
+| `conductor.suggest` | `conductorName: String, worktreeID: UUID, label: String?` | void | Set navigation suggestion |
+| `conductor.clearSuggestion` | `conductorName: String` | void | Clear navigation suggestion |
+| `conductor.info` | `repoID: UUID` | `Conductor?, Terminal?` | Conductor + terminal for a repo |
+
+### New CLI Commands
+
+```bash
+tbd conductor suggest <name> --worktree <id> [--label "waiting for input"]
+tbd conductor clear-suggestion <name>
+```
+
+### Suggestion Bar
+
+`ConductorSuggestionBar` sits below the drag handle. ~28px tall. Only visible when a suggestion is active.
+
+```
+│ 🔗 fix-auth — waiting for input    [Go] [✕] │
+```
+
+- **Click / Go button:** Sets `appState.selectedWorktreeIDs = [worktreeID]`, clears suggestion. Does NOT auto-hide the conductor — the user may want to keep it open.
+- **Dismiss (✕):** Clears suggestion without navigating.
+- **Cmd+G:** Same as clicking Go — navigates to suggested worktree, clears suggestion. Only active when a suggestion exists and conductor is focused.
+
+### StateDelta
+
+```swift
+case conductorSuggestionChanged(ConductorSuggestionDelta)
+
+struct ConductorSuggestionDelta: Codable, Sendable {
+    let conductorName: String
+    let worktreeID: UUID?  // nil = cleared
+    let worktreeName: String?
+    let label: String?
+}
+```
+
+### Daemon Side
+
+Suggestion state is in-memory on `ConductorManager` (not DB — transient UI state). Broadcast to app via `StateDelta.conductorSuggestionChanged`.
+
+### CLAUDE.md Template Additions
+
+```markdown
+## Navigation Suggestions
+
+When discussing a specific worktree, help the user navigate to it:
+
+| Command | Description |
+|---------|-------------|
+| `tbd conductor suggest <your-name> --worktree <id>` | Show a "Go to" pill in the UI |
+| `tbd conductor suggest <your-name> --worktree <id> --label "waiting for input"` | With context label |
+| `tbd conductor clear-suggestion <your-name>` | Remove the pill |
+
+Set a suggestion when surfacing info about a worktree. Clear it when moving on to a different topic or when the user has acknowledged it.
+```
+
+## AppState Additions
+
+```swift
+// Conductor state
+@Published var showConductor: Bool = false
+@Published var conductorHeight: CGFloat = 300  // persisted in UserDefaults
+@Published var conductorsByRepo: [UUID: Conductor] = [:]  // from polling
+@Published var conductorTerminalsByRepo: [UUID: Terminal] = [:]
+@Published var conductorSuggestion: ConductorSuggestion?  // from StateDelta
+
+struct ConductorSuggestion {
+    let worktreeID: UUID
+    let worktreeName: String
+    let label: String?
+}
+
+// Derived
+var currentConductor: Conductor?  // conductor for the repo of currently selected worktree
+var conductorActive: Bool  // currentConductor != nil && its terminal exists
+```
+
+## File Changes
+
+### New Files
+- `Sources/TBDApp/Conductor/ConductorOverlayView.swift` — overlay container
+- `Sources/TBDApp/Conductor/ConductorSuggestionBar.swift` — navigation pill strip
+- `Sources/TBDApp/Conductor/ConductorHotkeyMonitor.swift` — local NSEvent monitor
+
+### Modified Files
+- `Sources/TBDApp/ContentView.swift` — `.overlay()` + toolbar toggle button with context menu
+- `Sources/TBDApp/AppState.swift` — conductor state properties
+- `Sources/TBDShared/RPCProtocol.swift` — `conductor.suggest`, `conductor.clearSuggestion`, `conductor.info` methods + param/result structs
+- `Sources/TBDShared/ConductorModels.swift` — `ConductorSuggestion` model
+- `Sources/TBDShared/Models.swift` — `conductorSuggestionChanged` StateDelta case
+- `Sources/TBDDaemon/Server/RPCRouter+ConductorHandlers.swift` — suggest/clearSuggestion/info handlers
+- `Sources/TBDDaemon/Conductor/ConductorManager.swift` — in-memory suggestion state, CLAUDE.md template update
+- `Sources/TBDDaemon/Server/StateSubscription.swift` — broadcast suggestion deltas
+- `Sources/TBDApp/DaemonClient.swift` — conductor info client method
+- `Sources/TBDCLI/Commands/ConductorCommands.swift` — suggest/clear-suggestion subcommands
+
+### No DB Migration
+
+Suggestions are transient (in-memory). Conductor records already exist from Phase 1a (migration v9). The `conductor.info` RPC queries existing tables.
+
+## Testing
+
+- **RPC handler tests:** conductor.suggest sets suggestion, conductor.clearSuggestion clears it, suggest overwrites previous suggestion
+- **StateDelta tests:** encode/decode `conductorSuggestionChanged`
+- **ConductorManager tests:** suggestion state lifecycle (set, overwrite, clear, clear when none exists)
+- **UI:** Manual testing — toggle overlay, resize via drag handle, Cmd+. hotkey, suggestion pill click → navigation, dismiss suggestion, focus flow between conductor and worktree terminals


### PR DESCRIPTION
## Summary
- Adds a toggleable terminal overlay (Opt+.) that renders the conductor session inline — drops from the top of the content area, resizable via drag handle, keeps tmux alive when hidden
- One-click conductor setup from toolbar button: no config dialogs, auto-derives name from repo. Right-click for stop/remove.
- Navigation suggestions: conductor calls `tbd conductor suggest` to show a clickable "Go to worktree" pill, letting users jump to relevant worktrees without leaving the conductor conversation

## Test plan
- [ ] Click conductor toolbar button with no conductor → auto-setup + start + overlay appears
- [ ] Opt+. toggles overlay visibility; terminal stays alive when hidden
- [ ] Drag handle resizes overlay height; height persists across app restarts
- [ ] Right-click conductor button → Stop/Remove actions work
- [ ] `tbd conductor suggest <name> --worktree <id> --label "test"` shows suggestion pill
- [ ] Clicking "Go" navigates to worktree and clears suggestion server-side
- [ ] Clicking "✕" dismisses suggestion without navigation
- [ ] Switching repos shows/hides conductor for that repo
- [ ] Content below overlay remains clickable; clicking a terminal below steals focus from conductor
- [ ] `swift test` — all 204 tests pass