### PR TITLE
DX: Split swift build --build-tests from swift test --skip-build to isolate compile time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
             spm-${{ runner.os }}-${{ env.SWIFT_VERSION }}-${{ hashFiles('Package.resolved') }}-
             spm-${{ runner.os }}-${{ env.SWIFT_VERSION }}-
 
-      - name: Test
-        run: swift test --parallel
+      - name: Build (including tests)
+        run: swift build --build-tests
 
-      - name: Build (verify TBDCLI and TBDDaemon executable targets compile)
-        run: swift build
+      - name: Test
+        run: swift test --parallel --skip-build


### PR DESCRIPTION
## Summary

- **Problem**: `swift test --parallel` in CI shows `Build complete! (127.28s)` and 877 compile actions even on a warm primary-cache hit (1.23 GiB restored). PR #80 touched `.build/` mtimes after cache restore and got the same 127s rebuild — mtime wasn't the trigger.
- **Hypothesis**: `swift test` may invalidate or recompute something that `swift build` doesn't. Splitting into an explicit `swift build --build-tests` and then `swift test --parallel --skip-build` separates "produce binaries" from "run tests" so we can see which phase actually pays the 127s cost.
- **What we'll learn**: One of three outcomes — (a) the rebuild lands in the new Build step (then `swift test` was just inheriting it; this gives visibility but not wall-clock savings), (b) the Test step still does meaningful compile work despite `--skip-build` (then `swift test` is doing extra work `swift build` doesn't), or (c) Build is dramatically faster than 127s (would be a surprising win — investigate further).

Also drops the trailing redundant `Build (verify TBDCLI and TBDDaemon executable targets compile)` step: `swift build --build-tests` already builds all products + test targets.

## Test plan

CI is the test. Compare the new run against PR #80 run `25139997870`:

- [ ] `Build (including tests)` step duration vs. previous Test step's 127s compile portion.
- [ ] `Test` step duration vs. previous test execution time (~12s).
- [ ] Cache hit type (expect primary).
- [ ] Wall clock total vs. PR #80's 3m06s.

## Status

**Experiment — don't merge.** Will close if it doesn't reveal anything actionable.