### PR TITLE
Fix: Restore terminal windows after machine reboot instead of silently wiping them

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -137,17 +137,22 @@ extension WorktreeLifecycle {
             )
         }
 
-        // Clean up terminal records pointing to dead tmux windows (especially main worktrees)
+        // Clean up terminal records pointing to dead tmux windows (especially main worktrees).
+        // If the entire tmux server is gone (e.g. machine reboot), recreate windows from
+        // persisted records instead of deleting them.
         let allLiveWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
             + (try await db.worktrees.list(repoID: repoID, status: .main))
+        let serverAlive = await tmux.serverExists(server: correctTmuxServer)
         for wt in allLiveWorktrees {
             let terminals = try await db.terminals.list(worktreeID: wt.id)
-            for terminal in terminals {
-                let alive = await tmux.windowExists(
-                    server: wt.tmuxServer, windowID: terminal.tmuxWindowID
-                )
-                if !alive && terminal.suspendedAt == nil {
-                    try? await db.terminals.delete(id: terminal.id)
+            for terminal in terminals where terminal.suspendedAt == nil {
+                if serverAlive {
+                    let alive = await tmux.windowExists(server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
+                    if !alive {
+                        try? await db.terminals.delete(id: terminal.id)
+                    }
+                } else {
+                    try? await recreateAfterReboot(terminal: terminal, worktree: wt)
                 }
             }
         }
@@ -204,5 +209,70 @@ extension WorktreeLifecycle {
                 repoID: repo.id, path: repo.path, displayName: repo.displayName
             )))
         }
+    }
+
+    // MARK: - Reboot Recovery
+
+    /// Recreates a tmux window for a terminal record after the tmux server has been lost
+    /// (e.g. machine reboot). Updates the terminal's stored window/pane IDs in the DB.
+    private func recreateAfterReboot(terminal: Terminal, worktree: Worktree) async throws {
+        _ = try await tmux.ensureServer(server: worktree.tmuxServer, session: "main", cwd: worktree.path)
+
+        let spawn: ClaudeSpawnCommandBuilder.Result
+        var env: [String: String] = [:]
+
+        if let sessionID = terminal.claudeSessionID {
+            // Claude terminal — resume existing session with persisted token
+            var resolvedToken: ResolvedClaudeToken? = nil
+            if let tokenID = terminal.claudeTokenID, let resolver = claudeTokenResolver {
+                resolvedToken = try? await resolver.loadByID(tokenID)
+            }
+            spawn = ClaudeSpawnCommandBuilder.build(
+                resumeID: sessionID,
+                freshSessionID: nil,
+                appendSystemPrompt: nil,
+                initialPrompt: nil,
+                tokenSecret: resolvedToken?.secret,
+                tokenKind: resolvedToken?.kind,
+                cmd: nil,
+                shellFallback: defaultShell
+            )
+        } else if terminal.label == "Codex" {
+            // Codex terminal — restore with isolated home
+            let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
+            env["TBD_WORKTREE_ID"] = worktree.id.uuidString
+            env["CODEX_HOME"] = codexHome.path
+            spawn = ClaudeSpawnCommandBuilder.build(
+                resumeID: nil,
+                freshSessionID: nil,
+                appendSystemPrompt: nil,
+                initialPrompt: nil,
+                tokenSecret: nil,
+                cmd: "codex --full-auto",
+                shellFallback: defaultShell
+            )
+        } else {
+            // Shell terminal (plain shell or custom cmd stored in label)
+            let cmd = (terminal.label == "shell" || terminal.label == nil) ? nil : terminal.label
+            spawn = ClaudeSpawnCommandBuilder.build(
+                resumeID: nil,
+                freshSessionID: nil,
+                appendSystemPrompt: nil,
+                initialPrompt: nil,
+                tokenSecret: nil,
+                cmd: cmd,
+                shellFallback: defaultShell
+            )
+        }
+
+        let window = try await tmux.createWindow(
+            server: worktree.tmuxServer,
+            session: "main",
+            cwd: worktree.path,
+            shellCommand: spawn.command,
+            env: env,
+            sensitiveEnv: spawn.sensitiveEnv
+        )
+        try await db.terminals.updateTmuxIDs(id: terminal.id, windowID: window.windowID, paneID: window.paneID)
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -89,7 +89,7 @@ extension WorktreeLifecycle {
             do {
                 try await db.worktrees.updateTmuxServer(id: wt.id, tmuxServer: correctTmuxServer)
             } catch {
-                print("[TBD] reconcile: failed to update tmux server for worktree \(wt.id): \(error)")
+                logger.warning("reconcile: failed to update tmux server for worktree \(wt.id, privacy: .public): \(error, privacy: .public)")
             }
         }
         // Re-fetch with corrected names
@@ -108,7 +108,7 @@ extension WorktreeLifecycle {
                         windowID: terminal.tmuxWindowID
                     )
                 } catch {
-                    print("[TBD] reconcile: failed to kill window \(terminal.tmuxWindowID): \(error)")
+                    logger.warning("reconcile: failed to kill window \(terminal.tmuxWindowID, privacy: .public): \(error, privacy: .public)")
                 }
             }
             try await db.terminals.deleteForWorktree(worktreeID: wt.id)
