### PR TITLE
Feat: Per-repo custom instructions injected into Claude sessions via --append-system-prompt

### DIFF
--- a/Sources/TBDApp/AppState+Repos.swift
+++ b/Sources/TBDApp/AppState+Repos.swift
@@ -30,4 +30,17 @@ extension AppState {
             handleConnectionError(error)
         }
     }
+
+    /// Update per-repo instruction fields.
+    func updateRepoInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async {
+        do {
+            _ = try await daemonClient.repoUpdateInstructions(
+                repoID: repoID, renamePrompt: renamePrompt, customInstructions: customInstructions
+            )
+            await refreshRepos()
+        } catch {
+            logger.error("Failed to update instructions: \(error)")
+            handleConnectionError(error)
+        }
+    }
 }

--- a/Sources/TBDApp/AppState+Repos.swift
+++ b/Sources/TBDApp/AppState+Repos.swift
@@ -31,16 +31,19 @@ extension AppState {
         }
     }
 
-    /// Update per-repo instruction fields.
-    func updateRepoInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async {
+    /// Update per-repo instruction fields. Returns true on success.
+    @discardableResult
+    func updateRepoInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async -> Bool {
         do {
             _ = try await daemonClient.repoUpdateInstructions(
                 repoID: repoID, renamePrompt: renamePrompt, customInstructions: customInstructions
             )
             await refreshRepos()
+            return true
         } catch {
             logger.error("Failed to update instructions: \(error)")
             handleConnectionError(error)
+            return false
         }
     }
 }

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
                 } else if appState.repos.isEmpty {
                     emptyStateView
                 } else if let repoID = appState.selectedRepoID {
-                    ArchivedWorktreesView(repoID: repoID)
+                    RepoDetailView(repoID: repoID)
                 } else if appState.selectedWorktreeIDs.isEmpty {
                     Text("Select a worktree or click + to create one")
                         .foregroundStyle(.secondary)

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -303,6 +303,15 @@ actor DaemonClient {
         )
     }
 
+    /// Update per-repo instruction fields.
+    func repoUpdateInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) throws -> Repo {
+        return try call(
+            method: RPCMethod.repoUpdateInstructions,
+            params: RepoUpdateInstructionsParams(repoID: repoID, renamePrompt: renamePrompt, customInstructions: customInstructions),
+            resultType: Repo.self
+        )
+    }
+
     /// List all repositories.
     func listRepos() throws -> [Repo] {
         return try callNoParams(method: RPCMethod.repoList, resultType: [Repo].self)

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import TBDShared
+
+struct RepoDetailView: View {
+    let repoID: UUID
+
+    enum Tab: String, CaseIterable {
+        case archived = "Archived"
+        case instructions = "Instructions"
+    }
+
+    @State private var selectedTab: Tab = .archived
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $selectedTab) {
+                ForEach(Tab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 240)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            switch selectedTab {
+            case .archived:
+                ArchivedWorktreesView(repoID: repoID)
+            case .instructions:
+                RepoInstructionsView(repoID: repoID)
+            }
+        }
+    }
+}

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -29,6 +29,7 @@ struct RepoDetailView: View {
                 ArchivedWorktreesView(repoID: repoID)
             case .instructions:
                 RepoInstructionsView(repoID: repoID)
+                    .id(repoID)
             }
         }
     }

--- a/Sources/TBDApp/RepoInstructionsView.swift
+++ b/Sources/TBDApp/RepoInstructionsView.swift
@@ -105,6 +105,9 @@ struct RepoInstructionsView: View {
             guard initialized else { return }
             scheduleSave()
         }
+        .onDisappear {
+            saveTask?.cancel()
+        }
     }
 
     private func scheduleSave() {

--- a/Sources/TBDApp/RepoInstructionsView.swift
+++ b/Sources/TBDApp/RepoInstructionsView.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+import TBDShared
+
+struct RepoInstructionsView: View {
+    let repoID: UUID
+    @EnvironmentObject var appState: AppState
+
+    @State private var renamePromptDraft: String = ""
+    @State private var customInstructionsDraft: String = ""
+    @State private var showSaved = false
+    @State private var saveTask: Task<Void, Never>?
+    @State private var initialized = false
+
+    private var repo: Repo? {
+        appState.repos.first { $0.id == repoID }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // MARK: - Rename Prompt Section
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Rename Prompt")
+                        .font(.title3)
+                        .fontWeight(.medium)
+                    Text("Sent with the first message in worktrees that haven't been renamed yet.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    TextEditor(text: $renamePromptDraft)
+                        .font(.body.monospaced())
+                        .frame(minHeight: 160)
+                        .scrollContentBackground(.hidden)
+                        .padding(8)
+                        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
+
+                    HStack {
+                        Spacer()
+                        Button("Reset to Default") {
+                            renamePromptDraft = RepoConstants.defaultRenamePrompt
+                            scheduleSave()
+                        }
+                        .buttonStyle(.borderless)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+
+                Divider()
+
+                // MARK: - General Instructions Section
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("General Instructions")
+                        .font(.title3)
+                        .fontWeight(.medium)
+                    Text("Added to all new Claude sessions in this repo.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    ZStack(alignment: .topLeading) {
+                        TextEditor(text: $customInstructionsDraft)
+                            .font(.body.monospaced())
+                            .frame(minHeight: 120)
+                            .scrollContentBackground(.hidden)
+                            .padding(8)
+                            .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
+
+                        if customInstructionsDraft.isEmpty {
+                            Text("e.g. Always use pytest. Never mock the database.")
+                                .font(.body.monospaced())
+                                .foregroundStyle(.tertiary)
+                                .padding(12)
+                                .allowsHitTesting(false)
+                        }
+                    }
+                }
+
+                // MARK: - Save Indicator
+                HStack {
+                    Spacer()
+                    if showSaved {
+                        Text("Saved")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .transition(.opacity)
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            guard !initialized else { return }
+            initialized = true
+            if let repo {
+                renamePromptDraft = repo.renamePrompt ?? RepoConstants.defaultRenamePrompt
+                customInstructionsDraft = repo.customInstructions ?? ""
+            }
+        }
+        .onChange(of: renamePromptDraft) { _, _ in
+            guard initialized else { return }
+            scheduleSave()
+        }
+        .onChange(of: customInstructionsDraft) { _, _ in
+            guard initialized else { return }
+            scheduleSave()
+        }
+    }
+
+    private func scheduleSave() {
+        saveTask?.cancel()
+        saveTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled else { return }
+
+            let renameToSave: String?
+            if renamePromptDraft == RepoConstants.defaultRenamePrompt {
+                renameToSave = nil
+            } else {
+                renameToSave = renamePromptDraft
+            }
+
+            let instructionsToSave: String? = customInstructionsDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? nil
+                : customInstructionsDraft
+
+            await appState.updateRepoInstructions(
+                repoID: repoID,
+                renamePrompt: renameToSave,
+                customInstructions: instructionsToSave
+            )
+
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }
+        }
+    }
+}

--- a/Sources/TBDApp/RepoInstructionsView.swift
+++ b/Sources/TBDApp/RepoInstructionsView.swift
@@ -69,7 +69,7 @@ struct RepoInstructionsView: View {
                             Text("e.g. Always use pytest. Never mock the database.")
                                 .font(.body.monospaced())
                                 .foregroundStyle(.tertiary)
-                                .padding(12)
+                                .padding(8)
                                 .allowsHitTesting(false)
                         }
                     }
@@ -107,6 +107,12 @@ struct RepoInstructionsView: View {
         }
         .onDisappear {
             saveTask?.cancel()
+            // Flush any pending edits
+            let renameToSave = renamePromptDraft == RepoConstants.defaultRenamePrompt ? nil : renamePromptDraft
+            let instructionsToSave = customInstructionsDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : customInstructionsDraft
+            Task {
+                await appState.updateRepoInstructions(repoID: repoID, renamePrompt: renameToSave, customInstructions: instructionsToSave)
+            }
         }
     }
 

