### PR TITLE
Fix: Drag-reorder worktrees from anywhere on the row, not just whitespace

### DIFF
--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -117,6 +117,7 @@ struct WorktreeRowView: View {
     var body: some View {
         HStack(spacing: 6) {
             rowIcons()
+                .allowsHitTesting(false)
             if isEditing {
                 InlineTextField(
                     text: $editText,
@@ -182,6 +183,7 @@ struct WorktreeRowView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+                .allowsHitTesting(false)
             }
         }
         .contentShape(Rectangle())

--- a/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
+++ b/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
@@ -60,7 +60,7 @@ struct SystemPromptBuilderTests {
 
         let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
         #expect(result != nil)
-        #expect(result!.contains("To do immediately"))
+        #expect(result!.contains("Rename the git branch"))
         #expect(result!.contains("git branch -m"))
         #expect(result!.contains("tbd worktree rename"))
     }
@@ -74,7 +74,7 @@ struct SystemPromptBuilderTests {
 
         let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
         #expect(result != nil)
-        #expect(!result!.contains("To do immediately"))
+        #expect(!result!.contains("Rename the git branch"))
         #expect(result!.contains("TBD-managed worktree"))
     }
 
@@ -88,7 +88,7 @@ struct SystemPromptBuilderTests {
 
         let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
         #expect(result != nil)
-        #expect(!result!.contains("To do immediately"))
+        #expect(!result!.contains("Rename the git branch"))
         #expect(result!.contains("TBD-managed worktree"))
     }
 
@@ -103,7 +103,7 @@ struct SystemPromptBuilderTests {
         let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
         #expect(result != nil)
         #expect(result!.contains("cw/4/feat-"))
-        #expect(!result!.contains("To do immediately"))
+        #expect(!result!.contains("Rename the git branch"))
     }
 
     @Test("build always includes TBD context for fresh sessions")


### PR DESCRIPTION
## Summary
- Drag-to-reorder in the sidebar only worked when the drag started on a row's blank space — clicking the icons or worktree name would fail to initiate a drag.
- Cause: the `Image`, `Circle`, and name views had their own SwiftUI hit shapes that swallowed mouseDown before NSTableRowView (which owns `List.onMove`'s drag detection) could see it. Whitespace fell through to the row, hence drag worked only there.
- Fix: `.allowsHitTesting(false)` on `rowIcons()` and on the non-editing name `VStack`. Hits now propagate up to the row for drag and to the row's `.onTapGesture` for selection. Editing-mode `InlineTextField` is left interactive so click-to-rename still works.

## Test plan
- [ ] Mouse-down on a worktree's status icon, notification dot, or name text and drag — the row should latch and reorder
- [ ] Mouse-down on whitespace and drag — still works (regression check)
- [ ] Click a row to select; click again to inline-rename — still works
- [ ] In rename mode, click into the text field and edit — still works