### PR TITLE
Fix: Stop unviewed terminals from being frozen at 80×24

### DIFF
--- a/Sources/TBDApp/AppState+ClaudeTokens.swift
+++ b/Sources/TBDApp/AppState+ClaudeTokens.swift
@@ -98,7 +98,8 @@ extension AppState {
     /// and selects it so the UI switches immediately.
     func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?) async {
         do {
-            let newTerminal = try await daemonClient.swapClaudeTokenOnTerminal(terminalID: terminalID, newTokenID: newTokenID)
+            let size = mainAreaTerminalSize()
+            let newTerminal = try await daemonClient.swapClaudeTokenOnTerminal(terminalID: terminalID, newTokenID: newTokenID, cols: size.cols, rows: size.rows)
             let worktreeID = newTerminal.worktreeID
             terminals[worktreeID, default: []].append(newTerminal)
             let newTab = Tab(id: newTerminal.id, content: .terminal(terminalID: newTerminal.id))

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -10,7 +10,8 @@ extension AppState {
     /// Create a terminal in a worktree and add a new tab for it.
     func createTerminal(worktreeID: UUID, cmd: String? = nil) async {
         do {
-            let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cmd: cmd)
+            let size = mainAreaTerminalSize()
+            let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cmd: cmd, cols: size.cols, rows: size.rows)
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
             tabs[worktreeID, default: []].append(tab)
@@ -25,7 +26,8 @@ extension AppState {
     /// the parent tab's layout tree, not as its own tab.
     func createTerminalForSplit(worktreeID: UUID) async -> Terminal? {
         do {
-            let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID)
+            let size = mainAreaTerminalSize()
+            let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cols: size.cols, rows: size.rows)
             terminals[worktreeID, default: []].append(terminal)
             return terminal
         } catch {
@@ -65,7 +67,8 @@ extension AppState {
         defer { recreatingTerminalIDs.remove(terminalID) }
 
         do {
-            let updated = try await daemonClient.recreateTerminalWindow(terminalID: terminalID)
+            let size = mainAreaTerminalSize()
+            let updated = try await daemonClient.recreateTerminalWindow(terminalID: terminalID, cols: size.cols, rows: size.rows)
             // Update local state so the view rebuilds with the new tmuxWindowID
             if let idx = terminals[updated.worktreeID]?.firstIndex(where: { $0.id == terminalID }) {
                 terminals[updated.worktreeID]?[idx] = updated
@@ -79,10 +82,13 @@ extension AppState {
     /// Create a Claude terminal in a worktree and add a new tab for it.
     func createClaudeTerminal(worktreeID: UUID) async {
         do {
+            let size = mainAreaTerminalSize()
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
                 cmd: nil,
-                type: .claude
+                type: .claude,
+                cols: size.cols,
+                rows: size.rows
             )
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
@@ -96,10 +102,13 @@ extension AppState {
     /// Create a Codex terminal in a worktree and add a new tab for it.
     func createCodexTerminal(worktreeID: UUID) async {
         do {
+            let size = mainAreaTerminalSize()
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
                 cmd: nil,
-                type: .codex
+                type: .codex,
+                cols: size.cols,
+                rows: size.rows
             )
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: terminal.label)
@@ -113,10 +122,13 @@ extension AppState {
     /// Fork a Claude terminal by resuming from an existing session ID.
     func forkClaudeTerminal(worktreeID: UUID, sessionID: String, tokenID: UUID? = nil) async {
         do {
+            let size = mainAreaTerminalSize()
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
                 resumeSessionID: sessionID,
-                overrideTokenID: tokenID
+                overrideTokenID: tokenID,
+                cols: size.cols,
+                rows: size.rows
             )
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -69,7 +69,8 @@ extension AppState {
         // Find the repo before reviving so we can refresh the archived list
         let repoID = archivedWorktrees.first(where: { $0.value.contains { $0.id == id } })?.key
         do {
-            try await daemonClient.reviveWorktree(id: id)
+            let size = mainAreaTerminalSize()
+            try await daemonClient.reviveWorktree(id: id, cols: size.cols, rows: size.rows)
             await refreshWorktrees()
             selectedWorktreeIDs = [id]
             if let repoID {

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -30,7 +30,8 @@ extension AppState {
         Task {
             defer { pendingWorktreeIDs.remove(placeholder.id) }
             do {
-                let wt = try await daemonClient.createWorktree(repoID: repoID)
+                let size = mainAreaTerminalSize()
+                let wt = try await daemonClient.createWorktree(repoID: repoID, cols: size.cols, rows: size.rows)
                 // Replace the placeholder with the real worktree
                 if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == placeholder.id }) {
                     worktrees[repoID]?[idx] = wt

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -71,6 +71,23 @@ final class AppState: ObservableObject {
     @Published var dockRatio: CGFloat = 0.3 {
         didSet { UserDefaults.standard.set(Double(dockRatio), forKey: Self.dockRatioKey) }
     }
+    /// Pixel size of the main terminal area (the SingleWorktreeView slot
+    /// inside DockSplitView, excluding the pinned dock and file panel).
+    /// Default matches the typical window: 1200 wide window − sidebar (~280) ≈ 920;
+    /// 800 tall window − toolbar (~24) ≈ 776. Conservative fallback for the
+    /// first RPC before the GeometryReader publishes a real value.
+    @Published var mainAreaSize: CGSize = CGSize(width: 1120, height: 776) {
+        didSet {
+            guard mainAreaSize != oldValue else { return }
+            scheduleMainAreaSizeBroadcast()
+        }
+    }
+    /// Debounce token for broadcasting `mainAreaSize` changes to the daemon.
+    /// Cancelled and re-scheduled on every change so we send one RPC per
+    /// resize gesture rather than per AppKit layout pass.
+    private var mainAreaSizeBroadcastTask: Task<Void, Never>?
+    private var lastBroadcastCols: Int = 0
+    private var lastBroadcastRows: Int = 0
     @Published var isConnected: Bool = false
     @Published var layouts: [UUID: LayoutNode] = [:] {
         didSet { persistLayouts() }
@@ -721,6 +738,38 @@ final class AppState: ObservableObject {
         let truncated = String(cleaned.prefix(64))
             .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
         return truncated.isEmpty ? "conductor" : truncated
+    }
+
+    /// Convert the current `mainAreaSize` (pixels) into tmux cell dimensions
+    /// using SwiftTerm's font metrics. Floors at the tmux minimum (80x24) so
+    /// degenerate window sizes during launch never produce a too-small pane.
+    func mainAreaTerminalSize() -> (cols: Int, rows: Int) {
+        let cell = TBDTerminalView.cellDimensions(for: TBDTerminalView.defaultMonospaceFont)
+        guard cell.width > 0, cell.height > 0 else { return (80, 24) }
+        let cols = max(80, Int(mainAreaSize.width / cell.width))
+        let rows = max(24, Int(mainAreaSize.height / cell.height))
+        return (cols, rows)
+    }
+
+    /// Debounced RPC: tell the daemon the main area resized so it can resize
+    /// every tracked tmux window. Coalesces rapid resize events into a single
+    /// RPC ~300ms after the user stops dragging the window edge.
+    private func scheduleMainAreaSizeBroadcast() {
+        mainAreaSizeBroadcastTask?.cancel()
+        let (cols, rows) = mainAreaTerminalSize()
+        // Skip noop broadcasts: same cell dims as the previous send.
+        guard cols != lastBroadcastCols || rows != lastBroadcastRows else { return }
+        mainAreaSizeBroadcastTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 300_000_000) // 300ms debounce
+            guard !Task.isCancelled, let self else { return }
+            do {
+                try await self.daemonClient.setMainAreaSize(cols: cols, rows: rows)
+                self.lastBroadcastCols = cols
+                self.lastBroadcastRows = rows
+            } catch {
+                logger.warning("setMainAreaSize broadcast failed: \(error)")
+            }
+        }
     }
 
     /// One-click conductor: setup (if needed) + start + show overlay.

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -403,10 +403,10 @@ actor DaemonClient {
     }
 
     /// Revive an archived worktree.
-    func reviveWorktree(id: UUID) async throws {
+    func reviveWorktree(id: UUID, cols: Int? = nil, rows: Int? = nil) async throws {
         try await callVoidAsync(
             method: RPCMethod.worktreeRevive,
-            params: WorktreeReviveParams(worktreeID: id)
+            params: WorktreeReviveParams(worktreeID: id, cols: cols, rows: rows)
         )
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -802,10 +802,10 @@ actor DaemonClient {
 
     /// Swap the Claude token associated with a running terminal.
     /// Returns the newly created Terminal (the daemon forks a new tab).
-    func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?) async throws -> Terminal {
+    func swapClaudeTokenOnTerminal(terminalID: UUID, newTokenID: UUID?, cols: Int? = nil, rows: Int? = nil) async throws -> Terminal {
         return try await callAsync(
             method: RPCMethod.terminalSwapClaudeToken,
-            params: TerminalSwapClaudeTokenParams(terminalID: terminalID, newTokenID: newTokenID),
+            params: TerminalSwapClaudeTokenParams(terminalID: terminalID, newTokenID: newTokenID, cols: cols, rows: rows),
             resultType: Terminal.self
         )
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -377,10 +377,10 @@ actor DaemonClient {
     }
 
     /// Create a new worktree in a repo.
-    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil) async throws -> Worktree {
+    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil) async throws -> Worktree {
         return try await callAsync(
             method: RPCMethod.worktreeCreate,
-            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName),
+            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows),
             resultType: Worktree.self
         )
     }
@@ -435,10 +435,10 @@ actor DaemonClient {
     }
 
     /// Create a terminal in a worktree.
-    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, overrideTokenID: UUID? = nil) async throws -> Terminal {
+    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, overrideTokenID: UUID? = nil, cols: Int? = nil, rows: Int? = nil) async throws -> Terminal {
         return try await callAsync(
             method: RPCMethod.terminalCreate,
-            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, resumeSessionID: resumeSessionID, overrideTokenID: overrideTokenID),
+            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, resumeSessionID: resumeSessionID, overrideTokenID: overrideTokenID, cols: cols, rows: rows),
             resultType: Terminal.self
         )
     }
@@ -453,11 +453,21 @@ actor DaemonClient {
     }
 
     /// Recreate a dead tmux window for an existing terminal (preserves terminal ID).
-    func recreateTerminalWindow(terminalID: UUID) async throws -> Terminal {
+    func recreateTerminalWindow(terminalID: UUID, cols: Int? = nil, rows: Int? = nil) async throws -> Terminal {
         return try await callAsync(
             method: RPCMethod.terminalRecreateWindow,
-            params: TerminalRecreateWindowParams(terminalID: terminalID),
+            params: TerminalRecreateWindowParams(terminalID: terminalID, cols: cols, rows: rows),
             resultType: Terminal.self
+        )
+    }
+
+    /// Tell the daemon the app's main terminal area has been resized so it
+    /// can `tmux resize-window` every tracked window. Used to keep detached
+    /// panes' cell dims sane; attached panes get overwritten by SwiftTerm.
+    func setMainAreaSize(cols: Int, rows: Int) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.setMainAreaSize,
+            params: SetMainAreaSizeParams(cols: cols, rows: rows)
         )
     }
 

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -42,13 +42,25 @@ class TBDTerminalView: TerminalView {
 
     func cellDimensions() -> (width: CGFloat, height: CGFloat) {
         if let cached = cachedCellDimensions { return cached }
-        let font = self.font ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let activeFont = self.font ?? Self.defaultMonospaceFont
+        let dims = Self.cellDimensions(for: activeFont)
+        cachedCellDimensions = dims
+        return dims
+    }
+
+    /// The font SwiftTerm initializes a `TerminalView` with when no font is set.
+    /// AppState uses this for px → cells conversion before any live view exists.
+    static let defaultMonospaceFont: NSFont = NSFont.monospacedSystemFont(
+        ofSize: 13, weight: .regular
+    )
+
+    /// Pure font-metric calculation, exposed so AppState can compute cols/rows
+    /// for a px area without a live `TBDTerminalView` instance.
+    static func cellDimensions(for font: NSFont) -> (width: CGFloat, height: CGFloat) {
         let glyph = font.glyph(withName: "W")
         let cellWidth = font.advancement(forGlyph: glyph).width
         let cellHeight = ceil(CTFontGetAscent(font) + CTFontGetDescent(font) + CTFontGetLeading(font))
-        let dims = (cellWidth, cellHeight)
-        cachedCellDimensions = dims
-        return dims
+        return (cellWidth, cellHeight)
     }
 
     /// Capture the current visible terminal content as an NSImage.

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -42,8 +42,7 @@ class TBDTerminalView: TerminalView {
 
     func cellDimensions() -> (width: CGFloat, height: CGFloat) {
         if let cached = cachedCellDimensions { return cached }
-        let activeFont = self.font ?? Self.defaultMonospaceFont
-        let dims = Self.cellDimensions(for: activeFont)
+        let dims = Self.cellDimensions(for: self.font)
         cachedCellDimensions = dims
         return dims
     }

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -15,6 +15,10 @@ import TBDShared
 /// daemon-side resize broadcast.
 struct MainAreaSizeKey: PreferenceKey {
     nonisolated(unsafe) static var defaultValue: CGSize = .zero
+    /// Exactly one view in the hierarchy posts this key (TerminalContainerView's
+    /// background GeometryReader), so taking the latest value is fine. If a
+    /// second producer is ever added, this reduce will silently drop earlier
+    /// values — switch to `value = max(value, nextValue())` or similar.
     static func reduce(value: inout CGSize, nextValue: () -> CGSize) { value = nextValue() }
 }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -9,6 +9,15 @@ import TBDShared
 ///   for the active tab's layout.
 /// - Multi-select (Cmd-click): Auto-grid layout, one panel per selected worktree
 ///   showing its primary terminal. No tab bar.
+/// Preference key carrying the px size of the main terminal area (the slot
+/// inside DockSplitView's `mainContent`, excluding the pinned dock and any
+/// file panel). AppState reads this via `.onPreferenceChange` to drive the
+/// daemon-side resize broadcast.
+struct MainAreaSizeKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) { value = nextValue() }
+}
+
 struct TerminalContainerView: View {
     @EnvironmentObject var appState: AppState
 
@@ -44,6 +53,16 @@ struct TerminalContainerView: View {
                 Text("Select a worktree or click + to create one")
                     .foregroundStyle(.secondary)
             }
+        }
+        .background(GeometryReader { geometry in
+            Color.clear.preference(key: MainAreaSizeKey.self, value: geometry.size)
+        })
+        .onPreferenceChange(MainAreaSizeKey.self) { newSize in
+            // SwiftUI fires .onPreferenceChange with .zero in some early
+            // layout passes; ignore those so we don't broadcast a degenerate
+            // size to the daemon.
+            guard newSize.width > 0, newSize.height > 0 else { return }
+            appState.mainAreaSize = newSize
         }
 
         // Always render DockSplitView so mainContent stays in the same

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -94,7 +94,7 @@ extension WorktreeLifecycle {
     ///   - worktreeID: The archived worktree to revive.
     ///   - skipClaude: If true, skip launching claude in the first terminal window.
     /// - Returns: The revived worktree.
-    public func reviveWorktree(worktreeID: UUID, skipClaude: Bool = false) async throws -> Worktree {
+    public func reviveWorktree(worktreeID: UUID, skipClaude: Bool = false, cols: Int? = nil, rows: Int? = nil) async throws -> Worktree {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -135,7 +135,9 @@ extension WorktreeLifecycle {
         try await setupTerminals(
             worktree: worktree, repo: repo,
             skipClaude: skipClaude,
-            archivedClaudeSessions: worktree.archivedClaudeSessions
+            archivedClaudeSessions: worktree.archivedClaudeSessions,
+            cols: cols,
+            rows: rows
         )
 
         // Update status to active.

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -218,11 +218,11 @@ extension WorktreeLifecycle {
         let tmuxServer = worktree.tmuxServer
         let worktreePath = worktreePath ?? worktree.path
         // Resolve a usable size: prefer caller's value, otherwise fall back to
-        // 220x50. tmux's own 80x24 default would let Claude render into hard-
-        // wrapped scrollback that can never be reflowed when the user later
-        // attaches a wider SwiftTerm view.
-        let resolvedCols = cols ?? 220
-        let resolvedRows = rows ?? 50
+        // TmuxManager's defaults. tmux's own 80x24 default would let Claude
+        // render into hard-wrapped scrollback that can never be reflowed when
+        // the user later attaches a wider SwiftTerm view.
+        let resolvedCols = cols ?? TmuxManager.defaultCols
+        let resolvedRows = rows ?? TmuxManager.defaultRows
         // Ensure tmux server exists — capture initial window ID to kill later
         let initialWindowID = try await tmux.ensureServer(
             server: tmuxServer,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -11,9 +11,9 @@ extension WorktreeLifecycle {
     ///
     /// This is the legacy all-in-one method. Prefer `beginCreateWorktree` +
     /// `completeCreateWorktree` for non-blocking creation.
-    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil) async throws -> Worktree {
+    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil) async throws -> Worktree {
         let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude)
-        try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil)
+        try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows)
         guard let completed = try await db.worktrees.get(id: pending.id) else {
             throw WorktreeLifecycleError.worktreeNotFound(pending.id)
         }
@@ -68,7 +68,7 @@ extension WorktreeLifecycle {
 
     /// Phase 2: Async. Performs git fetch, git worktree add, tmux setup,
     /// then updates status to `.active`. On failure, deletes the DB row.
-    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false) async throws {
+    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil) async throws {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -112,7 +112,9 @@ extension WorktreeLifecycle {
                 worktree: worktree, repo: repo,
                 worktreePath: result.path,
                 skipClaude: skipClaude,
-                initialPrompt: initialPrompt
+                initialPrompt: initialPrompt,
+                cols: cols,
+                rows: rows
             )
 
             // 6. Update status to active
@@ -208,16 +210,26 @@ extension WorktreeLifecycle {
         worktree: Worktree, repo: Repo,
         worktreePath: String? = nil, skipClaude: Bool,
         archivedClaudeSessions: [String]? = nil,
-        initialPrompt: String? = nil
+        initialPrompt: String? = nil,
+        cols: Int? = nil,
+        rows: Int? = nil
     ) async throws {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
         let worktreePath = worktreePath ?? worktree.path
+        // Resolve a usable size: prefer caller's value, otherwise fall back to
+        // 220x50. tmux's own 80x24 default would let Claude render into hard-
+        // wrapped scrollback that can never be reflowed when the user later
+        // attaches a wider SwiftTerm view.
+        let resolvedCols = cols ?? 220
+        let resolvedRows = rows ?? 50
         // Ensure tmux server exists — capture initial window ID to kill later
         let initialWindowID = try await tmux.ensureServer(
             server: tmuxServer,
             session: "main",
-            cwd: worktreePath
+            cwd: worktreePath,
+            cols: resolvedCols,
+            rows: resolvedRows
         )
 
         // Resolve claude token (repo override → global default → none).
@@ -266,7 +278,9 @@ extension WorktreeLifecycle {
             session: "main",
             cwd: worktreePath,
             shellCommand: claudeCommand,
-            sensitiveEnv: claudeSensitiveEnv
+            sensitiveEnv: claudeSensitiveEnv,
+            cols: resolvedCols,
+            rows: resolvedRows
         )
         _ = try await db.terminals.create(
             worktreeID: worktreeID,
@@ -288,7 +302,9 @@ extension WorktreeLifecycle {
             server: tmuxServer,
             session: "main",
             cwd: worktreePath,
-            shellCommand: setupCommand
+            shellCommand: setupCommand,
+            cols: resolvedCols,
+            rows: resolvedRows
         )
         _ = try await db.terminals.create(
             worktreeID: worktreeID,
@@ -315,7 +331,9 @@ extension WorktreeLifecycle {
                     session: "main",
                     cwd: worktreePath,
                     shellCommand: spawn.command,
-                    sensitiveEnv: spawn.sensitiveEnv
+                    sensitiveEnv: spawn.sensitiveEnv,
+                    cols: resolvedCols,
+                    rows: resolvedRows
                 )
                 _ = try await db.terminals.create(
                     worktreeID: worktreeID,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -16,10 +16,10 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
         }
 
-        // Resolve initial size: caller-supplied → fallback to 220x50 to avoid
+        // Resolve initial size: caller-supplied → TmuxManager defaults to avoid
         // tmux's 80x24 default producing un-reflowable hard-wrapped scrollback.
-        let resolvedCols = params.cols ?? 220
-        let resolvedRows = params.rows ?? 50
+        let resolvedCols = params.cols ?? TmuxManager.defaultCols
+        let resolvedRows = params.rows ?? TmuxManager.defaultRows
 
         // Ensure tmux server exists before creating window
         _ = try await tmux.ensureServer(
@@ -220,8 +220,8 @@ extension RPCRouter {
         // Kill the old window if it still exists (avoids orphans)
         try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
 
-        let resolvedCols = params.cols ?? 220
-        let resolvedRows = params.rows ?? 50
+        let resolvedCols = params.cols ?? TmuxManager.defaultCols
+        let resolvedRows = params.rows ?? TmuxManager.defaultRows
 
         // Ensure tmux server exists
         _ = try await tmux.ensureServer(
@@ -422,10 +422,10 @@ extension RPCRouter {
             shellFallback: ""
         )
 
-        // Resolve initial size: caller-supplied → fallback to 220x50 to avoid
+        // Resolve initial size: caller-supplied → TmuxManager defaults to avoid
         // tmux's 80x24 default producing un-reflowable hard-wrapped scrollback.
-        let resolvedCols = params.cols ?? 220
-        let resolvedRows = params.rows ?? 50
+        let resolvedCols = params.cols ?? TmuxManager.defaultCols
+        let resolvedRows = params.rows ?? TmuxManager.defaultRows
 
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -521,7 +521,11 @@ extension RPCRouter {
         }
 
         let allTerminals = try await db.terminals.list()
-        let worktrees = try await db.worktrees.list()
+        // Filter to active worktrees only — archived worktrees have had their
+        // tmux servers killed, so resizing windows there spawns dead `tmux
+        // resize-window` processes (errors swallowed by `try?`) on every
+        // resize-debounce tick during a window drag.
+        let worktrees = try await db.worktrees.list(status: .active)
         let serverByWorktree = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0.tmuxServer) })
 
         logger.debug("setMainAreaSize \(params.cols, privacy: .public)x\(params.rows, privacy: .public) across \(allTerminals.count, privacy: .public) terminals")

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -16,11 +16,18 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
         }
 
+        // Resolve initial size: caller-supplied → fallback to 220x50 to avoid
+        // tmux's 80x24 default producing un-reflowable hard-wrapped scrollback.
+        let resolvedCols = params.cols ?? 220
+        let resolvedRows = params.rows ?? 50
+
         // Ensure tmux server exists before creating window
         _ = try await tmux.ensureServer(
             server: worktree.tmuxServer,
             session: "main",
-            cwd: worktree.path
+            cwd: worktree.path,
+            cols: resolvedCols,
+            rows: resolvedRows
         )
 
         // Look up repo once for system prompt env vars and Claude session setup
@@ -50,7 +57,9 @@ extension RPCRouter {
                 session: "main",
                 cwd: worktree.path,
                 shellCommand: "codex --full-auto",
-                env: codexEnv
+                env: codexEnv,
+                cols: resolvedCols,
+                rows: resolvedRows
             )
 
             let terminal = try await db.terminals.create(
@@ -137,7 +146,9 @@ extension RPCRouter {
             cwd: worktree.path,
             shellCommand: spawn.command,
             env: env,
-            sensitiveEnv: spawn.sensitiveEnv
+            sensitiveEnv: spawn.sensitiveEnv,
+            cols: resolvedCols,
+            rows: resolvedRows
         )
 
         let terminal = try await db.terminals.create(
@@ -209,11 +220,16 @@ extension RPCRouter {
         // Kill the old window if it still exists (avoids orphans)
         try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
 
+        let resolvedCols = params.cols ?? 220
+        let resolvedRows = params.rows ?? 50
+
         // Ensure tmux server exists
         _ = try await tmux.ensureServer(
             server: worktree.tmuxServer,
             session: "main",
-            cwd: worktree.path
+            cwd: worktree.path,
+            cols: resolvedCols,
+            rows: resolvedRows
         )
 
         // Create a new tmux window with a default shell.
@@ -224,7 +240,9 @@ extension RPCRouter {
             server: worktree.tmuxServer,
             session: "main",
             cwd: worktree.path,
-            shellCommand: shell
+            shellCommand: shell,
+            cols: resolvedCols,
+            rows: resolvedRows
         )
 
         // Update the terminal record with new window/pane IDs and clear stale
@@ -477,6 +495,39 @@ extension RPCRouter {
             )
         }
 
+        return .ok()
+    }
+
+    // MARK: - Main Area Size Broadcast
+
+    /// Resize every known tmux window to the new cell dimensions. Called by
+    /// the app when its main terminal area resizes (debounced) so detached
+    /// panes don't keep stale dimensions; attached panes get overwritten by
+    /// SwiftTerm's TIOCSWINSZ within milliseconds.
+    func handleSetMainAreaSize(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(SetMainAreaSizeParams.self, from: paramsData)
+        guard params.cols >= TmuxManager.minCols, params.rows >= TmuxManager.minRows else {
+            // Silently ignore degenerate sizes — clients can race below the
+            // minimum during window setup; tmux handles it correctly when the
+            // next valid size comes in.
+            return .ok()
+        }
+
+        let allTerminals = try await db.terminals.list()
+        let worktrees = try await db.worktrees.list()
+        let serverByWorktree = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0.tmuxServer) })
+
+        logger.debug("setMainAreaSize \(params.cols, privacy: .public)x\(params.rows, privacy: .public) across \(allTerminals.count, privacy: .public) terminals")
+
+        for terminal in allTerminals {
+            guard let server = serverByWorktree[terminal.worktreeID] else { continue }
+            try? await tmux.resizeWindow(
+                server: server,
+                windowID: terminal.tmuxWindowID,
+                cols: params.cols,
+                rows: params.rows
+            )
+        }
         return .ok()
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -422,13 +422,20 @@ extension RPCRouter {
             shellFallback: ""
         )
 
+        // Resolve initial size: caller-supplied → fallback to 220x50 to avoid
+        // tmux's 80x24 default producing un-reflowable hard-wrapped scrollback.
+        let resolvedCols = params.cols ?? 220
+        let resolvedRows = params.rows ?? 50
+
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
             session: "main",
             cwd: worktree.path,
             shellCommand: spawn.command,
             env: env,
-            sensitiveEnv: spawn.sensitiveEnv
+            sensitiveEnv: spawn.sensitiveEnv,
+            cols: resolvedCols,
+            rows: resolvedRows
         )
 
         let newTerminal = try await db.terminals.create(

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -17,9 +17,11 @@ extension RPCRouter {
         let initialPrompt = params.prompt
         let userSpecifiedFolder = params.folder != nil
         let userSpecifiedBranch = params.branch != nil
+        let cols = params.cols
+        let rows = params.rows
         Task.detached {
             do {
-                try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch)
+                try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows)
                 // Broadcast the completed worktree
                 subs.broadcast(delta: .worktreeCreated(WorktreeDelta(
                     worktreeID: pending.id, repoID: pending.repoID,

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -68,7 +68,7 @@ extension RPCRouter {
 
     func handleWorktreeRevive(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeReviveParams.self, from: paramsData)
-        let worktree = try await lifecycle.reviveWorktree(worktreeID: params.worktreeID)
+        let worktree = try await lifecycle.reviveWorktree(worktreeID: params.worktreeID, cols: params.cols, rows: params.rows)
 
         subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
             worktreeID: worktree.id, repoID: worktree.repoID,

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -177,6 +177,8 @@ public final class RPCRouter: Sendable {
                 let params = try decoder.decode(AppSetForegroundStateParams.self, from: request.paramsData)
                 await claudeUsagePoller?.onFocusChanged(isForeground: params.isForeground)
                 return .ok()
+            case RPCMethod.setMainAreaSize:
+                return try await handleSetMainAreaSize(request.paramsData)
             case RPCMethod.sessionList:
                 return try await handleSessionList(request.paramsData)
             case RPCMethod.sessionMessages:

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -48,15 +48,32 @@ public struct TmuxManager: Sendable {
         return "tbd-\(hex)"
     }
 
-    public static func newServerCommand(server: String, session: String, cwd: String) -> [String] {
-        ["-L", server, "new-session", "-d", "-s", session, "-c", cwd, "-PF", "#{window_id}"]
+    /// Minimum sane terminal size. Smaller values are ignored — tmux's own
+    /// default (80x24) is preferable to a degenerate value.
+    public static let minCols: Int = 80
+    public static let minRows: Int = 24
+
+    /// Returns the explicit `-x N -y M` flags to pass to tmux when the caller
+    /// supplied a usable size. Returns an empty array when either dimension
+    /// is nil or below the minimum, leaving tmux to use its own default.
+    private static func sizeFlags(cols: Int?, rows: Int?) -> [String] {
+        guard let cols, let rows, cols >= minCols, rows >= minRows else { return [] }
+        return ["-x", "\(cols)", "-y", "\(rows)"]
+    }
+
+    public static func newServerCommand(server: String, session: String, cwd: String, cols: Int? = nil, rows: Int? = nil) -> [String] {
+        // Place size flags before -PF so the format spec stays last (consistent
+        // with tmux argument-order conventions).
+        ["-L", server, "new-session", "-d", "-s", session, "-c", cwd]
+            + sizeFlags(cols: cols, rows: rows)
+            + ["-PF", "#{window_id}"]
     }
 
     public static func hasSessionCommand(server: String, session: String) -> [String] {
         ["-L", server, "has-session", "-t", session]
     }
 
-    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:]) -> [String] {
+    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:], cols: Int? = nil, rows: Int? = nil) -> [String] {
         // Use shell -ic so commands with arguments work (e.g. "claude --dangerously-skip-permissions")
         // -i keeps it interactive (loads .zshrc), -c runs the command
         // After the command exits, the pane closes (tmux default behavior)
@@ -78,7 +95,17 @@ public struct TmuxManager: Sendable {
             eFlags.append("-e")
             eFlags.append("\(key)=\(value)")
         }
-        return ["-L", server, "new-window", "-t", session, "-c", cwd] + eFlags + ["-PF", "#{window_id} #{pane_id}", userShell, "-ic", fullCommand]
+        // Place size flags after -c <cwd> (and after -e env flags) to keep the
+        // format-spec / shell command at the end where tmux expects them.
+        return ["-L", server, "new-window", "-t", session, "-c", cwd]
+            + eFlags
+            + sizeFlags(cols: cols, rows: rows)
+            + ["-PF", "#{window_id} #{pane_id}", userShell, "-ic", fullCommand]
+    }
+
+    /// Resize an existing tmux window to the given cell dimensions.
+    public static func resizeWindowCommand(server: String, windowID: String, cols: Int, rows: Int) -> [String] {
+        ["-L", server, "resize-window", "-t", windowID, "-x", "\(cols)", "-y", "\(rows)"]
     }
 
     public static func killWindowCommand(server: String, windowID: String) -> [String] {
@@ -126,8 +153,14 @@ public struct TmuxManager: Sendable {
     /// - Returns: The initial window ID if a new session was created (caller should kill it after
     ///   creating real windows), or `nil` if the session already existed.
     @discardableResult
-    public func ensureServer(server: String, session: String, cwd: String) async throws -> String? {
-        if dryRun { return nil }
+    public func ensureServer(server: String, session: String, cwd: String, cols: Int? = nil, rows: Int? = nil) async throws -> String? {
+        if dryRun {
+            // Even in dry-run, still record the new-session shape so tests can
+            // assert that size flags propagate.
+            let args = Self.newServerCommand(server: server, session: session, cwd: cwd, cols: cols, rows: rows)
+            dryRunRecorder?(args)
+            return nil
+        }
         // Check if the session already exists before creating
         let hasSessionArgs = Self.hasSessionCommand(server: server, session: session)
         do {
@@ -136,7 +169,7 @@ public struct TmuxManager: Sendable {
             return nil
         } catch {
             // Session does not exist, create it — capture the initial window ID
-            let args = Self.newServerCommand(server: server, session: session, cwd: cwd)
+            let args = Self.newServerCommand(server: server, session: session, cwd: cwd, cols: cols, rows: rows)
             let output = try await runTmux(args)
             // Hide tmux chrome globally — TBD app provides its own UI
             try? await runTmux(["-L", server, "set", "-g", "status", "off"])
@@ -162,14 +195,14 @@ public struct TmuxManager: Sendable {
         try await runTmux(["-L", server, "kill-server"])
     }
 
-    public func createWindow(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:]) async throws -> (windowID: String, paneID: String) {
+    public func createWindow(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:], cols: Int? = nil, rows: Int? = nil) async throws -> (windowID: String, paneID: String) {
         if dryRun {
-            let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env, sensitiveEnv: sensitiveEnv)
+            let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env, sensitiveEnv: sensitiveEnv, cols: cols, rows: rows)
             dryRunRecorder?(args)
             let n = counter.next()
             return (windowID: "@mock-\(n)", paneID: "%mock-\(n)")
         }
-        let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env, sensitiveEnv: sensitiveEnv)
+        let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env, sensitiveEnv: sensitiveEnv, cols: cols, rows: rows)
         let output = try await runTmux(args)
         let parts = output.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: " ")
         guard parts.count == 2 else {
@@ -181,6 +214,19 @@ public struct TmuxManager: Sendable {
     public func killWindow(server: String, windowID: String) async throws {
         if dryRun { return }
         let args = Self.killWindowCommand(server: server, windowID: windowID)
+        try await runTmux(args)
+    }
+
+    /// Resize an existing tmux window. Used by the main-window resize broadcast
+    /// so detached panes retain a sensible cell size after the user changes
+    /// the app window dimensions; attached panes get overwritten by SwiftTerm's
+    /// own ioctl within milliseconds, so we don't bother filtering.
+    public func resizeWindow(server: String, windowID: String, cols: Int, rows: Int) async throws {
+        let args = Self.resizeWindowCommand(server: server, windowID: windowID, cols: cols, rows: rows)
+        if dryRun {
+            dryRunRecorder?(args)
+            return
+        }
         try await runTmux(args)
     }
 

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -53,6 +53,13 @@ public struct TmuxManager: Sendable {
     public static let minCols: Int = 80
     public static let minRows: Int = 24
 
+    /// Default pane size used when a caller does not supply explicit
+    /// dimensions. Larger than tmux's own 80x24 default so Claude doesn't
+    /// render into hard-wrapped scrollback that can't be reflowed once a
+    /// wider SwiftTerm view attaches.
+    public static let defaultCols: Int = 220
+    public static let defaultRows: Int = 50
+
     /// Returns the explicit `-x N -y M` flags to pass to tmux when the caller
     /// supplied a usable size. Returns an empty array when either dimension
     /// is nil or below the minimum, leaving tmux to use its own default.

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -157,9 +157,14 @@ public struct AppSetForegroundStateParams: Codable, Sendable {
 public struct TerminalSwapClaudeTokenParams: Codable, Sendable {
     public let terminalID: UUID
     public let newTokenID: UUID?
-    public init(terminalID: UUID, newTokenID: UUID?) {
+    /// Initial tmux window size in cells (see WorktreeCreateParams).
+    public let cols: Int?
+    public let rows: Int?
+    public init(terminalID: UUID, newTokenID: UUID?, cols: Int? = nil, rows: Int? = nil) {
         self.terminalID = terminalID
         self.newTokenID = newTokenID
+        self.cols = cols
+        self.rows = rows
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -345,7 +345,14 @@ public struct WorktreeArchiveParams: Codable, Sendable {
 
 public struct WorktreeReviveParams: Codable, Sendable {
     public let worktreeID: UUID
-    public init(worktreeID: UUID) { self.worktreeID = worktreeID }
+    /// Initial tmux window size in cells (see WorktreeCreateParams).
+    public let cols: Int?
+    public let rows: Int?
+    public init(worktreeID: UUID, cols: Int? = nil, rows: Int? = nil) {
+        self.worktreeID = worktreeID
+        self.cols = cols
+        self.rows = rows
+    }
 }
 
 public struct WorktreeRenameParams: Codable, Sendable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -133,6 +133,18 @@ public enum RPCMethod {
     public static let repoRelocate = "repo.relocate"
     public static let sessionList = "session.list"
     public static let sessionMessages = "session.messages"
+    public static let setMainAreaSize = "app.setMainAreaSize"
+}
+
+// MARK: - Main Area Size
+
+public struct SetMainAreaSizeParams: Codable, Sendable {
+    public let cols: Int
+    public let rows: Int
+    public init(cols: Int, rows: Int) {
+        self.cols = cols
+        self.rows = rows
+    }
 }
 
 public struct AppSetForegroundStateParams: Codable, Sendable {
@@ -299,8 +311,14 @@ public struct WorktreeCreateParams: Codable, Sendable {
     public let branch: String?
     public let displayName: String?
     public let prompt: String?
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil) {
+    /// Initial tmux window size in cells. When nil, the daemon falls back to a
+    /// generous default (220x50) so Claude doesn't render at tmux's 80x24
+    /// default and produce hard-wrapped scrollback that can never be reflowed.
+    public let cols: Int?
+    public let rows: Int?
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
+        self.cols = cols; self.rows = rows
     }
 }
 
@@ -357,8 +375,12 @@ public struct TerminalCreateParams: Codable, Sendable {
     public let prompt: String?
     /// Pin a specific token ID for this terminal, bypassing resolve(repoID:).
     public let overrideTokenID: UUID?
-    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil, overrideTokenID: UUID? = nil) {
+    /// Initial tmux window size in cells (see WorktreeCreateParams).
+    public let cols: Int?
+    public let rows: Int?
+    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil, overrideTokenID: UUID? = nil, cols: Int? = nil, rows: Int? = nil) {
         self.worktreeID = worktreeID; self.cmd = cmd; self.type = type; self.resumeSessionID = resumeSessionID; self.prompt = prompt; self.overrideTokenID = overrideTokenID
+        self.cols = cols; self.rows = rows
     }
 }
 
@@ -437,7 +459,14 @@ public struct WorktreeResumeParams: Codable, Sendable {
 
 public struct TerminalRecreateWindowParams: Codable, Sendable {
     public let terminalID: UUID
-    public init(terminalID: UUID) { self.terminalID = terminalID }
+    /// Initial tmux window size in cells (see WorktreeCreateParams).
+    public let cols: Int?
+    public let rows: Int?
+    public init(terminalID: UUID, cols: Int? = nil, rows: Int? = nil) {
+        self.terminalID = terminalID
+        self.cols = cols
+        self.rows = rows
+    }
 }
 
 public struct NoteCreateParams: Codable, Sendable {

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -164,3 +164,136 @@ import Testing
     let args = TmuxManager.sendCommandArgs(server: "tbd-test", paneID: "%42", command: "/exit")
     #expect(args == ["-L", "tbd-test", "send-keys", "-t", "%42", "/exit", "Enter"])
 }
+
+// MARK: - Initial Window Size (cols/rows flags)
+//
+// Each branch of the new size-emission conditional is exercised: explicit
+// size produces `-x N -y M`, nil/below-minimum size produces no flags. The
+// dryRun recorder tests confirm the flags reach the argv that would have
+// been passed to `tmux`, even though the process isn't spawned.
+
+@Test func testNewServerCommandWithExplicitSize() {
+    let args = TmuxManager.newServerCommand(
+        server: "tbd-a1b2c3d4", session: "main", cwd: "/tmp/repo",
+        cols: 220, rows: 50
+    )
+    #expect(args.contains("-x"))
+    #expect(args.contains("220"))
+    #expect(args.contains("-y"))
+    #expect(args.contains("50"))
+    // -PF must remain trailing so tmux's positional parsing still works.
+    #expect(args.last == "#{window_id}")
+    #expect(args[args.count - 2] == "-PF")
+}
+
+@Test func testNewServerCommandWithoutSize() {
+    let args = TmuxManager.newServerCommand(
+        server: "tbd-a1b2c3d4", session: "main", cwd: "/tmp/repo"
+    )
+    #expect(!args.contains("-x"))
+    #expect(!args.contains("-y"))
+}
+
+@Test func testNewServerCommandIgnoresBelowMinimumSize() {
+    // Floor at 80x24 — anything smaller is silently dropped so tmux uses its
+    // own default rather than a degenerate size.
+    let args = TmuxManager.newServerCommand(
+        server: "tbd-test", session: "main", cwd: "/tmp",
+        cols: 40, rows: 10
+    )
+    #expect(!args.contains("-x"))
+    #expect(!args.contains("-y"))
+}
+
+@Test func testNewWindowCommandWithExplicitSize() {
+    let args = TmuxManager.newWindowCommand(
+        server: "tbd-a1b2c3d4", session: "main", cwd: "/tmp/worktree",
+        shellCommand: "claude --dangerously-skip-permissions",
+        cols: 200, rows: 60
+    )
+    #expect(args.contains("-x"))
+    #expect(args.contains("200"))
+    #expect(args.contains("-y"))
+    #expect(args.contains("60"))
+    // The shell command must remain at the very end (tmux's last positional
+    // arg is the spawn command).
+    #expect(args.last == "claude --dangerously-skip-permissions")
+}
+
+@Test func testNewWindowCommandWithoutSize() {
+    let args = TmuxManager.newWindowCommand(
+        server: "tbd-a1b2c3d4", session: "main", cwd: "/tmp/worktree",
+        shellCommand: "echo hi"
+    )
+    #expect(!args.contains("-x"))
+    #expect(!args.contains("-y"))
+}
+
+@Test func testCreateWindowDryRunForwardsSize() async throws {
+    let recorded = LockedCommandRecorder()
+    let manager = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    _ = try await manager.createWindow(
+        server: "tbd-test", session: "main", cwd: "/tmp",
+        shellCommand: "echo hi", cols: 220, rows: 50
+    )
+    let calls = recorded.snapshot()
+    #expect(calls.count == 1)
+    let args = calls[0]
+    #expect(args.contains("-x"))
+    #expect(args.contains("220"))
+    #expect(args.contains("-y"))
+    #expect(args.contains("50"))
+}
+
+@Test func testEnsureServerDryRunForwardsSize() async throws {
+    let recorded = LockedCommandRecorder()
+    let manager = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    try await manager.ensureServer(
+        server: "tbd-test", session: "main", cwd: "/tmp",
+        cols: 220, rows: 50
+    )
+    let calls = recorded.snapshot()
+    #expect(calls.count == 1)
+    let args = calls[0]
+    #expect(args.contains("new-session"))
+    #expect(args.contains("-x"))
+    #expect(args.contains("220"))
+    #expect(args.contains("-y"))
+    #expect(args.contains("50"))
+}
+
+@Test func testResizeWindowCommand() {
+    let args = TmuxManager.resizeWindowCommand(
+        server: "tbd-test", windowID: "@5", cols: 240, rows: 80
+    )
+    #expect(args == ["-L", "tbd-test", "resize-window", "-t", "@5", "-x", "240", "-y", "80"])
+}
+
+@Test func testResizeWindowDryRunRecords() async throws {
+    let recorded = LockedCommandRecorder()
+    let manager = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    try await manager.resizeWindow(server: "tbd-test", windowID: "@5", cols: 240, rows: 80)
+    let calls = recorded.snapshot()
+    #expect(calls.count == 1)
+    #expect(calls[0] == ["-L", "tbd-test", "resize-window", "-t", "@5", "-x", "240", "-y", "80"])
+}
+
+/// Thread-safe recorder for dry-run argv captures used by the tests above.
+final class LockedCommandRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls: [[String]] = []
+    func append(_ args: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        calls.append(args)
+    }
+    func snapshot() -> [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return calls
+    }
+}


### PR DESCRIPTION
## Summary

**The bug.** When TBD spawns a terminal programmatically — `tbd worktree create --prompt-file -`, autonomous Claude tabs from another worktree, anything where the user isn't currently looking at the new tab — the daemon called `tmux new-session` / `tmux new-window` **without `-x`/`-y` flags**. Tmux defaulted to 80×24, `claude` started rendering hard-wrapped output into scrollback at that width, and tmux's own reflow can never undo it (Claude Code emits literal newlines for diff/box rendering, not soft-wrapped lines). When the user later opened the tab at the real width, the early scrollback was permanently stuck narrow.

**The fix.**
- App now publishes the live "main terminal area" size (excluding pinned dock + file panel) into `AppState.mainAreaSize` via a `GeometryReader` preference key on the main slot of `DockSplitView`.
- App passes `cols`/`rows` (computed from that size + SwiftTerm's font cell metrics) on `worktreeCreate`, `terminalCreate`, and `terminalRecreateWindow` RPCs.
- Daemon threads the size into `tmux new-session -x N -y M` and `tmux new-window -x N -y M`. Falls back to 220×50 when params are nil (CLI path / no app connected).
- New `setMainAreaSize` RPC, debounced 300ms after the user stops resizing the main window, broadcasts the new size to the daemon, which iterates all tracked terminals and runs `tmux resize-window` so detached panes stay in sync if the user resizes before viewing them.

Optional fields, no DB migration, fully backward-compatible with older daemons/CLIs.

## Test plan

- [ ] `swift build` clean
- [ ] `swift test` — TmuxManager tests pass (9 new tests cover both branches of the cols/rows conditional + the new resize-window helper)
- [ ] `scripts/restart.sh` (full restart so the daemon picks up new RPC fields), then:
  - [ ] From an existing Claude tab, run `tbd worktree create --prompt-file -` with a prompt that produces wide output. Open the new tab — early scrollback should already be at the main window's width, not 80 cols.
  - [ ] Resize the main window noticeably wider after a worktree was created but before viewing its tab. Open the tab — scrollback should match the new width.
  - [ ] Existing terminals continue to render correctly when the main window is resized.
  - [ ] CLI `tbd worktree create` (no app size info) still creates terminals; daemon falls back to 220×50.