--- a/Sources/TBDApp/RepoInstructionsView.swift
+++ b/Sources/TBDApp/RepoInstructionsView.swift
@@ -133,12 +133,13 @@ struct RepoInstructionsView: View {
                 ? nil
                 : customInstructionsDraft
 
-            await appState.updateRepoInstructions(
+            let success = await appState.updateRepoInstructions(
                 repoID: repoID,
                 renamePrompt: renameToSave,
                 customInstructions: instructionsToSave
             )
 
+            guard success else { return }
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
             try? await Task.sleep(for: .seconds(2))
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }

--- a/Sources/TBDDaemon/Conductor/ConductorManager.swift
+++ b/Sources/TBDDaemon/Conductor/ConductorManager.swift
@@ -129,7 +129,24 @@ public final class ConductorManager: Sendable {
         }
 
         let conductorDir = TBDConstants.conductorsDir.appendingPathComponent(name)
-        let shellCommand = "claude --dangerously-skip-permissions"
+        var shellCommand = "claude --dangerously-skip-permissions"
+
+        // Inject TBD context + general instructions for single-repo conductors
+        let repoIDs = conductor.repos
+        if repoIDs.count == 1, let repoIDStr = repoIDs.first, repoIDStr != "*",
+           let repoUUID = UUID(uuidString: repoIDStr),
+           let repo = try await db.repos.get(id: repoUUID) {
+            var parts = [SystemPromptBuilder.builtInTBDContext]
+            if let instructions = repo.customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !instructions.isEmpty {
+                parts.append(instructions)
+            }
+            let combined = parts.joined(separator: "\n\n---\n\n")
+            shellCommand += " --append-system-prompt \(SystemPromptBuilder.shellEscape(combined))"
+        } else {
+            // Multi-repo or wildcard — just inject TBD context
+            shellCommand += " --append-system-prompt \(SystemPromptBuilder.shellEscape(SystemPromptBuilder.builtInTBDContext))"
+        }
 
         try await tmux.ensureServer(
             server: TBDConstants.conductorsTmuxServer,

--- a/Sources/TBDDaemon/Conductor/ConductorManager.swift
+++ b/Sources/TBDDaemon/Conductor/ConductorManager.swift
@@ -131,22 +131,17 @@ public final class ConductorManager: Sendable {
         let conductorDir = TBDConstants.conductorsDir.appendingPathComponent(name)
         var shellCommand = "claude --dangerously-skip-permissions"
 
-        // Inject TBD context + general instructions for single-repo conductors
+        // Inject TBD context + general instructions (single-repo only)
         let repoIDs = conductor.repos
+        let singleRepo: Repo?
         if repoIDs.count == 1, let repoIDStr = repoIDs.first, repoIDStr != "*",
-           let repoUUID = UUID(uuidString: repoIDStr),
-           let repo = try await db.repos.get(id: repoUUID) {
-            var parts = [SystemPromptBuilder.builtInTBDContext]
-            if let instructions = repo.customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !instructions.isEmpty {
-                parts.append(instructions)
-            }
-            let combined = parts.joined(separator: "\n\n---\n\n")
-            shellCommand += " --append-system-prompt \(SystemPromptBuilder.shellEscape(combined))"
+           let repoUUID = UUID(uuidString: repoIDStr) {
+            singleRepo = try await db.repos.get(id: repoUUID)
         } else {
-            // Multi-repo or wildcard — just inject TBD context
-            shellCommand += " --append-system-prompt \(SystemPromptBuilder.shellEscape(SystemPromptBuilder.builtInTBDContext))"
+            singleRepo = nil
         }
+        let prompt = SystemPromptBuilder.buildForConductor(repo: singleRepo)
+        shellCommand += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
 
         try await tmux.ensureServer(
             server: TBDConstants.conductorsTmuxServer,

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -189,6 +189,13 @@ public final class TBDDatabase: Sendable {
             try db.execute(sql: "UPDATE worktree SET sortOrder = rowid")
         }
 
+        migrator.registerMigration("v12") { db in
+            try db.alter(table: "repo") { t in
+                t.add(column: "renamePrompt", .text)
+                t.add(column: "customInstructions", .text)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -12,6 +12,8 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var displayName: String
     var defaultBranch: String
     var createdAt: Date
+    var renamePrompt: String?
+    var customInstructions: String?
 
     init(from repo: Repo) {
         self.id = repo.id.uuidString
@@ -20,6 +22,8 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.displayName = repo.displayName
         self.defaultBranch = repo.defaultBranch
         self.createdAt = repo.createdAt
+        self.renamePrompt = repo.renamePrompt
+        self.customInstructions = repo.customInstructions
     }
 
     func toModel() -> Repo {
@@ -29,7 +33,9 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             remoteURL: remoteURL,
             displayName: displayName,
             defaultBranch: defaultBranch,
-            createdAt: createdAt
+            createdAt: createdAt,
+            renamePrompt: renamePrompt,
+            customInstructions: customInstructions
         )
     }
 }
@@ -83,6 +89,16 @@ public struct RepoStore: Sendable {
     public func remove(id: UUID) async throws {
         _ = try await writer.write { db in
             try RepoRecord.deleteOne(db, key: id.uuidString)
+        }
+    }
+
+    /// Update per-repo instruction fields.
+    public func updateInstructions(id: UUID, renamePrompt: String?, customInstructions: String?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET renamePrompt = ?, customInstructions = ? WHERE id = ?",
+                arguments: [renamePrompt, customInstructions, id.uuidString]
+            )
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+++ b/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
@@ -54,8 +54,7 @@ enum SystemPromptBuilder {
     }
 
     /// Build the system prompt for a conductor session.
-    /// Conductors get TBD context + general instructions (no rename prompt).
-    /// Returns nil only if there's nothing to append.
+    /// Always includes TBD context; adds custom instructions for single-repo conductors.
     static func buildForConductor(repo: Repo?) -> String {
         var parts = [builtInTBDContext]
 

--- a/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+++ b/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
@@ -1,0 +1,55 @@
+import Foundation
+import TBDShared
+
+/// Builds the `--append-system-prompt` value for Claude sessions in TBD worktrees.
+enum SystemPromptBuilder {
+
+    /// Shell-escape a string for embedding in a single-quoted shell argument.
+    static func shellEscape(_ text: String) -> String {
+        "'" + text.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    static let defaultRenamePrompt = RepoConstants.defaultRenamePrompt
+
+    static let builtInTBDContext = """
+        You are running inside a TBD-managed worktree. TBD is a macOS worktree + terminal manager.
+
+        Available CLI commands:
+        - tbd worktree rename "<worktree-name>" "<display-name>" — rename the worktree display name
+        - tbd worktree list [--repo <id>] — list worktrees
+        - tbd terminal create <worktree> [--cmd <command>] — create a new terminal
+        - tbd terminal output <terminal-id> [--lines N] — read terminal output
+        - tbd notify --type <type> [--message <msg>] — send notifications to TBD UI
+          Types: response_complete, error, task_complete, attention_needed
+
+        Environment variables:
+        - TBD_WORKTREE_ID — UUID of the current worktree (auto-set in all TBD terminals)
+        """
+
+    /// Build the combined system prompt for a Claude session.
+    /// Returns nil if there's nothing to append (e.g., resume session).
+    static func build(repo: Repo, worktree: Worktree, isResume: Bool) -> String? {
+        if isResume { return nil }
+
+        var parts: [String] = []
+
+        // Layer 1: Rename prompt (conditional on worktree not yet renamed)
+        if worktree.displayName == worktree.name {
+            let renamePrompt = repo.renamePrompt ?? defaultRenamePrompt
+            if !renamePrompt.isEmpty {
+                parts.append(renamePrompt)
+            }
+        }
+
+        // Layer 2: Built-in TBD context (always)
+        parts.append(builtInTBDContext)
+
+        // Layer 3: User general instructions (if set)
+        if let instructions = repo.customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !instructions.isEmpty {
+            parts.append(instructions)
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: "\n\n---\n\n")
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+++ b/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
@@ -52,4 +52,18 @@ enum SystemPromptBuilder {
 
         return parts.isEmpty ? nil : parts.joined(separator: "\n\n---\n\n")
     }
+
+    /// Build the system prompt for a conductor session.
+    /// Conductors get TBD context + general instructions (no rename prompt).
+    /// Returns nil only if there's nothing to append.
+    static func buildForConductor(repo: Repo?) -> String {
+        var parts = [builtInTBDContext]
+
+        if let instructions = repo?.customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !instructions.isEmpty {
+            parts.append(instructions)
+        }
+
+        return parts.joined(separator: "\n\n---\n\n")
+    }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -122,7 +122,7 @@ extension WorktreeLifecycle {
         )
 
         try await setupTerminals(
-            worktreeID: worktree.id, repoPath: repo.path,
+            worktreeID: worktree.id, repo: repo,
             tmuxServer: worktree.tmuxServer, worktreePath: worktree.path,
             skipClaude: skipClaude,
             archivedClaudeSessions: worktree.archivedClaudeSessions

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -122,8 +122,7 @@ extension WorktreeLifecycle {
         )
 
         try await setupTerminals(
-            worktreeID: worktree.id, repo: repo,
-            tmuxServer: worktree.tmuxServer, worktreePath: worktree.path,
+            worktree: worktree, repo: repo,
             skipClaude: skipClaude,
             archivedClaudeSessions: worktree.archivedClaudeSessions
         )

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -89,7 +89,7 @@ extension WorktreeLifecycle {
 
             // 5. Setup tmux terminals
             try await setupTerminals(
-                worktreeID: worktreeID, repoPath: repo.path,
+                worktreeID: worktreeID, repo: repo,
                 tmuxServer: worktree.tmuxServer, worktreePath: result.path,
                 skipClaude: skipClaude
             )
@@ -174,7 +174,7 @@ extension WorktreeLifecycle {
     /// is reused for the main Claude terminal to restore the conversation, and any
     /// additional sessions get their own terminal windows.
     func setupTerminals(
-        worktreeID: UUID, repoPath: String,
+        worktreeID: UUID, repo: Repo,
         tmuxServer: String, worktreePath: String, skipClaude: Bool,
         archivedClaudeSessions: [String]? = nil
     ) async throws {
@@ -193,8 +193,17 @@ extension WorktreeLifecycle {
             claudeSessionID = nil
         } else {
             let sessionUUID = archivedClaudeSessions?.first ?? UUID().uuidString
-            claudeCommand = "claude --dangerously-skip-permissions --session-id \(sessionUUID)"
+            var cmd = "claude --dangerously-skip-permissions --session-id \(sessionUUID)"
             claudeSessionID = sessionUUID
+
+            // Inject per-repo system prompt
+            let isResume = archivedClaudeSessions?.first != nil
+            if let worktree = try await db.worktrees.get(id: worktreeID),
+               let prompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: isResume) {
+                cmd += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
+            }
+
+            claudeCommand = cmd
         }
         let window1 = try await tmux.createWindow(
             server: tmuxServer,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -89,8 +89,8 @@ extension WorktreeLifecycle {
 
             // 5. Setup tmux terminals
             try await setupTerminals(
-                worktreeID: worktreeID, repo: repo,
-                tmuxServer: worktree.tmuxServer, worktreePath: result.path,
+                worktree: worktree, repo: repo,
+                worktreePath: result.path,
                 skipClaude: skipClaude
             )
 
@@ -174,10 +174,13 @@ extension WorktreeLifecycle {
     /// is reused for the main Claude terminal to restore the conversation, and any
     /// additional sessions get their own terminal windows.
     func setupTerminals(
-        worktreeID: UUID, repo: Repo,
-        tmuxServer: String, worktreePath: String, skipClaude: Bool,
+        worktree: Worktree, repo: Repo,
+        worktreePath: String? = nil, skipClaude: Bool,
         archivedClaudeSessions: [String]? = nil
     ) async throws {
+        let worktreeID = worktree.id
+        let tmuxServer = worktree.tmuxServer
+        let worktreePath = worktreePath ?? worktree.path
         // Ensure tmux server exists — capture initial window ID to kill later
         let initialWindowID = try await tmux.ensureServer(
             server: tmuxServer,
@@ -198,8 +201,7 @@ extension WorktreeLifecycle {
 
             // Inject per-repo system prompt
             let isResume = archivedClaudeSessions?.first != nil
-            if let worktree = try await db.worktrees.get(id: worktreeID),
-               let prompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: isResume) {
+            if let prompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: isResume) {
                 cmd += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
             }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -110,4 +110,24 @@ extension RPCRouter {
         let repos = try await db.repos.list()
         return try RPCResponse(result: repos)
     }
+
+    func handleRepoUpdateInstructions(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(RepoUpdateInstructionsParams.self, from: paramsData)
+
+        guard try await db.repos.get(id: params.repoID) != nil else {
+            return RPCResponse(error: "Repository not found: \(params.repoID)")
+        }
+
+        try await db.repos.updateInstructions(
+            id: params.repoID,
+            renamePrompt: params.renamePrompt,
+            customInstructions: params.customInstructions
+        )
+
+        guard let updated = try await db.repos.get(id: params.repoID) else {
+            return RPCResponse(error: "Repository not found after update: \(params.repoID)")
+        }
+
+        return try RPCResponse(result: updated)
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -33,8 +33,16 @@ extension RPCRouter {
         } else if isClaudeType {
             let sessionID = UUID().uuidString
             claudeSessionID = sessionID
-            shellCommand = "claude --session-id \(sessionID) --dangerously-skip-permissions"
-            label = "claude"
+            var cmd = "claude --session-id \(sessionID) --dangerously-skip-permissions"
+
+            // Inject per-repo system prompt for new Claude sessions
+            if let repo = try await db.repos.get(id: worktree.repoID),
+               let prompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false) {
+                cmd += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
+            }
+
+            shellCommand = cmd
+            label = "Claude Code"
         } else if let cmd = params.cmd {
             claudeSessionID = nil
             shellCommand = cmd

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -59,6 +59,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRepoRemove(request.paramsData)
             case RPCMethod.repoList:
                 return try await handleRepoList()
+            case RPCMethod.repoUpdateInstructions:
+                return try await handleRepoUpdateInstructions(request.paramsData)
             case RPCMethod.worktreeCreate:
                 return try await handleWorktreeCreate(request.paramsData)
             case RPCMethod.worktreeList:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -7,15 +7,20 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
     public var displayName: String
     public var defaultBranch: String
     public var createdAt: Date
+    public var renamePrompt: String?
+    public var customInstructions: String?
 
     public init(id: UUID = UUID(), path: String, remoteURL: String? = nil,
-                displayName: String, defaultBranch: String = "main", createdAt: Date = Date()) {
+                displayName: String, defaultBranch: String = "main", createdAt: Date = Date(),
+                renamePrompt: String? = nil, customInstructions: String? = nil) {
         self.id = id
         self.path = path
         self.remoteURL = remoteURL
         self.displayName = displayName
         self.defaultBranch = defaultBranch
         self.createdAt = createdAt
+        self.renamePrompt = renamePrompt
+        self.customInstructions = customInstructions
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -120,6 +120,7 @@ public enum RPCMethod {
     public static let conductorSuggest = "conductor.suggest"
     public static let conductorClearSuggestion = "conductor.clearSuggestion"
     public static let terminalConversation = "terminal.conversation"
+    public static let repoUpdateInstructions = "repo.updateInstructions"
 }
 
 public struct NotificationsListResult: Codable, Sendable {
@@ -160,6 +161,17 @@ public struct RepoRemoveParams: Codable, Sendable {
     public let repoID: UUID
     public let force: Bool
     public init(repoID: UUID, force: Bool = false) { self.repoID = repoID; self.force = force }
+}
+
+public struct RepoUpdateInstructionsParams: Codable, Sendable {
+    public let repoID: UUID
+    public let renamePrompt: String?
+    public let customInstructions: String?
+    public init(repoID: UUID, renamePrompt: String?, customInstructions: String?) {
+        self.repoID = repoID
+        self.renamePrompt = renamePrompt
+        self.customInstructions = customInstructions
+    }
 }
 
 public struct WorktreeCreateParams: Codable, Sendable {

--- a/Sources/TBDShared/RepoConstants.swift
+++ b/Sources/TBDShared/RepoConstants.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public enum RepoConstants {
+    public static let defaultRenamePrompt = """
+        To do immediately, before any other work:
+
+        1. Rename the git branch to reflect the task:
+           git branch -m <new-branch-name>
+
+        2. Rename the TBD worktree display name:
+           tbd worktree rename "$(basename "$(git rev-parse --show-toplevel)")" "<emoji> <display name>"
+
+        Branch naming: use kebab-case, be concise (<30 chars), be specific.
+        Display name: pick a relevant emoji, convert branch name to title case with spaces.
+
+        Examples:
+          Branch: fix-login-timeout → Display: ⏱ Fix Login Timeout
+          Branch: add-export-csv   → Display: 📊 Add Export CSV
+
+        Do this before reading files, using skills, or any other tools.
+        """
+}

--- a/Tests/TBDDaemonTests/RPCRouterTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTests.swift
@@ -462,7 +462,7 @@ struct RPCRouterTests {
         #expect(createResp.success)
 
         let terminal = try createResp.decodeResult(Terminal.self)
-        #expect(terminal.label == "claude")
+        #expect(terminal.label == "Claude Code")
         #expect(terminal.claudeSessionID != nil)
     }
 

--- a/Tests/TBDDaemonTests/RPCRouterTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTests.swift
@@ -537,4 +537,90 @@ struct RPCRouterTests {
         #expect(!response.success)
         #expect(response.error?.contains("Unknown method") == true)
     }
+
+    // MARK: - Repo Instructions Tests
+
+    @Test("repo.updateInstructions stores and retrieves instructions")
+    func repoUpdateInstructions() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+
+        let request = try RPCRequest(
+            method: RPCMethod.repoUpdateInstructions,
+            params: RepoUpdateInstructionsParams(
+                repoID: repo.id,
+                renamePrompt: "Use cw/4/feat- prefix",
+                customInstructions: "Always use pytest"
+            )
+        )
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let updated = try response.decodeResult(Repo.self)
+        #expect(updated.renamePrompt == "Use cw/4/feat- prefix")
+        #expect(updated.customInstructions == "Always use pytest")
+
+        // Verify via repo.list
+        let listResp = await router.handle(RPCRequest(method: RPCMethod.repoList))
+        let repos = try listResp.decodeResult([Repo].self)
+        let found = repos.first { $0.id == repo.id }
+        #expect(found?.renamePrompt == "Use cw/4/feat- prefix")
+        #expect(found?.customInstructions == "Always use pytest")
+    }
+
+    @Test("repo.updateInstructions with nil clears instructions")
+    func repoUpdateInstructionsClear() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+
+        // Set instructions
+        let setReq = try RPCRequest(
+            method: RPCMethod.repoUpdateInstructions,
+            params: RepoUpdateInstructionsParams(repoID: repo.id, renamePrompt: "test", customInstructions: "test")
+        )
+        _ = await router.handle(setReq)
+
+        // Clear them
+        let clearReq = try RPCRequest(
+            method: RPCMethod.repoUpdateInstructions,
+            params: RepoUpdateInstructionsParams(repoID: repo.id, renamePrompt: nil, customInstructions: nil)
+        )
+        let response = await router.handle(clearReq)
+
+        #expect(response.success)
+        let updated = try response.decodeResult(Repo.self)
+        #expect(updated.renamePrompt == nil)
+        #expect(updated.customInstructions == nil)
+    }
+
+    @Test("repo.updateInstructions returns error for unknown repo")
+    func repoUpdateInstructionsUnknownRepo() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.repoUpdateInstructions,
+            params: RepoUpdateInstructionsParams(repoID: UUID(), renamePrompt: nil, customInstructions: nil)
+        )
+        let response = await router.handle(request)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("Repository not found") == true)
+    }
+
+    @Test("existing repos have nil instructions after migration")
+    func existingReposNilInstructions() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.renamePrompt == nil)
+        #expect(fetched?.customInstructions == nil)
+    }
 }

--- a/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
+++ b/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
@@ -1,0 +1,148 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("SystemPromptBuilder Tests")
+struct SystemPromptBuilderTests {
+
+    // MARK: - Shell Escaping
+
+    @Test("shellEscape wraps text in single quotes")
+    func shellEscapeSimple() {
+        let result = SystemPromptBuilder.shellEscape("hello world")
+        #expect(result == "'hello world'")
+    }
+
+    @Test("shellEscape handles single quotes")
+    func shellEscapeSingleQuotes() {
+        let result = SystemPromptBuilder.shellEscape("don't mock")
+        #expect(result == "'don'\\''t mock'")
+    }
+
+    @Test("shellEscape handles double quotes")
+    func shellEscapeDoubleQuotes() {
+        let result = SystemPromptBuilder.shellEscape("use \"pytest\"")
+        #expect(result == "'use \"pytest\"'")
+    }
+
+    @Test("shellEscape handles newlines")
+    func shellEscapeNewlines() {
+        let result = SystemPromptBuilder.shellEscape("line1\nline2")
+        #expect(result == "'line1\nline2'")
+    }
+
+    @Test("shellEscape handles special shell characters")
+    func shellEscapeSpecialChars() {
+        let result = SystemPromptBuilder.shellEscape("$HOME `cmd` $(eval)")
+        #expect(result == "'$HOME `cmd` $(eval)'")
+    }
+
+    // MARK: - Build Prompt
+
+    @Test("build returns nil for resumed sessions")
+    func buildReturnsNilForResume() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "test-wt", displayName: "test-wt",
+                          branch: "tbd/test-wt", path: "/test/.tbd/worktrees/test-wt",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: true)
+        #expect(result == nil)
+    }
+
+    @Test("build includes rename prompt when worktree not renamed")
+    func buildIncludesRenameWhenNotRenamed() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "gorgeous-panda",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("To do immediately"))
+        #expect(result!.contains("git branch -m"))
+        #expect(result!.contains("tbd worktree rename"))
+    }
+
+    @Test("build excludes rename prompt when worktree already renamed")
+    func buildExcludesRenameWhenRenamed() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "🔐 Auth Fix",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(!result!.contains("To do immediately"))
+        #expect(result!.contains("TBD-managed worktree"))
+    }
+
+    @Test("build excludes rename prompt when explicitly disabled (empty string)")
+    func buildExcludesRenameWhenDisabled() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main",
+                        renamePrompt: "")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "gorgeous-panda",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(!result!.contains("To do immediately"))
+        #expect(result!.contains("TBD-managed worktree"))
+    }
+
+    @Test("build uses custom rename prompt when set")
+    func buildUsesCustomRenamePrompt() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main",
+                        renamePrompt: "Use cw/4/feat- prefix")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "gorgeous-panda",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("cw/4/feat-"))
+        #expect(!result!.contains("To do immediately"))
+    }
+
+    @Test("build always includes TBD context for fresh sessions")
+    func buildAlwaysIncludesTBDContext() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "test-wt", displayName: "🔐 Renamed",
+                          branch: "tbd/test-wt", path: "/test/.tbd/worktrees/test-wt",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("TBD-managed worktree"))
+        #expect(result!.contains("tbd notify"))
+    }
+
+    @Test("build includes general instructions when set")
+    func buildIncludesGeneralInstructions() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main",
+                        customInstructions: "Always use pytest. Never mock the DB.")
+        let wt = Worktree(repoID: repo.id, name: "test-wt", displayName: "🔐 Renamed",
+                          branch: "tbd/test-wt", path: "/test/.tbd/worktrees/test-wt",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("Always use pytest"))
+    }
+
+    @Test("build excludes general instructions when empty/whitespace")
+    func buildExcludesEmptyInstructions() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main",
+                        customInstructions: "   \n  ")
+        let wt = Worktree(repoID: repo.id, name: "test-wt", displayName: "🔐 Renamed",
+                          branch: "tbd/test-wt", path: "/test/.tbd/worktrees/test-wt",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(!result!.contains("   \n  "))
+        #expect(result!.contains("TBD-managed worktree"))
+    }
+}

