### PR TITLE
fix: prevent TBD_WORKTREE_ID leak from daemon env into tmux servers and recreated panes

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -23,6 +23,22 @@ public final class Daemon: Sendable {
         self.startTime = Date()
     }
 
+    /// Remove inherited TBD_* environment variables from the daemon's own
+    /// process environment. Called at startup before any tmux server is spawned.
+    ///
+    /// Rationale: tmux servers persist the env they were spawned with as their
+    /// global environment, and that env is then injected into every new window
+    /// (including reboot-recovery recreations). If the daemon inherits e.g.
+    /// `TBD_WORKTREE_ID=<main-uuid>` from a TBD-spawned launcher shell, every
+    /// recreated pane in every sub-worktree would report itself as the main
+    /// worktree, causing notifications to be misattributed.
+    public static func scrubInheritedTBDEnv() {
+        unsetenv("TBD_WORKTREE_ID")
+        unsetenv("TBD_PROMPT_CONTEXT")
+        unsetenv("TBD_PROMPT_INSTRUCTIONS")
+        unsetenv("TBD_PROMPT_RENAME")
+    }
+
     /// Start the daemon: create config directory, clean up stale state,
     /// initialize database and all managers, start servers, reconcile worktrees.
     public func start() async throws {
@@ -48,7 +64,16 @@ public final class Daemon: Sendable {
         // 4. Write PID file
         try pidFile.write()
 
-        // 4a. Resolve SSH agent symlink and update daemon's own environment
+        // 4a. Scrub inherited TBD_* env vars before any tmux server is spawned.
+        // The daemon may have been launched from inside a TBD-spawned shell (e.g.
+        // `scripts/restart.sh` run from a terminal pane), which exports per-worktree
+        // TBD_* vars. Without this scrub, the first `tmux new-session` bakes those
+        // vars into the tmux server's global env, poisoning every recreated pane
+        // (notifications from sub-worktrees would route to whichever worktree the
+        // daemon was last restarted from).
+        Daemon.scrubInheritedTBDEnv()
+
+        // 4b. Resolve SSH agent symlink and update daemon's own environment
         let sshResolver = SSHAgentResolver()
         if await sshResolver.resolve() {
             setenv("SSH_AUTH_SOCK", sshResolver.symlinkPath, 1)

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -80,7 +80,7 @@ public final class Daemon: Sendable {
             print("[Daemon] SSH agent symlink resolved: \(sshResolver.symlinkPath)")
         }
 
-        // 4b. Start periodic SSH agent refresh (every 60s)
+        // 4c. Start periodic SSH agent refresh (every 60s)
         self.sshRefreshTask = Task {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(60))

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -223,13 +223,22 @@ extension WorktreeLifecycle {
 
     /// Recreates a tmux window for a terminal record after the tmux server has been lost
     /// (e.g. machine reboot). Updates the terminal's stored window/pane IDs in the DB.
-    private func recreateAfterReboot(terminal: Terminal, worktree: Worktree) async throws {
+    ///
+    /// Visibility: `internal` (not `private`) so tests in the same module can drive
+    /// this path directly. The reconcile dispatcher only enters this branch when
+    /// `serverExists → false`, which `TmuxManager(dryRun: true)` cannot simulate.
+    internal func recreateAfterReboot(terminal: Terminal, worktree: Worktree) async throws {
         if let bootstrapWindowID = try await tmux.ensureServer(server: worktree.tmuxServer, session: "main", cwd: worktree.path) {
             try? await tmux.killWindow(server: worktree.tmuxServer, windowID: bootstrapWindowID)
         }
 
         let spawn: ClaudeSpawnCommandBuilder.Result
         var env: [String: String] = [:]
+        // Always announce the worktree to recreated panes. Without this, the
+        // pane inherits whatever TBD_WORKTREE_ID the tmux server was spawned
+        // with — which would misattribute notifications to a different
+        // worktree. Applies to all branches below (claude, codex, shell/cmd).
+        env["TBD_WORKTREE_ID"] = worktree.id.uuidString
 
         if let sessionID = terminal.claudeSessionID {
             // Claude terminal — resume existing session with persisted token
@@ -251,7 +260,6 @@ extension WorktreeLifecycle {
             // Codex terminal — detected by label "Codex" (set during terminal creation).
             // No structured type field exists; label matching is the only discriminator available.
             let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
-            env["TBD_WORKTREE_ID"] = worktree.id.uuidString
             env["CODEX_HOME"] = codexHome.path
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -233,14 +233,20 @@ extension RPCRouter {
         )
 
         // Create a new tmux window with a default shell.
-        // Note: no TBD_WORKTREE_ID env var here (unlike handleTerminalCreate)
-        // since recreated windows run a plain shell, not Claude.
+        // Defensively set TBD_WORKTREE_ID even though the recreated pane runs a
+        // plain shell — the user may run `tbd` CLI commands or launch `claude`
+        // themselves from that shell, and those tools resolve the worktree from
+        // the env. Without this set, the pane would inherit whatever TBD_WORKTREE_ID
+        // got baked into the tmux server's global env, leaking another worktree's
+        // identity into this one.
         let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let env: [String: String] = ["TBD_WORKTREE_ID": worktree.id.uuidString]
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
             session: "main",
             cwd: worktree.path,
             shellCommand: shell,
+            env: env,
             cols: resolvedCols,
             rows: resolvedRows
         )

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -45,7 +45,17 @@ private func newWindowBodies(_ recorded: [[String]]) -> [String] {
 
 @Test("Daemon.scrubInheritedTBDEnv clears all four TBD_* vars")
 func testScrubInheritedTBDEnv() {
-    // Seed sentinel values for all four vars.
+    // setenv/unsetenv mutate the shared process environ. Guarantee cleanup
+    // even if #expect failures or future edits cause us to skip the scrub
+    // call below — Swift Testing runs tests concurrently by default and any
+    // future test that reads these vars must not see leaked sentinels.
+    defer {
+        unsetenv("TBD_WORKTREE_ID")
+        unsetenv("TBD_PROMPT_CONTEXT")
+        unsetenv("TBD_PROMPT_INSTRUCTIONS")
+        unsetenv("TBD_PROMPT_RENAME")
+    }
+
     setenv("TBD_WORKTREE_ID", "leaked-worktree-id", 1)
     setenv("TBD_PROMPT_CONTEXT", "leaked-context", 1)
     setenv("TBD_PROMPT_INSTRUCTIONS", "leaked-instructions", 1)

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -1,0 +1,290 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Regression tests for the bug where recreated tmux panes inherited a stale
+/// `TBD_WORKTREE_ID` from their tmux server's global env, mis-routing
+/// notifications from sub-worktrees to the main worktree.
+///
+/// Two surfaces are covered:
+///  1. `Daemon.scrubInheritedTBDEnv()` clears poisoning vars from the daemon's
+///     own env before any tmux server is spawned.
+///  2. The recreate paths (`recreateAfterReboot` and `handleTerminalRecreateWindow`)
+///     defensively set `TBD_WORKTREE_ID` on every new pane so they don't
+///     inherit a stale value from the tmux server's global environment.
+
+// MARK: - Recorder helper (mirrors LifecycleRecordedCommands in WorktreeLifecycleTests)
+
+private final class RecordedCommands: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands: [[String]] = []
+
+    func append(_ args: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        commands.append(args)
+    }
+
+    func snapshot() -> [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return commands
+    }
+}
+
+/// Returns the shell command body (last argument of `new-window`) for any
+/// recorded `new-window` invocation. tmux argv ends with `<shell> -ic <body>`
+/// when env vars are inlined, so the body is the last element.
+private func newWindowBodies(_ recorded: [[String]]) -> [String] {
+    recorded.compactMap { call in
+        guard call.contains("new-window") else { return nil }
+        return call.last
+    }
+}
+
+// MARK: - Fix 1: Daemon scrubInheritedTBDEnv
+
+@Test("Daemon.scrubInheritedTBDEnv clears all four TBD_* vars")
+func testScrubInheritedTBDEnv() {
+    // Seed sentinel values for all four vars.
+    setenv("TBD_WORKTREE_ID", "leaked-worktree-id", 1)
+    setenv("TBD_PROMPT_CONTEXT", "leaked-context", 1)
+    setenv("TBD_PROMPT_INSTRUCTIONS", "leaked-instructions", 1)
+    setenv("TBD_PROMPT_RENAME", "leaked-rename", 1)
+
+    // Sanity: setenv worked.
+    #expect(ProcessInfo.processInfo.environment["TBD_WORKTREE_ID"] == "leaked-worktree-id")
+
+    Daemon.scrubInheritedTBDEnv()
+
+    #expect(ProcessInfo.processInfo.environment["TBD_WORKTREE_ID"] == nil)
+    #expect(ProcessInfo.processInfo.environment["TBD_PROMPT_CONTEXT"] == nil)
+    #expect(ProcessInfo.processInfo.environment["TBD_PROMPT_INSTRUCTIONS"] == nil)
+    #expect(ProcessInfo.processInfo.environment["TBD_PROMPT_RENAME"] == nil)
+}
+
+// MARK: - Fix 2a: recreateAfterReboot sets TBD_WORKTREE_ID on every branch
+
+/// Drive `recreateAfterReboot` for a Claude terminal (has `claudeSessionID`).
+/// Assert the captured shell command exports the correct worktree UUID.
+@Test("recreateAfterReboot — claude branch sets TBD_WORKTREE_ID")
+func testRecreateAfterRebootClaudeBranchSetsWorktreeID() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: tmux,
+        hooks: HookResolver()
+    )
+
+    // Seed a repo + worktree + claude terminal directly in the DB so we can
+    // call recreateAfterReboot without driving full reconcile.
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-claude",
+        branch: "tbd/wt-claude",
+        path: "/tmp/fake-repo/wt-claude",
+        tmuxServer: "tbd-deadbeef"
+    )
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@stale",
+        tmuxPaneID: "%stale",
+        label: "Claude",
+        claudeSessionID: "session-abc-123"
+    )
+
+    try await lifecycle.recreateAfterReboot(terminal: terminal, worktree: wt)
+
+    let bodies = newWindowBodies(recorded.snapshot())
+    #expect(!bodies.isEmpty, "expected at least one new-window invocation")
+    let expected = "export TBD_WORKTREE_ID='\(wt.id.uuidString)';"
+    #expect(bodies.contains { $0.contains(expected) },
+            "claude-branch recreation must export TBD_WORKTREE_ID; got bodies: \(bodies)")
+}
+
+@Test("recreateAfterReboot — codex branch sets TBD_WORKTREE_ID")
+func testRecreateAfterRebootCodexBranchSetsWorktreeID() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: tmux,
+        hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-codex", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-codex",
+        branch: "tbd/wt-codex",
+        path: "/tmp/fake-repo-codex/wt-codex",
+        tmuxServer: "tbd-cafebabe"
+    )
+    // Codex branch is detected by label == "Codex" with no claudeSessionID.
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@stale-codex",
+        tmuxPaneID: "%stale-codex",
+        label: "Codex",
+        claudeSessionID: nil
+    )
+
+    try await lifecycle.recreateAfterReboot(terminal: terminal, worktree: wt)
+
+    let bodies = newWindowBodies(recorded.snapshot())
+    let expected = "export TBD_WORKTREE_ID='\(wt.id.uuidString)';"
+    #expect(bodies.contains { $0.contains(expected) },
+            "codex-branch recreation must export TBD_WORKTREE_ID; got bodies: \(bodies)")
+    // CODEX_HOME should still be exported alongside (regression guard).
+    #expect(bodies.contains { $0.contains("export CODEX_HOME=") },
+            "codex-branch must still export CODEX_HOME; got bodies: \(bodies)")
+}
+
+@Test("recreateAfterReboot — shell branch sets TBD_WORKTREE_ID")
+func testRecreateAfterRebootShellBranchSetsWorktreeID() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: tmux,
+        hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-shell", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-shell",
+        branch: "tbd/wt-shell",
+        path: "/tmp/fake-repo-shell/wt-shell",
+        tmuxServer: "tbd-feedface"
+    )
+    // Shell branch: label is "shell" (or nil), no claudeSessionID, not "Codex".
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@stale-sh",
+        tmuxPaneID: "%stale-sh",
+        label: "shell",
+        claudeSessionID: nil
+    )
+
+    try await lifecycle.recreateAfterReboot(terminal: terminal, worktree: wt)
+
+    let bodies = newWindowBodies(recorded.snapshot())
+    let expected = "export TBD_WORKTREE_ID='\(wt.id.uuidString)';"
+    #expect(bodies.contains { $0.contains(expected) },
+            "shell-branch recreation must export TBD_WORKTREE_ID; got bodies: \(bodies)")
+}
+
+// MARK: - Fix 2b: handleTerminalRecreateWindow sets TBD_WORKTREE_ID
+
+@Test("handleTerminalRecreateWindow sets TBD_WORKTREE_ID on the recreated pane")
+func testHandleTerminalRecreateWindowSetsWorktreeID() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: tmux,
+            hooks: HookResolver()
+        ),
+        tmux: tmux
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-recreate", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-recreate",
+        branch: "tbd/wt-recreate",
+        path: "/tmp/fake-repo-recreate/wt-recreate",
+        tmuxServer: "tbd-12345678"
+    )
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@old",
+        tmuxPaneID: "%old",
+        label: "shell"
+    )
+
+    let request = try RPCRequest(
+        method: RPCMethod.terminalRecreateWindow,
+        params: TerminalRecreateWindowParams(terminalID: terminal.id)
+    )
+    let response = await router.handle(request)
+    #expect(response.success, "expected success; error: \(response.error ?? "nil")")
+
+    let bodies = newWindowBodies(recorded.snapshot())
+    let expected = "export TBD_WORKTREE_ID='\(wt.id.uuidString)';"
+    #expect(bodies.contains { $0.contains(expected) },
+            "handleTerminalRecreateWindow must export TBD_WORKTREE_ID; got bodies: \(bodies)")
+}
+
+// MARK: - Regression: handleTerminalCreate still sets TBD_WORKTREE_ID
+
+@Test("handleTerminalCreate (regression) still exports the correct TBD_WORKTREE_ID")
+func testHandleTerminalCreateRegressionWorktreeID() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: tmux,
+            hooks: HookResolver()
+        ),
+        tmux: tmux
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-create", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-create",
+        branch: "tbd/wt-create",
+        path: "/tmp/fake-repo-create/wt-create",
+        tmuxServer: "tbd-87654321"
+    )
+
+    // type: .shell exercises the simple non-claude, non-codex path.
+    let request = try RPCRequest(
+        method: RPCMethod.terminalCreate,
+        params: TerminalCreateParams(worktreeID: wt.id, type: .shell)
+    )
+    let response = await router.handle(request)
+    #expect(response.success, "expected success; error: \(response.error ?? "nil")")
+
+    let bodies = newWindowBodies(recorded.snapshot())
+    let expected = "export TBD_WORKTREE_ID='\(wt.id.uuidString)';"
+    #expect(bodies.contains { $0.contains(expected) },
+            "handleTerminalCreate must export TBD_WORKTREE_ID matching params.worktreeID; got bodies: \(bodies)")
+}


