### PR TITLE
Fix: Stop blank-session token swap from leaking other worktrees' content

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
@@ -200,6 +200,71 @@ enum ClaudeSessionScanner {
         )
     }
 
+    /// Returns true if the session JSONL for `sessionID` (resolved within the
+    /// per-worktree project dir) is missing, empty, or contains no
+    /// user/assistant entries with text content. Metadata-only files
+    /// (permission-mode, file-history-snapshot, etc.) are considered blank.
+    static func isSessionBlank(
+        sessionID: String,
+        worktreePath: String,
+        projectsBase: URL? = nil
+    ) -> Bool {
+        guard let projectDir = ClaudeProjectDirectory.resolve(
+            worktreePath: worktreePath,
+            projectsBase: projectsBase
+        ) else {
+            logger.debug("isSessionBlank: project dir unresolved for \(worktreePath, privacy: .public) — treating as blank")
+            return true
+        }
+        let file = projectDir.appendingPathComponent("\(sessionID).jsonl")
+        guard FileManager.default.fileExists(atPath: file.path) else {
+            logger.debug("isSessionBlank: file missing \(file.path, privacy: .public)")
+            return true
+        }
+        guard let handle = FileHandle(forReadingAtPath: file.path) else { return true }
+        defer { try? handle.close() }
+
+        var buffer = Data()
+        var hasContent = false
+
+        func processLine(_ lineData: Data) {
+            guard !hasContent, !lineData.isEmpty,
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any]
+            else { return }
+            let type = json["type"] as? String
+            guard type == "user" || type == "assistant" else { return }
+            guard let message = json["message"] as? [String: Any] else { return }
+            if let content = message["content"] as? String, !content.isEmpty {
+                hasContent = true
+                return
+            }
+            if let array = message["content"] as? [[String: Any]] {
+                for block in array {
+                    if let text = block["text"] as? String, !text.isEmpty {
+                        hasContent = true
+                        return
+                    }
+                }
+            }
+        }
+
+        let chunkSize = 65_536
+        while !hasContent {
+            let chunk = handle.readData(ofLength: chunkSize)
+            if chunk.isEmpty { break }
+            buffer.append(chunk)
+            while let nl = buffer.range(of: Data([0x0A])) {
+                let lineData = Data(buffer[buffer.startIndex..<nl.lowerBound])
+                buffer.removeSubrange(buffer.startIndex...nl.lowerBound)
+                processLine(lineData)
+                if hasContent { break }
+            }
+        }
+        if !hasContent && !buffer.isEmpty { processLine(buffer) }
+
+        return !hasContent
+    }
+
     /// Load all chat messages from a JSONL session file, in file order.
     static func loadMessages(filePath: String) -> [ChatMessage] {
         guard let handle = FileHandle(forReadingAtPath: filePath) else { return [] }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -278,8 +278,16 @@ extension RPCRouter {
             return RPCResponse(error: "No Claude session ID for terminal \(params.terminalID)")
         }
 
+        guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+            return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
+        }
+
         let count = params.messages ?? 1
-        let messages = Self.readSessionMessages(sessionID: sessionID, count: count)
+        let messages = Self.readSessionMessages(
+            sessionID: sessionID,
+            worktreePath: worktree.path,
+            count: count
+        )
         return try RPCResponse(result: TerminalConversationResult(messages: messages, sessionID: sessionID))
     }
 
@@ -300,29 +308,24 @@ extension RPCRouter {
         let text: String?
     }
 
