### PR TITLE
Feat: Browse archived worktree conversations and revive into the one you want

### DIFF
--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -1,5 +1,8 @@
 import Foundation
 import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "AppState+History")
 
 // MARK: - HistoryLoadState
 
@@ -114,6 +117,7 @@ extension AppState {
             .flatMap({ $0 })
             .first(where: { $0.id == worktreeID })
         else {
+            logger.warning("reviveWithSession: no archived snapshot for \(worktreeID, privacy: .public)")
             return
         }
         revivingArchived[worktreeID] = .inFlight(snapshot: snapshot)

--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -103,4 +103,56 @@ extension AppState {
             handleConnectionError(error)
         }
     }
+
+    /// Revive an archived worktree and resume the selected Claude session.
+    /// Marks the row as `inFlight` immediately so the archived view can show
+    /// a status pill, then flips to `.done` on success or clears on failure.
+    func reviveWithSession(worktreeID: UUID, sessionId: String) async {
+        // Find the snapshot in archivedWorktrees so we can keep the row visible
+        // after the daemon reconciles the worktree out of the archived list.
+        guard let snapshot = archivedWorktrees.values
+            .flatMap({ $0 })
+            .first(where: { $0.id == worktreeID })
+        else {
+            return
+        }
+        revivingArchived[worktreeID] = .inFlight(snapshot: snapshot)
+
+        // Advance the archived row selection if this row is currently selected
+        // (rule: in-flight rows are non-selectable).
+        advanceArchivedSelectionIfNeeded(worktreeID: worktreeID)
+
+        do {
+            let size = mainAreaTerminalSize()
+            try await daemonClient.reviveWorktree(
+                id: worktreeID,
+                cols: size.cols,
+                rows: size.rows,
+                preferredSessionID: sessionId
+            )
+            revivingArchived[worktreeID] = .done(snapshot: snapshot)
+            await refreshWorktrees()
+            await refreshArchivedWorktrees(repoID: snapshot.repoID)
+        } catch {
+            revivingArchived.removeValue(forKey: worktreeID)
+            handleConnectionError(error)
+        }
+    }
+
+    /// If the in-flight worktree was the selected archived row for its repo,
+    /// move selection to the next-most-recent archived row (or clear).
+    private func advanceArchivedSelectionIfNeeded(worktreeID: UUID) {
+        let repoID = archivedWorktrees.first(where: { (_, wts) in
+            wts.contains(where: { $0.id == worktreeID })
+        })?.key
+        guard let repoID, selectedArchivedWorktreeIDs[repoID] == worktreeID else { return }
+        let remaining = (archivedWorktrees[repoID] ?? [])
+            .filter { $0.id != worktreeID }
+            .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+        if let next = remaining.first {
+            selectedArchivedWorktreeIDs[repoID] = next.id
+        } else {
+            selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
+        }
+    }
 }

