### PR TITLE
Fix: Stop sentence punctuation from breaking Cmd+Click on file paths in prose

### DIFF
--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -248,11 +248,10 @@ class TBDTerminalView: TerminalView {
             candidate = String(candidate[candidate.startIndex..<candidate.index(candidate.startIndex, offsetBy: match.range.location)])
         }
 
-        // Strip trailing sentence punctuation that the path-character word boundary may have absorbed
-        // from prose context (e.g., "see design.md." or "see (design.md)."). Only strip from the END
-        // — mid-path dots like "foo.md" must be preserved.
-        let trailingPunctuation: Set<Character> = [".", ",", ";", ":", "!", "?", ")", "]", "}", ">"]
-        while let last = candidate.last, trailingPunctuation.contains(last) {
+        // The path-character word boundary includes '.', so a trailing sentence period gets absorbed
+        // into the candidate (e.g., "see design.md."). Strip it before the existence check. Mid-path
+        // dots are preserved — only trailing.
+        while candidate.hasSuffix(".") {
             candidate.removeLast()
         }
 

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -248,6 +248,14 @@ class TBDTerminalView: TerminalView {
             candidate = String(candidate[candidate.startIndex..<candidate.index(candidate.startIndex, offsetBy: match.range.location)])
         }
 
+        // Strip trailing sentence punctuation that the path-character word boundary may have absorbed
+        // from prose context (e.g., "see design.md." or "see (design.md)."). Only strip from the END
+        // — mid-path dots like "foo.md" must be preserved.
+        let trailingPunctuation: Set<Character> = [".", ",", ";", ":", "!", "?", ")", "]", "}", ">"]
+        while let last = candidate.last, trailingPunctuation.contains(last) {
+            candidate.removeLast()
+        }
+
         guard !candidate.isEmpty else { return nil }
 
         // Resolve relative paths against worktreePath


### PR DESCRIPTION
## Summary

- Cmd+Clicking a file path mentioned in Claude Code's prose output (e.g. `Spec written to docs/foo/bar.md.`) didn't open the file, even though the same path inside a tool-block header (`Update(docs/foo/bar.md)`) worked.
- Tool-block headers work via OSC 8 hyperlink payloads, which carry a clean URL. Prose paths fall back to `extractFilePath`, which uses path-character word-boundary detection. Because `.` is a valid path character, the trailing sentence period got absorbed into the candidate (`bar.md.`), failing the `FileManager.fileExists` check and silently returning nil.
- Fix: strip trailing sentence punctuation (`.,;:!?)]}>`) from the candidate after the existing `:line:col` strip and before the existence check. Mid-path dots are preserved (only trims from the end).

## Test plan

- [ ] In a worktree, send Claude a message that ends with a path followed by a period: `See docs/superpowers/specs/2026-04-29-deep-link-terminals-design.md.` — Cmd+Click on the path opens the file viewer.
- [ ] Same path wrapped in parens: `(see docs/foo/bar.md).` — Cmd+Click still works.
- [ ] Existing OSC 8 click path (e.g. `Update(...)` headers) still works.
- [ ] A path that legitimately contains mid-path dots (`foo.bar.md`) still resolves.