### PR TITLE
Fix: Suspend never worked for Claude terminals because of a label case mismatch

### DIFF
--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -28,10 +28,10 @@ struct SidebarContextMenu: View {
 
                 let terminals = appState.terminals[worktree.id] ?? []
                 let hasUnsuspendedClaude = terminals.contains {
-                    $0.label?.hasPrefix("claude") == true && $0.suspendedAt == nil
+                    $0.claudeSessionID != nil && $0.suspendedAt == nil
                 }
                 let hasSuspendedClaude = terminals.contains {
-                    $0.label?.hasPrefix("claude") == true && $0.suspendedAt != nil
+                    $0.claudeSessionID != nil && $0.suspendedAt != nil
                 }
 
                 if hasUnsuspendedClaude {

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -470,20 +470,6 @@ public actor SuspendResumeCoordinator {
             }
         }
 
-        // Backfill session IDs for pre-existing Claude terminals that lack one.
-        // These were created before --session-id was added at terminal creation.
-        for terminal in allTerminals {
-            guard terminal.claudeSessionID == nil,
-                  terminal.label?.lowercased().hasPrefix("claude") == true,
-                  terminal.suspendedAt == nil else { continue }
-            guard let server = await worktreeServer(for: terminal.worktreeID) else { continue }
-            let alive = await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID)
-            guard alive else { continue }
-            if let sessionID = await detector.captureSessionID(server: server, paneID: terminal.tmuxPaneID) {
-                try? await db.terminals.updateSessionID(id: terminal.id, sessionID: sessionID)
-                logger.info("Startup: backfilled session ID for terminal \(terminal.id): \(sessionID)")
-            }
-        }
     }
 
     // MARK: - Helpers

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -84,14 +84,11 @@ public actor SuspendResumeCoordinator {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
         }
-        guard terminal.label?.hasPrefix("claude") == true else {
+        guard let sessionID = terminal.claudeSessionID else {
             return .notClaudeTerminal
         }
         guard terminal.suspendedAt == nil else {
             return .alreadySuspended
-        }
-        guard let sessionID = terminal.claudeSessionID else {
-            return .notClaudeTerminal
         }
         guard let server = await worktreeServer(for: terminal.worktreeID) else {
             return .notFound
@@ -228,10 +225,9 @@ public actor SuspendResumeCoordinator {
         Task {
             guard let terminals = try? await db.terminals.list(worktreeID: worktreeID) else { return }
             for terminal in terminals {
-                guard terminal.label?.hasPrefix("claude") == true,
+                guard terminal.claudeSessionID != nil,
                       terminal.pinnedAt == nil,
-                      terminal.suspendedAt == nil,
-                      terminal.claudeSessionID != nil else { continue }
+                      terminal.suspendedAt == nil else { continue }
 
                 inFlight[terminal.id]?.cancel()
                 let task = Task<Void, Never> { await suspendTerminal(terminal) }
@@ -465,9 +461,8 @@ public actor SuspendResumeCoordinator {
         // This handles the case where the daemon restarts while Claude is sitting idle —
         // without this, the in-memory flag would be empty and suspend would never trigger.
         for terminal in allTerminals {
-            guard terminal.label?.hasPrefix("claude") == true,
-                  terminal.suspendedAt == nil,
-                  terminal.claudeSessionID != nil else { continue }
+            guard terminal.claudeSessionID != nil,
+                  terminal.suspendedAt == nil else { continue }
             guard let server = await worktreeServer(for: terminal.worktreeID) else { continue }
             if await detector.isIdle(server: server, paneID: terminal.tmuxPaneID) {
                 worktreeIdleFromHook.insert(terminal.worktreeID)
@@ -479,7 +474,7 @@ public actor SuspendResumeCoordinator {
         // These were created before --session-id was added at terminal creation.
         for terminal in allTerminals {
             guard terminal.claudeSessionID == nil,
-                  terminal.label?.hasPrefix("claude") == true,
+                  terminal.label?.lowercased().hasPrefix("claude") == true,
                   terminal.suspendedAt == nil else { continue }
             guard let server = await worktreeServer(for: terminal.worktreeID) else { continue }
             let alive = await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID)

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -38,7 +38,7 @@ extension RPCRouter {
         }
 
         let claudeTerminals = terminals.filter {
-            $0.label?.hasPrefix("claude") == true && $0.suspendedAt == nil
+            $0.claudeSessionID != nil && $0.suspendedAt == nil
         }
 
         // Sequential — the coordinator is an actor so calls serialize anyway
@@ -56,7 +56,7 @@ extension RPCRouter {
         }
 
         let suspendedTerminals = terminals.filter {
-            $0.label?.hasPrefix("claude") == true && $0.suspendedAt != nil
+            $0.claudeSessionID != nil && $0.suspendedAt != nil
         }
 
         // Sequential — the coordinator is an actor so calls serialize anyway


### PR DESCRIPTION
## Summary

- Clicking "Suspend Claude" on any tab silently did nothing. The root cause: terminals created through the normal workflow get label `"Claude Code"` (capital C, space), but every suspend check gated on `label?.hasPrefix("claude")` (lowercase). `"Claude Code".hasPrefix("claude")` is `false`, so the daemon returned `.notClaudeTerminal` on every attempt — which the app discarded with `try?`, giving zero feedback.
- Replaced all suspend-path label checks with `claudeSessionID != nil`, which is the authoritative marker for a Claude terminal. Also fixes "Suspend Claude" never appearing in the sidebar context menu, and auto-suspend on worktree deselect silently skipping all terminals.
- Removed a stale startup backfill path that tried to assign session IDs to pre-feature terminals — those have all been archived by now.

## Test plan
- [ ] Right-click tab → "Suspend Claude" on a normal Claude terminal — should suspend (tab shows moon icon, terminal marked suspended in DB)
- [ ] Right-click worktree in sidebar → "Suspend Claude" should now appear and work
- [ ] Resume via tab context menu restores the session