### PR TITLE
Fix: Stop tmux windows from oversizing past the visible terminal pane (Claude's input row was rendering below the viewport)

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -22,58 +22,44 @@ struct ContentView: View {
             NavigationSplitView {
                 SidebarView()
             } detail: {
-                Group {
-                    if !appState.isConnected {
-                        disconnectedView
-                    } else if appState.repos.isEmpty {
-                        emptyStateView
-                    } else if let repoID = appState.selectedRepoID {
-                        RepoDetailView(repoID: repoID)
-                    } else if appState.selectedWorktreeIDs.isEmpty {
-                        Text("Select a worktree or click + to create one")
-                            .foregroundStyle(.secondary)
-                    } else {
-                        HStack(spacing: 0) {
-                            TerminalContainerView()
-                            if showFilePanel, let worktree = selectedWorktree, !worktree.path.isEmpty {
-                                FilePanelDivider(panelWidth: Binding(
-                                    get: { CGFloat(filePanelWidth) },
-                                    set: { filePanelWidth = Double($0) }
-                                ))
-                                FileViewerPanel(worktree: worktree)
-                                    .frame(width: CGFloat(filePanelWidth))
-                                    .id(worktree.id)
-                            }
+                if !appState.isConnected {
+                    disconnectedView
+                } else if appState.repos.isEmpty {
+                    emptyStateView
+                } else if let repoID = appState.selectedRepoID {
+                    RepoDetailView(repoID: repoID)
+                } else if appState.selectedWorktreeIDs.isEmpty {
+                    Text("Select a worktree or click + to create one")
+                        .foregroundStyle(.secondary)
+                } else {
+                    HStack(spacing: 0) {
+                        TerminalContainerView()
+                        if showFilePanel, let worktree = selectedWorktree, !worktree.path.isEmpty {
+                            FilePanelDivider(panelWidth: Binding(
+                                get: { CGFloat(filePanelWidth) },
+                                set: { filePanelWidth = Double($0) }
+                            ))
+                            FileViewerPanel(worktree: worktree)
+                                .frame(width: CGFloat(filePanelWidth))
+                                .id(worktree.id)
                         }
-                        .background(GeometryReader { geometry in
-                            Color.clear.preference(key: ContentHeightKey.self, value: geometry.size.height)
-                        })
-                        .onPreferenceChange(ContentHeightKey.self) { contentAreaHeight = $0 }
-                        .overlay(alignment: .top) {
-                            if let terminal = appState.currentConductorTerminal {
-                                ConductorOverlayView(
-                                    terminal: terminal,
-                                    tmuxServer: TBDConstants.conductorsTmuxServer,
-                                    parentHeight: contentAreaHeight
-                                )
-                                .opacity(appState.showConductor ? 1 : 0)
-                                .allowsHitTesting(appState.showConductor)
-                            }
+                    }
+                    .background(GeometryReader { geometry in
+                        Color.clear.preference(key: ContentHeightKey.self, value: geometry.size.height)
+                    })
+                    .onPreferenceChange(ContentHeightKey.self) { contentAreaHeight = $0 }
+                    .overlay(alignment: .top) {
+                        if let terminal = appState.currentConductorTerminal {
+                            ConductorOverlayView(
+                                terminal: terminal,
+                                tmuxServer: TBDConstants.conductorsTmuxServer,
+                                parentHeight: contentAreaHeight
+                            )
+                            .opacity(appState.showConductor ? 1 : 0)
+                            .allowsHitTesting(appState.showConductor)
                         }
                     }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(GeometryReader { geometry in
-                    Color.clear
-                        .onAppear {
-                            guard geometry.size.width > 0, geometry.size.height > 0 else { return }
-                            appState.mainAreaSize = geometry.size
-                        }
-                        .onChange(of: geometry.size) { _, newSize in
-                            guard newSize.width > 0, newSize.height > 0 else { return }
-                            appState.mainAreaSize = newSize
-                        }
-                })
             }
             .navigationSplitViewStyle(.prominentDetail)
             .toolbar(removing: .sidebarToggle)

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -9,16 +9,17 @@ import TBDShared
 ///   for the active tab's layout.
 /// - Multi-select (Cmd-click): Auto-grid layout, one panel per selected worktree
 ///   showing its primary terminal. No tab bar.
-/// Preference key carrying the px size of the main terminal area (the slot
-/// inside DockSplitView's `mainContent`, excluding the pinned dock and any
-/// file panel). AppState reads this via `.onPreferenceChange` to drive the
-/// daemon-side resize broadcast.
+/// Preference key carrying the px size of the actual terminal-rendering area
+/// — the SplitLayoutView slot inside SingleWorktreeView, or the grid inside
+/// MultiWorktreeView. Excludes the tab bar, divider, dock, and any file
+/// panel. AppState reads this via `.onPreferenceChange` to drive the
+/// daemon-side resize broadcast so tmux pane dimensions match what SwiftTerm
+/// actually renders.
 struct MainAreaSizeKey: PreferenceKey {
     nonisolated(unsafe) static var defaultValue: CGSize = .zero
-    /// Exactly one view in the hierarchy posts this key (TerminalContainerView's
-    /// background GeometryReader), so taking the latest value is fine. If a
-    /// second producer is ever added, this reduce will silently drop earlier
-    /// values — switch to `value = max(value, nextValue())` or similar.
+    /// Two views in the hierarchy can post this key — SingleWorktreeView's
+    /// layoutContent or MultiWorktreeView's grid — but only one is rendered
+    /// at a time, so taking the latest value is fine.
     static func reduce(value: inout CGSize, nextValue: () -> CGSize) { value = nextValue() }
 }
 
@@ -58,10 +59,10 @@ struct TerminalContainerView: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .background(GeometryReader { geometry in
-            Color.clear.preference(key: MainAreaSizeKey.self, value: geometry.size)
-        })
         .onPreferenceChange(MainAreaSizeKey.self) { newSize in
+            // The producing GeometryReader lives deeper, in
+            // SingleWorktreeView.layoutContent or MultiWorktreeView's grid,
+            // so the measurement excludes the tab bar / divider chrome.
             // SwiftUI fires .onPreferenceChange with .zero in some early
             // layout passes; ignore those so we don't broadcast a degenerate
             // size to the daemon.
@@ -193,8 +194,14 @@ private struct SingleWorktreeView: View {
                     Divider()
                 }
 
-                // Split layout view for the active tab's layout
+                // Split layout view for the active tab's layout. Publish its
+                // measured size to MainAreaSizeKey so the daemon-side tmux
+                // resize matches the actual SwiftTerm pane area (tab bar +
+                // divider above are excluded).
                 layoutContent(worktree: worktree)
+                    .background(GeometryReader { geometry in
+                        Color.clear.preference(key: MainAreaSizeKey.self, value: geometry.size)
+                    })
             }
             // TmuxBridge sessions are created on-demand by TerminalPanelView
             .task(id: worktreeID) {
@@ -333,6 +340,10 @@ private struct MultiWorktreeView: View {
                 }
             }
             .background(Color(nsColor: .separatorColor))
+            // No tab bar in multi-select mode, so the GeometryReader's size
+            // is already the actual rendering area. Publish it for the
+            // daemon-side tmux resize.
+            .preference(key: MainAreaSizeKey.self, value: geometry.size)
         }
     }
 }

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -9,6 +9,9 @@ import TBDShared
 ///   for the active tab's layout.
 /// - Multi-select (Cmd-click): Auto-grid layout, one panel per selected worktree
 ///   showing its primary terminal. No tab bar.
+
+// MARK: - MainAreaSizeKey
+
 /// Preference key carrying the px size of the actual terminal-rendering area
 /// — the SplitLayoutView slot inside SingleWorktreeView, or the grid inside
 /// MultiWorktreeView. Excludes the tab bar, divider, dock, and any file
@@ -340,10 +343,16 @@ private struct MultiWorktreeView: View {
                 }
             }
             .background(Color(nsColor: .separatorColor))
-            // No tab bar in multi-select mode, so the GeometryReader's size
-            // is already the actual rendering area. Publish it for the
-            // daemon-side tmux resize.
-            .preference(key: MainAreaSizeKey.self, value: geometry.size)
+            // Publish per-cell size, not full grid size. The daemon
+            // broadcasts mainAreaSize to every tmux window, so each window
+            // needs to match the visible SwiftTerm pane inside its own cell
+            // (gridWidth / cols × gridHeight / rows). Broadcasting the full
+            // grid would size every window to the entire grid and clip the
+            // bottom rows the same way the original detail-slot bug did.
+            .preference(
+                key: MainAreaSizeKey.self,
+                value: CGSize(width: cellWidth, height: cellHeight)
+            )
         }
     }
 }

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -9,6 +9,19 @@ import TBDShared
 ///   for the active tab's layout.
 /// - Multi-select (Cmd-click): Auto-grid layout, one panel per selected worktree
 ///   showing its primary terminal. No tab bar.
