### PR TITLE
feat: basic Codex CLI terminal type with CODEX_HOME isolation

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -102,7 +102,7 @@ extension AppState {
                 type: .codex
             )
             terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: terminal.label)
             tabs[worktreeID, default: []].append(tab)
         } catch {
             logger.error("Failed to create Codex terminal: \(error)")

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -93,6 +93,23 @@ extension AppState {
         }
     }
 
+    /// Create a Codex terminal in a worktree and add a new tab for it.
+    func createCodexTerminal(worktreeID: UUID) async {
+        do {
+            let terminal = try await daemonClient.createTerminal(
+                worktreeID: worktreeID,
+                cmd: nil,
+                type: .codex
+            )
+            terminals[worktreeID, default: []].append(terminal)
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            tabs[worktreeID, default: []].append(tab)
+        } catch {
+            logger.error("Failed to create Codex terminal: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
     /// Fork a Claude terminal by resuming from an existing session ID.
     func forkClaudeTerminal(worktreeID: UUID, sessionID: String, tokenID: UUID? = nil) async {
         do {

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -10,6 +10,7 @@ struct TabBar: View {
     @Binding var activeTabIndex: Int
     var onAddShell: () -> Void = {}
     var onAddClaude: () -> Void = {}
+    var onAddCodex: () -> Void = {}
     var onAddNote: () -> Void = {}
     var onCloseTab: (Int) -> Void
     var terminalForTab: (UUID) -> Terminal? = { _ in nil }
@@ -48,6 +49,7 @@ struct TabBar: View {
             AddTabButton(
                 onAddShell: onAddShell,
                 onAddClaude: onAddClaude,
+                onAddCodex: onAddCodex,
                 onAddNote: onAddNote
             )
             Spacer()
@@ -66,6 +68,7 @@ struct TabBar: View {
 private struct AddTabButton: View {
     let onAddShell: () -> Void
     let onAddClaude: () -> Void
+    let onAddCodex: () -> Void
     let onAddNote: () -> Void
     @State private var isHovering = false
 
@@ -103,6 +106,10 @@ private struct AddTabButton: View {
         claudeItem.image = claudeImage
         menu.addItem(claudeItem)
 
+        let codexItem = NSMenuItem(title: "Codex", action: nil, keyEquivalent: "")
+        codexItem.image = NSImage(systemSymbolName: "chevron.left.forwardslash.chevron.right", accessibilityDescription: nil)
+        menu.addItem(codexItem)
+
         menu.addItem(.separator())
 
         let noteItem = NSMenuItem(title: "Note", action: nil, keyEquivalent: "")
@@ -111,12 +118,14 @@ private struct AddTabButton: View {
 
         // Use a coordinator to handle menu item actions via closures
         let coordinator = MenuCoordinator(
-            onShell: onAddShell, onClaude: onAddClaude, onNote: onAddNote
+            onShell: onAddShell, onClaude: onAddClaude, onCodex: onAddCodex, onNote: onAddNote
         )
         shellItem.target = coordinator
         shellItem.action = #selector(MenuCoordinator.addShell)
         claudeItem.target = coordinator
         claudeItem.action = #selector(MenuCoordinator.addClaude)
+        codexItem.target = coordinator
+        codexItem.action = #selector(MenuCoordinator.addCodex)
         noteItem.target = coordinator
         noteItem.action = #selector(MenuCoordinator.addNote)
 
@@ -132,16 +141,19 @@ private struct AddTabButton: View {
 private class MenuCoordinator: NSObject {
     let onShell: () -> Void
     let onClaude: () -> Void
+    let onCodex: () -> Void
     let onNote: () -> Void
 
-    init(onShell: @escaping () -> Void, onClaude: @escaping () -> Void, onNote: @escaping () -> Void) {
+    init(onShell: @escaping () -> Void, onClaude: @escaping () -> Void, onCodex: @escaping () -> Void, onNote: @escaping () -> Void) {
         self.onShell = onShell
         self.onClaude = onClaude
+        self.onCodex = onCodex
         self.onNote = onNote
     }
 
     @objc func addShell() { onShell() }
     @objc func addClaude() { onClaude() }
+    @objc func addCodex() { onCodex() }
     @objc func addNote() { onNote() }
 }
 

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -188,6 +188,10 @@ private struct TabBarItem: View {
         terminal?.claudeSessionID != nil
     }
 
+    private var isCodexTerminal: Bool {
+        terminal?.label == "Codex"
+    }
+
     private var isSuspended: Bool {
         terminal?.suspendedAt != nil
     }
@@ -331,6 +335,10 @@ private struct TabBarItem: View {
                     .foregroundStyle(style)
             } else if isClaudeTerminal {
                 Text("✳")
+                    .font(.system(size: 10))
+                    .foregroundStyle(style)
+            } else if isCodexTerminal {
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
                     .font(.system(size: 10))
                     .foregroundStyle(style)
             } else {

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -116,6 +116,12 @@ private struct SingleWorktreeView: View {
                                 selectLastTab()
                             }
                         },
+                        onAddCodex: {
+                            Task {
+                                await appState.createCodexTerminal(worktreeID: worktreeID)
+                                selectLastTab()
+                            }
+                        },
                         onAddNote: {
                             Task {
                                 await appState.createNote(worktreeID: worktreeID)

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -1,0 +1,27 @@
+import Foundation
+import TBDShared
+
+/// Manages per-repo isolated `CODEX_HOME` directories under
+/// `~/.tbd/agents/codex/<repoID>/`. This keeps TBD-launched codex sessions
+/// from touching the user's real `~/.codex/` — so config, hooks, and
+/// sessions stay scoped per repo and TBD never pollutes global codex state.
+struct CodexHomeManager: Sendable {
+    let baseDirectory: URL
+
+    init(
+        baseDirectory: URL = TBDConstants.configDir.appendingPathComponent("agents/codex", isDirectory: true)
+    ) {
+        self.baseDirectory = baseDirectory
+    }
+
+    func homeDirectory(forRepoID repoID: UUID) -> URL {
+        baseDirectory.appendingPathComponent(repoID.uuidString.lowercased(), isDirectory: true)
+    }
+
+    @discardableResult
+    func ensureHome(forRepoID repoID: UUID) throws -> URL {
+        let home = homeDirectory(forRepoID: repoID)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        return home
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -30,6 +30,37 @@ extension RPCRouter {
         var env = SystemPromptBuilder.promptLayers(repo: repo, worktree: worktree)
         env["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
 
+        // Codex branch: minimal launch with isolated CODEX_HOME. No session
+        // tracking, no system prompt injection, no token resolution. Session
+        // resume / state detection / hooks are tracked as follow-up issues.
+        if params.type == .codex {
+            let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
+            env["CODEX_HOME"] = codexHome.path
+
+            let window = try await tmux.createWindow(
+                server: worktree.tmuxServer,
+                session: "main",
+                cwd: worktree.path,
+                shellCommand: "codex --full-auto",
+                env: env
+            )
+
+            let terminal = try await db.terminals.create(
+                worktreeID: params.worktreeID,
+                tmuxWindowID: window.windowID,
+                tmuxPaneID: window.paneID,
+                label: "Codex",
+                claudeSessionID: nil,
+                claudeTokenID: nil
+            )
+
+            subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
+                terminalID: terminal.id, worktreeID: terminal.worktreeID, label: terminal.label
+            )))
+
+            return try RPCResponse(result: terminal)
+        }
+
         let isClaudeType = params.type == .claude || params.resumeSessionID != nil
         let claudeSessionID: String?
         let label: String?

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -33,16 +33,24 @@ extension RPCRouter {
         // Codex branch: minimal launch with isolated CODEX_HOME. No session
         // tracking, no system prompt injection, no token resolution. Session
         // resume / state detection / hooks are tracked as follow-up issues.
+        //
+        // Build env independently — do NOT inherit the Claude-shaped
+        // TBD_PROMPT_CONTEXT / TBD_PROMPT_RENAME / TBD_PROMPT_INSTRUCTIONS
+        // vars from SystemPromptBuilder.promptLayers; those describe TBD as
+        // a Claude-centric host and would be misleading noise inside a
+        // Codex pane.
         if params.type == .codex {
             let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
-            env["CODEX_HOME"] = codexHome.path
+            var codexEnv: [String: String] = [:]
+            codexEnv["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
+            codexEnv["CODEX_HOME"] = codexHome.path
 
             let window = try await tmux.createWindow(
                 server: worktree.tmuxServer,
                 session: "main",
                 cwd: worktree.path,
                 shellCommand: "codex --full-auto",
-                env: env
+                env: codexEnv
             )
 
             let terminal = try await db.terminals.create(

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -341,6 +341,7 @@ public struct WorktreeReorderParams: Codable, Sendable {
 public enum TerminalCreateType: String, Codable, Sendable {
     case shell
     case claude
+    case codex
 }
 
 public struct TerminalCreateParams: Codable, Sendable {


### PR DESCRIPTION
## Summary
- Adds `TerminalCreateType.codex` and a branch in `handleTerminalCreate` that launches `codex --full-auto` with a per-repo `CODEX_HOME` (`~/.tbd/agents/codex/<repoID>/`) so TBD never touches the user's real `~/.codex/`.
- Adds Codex to the tab `+` menu (and `AppState.createCodexTerminal`).
- This is the minimum viable support to unblock a Codex-only contributor. Full parity with Claude (state detection, notify hook, session resume, suspend/resume) is intentionally deferred — see CLAUDE.md follow-ups.

## Out of scope (deferred)
- Codex state detection (idle/busy/waiting)
- `tbd setup-hooks` / notify hook for Codex
- `--prompt` initial-message support for Codex
- Session resume/fork UI for Codex
- Suspend/resume for Codex
- Generalized `AgentRuntime` abstraction / collapsing `claudeSessionID` → `agentSessionID`
- `AGENTS.md` symlink

## Test plan
- [x] `swift build` clean
- [x] `swift test` passes (321 tests)
- [x] Manual smoke: `tbd terminal create <wt> --type codex` returns `label: "Codex"`, codex launches, `~/.tbd/agents/codex/<repoID>/` is populated by codex on first run (sessions/, hooks/, etc.)
- [x] Regression: Claude session still launches via `--type claude`