### PR TITLE
DX: Trim SwiftPM CI cache to dependencies only (.build was unused)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,15 @@ jobs:
       - name: Capture Swift toolchain version
         run: echo "SWIFT_VERSION=$(xcrun swift --version | head -1)" >> $GITHUB_ENV
 
-      - name: Cache SwiftPM
+      - name: Cache SwiftPM dependencies
         uses: actions/cache@v4
         with:
           path: |
-            .build
+            .build/checkouts
             ~/Library/Caches/org.swift.swiftpm
-          key: spm-${{ runner.os }}-${{ env.SWIFT_VERSION }}-${{ hashFiles('Package.resolved') }}-${{ hashFiles('Sources/**/*.swift', 'Tests/**/*.swift') }}
+          key: spm-deps-${{ runner.os }}-${{ env.SWIFT_VERSION }}-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            spm-${{ runner.os }}-${{ env.SWIFT_VERSION }}-${{ hashFiles('Package.resolved') }}-
-            spm-${{ runner.os }}-${{ env.SWIFT_VERSION }}-
+            spm-deps-${{ runner.os }}-${{ env.SWIFT_VERSION }}-
 
       - name: Test
         run: swift test --parallel


### PR DESCRIPTION
## Summary

- We were caching the entire `.build/` directory on the assumption that restoring it would skip ~127s of recompilation on warm CI runs.
- That doesn't work on hosted runners. llbuild's incremental staleness check ([`FileInfo::operator==`](https://github.com/swiftlang/swift-llbuild/blob/main/include/llbuild/Basic/FileInfo.h)) compares device, inode, size, modTime, and checksum strictly — and every `actions/cache` restore lands on a fresh macOS VM with brand new inodes. Result: the 1.23 GiB `.build/` tarball is uploaded, downloaded, and then completely ignored by llbuild on every run.
- What the cache **does** buy us is the dependency fetch (~30s of cloning 7 packages): `.build/checkouts` (per-project working copies) and `~/Library/Caches/org.swift.swiftpm` (global SwiftPM source cache).
- This PR trims the cached paths to those two, drops the now-meaningless `Sources/**/*.swift` source-hash from the key, and renames the prefix to `spm-deps-` so old `spm-...` caches age out cleanly without leaking into the new namespace.

## Test plan

CI is the test. Two things to verify on this run:

- [ ] Wall clock is roughly the same as before (~3m03s warm-cache) — we are not making compilation any faster, just being honest about what the cache is for.
- [ ] Restored cache size in the post-cache step log drops from ~1.23 GiB to ~100–300 MiB.

## Closes #80

This supersedes the mtime-touch experiment in #80, which can't work given the inode finding above. Closing that PR in favor of this honest trim.