@@ -159,7 +159,7 @@ extension WorktreeLifecycle {
                         try await recreateAfterReboot(terminal: terminal, worktree: wt)
                         logger.info("Reboot recovery: recreated terminal \(terminal.id, privacy: .public) in worktree \(wt.id, privacy: .public)")
                     } catch {
-                        logger.error("Reboot recovery: failed to recreate terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                        logger.error("Reboot recovery: failed to recreate terminal \(terminal.id, privacy: .public): \(error, privacy: .public)")
                     }
                 }
             }
@@ -175,7 +175,7 @@ extension WorktreeLifecycle {
             do {
                 try await tmux.killServer(server: tmuxServer)
             } catch {
-                print("[TBD] reconcile: failed to kill tmux server \(tmuxServer): \(error)")
+                logger.warning("reconcile: failed to kill tmux server \(tmuxServer, privacy: .public): \(error, privacy: .public)")
             }
         } else {
             // Collect all tracked window IDs (active + main worktrees)
@@ -194,11 +194,11 @@ extension WorktreeLifecycle {
                     do {
                         try await tmux.killWindow(server: tmuxServer, windowID: window.windowID)
                     } catch {
-                        print("[TBD] reconcile: failed to kill orphaned window \(window.windowID): \(error)")
+                        logger.warning("reconcile: failed to kill orphaned window \(window.windowID, privacy: .public): \(error, privacy: .public)")
                     }
                 }
             } catch {
-                print("[TBD] reconcile: failed to list tmux windows for server \(tmuxServer): \(error)")
+                logger.warning("reconcile: failed to list tmux windows for server \(tmuxServer, privacy: .public): \(error, privacy: .public)")
             }
         }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "reconcile")
 
 extension WorktreeLifecycle {
     // MARK: - Git Status
@@ -152,7 +155,12 @@ extension WorktreeLifecycle {
                         try? await db.terminals.delete(id: terminal.id)
                     }
                 } else {
-                    try? await recreateAfterReboot(terminal: terminal, worktree: wt)
+                    do {
+                        try await recreateAfterReboot(terminal: terminal, worktree: wt)
+                        logger.info("Reboot recovery: recreated terminal \(terminal.id, privacy: .public) in worktree \(wt.id, privacy: .public)")
+                    } catch {
+                        logger.error("Reboot recovery: failed to recreate terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    }
                 }
             }
         }
