### PR TITLE
DX: Run swift test --parallel to overlap test target execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
             spm-${{ runner.os }}-${{ env.SWIFT_VERSION }}-
 
       - name: Test
-        run: swift test
+        run: swift test --parallel
 
       - name: Build (verify TBDCLI and TBDDaemon executable targets compile)
         run: swift build


### PR DESCRIPTION
## Problem

Warm-cache CI now finishes in ~3m15s, with test execution dominating the timeline (compile is cached, build step is fast). Test targets run sequentially by default.

## Change

Flip `swift test` to `swift test --parallel` in `.github/workflows/test.yml`. No other workflow changes.

## What `--parallel` does

In SwiftPM, `--parallel` runs distinct test *targets* (TBDDaemonTests, TBDAppTests, TBDSharedTests) in separate processes concurrently. Within-process parallelism for Swift Testing's `@Test` cases is already on by default, so this is purely between-target overlap. On the macos-15 runner with multiple cores this should reduce wall-clock test time meaningfully.

## Contention scan

Before flipping the flag I grep'd `Tests/` for shared-state hazards: `state.db`, `~/tbd`, `/tmp/` literals, `localhost:`, `127.0.0.1:`, `tmux -L`, `.pid`, `NSTemporaryDirectory`, `temporaryDirectory`, env-var mutation. Findings:

- **DB**: every DB test uses `TBDDatabase(inMemory: true)`. The one disk-based exception (`ClaudeTokenMigrationTests`) writes to `NSTemporaryDirectory() + "tbd-mig-test-\(UUID()).db"`. No collision risk.
- **Filesystem-touching tests** (`GitManagerTests`, `GitStatusTests`, `RepoRelocateTests`, `RepoHealthValidatorTests`, `WorktreeLifecycleTests`, `TerminalSwapPlanTests`, `HookResolverTests`, `ClaudeSessionScannerTests`) all scope to `FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)`.
- **SSH socket tests** (`SSHAgentResolverTests`) use `/tmp/tbd-test-...-\(UUID().uuidString).sock`.
- **`/tmp/...` literals elsewhere** are data strings stored in in-memory DB rows or used as expected values in assertions — they never touch the filesystem.
- No port literals, no real tmux server invocations, no env-var mutation in the test sources.

Conclusion: no obvious cross-target contention. Production code does call `setenv` (for `SSH_AUTH_SOCK` in the daemon), but tests don't exercise that path globally.

## Test plan

- [ ] CI run on this PR completes green. The CI run *is* the test — if any target races, the scan was incomplete and we'll fix the contention in a follow-up.
- [ ] Compare wall-clock test step duration vs. main (looking for measurable speedup).