### PR TITLE
Feat: Recover from moved repos and switch to visible ~/tbd home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ There should be exactly one `TBDDaemon` and one `TBDApp`, both from the worktree
 
 ## Critical Rules
 
-### NEVER delete ~/.tbd/state.db
+### NEVER delete ~/tbd/state.db
 The database stores worktree display names, custom config, and notification history. Deleting it orphans tmux servers (repo UUID changes → tmux server name changes → old sessions become unreachable). If you encounter DB issues, diagnose and fix the schema/code — don't wipe the DB.
 
 ### Database migrations must update the shared model

--- a/Sources/TBDApp/AppIcon.swift
+++ b/Sources/TBDApp/AppIcon.swift
@@ -7,10 +7,30 @@ import CoreText
 /// Returns the worktree name (without date prefix) if running from a worktree build, nil for main.
 func detectWorktreeName() -> String? {
     let path = ProcessInfo.processInfo.arguments[0]
-    guard let range = path.range(of: ".tbd/worktrees/") else { return nil }
-    let afterPrefix = path[range.upperBound...]
-    guard let slashIndex = afterPrefix.firstIndex(of: "/") else { return nil }
-    let name = String(afterPrefix[afterPrefix.startIndex..<slashIndex])
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    // Canonical lives under the user's home dir
+    // (~/tbd/worktrees/<slot>/<name>/...) so the worktree name is the SECOND
+    // path component after the marker.
+    let canonicalMarker = "\(home)/tbd/worktrees/"
+    let isCanonical: Bool
+    let afterPrefix: Substring
+    if let range = path.range(of: canonicalMarker) {
+        isCanonical = true
+        afterPrefix = path[range.upperBound...]
+    } else {
+        // LEGACY-WORKTREE-LOCATION: remove after 2026-06-01
+        // Reads worktrees from <repo>/.tbd/worktrees/ for backward compatibility with
+        // worktrees created before the canonical-location switch. New worktrees are
+        // always created under ~/tbd/worktrees/<repo>/<name>. After 2026-06-01, all
+        // pre-switch worktrees will have archived naturally and this path can be deleted.
+        guard let range = path.range(of: ".tbd/worktrees/") else { return nil }
+        isCanonical = false
+        afterPrefix = path[range.upperBound...]
+    }
+    let components = afterPrefix.split(separator: "/")
+    let nameIndex = isCanonical ? 1 : 0
+    guard components.count > nameIndex else { return nil }
+    let name = String(components[nameIndex])
     // Strip YYYYMMDD- date prefix: "20260323-familiar-sawfish" → "familiar-sawfish"
     if let dashIndex = name.firstIndex(of: "-"),
        name[name.startIndex..<dashIndex].allSatisfy(\.isNumber) {

--- a/Sources/TBDApp/AppState+Repos.swift
+++ b/Sources/TBDApp/AppState+Repos.swift
@@ -31,6 +31,20 @@ extension AppState {
         }
     }
 
+    /// Relocate a repository to a new on-disk path.
+    func relocateRepo(id: UUID, newPath: String) async {
+        do {
+            let result = try await daemonClient.relocateRepo(repoID: id, newPath: newPath)
+            if !result.worktreesFailed.isEmpty {
+                logger.warning("Relocate completed with \(result.worktreesFailed.count, privacy: .public) worktree(s) failed to repair")
+            }
+            await refreshRepos()
+        } catch {
+            logger.error("Failed to relocate repo: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
     /// Update per-repo instruction fields. Returns true on success.
     @discardableResult
     func updateRepoInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async -> Bool {

--- a/Sources/TBDApp/AppState+Repos.swift
+++ b/Sources/TBDApp/AppState+Repos.swift
@@ -37,10 +37,16 @@ extension AppState {
             let result = try await daemonClient.relocateRepo(repoID: id, newPath: newPath)
             if !result.worktreesFailed.isEmpty {
                 logger.warning("Relocate completed with \(result.worktreesFailed.count, privacy: .public) worktree(s) failed to repair")
+                alertMessage = "Relocated, but \(result.worktreesFailed.count) worktree(s) failed to repair. Check the daemon log for details."
+                alertIsError = true
             }
             await refreshRepos()
         } catch {
             logger.error("Failed to relocate repo: \(error)")
+            // Surface the failure so the user knows why the repo is still dimmed
+            // (e.g. they picked a directory that isn't a git repo).
+            alertMessage = "Couldn't relocate repo: \(error.localizedDescription)"
+            alertIsError = true
             handleConnectionError(error)
         }
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -316,6 +316,15 @@ actor DaemonClient {
         )
     }
 
+    /// Relocate a repository to a new on-disk path.
+    func relocateRepo(repoID: UUID, newPath: String) throws -> RepoRelocateResult {
+        return try call(
+            method: RPCMethod.repoRelocate,
+            params: RepoRelocateParams(repoID: repoID, newPath: newPath),
+            resultType: RepoRelocateResult.self
+        )
+    }
+
     /// Update per-repo instruction fields.
     func repoUpdateInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) throws -> Repo {
         return try call(

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import TBDShared
 
@@ -52,7 +53,22 @@ struct RepoSectionView: View {
 
             Text(repo.displayName)
                 .font(.headline)
-                .foregroundStyle(appState.selectedRepoID == repo.id ? .primary : .secondary)
+                .foregroundStyle(
+                    repo.status == .missing
+                        ? AnyShapeStyle(Color.secondary.opacity(0.5))
+                        : AnyShapeStyle(appState.selectedRepoID == repo.id ? HierarchicalShapeStyle.primary : HierarchicalShapeStyle.secondary)
+                )
+
+            if repo.status == .missing {
+                Text("[missing]")
+                    .font(.caption)
+                    .foregroundStyle(.red.opacity(0.7))
+                Button("Locate…") {
+                    locateRepo()
+                }
+                .buttonStyle(.link)
+                .font(.caption)
+            }
 
             Spacer()
 
@@ -63,6 +79,7 @@ struct RepoSectionView: View {
             }
             .buttonStyle(HoverPressButtonStyle())
             .help("New worktree")
+            .disabled(repo.status == .missing)
         }
         .contentShape(Rectangle())
         .onTapGesture {
@@ -90,5 +107,19 @@ struct RepoSectionView: View {
 
     private func createWorktree() {
         appState.createWorktree(repoID: repo.id)
+    }
+
+    private func locateRepo() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.message = "Select the new location of \(repo.displayName)"
+        panel.prompt = "Relocate"
+        if panel.runModal() == .OK, let url = panel.url {
+            Task {
+                await appState.relocateRepo(id: repo.id, newPath: url.path)
+            }
+        }
     }
 }

--- a/Sources/TBDCLI/Commands/RepoCommands.swift
+++ b/Sources/TBDCLI/Commands/RepoCommands.swift
@@ -6,7 +6,7 @@ struct RepoCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "repo",
         abstract: "Manage repositories",
-        subcommands: [RepoAdd.self, RepoRemove.self, RepoList.self]
+        subcommands: [RepoAdd.self, RepoRemove.self, RepoList.self, RepoRelocate.self]
     )
 }
 
@@ -103,15 +103,59 @@ struct RepoList: AsyncParsableCommand {
                 print("No repositories. Use 'tbd repo add <path>' to add one.")
                 return
             }
-            let header = String(format: "%-36s  %-20s  %s", "ID", "NAME", "PATH")
+            let header = String(format: "%-36s  %-20s  %-9s  %s", "ID", "NAME", "STATUS", "PATH")
             print(header)
-            print(String(repeating: "-", count: 80))
+            print(String(repeating: "-", count: 90))
             for repo in repos {
-                let line = String(format: "%-36s  %-20s  %s",
+                let tag = repo.status == .missing ? "[missing]" : "[ok]"
+                let line = String(format: "%-36s  %-20s  %-9s  %s",
                     repo.id.uuidString as NSString,
                     repo.displayName as NSString,
+                    tag as NSString,
                     repo.path as NSString)
                 print(line)
+            }
+        }
+    }
+}
+
+// MARK: - repo relocate
+
+struct RepoRelocate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "relocate",
+        abstract: "Update a repository's filesystem path after moving it on disk"
+    )
+
+    @Argument(help: "Repository ID")
+    var id: String
+
+    @Argument(help: "New path to the git repository")
+    var newPath: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        guard let repoID = UUID(uuidString: id) else {
+            throw CLIError.invalidArgument("Invalid repository ID: \(id)")
+        }
+        let resolved = resolvePath(newPath)
+        let client = SocketClient()
+        let result: RepoRelocateResult = try client.call(
+            method: RPCMethod.repoRelocate,
+            params: RepoRelocateParams(repoID: repoID, newPath: resolved),
+            resultType: RepoRelocateResult.self
+        )
+        if json {
+            printJSON(result)
+        } else {
+            print("Relocated \(result.repo.displayName) → \(result.repo.path)")
+            if !result.worktreesRepaired.isEmpty {
+                print("  Repaired worktrees: \(result.worktreesRepaired.count)")
+            }
+            if !result.worktreesFailed.isEmpty {
+                print("  Failed worktrees:   \(result.worktreesFailed.count) (marked .failed; manual cleanup required)")
             }
         }
     }

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -153,6 +153,8 @@ struct WorktreeList: AsyncParsableCommand {
                 print("No worktrees found.")
                 return
             }
+            let repos: [Repo] = try client.call(method: RPCMethod.repoList, resultType: [Repo].self)
+            let missingRepoIDs = Set(repos.filter { $0.status == .missing }.map { $0.id })
             let header = String(format: "%-36s  %-24s  %-8s  %s", "ID", "NAME", "STATUS", "BRANCH")
             print(header)
             print(String(repeating: "-", count: 100))
@@ -162,7 +164,8 @@ struct WorktreeList: AsyncParsableCommand {
                     wt.displayName as NSString,
                     wt.status.rawValue as NSString,
                     wt.branch as NSString)