--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -145,7 +145,7 @@ extension AppState {
 
     /// If the in-flight worktree was the selected archived row for its repo,
     /// move selection to the next-most-recent archived row (or clear).
-    private func advanceArchivedSelectionIfNeeded(worktreeID: UUID) {
+    func advanceArchivedSelectionIfNeeded(worktreeID: UUID) {
         let repoID = archivedWorktrees.first(where: { (_, wts) in
             wts.contains(where: { $0.id == worktreeID })
         })?.key

--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -62,6 +62,11 @@ extension AppState {
         do {
             let fresh = try await daemonClient.listSessions(worktreeID: worktreeID)
             historyLoadStates[worktreeID] = .loaded(fresh)
+            // Auto-select the first session on initial load if nothing is selected yet.
+            // Applies to both active and archived worktrees.
+            if selectedSessionIDs[worktreeID] == nil, let first = fresh.first {
+                await selectSession(first, worktreeID: worktreeID)
+            }
         } catch {
             historyLoadStates[worktreeID] = .failed(error.localizedDescription)
         }

--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -111,6 +111,10 @@ extension AppState {
     /// Marks the row as `inFlight` immediately so the archived view can show
     /// a status pill, then flips to `.done` on success or clears on failure.
     func reviveWithSession(worktreeID: UUID, sessionId: String) async {
+        // Idempotency: ignore re-entrant calls (e.g. rapid double-click)
+        // so a concurrent invocation can't overwrite the .done state with
+        // an "already active" error.
+        guard revivingArchived[worktreeID] == nil else { return }
         // Find the snapshot in archivedWorktrees so we can keep the row visible
         // after the daemon reconciles the worktree out of the archived list.
         guard let snapshot = archivedWorktrees.values

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -64,15 +64,29 @@ extension AppState {
     /// Apply a navigation entry to the live selection state. Mirrors the work
     /// `selectRepo` would do for repo entries (refreshing archived worktrees).
     private func applyNavigationEntry(_ entry: NavigationEntry) {
+        let leavingRepoID = selectedRepoID
         switch entry {
         case .worktrees(let ids):
+            if let leavingRepoID { clearRevivingArchived(repoID: leavingRepoID) }
             selectedRepoID = nil
             selectedWorktreeIDs = Set(ids)
             selectionOrder = ids // must come after; didSet above rebuilds from unordered Set
         case .repo(let id):
+            if let leavingRepoID, leavingRepoID != id {
+                clearRevivingArchived(repoID: leavingRepoID)
+            }
             selectedWorktreeIDs = []
             selectedRepoID = id
             Task { await refreshArchivedWorktrees(repoID: id) }
+        }
+    }
+
+    /// Drop any lingering revive snapshots that belong to the given repo —
+    /// called when the user leaves that repo's archived view, so coming back
+    /// shows a fresh list without "Revived ✓" rows.
+    func clearRevivingArchived(repoID: UUID) {
+        revivingArchived = revivingArchived.filter { _, state in
+            state.snapshot.repoID != repoID
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -70,6 +70,9 @@ extension AppState {
     /// visible with a status pill until the user navigates away, instead
     /// of yanking them into the now-active worktree.
     func reviveWorktree(id: UUID) async {
+        // Idempotency: see `reviveWithSession`. Concurrent invocations
+        // would race the `.done` state to nil on the second call's error.
+        guard revivingArchived[id] == nil else { return }
         guard let snapshot = archivedWorktrees.values
             .flatMap({ $0 })
             .first(where: { $0.id == id })

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -66,18 +66,28 @@ extension AppState {
     }
 
     /// Revive an archived worktree.
+    /// Mirrors `reviveWithSession`'s lingering-snapshot UX: keeps the row
+    /// visible with a status pill until the user navigates away, instead
+    /// of yanking them into the now-active worktree.
     func reviveWorktree(id: UUID) async {
-        // Find the repo before reviving so we can refresh the archived list
-        let repoID = archivedWorktrees.first(where: { $0.value.contains { $0.id == id } })?.key
+        guard let snapshot = archivedWorktrees.values
+            .flatMap({ $0 })
+            .first(where: { $0.id == id })
+        else {
+            logger.warning("reviveWorktree: no archived snapshot for \(id, privacy: .public)")
+            return
+        }
+        revivingArchived[id] = .inFlight(snapshot: snapshot)
+        advanceArchivedSelectionIfNeeded(worktreeID: id)
+
         do {
             let size = mainAreaTerminalSize()
             try await daemonClient.reviveWorktree(id: id, cols: size.cols, rows: size.rows)
+            revivingArchived[id] = .done(snapshot: snapshot)
             await refreshWorktrees()
-            selectedWorktreeIDs = [id]
-            if let repoID {
-                await refreshArchivedWorktrees(repoID: repoID)
-            }
+            await refreshArchivedWorktrees(repoID: snapshot.repoID)
         } catch {
+            revivingArchived.removeValue(forKey: id)
             logger.error("Failed to revive worktree: \(error)")
             handleConnectionError(error)
         }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -193,8 +193,35 @@ extension AppState {
         do {
             let archived = try await daemonClient.listWorktrees(repoID: repoID, status: .archived)
             archivedWorktrees[repoID] = archived
+            ensureArchivedSelectionValid(repoID: repoID)
         } catch {
             logger.error("Failed to list archived worktrees: \(error)")
+        }
+    }
+
+    /// Ensure `selectedArchivedWorktreeIDs[repoID]` points to a row that
+    /// actually exists in the archived list (or in `revivingArchived` for that
+    /// repo). If unset or stale, set it to the most-recently-archived row.
+    /// Also kicks off the session fetch for the newly-selected worktree.
+    private func ensureArchivedSelectionValid(repoID: UUID) {
+        let archived = (archivedWorktrees[repoID] ?? [])
+        let lingering = revivingArchived.values
+            .map(\.snapshot)
+            .filter { $0.repoID == repoID }
+        let allIDs = Set(archived.map(\.id) + lingering.map(\.id))
+
+        let current = selectedArchivedWorktreeIDs[repoID]
+        let needsNew = current == nil || !allIDs.contains(current!)
+        guard needsNew else { return }
+
+        let mostRecent = archived
+            .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+            .first
+        if let pick = mostRecent {
+            selectedArchivedWorktreeIDs[repoID] = pick.id
+            Task { await fetchSessions(worktreeID: pick.id) }
+        } else {
+            selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -47,6 +47,7 @@ final class AppState: ObservableObject {
             }
             // Clear repo selection when a worktree is selected
             if !selectedWorktreeIDs.isEmpty {
+                if let leaving = selectedRepoID { clearRevivingArchived(repoID: leaving) }
                 selectedRepoID = nil
                 recordNavigation(.worktrees(selectionOrder))
             }
@@ -57,6 +58,9 @@ final class AppState: ObservableObject {
     /// Selected repo ID — set when a repo header is clicked, shows archived worktrees in content pane.
     @Published var selectedRepoID: UUID? = nil {
         didSet {
+            if let old = oldValue, old != selectedRepoID {
+                clearRevivingArchived(repoID: old)
+            }
             guard selectedRepoID != oldValue, let id = selectedRepoID else { return }
             recordNavigation(.repo(id))
         }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -6,6 +6,20 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.app", category: "AppState")
 
+/// Transition state for a worktree being revived from the archived view.
+/// Holds a snapshot of the `Worktree` so the row can keep rendering even
+/// after the daemon removes it from `archivedWorktrees`.
+enum ReviveState: Equatable {
+    case inFlight(snapshot: Worktree)
+    case done(snapshot: Worktree)
+
+    var snapshot: Worktree {
+        switch self {
+        case .inFlight(let s), .done(let s): return s
+        }
+    }
+}
+
 @MainActor
 final class AppState: ObservableObject {
     @Published var repos: [Repo] = []
@@ -176,6 +190,15 @@ final class AppState: ObservableObject {
     @Published var selectedSessionIDs: [UUID: String] = [:]       // worktreeID → sessionId
     @Published var sessionTranscripts: [String: [ChatMessage]] = [:]  // sessionId → messages
     @Published var sessionTranscriptLoading: Set<String> = []
+
+    /// Selected archived worktree per repo (left rail of the archived view's nested master-detail).
+    @Published var selectedArchivedWorktreeIDs: [UUID: UUID] = [:]
+
+    /// Worktrees the user just revived from the archived view. Keeps the row
+    /// visible with a status indicator until the user navigates away from the
+    /// archived section. Cleared by `AppState+Navigation` when the active
+    /// sidebar selection moves elsewhere.
+    @Published var revivingArchived: [UUID: ReviveState] = [:]
 
     /// Conductor for each repo (wildcard conductors expanded across all repos).
     @Published var conductorsByRepo: [UUID: Conductor] = [:]

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -7,13 +7,14 @@ struct ArchivedWorktreesView: View {
 
     @State private var listWidth: CGFloat = 280
     @State private var dragStartWidth: CGFloat? = nil
+    @AppStorage("archived.hideEmpty") private var hideEmpty: Bool = true
 
-    /// Display rows = archived worktrees ∪ lingering revive snapshots,
-    /// deduped by id, sorted by archivedAt desc.
-    private var rows: [ArchivedRow] {
+    /// All archived rows for this repo (∪ lingering revive snapshots), unfiltered.
+    /// Used for the unfiltered count and to back the filter visibility decision.
+    private var allRows: [ArchivedRow] {
         let archived = (appState.archivedWorktrees[repoID] ?? [])
         let lingering = appState.revivingArchived
-            .compactMap { (id, state) -> Worktree? in
+            .compactMap { (_, state) -> Worktree? in
                 guard state.snapshot.repoID == repoID else { return nil }
                 return state.snapshot
             }
@@ -27,12 +28,22 @@ struct ArchivedWorktreesView: View {
             }
     }
 
+    /// Visible rows after applying the current filter. Lingering revives
+    /// always pass through so a just-revived row doesn't vanish mid-flight.
+    private var rows: [ArchivedRow] {
+        guard hideEmpty else { return allRows }
+        return allRows.filter { row in
+            row.reviveState != nil
+                || row.worktree.archivedClaudeSessions?.isEmpty == false
+        }
+    }
+
     private var selectedID: UUID? {
         appState.selectedArchivedWorktreeIDs[repoID]
     }
 
     var body: some View {
-        if rows.isEmpty {
+        if allRows.isEmpty {
             emptyState
         } else {
             HStack(spacing: 0) {
@@ -49,14 +60,32 @@ struct ArchivedWorktreesView: View {
 
     private var leftRail: some View {
         VStack(spacing: 0) {
-            HStack {
+            HStack(spacing: 8) {
                 Text("Archived")
                     .font(.title3)
                     .fontWeight(.medium)
                 Spacer()
-                Text("\(rows.count)")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+                if hideEmpty && rows.count < allRows.count {
+                    Text("\(rows.count) of \(allRows.count)")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("\(rows.count)")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                Menu {
+                    Toggle("Hide worktrees with no conversations", isOn: $hideEmpty)
+                } label: {
+                    Image(systemName: hideEmpty
+                          ? "line.3.horizontal.decrease.circle.fill"
+                          : "line.3.horizontal.decrease.circle")
+                        .foregroundStyle(hideEmpty ? Color.accentColor : .secondary)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("Filter")
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
@@ -64,7 +93,20 @@ struct ArchivedWorktreesView: View {
             Divider()
 
             ScrollViewReader { proxy in
-                List(rows) { row in
+                if rows.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "line.3.horizontal.decrease.circle")
+                            .font(.system(size: 28))
+                            .foregroundStyle(.tertiary)
+                        Text("No matches")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                        Button("Show all") { hideEmpty = false }
+                            .buttonStyle(.link)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List(rows) { row in
                     ArchivedWorktreeRow(
                         row: row,
                         isSelected: selectedID == row.id
@@ -83,30 +125,38 @@ struct ArchivedWorktreesView: View {
                         }
                     }
                 }
-                .listStyle(.plain)
-                .onChange(of: appState.highlightedArchivedWorktreeID, initial: true) { _, newValue in
-                    guard let id = newValue, rows.contains(where: { $0.id == id }) else { return }
-                    withAnimation(.easeInOut(duration: 0.3)) {
-                        proxy.scrollTo(id, anchor: .center)
-                    }
-                    Task { @MainActor in
-                        try? await Task.sleep(for: .milliseconds(900))
-                        if appState.highlightedArchivedWorktreeID == id {
-                            appState.highlightedArchivedWorktreeID = nil
+                    .listStyle(.plain)
+                    .onChange(of: appState.highlightedArchivedWorktreeID, initial: true) { _, newValue in
+                        guard let id = newValue, rows.contains(where: { $0.id == id }) else { return }
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            proxy.scrollTo(id, anchor: .center)
+                        }
+                        Task { @MainActor in
+                            try? await Task.sleep(for: .milliseconds(900))
+                            if appState.highlightedArchivedWorktreeID == id {
+                                appState.highlightedArchivedWorktreeID = nil
+                            }
                         }
                     }
                 }
             }
         }
-        .onAppear {
-            // Trigger initial selection if nothing is set yet. The async refresh
-            // path also calls into `ensureArchivedSelectionValid`, but on
-            // re-appearances (cached `archivedWorktrees`) we still need this.
-            if selectedID == nil,
-               let first = rows.first(where: { $0.reviveState == nil })?.worktree {
-                appState.selectedArchivedWorktreeIDs[repoID] = first.id
-                Task { await appState.fetchSessions(worktreeID: first.id) }
-            }
+        .onAppear { reconcileSelection() }
+        .onChange(of: hideEmpty) { _, _ in reconcileSelection() }
+    }
+
+    /// Make sure `selectedArchivedWorktreeIDs[repoID]` points to a row that
+    /// is currently visible. Picks the first non-lingering visible row when
+    /// unset or stale; clears when nothing is visible. Triggers a session
+    /// fetch for any newly-selected row.
+    private func reconcileSelection() {
+        let visibleIDs = Set(rows.map(\.id))
+        if let current = selectedID, visibleIDs.contains(current) { return }
+        if let first = rows.first(where: { $0.reviveState == nil })?.worktree {
+            appState.selectedArchivedWorktreeIDs[repoID] = first.id
+            Task { await appState.fetchSessions(worktreeID: first.id) }
+        } else {
+            appState.selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
         }
     }
 

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -282,13 +282,14 @@ private struct ArchivedWorktreeRow: View {
             HStack(spacing: 4) {
                 Text(row.worktree.branch)
                     .lineLimit(1)
-                if let archivedAt = row.worktree.archivedAt, row.reviveState == nil {
-                    separator
-                    Text(archivedAt, format: .relative(presentation: .named))
-                }
                 if row.effectiveSessionCount > 0, row.reviveState == nil {
                     separator
                     Text("\(row.effectiveSessionCount) session\(row.effectiveSessionCount == 1 ? "" : "s")")
+                }
+                Spacer(minLength: 6)
+                if let archivedAt = row.worktree.archivedAt, row.reviveState == nil {
+                    Text(archivedAt, format: .relative(presentation: .named))
+                        .lineLimit(1)
                 }
             }
             .font(.caption2)

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -64,19 +64,25 @@ struct ArchivedWorktreesView: View {
             Divider()
 
             ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(spacing: 1) {
-                        ForEach(rows) { row in
-                            ArchivedWorktreeRow(
-                                row: row,
-                                isSelected: selectedID == row.id,
-                                onSelect: { select(row) }
-                            )
-                            .id(row.id)
+                List(rows) { row in
+                    ArchivedWorktreeRow(
+                        row: row,
+                        isSelected: selectedID == row.id
+                    )
+                    .id(row.id)
+                    .contentShape(Rectangle())
+                    .onTapGesture { select(row) }
+                    .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
+                    .listRowBackground(rowBackground(for: row))
+                    .contextMenu {
+                        if row.reviveState == nil {
+                            Button("Revive") {
+                                Task { await appState.reviveWorktree(id: row.worktree.id) }
+                            }
                         }
                     }
-                    .padding(.vertical, 6)
                 }
+                .listStyle(.plain)
                 .onChange(of: appState.highlightedArchivedWorktreeID, initial: true) { _, newValue in
                     guard let id = newValue, rows.contains(where: { $0.id == id }) else { return }
                     withAnimation(.easeInOut(duration: 0.3)) {
@@ -180,6 +186,16 @@ struct ArchivedWorktreesView: View {
         appState.selectedArchivedWorktreeIDs[repoID] = row.id
         Task { await appState.fetchSessions(worktreeID: row.id) }
     }
+
+    private func rowBackground(for row: ArchivedRow) -> Color {
+        if appState.highlightedArchivedWorktreeID == row.id {
+            return Color.accentColor.opacity(0.25)
+        }
+        if selectedID == row.id {
+            return Color.accentColor.opacity(0.15)
+        }
+        return Color.clear
+    }
 }
 
 // MARK: - Row model
@@ -195,55 +211,42 @@ private struct ArchivedRow: Identifiable {
 private struct ArchivedWorktreeRow: View {
     let row: ArchivedRow
     let isSelected: Bool
-    let onSelect: () -> Void
-    @EnvironmentObject var appState: AppState
 
     private var hasClaudeSessions: Bool {
         row.worktree.archivedClaudeSessions?.isEmpty == false
     }
 
     var body: some View {
-        HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 6) {
-                    Text(row.worktree.displayName)
-                        .fontWeight(.medium)
-                        .lineLimit(1)
-                    statusPill
-                }
-                HStack(spacing: 6) {
-                    Label(row.worktree.branch, systemImage: "arrow.triangle.branch")
-                        .lineLimit(1)
-                    if let archivedAt = row.worktree.archivedAt, row.reviveState == nil {
-                        Text("·")
-                        Text(archivedAt, format: .relative(presentation: .named))
-                    }
-                    if hasClaudeSessions, row.reviveState == nil {
-                        let count = row.worktree.archivedClaudeSessions?.count ?? 0
-                        Text("·")
-                        Text("\(count) session\(count == 1 ? "" : "s")")
-                    }
-                }
-                .font(.caption)
-                .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text(row.worktree.displayName)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                statusPill
             }
-            Spacer(minLength: 0)
+            HStack(spacing: 4) {
+                Text(row.worktree.branch)
+                    .lineLimit(1)
+                if let archivedAt = row.worktree.archivedAt, row.reviveState == nil {
+                    separator
+                    Text(archivedAt, format: .relative(presentation: .named))
+                }
+                if hasClaudeSessions, row.reviveState == nil {
+                    let count = row.worktree.archivedClaudeSessions?.count ?? 0
+                    separator
+                    Text("\(count) session\(count == 1 ? "" : "s")")
+                }
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
-        .background(rowBackground)
-        .cornerRadius(6)
-        .padding(.horizontal, 8)
-        .onTapGesture { onSelect() }
-        .contextMenu {
-            if row.reviveState == nil {
-                Button("Revive") {
-                    Task { await appState.reviveWorktree(id: row.worktree.id) }
-                }
-            }
-        }
+        .padding(.vertical, 3)
+    }
+
+    private var separator: some View {
+        Text("·").foregroundStyle(.quaternary).font(.caption2)
     }
 
     @ViewBuilder
@@ -268,13 +271,4 @@ private struct ArchivedWorktreeRow: View {
         }
     }
 
-    private var rowBackground: Color {
-        if appState.highlightedArchivedWorktreeID == row.worktree.id {
-            return Color.accentColor.opacity(0.25)
-        }
-        if isSelected {
-            return Color.accentColor.opacity(0.18)
-        }
-        return Color.primary.opacity(0.03)
-    }
 }

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -74,6 +74,7 @@ struct ArchivedWorktreesView: View {
                     .onTapGesture { select(row) }
                     .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
                     .listRowBackground(rowBackground(for: row))
+                    .listRowSeparator(.hidden)
                     .contextMenu {
                         if row.reviveState == nil {
                             Button("Revive") {

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -95,7 +95,8 @@ struct ArchivedWorktreesView: View {
             // Trigger initial selection if nothing is set yet. The async refresh
             // path also calls into `ensureArchivedSelectionValid`, but on
             // re-appearances (cached `archivedWorktrees`) we still need this.
-            if selectedID == nil, let first = rows.first?.worktree {
+            if selectedID == nil,
+               let first = rows.first(where: { $0.reviveState == nil })?.worktree {
                 appState.selectedArchivedWorktreeIDs[repoID] = first.id
                 Task { await appState.fetchSessions(worktreeID: first.id) }
             }

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -182,7 +182,7 @@ struct ArchivedWorktreesView: View {
     private var rightPane: some View {
         if let id = selectedID,
            let row = rows.first(where: { $0.id == id }) {
-            if (row.worktree.archivedClaudeSessions ?? []).isEmpty {
+            if row.effectiveSessionCount == 0 {
                 noSessionsState(for: row.worktree)
             } else {
                 HistoryPaneView(worktreeID: id, transcriptAction: .reviveWithSession)
@@ -231,8 +231,8 @@ struct ArchivedWorktreesView: View {
     // MARK: - Actions
 
     private func select(_ row: ArchivedRow) {
-        // In-flight or done revives are non-selectable.
-        guard row.reviveState == nil else { return }
+        // In-flight revives are non-selectable; .done rows are fine to browse.
+        if case .inFlight = row.reviveState { return }
         appState.selectedArchivedWorktreeIDs[repoID] = row.id
         Task { await appState.fetchSessions(worktreeID: row.id) }
     }

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -5,142 +5,275 @@ struct ArchivedWorktreesView: View {
     let repoID: UUID
     @EnvironmentObject var appState: AppState
 
-    private var repo: Repo? {
-        appState.repos.first { $0.id == repoID }
+    @State private var listWidth: CGFloat = 280
+    @State private var dragStartWidth: CGFloat? = nil
+
+    /// Display rows = archived worktrees ∪ lingering revive snapshots,
+    /// deduped by id, sorted by archivedAt desc.
+    private var rows: [ArchivedRow] {
+        let archived = (appState.archivedWorktrees[repoID] ?? [])
+        let lingering = appState.revivingArchived
+            .compactMap { (id, state) -> Worktree? in
+                guard state.snapshot.repoID == repoID else { return nil }
+                return state.snapshot
+            }
+        var byID: [UUID: Worktree] = [:]
+        for wt in archived { byID[wt.id] = wt }
+        for wt in lingering where byID[wt.id] == nil { byID[wt.id] = wt }
+        return byID.values
+            .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+            .map { wt in
+                ArchivedRow(worktree: wt, reviveState: appState.revivingArchived[wt.id])
+            }
     }
 
-    private var archived: [Worktree] {
-        (appState.archivedWorktrees[repoID] ?? [])
-            .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+    private var selectedID: UUID? {
+        appState.selectedArchivedWorktreeIDs[repoID]
     }
 
     var body: some View {
-        if archived.isEmpty {
-            VStack(spacing: 12) {
-                Image(systemName: "archivebox")
-                    .font(.system(size: 36))
-                    .foregroundStyle(.secondary)
-                Text("No Archived Worktrees")
+        if rows.isEmpty {
+            emptyState
+        } else {
+            HStack(spacing: 0) {
+                leftRail
+                    .frame(width: listWidth)
+                divider
+                rightPane
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+    }
+
+    // MARK: - Left rail
+
+    private var leftRail: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Archived")
                     .font(.title3)
                     .fontWeight(.medium)
+                Spacer()
+                Text("\(rows.count)")
+                    .font(.callout)
                     .foregroundStyle(.secondary)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 1) {
+                        ForEach(rows) { row in
+                            ArchivedWorktreeRow(
+                                row: row,
+                                isSelected: selectedID == row.id,
+                                onSelect: { select(row) }
+                            )
+                            .id(row.id)
+                        }
+                    }
+                    .padding(.vertical, 6)
+                }
+                .onChange(of: appState.highlightedArchivedWorktreeID, initial: true) { _, newValue in
+                    guard let id = newValue, rows.contains(where: { $0.id == id }) else { return }
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        proxy.scrollTo(id, anchor: .center)
+                    }
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(900))
+                        if appState.highlightedArchivedWorktreeID == id {
+                            appState.highlightedArchivedWorktreeID = nil
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            // Trigger initial selection if nothing is set yet. The async refresh
+            // path also calls into `ensureArchivedSelectionValid`, but on
+            // re-appearances (cached `archivedWorktrees`) we still need this.
+            if selectedID == nil, let first = rows.first?.worktree {
+                appState.selectedArchivedWorktreeIDs[repoID] = first.id
+                Task { await appState.fetchSessions(worktreeID: first.id) }
+            }
+        }
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(Color(nsColor: .separatorColor))
+            .frame(width: 1)
+            .contentShape(Rectangle().inset(by: -3))
+            .cursor(.resizeLeftRight)
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        if dragStartWidth == nil { dragStartWidth = listWidth }
+                        let newWidth = (dragStartWidth ?? listWidth) + value.translation.width
+                        listWidth = max(220, min(400, newWidth))
+                    }
+                    .onEnded { _ in dragStartWidth = nil }
+            )
+    }
+
+    // MARK: - Right pane
+
+    @ViewBuilder
+    private var rightPane: some View {
+        if let id = selectedID,
+           let row = rows.first(where: { $0.id == id }) {
+            if (row.worktree.archivedClaudeSessions ?? []).isEmpty {
+                noSessionsState(for: row.worktree)
+            } else {
+                HistoryPaneView(worktreeID: id, transcriptAction: .reviveWithSession)
+            }
         } else {
-            VStack(spacing: 0) {
-                // Header
-                HStack {
-                    Text("Archived Worktrees")
-                        .font(.title3)
-                        .fontWeight(.medium)
-                    Spacer()
-                    Text("\(archived.count) worktree\(archived.count == 1 ? "" : "s")")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 16)
-
-                Divider()
-
-                // List
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 1) {
-                            ForEach(archived) { worktree in
-                                ArchivedWorktreeRow(worktree: worktree)
-                                    .id(worktree.id)
-                            }
-                        }
-                        .padding(.vertical, 8)
-                    }
-                    .onChange(of: appState.highlightedArchivedWorktreeID, initial: true) { _, newValue in
-                        guard let id = newValue,
-                              archived.contains(where: { $0.id == id }) else { return }
-                        withAnimation(.easeInOut(duration: 0.3)) {
-                            proxy.scrollTo(id, anchor: .center)
-                        }
-                        Task { @MainActor in
-                            try? await Task.sleep(for: .milliseconds(900))
-                            if appState.highlightedArchivedWorktreeID == id {
-                                appState.highlightedArchivedWorktreeID = nil
-                            }
-                        }
-                    }
-                }
+            VStack(spacing: 8) {
+                Text("Select a worktree")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
+
+    private func noSessionsState(for worktree: Worktree) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.system(size: 32))
+                .foregroundStyle(.tertiary)
+            Text("No archived sessions")
+                .foregroundStyle(.secondary)
+                .font(.callout)
+            Button("Revive") {
+                Task { await appState.reviveWorktree(id: worktree.id) }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Empty list state
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "archivebox")
+                .font(.system(size: 36))
+                .foregroundStyle(.secondary)
+            Text("No Archived Worktrees")
+                .font(.title3)
+                .fontWeight(.medium)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Actions
+
+    private func select(_ row: ArchivedRow) {
+        // In-flight or done revives are non-selectable.
+        guard row.reviveState == nil else { return }
+        appState.selectedArchivedWorktreeIDs[repoID] = row.id
+        Task { await appState.fetchSessions(worktreeID: row.id) }
+    }
 }
 
-private struct ArchivedWorktreeRow: View {
+// MARK: - Row model
+
+private struct ArchivedRow: Identifiable {
     let worktree: Worktree
+    let reviveState: ReviveState?
+    var id: UUID { worktree.id }
+}
+
+// MARK: - Row view
+
+private struct ArchivedWorktreeRow: View {
+    let row: ArchivedRow
+    let isSelected: Bool
+    let onSelect: () -> Void
     @EnvironmentObject var appState: AppState
-    @State private var isReviving = false
 
     private var hasClaudeSessions: Bool {
-        worktree.archivedClaudeSessions?.isEmpty == false
+        row.worktree.archivedClaudeSessions?.isEmpty == false
     }
 
     var body: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
-                    Text(worktree.displayName)
+                    Text(row.worktree.displayName)
                         .fontWeight(.medium)
-                    if hasClaudeSessions {
-                        let count = worktree.archivedClaudeSessions?.count ?? 0
-                        Text("\(count) Claude session\(count == 1 ? "" : "s")")
-                            .font(.caption)
-                            .foregroundStyle(.orange)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(.orange.opacity(0.1), in: Capsule())
-                    }
+                        .lineLimit(1)
+                    statusPill
                 }
-                HStack(spacing: 8) {
-                    Label(worktree.branch, systemImage: "arrow.triangle.branch")
-                    if let archivedAt = worktree.archivedAt {
-                        Text("archived \(archivedAt, format: .relative(presentation: .named))")
+                HStack(spacing: 6) {
+                    Label(row.worktree.branch, systemImage: "arrow.triangle.branch")
+                        .lineLimit(1)
+                    if let archivedAt = row.worktree.archivedAt, row.reviveState == nil {
+                        Text("·")
+                        Text(archivedAt, format: .relative(presentation: .named))
+                    }
+                    if hasClaudeSessions, row.reviveState == nil {
+                        let count = row.worktree.archivedClaudeSessions?.count ?? 0
+                        Text("·")
+                        Text("\(count) session\(count == 1 ? "" : "s")")
                     }
                 }
                 .font(.caption)
                 .foregroundStyle(.secondary)
             }
-
-            Spacer()
-
-            Button {
-                isReviving = true
-                Task {
-                    await appState.reviveWorktree(id: worktree.id)
-                    isReviving = false
-                }
-            } label: {
-                if isReviving {
-                    ProgressView()
-                        .controlSize(.small)
-                        .frame(width: 60)
-                } else {
-                    Text("Revive")
-                        .frame(width: 60)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .background(rowBackground)
+        .cornerRadius(6)
+        .padding(.horizontal, 8)
+        .onTapGesture { onSelect() }
+        .contextMenu {
+            if row.reviveState == nil {
+                Button("Revive") {
+                    Task { await appState.reviveWorktree(id: row.worktree.id) }
                 }
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.small)
-            .disabled(isReviving)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 10)
-        .background(
-            appState.highlightedArchivedWorktreeID == worktree.id
-                ? Color.accentColor.opacity(0.25)
-                : Color.primary.opacity(0.03)
-        )
-        .animation(.easeInOut(duration: 0.4),
-                   value: appState.highlightedArchivedWorktreeID)
-        .cornerRadius(6)
-        .padding(.horizontal, 12)
+    }
+
+    @ViewBuilder
+    private var statusPill: some View {
+        switch row.reviveState {
+        case .inFlight:
+            HStack(spacing: 4) {
+                ProgressView().controlSize(.mini)
+                Text("Reviving…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        case .done:
+            Text("Revived ✓")
+                .font(.caption)
+                .foregroundStyle(.green)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.green.opacity(0.12), in: Capsule())
+        case .none:
+            EmptyView()
+        }
+    }
+
+    private var rowBackground: Color {
+        if appState.highlightedArchivedWorktreeID == row.worktree.id {
+            return Color.accentColor.opacity(0.25)
+        }
+        if isSelected {
+            return Color.accentColor.opacity(0.18)
+        }
+        return Color.primary.opacity(0.03)
     }
 }

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -33,8 +33,7 @@ struct ArchivedWorktreesView: View {
     private var rows: [ArchivedRow] {
         guard hideEmpty else { return allRows }
         return allRows.filter { row in
-            row.reviveState != nil
-                || row.worktree.archivedClaudeSessions?.isEmpty == false
+            row.reviveState != nil || row.effectiveSessionCount > 0
         }
     }
 
@@ -255,6 +254,14 @@ private struct ArchivedRow: Identifiable {
     let worktree: Worktree
     let reviveState: ReviveState?
     var id: UUID { worktree.id }
+
+    /// Best available count of conversations for this worktree:
+    /// the daemon-supplied live file count when present, falling back to
+    /// the stored `archivedClaudeSessions` length (older archives or when
+    /// the daemon couldn't scan).
+    var effectiveSessionCount: Int {
+        worktree.liveClaudeSessionCount ?? worktree.archivedClaudeSessions?.count ?? 0
+    }
 }
 
 // MARK: - Row view
@@ -262,10 +269,6 @@ private struct ArchivedRow: Identifiable {
 private struct ArchivedWorktreeRow: View {
     let row: ArchivedRow
     let isSelected: Bool
-
-    private var hasClaudeSessions: Bool {
-        row.worktree.archivedClaudeSessions?.isEmpty == false
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -283,10 +286,9 @@ private struct ArchivedWorktreeRow: View {
                     separator
                     Text(archivedAt, format: .relative(presentation: .named))
                 }
-                if hasClaudeSessions, row.reviveState == nil {
-                    let count = row.worktree.archivedClaudeSessions?.count ?? 0
+                if row.effectiveSessionCount > 0, row.reviveState == nil {
                     separator
-                    Text("\(count) session\(count == 1 ? "" : "s")")
+                    Text("\(row.effectiveSessionCount) session\(row.effectiveSessionCount == 1 ? "" : "s")")
                 }
             }
             .font(.caption2)

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -403,10 +403,10 @@ actor DaemonClient {
     }
 
     /// Revive an archived worktree.
-    func reviveWorktree(id: UUID, cols: Int? = nil, rows: Int? = nil) async throws {
+    func reviveWorktree(id: UUID, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) async throws {
         try await callVoidAsync(
             method: RPCMethod.worktreeRevive,
-            params: WorktreeReviveParams(worktreeID: id, cols: cols, rows: rows)
+            params: WorktreeReviveParams(worktreeID: id, cols: cols, rows: rows, preferredSessionID: preferredSessionID)
         )
     }
 

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -1,10 +1,22 @@
 import SwiftUI
 import TBDShared
 
+/// The action exposed in the transcript header. Determines the button
+/// label and which AppState method the button invokes.
+enum TranscriptAction {
+    /// Active worktree: open a new terminal in the same worktree resuming
+    /// the selected Claude session.
+    case resume
+    /// Archived worktree: revive the worktree and resume the selected
+    /// session in its primary terminal.
+    case reviveWithSession
+}
+
 // MARK: - HistoryPaneView
 
 struct HistoryPaneView: View {
     let worktreeID: UUID
+    var transcriptAction: TranscriptAction = .resume
     @EnvironmentObject var appState: AppState
 
     private var loadState: HistoryLoadState {
@@ -54,7 +66,8 @@ struct HistoryPaneView: View {
                 SessionTranscriptView(
                     sessionId: summary.sessionId,
                     worktreeID: worktreeID,
-                    summary: summary
+                    summary: summary,
+                    action: transcriptAction
                 )
             } else {
                 emptyDetailState
@@ -260,6 +273,7 @@ struct SessionTranscriptView: View {
     let sessionId: String
     let worktreeID: UUID
     let summary: SessionSummary
+    let action: TranscriptAction
     @EnvironmentObject var appState: AppState
 
     private var messages: [ChatMessage] {
@@ -268,6 +282,13 @@ struct SessionTranscriptView: View {
 
     private var isLoading: Bool {
         appState.sessionTranscriptLoading.contains(sessionId)
+    }
+
+    private var actionLabel: String {
+        switch action {
+        case .resume: return "Resume"
+        case .reviveWithSession: return "Revive with this session"
+        }
     }
 
     var body: some View {
@@ -285,9 +306,14 @@ struct SessionTranscriptView: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                Button("Resume") {
+                Button(actionLabel) {
                     Task {
-                        await appState.resumeSession(worktreeID: worktreeID, sessionId: sessionId)
+                        switch action {
+                        case .resume:
+                            await appState.resumeSession(worktreeID: worktreeID, sessionId: sessionId)
+                        case .reviveWithSession:
+                            await appState.reviveWithSession(worktreeID: worktreeID, sessionId: sessionId)
+                        }
                     }
                 }
                 .buttonStyle(.borderedProminent)

--- a/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
@@ -118,6 +118,19 @@ enum ClaudeProjectDirectory {
 
 enum ClaudeSessionScanner {
 
+    /// Cheap count of `.jsonl` session files in a project directory. Does
+    /// not parse contents, so a returned count of N means "there are N
+    /// session files on disk" — files may still be empty stubs that
+    /// `listSessions` would skip. Sufficient for filtering archived
+    /// worktrees that have nothing left on disk.
+    static func countSessionFiles(projectDir: URL) -> Int {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(at: projectDir, includingPropertiesForKeys: nil) else {
+            return 0
+        }
+        return entries.filter { $0.pathExtension == "jsonl" }.count
+    }
+
     /// Lists all sessions in a project directory, sorted by mtime descending.
     static func listSessions(projectDir: URL) -> [SessionSummary] {
         let fm = FileManager.default

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -211,6 +211,18 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// Replace the archivedClaudeSessions list with `sessions` (re-encoded as JSON).
+    /// Used by the revive path when a `preferredSessionID` is supplied so the
+    /// last-resumed-first ordering is persisted across re-archive.
+    public func setArchivedClaudeSessions(id: UUID, sessions: [String]) async throws {
+        try await writer.write { db in
+            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else { return }
+            let json = try String(data: JSONEncoder().encode(sessions), encoding: .utf8) ?? "[]"
+            record.archivedClaudeSessions = json
+            try record.update(db)
+        }
+    }
+
     /// Rename a worktree's display name.
     public func rename(id: UUID, displayName: String) async throws {
         try await writer.write { db in

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -1,6 +1,14 @@
 import Foundation
 import TBDShared
 
+/// Reorders `stored` so `preferred` is first, preserving the relative order of
+/// the rest. Returns `stored` unchanged when `preferred` is nil, when `stored`
+/// is nil, or when `stored` does not contain `preferred`.
+internal func reorderSessions(stored: [String]?, preferred: String?) -> [String]? {
+    guard let preferred, let stored, stored.contains(preferred) else { return stored }
+    return [preferred] + stored.filter { $0 != preferred }
+}
+
 extension WorktreeLifecycle {
     // MARK: - Archive
 
@@ -94,7 +102,7 @@ extension WorktreeLifecycle {
     ///   - worktreeID: The archived worktree to revive.
     ///   - skipClaude: If true, skip launching claude in the first terminal window.
     /// - Returns: The revived worktree.
-    public func reviveWorktree(worktreeID: UUID, skipClaude: Bool = false, cols: Int? = nil, rows: Int? = nil) async throws -> Worktree {
+    public func reviveWorktree(worktreeID: UUID, skipClaude: Bool = false, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) async throws -> Worktree {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -132,10 +140,21 @@ extension WorktreeLifecycle {
             branch: worktree.branch
         )
 
+        // If the caller asked to prefer a specific session, float it to the
+        // front of the stored list and persist the new order so a subsequent
+        // re-archive preserves last-resumed-first ordering.
+        let sessions = reorderSessions(
+            stored: worktree.archivedClaudeSessions,
+            preferred: preferredSessionID
+        )
+        if let sessions, sessions != worktree.archivedClaudeSessions {
+            try await db.worktrees.setArchivedClaudeSessions(id: worktreeID, sessions: sessions)
+        }
+
         try await setupTerminals(
             worktree: worktree, repo: repo,
             skipClaude: skipClaude,
-            archivedClaudeSessions: worktree.archivedClaudeSessions,
+            archivedClaudeSessions: sessions,
             cols: cols,
             rows: rows
         )

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -68,7 +68,12 @@ extension RPCRouter {
 
     func handleWorktreeRevive(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeReviveParams.self, from: paramsData)
-        let worktree = try await lifecycle.reviveWorktree(worktreeID: params.worktreeID, cols: params.cols, rows: params.rows)
+        let worktree = try await lifecycle.reviveWorktree(
+            worktreeID: params.worktreeID,
+            cols: params.cols,
+            rows: params.rows,
+            preferredSessionID: params.preferredSessionID
+        )
 
         subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
             worktreeID: worktree.id, repoID: worktree.repoID,

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -42,7 +42,16 @@ extension RPCRouter {
 
     func handleWorktreeList(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeListParams.self, from: paramsData)
-        let worktrees = try await db.worktrees.list(repoID: params.repoID, status: params.status)
+        var worktrees = try await db.worktrees.list(repoID: params.repoID, status: params.status)
+        // Enrich archived worktrees with a real session-file count so the
+        // client can filter on actual disk state, not stale stored IDs.
+        for i in worktrees.indices where worktrees[i].status == .archived {
+            if let dir = ClaudeProjectDirectory.resolve(worktreePath: worktrees[i].path) {
+                worktrees[i].liveClaudeSessionCount = ClaudeSessionScanner.countSessionFiles(projectDir: dir)
+            } else {
+                worktrees[i].liveClaudeSessionCount = 0
+            }
+        }
         return try RPCResponse(result: worktrees)
     }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -80,12 +80,19 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public var tmuxServer: String
     public var archivedClaudeSessions: [String]?
     public var sortOrder: Int = 0
+    /// Transient enrichment populated by the daemon's `worktree.list` handler
+    /// for archived worktrees: count of actual session JSONL files in the
+    /// resolved Claude project directory. Not persisted in the DB. nil when
+    /// not enriched (active worktrees, or archived worktrees whose Claude
+    /// project dir could not be resolved).
+    public var liveClaudeSessionCount: Int?
 
     public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
                 hasConflicts: Bool = false,
                 createdAt: Date = Date(), archivedAt: Date? = nil, tmuxServer: String,
-                archivedClaudeSessions: [String]? = nil, sortOrder: Int = 0) {
+                archivedClaudeSessions: [String]? = nil, sortOrder: Int = 0,
+                liveClaudeSessionCount: Int? = nil) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -99,6 +106,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.tmuxServer = tmuxServer
         self.archivedClaudeSessions = archivedClaudeSessions
         self.sortOrder = sortOrder
+        self.liveClaudeSessionCount = liveClaudeSessionCount
     }
 
     public init(from decoder: Decoder) throws {
@@ -116,6 +124,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         tmuxServer = try c.decode(String.self, forKey: .tmuxServer)
         archivedClaudeSessions = try c.decodeIfPresent([String].self, forKey: .archivedClaudeSessions)
         sortOrder = try c.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
+        liveClaudeSessionCount = try c.decodeIfPresent(Int.self, forKey: .liveClaudeSessionCount)
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -348,10 +348,15 @@ public struct WorktreeReviveParams: Codable, Sendable {
     /// Initial tmux window size in cells (see WorktreeCreateParams).
     public let cols: Int?
     public let rows: Int?
-    public init(worktreeID: UUID, cols: Int? = nil, rows: Int? = nil) {
+    /// When set, the daemon reorders the worktree's stored
+    /// `archivedClaudeSessions` so this ID is first before resuming the
+    /// primary Claude terminal. Optional — nil preserves existing order.
+    public let preferredSessionID: String?
+    public init(worktreeID: UUID, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) {
         self.worktreeID = worktreeID
         self.cols = cols
         self.rows = rows
+        self.preferredSessionID = preferredSessionID
     }
 }
 

--- a/Tests/TBDDaemonTests/WorktreeReviveReorderTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveReorderTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import TBDDaemonLib
+import TBDShared
+
+final class WorktreeReviveReorderTests: XCTestCase {
+    func testReorderFloatsPreferredSessionFirst() {
+        let stored = ["a", "b", "c"]
+        let preferred = "b"
+        let result = reorderSessions(stored: stored, preferred: preferred)
+        XCTAssertEqual(result, ["b", "a", "c"])
+    }
+
+    func testNilPreferredKeepsOrder() {
+        let stored = ["a", "b", "c"]
+        let result = reorderSessions(stored: stored, preferred: String?.none)
+        XCTAssertEqual(result, ["a", "b", "c"])
+    }
+
+    func testUnknownPreferredKeepsOrder() {
+        let stored = ["a", "b", "c"]
+        let result = reorderSessions(stored: stored, preferred: "z")
+        XCTAssertEqual(result, ["a", "b", "c"])
+    }
+
+    func testNilStoredStaysNil() {
+        let result = reorderSessions(stored: [String]?.none, preferred: "anything")
+        XCTAssertNil(result)
+    }
+}

--- a/docs/superpowers/plans/2026-04-30-archived-worktree-history.md
+++ b/docs/superpowers/plans/2026-04-30-archived-worktree-history.md
@@ -1,0 +1,1065 @@
+# Archived Worktree Conversation History — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Browse Claude conversation history for archived worktrees in a nested master-detail view, with revive-with-session as the primary action.
+
+**Architecture:** `ArchivedWorktreesView` becomes an outer `HSplit`: left rail = selectable archived-worktree list, right pane = the existing `HistoryPaneView` rendered against the selected worktree's UUID. `HistoryPaneView` gains a `transcriptAction` parameter to swap "Resume" for "Revive with this session" in archived mode. Auto-select the most-recent archived row and the first session in any history view. Recently-revived rows linger with a status pill until the user navigates away.
+
+**Tech Stack:** Swift 6, SwiftUI, GRDB (daemon DB), NIO (RPC). macOS native unbundled SPM executable.
+
+**Spec:** [`docs/superpowers/specs/2026-04-30-archived-worktree-history-design.md`](../specs/2026-04-30-archived-worktree-history-design.md)
+
+---
+
+## Pre-flight
+
+- [ ] **Verify clean working tree.** Run `git status` — must be clean before starting. If not, ask the user how to proceed.
+- [ ] **Read the spec end-to-end** before starting any task. It is the source of truth for behavior.
+
+## Task 1: Add `preferredSessionID` to revive RPC params
+
+**Files:**
+- Modify: `Sources/TBDShared/RPCProtocol.swift:346-356` (extend `WorktreeReviveParams`)
+
+- [ ] **Step 1: Extend `WorktreeReviveParams`**
+
+Replace the struct at `Sources/TBDShared/RPCProtocol.swift:346-356` with:
+
+```swift
+public struct WorktreeReviveParams: Codable, Sendable {
+    public let worktreeID: UUID
+    /// Initial tmux window size in cells (see WorktreeCreateParams).
+    public let cols: Int?
+    public let rows: Int?
+    /// When set, the daemon reorders the worktree's stored
+    /// `archivedClaudeSessions` so this ID is first before resuming the
+    /// primary Claude terminal. Optional — nil preserves existing order.
+    public let preferredSessionID: String?
+    public init(worktreeID: UUID, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) {
+        self.worktreeID = worktreeID
+        self.cols = cols
+        self.rows = rows
+        self.preferredSessionID = preferredSessionID
+    }
+}
+```
+
+The parameter must be optional with a default so existing call sites compile unchanged. Codable's auto-synthesis will decode-or-default-nil when the field is missing in old daemon JSON, but since both sides ship together this is just defense in depth.
+
+- [ ] **Step 2: Build to verify**
+
+Run: `swift build`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDShared/RPCProtocol.swift
+git commit -m "feat(rpc): add preferredSessionID to WorktreeReviveParams"
+```
+
+---
+
+## Task 2: Daemon reorders `archivedClaudeSessions` on revive
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift` (revive path)
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift` (forward param)
+- Test: `Tests/TBDDaemonTests/WorktreeReviveReorderTests.swift` (new)
+
+- [ ] **Step 1: Read the existing revive lifecycle**
+
+Read `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift` from line 70 onward to see the `reviveWorktree(worktreeID:cols:rows:skipClaude:)` signature and how it loads the worktree, then calls `setupTerminals(...,  archivedClaudeSessions: worktree.archivedClaudeSessions, ...)`.
+
+- [ ] **Step 2: Extend the lifecycle function signature**
+
+In `WorktreeLifecycle+Archive.swift`, locate the `reviveWorktree` function (around line 70). Add a `preferredSessionID: String? = nil` parameter at the end of the signature.
+
+Inside the function, immediately before the `try await setupTerminals(...)` call (around line 135), build the session list with the preferred ID floated to the front:
+
+```swift
+let sessions: [String]?
+if let preferred = preferredSessionID,
+   let stored = worktree.archivedClaudeSessions,
+   stored.contains(preferred) {
+    sessions = [preferred] + stored.filter { $0 != preferred }
+} else {
+    sessions = worktree.archivedClaudeSessions
+}
+```
+
+Then change the call site to pass `archivedClaudeSessions: sessions` instead of `worktree.archivedClaudeSessions`.
+
+- [ ] **Step 3: Persist the reordered list back to the DB**
+
+Right after computing `sessions` and before `setupTerminals`, persist the new order so a subsequent re-archive preserves the user's last-resumed-first ordering:
+
+```swift
+if let sessions, sessions != worktree.archivedClaudeSessions {
+    try await db.worktrees.setArchivedClaudeSessions(id: worktreeID, sessions: sessions)
+}
+```
+
+If `WorktreeStore` does not have a `setArchivedClaudeSessions(id:sessions:)` method, add it. Check `Sources/TBDDaemon/Database/WorktreeStore.swift` first — there's an existing JSON-encode-and-store pattern around line 190 (`record.archivedClaudeSessions = try String(...)`). Mirror that pattern.
+
+If you add the method, signature:
+
+```swift
+func setArchivedClaudeSessions(id: UUID, sessions: [String]) async throws {
+    try await db.write { db in
+        guard var record = try WorktreeRecord.fetchOne(db, key: id) else { return }
+        let json = try String(data: JSONEncoder().encode(sessions), encoding: .utf8) ?? "[]"
+        record.archivedClaudeSessions = json
+        try record.update(db)
+    }
+}
+```
+
+- [ ] **Step 4: Forward the param from the RPC handler**
+
+In `Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift` find the revive handler (around line 71). Replace:
+
+```swift
+let worktree = try await lifecycle.reviveWorktree(worktreeID: params.worktreeID, cols: params.cols, rows: params.rows)
+```
+
+with:
+
+```swift
+let worktree = try await lifecycle.reviveWorktree(
+    worktreeID: params.worktreeID,
+    cols: params.cols,
+    rows: params.rows,
+    preferredSessionID: params.preferredSessionID
+)
+```
+
+- [ ] **Step 5: Write a focused test**
+
+Create `Tests/TBDDaemonTests/WorktreeReviveReorderTests.swift`:
+
+```swift
+import XCTest
+@testable import TBDDaemon
+import TBDShared
+
+final class WorktreeReviveReorderTests: XCTestCase {
+    func testReorderFloatsPreferredSessionFirst() {
+        let stored = ["a", "b", "c"]
+        let preferred = "b"
+        let result = reorderSessions(stored: stored, preferred: preferred)
+        XCTAssertEqual(result, ["b", "a", "c"])
+    }
+
+    func testNilPreferredKeepsOrder() {
+        let stored = ["a", "b", "c"]
+        let result = reorderSessions(stored: stored, preferred: nil)
+        XCTAssertEqual(result, ["a", "b", "c"])
+    }
+
+    func testUnknownPreferredKeepsOrder() {
+        let stored = ["a", "b", "c"]
+        let result = reorderSessions(stored: stored, preferred: "z")
+        XCTAssertEqual(result, ["a", "b", "c"])
+    }
+
+    func testNilStoredStaysNil() {
+        let result = reorderSessions(stored: nil, preferred: "anything")
+        XCTAssertNil(result)
+    }
+}
+```
+
+To make the logic testable without spinning up the full lifecycle, extract the reorder block into a free `internal func reorderSessions(stored: [String]?, preferred: String?) -> [String]?` near the top of `WorktreeLifecycle+Archive.swift` and call it from both places. The function:
+
+```swift
+internal func reorderSessions(stored: [String]?, preferred: String?) -> [String]? {
+    guard let preferred, let stored, stored.contains(preferred) else { return stored }
+    return [preferred] + stored.filter { $0 != preferred }
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `swift test --filter WorktreeReviveReorderTests`
+Expected: 4 tests pass.
+
+- [ ] **Step 7: Build everything**
+
+Run: `swift build`
+Expected: builds clean (no daemon callers broke).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift \
+        Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift \
+        Sources/TBDDaemon/Database/WorktreeStore.swift \
+        Tests/TBDDaemonTests/WorktreeReviveReorderTests.swift
+git commit -m "feat(daemon): reorder archivedClaudeSessions on revive when preferredSessionID provided"
+```
+
+---
+
+## Task 3: Update `DaemonClient.reviveWorktree` to pass `preferredSessionID`
+
+**Files:**
+- Modify: `Sources/TBDApp/DaemonClient.swift:406` (and the function body just below)
+
+- [ ] **Step 1: Locate the function**
+
+Read `Sources/TBDApp/DaemonClient.swift` around line 406. The current signature is `func reviveWorktree(id: UUID, cols: Int? = nil, rows: Int? = nil) async throws`.
+
+- [ ] **Step 2: Add the parameter**
+
+Add `preferredSessionID: String? = nil` as the last parameter, and pass it into the `WorktreeReviveParams` initializer in the function body.
+
+- [ ] **Step 3: Build**
+
+Run: `swift build`
+Expected: builds clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/DaemonClient.swift
+git commit -m "feat(app): plumb preferredSessionID through DaemonClient.reviveWorktree"
+```
+
+---
+
+## Task 4: Add `TranscriptAction` parameter to `HistoryPaneView`
+
+**Files:**
+- Modify: `Sources/TBDApp/Panes/HistoryPaneView.swift`
+
+- [ ] **Step 1: Add the enum and parameter**
+
+At the top of `Sources/TBDApp/Panes/HistoryPaneView.swift` (just below the imports), add:
+
+```swift
+/// The action exposed in the transcript header. Determines the button
+/// label and which AppState method the button invokes.
+enum TranscriptAction {
+    /// Active worktree: open a new terminal in the same worktree resuming
+    /// the selected Claude session.
+    case resume
+    /// Archived worktree: revive the worktree and resume the selected
+    /// session in its primary terminal.
+    case reviveWithSession
+}
+```
+
+- [ ] **Step 2: Thread the parameter through `HistoryPaneView`**
+
+Modify the `HistoryPaneView` struct (around line 6):
+
+```swift
+struct HistoryPaneView: View {
+    let worktreeID: UUID
+    var transcriptAction: TranscriptAction = .resume
+    @EnvironmentObject var appState: AppState
+    ...
+}
+```
+
+In `body`, where `SessionTranscriptView(...)` is constructed (around line 54), pass the action through:
+
+```swift
+SessionTranscriptView(
+    sessionId: summary.sessionId,
+    worktreeID: worktreeID,
+    summary: summary,
+    action: transcriptAction
+)
+```
+
+- [ ] **Step 3: Branch in `SessionTranscriptView`**
+
+Modify `SessionTranscriptView` (around line 259):
+
+```swift
+struct SessionTranscriptView: View {
+    let sessionId: String
+    let worktreeID: UUID
+    let summary: SessionSummary
+    let action: TranscriptAction
+    @EnvironmentObject var appState: AppState
+    ...
+}
+```
+
+In its `body`, replace the existing `Button("Resume") { ... }` block (around line 288) with:
+
+```swift
+Button(actionLabel) {
+    Task {
+        switch action {
+        case .resume:
+            await appState.resumeSession(worktreeID: worktreeID, sessionId: sessionId)
+        case .reviveWithSession:
+            await appState.reviveWithSession(worktreeID: worktreeID, sessionId: sessionId)
+        }
+    }
+}
+.buttonStyle(.borderedProminent)
+.controlSize(.small)
+```
+
+Add a computed property to `SessionTranscriptView`:
+
+```swift
+private var actionLabel: String {
+    switch action {
+    case .resume: return "Resume"
+    case .reviveWithSession: return "Revive with this session"
+    }
+}
+```
+
+`appState.reviveWithSession(...)` will be added in Task 7. The build will fail until then — that's fine, we'll fix the order if we batch it, otherwise this task ends with a known-broken build that Task 7 resolves. (See Step 4.)
+
+- [ ] **Step 4: Skip build verification for now**
+
+Do NOT run `swift build` after this task — the call to `reviveWithSession` will not yet exist. The next tasks add it. This is the only task in the plan that ends with a non-building tree.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDApp/Panes/HistoryPaneView.swift
+git commit -m "feat(app): add TranscriptAction parameter to HistoryPaneView"
+```
+
+---
+
+## Task 5: Add `selectedArchivedWorktreeIDs` and `revivingArchived` state
+
+**Files:**
+- Modify: `Sources/TBDApp/AppState.swift`
+
+- [ ] **Step 1: Add the published properties**
+
+In `Sources/TBDApp/AppState.swift`, immediately after the existing `historyActiveWorktrees` / `historyLoadStates` / `selectedSessionIDs` block (around lines 174-178), add:
+
+```swift
+/// Selected archived worktree per repo (left rail of the archived view's nested master-detail).
+@Published var selectedArchivedWorktreeIDs: [UUID: UUID] = [:]
+
+/// Worktrees the user just revived from the archived view. Keeps the row
+/// visible with a status indicator until the user navigates away from the
+/// archived section. Cleared by `AppState+Navigation` when the active
+/// sidebar selection moves elsewhere.
+@Published var revivingArchived: [UUID: ReviveState] = [:]
+```
+
+- [ ] **Step 2: Add the `ReviveState` enum**
+
+Define `ReviveState` at file scope (above the `AppState` class declaration, near line 8):
+
+```swift
+/// Transition state for a worktree being revived from the archived view.
+/// Holds a snapshot of the `Worktree` so the row can keep rendering even
+/// after the daemon removes it from `archivedWorktrees`.
+enum ReviveState: Equatable {
+    case inFlight(snapshot: Worktree)
+    case done(snapshot: Worktree)
+
+    var snapshot: Worktree {
+        switch self {
+        case .inFlight(let s), .done(let s): return s
+        }
+    }
+}
+```
+
+`Worktree` already conforms to `Equatable` via its `Codable`/`Hashable` synthesis; verify by reading `Sources/TBDShared/Models.swift`. If it does not, replace `Equatable` above with `: Equatable where Worktree: Equatable` is unnecessary — instead drop the `Equatable` conformance and provide manual `==` based on `snapshot.id`. (Equatable is needed only so SwiftUI diffs the dictionary efficiently.)
+
+- [ ] **Step 3: Build**
+
+Run: `swift build`
+Expected: builds clean (no consumers yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/AppState.swift
+git commit -m "feat(app): add ReviveState and per-repo archived selection state"
+```
+
+---
+
+## Task 6: Universal first-session auto-select in `fetchSessions`
+
+**Files:**
+- Modify: `Sources/TBDApp/AppState+History.swift`
+- Test: `Tests/TBDAppTests/HistoryAutoSelectTests.swift` (new)
+
+- [ ] **Step 1: Modify `fetchSessions`**
+
+In `Sources/TBDApp/AppState+History.swift`, locate the `fetchSessions(worktreeID:)` function (line 58). After the `historyLoadStates[worktreeID] = .loaded(fresh)` assignment, add auto-selection:
+
+```swift
+historyLoadStates[worktreeID] = .loaded(fresh)
+// Auto-select the first session on initial load if nothing is selected yet.
+// Applies to both active and archived worktrees.
+if selectedSessionIDs[worktreeID] == nil, let first = fresh.first {
+    await selectSession(first, worktreeID: worktreeID)
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: builds clean.
+
+- [ ] **Step 3: Manual verification note**
+
+Skip a unit test for this — `fetchSessions` calls into `daemonClient.listSessions` and the existing `TBDAppTests` target does not have a daemon mock pattern set up. Instead, after restarting we'll verify manually that opening the history pane on an active worktree now auto-selects the first session and loads its transcript. Add this to the test plan in Task 12.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/AppState+History.swift
+git commit -m "feat(app): auto-select first session on initial history load"
+```
+
+---
+
+## Task 7: Add `reviveWithSession` to AppState
+
+**Files:**
+- Modify: `Sources/TBDApp/AppState+History.swift` (add the method)
+- Modify: `Sources/TBDApp/AppState+Worktrees.swift` (helper for shared revive flow)
+
+- [ ] **Step 1: Add `reviveWithSession`**
+
+At the bottom of `Sources/TBDApp/AppState+History.swift` (inside the `extension AppState {}` block), add:
+
+```swift
+/// Revive an archived worktree and resume the selected Claude session.
+/// Marks the row as `inFlight` immediately so the archived view can show
+/// a status pill, then flips to `.done` on success or clears on failure.
+func reviveWithSession(worktreeID: UUID, sessionId: String) async {
+    // Find the snapshot in archivedWorktrees so we can keep the row visible
+    // after the daemon reconciles the worktree out of the archived list.
+    guard let snapshot = archivedWorktrees.values
+        .flatMap({ $0 })
+        .first(where: { $0.id == worktreeID })
+    else {
+        return
+    }
+    revivingArchived[worktreeID] = .inFlight(snapshot: snapshot)
+
+    // Advance the archived row selection if this row is currently selected
+    // (rule: in-flight rows are non-selectable).
+    advanceArchivedSelectionIfNeeded(worktreeID: worktreeID)
+
+    do {
+        let size = mainAreaTerminalSize()
+        try await daemonClient.reviveWorktree(
+            id: worktreeID,
+            cols: size.cols,
+            rows: size.rows,
+            preferredSessionID: sessionId
+        )
+        revivingArchived[worktreeID] = .done(snapshot: snapshot)
+        await refreshWorktrees()
+        if let repoID = snapshot.repoID as UUID? {
+            await refreshArchivedWorktrees(repoID: repoID)
+        }
+    } catch {
+        revivingArchived.removeValue(forKey: worktreeID)
+        handleConnectionError(error)
+    }
+}
+
+/// If the in-flight worktree was the selected archived row for its repo,
+/// move selection to the next-most-recent archived row (or clear).
+private func advanceArchivedSelectionIfNeeded(worktreeID: UUID) {
+    let repoID = archivedWorktrees.first(where: { (_, wts) in
+        wts.contains(where: { $0.id == worktreeID })
+    })?.key
+    guard let repoID, selectedArchivedWorktreeIDs[repoID] == worktreeID else { return }
+    let remaining = (archivedWorktrees[repoID] ?? [])
+        .filter { $0.id != worktreeID }
+        .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+    if let next = remaining.first {
+        selectedArchivedWorktreeIDs[repoID] = next.id
+    } else {
+        selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
+    }
+}
+```
+
+`snapshot.repoID` is a non-optional `UUID` on `Worktree`; the `as UUID?` cast above is wrong — drop it. Use `snapshot.repoID` directly:
+
+```swift
+await refreshArchivedWorktrees(repoID: snapshot.repoID)
+```
+
+(Remove the `if let repoID = ... as UUID?` block. The corrected version is just two lines.)
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: builds clean. The `HistoryPaneView` call site from Task 4 now resolves.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/AppState+History.swift
+git commit -m "feat(app): add reviveWithSession with lingering revive state"
+```
+
+---
+
+## Task 8: Auto-select most-recent archived row
+
+**Files:**
+- Modify: `Sources/TBDApp/AppState+Worktrees.swift` (in `refreshArchivedWorktrees`)
+
+- [ ] **Step 1: Add auto-select logic to `refreshArchivedWorktrees`**
+
+In `Sources/TBDApp/AppState+Worktrees.swift`, locate `refreshArchivedWorktrees(repoID:)` (line 192). Replace the body with:
+
+```swift
+func refreshArchivedWorktrees(repoID: UUID) async {
+    do {
+        let archived = try await daemonClient.listWorktrees(repoID: repoID, status: .archived)
+        archivedWorktrees[repoID] = archived
+        ensureArchivedSelectionValid(repoID: repoID)
+    } catch {
+        logger.error("Failed to list archived worktrees: \(error)")
+    }
+}
+
+/// Ensure `selectedArchivedWorktreeIDs[repoID]` points to a row that
+/// actually exists in the archived list (or in `revivingArchived` for that
+/// repo). If unset or stale, set it to the most-recently-archived row.
+/// Also kicks off the session fetch for the newly-selected worktree.
+private func ensureArchivedSelectionValid(repoID: UUID) {
+    let archived = (archivedWorktrees[repoID] ?? [])
+    let lingering = revivingArchived.values
+        .map(\.snapshot)
+        .filter { $0.repoID == repoID }
+    let allIDs = Set(archived.map(\.id) + lingering.map(\.id))
+
+    let current = selectedArchivedWorktreeIDs[repoID]
+    let needsNew = current == nil || !allIDs.contains(current!)
+    guard needsNew else { return }
+
+    let mostRecent = archived
+        .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+        .first
+    if let pick = mostRecent {
+        selectedArchivedWorktreeIDs[repoID] = pick.id
+        Task { await fetchSessions(worktreeID: pick.id) }
+    } else {
+        selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `swift build`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDApp/AppState+Worktrees.swift
+git commit -m "feat(app): auto-select most-recently-archived row on refresh"
+```
+
+---
+
+## Task 9: Clear `revivingArchived` on navigate-away
+
+**Files:**
+- Modify: `Sources/TBDApp/AppState+Navigation.swift`
+
+- [ ] **Step 1: Add a clear-on-leave hook**
+
+In `Sources/TBDApp/AppState+Navigation.swift`, modify `applyNavigationEntry` (around line 66) to clear lingering revive state for any repo whose archived view we are leaving:
+
+```swift
+private func applyNavigationEntry(_ entry: NavigationEntry) {
+    let leavingRepoID = selectedRepoID
+    switch entry {
+    case .worktrees(let ids):
+        if let leavingRepoID { clearRevivingArchived(repoID: leavingRepoID) }
+        selectedRepoID = nil
+        selectedWorktreeIDs = Set(ids)
+        selectionOrder = ids
+    case .repo(let id):
+        if let leavingRepoID, leavingRepoID != id {
+            clearRevivingArchived(repoID: leavingRepoID)
+        }
+        selectedWorktreeIDs = []
+        selectedRepoID = id
+        Task { await refreshArchivedWorktrees(repoID: id) }
+    }
+}
+```
+
+This handles back/forward. The forward "fresh navigation" path (e.g. clicking another sidebar entry) goes through `selectedWorktreeIDs.didSet` / `selectedRepoID.didSet` in `AppState.swift`. Add the same cleanup there.
+
+- [ ] **Step 2: Add the helper**
+
+At the bottom of `AppState+Navigation.swift` (still inside `extension AppState`), add:
+
+```swift
+/// Drop any lingering revive snapshots that belong to the given repo —
+/// called when the user leaves that repo's archived view, so coming back
+/// shows a fresh list without "Revived ✓" rows.
+func clearRevivingArchived(repoID: UUID) {
+    revivingArchived = revivingArchived.filter { _, state in
+        state.snapshot.repoID != repoID
+    }
+}
+```
+
+- [ ] **Step 3: Wire fresh navigation in `AppState.swift`**
+
+In `Sources/TBDApp/AppState.swift`, update the `selectedWorktreeIDs` `didSet` (lines 17-39). Inside the existing `if !selectedWorktreeIDs.isEmpty { ... }` block at line 35, add a clear call before `recordNavigation`:
+
+```swift
+if !selectedWorktreeIDs.isEmpty {
+    if let leaving = selectedRepoID { clearRevivingArchived(repoID: leaving) }
+    selectedRepoID = nil
+    recordNavigation(.worktrees(selectionOrder))
+}
+```
+
+Update the `selectedRepoID` `didSet` (lines 44-49) to clear the OLD repo's lingering state when switching to a different repo:
+
+```swift
+@Published var selectedRepoID: UUID? = nil {
+    didSet {
+        if let old = oldValue, old != selectedRepoID {
+            clearRevivingArchived(repoID: old)
+        }
+        guard selectedRepoID != oldValue, let id = selectedRepoID else { return }
+        recordNavigation(.repo(id))
+    }
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `swift build`
+Expected: builds clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDApp/AppState.swift Sources/TBDApp/AppState+Navigation.swift
+git commit -m "feat(app): clear lingering revive snapshots on navigate-away"
+```
+
+---
+
+## Task 10: Refactor `ArchivedWorktreesView` into nested HSplit
+
+**Files:**
+- Modify: `Sources/TBDApp/ArchivedWorktreesView.swift` (full rewrite)
+
+- [ ] **Step 1: Read the existing file**
+
+Read the current `Sources/TBDApp/ArchivedWorktreesView.swift` end-to-end. Note the empty state, the header row, and the `ArchivedWorktreeRow` styling — the new version preserves these patterns.
+
+- [ ] **Step 2: Rewrite the file**
+
+Replace the entire contents with:
+
+```swift
+import SwiftUI
+import TBDShared
+
+struct ArchivedWorktreesView: View {
+    let repoID: UUID
+    @EnvironmentObject var appState: AppState
+
+    @State private var listWidth: CGFloat = 280
+    @State private var dragStartWidth: CGFloat? = nil
+
+    /// Display rows = archived worktrees ∪ lingering revive snapshots,
+    /// deduped by id, sorted by archivedAt desc.
+    private var rows: [ArchivedRow] {
+        let archived = (appState.archivedWorktrees[repoID] ?? [])
+        let lingering = appState.revivingArchived
+            .compactMap { (id, state) -> Worktree? in
+                guard state.snapshot.repoID == repoID else { return nil }
+                return state.snapshot
+            }
+        var byID: [UUID: Worktree] = [:]
+        for wt in archived { byID[wt.id] = wt }
+        for wt in lingering where byID[wt.id] == nil { byID[wt.id] = wt }
+        return byID.values
+            .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
+            .map { wt in
+                ArchivedRow(worktree: wt, reviveState: appState.revivingArchived[wt.id])
+            }
+    }
+
+    private var selectedID: UUID? {
+        appState.selectedArchivedWorktreeIDs[repoID]
+    }
+
+    var body: some View {
+        if rows.isEmpty {
+            emptyState
+        } else {
+            HStack(spacing: 0) {
+                leftRail
+                    .frame(width: listWidth)
+                divider
+                rightPane
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+    }
+
+    // MARK: - Left rail
+
+    private var leftRail: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Archived")
+                    .font(.title3)
+                    .fontWeight(.medium)
+                Spacer()
+                Text("\(rows.count)")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 1) {
+                        ForEach(rows) { row in
+                            ArchivedWorktreeRow(
+                                row: row,
+                                isSelected: selectedID == row.id,
+                                onSelect: { select(row) }
+                            )
+                            .id(row.id)
+                        }
+                    }
+                    .padding(.vertical, 6)
+                }
+                .onChange(of: appState.highlightedArchivedWorktreeID, initial: true) { _, newValue in
+                    guard let id = newValue, rows.contains(where: { $0.id == id }) else { return }
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        proxy.scrollTo(id, anchor: .center)
+                    }
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(900))
+                        if appState.highlightedArchivedWorktreeID == id {
+                            appState.highlightedArchivedWorktreeID = nil
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            // Trigger initial selection if nothing is set yet. The async refresh
+            // path also calls into `ensureArchivedSelectionValid`, but on
+            // re-appearances (cached `archivedWorktrees`) we still need this.
+            if selectedID == nil, let first = rows.first?.worktree {
+                appState.selectedArchivedWorktreeIDs[repoID] = first.id
+                Task { await appState.fetchSessions(worktreeID: first.id) }
+            }
+        }
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(Color(nsColor: .separatorColor))
+            .frame(width: 1)
+            .contentShape(Rectangle().inset(by: -3))
+            .cursor(.resizeLeftRight)
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        if dragStartWidth == nil { dragStartWidth = listWidth }
+                        let newWidth = (dragStartWidth ?? listWidth) + value.translation.width
+                        listWidth = max(220, min(400, newWidth))
+                    }
+                    .onEnded { _ in dragStartWidth = nil }
+            )
+    }
+
+    // MARK: - Right pane
+
+    @ViewBuilder
+    private var rightPane: some View {
+        if let id = selectedID,
+           let row = rows.first(where: { $0.id == id }) {
+            if (row.worktree.archivedClaudeSessions ?? []).isEmpty {
+                noSessionsState(for: row.worktree)
+            } else {
+                HistoryPaneView(worktreeID: id, transcriptAction: .reviveWithSession)
+            }
+        } else {
+            VStack(spacing: 8) {
+                Text("Select a worktree")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func noSessionsState(for worktree: Worktree) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.system(size: 32))
+                .foregroundStyle(.tertiary)
+            Text("No archived sessions")
+                .foregroundStyle(.secondary)
+                .font(.callout)
+            Button("Revive") {
+                Task { await appState.reviveWorktree(id: worktree.id) }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Empty list state
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "archivebox")
+                .font(.system(size: 36))
+                .foregroundStyle(.secondary)
+            Text("No Archived Worktrees")
+                .font(.title3)
+                .fontWeight(.medium)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Actions
+
+    private func select(_ row: ArchivedRow) {
+        // In-flight or done revives are non-selectable.
+        guard row.reviveState == nil else { return }
+        appState.selectedArchivedWorktreeIDs[repoID] = row.id
+        Task { await appState.fetchSessions(worktreeID: row.id) }
+    }
+}
+
+// MARK: - Row model
+
+private struct ArchivedRow: Identifiable {
+    let worktree: Worktree
+    let reviveState: ReviveState?
+    var id: UUID { worktree.id }
+}
+
+// MARK: - Row view
+
+private struct ArchivedWorktreeRow: View {
+    let row: ArchivedRow
+    let isSelected: Bool
+    let onSelect: () -> Void
+    @EnvironmentObject var appState: AppState
+
+    private var hasClaudeSessions: Bool {
+        row.worktree.archivedClaudeSessions?.isEmpty == false
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(row.worktree.displayName)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+                    statusPill
+                }
+                HStack(spacing: 6) {
+                    Label(row.worktree.branch, systemImage: "arrow.triangle.branch")
+                        .lineLimit(1)
+                    if let archivedAt = row.worktree.archivedAt, row.reviveState == nil {
+                        Text("·")
+                        Text(archivedAt, format: .relative(presentation: .named))
+                    }
+                    if hasClaudeSessions, row.reviveState == nil {
+                        let count = row.worktree.archivedClaudeSessions?.count ?? 0
+                        Text("·")
+                        Text("\(count) session\(count == 1 ? "" : "s")")
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .background(rowBackground)
+        .cornerRadius(6)
+        .padding(.horizontal, 8)
+        .onTapGesture { onSelect() }
+        .contextMenu {
+            if row.reviveState == nil {
+                Button("Revive") {
+                    Task { await appState.reviveWorktree(id: row.worktree.id) }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var statusPill: some View {
+        switch row.reviveState {
+        case .inFlight:
+            HStack(spacing: 4) {
+                ProgressView().controlSize(.mini)
+                Text("Reviving…")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        case .done:
+            Text("Revived ✓")
+                .font(.caption)
+                .foregroundStyle(.green)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.green.opacity(0.12), in: Capsule())
+        case .none:
+            EmptyView()
+        }
+    }
+
+    private var rowBackground: Color {
+        if appState.highlightedArchivedWorktreeID == row.worktree.id {
+            return Color.accentColor.opacity(0.25)
+        }
+        if isSelected {
+            return Color.accentColor.opacity(0.18)
+        }
+        return Color.primary.opacity(0.03)
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `swift build`
+Expected: builds clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDApp/ArchivedWorktreesView.swift
+git commit -m "feat(app): nested master-detail layout for archived worktrees"
+```
+
+---
+
+## Task 11: Restart and manual verification
+
+**Files:** none (runtime testing)
+
+- [ ] **Step 1: Full restart**
+
+This touches daemon + shared code. Per `CLAUDE.md`, use the worktree's own script and verify only one daemon/app pair is running.
+
+Run from the worktree root: `scripts/restart.sh`
+
+Then verify exactly one TBDDaemon and one TBDApp from this worktree path:
+
+```bash
+ps aux | grep -E "\.build/debug/TBD" | grep -v grep
+```
+
+If stale processes exist: `pkill -f TBDDaemon; pkill -f TBDApp` then re-run `scripts/restart.sh`.
+
+- [ ] **Step 2: Verify active-worktree history auto-select**
+
+In TBD, select an active worktree that has past Claude sessions. Open the history pane (existing toggle). Expected: the first session is selected on initial load and its transcript renders without manual clicking. (This is the universal auto-select behavior added in Task 6.)
+
+- [ ] **Step 3: Verify archived view layout**
+
+Click a repo's "Archived" sidebar entry. Expected:
+- Left rail shows the archived list, draggable divider on its right edge.
+- Right pane shows the most-recently-archived worktree's session list and the first session's transcript.
+- No inline Revive buttons on rows.
+
+- [ ] **Step 4: Verify selection switching**
+
+Click a different archived row. Expected: right pane updates to show that worktree's sessions; the first session is auto-selected and its transcript loads.
+
+- [ ] **Step 5: Verify revive-with-session**
+
+With an archived row selected and a session selected in the middle column, click "Revive with this session" in the transcript header. Expected:
+- The archived row immediately shows a `ProgressView` + "Reviving…".
+- The row becomes non-selectable; selection moves to the next archived row.
+- After revive completes, the row shows "Revived ✓" pill (green).
+- The revived worktree appears in the active sidebar list.
+- The new active worktree's primary terminal is resuming the chosen Claude session (verify by reading the terminal contents — it should show the conversation, not a fresh `claude` invocation).
+
+- [ ] **Step 6: Verify lingering-row-clear-on-navigate**
+
+With a "Revived ✓" row visible, click any other sidebar entry (active worktree or different repo's archived). Then click the original repo's "Archived" entry again. Expected: the revived row is gone — list is fresh.
+
+- [ ] **Step 7: Verify context-menu Revive**
+
+Right-click any archived row. Expected: a "Revive" menu item appears. Selecting it kicks off a session-less revive (uses stored `archivedClaudeSessions.first` order), with the same in-flight / done UI feedback as Step 5.
+
+- [ ] **Step 8: Verify empty-archived-sessions state**
+
+Find or create an archived worktree with no Claude sessions (the `archivedClaudeSessions` field is nil/empty). Select it. Expected: right pane shows "No archived sessions" + a plain "Revive" button. Clicking the button revives the worktree.
+
+- [ ] **Step 9: Verify path-based session resolution survives archive**
+
+For an archived worktree with sessions, confirm the right pane's session list actually populates (not empty). This validates the spec's assumption that `worktree.path` is preserved in the DB after archive and that Claude's `~/.claude/projects/...` JSONLs still resolve. If the list is unexpectedly empty for an archived worktree that *did* have sessions before archive, escalate — the daemon's `handleSessionList` may need a fallback path that uses `archivedClaudeSessions` IDs to find files.
+
+- [ ] **Step 10: Note manual results**
+
+Reply with which steps passed and which (if any) revealed issues. Do not commit anything in this task — it's verification only.
+
+---
+
+## Self-Review
+
+Run this checklist after writing all the tasks above (the agent doing the implementation does NOT need to repeat this — it's for the planner).
+
+**Spec coverage:**
+- Layout (HSplit, draggable, 220–400 clamp): Task 10 ✓
+- HistoryPaneView parameterization: Task 4 ✓
+- AppState additions (selectedArchivedWorktreeIDs, revivingArchived, ReviveState): Task 5 ✓
+- reviveWithSession method: Task 7 ✓
+- Daemon reorder support: Tasks 1–3 ✓
+- Universal first-session auto-select: Task 6 ✓
+- Most-recent-archived auto-select: Task 8 ✓ + onAppear safety net in Task 10 ✓
+- Lingering revived rows + clear-on-navigate-away: Tasks 7, 9 ✓
+- Per-row inline Revive removed; context-menu Revive added: Task 10 ✓
+- Empty-state right pane Revive button: Task 10 ✓
+
+**Placeholder scan:** no TBD/TODO/"add appropriate" — fixed inline corrections in Tasks 5 and 7 (the `Equatable` aside, the `as UUID?` cast). All code blocks are complete.
+
+**Type consistency:** `ReviveState` defined in Task 5 used in Tasks 7, 9, 10. `TranscriptAction` defined in Task 4 used in Task 10. `WorktreeReviveParams.preferredSessionID` defined in Task 1, plumbed through Tasks 2–3, called in Task 7. `reviveWithSession` defined in Task 7, called in Task 4's view (build-broken-then-fixed gap noted explicitly).
+
+---
+
+## Execution Notes for the Implementer
+
+1. **Tasks 1–3 are tightly coupled** (shared-types + daemon + client) — execute as a unit, verify build at end of Task 3 before moving on.
+2. **Task 4 ends with a non-building tree** — this is intentional and called out. Task 7 closes the gap. Do not commit a "skip-build" note in the actual commit.
+3. **Task 6's auto-select change affects active worktrees too.** This is by design (per the spec). Manual verification step 2 in Task 11 covers the active-worktree path.
+4. **Watch for `Worktree` Equatable**: if Step 2 of Task 5 fails because `Worktree` isn't `Equatable`, drop the `: Equatable` from `ReviveState` and SwiftUI will fall back to identity-based diffs — fine for our use.
+5. **Restart correctly** (Task 11 Step 1): use `scripts/restart.sh`, not the absolute path to main's copy. Verify only one daemon/app pair via `ps`.

--- a/docs/superpowers/specs/2026-04-30-archived-worktree-history-design.md
+++ b/docs/superpowers/specs/2026-04-30-archived-worktree-history-design.md
@@ -1,0 +1,134 @@
+# Archived Worktree Conversation History
+
+**Date:** 2026-04-30
+**Status:** Design
+
+## Problem
+
+Active worktrees expose their Claude conversation history through `HistoryPaneView` — a master-detail of session list (left) + transcript (right) toggled from the worktree's main pane. Archived worktrees expose nothing equivalent: `ArchivedWorktreesView` is a flat list with inline Revive buttons. Users want to browse archived conversations the same way they browse live ones, and revive directly into a chosen past session.
+
+## Goals
+
+- Browse archived worktrees' Claude sessions and transcripts using the same interaction model as active worktrees.
+- Reuse `HistoryPaneView` rather than reimplementing master-detail logic.
+- Provide a one-click "revive and resume this conversation" path.
+- Keep recently-revived rows visible briefly so the action feels acknowledged, without making the archived list stale on return visits.
+
+## Non-Goals
+
+- Bulk operations (revive multiple, delete archived, etc.).
+- Editing or annotating archived sessions.
+- Surfacing archived sessions outside the archived view (e.g. global search).
+
+## Design
+
+### Layout — nested master-detail (option C)
+
+`ArchivedWorktreesView` becomes an outer `HSplit`:
+
+- **Left rail:** archived-worktree list. Default width 280pt, draggable, clamped 220–400. Rows become *selectable* (accent tint matches active sidebar). Header strip and empty state stay as-is.
+- **Right pane:** the existing `HistoryPaneView(worktreeID:)` rendered against the selected archived worktree. Its internal session-list/transcript divider stays draggable and independent.
+
+If the selected archived worktree has zero Claude sessions, the right pane shows an empty state with a plain **Revive** button (nothing to resume).
+
+### `HistoryPaneView` parameterization
+
+`HistoryPaneView` gains one parameter:
+
+```swift
+enum TranscriptAction {
+    case resume                    // active worktree: open new terminal resuming the session
+    case reviveWithSession         // archived worktree: revive worktree, resume selected session
+}
+
+struct HistoryPaneView: View {
+    let worktreeID: UUID
+    let transcriptAction: TranscriptAction = .resume   // default preserves current call sites
+    ...
+}
+```
+
+The transcript header dispatches on `transcriptAction`:
+
+- `.resume` → button label "Resume", calls existing `appState.resumeSession(worktreeID:sessionId:)`.
+- `.reviveWithSession` → button label "Revive with this session", calls new `appState.reviveWithSession(worktreeID:sessionId:)`.
+
+No other branching inside `HistoryPaneView`.
+
+### `AppState` additions
+
+```swift
+@Published var selectedArchivedWorktreeIDs: [UUID: UUID] = [:]   // repoID → archivedWorktreeID
+
+enum ReviveState {
+    case inFlight(snapshot: Worktree)
+    case done(snapshot: Worktree)
+}
+@Published var revivingArchived: [UUID: ReviveState] = [:]       // worktreeID → state
+```
+
+New methods:
+
+```swift
+func reviveWithSession(worktreeID: UUID, sessionId: String) async
+```
+
+Reorders `archivedClaudeSessions` so the selected `sessionId` is first, then calls the existing revive RPC. The daemon already resumes `archivedClaudeSessions.first` in the new terminal, so reordering is sufficient.
+
+### Auto-selection
+
+Two rules, both applied in `AppState`:
+
+1. **Archived row auto-select.** When `ArchivedWorktreesView` appears or when `archivedWorktrees[repoID]` changes, if `selectedArchivedWorktreeIDs[repoID]` is unset OR points to a worktree no longer in the archived list, set it to the most-recently-archived row (top of the existing `archivedAt` sort).
+
+2. **First-session auto-select (universal).** When `historyLoadStates[wt]` transitions to `.loaded(sessions)` and `selectedSessionIDs[wt]` is unset and `sessions` is non-empty, select `sessions.first` and call `selectSession` to load its transcript. This applies to active worktrees too — the simpler universal rule replaces today's "select nothing until clicked" default.
+
+Selection changes for archived rows trigger `fetchSessions(worktreeID:)` via the existing path.
+
+### Lingering revived rows
+
+When the user revives an archived worktree from this view, its row stays visible — with feedback — until they navigate away from the archived section.
+
+- **On revive start:** snapshot the `Worktree`, set `revivingArchived[id] = .inFlight(snapshot)`.
+  - Row shows a small `ProgressView` and "Reviving…" subtitle in place of the archived-at timestamp.
+  - Row becomes non-selectable; if it was the current selection, advance selection to the next archived row.
+- **On revive success:** flip to `.done(snapshot)`. Row shows a green "Revived ✓" pill.
+- **On revive failure:** clear `revivingArchived[id]`, surface error via existing `handleConnectionError` path.
+- **Row list computation:** `archived = (archivedWorktrees[repoID] ∪ revivingArchived.snapshots.filter { $0.repoID == repoID })` deduped by id, sorted by `archivedAt` desc. During the in-flight window the worktree is in both sets; once the daemon reconciles, only the snapshot keeps it visible.
+- **Clear-on-navigate-away:** in `AppState+Navigation`, when the active sidebar selection changes to anything other than this repo's Archived entry, drop all `revivingArchived` entries belonging to that repo. Coming back → list is fresh, no lingering rows.
+- **Edge case:** if the user navigates away while a revive is `.inFlight`, the RPC continues in the background. The worktree appears in the active sidebar normally; on return to the archived view, no lingering row is shown.
+
+### Per-row affordances
+
+- **Inline Revive button:** removed. The transcript-header "Revive with this session" covers the common case (auto-selected first session is the most recent conversation).
+- **Context menu on row:** add a single **Revive** item that calls the existing session-less revive (equivalent to today's button). Useful when the user wants to revive without picking a specific session.
+- **Selection styling:** accent tint (`Color.accentColor.opacity(0.18)`) matches the active sidebar's row treatment. The existing `highlightedArchivedWorktreeID` flash animation is unaffected.
+
+### Daemon-side considerations
+
+`handleSessionList` currently resolves the Claude project dir from `worktree.path`. After archive, the worktree row in the DB still has its `path` field, and Claude's JSONL files in `~/.claude/projects/...` are not deleted when the worktree dir is removed. So the existing RPC works for archived worktrees without daemon changes. (Verify during implementation: if the path-based resolution returns nil for some reason, the daemon may need to fall back to `archivedClaudeSessions` to filter sessions explicitly.)
+
+## Component map
+
+- `Sources/TBDApp/ArchivedWorktreesView.swift` — outer `HSplit`, row selection, lingering-revive merging, context menu.
+- `Sources/TBDApp/Panes/HistoryPaneView.swift` — add `transcriptAction` parameter, dispatch in header.
+- `Sources/TBDApp/AppState.swift` — add `selectedArchivedWorktreeIDs`, `revivingArchived`.
+- `Sources/TBDApp/AppState+History.swift` — add `reviveWithSession(...)`, add universal first-session auto-select in the post-load path.
+- `Sources/TBDApp/AppState+Worktrees.swift` — auto-select most-recent archived row on archived-list updates.
+- `Sources/TBDApp/AppState+Navigation.swift` — clear `revivingArchived` for repo on navigate-away.
+
+No daemon, RPC, or schema changes expected.
+
+## Testing
+
+- Selecting an archived row triggers session fetch; sessions load → first session auto-selected → transcript loads.
+- Most-recently-archived row is selected on first appearance.
+- "Revive with this session" reorders sessions and revives; new terminal resumes the chosen session.
+- Lingering row shows `Reviving…` then `Revived ✓`; disappears after navigate-away → return.
+- Context menu Revive works for rows with no sessions.
+- Empty-state right pane shows Revive button when archived worktree has zero sessions.
+- Active-worktree history view (existing call site) still works — first session auto-selects on initial load (new behavior; verify it matches expectations).
+
+## Open questions
+
+None.

--- a/docs/superpowers/specs/2026-04-30-archived-worktree-history-design.md
+++ b/docs/superpowers/specs/2026-04-30-archived-worktree-history-design.md
@@ -73,7 +73,7 @@ New methods:
 func reviveWithSession(worktreeID: UUID, sessionId: String) async
 ```
 
-Reorders `archivedClaudeSessions` so the selected `sessionId` is first, then calls the existing revive RPC. The daemon already resumes `archivedClaudeSessions.first` in the new terminal, so reordering is sufficient.
+Calls the revive RPC with a new optional `preferredSessionID` parameter. The daemon, when provided, reorders the worktree's stored `archivedClaudeSessions` so the preferred ID is first, then runs the existing setup-terminals path (which already resumes `archivedClaudeSessions.first`). Reordering happens in the daemon, not the client, so the on-disk DB state stays consistent if the user reverts.
 
 ### Auto-selection
 
@@ -117,7 +117,7 @@ When the user revives an archived worktree from this view, its row stays visible
 - `Sources/TBDApp/AppState+Worktrees.swift` — auto-select most-recent archived row on archived-list updates.
 - `Sources/TBDApp/AppState+Navigation.swift` — clear `revivingArchived` for repo on navigate-away.
 
-No daemon, RPC, or schema changes expected.
+Daemon: extend `WorktreeReviveParams` with `preferredSessionID: String?`, and the lifecycle revive path reorders `archivedClaudeSessions` accordingly before `setupTerminals`. No schema changes.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Archived worktrees now show a nested master-detail history view: archived list on the left, session list and transcript on the right (the existing `HistoryPaneView` reused as-is via a new `transcriptAction` parameter).
- The transcript header gains a "Revive with this session" action — revives the worktree and resumes the chosen Claude session in its primary terminal, in one click. Previously you had to revive blind and never picked up exactly the conversation you wanted.
- Auto-selects the most-recently-archived row on entry and the first session on load, so the view is useful without any clicking. (The same first-session auto-select also applies to active worktrees' history pane.)
- Filter dropdown in the archived header (default on) hides worktrees with no conversations on disk. Daemon scans each worktree's Claude project dir at list time and returns a real `liveClaudeSessionCount`, since the stored `archivedClaudeSessions` field can be stale.
- Just-revived rows linger with a "Reviving…" spinner and "Revived ✓" pill until you navigate away, so the action feels acknowledged.

Spec: `docs/superpowers/specs/2026-04-30-archived-worktree-history-design.md`
Plan: `docs/superpowers/plans/2026-04-30-archived-worktree-history.md`

## Test plan

- [ ] Open a repo's "Archived" sidebar entry. Most-recently-archived row is selected; right pane shows its session list with the first session's transcript loaded.
- [ ] Click a different archived row → sessions update; first session auto-selects and loads.
- [ ] With a session selected, click "Revive with this session". Row shows "Reviving…" spinner, then "Revived ✓"; the new active worktree's primary terminal is resuming that exact conversation.
- [ ] After revive, navigate to any other sidebar entry and back to Archived → lingering row is gone.
- [ ] Right-click a row → context menu Revive works without picking a session.
- [ ] Archived worktree with zero on-disk sessions: right pane shows "No archived sessions" + a plain Revive button.
- [ ] Filter dropdown toggles "Hide worktrees with no conversations". Default on. Worktrees whose stored session IDs point to deleted JSONL files (e.g. `lungfish`, `mollusk` in my workspace) are correctly hidden when the filter is on.
- [ ] Active worktree history pane: opening it auto-selects the first session and renders the transcript.
- [ ] Existing revive flow (without a session pick) still works: takes you to the new active worktree with sessions resumed in stored order.