### PR TITLE
Feat: Surface tbd link in spawned-Claude system prompt

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+++ b/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
@@ -18,6 +18,7 @@ enum SystemPromptBuilder {
         - tbd worktree rename "<worktree-name>" "<display-name>" — rename the worktree display name
         - tbd worktree create [--repo <path-or-id>] [--folder <dir>] [--branch <name>] [--name "<display>"] — create a new worktree
         - tbd worktree list [--repo <id>] — list worktrees
+        - tbd link [<worktree>] — print a tbd://open URL for a worktree (no arg = current); clicking opens TBD on that worktree, survives renames
         - tbd terminal create <worktree> [--type claude|shell] [--cmd <command>] — create a new terminal tab
         - tbd terminal send --terminal <id> --text <text> [--submit] — send text to a terminal (--submit presses Enter)
         - tbd terminal output <terminal-id> [--lines N] — read terminal output


### PR DESCRIPTION
## Summary
- Adds a one-line entry for `tbd link` to the CLI list in `SystemPromptBuilder.swift` so spawned Claude sessions know the affordance exists when a user asks to bookmark or share a worktree.

## Test plan
- [ ] `swift build` clean
- [ ] `scripts/restart.sh` (full restart since daemon code changed)
- [ ] Spawn a fresh Claude tab inside a TBD worktree, verify the system prompt now mentions `tbd link` (or just confirm `SystemPromptBuilder.swift` contains the new line — the prompt is a `static let` and is wired automatically when the file compiles)