-                print(line)
+                let tag = missingRepoIDs.contains(wt.repoID) ? "  [missing]" : ""
+                print(line + tag)
             }
         }
     }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -142,7 +142,9 @@ public final class Daemon: Sendable {
                 try? await Task.sleep(for: .seconds(60))
                 guard !Task.isCancelled else { break }
                 let allRepos = (try? await database.repos.list()) ?? []
-                for repo in allRepos {
+                // Skip .missing repos so we don't spam errors against stale paths
+                // until the user relocates them.
+                for repo in allRepos where repo.status != .missing {
                     do {
                         try await git.fetch(repoPath: repo.path, branch: repo.defaultBranch)
                     } catch {

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -26,7 +26,7 @@ public final class Daemon: Sendable {
     /// Start the daemon: create config directory, clean up stale state,
     /// initialize database and all managers, start servers, reconcile worktrees.
     public func start() async throws {
-        // 1. Create ~/.tbd/ directory if needed
+        // 1. Create ~/tbd/ directory if needed
         let configDir = TBDConstants.configDir.path
         let fm = FileManager.default
         if !fm.fileExists(atPath: configDir) {
@@ -128,6 +128,13 @@ public final class Daemon: Sendable {
         } catch {
             print("[Daemon] Warning: Failed to list repos for reconciliation: \(error)")
         }
+
+        // 11b. Validate repo health — flips repos with stale paths to .missing.
+        //      Must come *after* reconcile so newly-discovered worktrees see the
+        //      correct status, and *before* the periodic tasks so users get accurate
+        //      [missing] tags as soon as the daemon is up.
+        let healthValidator = RepoHealthValidator(git: git)
+        await healthValidator.validateAll(db: database)
 
         // 12. Start periodic git fetch for all repos (every 60s)
         self.gitFetchTask = Task {

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -174,7 +174,9 @@ public final class Daemon: Sendable {
             // Run once immediately (cold recovery), then every 10s
             while !Task.isCancelled {
                 let allRepos = (try? await database.repos.list()) ?? []
-                for repo in allRepos {
+                // Skip .missing repos to match gitFetchTask — running git
+                // against a stale path produces quiet 10s-cadence noise.
+                for repo in allRepos where repo.status != .missing {
                     await lifecycle.refreshGitStatuses(repoID: repo.id)
                 }
                 try? await Task.sleep(for: .seconds(10))

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -250,11 +250,9 @@ public final class TBDDatabase: Sendable {
             }
         }
 
-        // NOTE: We use a name-suffixed migration ID rather than a sequential
-        // version number because origin/main already shipped its own "v13"
-        // (Claude token switcher). GRDB tracks migrations by name, so a bare
-        // "v14" would still risk colliding with a parallel in-flight branch.
-        // The "_worktree_location" suffix makes the slot unambiguous.
+        // Suffixed migration name avoids collisions with parallel in-flight
+        // branches that may also be adding a "v14" — GRDB tracks migrations by
+        // name, so a descriptive suffix is unambiguous.
         migrator.registerMigration("v14_worktree_location") { db in
             try db.alter(table: "repo") { t in
                 t.add(column: "worktree_slot", .text)

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -18,6 +18,7 @@ public final class TBDDatabase: Sendable {
     public let claudeTokens: ClaudeTokenStore
     public let claudeTokenUsage: ClaudeTokenUsageStore
     public let config: ConfigStore
+    public let meta: TBDMetaStore
 
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
     public init(path: String) throws {
@@ -38,6 +39,7 @@ public final class TBDDatabase: Sendable {
         self.claudeTokens = ClaudeTokenStore(writer: pool)
         self.claudeTokenUsage = ClaudeTokenUsageStore(writer: pool)
         self.config = ConfigStore(writer: pool)
+        self.meta = TBDMetaStore(writer: pool)
         try Self.migrate(writer: pool)
     }
 
@@ -55,6 +57,7 @@ public final class TBDDatabase: Sendable {
         self.claudeTokens = ClaudeTokenStore(writer: queue)
         self.claudeTokenUsage = ClaudeTokenUsageStore(writer: queue)
         self.config = ConfigStore(writer: queue)
+        self.meta = TBDMetaStore(writer: queue)
         try Self.migrate(writer: queue)
     }
 
@@ -244,6 +247,60 @@ public final class TBDDatabase: Sendable {
 
             try db.alter(table: "terminal") { t in
                 t.add(column: "claude_token_id", .text)
+            }
+        }
+
+        // NOTE: We use a name-suffixed migration ID rather than a sequential
+        // version number because origin/main already shipped its own "v13"
+        // (Claude token switcher). GRDB tracks migrations by name, so a bare
+        // "v14" would still risk colliding with a parallel in-flight branch.
+        // The "_worktree_location" suffix makes the slot unambiguous.
+        migrator.registerMigration("v14_worktree_location") { db in
+            try db.alter(table: "repo") { t in
+                t.add(column: "worktree_slot", .text)
+                t.add(column: "worktree_root", .text)
+                t.add(column: "status", .text).notNull().defaults(to: "ok")
+            }
+            // SQLite ALTER TABLE ADD COLUMN can't add inline UNIQUE; use a partial
+            // index so pre-backfill NULLs coexist.
+            try db.execute(sql: """
+                CREATE UNIQUE INDEX idx_repo_worktree_slot
+                ON repo(worktree_slot)
+                WHERE worktree_slot IS NOT NULL
+            """)
+
+            try db.create(table: "tbd_meta") { t in
+                t.primaryKey("key", .text).notNull()
+                t.column("value", .text).notNull()
+            }
+
+            // Backfill worktree_slot for existing rows. Stable order
+            // (createdAt ASC, then id ASC) means older repos keep the bare
+            // slot; newer collisions get -2/-3/...
+            let rows = try Row.fetchAll(
+                db,
+                sql: "SELECT id, displayName FROM repo ORDER BY createdAt ASC, id ASC"
+            )
+            var assigned = Set<String>()
+            for row in rows {
+                let id: String = row["id"]
+                let displayName: String = row["displayName"]
+                var base = WorktreeLayout.sanitize(displayName)
+                if base.isEmpty {
+                    let prefix = String(id.replacingOccurrences(of: "-", with: "").prefix(6))
+                    base = "repo-\(prefix)"
+                }
+                var slot = base
+                var n = 2
+                while assigned.contains(slot) {
+                    slot = "\(base)-\(n)"
+                    n += 1
+                }
+                assigned.insert(slot)
+                try db.execute(
+                    sql: "UPDATE repo SET worktree_slot = ? WHERE id = ?",
+                    arguments: [slot, id]
+                )
             }
         }
 

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -15,6 +15,9 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var renamePrompt: String?
     var customInstructions: String?
     var claude_token_override_id: String?
+    var worktree_slot: String?
+    var worktree_root: String?
+    var status: String
 
     init(from repo: Repo) {
         self.id = repo.id.uuidString
@@ -26,6 +29,9 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.renamePrompt = repo.renamePrompt
         self.customInstructions = repo.customInstructions
         self.claude_token_override_id = repo.claudeTokenOverrideID?.uuidString
+        self.worktree_slot = repo.worktreeSlot
+        self.worktree_root = repo.worktreeRoot
+        self.status = repo.status.rawValue
     }
 
     func toModel() -> Repo {
@@ -38,7 +44,10 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             createdAt: createdAt,
             renamePrompt: renamePrompt,
             customInstructions: customInstructions,
-            claudeTokenOverrideID: claude_token_override_id.flatMap(UUID.init(uuidString:))
+            claudeTokenOverrideID: claude_token_override_id.flatMap(UUID.init(uuidString:)),
+            worktreeSlot: worktree_slot,
+            worktreeRoot: worktree_root,
+            status: RepoStatus(rawValue: status) ?? .ok
         )
     }
 }
@@ -58,12 +67,34 @@ public struct RepoStore: Sendable {
         defaultBranch: String,
         remoteURL: String? = nil
     ) async throws -> Repo {
-        let repo = Repo(
+        let slot = try await writer.write { db -> String in
+            let existing = try String.fetchAll(
+                db,
+                sql: "SELECT worktree_slot FROM repo WHERE worktree_slot IS NOT NULL"
+            )
+            let assigned = Set(existing)
+            var base = WorktreeLayout.sanitize(displayName)
+            if base.isEmpty {
+                let prefix = UUID().uuidString
+                    .replacingOccurrences(of: "-", with: "")
+                    .prefix(6)
+                base = "repo-\(prefix)"
+            }
+            var slot = base
+            var n = 2
+            while assigned.contains(slot) {
+                slot = "\(base)-\(n)"
+                n += 1
+            }
+            return slot
+        }
+        var repo = Repo(
             path: path,
             remoteURL: remoteURL,
             displayName: displayName,
             defaultBranch: defaultBranch
         )
+        repo.worktreeSlot = slot
         let record = RepoRecord(from: repo)
         try await writer.write { db in
             try record.insert(db)
@@ -121,6 +152,38 @@ public struct RepoStore: Sendable {
             try db.execute(
                 sql: "UPDATE repo SET claude_token_override_id = NULL WHERE claude_token_override_id = ?",
                 arguments: [tokenID.uuidString]
+            )
+        }
+    }
+
+    /// Update a repo's health status.
+    public func updateStatus(id: UUID, status: RepoStatus) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET status = ? WHERE id = ?",
+                arguments: [status.rawValue, id.uuidString]
+            )
+        }
+    }
+
+    /// Update a repo's filesystem path. Used by `tbd repo relocate`.
+    public func updatePath(id: UUID, path: String) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET path = ? WHERE id = ?",
+                arguments: [path, id.uuidString]
+            )
+        }
+    }
+
+    /// Override the canonical worktree base directory for a repo. Pass `nil`
+    /// to clear the override and fall back to `~/tbd/worktrees/<slot>`.
+    /// Primarily used by tests to redirect a repo's worktrees into a tmp dir.
+    public func updateWorktreeRoot(id: UUID, path: String?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET worktree_root = ? WHERE id = ?",
+                arguments: [path, id.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -61,13 +61,17 @@ public struct RepoStore: Sendable {
     }
 
     /// Create a new repo and return it.
+    ///
+    /// Slot allocation and insert run in a single transaction so a concurrent
+    /// `create` can't pick the same slot and trip the `idx_repo_worktree_slot`
+    /// unique partial index with an unfriendly GRDB crash.
     public func create(
         path: String,
         displayName: String,
         defaultBranch: String,
         remoteURL: String? = nil
     ) async throws -> Repo {
-        let slot = try await writer.write { db -> String in
+        try await writer.write { db -> Repo in
             let existing = try String.fetchAll(
                 db,
                 sql: "SELECT worktree_slot FROM repo WHERE worktree_slot IS NOT NULL"
@@ -86,20 +90,16 @@ public struct RepoStore: Sendable {
                 slot = "\(base)-\(n)"
                 n += 1
             }
-            return slot
+            var repo = Repo(
+                path: path,
+                remoteURL: remoteURL,
+                displayName: displayName,
+                defaultBranch: defaultBranch
+            )
+            repo.worktreeSlot = slot
+            try RepoRecord(from: repo).insert(db)
+            return repo
         }
-        var repo = Repo(
-            path: path,
-            remoteURL: remoteURL,
-            displayName: displayName,
-            defaultBranch: defaultBranch
-        )
-        repo.worktreeSlot = slot
-        let record = RepoRecord(from: repo)
-        try await writer.write { db in
-            try record.insert(db)
-        }
-        return repo
     }
 
     /// List all repos, excluding the synthetic conductors pseudo-repo.

--- a/Sources/TBDDaemon/Database/TBDMetaStore.swift
+++ b/Sources/TBDDaemon/Database/TBDMetaStore.swift
@@ -1,0 +1,34 @@
+import Foundation
+import GRDB
+
+public struct TBDMetaStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    public func getString(key: String) async throws -> String? {
+        try await writer.read { db in
+            try String.fetchOne(db, sql: "SELECT value FROM tbd_meta WHERE key = ?", arguments: [key])
+        }
+    }
+
+    public func setString(key: String, value: String) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "INSERT INTO tbd_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                arguments: [key, value]
+            )
+        }
+    }
+
+    public func getInt(key: String) async throws -> Int? {
+        guard let s = try await getString(key: key) else { return nil }
+        return Int(s)
+    }
+
+    public func setInt(key: String, value: Int) async throws {
+        try await setString(key: key, value: String(value))
+    }
+}

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -232,6 +232,17 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// Update the filesystem path for a worktree.
+    public func updatePath(id: UUID, path: String) async throws {
+        try await writer.write { db in
+            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Worktree not found")
+            }
+            record.path = path
+            try record.update(db)
+        }
+    }
+
     /// Update the branch name for a worktree.
     public func updateBranch(id: UUID, branch: String) async throws {
         try await writer.write { db in

--- a/Sources/TBDDaemon/Lifecycle/RepoHealthValidator.swift
+++ b/Sources/TBDDaemon/Lifecycle/RepoHealthValidator.swift
@@ -1,0 +1,70 @@
+import Foundation
+import os
+import TBDShared
+
+/// Validates repo health: does the path still exist, is it a git repo,
+/// does HEAD resolve. Used on daemon startup and after every reconcile.
+///
+/// This is the recovery surface for the latent "user moved the repo on disk"
+/// bug — see docs/worktree-location-design.md §4b.
+public struct RepoHealthValidator: Sendable {
+    private let git: GitManager
+    private let logger = Logger(subsystem: "com.tbd.daemon", category: "repoHealth")
+
+    public init(git: GitManager) {
+        self.git = git
+    }
+
+    /// Returns the status the repo *should* have based on filesystem reality.
+    /// Does not write to the database — caller is responsible for persisting
+    /// any change. The conductors pseudo-repo is hard-coded to `.ok` because
+    /// it isn't a real git repo.
+    public func validate(repo: Repo) async -> RepoStatus {
+        if repo.id == TBDConstants.conductorsRepoID {
+            return .ok
+        }
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: repo.path, isDirectory: &isDir)
+        if !exists || !isDir.boolValue {
+            logger.debug("Repo \(repo.displayName, privacy: .public) at \(repo.path, privacy: .public) is missing on disk")
+            return .missing
+        }
+        if await !git.isGitRepo(path: repo.path) {
+            logger.debug("Repo \(repo.displayName, privacy: .public) at \(repo.path, privacy: .public) exists but is not a git repo")
+            return .missing
+        }
+        do {
+            _ = try await git.detectDefaultBranch(repoPath: repo.path)
+        } catch {
+            logger.debug("Repo \(repo.displayName, privacy: .public) HEAD did not resolve: \(error.localizedDescription, privacy: .public)")
+            return .missing
+        }
+        return .ok
+    }
+
+    /// Validates every repo in the database, persisting status changes only
+    /// when the value actually changes. Logs transitions at info level.
+    /// Errors are swallowed and logged — this method must never throw because
+    /// it is called from daemon startup and a missing repo must not block
+    /// the daemon from coming up.
+    public func validateAll(db: TBDDatabase) async {
+        let repos: [Repo]
+        do {
+            repos = try await db.repos.list()
+        } catch {
+            logger.error("validateAll: failed to list repos: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        for repo in repos {
+            let observed = await validate(repo: repo)
+            if observed != repo.status {
+                do {
+                    try await db.repos.updateStatus(id: repo.id, status: observed)
+                    logger.info("Repo \(repo.displayName, privacy: .public) transitioned \(repo.status.rawValue, privacy: .public) → \(observed.rawValue, privacy: .public)")
+                } catch {
+                    logger.error("validateAll: failed to update status for \(repo.displayName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
+            }
+        }
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/RepoHealthValidator.swift
+++ b/Sources/TBDDaemon/Lifecycle/RepoHealthValidator.swift
@@ -33,6 +33,10 @@ public struct RepoHealthValidator: Sendable {
             logger.debug("Repo \(repo.displayName, privacy: .public) at \(repo.path, privacy: .public) exists but is not a git repo")
             return .missing
         }
+        // We use detectDefaultBranch as a HEAD-resolution probe — the result
+        // is discarded, we only care that the command succeeds (i.e. the repo
+        // is readable and HEAD is valid). If this ever grows network calls
+        // (e.g. ls-remote), swap to a purpose-built local-only health probe.
         do {
             _ = try await git.detectDefaultBranch(repoPath: repo.path)
         } catch {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLayout.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLayout.swift
@@ -1,0 +1,84 @@
+import Foundation
+import TBDShared
+
+/// Single source of truth for where TBD stores worktree directories on disk.
+///
+/// Phase A introduces this helper without wiring it into the create/reconcile
+/// paths. Phase C switches `WorktreeLifecycle+Create.swift` and
+/// `WorktreeLifecycle+Reconcile.swift` to call it.
+///
+/// See `docs/worktree-location-design.md` §4a / §5a.
+public struct WorktreeLayout: Sendable {
+
+    /// Current on-disk layout version. Bumped when a future release ships a
+    /// new filesystem migration. Persisted in the `tbd_meta` table under key
+    /// `layout_version` once the migration sweep completes end-to-end.
+    public static let currentVersion: Int = 1
+
+    public init() {}
+
+    /// Sanitize a repo display name into a filesystem-safe slot.
+    ///
+    /// Rules (per design §4a):
+    /// - Lowercase everything.
+    /// - Replace any char outside `[a-z0-9._-]` with `-`.
+    /// - Collapse runs of `-`.
+    /// - Trim leading/trailing `-`.
+    ///
+    /// Empty / `.` / `..` / leading-dot results return empty string; callers
+    /// must substitute a fallback (e.g. `repo-<uuid-prefix>`).
+    public static func sanitize(_ displayName: String) -> String {
+        let lowered = displayName.lowercased()
+        var out = ""
+        out.reserveCapacity(lowered.count)
+        for scalar in lowered.unicodeScalars {
+            let c = Character(scalar)
+            if c.isASCII, let ascii = c.asciiValue {
+                let isAllowed =
+                    (ascii >= 0x61 && ascii <= 0x7A) ||  // a-z
+                    (ascii >= 0x30 && ascii <= 0x39) ||  // 0-9
+                    ascii == 0x2E || ascii == 0x5F || ascii == 0x2D  // . _ -
+                out.append(isAllowed ? c : "-")
+            } else {
+                out.append("-")
+            }
+        }
+        while out.contains("--") {
+            out = out.replacingOccurrences(of: "--", with: "-")
+        }
+        while out.hasPrefix("-") { out.removeFirst() }
+        while out.hasSuffix("-") { out.removeLast() }
+        if out == "." || out == ".." || out.hasPrefix(".") {
+            return ""
+        }
+        return out
+    }
+
+    /// The canonical base directory for fresh worktrees of the given repo.
+    ///
+    /// - Returns `repo.worktreeRoot` verbatim if the override is set.
+    /// - Otherwise returns `~/tbd/worktrees/<slot>`.
+    public func basePath(for repo: Repo) -> String {
+        if let override = repo.worktreeRoot, !override.isEmpty {
+            return override
+        }
+        let slot = repo.worktreeSlot ?? ""
+        precondition(!slot.isEmpty, "Repo \(repo.id) has neither worktreeRoot nor worktreeSlot")
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/tbd/worktrees/\(slot)"
+    }
+
+    // LEGACY-WORKTREE-LOCATION: remove after 2026-06-01
+    // Reads worktrees from <repo>/.tbd/worktrees/ for backward compatibility with
+    // worktrees created before the canonical-location switch. New worktrees are
+    // always created under ~/tbd/worktrees/<repo>/<name>. After 2026-06-01, all
+    // pre-switch worktrees will have archived naturally and this path can be deleted.
+    /// Both the canonical (new-layout) and legacy (`<repo>/.tbd/worktrees`)
+    /// prefixes a worktree could currently live under. Reconcile matches
+    /// against either until the user has fully migrated. Canonical first.
+    public func legacyAndCanonicalPrefixes(for repo: Repo) -> [String] {
+        let canonical = basePath(for: repo)
+        let legacy = (repo.path as NSString).appendingPathComponent(".tbd/worktrees")
+        return [canonical, legacy]
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLayout.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLayout.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "WorktreeLayout")
 
 /// Single source of truth for where TBD stores worktree directories on disk.
 ///
@@ -59,13 +62,20 @@ public struct WorktreeLayout: Sendable {
     /// - Returns `repo.worktreeRoot` verbatim if the override is set.
     /// - Otherwise returns `~/tbd/worktrees/<slot>`.
     public func basePath(for repo: Repo) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
         if let override = repo.worktreeRoot, !override.isEmpty {
             return override
         }
-        let slot = repo.worktreeSlot ?? ""
-        precondition(!slot.isEmpty, "Repo \(repo.id) has neither worktreeRoot nor worktreeSlot")
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return "\(home)/tbd/worktrees/\(slot)"
+        if let slot = repo.worktreeSlot, !slot.isEmpty {
+            return "\(home)/tbd/worktrees/\(slot)"
+        }
+        // Should never happen — v14 backfills worktree_slot for every existing
+        // row and RepoStore.create always assigns one. But a precondition in a
+        // long-running daemon is a hard kill, so log loudly and fall back to a
+        // UUID-derived path instead.
+        logger.fault("Repo \(repo.id, privacy: .public) has neither worktreeRoot nor worktreeSlot — falling back to UUID-derived path")
+        let fallbackSlot = "repo-\(repo.id.uuidString.replacingOccurrences(of: "-", with: "").prefix(8))"
+        return "\(home)/tbd/worktrees/\(fallbackSlot)"
     }
 
     // LEGACY-WORKTREE-LOCATION: remove after 2026-06-01

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -42,6 +42,13 @@ extension WorktreeLifecycle {
         try? FileManager.default.createDirectory(
             atPath: canonicalBase, withIntermediateDirectories: true
         )
+        // try? above swallows both "already exists" (fine) and permission
+        // errors (not fine). Verify the dir actually exists so a permission
+        // failure surfaces here instead of as a misleading `git worktree add`
+        // error downstream.
+        if !FileManager.default.fileExists(atPath: canonicalBase) {
+            logger.error("Failed to create worktree base dir \(canonicalBase, privacy: .public)")
+        }
         let worktreePath = (canonicalBase as NSString).appendingPathComponent(name)
         let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -34,8 +34,15 @@ extension WorktreeLifecycle {
         // 2. Generate name and construct path
         let name = name ?? NameGenerator.generate()
         let branch = "tbd/\(name)"
-        let worktreePath = (repo.path as NSString)
-            .appendingPathComponent(".tbd/worktrees/\(name)")
+        let layout = WorktreeLayout()
+        let canonicalBase = layout.basePath(for: repo)
+        // Lazily create the canonical base directory for this slot.
+        // (Phase A's v14_worktree_location migration guarantees worktreeSlot is set
+        // for every repo, so basePath(for:) won't precondition-fail here.)
+        try? FileManager.default.createDirectory(
+            atPath: canonicalBase, withIntermediateDirectories: true
+        )
+        let worktreePath = (canonicalBase as NSString).appendingPathComponent(name)
         let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
 
         // 3. Insert DB row with status = .creating
@@ -79,8 +86,8 @@ extension WorktreeLifecycle {
 
             // 3. git worktree add
             let result = try await attemptWorktreeAdd(
-                repoPath: repo.path, name: worktree.name, branch: worktree.branch,
-                worktreePath: worktree.path, defaultBranch: repo.defaultBranch
+                repo: repo, name: worktree.name, branch: worktree.branch,
+                worktreePath: worktree.path
             )
 
             // 4. If the name changed due to collision, update the DB record
@@ -111,9 +118,11 @@ extension WorktreeLifecycle {
     /// Attempts to create a git worktree, trying origin/<default> then falling back
     /// to local <default> as the base branch. Retries once with a new name on collision.
     private func attemptWorktreeAdd(
-        repoPath: String, name: String, branch: String,
-        worktreePath: String, defaultBranch: String
+        repo: Repo, name: String, branch: String,
+        worktreePath: String
     ) async throws -> (name: String, branch: String, path: String) {
+        let repoPath = repo.path
+        let defaultBranch = repo.defaultBranch
         // Try with origin/<default> first, then local <default>
         let baseBranches = ["origin/\(defaultBranch)", defaultBranch]
 
@@ -135,11 +144,10 @@ extension WorktreeLifecycle {
         // Retry with a fresh name (branch collision case)
         let retryName = NameGenerator.generate()
         let retryBranch = "tbd/\(retryName)"
-        let retryPath = (repoPath as NSString)
-            .appendingPathComponent(".tbd/worktrees/\(retryName)")
-        let retryParentDir = (retryPath as NSString).deletingLastPathComponent
+        let retryCanonicalBase = WorktreeLayout().basePath(for: repo)
+        let retryPath = (retryCanonicalBase as NSString).appendingPathComponent(retryName)
         try FileManager.default.createDirectory(
-            atPath: retryParentDir,
+            atPath: retryCanonicalBase,
             withIntermediateDirectories: true
         )
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -68,6 +68,14 @@ extension WorktreeLifecycle {
             throw WorktreeLifecycleError.repoNotFound(repoID)
         }
 
+        // If the repo's filesystem path is gone, don't try to talk to git.
+        // The startup health validator will (or already has) flipped its status
+        // to .missing. Reconcile becomes a no-op until the user runs `tbd repo
+        // relocate`. The daemon must not crash or hang on stale paths.
+        if repo.status == .missing {
+            return
+        }
+
         let gitWorktrees = try await git.worktreeList(repoPath: repo.path)
         let correctTmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
         var dbWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
@@ -104,12 +112,19 @@ extension WorktreeLifecycle {
             try await db.worktrees.archive(id: wt.id)
         }
 
-        // Add unknown worktrees (skip the main repo worktree)
-        let tbdWorktreePrefix = (repo.path as NSString)
-            .appendingPathComponent(".tbd/worktrees/")
+        // Add unknown worktrees (skip the main repo worktree).
+        // LEGACY-WORKTREE-LOCATION: remove after 2026-06-01
+        // Reads worktrees from <repo>/.tbd/worktrees/ for backward compatibility with
+        // worktrees created before the canonical-location switch. New worktrees are
+        // always created under ~/tbd/worktrees/<repo>/<name>. After 2026-06-01, all
+        // pre-switch worktrees will have archived naturally and this path can be deleted.
+        // Dual-prefix view: accept worktrees living under either the canonical
+        // (~/tbd/worktrees/<slot>/) or legacy (<repo>/.tbd/worktrees/) layout.
+        let layout = WorktreeLayout()
+        let acceptablePrefixes = layout.legacyAndCanonicalPrefixes(for: repo)
+            .map { $0.hasSuffix("/") ? $0 : $0 + "/" }
         for gitWt in gitWorktrees where !dbPaths.contains(gitWt.path) {
-            // Only track worktrees inside .tbd/worktrees/
-            guard gitWt.path.hasPrefix(tbdWorktreePrefix) else { continue }
+            guard acceptablePrefixes.contains(where: { gitWt.path.hasPrefix($0) }) else { continue }
 
             let name = (gitWt.path as NSString).lastPathComponent
             let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
@@ -172,6 +187,15 @@ extension WorktreeLifecycle {
             } catch {
                 print("[TBD] reconcile: failed to list tmux windows for server \(tmuxServer): \(error)")
             }
+        }
+
+        // Recompute health so the next call sees the right status. A repo that
+        // just transitioned ok→missing here would otherwise stay ok in memory
+        // until the next startup sweep.
+        let validator = RepoHealthValidator(git: git)
+        let observed = await validator.validate(repo: repo)
+        if observed != repo.status {
+            try? await db.repos.updateStatus(id: repo.id, status: observed)
         }
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -196,6 +196,13 @@ extension WorktreeLifecycle {
         let observed = await validator.validate(repo: repo)
         if observed != repo.status {
             try? await db.repos.updateStatus(id: repo.id, status: observed)
+            // Broadcast a coarse refresh so the sidebar dims/un-dims immediately
+            // when reconcile is triggered via an RPC (e.g. cleanup) with active
+            // subscribers. .repoAdded is the existing coarse signal — see the
+            // matching call site in RPCRouter+RelocateHandler.
+            subscriptions?.broadcast(delta: .repoAdded(RepoDelta(
+                repoID: repo.id, path: repo.path, displayName: repo.displayName
+            )))
         }
     }
 }

--- a/Sources/TBDDaemon/Server/HTTPServer.swift
+++ b/Sources/TBDDaemon/Server/HTTPServer.swift
@@ -8,7 +8,7 @@ import TBDShared
 ///
 /// Accepts POST requests to `/rpc` with a JSON body containing an `RPCRequest`.
 /// Routes through `RPCRouter` and returns JSON `RPCResponse`.
-/// The assigned port is written to `~/.tbd/port` for discovery.
+/// The assigned port is written to `~/tbd/port` for discovery.
 public final class HTTPServer: Sendable {
     private let router: RPCRouter
     private let portFilePath: String

--- a/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
@@ -95,7 +95,11 @@ extension RPCRouter {
                 worktreesRepaired.append(wt.id)
             } else {
                 logger.error("git worktree repair failed for \(wt.name, privacy: .public) at \(rewrittenPath, privacy: .public); marking .failed")
-                try? await db.worktrees.updateStatus(id: wt.id, status: .failed)
+                do {
+                    try await db.worktrees.updateStatus(id: wt.id, status: .failed)
+                } catch {
+                    logger.error("Also failed to persist .failed status for \(wt.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
                 worktreesFailed.append(wt.id)
             }
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
@@ -1,0 +1,127 @@
+import Foundation
+import os
+import TBDShared
+
+extension RPCRouter {
+
+    /// Relocate a repo to a new on-disk path.
+    ///
+    /// 1. Validate new path exists and is a git repo (no origin-URL check; design §6).
+    /// 2. Update repo.path in the DB.
+    /// 3. For every legacy worktree (path inside the OLD legacy prefix
+    ///    `<oldRepo>/.tbd/worktrees/`), rewrite the recorded path to sit
+    ///    under the NEW legacy prefix. The synthetic main worktree row
+    ///    (status .main) gets its path updated to match the new repo root.
+    /// 4. Run `git -C <new-worktree-path> worktree repair` for each non-main
+    ///    worktree. If repair errors for one, mark it .failed and continue —
+    ///    do NOT abort the relocate.
+    /// 5. Set repo.status = .ok.
+    /// 6. Broadcast a delta so the app refreshes the sidebar.
+    func handleRepoRelocate(_ paramsData: Data) async throws -> RPCResponse {
+        let logger = Logger(subsystem: "com.tbd.daemon", category: "repoHealth")
+        let params = try decoder.decode(RepoRelocateParams.self, from: paramsData)
+
+        guard var repo = try await db.repos.get(id: params.repoID) else {
+            return RPCResponse(error: "Repository not found: \(params.repoID)")
+        }
+
+        let newPath = (params.newPath as NSString).standardizingPath
+
+        // 1. Validate.
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: newPath, isDirectory: &isDir), isDir.boolValue else {
+            return RPCResponse(error: "Path does not exist or is not a directory: \(newPath)")
+        }
+        guard await git.isGitRepo(path: newPath) else {
+            return RPCResponse(error: "Not a git repository: \(newPath)")
+        }
+
+        let oldPath = repo.path
+        // LEGACY-WORKTREE-LOCATION: remove after 2026-06-01
+        // Reads worktrees from <repo>/.tbd/worktrees/ for backward compatibility with
+        // worktrees created before the canonical-location switch. New worktrees are
+        // always created under ~/tbd/worktrees/<repo>/<name>. After 2026-06-01, all
+        // pre-switch worktrees will have archived naturally and this path can be deleted.
+        let oldLegacyPrefix = (oldPath as NSString).appendingPathComponent(".tbd/worktrees/")
+        let newLegacyPrefix = (newPath as NSString).appendingPathComponent(".tbd/worktrees/")
+
+        // 2. Update repo.path.
+        try await db.repos.updatePath(id: repo.id, path: newPath)
+        repo.path = newPath
+
+        // 3 + 4. Rewrite worktree paths and repair git bookkeeping.
+        let activeWorktrees = try await db.worktrees.list(repoID: repo.id, status: .active)
+        let mainWorktrees = try await db.worktrees.list(repoID: repo.id, status: .main)
+        let allWorktrees = activeWorktrees + mainWorktrees
+
+        var worktreesRepaired: [UUID] = []
+        var worktreesFailed: [UUID] = []
+
+        for wt in allWorktrees {
+            // Synthetic main worktree row points at the repo root, not a real
+            // git worktree dir. No `git worktree repair` needed.
+            if wt.status == .main {
+                if wt.path == oldPath {
+                    try? await db.worktrees.updatePath(id: wt.id, path: newPath)
+                }
+                continue
+            }
+
+            var rewrittenPath = wt.path
+            if wt.path.hasPrefix(oldLegacyPrefix) {
+                let suffix = String(wt.path.dropFirst(oldLegacyPrefix.count))
+                rewrittenPath = newLegacyPrefix + suffix
+                try? await db.worktrees.updatePath(id: wt.id, path: rewrittenPath)
+            }
+
+            let repairedOK = await runGitWorktreeRepair(worktreePath: rewrittenPath, logger: logger)
+            if repairedOK {
+                worktreesRepaired.append(wt.id)
+            } else {
+                logger.error("git worktree repair failed for \(wt.name, privacy: .public) at \(rewrittenPath, privacy: .public); marking .failed")
+                try? await db.worktrees.updateStatus(id: wt.id, status: .failed)
+                worktreesFailed.append(wt.id)
+            }
+        }
+
+        // 5. Reset health status.
+        try await db.repos.updateStatus(id: repo.id, status: .ok)
+        repo.status = .ok
+
+        // 6. Broadcast a delta so the app refreshes. RepoDelta is the coarse
+        //    refresh signal — no .repoUpdated variant exists yet.
+        subscriptions.broadcast(delta: .repoAdded(RepoDelta(
+            repoID: repo.id, path: repo.path, displayName: repo.displayName
+        )))
+
+        return try RPCResponse(result: RepoRelocateResult(
+            repo: repo,
+            worktreesRepaired: worktreesRepaired,
+            worktreesFailed: worktreesFailed
+        ))
+    }
+
+    /// Run `git -C <path> worktree repair`. Returns true on success.
+    private func runGitWorktreeRepair(worktreePath: String, logger: Logger) async -> Bool {
+        let task = Process()
+        task.launchPath = "/usr/bin/env"
+        task.arguments = ["git", "-C", worktreePath, "worktree", "repair"]
+        let stderr = Pipe()
+        task.standardError = stderr
+        task.standardOutput = Pipe()
+        do {
+            try task.run()
+            task.waitUntilExit()
+            if task.terminationStatus == 0 {
+                return true
+            }
+            let errData = stderr.fileHandleForReading.readDataToEndOfFile()
+            let err = String(data: errData, encoding: .utf8) ?? "<no stderr>"
+            logger.error("git worktree repair (\(worktreePath, privacy: .public)) exited \(task.terminationStatus): \(err, privacy: .public)")
+            return false
+        } catch {
+            logger.error("git worktree repair (\(worktreePath, privacy: .public)) failed to launch: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
@@ -77,7 +77,17 @@ extension RPCRouter {
             if wt.path.hasPrefix(oldLegacyPrefix) {
                 let suffix = String(wt.path.dropFirst(oldLegacyPrefix.count))
                 rewrittenPath = newLegacyPrefix + suffix
-                try? await db.worktrees.updatePath(id: wt.id, path: rewrittenPath)
+                do {
+                    try await db.worktrees.updatePath(id: wt.id, path: rewrittenPath)
+                } catch {
+                    // If we can't persist the new path, don't run git worktree
+                    // repair against it — that would leave git metadata pointing
+                    // at the new location while the DB still says the old one,
+                    // which the next reconcile would have to clean up.
+                    logger.error("Failed to update legacy worktree path for \(wt.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    worktreesFailed.append(wt.id)
+                    continue
+                }
             }
 
             let repairedOK = await runGitWorktreeRepair(worktreePath: rewrittenPath, logger: logger)

--- a/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
@@ -62,7 +62,13 @@ extension RPCRouter {
             // git worktree dir. No `git worktree repair` needed.
             if wt.status == .main {
                 if wt.path == oldPath {
-                    try? await db.worktrees.updatePath(id: wt.id, path: newPath)
+                    do {
+                        try await db.worktrees.updatePath(id: wt.id, path: newPath)
+                        worktreesRepaired.append(wt.id)
+                    } catch {
+                        logger.error("Failed to update synthetic main worktree path for \(repo.displayName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                        worktreesFailed.append(wt.id)
+                    }
                 }
                 continue
             }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -75,6 +75,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRepoList()
             case RPCMethod.repoUpdateInstructions:
                 return try await handleRepoUpdateInstructions(request.paramsData)
+            case RPCMethod.repoRelocate:
+                return try await handleRepoRelocate(request.paramsData)
             case RPCMethod.worktreeCreate:
                 return try await handleWorktreeCreate(request.paramsData)
             case RPCMethod.worktreeList:

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -3,7 +3,7 @@ import Foundation
 public enum TBDConstants {
     public static let version = "0.1.0"
     public static let configDir = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent(".tbd")
+        .appendingPathComponent("tbd")
     public static let socketPath = configDir.appendingPathComponent("sock").path
     public static let databasePath = configDir.appendingPathComponent("state.db").path
     public static let pidFilePath = configDir.appendingPathComponent("tbdd.pid").path

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+public enum RepoStatus: String, Codable, Sendable {
+    case ok
+    case missing
+}
+
 public struct Repo: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var path: String
@@ -10,11 +15,16 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
     public var renamePrompt: String?
     public var customInstructions: String?
     public var claudeTokenOverrideID: UUID?
+    public var worktreeSlot: String?
+    public var worktreeRoot: String?
+    public var status: RepoStatus
 
     public init(id: UUID = UUID(), path: String, remoteURL: String? = nil,
                 displayName: String, defaultBranch: String = "main", createdAt: Date = Date(),
                 renamePrompt: String? = nil, customInstructions: String? = nil,
-                claudeTokenOverrideID: UUID? = nil) {
+                claudeTokenOverrideID: UUID? = nil,
+                worktreeSlot: String? = nil, worktreeRoot: String? = nil,
+                status: RepoStatus = .ok) {
         self.id = id
         self.path = path
         self.remoteURL = remoteURL
@@ -24,6 +34,15 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         self.renamePrompt = renamePrompt
         self.customInstructions = customInstructions
         self.claudeTokenOverrideID = claudeTokenOverrideID
+        self.worktreeSlot = worktreeSlot
+        self.worktreeRoot = worktreeRoot
+        self.status = status
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, path, remoteURL, displayName, defaultBranch, createdAt
+        case renamePrompt, customInstructions, claudeTokenOverrideID
+        case worktreeSlot, worktreeRoot, status
     }
 
     public init(from decoder: Decoder) throws {
@@ -37,11 +56,14 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         renamePrompt = try c.decodeIfPresent(String.self, forKey: .renamePrompt)
         customInstructions = try c.decodeIfPresent(String.self, forKey: .customInstructions)
         claudeTokenOverrideID = try c.decodeIfPresent(UUID.self, forKey: .claudeTokenOverrideID)
+        worktreeSlot = try c.decodeIfPresent(String.self, forKey: .worktreeSlot)
+        worktreeRoot = try c.decodeIfPresent(String.self, forKey: .worktreeRoot)
+        status = try c.decodeIfPresent(RepoStatus.self, forKey: .status) ?? .ok
     }
 }
 
 public enum WorktreeStatus: String, Codable, Sendable {
-    case active, archived, main, creating, conductor
+    case active, archived, main, creating, conductor, failed
 }
 
 public struct Worktree: Codable, Sendable, Identifiable, Equatable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -130,6 +130,7 @@ public enum RPCMethod {
     public static let claudeTokenFetchUsage = "claudeToken.fetchUsage"
     public static let terminalSwapClaudeToken = "terminal.swapClaudeToken"
     public static let appSetForegroundState = "app.setForegroundState"
+    public static let repoRelocate = "repo.relocate"
 }
 
 public struct AppSetForegroundStateParams: Codable, Sendable {
@@ -267,6 +268,26 @@ public struct RepoUpdateInstructionsParams: Codable, Sendable {
         self.repoID = repoID
         self.renamePrompt = renamePrompt
         self.customInstructions = customInstructions
+    }
+}
+
+public struct RepoRelocateParams: Codable, Sendable {
+    public let repoID: UUID
+    public let newPath: String
+    public init(repoID: UUID, newPath: String) {
+        self.repoID = repoID
+        self.newPath = newPath
+    }
+}
+
+public struct RepoRelocateResult: Codable, Sendable {
+    public let repo: Repo
+    public let worktreesRepaired: [UUID]
+    public let worktreesFailed: [UUID]
+    public init(repo: Repo, worktreesRepaired: [UUID], worktreesFailed: [UUID]) {
+        self.repo = repo
+        self.worktreesRepaired = worktreesRepaired
+        self.worktreesFailed = worktreesFailed
     }
 }
 

--- a/Tests/TBDDaemonTests/MigrationV13Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV13Tests.swift
@@ -1,0 +1,46 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct MigrationV13Tests {
+
+    @Test func v13AddsRepoColumnsAndBackfillsSlot() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/fake-repo",
+            displayName: "Fake App",
+            defaultBranch: "main"
+        )
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.worktreeSlot == "fake-app")
+        #expect(fetched?.worktreeRoot == nil)
+        #expect(fetched?.status == .ok)
+    }
+
+    @Test func v13CreateDeduplicatesCollidingSlots() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let older = try await db.repos.create(
+            path: "/tmp/a", displayName: "MyApp", defaultBranch: "main"
+        )
+        let newer = try await db.repos.create(
+            path: "/tmp/b", displayName: "MyApp", defaultBranch: "main"
+        )
+        let o = try await db.repos.get(id: older.id)
+        let n = try await db.repos.get(id: newer.id)
+        #expect(o?.worktreeSlot == "myapp")
+        #expect(n?.worktreeSlot == "myapp-2")
+    }
+
+    @Test func v13FallbackForReservedDisplayName() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/c", displayName: "...", defaultBranch: "main"
+        )
+        let f = try await db.repos.get(id: repo.id)
+        let slot = try #require(f?.worktreeSlot)
+        #expect(slot.hasPrefix("repo-"))
+        #expect(slot.count == "repo-".count + 6)
+    }
+}

--- a/Tests/TBDDaemonTests/RepoHealthValidatorTests.swift
+++ b/Tests/TBDDaemonTests/RepoHealthValidatorTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct RepoHealthValidatorTests {
+
+    /// Make a real git repo at a tmp path. Returns the path.
+    private func makeGitRepo() throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("phase-b-health-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        for args in [["init", "-b", "main"], ["commit", "--allow-empty", "-m", "init"]] {
+            let p = Process()
+            p.launchPath = "/usr/bin/env"
+            p.arguments = ["git", "-C", tmp.path] + args
+            try p.run()
+            p.waitUntilExit()
+        }
+        return tmp
+    }
+
+    @Test func validatesExistingGitRepo() async throws {
+        let url = try makeGitRepo()
+        defer { try? FileManager.default.removeItem(at: url) }
+        var repo = Repo(path: url.path, displayName: "real")
+        repo.worktreeSlot = "real"
+        let v = RepoHealthValidator(git: GitManager())
+        #expect(await v.validate(repo: repo) == .ok)
+    }
+
+    @Test func reportsMissingForNonexistentPath() async throws {
+        var repo = Repo(path: "/this/path/does/not/exist/at/all/\(UUID().uuidString)", displayName: "ghost")
+        repo.worktreeSlot = "ghost"
+        let v = RepoHealthValidator(git: GitManager())
+        #expect(await v.validate(repo: repo) == .missing)
+    }
+
+    @Test func reportsMissingForNonGitDirectory() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("phase-b-not-git-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        var repo = Repo(path: tmp.path, displayName: "tmp")
+        repo.worktreeSlot = "tmp"
+        let v = RepoHealthValidator(git: GitManager())
+        #expect(await v.validate(repo: repo) == .missing)
+    }
+
+    @Test func conductorPseudoRepoAlwaysOK() async throws {
+        var repo = Repo(
+            id: TBDConstants.conductorsRepoID,
+            path: "/nonexistent/conductors-\(UUID().uuidString)",
+            displayName: "Conductors"
+        )
+        repo.worktreeSlot = "conductors"
+        #expect(await RepoHealthValidator(git: GitManager()).validate(repo: repo) == .ok)
+    }
+
+    @Test func validateAllPersistsTransitions() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/this/path/does/not/exist/\(UUID().uuidString)",
+            displayName: "ghost",
+            defaultBranch: "main"
+        )
+        // Starts ok by default.
+        #expect((try await db.repos.get(id: repo.id))?.status == .ok)
+        await RepoHealthValidator(git: GitManager()).validateAll(db: db)
+        #expect((try await db.repos.get(id: repo.id))?.status == .missing)
+    }
+}

--- a/Tests/TBDDaemonTests/RepoRelocateTests.swift
+++ b/Tests/TBDDaemonTests/RepoRelocateTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct RepoRelocateTests {
+
+    private func makeGitRepo(at url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        for args in [["init", "-b", "main"], ["commit", "--allow-empty", "-m", "init"]] {
+            let p = Process()
+            p.launchPath = "/usr/bin/env"
+            p.arguments = ["git", "-C", url.path] + args
+            p.standardOutput = Pipe()
+            p.standardError = Pipe()
+            try p.run()
+            p.waitUntilExit()
+        }
+    }
+
+    private func makeRouter(db: TBDDatabase) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+    }
+
+    @Test func relocateUpdatesRepoPathAndStatus() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("phase-b-rel-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let oldDir = tmp.appendingPathComponent("old").path
+        let newDir = tmp.appendingPathComponent("new")
+        try makeGitRepo(at: newDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: oldDir, displayName: "rel", defaultBranch: "main")
+        try await db.repos.updateStatus(id: repo.id, status: .missing)
+
+        let router = makeRouter(db: db)
+        let paramsData = try JSONEncoder().encode(
+            RepoRelocateParams(repoID: repo.id, newPath: newDir.path)
+        )
+        let response = try await router.handleRepoRelocate(paramsData)
+        #expect(response.success)
+
+        let after = try await db.repos.get(id: repo.id)
+        #expect(after?.path == newDir.path)
+        #expect(after?.status == .ok)
+    }
+
+    @Test func relocateRejectsNonGitNewPath() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("phase-b-rel-bad-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/old", displayName: "rel", defaultBranch: "main")
+
+        let router = makeRouter(db: db)
+        let paramsData = try JSONEncoder().encode(
+            RepoRelocateParams(repoID: repo.id, newPath: tmp.path)
+        )
+        let response = try await router.handleRepoRelocate(paramsData)
+        #expect(!response.success)
+        #expect(response.error?.contains("Not a git repository") == true)
+    }
+
+    @Test func relocateFailsForUnknownRepoID() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db)
+        let paramsData = try JSONEncoder().encode(
+            RepoRelocateParams(repoID: UUID(), newPath: "/tmp/whatever")
+        )
+        let response = try await router.handleRepoRelocate(paramsData)
+        #expect(!response.success)
+        #expect(response.error?.contains("Repository not found") == true)
+    }
+}

--- a/Tests/TBDDaemonTests/RepoStoreTests.swift
+++ b/Tests/TBDDaemonTests/RepoStoreTests.swift
@@ -1,0 +1,30 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct RepoStoreUpdateTests {
+
+    @Test func repoStoreUpdatesStatus() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/x", displayName: "x", defaultBranch: "main"
+        )
+        try await db.repos.updateStatus(id: repo.id, status: .missing)
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.status == .missing)
+        try await db.repos.updateStatus(id: repo.id, status: .ok)
+        let after = try await db.repos.get(id: repo.id)
+        #expect(after?.status == .ok)
+    }
+
+    @Test func repoStoreUpdatesPath() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/old", displayName: "x", defaultBranch: "main"
+        )
+        try await db.repos.updatePath(id: repo.id, path: "/tmp/new")
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.path == "/tmp/new")
+    }
+}

--- a/Tests/TBDDaemonTests/TBDMetaStoreTests.swift
+++ b/Tests/TBDDaemonTests/TBDMetaStoreTests.swift
@@ -1,0 +1,30 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+
+@Suite struct TBDMetaStoreTests {
+    @Test func roundTripsString() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.meta.setString(key: "k", value: "hello")
+        #expect(try await db.meta.getString(key: "k") == "hello")
+    }
+
+    @Test func roundTripsInt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.meta.setInt(key: "n", value: 42)
+        #expect(try await db.meta.getInt(key: "n") == 42)
+    }
+
+    @Test func returnsNilForMissingKey() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.meta.getString(key: "absent") == nil)
+        #expect(try await db.meta.getInt(key: "absent") == nil)
+    }
+
+    @Test func upsertReplacesValue() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.meta.setInt(key: "x", value: 1)
+        try await db.meta.setInt(key: "x", value: 2)
+        #expect(try await db.meta.getInt(key: "x") == 2)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeLayoutTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLayoutTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct WorktreeLayoutTests {
+
+    @Test func sanitizeLowercases() {
+        #expect(WorktreeLayout.sanitize("MyApp") == "myapp")
+    }
+
+    @Test func sanitizeReplacesBadChars() {
+        #expect(WorktreeLayout.sanitize("my app!") == "my-app")
+        #expect(WorktreeLayout.sanitize("a/b\\c") == "a-b-c")
+    }
+
+    @Test func sanitizeCollapsesDashRuns() {
+        #expect(WorktreeLayout.sanitize("a   b") == "a-b")
+        #expect(WorktreeLayout.sanitize("--a--b--") == "a-b")
+    }
+
+    @Test func sanitizeAllowsDotUnderscore() {
+        #expect(WorktreeLayout.sanitize("my_app.v2") == "my_app.v2")
+    }
+
+    @Test func sanitizeEmptyOrReserved() {
+        #expect(WorktreeLayout.sanitize("...") == "")
+        #expect(WorktreeLayout.sanitize("") == "")
+        #expect(WorktreeLayout.sanitize("   ") == "")
+    }
+
+    @Test func basePathUsesOverrideWhenSet() {
+        var repo = Repo(path: "/tmp/x", displayName: "X")
+        repo.worktreeSlot = "x"
+        repo.worktreeRoot = "/var/tmp/custom"
+        let layout = WorktreeLayout()
+        #expect(layout.basePath(for: repo) == "/var/tmp/custom")
+    }
+
+    @Test func basePathUsesSlotWhenNoOverride() {
+        var repo = Repo(path: "/tmp/x", displayName: "X")
+        repo.worktreeSlot = "x"
+        let layout = WorktreeLayout()
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        #expect(layout.basePath(for: repo) == "\(home)/tbd/worktrees/x")
+    }
+
+    @Test func legacyAndCanonicalPrefixesReturnsBoth() {
+        var repo = Repo(path: "/tmp/myrepo", displayName: "X")
+        repo.worktreeSlot = "x"
+        let layout = WorktreeLayout()
+        let prefixes = layout.legacyAndCanonicalPrefixes(for: repo)
+        #expect(prefixes.count == 2)
+        #expect(prefixes[0] == layout.basePath(for: repo))
+        #expect(prefixes[1] == "/tmp/myrepo/.tbd/worktrees")
+    }
+
+    @Test func currentVersionIsOne() {
+        #expect(WorktreeLayout.currentVersion == 1)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -46,6 +46,21 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
     return (tempDir: tempDir, repoDir: repoDir)
 }
 
+/// Creates a test repo row in the DB and overrides its `worktreeRoot` to a
+/// `.tbd/worktrees/` subdirectory of the test temp dir, so the canonical
+/// layout doesn't leak into the user's real `~/.tbd/worktrees/`. Returns the
+/// re-fetched repo with the override applied.
+private func makeTestRepo(
+    db: TBDDatabase, tempDir: URL, repoDir: URL
+) async throws -> Repo {
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+    let override = tempDir.appendingPathComponent(".tbd/worktrees").path
+    try await db.repos.updateWorktreeRoot(id: repo.id, path: override)
+    return try await db.repos.get(id: repo.id)!
+}
+
 @Test func testCreateWorktree() async throws {
     let (tempDir, repoDir) = try await createTestRepo()
     defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -58,9 +73,7 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
         hooks: HookResolver()
     )
 
-    let repo = try await db.repos.create(
-        path: repoDir.path, displayName: "test", defaultBranch: "main"
-    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let result = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
 
     #expect(result.status == .active)
@@ -99,9 +112,7 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
         hooks: HookResolver()
     )
 
-    let repo = try await db.repos.create(
-        path: repoDir.path, displayName: "test", defaultBranch: "main"
-    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
     #expect(FileManager.default.fileExists(atPath: wt.path))
 
@@ -142,9 +153,7 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
         hooks: HookResolver()
     )
 
-    let repo = try await db.repos.create(
-        path: repoDir.path, displayName: "test", defaultBranch: "main"
-    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
     try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
 
@@ -170,9 +179,7 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
         hooks: HookResolver()
     )
 
-    let repo = try await db.repos.create(
-        path: repoDir.path, displayName: "test", defaultBranch: "main"
-    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
 
     await #expect(throws: WorktreeLifecycleError.self) {
@@ -192,9 +199,7 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
         hooks: HookResolver()
     )
 
-    let repo = try await db.repos.create(
-        path: repoDir.path, displayName: "test", defaultBranch: "main"
-    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
 
     // Create worktree with Claude (skipClaude: false creates a session ID)
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
@@ -235,9 +240,7 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
         hooks: HookResolver()
     )
 
-    let repo = try await db.repos.create(
-        path: repoDir.path, displayName: "test", defaultBranch: "main"
-    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
 
     // Create worktree without Claude
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
@@ -260,9 +263,7 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
         hooks: HookResolver()
     )
 
-    let repo = try await db.repos.create(
-        path: repoDir.path, displayName: "test", defaultBranch: "main"
-    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
 
     // Create with Claude, archive, then revive with skipClaude
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
@@ -290,9 +291,7 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
         hooks: HookResolver()
     )
 
-    let repo = try await db.repos.create(
-        path: repoDir.path, displayName: "test", defaultBranch: "main"
-    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
 
     // Create worktree with Claude
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
@@ -401,13 +400,12 @@ private func createTestRepo() async throws -> (tempDir: URL, repoDir: URL) {
         hooks: HookResolver()
     )
 
-    let repo = try await db.repos.create(
-        path: repoDir.path, displayName: "test", defaultBranch: "main"
-    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
 
-    // Path should be under <repo>/.tbd/worktrees/<name>/
-    #expect(wt.path.hasPrefix(repoDir.path))
+    // Path should be under the canonical layout (tempDir/.tbd/worktrees/<name>)
+    // because makeTestRepo overrides worktreeRoot to <tempDir>/.tbd/worktrees.
+    #expect(wt.path.hasPrefix(tempDir.path))
     #expect(wt.path.contains(".tbd/worktrees/"))
     #expect(wt.path.contains(wt.name))
 }

--- a/Tests/TBDDaemonTests/WorktreeStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreTests.swift
@@ -111,4 +111,28 @@ import TBDShared
         let repo2List = try await db.worktrees.list(repoID: repo2.id)
         #expect(repo2List.map(\.id) == [wt3.id])
     }
+
+    @Test func worktreeStoreUpdatesPath() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "feat",
+            path: "/tmp/old/w", tmuxServer: "srv"
+        )
+        try await db.worktrees.updatePath(id: wt.id, path: "/tmp/new/w")
+        let fetched = try await db.worktrees.get(id: wt.id)
+        #expect(fetched?.path == "/tmp/new/w")
+    }
+
+    @Test func worktreeStoreCanMarkFailed() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "feat",
+            path: "/tmp/r/.tbd/worktrees/w", tmuxServer: "srv"
+        )
+        try await db.worktrees.updateStatus(id: wt.id, status: .failed)
+        let fetched = try await db.worktrees.get(id: wt.id)
+        #expect(fetched?.status == .failed)
+    }
 }

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -228,3 +228,45 @@ import Testing
     #expect(decoded.repoID == repoID)
     #expect(decoded.worktreeID == nil)
 }
+
+@Test func repoStatusRoundTrips() throws {
+    let ok = RepoStatus.ok
+    let missing = RepoStatus.missing
+    #expect(ok.rawValue == "ok")
+    #expect(missing.rawValue == "missing")
+    #expect(RepoStatus(rawValue: "ok") == .ok)
+    #expect(RepoStatus(rawValue: "missing") == .missing)
+}
+
+@Test func worktreeStatusHasFailedCase() {
+    #expect(WorktreeStatus(rawValue: "failed") == .failed)
+    #expect(WorktreeStatus.failed.rawValue == "failed")
+}
+
+@Test func repoDecodesLegacyJSONWithoutNewFields() throws {
+    let legacy = #"""
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "path": "/tmp/r",
+      "displayName": "r",
+      "defaultBranch": "main",
+      "createdAt": 0
+    }
+    """#
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .secondsSince1970
+    let repo = try decoder.decode(Repo.self, from: Data(legacy.utf8))
+    #expect(repo.worktreeSlot == nil)
+    #expect(repo.worktreeRoot == nil)
+    #expect(repo.status == .ok)
+}
+
+@Test func repoEncodesNewFields() throws {
+    var repo = Repo(path: "/tmp/r", displayName: "r")
+    repo.worktreeSlot = "r"
+    repo.status = .missing
+    let data = try JSONEncoder().encode(repo)
+    let s = String(decoding: data, as: UTF8.self)
+    #expect(s.contains("\"worktreeSlot\":\"r\""))
+    #expect(s.contains("\"status\":\"missing\""))
+}

--- a/docs/worktree-location-design.md
+++ b/docs/worktree-location-design.md
@@ -1,0 +1,398 @@
+# Worktree Location Design
+
+Status: **Proposal v13** — cross-volume step-2 partial-copy hazard: stat `new_path` before deleting the journal on inline failure; recovery "both exist" branch now distinguishes "journal present → bounded retry, safe to clobber partial `new_path`" from "journal absent → preserve both dirs, user investigates."
+Author: Claude (design pass, 2026-04-07)
+
+## Decisions locked in (round 1)
+
+1. Default location: **`~/tbd/worktrees/...`** (not Application Support).
+2. **No UUIDs in paths.** See §4a for the new naming scheme.
+3. **Ship `tbd repo relocate`** in the same change, plus startup validation that surfaces missing repos instead of silently breaking.
+4. Tests get routed through a `WorktreeLayout` helper.
+5. Auto-migrate on upgrade is the goal — see §5a for the failure-case analysis that shapes how we do it safely.
+
+## 1. Current behavior
+
+TBD creates every worktree inside the repo it belongs to:
+
+```
+<repo-root>/.tbd/worktrees/<auto-name>/
+```
+
+The path is hardcoded in `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift:34-35`:
+
+```swift
+let worktreePath = (repo.path as NSString)
+    .appendingPathComponent(".tbd/worktrees/\(name)")
+```
+
+Same string appears in the retry path (`+Create.swift:136`) and in the reconciliation filter (`+Reconcile.swift:108-112`), which uses `.appendingPathComponent(".tbd/worktrees/")` to decide which on-disk worktrees belong to TBD.
+
+Persistence:
+
+- **Repos** are keyed by UUID (`Sources/TBDShared/Models.swift:4`) but the `path` column has a `.unique()` constraint (`Sources/TBDDaemon/Database/Database.swift:55`). The DB has no relocation logic — moving a repo on disk silently breaks lookup, which is *also* an existing problem this design touches.
+- **Worktrees** store an absolute `path` with a `.unique()` constraint (`Database.swift:69`). Paths are persisted, not derived.
+- **TBD config dir** is `~/tbd/` (`Sources/TBDShared/Constants.swift:5-8`), holding `state.db`, `sock`, `tbdd.pid`, `port`, and `conductors/`. TBD does **not** use `~/Library/Application Support/`.
+
+The canonical layout is documented in `docs/superpowers/specs/2026-03-21-tbd-design.md:171` and exercised by 40+ tests across `WorktreeLifecycleTests`, `DatabaseTests`, and `SystemPromptBuilderTests` that hard-code the `.tbd/worktrees/` substring.
+
+## 2. Problem
+
+Putting TBD's metadata inside the repo working tree leaks TBD into every tool that looks at the repo:
+
+1. **`git status` noise** — `.tbd/` shows up as untracked (unless gitignored, which forces every TBD-managed repo to add a line to `.gitignore` or `.git/info/exclude`).
+2. **IDE/file-tree clutter** — Xcode, VS Code, and Finder all show `.tbd/` and recursively index the worktrees, which can be many GB and contain *other* `.git` directories. This regularly confuses search, "Find in Files", and indexers.
+3. **Backup/sync hazards** — Time Machine, Dropbox, iCloud Drive, and rsync-based backups will happily duplicate every worktree under the repo. A 200 MB repo with 10 worktrees becomes ~2 GB of backed-up duplicates.
+4. **Conceptual mismatch** — worktrees are a TBD-managed runtime concept, not a project artifact. They have no business living next to `Package.swift`.
+5. **Permission edge cases** — read-only repos, network-mounted repos, and repos under restricted directories (e.g. `/Applications/...`) cannot host worktrees today.
+
+## 3. Options
+
+| Option | Layout | Pollutes repo? | Survives repo move? | Collisions? | Discoverable? | Migration cost |
+|---|---|---|---|---|---|---|
+| **A. App-support, slot-namespaced** | `~/tbd/worktrees/<slot>/<wt-name>/` (slot = sanitized display name, see §4a) | No | Yes | No (UNIQUE slot) | Medium (hidden dir) | Medium |
+| **B. App-support, name-namespaced** | `~/tbd/worktrees/<repo-name>/<wt-name>/` | No | Yes | **Yes** (two repos named `app`) | Medium | Medium |
+| **C. Home dir, visible** | `~/tbd-worktrees/<repo-name>/<wt-name>/` | No | Yes | Yes | High | Medium |
+| **D. Sibling dir** | `<repo-parent>/<repo-name>.tbd/<wt-name>/` | No (sibling) | No (breaks on move) | Possible | High | Low |
+| **E. Status quo** | `<repo>/.tbd/worktrees/<wt-name>/` | **Yes** | No | No | High | None |
+| **F. Per-repo override + default A** | A by default, override stored in `repos.worktree_root` | No | Yes | No | Configurable | Medium |
+
+Notes on rejected options:
+
+- **B** loses the "no collisions" property the moment a user adds two repos with the same basename (e.g., a fork). Bad default.
+- **C** clutters `$HOME`, which users notice and dislike.
+- **D** preserves the move-fragility we already have *and* leaves crumbs in the parent directory, often a shared `~/projects/` folder. Worst of both worlds.
+- **E** is what we have. Section 2 lists why it has to go.
+
+## 4. Recommendation
+
+**Option F: default to `~/tbd/worktrees/<slot>/<wt-name>/` where `<slot>` is the sanitized repo display name (§4a), with an optional per-repo `worktree_root` override persisted in `state.db`.**
+
+Rationale:
+
+1. **Reuses existing infrastructure.** TBD already owns `~/tbd/`. No new directory convention to teach users. `~/Library/Application Support/TBD/` would be more "Mac-correct" but inconsistent with where `state.db` already lives, and migrating *that* is out of scope.
+2. **Readable, and stable across repo moves.** The display name is what the user already thinks of the repo as. The slot is frozen at add time, so the repo's filesystem path can change freely without touching the worktree directory. (The slot also doesn't change when the user later renames the display name — slot and display name diverge after a rename, and that's an accepted trade-off; see §4a.) This also nudges us toward fixing the latent "moved repo breaks lookup" bug — once worktrees no longer derive from `repo.path`, the only thing tying a repo to its filesystem location is the `repo.path` column, which can be repaired with `tbd repo relocate` (§4b).
+3. **Per-repo override gives power users an escape hatch** without changing the default. Useful for:
+   - Repos on a fast scratch SSD while the main repo lives on a slow networked drive.
+   - Users who *want* sibling-dir layout for muscle memory.
+   - Tests and CI that need a tmpdir.
+4. **Discoverability** is acceptable: `tbd worktree list` already prints absolute paths, and we can add `tbd worktree reveal <name>` (open in Finder) if users complain. The hidden-dir cost is real but small.
+5. **`~/tbd/worktrees/` is shallow enough** that `git worktree repair` and manual recovery work fine. Each `<slot>/` subdirectory is self-contained.
+
+### Resulting layout
+
+```
+~/tbd/
+  state.db
+  sock
+  tbdd.pid
+  port
+  conductors/
+  worktrees/
+    tbd/
+      20260407-negative-crane/
+      20260321-fuzzy-penguin/
+    longeye-app/
+      20260315-tame-otter/
+```
+
+See §4a for exactly how the per-repo directory name is chosen.
+
+## 4a. Per-repo directory naming
+
+`Sources/TBDShared/NameGenerator.swift:7-16` already gives us pleasant worktree names like `20260407-negative-crane`. The per-repo directory should be equally readable.
+
+**Scheme:** the per-repo directory is the **sanitized repo display name**, frozen at `tbd repo add` time. Collisions are refused.
+
+```
+slot = sanitize(repo.displayName)                  # e.g. "tbd", "longeye-app"
+if any existing repo has worktree_slot == slot:
+    refuse `tbd repo add` with:
+        "display name '<new.displayName>' sanitizes to slot '<slot>',
+         which is frozen to repo '<existing.displayName>' (at <existing.path>).
+         (Slot is set at add time and does not change when a repo is renamed,
+          so '<existing.displayName>' may hold a slot that no longer matches its
+          current display name.)
+         Pass --name <different-name>, or run
+         `tbd repo rename-slot <existing.displayName> <new-slot>` first."
+else:
+    repo.worktree_slot = slot
+```
+
+The error surfaces *both* display names and the sanitized slot so the user understands why `TBD` and `tbd`, or `my-app` and `my_app`, collide. It also explicitly names the slot-frozen-at-add-time invariant, because this is the *only* user-facing surface where slot/displayName divergence is visible — without this explanation, a user whose existing repo was renamed sees "slot `foo` is used by repo `bar`" and has no mental model for why.
+
+Properties:
+
+- **Readable.** `cd ~/tbd/worktrees/tbd/20260407-negative-crane` — no hashes anywhere.
+- **User-controlled.** TBD already exposes display names in the UI and `tbd worktree rename` (which also renames repos). The directory name is whatever the user chose. No magic.
+- **Frozen at add time.** The slot is persisted to `repo.worktree_slot` and **does not change when the user later renames the repo's display name.** Slot and display name diverge after the first rename, and that's fine — the slot is an on-disk detail, surfaced only when the user `cd`s into `~/tbd/worktrees/`. If they care enough to rename the on-disk slot, that's a separate `tbd repo rename-slot` operation (not in this design's scope; add later if anyone asks).
+- **Stable across repo moves.** Moving the repo on disk doesn't touch the slot. Same property the v3/v4 design had.
+- **Collision policy.** At `tbd repo add`, if the sanitized display name is already taken, refuse the add and tell the user to pick a different display name (`--name <new-name>` flag, or rename the existing repo first). This is cheap to implement, can never silently overwrite anyone's data, and matches how the user already thinks about repos (display names are the human identifier).
+- **Sanitization.** Lowercase, replace anything outside `[a-z0-9._-]` with `-`, collapse runs of `-`, trim leading/trailing `-`. Reject (force user to rename) if the result is empty, `.`, `..`, or starts with `.`. The UNIQUE constraint on `worktree_slot` enforces collisions at the DB level as a backstop.
+
+### Full schema delta (one GRDB migration `vN`)
+
+The `repo` table (singular — `Database.swift:53`) gains three columns in one migration:
+
+```sql
+ALTER TABLE repo ADD COLUMN worktree_slot TEXT UNIQUE;                -- sanitized display name, frozen at add
+ALTER TABLE repo ADD COLUMN worktree_root TEXT;                       -- NULL = default; absolute override
+ALTER TABLE repo ADD COLUMN status        TEXT NOT NULL DEFAULT 'ok'; -- 'ok' | 'missing'
+```
+
+Plus **a new `RepoStatus` enum** in `Sources/TBDShared/Models.swift` alongside the `Repo` model, matching the `status` column:
+
+```swift
+public enum RepoStatus: String, Codable, Sendable {
+    case ok, missing
+}
+```
+
+And a **new `WorktreeStatus` case** in `Sources/TBDShared/Models.swift:27-29`:
+
+```swift
+public enum WorktreeStatus: String, Codable, Sendable {
+    case active, archived, main, creating, conductor, failed   // 'failed' is new
+}
+```
+
+`worktree.status` is already a TEXT column (`Database.swift:69`), so no schema migration is needed for the new enum case — only the Swift enum and any switch statements that exhaustively match it. Per `CLAUDE.md` (TBDShared section), the daemon must be restarted after this change.
+
+Field roles:
+
+- **`worktree_slot`** — source of truth for the per-repo directory name. Sanitized display name at add-time. UNIQUE-constrained. Never auto-changes.
+- **`worktree_root`** — power-user override. When non-NULL, bypasses the slot mechanism entirely.
+- **`status`** — `ok` or `missing` (§4b). Validated on startup and reconcile.
+
+The `Repo` Codable model in `Sources/TBDShared/Models.swift` gains matching optional fields (`worktreeSlot`, `worktreeRoot`, `status`) so old rows decode.
+
+### Backfill: assigning slots to existing repos at migration time
+
+The GRDB migration must populate `worktree_slot` for every pre-existing row in `repo`. The `tbd repo add` interactive collision-rejection path doesn't apply here — the migration runs unattended and **must not fail**. Algorithm:
+
+```
+assigned_slots: Set<String> = SELECT worktree_slot FROM repo WHERE worktree_slot IS NOT NULL
+for each existing repo, ordered by createdAt ASC (stable):
+    if repo.worktree_slot IS NOT NULL:
+        continue   # already assigned (resumed run); don't re-suffix
+    base = sanitize(repo.displayName)
+    if base is empty, ".", "..", or starts with ".":
+        base = "repo-\(repo.id.uuidString.prefix(6))"   # always-valid fallback
+    slot = base
+    n = 2
+    while assigned_slots contains slot:
+        slot = "\(base)-\(n)"
+        n += 1
+    repo.worktree_slot = slot
+    assigned_slots.insert(slot)   # in-memory; UNIQUE constraint backstops the DB write
+```
+
+Properties:
+
+- **Never fails.** Empty/reserved sanitization falls through to a UUID-derived name; collisions get a numeric suffix. The DB-level `UNIQUE` constraint is a backstop, not a failure surface.
+- **Stable.** Ordering by `createdAt ASC` means the *older* repo keeps the bare slot and newer repos get suffixed — same asymmetry rule as the live `tbd repo add` path (newer thing moves), and a re-run of the migration on the same DB produces the same slots.
+- **Visible.** After migration, the daemon emits an `os.Logger` warning per repo whose slot doesn't match its sanitized display name (collision suffix or fallback). The user can `tbd repo rename-slot` later if they care; nothing is broken in the meantime.
+- **Backfill happens *before* the worktree-move phase.** Slot assignment is a pure DB operation and must complete (and commit) before §5b's per-worktree journal-and-move loop starts touching the filesystem. This keeps the DB always-consistent and means a crash mid-move never leaves an unslotted repo behind.
+
+### Code change surface (for the implementation pass, not this doc)
+
+- New helper `WorktreeLayout` in `TBDDaemon` (or `TBDShared`) with two methods:
+  - `basePath(for: Repo) -> String` — the *canonical* (new) base path for fresh worktree creation. Returns `repo.worktreeRoot` if non-NULL, otherwise `~/tbd/worktrees/<repo.worktreeSlot>/`. This is the single point that knows about the override.
+  - `legacyAndCanonicalPrefixes(for: Repo) -> [String]` — returns `[basePath(for: repo), legacyPath(for: repo)]`, where `legacyPath` is `<repo.path>/.tbd/worktrees/`. Reconcile uses this to adopt worktrees from either layout. **Critical: the canonical entry must come from `basePath(for:)`, not be hardcoded as `~/tbd/worktrees/<slot>/`.** Otherwise repos with a `worktree_root` override get their canonical prefix wrong, and worktrees at `<worktree_root>/…` become invisible to reconcile and get reaped. This is critical because §5a's pre-flight legitimately *skips* unsafe worktrees, leaving them in the legacy location indefinitely. If reconcile only knows about the new prefix, those skipped worktrees become invisible and get reaped on the next reconcile pass. The dual-prefix view stays in place until the user confirms full migration via `tbd repo migrate-worktrees --dry-run` reporting zero legacy paths across all repos; at that point a future TBD release can drop the legacy branch from `WorktreeLayout` and the `WorktreeLifecycle+Reconcile.swift` filter. There's no flag day — the dual-prefix path is cheap and can stay indefinitely if needed.
+- Replace the two hardcoded sites in `WorktreeLifecycle+Create.swift` (use `basePath(for:)`) and the filter in `WorktreeLifecycle+Reconcile.swift:108-112` (use `legacyAndCanonicalPrefixes(for:)` and match against either).
+- Update tests that currently grep for `.tbd/worktrees/` — they should call the same helper, or a test-only override sets `worktree_root` to a tmpdir.
+- Add `tbd repo set-worktree-root <repo> <path>` CLI command (and matching RPC) for the override.
+- Ensure the per-repo dir is created lazily on first worktree creation, not on repo add (so users who never create worktrees don't get empty dirs).
+
+## 4b. Fixing `repo.path` silent breakage
+
+The latent bug (§2 / §3): TBD identifies repos by absolute filesystem path, with no detection or recovery if the user moves the directory. The new layout doesn't make this worse, but it surfaces it during auto-migrate (§5a) and we said we'd fix it. Concretely:
+
+1. **Add a `repo.status` column** with values `.ok`, `.missing`. Default `.ok`. (Already in §4a's schema delta.)
+2. **On daemon startup and on every reconcile**, validate each repo: does `repo.path` exist, is it a git repo, does its `HEAD` resolve? If any check fails → `.missing`.
+3. **Every RPC handler that takes a repo ID** checks status first. `.missing` repos return a structured error (`.repoMissing(repoId, lastKnownPath)`) that the app surfaces with a "Locate…" button instead of a generic failure.
+4. **`tbd repo relocate <id-or-name> <new-path>`** (CLI + RPC):
+   - Validates `<new-path>` exists and is a git repo. That's it — no origin URL check (§6 explains why).
+   - Updates `repo.path`.
+   - Updates every `worktree.path` row whose old absolute path was inside the old repo path **only for legacy worktrees still living under the old `<repo>/.tbd/worktrees/`**. New-layout worktrees in `~/tbd/worktrees/<slot>/` are unaffected — that's another argument for the new layout.
+   - Runs `git worktree repair` for each worktree from the new repo path so git's metadata picks up the new location. If `repair` fails for a given worktree (e.g. the main repo's `.git/worktrees/<name>/` was pruned or corrupted), mark that worktree `.failed` and continue to the next one — do not abort the relocate. The user can re-run `git worktree repair` manually or `tbd worktree forget` + re-discover the orphan.
+   - Sets `repo.status = .ok`.
+5. **App UI:** missing repos are dimmed in the sidebar with a "Locate…" affordance that opens an `NSOpenPanel`. CLI (`tbd repo list`, `tbd worktree list`) shows them with a `[missing]` tag. No silent failures, no hiding.
+
+### Why this matters for *this* design
+
+The new layout makes the relocate problem dramatically simpler: once a worktree lives at `~/tbd/worktrees/<slot>/<wt-name>/`, it doesn't care where the main repo is on disk. Relocating the repo only needs to update `repo.path` and run `git worktree repair`. Today (legacy layout), relocating a repo would require moving every worktree directory too, which is exactly the pain we're getting rid of.
+
+## 5. Migration plan
+
+Existing installs have worktrees at `<repo>/.tbd/worktrees/<name>/` with absolute paths persisted in `state.db`. We need to move the directories *and* update the DB without leaving git's `.git/worktrees/<name>/gitdir` files pointing into space.
+
+## 5a. Auto-migrate failure cases (the question that decides the strategy)
+
+You asked what could go wrong with auto-migrate-on-upgrade. Here's the honest list, grouped by how dangerous each is:
+
+### Dangerous — can destroy work or corrupt state
+
+1. **A TBD terminal/Claude session is currently attached to the worktree.** Its shell has CWD inside the directory we're about to move. On macOS, `mv` succeeds (the inode is unchanged), but the shell's `$PWD` becomes a stale string. New commands using relative paths still work (kernel tracks the inode), but anything that re-resolves `$PWD` (prompts, `pwd -P`, build tools that re-canonicalize) breaks. If the user `cd .`s, they're in limbo.
+2. **An editor (VS Code, Xcode, Cursor) has the worktree open with unsaved buffers.** macOS file watchers (FSEvents) re-resolve paths after a move; behavior varies wildly. Xcode in particular will sometimes write the unsaved buffer back to the *old* path it cached at open time, creating a ghost file outside the new worktree. Lost work.
+3. **A build is running** (`swift build`, `xcodebuild`, `npm run`, conductor-launched script). Build systems with absolute-path artifact databases (DerivedData, `.build/`, `node_modules/.cache`) get poisoned. At minimum the build fails halfway; at worst the next build appears to succeed but links against stale objects.
+4. **Cross-volume move.** `~/tbd/` is on the boot volume; the repo might be on an external SSD. `FileManager.moveItem` falls back to copy-then-delete, which is **not atomic** — interrupt it (daemon crash, machine sleep, power loss) and you have two half-copies and no journal to tell you which is canonical.
+5. **The repo itself has been moved/deleted on disk** (`repos.path` is stale). We can't run `git worktree repair` because there's no main `.git/worktrees/<name>/` to fix up. The worktree's `.git` file becomes a dangling pointer. Today this is a latent bug; auto-migrate would surface it as a hard failure on upgrade.
+6. **Daemon crash mid-batch.** With `--all`, we're migrating N repos × M worktrees each. If we crash on item 17 of 200, we need to know exactly where we were.
+7. **Two daemons racing.** If a stale `tbdd` is still running from a previous install while the new one starts up, they both try to migrate the same DB rows. The PID file in `~/tbd/tbdd.pid` should prevent this, but only if we check it.
+
+### Annoying — won't lose data but will surprise the user
+
+8. **Symlinks pointing into the old path** from elsewhere on disk (a `~/work/current → .../old-worktree` shortcut, an IDE workspace file, a CI runner config). Silently break.
+9. **External hooks/scripts hardcoded to the old path** — a user's `~/.zshrc` alias, a launchd job, a tmux popup script.
+10. **`.gitignore` rules in the main repo that mention `.tbd/`** — harmless but now dead.
+11. **Disk full** in `~/tbd/`. Cross-volume copy fails partway through. Same recovery story as case 4.
+12. **Permission denied** writing to `~/tbd/worktrees/<slot>/` (unusual but possible if the user has chowned `~/tbd/`).
+13. **`git worktree repair` itself fails** — happens if the main repo's `.git/worktrees/` was manually edited or pruned.
+14. **Slot collision migration cascading.** If we're also rewriting an existing repo's directory because a same-basename repo was added, that's two move operations in one transaction.
+
+### Strategy that the failure list implies
+
+Given that the only current user has explicitly accepted editor-state loss as a non-issue ("editors are easy to reopen"), we **move everything** on first post-upgrade startup. The failure list above remains valid as a record of what we're consciously accepting, not a list of cases we defend against.
+
+- **Auto-migrate runs once on daemon startup after an upgrade**, gated by a `layout_version` value. Concrete shape:
+
+  ```sql
+  CREATE TABLE IF NOT EXISTS tbd_meta (
+      key   TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+  );
+  -- After successful migration: INSERT OR REPLACE INTO tbd_meta VALUES ('layout_version', '1');
+  ```
+
+  - **Table:** a new `tbd_meta` key/value table created in the same GRDB migration (`vN`) that adds the `repo` columns. This is just for daemon-managed sentinels that aren't GRDB schema versions.
+  - **Current version constant:** `WorktreeLayout.currentVersion: Int = 1`, hardcoded in Swift. Bumped manually if a future TBD release introduces a new layout migration.
+  - **Initial value for existing installs:** absent. The startup code reads `tbd_meta.layout_version`; if missing or `< currentVersion`, runs migration. After successful migration completes (every repo's worktrees processed, success or skip), writes `currentVersion` to the row.
+  - **Why this is deliberately not a GRDB migration:** GRDB migrations are single-pass and non-retryable — they run inside one transaction and either succeed or roll back. The filesystem migration must survive crashes mid-batch and resume on the next boot, exactly what the journal in §5b provides. A GRDB migration that called out to `FileManager.moveItem` would lose crash-resumability and could leave the schema marked "migrated" with the filesystem half-done. The `tbd_meta.layout_version` row records "the last layout version that finished migrating end-to-end," and only flips after the resume loop terminates with no journal entries left.
+
+  It does not run on every launch. No countdown, no user prompt — the user knows it's coming.
+- **Minimal pre-flight per worktree** (not for safety, but to avoid moving things that are demonstrably broken or in-flight):
+  - Status is `.active` (skip `.creating`/`.archived`/`.main`/`.conductor`/`.failed`).
+  - The migrator **actively closes** any TBD-owned terminal whose CWD is this worktree before the move. TBD-owned terminals are TBD's problem; the user reopens them post-migration. (No pre-flight check here — it's an action, not a gate.)
+  - The repo's main path still exists and is a git repo. **If not, the repo is marked `.missing` (§4b) and its worktrees are *skipped*, not failed.** The legacy worktrees stay where they are and remain reachable via the dual-prefix reconcile view (§4a code-change surface). When the user later runs `tbd repo relocate`, the next startup sweep (or manual `tbd repo migrate-worktrees`) picks them up.
+  - **Crucially: a missing repo must never block daemon startup.** Migration iterates repos in isolation — one missing repo skips that repo only, the daemon continues, and the user can invoke `tbd repo relocate` via RPC the moment startup finishes. Without this, the daemon would be unbootable any time a repo directory has moved, with no recovery path (relocate is an RPC that requires a running daemon).
+- **Cross-volume moves are allowed**, since `~/tbd/` and the repos are realistically all on the boot volume for the current user. The journal (§5b) covers the not-atomic case if the daemon crashes mid-copy.
+- **`worktree_root` override is honored.** If a repo has a non-NULL `worktree_root`, migration moves its worktrees to `<worktree_root>/<wt-name>/` instead of `~/tbd/worktrees/<slot>/<wt-name>/`. On first post-upgrade migration this is a no-op (all existing rows are NULL), but future manual re-runs of `tbd repo migrate-worktrees` after a user sets an override need the behavior to be defined.
+- **Progress is logged per worktree** via `os.Logger` (category: `migration`). A single cross-volume copy can take minutes for a large worktree, and the daemon will appear unresponsive to app/CLI clients during that window. Document the expectation in release notes; stream with `log stream --level debug --predicate 'category == "migration"'` to watch progress live. This is not a correctness fix — it's preventing future-you from debugging "frozen app on first boot after upgrade" as a bug.
+- **A two-phase journal** (see §5b) makes every individual move recoverable.
+- **A `migration.lock` file** prevents two daemon processes from racing.
+- **Block daemon startup on migration.** With one user and a small number of worktrees, there's no benefit to background migration — and a foreground migration is simpler to reason about (no "is the daemon ready yet?" race for RPC clients).
+
+The manual `tbd repo migrate-worktrees [--dry-run] [<repo>]` command stays around for the rare follow-up case (e.g., a worktree that was `.creating` during the auto-pass and finished afterward) and for inspection (`--dry-run`).
+
+## 5b. Migration mechanics
+
+### Strategy
+
+Auto-migrate at startup for the safe cases (§5a), with a manual `tbd repo migrate-worktrees` for everything else. Both paths share the same per-worktree machinery and the same journal.
+
+```
+tbd repo migrate-worktrees [<repo>]   # default: all repos
+                          [--dry-run]
+```
+
+### Locking and journal scope
+
+Migrations are **serialized one worktree at a time**, even with `--all`. The journal file at `~/tbd/migration-journal.json` holds **exactly one entry** at a time, not the whole batch. This makes recovery trivial: at startup, either the journal is absent (nothing in flight) or it describes exactly one half-done move.
+
+A separate **`~/tbd/migration.lock`** file prevents two daemon processes from racing. **The locking primitive is OS-level `fcntl(F_SETLK)` (`flock(2)` on macOS via `Foundation`'s `FileHandle.lock`/`unlock` or a direct `fcntl` call).** This is intentional — kernel-managed advisory locks are released automatically when the holding process dies, so a daemon crash cannot leave a permanent stale lock. The lock file itself may persist on disk, but the *lock state* does not.
+
+**Stale-lock recovery edge case:** if the daemon crashes after `acquire migration.lock` but *before* writing the journal in step 1, the kernel releases the lock on process death and the lock file remains as an empty marker. On next boot the recovery routine sees `migration.lock` exists but no journal entry — this means a crash made no filesystem changes. Treat the lock file as informational, attempt to acquire the kernel lock fresh (it will succeed since the dead process is gone), and proceed normally. If a stale lock file is encountered on a filesystem where `fcntl` is unavailable (network mounts), fall back to deleting the lock file after confirming via `tbd_meta` that no migration is in progress.
+
+The strict ordering for every move is:
+
+```
+acquire migration.lock
+  write journal entry          (step 1)
+  move directory               (step 2)
+  git worktree repair          (step 3)
+  update state.db row          (step 4)
+  delete journal entry         (step 5)
+release migration.lock
+```
+
+The lock is held only for the duration of one move, then released between worktrees. With migration currently blocking daemon startup (§5a), no RPCs can arrive between moves, so the per-move release is moot today — but the granularity is preserved so this code can move to background migration in a future release without redesigning the locking. On daemon startup, recovery (§5b "Failure recovery") runs *before* releasing the lock for normal operation.
+
+### Per-worktree migration steps
+
+For each worktree owned by the repo, **step 0 runs outside the lock** (so a skip is cheap), then **steps 1–5 run under the lock** and use the same numbering as the lock-sequence box above:
+
+**Step 0 — Pre-flight and prep** (outside lock; skip this worktree if any *check* fails; do not abort the batch):
+- *Check:* worktree status is `.active`.
+- *Check:* destination path does not already exist.
+- *Check:* the owning repo's status is `.ok` (not `.missing`).
+- *Action:* close/detach any TBD terminal in the `terminal` table whose CWD is this worktree. Logged at `info`.
+
+**Steps 1–5 — under the lock** (same numbering as the lock-sequence box):
+
+1. **Write the journal entry** (`{worktree_id, old_path, new_path, started_at}`) to `~/tbd/migration-journal.json`.
+2. **Move the directory** with `FileManager.moveItem(at:to:)`. On the same volume this resolves to `rename(2)`, whose final inode flip is atomic. Cross-volume falls back to copy-then-delete and is **not atomic**; the journal from step 1 is what makes it recoverable across crashes.
+
+   **If `moveItem` throws inline** (e.g. `ENOSPC`, `EPERM`) without crashing the daemon, **stat `new_path` before deciding how to handle the failure** — because the same-volume and cross-volume failure modes leave disk state in very different places:
+
+   - **`new_path` does not exist** — same-volume `rename(2)` failure, or cross-volume copy that never got far enough to create the destination. `old_path` is intact. This is the "safe" branch: delete the journal entry (no filesystem change occurred), log at `error` level, mark this worktree `.failed` (both in memory and persist to `worktree.status` in the DB), release the lock, and continue the batch to the next worktree.
+   - **`new_path` exists** — cross-volume copy failed mid-way, leaving a partial directory at `new_path` while `old_path` is still intact. **Do not delete the journal entry.** Both paths now exist on disk with the journal still describing an in-flight move; this matches the "both `old_path` and `new_path` exist" branch in §5b's recovery routine. Treat the failure as if the daemon had crashed: release the lock, continue the batch, and let the next daemon startup run the bounded-retry protocol (which will delete the partial `new_path` after a fresh attempt or bail after the retry count is exhausted). **Recovery logic extension for the "both exist" branch:** when the journal is present (i.e. we reached this state via an inline step-2 failure rather than a mystery recreation of `old_path`), recovery is safe to delete the partial `new_path` and re-attempt the move from scratch, bounded by `retry_count` (§Step 4 edge case). Without this, Step 0's "destination does not exist" pre-flight would skip the worktree forever on every subsequent run, stranding the partial copy.
+
+   The stat-before-decide protocol matters because Step 0's pre-flight check ("destination does not exist") would otherwise blacklist the stranded worktree permanently. Without this explicit handling, a cross-volume `ENOSPC` mid-copy would leak a corrupt partial directory *and* a leftover journal entry could block every subsequent worktree in the same sweep.
+3. **Repair git's bookkeeping** with `git -C <new-worktree-path> worktree repair`. This rewrites both `<main-repo>/.git/worktrees/<wt-name>/gitdir` (absolute path to the worktree's `.git` file) and `<worktree-path>/.git` (which contains `gitdir: <main-repo>/.git/worktrees/<wt-name>`). Verify with `git worktree list` from the main repo.
+4. **Update `state.db`** in a transaction: `UPDATE worktree SET path = ? WHERE id = ?`. If the transaction fails, **do not attempt inline recovery** — at this point `old_path` no longer exists on disk (Step 2 moved it) and git's metadata already points to `new_path` (Step 3 repaired it), so a `git worktree repair` from the old path would fail. The journal entry from Step 1 still describes the in-flight move, and the on-disk state matches the "only `new_path` exists" case in §5b's recovery routine: on next daemon startup, recovery re-runs Steps 3–5 idempotently. Inline behavior: log at `error` level (`os.Logger`, category `migration`), mark this worktree `.failed` in memory for the rest of the current sweep so nothing else touches it, and **continue the batch** to the next worktree. Do not abort the sweep — one DB write failure shouldn't strand every other worktree.
+
+   **Bounded-recovery edge case:** if *any* step in recovery's "only `new_path` exists" branch (step 3 `git worktree repair` *or* step 4 DB update) persistently fails across reboots, the journal would stay on disk indefinitely. To bound this, the journal entry carries a **`retry_count: Int`** field, and the recovery protocol on each boot is strict:
+
+   1. Read the journal entry, including `retry_count` (default `0` if absent — fresh entry from a pre-recovery crash).
+   2. **If `retry_count >= 3`:** delete the journal entry, mark the worktree `.failed` in the DB, log at `error` level with instructions to run `tbd worktree repair --reconcile` (or equivalent) to reconcile the DB pointer, and continue startup. The worktree is *physically intact* at `new_path` — only the DB row is stale, and reconcile (§4a code-change surface) can rebuild it from the dual-prefix scan.
+   3. **Otherwise**, write `retry_count + 1` to the journal file on disk **before attempting recovery**. The increment-then-fsync-then-attempt order is load-bearing: if the daemon crashes after the in-memory increment but before the write, the count would reset on next boot and the bound would never be reached.
+   4. Attempt steps 3–5 (repair → DB update → delete journal). On success, the journal is gone and the count is moot. On any failure, the next boot reads the incremented count and the loop converges.
+
+   This applies equally to step-3 (`git worktree repair`) failures — the most common real-world case being "the main repo was moved or deleted after migration started." Without the bound, that scenario would loop forever.
+5. **Delete the journal entry**, then **sweep the old `<repo>/.tbd/worktrees/` directory** if it's now empty. If `<repo>/.tbd/` is *also* empty after that removal, remove it too — leaving an empty `<repo>/.tbd/` behind would defeat the `.tbd/`-pollution fix in §2 (the directory would still show up in `git status` and IDE trees). Only remove if strictly empty; if the user has put anything else in there, leave it alone.
+
+### Failure recovery
+
+The dangerous moment is between step 2 (directory moved) and step 4 (DB updated). The journal makes it recoverable:
+
+- The journal is written *before* step 2 and deleted *after* step 4, so a daemon crash anywhere in the danger window leaves exactly one journal entry on disk.
+- **On daemon startup**, before running any new migrations, check `migration.lock` and `migration-journal.json`. If a journal entry exists, run recovery:
+  - Only `new_path` exists → step 2 succeeded; run the bounded-retry protocol from Step 4 above (read `retry_count`, bail if ≥3, otherwise increment-and-persist then attempt steps 3–5). If step 3 (`git worktree repair`) or step 4 (DB update) throws during this retry and the count hasn't reached the bound, the journal stays on disk with the incremented count and the next boot tries again. If either step throws *and* the count has now reached the bound, the worktree is marked `.failed`, the journal is deleted, and startup continues.
+  - Only `old_path` exists → step 2 failed or was rolled back; delete the journal entry and **re-queue the worktree into the current startup sweep** so it retries this boot. (Without re-queue, the iteration that started this attempt has already moved on, and the worktree would stay in legacy until the user manually runs `tbd repo migrate-worktrees`.)
+  - Both `old_path` and `new_path` exist → two sub-cases, distinguished by whether the journal entry was written *before* step 2 (normal) or whether something else recreated `old_path`:
+    - **Normal sub-case (journal describes an in-flight move):** this is the cross-volume step-2 partial-copy scenario from Step 2's inline-failure path above. The partial `new_path` is corrupt and `old_path` is still the canonical source. Run the bounded-retry protocol: delete the partial `new_path` recursively, then re-attempt steps 2–5 from scratch under the incremented `retry_count`. If the count has reached the bound, mark the worktree `.failed`, remove the partial `new_path`, delete the journal, and continue startup. This is safe because the journal unambiguously identifies `new_path` as in-flight — there's no legitimate worktree there to preserve.
+    - **Ambiguous sub-case (journal is absent but both paths still exist):** something outside the migration recreated `old_path`, or the journal was manually deleted. Mark the worktree `.failed`, leave *both* directories in place (the user may have put something at `old_path` that shouldn't be destroyed), log loudly (`os.Logger` at `error` level, category `migration`), and continue startup. The user investigates manually — `tbd worktree forget` + re-reconcile is the normal recovery.
+    Refusing to start would strand the user with no RPCs available in either sub-case.
+  - Neither exists → catastrophic. Mark the worktree `.failed` in the DB, delete the journal entry, continue startup.
+
+  In every case the daemon comes up. Migration never blocks startup on an unrecoverable state — startup is a prerequisite for the user to do anything about it.
+- Because the lock is held across the entire sequence and the journal is single-entry, "lost journal" is not a possible state under normal operation. (If the user manually deletes `~/tbd/migration-journal.json` mid-flight, that's on them.)
+
+### What if the repo itself can't be located anymore?
+
+**This section applies to the manual `tbd repo migrate-worktrees` command only.** The auto-migrate startup sweep (§5a) *skips* missing repos silently so that a moved repo never blocks the daemon from coming up — that's a load-bearing invariant and must not be broken.
+
+For the manual command: migration refuses. The repo is in `.missing` state (§4b) and the user must run `tbd repo relocate <repo> <new-path>` first. After relocate, migration can proceed normally because `git worktree repair` now has a valid main `.git/worktrees/` to talk to.
+
+## 6. Remaining open questions
+
+Round 4 (slot = sanitized display name, no disambiguator) and round 5 (decisions below) closed all the prior open questions. None remain.
+
+### Decisions locked in (round 5)
+
+- **Missing repo UX.** Both app and CLI show missing repos but **dimmed/marked**. App: dimmed sidebar entry with "Locate…" button. CLI (`tbd repo list`, `tbd worktree list`): show with a `[missing]` tag, exit code unchanged. Hiding them would make the user think they were silently dropped, which is exactly the bug we're fixing.
+- **Origin URL mismatch on relocate: drop the check entirely.** See note below — it doesn't earn its complexity.
+
+### Why the origin-URL check is gone
+
+Earlier drafts proposed caching `remote.origin.url` and `first_commit_sha` at `tbd repo add` so that `tbd repo relocate <new-path>` could verify the new path is "the same repo." Walking through the actual cases:
+
+- **Repos with no remote at all** (local-only experiments, scratch repos, this very TBD worktree if it weren't pushed). `origin_url` is empty. Check is a no-op.
+- **Repos whose remote has changed legitimately** (renamed GitHub repo, migrated from GitHub to a self-hosted gitea, switched from HTTPS to SSH URL — `https://github.com/x/y` → `git@github.com:x/y.git`). The URL string differs but it's the same repo. The check would false-positive constantly and we'd end up requiring `--force` every time, which means the check teaches the user to ignore it.
+- **The case it would actually catch** — user runs `tbd repo relocate /path/to/totally-unrelated-repo` by accident — is also caught, more directly, by the user noticing the worktree branches and history are wrong the moment they open it.
+- **`first_commit_sha`** is more stable but has the same problem with shallow clones, force-pushed root commits (rare but real), and repos that have been rewritten via `git filter-repo`.
+
+The cost of the check: two extra columns, add-time work to populate them, NULL-tolerance code in relocate, and a `--force` flag the user will reflexively pass. The benefit: catches a rare user error that the user will notice within seconds anyway.
+
+**Drop both `origin_url` and `first_commit_sha` from the schema delta.** Relocate becomes: validate the new path is a git repo, update `repo.path`, run `git worktree repair`, set status to `.ok`. Done.

--- a/scripts/move-home-dir.sh
+++ b/scripts/move-home-dir.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-shot: move TBD's home directory from ~/.tbd to ~/tbd.
+#
+# Why: TBD now uses a visible ~/tbd directory instead of the hidden ~/.tbd.
+# This script does the safe stop -> rename -> symlink -> restart dance.
+#
+# Safe to re-run: it refuses if ~/tbd already exists.
+#
+# Leaves a transitional symlink at ~/.tbd -> tbd as a safety net for any
+# stray reference. After a week or two of confidence, you can:
+#     rm ~/.tbd
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+OLD="$HOME/.tbd"
+NEW="$HOME/tbd"
+
+# Refuse if already migrated.
+if [ -d "$NEW" ] && [ ! -L "$NEW" ]; then
+    echo "~/tbd already exists. Nothing to do."
+    if [ -L "$OLD" ]; then
+        echo "  (~/.tbd is already a symlink to tbd — looks fine.)"
+    fi
+    exit 0
+fi
+
+# Refuse if old doesn't exist.
+if [ ! -d "$OLD" ] || [ -L "$OLD" ]; then
+    echo "~/.tbd is not a real directory. Nothing to move."
+    exit 1
+fi
+
+echo "Stopping TBDApp..."
+pkill -x TBDApp 2>/dev/null || true
+sleep 0.3
+
+echo "Stopping daemon..."
+if [ -f "$OLD/tbdd.pid" ]; then
+    pid=$(cat "$OLD/tbdd.pid")
+    if kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" || true
+        # Wait up to 5s for clean exit.
+        for _ in $(seq 1 10); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 0.5
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "  Daemon $pid did not exit cleanly. Aborting."
+            echo "  Investigate manually before re-running. (Do not kill -9 without knowing why.)"
+            exit 1
+        fi
+    fi
+fi
+
+# Final safety: nothing TBD should be left running.
+if pgrep -x TBDDaemon >/dev/null || pgrep -x TBDApp >/dev/null; then
+    echo "TBD processes still running:"
+    pgrep -lf 'TBDDaemon|TBDApp' || true
+    echo "Aborting."
+    exit 1
+fi
+
+echo "Renaming $OLD -> $NEW..."
+mv "$OLD" "$NEW"
+
+echo "Creating safety symlink ~/.tbd -> tbd..."
+ln -s tbd "$OLD"
+
+echo "Done moving. Restarting via scripts/restart.sh..."
+"$REPO_ROOT/scripts/restart.sh"
+
+echo
+echo "Migration complete."
+echo "  State now lives in: $NEW"
+echo "  Transitional symlink: $OLD -> tbd"
+echo
+echo "Smoke test: create a new worktree in TBD and confirm it lands at"
+echo "  ~/tbd/worktrees/<repo>/<name>"
+echo
+echo "After a week or two, remove the symlink with: rm ~/.tbd"

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -38,22 +38,22 @@ fi
 
 if [ "$app_only" = false ]; then
     echo "Stopping daemon..."
-    if [ -f ~/.tbd/tbdd.pid ]; then
-        pid=$(cat ~/.tbd/tbdd.pid)
+    if [ -f ~/tbd/tbdd.pid ]; then
+        pid=$(cat ~/tbd/tbdd.pid)
         kill "$pid" 2>/dev/null && sleep 0.5 || true
     fi
     # Clean stale files
-    rm -f ~/.tbd/sock ~/.tbd/tbdd.pid ~/.tbd/port
+    rm -f ~/tbd/sock ~/tbd/tbdd.pid ~/tbd/port
 
     echo "Starting daemon..."
     "$BUILD_DIR/TBDDaemon" > /tmp/tbdd.log 2>&1 &
     # Wait for socket
     for i in $(seq 1 30); do
-        [ -S ~/.tbd/sock ] && break
+        [ -S ~/tbd/sock ] && break
         sleep 0.1
     done
-    if [ -S ~/.tbd/sock ]; then
-        echo "  Daemon ready (PID $(cat ~/.tbd/tbdd.pid 2>/dev/null))"
+    if [ -S ~/tbd/sock ]; then
+        echo "  Daemon ready (PID $(cat ~/tbd/tbdd.pid 2>/dev/null))"
     else
         echo "  WARNING: Daemon socket not found after 3s"
     fi


### PR DESCRIPTION
## Summary

- **Recover from moved/missing repos.** TBD now validates repo health on startup and after reconcile, marks missing repos as such (dimmed in the app, `[missing]` in CLI), and offers a `Locate…` affordance + `tbd repo relocate` command to point them at the new location. Worktrees survive moves intact.
- **Canonical worktree location + visible home dir.** New worktrees now go to `~/tbd/worktrees/<repo>/<wt-name>/` instead of being scattered under each repo's `.tbd/worktrees/`. The daemon's home moved from hidden `~/.tbd` to visible `~/tbd`. Existing worktrees stay where they are and decay naturally — the legacy read path is marked `LEGACY-WORKTREE-LOCATION: remove after 2026-06-01`.
- **Migration was attempted then abandoned.** A `tbdd --migrate-worktrees` flow was built (with crash-recoverable journal, fcntl lock, manifest, db backup) but it broke every running Claude session whose cwd was inside a moved worktree (kernel held the dead inode → `posix_spawn` ENOENT). All migration code is deleted in this PR. The forward-only canonical path handles new worktrees; old ones age out.
- Adds `scripts/move-home-dir.sh` to safely do the one-shot `~/.tbd → ~/tbd` rename + transitional symlink + restart.

## Test plan

- [ ] `swift build` clean, `swift test` 260 passing
- [ ] After merge: run `scripts/move-home-dir.sh` once
- [ ] Verify `~/tbd/state.db`, `~/tbd/sock`, `~/tbd/tbdd.pid` exist; `~/.tbd` is a symlink to `tbd`
- [ ] Existing worktrees still appear in TBDApp and tmux panes work
- [ ] Create a new worktree → confirm it lands at `~/tbd/worktrees/<repo>/<wt-name>/`
- [ ] Move a repo on disk → TBDApp dims it and `Locate…` repairs it