### PR DESCRIPTION
## Root cause

Recreated tmux panes (after daemon restart, via reconcile, or via the `terminal.recreateWindow` RPC) inherited a stale `TBD_WORKTREE_ID` from their tmux server's **global** environment instead of the worktree they actually live in. Notifications from sub-worktrees showed up under the main worktree's row.

`scripts/restart.sh` is normally invoked from inside a TBD-spawned terminal that exports `TBD_WORKTREE_ID=<main UUID>`. The daemon inherits it; the first `tmux new-session -L tbd-<repo>` bakes that var into the tmux server's global env permanently. Fresh terminals were fine because `handleTerminalCreate` inlines `export TBD_WORKTREE_ID='<correct UUID>';` into the spawn command — but recreate paths didn't.

## Fix

**Fix 1 — `Daemon.scrubInheritedTBDEnv()`**: at daemon startup, before any tmux server is spawned, `unsetenv` the four TBD_* vars (`TBD_WORKTREE_ID`, `TBD_PROMPT_CONTEXT`, `TBD_PROMPT_INSTRUCTIONS`, `TBD_PROMPT_RENAME`). Stops the poison at the source for any fresh `tmux new-session`.

**Fix 2 — recreate paths**: explicitly export `TBD_WORKTREE_ID` on every recreated pane regardless of tmux server env state.
- `WorktreeLifecycle.recreateAfterReboot` (all three branches: claude, codex, shell/cmd) — env assignment hoisted to the top of the function.
- `RPCRouter.handleTerminalRecreateWindow` — previously had a comment claiming plain shells don't need it; that's wrong because users run `tbd` CLI and `claude` from those shells.

