### PR TITLE
Fix: Make ~/path file links clickable in terminal output

### DIFF
--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -280,7 +280,7 @@ class TBDTerminalView: TerminalView {
         let candidate: String
         if link.hasPrefix("file://~") {
             // URL parsing treats ~ as the host, dropping it from .path. Strip the scheme manually
-            // and let tilde expansion below handle the home-relative segment.
+            // and expand the tilde directly to recover the home-relative segment.
             candidate = NSString(string: String(link.dropFirst("file://".count))).expandingTildeInPath
         } else if link.hasPrefix("file://") {
             guard let path = URL(string: link)?.path, !path.isEmpty else { return nil }

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -257,10 +257,12 @@ class TBDTerminalView: TerminalView {
 
         guard !candidate.isEmpty else { return nil }
 
-        // Resolve relative paths against worktreePath
+        // Resolve relative paths against worktreePath; expand leading ~ as a home-relative path.
         let resolvedPath: String
         if candidate.hasPrefix("/") {
             resolvedPath = candidate
+        } else if candidate.hasPrefix("~") {
+            resolvedPath = NSString(string: candidate).expandingTildeInPath
         } else {
             resolvedPath = URL(fileURLWithPath: worktreePath).appendingPathComponent(candidate).path
         }
@@ -276,9 +278,15 @@ class TBDTerminalView: TerminalView {
     /// Returns the resolved path if the file exists, nil otherwise.
     func resolveAsFilePath(_ link: String) -> String? {
         let candidate: String
-        if link.hasPrefix("file://") {
+        if link.hasPrefix("file://~") {
+            // URL parsing treats ~ as the host, dropping it from .path. Strip the scheme manually
+            // and let tilde expansion below handle the home-relative segment.
+            candidate = NSString(string: String(link.dropFirst("file://".count))).expandingTildeInPath
+        } else if link.hasPrefix("file://") {
             guard let path = URL(string: link)?.path, !path.isEmpty else { return nil }
             candidate = path
+        } else if link.hasPrefix("~") {
+            candidate = NSString(string: link).expandingTildeInPath
         } else if link.hasPrefix("/") {
             candidate = link
         } else if !link.contains("://"), !worktreePath.isEmpty {


### PR DESCRIPTION
## Summary
- Claude Code's OSC 8 hyperlinks for home-relative paths (e.g. `Write(~/.longeye/pr-extras/foo.md)`) weren't opening on click — `~` is shell-only expansion, and `URL(string: "file://~/foo")?.path` treats `~` as the URL host and drops it.
- Fix: expand leading `~` via `expandingTildeInPath` in `resolveAsFilePath` and the pattern-match resolver, with a dedicated `file://~` branch that bypasses URL parsing.
- Absolute and relative paths still work as before.

## Test plan
- [ ] In a Claude Code terminal pane, click a tool-call header like `Write(~/.foo/bar.md)` for an existing file → opens in editor.
- [ ] Click a `Write(/Users/.../foo.md)` (absolute) path → still opens.
- [ ] Click a `Write(src/foo.swift)` (relative) path → still opens.