### PR TITLE
Feat: Drag-to-reorder worktrees in sidebar

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -127,7 +127,9 @@ extension AppState {
     // MARK: - Keyboard Shortcut Actions
 
     /// Reorder worktrees within a repo. Updates locally first (optimistic), then persists via RPC.
+    /// Rolls back local state if the RPC call fails.
     func reorderWorktrees(repoID: UUID, fromOffsets source: IndexSet, toOffset destination: Int) {
+        let previousWorktrees = worktrees[repoID]
         guard var repoWorktrees = worktrees[repoID]?.filter({ $0.status == .active || $0.status == .creating }) else { return }
         repoWorktrees.move(fromOffsets: source, toOffset: destination)
         for i in repoWorktrees.indices {
@@ -145,6 +147,7 @@ extension AppState {
                 try await daemonClient.reorderWorktrees(repoID: repoID, worktreeIDs: worktreeIDs)
             } catch {
                 logger.error("Failed to reorder worktrees: \(error)")
+                worktrees[repoID] = previousWorktrees
             }
         }
     }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -126,10 +126,30 @@ extension AppState {
 
     // MARK: - Keyboard Shortcut Actions
 
-    /// All worktrees in sidebar order (sorted by repo, then by creation date).
+    /// Reorder worktrees within a repo. Updates locally first (optimistic), then persists via RPC.
+    func reorderWorktrees(repoID: UUID, fromOffsets source: IndexSet, toOffset destination: Int) {
+        guard var repoWorktrees = worktrees[repoID]?.filter({ $0.status == .active || $0.status == .creating }) else { return }
+        repoWorktrees.move(fromOffsets: source, toOffset: destination)
+
+        // Rebuild the full array: keep main/other statuses in place, replace active/creating with reordered
+        let others = (worktrees[repoID] ?? []).filter { $0.status != .active && $0.status != .creating }
+        worktrees[repoID] = others + repoWorktrees
+
+        // Persist via RPC
+        let worktreeIDs = repoWorktrees.map(\.id)
+        Task {
+            do {
+                try await daemonClient.reorderWorktrees(repoID: repoID, worktreeIDs: worktreeIDs)
+            } catch {
+                logger.error("Failed to reorder worktrees: \(error)")
+            }
+        }
+    }
+
+    /// All worktrees in sidebar order (sorted by repo, then by sortOrder).
     var allWorktreesOrdered: [Worktree] {
         repos.flatMap { repo in
-            (worktrees[repo.id] ?? []).sorted { $0.createdAt < $1.createdAt }
+            (worktrees[repo.id] ?? []).sorted { $0.sortOrder < $1.sortOrder }
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -124,7 +124,7 @@ extension AppState {
         }
     }
 
-    // MARK: - Keyboard Shortcut Actions
+    // MARK: - Reorder
 
     /// Reorder worktrees within a repo. Updates locally first (optimistic), then persists via RPC.
     /// Rolls back local state if the RPC call fails.
@@ -151,6 +151,8 @@ extension AppState {
             }
         }
     }
+
+    // MARK: - Keyboard Shortcut Actions
 
     /// All worktrees in sidebar order (sorted by repo, then by sortOrder).
     var allWorktreesOrdered: [Worktree] {

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -130,6 +130,9 @@ extension AppState {
     func reorderWorktrees(repoID: UUID, fromOffsets source: IndexSet, toOffset destination: Int) {
         guard var repoWorktrees = worktrees[repoID]?.filter({ $0.status == .active || $0.status == .creating }) else { return }
         repoWorktrees.move(fromOffsets: source, toOffset: destination)
+        for i in repoWorktrees.indices {
+            repoWorktrees[i].sortOrder = i
+        }
 
         // Rebuild the full array: keep main/other statuses in place, replace active/creating with reordered
         let others = (worktrees[repoID] ?? []).filter { $0.status != .active && $0.status != .creating }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -350,6 +350,14 @@ actor DaemonClient {
         )
     }
 
+    /// Reorder worktrees within a repo.
+    func reorderWorktrees(repoID: UUID, worktreeIDs: [UUID]) throws {
+        try callVoid(
+            method: RPCMethod.worktreeReorder,
+            params: WorktreeReorderParams(repoID: repoID, worktreeIDs: worktreeIDs)
+        )
+    }
+
     /// Set or clear the pin on a terminal.
     func setTerminalPin(id: UUID, pinned: Bool) throws {
         try callVoid(

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -37,6 +37,7 @@ struct RepoSectionView: View {
     var worktrees: [Worktree] {
         (appState.worktrees[repo.id] ?? [])
             .filter { $0.status == .active || $0.status == .creating }
+            .sorted { $0.sortOrder < $1.sortOrder }
     }
 
     var body: some View {
@@ -78,6 +79,9 @@ struct RepoSectionView: View {
                 WorktreeRowView(worktree: worktree)
                     .listRowInsets(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 0))
                     .tag(worktree.id)
+            }
+            .onMove { source, destination in
+                appState.reorderWorktrees(repoID: repo.id, fromOffsets: source, toOffset: destination)
             }
         }
     }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -181,6 +181,14 @@ public final class TBDDatabase: Sendable {
             )
         }
 
+        migrator.registerMigration("v11") { db in
+            try db.alter(table: "worktree") { t in
+                t.add(column: "sortOrder", .integer).notNull().defaults(to: 0)
+            }
+            // Initialize sortOrder from rowid to preserve insertion order
+            try db.execute(sql: "UPDATE worktree SET sortOrder = rowid")
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -265,6 +265,7 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Reorder worktrees within a repo. The worktreeIDs array defines the new order.
+    /// Worktrees not in the array are pushed to sortOrder values after the provided list.
     public func reorder(repoID: UUID, worktreeIDs: [UUID]) async throws {
         try await writer.write { db in
             for (index, wtID) in worktreeIDs.enumerated() {
@@ -273,6 +274,17 @@ public struct WorktreeStore: Sendable {
                     arguments: [index, wtID.uuidString, repoID.uuidString]
                 )
             }
+            // Push any worktrees not in the provided list to after the reordered ones
+            let idStrings = worktreeIDs.map(\.uuidString)
+            let placeholders = idStrings.map { _ in "?" }.joined(separator: ",")
+            let args: [any DatabaseValueConvertible] = [worktreeIDs.count, repoID.uuidString] + idStrings
+            try db.execute(
+                sql: """
+                    UPDATE worktree SET sortOrder = ? + rowid
+                    WHERE repoID = ? AND id NOT IN (\(placeholders))
+                    """,
+                arguments: StatementArguments(args)
+            )
         }
     }
 

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -281,7 +281,7 @@ public struct WorktreeStore: Sendable {
             try db.execute(
                 sql: """
                     UPDATE worktree SET sortOrder = ? + rowid
-                    WHERE repoID = ? AND id NOT IN (\(placeholders))
+                    WHERE repoID = ? AND status IN ('active', 'creating') AND id NOT IN (\(placeholders))
                     """,
                 arguments: StatementArguments(args)
             )

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -18,6 +18,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var archivedAt: Date?
     var tmuxServer: String
     var archivedClaudeSessions: String?
+    var sortOrder: Int
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -31,6 +32,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.createdAt = wt.createdAt
         self.archivedAt = wt.archivedAt
         self.tmuxServer = wt.tmuxServer
+        self.sortOrder = wt.sortOrder
         if let sessions = wt.archivedClaudeSessions {
             self.archivedClaudeSessions = try? String(
                 data: JSONEncoder().encode(sessions), encoding: .utf8)
@@ -55,7 +57,8 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             createdAt: createdAt,
             archivedAt: archivedAt,
             tmuxServer: tmuxServer,
-            archivedClaudeSessions: sessions
+            archivedClaudeSessions: sessions,
+            sortOrder: sortOrder
         )
     }
 }
@@ -69,6 +72,7 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Create a new worktree. The displayName defaults to the name.
+    /// Automatically assigns sortOrder = max(sortOrder) + 1 for the repo.
     public func create(
         repoID: UUID,
         name: String,
@@ -77,20 +81,26 @@ public struct WorktreeStore: Sendable {
         tmuxServer: String,
         status: WorktreeStatus = .active
     ) async throws -> Worktree {
-        let wt = Worktree(
-            repoID: repoID,
-            name: name,
-            displayName: name,
-            branch: branch,
-            path: path,
-            status: status,
-            tmuxServer: tmuxServer
-        )
-        let record = WorktreeRecord(from: wt)
         try await writer.write { db in
+            let maxOrder = try Int.fetchOne(
+                db,
+                sql: "SELECT MAX(sortOrder) FROM worktree WHERE repoID = ?",
+                arguments: [repoID.uuidString]
+            ) ?? 0
+            let wt = Worktree(
+                repoID: repoID,
+                name: name,
+                displayName: name,
+                branch: branch,
+                path: path,
+                status: status,
+                tmuxServer: tmuxServer,
+                sortOrder: maxOrder + 1
+            )
+            let record = WorktreeRecord(from: wt)
             try record.insert(db)
+            return wt
         }
-        return wt
     }
 
     /// Update a worktree's status.
@@ -148,7 +158,7 @@ public struct WorktreeStore: Sendable {
                 // Exclude conductor worktrees from default listing
                 request = request.filter(Column("status") != WorktreeStatus.conductor.rawValue)
             }
-            return try request.fetchAll(db).map { $0.toModel() }
+            return try request.order(Column("sortOrder").asc).fetchAll(db).map { $0.toModel() }
         }
     }
 
@@ -251,6 +261,18 @@ public struct WorktreeStore: Sendable {
                 .filter(Column("path") == path)
                 .fetchOne(db)?
                 .toModel()
+        }
+    }
+
+    /// Reorder worktrees within a repo. The worktreeIDs array defines the new order.
+    public func reorder(repoID: UUID, worktreeIDs: [UUID]) async throws {
+        try await writer.write { db in
+            for (index, wtID) in worktreeIDs.enumerated() {
+                try db.execute(
+                    sql: "UPDATE worktree SET sortOrder = ? WHERE id = ? AND repoID = ?",
+                    arguments: [index, wtID.uuidString, repoID.uuidString]
+                )
+            }
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -83,4 +83,10 @@ extension RPCRouter {
 
         return .ok()
     }
+
+    func handleWorktreeReorder(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeReorderParams.self, from: paramsData)
+        try await db.worktrees.reorder(repoID: params.repoID, worktreeIDs: params.worktreeIDs)
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -87,6 +87,11 @@ extension RPCRouter {
     func handleWorktreeReorder(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeReorderParams.self, from: paramsData)
         try await db.worktrees.reorder(repoID: params.repoID, worktreeIDs: params.worktreeIDs)
+
+        subscriptions.broadcast(delta: .worktreeReordered(RepoIDDelta(
+            repoID: params.repoID
+        )))
+
         return .ok()
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -69,6 +69,8 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeRevive(request.paramsData)
             case RPCMethod.worktreeRename:
                 return try await handleWorktreeRename(request.paramsData)
+            case RPCMethod.worktreeReorder:
+                return try await handleWorktreeReorder(request.paramsData)
             case RPCMethod.terminalCreate:
                 return try await handleTerminalCreate(request.paramsData)
             case RPCMethod.terminalList:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -36,12 +36,13 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public var archivedAt: Date?
     public var tmuxServer: String
     public var archivedClaudeSessions: [String]?
+    public var sortOrder: Int = 0
 
     public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
                 hasConflicts: Bool = false,
                 createdAt: Date = Date(), archivedAt: Date? = nil, tmuxServer: String,
-                archivedClaudeSessions: [String]? = nil) {
+                archivedClaudeSessions: [String]? = nil, sortOrder: Int = 0) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -54,6 +55,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.archivedAt = archivedAt
         self.tmuxServer = tmuxServer
         self.archivedClaudeSessions = archivedClaudeSessions
+        self.sortOrder = sortOrder
     }
 
     public init(from decoder: Decoder) throws {
@@ -70,6 +72,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         archivedAt = try c.decodeIfPresent(Date.self, forKey: .archivedAt)
         tmuxServer = try c.decode(String.self, forKey: .tmuxServer)
         archivedClaudeSessions = try c.decodeIfPresent([String].self, forKey: .archivedClaudeSessions)
+        sortOrder = try c.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -84,6 +84,7 @@ public enum RPCMethod {
     public static let worktreeArchive = "worktree.archive"
     public static let worktreeRevive = "worktree.revive"
     public static let worktreeRename = "worktree.rename"
+    public static let worktreeReorder = "worktree.reorder"
     public static let terminalCreate = "terminal.create"
     public static let terminalList = "terminal.list"
     public static let terminalSend = "terminal.send"
@@ -193,6 +194,14 @@ public struct WorktreeRenameParams: Codable, Sendable {
     public let displayName: String
     public init(worktreeID: UUID, displayName: String) {
         self.worktreeID = worktreeID; self.displayName = displayName
+    }
+}
+
+public struct WorktreeReorderParams: Codable, Sendable {
+    public let repoID: UUID
+    public let worktreeIDs: [UUID]
+    public init(repoID: UUID, worktreeIDs: [UUID]) {
+        self.repoID = repoID; self.worktreeIDs = worktreeIDs
     }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -15,6 +15,7 @@ public enum StateDelta: Codable, Sendable {
     case terminalRemoved(TerminalIDDelta)
     case worktreeConflictsChanged(WorktreeConflictDelta)
     case terminalPinChanged(TerminalPinDelta)
+    case worktreeReordered(RepoIDDelta)
 }
 
 /// Delta payload for worktree creation/revival.

--- a/Tests/TBDDaemonTests/WorktreeStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreTests.swift
@@ -1,0 +1,114 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct WorktreeStoreTests {
+    func makeDB() throws -> TBDDatabase {
+        try TBDDatabase(inMemory: true)
+    }
+
+    func createRepo(db: TBDDatabase) async throws -> Repo {
+        try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "Test Repo",
+            defaultBranch: "main"
+        )
+    }
+
+    @Test func createAssignsSortOrder() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id, name: "first", branch: "b1",
+            path: "/tmp/wt1-\(UUID())", tmuxServer: "srv1"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id, name: "second", branch: "b2",
+            path: "/tmp/wt2-\(UUID())", tmuxServer: "srv2"
+        )
+        let wt3 = try await db.worktrees.create(
+            repoID: repo.id, name: "third", branch: "b3",
+            path: "/tmp/wt3-\(UUID())", tmuxServer: "srv3"
+        )
+
+        #expect(wt1.sortOrder == 1)
+        #expect(wt2.sortOrder == 2)
+        #expect(wt3.sortOrder == 3)
+    }
+
+    @Test func listReturnsSortedBySortOrder() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id, name: "first", branch: "b1",
+            path: "/tmp/wt1-\(UUID())", tmuxServer: "srv1"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id, name: "second", branch: "b2",
+            path: "/tmp/wt2-\(UUID())", tmuxServer: "srv2"
+        )
+        let wt3 = try await db.worktrees.create(
+            repoID: repo.id, name: "third", branch: "b3",
+            path: "/tmp/wt3-\(UUID())", tmuxServer: "srv3"
+        )
+
+        let listed = try await db.worktrees.list(repoID: repo.id)
+        #expect(listed.map(\.id) == [wt1.id, wt2.id, wt3.id])
+    }
+
+    @Test func reorderChangesListOrder() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id, name: "first", branch: "b1",
+            path: "/tmp/wt1-\(UUID())", tmuxServer: "srv1"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id, name: "second", branch: "b2",
+            path: "/tmp/wt2-\(UUID())", tmuxServer: "srv2"
+        )
+        let wt3 = try await db.worktrees.create(
+            repoID: repo.id, name: "third", branch: "b3",
+            path: "/tmp/wt3-\(UUID())", tmuxServer: "srv3"
+        )
+
+        // Reorder: third, first, second
+        try await db.worktrees.reorder(repoID: repo.id, worktreeIDs: [wt3.id, wt1.id, wt2.id])
+
+        let listed = try await db.worktrees.list(repoID: repo.id)
+        #expect(listed.map(\.id) == [wt3.id, wt1.id, wt2.id])
+        #expect(listed.map(\.sortOrder) == [0, 1, 2])
+    }
+
+    @Test func reorderDoesNotAffectOtherRepos() async throws {
+        let db = try makeDB()
+        let repo1 = try await createRepo(db: db)
+        let repo2 = try await createRepo(db: db)
+
+        let wt1 = try await db.worktrees.create(
+            repoID: repo1.id, name: "r1-first", branch: "b1",
+            path: "/tmp/wt1-\(UUID())", tmuxServer: "srv1"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo1.id, name: "r1-second", branch: "b2",
+            path: "/tmp/wt2-\(UUID())", tmuxServer: "srv2"
+        )
+        let wt3 = try await db.worktrees.create(
+            repoID: repo2.id, name: "r2-first", branch: "b3",
+            path: "/tmp/wt3-\(UUID())", tmuxServer: "srv3"
+        )
+
+        // Reorder repo1 only
+        try await db.worktrees.reorder(repoID: repo1.id, worktreeIDs: [wt2.id, wt1.id])
+
+        let repo1List = try await db.worktrees.list(repoID: repo1.id)
+        #expect(repo1List.map(\.id) == [wt2.id, wt1.id])
+
+        let repo2List = try await db.worktrees.list(repoID: repo2.id)
+        #expect(repo2List.map(\.id) == [wt3.id])
+    }
+}


### PR DESCRIPTION
## Summary
- Add drag-to-reorder for worktree entries in the sidebar, persisted via a new `sortOrder` column (migration v11) and `worktree.reorder` RPC method
- New worktrees appear at the bottom; reorder is optimistic with rollback on RPC failure
- 4 new tests covering sort order assignment, list ordering, reorder, and repo isolation

## Test plan
- [ ] Drag a worktree row up/down in the sidebar — verify it stays in the new position
- [ ] Create a new worktree — verify it appears at the bottom of the list
- [ ] Restart the app — verify the custom order persists
- [ ] `swift test` passes (206 tests)