+/// Preference key carrying the px size of the main terminal area (the slot
+/// inside DockSplitView's `mainContent`, excluding the pinned dock and any
+/// file panel). AppState reads this via `.onPreferenceChange` to drive the
+/// daemon-side resize broadcast.
+struct MainAreaSizeKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: CGSize = .zero
+    /// Exactly one view in the hierarchy posts this key (TerminalContainerView's
+    /// background GeometryReader), so taking the latest value is fine. If a
+    /// second producer is ever added, this reduce will silently drop earlier
+    /// values — switch to `value = max(value, nextValue())` or similar.
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) { value = nextValue() }
+}
+
 struct TerminalContainerView: View {
     @EnvironmentObject var appState: AppState
 
@@ -44,6 +57,16 @@ struct TerminalContainerView: View {
                 Text("Select a worktree or click + to create one")
                     .foregroundStyle(.secondary)
             }
+        }
+        .background(GeometryReader { geometry in
+            Color.clear.preference(key: MainAreaSizeKey.self, value: geometry.size)
+        })
+        .onPreferenceChange(MainAreaSizeKey.self) { newSize in
+            // SwiftUI fires .onPreferenceChange with .zero in some early
+            // layout passes; ignore those so we don't broadcast a degenerate
+            // size to the daemon.
+            guard newSize.width > 0, newSize.height > 0 else { return }
+            appState.mainAreaSize = newSize
         }
 
         // Always render DockSplitView so mainContent stays in the same

