### PR TITLE
Feat: Click tbd:// links to jump straight to worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,13 @@ TBDApp runs as a bare SPM executable, not a `.app` bundle. APIs that require a b
 
 Guard these with `Bundle.main.bundleIdentifier != nil` checks.
 
+### Deep links and TBD.app bundle
+
+`tbd://open?worktree=<uuid>` URL clicks reach the app via the `.app` bundle assembled by `scripts/restart.sh` at `.build/debug/TBD.app`. Two consequences:
+
+- **Bundled launch is required.** `swift run TBDApp` and direct execution of `.build/debug/TBDApp` produce a process with no surrounding `Info.plist`, so LaunchServices won't deliver `tbd://` URLs to it. Always launch via `scripts/restart.sh` when testing deep links.
+- **One worktree wins LaunchServices.** All TBD worktrees register the same `CFBundleIdentifier=com.tbd.app`, so whichever worktree most recently ran `restart.sh` becomes the `tbd://` handler. Restart the worktree you want to receive links — others stay built but inert for URL routing.
+
 ### NIO thread safety
 All `ChannelHandlerContext` property access (`context.channel`, `context.pipeline`) must happen on the channel's event loop. Accessing from any other thread triggers a precondition crash. Always wrap in `context.eventLoop.execute { ... }` — never use `context.channel.isActive` as a pre-check outside the event loop.
 

--- a/Resources/TBDApp.Info.plist
+++ b/Resources/TBDApp.Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.tbd.app</string>
+    <key>CFBundleName</key>
+    <string>TBD</string>
+    <key>CFBundleExecutable</key>
+    <string>TBDApp</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>15.0</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>com.tbd.deeplink</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>tbd</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -120,6 +120,54 @@ extension AppState {
         }
     }
 
