### PR TITLE
DX: Touch .build mtimes after cache restore to stop redundant compile (~127s → ~12s)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         run: echo "SWIFT_VERSION=$(xcrun swift --version | head -1)" >> $GITHUB_ENV
 
       - name: Cache SwiftPM
+        id: cache
         uses: actions/cache@v4
         with:
           path: |
@@ -29,6 +30,10 @@ jobs:
           restore-keys: |
             spm-${{ runner.os }}-${{ env.SWIFT_VERSION }}-${{ hashFiles('Package.resolved') }}-
             spm-${{ runner.os }}-${{ env.SWIFT_VERSION }}-
+
+      - name: Restore .build mtimes (workaround for actions/cache + SwiftPM incremental)
+        if: steps.cache.outputs.cache-hit == 'true' || steps.cache.outputs.cache-matched-key != ''
+        run: find .build -exec touch {} +
 
       - name: Test
         run: swift test --parallel


### PR DESCRIPTION
## Summary

- Recent CI runs land a primary-key SwiftPM cache hit but still burn ~127s of the 143s "Test" step recompiling before running 12s of actual tests.
- Root cause: `actions/cache` extraction restores file mtimes to cache-save time, which is older than the source files just written by `actions/checkout@v4` (current-time mtimes). SwiftPM's incremental build sees sources newer than artifacts and rebuilds from scratch despite a warm cache.
- Fix: after the cache step, `find .build -exec touch {} +` to bump artifact mtimes to current time. Gated by `cache-hit` / `cache-matched-key` so a complete cache miss skips it. No changes to cache paths, key, restore-keys, `swift test --parallel`, or the `swift build` verification step.

## Test plan

- CI is the actual test — compare wall-clock of the "Test" step on this PR's run vs. the previous ~143s baseline on `origin/main`.
- Expect Test step to drop from ~143s to ~25–35s (compile elided, test execution + small overhead remain).
- Confirm primary cache key still hits: this PR doesn't touch the toolchain version, `Package.resolved`, or any `Sources/**/*.swift` / `Tests/**/*.swift` content, so the next run after merge should still get a primary-key hit (the run that produces this PR's first build will be a cold miss to seed the cache for `main`).