--- a/docs/superpowers/plans/2026-04-05-per-repo-instructions.md
+++ b/docs/superpowers/plans/2026-04-05-per-repo-instructions.md
@@ -1,0 +1,1049 @@
+# Per-Repo Instructions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-repo configurable instructions (rename prompt + general instructions) that TBD injects into spawned Claude Code sessions via `--append-system-prompt`.
+
+**Architecture:** New DB columns on `repo` table for `renamePrompt` and `customInstructions`. A `SystemPromptBuilder` composes three layers (rename prompt, built-in TBD context, user instructions) into a single `--append-system-prompt` flag appended to the `claude` command at spawn time. New `RepoDetailView` with segmented control replaces `ArchivedWorktreesView` in the detail area. New `RepoInstructionsView` provides two text editors with debounced auto-save.
+
+**Tech Stack:** Swift, SwiftUI, GRDB, TBDShared models, TBDDaemon RPC
+
+**Spec:** `docs/superpowers/specs/2026-04-05-per-repo-instructions-design.md`
+
+---
+
+### Task 1: Data Model — Migration, Shared Model, RepoRecord, RPC Types
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Database/Database.swift:183` (add migration v11 before `try migrator.migrate`)
+- Modify: `Sources/TBDShared/Models.swift:1-20` (add fields to Repo)
+- Modify: `Sources/TBDDaemon/Database/RepoStore.swift:6-35` (add fields to RepoRecord + update method)
+- Modify: `Sources/TBDShared/RPCProtocol.swift:78-122` (add RPC method + params struct)
+
+- [ ] **Step 1: Add migration v11 to Database.swift**
+
+In `Sources/TBDDaemon/Database/Database.swift`, add before `try migrator.migrate(writer)` (line 184):
+
+```swift
+migrator.registerMigration("v11") { db in
+    try db.alter(table: "repo") { t in
+        t.add(column: "renamePrompt", .text)
+        t.add(column: "customInstructions", .text)
+    }
+}
+```
+
+- [ ] **Step 2: Add fields to Repo model in Models.swift**
+
+In `Sources/TBDShared/Models.swift`, add to the `Repo` struct after `createdAt`:
+
+```swift
+public var renamePrompt: String?
+public var customInstructions: String?
+```
+
+Update the `init` to include them with defaults:
+
+```swift
+public init(id: UUID = UUID(), path: String, remoteURL: String? = nil,
+            displayName: String, defaultBranch: String = "main", createdAt: Date = Date(),
+            renamePrompt: String? = nil, customInstructions: String? = nil) {
+    self.id = id
+    self.path = path
+    self.remoteURL = remoteURL
+    self.displayName = displayName
+    self.defaultBranch = defaultBranch
+    self.createdAt = createdAt
+    self.renamePrompt = renamePrompt
+    self.customInstructions = customInstructions
+}
+```
+
+Note: `Repo` uses the synthesized `Codable` conformance (no manual `init(from:)`), so optional properties decode as `nil` automatically from existing data.
+
+- [ ] **Step 3: Add fields to RepoRecord in RepoStore.swift**
+
+In `Sources/TBDDaemon/Database/RepoStore.swift`, add to `RepoRecord`:
+
+```swift
+var renamePrompt: String?
+var customInstructions: String?
+```
+
+Update `init(from repo:)`:
+
+```swift
+init(from repo: Repo) {
+    self.id = repo.id.uuidString
+    self.path = repo.path
+    self.remoteURL = repo.remoteURL
+    self.displayName = repo.displayName
+    self.defaultBranch = repo.defaultBranch
+    self.createdAt = repo.createdAt
+    self.renamePrompt = repo.renamePrompt
+    self.customInstructions = repo.customInstructions
+}
+```
+
+Update `toModel()`:
+
+```swift
+func toModel() -> Repo {
+    Repo(
+        id: UUID(uuidString: id)!,
+        path: path,
+        remoteURL: remoteURL,
+        displayName: displayName,
+        defaultBranch: defaultBranch,
+        createdAt: createdAt,
+        renamePrompt: renamePrompt,
+        customInstructions: customInstructions
+    )
+}
+```
+
+Add the update method to `RepoStore`:
+
+```swift
+/// Update per-repo instruction fields.
+public func updateInstructions(id: UUID, renamePrompt: String?, customInstructions: String?) async throws {
+    try await writer.write { db in
+        try db.execute(
+            sql: "UPDATE repo SET renamePrompt = ?, customInstructions = ? WHERE id = ?",
+            arguments: [renamePrompt, customInstructions, id.uuidString]
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Add RPC method and params to RPCProtocol.swift**
+
+In `Sources/TBDShared/RPCProtocol.swift`, add to `RPCMethod` enum (after `terminalConversation`):
+
+```swift
+public static let repoUpdateInstructions = "repo.updateInstructions"
+```
+
+Add the params struct after the existing param structs (e.g., after `RepoRemoveParams`):
+
+```swift
+public struct RepoUpdateInstructionsParams: Codable, Sendable {
+    public let repoID: UUID
+    public let renamePrompt: String?
+    public let customInstructions: String?
+    public init(repoID: UUID, renamePrompt: String?, customInstructions: String?) {
+        self.repoID = repoID
+        self.renamePrompt = renamePrompt
+        self.customInstructions = customInstructions
+    }
+}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDDaemon/Database/Database.swift Sources/TBDShared/Models.swift Sources/TBDDaemon/Database/RepoStore.swift Sources/TBDShared/RPCProtocol.swift
+git commit -m "feat: add renamePrompt and customInstructions to repo model (migration v11)"
+```
+
+---
+
+### Task 2: RPC Handler + DaemonClient Method
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Server/RPCRouter.swift:53-148` (add case for new method)
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift:109-113` (add handler method)
+- Modify: `Sources/TBDApp/DaemonClient.swift:286-295` (add client method)
+
+- [ ] **Step 1: Add handler method to RPCRouter+RepoHandlers.swift**
+
+In `Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift`, add after `handleRepoList()`:
+
+```swift
+func handleRepoUpdateInstructions(_ paramsData: Data) async throws -> RPCResponse {
+    let params = try decoder.decode(RepoUpdateInstructionsParams.self, from: paramsData)
+
+    guard try await db.repos.get(id: params.repoID) != nil else {
+        return RPCResponse(error: "Repository not found: \(params.repoID)")
+    }
+
+    try await db.repos.updateInstructions(
+        id: params.repoID,
+        renamePrompt: params.renamePrompt,
+        customInstructions: params.customInstructions
+    )
+
+    guard let updated = try await db.repos.get(id: params.repoID) else {
+        return RPCResponse(error: "Repository not found after update: \(params.repoID)")
+    }
+
+    return try RPCResponse(result: updated)
+}
+```
+
+- [ ] **Step 2: Add dispatch case to RPCRouter.swift**
+
+In `Sources/TBDDaemon/Server/RPCRouter.swift`, add a new case in the `switch request.method` block (after the `repoList` case around line 61):
+
+```swift
+case RPCMethod.repoUpdateInstructions:
+    return try await handleRepoUpdateInstructions(request.paramsData)
+```
+
+- [ ] **Step 3: Add DaemonClient method**
+
+In `Sources/TBDApp/DaemonClient.swift`, add after the `addRepo` method (around line 295):
+
+```swift
+/// Update per-repo instruction fields.
+func repoUpdateInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) throws -> Repo {
+    return try call(
+        method: RPCMethod.repoUpdateInstructions,
+        params: RepoUpdateInstructionsParams(repoID: repoID, renamePrompt: renamePrompt, customInstructions: customInstructions),
+        resultType: Repo.self
+    )
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Server/RPCRouter.swift Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift Sources/TBDApp/DaemonClient.swift
+git commit -m "feat: add repo.updateInstructions RPC handler and client method"
+```
+
+---
+
+### Task 3: Tests — Migration, RPC, Shell Escaping
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/RPCRouterTests.swift` (add tests)
+- Create: `Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift` (shell escape function — tested here, used in Task 4)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/TBDDaemonTests/RPCRouterTests.swift`, at the end of the struct before the closing `}`:
+
+```swift
+// MARK: - Repo Instructions Tests
+
+@Test("repo.updateInstructions stores and retrieves instructions")
+func repoUpdateInstructions() async throws {
+    let repo = try await db.repos.create(
+        path: "/tmp/test-repo-\(UUID().uuidString)",
+        displayName: "test-repo",
+        defaultBranch: "main"
+    )
+
+    let request = try RPCRequest(
+        method: RPCMethod.repoUpdateInstructions,
+        params: RepoUpdateInstructionsParams(
+            repoID: repo.id,
+            renamePrompt: "Use cw/4/feat- prefix",
+            customInstructions: "Always use pytest"
+        )
+    )
+    let response = await router.handle(request)
+
+    #expect(response.success)
+    let updated = try response.decodeResult(Repo.self)
+    #expect(updated.renamePrompt == "Use cw/4/feat- prefix")
+    #expect(updated.customInstructions == "Always use pytest")
+
+    // Verify via repo.list
+    let listResp = await router.handle(RPCRequest(method: RPCMethod.repoList))
+    let repos = try listResp.decodeResult([Repo].self)
+    let found = repos.first { $0.id == repo.id }
+    #expect(found?.renamePrompt == "Use cw/4/feat- prefix")
+    #expect(found?.customInstructions == "Always use pytest")
+}
+
+@Test("repo.updateInstructions with nil clears instructions")
+func repoUpdateInstructionsClear() async throws {
+    let repo = try await db.repos.create(
+        path: "/tmp/test-repo-\(UUID().uuidString)",
+        displayName: "test-repo",
+        defaultBranch: "main"
+    )
+
+    // Set instructions
+    let setReq = try RPCRequest(
+        method: RPCMethod.repoUpdateInstructions,
+        params: RepoUpdateInstructionsParams(repoID: repo.id, renamePrompt: "test", customInstructions: "test")
+    )
+    _ = await router.handle(setReq)
+
+    // Clear them
+    let clearReq = try RPCRequest(
+        method: RPCMethod.repoUpdateInstructions,
+        params: RepoUpdateInstructionsParams(repoID: repo.id, renamePrompt: nil, customInstructions: nil)
+    )
+    let response = await router.handle(clearReq)
+
+    #expect(response.success)
+    let updated = try response.decodeResult(Repo.self)
+    #expect(updated.renamePrompt == nil)
+    #expect(updated.customInstructions == nil)
+}
+
+@Test("repo.updateInstructions returns error for unknown repo")
+func repoUpdateInstructionsUnknownRepo() async throws {
+    let request = try RPCRequest(
+        method: RPCMethod.repoUpdateInstructions,
+        params: RepoUpdateInstructionsParams(repoID: UUID(), renamePrompt: nil, customInstructions: nil)
+    )
+    let response = await router.handle(request)
+
+    #expect(!response.success)
+    #expect(response.error?.contains("Repository not found") == true)
+}
+
+@Test("existing repos have nil instructions after migration")
+func existingReposNilInstructions() async throws {
+    let repo = try await db.repos.create(
+        path: "/tmp/test-repo-\(UUID().uuidString)",
+        displayName: "test-repo",
+        defaultBranch: "main"
+    )
+
+    let fetched = try await db.repos.get(id: repo.id)
+    #expect(fetched?.renamePrompt == nil)
+    #expect(fetched?.customInstructions == nil)
+}
+```
+
+- [ ] **Step 2: Create SystemPromptBuilder with shellEscape function**
+
+Create `Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift`:
+
+```swift
+import Foundation
+import TBDShared
+
+/// Builds the `--append-system-prompt` value for Claude sessions in TBD worktrees.
+enum SystemPromptBuilder {
+
+    /// Shell-escape a string for embedding in a single-quoted shell argument.
+    static func shellEscape(_ text: String) -> String {
+        "'" + text.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    static let defaultRenamePrompt = """
+        To do immediately, before any other work:
+
+        1. Rename the git branch to reflect the task:
+           git branch -m <new-branch-name>
+
+        2. Rename the TBD worktree display name:
+           tbd worktree rename "$(basename "$(git rev-parse --show-toplevel)")" "<emoji> <display name>"
+
+        Branch naming: use kebab-case, be concise (<30 chars), be specific.
+        Display name: pick a relevant emoji, convert branch name to title case with spaces.
+
+        Examples:
+          Branch: fix-login-timeout → Display: ⏱ Fix Login Timeout
+          Branch: add-export-csv   → Display: 📊 Add Export CSV
+
+        Do this before reading files, using skills, or any other tools.
+        """
+
+    static let builtInTBDContext = """
+        You are running inside a TBD-managed worktree. TBD is a macOS worktree + terminal manager.
+
+        Available CLI commands:
+        - tbd worktree rename "<worktree-name>" "<display-name>" — rename the worktree display name
+        - tbd worktree list [--repo <id>] — list worktrees
+        - tbd terminal create <worktree> [--cmd <command>] — create a new terminal
+        - tbd terminal output <terminal-id> [--lines N] — read terminal output
+        - tbd notify --type <type> [--message <msg>] — send notifications to TBD UI
+          Types: response_complete, error, task_complete, attention_needed
+
+        Environment variables:
+        - TBD_WORKTREE_ID — UUID of the current worktree (auto-set in all TBD terminals)
+        """
+
+    /// Build the combined system prompt for a Claude session.
+    /// Returns nil if there's nothing to append.
+    static func build(repo: Repo, worktree: Worktree, isResume: Bool) -> String? {
+        if isResume { return nil }
+
+        var parts: [String] = []
+
+        // Layer 1: Rename prompt (conditional on worktree not yet renamed)
+        if worktree.displayName == worktree.name {
+            let renamePrompt = repo.renamePrompt ?? defaultRenamePrompt
+            if !renamePrompt.isEmpty {
+                parts.append(renamePrompt)
+            }
+        }
+
+        // Layer 2: Built-in TBD context (always)
+        parts.append(builtInTBDContext)
+
+        // Layer 3: User general instructions (if set)
+        if let instructions = repo.customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !instructions.isEmpty {
+            parts.append(instructions)
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: "\n\n---\n\n")
+    }
+}
+```
+
+- [ ] **Step 3: Add SystemPromptBuilder tests**
+
+Create `Tests/TBDDaemonTests/SystemPromptBuilderTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("SystemPromptBuilder Tests")
+struct SystemPromptBuilderTests {
+
+    // MARK: - Shell Escaping
+
+    @Test("shellEscape wraps text in single quotes")
+    func shellEscapeSimple() {
+        let result = SystemPromptBuilder.shellEscape("hello world")
+        #expect(result == "'hello world'")
+    }
+
+    @Test("shellEscape handles single quotes")
+    func shellEscapeSingleQuotes() {
+        let result = SystemPromptBuilder.shellEscape("don't mock")
+        #expect(result == "'don'\\''t mock'")
+    }
+
+    @Test("shellEscape handles double quotes")
+    func shellEscapeDoubleQuotes() {
+        let result = SystemPromptBuilder.shellEscape("use \"pytest\"")
+        #expect(result == "'use \"pytest\"'")
+    }
+
+    @Test("shellEscape handles newlines")
+    func shellEscapeNewlines() {
+        let result = SystemPromptBuilder.shellEscape("line1\nline2")
+        #expect(result == "'line1\nline2'")
+    }
+
+    @Test("shellEscape handles special shell characters")
+    func shellEscapeSpecialChars() {
+        let result = SystemPromptBuilder.shellEscape("$HOME `cmd` $(eval)")
+        #expect(result == "'$HOME `cmd` $(eval)'")
+    }
+
+    // MARK: - Build Prompt
+
+    @Test("build returns nil for resumed sessions")
+    func buildReturnsNilForResume() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "test-wt", displayName: "test-wt",
+                          branch: "tbd/test-wt", path: "/test/.tbd/worktrees/test-wt",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: true)
+        #expect(result == nil)
+    }
+
+    @Test("build includes rename prompt when worktree not renamed")
+    func buildIncludesRenameWhenNotRenamed() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "gorgeous-panda",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("To do immediately"))
+        #expect(result!.contains("git branch -m"))
+        #expect(result!.contains("tbd worktree rename"))
+    }
+
+    @Test("build excludes rename prompt when worktree already renamed")
+    func buildExcludesRenameWhenRenamed() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "🔐 Auth Fix",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(!result!.contains("To do immediately"))
+        // Should still have TBD context
+        #expect(result!.contains("TBD-managed worktree"))
+    }
+
+    @Test("build excludes rename prompt when explicitly disabled (empty string)")
+    func buildExcludesRenameWhenDisabled() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main",
+                        renamePrompt: "")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "gorgeous-panda",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(!result!.contains("To do immediately"))
+        #expect(result!.contains("TBD-managed worktree"))
+    }
+
+    @Test("build uses custom rename prompt when set")
+    func buildUsesCustomRenamePrompt() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main",
+                        renamePrompt: "Use cw/4/feat- prefix")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "gorgeous-panda",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("cw/4/feat-"))
+        #expect(!result!.contains("To do immediately"))
+    }
+
+    @Test("build always includes TBD context for fresh sessions")
+    func buildAlwaysIncludesTBDContext() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "test-wt", displayName: "🔐 Renamed",
+                          branch: "tbd/test-wt", path: "/test/.tbd/worktrees/test-wt",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("TBD-managed worktree"))
+        #expect(result!.contains("tbd notify"))
+    }
+
+    @Test("build includes general instructions when set")
+    func buildIncludesGeneralInstructions() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main",
+                        customInstructions: "Always use pytest. Never mock the DB.")
+        let wt = Worktree(repoID: repo.id, name: "test-wt", displayName: "🔐 Renamed",
+                          branch: "tbd/test-wt", path: "/test/.tbd/worktrees/test-wt",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("Always use pytest"))
+    }
+
+    @Test("build excludes general instructions when empty/whitespace")
+    func buildExcludesEmptyInstructions() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main",
+                        customInstructions: "   \n  ")
+        let wt = Worktree(repoID: repo.id, name: "test-wt", displayName: "🔐 Renamed",
+                          branch: "tbd/test-wt", path: "/test/.tbd/worktrees/test-wt",
+                          tmuxServer: "tbd-test")
+
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(!result!.contains("   \n  "))
+        // Should still have TBD context
+        #expect(result!.contains("TBD-managed worktree"))
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test 2>&1 | tail -20`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift Tests/TBDDaemonTests/RPCRouterTests.swift Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
+git commit -m "feat: add SystemPromptBuilder with tests for prompt composition and shell escaping"
+```
+
+---
+
+### Task 4: Inject System Prompt at Spawn Time
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift:176-257` (inject in `setupTerminals`)
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift:8-68` (inject in `handleTerminalCreate`)
+- Modify: `Sources/TBDDaemon/Conductor/ConductorManager.swift:108-157` (inject in conductor start)
+
+- [ ] **Step 1: Inject in setupTerminals (worktree creation)**
+
+In `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift`, the `setupTerminals` method needs access to the repo to build the system prompt. The method already receives `repoPath` but needs the repo object. Modify `setupTerminals` signature and callers.
+
+First, update the method signature to accept a `Repo` parameter:
+
+```swift
+func setupTerminals(
+    worktreeID: UUID, repo: Repo,
+    tmuxServer: String, worktreePath: String, skipClaude: Bool,
+    archivedClaudeSessions: [String]? = nil
+) async throws {
+```
+
+Then, after building `claudeCommand` (around line 196), add system prompt injection before creating the window:
+
+```swift
+if skipClaude {
+    claudeCommand = defaultShell
+    claudeSessionID = nil
+} else {
+    let sessionUUID = archivedClaudeSessions?.first ?? UUID().uuidString
+    claudeCommand = "claude --dangerously-skip-permissions --session-id \(sessionUUID)"
+    claudeSessionID = sessionUUID
+
+    // Inject per-repo system prompt
+    if let worktree = try await db.worktrees.get(id: worktreeID),
+       let prompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false) {
+        claudeCommand += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
+    }
+}
+```
+
+Update the two call sites in `completeCreateWorktree` (line 91):
+
+```swift
+try await setupTerminals(
+    worktreeID: worktreeID, repo: repo,
+    tmuxServer: worktree.tmuxServer, worktreePath: result.path,
+    skipClaude: skipClaude
+)
+```
+
+And in `reviveWorktree` (search for the other `setupTerminals` call — it will be in `WorktreeLifecycle+Archive.swift` or similar):
+
+Find all call sites with:
+```bash
+grep -rn "setupTerminals(" Sources/
+```
+Update each to pass `repo:`.
+
+- [ ] **Step 2: Inject in handleTerminalCreate (new Claude terminal)**
+
+In `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`, in `handleTerminalCreate`, after the `isClaudeType` block builds `shellCommand` (around line 36), add prompt injection for new Claude sessions (not resume):
+
+After line 36 (`shellCommand = "claude --session-id \(sessionID) --dangerously-skip-permissions"`), add:
+
+```swift
+} else if isClaudeType {
+    let sessionID = UUID().uuidString
+    claudeSessionID = sessionID
+    var cmd = "claude --session-id \(sessionID) --dangerously-skip-permissions"
+
+    // Inject per-repo system prompt
+    if let repo = try await db.repos.get(id: worktree.repoID),
+       let prompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false) {
+        cmd += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
+    }
+
+    shellCommand = cmd
+    label = "claude"
+```
+
+Replace the existing `else if isClaudeType` block with this version.
+
+- [ ] **Step 3: Inject in conductor start**
+
+In `Sources/TBDDaemon/Conductor/ConductorManager.swift`, in the `start` method (line 132), the current command is:
+
+```swift
+let shellCommand = "claude --dangerously-skip-permissions"
+```
+
+Replace with:
+
+```swift
+var shellCommand = "claude --dangerously-skip-permissions"
+
+// Inject TBD context + general instructions (no rename prompt for conductors)
+// Only inject general instructions if conductor scopes to a single repo
+if let conductor = try await db.conductors.get(name: name) {
+    let repoIDs = conductor.repos
+    if repoIDs.count == 1, let repoIDStr = repoIDs.first, repoIDStr != "*",
+       let repoUUID = UUID(uuidString: repoIDStr),
+       let repo = try await db.repos.get(id: repoUUID) {
+        var parts = [SystemPromptBuilder.builtInTBDContext]
+        if let instructions = repo.customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !instructions.isEmpty {
+            parts.append(instructions)
+        }
+        let combined = parts.joined(separator: "\n\n---\n\n")
+        shellCommand += " --append-system-prompt \(SystemPromptBuilder.shellEscape(combined))"
+    } else {
+        // Multi-repo or wildcard — just inject TBD context
+        shellCommand += " --append-system-prompt \(SystemPromptBuilder.shellEscape(SystemPromptBuilder.builtInTBDContext))"
+    }
+}
+```
+
+Note: We already have a `conductor` variable from the `guard let` on line 109, so we need to reuse that instead of re-fetching. Adjust the code to use the existing `conductor` variable — the key fields are `conductor.repos` which is `[String]`.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 5: Run tests**
+
+Run: `swift test 2>&1 | tail -20`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift Sources/TBDDaemon/Conductor/ConductorManager.swift
+git commit -m "feat: inject per-repo system prompt at Claude session spawn time"
+```
+
+---
+
+### Task 5: UI — RepoDetailView with Segmented Control
+
+**Files:**
+- Create: `Sources/TBDApp/RepoDetailView.swift`
+- Modify: `Sources/TBDApp/ContentView.swift:30` (swap ArchivedWorktreesView for RepoDetailView)
+
+- [ ] **Step 1: Create RepoDetailView.swift**
+
+Create `Sources/TBDApp/RepoDetailView.swift`:
+
+```swift
+import SwiftUI
+import TBDShared
+
+struct RepoDetailView: View {
+    let repoID: UUID
+
+    enum Tab: String, CaseIterable {
+        case archived = "Archived"
+        case instructions = "Instructions"
+    }
+
+    @State private var selectedTab: Tab = .archived
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $selectedTab) {
+                ForEach(Tab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 240)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            switch selectedTab {
+            case .archived:
+                ArchivedWorktreesView(repoID: repoID)
+            case .instructions:
+                RepoInstructionsView(repoID: repoID)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update ContentView to use RepoDetailView**
+
+In `Sources/TBDApp/ContentView.swift`, replace line 30:
+
+```swift
+// Before:
+ArchivedWorktreesView(repoID: repoID)
+
+// After:
+RepoDetailView(repoID: repoID)
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded (RepoInstructionsView doesn't exist yet — create a stub if needed, or do Task 6 immediately after)
+
+Actually, since `RepoInstructionsView` is referenced but doesn't exist yet, create a minimal stub:
+
+Create `Sources/TBDApp/RepoInstructionsView.swift`:
+
+```swift
+import SwiftUI
+import TBDShared
+
+struct RepoInstructionsView: View {
+    let repoID: UUID
+
+    var body: some View {
+        Text("Instructions placeholder")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDApp/RepoDetailView.swift Sources/TBDApp/RepoInstructionsView.swift Sources/TBDApp/ContentView.swift
+git commit -m "feat: add RepoDetailView with segmented control (Archived | Instructions)"
+```
+
+---
+
+### Task 6: UI — RepoInstructionsView with Debounced Auto-Save
+
+**Files:**
+- Modify: `Sources/TBDApp/RepoInstructionsView.swift` (replace stub with full implementation)
+- Modify: `Sources/TBDApp/AppState+Repos.swift` (add updateRepoInstructions method)
+
+- [ ] **Step 1: Add updateRepoInstructions to AppState**
+
+In `Sources/TBDApp/AppState+Repos.swift`, add after the existing repo methods:
+
+```swift
+/// Update per-repo instruction fields.
+func updateRepoInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async {
+    do {
+        _ = try await daemonClient.repoUpdateInstructions(
+            repoID: repoID, renamePrompt: renamePrompt, customInstructions: customInstructions
+        )
+        await refreshRepos()
+    } catch {
+        showError("Failed to update instructions: \(error)")
+    }
+}
+```
+
+- [ ] **Step 2: Implement full RepoInstructionsView**
+
+Replace the contents of `Sources/TBDApp/RepoInstructionsView.swift`:
+
+```swift
+import SwiftUI
+import TBDShared
+
+struct RepoInstructionsView: View {
+    let repoID: UUID
+    @EnvironmentObject var appState: AppState
+
+    @State private var renamePromptDraft: String = ""
+    @State private var customInstructionsDraft: String = ""
+    @State private var showSaved = false
+    @State private var saveTask: Task<Void, Never>?
+    @State private var initialized = false
+
+    private var repo: Repo? {
+        appState.repos.first { $0.id == repoID }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // MARK: - Rename Prompt Section
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Rename Prompt")
+                        .font(.title3)
+                        .fontWeight(.medium)
+                    Text("Sent with the first message in worktrees that haven't been renamed yet.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    TextEditor(text: $renamePromptDraft)
+                        .font(.body.monospaced())
+                        .frame(minHeight: 160)
+                        .scrollContentBackground(.hidden)
+                        .padding(8)
+                        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
+
+                    HStack {
+                        Spacer()
+                        Button("Reset to Default") {
+                            renamePromptDraft = SystemPromptBuilder.defaultRenamePrompt
+                            scheduleSave()
+                        }
+                        .buttonStyle(.borderless)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+
+                Divider()
+
+                // MARK: - General Instructions Section
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("General Instructions")
+                        .font(.title3)
+                        .fontWeight(.medium)
+                    Text("Added to all new Claude sessions in this repo.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    ZStack(alignment: .topLeading) {
+                        TextEditor(text: $customInstructionsDraft)
+                            .font(.body.monospaced())
+                            .frame(minHeight: 120)
+                            .scrollContentBackground(.hidden)
+                            .padding(8)
+                            .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
+
+                        if customInstructionsDraft.isEmpty {
+                            Text("e.g. Always use pytest. Never mock the database.")
+                                .font(.body.monospaced())
+                                .foregroundStyle(.tertiary)
+                                .padding(12)
+                                .allowsHitTesting(false)
+                        }
+                    }
+                }
+
+                // MARK: - Save Indicator
+                HStack {
+                    Spacer()
+                    if showSaved {
+                        Text("Saved")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .transition(.opacity)
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            guard !initialized else { return }
+            initialized = true
+            if let repo {
+                renamePromptDraft = repo.renamePrompt ?? SystemPromptBuilder.defaultRenamePrompt
+                customInstructionsDraft = repo.customInstructions ?? ""
+            }
+        }
+        .onChange(of: renamePromptDraft) { _, _ in
+            guard initialized else { return }
+            scheduleSave()
+        }
+        .onChange(of: customInstructionsDraft) { _, _ in
+            guard initialized else { return }
+            scheduleSave()
+        }
+    }
+
+    private func scheduleSave() {
+        saveTask?.cancel()
+        saveTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled else { return }
+
+            // Determine what to persist:
+            // renamePrompt: nil if matches default, "" if user cleared it, otherwise custom text
+            let renameToSave: String?
+            if renamePromptDraft == SystemPromptBuilder.defaultRenamePrompt {
+                renameToSave = nil  // Use default
+            } else {
+                renameToSave = renamePromptDraft  // Custom or empty (disabled)
+            }
+
+            let instructionsToSave: String? = customInstructionsDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? nil
+                : customInstructionsDraft
+
+            await appState.updateRepoInstructions(
+                repoID: repoID,
+                renamePrompt: renameToSave,
+                customInstructions: instructionsToSave
+            )
+
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }
+        }
+    }
+}
+```
+
+Note: This references `SystemPromptBuilder.defaultRenamePrompt` — the `SystemPromptBuilder` type is in `TBDDaemonLib`, not accessible from the app target. We need to either:
+1. Move the default prompt string to `TBDShared` so both targets can use it, or
+2. Duplicate the string in the view.
+
+The cleanest approach is to add a static string to `TBDShared`. Add to `Sources/TBDShared/RepoConstants.swift`:
+
+```swift
+import Foundation
+
+public enum RepoConstants {
+    public static let defaultRenamePrompt = """
+        To do immediately, before any other work:
+
+        1. Rename the git branch to reflect the task:
+           git branch -m <new-branch-name>
+
+        2. Rename the TBD worktree display name:
+           tbd worktree rename "$(basename "$(git rev-parse --show-toplevel)")" "<emoji> <display name>"
+
+        Branch naming: use kebab-case, be concise (<30 chars), be specific.
+        Display name: pick a relevant emoji, convert branch name to title case with spaces.
+
+        Examples:
+          Branch: fix-login-timeout → Display: ⏱ Fix Login Timeout
+          Branch: add-export-csv   → Display: 📊 Add Export CSV
+
+        Do this before reading files, using skills, or any other tools.
+        """
+}
+```
+
+Then update `SystemPromptBuilder.defaultRenamePrompt` to reference `RepoConstants.defaultRenamePrompt`, and update `RepoInstructionsView` to use `RepoConstants.defaultRenamePrompt` instead of `SystemPromptBuilder.defaultRenamePrompt`.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `swift build 2>&1 | tail -5`
+Expected: Build succeeded
+
+- [ ] **Step 4: Run all tests**
+
+Run: `swift test 2>&1 | tail -20`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDShared/RepoConstants.swift Sources/TBDApp/RepoInstructionsView.swift Sources/TBDApp/AppState+Repos.swift Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+git commit -m "feat: add RepoInstructionsView with rename prompt and general instructions editors"
+```
+
+---
+
+### Task 7: Final Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `swift test 2>&1 | tail -30`
+Expected: All tests pass
+
+- [ ] **Step 2: Verify build is clean with no warnings**
+
+Run: `swift build 2>&1`
+Expected: Build succeeded with no warnings related to our changes
+
+- [ ] **Step 3: Restart daemon and app to verify end-to-end**
+
+Run: `scripts/restart.sh`
+Expected: Daemon restarts, app reconnects, no crashes

--- a/docs/superpowers/specs/2026-04-05-per-repo-instructions-design.md
+++ b/docs/superpowers/specs/2026-04-05-per-repo-instructions-design.md
@@ -1,0 +1,246 @@
+# Per-Repo Custom Instructions
+
+Add configurable per-repo instructions that TBD injects into spawned Claude Code sessions via `--append-system-prompt`, without modifying CLAUDE.md files.
+
+## Motivation
+
+Users want project-specific conventions (testing frameworks, code style, forbidden patterns) applied to every Claude session in a repo. Today the only option is CLAUDE.md, which is committed to the repo and visible to all collaborators. Per-repo instructions in TBD are local, per-user, and managed through the app UI.
+
+## Data Model & Storage
+
+### DB Migration v11
+
+Add a `customInstructions` TEXT column to the `repo` table, defaulting to NULL:
+
+```swift
+migrator.registerMigration("v11") { db in
+    try db.alter(table: "repo") { t in
+        t.add(column: "customInstructions", .text)
+    }
+}
+```
+
+### Shared Model (TBDShared/Models.swift)
+
+Add to `Repo`:
+
+```swift
+public var customInstructions: String?
+```
+
+Must be optional so existing JSON/rows decode without error. Add to `init` with default `nil`. Add to the manual `init(from decoder:)` with `decodeIfPresent`.
+
+### RepoRecord (TBDDaemon/Database/RepoStore.swift)
+
+Add `customInstructions: String?` to `RepoRecord`. Update `init(from:)` and `toModel()` to map the field.
+
+Add an update method:
+
+```swift
+public func update(id: UUID, customInstructions: String?) async throws {
+    try await writer.write { db in
+        try db.execute(
+            sql: "UPDATE repo SET customInstructions = ? WHERE id = ?",
+            arguments: [customInstructions, id.uuidString]
+        )
+    }
+}
+```
+
+### RPC
+
+New method `repo.updateInstructions`:
+
+```swift
+// RPCProtocol.swift
+public static let repoUpdateInstructions = "repo.updateInstructions"
+
+public struct RepoUpdateInstructionsParams: Codable, Sendable {
+    public let repoID: UUID
+    public let customInstructions: String?
+    public init(repoID: UUID, customInstructions: String?) {
+        self.repoID = repoID
+        self.customInstructions = customInstructions
+    }
+}
+```
+
+No separate read RPC needed — `repo.list` already returns `[Repo]` which will include `customInstructions` automatically.
+
+## Instruction Injection
+
+### Fresh Claude Sessions (WorktreeLifecycle+Create.swift)
+
+In `setupTerminals()`, after building the base `claudeCommand` and before spawning:
+
+1. Look up the repo's `customInstructions` from the database using the worktree's `repoID`.
+2. If non-nil and non-empty after trimming, append `--append-system-prompt '<escaped>'` to the command string.
+
+```swift
+// Pseudocode
+if let instructions = repo.customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines),
+   !instructions.isEmpty {
+    claudeCommand += " --append-system-prompt \(shellEscape(instructions))"
+}
+```
+
+### Conductor Sessions (ConductorManager.swift)
+
+Same logic at conductor start. The conductor's working directory is `~/.tbd/conductors/<name>/`, not a repo directory, so the injection must explicitly look up the repo. If the conductor's `repos` scope is a single repo ID, use that repo's instructions. If the scope is `["*"]` (all repos) or multiple repos, skip injection — there's no single set of instructions to apply.
+
+### Resumed Sessions
+
+`--resume` restores the full conversation including the original system prompt. Do NOT re-inject instructions on resume to avoid double-injection.
+
+### Shell Escaping
+
+Instructions are embedded in a tmux shell command string. Escape using single-quote wrapping with interior single quotes replaced by `'\''`:
+
+```swift
+func shellEscape(_ text: String) -> String {
+    "'" + text.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}
+```
+
+## UI
+
+### RepoDetailView (new file: TBDApp/RepoDetailView.swift)
+
+Replaces the `ArchivedWorktreesView(repoID:)` call in `ContentView.swift` line 30.
+
+```swift
+struct RepoDetailView: View {
+    let repoID: UUID
+
+    enum Tab: String, CaseIterable {
+        case archived = "Archived"
+        case instructions = "Instructions"
+    }
+
+    @State private var selectedTab: Tab = .archived
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Segmented control at top
+            Picker("", selection: $selectedTab) {
+                ForEach(Tab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            // Tab content
+            switch selectedTab {
+            case .archived:
+                ArchivedWorktreesView(repoID: repoID)
+            case .instructions:
+                RepoInstructionsView(repoID: repoID)
+            }
+        }
+    }
+}
+```
+
+### ContentView Change
+
+```swift
+// Before:
+ArchivedWorktreesView(repoID: repoID)
+
+// After:
+RepoDetailView(repoID: repoID)
+```
+
+### RepoInstructionsView (new file: TBDApp/RepoInstructionsView.swift)
+
+```
+┌─────────────────────────────────────────┐
+│  Custom Instructions                    │
+│  Added to all new Claude sessions in    │
+│  this repo via --append-system-prompt   │
+├─────────────────────────────────────────┤
+│                                         │
+│  ┌─────────────────────────────────┐    │
+│  │ TextEditor                      │    │
+│  │                                 │    │
+│  │ (placeholder when empty:        │    │
+│  │  "e.g. Always use pytest...")   │    │
+│  │                                 │    │
+│  └─────────────────────────────────┘    │
+│                                         │
+│                          Saved ✓  (fade)│
+└─────────────────────────────────────────┘
+```
+
+Behavior:
+- `@State var draft: String` initialized from `repo.customInstructions ?? ""`
+- Placeholder overlay that hides when draft is non-empty
+- `.onChange(of: draft)` triggers a debounced save (~1 second)
+- Calls `appState.updateRepoInstructions(repoID:instructions:)` on save
+- Subtle "Saved" text with a fade-in/fade-out animation after each successful save
+- Empty/whitespace-only text saves as `nil` (clears the instructions)
+
+## State & RPC Wiring
+
+### DaemonClient
+
+Add method:
+
+```swift
+func repoUpdateInstructions(repoID: UUID, customInstructions: String?) async throws
+```
+
+Wraps the `repo.updateInstructions` RPC call.
+
+### AppState
+
+Add method:
+
+```swift
+func updateRepoInstructions(repoID: UUID, instructions: String?) async {
+    try? await daemonClient.repoUpdateInstructions(repoID: repoID, customInstructions: instructions)
+    await refreshRepos()
+}
+```
+
+### RPCRouter (daemon side)
+
+Handle `repo.updateInstructions`:
+
+```swift
+case RPCMethod.repoUpdateInstructions:
+    let params = try decode(RepoUpdateInstructionsParams.self, from: request.params)
+    try await db.repos.update(id: params.repoID, customInstructions: params.customInstructions)
+    let repo = try await db.repos.get(id: params.repoID)
+    return encode(repo)
+```
+
+No new state subscriptions needed. Instructions only matter at spawn time (daemon-side read) and at edit time (app-side write).
+
+## Testing
+
+### DB Migration
+
+- Verify v11 migration adds `customInstructions` column
+- Existing repos have NULL instructions after migration
+- Can store and retrieve instructions text
+
+### Instruction Injection (branching conditional — both branches tested)
+
+- **With instructions**: when `customInstructions` is set, the spawned claude command includes `--append-system-prompt` with the instructions text
+- **Without instructions**: when `customInstructions` is nil or empty, the command does NOT include `--append-system-prompt`
+
+### Shell Escaping
+
+- Text with single quotes: `don't mock` → `'don'\''t mock'`
+- Text with double quotes: `use "pytest"` → correctly preserved
+- Text with newlines: multi-line instructions are escaped properly
+- Text with special shell characters: `$HOME`, backticks, etc.
+
+### Not Tested (UI)
+
+No existing SwiftUI test infrastructure. The segmented control, TextEditor, debounce, and save indicator are standard SwiftUI composition and are verified manually.

--- a/docs/superpowers/specs/2026-04-05-per-repo-instructions-design.md
+++ b/docs/superpowers/specs/2026-04-05-per-repo-instructions-design.md
@@ -6,42 +6,104 @@ Add configurable per-repo instructions that TBD injects into spawned Claude Code
 
 Users want project-specific conventions (testing frameworks, code style, forbidden patterns) applied to every Claude session in a repo. Today the only option is CLAUDE.md, which is committed to the repo and visible to all collaborators. Per-repo instructions in TBD are local, per-user, and managed through the app UI.
 
+Additionally, TBD creates worktrees with auto-generated adjective-animal names and `tbd/<name>` branches. Users want Claude to rename these to meaningful names on session start, following their preferred conventions — similar to how Conductor (conductor.build) handles branch renames.
+
+## Instruction Layers
+
+There are three distinct instruction layers, injected via `--append-system-prompt`:
+
+### 1. Rename Prompt (per-repo, user-editable, conditional)
+
+A prompt telling Claude to rename the git branch and TBD worktree display name on session start. Pre-populated with a sensible default that the user can fully customize.
+
+**When injected:** Only when the worktree hasn't been renamed yet — i.e., when `worktree.displayName == worktree.name` (the auto-generated adjective-animal name). Once anyone (Claude or the user) renames the worktree, this prompt stops firing for all sessions in that worktree.
+
+**Default prompt:**
+
+```
+To do immediately, before any other work:
+
+1. Rename the git branch to reflect the task:
+   git branch -m <new-branch-name>
+
+2. Rename the TBD worktree display name:
+   tbd worktree rename "$(basename "$(git rev-parse --show-toplevel)")" "<emoji> <display name>"
+
+Branch naming: use kebab-case, be concise (<30 chars), be specific.
+Display name: pick a relevant emoji, convert branch name to title case with spaces.
+
+Examples:
+  Branch: fix-login-timeout → Display: ⏱ Fix Login Timeout
+  Branch: add-export-csv   → Display: 📊 Add Export CSV
+
+Do this before reading files, using skills, or any other tools.
+```
+
+The user can edit this to add their own conventions (e.g., `cw/4/feat-{feature}` prefix, specific emoji rules, etc.).
+
+### 2. Built-in TBD Context (not user-editable, always injected)
+
+A system-level prompt that tells Claude it's running inside a TBD worktree and what CLI commands are available. Always injected on fresh sessions, not configurable by the user.
+
+```
+You are running inside a TBD-managed worktree. TBD is a macOS worktree + terminal manager.
+
+Available CLI commands:
+- tbd worktree rename "<worktree-name>" "<display-name>" — rename the worktree display name
+- tbd worktree list [--repo <id>] — list worktrees
+- tbd terminal create <worktree> [--cmd <command>] — create a new terminal
+- tbd terminal output <terminal-id> [--lines N] — read terminal output
+- tbd notify --type <type> [--message <msg>] — send notifications to TBD UI
+  Types: response_complete, error, task_complete, attention_needed
+
+Environment variables:
+- TBD_WORKTREE_ID — UUID of the current worktree (auto-set in all TBD terminals)
+```
+
+### 3. General Instructions (per-repo, user-editable, always injected)
+
+Freeform text for project conventions. Injected as user preferences after the TBD context.
+
 ## Data Model & Storage
 
 ### DB Migration v11
 
-Add a `customInstructions` TEXT column to the `repo` table, defaulting to NULL:
+Add two columns to the `repo` table:
 
 ```swift
 migrator.registerMigration("v11") { db in
     try db.alter(table: "repo") { t in
+        t.add(column: "renamePrompt", .text)
         t.add(column: "customInstructions", .text)
     }
 }
 ```
+
+Both default to NULL. NULL `renamePrompt` means "use the built-in default" (not "no rename prompt"). An explicitly empty string means "disabled."
 
 ### Shared Model (TBDShared/Models.swift)
 
 Add to `Repo`:
 
 ```swift
+public var renamePrompt: String?
 public var customInstructions: String?
 ```
 
-Must be optional so existing JSON/rows decode without error. Add to `init` with default `nil`. Add to the manual `init(from decoder:)` with `decodeIfPresent`.
+Both optional so existing JSON/rows decode without error. Add to `init` with default `nil`. Add to the manual `init(from decoder:)` with `decodeIfPresent`.
 
 ### RepoRecord (TBDDaemon/Database/RepoStore.swift)
 
-Add `customInstructions: String?` to `RepoRecord`. Update `init(from:)` and `toModel()` to map the field.
+Add both fields to `RepoRecord`. Update `init(from:)` and `toModel()` to map them.
 
 Add an update method:
 
 ```swift
-public func update(id: UUID, customInstructions: String?) async throws {
+public func updateInstructions(id: UUID, renamePrompt: String?, customInstructions: String?) async throws {
     try await writer.write { db in
         try db.execute(
-            sql: "UPDATE repo SET customInstructions = ? WHERE id = ?",
-            arguments: [customInstructions, id.uuidString]
+            sql: "UPDATE repo SET renamePrompt = ?, customInstructions = ? WHERE id = ?",
+            arguments: [renamePrompt, customInstructions, id.uuidString]
         )
     }
 }
@@ -57,40 +119,61 @@ public static let repoUpdateInstructions = "repo.updateInstructions"
 
 public struct RepoUpdateInstructionsParams: Codable, Sendable {
     public let repoID: UUID
+    public let renamePrompt: String?
     public let customInstructions: String?
-    public init(repoID: UUID, customInstructions: String?) {
+    public init(repoID: UUID, renamePrompt: String?, customInstructions: String?) {
         self.repoID = repoID
+        self.renamePrompt = renamePrompt
         self.customInstructions = customInstructions
     }
 }
 ```
 
-No separate read RPC needed — `repo.list` already returns `[Repo]` which will include `customInstructions` automatically.
+No separate read RPC needed — `repo.list` already returns `[Repo]` which will include both fields automatically.
 
 ## Instruction Injection
 
-### Fresh Claude Sessions (WorktreeLifecycle+Create.swift)
+### Composing the System Prompt
 
-In `setupTerminals()`, after building the base `claudeCommand` and before spawning:
-
-1. Look up the repo's `customInstructions` from the database using the worktree's `repoID`.
-2. If non-nil and non-empty after trimming, append `--append-system-prompt '<escaped>'` to the command string.
+At spawn time, build the appended system prompt by concatenating applicable layers:
 
 ```swift
-// Pseudocode
+var parts: [String] = []
+
+// Layer 1: Rename prompt (conditional)
+if worktree.displayName == worktree.name {
+    let renamePrompt = repo.renamePrompt ?? Self.defaultRenamePrompt
+    if !renamePrompt.isEmpty {
+        parts.append(renamePrompt)
+    }
+}
+
+// Layer 2: Built-in TBD context (always)
+parts.append(Self.builtInTBDContext)
+
+// Layer 3: User general instructions (if set)
 if let instructions = repo.customInstructions?.trimmingCharacters(in: .whitespacesAndNewlines),
    !instructions.isEmpty {
-    claudeCommand += " --append-system-prompt \(shellEscape(instructions))"
+    parts.append(instructions)
+}
+
+if !parts.isEmpty {
+    let combined = parts.joined(separator: "\n\n---\n\n")
+    claudeCommand += " --append-system-prompt \(shellEscape(combined))"
 }
 ```
 
-### Conductor Sessions (ConductorManager.swift)
+The default rename prompt and built-in TBD context are static strings defined on the lifecycle class.
 
-Same logic at conductor start. The conductor's working directory is `~/.tbd/conductors/<name>/`, not a repo directory, so the injection must explicitly look up the repo. If the conductor's `repos` scope is a single repo ID, use that repo's instructions. If the scope is `["*"]` (all repos) or multiple repos, skip injection — there's no single set of instructions to apply.
+### Where Injection Happens
 
-### Resumed Sessions
+**Fresh worktree Claude sessions** (`WorktreeLifecycle+Create.swift` `setupTerminals()`) — yes, with rename conditional check.
 
-`--resume` restores the full conversation including the original system prompt. Do NOT re-inject instructions on resume to avoid double-injection.
+**New Claude terminals** (`RPCRouter+TerminalHandlers.swift` terminal creation) — yes, same logic. This covers the case where a user opens a second Claude terminal before the first one has renamed.
+
+**Conductor sessions** (`ConductorManager.swift`) — inject layers 2 and 3 only (no rename prompt). If conductor's `repos` scope is a single repo ID, use that repo's instructions. If scope is `["*"]` or multiple repos, skip layer 3 (no single set of instructions to apply). Layer 2 (TBD context) is always injected.
+
+**Resumed sessions** (`--resume`) — no injection. The original session already has the prompt.
 
 ### Shell Escaping
 
@@ -121,7 +204,6 @@ struct RepoDetailView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Segmented control at top
             Picker("", selection: $selectedTab) {
                 ForEach(Tab.allCases, id: \.self) { tab in
                     Text(tab.rawValue).tag(tab)
@@ -133,7 +215,6 @@ struct RepoDetailView: View {
 
             Divider()
 
-            // Tab content
             switch selectedTab {
             case .archived:
                 ArchivedWorktreesView(repoID: repoID)
@@ -158,31 +239,43 @@ RepoDetailView(repoID: repoID)
 ### RepoInstructionsView (new file: TBDApp/RepoInstructionsView.swift)
 
 ```
-┌─────────────────────────────────────────┐
-│  Custom Instructions                    │
-│  Added to all new Claude sessions in    │
-│  this repo via --append-system-prompt   │
-├─────────────────────────────────────────┤
-│                                         │
-│  ┌─────────────────────────────────┐    │
-│  │ TextEditor                      │    │
-│  │                                 │    │
-│  │ (placeholder when empty:        │    │
-│  │  "e.g. Always use pytest...")   │    │
-│  │                                 │    │
-│  └─────────────────────────────────┘    │
-│                                         │
-│                          Saved ✓  (fade)│
-└─────────────────────────────────────────┘
+┌──────────────────────────────────────────────────┐
+│                                                  │
+│  Rename Prompt                                   │
+│  Sent with first message in worktrees that       │
+│  haven't been renamed yet                        │
+│                                                  │
+│  ┌────────────────────────────────────────────┐  │
+│  │ To do immediately, before any other work:  │  │
+│  │                                            │  │
+│  │ 1. Rename the git branch...               │  │
+│  │ 2. Rename the TBD worktree...             │  │
+│  │ ...                                       │  │
+│  └────────────────────────────────────────────┘  │
+│                                       [Reset]    │
+│                                                  │
+│  ──────────────────────────────────────────────  │
+│                                                  │
+│  General Instructions                            │
+│  Added to all new Claude sessions in this repo   │
+│                                                  │
+│  ┌────────────────────────────────────────────┐  │
+│  │ (placeholder: "e.g. Always use pytest...") │  │
+│  │                                            │  │
+│  │                                            │  │
+│  └────────────────────────────────────────────┘  │
+│                                                  │
+│                                    Saved ✓ (fade)│
+└──────────────────────────────────────────────────┘
 ```
 
 Behavior:
-- `@State var draft: String` initialized from `repo.customInstructions ?? ""`
-- Placeholder overlay that hides when draft is non-empty
-- `.onChange(of: draft)` triggers a debounced save (~1 second)
-- Calls `appState.updateRepoInstructions(repoID:instructions:)` on save
-- Subtle "Saved" text with a fade-in/fade-out animation after each successful save
-- Empty/whitespace-only text saves as `nil` (clears the instructions)
+- Two sections in a single scrollable view
+- **Rename prompt**: `TextEditor` pre-populated with the default rename prompt (or the user's saved version). A "Reset" button restores the default. Saving an empty string disables the rename prompt entirely.
+- **General instructions**: `TextEditor` with placeholder overlay, empty by default.
+- Both fields share the same debounced auto-save (~1 second). A single `Saved` indicator covers both.
+- Calls `appState.updateRepoInstructions(repoID:renamePrompt:customInstructions:)` on save.
+- `renamePrompt` saves as `nil` when it matches the default (so the DB only stores customizations). Saves as `""` (empty string) when the user explicitly clears it (disabling rename).
 
 ## State & RPC Wiring
 
@@ -191,7 +284,7 @@ Behavior:
 Add method:
 
 ```swift
-func repoUpdateInstructions(repoID: UUID, customInstructions: String?) async throws
+func repoUpdateInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async throws
 ```
 
 Wraps the `repo.updateInstructions` RPC call.
@@ -201,8 +294,10 @@ Wraps the `repo.updateInstructions` RPC call.
 Add method:
 
 ```swift
-func updateRepoInstructions(repoID: UUID, instructions: String?) async {
-    try? await daemonClient.repoUpdateInstructions(repoID: repoID, customInstructions: instructions)
+func updateRepoInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async {
+    try? await daemonClient.repoUpdateInstructions(
+        repoID: repoID, renamePrompt: renamePrompt, customInstructions: customInstructions
+    )
     await refreshRepos()
 }
 ```
@@ -214,7 +309,11 @@ Handle `repo.updateInstructions`:
 ```swift
 case RPCMethod.repoUpdateInstructions:
     let params = try decode(RepoUpdateInstructionsParams.self, from: request.params)
-    try await db.repos.update(id: params.repoID, customInstructions: params.customInstructions)
+    try await db.repos.updateInstructions(
+        id: params.repoID,
+        renamePrompt: params.renamePrompt,
+        customInstructions: params.customInstructions
+    )
     let repo = try await db.repos.get(id: params.repoID)
     return encode(repo)
 ```
@@ -225,14 +324,25 @@ No new state subscriptions needed. Instructions only matter at spawn time (daemo
 
 ### DB Migration
 
-- Verify v11 migration adds `customInstructions` column
-- Existing repos have NULL instructions after migration
-- Can store and retrieve instructions text
+- Verify v11 migration adds both `renamePrompt` and `customInstructions` columns
+- Existing repos have NULL for both after migration
+- Can store and retrieve both fields
 
-### Instruction Injection (branching conditional — both branches tested)
+### Rename Prompt Conditional (branching — both branches tested)
 
-- **With instructions**: when `customInstructions` is set, the spawned claude command includes `--append-system-prompt` with the instructions text
-- **Without instructions**: when `customInstructions` is nil or empty, the command does NOT include `--append-system-prompt`
+- **Worktree not renamed** (`displayName == name`): rename prompt is included in the appended system prompt
+- **Worktree already renamed** (`displayName != name`): rename prompt is NOT included
+- **Rename prompt explicitly disabled** (empty string in DB): rename prompt is NOT included even if worktree hasn't been renamed
+
+### General Instructions Injection (branching — both branches tested)
+
+- **With instructions**: when `customInstructions` is set, the spawned command includes it in `--append-system-prompt`
+- **Without instructions**: when `customInstructions` is nil or empty, it is omitted
+
+### Built-in TBD Context
+
+- Always present in the appended system prompt for fresh sessions
+- Not present for resumed sessions
 
 ### Shell Escaping
 
@@ -243,4 +353,4 @@ No new state subscriptions needed. Instructions only matter at spawn time (daemo
 
 ### Not Tested (UI)
 
-No existing SwiftUI test infrastructure. The segmented control, TextEditor, debounce, and save indicator are standard SwiftUI composition and are verified manually.
+No existing SwiftUI test infrastructure. The segmented control, text editors, debounce, and save indicator are standard SwiftUI composition and are verified manually.


### PR DESCRIPTION
## Summary
- Adds configurable per-repo instructions (rename prompt + general instructions) that TBD injects into spawned Claude Code sessions via `--append-system-prompt`, without modifying CLAUDE.md files
- Three instruction layers: conditional rename prompt (fires when worktree hasn't been renamed yet), built-in TBD context (always injected, tells Claude about available CLI commands), and user-editable general instructions
- New repo detail view with segmented control (Archived | Instructions) replaces the archived worktrees view when clicking a repo name in the sidebar

## Test plan
- [ ] Verify `swift test` passes (224 tests including new RPC, SystemPromptBuilder, and shell escaping tests)
- [ ] Create a worktree, verify Claude session receives the rename prompt and TBD context in system prompt
- [ ] Rename the worktree, create a new Claude terminal — verify rename prompt no longer fires
- [ ] Click a repo name in sidebar, verify segmented control appears with Archived and Instructions tabs
- [ ] Edit rename prompt and general instructions, verify debounced auto-save with "Saved" indicator
- [ ] Reset rename prompt to default, verify it saves as nil (uses built-in default)
- [ ] Clear rename prompt entirely, verify it disables rename injection