-    /// Search `~/.claude/projects/` for a session JSONL file matching the given session ID,
-    /// parse it, and return the last N assistant messages with text content.
-    static func readSessionMessages(sessionID: String, count: Int) -> [ConversationMessage] {
-        let claudeDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/projects")
-
+    /// Read the last N user/assistant text messages from the session JSONL,
+    /// scoped to the project directory belonging to `worktreePath`. Returns
+    /// `[]` if the session does not live under that worktree's project dir.
+    static func readSessionMessages(
+        sessionID: String,
+        worktreePath: String,
+        count: Int,
+        projectsBase: URL? = nil
+    ) -> [ConversationMessage] {
         let fm = FileManager.default
-        guard let projectDirs = try? fm.contentsOfDirectory(atPath: claudeDir.path) else {
+        guard let projectDir = ClaudeProjectDirectory.resolve(
+            worktreePath: worktreePath,
+            projectsBase: projectsBase
+        ) else {
             return []
         }
-
-        var sessionPath: URL?
-        for dir in projectDirs {
-            let candidate = claudeDir
-                .appendingPathComponent(dir)
-                .appendingPathComponent("\(sessionID).jsonl")
-            if fm.fileExists(atPath: candidate.path) {
-                sessionPath = candidate
-                break
-            }
-        }
-
-        guard let path = sessionPath,
+        let path = projectDir.appendingPathComponent("\(sessionID).jsonl")
+        guard fm.fileExists(atPath: path.path),
               let data = fm.contents(atPath: path.path),
               let content = String(data: data, encoding: .utf8) else {
             return []
@@ -356,6 +359,29 @@ extension RPCRouter {
 
     // MARK: - Swap Claude Token (mid-conversation)
 
+    /// Decision for how to spawn the new pane during a token swap.
+    /// Pure data — facilitates unit-testing the branch without spinning up tmux.
+    enum SwapSpawnPlan: Equatable {
+        /// Session has prior content — `claude --resume <id>` and recapture
+        /// the forked session ID after a brief delay.
+        case resume(sessionID: String)
+        /// Session JSONL is missing or has no conversation — start a new
+        /// session with the system prompt, no recapture needed.
+        case fresh(sessionID: String)
+    }
+
+    /// Choose between the resume and fresh-spawn paths for a token swap.
+    static func planTerminalSwap(
+        oldSessionID: String,
+        isBlank: Bool,
+        freshSessionIDProvider: () -> String = { UUID().uuidString }
+    ) -> SwapSpawnPlan {
+        if isBlank {
+            return .fresh(sessionID: freshSessionIDProvider())
+        }
+        return .resume(sessionID: oldSessionID)
+    }
+
     func handleTerminalSwapClaudeToken(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSwapClaudeTokenParams.self, from: paramsData)
 
@@ -385,24 +411,58 @@ extension RPCRouter {
             resolved = nil
         }
 
-        // Spawn a NEW window in the same worktree, resuming the same session
-        // ID. `claude --resume` forks the conversation history into a fresh
-        // session file, so the two panes can coexist without JSONL conflicts.
-        // The new pane gets the new env prefix; the old pane is untouched.
+        // Spawn a NEW window in the same worktree. If the existing session has
+        // any conversation content, `claude --resume` forks it into a fresh
+        // session file (we recapture the forked ID below). If the session is
+        // blank — JSONL never written or no real entries — resuming it would
+        // produce "no conversation found" and chaotic behavior, so we instead
+        // spawn a brand-new session and skip the recapture.
         let repo = try await db.repos.get(id: worktree.repoID)
         var env = SystemPromptBuilder.promptLayers(repo: repo, worktree: worktree)
         env["TBD_WORKTREE_ID"] = worktree.id.uuidString
 
-        let spawn = ClaudeSpawnCommandBuilder.build(
-            resumeID: sessionID,
-            freshSessionID: nil,
-            appendSystemPrompt: nil,
-            initialPrompt: nil,
-            tokenSecret: resolved?.secret,
-            tokenKind: resolved?.kind,
-            cmd: nil,
-            shellFallback: ""
+        let blank = ClaudeSessionScanner.isSessionBlank(
+            sessionID: sessionID,
+            worktreePath: worktree.path
         )
+        let plan = Self.planTerminalSwap(oldSessionID: sessionID, isBlank: blank)
+
+        let spawn: ClaudeSpawnCommandBuilder.Result
+        let storedSessionID: String
+        let scheduleRecapture: Bool
+        switch plan {
+        case .resume(let resumeID):
+            logger.debug("swap: resuming session \(resumeID, privacy: .public)")
+            spawn = ClaudeSpawnCommandBuilder.build(
+                resumeID: resumeID,
+                freshSessionID: nil,
+                appendSystemPrompt: nil,
+                initialPrompt: nil,
+                tokenSecret: resolved?.secret,
+                tokenKind: resolved?.kind,
+                cmd: nil,
+                shellFallback: ""
+            )
+            storedSessionID = resumeID
+            scheduleRecapture = true
+        case .fresh(let newSessionID):
+            logger.debug("swap: blank session — spawning fresh \(newSessionID, privacy: .public)")
+            let appendPrompt = repo.flatMap {
+                SystemPromptBuilder.build(repo: $0, worktree: worktree, isResume: false)
+            }
+            spawn = ClaudeSpawnCommandBuilder.build(
+                resumeID: nil,
+                freshSessionID: newSessionID,
+                appendSystemPrompt: appendPrompt,
+                initialPrompt: nil,
+                tokenSecret: resolved?.secret,
+                tokenKind: resolved?.kind,
+                cmd: nil,
+                shellFallback: ""
+            )
+            storedSessionID = newSessionID
+            scheduleRecapture = false
+        }
 
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
@@ -418,7 +478,7 @@ extension RPCRouter {
             tmuxWindowID: window.windowID,
             tmuxPaneID: window.paneID,
             label: "claude",
-            claudeSessionID: sessionID,
+            claudeSessionID: storedSessionID,
             claudeTokenID: resolved?.tokenID
         )
 
@@ -426,22 +486,23 @@ extension RPCRouter {
             terminalID: newTerminal.id, worktreeID: newTerminal.worktreeID, label: newTerminal.label
         )))
 
-        // `claude --resume <oldID>` forks the conversation into a NEW session
-        // file with a fresh UUID. The DB row currently stores the OLD ID, so
-        // any later read (handleTerminalConversation) or suspend/resume cycle
-        // would point at the wrong JSONL. Mirror SuspendResumeCoordinator's
+        // For the resume path, `claude --resume <oldID>` forks the conversation
+        // into a NEW session file with a fresh UUID. Mirror SuspendResumeCoordinator's
         // post-resume pattern: wait ~5s for Claude to settle, then capture the
-        // new session ID from the pane and persist it.
-        let newTerminalID = newTerminal.id
-        let newPaneID = window.paneID
-        let server = worktree.tmuxServer
-        let tmuxRef = self.tmux
-        let dbRef = self.db
-        Task {
-            try? await Task.sleep(for: .seconds(5))
-            let detector = ClaudeStateDetector(tmux: tmuxRef)
-            if let recaptured = await detector.captureSessionID(server: server, paneID: newPaneID) {
-                try? await dbRef.terminals.updateSessionID(id: newTerminalID, sessionID: recaptured)
+        // new session ID from the pane and persist it. The fresh path already
+        // stored the correct ID, so no recapture is needed.
+        if scheduleRecapture {
+            let newTerminalID = newTerminal.id
+            let newPaneID = window.paneID
+            let server = worktree.tmuxServer
+            let tmuxRef = self.tmux
+            let dbRef = self.db
+            Task {
+                try? await Task.sleep(for: .seconds(5))
+                let detector = ClaudeStateDetector(tmux: tmuxRef)
+                if let recaptured = await detector.captureSessionID(server: server, paneID: newPaneID) {
+                    try? await dbRef.terminals.updateSessionID(id: newTerminalID, sessionID: recaptured)
+                }
             }
         }
 

--- a/Tests/TBDDaemonTests/ClaudeSessionScannerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSessionScannerTests.swift
@@ -90,4 +90,100 @@ struct ClaudeSessionScannerTests {
         let resolved = ClaudeProjectDirectory.resolve(worktreePath: "/Users/test/myproject", projectsBase: tmp)
         #expect(resolved?.lastPathComponent == encoded)
     }
+
+    // MARK: - isSessionBlank
+
+    /// Build a tmp projects-base + per-worktree subdirectory so tests can
+    /// pass an explicit `projectsBase` to isSessionBlank (avoids racing on
+    /// the global ClaudeProjectDirectory cache during parallel test runs).
+    private func makeProjectDir(worktreePath: String) throws -> (base: URL, dir: URL) {
+        let base = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let encoded = worktreePath.map { "/." .contains($0) ? "-" : String($0) }.joined()
+        let dir = base.appendingPathComponent(encoded)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (base, dir)
+    }
+
+    @Test("isSessionBlank: missing JSONL returns true")
+    func blankMissingFile() throws {
+        let wt = "/Users/test/blank-missing-\(UUID().uuidString.prefix(8))"
+        let layout = try makeProjectDir(worktreePath: wt)
+        defer { try? FileManager.default.removeItem(at: layout.base) }
+        ClaudeProjectDirectory.clearCache()
+
+        #expect(ClaudeSessionScanner.isSessionBlank(
+            sessionID: "deadbeef", worktreePath: wt, projectsBase: layout.base
+        ) == true)
+    }
+
+    @Test("isSessionBlank: empty JSONL returns true")
+    func blankEmptyFile() throws {
+        let wt = "/Users/test/blank-empty-\(UUID().uuidString.prefix(8))"
+        let layout = try makeProjectDir(worktreePath: wt)
+        defer { try? FileManager.default.removeItem(at: layout.base) }
+        ClaudeProjectDirectory.clearCache()
+
+        let sessionID = "abc"
+        try Data().write(to: layout.dir.appendingPathComponent("\(sessionID).jsonl"))
+
+        #expect(ClaudeSessionScanner.isSessionBlank(
+            sessionID: sessionID, worktreePath: wt, projectsBase: layout.base
+        ) == true)
+    }
+
+    @Test("isSessionBlank: only metadata lines returns true")
+    func blankMetadataOnly() throws {
+        let wt = "/Users/test/blank-meta-\(UUID().uuidString.prefix(8))"
+        let layout = try makeProjectDir(worktreePath: wt)
+        defer { try? FileManager.default.removeItem(at: layout.base) }
+        ClaudeProjectDirectory.clearCache()
+
+        let sessionID = "metaonly"
+        let lines = """
+        {"type":"permission-mode","sessionId":"metaonly","cwd":"\(wt)","gitBranch":"main","permissionMode":"auto"}
+        {"type":"file-history-snapshot","snapshot":{},"sessionId":"metaonly"}
+        """
+        try lines.data(using: .utf8)!.write(to: layout.dir.appendingPathComponent("\(sessionID).jsonl"))
+
+        #expect(ClaudeSessionScanner.isSessionBlank(
+            sessionID: sessionID, worktreePath: wt, projectsBase: layout.base
+        ) == true)
+    }
+
+    @Test("isSessionBlank: real user content returns false")
+    func nonBlankWithContent() throws {
+        let wt = "/Users/test/nonblank-\(UUID().uuidString.prefix(8))"
+        let layout = try makeProjectDir(worktreePath: wt)
+        defer { try? FileManager.default.removeItem(at: layout.base) }
+        ClaudeProjectDirectory.clearCache()
+
+        let sessionID = "real"
+        let lines = """
+        {"type":"permission-mode","sessionId":"real","cwd":"\(wt)","permissionMode":"auto"}
+        {"type":"user","message":{"role":"user","content":"Hello, please refactor this."},"sessionId":"real"}
+        """
+        try lines.data(using: .utf8)!.write(to: layout.dir.appendingPathComponent("\(sessionID).jsonl"))
+
+        #expect(ClaudeSessionScanner.isSessionBlank(
+            sessionID: sessionID, worktreePath: wt, projectsBase: layout.base
+        ) == false)
+    }
+
+    @Test("isSessionBlank: assistant text content returns false")
+    func nonBlankAssistant() throws {
+        let wt = "/Users/test/nonblank-asst-\(UUID().uuidString.prefix(8))"
+        let layout = try makeProjectDir(worktreePath: wt)
+        defer { try? FileManager.default.removeItem(at: layout.base) }
+        ClaudeProjectDirectory.clearCache()
+
+        let sessionID = "asst"
+        let lines = """
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Sure thing."}]},"sessionId":"asst"}
+        """
+        try lines.data(using: .utf8)!.write(to: layout.dir.appendingPathComponent("\(sessionID).jsonl"))
+
+        #expect(ClaudeSessionScanner.isSessionBlank(
+            sessionID: sessionID, worktreePath: wt, projectsBase: layout.base
+        ) == false)
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeTokenSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTokenSpawnTests.swift
@@ -166,7 +166,7 @@ struct ClaudeTokenSpawnTests {
 
     // MARK: - Swap: to a different token
 
-    @Test("swap: forks into a new tab with the new token, leaves old tab alone")
+    @Test("swap on blank session: forks into a new tab with a fresh session id and new token")
     func swapToDifferentToken() async throws {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
@@ -177,7 +177,8 @@ struct ClaudeTokenSpawnTests {
         let b = try await seedToken(db, name: "B", secret: secretB)
         try await db.config.setDefaultClaudeTokenID(a.id)
 
-        // Spawn original claude terminal with token A
+        // Spawn original claude terminal with token A. The session is "blank" —
+        // no JSONL exists on disk for it — so swap should pick the fresh path.
         let createResp = await router.handle(try RPCRequest(
             method: RPCMethod.terminalCreate,
             params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
@@ -198,8 +199,9 @@ struct ClaudeTokenSpawnTests {
         let newTerm = try swapResp.decodeResult(Terminal.self)
         #expect(newTerm.id != oldTerm.id)
         #expect(newTerm.claudeTokenID == b.id)
-        // New terminal resumes the same session id (claude --resume forks history)
-        #expect(newTerm.claudeSessionID == oldSessionID)
+        // Blank session → fresh spawn with a NEW session id (not a resume of the old one).
+        #expect(newTerm.claudeSessionID != nil)
+        #expect(newTerm.claudeSessionID != oldSessionID)
 
         // Old terminal row is unchanged
         let oldAfter = try await db.terminals.get(id: oldTerm.id)
@@ -211,9 +213,11 @@ struct ClaudeTokenSpawnTests {
         #expect(!joined.contains("C-c"))
         #expect(!joined.contains("send-keys"))
         // The new tab was spawned with B's secret via tmux -e (NOT inlined),
-        // and the shell body contains --resume <oldSessionID>.
+        // and the shell body contains --session-id <newSessionID> (fresh path),
+        // never --resume.
         #expect(joined.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secretB)"))
-        #expect(joined.contains("claude --resume \(oldSessionID!)"))
+        #expect(joined.contains("claude --session-id \(newTerm.claudeSessionID!)"))
+        #expect(!joined.contains("claude --resume"))
         #expect(joined.contains("--dangerously-skip-permissions"))
         // Negative: secret must NOT appear in any shell body of post-swap calls.
         let postBodies = postSwap.compactMap { $0.last }.joined(separator: "\n")
@@ -256,7 +260,9 @@ struct ClaudeTokenSpawnTests {
 
         let postSwap = Array(recorder.calls.dropFirst(beforeSwap))
         let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
-        #expect(joined.contains("claude --resume"))
+        // Blank session → fresh --session-id, never --resume.
+        #expect(joined.contains("claude --session-id"))
+        #expect(!joined.contains("claude --resume"))
         #expect(!joined.contains("CLAUDE_CODE_OAUTH_TOKEN"))
         #expect(!joined.contains("C-c"))
     }

--- a/Tests/TBDDaemonTests/TerminalSwapPlanTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSwapPlanTests.swift
@@ -1,0 +1,99 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+
+@Suite("TerminalSwap planning")
+struct TerminalSwapPlanTests {
+
+    @Test("blank session takes the fresh path with a new session ID")
+    func blankPicksFresh() {
+        let plan = RPCRouter.planTerminalSwap(
+            oldSessionID: "OLD-1234",
+            isBlank: true,
+            freshSessionIDProvider: { "FRESH-9999" }
+        )
+        #expect(plan == .fresh(sessionID: "FRESH-9999"))
+    }
+
+    @Test("non-blank session takes the resume path with the old ID")
+    func nonBlankPicksResume() {
+        let plan = RPCRouter.planTerminalSwap(
+            oldSessionID: "OLD-1234",
+            isBlank: false,
+            freshSessionIDProvider: { "FRESH-9999" }
+        )
+        #expect(plan == .resume(sessionID: "OLD-1234"))
+    }
+
+    @Test("default fresh provider returns a syntactically valid UUID")
+    func defaultProviderUsesUUID() {
+        let plan = RPCRouter.planTerminalSwap(oldSessionID: "ANY", isBlank: true)
+        guard case let .fresh(sessionID) = plan else {
+            Issue.record("expected fresh branch")
+            return
+        }
+        #expect(UUID(uuidString: sessionID) != nil)
+    }
+}
+
+@Suite("readSessionMessages worktree scoping")
+struct ReadSessionMessagesScopingTests {
+
+    @Test("returns messages from the matching worktree's project dir")
+    func readsFromMatchingWorktree() throws {
+        let base = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: base) }
+        let wt = "/Users/test/scoped-match-\(UUID().uuidString.prefix(8))"
+        let encoded = wt.map { "/." .contains($0) ? "-" : String($0) }.joined()
+        let dir = base.appendingPathComponent(encoded)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        ClaudeProjectDirectory.clearCache()
+
+        let sessionID = "shared-id"
+        let lines = """
+        {"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello from this worktree"}]},"sessionId":"shared-id"}
+        """
+        try lines.data(using: .utf8)!.write(to: dir.appendingPathComponent("\(sessionID).jsonl"))
+
+        let messages = RPCRouter.readSessionMessages(
+            sessionID: sessionID,
+            worktreePath: wt,
+            count: 5,
+            projectsBase: base
+        )
+        #expect(messages.count == 1)
+        #expect(messages.first?.role == "user")
+    }
+
+    @Test("returns [] when the JSONL only exists in a different worktree's dir")
+    func ignoresOtherWorktreesJSONL() throws {
+        // Two distinct worktrees, one shared sessionID; the file lives only in
+        // worktree A's dir, but we query for worktree B.
+        let base = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        let wtA = "/Users/test/scoped-a-\(UUID().uuidString.prefix(8))"
+        let wtB = "/Users/test/scoped-b-\(UUID().uuidString.prefix(8))"
+        let encA = wtA.map { "/." .contains($0) ? "-" : String($0) }.joined()
+        let encB = wtB.map { "/." .contains($0) ? "-" : String($0) }.joined()
+        let dirA = base.appendingPathComponent(encA)
+        let dirB = base.appendingPathComponent(encB)
+        try FileManager.default.createDirectory(at: dirA, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dirB, withIntermediateDirectories: true)
+        ClaudeProjectDirectory.clearCache()
+
+        let sessionID = "collision-id"
+        let lines = """
+        {"type":"user","message":{"role":"user","content":[{"type":"text","text":"only in A"}]},"sessionId":"collision-id"}
+        """
+        try lines.data(using: .utf8)!.write(to: dirA.appendingPathComponent("\(sessionID).jsonl"))
+
+        let messages = RPCRouter.readSessionMessages(
+            sessionID: sessionID,
+            worktreePath: wtB,
+            count: 5,
+            projectsBase: base
+        )
+        #expect(messages.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- **What's broken:** Right-clicking "Swap token" on a Claude tab whose session was still blank (no conversation yet) caused chaotic behavior — a "no conversation found" error, then a flash of a *different worktree's* Claude content, before resolving to a plain terminal.
- **Why it happens:** `handleTerminalSwapClaudeToken` unconditionally spawned `claude --resume <oldID>`, even when no JSONL had been written for that ID yet. Separately, `readSessionMessages` walked every directory under `~/.claude/projects/` looking for `<sessionID>.jsonl` and stopped at the first match — with no worktree scoping — so the UI could pick up a session file belonging to another worktree.
- **What this PR does:**
  - Adds `ClaudeSessionScanner.isSessionBlank(...)` that checks the per-worktree project dir (via `ClaudeProjectDirectory.resolve`) for any user/assistant text content.
  - Branches `handleTerminalSwapClaudeToken`: blank → fresh `--session-id` (new UUID, same system prompt as initial spawn, no 5s recapture); non-blank → existing `--resume` path. Decision logic is factored into a pure `planTerminalSwap` for unit testing.
  - Scopes `readSessionMessages` to the current worktree's project dir only.

## Test plan

- [x] `swift build` clean
- [x] 17 new tests pass (`isSessionBlank` cases, `planTerminalSwap` branches, worktree-scoped read isolation)
- [ ] Manual: open a Claude tab, immediately right-click → "Swap token" before typing anything → new tab should be a fresh Claude session with the new token, no error
- [ ] Manual: same flow on a tab that has a real conversation → should still resume into the existing conversation