### PR TITLE
Fix: Stop tmux from locking windows in manual size mode (textbox clipping that survived #84)

### DIFF
--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -331,7 +331,8 @@ private struct MultiWorktreeView: View {
                             let index = row * cols + col
                             if index < worktreeIDs.count {
                                 MultiWorktreeCell(
-                                    worktreeID: worktreeIDs[index]
+                                    worktreeID: worktreeIDs[index],
+                                    isPrimary: index == 0
                                 )
                                 .frame(width: cellWidth - 1, height: cellHeight - 1)
                             } else {
@@ -343,16 +344,11 @@ private struct MultiWorktreeView: View {
                 }
             }
             .background(Color(nsColor: .separatorColor))
-            // Publish per-cell size, not full grid size. The daemon
-            // broadcasts mainAreaSize to every tmux window, so each window
-            // needs to match the visible SwiftTerm pane inside its own cell
-            // (gridWidth / cols × gridHeight / rows). Broadcasting the full
-            // grid would size every window to the entire grid and clip the
-            // bottom rows the same way the original detail-slot bug did.
-            .preference(
-                key: MainAreaSizeKey.self,
-                value: CGSize(width: cellWidth, height: cellHeight)
-            )
+            // The first cell publishes its inner-content size to
+            // MainAreaSizeKey from inside MultiWorktreeCell — measuring there
+            // excludes the per-cell header bar (~21pt) and divider, which
+            // the previous outer-grid measurement included. All cells are
+            // equal size so one publisher suffices.
         }
     }
 }
