### PR TITLE
Feat: Add WIP flag to disable terminal auto-resize (off by default)

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -827,10 +827,28 @@ final class AppState: ObservableObject {
         return truncated.isEmpty ? "conductor" : truncated
     }
 
+    /// UserDefaults key for the WIP terminal-auto-resize feature. Off by
+    /// default — the feature broadcasts main-area pixel size to the daemon
+    /// and resizes every tracked tmux window on app resize / terminal
+    /// create. See `mainAreaTerminalSize()` and `scheduleMainAreaSizeBroadcast()`
+    /// for the two enforcement points. Settings UI toggle lives in the
+    /// "Experimental" section of the General settings tab.
+    static let terminalAutoResizeKey = "enableTerminalAutoResize"
+
+    /// Whether the WIP main-area resize broadcast is enabled. Default false.
+    private var terminalAutoResizeEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Self.terminalAutoResizeKey)
+    }
+
     /// Convert the current `mainAreaSize` (pixels) into tmux cell dimensions
     /// using SwiftTerm's font metrics. Floors at the tmux minimum (80x24) so
     /// degenerate window sizes during launch never produce a too-small pane.
+    /// Returns `(0, 0)` when the auto-resize feature flag is off — both the
+    /// daemon-side `createWindow` resize and the `setMainAreaSize` broadcast
+    /// gate on `cols >= minCols, rows >= minRows` and silently no-op below
+    /// that, so this is the cleanest disable-everything signal.
     func mainAreaTerminalSize() -> (cols: Int, rows: Int) {
+        guard terminalAutoResizeEnabled else { return (0, 0) }
         let cell = TBDTerminalView.cellDimensions(for: TBDTerminalView.defaultMonospaceFont)
         guard cell.width > 0, cell.height > 0 else { return (80, 24) }
         let cols = max(80, Int(mainAreaSize.width / cell.width))
@@ -842,6 +860,7 @@ final class AppState: ObservableObject {
     /// every tracked tmux window. Coalesces rapid resize events into a single
     /// RPC ~300ms after the user stops dragging the window edge.
     private func scheduleMainAreaSizeBroadcast() {
+        guard terminalAutoResizeEnabled else { return }
         mainAreaSizeBroadcastTask?.cancel()
         let (cols, rows) = mainAreaTerminalSize()
         // Skip noop broadcasts: same cell dims as the previous send.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -843,12 +843,14 @@ final class AppState: ObservableObject {
     /// Convert the current `mainAreaSize` (pixels) into tmux cell dimensions
     /// using SwiftTerm's font metrics. Floors at the tmux minimum (80x24) so
     /// degenerate window sizes during launch never produce a too-small pane.
-    /// Returns `(0, 0)` when the auto-resize feature flag is off — both the
-    /// daemon-side `createWindow` resize and the `setMainAreaSize` broadcast
-    /// gate on `cols >= minCols, rows >= minRows` and silently no-op below
-    /// that, so this is the cleanest disable-everything signal.
-    func mainAreaTerminalSize() -> (cols: Int, rows: Int) {
-        guard terminalAutoResizeEnabled else { return (0, 0) }
+    /// Returns `(nil, nil)` when the auto-resize feature flag is off so the
+    /// daemon's `cols ?? TmuxManager.defaultCols` / `rows ?? defaultRows`
+    /// fallback fires (220×50). Returning `(0, 0)` would NOT trigger the
+    /// fallback — `Optional.some(0)` is non-nil — and tmux would drop back
+    /// to its own 80×24 default with the un-reflowable hard-wrapped
+    /// scrollback that #73 introduced these defaults to prevent.
+    func mainAreaTerminalSize() -> (cols: Int?, rows: Int?) {
+        guard terminalAutoResizeEnabled else { return (nil, nil) }
         let cell = TBDTerminalView.cellDimensions(for: TBDTerminalView.defaultMonospaceFont)
         guard cell.width > 0, cell.height > 0 else { return (80, 24) }
         let cols = max(80, Int(mainAreaSize.width / cell.width))
@@ -860,9 +862,14 @@ final class AppState: ObservableObject {
     /// every tracked tmux window. Coalesces rapid resize events into a single
     /// RPC ~300ms after the user stops dragging the window edge.
     private func scheduleMainAreaSizeBroadcast() {
+        // Belt-and-suspenders: `mainAreaTerminalSize()` already returns
+        // (nil, nil) when the flag is off, but this also avoids spinning up
+        // the debounce Task and the noop diff against `lastBroadcastCols/Rows`
+        // for every mainAreaSize change while disabled.
         guard terminalAutoResizeEnabled else { return }
         mainAreaSizeBroadcastTask?.cancel()
         let (cols, rows) = mainAreaTerminalSize()
+        guard let cols, let rows else { return }
         // Skip noop broadcasts: same cell dims as the previous send.
         guard cols != lastBroadcastCols || rows != lastBroadcastRows else { return }
         mainAreaSizeBroadcastTask = Task { [weak self] in

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -87,14 +87,11 @@ struct GeneralSettingsTab: View {
 
             Section {
                 Toggle("Auto-resize tmux windows to match the app pane (WIP)", isOn: $enableTerminalAutoResize)
-                    .help("When on, TBD broadcasts the live pane size to the daemon and resizes every tmux window on app resize. Currently unstable — can leave panes smaller than the visible area and clip the bottom rows. Restart the app after toggling.")
-                Text("Restart the app after toggling so the daemon picks up the change.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .help("When on, TBD broadcasts the live pane size to the daemon and resizes every tmux window on app resize. Currently unstable — can leave panes smaller than the visible area and clip the bottom rows.")
             } header: {
                 Text("Experimental")
             } footer: {
-                Text("Off by default — under active development. Opens you up to known bugs around tmux \"window-size manual\" lock-in. If you toggle this on and want to bail out, just turn it off and restart.")
+                Text("Off by default — under active development. Known bugs around tmux \"window-size manual\" lock-in can clip the bottom rows of a pane. To bail out, turn it off and restart the app.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -32,6 +32,7 @@ struct GeneralSettingsTab: View {
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
+    @AppStorage(AppState.terminalAutoResizeKey) private var enableTerminalAutoResize: Bool = false
 
     private var systemSounds: [String] { NotificationSoundPlayer.systemSoundNames() }
     private let soundPlayer = NotificationSoundPlayer()
@@ -82,6 +83,20 @@ struct GeneralSettingsTab: View {
                     .help("Skip the interactive permission prompt when launching claude in new worktrees")
                 Toggle("Auto-suspend idle Claude when switching worktrees", isOn: $autoSuspend)
                     .help("Exit idle Claude instances when you switch away and resume them when you switch back, freeing memory")
+            }
+
+            Section {
+                Toggle("Auto-resize tmux windows to match the app pane (WIP)", isOn: $enableTerminalAutoResize)
+                    .help("When on, TBD broadcasts the live pane size to the daemon and resizes every tmux window on app resize. Currently unstable — can leave panes smaller than the visible area and clip the bottom rows. Restart the app after toggling.")
+                Text("Restart the app after toggling so the daemon picks up the change.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text("Experimental")
+            } footer: {
+                Text("Off by default — under active development. Opens you up to known bugs around tmux \"window-size manual\" lock-in. If you toggle this on and want to bail out, just turn it off and restart.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)

--- a/Tests/TBDAppTests/TerminalAutoResizeFlagTests.swift
+++ b/Tests/TBDAppTests/TerminalAutoResizeFlagTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tests for the WIP `enableTerminalAutoResize` feature flag. The flag gates
+/// the main-area resize broadcast to the daemon and the per-create cell
+/// dimensions sent with `terminal.create` / `worktree.create` RPCs. Off by
+/// default; on flips the broadcast back on.
+
+@MainActor
+@Suite("Terminal auto-resize flag")
+struct TerminalAutoResizeFlagTests {
+    private let key = AppState.terminalAutoResizeKey
+
+    private func withFlag(_ enabled: Bool, _ body: () throws -> Void) rethrows {
+        let prior = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.set(enabled, forKey: key)
+        defer {
+            // Restore prior state so tests don't bleed into each other or
+            // into the developer's running app instance.
+            if let prior {
+                UserDefaults.standard.set(prior, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+        try body()
+    }
+
+    @Test("returns (0, 0) when flag is off so daemon-side resize gates skip")
+    func mainAreaTerminalSizeOff() throws {
+        try withFlag(false) {
+            let state = AppState()
+            // The defaults seed mainAreaSize at 1120x776, which would
+            // otherwise produce a real cell count — verify the flag wins.
+            state.mainAreaSize = CGSize(width: 1200, height: 800)
+            let size = state.mainAreaTerminalSize()
+            #expect(size.cols == 0)
+            #expect(size.rows == 0)
+        }
+    }
+
+    @Test("returns real cell counts when flag is on")
+    func mainAreaTerminalSizeOn() throws {
+        try withFlag(true) {
+            let state = AppState()
+            state.mainAreaSize = CGSize(width: 1200, height: 800)
+            let size = state.mainAreaTerminalSize()
+            // Exact cell metrics depend on the platform monospaced font, so
+            // we just assert plausible bounds — the floor is 80x24 and a
+            // 1200x800 viewport must not exceed it by more than the screen
+            // could fit at any reasonable cell size.
+            #expect(size.cols >= 80)
+            #expect(size.rows >= 24)
+            #expect(size.cols < 1200)
+            #expect(size.rows < 800)
+        }
+    }
+}

--- a/Tests/TBDAppTests/TerminalAutoResizeFlagTests.swift
+++ b/Tests/TBDAppTests/TerminalAutoResizeFlagTests.swift
@@ -27,7 +27,7 @@ struct TerminalAutoResizeFlagTests {
         try body()
     }
 
-    @Test("returns (0, 0) when flag is off so daemon-side resize gates skip")
+    @Test("returns (nil, nil) when flag is off so daemon falls back to its 220×50 default")
     func mainAreaTerminalSizeOff() throws {
         try withFlag(false) {
             let state = AppState()
@@ -35,8 +35,11 @@ struct TerminalAutoResizeFlagTests {
             // otherwise produce a real cell count — verify the flag wins.
             state.mainAreaSize = CGSize(width: 1200, height: 800)
             let size = state.mainAreaTerminalSize()
-            #expect(size.cols == 0)
-            #expect(size.rows == 0)
+            // nil (not 0) is required so callers' Int? params trigger the
+            // daemon's `?? TmuxManager.defaultCols` fallback. `Some(0)` would
+            // bypass the fallback and tmux would land at 80×24.
+            #expect(size.cols == nil)
+            #expect(size.rows == nil)
         }
     }
 
@@ -50,10 +53,12 @@ struct TerminalAutoResizeFlagTests {
             // we just assert plausible bounds — the floor is 80x24 and a
             // 1200x800 viewport must not exceed it by more than the screen
             // could fit at any reasonable cell size.
-            #expect(size.cols >= 80)
-            #expect(size.rows >= 24)
-            #expect(size.cols < 1200)
-            #expect(size.rows < 800)
+            let cols = try #require(size.cols)
+            let rows = try #require(size.rows)
+            #expect(cols >= 80)
+            #expect(rows >= 24)
+            #expect(cols < 1200)
+            #expect(rows < 800)
         }
     }
 }


### PR DESCRIPTION
## Summary

The terminal auto-resize broadcast (#73 → #84 → #85) has been buggy enough in practice that the overall experience is worse than before it landed — chrome-precision arms race for what gets broadcast, plus tmux's `window-size manual` lock-in causing textbox clipping that's persisted through multiple follow-up fixes. Adding an escape hatch so users can opt out while we keep iterating.

- New `enableTerminalAutoResize` AppStorage flag, **default off**.
- When off: `mainAreaTerminalSize()` returns `(0, 0)`. Both the daemon-side `createWindow` resize gate and the `setMainAreaSize` broadcast handler already no-op below the 80×24 minimum, so a single (0, 0) signal cleanly disables the per-create resize *and* the post-create broadcast.
- `scheduleMainAreaSizeBroadcast()` also early-returns when off — belt-and-suspenders that avoids spinning up the debounce `Task`.
- New "Experimental" section in **Settings → General** with a toggle, help text explaining the WIP state and the known clipping bug, and a footer noting that toggling off and restarting is the bailout.

## Test plan

- [ ] Open Settings → General; "Experimental" section appears at the bottom with the WIP toggle off. Help/footer text reads sensibly.
- [ ] With flag off (default): create a terminal in a worktree, resize the app window. tmux windows do not get sized via `tmux resize-window` from TBD — they keep tmux's session/inherited size and react to attached SwiftTerm clients via `TIOCSWINSZ` only. No textbox clipping.
- [ ] With flag on: behavior matches current main (broadcast fires, per-create resize fires). Existing precision/unfreeze logic from #84 / #85 stays in effect.
- [ ] Flip the flag mid-session, restart the app, verify behavior changes.
- [ ] `swift test --filter TerminalAutoResizeFlagTests` clean (2/2 pass — flag-off returns (0, 0); flag-on returns real cell counts).