### PR TITLE
Feat: Run multiple Claude accounts side-by-side in TBD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,13 @@ The main chat session agent should not write code directly. Delegate all impleme
 - Run `swift test` if you changed daemon or shared code.
 - When adding a branching conditional that gates behavior (feature flags, toggles, mode switches), add a test for each branch. Verify the gated behavior is off when the flag is off, and that ungated behavior still works.
 
+### Restart must use the worktree's own script
+Always run `scripts/restart.sh` (relative, from the worktree cwd), never an absolute path to the main project's copy. Using `/Users/chang/projects/tbd/scripts/restart.sh` builds and starts binaries from the main branch, leaving old worktree processes running and causing "Unknown method" RPC errors. After any restart, verify with:
+```
+ps aux | grep -E "\.build/debug/TBD" | grep -v grep
+```
+There should be exactly one `TBDDaemon` and one `TBDApp`, both from the worktree path. If stale processes exist: `pkill -f TBDDaemon; pkill -f TBDApp` then re-run `scripts/restart.sh`.
+
 ## Critical Rules
 
 ### NEVER delete ~/.tbd/state.db

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
                 "TBDDaemonLib",
             ],
             path: "Sources/TBDDaemon",
-            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Conductor", "Daemon.swift", "PIDFile.swift"],
+            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Conductor", "Keychain", "Daemon.swift", "PIDFile.swift"],
             sources: ["main.swift"]
         ),
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
                 "TBDDaemonLib",
             ],
             path: "Sources/TBDDaemon",
-            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Conductor", "Keychain", "Daemon.swift", "PIDFile.swift"],
+            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Conductor", "Keychain", "Claude", "Daemon.swift", "PIDFile.swift"],
             sources: ["main.swift"]
         ),
         .executableTarget(

--- a/Sources/TBDApp/AppState+ClaudeTokens.swift
+++ b/Sources/TBDApp/AppState+ClaudeTokens.swift
@@ -1,0 +1,119 @@
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "AppState+ClaudeTokens")
+
+extension AppState {
+    // MARK: - Claude Token Actions
+    //
+    // IMPORTANT: never include the raw token string in any logger / alert
+    // message. The `addClaudeToken` helper accepts the token as a parameter
+    // and forwards it directly to the daemon — that is the only place a
+    // secret crosses the boundary in the app process.
+
+    /// Refresh the full Claude token list and global default ID from the daemon.
+    func refreshClaudeTokens() async {
+        do {
+            let result = try await daemonClient.listClaudeTokens()
+            if result.tokens != claudeTokens {
+                claudeTokens = result.tokens
+            }
+            if result.defaultID != globalDefaultClaudeTokenID {
+                globalDefaultClaudeTokenID = result.defaultID
+            }
+        } catch {
+            logger.error("Failed to list Claude tokens: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
+    /// Add a new Claude token. Returns the daemon's warning string (if any).
+    /// On error sets `alertMessage` and returns nil. The raw token bytes are
+    /// not included in any log or alert.
+    @discardableResult
+    func addClaudeToken(name: String, token: String) async -> String? {
+        do {
+            let result = try await daemonClient.addClaudeToken(name: name, token: token)
+            await refreshClaudeTokens()
+            return result.warning
+        } catch {
+            logger.error("Failed to add Claude token (name=\(name)): \(error)")
+            showAlert("Failed to add Claude token: \(error.localizedDescription)", isError: true)
+            return nil
+        }
+    }
+
+    /// Delete a Claude token by ID.
+    func deleteClaudeToken(id: UUID) async {
+        do {
+            try await daemonClient.deleteClaudeToken(id: id)
+            await refreshClaudeTokens()
+        } catch {
+            logger.error("Failed to delete Claude token: \(error)")
+            showAlert("Failed to delete Claude token: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Rename a Claude token.
+    func renameClaudeToken(id: UUID, name: String) async {
+        do {
+            try await daemonClient.renameClaudeToken(id: id, name: name)
+            await refreshClaudeTokens()
+        } catch {
+            logger.error("Failed to rename Claude token: \(error)")
+            showAlert("Failed to rename Claude token: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set or clear the global default Claude token.
+    func setGlobalDefaultClaudeToken(id: UUID?) async {
+        do {
+            try await daemonClient.setGlobalDefaultClaudeToken(id: id)
+            globalDefaultClaudeTokenID = id
+        } catch {
+            logger.error("Failed to set global default Claude token: \(error)")
+            showAlert("Failed to set default Claude token: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set or clear a per-repo Claude token override.
+    func setRepoClaudeTokenOverride(repoID: UUID, tokenID: UUID?) async {
+        do {
+            try await daemonClient.setRepoClaudeTokenOverride(repoID: repoID, tokenID: tokenID)
+            // Optimistically update local repo state
+            if let idx = repos.firstIndex(where: { $0.id == repoID }) {
+                var repo = repos[idx]
+                repo.claudeTokenOverrideID = tokenID
+                repos[idx] = repo
+            }
+        } catch {
+            logger.error("Failed to set repo Claude token override: \(error)")
+            showAlert("Failed to set repo Claude token: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Swap the Claude token associated with a running terminal.
+    func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?) async {
+        do {
+            try await daemonClient.swapClaudeTokenOnTerminal(terminalID: terminalID, newTokenID: newTokenID)
+        } catch {
+            logger.error("Failed to swap Claude token on terminal: \(error)")
+            showAlert("Failed to swap Claude token: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Fetch fresh usage for a single Claude token and merge it into local state.
+    func fetchClaudeTokenUsage(id: UUID) async {
+        do {
+            let usage = try await daemonClient.fetchClaudeTokenUsage(id: id)
+            if let idx = claudeTokens.firstIndex(where: { $0.token.id == id }) {
+                let existing = claudeTokens[idx]
+                claudeTokens[idx] = ClaudeTokenWithUsage(token: existing.token, usage: usage)
+            }
+        } catch {
+            logger.error("Failed to fetch Claude token usage: \(error)")
+            showAlert("Failed to fetch token usage: \(error.localizedDescription)", isError: true)
+        }
+    }
+}

--- a/Sources/TBDApp/AppState+ClaudeTokens.swift
+++ b/Sources/TBDApp/AppState+ClaudeTokens.swift
@@ -94,9 +94,16 @@ extension AppState {
     }
 
     /// Swap the Claude token associated with a running terminal.
+    /// The daemon forks a new tmux tab; this method adds the new terminal and tab to local state
+    /// and selects it so the UI switches immediately.
     func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?) async {
         do {
-            try await daemonClient.swapClaudeTokenOnTerminal(terminalID: terminalID, newTokenID: newTokenID)
+            let newTerminal = try await daemonClient.swapClaudeTokenOnTerminal(terminalID: terminalID, newTokenID: newTokenID)
+            let worktreeID = newTerminal.worktreeID
+            terminals[worktreeID, default: []].append(newTerminal)
+            let newTab = Tab(id: newTerminal.id, content: .terminal(terminalID: newTerminal.id))
+            tabs[worktreeID, default: []].append(newTab)
+            selectedTabIndex[worktreeID] = (tabs[worktreeID]?.count ?? 1) - 1
         } catch {
             logger.error("Failed to swap Claude token on terminal: \(error)")
             showAlert("Failed to swap Claude token: \(error.localizedDescription)", isError: true)

--- a/Sources/TBDApp/AppState+ClaudeTokens.swift
+++ b/Sources/TBDApp/AppState+ClaudeTokens.swift
@@ -103,7 +103,7 @@ extension AppState {
             terminals[worktreeID, default: []].append(newTerminal)
             let newTab = Tab(id: newTerminal.id, content: .terminal(terminalID: newTerminal.id))
             tabs[worktreeID, default: []].append(newTab)
-            selectedTabIndex[worktreeID] = (tabs[worktreeID]?.count ?? 1) - 1
+            activeTabIndices[worktreeID] = (tabs[worktreeID]?.count ?? 1) - 1
         } catch {
             logger.error("Failed to swap Claude token on terminal: \(error)")
             showAlert("Failed to swap Claude token: \(error.localizedDescription)", isError: true)

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -94,11 +94,12 @@ extension AppState {
     }
 
     /// Fork a Claude terminal by resuming from an existing session ID.
-    func forkClaudeTerminal(worktreeID: UUID, sessionID: String) async {
+    func forkClaudeTerminal(worktreeID: UUID, sessionID: String, tokenID: UUID? = nil) async {
         do {
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
-                resumeSessionID: sessionID
+                resumeSessionID: sessionID,
+                overrideTokenID: tokenID
             )
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -96,10 +96,7 @@ final class AppState: ObservableObject {
     @Published var conductorHeight: CGFloat = 0 {
         didSet { UserDefaults.standard.set(Double(conductorHeight), forKey: Self.conductorHeightKey) }
     }
-    /// Remembers selected tab index per worktree so switching back restores the tab.
-    @Published var selectedTabIndex: [UUID: Int] = [:]
-
-    /// Terminal IDs currently being recreated — prevents duplicate RPC calls.
+/// Terminal IDs currently being recreated — prevents duplicate RPC calls.
     var recreatingTerminalIDs: Set<UUID> = []
 
     // Alert state for user feedback

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -81,6 +81,8 @@ final class AppState: ObservableObject {
     @Published var editingWorktreeID: UUID? = nil
     @Published var isRenamingWorktree = false
     @Published var prStatuses: [UUID: PRStatus] = [:]
+    @Published var claudeTokens: [ClaudeTokenWithUsage] = []
+    @Published var globalDefaultClaudeTokenID: UUID? = nil
 
     /// Conductor for each repo (wildcard conductors expanded across all repos).
     @Published var conductorsByRepo: [UUID: Conductor] = [:]
@@ -117,6 +119,7 @@ final class AppState: ObservableObject {
     private static let conductorHeightKey = "com.tbd.app.conductorHeight"
 
     private var memoryPressureSource: DispatchSourceMemoryPressure?
+    private var focusObservers: [NSObjectProtocol] = []
 
     init() {
         restoreLayouts()
@@ -127,10 +130,55 @@ final class AppState: ObservableObject {
             conductorHeight = max(100, min(800, CGFloat(savedHeight)))
         }
         startMemoryPressureMonitor()
+        registerFocusObservers()
         Task {
             await connectAndLoadInitialState()
             startPolling()
         }
+    }
+
+    // Note: AppState is singleton-lifetime in this app, so we deliberately
+    // omit a deinit that removes the focus observers — Swift 6 concurrency
+    // would require Sendable on the observer tokens to touch them from a
+    // nonisolated deinit, and the leak is bounded by app lifetime.
+
+    /// Forward macOS app focus changes to the daemon. The daemon uses this to
+    /// pause/resume the Claude usage poller while the app is in the background.
+    /// `NotificationCenter.addObserver` does not require a bundle ID, so this
+    /// is safe to call from an unbundled SPM executable.
+    private func registerFocusObservers() {
+        let center = NotificationCenter.default
+        let active = center.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await self.daemonClient.setAppForegroundState(isForeground: true)
+                } catch {
+                    logger.warning("setAppForegroundState(true) failed: \(error)")
+                }
+            }
+        }
+        let resigned = center.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await self.daemonClient.setAppForegroundState(isForeground: false)
+                } catch {
+                    logger.warning("setAppForegroundState(false) failed: \(error)")
+                }
+            }
+        }
+        focusObservers = [active, resigned]
     }
 
     /// Respond to system memory pressure by purging purgeable caches.
@@ -197,13 +245,27 @@ final class AppState: ObservableObject {
         subscriptionTask = nil
     }
 
-    private func handleDelta(_ delta: StateDelta) {
+    func handleDelta(_ delta: StateDelta) {
         switch delta {
         case .notificationReceived(let notification):
             handleNotificationDelta(notification)
+        case .claudeTokenUsageUpdated(let usage):
+            applyClaudeTokenUsageDelta(usage)
+        case .claudeTokensChanged:
+            Task { [weak self] in await self?.refreshClaudeTokens() }
         default:
             break
         }
+    }
+
+    /// Update the in-place usage entry for a single Claude token. If no match,
+    /// silently ignore — the next full refresh will pick it up.
+    private func applyClaudeTokenUsageDelta(_ usage: ClaudeTokenUsage) {
+        guard let idx = claudeTokens.firstIndex(where: { $0.token.id == usage.tokenID }) else {
+            return
+        }
+        let existing = claudeTokens[idx]
+        claudeTokens[idx] = ClaudeTokenWithUsage(token: existing.token, usage: usage)
     }
 
     private func handleNotificationDelta(_ notification: NotificationDelta) {
@@ -262,6 +324,7 @@ final class AppState: ObservableObject {
         isConnected = didConnect
         if didConnect {
             await refreshAll()
+            await refreshClaudeTokens()
             startSubscription()
             await refreshPRStatuses()
             Task {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -10,7 +10,7 @@ import os
 private let daemonClientLogger = Logger(subsystem: "com.tbd.app", category: "DaemonClient")
 
 /// Errors from the DaemonClient.
-enum DaemonClientError: Error, CustomStringConvertible, Sendable {
+enum DaemonClientError: Error, CustomStringConvertible, LocalizedError, Sendable {
     case daemonNotRunning
     case connectionFailed(String)
     case sendFailed(String)
@@ -34,6 +34,8 @@ enum DaemonClientError: Error, CustomStringConvertible, Sendable {
             return "RPC error: \(msg)"
         }
     }
+
+    var errorDescription: String? { description }
 }
 
 /// Actor that communicates with the TBD daemon over a Unix domain socket.
@@ -227,7 +229,18 @@ actor DaemonClient {
             while true {
                 let bytesRead = recv(fd, buffer, bufferSize, 0)
                 if bytesRead < 0 {
-                    throw DaemonClientError.receiveFailed("recv failed with errno \(errno)")
+                    let savedErrno = errno
+                    // Retry transient interruptions. Blocking recv on a Unix
+                    // socket can be kicked out with EINTR when the app process
+                    // services signals (GCD timers, Combine, etc.) during a
+                    // long handler like claudeToken.add where the daemon is
+                    // itself waiting on a network round-trip to Anthropic.
+                    if savedErrno == EINTR || savedErrno == EAGAIN {
+                        continue
+                    }
+                    throw DaemonClientError.receiveFailed(
+                        "recv failed with errno \(savedErrno) (\(String(cString: strerror(savedErrno))))"
+                    )
                 }
                 if bytesRead == 0 {
                     break

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -668,4 +668,82 @@ actor DaemonClient {
             params: ConductorNameParams(name: name)
         )
     }
+
+    // MARK: - Claude Tokens
+    //
+    // IMPORTANT: never log raw token bytes. The `addClaudeToken` wrapper is
+    // the only place a secret token crosses the actor boundary in the app
+    // process — keep it out of any logger / print statement.
+
+    /// List all Claude tokens with cached usage and the global default ID.
+    func listClaudeTokens() throws -> ClaudeTokenListResult {
+        return try callNoParams(method: RPCMethod.claudeTokenList, resultType: ClaudeTokenListResult.self)
+    }
+
+    /// Add a Claude token. The raw token string MUST NOT be logged.
+    func addClaudeToken(name: String, token: String) throws -> ClaudeTokenAddResult {
+        return try call(
+            method: RPCMethod.claudeTokenAdd,
+            params: ClaudeTokenAddParams(name: name, token: token),
+            resultType: ClaudeTokenAddResult.self
+        )
+    }
+
+    /// Delete a Claude token by ID.
+    func deleteClaudeToken(id: UUID) throws {
+        try callVoid(
+            method: RPCMethod.claudeTokenDelete,
+            params: ClaudeTokenDeleteParams(id: id)
+        )
+    }
+
+    /// Rename a Claude token.
+    func renameClaudeToken(id: UUID, name: String) throws {
+        try callVoid(
+            method: RPCMethod.claudeTokenRename,
+            params: ClaudeTokenRenameParams(id: id, name: name)
+        )
+    }
+
+    /// Set or clear the global default Claude token.
+    func setGlobalDefaultClaudeToken(id: UUID?) throws {
+        try callVoid(
+            method: RPCMethod.claudeTokenSetGlobalDefault,
+            params: ClaudeTokenSetGlobalDefaultParams(id: id)
+        )
+    }
+
+    /// Set or clear a per-repo Claude token override.
+    func setRepoClaudeTokenOverride(repoID: UUID, tokenID: UUID?) throws {
+        try callVoid(
+            method: RPCMethod.claudeTokenSetRepoOverride,
+            params: ClaudeTokenSetRepoOverrideParams(repoID: repoID, tokenID: tokenID)
+        )
+    }
+
+    /// Fetch fresh usage for a single Claude token (60s server-side dedupe).
+    func fetchClaudeTokenUsage(id: UUID) throws -> ClaudeTokenUsage {
+        let result = try call(
+            method: RPCMethod.claudeTokenFetchUsage,
+            params: ClaudeTokenFetchUsageParams(id: id),
+            resultType: ClaudeTokenFetchUsageResult.self
+        )
+        return result.usage
+    }
+
+    /// Swap the Claude token associated with a running terminal.
+    func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?) throws {
+        try callVoid(
+            method: RPCMethod.terminalSwapClaudeToken,
+            params: TerminalSwapClaudeTokenParams(terminalID: terminalID, newTokenID: newTokenID)
+        )
+    }
+
+    /// Notify the daemon whether the app is in the foreground (drives usage poller).
+    func setAppForegroundState(isForeground: Bool) throws {
+        try callVoid(
+            method: RPCMethod.appSetForegroundState,
+            params: AppSetForegroundStateParams(isForeground: isForeground)
+        )
+    }
 }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -389,10 +389,10 @@ actor DaemonClient {
     }
 
     /// Create a terminal in a worktree.
-    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil) throws -> Terminal {
+    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, overrideTokenID: UUID? = nil) throws -> Terminal {
         return try call(
             method: RPCMethod.terminalCreate,
-            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, resumeSessionID: resumeSessionID),
+            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, resumeSessionID: resumeSessionID, overrideTokenID: overrideTokenID),
             resultType: Terminal.self
         )
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -745,10 +745,12 @@ actor DaemonClient {
     }
 
     /// Swap the Claude token associated with a running terminal.
-    func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?) throws {
-        try callVoid(
+    /// Returns the newly created Terminal (the daemon forks a new tab).
+    func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?) throws -> Terminal {
+        return try call(
             method: RPCMethod.terminalSwapClaudeToken,
-            params: TerminalSwapClaudeTokenParams(terminalID: terminalID, newTokenID: newTokenID)
+            params: TerminalSwapClaudeTokenParams(terminalID: terminalID, newTokenID: newTokenID),
+            resultType: Terminal.self
         )
     }
 

--- a/Sources/TBDApp/MenuBar/ClaudeTokenMenu.swift
+++ b/Sources/TBDApp/MenuBar/ClaudeTokenMenu.swift
@@ -37,7 +37,7 @@ private struct ClaudeTokenMenuContent: View {
             if appState.globalDefaultClaudeTokenID == nil {
                 Label("Default (logged in)          —", systemImage: "checkmark")
             } else {
-                Text("Default (logged in)          —")
+                Text("Default (logged in)")
             }
         }
 
@@ -67,15 +67,10 @@ private struct ClaudeTokenMenuContent: View {
         }
     }
 
-    /// Format a token row as `name  5h NN% · 7d NN%`. Returns `—` placeholder
-    /// when usage is nil or the token is an api_key (no usage available).
+    /// Format a token row. Usage display is currently disabled (the
+    /// `/api/oauth/usage` endpoint requires a `user:profile` scope that
+    /// `claude setup-token` does not grant), so we render the bare name.
     private static func formatRow(entry: ClaudeTokenWithUsage) -> String {
-        let name = entry.token.name
-        guard entry.token.kind == .oauth, let usage = entry.usage else {
-            return "\(name)          —"
-        }
-        let five = usage.fiveHourPct.map { String(format: "5h %2.0f%%", $0 * 100) } ?? "5h —"
-        let seven = usage.sevenDayPct.map { String(format: "7d %2.0f%%", $0 * 100) } ?? "7d —"
-        return "\(name)  \(five) · \(seven)"
+        entry.token.name
     }
 }

--- a/Sources/TBDApp/MenuBar/ClaudeTokenMenu.swift
+++ b/Sources/TBDApp/MenuBar/ClaudeTokenMenu.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import AppKit
+import TBDShared
+
+/// Menu bar "Claude Token" submenu. Shows the keychain login fallback as
+/// "Default (logged in)", followed by each stored token with its 5h / 7d
+/// usage. The current global default has a checkmark. Selecting a row
+/// updates the global default (affects new spawns only — running terminals
+/// keep their resolved token).
+///
+/// Tab pre-selection in Settings is deferred — "Manage tokens…" simply
+/// opens the Settings window and the user clicks the Claude Tokens tab.
+struct ClaudeTokenMenu: Commands {
+    @ObservedObject var appState: AppState
+
+    var body: some Commands {
+        CommandMenu("Claude Token") {
+            ClaudeTokenMenuContent()
+                .environmentObject(appState)
+        }
+    }
+}
+
+/// Extracted into a `View` so SwiftUI re-renders the menu body when
+/// `@Published` properties on `AppState` change. `Commands` bodies do not
+/// always observe `@ObservedObject` mutations reliably for nested content.
+private struct ClaudeTokenMenuContent: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        // Default (keychain login fallback) row
+        Button(action: {
+            Task { @MainActor in
+                await appState.setGlobalDefaultClaudeToken(id: nil)
+            }
+        }) {
+            if appState.globalDefaultClaudeTokenID == nil {
+                Label("Default (logged in)          —", systemImage: "checkmark")
+            } else {
+                Text("Default (logged in)          —")
+            }
+        }
+
+        ForEach(appState.claudeTokens, id: \.token.id) { entry in
+            let tokenID = entry.token.id
+            Button(action: {
+                Task { @MainActor in
+                    await appState.setGlobalDefaultClaudeToken(id: tokenID)
+                }
+            }) {
+                if appState.globalDefaultClaudeTokenID == tokenID {
+                    Label(Self.formatRow(entry: entry), systemImage: "checkmark")
+                } else {
+                    Text(Self.formatRow(entry: entry))
+                }
+            }
+        }
+
+        Divider()
+
+        Button("Manage tokens…") {
+            NSApp.sendAction(
+                Selector(("showSettingsWindow:")),
+                to: nil,
+                from: nil
+            )
+        }
+    }
+
+    /// Format a token row as `name  5h NN% · 7d NN%`. Returns `—` placeholder
+    /// when usage is nil or the token is an api_key (no usage available).
+    private static func formatRow(entry: ClaudeTokenWithUsage) -> String {
+        let name = entry.token.name
+        guard entry.token.kind == .oauth, let usage = entry.usage else {
+            return "\(name)          —"
+        }
+        let five = usage.fiveHourPct.map { String(format: "5h %2.0f%%", $0 * 100) } ?? "5h —"
+        let seven = usage.sevenDayPct.map { String(format: "7d %2.0f%%", $0 * 100) } ?? "7d —"
+        return "\(name)  \(five) · \(seven)"
+    }
+}

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -7,6 +7,7 @@ struct RepoDetailView: View {
     enum Tab: String, CaseIterable {
         case archived = "Archived"
         case instructions = "Instructions"
+        case settings = "Settings"
     }
 
     @State private var selectedTab: Tab = .archived
@@ -19,7 +20,7 @@ struct RepoDetailView: View {
                 }
             }
             .pickerStyle(.segmented)
-            .frame(width: 240)
+            .frame(width: 340)
             .padding(.vertical, 12)
 
             Divider()
@@ -30,7 +31,64 @@ struct RepoDetailView: View {
             case .instructions:
                 RepoInstructionsView(repoID: repoID)
                     .id(repoID)
+            case .settings:
+                RepoSettingsView(repoID: repoID)
             }
         }
+    }
+}
+
+struct RepoSettingsView: View {
+    let repoID: UUID
+    @EnvironmentObject var appState: AppState
+
+    private var repo: Repo? {
+        appState.repos.first { $0.id == repoID }
+    }
+
+    var body: some View {
+        if let repo = repo {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Picker("Claude token", selection: tokenOverrideBinding(repo: repo)) {
+                        Text("Inherit global default").tag(UUID?.none)
+                        ForEach(appState.claudeTokens, id: \.token.id) { entry in
+                            Text(entry.token.name).tag(UUID?.some(entry.token.id))
+                        }
+                    }
+                    .pickerStyle(.menu)
+
+                    if let caption = tokenOverrideCaption(repo: repo) {
+                        Text(caption)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+
+    private func tokenOverrideBinding(repo: Repo) -> Binding<UUID?> {
+        Binding(
+            get: { repo.claudeTokenOverrideID },
+            set: { newValue in
+                Task {
+                    await appState.setRepoClaudeTokenOverride(repoID: repo.id, tokenID: newValue)
+                }
+            }
+        )
+    }
+
+    private func tokenOverrideCaption(repo: Repo) -> String? {
+        if let overrideID = repo.claudeTokenOverrideID {
+            let name = appState.claudeTokens.first(where: { $0.token.id == overrideID })?.token.name ?? "Unknown token"
+            return "Overriding with: \(name)"
+        }
+        if let defaultID = appState.globalDefaultClaudeTokenID,
+           let name = appState.claudeTokens.first(where: { $0.token.id == defaultID })?.token.name {
+            return "Inheriting: \(name)"
+        }
+        return "Inheriting: Default (claude keychain login)"
     }
 }

--- a/Sources/TBDApp/Settings/ClaudeTokensSettingsView.swift
+++ b/Sources/TBDApp/Settings/ClaudeTokensSettingsView.swift
@@ -109,9 +109,6 @@ struct ClaudeTokenRow: View {
             nameView
             kindBadge
             Spacer()
-            statusBadges
-            usageView
-            timestampView
             menuButton
         }
         .contentShape(Rectangle())
@@ -160,21 +157,25 @@ struct ClaudeTokenRow: View {
 
     @ViewBuilder
     private var statusBadges: some View {
-        if usage?.lastStatus == "http_401" {
-            Text("Invalid")
-                .font(.caption2).bold()
-                .padding(.horizontal, 6).padding(.vertical, 2)
-                .background(Color.red.opacity(0.2))
-                .foregroundColor(.red)
-                .clipShape(Capsule())
-        } else if usage?.lastStatus == "http_429" {
-            Text("Stale")
-                .font(.caption2).bold()
-                .padding(.horizontal, 6).padding(.vertical, 2)
-                .background(Color.orange.opacity(0.2))
-                .foregroundColor(.orange)
-                .clipShape(Capsule())
+        switch usage?.lastStatus {
+        case "http_401", "http401":
+            badge("Invalid", color: .red)
+        case "http_429", "http429":
+            badge("Stale", color: .orange)
+        case "network_error", "decode_error":
+            badge("Unverified", color: .orange)
+        default:
+            EmptyView()
         }
+    }
+
+    private func badge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption2).bold()
+            .padding(.horizontal, 6).padding(.vertical, 2)
+            .background(color.opacity(0.2))
+            .foregroundColor(color)
+            .clipShape(Capsule())
     }
 
     @ViewBuilder
@@ -327,10 +328,11 @@ struct AddClaudeTokenSheet: View {
                     appState.alertMessage = priorAlert
                     return
                 }
-                if let warning {
-                    errorMessage = warning
-                    return
-                }
+                // Token was saved. A non-nil `warning` means the daemon could
+                // not verify the token's quota with Anthropic but stored it
+                // anyway — surface that to the user via the row's status
+                // badge, not as a red error in this modal. Dismiss either way.
+                _ = warning
                 dismiss()
             }
         }

--- a/Sources/TBDApp/Settings/ClaudeTokensSettingsView.swift
+++ b/Sources/TBDApp/Settings/ClaudeTokensSettingsView.swift
@@ -158,9 +158,9 @@ struct ClaudeTokenRow: View {
     @ViewBuilder
     private var statusBadges: some View {
         switch usage?.lastStatus {
-        case "http_401", "http401":
+        case "http_401":
             badge("Invalid", color: .red)
-        case "http_429", "http429":
+        case "http_429":
             badge("Stale", color: .orange)
         case "network_error", "decode_error":
             badge("Unverified", color: .orange)

--- a/Sources/TBDApp/Settings/ClaudeTokensSettingsView.swift
+++ b/Sources/TBDApp/Settings/ClaudeTokensSettingsView.swift
@@ -1,0 +1,338 @@
+// ClaudeTokensSettingsView
+//
+// Settings tab for managing Claude tokens. SwiftUI-only; no automated tests.
+//
+// Manual verification steps:
+// 1. Open Settings → Claude Tokens. Empty state shows only "Default (claude
+//    keychain login)" in the global default picker.
+// 2. Click "Add token". The modal opens with Name + Token (SecureField) and
+//    helper text mentioning `claude setup-token`. Save is disabled until both
+//    fields are filled and the name is not a duplicate.
+// 3. Enter a name + paste a real `sk-ant-oat01-...` token. Spinner shows in
+//    the Save button while saving, then the modal dismisses on success.
+// 4. The new row shows the name, an OAuth/API key badge, and (after the next
+//    refresh) `5h X% · 7d Y%`. Hovering the percentages shows a tooltip with
+//    `Resets in Xh Ym` for each window.
+// 5. Double-click the row's name to inline-rename. Enter commits, Esc cancels.
+// 6. The trailing `…` menu offers "Set as global default", "Rename…", and
+//    "Delete…". Set-as-default updates the header picker.
+// 7. Delete… opens a confirm. If any running terminals use this token the
+//    copy includes the count from `appState.terminals`.
+// 8. Force `last_status = http_401` in the DB → red "Invalid" badge.
+//    Force `last_status = http_429` → amber "Stale" badge.
+
+import SwiftUI
+import TBDShared
+
+struct ClaudeTokensSettingsView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var showAddSheet = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            globalDefaultHeader
+            Divider()
+            tokenList
+            Spacer()
+            addButton
+        }
+        .padding(20)
+        .task { await appState.refreshClaudeTokens() }
+        .sheet(isPresented: $showAddSheet) {
+            AddClaudeTokenSheet()
+                .environmentObject(appState)
+        }
+    }
+
+    private var globalDefaultHeader: some View {
+        HStack {
+            Text("Global default:")
+                .font(.headline)
+            Picker("", selection: Binding(
+                get: { appState.globalDefaultClaudeTokenID },
+                set: { newValue in
+                    Task { await appState.setGlobalDefaultClaudeToken(id: newValue) }
+                }
+            )) {
+                Text("Default (claude keychain login)").tag(UUID?.none)
+                ForEach(appState.claudeTokens, id: \.token.id) { entry in
+                    Text(entry.token.name).tag(UUID?.some(entry.token.id))
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            Spacer()
+        }
+    }
+
+    private var tokenList: some View {
+        List {
+            ForEach(appState.claudeTokens, id: \.token.id) { entry in
+                ClaudeTokenRow(entry: entry)
+                    .environmentObject(appState)
+            }
+        }
+        .listStyle(.inset)
+        .frame(minHeight: 200)
+    }
+
+    private var addButton: some View {
+        Button {
+            showAddSheet = true
+        } label: {
+            Label("Add token", systemImage: "plus")
+        }
+    }
+}
+
+// MARK: - Row
+
+struct ClaudeTokenRow: View {
+    @EnvironmentObject var appState: AppState
+    let entry: ClaudeTokenWithUsage
+
+    @State private var isEditingName = false
+    @State private var draftName = ""
+    @State private var showDeleteConfirm = false
+
+    private var token: ClaudeToken { entry.token }
+    private var usage: ClaudeTokenUsage? { entry.usage }
+
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f
+    }()
+
+    var body: some View {
+        HStack(spacing: 10) {
+            nameView
+            kindBadge
+            Spacer()
+            statusBadges
+            usageView
+            timestampView
+            menuButton
+        }
+        .contentShape(Rectangle())
+        .confirmationDialog("Delete token?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                Task { await appState.deleteClaudeToken(id: token.id) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(deleteMessage)
+        }
+    }
+
+    @ViewBuilder
+    private var nameView: some View {
+        if isEditingName {
+            TextField("", text: $draftName, onCommit: commitRename)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: 180)
+                .onExitCommand { isEditingName = false }
+        } else {
+            Text(token.name)
+                .font(.body)
+                .onTapGesture(count: 2) {
+                    draftName = token.name
+                    isEditingName = true
+                }
+        }
+    }
+
+    private func commitRename() {
+        let trimmed = draftName.trimmingCharacters(in: .whitespaces)
+        isEditingName = false
+        guard !trimmed.isEmpty, trimmed != token.name else { return }
+        Task { await appState.renameClaudeToken(id: token.id, name: trimmed) }
+    }
+
+    private var kindBadge: some View {
+        Text(token.kind == .oauth ? "OAuth" : "API key")
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.secondary.opacity(0.15))
+            .clipShape(Capsule())
+    }
+
+    @ViewBuilder
+    private var statusBadges: some View {
+        if usage?.lastStatus == "http_401" {
+            Text("Invalid")
+                .font(.caption2).bold()
+                .padding(.horizontal, 6).padding(.vertical, 2)
+                .background(Color.red.opacity(0.2))
+                .foregroundColor(.red)
+                .clipShape(Capsule())
+        } else if usage?.lastStatus == "http_429" {
+            Text("Stale")
+                .font(.caption2).bold()
+                .padding(.horizontal, 6).padding(.vertical, 2)
+                .background(Color.orange.opacity(0.2))
+                .foregroundColor(.orange)
+                .clipShape(Capsule())
+        }
+    }
+
+    @ViewBuilder
+    private var usageView: some View {
+        if let usage,
+           let fiveHPct = usage.fiveHourPct,
+           let sevenDPct = usage.sevenDayPct {
+            let fiveH = Int((fiveHPct * 100).rounded())
+            let sevenD = Int((sevenDPct * 100).rounded())
+            Text("5h \(fiveH)% · 7d \(sevenD)%")
+                .font(.system(.caption, design: .monospaced))
+                .help(resetTooltip(usage))
+        } else {
+            Text("—")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func resetTooltip(_ usage: ClaudeTokenUsage) -> String {
+        let fiveH = formatRelativeFuture(usage.fiveHourResetsAt)
+        let sevenD = formatRelativeFuture(usage.sevenDayResetsAt)
+        return "Resets in \(fiveH) (5h) / \(sevenD) (7d)"
+    }
+
+    private func formatRelativeFuture(_ date: Date?) -> String {
+        guard let date else { return "—" }
+        let secs = max(0, Int(date.timeIntervalSinceNow))
+        let h = secs / 3600
+        let m = (secs % 3600) / 60
+        return "\(h)h \(m)m"
+    }
+
+    @ViewBuilder
+    private var timestampView: some View {
+        if let fetched = usage?.fetchedAt {
+            Text(Self.relativeFormatter.localizedString(for: fetched, relativeTo: Date()))
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var menuButton: some View {
+        Menu {
+            Button("Set as global default") {
+                Task { await appState.setGlobalDefaultClaudeToken(id: token.id) }
+            }
+            Button("Rename…") {
+                draftName = token.name
+                isEditingName = true
+            }
+            Divider()
+            Button("Delete…", role: .destructive) {
+                showDeleteConfirm = true
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+
+    private var inUseCount: Int {
+        appState.terminals.values.reduce(0) { acc, list in
+            acc + list.filter { $0.claudeTokenID == token.id }.count
+        }
+    }
+
+    private var deleteMessage: String {
+        let n = inUseCount
+        if n > 0 {
+            return "\(n) running terminal(s) are using this token. They'll keep running on it until closed. Delete anyway?"
+        }
+        return "This will remove the token from TBD. Are you sure?"
+    }
+}
+
+// MARK: - Add sheet
+
+struct AddClaudeTokenSheet: View {
+    @EnvironmentObject var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var token = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Add Claude Token").font(.headline)
+
+            Form {
+                TextField("Name", text: $name)
+                SecureField("Token", text: $token)
+                (Text("Run ")
+                    + Text("claude setup-token").font(.system(.caption, design: .monospaced))
+                    + Text(" in a terminal and paste the resulting sk-ant-oat01-… token."))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button(action: save) {
+                    if isSaving {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Save")
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSave)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+    }
+
+    private var canSave: Bool {
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmedName.isEmpty, !token.isEmpty, !isSaving else { return false }
+        let duplicate = appState.claudeTokens.contains { $0.token.name == trimmedName }
+        return !duplicate
+    }
+
+    private func save() {
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let tokenValue = token
+        isSaving = true
+        errorMessage = nil
+        Task {
+            // addClaudeToken sets appState.alertMessage on error and returns
+            // nil; on success it returns an optional warning string. We treat
+            // a nil return alongside a freshly-set alertMessage as failure.
+            let priorAlert = await MainActor.run { appState.alertMessage }
+            let warning = await appState.addClaudeToken(name: trimmedName, token: tokenValue)
+            await MainActor.run {
+                isSaving = false
+                let newAlert = appState.alertMessage
+                if newAlert != priorAlert, let msg = newAlert {
+                    errorMessage = msg
+                    appState.alertMessage = priorAlert
+                    return
+                }
+                if let warning {
+                    errorMessage = warning
+                    return
+                }
+                dismiss()
+            }
+        }
+    }
+}

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -195,8 +195,47 @@ struct RepoSettingsRow: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
+
+            Picker("Claude token", selection: tokenOverrideBinding) {
+                Text("Inherit global default").tag(UUID?.none)
+                ForEach(appState.claudeTokens, id: \.token.id) { entry in
+                    Text(entry.token.name).tag(UUID?.some(entry.token.id))
+                }
+            }
+            .pickerStyle(.menu)
+            .controlSize(.small)
+            .font(.caption)
+
+            if let caption = tokenOverrideCaption {
+                Text(caption)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding(.vertical, 4)
+    }
+
+    private var tokenOverrideBinding: Binding<UUID?> {
+        Binding(
+            get: { repo.claudeTokenOverrideID },
+            set: { newValue in
+                Task {
+                    await appState.setRepoClaudeTokenOverride(repoID: repo.id, tokenID: newValue)
+                }
+            }
+        )
+    }
+
+    private var tokenOverrideCaption: String? {
+        if let overrideID = repo.claudeTokenOverrideID {
+            let name = appState.claudeTokens.first(where: { $0.token.id == overrideID })?.token.name ?? "Unknown token"
+            return "Overriding with: \(name)"
+        }
+        if let defaultID = appState.globalDefaultClaudeTokenID,
+           let name = appState.claudeTokens.first(where: { $0.token.id == defaultID })?.token.name {
+            return "Inheriting: \(name)"
+        }
+        return "Inheriting: Default (claude keychain login)"
     }
 
     private func commitRename() {

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -15,8 +15,11 @@ struct SettingsView: View {
                 .tabItem {
                     Label("Repositories", systemImage: "folder")
                 }
+
+            ClaudeTokensSettingsView()
+                .tabItem { Label("Claude Tokens", systemImage: "key.fill") }
         }
-        .frame(width: 500, height: 420)
+        .frame(width: 500, height: 520)
     }
 }
 

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -25,6 +25,7 @@ struct TBDAppMain: App {
         .defaultSize(width: 1200, height: 800)
         .commands {
             TBDCommands(appState: appState)
+            ClaudeTokenMenu(appState: appState)
         }
 
         Settings {

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -364,15 +364,12 @@ private struct TabBarItem: View {
                     }
                     return false
                 }
-                if sameTokenTabs.count > 1 {
-                    let myTerminalID = terminal!.id
-                    let position = (sameTokenTabs.firstIndex { tab in
-                        if case .terminal(let tID) = tab.content { return tID == myTerminalID }
-                        return false
-                    } ?? 0) + 1
-                    return "\(name) \(position)"
-                }
-                return name
+                let myTerminalID = terminal!.id
+                let position = (sameTokenTabs.firstIndex { tab in
+                    if case .terminal(let tID) = tab.content { return tID == myTerminalID }
+                    return false
+                } ?? 0) + 1
+                return "\(name) \(position)"
             }
             return "Terminal \(index + 1)"
         case .webview(_, let url):

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -247,31 +247,16 @@ private struct TabBarItem: View {
         }
     }
 
-    private func formatPct(_ value: Double?) -> String? {
-        guard let value else { return nil }
-        return "\(Int(value.rounded()))%"
-    }
-
     private func formatTokenHeader(_ tokenID: UUID?) -> String {
         guard let tokenID else { return "Token: Default (logged in)" }
         guard let entry = appState.claudeTokens.first(where: { $0.token.id == tokenID }) else {
             return "Token: (missing)"
         }
-        if let usage = entry.usage,
-           let fiveH = formatPct(usage.fiveHourPct),
-           let sevenD = formatPct(usage.sevenDayPct) {
-            return "Token: \(entry.token.name) · 5h \(fiveH) · 7d \(sevenD)"
-        }
         return "Token: \(entry.token.name)"
     }
 
     private func formatTokenSubmenuLabel(_ entry: ClaudeTokenWithUsage) -> String {
-        if let usage = entry.usage,
-           let fiveH = formatPct(usage.fiveHourPct),
-           let sevenD = formatPct(usage.sevenDayPct) {
-            return "\(entry.token.name)  5h \(fiveH) · 7d \(sevenD)"
-        }
-        return entry.token.name
+        entry.token.name
     }
 
     @ViewBuilder

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -161,6 +161,7 @@ private struct TabBarItem: View {
     @State private var isHovering = false
     @State private var isHoveringClose = false
     @AppStorage("codeViewer.showSidebar") private var showSidebar = false
+    @EnvironmentObject private var appState: AppState
 
     private var showClose: Bool {
         isSelected || isHovering
@@ -246,9 +247,63 @@ private struct TabBarItem: View {
         }
     }
 
+    private func formatPct(_ value: Double?) -> String? {
+        guard let value else { return nil }
+        return "\(Int(value.rounded()))%"
+    }
+
+    private func formatTokenHeader(_ tokenID: UUID?) -> String {
+        guard let tokenID else { return "Token: Default (logged in)" }
+        guard let entry = appState.claudeTokens.first(where: { $0.token.id == tokenID }) else {
+            return "Token: (missing)"
+        }
+        if let usage = entry.usage,
+           let fiveH = formatPct(usage.fiveHourPct),
+           let sevenD = formatPct(usage.sevenDayPct) {
+            return "Token: \(entry.token.name) · 5h \(fiveH) · 7d \(sevenD)"
+        }
+        return "Token: \(entry.token.name)"
+    }
+
+    private func formatTokenSubmenuLabel(_ entry: ClaudeTokenWithUsage) -> String {
+        if let usage = entry.usage,
+           let fiveH = formatPct(usage.fiveHourPct),
+           let sevenD = formatPct(usage.sevenDayPct) {
+            return "\(entry.token.name)  5h \(fiveH) · 7d \(sevenD)"
+        }
+        return entry.token.name
+    }
+
     @ViewBuilder
     private var contextMenuContent: some View {
         if isClaudeTerminal {
+            Button(formatTokenHeader(terminal?.claudeTokenID)) {}
+                .disabled(true)
+
+            Menu("Swap token") {
+                Button {
+                    guard let terminalID = terminal?.id else { return }
+                    Task { await appState.swapClaudeTokenOnTerminal(terminalID: terminalID, newTokenID: nil) }
+                } label: {
+                    let prefix = terminal?.claudeTokenID == nil ? "● " : "  "
+                    Text("\(prefix)Default (logged in)")
+                }
+
+                Divider()
+
+                ForEach(appState.claudeTokens, id: \.token.id) { entry in
+                    Button {
+                        guard let terminalID = terminal?.id else { return }
+                        Task { await appState.swapClaudeTokenOnTerminal(terminalID: terminalID, newTokenID: entry.token.id) }
+                    } label: {
+                        let prefix = terminal?.claudeTokenID == entry.token.id ? "● " : "  "
+                        Text("\(prefix)\(formatTokenSubmenuLabel(entry))")
+                    }
+                }
+            }
+
+            Divider()
+
             Button(action: onFork) {
                 Label("Fork Session", systemImage: "arrow.triangle.branch")
             }

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -349,7 +349,30 @@ private struct TabBarItem: View {
         case .terminal:
             if isClaudeTerminal, let tokenID = terminal?.claudeTokenID,
                let entry = appState.claudeTokens.first(where: { $0.token.id == tokenID }) {
-                return entry.token.name
+                let name = entry.token.name
+                let worktreeID = terminal!.worktreeID
+                let allTabs = appState.tabs[worktreeID] ?? []
+                let allTerminals = appState.terminals[worktreeID] ?? []
+                let sameTokenTerminalIDs = Set(
+                    allTerminals
+                        .filter { $0.claudeTokenID == tokenID }
+                        .map { $0.id }
+                )
+                let sameTokenTabs = allTabs.filter { tab in
+                    if case .terminal(let tID) = tab.content {
+                        return sameTokenTerminalIDs.contains(tID)
+                    }
+                    return false
+                }
+                if sameTokenTabs.count > 1 {
+                    let myTerminalID = terminal!.id
+                    let position = (sameTokenTabs.firstIndex { tab in
+                        if case .terminal(let tID) = tab.content { return tID == myTerminalID }
+                        return false
+                    } ?? 0) + 1
+                    return "\(name) \(position)"
+                }
+                return name
             }
             return "Terminal \(index + 1)"
         case .webview(_, let url):

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -371,7 +371,7 @@ private struct TabBarItem: View {
                 } ?? 0) + 1
                 return "\(name) \(position)"
             }
-            return "Terminal \(index + 1)"
+            return isClaudeTerminal ? "Claude" : "Terminal \(index + 1)"
         case .webview(_, let url):
             return url.host ?? "Web"
         case .codeViewer(_, let path):

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -347,6 +347,10 @@ private struct TabBarItem: View {
         }
         switch tab.content {
         case .terminal:
+            if isClaudeTerminal, let tokenID = terminal?.claudeTokenID,
+               let entry = appState.claudeTokens.first(where: { $0.token.id == tokenID }) {
+                return entry.token.name
+            }
             return "Terminal \(index + 1)"
         case .webview(_, let url):
             return url.host ?? "Web"

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -148,7 +148,7 @@ private struct SingleWorktreeView: View {
                             let terminal = appState.terminals[worktreeID]?.first { $0.id == tID }
                             guard let sessionID = terminal?.claudeSessionID else { return }
                             Task {
-                                await appState.forkClaudeTerminal(worktreeID: worktreeID, sessionID: sessionID)
+                                await appState.forkClaudeTerminal(worktreeID: worktreeID, sessionID: sessionID, tokenID: terminal?.claudeTokenID)
                                 selectLastTab()
                             }
                         }

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -16,15 +16,23 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeSpawn"
 /// - Otherwise → `cmd` if set, else `shellFallback`.
 ///
 /// If `tokenSecret` is non-nil AND we built a claude command (resume or fresh),
-/// the command is prefixed with `CLAUDE_CODE_OAUTH_TOKEN='<value>' `. The token is
-/// asserted to be alphanumeric / `-` / `_` only — Claude OAuth tokens and Anthropic
-/// API keys both fit this charset, so a value with anything else indicates a bug
-/// or corrupted entry and traps loudly rather than producing a broken shell line.
-/// The token is single-quoted defensively even though it cannot contain quotes.
+/// the token is returned in `sensitiveEnv` keyed by `CLAUDE_CODE_OAUTH_TOKEN`
+/// (oauth) or `ANTHROPIC_API_KEY` (api key). The token is **never** embedded in
+/// the returned `command` string — callers must pass `sensitiveEnv` through
+/// `TmuxManager.createWindow(sensitiveEnv:)` so tmux's `-e KEY=VALUE` flag puts
+/// it directly into the spawned window's environment without ever appearing in
+/// the long-running shell command's `ps` argv.
 ///
-/// The token is **not** injected when the resolved path is `cmd` or `shellFallback`,
-/// since those branches are for non-claude shells.
+/// The token is **not** returned when the resolved path is `cmd` or
+/// `shellFallback`, since those branches are for non-claude shells.
 enum ClaudeSpawnCommandBuilder {
+    struct Result: Equatable {
+        let command: String
+        /// Env vars containing secrets. MUST be passed to tmux via `-e KEY=VALUE`,
+        /// never inlined into the shell command (would leak via `ps`).
+        let sensitiveEnv: [String: String]
+    }
+
     static func build(
         resumeID: String?,
         freshSessionID: String?,
@@ -34,7 +42,7 @@ enum ClaudeSpawnCommandBuilder {
         tokenKind: ClaudeTokenKind? = nil,
         cmd: String?,
         shellFallback: String
-    ) -> String {
+    ) -> Result {
         let base: String
         if let resumeID {
             base = "claude --resume \(resumeID) --dangerously-skip-permissions"
@@ -48,21 +56,21 @@ enum ClaudeSpawnCommandBuilder {
             }
             base = b
         } else if let cmd {
-            return cmd
+            return Result(command: cmd, sensitiveEnv: [:])
         } else {
-            return shellFallback
+            return Result(command: shellFallback, sensitiveEnv: [:])
         }
 
-        guard let secret = tokenSecret else { return base }
+        guard let secret = tokenSecret else {
+            return Result(command: base, sensitiveEnv: [:])
+        }
         guard secret.allSatisfy({ ch in
             ch.isLetter || ch.isNumber || ch == "-" || ch == "_"
         }) else {
             logger.error("Claude token contains unexpected characters; falling back to keychain login without env injection")
-            return base
+            return Result(command: base, sensitiveEnv: [:])
         }
-        // Defensive single-quote escape; tokens never contain `'`.
-        let escaped = secret.replacingOccurrences(of: "'", with: "'\\''")
         let envVar = tokenKind == .apiKey ? "ANTHROPIC_API_KEY" : "CLAUDE_CODE_OAUTH_TOKEN"
-        return "\(envVar)='\(escaped)' \(base)"
+        return Result(command: base, sensitiveEnv: [envVar: secret])
     }
 }

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Builds the shell command string for spawning (or respawning) a claude terminal.
+///
+/// Pure function — no DB, no Keychain, no tmux. Easy to unit-test. The caller is
+/// responsible for resolving the token secret (if any) before invoking.
+///
+/// Behavior:
+/// - `resumeID` non-nil → `claude --resume <id> --dangerously-skip-permissions`
+/// - `freshSessionID` non-nil → `claude --session-id <id> --dangerously-skip-permissions`
+///   with optional `--append-system-prompt` and trailing initial-prompt arg.
+/// - Otherwise → `cmd` if set, else `shellFallback`.
+///
+/// If `tokenSecret` is non-nil AND we built a claude command (resume or fresh),
+/// the command is prefixed with `CLAUDE_CODE_OAUTH_TOKEN='<value>' `. The token is
+/// asserted to be alphanumeric / `-` / `_` only — Claude OAuth tokens and Anthropic
+/// API keys both fit this charset, so a value with anything else indicates a bug
+/// or corrupted entry and traps loudly rather than producing a broken shell line.
+/// The token is single-quoted defensively even though it cannot contain quotes.
+///
+/// The token is **not** injected when the resolved path is `cmd` or `shellFallback`,
+/// since those branches are for non-claude shells.
+enum ClaudeSpawnCommandBuilder {
+    static func build(
+        resumeID: String?,
+        freshSessionID: String?,
+        appendSystemPrompt: String?,
+        initialPrompt: String?,
+        tokenSecret: String?,
+        cmd: String?,
+        shellFallback: String
+    ) -> String {
+        let base: String
+        if let resumeID {
+            base = "claude --resume \(resumeID) --dangerously-skip-permissions"
+        } else if let sessionID = freshSessionID {
+            var b = "claude --session-id \(sessionID) --dangerously-skip-permissions"
+            if let prompt = appendSystemPrompt {
+                b += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
+            }
+            if let p = initialPrompt, !p.isEmpty {
+                b += " \(SystemPromptBuilder.shellEscape(p))"
+            }
+            base = b
+        } else if let cmd {
+            return cmd
+        } else {
+            return shellFallback
+        }
+
+        guard let secret = tokenSecret else { return base }
+        precondition(
+            secret.allSatisfy { ch in
+                ch.isLetter || ch.isNumber || ch == "-" || ch == "_"
+            },
+            "Claude token contains unexpected characters; refusing to inject"
+        )
+        // Defensive single-quote escape; OAuth tokens never contain `'`.
+        let escaped = secret.replacingOccurrences(of: "'", with: "'\\''")
+        return "CLAUDE_CODE_OAUTH_TOKEN='\(escaped)' \(base)"
+    }
+}

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -1,8 +1,5 @@
 import Foundation
-import os
 import TBDShared
-
-private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeSpawn")
 
 /// Builds the shell command string for spawning (or respawning) a claude terminal.
 ///
@@ -64,12 +61,10 @@ enum ClaudeSpawnCommandBuilder {
         guard let secret = tokenSecret else {
             return Result(command: base, sensitiveEnv: [:])
         }
-        guard secret.allSatisfy({ ch in
-            ch.isLetter || ch.isNumber || ch == "-" || ch == "_"
-        }) else {
-            logger.error("Claude token contains unexpected characters; falling back to keychain login without env injection")
-            return Result(command: base, sensitiveEnv: [:])
-        }
+        // Tokens flow through tmux's `-e KEY=VALUE` (argv, no shell parsing),
+        // so we don't need shell-escape allowlists here. Storage-time validation
+        // (handleClaudeTokenAdd) rejects newlines / NULL bytes that would break
+        // tmux's single-line arg parsing.
         let envVar = tokenKind == .apiKey ? "ANTHROPIC_API_KEY" : "CLAUDE_CODE_OAUTH_TOKEN"
         return Result(command: base, sensitiveEnv: [envVar: secret])
     }

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 
 /// Builds the shell command string for spawning (or respawning) a claude terminal.
 ///
@@ -27,6 +28,7 @@ enum ClaudeSpawnCommandBuilder {
         appendSystemPrompt: String?,
         initialPrompt: String?,
         tokenSecret: String?,
+        tokenKind: ClaudeTokenKind? = nil,
         cmd: String?,
         shellFallback: String
     ) -> String {
@@ -55,8 +57,9 @@ enum ClaudeSpawnCommandBuilder {
             },
             "Claude token contains unexpected characters; refusing to inject"
         )
-        // Defensive single-quote escape; OAuth tokens never contain `'`.
+        // Defensive single-quote escape; tokens never contain `'`.
         let escaped = secret.replacingOccurrences(of: "'", with: "'\\''")
-        return "CLAUDE_CODE_OAUTH_TOKEN='\(escaped)' \(base)"
+        let envVar = tokenKind == .apiKey ? "ANTHROPIC_API_KEY" : "CLAUDE_CODE_OAUTH_TOKEN"
+        return "\(envVar)='\(escaped)' \(base)"
     }
 }

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeSpawn")
 
 /// Builds the shell command string for spawning (or respawning) a claude terminal.
 ///
@@ -51,12 +54,12 @@ enum ClaudeSpawnCommandBuilder {
         }
 
         guard let secret = tokenSecret else { return base }
-        precondition(
-            secret.allSatisfy { ch in
-                ch.isLetter || ch.isNumber || ch == "-" || ch == "_"
-            },
-            "Claude token contains unexpected characters; refusing to inject"
-        )
+        guard secret.allSatisfy({ ch in
+            ch.isLetter || ch.isNumber || ch == "-" || ch == "_"
+        }) else {
+            logger.error("Claude token contains unexpected characters; falling back to keychain login without env injection")
+            return base
+        }
         // Defensive single-quote escape; tokens never contain `'`.
         let escaped = secret.replacingOccurrences(of: "'", with: "'\\''")
         let envVar = tokenKind == .apiKey ? "ANTHROPIC_API_KEY" : "CLAUDE_CODE_OAUTH_TOKEN"

--- a/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
@@ -62,6 +62,9 @@ public struct ClaudeTokenResolver: Sendable {
             if let resolved = try await loadResolved(id: defaultID) {
                 return resolved
             }
+            FileHandle.standardError.write(Data(
+                "[ClaudeTokenResolver] warning: global default claude token \(defaultID) is missing; no token will be injected\n".utf8
+            ))
             return nil
         }
 

--- a/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeTokenResolver")
 
 public struct ResolvedClaudeToken: Sendable, Equatable {
     public let tokenID: UUID
@@ -52,9 +55,7 @@ public struct ClaudeTokenResolver: Sendable {
             if let resolved = try await loadResolved(id: overrideID) {
                 return resolved
             }
-            FileHandle.standardError.write(Data(
-                "[ClaudeTokenResolver] warning: claude token override \(overrideID) for repo \(repoID) is missing; falling back to global default\n".utf8
-            ))
+            logger.warning("claude token override \(overrideID) for repo \(repoID) is missing; falling back to global default")
         }
 
         // Step 2: global default
@@ -62,9 +63,7 @@ public struct ClaudeTokenResolver: Sendable {
             if let resolved = try await loadResolved(id: defaultID) {
                 return resolved
             }
-            FileHandle.standardError.write(Data(
-                "[ClaudeTokenResolver] warning: global default claude token \(defaultID) is missing; no token will be injected\n".utf8
-            ))
+            logger.warning("global default claude token \(defaultID) is missing; no token will be injected")
             return nil
         }
 

--- a/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
@@ -1,0 +1,65 @@
+import Foundation
+import TBDShared
+
+public struct ResolvedClaudeToken: Sendable, Equatable {
+    public let tokenID: UUID
+    public let name: String
+    public let kind: ClaudeTokenKind
+    public let secret: String
+}
+
+public struct ClaudeTokenResolver: Sendable {
+    let tokens: ClaudeTokenStore
+    let repos: RepoStore
+    let config: ConfigStore
+    let keychain: @Sendable (String) throws -> String?
+
+    public init(
+        tokens: ClaudeTokenStore,
+        repos: RepoStore,
+        config: ConfigStore,
+        keychain: @Sendable @escaping (String) throws -> String? = { try ClaudeTokenKeychain.load(id: $0) }
+    ) {
+        self.tokens = tokens
+        self.repos = repos
+        self.config = config
+        self.keychain = keychain
+    }
+
+    private func loadResolved(id: UUID) async throws -> ResolvedClaudeToken? {
+        guard let row = try await tokens.get(id: id) else { return nil }
+        guard let secret = try keychain(id.uuidString), !secret.isEmpty else { return nil }
+        return ResolvedClaudeToken(
+            tokenID: row.id,
+            name: row.name,
+            kind: row.kind,
+            secret: secret
+        )
+    }
+
+    public func resolve(repoID: UUID?) async throws -> ResolvedClaudeToken? {
+        // Step 1: repo override
+        if let repoID, let repo = try await repos.get(id: repoID),
+           let overrideID = repo.claudeTokenOverrideID {
+            if let resolved = try await loadResolved(id: overrideID) {
+                try await tokens.touchLastUsed(id: resolved.tokenID)
+                return resolved
+            }
+            FileHandle.standardError.write(Data(
+                "[ClaudeTokenResolver] warning: claude token override \(overrideID) for repo \(repoID) is missing; falling back to global default\n".utf8
+            ))
+        }
+
+        // Step 2: global default
+        if let defaultID = try await config.get().defaultClaudeTokenID {
+            if let resolved = try await loadResolved(id: defaultID) {
+                try await tokens.touchLastUsed(id: resolved.tokenID)
+                return resolved
+            }
+            return nil
+        }
+
+        // Step 3: nothing applies
+        return nil
+    }
+}

--- a/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
@@ -50,7 +50,6 @@ public struct ClaudeTokenResolver: Sendable {
         if let repoID, let repo = try await repos.get(id: repoID),
            let overrideID = repo.claudeTokenOverrideID {
             if let resolved = try await loadResolved(id: overrideID) {
-                try await tokens.touchLastUsed(id: resolved.tokenID)
                 return resolved
             }
             FileHandle.standardError.write(Data(
@@ -61,7 +60,6 @@ public struct ClaudeTokenResolver: Sendable {
         // Step 2: global default
         if let defaultID = try await config.get().defaultClaudeTokenID {
             if let resolved = try await loadResolved(id: defaultID) {
-                try await tokens.touchLastUsed(id: resolved.tokenID)
                 return resolved
             }
             return nil

--- a/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
@@ -36,6 +36,7 @@ public struct ClaudeTokenResolver: Sendable {
     private func loadResolved(id: UUID) async throws -> ResolvedClaudeToken? {
         guard let row = try await tokens.get(id: id) else { return nil }
         guard let secret = try keychain(id.uuidString), !secret.isEmpty else { return nil }
+        try await tokens.touchLastUsed(id: row.id)
         return ResolvedClaudeToken(
             tokenID: row.id,
             name: row.name,

--- a/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift
@@ -26,6 +26,13 @@ public struct ClaudeTokenResolver: Sendable {
         self.keychain = keychain
     }
 
+    /// Load a token by explicit ID, bypassing the repo/global precedence chain.
+    /// Used by mid-conversation swap when the caller has already chosen a specific token.
+    /// Returns nil if the row is missing OR the keychain secret is missing/empty.
+    public func loadByID(_ id: UUID) async throws -> ResolvedClaudeToken? {
+        try await loadResolved(id: id)
+    }
+
     private func loadResolved(id: UUID) async throws -> ResolvedClaudeToken? {
         guard let row = try await tokens.get(id: id) else { return nil }
         guard let secret = try keychain(id.uuidString), !secret.isEmpty else { return nil }

--- a/Sources/TBDDaemon/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeUsageFetcher.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+public struct ClaudeUsageResult: Equatable, Sendable {
+    public var fiveHourPct: Double       // 0.0 ... 1.0 (utilization from the API)
+    public var sevenDayPct: Double
+    public var fiveHourResetsAt: Date
+    public var sevenDayResetsAt: Date
+
+    public init(
+        fiveHourPct: Double,
+        sevenDayPct: Double,
+        fiveHourResetsAt: Date,
+        sevenDayResetsAt: Date
+    ) {
+        self.fiveHourPct = fiveHourPct
+        self.sevenDayPct = sevenDayPct
+        self.fiveHourResetsAt = fiveHourResetsAt
+        self.sevenDayResetsAt = sevenDayResetsAt
+    }
+}
+
+public enum ClaudeUsageStatus: Equatable, Sendable {
+    case ok(ClaudeUsageResult)
+    case http429
+    case http401
+    case networkError(String)  // human-readable; MUST NOT contain token bytes
+    case decodeError(String)
+}
+
+public protocol ClaudeUsageFetcher: Sendable {
+    func fetchUsage(token: String) async -> ClaudeUsageStatus
+}
+
+public struct LiveClaudeUsageFetcher: ClaudeUsageFetcher {
+    public let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func fetchUsage(token: String) async -> ClaudeUsageStatus {
+        guard let url = URL(string: "https://api.anthropic.com/api/oauth/usage") else {
+            return .networkError("invalid URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch let urlError as URLError {
+            return .networkError(urlError.localizedDescription)
+        } catch {
+            return .networkError(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            return .networkError("non-HTTP response")
+        }
+
+        switch http.statusCode {
+        case 200:
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            do {
+                let payload = try decoder.decode(UsagePayload.self, from: data)
+                return .ok(ClaudeUsageResult(
+                    fiveHourPct: payload.fiveHour.utilization,
+                    sevenDayPct: payload.sevenDay.utilization,
+                    fiveHourResetsAt: payload.fiveHour.resetsAt,
+                    sevenDayResetsAt: payload.sevenDay.resetsAt
+                ))
+            } catch {
+                return .decodeError(error.localizedDescription)
+            }
+        case 401:
+            return .http401
+        case 429:
+            return .http429
+        default:
+            return .networkError("HTTP \(http.statusCode)")
+        }
+    }
+
+    private struct UsagePayload: Decodable {
+        struct Window: Decodable {
+            let utilization: Double
+            let resetsAt: Date
+        }
+        let fiveHour: Window
+        let sevenDay: Window
+    }
+}

--- a/Sources/TBDDaemon/Claude/ClaudeUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeUsagePoller.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "usagePoller")
 
 /// Background poller that keeps `claude_token_usage` rows fresh for OAuth tokens.
 ///
@@ -316,7 +319,7 @@ public actor ClaudeUsagePoller {
             entry.backoffActive = true
             if !loggedBackoff.contains(tokenID) {
                 loggedBackoff.insert(tokenID)
-                print("[ClaudeUsagePoller] 429 backoff for token \(tokenID)")
+                logger.warning("429 backoff for token \(tokenID)")
             }
             entry.nextFireAt = clock.now().addingTimeInterval(Self.backoff)
             schedule[tokenID] = entry

--- a/Sources/TBDDaemon/Claude/ClaudeUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeUsagePoller.swift
@@ -1,0 +1,361 @@
+import Foundation
+import TBDShared
+
+/// Background poller that keeps `claude_token_usage` rows fresh for OAuth tokens.
+///
+/// Rules (from spec "Usage fetching"):
+/// - OAuth only; api_key kind is skipped permanently.
+/// - Default cadence: 30 min per token.
+/// - Startup stagger: first poll for each token at random(0..30s) from start().
+/// - HTTP 429 → next poll 60 min out; first success after that reverts to 30 min.
+/// - HTTP 401 → stop polling that token entirely.
+/// - Focus loss > 10 min → pause loop. On focus regained, resume + pokeAll.
+/// - Dedupe: if fetched_at < 60 s ago, skip the network call.
+public actor ClaudeUsagePoller {
+
+    // MARK: - Constants
+
+    public static let cadence: TimeInterval = 30 * 60      // 30 minutes
+    public static let backoff: TimeInterval = 60 * 60      // 60 minutes
+    public static let stagger: TimeInterval = 30           // 30 seconds
+    public static let dedupeWindow: TimeInterval = 60      // 60 seconds
+    public static let focusPauseThreshold: TimeInterval = 10 * 60 // 10 minutes
+
+    // MARK: - Per-token schedule entry
+
+    struct Entry {
+        var nextFireAt: Date
+        var backoffActive: Bool
+        var excluded: Bool
+    }
+
+    // MARK: - Dependencies
+
+    private let tokens: ClaudeTokenStore
+    private let usage: ClaudeTokenUsageStore
+    private let keychain: @Sendable (String) throws -> String?
+    private let fetcher: ClaudeUsageFetcher
+    private let clock: PollerClock
+    private let broadcast: @Sendable (ClaudeTokenUsage) -> Void
+    /// Optional jitter override for tests; production uses `Double.random`.
+    private let staggerProvider: @Sendable () -> TimeInterval
+
+    // MARK: - State
+
+    private var schedule: [String: Entry] = [:]
+    private var loopTask: Task<Void, Never>?
+    private var isPaused: Bool = false
+    private var lastFocusLostAt: Date?
+    /// Resumed when an idle loop (no schedule entries, or paused) should wake.
+    private var idleWakeContinuation: CheckedContinuation<Void, Never>?
+    /// In-flight sleep task; cancelled by `wake()` to interrupt the current sleep.
+    private var currentSleepTask: Task<Void, Error>?
+    private var loggedBackoff: Set<String> = []
+    /// Tokens that returned HTTP 401 and must never be polled again until restart.
+    private var permanentlyExcluded: Set<String> = []
+
+    // MARK: - Init
+
+    public init(
+        tokens: ClaudeTokenStore,
+        usage: ClaudeTokenUsageStore,
+        keychain: @escaping @Sendable (String) throws -> String?,
+        fetcher: ClaudeUsageFetcher,
+        clock: PollerClock,
+        broadcast: @escaping @Sendable (ClaudeTokenUsage) -> Void,
+        staggerProvider: (@Sendable () -> TimeInterval)? = nil
+    ) {
+        self.tokens = tokens
+        self.usage = usage
+        self.keychain = keychain
+        self.fetcher = fetcher
+        self.clock = clock
+        self.broadcast = broadcast
+        self.staggerProvider = staggerProvider ?? { Double.random(in: 0..<Self.stagger) }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Initial population of the schedule from the token store, then launches loop.
+    /// Idempotent: if already started, does nothing.
+    public func start() async {
+        guard loopTask == nil else { return }
+        await refreshSchedule()
+        loopTask = Task { [weak self] in
+            await self?.runLoop()
+        }
+    }
+
+    /// Cancels the loop. Idempotent.
+    public func stop() {
+        loopTask?.cancel()
+        loopTask = nil
+        currentSleepTask?.cancel()
+        currentSleepTask = nil
+        if let cont = idleWakeContinuation {
+            idleWakeContinuation = nil
+            cont.resume()
+        }
+        schedule.removeAll()
+    }
+
+    // MARK: - External signals
+
+    /// App focus changed. `false` records the timestamp; `true` clears it,
+    /// resumes if paused, and pokes all eligible tokens.
+    public func onFocusChanged(isForeground: Bool) async {
+        if isForeground {
+            lastFocusLostAt = nil
+            isPaused = false
+            if let cont = idleWakeContinuation {
+                idleWakeContinuation = nil
+                cont.resume()
+            }
+            await pokeAll()
+        } else {
+            lastFocusLostAt = clock.now()
+        }
+    }
+
+    /// Set every non-excluded entry's `nextFireAt = now` and wake the loop.
+    public func pokeAll() async {
+        let now = clock.now()
+        for key in schedule.keys {
+            guard var entry = schedule[key], !entry.excluded else { continue }
+            entry.nextFireAt = now
+            schedule[key] = entry
+        }
+        wake()
+    }
+
+    /// Single-token poke (used by RPC fetchUsage handler).
+    public func poke(tokenID: String) async {
+        guard var entry = schedule[tokenID], !entry.excluded else { return }
+        entry.nextFireAt = clock.now()
+        schedule[tokenID] = entry
+        wake()
+    }
+
+    // MARK: - Test introspection
+
+    /// For tests: snapshot schedule.
+    func _scheduleSnapshot() -> [String: Entry] { schedule }
+    func _isPaused() -> Bool { isPaused }
+
+    // MARK: - Loop
+
+    private func runLoop() async {
+        while !Task.isCancelled {
+            await refreshSchedule()
+
+            // Focus pause check.
+            if let lostAt = lastFocusLostAt,
+               clock.now().timeIntervalSince(lostAt) > Self.focusPauseThreshold {
+                isPaused = true
+            }
+            if isPaused {
+                await waitIdle()
+                if Task.isCancelled { return }
+                continue
+            }
+
+            // Pick earliest non-excluded entry.
+            let eligible = schedule.filter { !$0.value.excluded }
+            guard let next = eligible.min(by: { $0.value.nextFireAt < $1.value.nextFireAt }) else {
+                await waitIdle()
+                if Task.isCancelled { return }
+                continue
+            }
+
+            // Sleep until the earliest deadline. Stash the sleep task so wake()
+            // can cancel it without killing the loop task itself.
+            let deadline = next.value.nextFireAt
+            let clock = self.clock
+            let sleepTask = Task<Void, Error> {
+                try await clock.sleep(until: deadline)
+            }
+            currentSleepTask = sleepTask
+            _ = try? await sleepTask.value
+            currentSleepTask = nil
+            if Task.isCancelled { return }
+
+            // Tick all tokens that are due now.
+            let now = clock.now()
+            let due = schedule
+                .filter { !$0.value.excluded && $0.value.nextFireAt <= now }
+                .map { $0.key }
+            for tokenID in due {
+                await tick(tokenID: tokenID)
+            }
+        }
+    }
+
+    private func waitIdle() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            idleWakeContinuation = cont
+        }
+    }
+
+    /// Re-read tokens from the store, add new oauth tokens to schedule,
+    /// drop missing/api_key tokens.
+    private func refreshSchedule() async {
+        let allTokens: [ClaudeToken]
+        do {
+            allTokens = try await tokens.list()
+        } catch {
+            return
+        }
+        let oauthIDs = Set(allTokens.filter { $0.kind == .oauth }.map { $0.id.uuidString })
+
+        // Drop tokens no longer present or no longer oauth.
+        for key in schedule.keys where !oauthIDs.contains(key) {
+            schedule.removeValue(forKey: key)
+        }
+        // Add new tokens with stagger.
+        let now = clock.now()
+        for id in oauthIDs where schedule[id] == nil && !permanentlyExcluded.contains(id) {
+            schedule[id] = Entry(
+                nextFireAt: now.addingTimeInterval(staggerProvider()),
+                backoffActive: false,
+                excluded: false
+            )
+        }
+    }
+
+    private func wake() {
+        if let cont = idleWakeContinuation {
+            idleWakeContinuation = nil
+            cont.resume()
+        }
+        currentSleepTask?.cancel()
+        currentSleepTask = nil
+    }
+
+    // MARK: - Tick (single-token fetch)
+
+    private func tick(tokenID: String) async {
+        // 1. Confirm still exists & is oauth.
+        guard let uuid = UUID(uuidString: tokenID) else {
+            schedule.removeValue(forKey: tokenID)
+            return
+        }
+        let row: ClaudeToken?
+        do {
+            row = try await tokens.get(id: uuid)
+        } catch {
+            return
+        }
+        guard let token = row, token.kind == .oauth else {
+            schedule.removeValue(forKey: tokenID)
+            return
+        }
+
+        var entry = schedule[tokenID] ?? Entry(nextFireAt: clock.now(), backoffActive: false, excluded: false)
+        let now = clock.now()
+
+        // 2. Dedupe against fetched_at.
+        if let cached = try? await usage.get(tokenID: uuid),
+           let fetchedAt = cached.fetchedAt,
+           now.timeIntervalSince(fetchedAt) < Self.dedupeWindow {
+            entry.nextFireAt = now.addingTimeInterval(entry.backoffActive ? Self.backoff : Self.cadence)
+            schedule[tokenID] = entry
+            return
+        }
+
+        // 3. Load secret.
+        let secret: String?
+        do {
+            secret = try keychain(tokenID)
+        } catch {
+            entry.nextFireAt = now.addingTimeInterval(Self.cadence)
+            schedule[tokenID] = entry
+            return
+        }
+        guard let bytes = secret else {
+            entry.nextFireAt = now.addingTimeInterval(Self.cadence)
+            schedule[tokenID] = entry
+            return
+        }
+
+        // 4. Fetch.
+        let status = await fetcher.fetchUsage(token: bytes)
+
+        // 5. Branch on result.
+        switch status {
+        case .ok(let result):
+            let updated = ClaudeTokenUsage(
+                tokenID: uuid,
+                fiveHourPct: result.fiveHourPct,
+                sevenDayPct: result.sevenDayPct,
+                fiveHourResetsAt: result.fiveHourResetsAt,
+                sevenDayResetsAt: result.sevenDayResetsAt,
+                fetchedAt: clock.now(),
+                lastStatus: "ok"
+            )
+            try? await usage.upsert(updated)
+            broadcast(updated)
+            entry.backoffActive = false
+            loggedBackoff.remove(tokenID)
+            entry.nextFireAt = clock.now().addingTimeInterval(Self.cadence)
+            schedule[tokenID] = entry
+
+        case .http429:
+            // Preserve cached pcts; only update status + fetched_at.
+            let cached = try? await usage.get(tokenID: uuid)
+            let updated = ClaudeTokenUsage(
+                tokenID: uuid,
+                fiveHourPct: cached?.fiveHourPct,
+                sevenDayPct: cached?.sevenDayPct,
+                fiveHourResetsAt: cached?.fiveHourResetsAt,
+                sevenDayResetsAt: cached?.sevenDayResetsAt,
+                fetchedAt: clock.now(),
+                lastStatus: "http_429"
+            )
+            try? await usage.upsert(updated)
+            broadcast(updated)
+            entry.backoffActive = true
+            if !loggedBackoff.contains(tokenID) {
+                loggedBackoff.insert(tokenID)
+                print("[ClaudeUsagePoller] 429 backoff for token \(tokenID)")
+            }
+            entry.nextFireAt = clock.now().addingTimeInterval(Self.backoff)
+            schedule[tokenID] = entry
+
+        case .http401:
+            let cached = try? await usage.get(tokenID: uuid)
+            let updated = ClaudeTokenUsage(
+                tokenID: uuid,
+                fiveHourPct: cached?.fiveHourPct,
+                sevenDayPct: cached?.sevenDayPct,
+                fiveHourResetsAt: cached?.fiveHourResetsAt,
+                sevenDayResetsAt: cached?.sevenDayResetsAt,
+                fetchedAt: clock.now(),
+                lastStatus: "http_401"
+            )
+            try? await usage.upsert(updated)
+            broadcast(updated)
+            permanentlyExcluded.insert(tokenID)
+            schedule.removeValue(forKey: tokenID)
+
+        case .networkError:
+            let cached = try? await usage.get(tokenID: uuid)
+            let updated = ClaudeTokenUsage(
+                tokenID: uuid,
+                fiveHourPct: cached?.fiveHourPct,
+                sevenDayPct: cached?.sevenDayPct,
+                fiveHourResetsAt: cached?.fiveHourResetsAt,
+                sevenDayResetsAt: cached?.sevenDayResetsAt,
+                fetchedAt: clock.now(),
+                lastStatus: "network_error"
+            )
+            try? await usage.upsert(updated)
+            broadcast(updated)
+            entry.nextFireAt = clock.now().addingTimeInterval(entry.backoffActive ? Self.backoff : Self.cadence)
+            schedule[tokenID] = entry
+
+        case .decodeError:
+            entry.nextFireAt = clock.now().addingTimeInterval(entry.backoffActive ? Self.backoff : Self.cadence)
+            schedule[tokenID] = entry
+        }
+    }
+}

--- a/Sources/TBDDaemon/Claude/PollerClock.swift
+++ b/Sources/TBDDaemon/Claude/PollerClock.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Abstract clock used by `ClaudeUsagePoller` so tests can advance virtual time
+/// instead of sleeping. Production uses `SystemPollerClock`; tests use a fake.
+public protocol PollerClock: Sendable {
+    func now() -> Date
+    /// Sleep until `deadline`. May throw `CancellationError` to wake early.
+    func sleep(until deadline: Date) async throws
+}
+
+public struct SystemPollerClock: PollerClock {
+    public init() {}
+    public func now() -> Date { Date() }
+    public func sleep(until deadline: Date) async throws {
+        let interval = deadline.timeIntervalSince(Date())
+        if interval > 0 {
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        }
+    }
+}

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -14,6 +14,7 @@ public final class Daemon: Sendable {
     public nonisolated(unsafe) var sshRefreshTask: Task<Void, Never>?
     public nonisolated(unsafe) var gitFetchTask: Task<Void, Never>?
     public nonisolated(unsafe) var gitStatusTask: Task<Void, Never>?
+    public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     public let pidFile: PIDFile
     public let startTime: Date
 
@@ -134,6 +135,19 @@ public final class Daemon: Sendable {
             }
         }
 
+        // 12b. Start Claude OAuth usage poller (30-min cadence, 30s stagger).
+        let poller = ClaudeUsagePoller(
+            tokens: database.claudeTokens,
+            usage: database.claudeTokenUsage,
+            keychain: { id in try ClaudeTokenKeychain.load(id: id) },
+            fetcher: LiveClaudeUsageFetcher(),
+            clock: SystemPollerClock(),
+            broadcast: { [weak subs] row in subs?.broadcastClaudeTokenUsage(row) }
+        )
+        self.claudeUsagePoller = poller
+        rpcRouter.claudeUsagePoller = poller
+        await poller.start()
+
         print("[Daemon] Started successfully (PID \(ProcessInfo.processInfo.processIdentifier))")
 
         // 13. Periodic git status refresh (branch sync, conflict detection)
@@ -153,6 +167,11 @@ public final class Daemon: Sendable {
     /// Stop the daemon: shut down servers, remove PID and socket files.
     public func stop() async {
         print("[Daemon] Shutting down...")
+
+        // Stop Claude usage poller before other background tasks.
+        if let poller = claudeUsagePoller {
+            await poller.stop()
+        }
 
         // Cancel background tasks
         sshRefreshTask?.cancel()

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -99,7 +99,8 @@ public final class Daemon: Sendable {
             git: git,
             startTime: startTime,
             subscriptions: subs,
-            prManager: prManager
+            prManager: prManager,
+            claudeTokenResolver: claudeTokenResolver
         )
         self.router = rpcRouter
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -79,7 +79,16 @@ public final class Daemon: Sendable {
         let git = GitManager()
         let tmux = TmuxManager()
         let hooks = HookResolver()
-        let lifecycle = WorktreeLifecycle(db: database, git: git, tmux: tmux, hooks: hooks, subscriptions: subs)
+        let claudeTokenResolver = ClaudeTokenResolver(
+            tokens: database.claudeTokens,
+            repos: database.repos,
+            config: database.config
+        )
+        let lifecycle = WorktreeLifecycle(
+            db: database, git: git, tmux: tmux, hooks: hooks,
+            subscriptions: subs,
+            claudeTokenResolver: claudeTokenResolver
+        )
         let prManager = PRStatusManager()
 
         // 8. Initialize RPC router

--- a/Sources/TBDDaemon/Database/ClaudeTokenRecord.swift
+++ b/Sources/TBDDaemon/Database/ClaudeTokenRecord.swift
@@ -1,0 +1,95 @@
+import Foundation
+import GRDB
+import TBDShared
+
+struct ClaudeTokenRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "claude_tokens"
+
+    var id: String
+    var name: String
+    var keychain_ref: String
+    var kind: String
+    var created_at: Date
+    var last_used_at: Date?
+
+    init(from token: ClaudeToken) {
+        self.id = token.id.uuidString
+        self.name = token.name
+        self.keychain_ref = token.id.uuidString
+        self.kind = token.kind.rawValue
+        self.created_at = token.createdAt
+        self.last_used_at = token.lastUsedAt
+    }
+
+    func toModel() -> ClaudeToken {
+        ClaudeToken(
+            id: UUID(uuidString: id)!,
+            name: name,
+            kind: ClaudeTokenKind(rawValue: kind) ?? .oauth,
+            createdAt: created_at,
+            lastUsedAt: last_used_at
+        )
+    }
+}
+
+public struct ClaudeTokenStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    public func create(name: String, kind: ClaudeTokenKind) async throws -> ClaudeToken {
+        let token = ClaudeToken(name: name, kind: kind)
+        let record = ClaudeTokenRecord(from: token)
+        try await writer.write { db in
+            try record.insert(db)
+        }
+        return token
+    }
+
+    public func list() async throws -> [ClaudeToken] {
+        try await writer.read { db in
+            try ClaudeTokenRecord.fetchAll(db).map { $0.toModel() }
+        }
+    }
+
+    public func get(id: UUID) async throws -> ClaudeToken? {
+        try await writer.read { db in
+            try ClaudeTokenRecord.fetchOne(db, key: id.uuidString)?.toModel()
+        }
+    }
+
+    public func getByName(_ name: String) async throws -> ClaudeToken? {
+        try await writer.read { db in
+            try ClaudeTokenRecord
+                .filter(Column("name") == name)
+                .fetchOne(db)?
+                .toModel()
+        }
+    }
+
+    public func rename(id: UUID, name: String) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE claude_tokens SET name = ? WHERE id = ?",
+                arguments: [name, id.uuidString]
+            )
+        }
+    }
+
+    public func delete(id: UUID) async throws {
+        _ = try await writer.write { db in
+            try ClaudeTokenRecord.deleteOne(db, key: id.uuidString)
+        }
+    }
+
+    public func touchLastUsed(id: UUID, at date: Date = Date()) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE claude_tokens SET last_used_at = ? WHERE id = ?",
+                arguments: [date, id.uuidString]
+            )
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/ClaudeTokenUsageRecord.swift
+++ b/Sources/TBDDaemon/Database/ClaudeTokenUsageRecord.swift
@@ -1,0 +1,64 @@
+import Foundation
+import GRDB
+import TBDShared
+
+struct ClaudeTokenUsageRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "claude_token_usage"
+
+    var token_id: String
+    var five_hour_pct: Double?
+    var seven_day_pct: Double?
+    var five_hour_resets_at: Date?
+    var seven_day_resets_at: Date?
+    var fetched_at: Date?
+    var last_status: String?
+
+    init(from u: ClaudeTokenUsage) {
+        self.token_id = u.tokenID.uuidString
+        self.five_hour_pct = u.fiveHourPct
+        self.seven_day_pct = u.sevenDayPct
+        self.five_hour_resets_at = u.fiveHourResetsAt
+        self.seven_day_resets_at = u.sevenDayResetsAt
+        self.fetched_at = u.fetchedAt
+        self.last_status = u.lastStatus
+    }
+
+    func toModel() -> ClaudeTokenUsage {
+        ClaudeTokenUsage(
+            tokenID: UUID(uuidString: token_id)!,
+            fiveHourPct: five_hour_pct,
+            sevenDayPct: seven_day_pct,
+            fiveHourResetsAt: five_hour_resets_at,
+            sevenDayResetsAt: seven_day_resets_at,
+            fetchedAt: fetched_at,
+            lastStatus: last_status
+        )
+    }
+}
+
+public struct ClaudeTokenUsageStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    public func upsert(_ usage: ClaudeTokenUsage) async throws {
+        let record = ClaudeTokenUsageRecord(from: usage)
+        try await writer.write { db in
+            try record.save(db)
+        }
+    }
+
+    public func get(tokenID: UUID) async throws -> ClaudeTokenUsage? {
+        try await writer.read { db in
+            try ClaudeTokenUsageRecord.fetchOne(db, key: tokenID.uuidString)?.toModel()
+        }
+    }
+
+    public func deleteForToken(id: UUID) async throws {
+        _ = try await writer.write { db in
+            try ClaudeTokenUsageRecord.deleteOne(db, key: id.uuidString)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -1,0 +1,40 @@
+import Foundation
+import GRDB
+import TBDShared
+
+struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "config"
+
+    var id: String
+    var default_claude_token_id: String?
+
+    func toModel() -> Config {
+        Config(
+            defaultClaudeTokenID: default_claude_token_id.flatMap(UUID.init(uuidString:))
+        )
+    }
+}
+
+public struct ConfigStore: Sendable {
+    static let singletonID = "singleton"
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    public func get() async throws -> Config {
+        try await writer.read { db in
+            try ConfigRecord.fetchOne(db, key: Self.singletonID)?.toModel() ?? Config()
+        }
+    }
+
+    public func setDefaultClaudeTokenID(_ id: UUID?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET default_claude_token_id = ? WHERE id = ?",
+                arguments: [id?.uuidString, Self.singletonID]
+            )
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -17,6 +17,7 @@ public final class TBDDatabase: Sendable {
     public let conductors: ConductorStore
     public let claudeTokens: ClaudeTokenStore
     public let claudeTokenUsage: ClaudeTokenUsageStore
+    public let config: ConfigStore
 
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
     public init(path: String) throws {
@@ -36,6 +37,7 @@ public final class TBDDatabase: Sendable {
         self.conductors = ConductorStore(writer: pool)
         self.claudeTokens = ClaudeTokenStore(writer: pool)
         self.claudeTokenUsage = ClaudeTokenUsageStore(writer: pool)
+        self.config = ConfigStore(writer: pool)
         try Self.migrate(writer: pool)
     }
 
@@ -52,6 +54,7 @@ public final class TBDDatabase: Sendable {
         self.conductors = ConductorStore(writer: queue)
         self.claudeTokens = ClaudeTokenStore(writer: queue)
         self.claudeTokenUsage = ClaudeTokenUsageStore(writer: queue)
+        self.config = ConfigStore(writer: queue)
         try Self.migrate(writer: queue)
     }
 

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -16,6 +16,7 @@ public final class TBDDatabase: Sendable {
     public let notes: NoteStore
     public let conductors: ConductorStore
     public let claudeTokens: ClaudeTokenStore
+    public let claudeTokenUsage: ClaudeTokenUsageStore
 
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
     public init(path: String) throws {
@@ -34,6 +35,7 @@ public final class TBDDatabase: Sendable {
         self.notes = NoteStore(writer: pool)
         self.conductors = ConductorStore(writer: pool)
         self.claudeTokens = ClaudeTokenStore(writer: pool)
+        self.claudeTokenUsage = ClaudeTokenUsageStore(writer: pool)
         try Self.migrate(writer: pool)
     }
 
@@ -49,6 +51,7 @@ public final class TBDDatabase: Sendable {
         self.notes = NoteStore(writer: queue)
         self.conductors = ConductorStore(writer: queue)
         self.claudeTokens = ClaudeTokenStore(writer: queue)
+        self.claudeTokenUsage = ClaudeTokenUsageStore(writer: queue)
         try Self.migrate(writer: queue)
     }
 

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -15,6 +15,7 @@ public final class TBDDatabase: Sendable {
     public let notifications: NotificationStore
     public let notes: NoteStore
     public let conductors: ConductorStore
+    public let claudeTokens: ClaudeTokenStore
 
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
     public init(path: String) throws {
@@ -32,6 +33,7 @@ public final class TBDDatabase: Sendable {
         self.notifications = NotificationStore(writer: pool)
         self.notes = NoteStore(writer: pool)
         self.conductors = ConductorStore(writer: pool)
+        self.claudeTokens = ClaudeTokenStore(writer: pool)
         try Self.migrate(writer: pool)
     }
 
@@ -46,6 +48,7 @@ public final class TBDDatabase: Sendable {
         self.notifications = NotificationStore(writer: queue)
         self.notes = NoteStore(writer: queue)
         self.conductors = ConductorStore(writer: queue)
+        self.claudeTokens = ClaudeTokenStore(writer: queue)
         try Self.migrate(writer: queue)
     }
 

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -6,6 +6,9 @@ import TBDShared
 public final class TBDDatabase: Sendable {
     private let writer: any DatabaseWriter
 
+    /// Test-only accessor exposing the underlying writer for migration / schema tests.
+    internal var writerForTests: any DatabaseWriter { writer }
+
     public let repos: RepoStore
     public let worktrees: WorktreeStore
     public let terminals: TerminalStore
@@ -193,6 +196,45 @@ public final class TBDDatabase: Sendable {
             try db.alter(table: "repo") { t in
                 t.add(column: "renamePrompt", .text)
                 t.add(column: "customInstructions", .text)
+            }
+        }
+
+        migrator.registerMigration("v13") { db in
+            try db.create(table: "claude_tokens") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("name", .text).notNull().unique()
+                t.column("keychain_ref", .text).notNull()
+                t.column("kind", .text).notNull()
+                t.column("created_at", .datetime).notNull()
+                t.column("last_used_at", .datetime)
+            }
+
+            try db.create(table: "claude_token_usage") { t in
+                t.primaryKey("token_id", .text).notNull()
+                    .references("claude_tokens", onDelete: .cascade)
+                t.column("five_hour_pct", .double)
+                t.column("seven_day_pct", .double)
+                t.column("five_hour_resets_at", .datetime)
+                t.column("seven_day_resets_at", .datetime)
+                t.column("fetched_at", .datetime)
+                t.column("last_status", .text)
+            }
+
+            try db.create(table: "config") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("default_claude_token_id", .text)
+                    .references("claude_tokens", onDelete: .setNull)
+            }
+            try db.execute(
+                sql: "INSERT OR IGNORE INTO config (id, default_claude_token_id) VALUES ('singleton', NULL)"
+            )
+
+            try db.alter(table: "repo") { t in
+                t.add(column: "claude_token_override_id", .text)
+            }
+
+            try db.alter(table: "terminal") { t in
+                t.add(column: "claude_token_id", .text)
             }
         }
 

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -115,6 +115,16 @@ public struct RepoStore: Sendable {
         }
     }
 
+    /// Clear the Claude token override on every repo whose override matches the given token.
+    public func clearClaudeTokenOverride(matching tokenID: UUID) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET claude_token_override_id = NULL WHERE claude_token_override_id = ?",
+                arguments: [tokenID.uuidString]
+            )
+        }
+    }
+
     /// Find a repo by its filesystem path.
     public func findByPath(path: String) async throws -> Repo? {
         try await writer.read { db in

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -14,6 +14,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var createdAt: Date
     var renamePrompt: String?
     var customInstructions: String?
+    var claude_token_override_id: String?
 
     init(from repo: Repo) {
         self.id = repo.id.uuidString
@@ -24,6 +25,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.createdAt = repo.createdAt
         self.renamePrompt = repo.renamePrompt
         self.customInstructions = repo.customInstructions
+        self.claude_token_override_id = repo.claudeTokenOverrideID?.uuidString
     }
 
     func toModel() -> Repo {
@@ -35,7 +37,8 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             defaultBranch: defaultBranch,
             createdAt: createdAt,
             renamePrompt: renamePrompt,
-            customInstructions: customInstructions
+            customInstructions: customInstructions,
+            claudeTokenOverrideID: claude_token_override_id.flatMap(UUID.init(uuidString:))
         )
     }
 }
@@ -98,6 +101,16 @@ public struct RepoStore: Sendable {
             try db.execute(
                 sql: "UPDATE repo SET renamePrompt = ?, customInstructions = ? WHERE id = ?",
                 arguments: [renamePrompt, customInstructions, id.uuidString]
+            )
+        }
+    }
+
+    /// Set or clear the Claude token override for a repo.
+    public func setClaudeTokenOverride(id: UUID, tokenID: UUID?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET claude_token_override_id = ? WHERE id = ?",
+                arguments: [tokenID?.uuidString, id.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -16,6 +16,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var claudeSessionID: String?
     var suspendedAt: Date?
     var suspendedSnapshot: String?
+    var claude_token_id: String?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -28,6 +29,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.claudeSessionID = terminal.claudeSessionID
         self.suspendedAt = terminal.suspendedAt
         self.suspendedSnapshot = terminal.suspendedSnapshot
+        self.claude_token_id = terminal.claudeTokenID?.uuidString
     }
 
     func toModel() -> Terminal {
@@ -41,7 +43,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             pinnedAt: pinnedAt,
             claudeSessionID: claudeSessionID,
             suspendedAt: suspendedAt,
-            suspendedSnapshot: suspendedSnapshot
+            suspendedSnapshot: suspendedSnapshot,
+            claudeTokenID: claude_token_id.flatMap(UUID.init(uuidString:))
         )
     }
 }
@@ -60,14 +63,16 @@ public struct TerminalStore: Sendable {
         tmuxWindowID: String,
         tmuxPaneID: String,
         label: String? = nil,
-        claudeSessionID: String? = nil
+        claudeSessionID: String? = nil,
+        claudeTokenID: UUID? = nil
     ) async throws -> Terminal {
         let terminal = Terminal(
             worktreeID: worktreeID,
             tmuxWindowID: tmuxWindowID,
             tmuxPaneID: tmuxPaneID,
             label: label,
-            claudeSessionID: claudeSessionID
+            claudeSessionID: claudeSessionID,
+            claudeTokenID: claudeTokenID
         )
         let record = TerminalRecord(from: terminal)
         try await writer.write { db in
@@ -170,6 +175,16 @@ public struct TerminalStore: Sendable {
             record.suspendedSnapshot = nil
             record.label = "shell"
             try record.update(db)
+        }
+    }
+
+    /// Set or clear the Claude token ID for a terminal.
+    public func setClaudeTokenID(id: UUID, tokenID: UUID?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE terminal SET claude_token_id = ? WHERE id = ?",
+                arguments: [tokenID?.uuidString, id.uuidString]
+            )
         }
     }
 

--- a/Sources/TBDDaemon/Keychain/ClaudeTokenKeychain.swift
+++ b/Sources/TBDDaemon/Keychain/ClaudeTokenKeychain.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Security
+
+public enum ClaudeTokenKeychainError: Error, Equatable {
+    case unexpectedStatus(OSStatus)
+    case dataEncoding
+}
+
+public enum ClaudeTokenKeychain {
+    public static let service = "app.tbd.claude-token"
+
+    /// Base query identifying a single item by (service, account).
+    private static func baseQuery(id: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: id,
+        ]
+    }
+
+    /// Upsert a token. Implements delete+add because SecItemAdd returns
+    /// errSecDuplicateItem on existing entries.
+    public static func store(id: String, token: String) throws {
+        guard let data = token.data(using: .utf8) else {
+            throw ClaudeTokenKeychainError.dataEncoding
+        }
+
+        let base = baseQuery(id: id)
+
+        // Clear any existing item with the same identity. Ignore not-found.
+        let deleteStatus = SecItemDelete(base as CFDictionary)
+        if deleteStatus != errSecSuccess && deleteStatus != errSecItemNotFound {
+            throw ClaudeTokenKeychainError.unexpectedStatus(deleteStatus)
+        }
+
+        var addQuery = base
+        addQuery[kSecValueData as String] = data
+
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw ClaudeTokenKeychainError.unexpectedStatus(addStatus)
+        }
+    }
+
+    /// Returns nil if no item with the given id exists.
+    public static func load(id: String) throws -> String? {
+        var query = baseQuery(id: id)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data,
+                  let token = String(data: data, encoding: .utf8) else {
+                throw ClaudeTokenKeychainError.dataEncoding
+            }
+            return token
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw ClaudeTokenKeychainError.unexpectedStatus(status)
+        }
+    }
+
+    /// Idempotent; does not throw on missing item.
+    public static func delete(id: String) throws {
+        let status = SecItemDelete(baseQuery(id: id) as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            throw ClaudeTokenKeychainError.unexpectedStatus(status)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Keychain/ClaudeTokenKeychain.swift
+++ b/Sources/TBDDaemon/Keychain/ClaudeTokenKeychain.swift
@@ -1,75 +1,125 @@
 import Foundation
-import Security
 
+/// File-backed secret store for Claude OAuth tokens.
+///
+/// **Naming note:** the type is still `ClaudeTokenKeychain` for historical
+/// reasons — the original implementation used macOS Keychain, but Keychain's
+/// per-binary ACL model is incompatible with an unbundled / unsigned SPM
+/// daemon that rebuilds frequently (each rebuild changes the binary signature
+/// and the legacy keychain's `SecItemCopyMatching` hangs forever waiting on a
+/// user-auth GUI prompt that a background daemon can't display, wedging the
+/// keychain's global mutex for every other thread in the process).
+///
+/// We now write tokens as plain files under `~/.tbd/claude-tokens/<uuid>.token`
+/// with mode 0600 (parent dir 0700). This matches the storage model used by
+/// `claude setup-token` itself (writes to `~/.claude/.credentials.json`), as
+/// well as `gh`, `aws`, `kubectl`, `docker`, `npm`, and most other CLI tools
+/// on macOS. The threat model is effectively equivalent to the Keychain for
+/// the cases that matter (multi-user POSIX perms, FileVault-at-rest) and
+/// strictly better than the deadlock we had with Keychain.
 public enum ClaudeTokenKeychainError: Error, Equatable {
-    case unexpectedStatus(OSStatus)
     case dataEncoding
+    case permissionMismatch(String)
+    case ownerMismatch
+    case ioFailure(String)
 }
 
 public enum ClaudeTokenKeychain {
-    public static let service = "app.tbd.claude-token"
-
-    /// Base query identifying a single item by (service, account).
-    private static func baseQuery(id: String) -> [String: Any] {
-        [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: id,
-        ]
+    /// Storage directory. Resolved lazily so tests can override via TMPDIR if needed.
+    private static var storageDir: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent(".tbd/claude-tokens", isDirectory: true)
     }
 
-    /// Upsert a token. Implements delete+add because SecItemAdd returns
-    /// errSecDuplicateItem on existing entries.
+    private static func fileURL(id: String) -> URL {
+        storageDir.appendingPathComponent("\(id).token", isDirectory: false)
+    }
+
+    /// Create the storage directory if missing, with mode 0700.
+    private static func ensureStorageDir() throws {
+        let dir = storageDir
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: dir.path) {
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true, attributes: [
+                .posixPermissions: 0o700
+            ])
+        } else {
+            // Enforce 0700 on an existing dir in case it was created with a
+            // looser umask by an earlier version of the code or by the user.
+            try fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+        }
+    }
+
+    /// Store (or overwrite) a token.
     public static func store(id: String, token: String) throws {
         guard let data = token.data(using: .utf8) else {
             throw ClaudeTokenKeychainError.dataEncoding
         }
-
-        let base = baseQuery(id: id)
-
-        // Clear any existing item with the same identity. Ignore not-found.
-        let deleteStatus = SecItemDelete(base as CFDictionary)
-        if deleteStatus != errSecSuccess && deleteStatus != errSecItemNotFound {
-            throw ClaudeTokenKeychainError.unexpectedStatus(deleteStatus)
+        try ensureStorageDir()
+        let url = fileURL(id: id)
+        do {
+            try data.write(to: url, options: [.atomic])
+        } catch {
+            throw ClaudeTokenKeychainError.ioFailure(error.localizedDescription)
         }
-
-        var addQuery = base
-        addQuery[kSecValueData as String] = data
-
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        guard addStatus == errSecSuccess else {
-            throw ClaudeTokenKeychainError.unexpectedStatus(addStatus)
-        }
+        // Atomic write uses a temp file + rename, which may drop our intended
+        // mode bits. Set them explicitly after the write.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: url.path
+        )
     }
 
-    /// Returns nil if no item with the given id exists.
+    /// Load a token. Returns nil if no file exists for the given id.
+    /// Throws if the file exists but has wrong mode or wrong owner — we don't
+    /// want to return tokens from a misconfigured restore.
     public static func load(id: String) throws -> String? {
-        var query = baseQuery(id: id)
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        let url = fileURL(id: id)
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else { return nil }
 
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-
-        switch status {
-        case errSecSuccess:
-            guard let data = item as? Data,
-                  let token = String(data: data, encoding: .utf8) else {
-                throw ClaudeTokenKeychainError.dataEncoding
-            }
-            return token
-        case errSecItemNotFound:
-            return nil
-        default:
-            throw ClaudeTokenKeychainError.unexpectedStatus(status)
+        let attrs: [FileAttributeKey: Any]
+        do {
+            attrs = try fm.attributesOfItem(atPath: url.path)
+        } catch {
+            throw ClaudeTokenKeychainError.ioFailure(error.localizedDescription)
         }
+
+        if let perms = attrs[.posixPermissions] as? NSNumber {
+            let mode = perms.int16Value & 0o777
+            if mode != 0o600 {
+                throw ClaudeTokenKeychainError.permissionMismatch(
+                    String(format: "expected 0600, got 0%o", mode)
+                )
+            }
+        }
+        if let ownerID = attrs[.ownerAccountID] as? NSNumber {
+            if ownerID.uint32Value != getuid() {
+                throw ClaudeTokenKeychainError.ownerMismatch
+            }
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw ClaudeTokenKeychainError.ioFailure(error.localizedDescription)
+        }
+        guard let token = String(data: data, encoding: .utf8) else {
+            throw ClaudeTokenKeychainError.dataEncoding
+        }
+        return token
     }
 
-    /// Idempotent; does not throw on missing item.
+    /// Idempotent delete.
     public static func delete(id: String) throws {
-        let status = SecItemDelete(baseQuery(id: id) as CFDictionary)
-        if status != errSecSuccess && status != errSecItemNotFound {
-            throw ClaudeTokenKeychainError.unexpectedStatus(status)
+        let url = fileURL(id: id)
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else { return }
+        do {
+            try fm.removeItem(at: url)
+        } catch {
+            throw ClaudeTokenKeychainError.ioFailure(error.localizedDescription)
         }
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -50,6 +50,7 @@ public actor SuspendResumeCoordinator {
     private let db: TBDDatabase
     private let tmux: TmuxManager
     private let detector: ClaudeStateDetector
+    private let claudeTokenResolver: ClaudeTokenResolver?
     private var inFlight: [UUID: Task<Void, Never>] = [:]
     private var lastKnownSelection: Set<UUID> = []
     /// Tracks whether each worktree has received a response_complete since last
@@ -57,10 +58,16 @@ public actor SuspendResumeCoordinator {
     /// this signal AND capture-pane confirmation.
     private var worktreeIdleFromHook: Set<UUID> = []
 
-    public init(db: TBDDatabase, tmux: TmuxManager) {
+    /// The user's default shell (from $SHELL, falls back to /bin/zsh).
+    private var defaultShell: String {
+        ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+    }
+
+    public init(db: TBDDatabase, tmux: TmuxManager, claudeTokenResolver: ClaudeTokenResolver? = nil) {
         self.db = db
         self.tmux = tmux
         self.detector = ClaudeStateDetector(tmux: tmux)
+        self.claudeTokenResolver = claudeTokenResolver
     }
 
     /// Called when the daemon receives a response_complete notification for a worktree.
@@ -353,7 +360,37 @@ public actor SuspendResumeCoordinator {
             return
         }
 
-        let resumeCommand = "claude --resume \(sessionID) --dangerously-skip-permissions"
+        // Honor per-terminal claude token. We use loadByID (NOT resolve(repoID:))
+        // to load the EXACT token persisted on this terminal — a re-resolution
+        // could pick a different override if the user changed defaults since
+        // suspend. Failures degrade gracefully to keychain login.
+        var resolvedToken: ResolvedClaudeToken? = nil
+        if let tokenID = terminal.claudeTokenID, let resolver = claudeTokenResolver {
+            do {
+                resolvedToken = try await resolver.loadByID(tokenID)
+                if resolvedToken == nil {
+                    FileHandle.standardError.write(Data(
+                        "[SuspendResumeCoordinator] warning: claude token \(tokenID) for terminal \(terminal.id) is missing; falling back to keychain login\n".utf8
+                    ))
+                }
+            } catch {
+                FileHandle.standardError.write(Data(
+                    "[SuspendResumeCoordinator] warning: claude token lookup failed for terminal \(terminal.id); falling back to keychain login: \(error)\n".utf8
+                ))
+                resolvedToken = nil
+            }
+        }
+
+        let resumeCommand = ClaudeSpawnCommandBuilder.build(
+            resumeID: sessionID,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: resolvedToken?.secret,
+            tokenKind: resolvedToken?.kind,
+            cmd: nil,
+            shellFallback: defaultShell
+        )
         do {
             let window = try await tmux.createWindow(
                 server: server, session: "main",

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -369,14 +369,10 @@ public actor SuspendResumeCoordinator {
             do {
                 resolvedToken = try await resolver.loadByID(tokenID)
                 if resolvedToken == nil {
-                    FileHandle.standardError.write(Data(
-                        "[SuspendResumeCoordinator] warning: claude token \(tokenID) for terminal \(terminal.id) is missing; falling back to keychain login\n".utf8
-                    ))
+                    logger.warning("claude token \(tokenID) for terminal \(terminal.id) is missing; falling back to keychain login")
                 }
             } catch {
-                FileHandle.standardError.write(Data(
-                    "[SuspendResumeCoordinator] warning: claude token lookup failed for terminal \(terminal.id); falling back to keychain login: \(error)\n".utf8
-                ))
+                logger.warning("claude token lookup failed for terminal \(terminal.id); falling back to keychain login: \(error.localizedDescription, privacy: .public)")
                 resolvedToken = nil
             }
         }

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -381,7 +381,7 @@ public actor SuspendResumeCoordinator {
             }
         }
 
-        let resumeCommand = ClaudeSpawnCommandBuilder.build(
+        let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: sessionID,
             freshSessionID: nil,
             appendSystemPrompt: nil,
@@ -394,7 +394,8 @@ public actor SuspendResumeCoordinator {
         do {
             let window = try await tmux.createWindow(
                 server: server, session: "main",
-                cwd: worktree.path, shellCommand: resumeCommand
+                cwd: worktree.path, shellCommand: spawn.command,
+                sensitiveEnv: spawn.sensitiveEnv
             )
             try await db.terminals.updateTmuxIDs(
                 id: terminal.id, windowID: window.windowID, paneID: window.paneID

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "worktreeLifecycle")
 
 extension WorktreeLifecycle {
     // MARK: - Create
@@ -197,9 +200,7 @@ extension WorktreeLifecycle {
             do {
                 resolvedToken = try await resolver.resolve(repoID: repo.id)
             } catch {
-                FileHandle.standardError.write(Data(
-                    "[WorktreeLifecycle] warning: claude token resolution failed; falling back to keychain login\n".utf8
-                ))
+                logger.warning("claude token resolution failed; falling back to keychain login")
                 resolvedToken = nil
             }
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -190,29 +190,44 @@ extension WorktreeLifecycle {
             cwd: worktreePath
         )
 
+        // Resolve claude token (repo override → global default → none).
+        // Failures here must NOT break worktree creation — fall back to keychain login.
+        var resolvedToken: ResolvedClaudeToken? = nil
+        if !skipClaude, let resolver = claudeTokenResolver {
+            do {
+                resolvedToken = try await resolver.resolve(repoID: repo.id)
+            } catch {
+                FileHandle.standardError.write(Data(
+                    "[WorktreeLifecycle] warning: claude token resolution failed; falling back to keychain login\n".utf8
+                ))
+                resolvedToken = nil
+            }
+        }
+
         // Create terminal 1: claude (or shell if skipClaude)
         let claudeCommand: String
         let claudeSessionID: String?
+        let claudeTokenID: UUID?
         if skipClaude {
             claudeCommand = defaultShell
             claudeSessionID = nil
+            claudeTokenID = nil
         } else {
             let sessionUUID = archivedClaudeSessions?.first ?? UUID().uuidString
-            var cmd = "claude --dangerously-skip-permissions --session-id \(sessionUUID)"
             claudeSessionID = sessionUUID
-
-            // Inject per-repo system prompt
             let isResume = archivedClaudeSessions?.first != nil
-            if let prompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: isResume) {
-                cmd += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
-            }
-
-            // Pass initial prompt as positional arg (only for fresh sessions, not resumes)
-            if !isResume, let initialPrompt, !initialPrompt.isEmpty {
-                cmd += " \(SystemPromptBuilder.shellEscape(initialPrompt))"
-            }
-
-            claudeCommand = cmd
+            let appendPrompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: isResume)
+            claudeCommand = ClaudeSpawnCommandBuilder.build(
+                resumeID: nil,
+                freshSessionID: sessionUUID,
+                appendSystemPrompt: appendPrompt,
+                initialPrompt: isResume ? nil : initialPrompt,
+                tokenSecret: resolvedToken?.secret,
+                tokenKind: resolvedToken?.kind,
+                cmd: nil,
+                shellFallback: defaultShell
+            )
+            claudeTokenID = resolvedToken?.tokenID
         }
         let window1 = try await tmux.createWindow(
             server: tmuxServer,
@@ -225,7 +240,8 @@ extension WorktreeLifecycle {
             tmuxWindowID: window1.windowID,
             tmuxPaneID: window1.paneID,
             label: skipClaude ? "shell" : "Claude Code",
-            claudeSessionID: claudeSessionID
+            claudeSessionID: claudeSessionID,
+            claudeTokenID: claudeTokenID
         )
 
         // Create terminal 2: setup hook
@@ -251,7 +267,16 @@ extension WorktreeLifecycle {
         // Restore additional archived Claude sessions (beyond the first which was used above)
         if !skipClaude, let sessions = archivedClaudeSessions, sessions.count > 1 {
             for sessionID in sessions.dropFirst() {
-                let cmd = "claude --dangerously-skip-permissions --session-id \(sessionID)"
+                let cmd = ClaudeSpawnCommandBuilder.build(
+                    resumeID: nil,
+                    freshSessionID: sessionID,
+                    appendSystemPrompt: nil,
+                    initialPrompt: nil,
+                    tokenSecret: resolvedToken?.secret,
+                    tokenKind: resolvedToken?.kind,
+                    cmd: nil,
+                    shellFallback: defaultShell
+                )
                 let window = try await tmux.createWindow(
                     server: tmuxServer,
                     session: "main",
@@ -263,7 +288,8 @@ extension WorktreeLifecycle {
                     tmuxWindowID: window.windowID,
                     tmuxPaneID: window.paneID,
                     label: "Claude Code",
-                    claudeSessionID: sessionID
+                    claudeSessionID: sessionID,
+                    claudeTokenID: resolvedToken?.tokenID
                 )
             }
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -206,10 +206,12 @@ extension WorktreeLifecycle {
 
         // Create terminal 1: claude (or shell if skipClaude)
         let claudeCommand: String
+        let claudeSensitiveEnv: [String: String]
         let claudeSessionID: String?
         let claudeTokenID: UUID?
         if skipClaude {
             claudeCommand = defaultShell
+            claudeSensitiveEnv = [:]
             claudeSessionID = nil
             claudeTokenID = nil
         } else {
@@ -217,7 +219,7 @@ extension WorktreeLifecycle {
             claudeSessionID = sessionUUID
             let isResume = archivedClaudeSessions?.first != nil
             let appendPrompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: isResume)
-            claudeCommand = ClaudeSpawnCommandBuilder.build(
+            let spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,
                 freshSessionID: sessionUUID,
                 appendSystemPrompt: appendPrompt,
@@ -227,13 +229,16 @@ extension WorktreeLifecycle {
                 cmd: nil,
                 shellFallback: defaultShell
             )
+            claudeCommand = spawn.command
+            claudeSensitiveEnv = spawn.sensitiveEnv
             claudeTokenID = resolvedToken?.tokenID
         }
         let window1 = try await tmux.createWindow(
             server: tmuxServer,
             session: "main",
             cwd: worktreePath,
-            shellCommand: claudeCommand
+            shellCommand: claudeCommand,
+            sensitiveEnv: claudeSensitiveEnv
         )
         _ = try await db.terminals.create(
             worktreeID: worktreeID,
@@ -267,7 +272,7 @@ extension WorktreeLifecycle {
         // Restore additional archived Claude sessions (beyond the first which was used above)
         if !skipClaude, let sessions = archivedClaudeSessions, sessions.count > 1 {
             for sessionID in sessions.dropFirst() {
-                let cmd = ClaudeSpawnCommandBuilder.build(
+                let spawn = ClaudeSpawnCommandBuilder.build(
                     resumeID: nil,
                     freshSessionID: sessionID,
                     appendSystemPrompt: nil,
@@ -281,7 +286,8 @@ extension WorktreeLifecycle {
                     server: tmuxServer,
                     session: "main",
                     cwd: worktreePath,
-                    shellCommand: cmd
+                    shellCommand: spawn.command,
+                    sensitiveEnv: spawn.sensitiveEnv
                 )
                 _ = try await db.terminals.create(
                     worktreeID: worktreeID,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -38,17 +38,26 @@ public struct WorktreeLifecycle: Sendable {
     public let tmux: TmuxManager
     public let hooks: HookResolver
     public let subscriptions: StateSubscriptionManager?
+    public let claudeTokenResolver: ClaudeTokenResolver?
 
     /// The user's default shell (from $SHELL, falls back to /bin/zsh)
     var defaultShell: String {
         ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
     }
 
-    public init(db: TBDDatabase, git: GitManager, tmux: TmuxManager, hooks: HookResolver, subscriptions: StateSubscriptionManager? = nil) {
+    public init(
+        db: TBDDatabase,
+        git: GitManager,
+        tmux: TmuxManager,
+        hooks: HookResolver,
+        subscriptions: StateSubscriptionManager? = nil,
+        claudeTokenResolver: ClaudeTokenResolver? = nil
+    ) {
         self.db = db
         self.git = git
         self.tmux = tmux
         self.hooks = hooks
         self.subscriptions = subscriptions
+        self.claudeTokenResolver = claudeTokenResolver
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeTokenHandlers")
 
 extension RPCRouter {
 
@@ -120,7 +123,14 @@ extension RPCRouter {
         // Running terminals keep the env var that was injected at spawn time;
         // mutating their stored token id would mislead the UI about what the
         // already-running claude process is actually using.
-        try? ClaudeTokenKeychain.delete(id: params.id.uuidString)
+        // DB row deletion is the source of truth — don't fail the RPC if the
+        // on-disk token file delete fails (permission, missing, disk error).
+        // Log so an orphan file isn't completely silent.
+        do {
+            try ClaudeTokenKeychain.delete(id: params.id.uuidString)
+        } catch {
+            logger.warning("Failed to delete token file for \(params.id): \(error.localizedDescription, privacy: .public)")
+        }
 
         return .ok()
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
@@ -55,7 +55,7 @@ extension RPCRouter {
                 return RPCResponse(error: "Token invalid")
             case .http429:
                 warning = "Could not verify token with Anthropic; saved anyway"
-                freshStatus = "http429"
+                freshStatus = "http_429"
             case .networkError:
                 warning = "Could not verify token with Anthropic; saved anyway"
                 freshStatus = "network_error"

--- a/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
@@ -28,6 +28,13 @@ extension RPCRouter {
             return RPCResponse(error: "Name cannot be empty")
         }
 
+        // Tokens are passed through tmux's `-e KEY=VALUE` argv (no shell), so
+        // most printables are safe. Reject only chars that would break a
+        // single-line tmux arg: newlines, carriage returns, NULL bytes.
+        if trimmed.contains(where: { $0 == "\n" || $0 == "\r" || $0 == "\0" }) {
+            return RPCResponse(error: "Token contains invalid characters (newlines or NULL bytes are not allowed)")
+        }
+
         let kind: ClaudeTokenKind
         if trimmed.hasPrefix("sk-ant-oat01-") {
             kind = .oauth

--- a/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
@@ -168,7 +168,7 @@ extension RPCRouter {
         do {
             bytes = try ClaudeTokenKeychain.load(id: params.id.uuidString)
         } catch {
-            return RPCResponse(error: "Failed to read token from keychain")
+            return RPCResponse(error: "Failed to read token: \(error)")
         }
         guard let token = bytes else {
             return RPCResponse(error: "Token missing from keychain")

--- a/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
@@ -13,7 +13,8 @@ extension RPCRouter {
             let usage = try await db.claudeTokenUsage.get(tokenID: token.id)
             result.append(ClaudeTokenWithUsage(token: token, usage: usage))
         }
-        return try RPCResponse(result: ClaudeTokenListResult(tokens: result))
+        let config = try await db.config.get()
+        return try RPCResponse(result: ClaudeTokenListResult(tokens: result, defaultID: config.defaultClaudeTokenID))
     }
 
     // MARK: - Add

--- a/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
@@ -186,6 +186,7 @@ extension RPCRouter {
                 lastStatus: "ok"
             )
             try await db.claudeTokenUsage.upsert(row)
+            subscriptions.broadcastClaudeTokenUsage(row)
             return try RPCResponse(result: ClaudeTokenFetchUsageResult(usage: row))
         case .http401:
             return RPCResponse(error: "Token invalid")

--- a/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift
@@ -1,0 +1,200 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+
+    // MARK: - List
+
+    func handleClaudeTokenList() async throws -> RPCResponse {
+        let tokens = try await db.claudeTokens.list()
+        var result: [ClaudeTokenWithUsage] = []
+        result.reserveCapacity(tokens.count)
+        for token in tokens {
+            let usage = try await db.claudeTokenUsage.get(tokenID: token.id)
+            result.append(ClaudeTokenWithUsage(token: token, usage: usage))
+        }
+        return try RPCResponse(result: ClaudeTokenListResult(tokens: result))
+    }
+
+    // MARK: - Add
+
+    func handleClaudeTokenAdd(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ClaudeTokenAddParams.self, from: paramsData)
+        let trimmed = params.token.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = params.name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !name.isEmpty else {
+            return RPCResponse(error: "Name cannot be empty")
+        }
+
+        let kind: ClaudeTokenKind
+        if trimmed.hasPrefix("sk-ant-oat01-") {
+            kind = .oauth
+        } else if trimmed.hasPrefix("sk-ant-api03-") {
+            kind = .apiKey
+        } else {
+            return RPCResponse(error: "Token must start with sk-ant-oat01- or sk-ant-api03-")
+        }
+
+        if try await db.claudeTokens.getByName(name) != nil {
+            return RPCResponse(error: "A token named '\(name)' already exists")
+        }
+
+        var warning: String? = nil
+        var freshUsage: ClaudeUsageResult? = nil
+        var freshStatus: String? = nil
+
+        if kind == .oauth {
+            let status = await usageFetcher.fetchUsage(token: trimmed)
+            switch status {
+            case .ok(let usage):
+                freshUsage = usage
+                freshStatus = "ok"
+            case .http401:
+                return RPCResponse(error: "Token invalid")
+            case .http429:
+                warning = "Could not verify token with Anthropic; saved anyway"
+                freshStatus = "http429"
+            case .networkError:
+                warning = "Could not verify token with Anthropic; saved anyway"
+                freshStatus = "network_error"
+            case .decodeError:
+                warning = "Could not verify token with Anthropic; saved anyway"
+                freshStatus = "decode_error"
+            }
+        }
+
+        // Create DB row first so we have the canonical UUID; the keychain entry
+        // is keyed by that UUID. If the keychain write fails we roll back the row.
+        let tokenRow = try await db.claudeTokens.create(name: name, kind: kind)
+        do {
+            try ClaudeTokenKeychain.store(id: tokenRow.id.uuidString, token: trimmed)
+        } catch {
+            try? await db.claudeTokens.delete(id: tokenRow.id)
+            return RPCResponse(error: "Failed to store token in keychain")
+        }
+
+        if let usage = freshUsage {
+            let usageRow = ClaudeTokenUsage(
+                tokenID: tokenRow.id,
+                fiveHourPct: usage.fiveHourPct,
+                sevenDayPct: usage.sevenDayPct,
+                fiveHourResetsAt: usage.fiveHourResetsAt,
+                sevenDayResetsAt: usage.sevenDayResetsAt,
+                fetchedAt: Date(),
+                lastStatus: freshStatus
+            )
+            try await db.claudeTokenUsage.upsert(usageRow)
+        }
+
+        return try RPCResponse(result: ClaudeTokenAddResult(token: tokenRow, warning: warning))
+    }
+
+    // MARK: - Delete
+
+    func handleClaudeTokenDelete(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ClaudeTokenDeleteParams.self, from: paramsData)
+        guard try await db.claudeTokens.get(id: params.id) != nil else {
+            return RPCResponse(error: "Token not found")
+        }
+
+        let config = try await db.config.get()
+        if config.defaultClaudeTokenID == params.id {
+            try await db.config.setDefaultClaudeTokenID(nil)
+        }
+
+        try await db.repos.clearClaudeTokenOverride(matching: params.id)
+
+        try await db.claudeTokenUsage.deleteForToken(id: params.id)
+        try await db.claudeTokens.delete(id: params.id)
+
+        // NOTE: We deliberately do NOT touch terminal.claude_token_id here.
+        // Running terminals keep the env var that was injected at spawn time;
+        // mutating their stored token id would mislead the UI about what the
+        // already-running claude process is actually using.
+        try? ClaudeTokenKeychain.delete(id: params.id.uuidString)
+
+        return .ok()
+    }
+
+    // MARK: - Rename
+
+    func handleClaudeTokenRename(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ClaudeTokenRenameParams.self, from: paramsData)
+        let name = params.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return RPCResponse(error: "Name cannot be empty")
+        }
+        if let existing = try await db.claudeTokens.getByName(name), existing.id != params.id {
+            return RPCResponse(error: "A token named '\(name)' already exists")
+        }
+        try await db.claudeTokens.rename(id: params.id, name: name)
+        return .ok()
+    }
+
+    // MARK: - Defaults
+
+    func handleClaudeTokenSetGlobalDefault(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ClaudeTokenSetGlobalDefaultParams.self, from: paramsData)
+        try await db.config.setDefaultClaudeTokenID(params.id)
+        return .ok()
+    }
+
+    func handleClaudeTokenSetRepoOverride(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ClaudeTokenSetRepoOverrideParams.self, from: paramsData)
+        guard try await db.repos.get(id: params.repoID) != nil else {
+            return RPCResponse(error: "Repo not found")
+        }
+        try await db.repos.setClaudeTokenOverride(id: params.repoID, tokenID: params.tokenID)
+        return .ok()
+    }
+
+    // MARK: - Fetch Usage (60s dedupe)
+
+    func handleClaudeTokenFetchUsage(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ClaudeTokenFetchUsageParams.self, from: paramsData)
+        guard try await db.claudeTokens.get(id: params.id) != nil else {
+            return RPCResponse(error: "Token not found")
+        }
+
+        if let cached = try await db.claudeTokenUsage.get(tokenID: params.id),
+           let fetchedAt = cached.fetchedAt,
+           Date().timeIntervalSince(fetchedAt) < 60 {
+            return try RPCResponse(result: ClaudeTokenFetchUsageResult(usage: cached))
+        }
+
+        let bytes: String?
+        do {
+            bytes = try ClaudeTokenKeychain.load(id: params.id.uuidString)
+        } catch {
+            return RPCResponse(error: "Failed to read token from keychain")
+        }
+        guard let token = bytes else {
+            return RPCResponse(error: "Token missing from keychain")
+        }
+
+        let status = await usageFetcher.fetchUsage(token: token)
+        switch status {
+        case .ok(let usage):
+            let row = ClaudeTokenUsage(
+                tokenID: params.id,
+                fiveHourPct: usage.fiveHourPct,
+                sevenDayPct: usage.sevenDayPct,
+                fiveHourResetsAt: usage.fiveHourResetsAt,
+                sevenDayResetsAt: usage.sevenDayResetsAt,
+                fetchedAt: Date(),
+                lastStatus: "ok"
+            )
+            try await db.claudeTokenUsage.upsert(row)
+            return try RPCResponse(result: ClaudeTokenFetchUsageResult(usage: row))
+        case .http401:
+            return RPCResponse(error: "Token invalid")
+        case .http429:
+            return RPCResponse(error: "Rate limited; try again later")
+        case .networkError(let msg):
+            return RPCResponse(error: "Network error: \(msg)")
+        case .decodeError(let msg):
+            return RPCResponse(error: "Decode error: \(msg)")
+        }
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -36,7 +36,11 @@ extension RPCRouter {
         var resolvedToken: ResolvedClaudeToken? = nil
         if isClaudeType {
             do {
-                resolvedToken = try await claudeTokenResolver.resolve(repoID: worktree.repoID)
+                if let overrideID = params.overrideTokenID {
+                    resolvedToken = try await claudeTokenResolver.loadByID(overrideID)
+                } else {
+                    resolvedToken = try await claudeTokenResolver.resolve(repoID: worktree.repoID)
+                }
             } catch {
                 FileHandle.standardError.write(Data(
                     "[RPCRouter] warning: claude token resolution failed; falling back to keychain login\n".utf8

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "terminalHandlers")
 
 extension RPCRouter {
 
@@ -42,9 +45,7 @@ extension RPCRouter {
                     resolvedToken = try await claudeTokenResolver.resolve(repoID: worktree.repoID)
                 }
             } catch {
-                FileHandle.standardError.write(Data(
-                    "[RPCRouter] warning: claude token resolution failed; falling back to keychain login\n".utf8
-                ))
+                logger.warning("claude token resolution failed; falling back to keychain login")
                 resolvedToken = nil
             }
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -86,6 +86,7 @@ extension RPCRouter {
             appendSystemPrompt: appendSystemPrompt,
             initialPrompt: params.prompt,
             tokenSecret: resolvedToken?.secret,
+            tokenKind: resolvedToken?.kind,
             cmd: params.cmd,
             shellFallback: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         )
@@ -357,6 +358,7 @@ extension RPCRouter {
             appendSystemPrompt: nil,
             initialPrompt: nil,
             tokenSecret: resolved?.secret,
+            tokenKind: resolved?.kind,
             cmd: nil,
             shellFallback: ""
         )

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -386,6 +386,25 @@ extension RPCRouter {
             terminalID: newTerminal.id, worktreeID: newTerminal.worktreeID, label: newTerminal.label
         )))
 
+        // `claude --resume <oldID>` forks the conversation into a NEW session
+        // file with a fresh UUID. The DB row currently stores the OLD ID, so
+        // any later read (handleTerminalConversation) or suspend/resume cycle
+        // would point at the wrong JSONL. Mirror SuspendResumeCoordinator's
+        // post-resume pattern: wait ~5s for Claude to settle, then capture the
+        // new session ID from the pane and persist it.
+        let newTerminalID = newTerminal.id
+        let newPaneID = window.paneID
+        let server = worktree.tmuxServer
+        let tmuxRef = self.tmux
+        let dbRef = self.db
+        Task {
+            try? await Task.sleep(for: .seconds(5))
+            let detector = ClaudeStateDetector(tmux: tmuxRef)
+            if let recaptured = await detector.captureSessionID(server: server, paneID: newPaneID) {
+                try? await dbRef.terminals.updateSessionID(id: newTerminalID, sessionID: recaptured)
+            }
+        }
+
         guard let updated = try await db.terminals.get(id: newTerminal.id) else {
             return RPCResponse(error: "Terminal vanished after swap")
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -29,41 +29,62 @@ extension RPCRouter {
 
         let isClaudeType = params.type == .claude || params.resumeSessionID != nil
         let claudeSessionID: String?
-        let shellCommand: String
         let label: String?
 
+        // Resolve claude token (repo override → global default → none).
+        // Failure here must NOT break terminal spawn — fall back to keychain login.
+        var resolvedToken: ResolvedClaudeToken? = nil
+        if isClaudeType {
+            do {
+                resolvedToken = try await claudeTokenResolver.resolve(repoID: worktree.repoID)
+            } catch {
+                FileHandle.standardError.write(Data(
+                    "[RPCRouter] warning: claude token resolution failed; falling back to keychain login\n".utf8
+                ))
+                resolvedToken = nil
+            }
+        }
+
+        // Build the spawn command via the pure helper.
+        let appendSystemPrompt: String?
+        let freshSessionID: String?
         if let resumeID = params.resumeSessionID {
-            // Fork: resume from an existing session (creates a new session that shares context)
             claudeSessionID = resumeID
-            shellCommand = "claude --resume \(resumeID) --dangerously-skip-permissions"
+            freshSessionID = nil
+            appendSystemPrompt = nil
             label = "claude"
         } else if isClaudeType {
             let sessionID = UUID().uuidString
             claudeSessionID = sessionID
-            var cmd = "claude --session-id \(sessionID) --dangerously-skip-permissions"
-
-            // Inject per-repo system prompt for new Claude sessions
+            freshSessionID = sessionID
             if let repo,
                let prompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false) {
-                cmd += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
+                appendSystemPrompt = prompt
+            } else {
+                appendSystemPrompt = nil
             }
-
-            // Pass initial prompt as positional arg (starts interactive session with this message)
-            if let initialPrompt = params.prompt, !initialPrompt.isEmpty {
-                cmd += " \(SystemPromptBuilder.shellEscape(initialPrompt))"
-            }
-
-            shellCommand = cmd
             label = "Claude Code"
         } else if let cmd = params.cmd {
             claudeSessionID = nil
-            shellCommand = cmd
+            freshSessionID = nil
+            appendSystemPrompt = nil
             label = cmd
         } else {
             claudeSessionID = nil
-            shellCommand = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+            freshSessionID = nil
+            appendSystemPrompt = nil
             label = nil
         }
+
+        let shellCommand = ClaudeSpawnCommandBuilder.build(
+            resumeID: params.resumeSessionID,
+            freshSessionID: freshSessionID,
+            appendSystemPrompt: appendSystemPrompt,
+            initialPrompt: params.prompt,
+            tokenSecret: resolvedToken?.secret,
+            cmd: params.cmd,
+            shellFallback: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        )
 
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
@@ -78,7 +99,8 @@ extension RPCRouter {
             tmuxWindowID: window.windowID,
             tmuxPaneID: window.paneID,
             label: label,
-            claudeSessionID: claudeSessionID
+            claudeSessionID: claudeSessionID,
+            claudeTokenID: resolvedToken?.tokenID
         )
 
         subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
@@ -284,6 +306,93 @@ extension RPCRouter {
         }
 
         return Array(allMessages.suffix(count))
+    }
+
+    // MARK: - Swap Claude Token (mid-conversation)
+
+    func handleTerminalSwapClaudeToken(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalSwapClaudeTokenParams.self, from: paramsData)
+
+        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+            return RPCResponse(error: "Terminal not found: \(params.terminalID)")
+        }
+        guard let sessionID = terminal.claudeSessionID else {
+            return RPCResponse(error: "Terminal \(params.terminalID) is not a Claude terminal")
+        }
+        guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+            return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
+        }
+
+        // Resolve the requested token (nil = clear; fall back to keychain login).
+        let resolved: ResolvedClaudeToken?
+        if let newID = params.newTokenID {
+            do {
+                resolved = try await claudeTokenResolver.loadByID(newID)
+            } catch {
+                return RPCResponse(error: "Failed to load token")
+            }
+            if resolved == nil {
+                return RPCResponse(error: "Token not found or unreadable")
+            }
+        } else {
+            resolved = nil
+        }
+
+        // 1. Interrupt the running claude process.
+        try await tmux.sendKey(
+            server: worktree.tmuxServer,
+            paneID: terminal.tmuxPaneID,
+            key: "C-c"
+        )
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // 2. Build the respawn command (resume the same session, new env).
+        let respawn = ClaudeSpawnCommandBuilder.build(
+            resumeID: sessionID,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: resolved?.secret,
+            cmd: nil,
+            shellFallback: ""
+        )
+
+        // 3. Type the command into the existing pane and submit.
+        try await tmux.sendCommand(
+            server: worktree.tmuxServer,
+            paneID: terminal.tmuxPaneID,
+            command: respawn
+        )
+
+        // 4. Persist the new token id on the terminal.
+        try await db.terminals.setClaudeTokenID(id: terminal.id, tokenID: resolved?.tokenID)
+
+        // 5. Fire-and-forget usage refresh for the new token.
+        if let newID = resolved?.tokenID {
+            let fetcher = self.usageFetcher
+            let database = self.db
+            Task.detached {
+                guard let secret = (try? ClaudeTokenKeychain.load(id: newID.uuidString)) ?? nil else { return }
+                let status = await fetcher.fetchUsage(token: secret)
+                if case .ok(let usage) = status {
+                    let row = ClaudeTokenUsage(
+                        tokenID: newID,
+                        fiveHourPct: usage.fiveHourPct,
+                        sevenDayPct: usage.sevenDayPct,
+                        fiveHourResetsAt: usage.fiveHourResetsAt,
+                        sevenDayResetsAt: usage.sevenDayResetsAt,
+                        fetchedAt: Date(),
+                        lastStatus: "ok"
+                    )
+                    try? await database.claudeTokenUsage.upsert(row)
+                }
+            }
+        }
+
+        guard let updated = try await db.terminals.get(id: terminal.id) else {
+            return RPCResponse(error: "Terminal vanished after swap")
+        }
+        return try RPCResponse(result: updated)
     }
 
     func handleTerminalSend(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -313,17 +313,18 @@ extension RPCRouter {
     func handleTerminalSwapClaudeToken(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSwapClaudeTokenParams.self, from: paramsData)
 
-        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+        guard let oldTerminal = try await db.terminals.get(id: params.terminalID) else {
             return RPCResponse(error: "Terminal not found: \(params.terminalID)")
         }
-        guard let sessionID = terminal.claudeSessionID else {
+        guard let sessionID = oldTerminal.claudeSessionID else {
             return RPCResponse(error: "Terminal \(params.terminalID) is not a Claude terminal")
         }
-        guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+        guard let worktree = try await db.worktrees.get(id: oldTerminal.worktreeID) else {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
 
-        // Resolve the requested token (nil = clear; fall back to keychain login).
+        // Resolve the requested token (nil = no override; keychain login).
+        // We do NOT touch the old terminal — both tabs coexist after the swap.
         let resolved: ResolvedClaudeToken?
         if let newID = params.newTokenID {
             do {
@@ -338,16 +339,15 @@ extension RPCRouter {
             resolved = nil
         }
 
-        // 1. Interrupt the running claude process.
-        try await tmux.sendKey(
-            server: worktree.tmuxServer,
-            paneID: terminal.tmuxPaneID,
-            key: "C-c"
-        )
-        try await Task.sleep(nanoseconds: 500_000_000)
+        // Spawn a NEW window in the same worktree, resuming the same session
+        // ID. `claude --resume` forks the conversation history into a fresh
+        // session file, so the two panes can coexist without JSONL conflicts.
+        // The new pane gets the new env prefix; the old pane is untouched.
+        let repo = try await db.repos.get(id: worktree.repoID)
+        var env = SystemPromptBuilder.promptLayers(repo: repo, worktree: worktree)
+        env["TBD_WORKTREE_ID"] = worktree.id.uuidString
 
-        // 2. Build the respawn command (resume the same session, new env).
-        let respawn = ClaudeSpawnCommandBuilder.build(
+        let shellCommand = ClaudeSpawnCommandBuilder.build(
             resumeID: sessionID,
             freshSessionID: nil,
             appendSystemPrompt: nil,
@@ -357,39 +357,28 @@ extension RPCRouter {
             shellFallback: ""
         )
 
-        // 3. Type the command into the existing pane and submit.
-        try await tmux.sendCommand(
+        let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
-            paneID: terminal.tmuxPaneID,
-            command: respawn
+            session: "main",
+            cwd: worktree.path,
+            shellCommand: shellCommand,
+            env: env
         )
 
-        // 4. Persist the new token id on the terminal.
-        try await db.terminals.setClaudeTokenID(id: terminal.id, tokenID: resolved?.tokenID)
+        let newTerminal = try await db.terminals.create(
+            worktreeID: worktree.id,
+            tmuxWindowID: window.windowID,
+            tmuxPaneID: window.paneID,
+            label: "claude",
+            claudeSessionID: sessionID,
+            claudeTokenID: resolved?.tokenID
+        )
 
-        // 5. Fire-and-forget usage refresh for the new token.
-        if let newID = resolved?.tokenID {
-            let fetcher = self.usageFetcher
-            let database = self.db
-            Task.detached {
-                guard let secret = (try? ClaudeTokenKeychain.load(id: newID.uuidString)) ?? nil else { return }
-                let status = await fetcher.fetchUsage(token: secret)
-                if case .ok(let usage) = status {
-                    let row = ClaudeTokenUsage(
-                        tokenID: newID,
-                        fiveHourPct: usage.fiveHourPct,
-                        sevenDayPct: usage.sevenDayPct,
-                        fiveHourResetsAt: usage.fiveHourResetsAt,
-                        sevenDayResetsAt: usage.sevenDayResetsAt,
-                        fetchedAt: Date(),
-                        lastStatus: "ok"
-                    )
-                    try? await database.claudeTokenUsage.upsert(row)
-                }
-            }
-        }
+        subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
+            terminalID: newTerminal.id, worktreeID: newTerminal.worktreeID, label: newTerminal.label
+        )))
 
-        guard let updated = try await db.terminals.get(id: terminal.id) else {
+        guard let updated = try await db.terminals.get(id: newTerminal.id) else {
             return RPCResponse(error: "Terminal vanished after swap")
         }
         return try RPCResponse(result: updated)

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -80,7 +80,7 @@ extension RPCRouter {
             label = nil
         }
 
-        let shellCommand = ClaudeSpawnCommandBuilder.build(
+        let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: params.resumeSessionID,
             freshSessionID: freshSessionID,
             appendSystemPrompt: appendSystemPrompt,
@@ -95,8 +95,9 @@ extension RPCRouter {
             server: worktree.tmuxServer,
             session: "main",
             cwd: worktree.path,
-            shellCommand: shellCommand,
-            env: env
+            shellCommand: spawn.command,
+            env: env,
+            sensitiveEnv: spawn.sensitiveEnv
         )
 
         let terminal = try await db.terminals.create(
@@ -352,7 +353,7 @@ extension RPCRouter {
         var env = SystemPromptBuilder.promptLayers(repo: repo, worktree: worktree)
         env["TBD_WORKTREE_ID"] = worktree.id.uuidString
 
-        let shellCommand = ClaudeSpawnCommandBuilder.build(
+        let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: sessionID,
             freshSessionID: nil,
             appendSystemPrompt: nil,
@@ -367,8 +368,9 @@ extension RPCRouter {
             server: worktree.tmuxServer,
             session: "main",
             cwd: worktree.path,
-            shellCommand: shellCommand,
-            env: env
+            shellCommand: spawn.command,
+            env: env,
+            sensitiveEnv: spawn.sensitiveEnv
         )
 
         let newTerminal = try await db.terminals.create(

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -15,6 +15,7 @@ public final class RPCRouter: Sendable {
     public let conductorManager: ConductorManager
     public let usageFetcher: ClaudeUsageFetcher
     public let claudeTokenResolver: ClaudeTokenResolver
+    public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -167,6 +168,10 @@ public final class RPCRouter: Sendable {
                 return try await handleClaudeTokenSetRepoOverride(request.paramsData)
             case RPCMethod.claudeTokenFetchUsage:
                 return try await handleClaudeTokenFetchUsage(request.paramsData)
+            case RPCMethod.appSetForegroundState:
+                let params = try decoder.decode(AppSetForegroundStateParams.self, from: request.paramsData)
+                await claudeUsagePoller?.onFocusChanged(isForeground: params.isForeground)
+                return .ok()
             case RPCMethod.stateSubscribe:
                 return RPCResponse(error: "state.subscribe must be handled by SocketServer")
             default:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -14,6 +14,7 @@ public final class RPCRouter: Sendable {
     public let suspendResumeCoordinator: SuspendResumeCoordinator
     public let conductorManager: ConductorManager
     public let usageFetcher: ClaudeUsageFetcher
+    public let claudeTokenResolver: ClaudeTokenResolver
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -27,7 +28,8 @@ public final class RPCRouter: Sendable {
         subscriptions: StateSubscriptionManager = StateSubscriptionManager(),
         prManager: PRStatusManager = PRStatusManager(),
         conductorManager: ConductorManager? = nil,
-        usageFetcher: ClaudeUsageFetcher = LiveClaudeUsageFetcher()
+        usageFetcher: ClaudeUsageFetcher = LiveClaudeUsageFetcher(),
+        claudeTokenResolver: ClaudeTokenResolver? = nil
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -39,6 +41,11 @@ public final class RPCRouter: Sendable {
         self.suspendResumeCoordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
         self.conductorManager = conductorManager ?? ConductorManager(db: db, tmux: tmux)
         self.usageFetcher = usageFetcher
+        self.claudeTokenResolver = claudeTokenResolver ?? ClaudeTokenResolver(
+            tokens: db.claudeTokens,
+            repos: db.repos,
+            config: db.config
+        )
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.
@@ -86,6 +93,8 @@ public final class RPCRouter: Sendable {
                 return try await handleTerminalDelete(request.paramsData)
             case RPCMethod.terminalSetPin:
                 return try await handleTerminalSetPin(request.paramsData)
+            case RPCMethod.terminalSwapClaudeToken:
+                return try await handleTerminalSwapClaudeToken(request.paramsData)
             case RPCMethod.notify:
                 return try await handleNotify(request.paramsData)
             case RPCMethod.daemonStatus:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -39,14 +39,17 @@ public final class RPCRouter: Sendable {
         self.startTime = startTime
         self.subscriptions = subscriptions
         self.prManager = prManager
-        self.suspendResumeCoordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
-        self.conductorManager = conductorManager ?? ConductorManager(db: db, tmux: tmux)
-        self.usageFetcher = usageFetcher
-        self.claudeTokenResolver = claudeTokenResolver ?? ClaudeTokenResolver(
+        let resolvedClaudeTokenResolver = claudeTokenResolver ?? ClaudeTokenResolver(
             tokens: db.claudeTokens,
             repos: db.repos,
             config: db.config
         )
+        self.claudeTokenResolver = resolvedClaudeTokenResolver
+        self.suspendResumeCoordinator = SuspendResumeCoordinator(
+            db: db, tmux: tmux, claudeTokenResolver: resolvedClaudeTokenResolver
+        )
+        self.conductorManager = conductorManager ?? ConductorManager(db: db, tmux: tmux)
+        self.usageFetcher = usageFetcher
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -13,6 +13,7 @@ public final class RPCRouter: Sendable {
     public let prManager: PRStatusManager
     public let suspendResumeCoordinator: SuspendResumeCoordinator
     public let conductorManager: ConductorManager
+    public let usageFetcher: ClaudeUsageFetcher
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -25,7 +26,8 @@ public final class RPCRouter: Sendable {
         startTime: Date = Date(),
         subscriptions: StateSubscriptionManager = StateSubscriptionManager(),
         prManager: PRStatusManager = PRStatusManager(),
-        conductorManager: ConductorManager? = nil
+        conductorManager: ConductorManager? = nil,
+        usageFetcher: ClaudeUsageFetcher = LiveClaudeUsageFetcher()
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -36,6 +38,7 @@ public final class RPCRouter: Sendable {
         self.prManager = prManager
         self.suspendResumeCoordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
         self.conductorManager = conductorManager ?? ConductorManager(db: db, tmux: tmux)
+        self.usageFetcher = usageFetcher
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.
@@ -141,6 +144,20 @@ public final class RPCRouter: Sendable {
                 return try await handleConductorSuggest(request.paramsData)
             case RPCMethod.conductorClearSuggestion:
                 return try await handleConductorClearSuggestion(request.paramsData)
+            case RPCMethod.claudeTokenList:
+                return try await handleClaudeTokenList()
+            case RPCMethod.claudeTokenAdd:
+                return try await handleClaudeTokenAdd(request.paramsData)
+            case RPCMethod.claudeTokenDelete:
+                return try await handleClaudeTokenDelete(request.paramsData)
+            case RPCMethod.claudeTokenRename:
+                return try await handleClaudeTokenRename(request.paramsData)
+            case RPCMethod.claudeTokenSetGlobalDefault:
+                return try await handleClaudeTokenSetGlobalDefault(request.paramsData)
+            case RPCMethod.claudeTokenSetRepoOverride:
+                return try await handleClaudeTokenSetRepoOverride(request.paramsData)
+            case RPCMethod.claudeTokenFetchUsage:
+                return try await handleClaudeTokenFetchUsage(request.paramsData)
             case RPCMethod.stateSubscribe:
                 return RPCResponse(error: "state.subscribe must be handled by SocketServer")
             default:

--- a/Sources/TBDDaemon/Server/StateSubscription.swift
+++ b/Sources/TBDDaemon/Server/StateSubscription.swift
@@ -44,6 +44,11 @@ public final class StateSubscriptionManager: @unchecked Sendable {
         return subscribers.count
     }
 
+    /// Convenience: broadcast a Claude token usage update.
+    public func broadcastClaudeTokenUsage(_ usage: ClaudeTokenUsage) {
+        broadcast(delta: .claudeTokenUsageUpdated(usage))
+    }
+
     /// Broadcast a delta event to all subscribers.
     ///
     /// Encodes the delta as JSON and sends it to each subscriber callback.

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -56,7 +56,7 @@ public struct TmuxManager: Sendable {
         ["-L", server, "has-session", "-t", session]
     }
 
-    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:]) -> [String] {
+    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:]) -> [String] {
         // Use shell -ic so commands with arguments work (e.g. "claude --dangerously-skip-permissions")
         // -i keeps it interactive (loads .zshrc), -c runs the command
         // After the command exits, the pane closes (tmux default behavior)
@@ -67,7 +67,18 @@ public struct TmuxManager: Sendable {
             envPrefix += "export \(key)='\(escaped)'; "
         }
         let fullCommand = envPrefix.isEmpty ? shellCommand : "\(envPrefix)\(shellCommand)"
-        return ["-L", server, "new-window", "-t", session, "-c", cwd, "-PF", "#{window_id} #{pane_id}", userShell, "-ic", fullCommand]
+        // Sensitive env vars use tmux's -e KEY=VALUE flag so the secret is set in
+        // the spawned window's environment directly, NOT inlined into the shell
+        // command argv. This keeps the secret out of `ps aux` for the
+        // long-running shell/claude process. (The secret still appears briefly
+        // in the tmux invocation's own argv during fork/exec, but tmux re-execs
+        // and its server process does not retain the original argv visibly.)
+        var eFlags: [String] = []
+        for (key, value) in sensitiveEnv.sorted(by: { $0.key < $1.key }) {
+            eFlags.append("-e")
+            eFlags.append("\(key)=\(value)")
+        }
+        return ["-L", server, "new-window", "-t", session, "-c", cwd] + eFlags + ["-PF", "#{window_id} #{pane_id}", userShell, "-ic", fullCommand]
     }
 
     public static func killWindowCommand(server: String, windowID: String) -> [String] {
@@ -151,14 +162,14 @@ public struct TmuxManager: Sendable {
         try await runTmux(["-L", server, "kill-server"])
     }
 
-    public func createWindow(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:]) async throws -> (windowID: String, paneID: String) {
+    public func createWindow(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:]) async throws -> (windowID: String, paneID: String) {
         if dryRun {
-            let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env)
+            let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env, sensitiveEnv: sensitiveEnv)
             dryRunRecorder?(args)
             let n = counter.next()
             return (windowID: "@mock-\(n)", paneID: "%mock-\(n)")
         }
-        let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env)
+        let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env, sensitiveEnv: sensitiveEnv)
         let output = try await runTmux(args)
         let parts = output.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: " ")
         guard parts.count == 2 else {

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -4,6 +4,11 @@ import os
 public struct TmuxManager: Sendable {
     public let dryRun: Bool
     private let counter: Counter
+    /// Optional test hook that records every dryRun command invocation. When set,
+    /// dry-run paths still no-op, but the recorder receives the argv that would
+    /// have been passed to tmux. Used by spawn / swap integration tests to assert
+    /// command shapes without spawning an actual tmux server.
+    public let dryRunRecorder: (@Sendable ([String]) -> Void)?
 
     // Thread-safe counter for generating unique mock IDs
     private final class Counter: Sendable {
@@ -18,9 +23,10 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil) {
         self.dryRun = dryRun
         self.counter = Counter()
+        self.dryRunRecorder = dryRunRecorder
     }
 
     // MARK: - Static Command Builders
@@ -147,6 +153,8 @@ public struct TmuxManager: Sendable {
 
     public func createWindow(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:]) async throws -> (windowID: String, paneID: String) {
         if dryRun {
+            let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env)
+            dryRunRecorder?(args)
             let n = counter.next()
             return (windowID: "@mock-\(n)", paneID: "%mock-\(n)")
         }
@@ -172,8 +180,11 @@ public struct TmuxManager: Sendable {
     }
 
     public func sendKey(server: String, paneID: String, key: String) async throws {
-        if dryRun { return }
         let args = Self.sendKeyCommand(server: server, paneID: paneID, key: key)
+        if dryRun {
+            dryRunRecorder?(args)
+            return
+        }
         try await runTmux(args)
     }
 
@@ -203,8 +214,11 @@ public struct TmuxManager: Sendable {
     }
 
     public func sendCommand(server: String, paneID: String, command: String) async throws {
-        if dryRun { return }
         let args = Self.sendCommandArgs(server: server, paneID: paneID, command: command)
+        if dryRun {
+            dryRunRecorder?(args)
+            return
+        }
         try await runTmux(args)
     }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -9,10 +9,12 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
     public var createdAt: Date
     public var renamePrompt: String?
     public var customInstructions: String?
+    public var claudeTokenOverrideID: UUID?
 
     public init(id: UUID = UUID(), path: String, remoteURL: String? = nil,
                 displayName: String, defaultBranch: String = "main", createdAt: Date = Date(),
-                renamePrompt: String? = nil, customInstructions: String? = nil) {
+                renamePrompt: String? = nil, customInstructions: String? = nil,
+                claudeTokenOverrideID: UUID? = nil) {
         self.id = id
         self.path = path
         self.remoteURL = remoteURL
@@ -21,6 +23,20 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         self.createdAt = createdAt
         self.renamePrompt = renamePrompt
         self.customInstructions = customInstructions
+        self.claudeTokenOverrideID = claudeTokenOverrideID
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        path = try c.decode(String.self, forKey: .path)
+        remoteURL = try c.decodeIfPresent(String.self, forKey: .remoteURL)
+        displayName = try c.decode(String.self, forKey: .displayName)
+        defaultBranch = try c.decode(String.self, forKey: .defaultBranch)
+        createdAt = try c.decode(Date.self, forKey: .createdAt)
+        renamePrompt = try c.decodeIfPresent(String.self, forKey: .renamePrompt)
+        customInstructions = try c.decodeIfPresent(String.self, forKey: .customInstructions)
+        claudeTokenOverrideID = try c.decodeIfPresent(UUID.self, forKey: .claudeTokenOverrideID)
     }
 }
 
@@ -92,11 +108,13 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public var claudeSessionID: String?
     public var suspendedAt: Date?
     public var suspendedSnapshot: String?
+    public var claudeTokenID: UUID?
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
                 pinnedAt: Date? = nil, claudeSessionID: String? = nil,
-                suspendedAt: Date? = nil, suspendedSnapshot: String? = nil) {
+                suspendedAt: Date? = nil, suspendedSnapshot: String? = nil,
+                claudeTokenID: UUID? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -107,6 +125,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.claudeSessionID = claudeSessionID
         self.suspendedAt = suspendedAt
         self.suspendedSnapshot = suspendedSnapshot
+        self.claudeTokenID = claudeTokenID
     }
 
     public init(from decoder: Decoder) throws {
@@ -121,6 +140,64 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         claudeSessionID = try c.decodeIfPresent(String.self, forKey: .claudeSessionID)
         suspendedAt = try c.decodeIfPresent(Date.self, forKey: .suspendedAt)
         suspendedSnapshot = try c.decodeIfPresent(String.self, forKey: .suspendedSnapshot)
+        claudeTokenID = try c.decodeIfPresent(UUID.self, forKey: .claudeTokenID)
+    }
+}
+
+public enum ClaudeTokenKind: String, Codable, Sendable {
+    case oauth
+    case apiKey
+}
+
+public struct ClaudeToken: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var name: String
+    public var kind: ClaudeTokenKind
+    public var createdAt: Date
+    public var lastUsedAt: Date?
+
+    public init(id: UUID = UUID(), name: String, kind: ClaudeTokenKind,
+                createdAt: Date = Date(), lastUsedAt: Date? = nil) {
+        self.id = id
+        self.name = name
+        self.kind = kind
+        self.createdAt = createdAt
+        self.lastUsedAt = lastUsedAt
+    }
+}
+
+public struct ClaudeTokenUsage: Codable, Sendable, Equatable {
+    public var tokenID: UUID
+    public var fiveHourPct: Double?
+    public var sevenDayPct: Double?
+    public var fiveHourResetsAt: Date?
+    public var sevenDayResetsAt: Date?
+    public var fetchedAt: Date?
+    public var lastStatus: String?
+
+    public init(tokenID: UUID, fiveHourPct: Double? = nil, sevenDayPct: Double? = nil,
+                fiveHourResetsAt: Date? = nil, sevenDayResetsAt: Date? = nil,
+                fetchedAt: Date? = nil, lastStatus: String? = nil) {
+        self.tokenID = tokenID
+        self.fiveHourPct = fiveHourPct
+        self.sevenDayPct = sevenDayPct
+        self.fiveHourResetsAt = fiveHourResetsAt
+        self.sevenDayResetsAt = sevenDayResetsAt
+        self.fetchedAt = fetchedAt
+        self.lastStatus = lastStatus
+    }
+}
+
+public struct Config: Codable, Sendable, Equatable {
+    public var defaultClaudeTokenID: UUID?
+
+    public init(defaultClaudeTokenID: UUID? = nil) {
+        self.defaultClaudeTokenID = defaultClaudeTokenID
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        defaultClaudeTokenID = try c.decodeIfPresent(UUID.self, forKey: .defaultClaudeTokenID)
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -188,6 +188,15 @@ public struct ClaudeTokenUsage: Codable, Sendable, Equatable {
     }
 }
 
+public struct ClaudeTokenWithUsage: Codable, Sendable, Equatable {
+    public let token: ClaudeToken
+    public let usage: ClaudeTokenUsage?
+    public init(token: ClaudeToken, usage: ClaudeTokenUsage? = nil) {
+        self.token = token
+        self.usage = usage
+    }
+}
+
 public struct Config: Codable, Sendable, Equatable {
     public var defaultClaudeTokenID: UUID?
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -121,6 +121,74 @@ public enum RPCMethod {
     public static let conductorClearSuggestion = "conductor.clearSuggestion"
     public static let terminalConversation = "terminal.conversation"
     public static let repoUpdateInstructions = "repo.updateInstructions"
+    public static let claudeTokenList = "claudeToken.list"
+    public static let claudeTokenAdd = "claudeToken.add"
+    public static let claudeTokenDelete = "claudeToken.delete"
+    public static let claudeTokenRename = "claudeToken.rename"
+    public static let claudeTokenSetGlobalDefault = "claudeToken.setGlobalDefault"
+    public static let claudeTokenSetRepoOverride = "claudeToken.setRepoOverride"
+    public static let claudeTokenFetchUsage = "claudeToken.fetchUsage"
+}
+
+// MARK: - Claude Token RPC
+
+public struct ClaudeTokenAddParams: Codable, Sendable {
+    public let name: String
+    public let token: String
+    public init(name: String, token: String) {
+        self.name = name
+        self.token = token
+    }
+}
+
+public struct ClaudeTokenAddResult: Codable, Sendable {
+    public let token: ClaudeToken
+    public let warning: String?
+    public init(token: ClaudeToken, warning: String? = nil) {
+        self.token = token
+        self.warning = warning
+    }
+}
+
+public struct ClaudeTokenDeleteParams: Codable, Sendable {
+    public let id: UUID
+    public init(id: UUID) { self.id = id }
+}
+
+public struct ClaudeTokenRenameParams: Codable, Sendable {
+    public let id: UUID
+    public let name: String
+    public init(id: UUID, name: String) {
+        self.id = id; self.name = name
+    }
+}
+
+public struct ClaudeTokenSetGlobalDefaultParams: Codable, Sendable {
+    public let id: UUID?
+    public init(id: UUID?) { self.id = id }
+}
+
+public struct ClaudeTokenSetRepoOverrideParams: Codable, Sendable {
+    public let repoID: UUID
+    public let tokenID: UUID?
+    public init(repoID: UUID, tokenID: UUID?) {
+        self.repoID = repoID; self.tokenID = tokenID
+    }
+}
+
+public struct ClaudeTokenFetchUsageParams: Codable, Sendable {
+    public let id: UUID
+    public init(id: UUID) { self.id = id }
+}
+
+public struct ClaudeTokenListResult: Codable, Sendable {
+    public let tokens: [ClaudeTokenWithUsage]
+    public init(tokens: [ClaudeTokenWithUsage]) { self.tokens = tokens }
+}
+
+public struct ClaudeTokenFetchUsageResult: Codable, Sendable {
+    public let usage: ClaudeTokenUsage
+    public init(usage: ClaudeTokenUsage) { self.usage = usage }
 }
 
 public struct NotificationsListResult: Codable, Sendable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -201,7 +201,17 @@ public struct ClaudeTokenFetchUsageParams: Codable, Sendable {
 
 public struct ClaudeTokenListResult: Codable, Sendable {
     public let tokens: [ClaudeTokenWithUsage]
-    public init(tokens: [ClaudeTokenWithUsage]) { self.tokens = tokens }
+    public let defaultID: UUID?
+    public init(tokens: [ClaudeTokenWithUsage], defaultID: UUID? = nil) {
+        self.tokens = tokens
+        self.defaultID = defaultID
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        tokens = try c.decode([ClaudeTokenWithUsage].self, forKey: .tokens)
+        defaultID = try c.decodeIfPresent(UUID.self, forKey: .defaultID)
+    }
 }
 
 public struct ClaudeTokenFetchUsageResult: Codable, Sendable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -330,8 +330,10 @@ public struct TerminalCreateParams: Codable, Sendable {
     public let resumeSessionID: String?
     /// Initial prompt to send to the Claude session (only used with type: .claude).
     public let prompt: String?
-    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil) {
-        self.worktreeID = worktreeID; self.cmd = cmd; self.type = type; self.resumeSessionID = resumeSessionID; self.prompt = prompt
+    /// Pin a specific token ID for this terminal, bypassing resolve(repoID:).
+    public let overrideTokenID: UUID?
+    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil, overrideTokenID: UUID? = nil) {
+        self.worktreeID = worktreeID; self.cmd = cmd; self.type = type; self.resumeSessionID = resumeSessionID; self.prompt = prompt; self.overrideTokenID = overrideTokenID
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -128,6 +128,18 @@ public enum RPCMethod {
     public static let claudeTokenSetGlobalDefault = "claudeToken.setGlobalDefault"
     public static let claudeTokenSetRepoOverride = "claudeToken.setRepoOverride"
     public static let claudeTokenFetchUsage = "claudeToken.fetchUsage"
+    public static let terminalSwapClaudeToken = "terminal.swapClaudeToken"
+}
+
+// MARK: - Terminal Swap Claude Token
+
+public struct TerminalSwapClaudeTokenParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let newTokenID: UUID?
+    public init(terminalID: UUID, newTokenID: UUID?) {
+        self.terminalID = terminalID
+        self.newTokenID = newTokenID
+    }
 }
 
 // MARK: - Claude Token RPC

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -129,6 +129,12 @@ public enum RPCMethod {
     public static let claudeTokenSetRepoOverride = "claudeToken.setRepoOverride"
     public static let claudeTokenFetchUsage = "claudeToken.fetchUsage"
     public static let terminalSwapClaudeToken = "terminal.swapClaudeToken"
+    public static let appSetForegroundState = "app.setForegroundState"
+}
+
+public struct AppSetForegroundStateParams: Codable, Sendable {
+    public let isForeground: Bool
+    public init(isForeground: Bool) { self.isForeground = isForeground }
 }
 
 // MARK: - Terminal Swap Claude Token

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -17,6 +17,7 @@ public enum StateDelta: Codable, Sendable {
     case terminalPinChanged(TerminalPinDelta)
     case worktreeReordered(RepoIDDelta)
     case claudeTokenUsageUpdated(ClaudeTokenUsage)
+    case claudeTokensChanged
 }
 
 /// Delta payload for worktree creation/revival.

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -16,6 +16,7 @@ public enum StateDelta: Codable, Sendable {
     case worktreeConflictsChanged(WorktreeConflictDelta)
     case terminalPinChanged(TerminalPinDelta)
     case worktreeReordered(RepoIDDelta)
+    case claudeTokenUsageUpdated(ClaudeTokenUsage)
 }
 
 /// Delta payload for worktree creation/revival.

--- a/Tests/TBDAppTests/ClaudeTokenAppStateTests.swift
+++ b/Tests/TBDAppTests/ClaudeTokenAppStateTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// DaemonClient is a concrete actor (no protocol), so we can't inject a stub.
+// These tests verify pure-Swift state mutations on AppState — full integration
+// coverage lives in the daemon RPC tests (Phase 05/06/07) and manual QA per
+// the parent plan's DoD.
+
+@MainActor
+@Test func appState_initialClaudeTokensEmpty() {
+    let state = AppState()
+    #expect(state.claudeTokens.isEmpty)
+    #expect(state.globalDefaultClaudeTokenID == nil)
+}
+
+@MainActor
+@Test func appState_handlesUsageUpdatedDeltaInPlace() {
+    let state = AppState()
+    let tokenID = UUID()
+    let token = ClaudeToken(id: tokenID, name: "test", kind: .oauth)
+    state.claudeTokens = [ClaudeTokenWithUsage(token: token, usage: nil)]
+
+    let usage = ClaudeTokenUsage(tokenID: tokenID, fiveHourPct: 0.42)
+    state.handleDelta(.claudeTokenUsageUpdated(usage))
+
+    #expect(state.claudeTokens.count == 1)
+    #expect(state.claudeTokens[0].usage?.fiveHourPct == 0.42)
+}
+
+@MainActor
+@Test func appState_handlesTokensChangedDeltaWithoutCrash() {
+    let state = AppState()
+    // No daemon running — the spawned refresh task will fail and be swallowed.
+    state.handleDelta(.claudeTokensChanged)
+    #expect(true)
+}

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("ClaudeSpawnCommandBuilder")
+struct ClaudeSpawnCommandBuilderTests {
+
+    private let fakeOauth = "sk-ant-oat01-fake"
+
+    // MARK: - Fallback / non-token branches
+
+    @Test("resume id only")
+    func resumeOnly() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc-123",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(cmd == "claude --resume abc-123 --dangerously-skip-permissions")
+    }
+
+    @Test("fresh session id only")
+    func freshOnly() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(cmd == "claude --session-id sid-1 --dangerously-skip-permissions")
+    }
+
+    @Test("fresh + appendSystemPrompt")
+    func freshWithAppend() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid",
+            appendSystemPrompt: "hello world",
+            initialPrompt: nil,
+            tokenSecret: nil,
+            cmd: nil,
+            shellFallback: ""
+        )
+        #expect(cmd.contains("--append-system-prompt 'hello world'"))
+    }
+
+    @Test("fresh + initial prompt")
+    func freshWithInitialPrompt() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid",
+            appendSystemPrompt: nil,
+            initialPrompt: "do the thing",
+            tokenSecret: nil,
+            cmd: nil,
+            shellFallback: ""
+        )
+        #expect(cmd.hasSuffix(" 'do the thing'"))
+    }
+
+    @Test("cmd path returns verbatim")
+    func cmdVerbatim() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: nil,
+            cmd: "ls -la",
+            shellFallback: "/bin/zsh"
+        )
+        #expect(cmd == "ls -la")
+    }
+
+    @Test("all nil returns shell fallback")
+    func shellFallback() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(cmd == "/bin/zsh")
+    }
+
+    // MARK: - Token-prefix branches
+
+    @Test("resume + token prefixes env var")
+    func resumeWithToken() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: fakeOauth,
+            cmd: nil,
+            shellFallback: ""
+        )
+        #expect(cmd == "CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake' claude --resume abc --dangerously-skip-permissions")
+    }
+
+    @Test("fresh + token prefixes env var")
+    func freshWithToken() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: fakeOauth,
+            cmd: nil,
+            shellFallback: ""
+        )
+        #expect(cmd.hasPrefix("CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake' claude --session-id sid"))
+    }
+
+    @Test("cmd path ignores token (non-claude shell)")
+    func cmdIgnoresToken() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: fakeOauth,
+            cmd: "make test",
+            shellFallback: ""
+        )
+        #expect(cmd == "make test")
+        #expect(!cmd.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+    }
+
+    @Test("shell fallback ignores token")
+    func shellFallbackIgnoresToken() {
+        let cmd = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: fakeOauth,
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(cmd == "/bin/zsh")
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -11,7 +11,7 @@ struct ClaudeSpawnCommandBuilderTests {
 
     @Test("resume id only")
     func resumeOnly() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: "abc-123",
             freshSessionID: nil,
             appendSystemPrompt: nil,
@@ -20,12 +20,13 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: "/bin/zsh"
         )
-        #expect(cmd == "claude --resume abc-123 --dangerously-skip-permissions")
+        #expect(r.command == "claude --resume abc-123 --dangerously-skip-permissions")
+        #expect(r.sensitiveEnv.isEmpty)
     }
 
     @Test("fresh session id only")
     func freshOnly() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "sid-1",
             appendSystemPrompt: nil,
@@ -34,12 +35,13 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: "/bin/zsh"
         )
-        #expect(cmd == "claude --session-id sid-1 --dangerously-skip-permissions")
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions")
+        #expect(r.sensitiveEnv.isEmpty)
     }
 
     @Test("fresh + appendSystemPrompt")
     func freshWithAppend() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "sid",
             appendSystemPrompt: "hello world",
@@ -48,12 +50,12 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: ""
         )
-        #expect(cmd.contains("--append-system-prompt 'hello world'"))
+        #expect(r.command.contains("--append-system-prompt 'hello world'"))
     }
 
     @Test("fresh + initial prompt")
     func freshWithInitialPrompt() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "sid",
             appendSystemPrompt: nil,
@@ -62,12 +64,12 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: ""
         )
-        #expect(cmd.hasSuffix(" 'do the thing'"))
+        #expect(r.command.hasSuffix(" 'do the thing'"))
     }
 
     @Test("cmd path returns verbatim")
     func cmdVerbatim() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: nil,
             appendSystemPrompt: nil,
@@ -76,12 +78,13 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: "ls -la",
             shellFallback: "/bin/zsh"
         )
-        #expect(cmd == "ls -la")
+        #expect(r.command == "ls -la")
+        #expect(r.sensitiveEnv.isEmpty)
     }
 
     @Test("all nil returns shell fallback")
     func shellFallback() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: nil,
             appendSystemPrompt: nil,
@@ -90,14 +93,15 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: "/bin/zsh"
         )
-        #expect(cmd == "/bin/zsh")
+        #expect(r.command == "/bin/zsh")
+        #expect(r.sensitiveEnv.isEmpty)
     }
 
-    // MARK: - Token-prefix branches
+    // MARK: - Token branches: secret returned via sensitiveEnv, NOT in command
 
-    @Test("resume + token prefixes env var")
+    @Test("resume + token: token in sensitiveEnv, not command")
     func resumeWithToken() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: "abc",
             freshSessionID: nil,
             appendSystemPrompt: nil,
@@ -106,12 +110,15 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: ""
         )
-        #expect(cmd == "CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake' claude --resume abc --dangerously-skip-permissions")
+        #expect(r.command == "claude --resume abc --dangerously-skip-permissions")
+        #expect(!r.command.contains(fakeOauth))
+        #expect(!r.command.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+        #expect(r.sensitiveEnv == ["CLAUDE_CODE_OAUTH_TOKEN": fakeOauth])
     }
 
-    @Test("fresh + token prefixes env var")
+    @Test("fresh + token: token in sensitiveEnv, not command")
     func freshWithToken() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "sid",
             appendSystemPrompt: nil,
@@ -120,12 +127,30 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: ""
         )
-        #expect(cmd.hasPrefix("CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake' claude --session-id sid"))
+        #expect(r.command.hasPrefix("claude --session-id sid"))
+        #expect(!r.command.contains(fakeOauth))
+        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == fakeOauth)
+    }
+
+    @Test("api key kind uses ANTHROPIC_API_KEY")
+    func apiKeyKind() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            tokenSecret: fakeOauth,
+            tokenKind: .apiKey,
+            cmd: nil,
+            shellFallback: ""
+        )
+        #expect(!r.command.contains(fakeOauth))
+        #expect(r.sensitiveEnv == ["ANTHROPIC_API_KEY": fakeOauth])
     }
 
     @Test("cmd path ignores token (non-claude shell)")
     func cmdIgnoresToken() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: nil,
             appendSystemPrompt: nil,
@@ -134,13 +159,13 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: "make test",
             shellFallback: ""
         )
-        #expect(cmd == "make test")
-        #expect(!cmd.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+        #expect(r.command == "make test")
+        #expect(r.sensitiveEnv.isEmpty)
     }
 
     @Test("shell fallback ignores token")
     func shellFallbackIgnoresToken() {
-        let cmd = ClaudeSpawnCommandBuilder.build(
+        let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: nil,
             appendSystemPrompt: nil,
@@ -149,6 +174,7 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: "/bin/zsh"
         )
-        #expect(cmd == "/bin/zsh")
+        #expect(r.command == "/bin/zsh")
+        #expect(r.sensitiveEnv.isEmpty)
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeTokenKeychainTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenKeychainTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("ClaudeTokenKeychain")
+struct ClaudeTokenKeychainTests {
+
+    private func freshID() -> String {
+        "test-\(UUID().uuidString)"
+    }
+
+    @Test("store + load round-trip")
+    func roundTrip() throws {
+        let id = freshID()
+        defer { try? ClaudeTokenKeychain.delete(id: id) }
+
+        try ClaudeTokenKeychain.store(id: id, token: "sk-ant-secret-A")
+        let loaded = try ClaudeTokenKeychain.load(id: id)
+        #expect(loaded == "sk-ant-secret-A")
+    }
+
+    @Test("store overwrites existing (upsert)")
+    func upsert() throws {
+        let id = freshID()
+        defer { try? ClaudeTokenKeychain.delete(id: id) }
+
+        try ClaudeTokenKeychain.store(id: id, token: "value-A")
+        try ClaudeTokenKeychain.store(id: id, token: "value-B")
+        let loaded = try ClaudeTokenKeychain.load(id: id)
+        #expect(loaded == "value-B")
+    }
+
+    @Test("delete removes item")
+    func deleteRemoves() throws {
+        let id = freshID()
+        defer { try? ClaudeTokenKeychain.delete(id: id) }
+
+        try ClaudeTokenKeychain.store(id: id, token: "to-be-deleted")
+        try ClaudeTokenKeychain.delete(id: id)
+        let loaded = try ClaudeTokenKeychain.load(id: id)
+        #expect(loaded == nil)
+    }
+
+    @Test("delete of nonexistent id is idempotent")
+    func deleteIdempotent() throws {
+        let id = freshID()
+        // No store; delete should not throw.
+        try ClaudeTokenKeychain.delete(id: id)
+    }
+
+    @Test("load of nonexistent id returns nil")
+    func loadMissing() throws {
+        let id = freshID()
+        let loaded = try ClaudeTokenKeychain.load(id: id)
+        #expect(loaded == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeTokenMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenMigrationTests.swift
@@ -32,6 +32,33 @@ struct ClaudeTokenMigrationTests {
         #expect(cols.1.contains("claude_token_id"))
     }
 
+    @Test func migrationPreservesExistingRowsAndAddsColumns() async throws {
+        let tmp = NSTemporaryDirectory() + "tbd-mig-test-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        do {
+            let db = try TBDDatabase(path: tmp)
+            let repo = try await db.repos.create(path: "/tmp/x", displayName: "x", defaultBranch: "main")
+            let wt = try await db.worktrees.create(
+                repoID: repo.id, name: "w", branch: "tbd/w",
+                path: "/tmp/x/.tbd/worktrees/w", tmuxServer: "tbd-test"
+            )
+            _ = try await db.terminals.create(
+                worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%0", label: "claude"
+            )
+        }
+
+        let db2 = try TBDDatabase(path: tmp)
+        let repos = try await db2.repos.list()
+        #expect(repos.count == 1)
+        #expect(repos[0].claudeTokenOverrideID == nil)
+        let terms = try await db2.terminals.list()
+        #expect(terms.count == 1)
+        #expect(terms[0].claudeTokenID == nil)
+        let cfg = try await db2.config.get()
+        #expect(cfg.defaultClaudeTokenID == nil)
+    }
+
     @Test func v13InsertsConfigSingleton() async throws {
         let db = try TBDDatabase(inMemory: true)
         let count: Int? = try await db.writerForTests.read { conn in

--- a/Tests/TBDDaemonTests/ClaudeTokenMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenMigrationTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("Claude Token Migration")
+struct ClaudeTokenMigrationTests {
+    @Test func v13CreatesClaudeTokensTable() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let exists: (Bool, Bool, Bool) = try await db.writerForTests.read { conn in
+            (
+                try conn.tableExists("claude_tokens"),
+                try conn.tableExists("claude_token_usage"),
+                try conn.tableExists("config")
+            )
+        }
+        #expect(exists.0)
+        #expect(exists.1)
+        #expect(exists.2)
+    }
+
+    @Test func v13AddsRepoAndTerminalColumns() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cols: ([String], [String]) = try await db.writerForTests.read { conn in
+            (
+                try conn.columns(in: "repo").map(\.name),
+                try conn.columns(in: "terminal").map(\.name)
+            )
+        }
+        #expect(cols.0.contains("claude_token_override_id"))
+        #expect(cols.1.contains("claude_token_id"))
+    }
+
+    @Test func v13InsertsConfigSingleton() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let count: Int? = try await db.writerForTests.read { conn in
+            try Int.fetchOne(conn, sql: "SELECT COUNT(*) FROM config WHERE id = 'singleton'")
+        }
+        #expect(count == 1)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeTokenModelTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenModelTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite("Claude Token Models")
+struct ClaudeTokenModelTests {
+    @Test func decodeClaudeToken() throws {
+        let json = #"{"id":"11111111-1111-1111-1111-111111111111","name":"Personal","kind":"oauth","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+        let dec = JSONDecoder()
+        dec.dateDecodingStrategy = .iso8601
+        let tok = try dec.decode(ClaudeToken.self, from: json)
+        #expect(tok.name == "Personal")
+        #expect(tok.kind == .oauth)
+        #expect(tok.lastUsedAt == nil)
+    }
+
+    @Test func decodeClaudeTokenKindApiKey() throws {
+        let json = #"{"id":"11111111-1111-1111-1111-111111111111","name":"Work","kind":"apiKey","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+        let dec = JSONDecoder()
+        dec.dateDecodingStrategy = .iso8601
+        let tok = try dec.decode(ClaudeToken.self, from: json)
+        #expect(tok.kind == .apiKey)
+    }
+
+    @Test func decodeClaudeTokenUsage() throws {
+        let json = #"{"tokenID":"11111111-1111-1111-1111-111111111111","fiveHourPct":0.42,"sevenDayPct":0.18,"lastStatus":"ok"}"#.data(using: .utf8)!
+        let u = try JSONDecoder().decode(ClaudeTokenUsage.self, from: json)
+        #expect(u.fiveHourPct == 0.42)
+        #expect(u.sevenDayPct == 0.18)
+        #expect(u.lastStatus == "ok")
+    }
+
+    @Test func decodeConfigEmpty() throws {
+        let u = try JSONDecoder().decode(Config.self, from: "{}".data(using: .utf8)!)
+        #expect(u.defaultClaudeTokenID == nil)
+    }
+
+    @Test func repoDecodesWithoutOverride() throws {
+        let json = #"{"id":"11111111-1111-1111-1111-111111111111","path":"/tmp/x","displayName":"x","defaultBranch":"main","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+        let dec = JSONDecoder()
+        dec.dateDecodingStrategy = .iso8601
+        let r = try dec.decode(Repo.self, from: json)
+        #expect(r.claudeTokenOverrideID == nil)
+    }
+
+    @Test func terminalDecodesWithoutTokenID() throws {
+        let json = #"{"id":"11111111-1111-1111-1111-111111111111","worktreeID":"22222222-2222-2222-2222-222222222222","tmuxWindowID":"@1","tmuxPaneID":"%0","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+        let dec = JSONDecoder()
+        dec.dateDecodingStrategy = .iso8601
+        let t = try dec.decode(Terminal.self, from: json)
+        #expect(t.claudeTokenID == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeTokenRPCTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenRPCTests.swift
@@ -157,6 +157,18 @@ struct ClaudeTokenRPCTests {
         #expect(try await db.claudeTokens.list().isEmpty)
     }
 
+    @Test("add: token with embedded newline rejected at storage")
+    func addRejectsNewline() async throws {
+        let (router, db, _) = makeRouter()
+        let bad = Self.oauthPrefix + "abc\ndef"
+        let req = try RPCRequest(method: RPCMethod.claudeTokenAdd,
+                                 params: ClaudeTokenAddParams(name: "Bad", token: bad))
+        let resp = await router.handle(req)
+        #expect(!resp.success)
+        #expect(resp.error?.contains("invalid characters") == true)
+        #expect(try await db.claudeTokens.list().isEmpty)
+    }
+
     @Test("add: duplicate name rejected")
     func addDuplicateName() async throws {
         let stub = StubClaudeUsageFetcher(responses: [.ok(sampleUsage())])

--- a/Tests/TBDDaemonTests/ClaudeTokenRPCTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenRPCTests.swift
@@ -1,0 +1,357 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Stub fetcher with a queued response list.
+final class StubClaudeUsageFetcher: ClaudeUsageFetcher, @unchecked Sendable {
+    private var responses: [ClaudeUsageStatus]
+    private(set) var callCount: Int = 0
+    private(set) var lastToken: String? = nil
+
+    init(responses: [ClaudeUsageStatus] = []) {
+        self.responses = responses
+    }
+
+    func enqueue(_ status: ClaudeUsageStatus) {
+        responses.append(status)
+    }
+
+    func fetchUsage(token: String) async -> ClaudeUsageStatus {
+        callCount += 1
+        lastToken = token
+        if responses.isEmpty {
+            return .networkError("no stub response queued")
+        }
+        return responses.removeFirst()
+    }
+}
+
+@Suite("ClaudeToken RPC Handlers")
+struct ClaudeTokenRPCTests {
+
+    private static let oauthPrefix = "sk-ant-oat01-"
+    private static let apiPrefix = "sk-ant-api03-"
+
+    private func freshToken(_ prefix: String = oauthPrefix) -> String {
+        prefix + UUID().uuidString
+    }
+
+    private func makeRouter(stub: StubClaudeUsageFetcher = StubClaudeUsageFetcher())
+        -> (RPCRouter, TBDDatabase, StubClaudeUsageFetcher)
+    {
+        let db = try! TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            usageFetcher: stub
+        )
+        return (router, db, stub)
+    }
+
+    private func sampleUsage() -> ClaudeUsageResult {
+        ClaudeUsageResult(
+            fiveHourPct: 0.42,
+            sevenDayPct: 0.13,
+            fiveHourResetsAt: Date().addingTimeInterval(3600),
+            sevenDayResetsAt: Date().addingTimeInterval(7 * 86_400)
+        )
+    }
+
+    /// Cleanup helper that drops every keychain entry for the tokens currently in db.
+    private func cleanupKeychain(_ db: TBDDatabase) async {
+        let tokens = (try? await db.claudeTokens.list()) ?? []
+        for t in tokens {
+            try? ClaudeTokenKeychain.delete(id: t.id.uuidString)
+        }
+    }
+
+    // MARK: - add
+
+    @Test("add: oauth + .ok stores row, keychain, usage")
+    func addOauthOk() async throws {
+        let stub = StubClaudeUsageFetcher(responses: [.ok(sampleUsage())])
+        let (router, db, _) = makeRouter(stub: stub)
+        defer { Task { await cleanupKeychain(db) } }
+
+        let tokenBytes = freshToken()
+        let req = try RPCRequest(method: RPCMethod.claudeTokenAdd,
+                                 params: ClaudeTokenAddParams(name: "Personal", token: tokenBytes))
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ClaudeTokenAddResult.self)
+        #expect(result.warning == nil)
+        #expect(result.token.kind == .oauth)
+
+        let listed = try await db.claudeTokens.list()
+        #expect(listed.count == 1)
+        let kc = try ClaudeTokenKeychain.load(id: result.token.id.uuidString)
+        #expect(kc == tokenBytes)
+        let usage = try await db.claudeTokenUsage.get(tokenID: result.token.id)
+        #expect(usage != nil)
+        #expect(usage?.fiveHourPct == 0.42)
+        try? ClaudeTokenKeychain.delete(id: result.token.id.uuidString)
+    }
+
+    @Test("add: oauth + .http401 rejects without persisting")
+    func addOauth401() async throws {
+        let stub = StubClaudeUsageFetcher(responses: [.http401])
+        let (router, db, _) = makeRouter(stub: stub)
+        let req = try RPCRequest(method: RPCMethod.claudeTokenAdd,
+                                 params: ClaudeTokenAddParams(name: "Bad", token: freshToken()))
+        let resp = await router.handle(req)
+        #expect(!resp.success)
+        #expect(resp.error == "Token invalid")
+        #expect(try await db.claudeTokens.list().isEmpty)
+    }
+
+    @Test("add: oauth + .networkError saves with warning, no usage row")
+    func addOauthNetworkError() async throws {
+        let stub = StubClaudeUsageFetcher(responses: [.networkError("offline")])
+        let (router, db, _) = makeRouter(stub: stub)
+        defer { Task { await cleanupKeychain(db) } }
+
+        let req = try RPCRequest(method: RPCMethod.claudeTokenAdd,
+                                 params: ClaudeTokenAddParams(name: "Maybe", token: freshToken()))
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ClaudeTokenAddResult.self)
+        #expect(result.warning != nil)
+        #expect(try await db.claudeTokens.list().count == 1)
+        #expect(try await db.claudeTokenUsage.get(tokenID: result.token.id) == nil)
+        try? ClaudeTokenKeychain.delete(id: result.token.id.uuidString)
+    }
+
+    @Test("add: api_key prefix skips fetcher")
+    func addApiKey() async throws {
+        let stub = StubClaudeUsageFetcher()
+        let (router, db, _) = makeRouter(stub: stub)
+        defer { Task { await cleanupKeychain(db) } }
+
+        let req = try RPCRequest(method: RPCMethod.claudeTokenAdd,
+                                 params: ClaudeTokenAddParams(name: "Work", token: freshToken(Self.apiPrefix)))
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ClaudeTokenAddResult.self)
+        #expect(stub.callCount == 0)
+        #expect(result.token.kind == .apiKey)
+        #expect(try await db.claudeTokenUsage.get(tokenID: result.token.id) == nil)
+        try? ClaudeTokenKeychain.delete(id: result.token.id.uuidString)
+    }
+
+    @Test("add: bad prefix rejected")
+    func addBadPrefix() async throws {
+        let stub = StubClaudeUsageFetcher()
+        let (router, db, _) = makeRouter(stub: stub)
+        let req = try RPCRequest(method: RPCMethod.claudeTokenAdd,
+                                 params: ClaudeTokenAddParams(name: "Junk", token: "garbage"))
+        let resp = await router.handle(req)
+        #expect(!resp.success)
+        #expect(stub.callCount == 0)
+        #expect(try await db.claudeTokens.list().isEmpty)
+    }
+
+    @Test("add: duplicate name rejected")
+    func addDuplicateName() async throws {
+        let stub = StubClaudeUsageFetcher(responses: [.ok(sampleUsage())])
+        let (router, db, _) = makeRouter(stub: stub)
+        defer { Task { await cleanupKeychain(db) } }
+
+        let first = try RPCRequest(method: RPCMethod.claudeTokenAdd,
+                                   params: ClaudeTokenAddParams(name: "Personal", token: freshToken()))
+        _ = await router.handle(first)
+
+        let second = try RPCRequest(method: RPCMethod.claudeTokenAdd,
+                                    params: ClaudeTokenAddParams(name: "Personal", token: freshToken()))
+        let resp = await router.handle(second)
+        #expect(!resp.success)
+        #expect(try await db.claudeTokens.list().count == 1)
+    }
+
+    // MARK: - list
+
+    @Test("list joins usage")
+    func listJoinsUsage() async throws {
+        let (router, db, _) = makeRouter()
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let b = try await db.claudeTokens.create(name: "B", kind: .apiKey)
+        try await db.claudeTokenUsage.upsert(ClaudeTokenUsage(
+            tokenID: a.id, fiveHourPct: 0.5, sevenDayPct: 0.1, fetchedAt: Date()
+        ))
+
+        let resp = await router.handle(RPCRequest(method: RPCMethod.claudeTokenList))
+        #expect(resp.success)
+        let result = try resp.decodeResult(ClaudeTokenListResult.self)
+        #expect(result.tokens.count == 2)
+        let withA = result.tokens.first { $0.token.id == a.id }
+        let withB = result.tokens.first { $0.token.id == b.id }
+        #expect(withA?.usage != nil)
+        #expect(withB?.usage == nil)
+    }
+
+    // MARK: - delete
+
+    @Test("delete clears global default + keychain + usage")
+    func deleteClearsDefault() async throws {
+        let (router, db, _) = makeRouter()
+        let tok = try await db.claudeTokens.create(name: "Solo", kind: .oauth)
+        try ClaudeTokenKeychain.store(id: tok.id.uuidString, token: "value")
+        try await db.claudeTokenUsage.upsert(ClaudeTokenUsage(tokenID: tok.id, fetchedAt: Date()))
+        try await db.config.setDefaultClaudeTokenID(tok.id)
+
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenDelete,
+                                                      params: ClaudeTokenDeleteParams(id: tok.id)))
+        #expect(resp.success)
+        #expect(try await db.claudeTokens.get(id: tok.id) == nil)
+        #expect(try await db.claudeTokenUsage.get(tokenID: tok.id) == nil)
+        #expect(try await db.config.get().defaultClaudeTokenID == nil)
+        #expect(try ClaudeTokenKeychain.load(id: tok.id.uuidString) == nil)
+    }
+
+    @Test("delete clears repo override")
+    func deleteClearsRepoOverride() async throws {
+        let (router, db, _) = makeRouter()
+        let tok = try await db.claudeTokens.create(name: "Solo", kind: .oauth)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID().uuidString)",
+                                              displayName: "r", defaultBranch: "main")
+        try await db.repos.setClaudeTokenOverride(id: repo.id, tokenID: tok.id)
+
+        _ = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenDelete,
+                                               params: ClaudeTokenDeleteParams(id: tok.id)))
+        let after = try await db.repos.get(id: repo.id)
+        #expect(after?.claudeTokenOverrideID == nil)
+    }
+
+    @Test("delete leaves unrelated default in place")
+    func deleteUnrelated() async throws {
+        let (router, db, _) = makeRouter()
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let b = try await db.claudeTokens.create(name: "B", kind: .oauth)
+        try await db.config.setDefaultClaudeTokenID(a.id)
+
+        _ = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenDelete,
+                                               params: ClaudeTokenDeleteParams(id: b.id)))
+        #expect(try await db.config.get().defaultClaudeTokenID == a.id)
+    }
+
+    // MARK: - rename
+
+    @Test("rename success")
+    func renameSuccess() async throws {
+        let (router, db, _) = makeRouter()
+        let tok = try await db.claudeTokens.create(name: "Old", kind: .oauth)
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenRename,
+                                                      params: ClaudeTokenRenameParams(id: tok.id, name: "New")))
+        #expect(resp.success)
+        #expect(try await db.claudeTokens.get(id: tok.id)?.name == "New")
+    }
+
+    @Test("rename duplicate rejected")
+    func renameDuplicate() async throws {
+        let (router, db, _) = makeRouter()
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let b = try await db.claudeTokens.create(name: "B", kind: .oauth)
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenRename,
+                                                      params: ClaudeTokenRenameParams(id: b.id, name: "A")))
+        #expect(!resp.success)
+        #expect(try await db.claudeTokens.get(id: b.id)?.name == "B")
+        _ = a
+    }
+
+    // MARK: - defaults
+
+    @Test("setGlobalDefault round-trip")
+    func setGlobalDefault() async throws {
+        let (router, db, _) = makeRouter()
+        let tok = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        _ = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenSetGlobalDefault,
+                                               params: ClaudeTokenSetGlobalDefaultParams(id: tok.id)))
+        #expect(try await db.config.get().defaultClaudeTokenID == tok.id)
+        _ = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenSetGlobalDefault,
+                                               params: ClaudeTokenSetGlobalDefaultParams(id: nil)))
+        #expect(try await db.config.get().defaultClaudeTokenID == nil)
+    }
+
+    @Test("setRepoOverride round-trip")
+    func setRepoOverride() async throws {
+        let (router, db, _) = makeRouter()
+        let tok = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID().uuidString)",
+                                              displayName: "r", defaultBranch: "main")
+        _ = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenSetRepoOverride,
+                                               params: ClaudeTokenSetRepoOverrideParams(repoID: repo.id, tokenID: tok.id)))
+        #expect(try await db.repos.get(id: repo.id)?.claudeTokenOverrideID == tok.id)
+        _ = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenSetRepoOverride,
+                                               params: ClaudeTokenSetRepoOverrideParams(repoID: repo.id, tokenID: nil)))
+        #expect(try await db.repos.get(id: repo.id)?.claudeTokenOverrideID == nil)
+    }
+
+    // MARK: - fetchUsage
+
+    @Test("fetchUsage dedupes within 60s")
+    func fetchUsageDedupes() async throws {
+        let stub = StubClaudeUsageFetcher()
+        let (router, db, _) = makeRouter(stub: stub)
+        let tok = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        try await db.claudeTokenUsage.upsert(ClaudeTokenUsage(
+            tokenID: tok.id, fiveHourPct: 0.7, sevenDayPct: 0.2, fetchedAt: Date()
+        ))
+
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenFetchUsage,
+                                                      params: ClaudeTokenFetchUsageParams(id: tok.id)))
+        #expect(resp.success)
+        let result = try resp.decodeResult(ClaudeTokenFetchUsageResult.self)
+        #expect(result.usage.fiveHourPct == 0.7)
+        #expect(stub.callCount == 0)
+    }
+
+    @Test("fetchUsage refreshes after 60s")
+    func fetchUsageRefreshes() async throws {
+        let new = ClaudeUsageResult(
+            fiveHourPct: 0.99, sevenDayPct: 0.5,
+            fiveHourResetsAt: Date().addingTimeInterval(3600),
+            sevenDayResetsAt: Date().addingTimeInterval(7 * 86_400)
+        )
+        let stub = StubClaudeUsageFetcher(responses: [.ok(new)])
+        let (router, db, _) = makeRouter(stub: stub)
+        defer { Task { await cleanupKeychain(db) } }
+
+        let tok = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        try ClaudeTokenKeychain.store(id: tok.id.uuidString, token: "secret")
+        try await db.claudeTokenUsage.upsert(ClaudeTokenUsage(
+            tokenID: tok.id, fiveHourPct: 0.1, sevenDayPct: 0.0,
+            fetchedAt: Date().addingTimeInterval(-120)
+        ))
+
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenFetchUsage,
+                                                      params: ClaudeTokenFetchUsageParams(id: tok.id)))
+        #expect(resp.success)
+        let result = try resp.decodeResult(ClaudeTokenFetchUsageResult.self)
+        #expect(result.usage.fiveHourPct == 0.99)
+        #expect(stub.callCount == 1)
+        let cached = try await db.claudeTokenUsage.get(tokenID: tok.id)
+        #expect(cached?.fiveHourPct == 0.99)
+        try? ClaudeTokenKeychain.delete(id: tok.id.uuidString)
+    }
+
+    @Test("fetchUsage propagates 401")
+    func fetchUsage401() async throws {
+        let stub = StubClaudeUsageFetcher(responses: [.http401])
+        let (router, db, _) = makeRouter(stub: stub)
+        defer { Task { await cleanupKeychain(db) } }
+
+        let tok = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        try ClaudeTokenKeychain.store(id: tok.id.uuidString, token: "secret")
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.claudeTokenFetchUsage,
+                                                      params: ClaudeTokenFetchUsageParams(id: tok.id)))
+        #expect(!resp.success)
+        #expect(resp.error?.lowercased().contains("invalid") == true)
+        try? ClaudeTokenKeychain.delete(id: tok.id.uuidString)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeTokenResolverTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenResolverTests.swift
@@ -1,0 +1,129 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("ClaudeTokenResolver")
+struct ClaudeTokenResolverTests {
+    final class KeychainBox: @unchecked Sendable {
+        var map: [String: String] = [:]
+    }
+
+    private func makeHarness() throws -> (TBDDatabase, KeychainBox, ClaudeTokenResolver) {
+        let db = try TBDDatabase(inMemory: true)
+        let box = KeychainBox()
+        let resolver = ClaudeTokenResolver(
+            tokens: db.claudeTokens,
+            repos: db.repos,
+            config: db.config,
+            keychain: { id in box.map[id] }
+        )
+        return (db, box, resolver)
+    }
+
+    private func makeRepo(_ db: TBDDatabase, override: UUID? = nil) async throws -> Repo {
+        let repo = try await db.repos.create(
+            path: "/tmp/repo-\(UUID().uuidString)",
+            displayName: "repo",
+            defaultBranch: "main"
+        )
+        if let override {
+            try await db.repos.setClaudeTokenOverride(id: repo.id, tokenID: override)
+        }
+        return repo
+    }
+
+    @Test func resolve_nilRepo_noDefault_returnsNil() async throws {
+        let (_, _, resolver) = try makeHarness()
+        let result = try await resolver.resolve(repoID: nil)
+        #expect(result == nil)
+    }
+
+    @Test func resolve_nilRepo_globalDefault_keychainPresent_returnsResolved() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+        try await db.config.setDefaultClaudeTokenID(tok.id)
+        box.map[tok.id.uuidString] = "secret-A"
+
+        let result = try await resolver.resolve(repoID: nil)
+        #expect(result?.tokenID == tok.id)
+        #expect(result?.name == "Personal")
+        #expect(result?.kind == .oauth)
+        #expect(result?.secret == "secret-A")
+    }
+
+    @Test func resolve_nilRepo_globalDefault_keychainMissing_returnsNil() async throws {
+        let (db, _, resolver) = try makeHarness()
+        let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+        try await db.config.setDefaultClaudeTokenID(tok.id)
+
+        let result = try await resolver.resolve(repoID: nil)
+        #expect(result == nil)
+    }
+
+    @Test func resolve_repoOverride_keychainPresent_overrideWins() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let b = try await db.claudeTokens.create(name: "B", kind: .apiKey)
+        try await db.config.setDefaultClaudeTokenID(b.id)
+        let repo = try await makeRepo(db, override: a.id)
+        box.map[a.id.uuidString] = "secret-A"
+        box.map[b.id.uuidString] = "secret-B"
+
+        let result = try await resolver.resolve(repoID: repo.id)
+        #expect(result?.tokenID == a.id)
+        #expect(result?.secret == "secret-A")
+    }
+
+    @Test func resolve_repoOverride_keychainMissing_fallsBackToGlobal() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let b = try await db.claudeTokens.create(name: "B", kind: .apiKey)
+        try await db.config.setDefaultClaudeTokenID(b.id)
+        let repo = try await makeRepo(db, override: a.id)
+        box.map[b.id.uuidString] = "secret-B"
+
+        let result = try await resolver.resolve(repoID: repo.id)
+        #expect(result?.tokenID == b.id)
+        #expect(result?.secret == "secret-B")
+    }
+
+    @Test func resolve_repoNoOverride_globalSet_usesGlobal() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let g = try await db.claudeTokens.create(name: "G", kind: .oauth)
+        try await db.config.setDefaultClaudeTokenID(g.id)
+        let repo = try await makeRepo(db)
+        box.map[g.id.uuidString] = "secret-G"
+
+        let result = try await resolver.resolve(repoID: repo.id)
+        #expect(result?.tokenID == g.id)
+    }
+
+    @Test func resolve_success_bumpsLastUsedAt() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let tok = try await db.claudeTokens.create(name: "T", kind: .oauth)
+        #expect(tok.lastUsedAt == nil)
+        try await db.config.setDefaultClaudeTokenID(tok.id)
+        box.map[tok.id.uuidString] = "secret"
+
+        let before = Date()
+        _ = try await resolver.resolve(repoID: nil)
+        let reloaded = try await db.claudeTokens.get(id: tok.id)
+        #expect(reloaded?.lastUsedAt != nil)
+        if let lu = reloaded?.lastUsedAt {
+            #expect(lu.timeIntervalSince(before) >= -1)
+            #expect(lu.timeIntervalSinceNow >= -5)
+        }
+    }
+
+    @Test func resolve_failure_doesNotBumpLastUsedAt() async throws {
+        let (db, _, resolver) = try makeHarness()
+        let tok = try await db.claudeTokens.create(name: "T", kind: .oauth)
+        try await db.config.setDefaultClaudeTokenID(tok.id)
+        // no keychain entry
+
+        _ = try await resolver.resolve(repoID: nil)
+        let reloaded = try await db.claudeTokens.get(id: tok.id)
+        #expect(reloaded?.lastUsedAt == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeTokenSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenSpawnTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("Claude Token Spawn + Swap")
+struct ClaudeTokenSpawnTests {
+
+    /// Recorder for tmux argv lists invoked during dryRun.
+    final class TmuxRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _calls: [[String]] = []
+        var calls: [[String]] {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+        func record(_ args: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            _calls.append(args)
+        }
+        var joinedAll: String { calls.map { $0.joined(separator: " ") }.joined(separator: "\n") }
+    }
+
+    private func makeFixture() -> (RPCRouter, TBDDatabase, TmuxRecorder) {
+        let recorder = TmuxRecorder()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
+        let db = try! TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let router = RPCRouter(
+            db: db,
+            lifecycle: lifecycle,
+            tmux: tmux,
+            startTime: Date(),
+            usageFetcher: StubClaudeUsageFetcher()
+        )
+        return (router, db, recorder)
+    }
+
+    private func seedRepoAndWorktree(_ db: TBDDatabase) async throws -> (Repo, Worktree) {
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)",
+            displayName: "r",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "main",
+            path: "/tmp/wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        return (repo, wt)
+    }
+
+    private func seedToken(_ db: TBDDatabase, name: String, secret: String) async throws -> ClaudeToken {
+        let row = try await db.claudeTokens.create(name: name, kind: .oauth)
+        try ClaudeTokenKeychain.store(id: row.id.uuidString, token: secret)
+        return row
+    }
+
+    private func cleanup(_ db: TBDDatabase) async {
+        let toks = (try? await db.claudeTokens.list()) ?? []
+        for t in toks { try? ClaudeTokenKeychain.delete(id: t.id.uuidString) }
+    }
+
+    // MARK: - Spawn: no token configured
+
+    @Test("spawn: no tokens → no env prefix, claudeTokenID nil")
+    func spawnNoToken() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let term = try resp.decodeResult(Terminal.self)
+        #expect(term.claudeTokenID == nil)
+        #expect(!recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+    }
+
+    // MARK: - Spawn: global default
+
+    @Test("spawn: global default → env prefix + claudeTokenID")
+    func spawnWithGlobalDefault() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let secret = "sk-ant-oat01-fakeAAAA"
+        let tok = try await seedToken(db, name: "Default", secret: secret)
+        try await db.config.setDefaultClaudeTokenID(tok.id)
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let term = try resp.decodeResult(Terminal.self)
+        #expect(term.claudeTokenID == tok.id)
+        #expect(recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secret)'"))
+    }
+
+    // MARK: - Spawn: repo override beats default
+
+    @Test("spawn: repo override beats global default")
+    func spawnRepoOverride() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (repo, wt) = try await seedRepoAndWorktree(db)
+        let secretA = "sk-ant-oat01-AAAA"
+        let secretB = "sk-ant-oat01-BBBB"
+        let a = try await seedToken(db, name: "A", secret: secretA)
+        let b = try await seedToken(db, name: "B", secret: secretB)
+        try await db.config.setDefaultClaudeTokenID(a.id)
+        try await db.repos.setClaudeTokenOverride(id: repo.id, tokenID: b.id)
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let term = try resp.decodeResult(Terminal.self)
+        #expect(term.claudeTokenID == b.id)
+        #expect(recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secretB)'"))
+        #expect(!recorder.joinedAll.contains(secretA))
+    }
+
+    // MARK: - Spawn: non-claude type ignores token
+
+    @Test("spawn: non-claude type ignores token")
+    func spawnNonClaudeIgnoresToken() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let secret = "sk-ant-oat01-AAAA"
+        let tok = try await seedToken(db, name: "A", secret: secret)
+        try await db.config.setDefaultClaudeTokenID(tok.id)
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, cmd: "ls", type: .shell)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let term = try resp.decodeResult(Terminal.self)
+        #expect(term.claudeTokenID == nil)
+        #expect(!recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+    }
+
+    // MARK: - Swap: to a different token
+
+    @Test("swap: to different token updates row + sends respawn with new prefix")
+    func swapToDifferentToken() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let secretA = "sk-ant-oat01-AAAA"
+        let secretB = "sk-ant-oat01-BBBB"
+        let a = try await seedToken(db, name: "A", secret: secretA)
+        let b = try await seedToken(db, name: "B", secret: secretB)
+        try await db.config.setDefaultClaudeTokenID(a.id)
+
+        // Spawn a claude terminal with token A
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        ))
+        #expect(createResp.success)
+        let term = try createResp.decodeResult(Terminal.self)
+        #expect(term.claudeTokenID == a.id)
+
+        // Swap to B
+        let swapResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapClaudeToken,
+            params: TerminalSwapClaudeTokenParams(terminalID: term.id, newTokenID: b.id)
+        ))
+        #expect(swapResp.success)
+        let updated = try swapResp.decodeResult(Terminal.self)
+        #expect(updated.claudeTokenID == b.id)
+
+        let joined = recorder.joinedAll
+        #expect(joined.contains("send-keys"))
+        // C-c was sent
+        #expect(recorder.calls.contains { $0.contains("C-c") })
+        // Respawn command contains B's secret
+        #expect(joined.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secretB)' claude --resume"))
+        #expect(joined.contains("--dangerously-skip-permissions"))
+    }
+
+    // MARK: - Swap: to nil
+
+    @Test("swap: to nil clears token + no env prefix")
+    func swapToNil() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let secretA = "sk-ant-oat01-AAAA"
+        let a = try await seedToken(db, name: "A", secret: secretA)
+        try await db.config.setDefaultClaudeTokenID(a.id)
+
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        ))
+        let term = try createResp.decodeResult(Terminal.self)
+
+        // Clear recorder of spawn commands so we only inspect swap output
+        let beforeSwap = recorder.calls.count
+
+        let swapResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapClaudeToken,
+            params: TerminalSwapClaudeTokenParams(terminalID: term.id, newTokenID: nil)
+        ))
+        #expect(swapResp.success)
+        let updated = try swapResp.decodeResult(Terminal.self)
+        #expect(updated.claudeTokenID == nil)
+
+        let postSwap = Array(recorder.calls.dropFirst(beforeSwap))
+        let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
+        #expect(joined.contains("claude --resume"))
+        #expect(!joined.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+    }
+
+    // MARK: - Swap: non-claude terminal errors
+
+    @Test("swap: on non-claude terminal returns error")
+    func swapOnNonClaude() async throws {
+        let (router, db, _) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, cmd: "ls", type: .shell)
+        ))
+        let term = try createResp.decodeResult(Terminal.self)
+        #expect(term.claudeSessionID == nil)
+
+        let swapResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapClaudeToken,
+            params: TerminalSwapClaudeTokenParams(terminalID: term.id, newTokenID: nil)
+        ))
+        #expect(!swapResp.success)
+        #expect(swapResp.error?.contains("not a Claude terminal") == true)
+    }
+
+    // MARK: - Swap: unknown token id
+
+    @Test("swap: unknown token id returns error")
+    func swapUnknownToken() async throws {
+        let (router, db, _) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        ))
+        let term = try createResp.decodeResult(Terminal.self)
+
+        let swapResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapClaudeToken,
+            params: TerminalSwapClaudeTokenParams(terminalID: term.id, newTokenID: UUID())
+        ))
+        #expect(!swapResp.success)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeTokenSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenSpawnTests.swift
@@ -154,7 +154,7 @@ struct ClaudeTokenSpawnTests {
 
     // MARK: - Swap: to a different token
 
-    @Test("swap: to different token updates row + sends respawn with new prefix")
+    @Test("swap: forks into a new tab with the new token, leaves old tab alone")
     func swapToDifferentToken() async throws {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
@@ -165,36 +165,47 @@ struct ClaudeTokenSpawnTests {
         let b = try await seedToken(db, name: "B", secret: secretB)
         try await db.config.setDefaultClaudeTokenID(a.id)
 
-        // Spawn a claude terminal with token A
+        // Spawn original claude terminal with token A
         let createResp = await router.handle(try RPCRequest(
             method: RPCMethod.terminalCreate,
             params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
         ))
         #expect(createResp.success)
-        let term = try createResp.decodeResult(Terminal.self)
-        #expect(term.claudeTokenID == a.id)
+        let oldTerm = try createResp.decodeResult(Terminal.self)
+        #expect(oldTerm.claudeTokenID == a.id)
+        let oldSessionID = oldTerm.claudeSessionID
 
-        // Swap to B
+        let beforeSwap = recorder.calls.count
+
+        // Swap to B → returns a NEW terminal row, old one untouched
         let swapResp = await router.handle(try RPCRequest(
             method: RPCMethod.terminalSwapClaudeToken,
-            params: TerminalSwapClaudeTokenParams(terminalID: term.id, newTokenID: b.id)
+            params: TerminalSwapClaudeTokenParams(terminalID: oldTerm.id, newTokenID: b.id)
         ))
         #expect(swapResp.success)
-        let updated = try swapResp.decodeResult(Terminal.self)
-        #expect(updated.claudeTokenID == b.id)
+        let newTerm = try swapResp.decodeResult(Terminal.self)
+        #expect(newTerm.id != oldTerm.id)
+        #expect(newTerm.claudeTokenID == b.id)
+        // New terminal resumes the same session id (claude --resume forks history)
+        #expect(newTerm.claudeSessionID == oldSessionID)
 
-        let joined = recorder.joinedAll
-        #expect(joined.contains("send-keys"))
-        // C-c was sent
-        #expect(recorder.calls.contains { $0.contains("C-c") })
-        // Respawn command contains B's secret
-        #expect(joined.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secretB)' claude --resume"))
+        // Old terminal row is unchanged
+        let oldAfter = try await db.terminals.get(id: oldTerm.id)
+        #expect(oldAfter?.claudeTokenID == a.id)
+
+        // Daemon did NOT send C-c or send-keys to the old pane
+        let postSwap = Array(recorder.calls.dropFirst(beforeSwap))
+        let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
+        #expect(!joined.contains("C-c"))
+        #expect(!joined.contains("send-keys"))
+        // The new tab was spawned with B's secret + --resume <oldSessionID>
+        #expect(joined.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secretB)' claude --resume \(oldSessionID!)"))
         #expect(joined.contains("--dangerously-skip-permissions"))
     }
 
     // MARK: - Swap: to nil
 
-    @Test("swap: to nil clears token + no env prefix")
+    @Test("swap: to nil forks new tab with no env prefix; old tab untouched")
     func swapToNil() async throws {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
@@ -207,23 +218,28 @@ struct ClaudeTokenSpawnTests {
             method: RPCMethod.terminalCreate,
             params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
         ))
-        let term = try createResp.decodeResult(Terminal.self)
+        let oldTerm = try createResp.decodeResult(Terminal.self)
+        #expect(oldTerm.claudeTokenID == a.id)
 
-        // Clear recorder of spawn commands so we only inspect swap output
         let beforeSwap = recorder.calls.count
 
         let swapResp = await router.handle(try RPCRequest(
             method: RPCMethod.terminalSwapClaudeToken,
-            params: TerminalSwapClaudeTokenParams(terminalID: term.id, newTokenID: nil)
+            params: TerminalSwapClaudeTokenParams(terminalID: oldTerm.id, newTokenID: nil)
         ))
         #expect(swapResp.success)
-        let updated = try swapResp.decodeResult(Terminal.self)
-        #expect(updated.claudeTokenID == nil)
+        let newTerm = try swapResp.decodeResult(Terminal.self)
+        #expect(newTerm.id != oldTerm.id)
+        #expect(newTerm.claudeTokenID == nil)
+        // Old terminal still has its original token
+        let oldAfter = try await db.terminals.get(id: oldTerm.id)
+        #expect(oldAfter?.claudeTokenID == a.id)
 
         let postSwap = Array(recorder.calls.dropFirst(beforeSwap))
         let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
         #expect(joined.contains("claude --resume"))
         #expect(!joined.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+        #expect(!joined.contains("C-c"))
     }
 
     // MARK: - Swap: non-claude terminal errors

--- a/Tests/TBDDaemonTests/ClaudeTokenSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenSpawnTests.swift
@@ -19,6 +19,12 @@ struct ClaudeTokenSpawnTests {
             _calls.append(args)
         }
         var joinedAll: String { calls.map { $0.joined(separator: " ") }.joined(separator: "\n") }
+        /// Concatenation of just the shell-command bodies (last argv element of
+        /// each new-window call). Used to assert that secrets do NOT leak into
+        /// the long-running shell process arg.
+        var shellBodies: String {
+            calls.compactMap { $0.last }.joined(separator: "\n")
+        }
     }
 
     private func makeFixture() -> (RPCRouter, TBDDatabase, TmuxRecorder) {
@@ -101,7 +107,11 @@ struct ClaudeTokenSpawnTests {
         #expect(resp.success)
         let term = try resp.decodeResult(Terminal.self)
         #expect(term.claudeTokenID == tok.id)
-        #expect(recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secret)'"))
+        // Token must be passed via tmux -e flag, never inlined in shell body.
+        #expect(recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secret)"))
+        #expect(!recorder.shellBodies.contains(secret),
+                "secret leaked into shell body")
+        #expect(!recorder.shellBodies.contains("CLAUDE_CODE_OAUTH_TOKEN"))
     }
 
     // MARK: - Spawn: repo override beats default
@@ -126,8 +136,10 @@ struct ClaudeTokenSpawnTests {
         #expect(resp.success)
         let term = try resp.decodeResult(Terminal.self)
         #expect(term.claudeTokenID == b.id)
-        #expect(recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secretB)'"))
+        #expect(recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secretB)"))
         #expect(!recorder.joinedAll.contains(secretA))
+        #expect(!recorder.shellBodies.contains(secretB),
+                "secret leaked into shell body")
     }
 
     // MARK: - Spawn: non-claude type ignores token
@@ -198,9 +210,16 @@ struct ClaudeTokenSpawnTests {
         let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
         #expect(!joined.contains("C-c"))
         #expect(!joined.contains("send-keys"))
-        // The new tab was spawned with B's secret + --resume <oldSessionID>
-        #expect(joined.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secretB)' claude --resume \(oldSessionID!)"))
+        // The new tab was spawned with B's secret via tmux -e (NOT inlined),
+        // and the shell body contains --resume <oldSessionID>.
+        #expect(joined.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secretB)"))
+        #expect(joined.contains("claude --resume \(oldSessionID!)"))
         #expect(joined.contains("--dangerously-skip-permissions"))
+        // Negative: secret must NOT appear in any shell body of post-swap calls.
+        let postBodies = postSwap.compactMap { $0.last }.joined(separator: "\n")
+        #expect(!postBodies.contains(secretB),
+                "secret leaked into shell body: \(postBodies)")
+        #expect(!postBodies.contains("CLAUDE_CODE_OAUTH_TOKEN"))
     }
 
     // MARK: - Swap: to nil

--- a/Tests/TBDDaemonTests/ClaudeTokenStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenStoreTests.swift
@@ -53,6 +53,28 @@ struct ClaudeTokenStoreTests {
         #expect(cleared?.claudeTokenOverrideID == nil)
     }
 
+    @Test func terminalTokenIDRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+        let repo = try await db.repos.create(path: "/tmp/r2", displayName: "r2", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "tbd/w",
+            path: "/tmp/r2/.tbd/worktrees/w", tmuxServer: "tbd-test"
+        )
+        let term = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%0", label: "claude"
+        )
+        #expect(term.claudeTokenID == nil)
+
+        try await db.terminals.setClaudeTokenID(id: term.id, tokenID: tok.id)
+        let fetched = try await db.terminals.get(id: term.id)
+        #expect(fetched?.claudeTokenID == tok.id)
+
+        try await db.terminals.setClaudeTokenID(id: term.id, tokenID: nil)
+        let cleared = try await db.terminals.get(id: term.id)
+        #expect(cleared?.claudeTokenID == nil)
+    }
+
     @Test func touchLastUsed() async throws {
         let db = try TBDDatabase(inMemory: true)
         let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)

--- a/Tests/TBDDaemonTests/ClaudeTokenStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenStoreTests.swift
@@ -38,6 +38,21 @@ struct ClaudeTokenStoreTests {
         #expect(try await db.claudeTokens.get(id: tok.id) == nil)
     }
 
+    @Test func repoOverrideRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+        let repo = try await db.repos.create(path: "/tmp/r", displayName: "r", defaultBranch: "main")
+        #expect(repo.claudeTokenOverrideID == nil)
+
+        try await db.repos.setClaudeTokenOverride(id: repo.id, tokenID: tok.id)
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.claudeTokenOverrideID == tok.id)
+
+        try await db.repos.setClaudeTokenOverride(id: repo.id, tokenID: nil)
+        let cleared = try await db.repos.get(id: repo.id)
+        #expect(cleared?.claudeTokenOverrideID == nil)
+    }
+
     @Test func touchLastUsed() async throws {
         let db = try TBDDatabase(inMemory: true)
         let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)

--- a/Tests/TBDDaemonTests/ClaudeTokenStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenStoreTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("ClaudeTokenStore")
+struct ClaudeTokenStoreTests {
+    @Test func createListGet() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+        #expect(tok.name == "Personal")
+        #expect(tok.kind == .oauth)
+
+        let all = try await db.claudeTokens.list()
+        #expect(all.count == 1)
+
+        let fetched = try await db.claudeTokens.get(id: tok.id)
+        #expect(fetched?.id == tok.id)
+    }
+
+    @Test func getByName() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.claudeTokens.create(name: "Work", kind: .apiKey)
+        let found = try await db.claudeTokens.getByName("Work")
+        #expect(found?.kind == .apiKey)
+        let missing = try await db.claudeTokens.getByName("Nope")
+        #expect(missing == nil)
+    }
+
+    @Test func renameAndDelete() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "Old", kind: .oauth)
+        try await db.claudeTokens.rename(id: tok.id, name: "New")
+        let renamed = try await db.claudeTokens.get(id: tok.id)
+        #expect(renamed?.name == "New")
+
+        try await db.claudeTokens.delete(id: tok.id)
+        #expect(try await db.claudeTokens.get(id: tok.id) == nil)
+    }
+
+    @Test func touchLastUsed() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+        #expect(tok.lastUsedAt == nil)
+        try await db.claudeTokens.touchLastUsed(id: tok.id)
+        let updated = try await db.claudeTokens.get(id: tok.id)
+        #expect(updated?.lastUsedAt != nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeTokenUsageStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenUsageStoreTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("ClaudeTokenUsageStore")
+struct ClaudeTokenUsageStoreTests {
+    @Test func upsertIsIdempotent() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "T", kind: .oauth)
+        let u1 = ClaudeTokenUsage(tokenID: tok.id, fiveHourPct: 0.1, sevenDayPct: 0.2, lastStatus: "ok")
+        try await db.claudeTokenUsage.upsert(u1)
+        let u2 = ClaudeTokenUsage(tokenID: tok.id, fiveHourPct: 0.5, sevenDayPct: 0.6, lastStatus: "ok")
+        try await db.claudeTokenUsage.upsert(u2)
+
+        let fetched = try await db.claudeTokenUsage.get(tokenID: tok.id)
+        #expect(fetched?.fiveHourPct == 0.5)
+        #expect(fetched?.sevenDayPct == 0.6)
+    }
+
+    @Test func deleteForToken() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "T", kind: .oauth)
+        try await db.claudeTokenUsage.upsert(ClaudeTokenUsage(tokenID: tok.id, lastStatus: "ok"))
+        try await db.claudeTokenUsage.deleteForToken(id: tok.id)
+        #expect(try await db.claudeTokenUsage.get(tokenID: tok.id) == nil)
+    }
+
+    @Test func cascadeOnTokenDelete() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "T", kind: .oauth)
+        try await db.claudeTokenUsage.upsert(ClaudeTokenUsage(tokenID: tok.id, lastStatus: "ok"))
+        try await db.claudeTokens.delete(id: tok.id)
+        #expect(try await db.claudeTokenUsage.get(tokenID: tok.id) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeUsageFetcherTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeUsageFetcherTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+final class MockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var lastRequest: URLRequest?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        MockURLProtocol.lastRequest = request
+        guard let handler = MockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeFetcher() -> LiveClaudeUsageFetcher {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return LiveClaudeUsageFetcher(session: URLSession(configuration: config))
+}
+
+private func httpResponse(_ url: URL, _ status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: nil)!
+}
+
+private let testToken = "sk-ant-oat01-SECRETSECRETSECRET"
+
+@Suite(.serialized)
+struct ClaudeUsageFetcherTests {
+    init() {
+        MockURLProtocol.handler = nil
+        MockURLProtocol.lastRequest = nil
+    }
+
+    @Test func happyPath200() async throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 0.42, "resets_at": "2026-04-06T15:00:00Z" },
+          "seven_day": { "utilization": 0.18, "resets_at": "2026-04-13T00:00:00Z" }
+        }
+        """.data(using: .utf8)!
+        MockURLProtocol.handler = { req in
+            (httpResponse(req.url!, 200), json)
+        }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        guard case .ok(let usage) = result else {
+            Issue.record("expected .ok, got \(result)")
+            return
+        }
+        #expect(usage.fiveHourPct == 0.42)
+        #expect(usage.sevenDayPct == 0.18)
+        let fiveH = ISO8601DateFormatter().date(from: "2026-04-06T15:00:00Z")!
+        let sevenD = ISO8601DateFormatter().date(from: "2026-04-13T00:00:00Z")!
+        #expect(usage.fiveHourResetsAt == fiveH)
+        #expect(usage.sevenDayResetsAt == sevenD)
+    }
+
+    @Test func unauthorized401() async {
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 401), Data()) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        #expect(result == .http401)
+    }
+
+    @Test func rateLimited429() async {
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 429), Data()) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        #expect(result == .http429)
+    }
+
+    @Test func serverError500() async {
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 500), Data()) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        guard case .networkError(let msg) = result else {
+            Issue.record("expected .networkError, got \(result)")
+            return
+        }
+        #expect(msg.contains("500"))
+        #expect(!msg.contains(testToken))
+    }
+
+    @Test func networkFailure() async {
+        MockURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        guard case .networkError = result else {
+            Issue.record("expected .networkError, got \(result)")
+            return
+        }
+    }
+
+    @Test func decodeFailure() async {
+        let bad = "{ not json".data(using: .utf8)!
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 200), bad) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        guard case .decodeError(let msg) = result else {
+            Issue.record("expected .decodeError, got \(result)")
+            return
+        }
+        #expect(!msg.contains(testToken))
+    }
+
+    @Test func requestShape() async {
+        let json = """
+        {
+          "five_hour": { "utilization": 0.0, "resets_at": "2026-04-06T15:00:00Z" },
+          "seven_day": { "utilization": 0.0, "resets_at": "2026-04-13T00:00:00Z" }
+        }
+        """.data(using: .utf8)!
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 200), json) }
+        _ = await makeFetcher().fetchUsage(token: testToken)
+        let req = MockURLProtocol.lastRequest
+        #expect(req?.url?.absoluteString == "https://api.anthropic.com/api/oauth/usage")
+        #expect(req?.value(forHTTPHeaderField: "Authorization") == "Bearer \(testToken)")
+        #expect(req?.value(forHTTPHeaderField: "anthropic-beta") == "oauth-2025-04-20")
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeUsagePollerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeUsagePollerTests.swift
@@ -1,0 +1,386 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// MARK: - Test clock
+
+/// Virtual clock. `advance(by:)` moves wall time forward and resolves any
+/// in-flight `sleep(until:)` continuations whose deadlines have been crossed.
+final class TestPollerClock: PollerClock, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "TestPollerClock")
+    private var _now: Date
+    private var sleepers: [(deadline: Date, cont: CheckedContinuation<Void, Error>, id: UUID)] = []
+    private var cancellableSleepers: [UUID: CheckedContinuation<Void, Error>] = [:]
+
+    init(start: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+        self._now = start
+    }
+
+    func now() -> Date {
+        queue.sync { _now }
+    }
+
+    func sleep(until deadline: Date) async throws {
+        // Use a unique id so we can drain on cancel.
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                let resumeNow: Bool = queue.sync {
+                    if _now >= deadline { return true }
+                    cancellableSleepers[id] = cont
+                    sleepers.append((deadline, cont, id))
+                    return false
+                }
+                if resumeNow { cont.resume() }
+            }
+        } onCancel: {
+            let cont: CheckedContinuation<Void, Error>? = queue.sync {
+                let c = cancellableSleepers.removeValue(forKey: id)
+                sleepers.removeAll { $0.id == id }
+                return c
+            }
+            cont?.resume(throwing: CancellationError())
+        }
+    }
+
+    /// Advance virtual time. Resolves all sleepers whose deadlines have passed.
+    func advance(by interval: TimeInterval) async {
+        let due: [(deadline: Date, cont: CheckedContinuation<Void, Error>, id: UUID)] = queue.sync {
+            _now = _now.addingTimeInterval(interval)
+            let matched = sleepers.filter { $0.deadline <= _now }
+            sleepers.removeAll { $0.deadline <= _now }
+            for m in matched { cancellableSleepers.removeValue(forKey: m.id) }
+            return matched
+        }
+        for entry in due { entry.cont.resume() }
+        for _ in 0..<30 { await Task.yield() }
+    }
+}
+
+// MARK: - Mock fetcher
+
+final class MockUsageFetcher: ClaudeUsageFetcher, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "MockUsageFetcher")
+    private var queues: [String: [ClaudeUsageStatus]] = [:]
+    private var defaults: ClaudeUsageStatus
+    private var _calls: [String] = []
+
+    init(default defaultResult: ClaudeUsageStatus) {
+        self.defaults = defaultResult
+    }
+
+    func enqueue(token: String, _ status: ClaudeUsageStatus) {
+        queue.sync { queues[token, default: []].append(status) }
+    }
+
+    func callCount(for token: String) -> Int {
+        queue.sync { _calls.filter { $0 == token }.count }
+    }
+
+    var totalCalls: Int {
+        queue.sync { _calls.count }
+    }
+
+    func fetchUsage(token: String) async -> ClaudeUsageStatus {
+        queue.sync {
+            _calls.append(token)
+            if var q = queues[token], !q.isEmpty {
+                let s = q.removeFirst()
+                queues[token] = q
+                return s
+            }
+            return defaults
+        }
+    }
+}
+
+// MARK: - Broadcast collector
+
+final class BroadcastCollector: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "BroadcastCollector")
+    private var _rows: [ClaudeTokenUsage] = []
+    var rows: [ClaudeTokenUsage] { queue.sync { _rows } }
+    func record(_ row: ClaudeTokenUsage) { queue.sync { _rows.append(row) } }
+}
+
+// MARK: - Helpers
+
+private func sampleUsageOK() -> ClaudeUsageResult {
+    ClaudeUsageResult(
+        fiveHourPct: 0.25,
+        sevenDayPct: 0.10,
+        fiveHourResetsAt: Date(timeIntervalSince1970: 2_000_000_000),
+        sevenDayResetsAt: Date(timeIntervalSince1970: 2_100_000_000)
+    )
+}
+
+/// Build a poller with deterministic stagger=0 (no jitter) so tests are stable.
+private func makePoller(
+    db: TBDDatabase,
+    fetcher: ClaudeUsageFetcher,
+    clock: TestPollerClock,
+    keychain: @escaping @Sendable (String) throws -> String? = { id in id },
+    broadcast: @escaping @Sendable (ClaudeTokenUsage) -> Void = { _ in },
+    stagger: TimeInterval = 0
+) -> ClaudeUsagePoller {
+    ClaudeUsagePoller(
+        tokens: db.claudeTokens,
+        usage: db.claudeTokenUsage,
+        keychain: keychain,
+        fetcher: fetcher,
+        clock: clock,
+        broadcast: broadcast,
+        staggerProvider: { stagger }
+    )
+}
+
+/// Pump the actor's loop several times so it can transition through
+/// refresh/sleep states between virtual-time advances. Uses tiny real-time
+/// sleeps because the loop awaits the GRDB executor (a separate thread), so
+/// pure `Task.yield()` is not sufficient to settle the actor between steps.
+private func pump() async {
+    for _ in 0..<20 {
+        try? await Task.sleep(nanoseconds: 5_000_000) // 5 ms
+        await Task.yield()
+    }
+}
+
+// MARK: - Tests
+
+@Suite("ClaudeUsagePoller")
+struct ClaudeUsagePollerTests {
+
+    @Test func happyPathStaggerAndCadence() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let b = try await db.claudeTokens.create(name: "B", kind: .oauth)
+        let clock = TestPollerClock()
+        let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
+        let poller = makePoller(db: db, fetcher: fetcher, clock: clock, stagger: 30)
+
+        await poller.start()
+        await pump()
+
+        // Before advancing, no calls have happened.
+        #expect(fetcher.totalCalls == 0)
+
+        // Advance past the 30s stagger.
+        await clock.advance(by: 31)
+        await pump()
+
+        #expect(fetcher.callCount(for: a.id.uuidString) == 1)
+        #expect(fetcher.callCount(for: b.id.uuidString) == 1)
+
+        // Advance another 30 minutes — second tick.
+        await clock.advance(by: 30 * 60 + 1)
+        await pump()
+
+        #expect(fetcher.callCount(for: a.id.uuidString) == 2)
+        #expect(fetcher.callCount(for: b.id.uuidString) == 2)
+
+        await poller.stop()
+    }
+
+    @Test func dedupeWithinSixtySeconds() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let clock = TestPollerClock()
+
+        // Pre-populate a fresh usage row (fetched 30s ago).
+        let prePop = ClaudeTokenUsage(
+            tokenID: a.id,
+            fiveHourPct: 0.5,
+            sevenDayPct: 0.2,
+            fiveHourResetsAt: Date(timeIntervalSince1970: 1_900_000_000),
+            sevenDayResetsAt: Date(timeIntervalSince1970: 1_950_000_000),
+            fetchedAt: clock.now().addingTimeInterval(-30),
+            lastStatus: "ok"
+        )
+        try await db.claudeTokenUsage.upsert(prePop)
+
+        let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
+        let poller = makePoller(db: db, fetcher: fetcher, clock: clock)
+
+        await poller.start()
+        await pump()
+        await clock.advance(by: 1) // first tick fires immediately (stagger=0)
+        await pump()
+
+        // Dedupe hit — no fetch.
+        #expect(fetcher.callCount(for: a.id.uuidString) == 0)
+
+        await poller.stop()
+    }
+
+    @Test func http429BackoffThenRecovery() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let clock = TestPollerClock()
+        let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
+        // First call: 429. Subsequent: ok.
+        fetcher.enqueue(token: a.id.uuidString, .http429)
+
+        let poller = makePoller(db: db, fetcher: fetcher, clock: clock)
+        await poller.start()
+        await pump()
+
+        // First tick → 429.
+        await clock.advance(by: 1)
+        await pump()
+        #expect(fetcher.callCount(for: a.id.uuidString) == 1)
+
+        // After 30 minutes nothing should fire (backoff is 60 min).
+        await clock.advance(by: 30 * 60)
+        await pump()
+        #expect(fetcher.callCount(for: a.id.uuidString) == 1)
+
+        // After another 30 minutes (total 60 min) it fires again — this time .ok (default).
+        await clock.advance(by: 30 * 60 + 1)
+        await pump()
+        #expect(fetcher.callCount(for: a.id.uuidString) == 2)
+
+        // After this success, backoff should be cleared. 30 more minutes should fire again.
+        await clock.advance(by: 30 * 60 + 1)
+        await pump()
+        #expect(fetcher.callCount(for: a.id.uuidString) == 3)
+
+        await poller.stop()
+    }
+
+    @Test func http401PermanentExclusion() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let clock = TestPollerClock()
+        let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
+        fetcher.enqueue(token: a.id.uuidString, .http401)
+
+        let poller = makePoller(db: db, fetcher: fetcher, clock: clock)
+        await poller.start()
+        await pump()
+        await clock.advance(by: 1)
+        await pump()
+        #expect(fetcher.callCount(for: a.id.uuidString) == 1)
+
+        // Advance well past the cadence — no further calls because token excluded.
+        await clock.advance(by: 60 * 60)
+        await pump()
+        #expect(fetcher.callCount(for: a.id.uuidString) == 1)
+
+        await poller.stop()
+    }
+
+    @Test func apiKeyTokensSkipped() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let oauthTok = try await db.claudeTokens.create(name: "Oauth", kind: .oauth)
+        let apiKey = try await db.claudeTokens.create(name: "Api", kind: .apiKey)
+        let clock = TestPollerClock()
+        let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
+        let poller = makePoller(db: db, fetcher: fetcher, clock: clock)
+
+        await poller.start()
+        await pump()
+        await clock.advance(by: 5 * 60)
+        await pump()
+
+        #expect(fetcher.callCount(for: oauthTok.id.uuidString) == 1)
+        #expect(fetcher.callCount(for: apiKey.id.uuidString) == 0)
+
+        await poller.stop()
+    }
+
+    @Test func focusPauseAndResume() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let b = try await db.claudeTokens.create(name: "B", kind: .oauth)
+        let clock = TestPollerClock()
+        let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
+        let poller = makePoller(db: db, fetcher: fetcher, clock: clock)
+
+        await poller.start()
+        await pump()
+        await clock.advance(by: 1)
+        await pump()
+        #expect(fetcher.callCount(for: a.id.uuidString) == 1)
+        #expect(fetcher.callCount(for: b.id.uuidString) == 1)
+
+        // Lose focus.
+        await poller.onFocusChanged(isForeground: false)
+        // Advance 11 minutes — past the 10-min focus pause threshold but not past the 30-min cadence.
+        await clock.advance(by: 11 * 60)
+        await pump()
+
+        // Loop should be paused; no new fetches.
+        #expect(fetcher.callCount(for: a.id.uuidString) == 1)
+        #expect(fetcher.callCount(for: b.id.uuidString) == 1)
+
+        // Regain focus → immediate pokeAll.
+        await poller.onFocusChanged(isForeground: true)
+        await pump()
+        await clock.advance(by: 1)
+        await pump()
+
+        #expect(fetcher.callCount(for: a.id.uuidString) == 2)
+        #expect(fetcher.callCount(for: b.id.uuidString) == 2)
+
+        await poller.stop()
+    }
+
+    @Test func pokeAllFiresEverythingEligible() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let b = try await db.claudeTokens.create(name: "B", kind: .oauth)
+        let clock = TestPollerClock()
+        let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
+        // Use big stagger so first tick is far in the future.
+        let poller = makePoller(db: db, fetcher: fetcher, clock: clock, stagger: 30 * 60)
+
+        await poller.start()
+        await pump()
+        // Verify nothing fired yet.
+        #expect(fetcher.totalCalls == 0)
+
+        await poller.pokeAll()
+        await pump()
+        await clock.advance(by: 1)
+        await pump()
+
+        #expect(fetcher.callCount(for: a.id.uuidString) == 1)
+        #expect(fetcher.callCount(for: b.id.uuidString) == 1)
+
+        await poller.stop()
+    }
+
+    @Test func broadcastCalledOnEachWrite() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let a = try await db.claudeTokens.create(name: "A", kind: .oauth)
+        let clock = TestPollerClock()
+        let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
+        // First .ok, then .http429.
+        fetcher.enqueue(token: a.id.uuidString, .ok(sampleUsageOK()))
+        fetcher.enqueue(token: a.id.uuidString, .http429)
+
+        let collector = BroadcastCollector()
+        let poller = makePoller(
+            db: db, fetcher: fetcher, clock: clock,
+            broadcast: { row in collector.record(row) }
+        )
+
+        await poller.start()
+        await pump()
+        await clock.advance(by: 1)
+        await pump()
+
+        #expect(collector.rows.count == 1)
+        #expect(collector.rows[0].lastStatus == "ok")
+
+        // Trigger another tick.
+        await clock.advance(by: 30 * 60 + 1)
+        await pump()
+
+        #expect(collector.rows.count == 2)
+        #expect(collector.rows[1].lastStatus == "http_429")
+
+        await poller.stop()
+    }
+}

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -1,0 +1,30 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("ConfigStore")
+struct ConfigStoreTests {
+    @Test func defaultsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.defaultClaudeTokenID == nil)
+    }
+
+    @Test func setAndGetDefaultClaudeTokenID() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+        try await db.config.setDefaultClaudeTokenID(tok.id)
+        let cfg = try await db.config.get()
+        #expect(cfg.defaultClaudeTokenID == tok.id)
+    }
+
+    @Test func clearDefaultClaudeTokenID() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+        try await db.config.setDefaultClaudeTokenID(tok.id)
+        try await db.config.setDefaultClaudeTokenID(nil)
+        let cfg = try await db.config.get()
+        #expect(cfg.defaultClaudeTokenID == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
@@ -107,6 +107,81 @@ struct SuspendResumeCoordinatorTests {
         #expect(result == .notSuspended)
     }
 
+    @Test func resumeInjectsTokenWhenResolverProvided() async throws {
+        // Build DB with a token row + suspended terminal referencing it.
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-repo", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt",
+            branch: "main", path: "/tmp/test-repo",
+            tmuxServer: "tbd-test"
+        )
+        let token = try await db.claudeTokens.create(name: "test-token", kind: .oauth)
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude-1", claudeSessionID: "session-abc",
+            claudeTokenID: token.id
+        )
+        try await db.terminals.setSuspended(
+            id: terminal.id, sessionID: "session-abc", snapshot: nil
+        )
+
+        // Stub keychain closure returns a known secret only for this token.
+        let secret = "sk-ant-oat01-FAKETOKEN_value"
+        let resolver = ClaudeTokenResolver(
+            tokens: db.claudeTokens,
+            repos: db.repos,
+            config: db.config,
+            keychain: { id in id == token.id.uuidString ? secret : nil }
+        )
+
+        // Recorder to capture the createWindow shellCommand argument.
+        let recorded = RecordedCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+            recorded.append(args)
+        })
+        let coordinator = SuspendResumeCoordinator(db: db, tmux: tmux, claudeTokenResolver: resolver)
+
+        await coordinator.selectionChanged(to: [wt.id], suspendEnabled: false)
+        try await Task.sleep(for: .seconds(5))
+
+        let after = try await db.terminals.get(id: terminal.id)
+        #expect(after?.suspendedAt == nil)
+
+        // Find the createWindow invocation (it's the only dryRun call recorded here).
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        let resumeArg = joined.first { $0.contains("claude --resume") }
+        #expect(resumeArg != nil, "expected a createWindow call containing claude --resume")
+        #expect(resumeArg?.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secret)'") == true,
+                "expected token env var injected; got: \(resumeArg ?? "nil")")
+        #expect(resumeArg?.contains("claude --resume session-abc") == true)
+    }
+
+    @Test func resumeOmitsTokenWhenResolverNil() async throws {
+        let (db, worktreeID, terminalID) = try await setupSuspendedTerminal()
+
+        let recorded = RecordedCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+            recorded.append(args)
+        })
+        // No resolver supplied — fallback branch.
+        let coordinator = SuspendResumeCoordinator(db: db, tmux: tmux, claudeTokenResolver: nil)
+
+        await coordinator.selectionChanged(to: [worktreeID], suspendEnabled: false)
+        try await Task.sleep(for: .seconds(5))
+
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.suspendedAt == nil)
+
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        let resumeArg = joined.first { $0.contains("claude --resume") }
+        #expect(resumeArg != nil, "expected a createWindow call containing claude --resume")
+        #expect(resumeArg?.contains("CLAUDE_CODE_OAUTH_TOKEN") == false,
+                "fallback branch must not inject CLAUDE_CODE_OAUTH_TOKEN; got: \(resumeArg ?? "nil")")
+        #expect(resumeArg?.contains("ANTHROPIC_API_KEY") == false)
+        #expect(resumeArg?.contains("claude --resume session-abc") == true)
+    }
+
     @Test func suspendSkippedWhenDisabled() async throws {
         let db = try TBDDatabase(inMemory: true)
         let repo = try await db.repos.create(path: "/tmp/test-repo", displayName: "test", defaultBranch: "main")
@@ -135,5 +210,21 @@ struct SuspendResumeCoordinatorTests {
 
         let after = try await db.terminals.get(id: terminal.id)
         #expect(after?.suspendedAt == nil, "Terminal should NOT be suspended when suspendEnabled is false")
+    }
+}
+
+/// Thread-safe collector for TmuxManager dryRun recorded args.
+private final class RecordedCommands: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands: [[String]] = []
+
+    func append(_ args: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        commands.append(args)
+    }
+
+    func snapshot() -> [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return commands
     }
 }

--- a/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
@@ -149,12 +149,19 @@ struct SuspendResumeCoordinatorTests {
         #expect(after?.suspendedAt == nil)
 
         // Find the createWindow invocation (it's the only dryRun call recorded here).
-        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
-        let resumeArg = joined.first { $0.contains("claude --resume") }
-        #expect(resumeArg != nil, "expected a createWindow call containing claude --resume")
-        #expect(resumeArg?.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secret)'") == true,
-                "expected token env var injected; got: \(resumeArg ?? "nil")")
-        #expect(resumeArg?.contains("claude --resume session-abc") == true)
+        let snap = recorded.snapshot()
+        let resumeCall = snap.first { $0.joined(separator: " ").contains("claude --resume") }
+        #expect(resumeCall != nil, "expected a createWindow call containing claude --resume")
+        // Token must be passed via tmux -e flag, NOT inlined in the shell command argv.
+        #expect(resumeCall?.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secret)") == true,
+                "expected token in tmux -e flag; got: \(resumeCall ?? [])")
+        // The shell command body (last arg, after -ic) must NOT contain the secret.
+        let shellBody = resumeCall?.last ?? ""
+        #expect(!shellBody.contains(secret),
+                "secret leaked into shell command body: \(shellBody)")
+        #expect(!shellBody.contains("CLAUDE_CODE_OAUTH_TOKEN"),
+                "env var name leaked into shell command body: \(shellBody)")
+        #expect(shellBody.contains("claude --resume session-abc"))
     }
 
     @Test func resumeOmitsTokenWhenResolverNil() async throws {

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -330,6 +330,56 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
     #expect(restoredSessionIDs.count == 2)
 }
 
+@Test func testCreateInjectsTokenWhenResolverProvided() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+
+    // Seed a token row and set it as the global default.
+    let token = try await db.claudeTokens.create(name: "Test", kind: .oauth)
+    try await db.config.setDefaultClaudeTokenID(token.id)
+
+    let secret = "sk-ant-oat01-FAKETOKEN_value"
+    let resolver = ClaudeTokenResolver(
+        tokens: db.claudeTokens,
+        repos: db.repos,
+        config: db.config,
+        keychain: { id in id == token.id.uuidString ? secret : nil }
+    )
+
+    // Recorder captures the dryRun shellCommand args from createWindow.
+    let recorded = LifecycleRecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: tmux,
+        hooks: HookResolver(),
+        claudeTokenResolver: resolver
+    )
+
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+
+    // (a) Captured shell command for the Claude window contains the env var injection.
+    let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+    let claudeCmd = joined.first { $0.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secret)'") }
+    #expect(claudeCmd != nil,
+            "expected createWindow call with CLAUDE_CODE_OAUTH_TOKEN injected; got: \(joined)")
+
+    // (b) Persisted terminal row has claudeTokenID set to the known token UUID.
+    let terminals = try await db.terminals.list(worktreeID: wt.id)
+    let claudeTerminal = terminals.first { $0.claudeTokenID != nil }
+    #expect(claudeTerminal?.claudeTokenID == token.id,
+            "expected the Claude terminal to persist claudeTokenID=\(token.id)")
+}
+
 @Test func testWorktreePathStructure() async throws {
     let (tempDir, repoDir) = try await createTestRepo()
     defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -351,4 +401,20 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
     #expect(wt.path.hasPrefix(repoDir.path))
     #expect(wt.path.contains(".tbd/worktrees/"))
     #expect(wt.path.contains(wt.name))
+}
+
+/// Thread-safe collector for TmuxManager dryRun recorded args.
+private final class LifecycleRecordedCommands: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands: [[String]] = []
+
+    func append(_ args: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        commands.append(args)
+    }
+
+    func snapshot() -> [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return commands
+    }
 }

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -367,11 +367,20 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
     )
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
 
-    // (a) Captured shell command for the Claude window contains the env var injection.
-    let joined = recorded.snapshot().map { $0.joined(separator: " ") }
-    let claudeCmd = joined.first { $0.contains("CLAUDE_CODE_OAUTH_TOKEN='\(secret)'") }
-    #expect(claudeCmd != nil,
-            "expected createWindow call with CLAUDE_CODE_OAUTH_TOKEN injected; got: \(joined)")
+    // (a) Token must be passed via tmux -e flag, NOT inlined into the shell command body.
+    let snap = recorded.snapshot()
+    let claudeCall = snap.first { call in
+        let body = call.last ?? ""
+        return body.contains("claude --session-id")
+    }
+    #expect(claudeCall != nil, "expected a createWindow call spawning claude")
+    #expect(claudeCall?.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secret)") == true,
+            "expected token in tmux -e flag; got: \(claudeCall ?? [])")
+    let shellBody = claudeCall?.last ?? ""
+    #expect(!shellBody.contains(secret),
+            "secret leaked into shell command body: \(shellBody)")
+    #expect(!shellBody.contains("CLAUDE_CODE_OAUTH_TOKEN"),
+            "env var name leaked into shell command body: \(shellBody)")
 
     // (b) Persisted terminal row has claudeTokenID set to the known token UUID.
     let terminals = try await db.terminals.list(worktreeID: wt.id)

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher.md
@@ -1,0 +1,75 @@
+# Claude Token Switcher — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. This is a **fractal plan** — each phase has its own child document with full task breakdown. Follow the dependency order below.
+
+**Goal:** Let the user store multiple Claude tokens, designate a global default with per-repo overrides, swap a running claude terminal's token mid-conversation without losing context, and see 5h/7d usage per token.
+
+**Spec:** [`docs/superpowers/specs/2026-04-06-claude-token-switcher-design.md`](../specs/2026-04-06-claude-token-switcher-design.md)
+
+**Architecture:** Tokens live in macOS Keychain, referenced by UUID from new `claude_tokens` / `claude_token_usage` tables in `state.db`. A new `config` table holds the global default; `repo` and `terminal` tables gain optional token-ID columns. Spawning a claude terminal resolves the token (repo override → global default → none) and prefixes `CLAUDE_CODE_OAUTH_TOKEN=<value> ` on the shell command passed to tmux. Mid-conversation swap kills the claude process, respawns with `--resume <session-id>` and the new env var. Usage is fetched lazily + on a 30-min background poll from `/api/oauth/usage`, cached in the DB. UI spans a new Settings tab, a repo settings picker row, a menu bar submenu, and a context menu section on claude tabs.
+
+**Tech Stack:** Swift 5.9+, GRDB (SQLite), Security.framework (Keychain), URLSession (HTTP), SwiftUI, Swift Testing (`@Test` / `#expect`), swift-nio (already in daemon, unrelated to this feature).
+
+---
+
+## Phase order and dependencies
+
+Phases may be implemented by separate subagents in parallel where deps allow. Arrows = "must finish before".
+
+```
+Phase 01 (schema + models)
+  ├── Phase 02 (keychain wrapper)          [independent]
+  ├── Phase 03 (usage fetcher)             [independent]
+  └── Phase 04 (token resolver)
+        └── Phase 05 (RPC: CRUD + fetch)
+        └── Phase 06 (spawn + swap RPC)
+              └── Phase 07 (background poll scheduler)
+                    └── Phase 08 (DaemonClient stubs)
+                          ├── Phase 09 (Settings → Claude Tokens tab)
+                          ├── Phase 10 (repo override picker)
+                          ├── Phase 11 (menu bar submenu)
+                          └── Phase 12 (claude tab context menu)
+```
+
+**Parallelism notes for the executor:**
+- Phases 02, 03, 04 all depend only on 01 and can run in parallel once 01 lands.
+- Phases 09–12 all depend on 08 and can run in parallel.
+- Phases 05 and 06 both touch `RPCRouter.swift` / `RPCProtocol.swift` — serialize them or expect a merge.
+
+---
+
+## Child plans
+
+| # | Phase | Child plan | Scope |
+|---|---|---|---|
+| 01 | Schema & models | [`01-schema-and-models.md`](2026-04-06-claude-token-switcher/01-schema-and-models.md) | Migration v13, `ClaudeToken` / `ClaudeTokenUsage` / `Config` records & stores, optional fields on `Repo` / `Terminal`, model updates in `TBDShared`. |
+| 02 | Keychain wrapper | [`02-keychain.md`](2026-04-06-claude-token-switcher/02-keychain.md) | `ClaudeTokenKeychain.store/load/delete` via `SecItem` with delete+add upsert pattern. |
+| 03 | Usage fetcher | [`03-usage-fetcher.md`](2026-04-06-claude-token-switcher/03-usage-fetcher.md) | `ClaudeUsageFetcher` hitting `/api/oauth/usage`, status mapping, JSON decoding, unit tests with `URLProtocol` mock. |
+| 04 | Token resolver | [`04-token-resolver.md`](2026-04-06-claude-token-switcher/04-token-resolver.md) | `ClaudeTokenResolver.resolve(repoID:)` order: per-repo override → global default → none. Loads from Keychain. |
+| 05 | RPC: CRUD + manual fetch | [`05-rpc-crud.md`](2026-04-06-claude-token-switcher/05-rpc-crud.md) | `claudeToken.list/add/delete/rename/setGlobalDefault/setRepoOverride/fetchUsage` in new `RPCRouter+ClaudeTokenHandlers.swift`, proto constants, validation via fetcher on add. |
+| 06 | Spawn + swap RPC | [`06-spawn-and-swap.md`](2026-04-06-claude-token-switcher/06-spawn-and-swap.md) | Inject env prefix in `RPCRouter+TerminalHandlers.swift` spawn path; new `terminal.swapClaudeToken` handler that C-c's + respawns via `claude --resume`. |
+| 07 | Background poll | [`07-background-poll.md`](2026-04-06-claude-token-switcher/07-background-poll.md) | 30-min poll loop with 30 s stagger, 60-min backoff on 429, pause when app unfocused >10 min, resume + immediate fetch on focus. State-update broadcast on cache write. |
+| 08 | DaemonClient stubs | [`08-daemon-client.md`](2026-04-06-claude-token-switcher/08-daemon-client.md) | Swift client-side RPC call wrappers used by TBDApp for all new methods + new state-update handling for usage cache changes. |
+| 09 | Settings tab | [`09-settings-ui.md`](2026-04-06-claude-token-switcher/09-settings-ui.md) | `ClaudeTokensSettingsView` — list, add modal with tooltip, rename/delete/set-default, usage badges + reset-timer tooltips, tab wired into `SettingsView.swift`. |
+| 10 | Repo override UI | [`10-repo-override-ui.md`](2026-04-06-claude-token-switcher/10-repo-override-ui.md) | Picker row in `RepoSettingsRow` (or equivalent) for "Claude token override", writes via `claudeToken.setRepoOverride`. |
+| 11 | Menu bar | [`11-menu-bar.md`](2026-04-06-claude-token-switcher/11-menu-bar.md) | TBD app menu gets a "Claude Token" submenu with radio selection + usage badges + "Manage tokens…". Selecting an item updates global default. |
+| 12 | Claude tab context menu | [`12-context-menu.md`](2026-04-06-claude-token-switcher/12-context-menu.md) | In `TabBar.swift:contextMenuContent`, add disabled header row + "Swap token →" submenu inside `if isClaudeTerminal` block. One-shot swap. |
+
+---
+
+## Cross-cutting rules
+
+All phases must adhere to:
+
+- **Per CLAUDE.md**: commit after completing each phase; verify `swift build` passes before committing; run `swift test` if the phase touched daemon/shared code.
+- **Migration rule**: every DB change lands in the same commit as the GRDB record type update and the `TBDShared/Models.swift` update, and new fields MUST be optional or have defaults.
+- **Branching conditional rule**: when adding a branch that gates behavior (e.g. token present vs not, per-repo override vs global vs none), add a test for each branch.
+- **Never delete `~/.tbd/state.db`**. If a schema issue arises, diagnose and add a new migration.
+- **Token bytes** must never be logged, written outside Keychain, or included in error strings.
+- **NIO thread safety**: any `ChannelHandlerContext` access from the poll scheduler or swap flow must be wrapped in `context.eventLoop.execute { ... }`.
+
+## Definition of done for the feature
+
+1. `swift build && swift test` green.
+2. Manual: add an OAuth token via Settings, see 5h/7d % populate; swap via menu bar, open a new claude tab, verify it uses the token (spot-check with `env | grep CLAUDE` inside the pane); swap mid-conversation via context menu, verify `/resume` preserves context and new env is applied; delete a token in use, verify the running terminal keeps working and the confirmation copy is correct.
+3. All new child plans' task checkboxes ticked.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/01-schema-and-models.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/01-schema-and-models.md
@@ -1,0 +1,797 @@
+# Phase 01: Schema & Models
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** nothing
+> **Unblocks:** all other phases
+
+**Scope:** Database migration v13, new records/stores for Claude tokens & usage cache, a new Config singleton store, and optional field additions to Repo and Terminal models.
+
+---
+
+## Conventions used in this phase
+
+- **Migration style:** copy `Database.swift` v12 — `migrator.registerMigration("v13") { db in ... }` with `try db.create(table:)` / `try db.alter(table:)` and `.defaults(to:)` on every new column.
+- **Record + Store style:** copy `RepoStore.swift` exactly — top-level `XxxRecord: Codable, FetchableRecord, PersistableRecord, Sendable` with `init(from:)` and `toModel()`, then `public struct XxxStore: Sendable { let writer: any DatabaseWriter }`.
+- **Test style:** Swift Testing — `@Suite("...")`, `@Test func ...() async throws`, `#expect(...)`, `let db = try TBDDatabase(inMemory: true)`.
+- **Backward-compat decoders:** every new optional field on `Repo` and `Terminal` must be wired through a custom `init(from decoder:)` using `decodeIfPresent` (matching `Worktree`/`Terminal` precedent in `Models.swift`).
+- **Commit cadence:** one commit per task. Each commit must `swift build` and `swift test` clean.
+
+---
+
+## Task list
+
+### 1. Add models to TBDShared
+
+- [ ] **Files**
+  - Modify: `Sources/TBDShared/Models.swift`
+  - Test: `Tests/TBDDaemonTests/ClaudeTokenModelTests.swift` (new)
+
+- [ ] **Steps**
+  1. Write a failing test that decodes JSON for each new type:
+     ```swift
+     import Testing
+     import Foundation
+     @testable import TBDShared
+
+     @Suite("Claude Token Models")
+     struct ClaudeTokenModelTests {
+         @Test func decodeClaudeToken() throws {
+             let json = #"{"id":"11111111-1111-1111-1111-111111111111","name":"Personal","kind":"oauth","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+             let dec = JSONDecoder()
+             dec.dateDecodingStrategy = .iso8601
+             let tok = try dec.decode(ClaudeToken.self, from: json)
+             #expect(tok.name == "Personal")
+             #expect(tok.kind == .oauth)
+             #expect(tok.lastUsedAt == nil)
+         }
+
+         @Test func decodeClaudeTokenKindApiKey() throws {
+             let json = #"{"id":"11111111-1111-1111-1111-111111111111","name":"Work","kind":"apiKey","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+             let dec = JSONDecoder()
+             dec.dateDecodingStrategy = .iso8601
+             let tok = try dec.decode(ClaudeToken.self, from: json)
+             #expect(tok.kind == .apiKey)
+         }
+
+         @Test func decodeClaudeTokenUsage() throws {
+             let json = #"{"tokenID":"11111111-1111-1111-1111-111111111111","fiveHourPct":0.42,"sevenDayPct":0.18,"lastStatus":"ok"}"#.data(using: .utf8)!
+             let u = try JSONDecoder().decode(ClaudeTokenUsage.self, from: json)
+             #expect(u.fiveHourPct == 0.42)
+             #expect(u.sevenDayPct == 0.18)
+             #expect(u.lastStatus == "ok")
+         }
+
+         @Test func decodeConfigEmpty() throws {
+             let u = try JSONDecoder().decode(Config.self, from: "{}".data(using: .utf8)!)
+             #expect(u.defaultClaudeTokenID == nil)
+         }
+
+         @Test func repoDecodesWithoutOverride() throws {
+             let json = #"{"id":"11111111-1111-1111-1111-111111111111","path":"/tmp/x","displayName":"x","defaultBranch":"main","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+             let dec = JSONDecoder()
+             dec.dateDecodingStrategy = .iso8601
+             let r = try dec.decode(Repo.self, from: json)
+             #expect(r.claudeTokenOverrideID == nil)
+         }
+
+         @Test func terminalDecodesWithoutTokenID() throws {
+             let json = #"{"id":"11111111-1111-1111-1111-111111111111","worktreeID":"22222222-2222-2222-2222-222222222222","tmuxWindowID":"@1","tmuxPaneID":"%0","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+             let dec = JSONDecoder()
+             dec.dateDecodingStrategy = .iso8601
+             let t = try dec.decode(Terminal.self, from: json)
+             #expect(t.claudeTokenID == nil)
+         }
+     }
+     ```
+  2. Run `swift test --filter ClaudeTokenModelTests` and verify it fails (types don't exist yet).
+  3. Add to `Sources/TBDShared/Models.swift`:
+     ```swift
+     public enum ClaudeTokenKind: String, Codable, Sendable {
+         case oauth
+         case apiKey
+     }
+
+     public struct ClaudeToken: Codable, Sendable, Identifiable, Equatable {
+         public let id: UUID
+         public var name: String
+         public var kind: ClaudeTokenKind
+         public var createdAt: Date
+         public var lastUsedAt: Date?
+
+         public init(id: UUID = UUID(), name: String, kind: ClaudeTokenKind,
+                     createdAt: Date = Date(), lastUsedAt: Date? = nil) {
+             self.id = id
+             self.name = name
+             self.kind = kind
+             self.createdAt = createdAt
+             self.lastUsedAt = lastUsedAt
+         }
+     }
+
+     public struct ClaudeTokenUsage: Codable, Sendable, Equatable {
+         public var tokenID: UUID
+         public var fiveHourPct: Double?
+         public var sevenDayPct: Double?
+         public var fiveHourResetsAt: Date?
+         public var sevenDayResetsAt: Date?
+         public var fetchedAt: Date?
+         public var lastStatus: String?
+
+         public init(tokenID: UUID, fiveHourPct: Double? = nil, sevenDayPct: Double? = nil,
+                     fiveHourResetsAt: Date? = nil, sevenDayResetsAt: Date? = nil,
+                     fetchedAt: Date? = nil, lastStatus: String? = nil) {
+             self.tokenID = tokenID
+             self.fiveHourPct = fiveHourPct
+             self.sevenDayPct = sevenDayPct
+             self.fiveHourResetsAt = fiveHourResetsAt
+             self.sevenDayResetsAt = sevenDayResetsAt
+             self.fetchedAt = fetchedAt
+             self.lastStatus = lastStatus
+         }
+     }
+
+     public struct Config: Codable, Sendable, Equatable {
+         public var defaultClaudeTokenID: UUID?
+
+         public init(defaultClaudeTokenID: UUID? = nil) {
+             self.defaultClaudeTokenID = defaultClaudeTokenID
+         }
+
+         public init(from decoder: Decoder) throws {
+             let c = try decoder.container(keyedBy: CodingKeys.self)
+             defaultClaudeTokenID = try c.decodeIfPresent(UUID.self, forKey: .defaultClaudeTokenID)
+         }
+     }
+     ```
+  4. Add `claudeTokenOverrideID: UUID?` to `Repo`:
+     - Add the stored property with default `nil`.
+     - Extend the initializer with a `claudeTokenOverrideID: UUID? = nil` parameter.
+     - Add a custom `init(from decoder:)`:
+       ```swift
+       public init(from decoder: Decoder) throws {
+           let c = try decoder.container(keyedBy: CodingKeys.self)
+           id = try c.decode(UUID.self, forKey: .id)
+           path = try c.decode(String.self, forKey: .path)
+           remoteURL = try c.decodeIfPresent(String.self, forKey: .remoteURL)
+           displayName = try c.decode(String.self, forKey: .displayName)
+           defaultBranch = try c.decode(String.self, forKey: .defaultBranch)
+           createdAt = try c.decode(Date.self, forKey: .createdAt)
+           renamePrompt = try c.decodeIfPresent(String.self, forKey: .renamePrompt)
+           customInstructions = try c.decodeIfPresent(String.self, forKey: .customInstructions)
+           claudeTokenOverrideID = try c.decodeIfPresent(UUID.self, forKey: .claudeTokenOverrideID)
+       }
+       ```
+  5. Add `claudeTokenID: UUID?` to `Terminal`:
+     - Add the stored property with default `nil`.
+     - Extend the initializer with `claudeTokenID: UUID? = nil`.
+     - Add `claudeTokenID = try c.decodeIfPresent(UUID.self, forKey: .claudeTokenID)` to the existing custom decoder.
+  6. Run `swift test --filter ClaudeTokenModelTests`. Expected: 6 tests pass.
+  7. Commit: `feat: add ClaudeToken / ClaudeTokenUsage / Config models and optional fields on Repo/Terminal`.
+
+---
+
+### 2. Migration v13 — `claude_tokens` and `claude_token_usage` tables
+
+- [ ] **Files**
+  - Modify: `Sources/TBDDaemon/Database/Database.swift`
+  - Test: `Tests/TBDDaemonTests/ClaudeTokenMigrationTests.swift` (new)
+
+- [ ] **Steps**
+  1. Write failing test:
+     ```swift
+     import Testing
+     import Foundation
+     import GRDB
+     @testable import TBDDaemonLib
+     @testable import TBDShared
+
+     @Suite("Claude Token Migration")
+     struct ClaudeTokenMigrationTests {
+         @Test func v13CreatesClaudeTokensTable() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             try await db.writerForTests.read { conn in
+                 #expect(try conn.tableExists("claude_tokens"))
+                 #expect(try conn.tableExists("claude_token_usage"))
+                 #expect(try conn.tableExists("config"))
+             }
+         }
+
+         @Test func v13AddsRepoAndTerminalColumns() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             try await db.writerForTests.read { conn in
+                 let repoCols = try conn.columns(in: "repo").map(\.name)
+                 #expect(repoCols.contains("claude_token_override_id"))
+                 let termCols = try conn.columns(in: "terminal").map(\.name)
+                 #expect(termCols.contains("claude_token_id"))
+             }
+         }
+
+         @Test func v13InsertsConfigSingleton() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             try await db.writerForTests.read { conn in
+                 let count = try Int.fetchOne(conn, sql: "SELECT COUNT(*) FROM config WHERE id = 'singleton'")
+                 #expect(count == 1)
+             }
+         }
+     }
+     ```
+     Note: this test references `db.writerForTests` — add an `internal var writerForTests: any DatabaseWriter { writer }` accessor on `TBDDatabase` (test-only convenience; daemon code never uses it).
+  2. Run `swift test --filter ClaudeTokenMigrationTests`. Expected: fails (tables don't exist).
+  3. In `Database.swift`, after the `v12` block, add:
+     ```swift
+     migrator.registerMigration("v13") { db in
+         try db.create(table: "claude_tokens") { t in
+             t.primaryKey("id", .text).notNull()
+             t.column("name", .text).notNull().unique()
+             t.column("keychain_ref", .text).notNull()
+             t.column("kind", .text).notNull()
+             t.column("created_at", .datetime).notNull()
+             t.column("last_used_at", .datetime)
+         }
+
+         try db.create(table: "claude_token_usage") { t in
+             t.primaryKey("token_id", .text).notNull()
+                 .references("claude_tokens", onDelete: .cascade)
+             t.column("five_hour_pct", .double)
+             t.column("seven_day_pct", .double)
+             t.column("five_hour_resets_at", .datetime)
+             t.column("seven_day_resets_at", .datetime)
+             t.column("fetched_at", .datetime)
+             t.column("last_status", .text)
+         }
+
+         try db.create(table: "config") { t in
+             t.primaryKey("id", .text).notNull()
+             t.column("default_claude_token_id", .text)
+                 .references("claude_tokens", onDelete: .setNull)
+         }
+         try db.execute(
+             sql: "INSERT OR IGNORE INTO config (id, default_claude_token_id) VALUES ('singleton', NULL)"
+         )
+
+         try db.alter(table: "repo") { t in
+             t.add(column: "claude_token_override_id", .text)
+         }
+
+         try db.alter(table: "terminal") { t in
+             t.add(column: "claude_token_id", .text)
+         }
+     }
+     ```
+  4. Add the `writerForTests` accessor on `TBDDatabase`.
+  5. Run `swift test --filter ClaudeTokenMigrationTests`. Expected: 3 tests pass.
+  6. Run the full `swift test` to ensure no existing test broke.
+  7. Commit: `feat: add migration v13 for claude_tokens, claude_token_usage, config tables`.
+
+---
+
+### 3. `ClaudeTokenRecord` + `ClaudeTokenStore`
+
+- [ ] **Files**
+  - Create: `Sources/TBDDaemon/Database/ClaudeTokenRecord.swift`
+  - Modify: `Sources/TBDDaemon/Database/Database.swift` (wire `claudeTokens` accessor)
+  - Test: `Tests/TBDDaemonTests/ClaudeTokenStoreTests.swift` (new)
+
+- [ ] **Steps**
+  1. Write failing test:
+     ```swift
+     import Testing
+     import Foundation
+     @testable import TBDDaemonLib
+     @testable import TBDShared
+
+     @Suite("ClaudeTokenStore")
+     struct ClaudeTokenStoreTests {
+         @Test func createListGet() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+             #expect(tok.name == "Personal")
+             #expect(tok.kind == .oauth)
+
+             let all = try await db.claudeTokens.list()
+             #expect(all.count == 1)
+
+             let fetched = try await db.claudeTokens.get(id: tok.id)
+             #expect(fetched?.id == tok.id)
+         }
+
+         @Test func getByName() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             _ = try await db.claudeTokens.create(name: "Work", kind: .apiKey)
+             let found = try await db.claudeTokens.getByName("Work")
+             #expect(found?.kind == .apiKey)
+             let missing = try await db.claudeTokens.getByName("Nope")
+             #expect(missing == nil)
+         }
+
+         @Test func renameAndDelete() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             let tok = try await db.claudeTokens.create(name: "Old", kind: .oauth)
+             try await db.claudeTokens.rename(id: tok.id, name: "New")
+             let renamed = try await db.claudeTokens.get(id: tok.id)
+             #expect(renamed?.name == "New")
+
+             try await db.claudeTokens.delete(id: tok.id)
+             #expect(try await db.claudeTokens.get(id: tok.id) == nil)
+         }
+
+         @Test func touchLastUsed() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+             #expect(tok.lastUsedAt == nil)
+             try await db.claudeTokens.touchLastUsed(id: tok.id)
+             let updated = try await db.claudeTokens.get(id: tok.id)
+             #expect(updated?.lastUsedAt != nil)
+         }
+     }
+     ```
+  2. Run and verify failure (`db.claudeTokens` doesn't exist).
+  3. Create `Sources/TBDDaemon/Database/ClaudeTokenRecord.swift`:
+     ```swift
+     import Foundation
+     import GRDB
+     import TBDShared
+
+     struct ClaudeTokenRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+         static let databaseTableName = "claude_tokens"
+
+         var id: String
+         var name: String
+         var keychain_ref: String
+         var kind: String
+         var created_at: Date
+         var last_used_at: Date?
+
+         init(from token: ClaudeToken) {
+             self.id = token.id.uuidString
+             self.name = token.name
+             self.keychain_ref = token.id.uuidString
+             self.kind = token.kind.rawValue
+             self.created_at = token.createdAt
+             self.last_used_at = token.lastUsedAt
+         }
+
+         func toModel() -> ClaudeToken {
+             ClaudeToken(
+                 id: UUID(uuidString: id)!,
+                 name: name,
+                 kind: ClaudeTokenKind(rawValue: kind) ?? .oauth,
+                 createdAt: created_at,
+                 lastUsedAt: last_used_at
+             )
+         }
+     }
+
+     public struct ClaudeTokenStore: Sendable {
+         let writer: any DatabaseWriter
+
+         init(writer: any DatabaseWriter) {
+             self.writer = writer
+         }
+
+         public func create(name: String, kind: ClaudeTokenKind) async throws -> ClaudeToken {
+             let token = ClaudeToken(name: name, kind: kind)
+             let record = ClaudeTokenRecord(from: token)
+             try await writer.write { db in
+                 try record.insert(db)
+             }
+             return token
+         }
+
+         public func list() async throws -> [ClaudeToken] {
+             try await writer.read { db in
+                 try ClaudeTokenRecord.fetchAll(db).map { $0.toModel() }
+             }
+         }
+
+         public func get(id: UUID) async throws -> ClaudeToken? {
+             try await writer.read { db in
+                 try ClaudeTokenRecord.fetchOne(db, key: id.uuidString)?.toModel()
+             }
+         }
+
+         public func getByName(_ name: String) async throws -> ClaudeToken? {
+             try await writer.read { db in
+                 try ClaudeTokenRecord
+                     .filter(Column("name") == name)
+                     .fetchOne(db)?
+                     .toModel()
+             }
+         }
+
+         public func rename(id: UUID, name: String) async throws {
+             try await writer.write { db in
+                 try db.execute(
+                     sql: "UPDATE claude_tokens SET name = ? WHERE id = ?",
+                     arguments: [name, id.uuidString]
+                 )
+             }
+         }
+
+         public func delete(id: UUID) async throws {
+             _ = try await writer.write { db in
+                 try ClaudeTokenRecord.deleteOne(db, key: id.uuidString)
+             }
+         }
+
+         public func touchLastUsed(id: UUID, at date: Date = Date()) async throws {
+             try await writer.write { db in
+                 try db.execute(
+                     sql: "UPDATE claude_tokens SET last_used_at = ? WHERE id = ?",
+                     arguments: [date, id.uuidString]
+                 )
+             }
+         }
+     }
+     ```
+  4. Wire into `TBDDatabase`:
+     - Add `public let claudeTokens: ClaudeTokenStore` next to existing stores.
+     - Initialize in both `init(path:)` and `init(inMemory:)` after the pool/queue is created: `self.claudeTokens = ClaudeTokenStore(writer: pool)` (or `queue`).
+  5. Run `swift test --filter ClaudeTokenStoreTests`. Expected: 4 pass.
+  6. Commit: `feat: add ClaudeTokenStore with CRUD + touchLastUsed`.
+
+---
+
+### 4. `ClaudeTokenUsageRecord` + `ClaudeTokenUsageStore`
+
+- [ ] **Files**
+  - Create: `Sources/TBDDaemon/Database/ClaudeTokenUsageRecord.swift`
+  - Modify: `Sources/TBDDaemon/Database/Database.swift` (wire `claudeTokenUsage`)
+  - Test: `Tests/TBDDaemonTests/ClaudeTokenUsageStoreTests.swift` (new)
+
+- [ ] **Steps**
+  1. Write failing test:
+     ```swift
+     import Testing
+     import Foundation
+     @testable import TBDDaemonLib
+     @testable import TBDShared
+
+     @Suite("ClaudeTokenUsageStore")
+     struct ClaudeTokenUsageStoreTests {
+         @Test func upsertIsIdempotent() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             let tok = try await db.claudeTokens.create(name: "T", kind: .oauth)
+             let u1 = ClaudeTokenUsage(tokenID: tok.id, fiveHourPct: 0.1, sevenDayPct: 0.2, lastStatus: "ok")
+             try await db.claudeTokenUsage.upsert(u1)
+             let u2 = ClaudeTokenUsage(tokenID: tok.id, fiveHourPct: 0.5, sevenDayPct: 0.6, lastStatus: "ok")
+             try await db.claudeTokenUsage.upsert(u2)
+
+             let fetched = try await db.claudeTokenUsage.get(tokenID: tok.id)
+             #expect(fetched?.fiveHourPct == 0.5)
+             #expect(fetched?.sevenDayPct == 0.6)
+         }
+
+         @Test func deleteForToken() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             let tok = try await db.claudeTokens.create(name: "T", kind: .oauth)
+             try await db.claudeTokenUsage.upsert(ClaudeTokenUsage(tokenID: tok.id, lastStatus: "ok"))
+             try await db.claudeTokenUsage.deleteForToken(id: tok.id)
+             #expect(try await db.claudeTokenUsage.get(tokenID: tok.id) == nil)
+         }
+
+         @Test func cascadeOnTokenDelete() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             let tok = try await db.claudeTokens.create(name: "T", kind: .oauth)
+             try await db.claudeTokenUsage.upsert(ClaudeTokenUsage(tokenID: tok.id, lastStatus: "ok"))
+             try await db.claudeTokens.delete(id: tok.id)
+             #expect(try await db.claudeTokenUsage.get(tokenID: tok.id) == nil)
+         }
+     }
+     ```
+  2. Run and verify failure.
+  3. Create `Sources/TBDDaemon/Database/ClaudeTokenUsageRecord.swift`:
+     ```swift
+     import Foundation
+     import GRDB
+     import TBDShared
+
+     struct ClaudeTokenUsageRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+         static let databaseTableName = "claude_token_usage"
+
+         var token_id: String
+         var five_hour_pct: Double?
+         var seven_day_pct: Double?
+         var five_hour_resets_at: Date?
+         var seven_day_resets_at: Date?
+         var fetched_at: Date?
+         var last_status: String?
+
+         init(from u: ClaudeTokenUsage) {
+             self.token_id = u.tokenID.uuidString
+             self.five_hour_pct = u.fiveHourPct
+             self.seven_day_pct = u.sevenDayPct
+             self.five_hour_resets_at = u.fiveHourResetsAt
+             self.seven_day_resets_at = u.sevenDayResetsAt
+             self.fetched_at = u.fetchedAt
+             self.last_status = u.lastStatus
+         }
+
+         func toModel() -> ClaudeTokenUsage {
+             ClaudeTokenUsage(
+                 tokenID: UUID(uuidString: token_id)!,
+                 fiveHourPct: five_hour_pct,
+                 sevenDayPct: seven_day_pct,
+                 fiveHourResetsAt: five_hour_resets_at,
+                 sevenDayResetsAt: seven_day_resets_at,
+                 fetchedAt: fetched_at,
+                 lastStatus: last_status
+             )
+         }
+     }
+
+     public struct ClaudeTokenUsageStore: Sendable {
+         let writer: any DatabaseWriter
+
+         init(writer: any DatabaseWriter) {
+             self.writer = writer
+         }
+
+         public func upsert(_ usage: ClaudeTokenUsage) async throws {
+             let record = ClaudeTokenUsageRecord(from: usage)
+             try await writer.write { db in
+                 try record.save(db) // GRDB upsert by primary key
+             }
+         }
+
+         public func get(tokenID: UUID) async throws -> ClaudeTokenUsage? {
+             try await writer.read { db in
+                 try ClaudeTokenUsageRecord.fetchOne(db, key: tokenID.uuidString)?.toModel()
+             }
+         }
+
+         public func deleteForToken(id: UUID) async throws {
+             _ = try await writer.write { db in
+                 try ClaudeTokenUsageRecord.deleteOne(db, key: id.uuidString)
+             }
+         }
+     }
+     ```
+  4. Wire `public let claudeTokenUsage: ClaudeTokenUsageStore` into `TBDDatabase` (both inits).
+  5. Run `swift test --filter ClaudeTokenUsageStoreTests`. Expected: 3 pass.
+  6. Commit: `feat: add ClaudeTokenUsageStore with upsert, get, delete, cascade-on-token-delete`.
+
+---
+
+### 5. `ConfigStore` singleton
+
+- [ ] **Files**
+  - Create: `Sources/TBDDaemon/Database/ConfigStore.swift`
+  - Modify: `Sources/TBDDaemon/Database/Database.swift` (wire `config`)
+  - Test: `Tests/TBDDaemonTests/ConfigStoreTests.swift` (new)
+
+- [ ] **Steps**
+  1. Write failing test:
+     ```swift
+     import Testing
+     import Foundation
+     @testable import TBDDaemonLib
+     @testable import TBDShared
+
+     @Suite("ConfigStore")
+     struct ConfigStoreTests {
+         @Test func defaultsToNil() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             let cfg = try await db.config.get()
+             #expect(cfg.defaultClaudeTokenID == nil)
+         }
+
+         @Test func setAndGetDefaultClaudeTokenID() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+             try await db.config.setDefaultClaudeTokenID(tok.id)
+             let cfg = try await db.config.get()
+             #expect(cfg.defaultClaudeTokenID == tok.id)
+         }
+
+         @Test func clearDefaultClaudeTokenID() async throws {
+             let db = try TBDDatabase(inMemory: true)
+             let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+             try await db.config.setDefaultClaudeTokenID(tok.id)
+             try await db.config.setDefaultClaudeTokenID(nil)
+             let cfg = try await db.config.get()
+             #expect(cfg.defaultClaudeTokenID == nil)
+         }
+     }
+     ```
+  2. Run and verify failure.
+  3. Create `Sources/TBDDaemon/Database/ConfigStore.swift`:
+     ```swift
+     import Foundation
+     import GRDB
+     import TBDShared
+
+     struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+         static let databaseTableName = "config"
+
+         var id: String
+         var default_claude_token_id: String?
+
+         func toModel() -> Config {
+             Config(
+                 defaultClaudeTokenID: default_claude_token_id.flatMap(UUID.init(uuidString:))
+             )
+         }
+     }
+
+     public struct ConfigStore: Sendable {
+         static let singletonID = "singleton"
+         let writer: any DatabaseWriter
+
+         init(writer: any DatabaseWriter) {
+             self.writer = writer
+         }
+
+         public func get() async throws -> Config {
+             try await writer.read { db in
+                 try ConfigRecord.fetchOne(db, key: Self.singletonID)?.toModel() ?? Config()
+             }
+         }
+
+         public func setDefaultClaudeTokenID(_ id: UUID?) async throws {
+             try await writer.write { db in
+                 try db.execute(
+                     sql: "UPDATE config SET default_claude_token_id = ? WHERE id = ?",
+                     arguments: [id?.uuidString, Self.singletonID]
+                 )
+             }
+         }
+     }
+     ```
+  4. Wire `public let config: ConfigStore` into `TBDDatabase` (both inits).
+  5. Run `swift test --filter ConfigStoreTests`. Expected: 3 pass.
+  6. Commit: `feat: add ConfigStore singleton for default Claude token ID`.
+
+---
+
+### 6. `RepoStore.setClaudeTokenOverride` + round-trip through `RepoRecord`
+
+- [ ] **Files**
+  - Modify: `Sources/TBDDaemon/Database/RepoStore.swift`
+  - Test: extend `Tests/TBDDaemonTests/ClaudeTokenStoreTests.swift`
+
+- [ ] **Steps**
+  1. Write failing test (append to `ClaudeTokenStoreTests`):
+     ```swift
+     @Test func repoOverrideRoundTrip() async throws {
+         let db = try TBDDatabase(inMemory: true)
+         let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+         let repo = try await db.repos.create(path: "/tmp/r", displayName: "r", defaultBranch: "main")
+         #expect(repo.claudeTokenOverrideID == nil)
+
+         try await db.repos.setClaudeTokenOverride(id: repo.id, tokenID: tok.id)
+         let fetched = try await db.repos.get(id: repo.id)
+         #expect(fetched?.claudeTokenOverrideID == tok.id)
+
+         try await db.repos.setClaudeTokenOverride(id: repo.id, tokenID: nil)
+         let cleared = try await db.repos.get(id: repo.id)
+         #expect(cleared?.claudeTokenOverrideID == nil)
+     }
+     ```
+  2. Run and verify failure.
+  3. Modify `RepoRecord` in `RepoStore.swift`:
+     - Add `var claude_token_override_id: String?`.
+     - Update `init(from repo:)` to set it from `repo.claudeTokenOverrideID?.uuidString`.
+     - Update `toModel()` to pass `claudeTokenOverrideID: claude_token_override_id.flatMap(UUID.init(uuidString:))`.
+  4. Add to `RepoStore`:
+     ```swift
+     public func setClaudeTokenOverride(id: UUID, tokenID: UUID?) async throws {
+         try await writer.write { db in
+             try db.execute(
+                 sql: "UPDATE repo SET claude_token_override_id = ? WHERE id = ?",
+                 arguments: [tokenID?.uuidString, id.uuidString]
+             )
+         }
+     }
+     ```
+  5. Run `swift test --filter ClaudeTokenStoreTests/repoOverrideRoundTrip`. Expected: pass.
+  6. Run full `swift test` to check no regressions in existing repo tests.
+  7. Commit: `feat: round-trip claude_token_override_id on repo and add setClaudeTokenOverride`.
+
+---
+
+### 7. `TerminalStore.setClaudeTokenID` + round-trip through `TerminalRecord`
+
+- [ ] **Files**
+  - Modify: `Sources/TBDDaemon/Database/TerminalStore.swift`
+  - Test: extend `Tests/TBDDaemonTests/ClaudeTokenStoreTests.swift`
+
+- [ ] **Steps**
+  1. Write failing test:
+     ```swift
+     @Test func terminalTokenIDRoundTrip() async throws {
+         let db = try TBDDatabase(inMemory: true)
+         let tok = try await db.claudeTokens.create(name: "Personal", kind: .oauth)
+         let repo = try await db.repos.create(path: "/tmp/r2", displayName: "r2", defaultBranch: "main")
+         let wt = try await db.worktrees.create(
+             repoID: repo.id, name: "w", branch: "tbd/w",
+             path: "/tmp/r2/.tbd/worktrees/w", tmuxServer: "tbd-test"
+         )
+         let term = try await db.terminals.create(
+             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%0", label: "claude"
+         )
+         #expect(term.claudeTokenID == nil)
+
+         try await db.terminals.setClaudeTokenID(id: term.id, tokenID: tok.id)
+         let fetched = try await db.terminals.get(id: term.id)
+         #expect(fetched?.claudeTokenID == tok.id)
+
+         try await db.terminals.setClaudeTokenID(id: term.id, tokenID: nil)
+         let cleared = try await db.terminals.get(id: term.id)
+         #expect(cleared?.claudeTokenID == nil)
+     }
+     ```
+  2. Run and verify failure.
+  3. Modify `TerminalRecord` in `TerminalStore.swift`:
+     - Add `var claude_token_id: String?`.
+     - Update `init(from terminal:)` to set it from `terminal.claudeTokenID?.uuidString`.
+     - Update `toModel()` to pass `claudeTokenID: claude_token_id.flatMap(UUID.init(uuidString:))`.
+  4. Extend `TerminalStore.create` to accept `claudeTokenID: UUID? = nil` and pass through to the model. (Default `nil` keeps existing call sites compiling.)
+  5. Add to `TerminalStore`:
+     ```swift
+     public func setClaudeTokenID(id: UUID, tokenID: UUID?) async throws {
+         try await writer.write { db in
+             try db.execute(
+                 sql: "UPDATE terminal SET claude_token_id = ? WHERE id = ?",
+                 arguments: [tokenID?.uuidString, id.uuidString]
+             )
+         }
+     }
+     ```
+  6. Run `swift test --filter ClaudeTokenStoreTests/terminalTokenIDRoundTrip`. Expected: pass.
+  7. Run full `swift test`. Expected: all green.
+  8. Commit: `feat: round-trip claude_token_id on terminal and add setClaudeTokenID`.
+
+---
+
+### 8. Migration-on-existing-DB safety check
+
+- [ ] **Files**
+  - Test: extend `Tests/TBDDaemonTests/ClaudeTokenMigrationTests.swift`
+
+- [ ] **Steps**
+  1. Add a test that simulates an upgrade by creating a DB, populating a repo + terminal, closing it, reopening, and verifying the new columns are accessible and existing rows still decode:
+     ```swift
+     @Test func migrationPreservesExistingRowsAndAddsColumns() async throws {
+         // Use a temp file (not :memory:) so the DB persists across reopen.
+         let tmp = NSTemporaryDirectory() + "tbd-mig-test-\(UUID().uuidString).db"
+         defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+         do {
+             let db = try TBDDatabase(path: tmp)
+             let repo = try await db.repos.create(path: "/tmp/x", displayName: "x", defaultBranch: "main")
+             let wt = try await db.worktrees.create(
+                 repoID: repo.id, name: "w", branch: "tbd/w",
+                 path: "/tmp/x/.tbd/worktrees/w", tmuxServer: "tbd-test"
+             )
+             _ = try await db.terminals.create(
+                 worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%0", label: "claude"
+             )
+         }
+
+         // Reopen — migrator must be a no-op past v13 and rows must decode.
+         let db2 = try TBDDatabase(path: tmp)
+         let repos = try await db2.repos.list()
+         #expect(repos.count == 1)
+         #expect(repos[0].claudeTokenOverrideID == nil)
+         let terms = try await db2.terminals.list()
+         #expect(terms.count == 1)
+         #expect(terms[0].claudeTokenID == nil)
+         let cfg = try await db2.config.get()
+         #expect(cfg.defaultClaudeTokenID == nil)
+     }
+     ```
+  2. Run `swift test --filter ClaudeTokenMigrationTests`. Expected: all pass.
+  3. Run full `swift test`. Expected: all green.
+  4. Commit: `test: verify v13 migration preserves existing rows and exposes new columns on reopen`.
+
+---
+
+## Phase exit checklist
+
+- [ ] `swift build` clean
+- [ ] `swift test` all green
+- [ ] All 8 tasks committed in order
+- [ ] No source files outside `Sources/TBDShared/Models.swift` and `Sources/TBDDaemon/Database/` modified
+- [ ] No RPC, spawn, Keychain, UI, or fetcher code touched (those are later phases)
+- [ ] New optional fields confirmed backward-compatible via JSON-decode tests in Task 1

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/02-keychain.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/02-keychain.md
@@ -1,0 +1,205 @@
+# Phase 02: Keychain Wrapper
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 01 (only for knowing the UUID-as-account convention; no code dep)
+> **Unblocks:** Phase 04 (token resolver), Phase 05 (CRUD RPC)
+
+**Scope:** A thin `ClaudeTokenKeychain` enum wrapping `SecItem` APIs for secure token storage. Upsert via delete+add; default accessibility; no biometric gate.
+
+---
+
+## Conventions
+
+- Swift Testing (`@Suite`, `@Test`, `#expect`) — see `Tests/TBDDaemonTests/DatabaseTests.swift`.
+- Tests use unique random UUID per `id` and clean up via `defer { try? ClaudeTokenKeychain.delete(id: id) }`. No test-only API surface.
+- Real login keychain is used; cleanup is mandatory.
+
+---
+
+## Task 1 — Write failing tests
+
+- [ ] Create `Tests/TBDDaemonTests/ClaudeTokenKeychainTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import TBDDaemon
+
+@Suite("ClaudeTokenKeychain")
+struct ClaudeTokenKeychainTests {
+
+    private func freshID() -> String {
+        "test-\(UUID().uuidString)"
+    }
+
+    @Test("store + load round-trip")
+    func roundTrip() throws {
+        let id = freshID()
+        defer { try? ClaudeTokenKeychain.delete(id: id) }
+
+        try ClaudeTokenKeychain.store(id: id, token: "sk-ant-secret-A")
+        let loaded = try ClaudeTokenKeychain.load(id: id)
+        #expect(loaded == "sk-ant-secret-A")
+    }
+
+    @Test("store overwrites existing (upsert)")
+    func upsert() throws {
+        let id = freshID()
+        defer { try? ClaudeTokenKeychain.delete(id: id) }
+
+        try ClaudeTokenKeychain.store(id: id, token: "value-A")
+        try ClaudeTokenKeychain.store(id: id, token: "value-B")
+        let loaded = try ClaudeTokenKeychain.load(id: id)
+        #expect(loaded == "value-B")
+    }
+
+    @Test("delete removes item")
+    func deleteRemoves() throws {
+        let id = freshID()
+        defer { try? ClaudeTokenKeychain.delete(id: id) }
+
+        try ClaudeTokenKeychain.store(id: id, token: "to-be-deleted")
+        try ClaudeTokenKeychain.delete(id: id)
+        let loaded = try ClaudeTokenKeychain.load(id: id)
+        #expect(loaded == nil)
+    }
+
+    @Test("delete of nonexistent id is idempotent")
+    func deleteIdempotent() throws {
+        let id = freshID()
+        // No store; delete should not throw.
+        try ClaudeTokenKeychain.delete(id: id)
+    }
+
+    @Test("load of nonexistent id returns nil")
+    func loadMissing() throws {
+        let id = freshID()
+        let loaded = try ClaudeTokenKeychain.load(id: id)
+        #expect(loaded == nil)
+    }
+}
+```
+
+- [ ] Confirm tests fail to compile (symbol missing): `swift test 2>&1 | head -40`
+
+---
+
+## Task 2 — Implement `ClaudeTokenKeychain.swift`
+
+- [ ] Create `Sources/TBDDaemon/Keychain/ClaudeTokenKeychain.swift`:
+
+```swift
+import Foundation
+import Security
+
+public enum ClaudeTokenKeychainError: Error, Equatable {
+    case unexpectedStatus(OSStatus)
+    case dataEncoding
+}
+
+public enum ClaudeTokenKeychain {
+    public static let service = "app.tbd.claude-token"
+
+    /// Base query identifying a single item by (service, account).
+    private static func baseQuery(id: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: id,
+        ]
+    }
+
+    /// Upsert a token. Implements delete+add because SecItemAdd returns
+    /// errSecDuplicateItem on existing entries.
+    public static func store(id: String, token: String) throws {
+        guard let data = token.data(using: .utf8) else {
+            throw ClaudeTokenKeychainError.dataEncoding
+        }
+
+        let base = baseQuery(id: id)
+
+        // Clear any existing item with the same identity. Ignore not-found.
+        let deleteStatus = SecItemDelete(base as CFDictionary)
+        if deleteStatus != errSecSuccess && deleteStatus != errSecItemNotFound {
+            throw ClaudeTokenKeychainError.unexpectedStatus(deleteStatus)
+        }
+
+        var addQuery = base
+        addQuery[kSecValueData as String] = data
+
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw ClaudeTokenKeychainError.unexpectedStatus(addStatus)
+        }
+    }
+
+    /// Returns nil if no item with the given id exists.
+    public static func load(id: String) throws -> String? {
+        var query = baseQuery(id: id)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data,
+                  let token = String(data: data, encoding: .utf8) else {
+                throw ClaudeTokenKeychainError.dataEncoding
+            }
+            return token
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw ClaudeTokenKeychainError.unexpectedStatus(status)
+        }
+    }
+
+    /// Idempotent; does not throw on missing item.
+    public static func delete(id: String) throws {
+        let status = SecItemDelete(baseQuery(id: id) as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            throw ClaudeTokenKeychainError.unexpectedStatus(status)
+        }
+    }
+}
+```
+
+- [ ] Build: `swift build`
+
+---
+
+## Task 3 — Run tests
+
+- [ ] `swift test --filter ClaudeTokenKeychainTests`
+- [ ] All five tests pass.
+- [ ] Verify no leftover `app.tbd.claude-token` test entries: open Keychain Access.app, search "app.tbd.claude-token", expect no `test-<uuid>` accounts. (If any leak, investigate `defer` cleanup before proceeding.)
+
+---
+
+## Task 4 — Commit
+
+- [ ] Stage only the two new files:
+
+```bash
+git add Sources/TBDDaemon/Keychain/ClaudeTokenKeychain.swift Tests/TBDDaemonTests/ClaudeTokenKeychainTests.swift
+```
+
+- [ ] Commit:
+
+```bash
+git commit -m "feat: add ClaudeTokenKeychain wrapper for secure token storage"
+```
+
+---
+
+## Acceptance
+
+- `Sources/TBDDaemon/Keychain/ClaudeTokenKeychain.swift` exists with `store` / `load` / `delete` matching the spec.
+- Service constant is `app.tbd.claude-token`; account field is the passed `id`.
+- `store` uses delete+add upsert pattern with a shared base query.
+- `load` returns nil on `errSecItemNotFound`; throws `unexpectedStatus` otherwise.
+- `delete` is idempotent on missing items.
+- Five Swift Testing cases pass; no Keychain pollution remains.
+- `swift build` and `swift test` are clean.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/03-usage-fetcher.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/03-usage-fetcher.md
@@ -1,0 +1,278 @@
+# Phase 03: Usage Fetcher
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** nothing
+> **Unblocks:** Phase 05 (used to validate pasted tokens), Phase 07 (background poll)
+
+**Scope:** A `ClaudeUsageFetcher` protocol + `LiveClaudeUsageFetcher` implementation that hits the undocumented `/api/oauth/usage` endpoint and returns 5h/7d utilization with reset timestamps. HTTP status mapping, decode error mapping, token never leaked into errors. Fully unit-tested via `URLProtocol` mock.
+
+## Tasks
+
+### 1. Create `Sources/TBDDaemon/Claude/ClaudeUsageFetcher.swift`
+
+- [ ] Create directory if needed: `mkdir -p Sources/TBDDaemon/Claude`
+- [ ] Write the file with public types, protocol, and live implementation:
+
+```swift
+import Foundation
+
+public struct ClaudeUsageResult: Equatable, Sendable {
+    public var fiveHourPct: Double       // 0.0 ... 1.0 (utilization from the API)
+    public var sevenDayPct: Double
+    public var fiveHourResetsAt: Date
+    public var sevenDayResetsAt: Date
+
+    public init(
+        fiveHourPct: Double,
+        sevenDayPct: Double,
+        fiveHourResetsAt: Date,
+        sevenDayResetsAt: Date
+    ) {
+        self.fiveHourPct = fiveHourPct
+        self.sevenDayPct = sevenDayPct
+        self.fiveHourResetsAt = fiveHourResetsAt
+        self.sevenDayResetsAt = sevenDayResetsAt
+    }
+}
+
+public enum ClaudeUsageStatus: Equatable, Sendable {
+    case ok(ClaudeUsageResult)
+    case http429
+    case http401
+    case networkError(String)  // human-readable; MUST NOT contain token bytes
+    case decodeError(String)
+}
+
+public protocol ClaudeUsageFetcher: Sendable {
+    func fetchUsage(token: String) async -> ClaudeUsageStatus
+}
+
+public struct LiveClaudeUsageFetcher: ClaudeUsageFetcher {
+    public let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func fetchUsage(token: String) async -> ClaudeUsageStatus {
+        guard let url = URL(string: "https://api.anthropic.com/api/oauth/usage") else {
+            return .networkError("invalid URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch let urlError as URLError {
+            return .networkError(urlError.localizedDescription)
+        } catch {
+            return .networkError(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            return .networkError("non-HTTP response")
+        }
+
+        switch http.statusCode {
+        case 200:
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            do {
+                let payload = try decoder.decode(UsagePayload.self, from: data)
+                return .ok(ClaudeUsageResult(
+                    fiveHourPct: payload.fiveHour.utilization,
+                    sevenDayPct: payload.sevenDay.utilization,
+                    fiveHourResetsAt: payload.fiveHour.resetsAt,
+                    sevenDayResetsAt: payload.sevenDay.resetsAt
+                ))
+            } catch {
+                return .decodeError(error.localizedDescription)
+            }
+        case 401:
+            return .http401
+        case 429:
+            return .http429
+        default:
+            return .networkError("HTTP \(http.statusCode)")
+        }
+    }
+
+    private struct UsagePayload: Decodable {
+        struct Window: Decodable {
+            let utilization: Double
+            let resetsAt: Date
+        }
+        let fiveHour: Window
+        let sevenDay: Window
+    }
+}
+```
+
+### 2. Build
+
+- [ ] `swift build`
+
+### 3. Create `Tests/TBDDaemonTests/ClaudeUsageFetcherTests.swift`
+
+- [ ] Add the test file with a `MockURLProtocol` helper and Swift Testing cases:
+
+```swift
+import Foundation
+import Testing
+@testable import TBDDaemon
+
+final class MockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var lastRequest: URLRequest?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        MockURLProtocol.lastRequest = request
+        guard let handler = MockURLProtocol.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeFetcher() -> LiveClaudeUsageFetcher {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return LiveClaudeUsageFetcher(session: URLSession(configuration: config))
+}
+
+private func httpResponse(_ url: URL, _ status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: nil)!
+}
+
+private let testToken = "sk-ant-oat01-SECRETSECRETSECRET"
+
+@Suite(.serialized)
+struct ClaudeUsageFetcherTests {
+    init() {
+        MockURLProtocol.handler = nil
+        MockURLProtocol.lastRequest = nil
+    }
+
+    @Test func happyPath200() async throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 0.42, "resets_at": "2026-04-06T15:00:00Z" },
+          "seven_day": { "utilization": 0.18, "resets_at": "2026-04-13T00:00:00Z" }
+        }
+        """.data(using: .utf8)!
+        MockURLProtocol.handler = { req in
+            (httpResponse(req.url!, 200), json)
+        }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        guard case .ok(let usage) = result else {
+            Issue.record("expected .ok, got \(result)")
+            return
+        }
+        #expect(usage.fiveHourPct == 0.42)
+        #expect(usage.sevenDayPct == 0.18)
+        let fiveH = ISO8601DateFormatter().date(from: "2026-04-06T15:00:00Z")!
+        let sevenD = ISO8601DateFormatter().date(from: "2026-04-13T00:00:00Z")!
+        #expect(usage.fiveHourResetsAt == fiveH)
+        #expect(usage.sevenDayResetsAt == sevenD)
+    }
+
+    @Test func unauthorized401() async {
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 401), Data()) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        #expect(result == .http401)
+    }
+
+    @Test func rateLimited429() async {
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 429), Data()) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        #expect(result == .http429)
+    }
+
+    @Test func serverError500() async {
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 500), Data()) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        guard case .networkError(let msg) = result else {
+            Issue.record("expected .networkError, got \(result)")
+            return
+        }
+        #expect(msg.contains("500"))
+        #expect(!msg.contains(testToken))
+    }
+
+    @Test func networkFailure() async {
+        MockURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        guard case .networkError = result else {
+            Issue.record("expected .networkError, got \(result)")
+            return
+        }
+    }
+
+    @Test func decodeFailure() async {
+        let bad = "{ not json".data(using: .utf8)!
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 200), bad) }
+        let result = await makeFetcher().fetchUsage(token: testToken)
+        guard case .decodeError(let msg) = result else {
+            Issue.record("expected .decodeError, got \(result)")
+            return
+        }
+        #expect(!msg.contains(testToken))
+    }
+
+    @Test func requestShape() async {
+        let json = """
+        {
+          "five_hour": { "utilization": 0.0, "resets_at": "2026-04-06T15:00:00Z" },
+          "seven_day": { "utilization": 0.0, "resets_at": "2026-04-13T00:00:00Z" }
+        }
+        """.data(using: .utf8)!
+        MockURLProtocol.handler = { req in (httpResponse(req.url!, 200), json) }
+        _ = await makeFetcher().fetchUsage(token: testToken)
+        let req = MockURLProtocol.lastRequest
+        #expect(req?.url?.absoluteString == "https://api.anthropic.com/api/oauth/usage")
+        // URLProtocol may strip headers from request.allHTTPHeaderFields; check via value(forHTTPHeaderField:)
+        #expect(req?.value(forHTTPHeaderField: "Authorization") == "Bearer \(testToken)")
+        #expect(req?.value(forHTTPHeaderField: "anthropic-beta") == "oauth-2025-04-20")
+    }
+}
+```
+
+### 4. Run tests
+
+- [ ] `swift test --filter ClaudeUsageFetcherTests`
+
+### 5. Verify token-leak guarantees
+
+- [ ] Re-read `LiveClaudeUsageFetcher.fetchUsage`. Confirm no code path interpolates `token` into a returned string. The only use of `token` is in the `Authorization` header.
+
+### 6. Verify build is clean
+
+- [ ] `swift build` exits 0 with no warnings introduced by the new file.
+
+### 7. Commit
+
+- [ ] `git add Sources/TBDDaemon/Claude/ClaudeUsageFetcher.swift Tests/TBDDaemonTests/ClaudeUsageFetcherTests.swift`
+- [ ] Commit with message: `feat: add ClaudeUsageFetcher for /api/oauth/usage`
+
+### 8. Mark phase complete
+
+- [ ] Update parent plan checkbox for Phase 03.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/04-token-resolver.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/04-token-resolver.md
@@ -1,0 +1,170 @@
+# Phase 04: Token Resolver
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 01, Phase 02
+> **Unblocks:** Phase 06 (spawn path), Phase 07 (poll scheduler)
+
+**Scope:** `ClaudeTokenResolver` that combines per-repo override, global default, and Keychain load into a single `resolve(repoID:)` call used by the spawn path.
+
+## Context
+
+The spawn path needs a single entry point that, given an optional repo ID, returns either a fully-loaded token (row + secret bytes) or `nil`. Resolution order per spec section "Token resolution":
+
+1. Repo override (`repo.claudeTokenOverrideID`) — if the row or Keychain entry is missing, fall through with a logged warning (do **not** error; the user may have deleted the token while a repo still references it).
+2. Global default (`config.defaultClaudeTokenID`) — if the row or Keychain entry is missing, return `nil`.
+3. Otherwise return `nil`.
+
+On any successful resolution, bump `tokens.touchLastUsed(id:)` so the Settings UI can sort by recency.
+
+The Keychain accessor is injected as a closure so tests can run without touching the real Keychain.
+
+## Tasks
+
+### Task 1: Add `ResolvedClaudeToken` value type
+
+In a new file `Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift`, declare:
+
+```swift
+public struct ResolvedClaudeToken: Sendable, Equatable {
+    public let tokenID: UUID
+    public let name: String
+    public let kind: ClaudeTokenKind
+    public let secret: String
+}
+```
+
+`ClaudeTokenKind` is the enum introduced in Phase 01 (`oauth` / `apiKey`).
+
+### Task 2: Declare `ClaudeTokenResolver` struct and initializer
+
+In the same file:
+
+```swift
+public struct ClaudeTokenResolver: Sendable {
+    let tokens: ClaudeTokenStore
+    let repos: RepoStore
+    let config: ConfigStore
+    let keychain: @Sendable (String) throws -> String?
+
+    public init(
+        tokens: ClaudeTokenStore,
+        repos: RepoStore,
+        config: ConfigStore,
+        keychain: @Sendable @escaping (String) throws -> String? = { try ClaudeTokenKeychain.load(id: $0) }
+    ) {
+        self.tokens = tokens
+        self.repos = repos
+        self.config = config
+        self.keychain = keychain
+    }
+}
+```
+
+The default keychain closure forwards to `ClaudeTokenKeychain.load` from Phase 02.
+
+### Task 3: Implement private `loadResolved(id:)` helper
+
+Add a private helper that, given a token UUID, attempts to load the row and secret:
+
+```swift
+private func loadResolved(id: UUID) async throws -> ResolvedClaudeToken? {
+    guard let row = try await tokens.get(id: id) else { return nil }
+    guard let secret = try keychain(id.uuidString), !secret.isEmpty else { return nil }
+    return ResolvedClaudeToken(
+        tokenID: row.id,
+        name: row.name,
+        kind: row.kind,
+        secret: secret
+    )
+}
+```
+
+Returning `nil` (not throwing) lets the caller decide whether to fall through or give up.
+
+### Task 4: Implement `resolve(repoID:)` with the documented precedence
+
+```swift
+public func resolve(repoID: UUID?) async throws -> ResolvedClaudeToken? {
+    // Step 1: repo override
+    if let repoID, let repo = try await repos.get(id: repoID),
+       let overrideID = repo.claudeTokenOverrideID {
+        if let resolved = try await loadResolved(id: overrideID) {
+            try await tokens.touchLastUsed(id: resolved.tokenID)
+            return resolved
+        }
+        // Row or keychain missing — log and fall through to global default.
+        TBDLog.warning("claude token override \(overrideID) for repo \(repoID) is missing; falling back to global default")
+    }
+
+    // Step 2: global default
+    if let defaultID = try await config.get().defaultClaudeTokenID {
+        if let resolved = try await loadResolved(id: defaultID) {
+            try await tokens.touchLastUsed(id: resolved.tokenID)
+            return resolved
+        }
+        return nil
+    }
+
+    // Step 3: nothing applies
+    return nil
+}
+```
+
+Use whichever logger the daemon already exposes (the warning string is the spec wording — if `TBDLog` is named differently, match the existing convention).
+
+### Task 5: Wire up an in-memory test harness
+
+Create `Tests/TBDDaemonTests/ClaudeTokenResolverTests.swift`. In `setUp`, build a fresh in-memory database and stores:
+
+```swift
+let db = try TBDDatabase(inMemory: true)
+let tokens = ClaudeTokenStore(database: db)
+let repos = RepoStore(database: db)
+let config = ConfigStore(database: db)
+var keychainMap: [String: String] = [:]
+let resolver = ClaudeTokenResolver(
+    tokens: tokens, repos: repos, config: config,
+    keychain: { id in keychainMap[id] }
+)
+```
+
+Add small helpers to insert a token row and to register a repo. Use `XCTestCase` (or whatever framework `TBDDaemonTests` already uses).
+
+### Task 6: Test all resolution branches
+
+Cover each branch from the spec, one test per case:
+
+1. `resolve_nilRepo_noDefault_returnsNil` — empty config, `repoID: nil` → `nil`.
+2. `resolve_nilRepo_globalDefault_keychainPresent_returnsResolved` — insert token row, set `config.defaultClaudeTokenID`, populate `keychainMap` → returns `ResolvedClaudeToken` with the right id/name/kind/secret.
+3. `resolve_nilRepo_globalDefault_keychainMissing_returnsNil` — same as above but leave `keychainMap` empty → `nil`.
+4. `resolve_repoOverride_keychainPresent_overrideWins` — insert two tokens (`A`, `B`), set `B` as global default and `A` as repo override, populate keychain for both → resolved token is `A`.
+5. `resolve_repoOverride_keychainMissing_fallsBackToGlobal` — same as above but only `B`'s secret is in `keychainMap` → resolved token is `B` (no error thrown).
+6. `resolve_repoNoOverride_globalSet_usesGlobal` — repo with `claudeTokenOverrideID == nil`, global default set → resolved token matches global.
+
+### Task 7: Test `touchLastUsed` side effect on the success path
+
+Add `resolve_success_bumpsLastUsedAt`:
+
+1. Insert a token row, capture its `lastUsedAt` (expect `nil` initially per Phase 01).
+2. Set it as the global default and populate the keychain map.
+3. Call `resolver.resolve(repoID: nil)`.
+4. Reload the row via `tokens.get(id:)` and assert `lastUsedAt != nil` and is within the last few seconds of `Date()`.
+
+Optionally add a negative assertion: when resolution returns `nil` (e.g. keychain missing), `lastUsedAt` is **not** bumped.
+
+### Task 8: Build and run the new test target
+
+```sh
+swift build
+swift test --filter ClaudeTokenResolverTests
+```
+
+Fix any compile errors against the actual Phase 01/02 APIs (record field names, store method signatures, logger name) before committing. Commit with `feat: add ClaudeTokenResolver with repo override and global default precedence`.
+
+## Acceptance criteria
+
+- `Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift` exists and exposes `ResolvedClaudeToken` and `ClaudeTokenResolver` with the signatures above.
+- `resolve(repoID:)` implements the three-step precedence and only bumps `lastUsedAt` on success.
+- A missing repo override row or Keychain entry logs a warning and falls through; a missing global default row or Keychain entry returns `nil`.
+- All seven test cases pass under `swift test`.
+- No real Keychain access in tests — all reads go through the injected closure.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/05-rpc-crud.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/05-rpc-crud.md
@@ -1,0 +1,193 @@
+# Phase 05: RPC — CRUD + Manual Fetch
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 01, 02, 03
+> **Unblocks:** Phase 08 (DaemonClient stubs)
+
+**Scope:** Seven RPC methods for Claude token management — list, add (with validation), delete, rename, setGlobalDefault, setRepoOverride, fetchUsage (dedup-cached).
+
+---
+
+## Context
+
+Phase 01 has landed `ClaudeToken`, `ClaudeTokenUsage`, `ClaudeTokenKind`, and the GRDB stores (`db.claudeTokens`, `db.claudeTokenUsage`, `db.config`) plus the optional `repo.claude_token_override_id` column. Phase 02 has landed `ClaudeTokenKeychain` (with an injectable seam for tests). Phase 03 has landed `ClaudeUsageFetcher` (protocol + `LiveClaudeUsageFetcher`) returning a `ClaudeUsageFetchResult` whose cases include `.ok(ClaudeTokenUsage)`, `.http401`, `.http429`, `.networkError`.
+
+This phase wires those pieces into the daemon RPC surface so the app (Phase 08+) can manage tokens. It does NOT touch terminal spawn — that is Phase 06.
+
+Token bytes are received once on `add`, immediately written to Keychain, and never returned to the client again. `list` returns metadata + cached usage only.
+
+---
+
+## Task list
+
+### 1. Add shared types to `Sources/TBDShared/Models.swift`
+
+- [ ] Add `public struct ClaudeTokenWithUsage: Codable, Sendable { public let token: ClaudeToken; public let usage: ClaudeTokenUsage? }` with public init.
+- [ ] Verify `ClaudeToken`, `ClaudeTokenUsage`, `ClaudeTokenKind` from Phase 01 are already `Codable & Sendable` and `public`. If not, fix in this phase (note in commit).
+
+### 2. Add RPC method constants to `Sources/TBDShared/RPCProtocol.swift`
+
+- [ ] In `enum RPCMethod` add:
+  - `claudeTokenList = "claudeToken.list"`
+  - `claudeTokenAdd = "claudeToken.add"`
+  - `claudeTokenDelete = "claudeToken.delete"`
+  - `claudeTokenRename = "claudeToken.rename"`
+  - `claudeTokenSetGlobalDefault = "claudeToken.setGlobalDefault"`
+  - `claudeTokenSetRepoOverride = "claudeToken.setRepoOverride"`
+  - `claudeTokenFetchUsage = "claudeToken.fetchUsage"`
+
+### 3. Add parameter and result structs to `RPCProtocol.swift`
+
+- [ ] `ClaudeTokenAddParams { name: String; token: String }`
+- [ ] `ClaudeTokenAddResult { token: ClaudeToken; warning: String? }` — `warning` populated when oauth validation could not reach the server (network/429) and the token was accepted optimistically.
+- [ ] `ClaudeTokenDeleteParams { id: UUID }`
+- [ ] `ClaudeTokenRenameParams { id: UUID; name: String }`
+- [ ] `ClaudeTokenSetGlobalDefaultParams { id: UUID? }` (nil clears the default)
+- [ ] `ClaudeTokenSetRepoOverrideParams { repoID: UUID; tokenID: UUID? }` (nil clears the override)
+- [ ] `ClaudeTokenFetchUsageParams { id: UUID }`
+- [ ] `ClaudeTokenListResult { tokens: [ClaudeTokenWithUsage] }`
+- [ ] `ClaudeTokenFetchUsageResult { usage: ClaudeTokenUsage }`
+- [ ] All structs `public Codable Sendable` with public memberwise inits, matching the existing style in this file.
+
+### 4. Extend `RPCRouter.init` with a `ClaudeUsageFetcher`
+
+- [ ] Add a `public let usageFetcher: ClaudeUsageFetcher` stored property.
+- [ ] Add `usageFetcher: ClaudeUsageFetcher = LiveClaudeUsageFetcher()` to the init signature (default after `conductorManager`).
+- [ ] Assign in init.
+- [ ] Confirm `ClaudeUsageFetcher` is declared `Sendable` so the router stays `Sendable`. If the protocol from Phase 03 is not `Sendable`, this phase widens it.
+- [ ] Update any existing call sites of `RPCRouter.init` (search the codebase) — the new parameter is defaulted, so they should still compile.
+
+### 5. Create `Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift`
+
+- [ ] New file mirroring the layout of `RPCRouter+TerminalHandlers.swift`: `import Foundation; import TBDShared; extension RPCRouter { ... }`.
+- [ ] One section comment per handler group.
+
+### 6. Implement `handleClaudeTokenList`
+
+- [ ] No params.
+- [ ] Load all rows from `db.claudeTokens.list()`.
+- [ ] For each, fetch cached usage from `db.claudeTokenUsage.get(tokenID:)` (returns `ClaudeTokenUsage?`).
+- [ ] Map to `[ClaudeTokenWithUsage]`, return `ClaudeTokenListResult`.
+
+### 7. Implement `handleClaudeTokenAdd`
+
+- [ ] Decode `ClaudeTokenAddParams`.
+- [ ] Trim whitespace from `token`.
+- [ ] Determine kind:
+  - prefix `sk-ant-oat01-` → `.oauth`
+  - prefix `sk-ant-api03-` → `.apiKey`
+  - else → return `RPCResponse(error: "Token must start with sk-ant-oat01- or sk-ant-api03-")`.
+- [ ] Check for duplicate name via `db.claudeTokens.findByName(name:)`. If exists → return `RPCResponse(error: "A token named '\(name)' already exists")`.
+- [ ] If kind is `.oauth`:
+  - Call `usageFetcher.fetch(token: trimmed)`.
+  - On `.http401` → return `RPCResponse(error: "Token invalid")`. Do NOT write keychain or DB.
+  - On `.http429` or `.networkError` → set `warning = "Could not verify token with Anthropic; saved anyway"`. Do NOT cache usage.
+  - On `.ok(let usage)` → `warning = nil`, remember `usage` to upsert after the row is created.
+- [ ] If kind is `.apiKey`: skip fetcher entirely; `warning = nil`.
+- [ ] Generate `let id = UUID()`.
+- [ ] Write to keychain: `try ClaudeTokenKeychain.store(id: id, token: trimmed)`. If this throws, return the error and DO NOT insert a DB row.
+- [ ] Insert DB row: `let token = try await db.claudeTokens.create(id: id, name: name, kind: kind)`. If this throws, attempt `try? ClaudeTokenKeychain.delete(id: id)` to roll back the keychain write, then rethrow.
+- [ ] If we have a fresh `usage` from the validation step, upsert it via `db.claudeTokenUsage.upsert(usage)` (with `tokenID == id`, `fetchedAt = Date()`).
+- [ ] Return `try RPCResponse(result: ClaudeTokenAddResult(token: token, warning: warning))`.
+
+### 8. Implement `handleClaudeTokenDelete`
+
+- [ ] Decode `ClaudeTokenDeleteParams`.
+- [ ] Look up the token; if missing return `RPCResponse(error: "Token not found")`.
+- [ ] If `db.config.get().defaultClaudeTokenID == params.id` → call `db.config.setDefaultClaudeTokenID(nil)`.
+- [ ] Null out any `repo.claude_token_override_id == params.id` via a new `db.repos.clearClaudeTokenOverride(matching: params.id)` helper. (If Phase 01 did not add this helper, add it now in `RepoStore` and document the addition in this task's checkbox.)
+- [ ] Delete usage cache row: `try await db.claudeTokenUsage.delete(tokenID: params.id)`.
+- [ ] Delete DB row: `try await db.claudeTokens.delete(id: params.id)`.
+- [ ] Delete keychain entry: `try? ClaudeTokenKeychain.delete(id: params.id)` (best-effort; missing entry is not fatal).
+- [ ] **Do NOT** touch `terminal.claude_token_id` — running terminals keep their spawn-time env var. Add a `// NOTE:` comment in the handler explaining why.
+- [ ] Return `.ok()`.
+
+### 9. Implement `handleClaudeTokenRename`
+
+- [ ] Decode `ClaudeTokenRenameParams`.
+- [ ] Trim/validate `name` non-empty; if empty return `RPCResponse(error: "Name cannot be empty")`.
+- [ ] If `db.claudeTokens.findByName(name:)` returns a row whose id != params.id → return `RPCResponse(error: "A token named '\(name)' already exists")`.
+- [ ] Call `try await db.claudeTokens.rename(id:, name:)`.
+- [ ] Return `.ok()`.
+
+### 10. Implement `handleClaudeTokenSetGlobalDefault` and `handleClaudeTokenSetRepoOverride`
+
+- [ ] `setGlobalDefault`: decode, call `db.config.setDefaultClaudeTokenID(params.id)`, return `.ok()`.
+- [ ] `setRepoOverride`: decode, look up repo (404 if missing), call `db.repos.setClaudeTokenOverride(repoID:, tokenID:)`, return `.ok()`.
+- [ ] If Phase 01 did not add `setClaudeTokenOverride`, add it on `RepoStore` in this phase.
+
+### 11. Implement `handleClaudeTokenFetchUsage` with 60 s dedupe
+
+- [ ] Decode `ClaudeTokenFetchUsageParams`.
+- [ ] Look up the token row; 404 if missing.
+- [ ] Check existing cache row: `if let cached = try await db.claudeTokenUsage.get(tokenID: params.id), Date().timeIntervalSince(cached.fetchedAt) < 60 { return RPCResponse(result: ClaudeTokenFetchUsageResult(usage: cached)) }`.
+- [ ] Otherwise load token bytes from keychain: `guard let bytes = try ClaudeTokenKeychain.load(id: params.id) else { return RPCResponse(error: "Token missing from keychain") }`.
+- [ ] Call `usageFetcher.fetch(token: bytes)`.
+- [ ] On `.ok(let usage)` upsert and return.
+- [ ] On `.http401` return `RPCResponse(error: "Token invalid")`.
+- [ ] On `.http429` return `RPCResponse(error: "Rate limited; try again later")`.
+- [ ] On `.networkError(let msg)` return `RPCResponse(error: "Network error: \(msg)")`.
+
+### 12. Wire handlers into `RPCRouter.handle()` switch
+
+- [ ] In `Sources/TBDDaemon/Server/RPCRouter.swift`, add seven new `case` arms in the same style as the existing cases:
+  ```swift
+  case RPCMethod.claudeTokenList:           return try await handleClaudeTokenList()
+  case RPCMethod.claudeTokenAdd:            return try await handleClaudeTokenAdd(request.paramsData)
+  case RPCMethod.claudeTokenDelete:         return try await handleClaudeTokenDelete(request.paramsData)
+  case RPCMethod.claudeTokenRename:         return try await handleClaudeTokenRename(request.paramsData)
+  case RPCMethod.claudeTokenSetGlobalDefault: return try await handleClaudeTokenSetGlobalDefault(request.paramsData)
+  case RPCMethod.claudeTokenSetRepoOverride:  return try await handleClaudeTokenSetRepoOverride(request.paramsData)
+  case RPCMethod.claudeTokenFetchUsage:     return try await handleClaudeTokenFetchUsage(request.paramsData)
+  ```
+- [ ] Place them above the `case RPCMethod.stateSubscribe:` arm so the conventional ordering is preserved.
+
+### 13. Tests — `Tests/TBDDaemonTests/ClaudeTokenRPCTests.swift`
+
+Use Swift Testing (`@Test` / `#expect`) consistent with the rest of the test target. Use an in-memory `TBDDatabase` (per the helper used elsewhere in the daemon tests — search `TBDDatabase(path: ":memory:")` or the existing test factory).
+
+Build a `StubClaudeUsageFetcher: ClaudeUsageFetcher` that holds `var responses: [ClaudeUsageFetchResult]` and a `var callCount: Int`, popping the head on each call. Make it a `final class` and mark with `@unchecked Sendable` if needed.
+
+Mock the keychain with the same injectable closure pattern Phase 02 introduced. If Phase 02 chose the "real keychain with random UUIDs + cleanup `defer`" route, follow that route here too — read `ClaudeTokenKeychain.swift` to see which.
+
+- [ ] **add: oauth + .ok** — fetcher returns `.ok(usage)`. Expect: row inserted with `kind == .oauth`, keychain has the bytes, `db.claudeTokenUsage.get(tokenID:)` returns the usage, result has `warning == nil`.
+- [ ] **add: oauth + .http401** — fetcher returns `.http401`. Expect: response `success == false`, error == "Token invalid", `db.claudeTokens.list()` empty, keychain empty, no usage row.
+- [ ] **add: oauth + .networkError** — fetcher returns `.networkError("offline")`. Expect: row inserted, keychain has bytes, NO usage row, `result.warning != nil`.
+- [ ] **add: api_key prefix** — params with `sk-ant-api03-...`. Expect: fetcher `callCount == 0`, row inserted with `kind == .apiKey`, no usage row.
+- [ ] **add: bad prefix** — params with `garbage`. Expect: error response, `callCount == 0`, no row, no keychain entry.
+- [ ] **add: duplicate name** — pre-seed a token named "Personal", call add with the same name. Expect: error response, only the original row exists.
+- [ ] **list joins usage** — seed two tokens, upsert usage for one, call list. Expect: 2 results, one with `usage != nil`, one with `usage == nil`.
+- [ ] **delete clears global default** — seed token, set as global default, call delete. Expect: token gone, keychain entry gone, usage row gone, `db.config.get().defaultClaudeTokenID == nil`.
+- [ ] **delete clears repo override** — seed token + repo with override pointing at it, call delete. Expect: `repo.claudeTokenOverrideID == nil` after.
+- [ ] **delete leaves matching default for unrelated token** — seed two tokens A and B, set A as global default, delete B. Expect: `defaultClaudeTokenID == A.id` still.
+- [ ] **rename success** — seed token, rename to a fresh name, expect row updated.
+- [ ] **rename duplicate** — seed two tokens A and B, attempt to rename B to A's name, expect error and B's name unchanged.
+- [ ] **setGlobalDefault round-trip** — call with id, then with nil, assert config reflects each.
+- [ ] **setRepoOverride round-trip** — seed repo + token, set override, assert repo row; clear with nil, assert cleared.
+- [ ] **fetchUsage dedupes within 60 s** — pre-seed usage row with `fetchedAt = Date()`, call handler. Expect: returns cached value, `stub.callCount == 0`.
+- [ ] **fetchUsage refreshes after 60 s** — pre-seed usage with `fetchedAt = Date().addingTimeInterval(-120)`, queue stub `.ok(newUsage)`, call handler. Expect: `callCount == 1`, returned usage matches `newUsage`, DB cache row updated.
+- [ ] **fetchUsage propagates 401** — queue stub `.http401`, call handler with no cached row. Expect: error response containing "invalid".
+
+### 14. Verify and commit
+
+- [ ] `swift build` — clean.
+- [ ] `swift test --filter ClaudeTokenRPCTests` — all green.
+- [ ] `swift test` — full suite still green (sanity check that we didn't break the existing router init call sites).
+- [ ] Commit with `feat: add Claude token RPC handlers (list, add, delete, rename, defaults, fetch)`.
+- [ ] Note in the commit body that Phase 06 will add `terminal.swapClaudeToken` and the spawn env wiring.
+
+---
+
+## Out of scope (handled later)
+
+- `terminal.swapClaudeToken` and any spawn-time env injection — Phase 06.
+- Background poll scheduler — Phase 07.
+- Client-side `DaemonClient` wrappers — Phase 08.
+- State-update broadcasts on usage cache writes — added in Phase 07 (the poll path is the primary writer; manual `fetchUsage` from this phase will get broadcast support retroactively in Phase 07).
+
+## Risks / watch-outs
+
+- **Token bytes in error strings.** Never include the raw token in any `RPCResponse(error:)`. The validator branch is the easiest place to slip up — keep error messages generic.
+- **Keychain rollback on DB insert failure.** If `db.claudeTokens.create` throws after the keychain write, leaving an orphaned keychain entry would shadow a future re-add with the same UUID. Always `try? ClaudeTokenKeychain.delete(id:)` in the catch path.
+- **Router `Sendable` conformance.** Adding `usageFetcher` as a stored property requires the protocol to be `Sendable`. If Phase 03 didn't mark it, do so here and call it out in the commit.
+- **Duplicate-name check race.** The check-then-insert is not atomic. For now we accept the race (single-process daemon, single client); if it bites, swap to a UNIQUE index in a later migration.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/06-spawn-and-swap.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/06-spawn-and-swap.md
@@ -1,0 +1,303 @@
+# Phase 06: Spawn Env Prefix + Mid-Conversation Swap
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 01, 02, 04
+> **Unblocks:** Phase 07 (poll scheduler uses terminal.claudeTokenID), Phase 08 (DaemonClient)
+
+**Scope:** Inject `CLAUDE_CODE_OAUTH_TOKEN` into the claude spawn path via `ClaudeTokenResolver`, and implement the `terminal.swapClaudeToken` RPC that kills + respawns the in-pane claude process with `--resume` and the new env var. Context preserved via Claude Code's JSONL transcript.
+
+## Assumptions
+
+- Phase 01 landed `Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift` exposing something like
+  `func resolve(repoID: UUID?) async throws -> ResolvedClaudeToken?` where `ResolvedClaudeToken`
+  has `tokenID: UUID` and `secret: String` (Keychain-loaded). It also has a by-id path
+  `func loadByID(_ id: UUID) async throws -> ResolvedClaudeToken?` (or we add it in task 02).
+- Phase 02 added `terminals.setClaudeTokenID(id:tokenID:)` to `TerminalStore`.
+- Phase 04 added `Terminal.claudeTokenID: UUID?` to `Sources/TBDShared/Models.swift` and the
+  GRDB record + migration.
+- `RPCRouter` already has stored properties `db`, `tmux`, `subscriptions`, and we will inject
+  `claudeTokenResolver: ClaudeTokenResolver` the same way (constructor arg, wired in
+  `TBDDaemon` startup).
+- Claude OAuth tokens (`sk-ant-oat01-...`) and Anthropic API keys (`sk-ant-api03-...`) contain
+  only `[A-Za-z0-9_-]` characters. We assert this at injection time so a bad value
+  fails loudly instead of silently producing a broken shell line. We still single-quote.
+
+## Tasks
+
+### Task 1: Extract `buildClaudeSpawnCommand` pure helper
+
+Create `Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift`:
+
+```swift
+import Foundation
+
+enum ClaudeSpawnCommandBuilder {
+    /// Build the shell command string for spawning a claude terminal.
+    /// Pure function — no DB, no Keychain, no tmux. Easy to unit-test.
+    ///
+    /// Exactly one of `resumeID` or `freshSessionID` must be non-nil for a claude spawn.
+    /// If both are nil, returns the fallback (`cmd` if set, else `$SHELL`).
+    static func build(
+        resumeID: String?,
+        freshSessionID: String?,
+        appendSystemPrompt: String?,
+        initialPrompt: String?,
+        tokenSecret: String?,
+        cmd: String?,
+        shellFallback: String
+    ) -> String {
+        let base: String
+        if let resumeID {
+            base = "claude --resume \(resumeID) --dangerously-skip-permissions"
+        } else if let sessionID = freshSessionID {
+            var b = "claude --session-id \(sessionID) --dangerously-skip-permissions"
+            if let prompt = appendSystemPrompt {
+                b += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
+            }
+            if let p = initialPrompt, !p.isEmpty {
+                b += " \(SystemPromptBuilder.shellEscape(p))"
+            }
+            base = b
+        } else if let cmd {
+            return cmd
+        } else {
+            return shellFallback
+        }
+
+        guard let secret = tokenSecret else { return base }
+        precondition(
+            secret.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" },
+            "Claude token contains unexpected characters; refusing to inject"
+        )
+        return "CLAUDE_CODE_OAUTH_TOKEN='\(secret)' \(base)"
+    }
+}
+```
+
+Note the env-prefix form `CLAUDE_CODE_OAUTH_TOKEN='...' claude ...` matches what zsh evaluates
+when tmux runs the command, and avoids `ps` leakage of the token in the `claude` arg list.
+
+### Task 2: Make `ClaudeTokenResolver` loadable by explicit ID
+
+If Phase 01's resolver does not already expose a by-id load, add:
+
+```swift
+func loadByID(_ id: UUID) async throws -> ResolvedClaudeToken?
+```
+
+It bypasses the repo/global precedence chain, looks up the row by id, loads the secret from
+`ClaudeTokenKeychain`, and returns nil if either step fails. Used by `swapClaudeToken` when
+the caller has already chosen a specific token.
+
+### Task 3: Wire `ClaudeTokenResolver` into `RPCRouter`
+
+Add a stored property `let claudeTokenResolver: ClaudeTokenResolver` to `RPCRouter` and
+pass it through the daemon startup site (search for `RPCRouter(` to find the construction
+point in `TBDDaemon`). No behavior change yet — just plumbing.
+
+### Task 4: Use the builder in `handleTerminalCreate`
+
+Replace the inline `if let resumeID ... else if isClaudeType ... else if let cmd ... else`
+chain in `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift` (lines ~30–66) with:
+
+1. Resolve `appendSystemPrompt` exactly as today (only for fresh sessions, only when the
+   repo provides one).
+2. Generate `freshSessionID` only when `isClaudeType && resumeID == nil`.
+3. Resolve token: `let resolved = isClaudeType ? try? await claudeTokenResolver.resolve(repoID: worktree.repoID) : nil`.
+4. Call `ClaudeSpawnCommandBuilder.build(...)` with the assembled inputs.
+5. Compute `label` as today.
+6. Pass `claudeTokenID: resolved?.tokenID` into `db.terminals.create(...)`.
+
+`db.terminals.create` already accepts `claudeSessionID`; extend it (or use the Phase 02
+setter immediately after) to persist `claudeTokenID`. Prefer extending `create` so the row
+is consistent on insert.
+
+### Task 5: Token-resolution failure must not break spawn
+
+`claudeTokenResolver.resolve` may throw (Keychain locked, missing secret, DB issue). Wrap
+the call in `try?` and treat nil as "no token". The user gets a working terminal that falls
+back to claude's keychain login. Log a single warning to `os_log` so we can diagnose.
+
+### Task 6: Add `RPCMethod.terminalSwapClaudeToken` constant
+
+In whichever file holds the `RPCMethod` enum / string constants, add
+`static let terminalSwapClaudeToken = "terminal.swapClaudeToken"`. Add params/result types in
+`Sources/TBDShared/Models.swift`:
+
+```swift
+public struct TerminalSwapClaudeTokenParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let newTokenID: UUID?
+}
+```
+
+Result is the updated `Terminal` row.
+
+### Task 7: Implement `handleTerminalSwapClaudeToken`
+
+Add to `RPCRouter+TerminalHandlers.swift`:
+
+```swift
+func handleTerminalSwapClaudeToken(_ paramsData: Data) async throws -> RPCResponse {
+    let params = try decoder.decode(TerminalSwapClaudeTokenParams.self, from: paramsData)
+
+    guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+        return RPCResponse(error: "Terminal not found: \(params.terminalID)")
+    }
+    guard let sessionID = terminal.claudeSessionID else {
+        return RPCResponse(error: "Terminal \(params.terminalID) is not a Claude terminal")
+    }
+    guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+        return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
+    }
+
+    // Resolve the new token (nil = clear override, fall back to keychain login).
+    let resolved: ResolvedClaudeToken?
+    if let newID = params.newTokenID {
+        resolved = try await claudeTokenResolver.loadByID(newID)
+        if resolved == nil {
+            return RPCResponse(error: "Token not found or unreadable: \(newID)")
+        }
+    } else {
+        resolved = nil
+    }
+
+    // 1. C-c the running claude process.
+    try await tmux.sendKey(server: worktree.tmuxServer, paneID: terminal.tmuxPaneID, key: "C-c")
+    try await Task.sleep(nanoseconds: 500_000_000)
+
+    // 2. Build respawn command (resume the same session).
+    let respawn = ClaudeSpawnCommandBuilder.build(
+        resumeID: sessionID,
+        freshSessionID: nil,
+        appendSystemPrompt: nil,
+        initialPrompt: nil,
+        tokenSecret: resolved?.secret,
+        cmd: nil,
+        shellFallback: ""
+    )
+
+    // 3. Type the command into the existing pane and submit.
+    try await tmux.sendKeys(server: worktree.tmuxServer, paneID: terminal.tmuxPaneID, text: respawn)
+    try await tmux.sendKey(server: worktree.tmuxServer, paneID: terminal.tmuxPaneID, key: "Enter")
+
+    // 4. Persist the new token id on the terminal.
+    try await db.terminals.setClaudeTokenID(id: terminal.id, tokenID: resolved?.tokenID)
+
+    // 5. Fire-and-forget usage refresh for the new token.
+    if let newID = resolved?.tokenID {
+        Task.detached { [usage = self.claudeUsageFetcher] in
+            await usage?.fetch(tokenID: newID)
+        }
+    }
+
+    // 6. Broadcast delta so UI updates immediately.
+    guard let updated = try await db.terminals.get(id: terminal.id) else {
+        return RPCResponse(error: "Terminal vanished after swap")
+    }
+    subscriptions.broadcast(delta: .terminalUpdated(TerminalDelta(
+        terminalID: updated.id, worktreeID: updated.worktreeID, label: updated.label
+    )))
+    return try RPCResponse(result: updated)
+}
+```
+
+Notes:
+- `tmux.sendKey` / `tmux.sendKeys` already exist (see `handleTerminalSend` at line 301 and 308).
+- If `tmux.respawnPane` exists in `TmuxManager`, prefer it over the type-then-Enter dance and
+  call it with `shellCommand: respawn`. Verify by grepping `TmuxManager` during this task; if
+  not present, the type-and-Enter approach is fine and matches what a user would do manually.
+- The `claudeUsageFetcher` reference assumes Phase 03 wired a fetcher into the router. If
+  Phase 03 isn't merged yet, gate the fire-and-forget behind `if let usage = claudeUsageFetcher`
+  or skip the call and add a TODO referencing Phase 07.
+
+### Task 8: Register the new method in `RPCRouter.handle`
+
+Find `RPCRouter.handle()` (likely `Sources/TBDDaemon/Server/RPCRouter.swift`) and add a case:
+
+```swift
+case RPCMethod.terminalSwapClaudeToken:
+    return try await handleTerminalSwapClaudeToken(paramsData)
+```
+
+### Task 9: Builder unit tests — fallback paths
+
+Create `Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift`. Cover the non-token branches:
+- `resumeID` only → `claude --resume X --dangerously-skip-permissions`
+- `freshSessionID` only → `claude --session-id Y --dangerously-skip-permissions`
+- fresh + appendSystemPrompt → contains `--append-system-prompt '...'`
+- fresh + initialPrompt → trailing `'...'`
+- `cmd` only → returns `cmd` verbatim
+- all nils → returns `shellFallback`
+
+### Task 10: Builder unit tests — token prefix branches
+
+Same file:
+- resume + token → starts with `CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake' `
+- fresh + token → starts with the same prefix
+- `cmd` + token → token is **ignored** (cmd path is for non-claude shells); assert no prefix
+- shellFallback + token → no prefix
+- token with bad char → `precondition` traps (XCTAssertThrowsError via a wrapper, or
+  document as a non-test invariant if XCTest can't catch preconditions cleanly)
+
+### Task 11: Spawn integration test — no tokens configured
+
+Create `Tests/TBDDaemonTests/ClaudeTokenSpawnTests.swift`. Set up an in-memory DB with one
+repo + one worktree, no `claude_tokens` rows, `config.default_claude_token_id = nil`. Stub
+tmux with a recording double that captures the `shellCommand` arg to `createWindow`.
+Call `handleTerminalCreate` with `type: .claude`. Assert:
+- captured `shellCommand` matches the existing format (no env prefix)
+- created terminal row has `claudeTokenID == nil`
+
+### Task 12: Spawn integration test — global default set
+
+Same fixture, but seed one token (Keychain set to `sk-ant-oat01-fake`) and set
+`config.default_claude_token_id`. Call `handleTerminalCreate`. Assert:
+- captured `shellCommand` begins with `CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake' `
+- created terminal row's `claudeTokenID` equals the default token's id
+- `last_used_at` on the token row is bumped (if Phase 01 implemented this — otherwise
+  defer the assertion to that phase's tests)
+
+### Task 13: Spawn integration tests — repo override + non-claude
+
+Two more cases in the same file:
+- **Repo override beats default.** Seed two tokens A and B, default = A,
+  `repo.claude_token_override_id = B`. Spawn → command uses B's secret, terminal row's
+  `claudeTokenID == B.id`.
+- **Non-claude type ignores tokens.** Default = A. Call `handleTerminalCreate` with
+  `type: .shell` (no `resumeSessionID`). Assert no `CLAUDE_CODE_OAUTH_TOKEN=` in the
+  captured `shellCommand`, and `claudeTokenID == nil` on the row.
+
+### Task 14: Swap RPC integration tests
+
+Same test file. Use the same recording tmux double, plus a way to inspect the bytes sent
+to `sendKeys` (capture into an array per pane).
+
+- **Swap to a different token.** Spawn a claude terminal with token A. Call
+  `handleTerminalSwapClaudeToken(terminalID: t, newTokenID: B.id)`. Assert:
+  - a `C-c` key was sent
+  - the typed text contains `CLAUDE_CODE_OAUTH_TOKEN='<B-secret>' claude --resume <sessionID> --dangerously-skip-permissions`
+  - terminal row's `claudeTokenID == B.id`
+- **Swap to nil.** Same setup, call with `newTokenID: nil`. Assert typed text has **no**
+  `CLAUDE_CODE_OAUTH_TOKEN=` prefix and terminal row's `claudeTokenID == nil`.
+- **Swap on a non-claude terminal.** Spawn with `type: .shell`. Swap call returns an
+  RPC error and does not touch tmux.
+- **Swap with unknown tokenID.** Returns an RPC error, no tmux interaction, terminal row
+  unchanged.
+
+## Verification
+
+- `swift build` clean.
+- `swift test --filter ClaudeSpawnCommandBuilderTests` green.
+- `swift test --filter ClaudeTokenSpawnTests` green.
+- Manual smoke (after Phase 07/08 land the UI): create a claude terminal with no default,
+  confirm it works as before; set a default, create another terminal, confirm `ps` shows
+  no token in the claude arg list; right-click → swap token, confirm the conversation
+  resumes against the new account.
+
+## Out of scope
+
+- Touching `repo.claudeTokenOverrideID` or `config.defaultClaudeTokenID` from the swap path
+  (one-shot, per spec).
+- Retrying a failed `--resume` after swap. The pane is left dead per spec.
+- UI surfaces for swap and default selection — Phase 08+.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/07-background-poll.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/07-background-poll.md
@@ -1,0 +1,158 @@
+# Phase 07: Background Usage Poller
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 01, 02, 03, 05
+> **Unblocks:** Phase 08
+
+**Scope:** A `ClaudeUsagePoller` actor that keeps `claude_token_usage` fresh for OAuth tokens on a 30-minute cadence with 30 s startup stagger, 60 min 429 backoff, 401 exclusion, focus-pause + resume, and dedupe. Wired into daemon lifecycle. Fully testable with an injected clock.
+
+## Context
+
+Spec section "Usage fetching" (`docs/superpowers/specs/2026-04-06-claude-token-switcher-design.md` lines 139–178) defines triggers and rules. This phase implements the *background* trigger and the *focus regained* trigger; the on-demand triggers (Settings opened, swap RPC, menu opened) are handled by Phase 05's `claudeToken.fetchUsage` handler invoking `pokeAll()` / single-token `poke()` on this poller.
+
+Existing daemon lifecycle hook for long-running tasks: `Sources/TBDDaemon/Daemon.swift:122-150` already starts background `Task`s (`gitFetchTask`, `gitStatusTask`) at the bottom of `Daemon.start()`. The poller is wired in beside them and cancelled in `Daemon.stop()`.
+
+There is **no existing app→daemon focus signal** (verified via grep for `setForeground|focus|appLifecycle` across `Sources/`). This phase adds an `app.setForegroundState(isForeground: Bool)` RPC.
+
+## Key rules (verbatim from spec)
+
+- OAuth tokens only; `kind == api_key` skipped permanently.
+- Default cadence: 30 min per token.
+- Startup stagger: first poll for each token at `random(0..30s)` from `start()`.
+- HTTP 429 → next poll for that token 60 min out; first success after that reverts to 30 min.
+- HTTP 401 → stop polling that token entirely. Row stays; Settings shows "Invalid".
+- Focus loss: if app stays unfocused for >10 min, pause the loop. On focus regained, resume immediately and `pokeAll()`.
+- Dedupe: if `fetched_at < 60 s` ago, skip the network call (reuse cache).
+- Every successful poll writes to `ClaudeTokenUsageStore` and calls `broadcast` with the updated row.
+
+## Design
+
+**Single scheduler loop, not one task per token.** A single `Task` inside the actor runs `while !cancelled { sleep until earliest nextFireAt; tick(); }`. Per-token state lives in `var schedule: [TokenID: Entry]` where `Entry { nextFireAt: Date, backoffActive: Bool, excluded: Bool }`. This is lighter than N tasks and avoids cross-task synchronization for the per-token map.
+
+**Clock injection.** Define a `protocol PollerClock: Sendable { func now() -> Date; func sleep(until: Date) async throws }`. Production impl wraps `Date()` + `Task.sleep(for:)`. Test impl is a `TestPollerClock` actor that tracks a virtual `now`, exposes `advance(by:)`, and resolves any in-flight `sleep(until:)` continuations whose deadlines have been crossed. All scheduling uses wall-clock `Date` (not `ContinuousClock`) so the 60 s dedupe against `fetched_at` and the 10-min focus threshold use the same time base.
+
+**Focus tracking.** Actor stores `lastFocusLostAt: Date?` and `isPaused: Bool`. `onFocusChanged(false)` records the timestamp; `onFocusChanged(true)` clears it, sets `isPaused = false`, fires `pokeAll()`, and resumes the loop. The scheduler loop, before each tick, checks `if let lostAt = lastFocusLostAt, now - lostAt > 10*60 { isPaused = true; }` and waits on a `CheckedContinuation` until focus returns. (No timer needed for the 10-min threshold itself — the loop's natural wakeups catch it.)
+
+**Dedupe.** Before each network call, the poller reads the current `ClaudeTokenUsage` row for the token via `usage.get(tokenID:)`; if `fetched_at` is within 60 s, skip the call entirely (do not even update `nextFireAt` cadence — the next tick simply rolls forward by 30 min from now).
+
+## Tasks
+
+### Task 1: Define `PollerClock` protocol and production impl
+
+Create `Sources/TBDDaemon/Claude/PollerClock.swift`:
+
+```swift
+public protocol PollerClock: Sendable {
+    func now() -> Date
+    func sleep(until deadline: Date) async throws
+}
+
+public struct SystemPollerClock: PollerClock {
+    public init() {}
+    public func now() -> Date { Date() }
+    public func sleep(until deadline: Date) async throws {
+        let interval = deadline.timeIntervalSince(Date())
+        if interval > 0 { try await Task.sleep(for: .seconds(interval)) }
+    }
+}
+```
+
+### Task 2: Define `ClaudeUsagePoller` actor skeleton
+
+Create `Sources/TBDDaemon/Claude/ClaudeUsagePoller.swift` with the actor declaration, init, stored state (`schedule: [String: Entry]`, `isPaused: Bool`, `lastFocusLostAt: Date?`, `loopTask: Task<Void, Never>?`, `wakeContinuation: CheckedContinuation<Void, Never>?`), and stub methods `start`, `stop`, `onFocusChanged`, `pokeAll`. Wire dependencies (`tokens`, `usage`, `keychain`, `fetcher`, `clock`, `broadcast`).
+
+### Task 3: Implement `start()` with stagger
+
+`start()` lists tokens via `tokens.list()`, filters to `kind == .oauth`, assigns each a `nextFireAt = clock.now() + Double.random(in: 0..<30)` seconds, populates `schedule`, then launches the scheduler loop `Task`. Idempotent: if `loopTask` already exists, no-op.
+
+### Task 4: Implement scheduler loop
+
+The loop: pick the entry with the earliest `nextFireAt`; await `clock.sleep(until: that)`; if focus is paused, `await withCheckedContinuation { wakeContinuation = $0 }` until `onFocusChanged(true)` resumes it; then call `tick(tokenID:)`. After each tick, recompute and continue. Handles `tokens.list()` changes by re-reading the token list at the top of every iteration so newly added tokens get scheduled and deleted ones drop out.
+
+### Task 5: Implement `tick(tokenID:)` core fetch path
+
+Inside `tick`:
+1. Load token from `tokens` to confirm it still exists and is `oauth`. If not, drop from `schedule` and return.
+2. Dedupe: if `usage.get(tokenID:)?.fetchedAt` is within 60 s of `clock.now()`, skip network and just reschedule `nextFireAt += 30 min` (or `+ 60 min` if backoff still active).
+3. Load secret via `keychain(tokenID)`. If nil, skip and reschedule normally.
+4. Call `fetcher.fetchUsage(token:)`.
+5. Branch on result:
+   - `.ok(let result)` → write to `usage.upsert(...)`, call `broadcast(updatedRow)`, clear `backoffActive`, set `nextFireAt = now + 30 min`.
+   - `.http429` → write status `http_429` to usage row (preserving cached pcts), set `backoffActive = true`, `nextFireAt = now + 60 min`. Log once per token (track in a `loggedBackoff: Set<String>` to avoid log spam).
+   - `.http401` → write status `http_401`, mark entry `excluded = true`, remove from `schedule`. Do not reschedule.
+   - `.networkError` → write status `network_error`, reschedule `nextFireAt = now + 30 min` (or 60 min if backoff active). No status escalation.
+
+### Task 6: Implement `pokeAll()` and `poke(tokenID:)`
+
+`pokeAll()` sets every non-excluded entry's `nextFireAt = clock.now()` and signals the loop to wake (resume `wakeContinuation` if waiting, or cancel current sleep via a sentinel — simplest impl: store the loop's current sleep task and `cancel()` it; the loop catches `CancellationError` from `clock.sleep`, treats it as wake-up, and re-evaluates). `poke(tokenID:)` does the same for one token; used by Phase 05's `claudeToken.fetchUsage` handler for single-token refresh on UI surfaces.
+
+### Task 7: Implement `onFocusChanged(isForeground:)`
+
+- `isForeground == false` → set `lastFocusLostAt = clock.now()`. Loop continues normally for the first 10 minutes; on the next tick after the threshold crosses, the loop sets `isPaused = true` and parks on the continuation.
+- `isForeground == true` → set `lastFocusLostAt = nil`, `isPaused = false`. If `wakeContinuation` is set, resume it. Then call `pokeAll()`.
+
+### Task 8: Implement `stop()`
+
+Cancel `loopTask`, nil it out, resume `wakeContinuation` (so cancellation propagates), clear `schedule`. Idempotent.
+
+### Task 9: Wire poller into `Daemon.start()`
+
+In `Sources/TBDDaemon/Daemon.swift`, after Task 12 (git fetch task) and before Task 13 (git status task):
+
+- Construct `ClaudeUsagePoller(tokens: ..., usage: ..., keychain: { id in try ClaudeTokenKeychain.load(id: id) }, fetcher: ClaudeUsageFetcher(), clock: SystemPollerClock(), broadcast: { row in subs.broadcastClaudeTokenUsage(row) })`.
+- Store on `Daemon` as `nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?`.
+- Call `await poller.start()`.
+- In `Daemon.stop()`, call `await claudeUsagePoller?.stop()` before cancelling other background tasks.
+
+Note: `subs.broadcastClaudeTokenUsage` is added as a thin wrapper in this phase if it doesn't exist on `StateSubscriptionManager` yet (delegates to the existing state-update channel — see Phase 05 for the broadcast plumbing). If Phase 05 already added it, reuse.
+
+### Task 10: Add `app.setForegroundState` RPC
+
+There is no existing app→daemon focus signal. Add to `Sources/TBDDaemon/Server/RPCRouter.swift` (or a new `RPCRouter+AppHandlers.swift` if no app section exists yet) a handler:
+
+- Method name: `app.setForegroundState`
+- Params: `{ "isForeground": Bool }`
+- Body: `await daemon.claudeUsagePoller?.onFocusChanged(isForeground: params.isForeground)` (router needs a reference to the poller — pass it through the `RPCRouter` init alongside the other deps, or expose via a closure to keep coupling minimal).
+
+Add the matching method declaration to `Sources/TBDShared/` RPC method enum / constants if one exists; otherwise add the method string in the router switch only. Update `Sources/TBDShared/Models.swift` if a typed params struct is required by convention there.
+
+This RPC is wired up by the app in a later phase (Phase 09 / wire-up); this phase only adds the daemon side.
+
+### Task 11: Test — happy path stagger and cadence
+
+`Tests/TBDDaemonTests/ClaudeUsagePollerTests.swift`. Use a `TestPollerClock` and an in-memory `MockClaudeUsageFetcher` (records calls, returns scripted results). Two oauth tokens in an in-memory `ClaudeTokenStore`/`ClaudeTokenUsageStore`.
+
+- After `start()`, advance clock by 30 s → both tokens fetched exactly once each.
+- Advance another 30 min → both fetched again (total: 2 each).
+
+### Task 12: Test — dedupe and 429 backoff
+
+- Pre-populate `usage` row with `fetchedAt = clock.now() - 30s`. Advance clock past first stagger; assert `fetcher.callCount == 0` for that token (dedupe hit), `nextFireAt` rolled to ~30 min.
+- Script fetcher to return `.http429` for one token; advance past stagger; assert next `nextFireAt` is 60 min out, not 30. Then script `.ok`; advance 60 min; assert success and that the *following* `nextFireAt` is 30 min out (backoff cleared).
+
+### Task 13: Test — 401 exclusion and api_key skip
+
+- Token A oauth, token B api_key. Start poller; advance 30 s + a few minutes; assert fetcher only called for A.
+- Script A to return `.http401`; advance; assert A removed from schedule; advance another hour; assert A never fetched again.
+
+### Task 14: Test — focus pause/resume + pokeAll
+
+- Start poller, let it complete first stagger (1 fetch per token).
+- `onFocusChanged(false)` at `t0`; advance clock 11 minutes without firing the next 30-min tick (i.e., scheduler wakes via injected timer for a check) → assert no new fetches and `isPaused == true`.
+- `onFocusChanged(true)` → assert immediate fetch for both tokens (pokeAll), and that the loop has resumed (subsequent 30-min advancement triggers another fetch).
+- Separately, with a fresh poller mid-cadence, call `pokeAll()` directly → assert both eligible tokens fetched immediately regardless of `nextFireAt`.
+
+### Task 15: Test — broadcast invocation
+
+- Capture broadcast calls into a thread-safe collector. After two successful ticks, assert `broadcast` was called twice with the expected `ClaudeTokenUsage` rows (matching what's in the store).
+- After a `.http429` tick, assert broadcast is *also* called (UI needs to know status changed) with the row whose `lastStatus == "http_429"`.
+
+### Task 16: Verification
+
+Run `swift build` and `swift test --filter ClaudeUsagePollerTests`. Confirm:
+- All 6 test methods pass.
+- No real-time sleeps in tests (whole suite completes in <1 s).
+- `Daemon.start()` still compiles after wiring; manual `scripts/restart.sh` shows `[Daemon] Started successfully` and no warnings about the poller.
+- Per CLAUDE.md branching rule: every new gated branch (oauth-only filter, dedupe hit, 429 backoff, 401 exclusion, focus pause threshold) is covered by at least one assertion in Tasks 11–15.
+
+Commit as `feat: add background Claude usage poller`.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/08-daemon-client.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/08-daemon-client.md
@@ -1,0 +1,135 @@
+# Phase 08: DaemonClient Stubs + AppState Wiring
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 05, 06, 07
+> **Unblocks:** Phase 09, 10, 11, 12 (all UI phases)
+
+**Scope:** App-side RPC stubs for all new claude-token methods, `AppState` published properties + helpers, and focus-change forwarding to the daemon so the poller can pause/resume.
+
+---
+
+## Context
+
+- Client lives in `Sources/TBDApp/DaemonClient.swift` — actor with private `call` / `callVoid` / `callNoParams` helpers wrapping `sendRaw`. Each new RPC is a thin typed wrapper over those.
+- Existing pattern: one wrapper per RPC method, taking primitive args and constructing the `*Params` struct from `TBDShared`. Examples: `addRepo`, `worktreeSelectionChanged`, `terminalSuspend`.
+- `AppState` (`Sources/TBDApp/AppState.swift`) is a `@MainActor ObservableObject`. Real-time updates flow through `subscribe(onDelta:)` → `handleDelta(_:)` switch on `StateDelta`. New delta cases must be added to `Sources/TBDShared/StateDelta.swift` and handled in both daemon broadcast sites and `AppState.handleDelta`.
+- `StateDelta` enum is in `Sources/TBDShared/StateDelta.swift`. Adding a case is a backward-compatible Codable change as long as old daemons never emit it.
+- App focus: `TBDAppMain` in `Sources/TBDApp/TBDApp.swift` uses `AppDelegate` (NSApplicationDelegate). There are no existing `didBecomeActive`/`didResignActive` handlers — Phase 08 adds them.
+- `Tests/TBDAppTests/` exists (`LayoutNodeTests`, `PaneContentTests`, `PlaceholderTests`) but does **not** mock `DaemonClient` — it's a concrete actor, not a protocol. We will not retrofit a protocol in this phase; instead add a single smoke test that constructs `AppState` and calls a no-op helper path that doesn't require a daemon.
+- Per `Sources/TBDShared/CLAUDE.md`: any change in `TBDShared` requires `scripts/restart.sh` after building.
+
+---
+
+## Tasks
+
+### Task 1: Add `claudeTokenUsageUpdated` delta case to `StateDelta`
+
+- [ ] In `Sources/TBDShared/StateDelta.swift`, add:
+  - `case claudeTokenUsageUpdated(ClaudeTokenUsageDelta)`
+  - New `public struct ClaudeTokenUsageDelta: Codable, Sendable` with fields `tokenID: UUID`, `usage: ClaudeTokenUsage` (type from Phase 01).
+- [ ] Confirm `ClaudeTokenUsage` is `Sendable` (added in Phase 01); if not, fix it there or add a TODO comment referencing Phase 01.
+- [ ] Verify `swift build` (TBDShared target) compiles.
+
+### Task 2: Add `claudeTokensChanged` delta case (covers add/delete/rename/default change)
+
+- [ ] In `Sources/TBDShared/StateDelta.swift`, add:
+  - `case claudeTokensChanged` (no payload — coarse signal that triggers a `listClaudeTokens` refresh in the app).
+  - Rationale: token CRUD is rare and the list is small; full refresh is simpler than per-row deltas and avoids leaking secret-bearing models through the wire (none of the public delta payloads carry token bytes, but the simpler shape removes that whole class of risk).
+- [ ] Note in plan: Phase 05 (RPC CRUD) and Phase 06 (swap RPC) must broadcast this delta on every mutation; Phase 07 must broadcast `claudeTokenUsageUpdated` after each cache write. If those broadcasts aren't already in 05/06/07, this phase adds them as part of integration (search `subscriptions.broadcast` in `Sources/TBDDaemon/`).
+
+### Task 3: Create `Sources/TBDApp/DaemonClient+ClaudeTokens.swift`
+
+- [ ] New extension file (keeps the main `DaemonClient.swift` file from growing further). Mirrors structure of existing `MARK: -` sections.
+- [ ] Add `extension DaemonClient {` containing:
+  - `func listClaudeTokens() throws -> [ClaudeTokenWithUsage]` → `callNoParams(method: RPCMethod.claudeTokenList, ...)`
+  - `func addClaudeToken(name: String, token: String) throws -> ClaudeToken` → `call(method: RPCMethod.claudeTokenAdd, params: ClaudeTokenAddParams(name: name, token: token), ...)`
+  - `func deleteClaudeToken(id: UUID) throws` → `callVoid(method: RPCMethod.claudeTokenDelete, params: ClaudeTokenDeleteParams(id: id))`
+  - `func renameClaudeToken(id: UUID, name: String) throws` → `callVoid(...)`
+  - `func setGlobalDefaultClaudeToken(id: UUID?) throws` → `callVoid(...)`
+  - `func setRepoClaudeTokenOverride(repoID: UUID, tokenID: UUID?) throws` → `callVoid(...)`
+  - `func fetchClaudeTokenUsage(id: UUID) throws -> ClaudeTokenUsage` → `call(...)`
+  - `func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?) throws` → `callVoid(method: RPCMethod.terminalSwapClaudeToken, ...)`
+  - `func setAppForegroundState(isForeground: Bool) throws` → `callVoid(method: RPCMethod.appSetForegroundState, params: AppForegroundStateParams(isForeground: isForeground))` (only if Phase 07 added the RPC; if it didn't, omit and add a TODO + cross-link).
+- [ ] All methods must be `nonisolated` if they're plain wrappers around the actor's existing helpers — match the style of the existing methods (which are actor-isolated synchronous `throws` functions; callers `await` on the actor). Do NOT add `async` to the wrappers — `call`/`callVoid` are synchronous from inside the actor.
+- [ ] **Never** log token bytes. The `addClaudeToken` wrapper must not pass the token through any `Logger` call.
+
+### Task 4: Add published properties to `AppState`
+
+- [ ] In `Sources/TBDApp/AppState.swift`, after the existing `@Published var prStatuses` block, add:
+  - `@Published var claudeTokens: [ClaudeTokenWithUsage] = []`
+  - `@Published var globalDefaultClaudeTokenID: UUID? = nil`
+- [ ] Both must be on `@MainActor` (already implied by class declaration).
+
+### Task 5: Add helper methods to `AppState` (new file `AppState+ClaudeTokens.swift`)
+
+- [ ] Create `Sources/TBDApp/AppState+ClaudeTokens.swift` mirroring the pattern of `AppState+Notes.swift` etc.
+- [ ] `@MainActor extension AppState` with methods:
+  - `func refreshClaudeTokens() async` — calls `daemonClient.listClaudeTokens()` inside a `do/catch`, on success assigns to `self.claudeTokens` and updates `globalDefaultClaudeTokenID` from whichever element is marked default (or via a separate field on `ClaudeTokenWithUsage` — depends on Phase 01 model shape).
+  - `func addClaudeToken(name: String, token: String) async` — calls daemon, on success calls `await refreshClaudeTokens()`. On failure sets `alertMessage` / `alertIsError` like other helpers.
+  - `func deleteClaudeToken(id: UUID) async`
+  - `func renameClaudeToken(id: UUID, name: String) async`
+  - `func setGlobalDefaultClaudeToken(id: UUID?) async`
+  - `func setRepoClaudeTokenOverride(repoID: UUID, tokenID: UUID?) async`
+  - `func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?) async`
+  - `func fetchClaudeTokenUsage(id: UUID) async` — on success, mutates the matching entry in `self.claudeTokens` rather than refetching the whole list.
+- [ ] All methods set `alertMessage` on failure with a user-readable string; never include the token bytes in the alert.
+
+### Task 6: Wire delta handling for token + usage updates
+
+- [ ] In `AppState.handleDelta(_:)` add cases:
+  - `.claudeTokensChanged`: `Task { await self.refreshClaudeTokens() }`
+  - `.claudeTokenUsageUpdated(let payload)`: locate the matching token in `self.claudeTokens` by `payload.tokenID` and update its `usage` field in place. If no match, ignore (the next full refresh will pick it up).
+- [ ] Make sure both are inside the existing `switch` and the `default: break` clause still compiles.
+
+### Task 7: Forward app focus changes to the daemon
+
+- [ ] In `Sources/TBDApp/TBDApp.swift`, extend `AppDelegate`:
+  - Implement `applicationDidBecomeActive(_:)` → call into `AppState` (need a reference; either pass via `init` or look it up via the existing `@StateObject` indirection — easiest is to add a static-shared accessor on `AppState`, or call directly via `NotificationCenter` from inside `AppState.init` by observing `NSApplication.didBecomeActiveNotification` and `didResignActiveNotification`).
+  - **Preferred approach:** observe the notifications inside `AppState.init` (avoids coupling AppDelegate to AppState). In `init()`, after `startMemoryPressureMonitor()`, register two observers:
+    - `NSApplication.didBecomeActiveNotification` → `Task { try? await self.daemonClient.setAppForegroundState(isForeground: true) }`
+    - `NSApplication.didResignActiveNotification` → `Task { try? await self.daemonClient.setAppForegroundState(isForeground: false) }`
+  - Store the observer tokens and remove them in `deinit`.
+- [ ] Per `CLAUDE.md` unbundled-executable rule: `NotificationCenter.default.addObserver(forName:object:queue:using:)` does not require a bundle ID — safe to use without a guard. Document this in a comment.
+- [ ] **Branching test** (per CLAUDE.md branching rule): the gated behavior here is "send `setAppForegroundState` only when Phase 07's RPC method exists." If Phase 07 has not added the RPC, skip the observer registration and add a `// TODO Phase 07` comment. The test for "off" branch is implicit (compile-time absence); the "on" branch test goes in Task 9.
+
+### Task 8: Restart daemon + verify build
+
+- [ ] Run `scripts/restart.sh` (per `Sources/TBDShared/CLAUDE.md` — any TBDShared change requires a full restart).
+- [ ] Run `swift build` and confirm zero warnings/errors.
+- [ ] Run `swift test` (we touched TBDShared, per top-level CLAUDE.md).
+
+### Task 9: Smoke test in `Tests/TBDAppTests/`
+
+- [ ] Add `Tests/TBDAppTests/ClaudeTokenAppStateTests.swift`.
+- [ ] Note in the file header: `DaemonClient` is a concrete actor (no protocol), so we cannot inject a stub. These tests verify compile-time wiring + pure-Swift state mutations only. Full integration coverage lives in the daemon RPC tests (Phase 05/06/07) and manual QA per the parent plan's DoD.
+- [ ] Tests (using Swift Testing — `@Test` / `#expect`):
+  - `@Test func appState_initialClaudeTokensEmpty()` → construct `AppState` on `@MainActor`, assert `claudeTokens.isEmpty` and `globalDefaultClaudeTokenID == nil`.
+  - `@Test func appState_handlesUsageUpdatedDeltaInPlace()` → seed `appState.claudeTokens` with one entry, manually invoke `handleDelta(.claudeTokenUsageUpdated(...))` (may require making `handleDelta` `internal` instead of `private`, or exposing a test-only entry point), assert the in-place mutation took effect.
+  - `@Test func appState_handlesTokensChangedDeltaTriggersRefresh()` → just confirm the case is handled without crashing; the actual refresh will fail because no daemon is running, but the `Task` swallowing the error is the documented behavior.
+- [ ] If `handleDelta` must stay private, add an `#if DEBUG` test hook: `@MainActor func _testApplyDelta(_ delta: StateDelta) { handleDelta(delta) }`.
+
+### Task 10: Commit
+
+- [ ] Verify `swift build` passes.
+- [ ] Verify only files this phase touched are staged:
+  - `Sources/TBDShared/StateDelta.swift`
+  - `Sources/TBDApp/DaemonClient+ClaudeTokens.swift` (new)
+  - `Sources/TBDApp/AppState.swift`
+  - `Sources/TBDApp/AppState+ClaudeTokens.swift` (new)
+  - `Sources/TBDApp/TBDApp.swift` (only if AppDelegate path was taken instead of AppState observers)
+  - `Tests/TBDAppTests/ClaudeTokenAppStateTests.swift` (new)
+- [ ] Conventional commit: `feat: app-side claude token RPC client + state wiring`
+
+---
+
+## Out of scope (deferred to later phases)
+
+- Any SwiftUI view code — Phases 09–12.
+- Adding a `DaemonClientProtocol` for full mock-based testing — would require touching every existing call site; not justified for this feature alone.
+- Daemon-side broadcast of the new delta cases — that's the responsibility of Phases 05, 06, 07. This phase only adds the case definitions and the receiver. If those phases land before 08, just verify the broadcasts exist; if they land after, this phase's deltas will simply never fire until they do, and the smoke test still passes.
+
+## Risks
+
+- **Delta enum ordering:** Adding a new case at the end of `StateDelta` is Codable-safe (Swift synthesizes by case name, not ordinal). Do not reorder existing cases.
+- **Token bytes leakage:** The `addClaudeToken` path is the only place a raw token crosses the actor boundary. Audit the final diff for any `logger.*(... token ...)` or `print(... token ...)` calls before committing.
+- **Focus observer leak:** if observers aren't removed in `deinit`, the closure retains `self` and `AppState` (singleton-lifetime in this app) never deallocates — acceptable in practice but document it.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/09-settings-ui.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/09-settings-ui.md
@@ -1,0 +1,404 @@
+# Phase 09: Settings → Claude Tokens Tab
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 08
+> **Unblocks:** nothing (terminal UI phase)
+
+**Scope:** A new Settings tab for managing Claude tokens: list with usage badges and reset tooltips, add modal with `claude setup-token` guidance, rename/delete with in-use warning, and a global-default picker.
+
+## Context
+
+Phase 08 wired up `AppState.claudeTokens`, `globalDefaultClaudeTokenID`, `addClaudeToken(name:token:)`, `renameClaudeToken`, `deleteClaudeToken`, `setGlobalDefaultClaudeToken`, and `refreshClaudeTokens()`. Each `ClaudeToken` carries `id`, `name`, `kind` ("oauth" | "api_key"), `usage: ClaudeTokenUsage?` (with `fiveHourPercent`, `sevenDayPercent`, `fiveHourResetsAt`, `sevenDayResetsAt`, `fetchedAt`), and `lastStatus: String?`.
+
+This phase is purely SwiftUI. Mirror the rename UX from `RepoSettingsRow` (double-click to edit inline, Enter to commit, Esc to cancel).
+
+## Tasks
+
+### Task 1: Create file skeleton
+
+Create `Sources/TBDApp/Settings/ClaudeTokensSettingsView.swift` with imports and the top-level `ClaudeTokensSettingsView` struct stub:
+
+```swift
+import SwiftUI
+import TBDShared
+
+struct ClaudeTokensSettingsView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var showAddSheet = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            globalDefaultHeader
+            Divider()
+            tokenList
+            Spacer()
+            addButton
+        }
+        .padding(20)
+        .task { await appState.refreshClaudeTokens() }
+        .sheet(isPresented: $showAddSheet) {
+            AddClaudeTokenSheet()
+                .environmentObject(appState)
+        }
+    }
+}
+```
+
+### Task 2: Global default header
+
+Add the picker bound to `appState.globalDefaultClaudeTokenID`. The `nil` option represents the keychain login fallback.
+
+```swift
+private var globalDefaultHeader: some View {
+    HStack {
+        Text("Global default:")
+            .font(.headline)
+        Picker("", selection: Binding(
+            get: { appState.globalDefaultClaudeTokenID },
+            set: { newValue in
+                Task { await appState.setGlobalDefaultClaudeToken(newValue) }
+            }
+        )) {
+            Text("Default (claude keychain login)").tag(String?.none)
+            ForEach(appState.claudeTokens) { token in
+                Text(token.name).tag(String?.some(token.id))
+            }
+        }
+        .pickerStyle(.menu)
+        .labelsHidden()
+        Spacer()
+    }
+}
+```
+
+### Task 3: Token list
+
+Render rows in a `List` so selection/scrolling feels native. Use `ForEach` over `appState.claudeTokens`.
+
+```swift
+private var tokenList: some View {
+    List {
+        ForEach(appState.claudeTokens) { token in
+            ClaudeTokenRow(token: token)
+                .environmentObject(appState)
+        }
+    }
+    .listStyle(.inset)
+    .frame(minHeight: 200)
+}
+```
+
+### Task 4: Add button
+
+```swift
+private var addButton: some View {
+    Button {
+        showAddSheet = true
+    } label: {
+        Label("Add token", systemImage: "plus")
+    }
+}
+```
+
+### Task 5: ClaudeTokenRow scaffolding
+
+Create `ClaudeTokenRow` with state for inline rename and delete confirmation:
+
+```swift
+struct ClaudeTokenRow: View {
+    @EnvironmentObject var appState: AppState
+    let token: ClaudeToken
+
+    @State private var isEditingName = false
+    @State private var draftName = ""
+    @State private var showDeleteConfirm = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            nameView
+            kindBadge
+            Spacer()
+            statusBadges
+            usageView
+            timestampView
+            menuButton
+        }
+        .contentShape(Rectangle())
+        .confirmationDialog("Delete token?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                Task { await appState.deleteClaudeToken(token.id) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(deleteMessage)
+        }
+    }
+}
+```
+
+### Task 6: Inline rename UX (mirror RepoSettingsRow)
+
+Double-click to enter edit mode, commit on Enter, cancel on Esc.
+
+```swift
+@ViewBuilder
+private var nameView: some View {
+    if isEditingName {
+        TextField("", text: $draftName, onCommit: commitRename)
+            .textFieldStyle(.roundedBorder)
+            .frame(maxWidth: 180)
+            .onExitCommand { isEditingName = false }
+    } else {
+        Text(token.name)
+            .font(.body)
+            .onTapGesture(count: 2) {
+                draftName = token.name
+                isEditingName = true
+            }
+    }
+}
+
+private func commitRename() {
+    let trimmed = draftName.trimmingCharacters(in: .whitespaces)
+    isEditingName = false
+    guard !trimmed.isEmpty, trimmed != token.name else { return }
+    Task { await appState.renameClaudeToken(token.id, to: trimmed) }
+}
+```
+
+### Task 7: Kind and status badges
+
+```swift
+private var kindBadge: some View {
+    Text(token.kind == "oauth" ? "OAuth" : "API key")
+        .font(.caption2)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(Color.secondary.opacity(0.15))
+        .clipShape(Capsule())
+}
+
+@ViewBuilder
+private var statusBadges: some View {
+    if token.lastStatus == "http_401" {
+        Text("Invalid")
+            .font(.caption2).bold()
+            .padding(.horizontal, 6).padding(.vertical, 2)
+            .background(Color.red.opacity(0.2))
+            .foregroundColor(.red)
+            .clipShape(Capsule())
+    } else if token.lastStatus == "http_429" {
+        Text("Stale")
+            .font(.caption2).bold()
+            .padding(.horizontal, 6).padding(.vertical, 2)
+            .background(Color.orange.opacity(0.2))
+            .foregroundColor(.orange)
+            .clipShape(Capsule())
+    }
+}
+```
+
+### Task 8: Usage text + reset tooltip
+
+Format `5h X% · 7d Y%`. Show `—` when usage is nil. Tooltip shows reset times computed from `resetsAt`.
+
+```swift
+@ViewBuilder
+private var usageView: some View {
+    if let usage = token.usage {
+        let fiveH = Int((usage.fiveHourPercent * 100).rounded())
+        let sevenD = Int((usage.sevenDayPercent * 100).rounded())
+        Text("5h \(fiveH)% · 7d \(sevenD)%")
+            .font(.system(.caption, design: .monospaced))
+            .help(resetTooltip(usage))
+    } else {
+        Text("—")
+            .font(.caption)
+            .foregroundColor(.secondary)
+    }
+}
+
+private func resetTooltip(_ usage: ClaudeTokenUsage) -> String {
+    let fiveH = formatRelativeFuture(usage.fiveHourResetsAt)
+    let sevenD = formatRelativeFuture(usage.sevenDayResetsAt)
+    return "5h resets in \(fiveH) / 7d resets in \(sevenD)"
+}
+
+private func formatRelativeFuture(_ date: Date?) -> String {
+    guard let date else { return "—" }
+    let secs = max(0, Int(date.timeIntervalSinceNow))
+    let h = secs / 3600
+    let m = (secs % 3600) / 60
+    return "\(h)h \(m)m"
+}
+```
+
+### Task 9: Relative fetched-at timestamp
+
+Use `RelativeDateTimeFormatter`. Cache it as a static.
+
+```swift
+private static let relativeFormatter: RelativeDateTimeFormatter = {
+    let f = RelativeDateTimeFormatter()
+    f.unitsStyle = .abbreviated
+    return f
+}()
+
+@ViewBuilder
+private var timestampView: some View {
+    if let fetched = token.usage?.fetchedAt {
+        Text(Self.relativeFormatter.localizedString(for: fetched, relativeTo: Date()))
+            .font(.caption2)
+            .foregroundColor(.secondary)
+    }
+}
+```
+
+### Task 10: Trailing menu
+
+```swift
+private var menuButton: some View {
+    Menu {
+        Button("Set as global default") {
+            Task { await appState.setGlobalDefaultClaudeToken(token.id) }
+        }
+        Button("Rename…") {
+            draftName = token.name
+            isEditingName = true
+        }
+        Divider()
+        Button("Delete…", role: .destructive) {
+            showDeleteConfirm = true
+        }
+    } label: {
+        Image(systemName: "ellipsis")
+    }
+    .menuStyle(.borderlessButton)
+    .fixedSize()
+}
+
+private var inUseCount: Int {
+    appState.terminals.filter { $0.claudeTokenID == token.id }.count
+}
+
+private var deleteMessage: String {
+    let n = inUseCount
+    if n > 0 {
+        return "\(n) running terminal(s) are using this token. They'll keep running on it until closed. Delete anyway?"
+    }
+    return "This will remove the token from TBD. Are you sure?"
+}
+```
+
+### Task 11: AddClaudeTokenSheet — fields
+
+Use `SecureField` for the token (it's a secret).
+
+```swift
+struct AddClaudeTokenSheet: View {
+    @EnvironmentObject var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name = ""
+    @State private var token = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Add Claude Token").font(.headline)
+
+            Form {
+                TextField("Name", text: $name)
+                SecureField("Token", text: $token)
+                (Text("Run ")
+                    + Text("claude setup-token").font(.system(.caption, design: .monospaced))
+                    + Text(" in a terminal and paste the resulting sk-ant-oat01-... token."))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button(action: save) {
+                    if isSaving { ProgressView().controlSize(.small) }
+                    else { Text("Save") }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSave)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+    }
+}
+```
+
+### Task 12: AddClaudeTokenSheet — validation + save
+
+Client-side: name non-empty, not duplicate, token non-empty. Server-side covers format checks.
+
+```swift
+private var canSave: Bool {
+    let trimmedName = name.trimmingCharacters(in: .whitespaces)
+    guard !trimmedName.isEmpty, !token.isEmpty, !isSaving else { return false }
+    let duplicate = appState.claudeTokens.contains { $0.name == trimmedName }
+    return !duplicate
+}
+
+private func save() {
+    let trimmedName = name.trimmingCharacters(in: .whitespaces)
+    isSaving = true
+    errorMessage = nil
+    Task {
+        do {
+            try await appState.addClaudeToken(name: trimmedName, token: token)
+            await appState.refreshClaudeTokens()
+            await MainActor.run {
+                isSaving = false
+                dismiss()
+            }
+        } catch {
+            await MainActor.run {
+                isSaving = false
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+```
+
+### Task 13: Wire tab into SettingsView
+
+Open `Sources/TBDApp/Settings/SettingsView.swift`. Add the new `TabView` item alongside the existing tabs:
+
+```swift
+ClaudeTokensSettingsView()
+    .tabItem { Label("Claude Tokens", systemImage: "key.fill") }
+```
+
+Bump the frame height from `420` to `520` (or as needed) so the token list and add button fit comfortably without scrolling jitter.
+
+### Task 14: Build + manual verification
+
+Run `swift build` to confirm everything compiles. Then `scripts/restart.sh` and walk through:
+
+1. Open Settings → Claude Tokens tab. List is empty, global default picker shows only "Default (claude keychain login)".
+2. Click "+ Add token". Modal opens. Try Save with empty name → button disabled. Enter "Personal" + paste a real `sk-ant-oat01-...` token. Spinner appears, then modal dismisses.
+3. Row appears showing "Personal" + "OAuth" badge. Within a few seconds usage populates: e.g. `5h 12% · 7d 4%`. Hover the percentages → tooltip shows reset times.
+4. Double-click the name → inline edit. Type "Work", press Enter. Row updates.
+5. Open the `•••` menu → "Set as global default". Header picker now shows "Work".
+6. Add a second token "Bad" with an obviously invalid string → modal shows red error inline, stays open.
+7. Open a terminal that uses the "Work" token (Phase 10 work, may need to fake by inserting a row). Then `•••` → Delete… → confirm copy mentions "1 running terminal(s) are using this token". Cancel.
+8. Cancel modal closes without saving. Re-open and Cancel mid-spinner — should not crash.
+9. Force a 401 by editing the DB row's `last_status` to `http_401` → row shows red "Invalid" badge after refresh.
+10. Force a 429 similarly → amber "Stale" badge.
+
+Commit when green: `feat: add Claude Tokens settings tab`.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/10-repo-override-ui.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/10-repo-override-ui.md
@@ -1,0 +1,95 @@
+# Phase 10: Repo Override Picker
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 08
+> **Unblocks:** nothing
+
+**Scope:** Add a "Claude token override" picker to the per-repo settings UI. Options: "Inherit global default" (nil) or one of the stored tokens. Caption shows the currently-effective global default so users understand inheritance.
+
+## Context
+
+There is no separate per-repo settings sheet — `Sources/TBDApp/Settings/SettingsView.swift` renders each repo inline as a `RepoSettingsRow` (lines 132–212). The picker is added to that row.
+
+Phase 08 has already exposed:
+
+- `appState.claudeTokens: [ClaudeToken]`
+- `appState.setRepoClaudeTokenOverride(repoID:tokenID:)`
+- `repo.claudeTokenOverrideID: UUID?`
+
+We also assume the global default is reachable as `appState.defaultClaudeTokenID: UUID?` (set in earlier phases). If the actual property name differs, adjust during implementation — do not invent new state.
+
+## Design decision: no "force keychain login" option per repo
+
+The per-repo picker offers exactly two kinds of choices:
+
+1. **Inherit global default** — stored as `nil` in `repo.claudeTokenOverrideID`.
+2. **A specific named token** — stored as that token's UUID.
+
+We deliberately do **not** offer a third "Default (claude keychain login)" option at the per-repo level. Doing so would require distinguishing "inherit" from "force keychain" while both naturally map to `nil`. The two options to resolve that were:
+
+- **(a) Drop the option.** Per-repo override is either inherit or a specific token. Simpler, no schema change. The user can still force keychain login for *every* repo by clearing the global default in the global settings UI.
+- **(b) Introduce a sentinel UUID** (e.g. all-zero) meaning "force keychain even if a global default is set". Requires schema/model carve-outs and special-casing in the spawn path.
+
+We pick **(a)**. The tradeoff: a user who has set a global default token but wants *one specific repo* to use raw keychain login has no way to express that without clearing the global default. We accept this — it's an unusual workflow, and Phase 11+ can revisit if real users hit it.
+
+The caption below the picker makes the inheritance behavior visible so users aren't confused about what `nil` resolves to.
+
+## Tasks
+
+### Task 1: Add picker state and binding helper to `RepoSettingsRow`
+
+In `Sources/TBDApp/Settings/SettingsView.swift`, inside `RepoSettingsRow`, add a computed `Binding<UUID?>` that reads `repo.claudeTokenOverrideID` and on `set` calls `appState.setRepoClaudeTokenOverride(repoID: repo.id, tokenID: newValue)` inside a `Task`. Do not add `@State` for the selection — the source of truth is `appState.repos`, and the row already re-renders when `appState` publishes.
+
+### Task 2: Render the picker
+
+Below the existing `HStack` that shows branch + path (after line 194, still inside the outer `VStack`), add:
+
+```swift
+Picker("Claude token", selection: tokenOverrideBinding) {
+    Text("Inherit global default").tag(UUID?.none)
+    ForEach(appState.claudeTokens) { token in
+        Text(token.name).tag(UUID?.some(token.id))
+    }
+}
+.pickerStyle(.menu)
+.controlSize(.small)
+.font(.caption)
+```
+
+Tag types must match exactly (`UUID?.none` / `UUID?.some(...)`) or SwiftUI silently fails to preselect.
+
+### Task 3: Render the inheritance caption
+
+Directly under the picker, show a `Text` caption that resolves what `nil` currently means. Only render it when `repo.claudeTokenOverrideID == nil`:
+
+- If `appState.defaultClaudeTokenID` is non-nil and matches a token in `appState.claudeTokens`: `"Inheriting global default: <token.name>"`.
+- Otherwise: `"Inheriting global default: keychain login"`.
+
+Style: `.font(.caption2).foregroundStyle(.secondary)`.
+
+If `appState.defaultClaudeTokenID` doesn't exist under that exact name, locate the actual property added in earlier phases (search for `defaultClaudeToken` in `Sources/TBDApp/AppState.swift` and `Sources/TBDShared/Models.swift`) and use it. Do not introduce new state.
+
+### Task 4: Empty-tokens edge case
+
+If `appState.claudeTokens.isEmpty`, the picker still renders with only the "Inherit global default" row. That's acceptable — it degenerates to a no-op control. Do not hide the picker; users seeing a single-option picker is a useful hint that they need to add tokens in global settings.
+
+### Task 5: Build
+
+Run `swift build` and fix any errors. Pay attention to:
+
+- Tag type inference (force `UUID?` if needed via explicit `as UUID?`).
+- `ForEach` requires `ClaudeToken: Identifiable` — confirm it is, otherwise add `id: \.id`.
+- `setRepoClaudeTokenOverride` is async; wrap in `Task { await ... }` inside the binding setter.
+
+### Task 6: Manual verification
+
+No automated SwiftUI tests in this phase. Verify by hand:
+
+1. Open Settings → Repos. Confirm the picker appears under each repo with "Inherit global default" preselected.
+2. With at least two named tokens in global settings, pick a non-default token for repo A. Caption disappears (since override is no longer nil).
+3. Spawn a new terminal in a worktree of repo A. Spot-check (env var, log line, or whatever Phase 09 wired up) that the chosen token is used.
+4. Switch repo A back to "Inherit global default". Confirm the caption returns and reflects the current global default name (or "keychain login" if none).
+5. Clear the global default in global settings while repo A is set to inherit. Confirm caption updates live to "keychain login".
+6. Restart the app. Confirm the per-repo selection persists.
+
+Record any discrepancies as follow-up tasks; do not patch them in this phase.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/11-menu-bar.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/11-menu-bar.md
@@ -1,0 +1,128 @@
+# Phase 11: Menu Bar Claude Token Submenu
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 08
+> **Unblocks:** nothing
+
+**Scope:** Add a "Claude Token" section to the app menu bar showing each stored token with its 5h/7d usage, a checkmark on the current global default, and a "Manage tokens…" link into Settings. Selecting a row updates the global default (affects new spawns only).
+
+## Context
+
+The app uses SwiftUI `CommandMenu` for menu bar items, wired in `Sources/TBDApp/TBDApp.swift` via `TBDCommands(appState: appState)` inside `.commands { ... }`. Existing menus live in `Sources/TBDApp/Helpers/KeyboardShortcuts.swift` (`TBDCommands: Commands` with `@ObservedObject var appState: AppState`). They use plain `Button { ... }` with optional `.keyboardShortcut`, no checkmarks.
+
+Phase 08 already added `appState.claudeTokens: [ClaudeToken]`, `appState.globalDefaultClaudeTokenID: String?`, and `appState.setGlobalDefaultClaudeToken(id:)`. Each token is assumed to expose optional `usage5h: Double?` and `usage7d: Double?` (percentages 0–100); render `—` when nil.
+
+`CommandMenu`'s body re-evaluates when its enclosing `Commands` struct's observed state changes — `TBDCommands` already uses `@ObservedObject var appState`, so adding bindings to `appState.claudeTokens` / `appState.globalDefaultClaudeTokenID` will reactively update the menu without further wrapping.
+
+For "Manage tokens…": SwiftUI provides no documented way to pre-select a Settings tab from a `Button` action. Use `NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)` (the macOS 13+ selector) and let the user click the Claude Tokens tab. If a `SettingsLink` pattern already exists elsewhere, prefer that.
+
+## Tasks
+
+### Task 1: Create `ClaudeTokenMenu.swift`
+
+Create `Sources/TBDApp/MenuBar/ClaudeTokenMenu.swift` with a `ClaudeTokenMenu: Commands` struct:
+
+```swift
+import SwiftUI
+import TBDShared
+
+struct ClaudeTokenMenu: Commands {
+    @ObservedObject var appState: AppState
+
+    var body: some Commands {
+        CommandMenu("Claude Token") {
+            // Default (logged in) row
+            Button(action: {
+                Task { @MainActor in
+                    appState.setGlobalDefaultClaudeToken(id: nil)
+                }
+            }) {
+                Label(
+                    "Default (logged in)          —",
+                    systemImage: appState.globalDefaultClaudeTokenID == nil
+                        ? "checkmark"
+                        : ""
+                )
+            }
+
+            ForEach(appState.claudeTokens, id: \.id) { token in
+                Button(action: {
+                    let id = token.id
+                    Task { @MainActor in
+                        appState.setGlobalDefaultClaudeToken(id: id)
+                    }
+                }) {
+                    Label(
+                        Self.formatRow(token: token),
+                        systemImage: appState.globalDefaultClaudeTokenID == token.id
+                            ? "checkmark"
+                            : ""
+                    )
+                }
+            }
+
+            Divider()
+
+            Button("Manage tokens…") {
+                NSApp.sendAction(
+                    Selector(("showSettingsWindow:")),
+                    to: nil,
+                    from: nil
+                )
+            }
+        }
+    }
+
+    private static func formatRow(token: ClaudeToken) -> String {
+        let five = token.usage5h.map { String(format: "5h %2.0f%%", $0) } ?? "5h —"
+        let seven = token.usage7d.map { String(format: "7d %2.0f%%", $0) } ?? "7d —"
+        return "\(token.name)  \(five) · \(seven)"
+    }
+}
+```
+
+Adjust property names (`usage5h`, `usage7d`, `name`, `id`) to match the actual `ClaudeToken` model from Phase 08. If usage fields differ, mirror them here.
+
+### Task 2: Verify `mkdir` of `MenuBar` directory
+
+`Sources/TBDApp/MenuBar/` likely does not exist yet. Confirm with `ls Sources/TBDApp` and create the directory before writing the file. SPM picks it up automatically (no Package.swift edit needed).
+
+### Task 3: Wire menu into `TBDApp.swift`
+
+Edit `Sources/TBDApp/TBDApp.swift`. In the `.commands { ... }` block, add `ClaudeTokenMenu(appState: appState)` after `TBDCommands(appState: appState)`:
+
+```swift
+.commands {
+    TBDCommands(appState: appState)
+    ClaudeTokenMenu(appState: appState)
+}
+```
+
+### Task 4: Confirm reactivity assumption
+
+After build, open the running app, change the global default via the Settings UI (Phase 09/10), then open the menu bar — the checkmark should reflect the new default without restarting. If it doesn't, the body isn't observing changes; fix by extracting the menu contents into a small `View` with `@EnvironmentObject var appState: AppState` and rendering it inside the `CommandMenu`. (This is the documented escape hatch for `Commands` reactivity.)
+
+### Task 5: Verify "Manage tokens…" opens Settings
+
+Click "Manage tokens…" from the menu bar. The Settings window should appear. Pre-selecting the Claude Tokens tab is out of scope — note in a code comment that tab pre-selection is deferred.
+
+### Task 6: Build
+
+Run `swift build`. Fix any property-name mismatches against the actual `ClaudeToken` model. The menu must compile cleanly.
+
+### Task 7: Manual verification
+
+1. Launch the app, open the **Claude Token** menu in the menu bar.
+2. Confirm "Default (logged in)" has a checkmark on first launch (no global default).
+3. Confirm each stored token appears with `name  5h NN% · 7d NN%` (or `—` placeholders if usage is unavailable).
+4. Select a non-default token. Reopen the menu — the checkmark should move.
+5. Spawn a **new** Claude terminal in a worktree with no override; spot-check that its environment uses the newly-selected token (e.g. `echo $ANTHROPIC_API_KEY` or whatever env var Phase 08 sets).
+6. Confirm any **already-running** terminal continues to use its original token (no live swap).
+7. Confirm "Manage tokens…" opens the Settings window.
+
+## Out of Scope
+
+- Pre-selecting the Claude Tokens tab in Settings.
+- Live-updating running terminals (spec explicitly: new spawns only).
+- Per-repo override surfacing in this menu (lives in repo context menu, separate phase).
+- Automated tests — this phase is manual-verification only, consistent with the rest of the menu bar code.

--- a/docs/superpowers/plans/2026-04-06-claude-token-switcher/12-context-menu.md
+++ b/docs/superpowers/plans/2026-04-06-claude-token-switcher/12-context-menu.md
@@ -1,0 +1,138 @@
+# Phase 12: Claude Tab Context Menu
+
+> **Parent plan:** [../2026-04-06-claude-token-switcher.md](../2026-04-06-claude-token-switcher.md)
+> **Depends on:** Phase 06 (swap RPC), Phase 08 (client wiring)
+> **Unblocks:** nothing (final phase)
+
+**Scope:** Add a "Token" section to the claude tab context menu (`TabBar.swift:contextMenuContent`) containing a disabled header row showing the current token + 5h/7d usage and a "Swap token →" submenu that triggers a one-shot mid-conversation swap via `terminal.swapClaudeToken`.
+
+---
+
+## Context
+
+Spec section: **"Claude tab context menu — new section"** (`docs/superpowers/specs/2026-04-06-claude-token-switcher-design.md` §223–238).
+
+Target file: `Sources/TBDApp/TabBar.swift`. The relevant view is `TabBarItem` (private struct, ~line 150) and its `contextMenuContent` `@ViewBuilder` (~lines 249–269). The existing `if isClaudeTerminal { ... }` block currently contains:
+
+1. Fork Session button
+2. Suspend/Resume Claude button
+3. `Divider()`
+
+The new Token section must sit **above** these items (still inside the same `if isClaudeTerminal` block), with its own trailing `Divider()` separating it from Fork/Suspend.
+
+`TabBarItem` already receives a `terminal: Terminal?` prop (line 154) — `terminal.claudeTokenID` (added in Phase 01) is reachable from there. No new prop threading is needed for the token ID itself.
+
+What **is** needed: access to `appState.claudeTokens` (added in Phase 08) to look up token name + usage, and access to `appState.swapClaudeTokenOnTerminal(terminalID:newTokenID:)` to invoke the swap. `TabBarItem` is currently pure-prop and does not see `AppState`. Cleanest path: add an `@EnvironmentObject var appState: AppState` to `TabBarItem` (the parent `TerminalTabView` already has one, and SwiftUI propagates environment objects automatically — no parent change required). This is preferable to threading a token list + a swap closure through `TabBar` → `TabBarItem` props because the data is read-only inside the menu and the menu rebuilds on every open.
+
+The `Terminal` model field name from Phase 01 is assumed to be `claudeTokenID: UUID?`. The `ClaudeToken` model is assumed to expose `id: UUID`, `name: String`, and an optional `usage: ClaudeTokenUsage?` (with `fiveHourPercent: Int?` and `sevenDayPercent: Int?`). Confirm exact field names against Phase 01 / Phase 08 output during implementation and adjust formatting helpers accordingly.
+
+---
+
+## Tasks
+
+### Task 1: Expose AppState to TabBarItem
+
+- [ ] Add `@EnvironmentObject private var appState: AppState` to `TabBarItem` in `Sources/TBDApp/TabBar.swift`.
+- [ ] Verify `TabBar`'s parent (`TerminalTabView`) already injects `AppState` into the environment. If not, add `.environmentObject(appState)` at the appropriate ancestor (do **not** re-inject inside `TabBar` — environment objects flow down automatically).
+- [ ] `swift build` to confirm no preview/wiring breakage.
+
+### Task 2: Add a token-display formatting helper
+
+- [ ] Inside `TabBarItem`, add a private helper:
+  ```swift
+  private func formatTokenHeader(_ tokenID: UUID?) -> String {
+      guard let tokenID else { return "Token: Default (logged in)" }
+      guard let token = appState.claudeTokens.first(where: { $0.id == tokenID }) else {
+          return "Token: (missing)"
+      }
+      if let usage = token.usage,
+         let fiveH = usage.fiveHourPercent,
+         let sevenD = usage.sevenDayPercent {
+          return "Token: \(token.name) · 5h \(fiveH)% · 7d \(sevenD)%"
+      }
+      return "Token: \(token.name)"
+  }
+  ```
+- [ ] Add a sibling helper `formatTokenSubmenuLabel(_ token: ClaudeToken) -> String` that returns `"<name>  5h NN% · 7d NN%"` or just `"<name>"` when usage is nil. Verify field names against the Phase 01/08 model and adjust as needed.
+
+### Task 3: Insert the disabled header row
+
+- [ ] In `contextMenuContent`, inside the existing `if isClaudeTerminal { ... }` block, **above** the Fork button, add:
+  ```swift
+  Button(formatTokenHeader(terminal?.claudeTokenID)) {}
+      .disabled(true)
+  ```
+- [ ] Confirm visually that a disabled `Button` renders as a non-interactive header line in a SwiftUI `.contextMenu`. (SwiftUI menus do not support arbitrary `Text`; a disabled Button is the standard idiom.)
+
+### Task 4: Insert the "Swap token" submenu
+
+- [ ] Directly below the header row (still above Fork), add:
+  ```swift
+  Menu("Swap token") {
+      // Default option
+      Button {
+          guard let terminalID = terminal?.id else { return }
+          appState.swapClaudeTokenOnTerminal(terminalID: terminalID, newTokenID: nil)
+      } label: {
+          let prefix = terminal?.claudeTokenID == nil ? "● " : "  "
+          Text("\(prefix)Default (logged in)")
+      }
+
+      Divider()
+
+      ForEach(appState.claudeTokens) { token in
+          Button {
+              guard let terminalID = terminal?.id else { return }
+              appState.swapClaudeTokenOnTerminal(terminalID: terminalID, newTokenID: token.id)
+          } label: {
+              let prefix = terminal?.claudeTokenID == token.id ? "● " : "  "
+              Text("\(prefix)\(formatTokenSubmenuLabel(token))")
+          }
+      }
+  }
+  ```
+- [ ] Confirm `ClaudeToken` is `Identifiable` (or use `id: \.id`).
+- [ ] The selected-state marker uses a leading `●` for the current token and two spaces of padding for the others to keep labels aligned. SwiftUI's menu does not support `Image(systemName:)` checkmarks as a leading affordance reliably across the macOS menu styles, so a unicode bullet is the simplest and matches the spec mockup (`●`/`○`).
+
+### Task 5: Add the trailing divider
+
+- [ ] After the `Menu("Swap token") { ... }` block and **before** the existing `Button(action: onFork)`, insert a `Divider()`.
+- [ ] The result inside `if isClaudeTerminal` should read in this order:
+  1. Disabled header `Button`
+  2. `Menu("Swap token") { ... }`
+  3. `Divider()`
+  4. `Button(action: onFork) { ... }` (unchanged)
+  5. `Button(action: isSuspended ? onResume : onSuspend) { ... }` (unchanged)
+  6. `Divider()` (the existing one)
+
+### Task 6: Build verification
+
+- [ ] `swift build` passes.
+- [ ] No new warnings introduced in `TabBar.swift`.
+- [ ] If `Sources/TBDApp/AppState.swift` does not yet expose `claudeTokens` or `swapClaudeTokenOnTerminal(terminalID:newTokenID:)`, halt and report — this phase **depends on Phase 08** and should not stub them locally.
+
+### Task 7: Manual verification
+
+Per CLAUDE.md, no automated UI test exists for context menus. Verify by hand:
+
+- [ ] Restart with `scripts/restart.sh`.
+- [ ] Open a worktree, spawn a Claude tab with **no** token configured. Right-click the tab. Verify the header shows `"Token: Default (logged in)"` and the submenu lists "Default (logged in)" with a leading `●` plus all configured tokens unmarked.
+- [ ] Configure at least one token in Settings (Phase 09). Right-click again. Verify the submenu lists that token with a usage badge (e.g. `"Personal  5h 42% · 7d 18%"`) and no leading `●`.
+- [ ] Click that token in the submenu. Verify the daemon respawns claude with `--resume`, the broadcast updates `terminal.claudeTokenID`, and on re-opening the menu the header now shows `"Token: Personal · 5h 42% · 7d 18%"` and the bullet has moved.
+- [ ] Inside the resumed pane, type a message and confirm prior conversation context is preserved (the spec's correctness criterion for swap).
+- [ ] Verify the **global default** in the menu bar (Phase 11) and the **repo override** in Repo Settings (Phase 10) are **unchanged** — this swap is one-shot per the spec.
+- [ ] Right-click a non-claude (shell) tab. Verify the Token section does **not** appear (still gated by `isClaudeTerminal`).
+
+### Task 8: Commit
+
+- [ ] Stage only `Sources/TBDApp/TabBar.swift` (and any environment-object plumbing file you had to touch in Task 1, if applicable).
+- [ ] Commit with `feat: add token swap section to claude tab context menu`.
+
+---
+
+## Out of scope (explicitly dropped during brainstorming)
+
+- "Clone tab with different token" action
+- "Pin to token" action
+- A "Refresh usage now" menu item
+- Any change to repo override or global default from this menu — swap is **one-shot per terminal**

--- a/docs/superpowers/specs/2026-04-06-claude-token-switcher-design.md
+++ b/docs/superpowers/specs/2026-04-06-claude-token-switcher-design.md
@@ -1,0 +1,289 @@
+# Multi-token Claude switcher for tbd
+
+**Status:** Design approved, ready for implementation plan
+**Date:** 2026-04-06
+
+## Motivation
+
+The user holds multiple Claude accounts and wants to swap between them when one runs out of quota, without losing conversation context. Today, tbd spawns `claude` with no auth overrides and inherits whatever OAuth login is stored in Claude Code's keychain. There's no way to store additional tokens, swap between them, or see how much headroom each one has.
+
+## Goals
+
+1. Store multiple named Claude tokens securely and let the user designate a global default.
+2. Allow per-repo override of the global default.
+3. Allow a one-shot mid-conversation swap of a running claude terminal's token — without losing context.
+4. Show 5-hour and 7-day usage percentages per token, lazily fetched and cached.
+
+## Non-goals
+
+- Per-terminal persistent override (covered by one-shot swap).
+- `CLAUDE_CONFIG_DIR` isolation per token — all tokens share `~/.claude` so `--resume` works across swaps.
+- Aggressive polling, usage graphs, historical tracking.
+- Managing tokens for tools other than `claude` CLI.
+
+## Background: how Claude Code auth works
+
+- `claude setup-token` produces a long-lived OAuth token of the form `sk-ant-oat01-...`, backed by a Claude.ai Pro/Max subscription.
+- Setting `CLAUDE_CODE_OAUTH_TOKEN=<token>` in a process's environment overrides the keychain login for that process only, with no interactive prompt.
+- The undocumented endpoint `GET https://api.anthropic.com/api/oauth/usage` with `Authorization: Bearer <oauth-token>` and `anthropic-beta: oauth-2025-04-20` returns `{ five_hour: { utilization, resets_at }, seven_day: { utilization, resets_at } }`. Costs zero tokens. Rate-limited (persistent 429s reported in anthropics/claude-code#31021), so polling must be conservative.
+- `sk-ant-api03-...` console API keys do not support the OAuth usage endpoint. They can still be stored and used for auth, but will show no usage numbers.
+
+## Data model
+
+New GRDB migration (next sequential version in `Database.swift`), adding:
+
+### `claude_tokens` table
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | TEXT (UUID) | Primary key |
+| `name` | TEXT | Unique, user-supplied (e.g. "Personal", "Work") |
+| `keychain_ref` | TEXT | Opaque identifier; actual token bytes live in macOS Keychain under service `app.tbd.claude-token`, account = this UUID |
+| `kind` | TEXT | `oauth` or `api_key`, inferred from prefix at paste time |
+| `created_at` | DATETIME | |
+| `last_used_at` | DATETIME | Nullable; updated on spawn |
+
+### `claude_token_usage` table (cache)
+
+| Column | Type | Notes |
+|---|---|---|
+| `token_id` | TEXT | FK to `claude_tokens.id`, primary key |
+| `five_hour_pct` | REAL | Nullable |
+| `seven_day_pct` | REAL | Nullable |
+| `five_hour_resets_at` | DATETIME | Nullable |
+| `seven_day_resets_at` | DATETIME | Nullable |
+| `fetched_at` | DATETIME | Nullable |
+| `last_status` | TEXT | `ok`, `http_429`, `http_401`, `network_error` |
+
+### `config` table additions
+
+| Column | Type | Notes |
+|---|---|---|
+| `default_claude_token_id` | TEXT | Nullable, FK to `claude_tokens.id`. Null = use claude's own keychain login. |
+
+### `repo` table additions
+
+| Column | Type | Notes |
+|---|---|---|
+| `claude_token_override_id` | TEXT | Nullable, FK to `claude_tokens.id`. Null = inherit global default. |
+
+### `terminal` table additions
+
+| Column | Type | Notes |
+|---|---|---|
+| `claude_token_id` | TEXT | Nullable. Records which token this terminal was actually spawned with (after override/default resolution and any subsequent swap). Used by UI to show the current token and to respawn on swap. |
+
+All new fields have `.defaults(to:)` in the migration. Matching updates land in the same commit in:
+- `Sources/TBDDaemon/Database/` record types
+- `Sources/TBDShared/Models.swift` (new fields optional)
+
+## Token storage
+
+macOS Keychain via Security.framework. Wrapper at `Sources/TBDDaemon/Keychain/ClaudeTokenKeychain.swift`:
+
+```swift
+enum ClaudeTokenKeychain {
+    static func store(id: String, token: String) throws
+    static func load(id: String) throws -> String?
+    static func delete(id: String) throws
+}
+```
+
+Service constant `app.tbd.claude-token`, account field = token UUID. No Touch ID gate in v1. Tokens never written to disk outside Keychain, never logged, never included in error messages.
+
+### Keychain implementation notes (verified via dry run 2026-04-06)
+
+A Swift `SecItem` round-trip was executed end-to-end (`SecItemAdd` → `SecItemCopyMatching` → update → `SecItemDelete` → load-after-delete returned `errSecItemNotFound` / -25300) and confirmed the API behaves as expected on this machine.
+
+- **Upsert pattern.** `SecItemAdd` returns `errSecDuplicateItem` when an entry exists, so `store(id:, token:)` performs `SecItemDelete` + `SecItemAdd` as a single unit for both initial writes and updates. No `SecItemUpdate` needed.
+- **Access attributes.** Use the default `kSecAttrAccessibleWhenUnlocked`, no `SecAccessControl`, no biometric gate. Reads succeed without prompts once the login keychain is unlocked — consistent with the v1 no-Touch-ID decision.
+- **Unbundled-executable caveat.** TBDApp runs as a bare SPM executable, not a `.app` bundle (see `CLAUDE.md`). Keychain APIs do work without a bundle identifier — unlike `UNUserNotificationCenter` — but items stored by a SPM binary get the calling binary's path in their ACL. After a rebuild, the daemon binary path changes and macOS may show a one-time *"tbd-daemon wants to use your keychain"* prompt the first time a rebuilt binary tries to read an existing item. Expected UX, not a defect. A user can click "Always Allow" to suppress subsequent prompts for that binary path.
+
+## Token resolution
+
+When spawning a `--type claude` terminal, the daemon resolves the token in order:
+
+1. If the repo has `claude_token_override_id` set → use that token.
+2. Else if `config.default_claude_token_id` is set → use that token.
+3. Else → no env var injection. Claude uses its own keychain login.
+
+The resolved token's UUID is written to `terminal.claude_token_id` at spawn time (null if none resolved). `last_used_at` is bumped on the token row.
+
+## Spawn mechanism
+
+The existing claude spawn path at `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift:38` gains a branch:
+
+- If a token was resolved, the daemon loads the token from Keychain and prepends `CLAUDE_CODE_OAUTH_TOKEN=<value> ` to the shell command string before handing it to tmux.
+- If no token was resolved, the command is unchanged from today.
+
+No `CLAUDE_CONFIG_DIR` injection — all tokens share `~/.claude`, which means:
+- `claude --resume` works across token swaps (critical for mid-conversation swap).
+- Settings, MCP config, and CLAUDE.md are shared across tokens.
+- The in-claude `/resume` picker shows sessions from all accounts interleaved.
+
+## Mid-conversation token swap
+
+New RPC: `terminal.swapClaudeToken(terminal_id: UUID, new_token_id: UUID?)`.
+
+Daemon flow:
+
+1. Look up the terminal's current claude session ID (already tracked for the existing resume flow).
+2. Send `C-c` to the pane, wait 500 ms for the running claude process to terminate.
+3. Respawn `claude --resume <session-id> --dangerously-skip-permissions` in the same pane. If `new_token_id` is non-null, prefix with `CLAUDE_CODE_OAUTH_TOKEN=<value> `; if null, omit (falls back to keychain login).
+4. Update `terminal.claude_token_id` to the new value. **One-shot only** — does not write to `repo.claude_token_override_id` or `config.default_claude_token_id`.
+5. Trigger an immediate usage fetch for the new token (see below).
+
+If `--resume` fails (stale session, claude crashes), the pane is left in its dead state for the user to close manually. Daemon surfaces the error via existing terminal-status channels; it does not retry automatically.
+
+## Usage fetching
+
+New module `Sources/TBDDaemon/Claude/ClaudeUsageFetcher.swift`:
+
+```swift
+struct ClaudeUsageResult {
+    var fiveHourPct: Double
+    var sevenDayPct: Double
+    var fiveHourResetsAt: Date
+    var sevenDayResetsAt: Date
+}
+
+enum ClaudeUsageStatus { case ok(ClaudeUsageResult), http429, http401, networkError }
+
+func fetchUsage(token: String) async -> ClaudeUsageStatus
+```
+
+Implementation: `URLSession` GET to `https://api.anthropic.com/api/oauth/usage` with:
+- `Authorization: Bearer <token>`
+- `anthropic-beta: oauth-2025-04-20`
+
+Parses both `five_hour` and `seven_day` blocks.
+
+### Triggers
+
+| Trigger | Notes |
+|---|---|
+| Token added in Settings | Validates + first reading. 401 → reject save. |
+| UI surface opened (menu bar submenu, context menu on claude tab, Settings tab) | Lazy fetch; dedupe if `fetched_at < 60s` ago. |
+| Token swap (RPC) | Immediate fetch for the newly selected token. |
+| Background poll every 30 min per token | Staggered across first 30 s of daemon startup. |
+| App focus regained after >10 min unfocused | Resume background poll + immediate fetch for all tokens. |
+
+### Rules
+
+- **OAuth tokens only.** Tokens with `kind = api_key` are skipped permanently and displayed as `—`.
+- **On HTTP 429:** back off that specific token to 60 min until next success. Log once, do not surface as an error. UI shows last cached value with a `· stale` indicator.
+- **On HTTP 401:** mark the token invalid (red badge in Settings). Stop polling that token. Do not auto-delete — user may be rotating.
+- **App unfocused >10 min:** pause all background polling until focus returns.
+
+All successful results are written to `claude_token_usage` and broadcast to the app via the existing state-update channel so UI stays live.
+
+## UI
+
+### Settings → new "Claude Tokens" tab
+
+Top of tab: `Global default: [Default (claude keychain login) ▾]` picker. Options: "Default (claude keychain login)" + each stored token.
+
+List of tokens below. Each row shows:
+- Name
+- Kind badge (`OAuth` or `API key`)
+- Usage: `5h 42% · 7d 18%` with relative `fetched_at` timestamp (or `—` for API keys, or a red "Invalid" badge, or "Stale" badge after a 429)
+- Tooltip on the percentage: `Resets in 2h 14m` (computed from `resets_at`)
+- Row actions: rename, delete, "Set as global default"
+
+"+" button opens an add-token modal:
+- Field: `Name` (required, unique)
+- Field: `Token` (required, monospaced input)
+- Tooltip below the token field: *"Run `claude setup-token` in a terminal and paste the resulting `sk-ant-oat01-...` token here."*
+- On save:
+  - Detect kind from prefix (`sk-ant-oat01-` → oauth, `sk-ant-api03-` → api_key, else → reject).
+  - If oauth: call `/api/oauth/usage` to validate. 401 → reject with "Token invalid". 200 → store in Keychain, insert row, cache the fresh usage.
+  - If api_key: warn "Usage percentage is not available for API keys. Continue?" On confirm, store without validation.
+
+Delete flow: if any terminals have `claude_token_id = <this>`, confirm with "N running terminal(s) are using this token. They'll keep running on this token until closed. Delete anyway?"
+
+### Repo settings sheet (existing)
+
+New row: `Claude token override: [Inherit global default ▾]` picker. Options: "Inherit global default", "Default (claude keychain login)", + each stored token. Writes to `repo.claude_token_override_id`.
+
+### Menu bar — TBD menu → new "Claude Token" submenu
+
+```
+● Default (logged in)         —
+○ Personal          5h 42% · 7d 18%
+○ Work              5h  8% · 7d  3%
+──
+Manage tokens…
+```
+
+- `●` marks the currently selected **global default**.
+- Selecting a row updates `config.default_claude_token_id`. Takes effect for newly spawned claude terminals. Does not touch repo overrides or running terminals.
+- "Manage tokens…" opens the Settings tab.
+- Usage values come from the `claude_token_usage` cache; opening the submenu triggers a lazy fetch (subject to 60 s dedupe).
+
+### Claude tab context menu — new section
+
+Rendered only on `--type claude` terminals. Section sits above existing context-menu items, separated by a divider.
+
+```
+Token: Personal · 5h 42% · 7d 18%   [disabled header]
+Swap token →
+    ● Personal           5h 42% · 7d 18%
+    ○ Work               5h  8% · 7d  3%
+    ○ Default (logged in)            —
+```
+
+- Header shows `terminal.claude_token_id`'s current state. If null: `Token: Default (logged in)`.
+- "Swap token" submenu triggers `terminal.swapClaudeToken` RPC. One-shot — does not change repo or global default.
+- Usage values come from cache; opening the context menu triggers a lazy fetch.
+
+## Failure modes
+
+| Case | Behavior |
+|---|---|
+| Token deleted while terminals use it | Terminals keep running (env was set at spawn). On next swap/resume from the daemon, falls back to repo/global default. Settings delete confirmation surfaces the count. |
+| `/api/oauth/usage` 429 | Back off that token to 60 min. UI shows last cached value with `· stale`. |
+| `/api/oauth/usage` 401 | Mark token invalid. Stop polling. Red badge in Settings. |
+| Swap during active claude prompt | Daemon sends `C-c`, waits 500 ms, respawns. If in-flight response is lost, user notices and can redo the message from the resumed conversation. |
+| `claude --resume` fails after swap | Pane left in its dead state. Error surfaced via existing terminal-status channel. |
+| Keychain access denied | Settings surfaces a clear error. Tokens unavailable until resolved. No plaintext fallback. |
+| App running on a machine without the token in its Keychain (e.g. state.db restored from backup) | Token rows exist but `ClaudeTokenKeychain.load` returns nil. Settings shows "Missing from Keychain — re-add". Spawns skip the env prefix and fall back as if no token resolved. |
+
+## File layout
+
+**New:**
+- `Sources/TBDDaemon/Database/ClaudeTokenRecord.swift`
+- `Sources/TBDDaemon/Database/ClaudeTokenUsageRecord.swift`
+- `Sources/TBDDaemon/Keychain/ClaudeTokenKeychain.swift`
+- `Sources/TBDDaemon/Claude/ClaudeUsageFetcher.swift`
+- `Sources/TBDDaemon/Claude/ClaudeTokenResolver.swift` (resolution order + Keychain load)
+- `Sources/TBDDaemon/Server/RPCRouter+ClaudeTokenHandlers.swift` (CRUD + swap RPC)
+- `Sources/TBDApp/Settings/ClaudeTokensSettingsView.swift`
+- `Sources/TBDApp/MenuBar/ClaudeTokenMenu.swift`
+
+**Modified:**
+- `Sources/TBDDaemon/Database/Database.swift` — new sequential migration
+- `Sources/TBDShared/Models.swift` — new token/usage model types, new optional fields on Config/Repo/Terminal
+- `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift` — env prefix on spawn, `swapClaudeToken` handler
+- `Sources/TBDApp/Settings/SettingsView.swift` — new tab
+- Existing repo settings sheet — new picker row
+- Existing claude-tab context menu builder — new section
+
+## Testing
+
+- **Migration test** applies cleanly to an existing DB, decodes pre-existing rows.
+- **Keychain wrapper** round-trip (store → load → delete) test.
+- **Token resolution** precedence test: per-repo beats global; null repo falls through; both null = no env.
+- **Spawn test:** when a token resolves, command string begins with `CLAUDE_CODE_OAUTH_TOKEN=`; when none, command is byte-identical to today.
+- **Usage fetcher:** mock `URLSession` for 200/401/429/network error; assert parsed fields and status mapping.
+- **Backoff:** after 429, next scheduled poll is 60 min out; after subsequent 200, returns to 30 min.
+- **Stagger:** N tokens polling on startup spread across 0–30 s.
+- **Swap RPC:** `terminal.claude_token_id` updated, session ID preserved, new command string includes new token's env.
+- **Per CLAUDE.md branching rule:** each gated branch in resolution and env injection has a test asserting on/off behavior.
+
+## Open questions (deferred)
+
+- Whether to fetch usage reset timestamps in a machine-readable format usable for more than tooltips (e.g. "Personal resets in 12 min" alerts).
+- Whether to surface total remaining budget as a tbd menu bar badge when the active default is running low.
+- Touch ID gating on Keychain reads.
+
+These can be layered on without schema changes.


### PR DESCRIPTION
## Summary
- Adds a multi-token Claude switcher: store multiple OAuth tokens, set a global default with per-repo overrides, and swap tokens mid-conversation by forking the session into a new tab.
- Tokens stored as 0600 files at `~/.tbd/claude-tokens/<uuid>.token` (Keychain rejected — code-signing-free SPM daemon can't get a stable ACL across rebuilds without a GUI auth prompt).
- Token-aware spawn paths: `WorktreeCreate`, `TerminalCreate`, fork, swap, and **suspend/resume** all route through `ClaudeSpawnCommandBuilder` and persist `claudeTokenID` on the terminal row, so the override survives restarts.
- UI: Settings → Claude Tokens manages the list; menu bar shows the active default; Claude tabs display the token name (numbered "Michel 1 / Michel 2" when forking the same token); right-click → "Swap token" opens a fresh forked tab on the chosen account.

## Test plan
- [ ] Add a token via Settings → Claude Tokens; verify the row appears with a "Saved" badge (and an "Unverified" orange badge if `/api/oauth/usage` 403s — expected for `claude setup-token` tokens lacking `user:profile` scope).
- [ ] Set a global default; create a new worktree; confirm the spawned Claude tab is labeled with the token name and the process is using that token (`echo \$CLAUDE_CODE_OAUTH_TOKEN` in a shell tab).
- [ ] Set a per-repo override on a different repo; create a worktree there; confirm it uses the override (not the global default).
- [ ] In a Claude tab, right-click → "Swap token → \<other token\>"; verify a NEW tab opens (old tab untouched), is auto-selected, and the label shows the new token name.
- [ ] Suspend a Claude tab with a non-default token, then resume; verify the resumed process is still on the correct token (covered by `SuspendResumeCoordinatorTests.resumeInjectsTokenWhenResolverProvided`).
- [ ] Restart the daemon; reopen the worktree; verify token-labeled tabs reload with their token name (not "Terminal N").
- [ ] `swift test` — 319/319 passing locally.