@@ -216,7 +224,9 @@ extension WorktreeLifecycle {
     /// Recreates a tmux window for a terminal record after the tmux server has been lost
     /// (e.g. machine reboot). Updates the terminal's stored window/pane IDs in the DB.
     private func recreateAfterReboot(terminal: Terminal, worktree: Worktree) async throws {
-        _ = try await tmux.ensureServer(server: worktree.tmuxServer, session: "main", cwd: worktree.path)
+        if let bootstrapWindowID = try await tmux.ensureServer(server: worktree.tmuxServer, session: "main", cwd: worktree.path) {
+            try? await tmux.killWindow(server: worktree.tmuxServer, windowID: bootstrapWindowID)
+        }
 
         let spawn: ClaudeSpawnCommandBuilder.Result
         var env: [String: String] = [:]
@@ -238,7 +248,8 @@ extension WorktreeLifecycle {
                 shellFallback: defaultShell
             )
         } else if terminal.label == "Codex" {
-            // Codex terminal — restore with isolated home
+            // Codex terminal — detected by label "Codex" (set during terminal creation).
+            // No structured type field exists; label matching is the only discriminator available.
             let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
             env["TBD_WORKTREE_ID"] = worktree.id.uuidString
             env["CODEX_HOME"] = codexHome.path
@@ -252,7 +263,8 @@ extension WorktreeLifecycle {
                 shellFallback: defaultShell
             )
         } else {
-            // Shell terminal (plain shell or custom cmd stored in label)
+            // Shell or custom-cmd terminal. Plain shell terminals have label nil or "shell";
+            // custom-cmd terminals store the command string directly in label.
             let cmd = (terminal.label == "shell" || terminal.label == nil) ? nil : terminal.label
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -258,6 +258,18 @@ public struct TmuxManager: Sendable {
         }
     }
 
+    /// Check whether a tmux server is running by querying list-sessions.
+    public func serverExists(server: String) async -> Bool {
+        if dryRun { return true }
+        do {
+            let args = ["-L", server, "list-sessions"]
+            _ = try await runTmux(args)
+            return true
+        } catch {
+            return false
+        }
+    }
+
     // MARK: - Private
 
     /// Resolves the path to the tmux binary, checking common locations.

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -473,6 +473,12 @@ private func createTestRepoResolvingSymlinks() async throws -> (tempDir: URL, re
 /// Alive server + alive windows: no terminals are deleted, window IDs unchanged.
 /// (dryRun makes serverExists → true and windowExists → true, so this exercises
 /// the "server alive, window alive → keep terminal" branch.)
+///
+/// This also serves as a regression guard for the dead-window deletion path: any
+/// bug that incorrectly triggers dead-window deletion would drop terminals here,
+/// because the setup is identical to what a "dead window" scenario looks like
+/// before the windowExists check. The dead-window path itself (windowExists → false)
+/// requires a non-dryRun integration test against a real tmux server with stale IDs.
 @Test func testReconcileAliveTerminalUntouched() async throws {
     let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
     defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -552,47 +558,12 @@ private func createTestRepoResolvingSymlinks() async throws -> (tempDir: URL, re
     #expect(suspendedAfter?.claudeSessionID == fakeSessionID, "claudeSessionID must be preserved for suspended terminal")
 }
 
-/// Reconcile with dryRun (serverExists → true, windowExists → true) must NOT
-/// delete any terminals. This serves as a regression guard for the alive-window path.
-/// Note: the dead-window-deletion path (server alive, window dead) and the reboot
-/// recreation path (server gone) cannot be simulated with dryRun=true because both
-/// serverExists and windowExists always return true in dry-run mode. Those paths
-/// require a non-dryRun integration test against a real tmux server.
-@Test func testReconcileDeadWindowDeletedWhenServerAlive() async throws {
-    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
-    defer { try? FileManager.default.removeItem(at: tempDir) }
-
-    let db = try TBDDatabase(inMemory: true)
-    let lifecycle = WorktreeLifecycle(
-        db: db,
-        git: GitManager(),
-        tmux: TmuxManager(dryRun: true),
-        hooks: HookResolver()
-    )
-
-    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
-    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-
-    // In dryRun mode, windowExists always returns true, so no terminals can be
-    // deleted via the dead-window path. This test verifies the positive case:
-    // all terminals survive reconcile when the server reports all windows alive.
-    let terminalsBefore = try await db.terminals.list(worktreeID: wt.id)
-    #expect(terminalsBefore.count == 2)
-
-    try await lifecycle.reconcile(repoID: repo.id)
-
-    let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
-    #expect(terminalsAfter.count == 2, "No terminals deleted when server alive and all windows alive")
-    // Dead-window deletion path (windowExists → false) requires a non-dryRun
-    // integration test with a real tmux server that has stale window IDs.
-}
-
 /// Server gone path (reboot): in dryRun mode serverExists → true, so this path
 /// cannot be directly triggered. Instead, this test seeds a stale windowID and
 /// verifies that when the server IS alive (dryRun), the stale window is treated
 /// as alive (windowExists → true in dryRun) and NOT deleted.
 /// This is the inverse regression guard: ensures dryRun never triggers reboot recreation.
-@Test func testReconcileRebootRecreatesTerminals() async throws {
+@Test func testReconcileDryRunDoesNotTriggerRebootRecreation() async throws {
     let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
     defer { try? FileManager.default.removeItem(at: tempDir) }
 

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -445,6 +445,197 @@ private func makeTestRepo(
     #expect(wt.path.contains(wt.name))
 }
 
+// MARK: - Reconcile Tests
+
+/// Like `createTestRepo()` but resolves symlinks in the returned paths so the
+/// path stored in the DB matches what `git worktree list` reports.
+///
+/// On macOS, `FileManager.default.temporaryDirectory` returns `/var/folders/…`
+/// which is a symlink to `/private/var/folders/…`. `URL.resolvingSymlinksInPath()`
+/// does NOT resolve this particular symlink, but the C `realpath()` function does.
+/// Git resolves the real path when recording worktree entries, so DB paths must also
+/// use the real path for reconcile path-matching to succeed.
+private func createTestRepoResolvingSymlinks() async throws -> (tempDir: URL, repoDir: URL) {
+    let (rawTempDir, _) = try await createTestRepo()
+    // Use C realpath() to fully resolve all symlinks (URL.resolvingSymlinksInPath
+    // does not resolve the /var → /private/var symlink on macOS).
+    let resolved: URL
+    if let cReal = realpath(rawTempDir.path, nil) {
+        resolved = URL(fileURLWithPath: String(cString: cReal))
+        free(cReal)
+    } else {
+        resolved = rawTempDir
+    }
+    let repoDir = resolved.appendingPathComponent("repo")
+    return (tempDir: resolved, repoDir: repoDir)
+}
+
+/// Alive server + alive windows: no terminals are deleted, window IDs unchanged.
+/// (dryRun makes serverExists → true and windowExists → true, so this exercises
+/// the "server alive, window alive → keep terminal" branch.)
+@Test func testReconcileAliveTerminalUntouched() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+    let terminalsBefore = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminalsBefore.count == 2, "Expected 2 terminals after createWorktree")
+
+    let windowIDsBefore = Set(terminalsBefore.map { $0.tmuxWindowID })
+
+    try await lifecycle.reconcile(repoID: repo.id)
+
+    let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminalsAfter.count == 2, "Alive terminals must not be deleted during reconcile")
+
+    // In dryRun mode, serverExists → true → windowExists path is taken.
+    // windowExists → true → terminals are kept with their original IDs.
+    // In the reboot path, windowIDs would be replaced with mock IDs.
+    // So if IDs are unchanged OR updated to mock IDs, we know reconcile ran.
+    // The important invariant: terminal COUNT must not drop.
+    let windowIDsAfter = Set(terminalsAfter.map { $0.tmuxWindowID })
+    #expect(!windowIDsAfter.isEmpty, "Terminal window IDs must be present after reconcile")
+    // Since serverExists → true and windowExists → true, the alive-window branch
+    // is taken and IDs are NOT replaced (no recreateAfterReboot call).
+    #expect(windowIDsAfter == windowIDsBefore, "Window IDs must be unchanged when server and windows are alive")
+}
+
+/// Suspended terminals must not be touched during reconcile, regardless of server/window state.
+/// dryRun mode exercises the serverAlive=true branch; suspended terminals are skipped
+/// before the windowExists check, so this works with dryRun=true.
+@Test func testReconcileSuspendedTerminalSkippedOnReboot() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+    var terminals = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminals.count == 2)
+
+    // Suspend one terminal — simulate a terminal that was suspended before reboot.
+    let suspended = terminals[0]
+    let fakeSessionID = UUID().uuidString
+    try await db.terminals.setSuspended(id: suspended.id, sessionID: fakeSessionID)
+
+    // Verify suspension was recorded.
+    let suspendedBefore = try await db.terminals.get(id: suspended.id)
+    #expect(suspendedBefore?.suspendedAt != nil, "Terminal should have suspendedAt set")
+
+    try await lifecycle.reconcile(repoID: repo.id)
+
+    // All terminals must still exist after reconcile.
+    terminals = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminals.count == 2, "Suspended terminal must not be deleted during reconcile")
+
+    // The suspended terminal's state must be untouched.
+    let suspendedAfter = try await db.terminals.get(id: suspended.id)
+    #expect(suspendedAfter?.suspendedAt != nil, "suspendedAt must still be set after reconcile")
+    #expect(suspendedAfter?.claudeSessionID == fakeSessionID, "claudeSessionID must be preserved for suspended terminal")
+}
+
+/// Reconcile with dryRun (serverExists → true, windowExists → true) must NOT
+/// delete any terminals. This serves as a regression guard for the alive-window path.
+/// Note: the dead-window-deletion path (server alive, window dead) and the reboot
+/// recreation path (server gone) cannot be simulated with dryRun=true because both
+/// serverExists and windowExists always return true in dry-run mode. Those paths
+/// require a non-dryRun integration test against a real tmux server.
+@Test func testReconcileDeadWindowDeletedWhenServerAlive() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+    // In dryRun mode, windowExists always returns true, so no terminals can be
+    // deleted via the dead-window path. This test verifies the positive case:
+    // all terminals survive reconcile when the server reports all windows alive.
+    let terminalsBefore = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminalsBefore.count == 2)
+
+    try await lifecycle.reconcile(repoID: repo.id)
+
+    let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminalsAfter.count == 2, "No terminals deleted when server alive and all windows alive")
+    // Dead-window deletion path (windowExists → false) requires a non-dryRun
+    // integration test with a real tmux server that has stale window IDs.
+}
+
+/// Server gone path (reboot): in dryRun mode serverExists → true, so this path
+/// cannot be directly triggered. Instead, this test seeds a stale windowID and
+/// verifies that when the server IS alive (dryRun), the stale window is treated
+/// as alive (windowExists → true in dryRun) and NOT deleted.
+/// This is the inverse regression guard: ensures dryRun never triggers reboot recreation.
+@Test func testReconcileRebootRecreatesTerminals() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+    // Seed a stale window ID to simulate what happens after a reboot
+    // (the DB still has the old window ID, but the tmux server is gone).
+    let terminals = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminals.count == 2)
+    let terminal = terminals[0]
+    let staleWindowID = "@stale-99"
+    try await db.terminals.updateTmuxIDs(id: terminal.id, windowID: staleWindowID, paneID: "%stale-99")
+
+    // In dryRun mode, serverExists → true (not the reboot path).
+    // windowExists → true for any ID, so the stale window is treated as alive.
+    // Result: the terminal record must NOT be deleted (no dead-window deletion).
+    try await lifecycle.reconcile(repoID: repo.id)
+
+    let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminalsAfter.count == 2, "Terminal with stale window ID must survive when server is alive (dryRun)")
+
+    // The stale window ID should be unchanged (no recreation happened).
+    let terminalAfter = terminalsAfter.first { $0.id == terminal.id }
+    #expect(terminalAfter?.tmuxWindowID == staleWindowID,
+            "dryRun: stale window ID must not be replaced when server reports alive")
+
+    // NOTE: The actual reboot recovery path (serverExists → false → recreateAfterReboot)
+    // cannot be tested with dryRun=true. A non-dryRun integration test with a real
+    // tmux server would be needed to verify that stale IDs ARE replaced with fresh
+    // mock IDs when the server is gone.
+}
+
+// MARK: - Helpers
+
 /// Thread-safe collector for TmuxManager dryRun recorded args.
 private final class LifecycleRecordedCommands: @unchecked Sendable {
     private let lock = NSLock()


### PR DESCRIPTION
## Summary
- After a macOS reboot, tmux servers don't survive — all sessions are gone. The daemon's startup reconcile was treating missing windows as user-closed, deleting all terminal DB records. Users came back to find every worktree empty.
- Root cause: reconcile called `windowExists` per terminal without first checking whether the tmux *server* itself was alive. A dead server (reboot) and a user-closed window look identical at the per-window level.
- This PR adds `TmuxManager.serverExists` and uses it in `reconcile` to distinguish the two cases: if the server is entirely gone, recreate windows from DB records (Claude via `--resume <sessionID>`, Codex via `codex --full-auto`, shell via stored cmd); if the server is alive but a window is missing, delete as before (user closed it).

## Test plan
- [ ] Reboot and verify worktrees come back with terminal windows open and Claude sessions resumed
- [ ] Close a tmux window manually, run cleanup (`tbd repo cleanup`), verify that terminal tab is removed — existing behavior preserved
- [ ] Suspended terminals remain suspended across reboot (not recreated)
- [ ] `swift test --filter WorktreeLifecycleTests` passes (16 tests)