## Tests

`Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift` (new, 6 tests):
1. `scrubInheritedTBDEnv` clears all four sentinel vars.
2. `recreateAfterReboot` claude branch exports the worktree UUID.
3. `recreateAfterReboot` codex branch exports the worktree UUID (and still exports `CODEX_HOME`).
4. `recreateAfterReboot` shell branch exports the worktree UUID.
5. `handleTerminalRecreateWindow` exports the worktree UUID.
6. Regression: `handleTerminalCreate` still exports `params.worktreeID.uuidString`.

`swift test` — all 426 tests pass.

## Verification on a running system

After restarting the daemon (`scripts/restart.sh`) and recreating any window, every claude process under any worktree should report its own worktree's UUID:

```bash
for pid in $(pgrep -f '^.*claude '); do
  env=$(ps eww -o command= -p $pid | grep -oE 'TBD_WORKTREE_ID=[A-F0-9-]+')
  cwd=$(lsof -p $pid 2>/dev/null | awk '$4=="cwd"{print $NF; exit}')
  echo "$pid  $cwd  $env"
done
```

The `TBD_WORKTREE_ID=...` should match the worktree directory in `cwd` for every row.

## Note on existing state

Existing tmux servers spawned before this change still have the poisoned `TBD_WORKTREE_ID` baked into their global env. Users must manually clear them (e.g. `tmux -L tbd-<repo> kill-server`) or reboot to fully drop the leaked state — done deliberately so this fix doesn't disrupt live sessions.

## Test plan

- [x] `swift build` succeeds
- [x] `swift test` succeeds (426/426)
- [ ] Restart daemon, recreate a window in a sub-worktree, verify with the snippet above that the new pane reports the sub-worktree's UUID (not the main one)
- [ ] Trigger a reconcile reboot path (kill tmux server, restart daemon) and verify recreated panes also report the correct UUID