+    /// Archived-worktree path for deep-link navigation. Async — issues an RPC
+    /// to find the worktree across all archived ones, then opens the
+    /// archived pane and flashes the row.
+    @MainActor
+    func navigateToArchivedWorktree(_ id: UUID) async {
+        let archived: [Worktree]
+        if let override = archivedLookupOverride {
+            archived = await override(id)
+        } else {
+            do {
+                archived = try await daemonClient.listWorktrees(
+                    repoID: nil, status: .archived
+                )
+            } catch {
+                logger.error("Deep-link archived lookup failed: \(error.localizedDescription)")
+                return
+            }
+        }
+
+        guard let wt = archived.first(where: { $0.id == id }) else {
+            logger.warning("Deep link references unknown worktree \(id.uuidString, privacy: .public)")
+            return
+        }
+
+        selectedWorktreeIDs = []
+        selectedRepoID = wt.repoID
+        archivedWorktrees[wt.repoID] = archived.filter { $0.repoID == wt.repoID }
+        highlightedArchivedWorktreeID = id
+        if NSApplication.shared.isRunning {
+            NSApplication.shared.activate(ignoringOtherApps: true)
+        }
+    }
+
+    /// Public entry point for deep-link navigation. Synchronous fast path
+    /// for active worktrees; falls through to the async archived path on a
+    /// miss.
+    @MainActor
+    func navigateToWorktree(_ id: UUID) {
+        let activeMatch = worktrees.values
+            .flatMap { $0 }
+            .contains(where: { $0.id == id })
+        if activeMatch {
+            navigateToActiveWorktree(id)
+        } else {
+            Task { await navigateToArchivedWorktree(id) }
+        }
+    }
+
     /// Select a repo to show its archived worktrees in the content pane.
     func selectRepo(id: UUID) {
         selectedWorktreeIDs = []

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import TBDShared
 import os
@@ -106,6 +107,18 @@ extension AppState {
     }
 
     // MARK: - Archived Worktrees
+
+    /// Active-worktree path for deep-link navigation. Caller is responsible
+    /// for verifying the id exists in `self.worktrees` first.
+    @MainActor
+    func navigateToActiveWorktree(_ id: UUID) {
+        selectedWorktreeIDs = [id]
+        // Only foreground when the AppKit run loop is live — `NSApp` is nil
+        // under unit tests, which would crash on the implicit unwrap.
+        if NSApplication.shared.isRunning {
+            NSApplication.shared.activate(ignoringOtherApps: true)
+        }
+    }
 
     /// Select a repo to show its archived worktrees in the content pane.
     func selectRepo(id: UUID) {

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -112,6 +112,7 @@ extension AppState {
     /// for verifying the id exists in `self.worktrees` first.
     @MainActor
     func navigateToActiveWorktree(_ id: UUID) {
+        highlightedArchivedWorktreeID = nil
         selectedWorktreeIDs = [id]
         // Only foreground when the AppKit run loop is live — `NSApp` is nil
         // under unit tests, which would crash on the implicit unwrap.
@@ -170,6 +171,7 @@ extension AppState {
 
     /// Select a repo to show its archived worktrees in the content pane.
     func selectRepo(id: UUID) {
+        highlightedArchivedWorktreeID = nil
         selectedWorktreeIDs = []
         selectedRepoID = id
         Task { await refreshArchivedWorktrees(repoID: id) }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -159,6 +159,15 @@ extension AppState {
     /// miss.
     @MainActor
     func navigateToWorktree(_ id: UUID) {
+        // Cold-start guard: a tbd:// click can arrive between AppState.init()
+        // and the daemon RPC populating `worktrees`. If we fall through to
+        // archived lookup now we'll miss real active worktrees. Buffer
+        // instead and let connectAndLoadInitialState drain at the end.
+        if !isInitialStateLoaded {
+            pendingDeepLinkID = id
+            return
+        }
+
         let activeMatch = worktrees.values
             .flatMap { $0 }
             .contains(where: { $0.id == id })

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -55,6 +55,18 @@ final class AppState: ObservableObject {
     /// list.
     var archivedLookupOverride: ((UUID) async -> [Worktree])?
 
+    /// True once `connectAndLoadInitialState()` has finished its initial
+    /// `refreshAll()` and the worktree list is populated. Used by
+    /// `navigateToWorktree(_:)` to detect cold-start clicks that arrive
+    /// before the daemon RPC has returned.
+    @Published var isInitialStateLoaded: Bool = false
+
+    /// Buffers a deep-link target UUID when `.onOpenURL` fires before the
+    /// initial state load completes. Drained at the end of
+    /// `connectAndLoadInitialState()`. Internal-only — never written from
+    /// outside the AppState extension that consumes it.
+    var pendingDeepLinkID: UUID?
+
     /// The first selected worktree, if any.
     var selectedWorktree: Worktree? {
         guard let id = selectedWorktreeIDs.first else { return nil }
@@ -363,6 +375,11 @@ final class AppState: ObservableObject {
             }
         } else {
             logger.warning("Could not connect to daemon — is tbdd running?")
+        }
+        isInitialStateLoaded = true
+        if let pendingID = pendingDeepLinkID {
+            pendingDeepLinkID = nil
+            navigateToWorktree(pendingID)
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -44,6 +44,17 @@ final class AppState: ObservableObject {
     /// Archived worktrees keyed by repo ID, fetched on demand.
     @Published var archivedWorktrees: [UUID: [Worktree]] = [:]
 
+    /// Set briefly when a deep link lands on an archived worktree. The
+    /// ArchivedWorktreesView observes this and scrolls/flashes the matching
+    /// row, then clears the value after the flash animation completes.
+    @Published var highlightedArchivedWorktreeID: UUID?
+
+    /// Test seam: when set, replaces the daemon roundtrip for archived
+    /// lookups in `navigateToArchivedWorktree(_:)`. Production code leaves
+    /// this nil; tests assign a closure returning a deterministic worktree
+    /// list.
+    var archivedLookupOverride: ((UUID) async -> [Worktree])?
+
     /// The first selected worktree, if any.
     var selectedWorktree: Worktree? {
         guard let id = selectedWorktreeIDs.first else { return nil }

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -44,13 +44,28 @@ struct ArchivedWorktreesView: View {
                 Divider()
 
                 // List
-                ScrollView {
-                    LazyVStack(spacing: 1) {
-                        ForEach(archived) { worktree in
-                            ArchivedWorktreeRow(worktree: worktree)
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 1) {
+                            ForEach(archived) { worktree in
+                                ArchivedWorktreeRow(worktree: worktree)
+                                    .id(worktree.id)
+                            }
+                        }
+                        .padding(.vertical, 8)
+                    }
+                    .onChange(of: appState.highlightedArchivedWorktreeID) { _, newValue in
+                        guard let id = newValue,
+                              archived.contains(where: { $0.id == id }) else { return }
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            proxy.scrollTo(id, anchor: .center)
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
+                            if appState.highlightedArchivedWorktreeID == id {
+                                appState.highlightedArchivedWorktreeID = nil
+                            }
                         }
                     }
-                    .padding(.vertical, 8)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -117,7 +132,13 @@ private struct ArchivedWorktreeRow: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 10)
-        .background(Color.primary.opacity(0.03))
+        .background(
+            appState.highlightedArchivedWorktreeID == worktree.id
+                ? Color.accentColor.opacity(0.25)
+                : Color.primary.opacity(0.03)
+        )
+        .animation(.easeInOut(duration: 0.4),
+                   value: appState.highlightedArchivedWorktreeID)
         .cornerRadius(6)
         .padding(.horizontal, 12)
     }

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -54,7 +54,7 @@ struct ArchivedWorktreesView: View {
                         }
                         .padding(.vertical, 8)
                     }
-                    .onChange(of: appState.highlightedArchivedWorktreeID) { _, newValue in
+                    .onChange(of: appState.highlightedArchivedWorktreeID, initial: true) { _, newValue in
                         guard let id = newValue,
                               archived.contains(where: { $0.id == id }) else { return }
                         withAnimation(.easeInOut(duration: 0.3)) {

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -60,7 +60,8 @@ struct ArchivedWorktreesView: View {
                         withAnimation(.easeInOut(duration: 0.3)) {
                             proxy.scrollTo(id, anchor: .center)
                         }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
+                        Task { @MainActor in
+                            try? await Task.sleep(for: .milliseconds(900))
                             if appState.highlightedArchivedWorktreeID == id {
                                 appState.highlightedArchivedWorktreeID = nil
                             }

--- a/Sources/TBDApp/DeepLinkHandler.swift
+++ b/Sources/TBDApp/DeepLinkHandler.swift
@@ -14,17 +14,6 @@ enum DeepLinkHandler {
             logger.warning("Ignoring malformed deep link: \(url.absoluteString, privacy: .public)")
             return
         }
-
-        let activeMatch = appState.worktrees.values
-            .flatMap { $0 }
-            .contains(where: { $0.id == worktreeID })
-        if activeMatch {
-            appState.navigateToActiveWorktree(worktreeID)
-            return
-        }
-
-        // Active miss. Archived fallback is wired up in Task 4 of the deep-link
-        // implementation plan; for now, log and stop.
-        logger.warning("Deep link references unknown worktree \(worktreeID, privacy: .public)")
+        appState.navigateToWorktree(worktreeID)
     }
 }

--- a/Sources/TBDApp/DeepLinkHandler.swift
+++ b/Sources/TBDApp/DeepLinkHandler.swift
@@ -1,0 +1,30 @@
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "deeplink")
+
+/// Parses `tbd://` URLs and dispatches navigation against an `AppState`.
+/// Never throws, never surfaces UI errors — invalid or stale links are
+/// logged and silently ignored.
+enum DeepLinkHandler {
+    @MainActor
+    static func handle(_ url: URL, appState: AppState) {
+        guard let worktreeID = DeepLink.parseOpenURL(url) else {
+            logger.warning("Ignoring malformed deep link: \(url.absoluteString, privacy: .public)")
+            return
+        }
+
+        let activeMatch = appState.worktrees.values
+            .flatMap { $0 }
+            .contains(where: { $0.id == worktreeID })
+        if activeMatch {
+            appState.navigateToActiveWorktree(worktreeID)
+            return
+        }
+
+        // Active miss. Archived fallback is wired up in Task 4 of the deep-link
+        // implementation plan; for now, log and stop.
+        logger.warning("Deep link references unknown worktree \(worktreeID, privacy: .public)")
+    }
+}

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -20,6 +20,9 @@ struct TBDAppMain: App {
         Window("TBD", id: "main") {
             ContentView()
                 .environmentObject(appState)
+                .onOpenURL { url in
+                    DeepLinkHandler.handle(url, appState: appState)
+                }
         }
         .defaultSize(width: 1200, height: 800)
         .commands {

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -4,7 +4,6 @@ import TBDShared
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
-        NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
 
         let worktreeName = detectWorktreeName()

--- a/Sources/TBDCLI/Commands/LinkCommand.swift
+++ b/Sources/TBDCLI/Commands/LinkCommand.swift
@@ -1,0 +1,41 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct LinkCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "link",
+        abstract: "Print a tbd:// deep link for a worktree",
+        discussion: """
+        With no arguments, prints a link to the current worktree, read from
+        the TBD_WORKTREE_ID environment variable that TBD-spawned terminals
+        inherit. With an argument, accepts a worktree UUID, name, or
+        display name (matches the same conventions as other tbd commands).
+        """
+    )
+
+    @Argument(help: "Worktree UUID, name, or display name (optional)")
+    var worktree: String?
+
+    mutating func run() async throws {
+        let id = try resolveWorktreeID()
+        let url = DeepLink.makeOpenWorktreeURL(id)
+        print(url.absoluteString)
+    }
+
+    private func resolveWorktreeID() throws -> UUID {
+        if let arg = worktree {
+            let client = SocketClient()
+            return try resolveWorktreeNameOrID(arg, client: client)
+        }
+        guard
+            let envValue = ProcessInfo.processInfo.environment["TBD_WORKTREE_ID"],
+            let id = UUID(uuidString: envValue)
+        else {
+            throw CLIError.invalidArgument(
+                "not inside a TBD terminal; pass a worktree name or UUID"
+            )
+        }
+        return id
+    }
+}

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -296,7 +296,7 @@ struct WorktreeRename: AsyncParsableCommand {
 // MARK: - Helpers
 
 /// Try to parse as UUID first; if that fails, look up by name using worktree.list.
-private func resolveWorktreeNameOrID(_ nameOrID: String, client: SocketClient) throws -> UUID {
+func resolveWorktreeNameOrID(_ nameOrID: String, client: SocketClient) throws -> UUID {
     // Try UUID first
     if let id = UUID(uuidString: nameOrID) {
         return id

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -16,6 +16,7 @@ struct TBDCommand: AsyncParsableCommand {
             DaemonCommand.self,
             SetupHooksCommand.self,
             CleanupCommand.self,
+            LinkCommand.self,
         ]
     )
 }

--- a/Sources/TBDShared/DeepLinks.swift
+++ b/Sources/TBDShared/DeepLinks.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Shared format for `tbd://` deep-link URLs used by both the app and the CLI.
+public enum DeepLink {
+    public static let scheme = "tbd"
+    public static let openHost = "open"
+
+    /// Build a `tbd://open?worktree=<uuid>` URL for the given worktree.
+    public static func makeOpenWorktreeURL(_ id: UUID) -> URL {
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = openHost
+        components.queryItems = [URLQueryItem(name: "worktree", value: id.uuidString)]
+        guard let url = components.url else {
+            preconditionFailure("DeepLink components produced an invalid URL")
+        }
+        return url
+    }
+
+    /// Parse a `tbd://open?worktree=<uuid>` URL. Returns the worktree UUID on
+    /// success, or `nil` if the URL doesn't match the expected shape. Does NOT
+    /// validate that the worktree exists.
+    public static func parseOpenURL(_ url: URL) -> UUID? {
+        guard
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            components.scheme == scheme,
+            components.host == openHost,
+            let items = components.queryItems,
+            let worktreeValue = items.first(where: { $0.name == "worktree" })?.value,
+            let id = UUID(uuidString: worktreeValue)
+        else {
+            return nil
+        }
+        return id
+    }
+}

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import Foundation
+import TBDShared
+@testable import TBDApp
+
+@MainActor
+@Test func handle_knownActiveUUID_selectsWorktree() async {
+    let appState = AppState()
+    let id = UUID()
+    let repoID = UUID()
+    appState.worktrees = [
+        repoID: [
+            Worktree(id: id, repoID: repoID, name: "x", displayName: "X",
+                     branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x"),
+        ],
+    ]
+    let url = DeepLink.makeOpenWorktreeURL(id)
+
+    DeepLinkHandler.handle(url, appState: appState)
+
+    #expect(appState.selectedWorktreeIDs == [id])
+}
+
+@MainActor
+@Test func handle_unknownUUID_doesNotMutateSelection() async {
+    let appState = AppState()
+    appState.worktrees = [:]
+    let url = DeepLink.makeOpenWorktreeURL(UUID())
+
+    DeepLinkHandler.handle(url, appState: appState)
+
+    #expect(appState.selectedWorktreeIDs.isEmpty)
+}
+
+@MainActor
+@Test func handle_malformedURL_doesNotMutateSelection() async {
+    let appState = AppState()
+    let id = UUID()
+    let repoID = UUID()
+    appState.worktrees = [
+        repoID: [
+            Worktree(id: id, repoID: repoID, name: "x", displayName: "X",
+                     branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x"),
+        ],
+    ]
+    appState.selectedWorktreeIDs = []
+    let url = URL(string: "https://wrong-scheme/?worktree=\(id.uuidString)")!
+
+    DeepLinkHandler.handle(url, appState: appState)
+
+    #expect(appState.selectedWorktreeIDs.isEmpty)
+}

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -79,3 +79,19 @@ import TBDShared
     #expect(appState.selectedWorktreeIDs.isEmpty)
     #expect(appState.archivedWorktrees[repoID]?.contains(where: { $0.id == archivedID }) == true)
 }
+
+@MainActor
+@Test func navigateToActive_clearsArchivedHighlight() async {
+    let appState = AppState()
+    let id = UUID()
+    appState.worktrees = [
+        UUID(): [Worktree(id: id, repoID: UUID(), name: "x", displayName: "X",
+                          branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x")]
+    ]
+    appState.highlightedArchivedWorktreeID = UUID()  // stale highlight from a prior archived link
+
+    appState.navigateToActiveWorktree(id)
+
+    #expect(appState.highlightedArchivedWorktreeID == nil)
+    #expect(appState.selectedWorktreeIDs == [id])
+}

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -50,3 +50,29 @@ import TBDShared
 
     #expect(appState.selectedWorktreeIDs.isEmpty)
 }
+
+@MainActor
+@Test func handle_archivedUUID_opensArchivedPaneAndHighlightsRow() async {
+    let appState = AppState()
+    let repoID = UUID()
+    let archivedID = UUID()
+    let archivedWT = Worktree(
+        id: archivedID, repoID: repoID, name: "old", displayName: "Old",
+        branch: "tbd/old", path: "/tmp/old", status: .archived,
+        tmuxServer: "tbd-old"
+    )
+    // Test seam: short-circuit the daemon RPC.
+    appState.archivedLookupOverride = { _ in [archivedWT] }
+    appState.worktrees = [:] // active miss
+
+    let url = DeepLink.makeOpenWorktreeURL(archivedID)
+    DeepLinkHandler.handle(url, appState: appState)
+
+    // navigateToArchivedWorktree is async — wait for it to settle.
+    try? await Task.sleep(nanoseconds: 50_000_000)
+
+    #expect(appState.selectedRepoID == repoID)
+    #expect(appState.highlightedArchivedWorktreeID == archivedID)
+    #expect(appState.selectedWorktreeIDs.isEmpty)
+    #expect(appState.archivedWorktrees[repoID]?.contains(where: { $0.id == archivedID }) == true)
+}

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -25,11 +25,14 @@ import TBDShared
 @Test func handle_unknownUUID_doesNotMutateSelection() async {
     let appState = AppState()
     appState.worktrees = [:]
+    appState.archivedLookupOverride = { _ in [] }
     let url = DeepLink.makeOpenWorktreeURL(UUID())
 
     DeepLinkHandler.handle(url, appState: appState)
 
+    try? await Task.sleep(nanoseconds: 50_000_000)
     #expect(appState.selectedWorktreeIDs.isEmpty)
+    #expect(appState.selectedRepoID == nil)
 }
 
 @MainActor

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -6,6 +6,7 @@ import TBDShared
 @MainActor
 @Test func handle_knownActiveUUID_selectsWorktree() async {
     let appState = AppState()
+    appState.isInitialStateLoaded = true
     let id = UUID()
     let repoID = UUID()
     appState.worktrees = [
@@ -24,6 +25,7 @@ import TBDShared
 @MainActor
 @Test func handle_unknownUUID_doesNotMutateSelection() async {
     let appState = AppState()
+    appState.isInitialStateLoaded = true
     appState.worktrees = [:]
     appState.archivedLookupOverride = { _ in [] }
     let url = DeepLink.makeOpenWorktreeURL(UUID())
@@ -38,6 +40,7 @@ import TBDShared
 @MainActor
 @Test func handle_malformedURL_doesNotMutateSelection() async {
     let appState = AppState()
+    appState.isInitialStateLoaded = true
     let id = UUID()
     let repoID = UUID()
     appState.worktrees = [
@@ -57,6 +60,7 @@ import TBDShared
 @MainActor
 @Test func handle_archivedUUID_opensArchivedPaneAndHighlightsRow() async {
     let appState = AppState()
+    appState.isInitialStateLoaded = true
     let repoID = UUID()
     let archivedID = UUID()
     let archivedWT = Worktree(
@@ -94,4 +98,32 @@ import TBDShared
 
     #expect(appState.highlightedArchivedWorktreeID == nil)
     #expect(appState.selectedWorktreeIDs == [id])
+}
+
+@MainActor
+@Test func navigateToWorktree_beforeInitialLoad_buffersID() async {
+    let appState = AppState()
+    let id = UUID()
+    // Default: isInitialStateLoaded == false on a fresh AppState.
+    appState.worktrees = [:]
+
+    appState.navigateToWorktree(id)
+
+    #expect(appState.pendingDeepLinkID == id)
+    #expect(appState.selectedWorktreeIDs.isEmpty)
+    #expect(appState.selectedRepoID == nil)
+}
+
+@MainActor
+@Test func navigateToWorktree_afterInitialLoad_doesNotBuffer() async {
+    let appState = AppState()
+    appState.isInitialStateLoaded = true
+    appState.archivedLookupOverride = { _ in [] }
+    appState.worktrees = [:]
+    let id = UUID()
+
+    appState.navigateToWorktree(id)
+
+    // No buffering once initial state is loaded.
+    #expect(appState.pendingDeepLinkID == nil)
 }

--- a/Tests/TBDSharedTests/DeepLinksTests.swift
+++ b/Tests/TBDSharedTests/DeepLinksTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Test func makeOpenWorktreeURL_buildsExpectedURL() {
+    let id = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
+    let url = DeepLink.makeOpenWorktreeURL(id)
+    #expect(url.scheme == "tbd")
+    #expect(url.host == "open")
+    #expect(url.absoluteString == "tbd://open?worktree=12345678-1234-1234-1234-123456789ABC")
+}
+
+@Test func parseOpenURL_happyPath_returnsUUID() {
+    let id = UUID()
+    let url = DeepLink.makeOpenWorktreeURL(id)
+    #expect(DeepLink.parseOpenURL(url) == id)
+}
+
+@Test func parseOpenURL_rejectsWrongScheme() {
+    let url = URL(string: "https://open?worktree=12345678-1234-1234-1234-123456789ABC")!
+    #expect(DeepLink.parseOpenURL(url) == nil)
+}
+
+@Test func parseOpenURL_rejectsWrongHost() {
+    let url = URL(string: "tbd://other?worktree=12345678-1234-1234-1234-123456789ABC")!
+    #expect(DeepLink.parseOpenURL(url) == nil)
+}
+
+@Test func parseOpenURL_rejectsMissingQuery() {
+    let url = URL(string: "tbd://open")!
+    #expect(DeepLink.parseOpenURL(url) == nil)
+}
+
+@Test func parseOpenURL_rejectsMalformedUUID() {
+    let url = URL(string: "tbd://open?worktree=not-a-uuid")!
+    #expect(DeepLink.parseOpenURL(url) == nil)
+}
+
+@Test func parseOpenURL_acceptsExtraQueryItems() {
+    let id = UUID()
+    let url = URL(string: "tbd://open?worktree=\(id.uuidString)&future=anchor")!
+    #expect(DeepLink.parseOpenURL(url) == id)
+}

--- a/docs/superpowers/specs/2026-04-29-deep-link-terminals-design.md
+++ b/docs/superpowers/specs/2026-04-29-deep-link-terminals-design.md
@@ -1,0 +1,325 @@
+# Deep-linkable worktrees in TBD
+
+**Status:** design accepted
+**Date:** 2026-04-29
+
+## Problem
+
+Open a TBD worktree from anywhere by clicking a URL. Use case is personal —
+links sit in notes, browser bookmarks, Slack-to-self, and clicking them should
+focus the TBD app on the linked worktree.
+
+The link must remain valid even if internal state has changed since it was
+generated, as long as the worktree itself still exists.
+
+## Out of scope (deferred)
+
+- **Terminal-precision anchors.** Earlier draft included `&terminal=<uuid>`.
+  Dropped to keep v1 small. URL format below leaves room to add it later.
+- **Cross-machine sharing.** UUIDs are local; teammates clicking your link
+  won't land on their equivalent worktree. Personal use only.
+- **App-side "Copy Link" UI.** No right-click affordance in v1. CLI-only
+  generation.
+- **Clipboard / auto-open flags** on the CLI. Pipe to `pbcopy` if you want
+  clipboard. No `--open` either.
+
+## URL format
+
+```
+tbd://open?worktree=<uuid>
+```
+
+- Scheme: `tbd`
+- Host: `open` (acts as a verb; leaves room for additional verbs later
+  without colliding)
+- Required query item: `worktree` (canonical lowercased UUID string)
+- Query-string form chosen over path segments so future params (e.g.
+  `&terminal=`, `&tab=`, `&note=`) extend without breaking parsers
+
+## Click contract
+
+When the OS hands `tbd://open?worktree=X` to TBDApp:
+
+1. Parse `URLComponents`. Validate scheme is `tbd`, host is `open`,
+   `worktree` query item parses as a `UUID`. On any failure → log + no-op.
+2. Look up the worktree in `appState.worktrees`.
+   - If not found (unknown UUID, or worktree was deleted) → log a warning,
+     no UI side-effect, no error popup. Stale links should fail quietly.
+3. If found:
+   - Set `appState.selectedWorktreeIDs = [worktreeID]`
+   - Bring the main window to front and activate the app
+     (`NSApp.activate(ignoringOtherApps: true)`)
+   - Default tab-selection behavior takes over for terminals — we do not
+     touch `activeTabIndices`.
+
+If the app is not running when the link is clicked, macOS launches it via
+the bundled `.app` registration described below. SwiftUI's
+`.onOpenURL { ... }` on the main `Window` scene fires for both
+already-running delivery and cold-launch delivery on macOS 13+, so a
+single wiring point is sufficient. (If a future regression shows
+cold-launch URLs being dropped, add a buffering `application(_:open:)`
+fallback in `AppDelegate` — not implemented in v1.)
+
+## Architecture: bundling TBDApp
+
+This is the load-bearing change. macOS LaunchServices resolves `tbd://`
+clicks via `CFBundleURLTypes` in an `Info.plist`. TBDApp currently runs as
+a bare SPM executable with no bundle, so the URL scheme cannot be
+registered.
+
+### Bundle layout
+
+Created at build/restart time inside the existing build output dir:
+
+```
+.build/debug/TBD.app/
+  Contents/
+    Info.plist                  ← copied from Resources/TBDApp.Info.plist
+    MacOS/
+      TBDApp                    ← symlink → ../../../TBDApp
+```
+
+- `Resources/TBDApp.Info.plist` is committed to the repo and is the source
+  of truth for bundle identity.
+- `Contents/MacOS/TBDApp` is a **symlink** (not a copy) so every
+  `swift build` automatically updates what the bundle launches without
+  requiring a copy step. Iteration speed unchanged.
+- The bundle dir lives under `.build/` and is gitignored along with the
+  rest of build output.
+
+### Info.plist contents
+
+Minimum keys for URL handling and proper macOS app behavior:
+
+- `CFBundleIdentifier` = `com.tbd.app`
+- `CFBundleName` = `TBD`
+- `CFBundleExecutable` = `TBDApp`
+- `CFBundlePackageType` = `APPL`
+- `CFBundleVersion` / `CFBundleShortVersionString` = `1.0` (placeholder; not
+  user-visible in this dev tool)
+- `LSMinimumSystemVersion` = matches `Package.swift` deployment target
+- `CFBundleURLTypes`:
+  ```
+  CFBundleURLName    = com.tbd.deeplink
+  CFBundleURLSchemes = [ "tbd" ]
+  ```
+
+### restart.sh changes
+
+`scripts/restart.sh` learns to:
+
+1. After `swift build`, ensure `.build/debug/TBD.app/` exists (mkdir -p).
+2. Copy `Resources/TBDApp.Info.plist` to `Contents/Info.plist` if the
+   source is newer (or doesn't exist in the bundle yet).
+3. Maintain `Contents/MacOS/TBDApp` as a symlink to `../../../TBDApp`
+   (idempotent `ln -sf`).
+4. If the `Info.plist` was just (re)written, run
+   `/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f .build/debug/TBD.app`
+   to inform LaunchServices about the URL scheme registration. This is a
+   no-op the rest of the time.
+5. Launch via `open .build/debug/TBD.app` instead of executing the bare
+   `.build/debug/TBDApp`.
+
+Restart timing is unchanged in steady state — the symlink trick avoids
+copies, plist registration only re-runs when the plist actually changes.
+
+### Cleanup that falls out of bundling
+
+In scope, since we're already touching this surface:
+
+- Delete the manual `NSApp.setActivationPolicy(.regular)` call in
+  `Sources/TBDApp/TBDApp.swift:7`. A bundled app gets the right activation
+  policy from its bundle by default.
+- The `setActivationPolicy`-before-icon-set workaround noted in the
+  project CLAUDE.md (re: `NSApp.applicationIconImage` ordering) becomes
+  unnecessary; preserve current behavior but a follow-up can simplify.
+
+Future fixes that bundling **enables** but are *not* implemented here:
+
+- `UNUserNotificationCenter.current()` no longer crashes (the existing
+  guard in code can be removed in a later cleanup pass).
+- `Info.plist`-dependent APIs become available without case-by-case
+  guards.
+
+These are noted only to motivate the bundling cost — they are out of scope
+for this spec.
+
+## App-side implementation
+
+### New file: `Sources/TBDApp/DeepLinkHandler.swift`
+
+A small, isolated unit. Two responsibilities:
+
+```swift
+enum DeepLinkHandler {
+    /// Parse and dispatch a tbd:// URL. Logs and returns silently on any
+    /// failure (invalid format, unknown worktree). Never throws, never
+    /// surfaces UI errors.
+    static func handle(_ url: URL, appState: AppState)
+}
+```
+
+Internal helpers:
+
+- `parse(_ url: URL) -> UUID?` — validates scheme/host, extracts and
+  parses `worktree` query item. Returns nil on any malformed input.
+- Calls `appState.navigateToWorktree(_:)` (new method, see below) on
+  success.
+- All log lines use the existing `os.Logger` infrastructure under
+  subsystem `com.tbd.app`, category `deeplink`.
+
+### Wiring
+
+Single site: `.onOpenURL { url in DeepLinkHandler.handle(url, appState:
+appState) }` on the main `Window` scene in `Sources/TBDApp/TBDApp.swift`.
+On macOS 13+ this fires for both cold-launch URLs and URLs delivered to
+an already-running app. AppState is already in scope at that call site
+via `@StateObject`.
+
+If we later discover a case where cold-launch URLs are dropped (e.g. the
+scene isn't mounted by the time the URL is delivered), the fallback is
+to add `application(_:open urls:)` in `AppDelegate` that buffers URLs
+into an array, and drain the buffer once AppState is reachable. Not
+implemented in v1.
+
+### New AppState method
+
+In `Sources/TBDApp/AppState+Worktrees.swift` (already the home for
+worktree-related extensions):
+
+```swift
+func navigateToWorktree(_ id: UUID) {
+    guard worktrees.contains(where: { $0.id == id }) else {
+        // Logged at handler layer; this is a defensive guard.
+        return
+    }
+    selectedWorktreeIDs = [id]
+    NSApp.activate(ignoringOtherApps: true)
+    // Bring the main window to front. SwiftUI's window restoration
+    // handles re-showing if it was minimized.
+}
+```
+
+The existing `selectedWorktreeIDs` setter already maintains
+`selectionOrder` invariants (see `Sources/TBDApp/AppState.swift:16`), so
+nothing else needs to change.
+
+## CLI-side implementation
+
+### New file: `Sources/TBDCLI/Commands/LinkCommand.swift`
+
+```
+tbd link             # zero-arg form: read TBD_WORKTREE_ID from env
+tbd link <worktree>  # explicit form: UUID, name, or displayName
+```
+
+Behavior:
+
+- **Zero-arg.** Read `TBD_WORKTREE_ID` from the process environment. If
+  unset, exit 1 with stderr message:
+  `error: not inside a TBD terminal; pass a worktree name or UUID`.
+  No daemon roundtrip — env var is the source of truth and is already
+  injected by `RPCRouter+TerminalHandlers.swift:31` and
+  `WorktreeLifecycle+Reconcile.swift:254`.
+- **Explicit form.** Reuse the existing
+  `resolveWorktreeNameOrID(_:client:)` helper in
+  `Sources/TBDCLI/Commands/WorktreeCommands.swift:298`. It handles UUID,
+  `name`, and `displayName` matching, and emits a clear error on
+  ambiguous `displayName` matches.
+
+Output: one line to stdout, no trailing decoration:
+
+```
+tbd://open?worktree=<uuid>
+```
+
+No flags in v1.
+
+### Shared URL utilities: `Sources/TBDShared/DeepLinks.swift`
+
+A new tiny module so app and CLI agree on format:
+
+```swift
+public enum DeepLink {
+    public static let scheme = "tbd"
+    public static let openHost = "open"
+
+    /// Build a tbd://open URL pointing at a worktree.
+    public static func makeOpenWorktreeURL(_ id: UUID) -> URL
+
+    /// Parse a tbd:// URL. Returns the target worktree UUID if the URL is
+    /// well-formed and recognized; nil otherwise. Does NOT validate that
+    /// the worktree exists — that's the caller's job.
+    public static func parseOpenURL(_ url: URL) -> UUID?
+}
+```
+
+Per the project CLAUDE.md note on TBDShared, no migration is needed for
+this addition — it's a new file, not a model change.
+
+## Testing
+
+In-scope test surface:
+
+- `DeepLink.makeOpenWorktreeURL(_:)` returns a URL with the expected
+  components.
+- `DeepLink.parseOpenURL(_:)` happy path: round-trips a `make`d URL.
+- `DeepLink.parseOpenURL(_:)` rejects: wrong scheme, wrong host, missing
+  query item, malformed UUID, extra unrelated query items (the last
+  should still parse — extra params are forward-compatible).
+- `DeepLinkHandler.handle(_:appState:)` test against a stub `AppState`
+  populated with one worktree:
+  - Known UUID → `selectedWorktreeIDs` becomes `[id]`.
+  - Unknown UUID → no mutation to selection.
+  - Malformed URL → no mutation.
+- CLI: zero-arg with no `TBD_WORKTREE_ID` exits non-zero with a
+  recognizable message; with the env var set, prints the expected URL.
+- CLI: explicit form resolves a worktree by `name` and prints the URL;
+  ambiguous `displayName` produces the existing helper's error.
+
+Tests use Swift Testing (`import Testing`, `@Test`, `#expect`) per project
+convention.
+
+Out-of-scope (manual verification): the actual LaunchServices round-trip
+(clicking a `tbd://` link in a browser launches/focuses the app). Worth a
+manual check after first build, but not automatable.
+
+## File-level change list
+
+**New files:**
+
+- `Resources/TBDApp.Info.plist`
+- `Sources/TBDShared/DeepLinks.swift`
+- `Sources/TBDApp/DeepLinkHandler.swift`
+- `Sources/TBDCLI/Commands/LinkCommand.swift`
+- Tests for the above (locations follow existing test layout)
+
+**Modified files:**
+
+- `scripts/restart.sh` — bundle creation, `lsregister`, launch via `open`
+- `Sources/TBDApp/TBDApp.swift` — `.onOpenURL` on the main Window scene
+- `Sources/TBDApp/AppState+Worktrees.swift` — `navigateToWorktree(_:)`
+- `Sources/TBDCLI/TBD.swift` — register the new `link` subcommand
+
+The `Resources/TBDApp.Info.plist` file is read by macOS at app launch
+(not by Swift code), so no `Package.swift` change is needed.
+
+**Removed:**
+
+- `NSApp.setActivationPolicy(.regular)` from
+  `Sources/TBDApp/TBDApp.swift:7` (now redundant with bundle)
+
+## Risks and mitigations
+
+- **LaunchServices caches.** macOS sometimes caches a stale URL handler
+  registration. If clicks open the wrong app after first run, manually
+  re-run the `lsregister -f` command from restart.sh. Documented in
+  troubleshooting comments inside the script.
+- **Multiple TBD checkouts.** If the user has multiple worktrees of the
+  TBD repo itself, each has its own `.build/debug/TBD.app`. Whichever
+  was registered most recently with `lsregister` wins. This is the same
+  behavior as today's "which TBDApp launches" question — restart.sh
+  re-registers on every restart, so the most-recently-restarted checkout
+  is the URL handler. Documented as a known quirk.
+- **Stale links.** Worktrees can be archived or deleted. The click
+  contract handles this silently per the design above.

--- a/docs/superpowers/specs/2026-04-29-deep-link-terminals-design.md
+++ b/docs/superpowers/specs/2026-04-29-deep-link-terminals-design.md
@@ -42,15 +42,33 @@ When the OS hands `tbd://open?worktree=X` to TBDApp:
 
 1. Parse `URLComponents`. Validate scheme is `tbd`, host is `open`,
    `worktree` query item parses as a `UUID`. On any failure → log + no-op.
-2. Look up the worktree in `appState.worktrees`.
-   - If not found (unknown UUID, or worktree was deleted) → log a warning,
-     no UI side-effect, no error popup. Stale links should fail quietly.
-3. If found:
+2. **First lookup — active worktrees.** Search `appState.worktrees`. If
+   found:
    - Set `appState.selectedWorktreeIDs = [worktreeID]`
    - Bring the main window to front and activate the app
      (`NSApp.activate(ignoringOtherApps: true)`)
    - Default tab-selection behavior takes over for terminals — we do not
      touch `activeTabIndices`.
+3. **Second lookup — archived worktrees.** Active miss → fire an
+   `RPCMethod.worktreeList` RPC with `WorktreeListParams(repoID: nil,
+   status: .archived)`. The daemon returns all archived worktrees across
+   all repos; client finds the matching UUID. If found:
+   - Set `appState.selectedRepoID = worktree.repoID` (opens that repo's
+     archived pane in the content area — see `AppState.swift:42` and
+     `ArchivedWorktreesView`)
+   - Set `appState.highlightedArchivedWorktreeID = id` so
+     `ArchivedWorktreesView` can scroll the row into view and flash it
+     (see "Archived row highlight" below)
+   - Activate the app and bring main window to front
+   - Clear `selectedWorktreeIDs` (archived view replaces the active
+     worktree detail pane in this layout)
+4. **Both lookups miss** (truly deleted, or never existed) → log a warning
+   to `os.Logger`, no UI side-effect.
+
+This two-stage lookup runs on every deep-link click. The active-worktree
+path is synchronous against in-memory state; only the archived fallback
+involves a daemon roundtrip. Worst-case (truly stale link) is one
+roundtrip plus a log line — acceptable for a user-initiated action.
 
 If the app is not running when the link is clicked, macOS launches it via
 the bundled `.app` registration described below. SwiftUI's
@@ -182,27 +200,82 @@ to add `application(_:open urls:)` in `AppDelegate` that buffers URLs
 into an array, and drain the buffer once AppState is reachable. Not
 implemented in v1.
 
-### New AppState method
+### New AppState methods
 
 In `Sources/TBDApp/AppState+Worktrees.swift` (already the home for
 worktree-related extensions):
 
 ```swift
-func navigateToWorktree(_ id: UUID) {
-    guard worktrees.contains(where: { $0.id == id }) else {
-        // Logged at handler layer; this is a defensive guard.
-        return
-    }
+/// Active-worktree path. Synchronous; assumes id is in self.worktrees.
+private func navigateToActiveWorktree(_ id: UUID) {
     selectedWorktreeIDs = [id]
     NSApp.activate(ignoringOtherApps: true)
-    // Bring the main window to front. SwiftUI's window restoration
-    // handles re-showing if it was minimized.
+}
+
+/// Archived-worktree path. Async; issues an RPC to find the worktree
+/// across all archived ones, then opens the archived pane and flashes
+/// the row.
+private func navigateToArchivedWorktree(_ id: UUID) async {
+    let archived: [Worktree]
+    do {
+        archived = try await daemonClient.listWorktrees(
+            repoID: nil, status: .archived
+        )
+    } catch {
+        logger.error("Deep-link archived lookup failed: \(error)")
+        return
+    }
+    guard let wt = archived.first(where: { $0.id == id }) else {
+        // Final miss — truly stale link.
+        return
+    }
+    selectedWorktreeIDs = []
+    selectedRepoID = wt.repoID
+    archivedWorktrees[wt.repoID] = archived.filter { $0.repoID == wt.repoID }
+    highlightedArchivedWorktreeID = id
+    NSApp.activate(ignoringOtherApps: true)
+}
+
+/// Public entry point. Tries active first, falls through to archived.
+func navigateToWorktree(_ id: UUID) {
+    if worktrees.contains(where: { $0.id == id }) {
+        navigateToActiveWorktree(id)
+    } else {
+        Task { await navigateToArchivedWorktree(id) }
+    }
 }
 ```
 
 The existing `selectedWorktreeIDs` setter already maintains
 `selectionOrder` invariants (see `Sources/TBDApp/AppState.swift:16`), so
-nothing else needs to change.
+nothing else needs to change there.
+
+### New AppState property
+
+```swift
+/// Set briefly when a deep link lands on an archived worktree. The
+/// ArchivedWorktreesView observes this and scrolls/flashes the matching
+/// row, then clears the value after the flash animation completes.
+@Published var highlightedArchivedWorktreeID: UUID?
+```
+
+### Archived row highlight
+
+In `Sources/TBDApp/ArchivedWorktreesView.swift`:
+
+- Wrap the existing `ForEach(archived) { ... }` row list in a
+  `ScrollViewReader` so we can call `proxy.scrollTo(id, anchor: .center)`.
+- Add `.onChange(of: appState.highlightedArchivedWorktreeID)` on the
+  outer view: when it transitions to a non-nil value matching a row in
+  this repo's archived list, scroll to it and trigger a brief background
+  flash (e.g. 800ms `.background(...)` animation that fades from accent
+  color back to clear).
+- After the animation completes, set
+  `appState.highlightedArchivedWorktreeID = nil` so a re-click on the
+  same link re-triggers the flash.
+
+Use the project's existing animation/color conventions — no new
+dependencies.
 
 ## CLI-side implementation
 
@@ -267,10 +340,13 @@ In-scope test surface:
 - `DeepLink.parseOpenURL(_:)` rejects: wrong scheme, wrong host, missing
   query item, malformed UUID, extra unrelated query items (the last
   should still parse — extra params are forward-compatible).
-- `DeepLinkHandler.handle(_:appState:)` test against a stub `AppState`
-  populated with one worktree:
-  - Known UUID → `selectedWorktreeIDs` becomes `[id]`.
-  - Unknown UUID → no mutation to selection.
+- `DeepLinkHandler.handle(_:appState:)` test against a stub `AppState`:
+  - Known active UUID → `selectedWorktreeIDs` becomes `[id]`.
+  - Known archived UUID (stub daemon returns it) → `selectedRepoID` is
+    set to the worktree's repoID, `highlightedArchivedWorktreeID` is
+    set to the worktree id, `selectedWorktreeIDs` is cleared.
+  - Unknown UUID (active miss + archived miss) → no mutation to
+    selection or repo focus.
   - Malformed URL → no mutation.
 - CLI: zero-arg with no `TBD_WORKTREE_ID` exits non-zero with a
   recognizable message; with the env var set, prints the expected URL.
@@ -298,7 +374,12 @@ manual check after first build, but not automatable.
 
 - `scripts/restart.sh` — bundle creation, `lsregister`, launch via `open`
 - `Sources/TBDApp/TBDApp.swift` — `.onOpenURL` on the main Window scene
-- `Sources/TBDApp/AppState+Worktrees.swift` — `navigateToWorktree(_:)`
+- `Sources/TBDApp/AppState+Worktrees.swift` — `navigateToWorktree(_:)`,
+  `navigateToActiveWorktree(_:)`, `navigateToArchivedWorktree(_:)`
+- `Sources/TBDApp/AppState.swift` — new
+  `@Published var highlightedArchivedWorktreeID: UUID?`
+- `Sources/TBDApp/ArchivedWorktreesView.swift` — `ScrollViewReader`
+  wrapper, `.onChange` reaction, row flash animation
 - `Sources/TBDCLI/TBD.swift` — register the new `link` subcommand
 
 The `Resources/TBDApp.Info.plist` file is read by macOS at app launch

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -34,6 +34,41 @@ if [ "$skip_build" = false ]; then
     echo "  Build: $((SECONDS - t0))s"
 fi
 
+# MARK: - Assemble TBD.app bundle
+#
+# macOS resolves tbd:// URLs via LaunchServices, which requires a
+# CFBundleURLTypes entry in an Info.plist inside a .app bundle. We assemble
+# a minimal bundle in .build/debug/TBD.app whose binary is a symlink to
+# .build/debug/TBDApp, so swift build continues to update it directly.
+
+BUNDLE_DIR="$BUILD_DIR/TBD.app"
+BUNDLE_MACOS="$BUNDLE_DIR/Contents/MacOS"
+BUNDLE_PLIST="$BUNDLE_DIR/Contents/Info.plist"
+SOURCE_PLIST="$REPO_ROOT/Resources/TBDApp.Info.plist"
+
+mkdir -p "$BUNDLE_MACOS"
+
+# Symlink the binary (idempotent).
+# Path is relative to $BUNDLE_MACOS (.build/debug/TBD.app/Contents/MacOS),
+# so three "..") gets us back to .build/debug/.
+ln -sf "../../../TBDApp" "$BUNDLE_MACOS/TBDApp"
+
+# Copy the Info.plist if missing or older than the source.
+plist_changed=false
+if [ ! -f "$BUNDLE_PLIST" ] || [ "$SOURCE_PLIST" -nt "$BUNDLE_PLIST" ]; then
+    cp "$SOURCE_PLIST" "$BUNDLE_PLIST"
+    plist_changed=true
+fi
+
+# Re-register with LaunchServices when the plist changes (URL scheme update).
+if [ "$plist_changed" = true ]; then
+    LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"
+    if [ -x "$LSREGISTER" ]; then
+        "$LSREGISTER" -f "$BUNDLE_DIR" >/dev/null 2>&1 || true
+        echo "  Registered tbd:// URL scheme"
+    fi
+fi
+
 # MARK: - Restart Daemon
 
 if [ "$app_only" = false ]; then
@@ -63,16 +98,20 @@ fi
 
 if [ "$daemon_only" = false ]; then
     echo "Stopping app..."
-    pkill -f "$BUILD_DIR/TBDApp" 2>/dev/null && sleep 0.3 || true
+    # `.build/debug` is a symlink to `.build/<triple>/debug`, and `open` resolves it
+    # to the real path before exec, so match either form via $REPO_ROOT.
+    pkill -f "$REPO_ROOT/.*TBDApp$" 2>/dev/null && sleep 0.3 || true
 
     echo "Starting app..."
-    "$BUILD_DIR/TBDApp" > /tmp/tbdapp.log 2>&1 &
-    APP_PID=$!
-    echo "  App launched (PID $APP_PID) — logs: /tmp/tbdapp.log"
-    # Give it a moment and check it didn't immediately exit
+    open "$BUNDLE_DIR" --stdout /tmp/tbdapp.log --stderr /tmp/tbdapp.log
+    # `open` returns immediately after asking LaunchServices to spawn the app.
+    # Give it a moment, then verify the process is alive.
     sleep 0.5
-    if ! kill -0 "$APP_PID" 2>/dev/null; then
-        echo "  ERROR: App exited immediately. Last lines of /tmp/tbdapp.log:"
+    if pgrep -f "$REPO_ROOT/.*TBDApp$" >/dev/null; then
+        APP_PID=$(pgrep -f "$REPO_ROOT/.*TBDApp$" | head -1)
+        echo "  App launched (PID $APP_PID) — logs: /tmp/tbdapp.log"
+    else
+        echo "  ERROR: App failed to launch. Last lines of /tmp/tbdapp.log:"
         tail -20 /tmp/tbdapp.log
     fi
 fi

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -59,7 +59,7 @@ ln -sf "../../../TBDApp" "$BUNDLE_MACOS/TBDApp"
 # we never match unrelated processes whose command line happens to
 # contain the repo path or the string "TBDApp".
 APP_EXEC_PATH="$(/usr/bin/readlink -f "$BUNDLE_MACOS/TBDApp")"
-APP_EXEC_PATTERN="$(printf '%s' "$APP_EXEC_PATH" | sed 's/\./\\./g')"
+APP_EXEC_PATTERN="$(printf '%s' "$APP_EXEC_PATH" | sed 's/[.+*?()\[\]^$|\\]/\\&/g')"
 
 # Copy the Info.plist if missing or older than the source.
 plist_changed=false

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -53,6 +53,14 @@ mkdir -p "$BUNDLE_MACOS"
 # so three "..") gets us back to .build/debug/.
 ln -sf "../../../TBDApp" "$BUNDLE_MACOS/TBDApp"
 
+# Resolve the symlink to the absolute real path the OS will exec (open(1)
+# resolves symlinks before exec, so the running TBDApp's command line will
+# contain this exact path). We use it as the pgrep/pkill match target so
+# we never match unrelated processes whose command line happens to
+# contain the repo path or the string "TBDApp".
+APP_EXEC_PATH="$(/usr/bin/readlink -f "$BUNDLE_MACOS/TBDApp")"
+APP_EXEC_PATTERN="$(printf '%s' "$APP_EXEC_PATH" | sed 's/\./\\./g')"
+
 # Copy the Info.plist if missing or older than the source.
 plist_changed=false
 if [ ! -f "$BUNDLE_PLIST" ] || [ "$SOURCE_PLIST" -nt "$BUNDLE_PLIST" ]; then
@@ -98,17 +106,18 @@ fi
 
 if [ "$daemon_only" = false ]; then
     echo "Stopping app..."
-    # `.build/debug` is a symlink to `.build/<triple>/debug`, and `open` resolves it
-    # to the real path before exec, so match either form via $REPO_ROOT.
-    pkill -f "$REPO_ROOT/.*TBDApp$" 2>/dev/null && sleep 0.3 || true
+    # Match end-anchored against the resolved exec path so we only ever
+    # affect THIS worktree's running TBDApp — never swift build subprocesses,
+    # editors, or sibling worktrees whose command line contains "TBDApp".
+    pkill -f "^${APP_EXEC_PATTERN}\$" 2>/dev/null && sleep 0.3 || true
 
     echo "Starting app..."
     open "$BUNDLE_DIR" --stdout /tmp/tbdapp.log --stderr /tmp/tbdapp.log
     # `open` returns immediately after asking LaunchServices to spawn the app.
     # Give it a moment, then verify the process is alive.
     sleep 0.5
-    if pgrep -f "$REPO_ROOT/.*TBDApp$" >/dev/null; then
-        APP_PID=$(pgrep -f "$REPO_ROOT/.*TBDApp$" | head -1)
+    if pgrep -f "^${APP_EXEC_PATTERN}\$" >/dev/null; then
+        APP_PID=$(pgrep -f "^${APP_EXEC_PATTERN}\$" | head -1)
         echo "  App launched (PID $APP_PID) — logs: /tmp/tbdapp.log"
     else
         echo "  ERROR: App failed to launch. Last lines of /tmp/tbdapp.log:"


### PR DESCRIPTION
## Summary
- Adds `tbd://open?worktree=<uuid>` URL handling so worktree links pasted into notes, browsers, or Slack focus the TBD app on the linked worktree. Archived worktrees open the archived pane and briefly flash the matching row; missing worktrees fail silently.
- New `tbd link` CLI prints a deep link for the current worktree (zero-arg, via `TBD_WORKTREE_ID`) or any named worktree (`tbd link <name|uuid>`).
- Wraps TBDApp as a `TBD.app` bundle assembled by `scripts/restart.sh` so macOS LaunchServices can register the `tbd://` scheme. Iteration speed is unchanged — the bundle's exec is a symlink to `.build/debug/TBDApp`.

## Test plan
- [ ] `swift test` — 7 DeepLink parser tests + 4 handler tests pass
- [ ] `scripts/restart.sh` — bundle assembled, daemon and app start, "Registered tbd:// URL scheme" prints on first run
- [ ] From any TBD-spawned terminal: `tbd link | pbcopy`, then click the link → app comes to front, worktree selected
- [ ] Archive that worktree, click the same link → app comes to front, archived pane opens for that repo, matching row scrolls into view and flashes accent color
- [ ] Edit the UUID in the link to garbage, click → nothing happens (silent log in Console.app)
- [ ] `unset TBD_WORKTREE_ID && tbd link` → exits non-zero with "not inside a TBD terminal"