### PR TITLE
Feat: Add browser-style back/forward to revisit recently selected worktrees

### DIFF
--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A single navigable view state — either a worktree selection (one or more)
 /// or a repo selection (showing archived worktrees in the detail pane).
 enum NavigationEntry: Equatable {
-    case worktrees(Set<UUID>)
+    case worktrees([UUID])
     case repo(UUID)
 }
 
@@ -67,7 +67,8 @@ extension AppState {
         switch entry {
         case .worktrees(let ids):
             selectedRepoID = nil
-            selectedWorktreeIDs = ids
+            selectedWorktreeIDs = Set(ids)
+            selectionOrder = ids
         case .repo(let id):
             selectedWorktreeIDs = []
             selectedRepoID = id

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -68,7 +68,7 @@ extension AppState {
         case .worktrees(let ids):
             selectedRepoID = nil
             selectedWorktreeIDs = Set(ids)
-            selectionOrder = ids
+            selectionOrder = ids // must come after; didSet above rebuilds from unordered Set
         case .repo(let id):
             selectedWorktreeIDs = []
             selectedRepoID = id

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// A single navigable view state — either a worktree selection (one or more)
+/// or a repo selection (showing archived worktrees in the detail pane).
+enum NavigationEntry: Equatable {
+    case worktrees(Set<UUID>)
+    case repo(UUID)
+}
+
+extension AppState {
+    /// Maximum number of entries to retain in the navigation history.
+    private static let navigationHistoryCap = 100
+
+    /// Record a new navigation entry. No-op while navigating (back/forward in
+    /// progress) or when the entry equals the current head. Truncates any
+    /// forward history when the user navigates somewhere new mid-stack.
+    func recordNavigation(_ entry: NavigationEntry) {
+        guard !isNavigating else { return }
+        if navigationIndex >= 0 && navigationIndex < navigationEntries.count {
+            if navigationEntries[navigationIndex] == entry { return }
+        }
+        // Truncate forward history if we're not at the head.
+        if navigationIndex < navigationEntries.count - 1 {
+            navigationEntries.removeSubrange((navigationIndex + 1)...)
+        }
+        navigationEntries.append(entry)
+        navigationIndex = navigationEntries.count - 1
+
+        // Cap history — drop oldest, keep currentIndex pointing to the same entry.
+        while navigationEntries.count > Self.navigationHistoryCap {
+            navigationEntries.removeFirst()
+            navigationIndex -= 1
+        }
+
+        updateNavigationFlags()
+    }
+
+    /// Move back one entry in the history and apply it. No-op if no prior entry.
+    func navigateBack() {
+        guard canGoBack else { return }
+        navigationIndex -= 1
+        let entry = navigationEntries[navigationIndex]
+        withNavigating { applyNavigationEntry(entry) }
+        updateNavigationFlags()
+    }
+
+    /// Move forward one entry in the history and apply it. No-op if no next entry.
+    func navigateForward() {
+        guard canGoForward else { return }
+        navigationIndex += 1
+        let entry = navigationEntries[navigationIndex]
+        withNavigating { applyNavigationEntry(entry) }
+        updateNavigationFlags()
+    }
+
+    /// Run `block` with `isNavigating` set so the resulting selection mutations
+    /// don't get recorded as new history entries.
+    private func withNavigating(_ block: () -> Void) {
+        isNavigating = true
+        defer { isNavigating = false }
+        block()
+    }
+
+    /// Apply a navigation entry to the live selection state. Mirrors the work
+    /// `selectRepo` would do for repo entries (refreshing archived worktrees).
+    private func applyNavigationEntry(_ entry: NavigationEntry) {
+        switch entry {
+        case .worktrees(let ids):
+            selectedRepoID = nil
+            selectedWorktreeIDs = ids
+        case .repo(let id):
+            selectedWorktreeIDs = []
+            selectedRepoID = id
+            Task { await refreshArchivedWorktrees(repoID: id) }
+        }
+    }
+
+}

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -34,7 +34,7 @@ final class AppState: ObservableObject {
             // Clear repo selection when a worktree is selected
             if !selectedWorktreeIDs.isEmpty {
                 selectedRepoID = nil
-                recordNavigation(.worktrees(selectedWorktreeIDs))
+                recordNavigation(.worktrees(selectionOrder))
             }
         }
     }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -50,6 +50,10 @@ final class AppState: ObservableObject {
 
     // MARK: - Navigation history (back/forward)
 
+    /// Back/forward state. Mutated only by the helpers in `AppState+Navigation.swift` —
+    /// any change to `navigationIndex` or `navigationEntries` must be followed by
+    /// `updateNavigationFlags()` to keep the published toolbar flags in sync.
+
     /// Published flags driving the toolbar back/forward buttons.
     @Published private(set) var canGoBack: Bool = false
     @Published private(set) var canGoForward: Bool = false

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -34,13 +34,41 @@ final class AppState: ObservableObject {
             // Clear repo selection when a worktree is selected
             if !selectedWorktreeIDs.isEmpty {
                 selectedRepoID = nil
+                recordNavigation(.worktrees(selectedWorktreeIDs))
             }
         }
     }
     /// Tracks the order of selected worktrees for split view rendering (cmd+click order).
     @Published var selectionOrder: [UUID] = []
     /// Selected repo ID — set when a repo header is clicked, shows archived worktrees in content pane.
-    @Published var selectedRepoID: UUID? = nil
+    @Published var selectedRepoID: UUID? = nil {
+        didSet {
+            guard selectedRepoID != oldValue, let id = selectedRepoID else { return }
+            recordNavigation(.repo(id))
+        }
+    }
+
+    // MARK: - Navigation history (back/forward)
+
+    /// Published flags driving the toolbar back/forward buttons.
+    @Published private(set) var canGoBack: Bool = false
+    @Published private(set) var canGoForward: Bool = false
+    /// Recorded navigation entries (most recent at the end).
+    var navigationEntries: [NavigationEntry] = []
+    /// Index into `navigationEntries` of the currently-displayed view state, or -1 if none.
+    var navigationIndex: Int = -1
+    /// True while applying a back/forward entry, to suppress recording the resulting selection change.
+    var isNavigating: Bool = false
+
+    /// Refresh the @Published `canGoBack` / `canGoForward` flags from the index.
+    /// Lives in the same file as the @Published properties so the `private(set)`
+    /// setters are reachable.
+    func updateNavigationFlags() {
+        let back = navigationIndex > 0
+        let forward = navigationIndex >= 0 && navigationIndex < navigationEntries.count - 1
+        if back != canGoBack { canGoBack = back }
+        if forward != canGoForward { canGoForward = forward }
+    }
     /// Archived worktrees keyed by repo ID, fetched on demand.
     @Published var archivedWorktrees: [UUID: [Worktree]] = [:]
 

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -64,6 +64,26 @@ struct ContentView: View {
             .navigationSplitViewStyle(.prominentDetail)
             .toolbar(removing: .sidebarToggle)
             .toolbar {
+                ToolbarItemGroup(placement: .navigation) {
+                    Button {
+                        appState.navigateBack()
+                    } label: {
+                        Image(systemName: "chevron.left")
+                    }
+                    .disabled(!appState.canGoBack)
+                    .help("Back")
+                    .keyboardShortcut("[", modifiers: .command)
+
+                    Button {
+                        appState.navigateForward()
+                    } label: {
+                        Image(systemName: "chevron.right")
+                    }
+                    .disabled(!appState.canGoForward)
+                    .help("Forward")
+                    .keyboardShortcut("]", modifiers: .command)
+                }
+
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button {
                         autoSuspendClaude.toggle()


### PR DESCRIPTION
## Summary
- Adds chevron-left / chevron-right buttons to the toolbar (also bound to Cmd-[ / Cmd-]) that walk a per-session history of worktree and repo selections, so you can quickly jump back to a worktree you just had open.
- History is suppressed while applying a back/forward entry, deduped against the current head, and capped at 100 entries.
- Preserves cmd-click pane order for multi-select split view by storing the ordered `[UUID]` instead of an unordered Set.

## Test plan
- [ ] Click worktree A, then B, then C. Cmd-[ walks back to B, then A; Cmd-] walks forward.
- [ ] Mid-history, click a new worktree D — forward becomes disabled (forward history truncated).
- [ ] Click a repo header to view archived worktrees, then a worktree — back returns to the archived view.
- [ ] Cmd-click two worktrees in a specific order to get split view, switch away, then back — pane order matches the original cmd-click order.
- [ ] Buttons disable correctly at the ends of history.