--- a/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
+++ b/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
@@ -60,7 +60,7 @@ struct SystemPromptBuilderTests {
 
         let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
         #expect(result != nil)
-        #expect(result!.contains("To do immediately"))
+        #expect(result!.contains("Rename the git branch"))
         #expect(result!.contains("git branch -m"))
         #expect(result!.contains("tbd worktree rename"))
     }
@@ -74,7 +74,7 @@ struct SystemPromptBuilderTests {
 
         let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
         #expect(result != nil)
-        #expect(!result!.contains("To do immediately"))
+        #expect(!result!.contains("Rename the git branch"))
         #expect(result!.contains("TBD-managed worktree"))
     }
 
@@ -88,7 +88,7 @@ struct SystemPromptBuilderTests {
 
         let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
         #expect(result != nil)
-        #expect(!result!.contains("To do immediately"))
+        #expect(!result!.contains("Rename the git branch"))
         #expect(result!.contains("TBD-managed worktree"))
     }
 


### PR DESCRIPTION
## Summary

- **What's broken:** In some worktrees the terminal looked too wide and Claude's input box rendered below the visible area — typing worked but the prompt was invisible.
- **Why it happens:** Recent commits (`bd549d0`, `c80dfa9`) hoisted the `mainAreaSize` `GeometryReader` to `ContentView`'s entire NavigationSplitView detail slot and forced it to `.frame(maxWidth: .infinity, maxHeight: .infinity)`. That measurement now includes the tab bar, dock column, and file panel — strictly larger than the actual SwiftTerm pane. The daemon feeds it to `tmux resize-window`, which puts the window into **manual size mode**, and SwiftTerm's later `TIOCSWINSZ` from the truly-smaller pane can't shrink it back. Tmux thinks there are more rows than the view actually shows, so the bottom rows clip below.
- **What this PR does:** Reverts those two commits. The `GeometryReader` lives back inside `TerminalContainerView` where it measures the actual pane area. Kept `13c6dfc` (`resize-window` after `new-window`), which independently fixes the original "unviewed terminals stuck at 80×24" problem — new windows get sized to `mainAreaTerminalSize()`, which uses the sensible 1120×776 default (~145×48 cells) when nothing's been measured yet.

## Test plan

- [ ] Open a worktree where the issue reproduced (e.g. "🔀 Reorder Worktrees") — Claude's input row should be visible at the bottom.
- [ ] Resize the app window — terminal should reflow, not over- or under-fill.
- [ ] Show/hide the file panel and dock — terminal should resize sensibly without clipping rows.
- [ ] Create a new worktree with no main-area measurement yet — pane should not be 80×24.
- [ ] `swift test --filter TmuxManagerTests` still green.