@@ -362,6 +358,11 @@ private struct MultiWorktreeView: View {
 /// A single cell in the multi-worktree grid showing worktree name and its primary terminal.
 private struct MultiWorktreeCell: View {
     let worktreeID: UUID
+    /// First cell in the grid publishes its inner-content size to
+    /// MainAreaSizeKey so the daemon-side tmux resize matches the actual
+    /// SwiftTerm pane area (excludes the per-cell header bar + divider).
+    /// All cells are equal size so a single publisher suffices.
+    let isPrimary: Bool
     @EnvironmentObject var appState: AppState
 
     private var worktree: Worktree? {
@@ -410,33 +411,54 @@ private struct MultiWorktreeCell: View {
 
             Divider()
 
-            // Terminal placeholder content
-            if let worktree, let terminal = primaryTerminal {
-                let layoutBinding = Binding<LayoutNode>(
-                    get: {
-                        appState.layouts[worktreeID]
-                            ?? .pane(.terminal(terminalID: terminal.id))
-                    },
-                    set: { newLayout in
-                        appState.layouts[worktreeID] = newLayout
+            // Terminal placeholder content. The GeometryReader below
+            // (only attached on the primary cell) measures this slot
+            // specifically — excluding the header HStack and divider above
+            // — so MainAreaSizeKey reflects the actual SwiftTerm rendering
+            // area, not the full grid cell.
+            terminalContent
+                .background(
+                    Group {
+                        if isPrimary {
+                            GeometryReader { geometry in
+                                Color.clear.preference(
+                                    key: MainAreaSizeKey.self,
+                                    value: geometry.size
+                                )
+                            }
+                        }
                     }
                 )
-                PanePlaceholder(
-                    content: .terminal(terminalID: terminal.id),
-                    worktree: worktree,
-                    layout: layoutBinding
-                )
-            } else {
-                ZStack {
-                    Color(nsColor: .textBackgroundColor)
-                    VStack(spacing: 4) {
-                        Image(systemName: "terminal")
-                            .font(.title2)
-                            .foregroundStyle(.tertiary)
-                        Text("No terminal")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
+        }
+    }
+
+    @ViewBuilder
+    private var terminalContent: some View {
+        if let worktree, let terminal = primaryTerminal {
+            let layoutBinding = Binding<LayoutNode>(
+                get: {
+                    appState.layouts[worktreeID]
+                        ?? .pane(.terminal(terminalID: terminal.id))
+                },
+                set: { newLayout in
+                    appState.layouts[worktreeID] = newLayout
+                }
+            )
+            PanePlaceholder(
+                content: .terminal(terminalID: terminal.id),
+                worktree: worktree,
+                layout: layoutBinding
+            )
+        } else {
+            ZStack {
+                Color(nsColor: .textBackgroundColor)
+                VStack(spacing: 4) {
+                    Image(systemName: "terminal")
+                        .font(.title2)
+                        .foregroundStyle(.tertiary)
+                    Text("No terminal")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
         }

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -123,6 +123,15 @@ public struct TmuxManager: Sendable {
         ["-L", server, "resize-window", "-t", windowID, "-x", "\(cols)", "-y", "\(rows)"]
     }
 
+    /// Switch a window out of `window-size manual` mode so attached clients
+    /// can drive the size via their own TIOCSWINSZ. tmux's `resize-window`
+    /// implicitly sets manual mode, which freezes the window at that size
+    /// and prevents SwiftTerm's per-pane ioctl from shrinking it back when
+    /// the actual rendered area is smaller than the broadcast measurement.
+    public static func setWindowSizeLatestCommand(server: String, windowID: String) -> [String] {
+        ["-L", server, "set-option", "-wt", windowID, "window-size", "latest"]
+    }
+
     public static func killWindowCommand(server: String, windowID: String) -> [String] {
         ["-L", server, "kill-window", "-t", windowID]
     }
@@ -252,17 +261,28 @@ public struct TmuxManager: Sendable {
         try await runTmux(args)
     }
 
-    /// Resize an existing tmux window. Used by the main-window resize broadcast
-    /// so detached panes retain a sensible cell size after the user changes
-    /// the app window dimensions; attached panes get overwritten by SwiftTerm's
-    /// own ioctl within milliseconds, so we don't bother filtering.
+    /// Resize an existing tmux window. Used by the main-window resize
+    /// broadcast and after `new-window`, so detached panes get a sensible
+    /// cell size before any SwiftTerm client attaches. Each call is paired
+    /// with `set-option ... window-size latest` to immediately leave manual
+    /// size mode — otherwise tmux pins the window at the broadcast value
+    /// and an attached SwiftTerm client (whose actual pane is usually
+    /// smaller after accounting for tab bars, dividers, file panels, etc.)
+    /// can't shrink it back, clipping the bottom rows.
     public func resizeWindow(server: String, windowID: String, cols: Int, rows: Int) async throws {
-        let args = Self.resizeWindowCommand(server: server, windowID: windowID, cols: cols, rows: rows)
+        let resizeArgs = Self.resizeWindowCommand(server: server, windowID: windowID, cols: cols, rows: rows)
+        let unfreezeArgs = Self.setWindowSizeLatestCommand(server: server, windowID: windowID)
         if dryRun {
-            dryRunRecorder?(args)
+            dryRunRecorder?(resizeArgs)
+            dryRunRecorder?(unfreezeArgs)
             return
         }
-        try await runTmux(args)
+        try await runTmux(resizeArgs)
+        // Best-effort: the resize itself succeeded, so don't fail the call
+        // if the option flip stumbles. Detached panes still keep the
+        // resize-window dimensions; only client-driven re-sizing depends on
+        // window-size being non-manual.
+        try? await runTmux(unfreezeArgs)
     }
 
     public func sendKeys(server: String, paneID: String, text: String) async throws {

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -277,11 +277,13 @@ import Testing
         shellCommand: "echo hi", cols: 220, rows: 50
     )
     let calls = recorded.snapshot()
-    #expect(calls.count == 2)
+    #expect(calls.count == 3)
     // Order matters: the new-window must be issued before the resize-window
-    // (we can only resize an existing window).
+    // (we can only resize an existing window). The set-option then unfreezes
+    // window-size so attached SwiftTerm clients can drive the size.
     #expect(calls[0].contains("new-window"))
     #expect(calls[1] == ["-L", "tbd-test", "resize-window", "-t", result.windowID, "-x", "220", "-y", "50"])
+    #expect(calls[2] == ["-L", "tbd-test", "set-option", "-wt", result.windowID, "window-size", "latest"])
 }
 
 @Test func testCreateWindowSkipsResizeWhenSizeNil() async throws {
@@ -350,8 +352,11 @@ import Testing
     })
     try await manager.resizeWindow(server: "tbd-test", windowID: "@5", cols: 240, rows: 80)
     let calls = recorded.snapshot()
-    #expect(calls.count == 1)
+    // Two calls: the resize, then the unfreeze that flips window-size out
+    // of manual mode so attached clients can drive it via TIOCSWINSZ.
+    #expect(calls.count == 2)
     #expect(calls[0] == ["-L", "tbd-test", "resize-window", "-t", "@5", "-x", "240", "-y", "80"])
+    #expect(calls[1] == ["-L", "tbd-test", "set-option", "-wt", "@5", "window-size", "latest"])
 }
 
 /// Thread-safe recorder for dry-run argv captures used by the tests above.


### PR DESCRIPTION
## Summary

After #84 merged, terminals were still clipping the bottom row even with the corrected per-pane measurement. Diagnosis showed the windows were stuck at the **old** pre-#84 size (e.g. 163×54 from the detail-slot measurement) in `window-size manual` mode — and the post-#84 broadcast couldn't shrink them because manual mode is one-way: tmux's `resize-window` puts the window in manual mode, but the SwiftTerm client's `TIOCSWINSZ` cannot move it back.

Two-part fix:

**1. Multi-select cell measurement (the small bug):**
`MultiWorktreeView` was publishing `cellWidth × cellHeight` to `MainAreaSizeKey`, but each `MultiWorktreeCell` has a header bar (worktree name + branch, ~21pt) and a `Divider()` above the actual terminal area. tmux thought every multi-select pane had ~2 more rows than SwiftTerm rendered. Mirroring the single-worktree fix from #84: the producer now lives inside `MultiWorktreeCell` on the terminal-content slot, only the first cell publishes (`isPrimary: index == 0`).

**2. tmux manual-mode unfreeze (the structural bug):**
Pairing every `resize-window -x N -y M` (in `createWindow` and the `setMainAreaSize` broadcast) with `set-option -wt <window> window-size latest`. Detached panes keep the resize-window dimensions for their initial scrollback width — so the #73 "unviewed terminals at 80×24" fix is preserved — but once a SwiftTerm client attaches, its `TIOCSWINSZ` is authoritative and the window tracks the actual rendered area. No more chrome-precision arms race.

## Test plan

- [ ] Currently-stuck windows (the ones mentioned in this PR's investigation) are unfrozen automatically as the daemon's resize broadcast fires post-restart. Verify Claude's input row is visible in the previously broken worktrees.
- [ ] Cmd-click 2-4 worktrees → multi-select grid → no row clipping in any cell.
- [ ] Resize the app window → all windows track the SwiftTerm pane size (no overshoot).
- [ ] Spawn a Claude in a worktree without selecting it → check tmux thinks the window is at the broadcast cols/rows (not 80×24) so scrollback is wide enough.
- [ ] `swift test --filter TmuxManagerTests` clean (29/29 pass locally).