### PR TITLE
Feat: Auto-install tbd CLI to ~/.local/bin so commands work from any shell

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -225,6 +225,7 @@ final class AppState: ObservableObject {
 
     let daemonClient = DaemonClient()
     let tmuxBridge = TmuxBridge()
+    lazy var cliInstallerCoordinator = CLIInstallerCoordinator(daemonClient: daemonClient)
     private var pollTimer: Timer?
     private var pollCycle = 0
     private var subscriptionTask: Task<Void, Never>?
@@ -457,6 +458,15 @@ final class AppState: ObservableObject {
             pendingDeepLinkID = nil
             navigateToWorktree(pendingID)
         }
+        Task { [weak self] in
+            guard let self else { return }
+            await self.cliInstallerCoordinator.checkOnLaunch()
+        }
+    }
+
+    /// Menu entry point — install or refresh the `tbd` CLI symlink.
+    func installCLITool() async {
+        await cliInstallerCoordinator.runFromMenu()
     }
 
     /// Launch the daemon process and connect.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -458,9 +458,11 @@ final class AppState: ObservableObject {
             pendingDeepLinkID = nil
             navigateToWorktree(pendingID)
         }
-        Task { [weak self] in
-            guard let self else { return }
-            await self.cliInstallerCoordinator.checkOnLaunch()
+        if didConnect {
+            Task { [weak self] in
+                guard let self else { return }
+                await self.cliInstallerCoordinator.checkOnLaunch()
+            }
         }
     }
 

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -1,0 +1,174 @@
+import Foundation
+import AppKit
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "cli-installer")
+
+@MainActor
+final class CLIInstallerCoordinator {
+    private let daemonClient: DaemonClient
+    private let installer = CLIInstaller()
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    /// Called once at end of `connectAndLoadInitialState`. Surfaces a one-click
+    /// prompt if the symlink is missing or stale. Silent if everything's healthy.
+    func checkOnLaunch() async {
+        guard let target = await fetchExpectedTarget() else { return }
+        let state = installer.currentState(expectedTarget: target)
+        switch state {
+        case .installed:
+            logger.debug("CLI symlink installed and current at \(self.installer.symlinkPath, privacy: .public)")
+            return
+        case .notInstalled:
+            logger.info("CLI symlink missing — prompting to install")
+            await presentLaunchPrompt(target: target, kind: .missing)
+        case .stale(let current):
+            logger.info("CLI symlink stale: current=\(current, privacy: .public) expected=\(target, privacy: .public) — prompting to refresh")
+            await presentLaunchPrompt(target: target, kind: .stale(current: current))
+        }
+    }
+
+    /// Called from the menu item. Confirms, runs install, presents post-install dialog.
+    func runFromMenu() async {
+        guard let target = await fetchExpectedTarget() else {
+            presentTargetUnavailableAlert()
+            return
+        }
+        let state = installer.currentState(expectedTarget: target)
+        switch state {
+        case .installed:
+            presentAlreadyInstalledAlert(target: target)
+        case .notInstalled, .stale:
+            await performInstall(target: target, confirm: true)
+        }
+    }
+
+    // MARK: - Private
+
+    private enum LaunchPromptKind {
+        case missing
+        case stale(current: String)
+    }
+
+    private func fetchExpectedTarget() async -> String? {
+        let status: DaemonStatusResult
+        do {
+            status = try await daemonClient.daemonStatus()
+        } catch {
+            logger.warning("daemon.status failed during CLI install check: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        guard let exec = status.executablePath, !exec.isEmpty else {
+            logger.info("Daemon did not report executablePath (likely older daemon); skipping CLI install check")
+            return nil
+        }
+        let cli = CLIInstaller.cliPath(forDaemonExecutable: exec)
+        guard FileManager.default.fileExists(atPath: cli) else {
+            logger.warning("Expected TBDCLI binary not found at \(cli, privacy: .public)")
+            return nil
+        }
+        return cli
+    }
+
+    private func presentLaunchPrompt(target: String, kind: LaunchPromptKind) async {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        switch kind {
+        case .missing:
+            alert.messageText = "Install the tbd command-line tool?"
+            alert.informativeText = "TBD can add a `tbd` command at ~/.local/bin/tbd so you can launch and control TBD from the terminal. No sudo required."
+        case .stale(let current):
+            alert.messageText = "Refresh the tbd command-line tool?"
+            alert.informativeText = "Your `tbd` symlink at ~/.local/bin/tbd points at \(current), which doesn't match this TBD's CLI. Update it?"
+        }
+        alert.addButton(withTitle: "Install")
+        alert.addButton(withTitle: "Not Now")
+
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            await performInstall(target: target, confirm: false)
+        }
+    }
+
+    private func performInstall(target: String, confirm: Bool) async {
+        if confirm {
+            let alert = NSAlert()
+            alert.alertStyle = .informational
+            alert.messageText = "Install tbd to ~/.local/bin?"
+            alert.informativeText = "This creates a symlink at ~/.local/bin/tbd pointing at \(target)."
+            alert.addButton(withTitle: "Install")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() != .alertFirstButtonReturn { return }
+        }
+
+        let result: CLIInstallResult
+        do {
+            result = try installer.install(target: target)
+        } catch {
+            logger.error("CLI install failed: \(error.localizedDescription, privacy: .public)")
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = "Couldn't install tbd"
+            alert.informativeText = error.localizedDescription
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+
+        logger.info("CLI symlink installed: \(result.symlinkPath, privacy: .public) -> \(result.target, privacy: .public) onPath=\(result.onPath, privacy: .public)")
+
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        if result.onPath {
+            alert.messageText = "tbd installed"
+            alert.informativeText = "Symlink created at \(result.symlinkPath). You can now run `tbd` from any terminal."
+            alert.addButton(withTitle: "OK")
+        } else {
+            alert.messageText = "tbd installed — one more step"
+            let rc = result.suggestedShellRC ?? "your shell rc file"
+            let line = result.exportLine ?? ""
+            alert.informativeText = """
+            Symlink created at \(result.symlinkPath).
+
+            ~/.local/bin is not on your shell's PATH. Add this line to \(rc) and restart your shell:
+
+            \(line)
+            """
+            alert.addButton(withTitle: "Copy export line")
+            alert.addButton(withTitle: "OK")
+        }
+        let response = alert.runModal()
+        if !result.onPath, response == .alertFirstButtonReturn, let line = result.exportLine {
+            let pb = NSPasteboard.general
+            pb.clearContents()
+            pb.setString(line, forType: .string)
+        }
+    }
+
+    private func presentAlreadyInstalledAlert(target: String) {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "tbd is already installed"
+        alert.informativeText = "\(installer.symlinkPath) → \(target)"
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Reinstall")
+        if alert.runModal() == .alertSecondButtonReturn {
+            Task { @MainActor in
+                await self.performInstall(target: target, confirm: false)
+            }
+        }
+    }
+
+    private func presentTargetUnavailableAlert() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Couldn't locate the TBD CLI binary"
+        alert.informativeText = "TBD couldn't determine where its TBDCLI binary lives. Make sure the daemon is running (try restarting TBD) and try again."
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -82,18 +82,22 @@ final class CLIInstallerCoordinator {
         let alert = NSAlert()
         alert.alertStyle = .informational
         let symlinkPath = installer.symlinkPath
+        let primaryButton: String
         switch kind {
         case .missing:
             alert.messageText = "Install the tbd command-line tool?"
             alert.informativeText = "TBD can add a `tbd` command at \(symlinkPath) so you can launch and control TBD from the terminal. No sudo required."
+            primaryButton = "Install"
         case .stale(let current):
             alert.messageText = "Refresh the tbd command-line tool?"
             alert.informativeText = "Your `tbd` symlink at \(symlinkPath) points at \(current), which doesn't match this TBD's CLI. Update it?"
+            primaryButton = "Refresh"
         case .nonSymlink:
             alert.messageText = "Replace the file at \(symlinkPath)?"
             alert.informativeText = "A regular file already exists at \(symlinkPath). TBD can replace it with a symlink to this TBD's CLI."
+            primaryButton = "Replace"
         }
-        alert.addButton(withTitle: "Install")
+        alert.addButton(withTitle: primaryButton)
         alert.addButton(withTitle: "Not Now")
 
         let response = alert.runModal()

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -130,7 +130,7 @@ final class CLIInstallerCoordinator {
             primaryButton = "Refresh"
         case .nonSymlink:
             alert.messageText = "Replace the file at \(symlinkPath)?"
-            alert.informativeText = "A regular file already exists at \(symlinkPath). TBD can replace it with a symlink to this TBD's CLI."
+            alert.informativeText = "A file already exists at \(symlinkPath). TBD can replace it with a symlink to this TBD's CLI."
             primaryButton = "Replace"
         }
         alert.addButton(withTitle: primaryButton)

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -114,13 +114,10 @@ final class CLIInstallerCoordinator {
 
         let result: CLIInstallResult
         do {
-            // Offload off the main actor: install() invokes the login-shell
-            // PATH probe, which spawns a child process and waits up to 2s.
-            // Running it on the main thread freezes AppKit event handling.
-            let installer = self.installer
-            result = try await Task.detached(priority: .userInitiated) {
-                try installer.install(target: target)
-            }.value
+            // install() is async — its PATH probe bridges Process termination
+            // into a continuation, so the awaiting task yields its thread
+            // instead of blocking AppKit during the 2s wait.
+            result = try await installer.install(target: target)
         } catch {
             logger.error("CLI install failed: \(error.localizedDescription, privacy: .public)")
             let alert = NSAlert()

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -53,22 +53,31 @@ final class CLIInstallerCoordinator {
         case .nonSymlink:
             logger.info("Non-symlink at \(self.installer.symlinkPath, privacy: .public) — prompting to replace")
         }
-        await presentLaunchPrompt(target: target, kind: kind)
+        await presentLaunchPrompt(target: target, kind: kind, recordDismissalOnDecline: true)
     }
 
-    /// Called from the menu item. Confirms, runs install, presents post-install dialog.
+    /// Called from the menu item. Routes through the same prompt as the
+    /// launch-time check (so verb/wording stays accurate per state) but
+    /// doesn't record a Not-Now dismissal — the user explicitly invoked us.
     func runFromMenu() async {
         guard let target = await fetchExpectedTarget() else {
             presentTargetUnavailableAlert()
             return
         }
         let state = installer.currentState(expectedTarget: target)
+        let kind: CLILaunchPromptKind
         switch state {
         case .installed:
             presentAlreadyInstalledAlert(target: target)
-        case .notInstalled, .stale, .nonSymlink:
-            await performInstall(target: target, confirm: true)
+            return
+        case .notInstalled:
+            kind = .missing
+        case .stale(let current):
+            kind = .stale(current: current)
+        case .nonSymlink:
+            kind = .nonSymlink
         }
+        await presentLaunchPrompt(target: target, kind: kind, recordDismissalOnDecline: false)
     }
 
     // MARK: - Private
@@ -93,7 +102,7 @@ final class CLIInstallerCoordinator {
         return cli
     }
 
-    private func presentLaunchPrompt(target: String, kind: CLILaunchPromptKind) async {
+    private func presentLaunchPrompt(target: String, kind: CLILaunchPromptKind, recordDismissalOnDecline: Bool) async {
         let alert = NSAlert()
         alert.alertStyle = .informational
         let symlinkPath = installer.symlinkPath
@@ -117,29 +126,21 @@ final class CLIInstallerCoordinator {
 
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
-            await performInstall(target: target, confirm: false)
-        } else if case .missing = kind {
-            // User declined the missing-CLI prompt. Suppress on future launches
-            // until they install — manually, via menu, or after we observe a
-            // healthy `.installed` state. Stale/nonSymlink dismissals are NOT
-            // remembered: those are broken-install states they opted into.
+            await performInstall(target: target)
+        } else if recordDismissalOnDecline, case .missing = kind {
+            // User declined the auto-launch missing-CLI prompt. Suppress on
+            // future launches until they install — manually, via menu, or
+            // after we observe a healthy `.installed` state. Stale/nonSymlink
+            // dismissals are NOT remembered: those are broken-install states
+            // they opted into. Menu-invoked declines also aren't remembered
+            // (the user explicitly opened the dialog themselves).
             logger.info("User dismissed install prompt — not auto-prompting next launch")
             notInstalledDismissed = true
         }
     }
 
-    private func performInstall(target: String, confirm: Bool) async {
+    private func performInstall(target: String) async {
         let symlinkDir = (installer.symlinkPath as NSString).deletingLastPathComponent
-        if confirm {
-            let alert = NSAlert()
-            alert.alertStyle = .informational
-            alert.messageText = "Install tbd to \(symlinkDir)?"
-            alert.informativeText = "This creates a symlink at \(installer.symlinkPath) pointing at \(target)."
-            alert.addButton(withTitle: "Install")
-            alert.addButton(withTitle: "Cancel")
-            if alert.runModal() != .alertFirstButtonReturn { return }
-        }
-
         let result: CLIInstallResult
         do {
             // install() is async — its PATH probe bridges Process termination
@@ -198,7 +199,7 @@ final class CLIInstallerCoordinator {
         alert.addButton(withTitle: "Reinstall")
         if alert.runModal() == .alertSecondButtonReturn {
             Task { @MainActor in
-                await self.performInstall(target: target, confirm: false)
+                await self.performInstall(target: target)
             }
         }
     }

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -81,16 +81,17 @@ final class CLIInstallerCoordinator {
     private func presentLaunchPrompt(target: String, kind: LaunchPromptKind) async {
         let alert = NSAlert()
         alert.alertStyle = .informational
+        let symlinkPath = installer.symlinkPath
         switch kind {
         case .missing:
             alert.messageText = "Install the tbd command-line tool?"
-            alert.informativeText = "TBD can add a `tbd` command at ~/.local/bin/tbd so you can launch and control TBD from the terminal. No sudo required."
+            alert.informativeText = "TBD can add a `tbd` command at \(symlinkPath) so you can launch and control TBD from the terminal. No sudo required."
         case .stale(let current):
             alert.messageText = "Refresh the tbd command-line tool?"
-            alert.informativeText = "Your `tbd` symlink at ~/.local/bin/tbd points at \(current), which doesn't match this TBD's CLI. Update it?"
+            alert.informativeText = "Your `tbd` symlink at \(symlinkPath) points at \(current), which doesn't match this TBD's CLI. Update it?"
         case .nonSymlink:
-            alert.messageText = "Replace the file at ~/.local/bin/tbd?"
-            alert.informativeText = "A regular file already exists at ~/.local/bin/tbd. TBD can replace it with a symlink to this TBD's CLI."
+            alert.messageText = "Replace the file at \(symlinkPath)?"
+            alert.informativeText = "A regular file already exists at \(symlinkPath). TBD can replace it with a symlink to this TBD's CLI."
         }
         alert.addButton(withTitle: "Install")
         alert.addButton(withTitle: "Not Now")
@@ -102,11 +103,12 @@ final class CLIInstallerCoordinator {
     }
 
     private func performInstall(target: String, confirm: Bool) async {
+        let symlinkDir = (installer.symlinkPath as NSString).deletingLastPathComponent
         if confirm {
             let alert = NSAlert()
             alert.alertStyle = .informational
-            alert.messageText = "Install tbd to ~/.local/bin?"
-            alert.informativeText = "This creates a symlink at ~/.local/bin/tbd pointing at \(target)."
+            alert.messageText = "Install tbd to \(symlinkDir)?"
+            alert.informativeText = "This creates a symlink at \(installer.symlinkPath) pointing at \(target)."
             alert.addButton(withTitle: "Install")
             alert.addButton(withTitle: "Cancel")
             if alert.runModal() != .alertFirstButtonReturn { return }
@@ -144,7 +146,7 @@ final class CLIInstallerCoordinator {
             alert.informativeText = """
             Symlink created at \(result.symlinkPath).
 
-            ~/.local/bin is not on your shell's PATH. Add this line to \(rc) and restart your shell:
+            \(symlinkDir) is not on your shell's PATH. Add this line to \(rc) and restart your shell:
 
             \(line)
             """

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -10,6 +10,10 @@ final class CLIInstallerCoordinator {
     private let daemonClient: DaemonClient
     private let installer = CLIInstaller()
 
+    /// Set after `checkOnLaunch` runs, so daemon reconnects within the same
+    /// app session don't keep re-prompting for stale/nonSymlink states.
+    private var hasCheckedThisSession = false
+
     /// Persists across launches. Set when the user clicks "Not Now" on the
     /// `.notInstalled` prompt; cleared on successful install or whenever we
     /// observe a healthy install at launch (so a manual install or a later
@@ -26,9 +30,17 @@ final class CLIInstallerCoordinator {
 
     /// Called once at end of `connectAndLoadInitialState`. Surfaces a one-click
     /// prompt if the symlink is missing or stale. Silent if everything's healthy
-    /// or if the user previously dismissed the missing-CLI prompt.
+    /// or if the user previously dismissed the missing-CLI prompt. No-op on
+    /// subsequent calls within the same app session — daemon reconnects
+    /// shouldn't re-prompt for stale/nonSymlink.
     func checkOnLaunch() async {
-        guard let target = await fetchExpectedTarget() else { return }
+        guard !hasCheckedThisSession else { return }
+        guard let target = await fetchExpectedTarget() else {
+            // Don't latch the flag — a later reconnect with a healthy daemon
+            // status response should still get its first chance to check.
+            return
+        }
+        hasCheckedThisSession = true
         let state = installer.currentState(expectedTarget: target)
 
         if case .installed = state {

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -80,7 +80,7 @@ final class CLIInstallerCoordinator {
         let kind: CLILaunchPromptKind
         switch state {
         case .installed:
-            presentAlreadyInstalledAlert(target: target)
+            await presentAlreadyInstalledAlert(target: target)
             return
         case .notInstalled:
             kind = .missing
@@ -202,7 +202,7 @@ final class CLIInstallerCoordinator {
         }
     }
 
-    private func presentAlreadyInstalledAlert(target: String) {
+    private func presentAlreadyInstalledAlert(target: String) async {
         let alert = NSAlert()
         alert.alertStyle = .informational
         alert.messageText = "tbd is already installed"
@@ -210,9 +210,7 @@ final class CLIInstallerCoordinator {
         alert.addButton(withTitle: "OK")
         alert.addButton(withTitle: "Reinstall")
         if alert.runModal() == .alertSecondButtonReturn {
-            Task { @MainActor in
-                await self.performInstall(target: target)
-            }
+            await performInstall(target: target)
         }
     }
 

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -10,29 +10,50 @@ final class CLIInstallerCoordinator {
     private let daemonClient: DaemonClient
     private let installer = CLIInstaller()
 
+    /// Persists across launches. Set when the user clicks "Not Now" on the
+    /// `.notInstalled` prompt; cleared on successful install or whenever we
+    /// observe a healthy install at launch (so a manual install or a later
+    /// re-install via the menu re-arms the prompt for future deletions).
+    private static let dismissedKey = "com.tbd.app.cliInstaller.notInstalledDismissed"
+    private var notInstalledDismissed: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.dismissedKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.dismissedKey) }
+    }
+
     init(daemonClient: DaemonClient) {
         self.daemonClient = daemonClient
     }
 
     /// Called once at end of `connectAndLoadInitialState`. Surfaces a one-click
-    /// prompt if the symlink is missing or stale. Silent if everything's healthy.
+    /// prompt if the symlink is missing or stale. Silent if everything's healthy
+    /// or if the user previously dismissed the missing-CLI prompt.
     func checkOnLaunch() async {
         guard let target = await fetchExpectedTarget() else { return }
         let state = installer.currentState(expectedTarget: target)
-        switch state {
-        case .installed:
+
+        if case .installed = state {
             logger.debug("CLI symlink installed and current at \(self.installer.symlinkPath, privacy: .public)")
+            if notInstalledDismissed {
+                logger.info("CLI symlink healthy — clearing prior dismissal")
+                notInstalledDismissed = false
+            }
             return
-        case .notInstalled:
+        }
+
+        guard let kind = state.launchPromptKind(userPreviouslyDismissed: notInstalledDismissed) else {
+            logger.debug("Skipping CLI install prompt — user previously dismissed Not Now")
+            return
+        }
+
+        switch kind {
+        case .missing:
             logger.info("CLI symlink missing — prompting to install")
-            await presentLaunchPrompt(target: target, kind: .missing)
         case .stale(let current):
             logger.info("CLI symlink stale: current=\(current, privacy: .public) expected=\(target, privacy: .public) — prompting to refresh")
-            await presentLaunchPrompt(target: target, kind: .stale(current: current))
         case .nonSymlink:
             logger.info("Non-symlink at \(self.installer.symlinkPath, privacy: .public) — prompting to replace")
-            await presentLaunchPrompt(target: target, kind: .nonSymlink)
         }
+        await presentLaunchPrompt(target: target, kind: kind)
     }
 
     /// Called from the menu item. Confirms, runs install, presents post-install dialog.
@@ -51,12 +72,6 @@ final class CLIInstallerCoordinator {
     }
 
     // MARK: - Private
-
-    private enum LaunchPromptKind {
-        case missing
-        case stale(current: String)
-        case nonSymlink
-    }
 
     private func fetchExpectedTarget() async -> String? {
         let status: DaemonStatusResult
@@ -78,7 +93,7 @@ final class CLIInstallerCoordinator {
         return cli
     }
 
-    private func presentLaunchPrompt(target: String, kind: LaunchPromptKind) async {
+    private func presentLaunchPrompt(target: String, kind: CLILaunchPromptKind) async {
         let alert = NSAlert()
         alert.alertStyle = .informational
         let symlinkPath = installer.symlinkPath
@@ -103,6 +118,13 @@ final class CLIInstallerCoordinator {
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
             await performInstall(target: target, confirm: false)
+        } else if case .missing = kind {
+            // User declined the missing-CLI prompt. Suppress on future launches
+            // until they install — manually, via menu, or after we observe a
+            // healthy `.installed` state. Stale/nonSymlink dismissals are NOT
+            // remembered: those are broken-install states they opted into.
+            logger.info("User dismissed install prompt — not auto-prompting next launch")
+            notInstalledDismissed = true
         }
     }
 
@@ -136,6 +158,8 @@ final class CLIInstallerCoordinator {
         }
 
         logger.info("CLI symlink installed: \(result.symlinkPath, privacy: .public) -> \(result.target, privacy: .public) onPath=\(result.onPath, privacy: .public)")
+        // Re-arm the launch prompt for any future unintended deletion.
+        notInstalledDismissed = false
 
         let alert = NSAlert()
         alert.alertStyle = .informational

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -29,6 +29,9 @@ final class CLIInstallerCoordinator {
         case .stale(let current):
             logger.info("CLI symlink stale: current=\(current, privacy: .public) expected=\(target, privacy: .public) — prompting to refresh")
             await presentLaunchPrompt(target: target, kind: .stale(current: current))
+        case .nonSymlink:
+            logger.info("Non-symlink at \(self.installer.symlinkPath, privacy: .public) — prompting to replace")
+            await presentLaunchPrompt(target: target, kind: .nonSymlink)
         }
     }
 
@@ -42,7 +45,7 @@ final class CLIInstallerCoordinator {
         switch state {
         case .installed:
             presentAlreadyInstalledAlert(target: target)
-        case .notInstalled, .stale:
+        case .notInstalled, .stale, .nonSymlink:
             await performInstall(target: target, confirm: true)
         }
     }
@@ -52,6 +55,7 @@ final class CLIInstallerCoordinator {
     private enum LaunchPromptKind {
         case missing
         case stale(current: String)
+        case nonSymlink
     }
 
     private func fetchExpectedTarget() async -> String? {
@@ -84,6 +88,9 @@ final class CLIInstallerCoordinator {
         case .stale(let current):
             alert.messageText = "Refresh the tbd command-line tool?"
             alert.informativeText = "Your `tbd` symlink at ~/.local/bin/tbd points at \(current), which doesn't match this TBD's CLI. Update it?"
+        case .nonSymlink:
+            alert.messageText = "Replace the file at ~/.local/bin/tbd?"
+            alert.informativeText = "A regular file already exists at ~/.local/bin/tbd. TBD can replace it with a symlink to this TBD's CLI."
         }
         alert.addButton(withTitle: "Install")
         alert.addButton(withTitle: "Not Now")
@@ -107,7 +114,13 @@ final class CLIInstallerCoordinator {
 
         let result: CLIInstallResult
         do {
-            result = try installer.install(target: target)
+            // Offload off the main actor: install() invokes the login-shell
+            // PATH probe, which spawns a child process and waits up to 2s.
+            // Running it on the main thread freezes AppKit event handling.
+            let installer = self.installer
+            result = try await Task.detached(priority: .userInitiated) {
+                try installer.install(target: target)
+            }.value
         } catch {
             logger.error("CLI install failed: \(error.localizedDescription, privacy: .public)")
             let alert = NSAlert()

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -115,9 +115,17 @@ final class CLIInstallerCoordinator {
     }
 
     private func presentLaunchPrompt(target: String, kind: CLILaunchPromptKind, recordDismissalOnDecline: Bool) async {
+        let symlinkPath = installer.symlinkPath
+        // Directory at the symlink path needs different copy and a single
+        // button: install() refuses to recursively delete a directory, so
+        // there's no "Replace" path to offer.
+        if case .nonSymlink = kind, Self.isDirectory(at: symlinkPath) {
+            presentDirectoryAtSymlinkPathAlert(symlinkPath: symlinkPath)
+            return
+        }
+
         let alert = NSAlert()
         alert.alertStyle = .informational
-        let symlinkPath = installer.symlinkPath
         let primaryButton: String
         switch kind {
         case .missing:
@@ -212,6 +220,22 @@ final class CLIInstallerCoordinator {
         if alert.runModal() == .alertSecondButtonReturn {
             await performInstall(target: target)
         }
+    }
+
+    private func presentDirectoryAtSymlinkPathAlert(symlinkPath: String) {
+        logger.info("Directory at \(symlinkPath, privacy: .public) — surfacing manual-removal alert instead of Replace prompt")
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "A directory exists at \(symlinkPath)"
+        alert.informativeText = "TBD won't replace a directory automatically. Remove it manually (along with anything you want to keep) and try installing again from the menu."
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private static func isDirectory(at path: String) -> Bool {
+        var st = stat()
+        guard lstat(path, &st) == 0 else { return false }
+        return (st.st_mode & S_IFMT) == S_IFDIR
     }
 
     private func presentTargetUnavailableAlert() {

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -5,6 +5,14 @@ struct TBDCommands: Commands {
     @ObservedObject var appState: AppState
 
     var body: some Commands {
+        CommandGroup(after: .appInfo) {
+            Button("Install Command-Line Tool…") {
+                Task { @MainActor in
+                    await appState.installCLITool()
+                }
+            }
+        }
+
         // Worktree commands
         CommandMenu("Worktree") {
             Button("New Worktree") {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -694,9 +694,24 @@ extension RPCRouter {
         let status = DaemonStatusResult(
             version: TBDConstants.version,
             uptime: uptime,
-            connectedClients: 0  // Will be updated when socket server is implemented
+            connectedClients: 0,  // Will be updated when socket server is implemented
+            executablePath: Self.resolvedExecutablePath()
         )
         return try RPCResponse(result: status)
+    }
+
+    /// Resolve the daemon's own executable path to an absolute, standardized
+    /// path. Falls back to nil if no usable argv[0] is available.
+    private static func resolvedExecutablePath() -> String? {
+        guard let argv0 = CommandLine.arguments.first, !argv0.isEmpty else { return nil }
+        let url: URL
+        if argv0.hasPrefix("/") {
+            url = URL(fileURLWithPath: argv0)
+        } else {
+            let cwd = FileManager.default.currentDirectoryPath
+            url = URL(fileURLWithPath: argv0, relativeTo: URL(fileURLWithPath: cwd))
+        }
+        return url.standardizedFileURL.path
     }
 
     // MARK: - Resolve Path

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -695,14 +695,18 @@ extension RPCRouter {
             version: TBDConstants.version,
             uptime: uptime,
             connectedClients: 0,  // Will be updated when socket server is implemented
-            executablePath: Self.resolvedExecutablePath()
+            executablePath: Self.resolvedExecutablePath
         )
         return try RPCResponse(result: status)
     }
 
-    /// Resolve the daemon's own executable path to an absolute, standardized
-    /// path. Falls back to nil if no usable argv[0] is available.
-    private static func resolvedExecutablePath() -> String? {
+    /// Daemon's own executable path, resolved once at module load. Captures
+    /// CWD at startup (rather than at each `daemon.status` RPC) so a later
+    /// `chdir` can't make the resolution wrong if `argv[0]` is relative.
+    /// Symlinks are followed so we return the real binary path — `cliPath()`
+    /// looks for `TBDCLI` next to the actual TBDDaemon binary, not next to
+    /// a symlink that points at it.
+    private static let resolvedExecutablePath: String? = {
         guard let argv0 = CommandLine.arguments.first, !argv0.isEmpty else { return nil }
         let url: URL
         if argv0.hasPrefix("/") {
@@ -711,11 +715,8 @@ extension RPCRouter {
             let cwd = FileManager.default.currentDirectoryPath
             url = URL(fileURLWithPath: argv0, relativeTo: URL(fileURLWithPath: cwd))
         }
-        // Resolve symlinks so we return the real binary path — `cliPath()`
-        // expects to find `TBDCLI` next to the actual TBDDaemon binary, not
-        // next to a symlink that points at it.
         return url.resolvingSymlinksInPath().standardizedFileURL.path
-    }
+    }()
 
     // MARK: - Resolve Path
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -711,7 +711,10 @@ extension RPCRouter {
             let cwd = FileManager.default.currentDirectoryPath
             url = URL(fileURLWithPath: argv0, relativeTo: URL(fileURLWithPath: cwd))
         }
-        return url.standardizedFileURL.path
+        // Resolve symlinks so we return the real binary path — `cliPath()`
+        // expects to find `TBDCLI` next to the actual TBDDaemon binary, not
+        // next to a symlink that points at it.
+        return url.resolvingSymlinksInPath().standardizedFileURL.path
     }
 
     // MARK: - Resolve Path

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -222,16 +222,6 @@ public struct CLIInstaller: Sendable {
         return abs
     }
 
-    /// Render a path as `~/...` if it's under the home dir, else the absolute path.
-    static func displayPath(_ path: String, homeDir: String) -> String {
-        let abs = absolutize(path, relativeTo: homeDir, homeDir: homeDir)
-        if abs == homeDir { return "~" }
-        if abs.hasPrefix(homeDir + "/") {
-            return "~" + abs.dropFirst(homeDir.count)
-        }
-        return abs
-    }
-
     static func expandTilde(_ path: String, homeDir: String) -> String {
         if path == "~" { return homeDir }
         if path.hasPrefix("~/") {

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -42,7 +42,7 @@ public enum CLIInstallerError: Error, Equatable {
 
 public struct CLIInstaller: Sendable {
     public let symlinkPath: String
-    public let pathProbe: @Sendable () -> String?
+    public let pathProbe: @Sendable () async -> String?
     public let homeDir: String
     public let shellPath: String
 
@@ -50,12 +50,12 @@ public struct CLIInstaller: Sendable {
         symlinkPath: String? = nil,
         homeDir: String = NSHomeDirectory(),
         shellPath: String = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
-        pathProbe: (@Sendable () -> String?)? = nil
+        pathProbe: (@Sendable () async -> String?)? = nil
     ) {
         self.homeDir = homeDir
         self.symlinkPath = symlinkPath ?? (homeDir as NSString).appendingPathComponent(".local/bin/tbd")
         self.shellPath = shellPath
-        self.pathProbe = pathProbe ?? { Self.defaultLoginShellPathProbe(shellPath: shellPath) }
+        self.pathProbe = pathProbe ?? { await Self.defaultLoginShellPathProbe(shellPath: shellPath) }
     }
 
     /// Compute the TBDCLI path given the daemon's executable path.
@@ -104,7 +104,7 @@ public struct CLIInstaller: Sendable {
     }
 
     /// Create or replace the symlink to point at `target`. Idempotent.
-    public func install(target: String) throws -> CLIInstallResult {
+    public func install(target: String) async throws -> CLIInstallResult {
         let fm = FileManager.default
         let parent = (symlinkPath as NSString).deletingLastPathComponent
         if !fm.fileExists(atPath: parent) {
@@ -132,7 +132,7 @@ public struct CLIInstaller: Sendable {
             throw CLIInstallerError.symlinkCreationFailed(error.localizedDescription)
         }
 
-        let pathInfo = pathStatus()
+        let pathInfo = await pathStatus()
         return CLIInstallResult(
             symlinkPath: symlinkPath,
             target: target,
@@ -144,9 +144,9 @@ public struct CLIInstaller: Sendable {
 
     /// Compute current path status (whether the symlink's parent dir is on the
     /// user's login-shell PATH, plus suggested rc / export line if not).
-    public func pathStatus() -> (onPath: Bool, shellRC: String, exportLine: String) {
+    public func pathStatus() async -> (onPath: Bool, shellRC: String, exportLine: String) {
         let binDir = (symlinkPath as NSString).deletingLastPathComponent
-        let probed = pathProbe()
+        let probed = await pathProbe()
         let onPath = Self.directoryIsOnPath(binDir, pathString: probed, homeDir: homeDir)
         let (rc, line) = Self.shellRCAndExport(forShellPath: shellPath, binDir: binDir, homeDir: homeDir)
         return (onPath, rc, line)
@@ -175,7 +175,8 @@ public struct CLIInstaller: Sendable {
             if displayBinDir == "~/.local/bin" {
                 line = "set -gx PATH $HOME/.local/bin $PATH"
             } else {
-                line = "set -gx PATH \(displayBinDir) $PATH"
+                // Single-quote so paths with spaces don't word-split.
+                line = "set -gx PATH '\(displayBinDir)' $PATH"
             }
             return (rc, line)
         case "bash":
@@ -228,7 +229,10 @@ public struct CLIInstaller: Sendable {
     }
 
     /// Spawn the user's login shell to print PATH. Returns nil on any failure.
-    public static func defaultLoginShellPathProbe(shellPath: String) -> String? {
+    /// Bridges `Process.terminationHandler` and a 2-second `DispatchQueue` timer
+    /// into a continuation so the awaiting task yields its cooperative-pool
+    /// thread instead of blocking on `Thread.sleep`.
+    public static func defaultLoginShellPathProbe(shellPath: String) async -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shellPath)
         process.arguments = ["-ilc", "echo $PATH"]
@@ -236,31 +240,55 @@ public struct CLIInstaller: Sendable {
         process.standardOutput = pipe
         process.standardError = Pipe()  // discard
 
-        do {
-            try process.run()
-        } catch {
-            logger.warning("Login-shell PATH probe failed to launch \(shellPath, privacy: .public): \(error.localizedDescription, privacy: .public)")
-            return nil
-        }
+        return await withCheckedContinuation { (cont: CheckedContinuation<String?, Never>) in
+            // Guard against double-resume (terminationHandler vs timeout race).
+            let resumed = ManagedAtomicBool()
+            let resume: @Sendable (String?) -> Void = { value in
+                if resumed.exchange(true) { return }
+                cont.resume(returning: value)
+            }
 
-        // Best-effort 2-second timeout.
-        let deadline = Date().addingTimeInterval(2.0)
-        while process.isRunning && Date() < deadline {
-            Thread.sleep(forTimeInterval: 0.05)
-        }
-        if process.isRunning {
-            process.terminate()
-            logger.warning("Login-shell PATH probe timed out")
-            return nil
-        }
+            process.terminationHandler = { _ in
+                guard let data = try? pipe.fileHandleForReading.readToEnd(),
+                      let output = String(data: data, encoding: .utf8) else {
+                    resume(nil); return
+                }
+                let firstLine = output.split(whereSeparator: { $0 == "\n" || $0 == "\r" }).first.map(String.init) ?? ""
+                let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
+                resume(trimmed.isEmpty ? nil : trimmed)
+            }
 
-        guard let data = try? pipe.fileHandleForReading.readToEnd(),
-              let output = String(data: data, encoding: .utf8) else {
-            return nil
+            DispatchQueue.global().asyncAfter(deadline: .now() + 2.0) {
+                if process.isRunning {
+                    process.terminate()
+                    logger.warning("Login-shell PATH probe timed out")
+                }
+                resume(nil)
+            }
+
+            do {
+                try process.run()
+            } catch {
+                logger.warning("Login-shell PATH probe failed to launch \(shellPath, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                resume(nil)
+            }
         }
-        let firstLine = output.split(whereSeparator: { $0 == "\n" || $0 == "\r" }).first.map(String.init) ?? ""
-        let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
-        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+/// Lock-protected bool used to gate single-resume semantics on the probe
+/// continuation. `swift-atomics` is not in this package's deps, so a tiny
+/// `NSLock`-backed flag does the job.
+private final class ManagedAtomicBool: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+    /// Sets the flag to true and returns the *previous* value.
+    func exchange(_ newValue: Bool) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let old = value
+        value = newValue
+        return old
     }
 }
 

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -244,7 +244,7 @@ public struct CLIInstaller: Sendable {
 
         return await withCheckedContinuation { (cont: CheckedContinuation<String?, Never>) in
             // Guard against double-resume (terminationHandler vs timeout race).
-            let resumed = ManagedAtomicBool()
+            let resumed = OnceFlag()
             let resume: @Sendable (String?) -> Void = { value in
                 if resumed.exchange(true) { return }
                 cont.resume(returning: value)
@@ -278,10 +278,10 @@ public struct CLIInstaller: Sendable {
     }
 }
 
-/// Lock-protected bool used to gate single-resume semantics on the probe
-/// continuation. `swift-atomics` is not in this package's deps, so a tiny
-/// `NSLock`-backed flag does the job.
-private final class ManagedAtomicBool: @unchecked Sendable {
+/// One-shot flag used to gate single-resume semantics on the probe
+/// continuation when terminationHandler and the timeout race. `swift-atomics`
+/// is not in this package's deps, so a tiny `NSLock`-backed flag does the job.
+private final class OnceFlag: @unchecked Sendable {
     private let lock = NSLock()
     private var value = false
     /// Sets the flag to true and returns the *previous* value.

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -5,7 +5,7 @@ import os
 // the established subsystem taxonomy from docs/diagnostics-strategy.md intact.
 private let logger = Logger(subsystem: "com.tbd.app", category: "cli-installer")
 
-public enum CLIInstallState: Equatable {
+public enum CLIInstallState: Equatable, Sendable {
     case notInstalled
     case installed(target: String)
     case stale(currentTarget: String)

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -248,8 +248,12 @@ public struct CLIInstaller: Sendable {
                       let output = String(data: data, encoding: .utf8) else {
                     resume(nil); return
                 }
-                let firstLine = output.split(whereSeparator: { $0 == "\n" || $0 == "\r" }).first.map(String.init) ?? ""
-                let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
+                // Interactive shells (-i) source rc files that may print
+                // banners (nvm/rbenv version notices, welcome messages) to
+                // stdout *before* our `echo $PATH`, so PATH is always the
+                // last non-empty line.
+                let lastLine = output.split(whereSeparator: { $0 == "\n" || $0 == "\r" }).last.map(String.init) ?? ""
+                let trimmed = lastLine.trimmingCharacters(in: .whitespaces)
                 resume(trimmed.isEmpty ? nil : trimmed)
             }
 

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -69,6 +69,19 @@ public enum CLIInstallerError: Error, Equatable {
     case symlinkCreationFailed(String)
 }
 
+extension CLIInstallerError: LocalizedError {
+    // Without this, error.localizedDescription returns the NSError bridge
+    // string ("The operation couldn't be completed…") and the actual reason
+    // (e.g. "create parent: …", "remove existing: …") is lost in both the
+    // user-facing alert and the os.Logger error line.
+    public var errorDescription: String? {
+        switch self {
+        case .symlinkCreationFailed(let reason):
+            return "Symlink creation failed: \(reason)"
+        }
+    }
+}
+
 public struct CLIInstaller: Sendable {
     public let symlinkPath: String
     public let pathProbe: @Sendable () async -> String?

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -162,9 +162,18 @@ public struct CLIInstaller: Sendable {
         }
 
         // Remove any existing entry (symlink or file). Use lstat so we don't
-        // follow a broken symlink and miss the removal.
+        // follow a broken symlink and miss the removal. Refuse to recurse
+        // into a directory: FileManager.removeItem deletes directories
+        // recursively, and the "Replace the file at …" alert doesn't signal
+        // that scope. A directory at this path is improbable in practice,
+        // but the safer behavior is to surface the situation to the user.
         var st = stat()
         if lstat(symlinkPath, &st) == 0 {
+            if (st.st_mode & S_IFMT) == S_IFDIR {
+                throw CLIInstallerError.symlinkCreationFailed(
+                    "a directory exists at \(symlinkPath); remove it manually before installing"
+                )
+            }
             do {
                 try fm.removeItem(atPath: symlinkPath)
             } catch {

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -66,8 +66,6 @@ public struct CLIInstallResult: Equatable, Sendable {
 }
 
 public enum CLIInstallerError: Error, Equatable {
-    case daemonExecutablePathUnavailable
-    case cliBinaryNotFound(searched: String)
     case symlinkCreationFailed(String)
 }
 

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -14,6 +14,35 @@ public enum CLIInstallState: Equatable {
     case nonSymlink
 }
 
+/// What the launch-time check should prompt the user about, if anything.
+public enum CLILaunchPromptKind: Equatable, Sendable {
+    case missing
+    case stale(current: String)
+    case nonSymlink
+}
+
+public extension CLIInstallState {
+    /// Decide whether the launch-time check should surface a prompt.
+    ///
+    /// `userPreviouslyDismissed` should be true if the user clicked "Not Now"
+    /// on a previous `.notInstalled` prompt — in which case we suppress the
+    /// re-prompt to avoid nagging. `.stale` and `.nonSymlink` are always
+    /// surfaced because they represent a broken install the user likely wants
+    /// fixed (and they explicitly opted in by installing once before).
+    func launchPromptKind(userPreviouslyDismissed: Bool) -> CLILaunchPromptKind? {
+        switch self {
+        case .installed:
+            return nil
+        case .notInstalled:
+            return userPreviouslyDismissed ? nil : .missing
+        case .stale(let current):
+            return .stale(current: current)
+        case .nonSymlink:
+            return .nonSymlink
+        }
+    }
+}
+
 public struct CLIInstallResult: Equatable, Sendable {
     public let symlinkPath: String
     public let target: String

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -1,7 +1,9 @@
 import Foundation
 import os
 
-private let logger = Logger(subsystem: "com.tbd.shared", category: "cli-installer")
+// CLIInstaller is currently only invoked from TBDApp; using com.tbd.app keeps
+// the established subsystem taxonomy from docs/diagnostics-strategy.md intact.
+private let logger = Logger(subsystem: "com.tbd.app", category: "cli-installer")
 
 public enum CLIInstallState: Equatable {
     case notInstalled

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -122,7 +122,11 @@ public struct CLIInstaller: Sendable {
         do {
             destination = try fm.destinationOfSymbolicLink(atPath: symlinkPath)
         } catch {
-            return .notInstalled
+            // Symlink confirmed present but unreadable (exotic permission
+            // failure). Treat as stale so the prompt still fires even when
+            // the user has previously dismissed the .notInstalled prompt —
+            // .notInstalled would be silently swallowed by the dismissal flag.
+            return .stale(currentTarget: symlinkPath)
         }
 
         let resolvedDest = Self.absolutize(

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -7,9 +7,12 @@ public enum CLIInstallState: Equatable {
     case notInstalled
     case installed(target: String)
     case stale(currentTarget: String)
+    /// A non-symlink (regular file or directory) exists at `symlinkPath`.
+    /// `install()` will overwrite it, but the UI should warn before doing so.
+    case nonSymlink
 }
 
-public struct CLIInstallResult: Equatable {
+public struct CLIInstallResult: Equatable, Sendable {
     public let symlinkPath: String
     public let target: String
     public let onPath: Bool
@@ -37,9 +40,9 @@ public enum CLIInstallerError: Error, Equatable {
     case symlinkCreationFailed(String)
 }
 
-public struct CLIInstaller {
+public struct CLIInstaller: Sendable {
     public let symlinkPath: String
-    public let pathProbe: () -> String?
+    public let pathProbe: @Sendable () -> String?
     public let homeDir: String
     public let shellPath: String
 
@@ -47,7 +50,7 @@ public struct CLIInstaller {
         symlinkPath: String? = nil,
         homeDir: String = NSHomeDirectory(),
         shellPath: String = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
-        pathProbe: (() -> String?)? = nil
+        pathProbe: (@Sendable () -> String?)? = nil
     ) {
         self.homeDir = homeDir
         self.symlinkPath = symlinkPath ?? (homeDir as NSString).appendingPathComponent(".local/bin/tbd")
@@ -68,9 +71,8 @@ public struct CLIInstaller {
         let fm = FileManager.default
         let attrs = try? fm.attributesOfItem(atPath: symlinkPath)
         guard let attrs, attrs[.type] as? FileAttributeType == .typeSymbolicLink else {
-            // Either missing entirely, or a non-symlink we'd need to overwrite.
             if (attrs?[.type] as? FileAttributeType) != nil {
-                return .stale(currentTarget: symlinkPath)
+                return .nonSymlink
             }
             return .notInstalled
         }

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -243,7 +243,7 @@ public struct CLIInstaller: Sendable {
         return path
     }
 
-    static func absolutize(_ path: String, relativeTo base: String, homeDir: String = NSHomeDirectory()) -> String {
+    static func absolutize(_ path: String, relativeTo base: String, homeDir: String) -> String {
         let expanded = expandTilde(path, homeDir: homeDir)
         let nsPath = expanded as NSString
         if nsPath.isAbsolutePath {

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -169,37 +169,30 @@ public struct CLIInstaller: Sendable {
 
     static func shellRCAndExport(forShellPath shellPath: String, binDir: String, homeDir: String) -> (rc: String, exportLine: String) {
         let shellName = (shellPath as NSString).lastPathComponent.lowercased()
-        let displayBinDir = displayPath(binDir, homeDir: homeDir)
+        // Use $HOME (not ~) so the path expands inside quoted strings —
+        // bash/zsh don't expand ~ inside double quotes; fish doesn't expand
+        // anything inside single quotes. Double-quoting keeps space-safety.
+        let exportPath = shellExpandable(binDir, homeDir: homeDir)
         switch shellName {
         case "fish":
-            let rc = "~/.config/fish/config.fish"
-            let line: String
-            if displayBinDir == "~/.local/bin" {
-                line = "set -gx PATH $HOME/.local/bin $PATH"
-            } else {
-                // Single-quote so paths with spaces don't word-split.
-                line = "set -gx PATH '\(displayBinDir)' $PATH"
-            }
-            return (rc, line)
+            return ("~/.config/fish/config.fish", "set -gx PATH \"\(exportPath)\" $PATH")
         case "bash":
-            let rc = "~/.bash_profile"
-            let line: String
-            if displayBinDir == "~/.local/bin" {
-                line = "export PATH=\"$HOME/.local/bin:$PATH\""
-            } else {
-                line = "export PATH=\"\(displayBinDir):$PATH\""
-            }
-            return (rc, line)
+            return ("~/.bash_profile", "export PATH=\"\(exportPath):$PATH\"")
         default:
-            let rc = "~/.zshrc"
-            let line: String
-            if displayBinDir == "~/.local/bin" {
-                line = "export PATH=\"$HOME/.local/bin:$PATH\""
-            } else {
-                line = "export PATH=\"\(displayBinDir):$PATH\""
-            }
-            return (rc, line)
+            return ("~/.zshrc", "export PATH=\"\(exportPath):$PATH\"")
         }
+    }
+
+    /// Render a path as `$HOME/...` if it's under the home dir, else the
+    /// absolute path. Suitable for embedding inside double-quoted strings
+    /// in bash/zsh and fish, where `~` would NOT be expanded.
+    static func shellExpandable(_ path: String, homeDir: String) -> String {
+        let abs = absolutize(path, relativeTo: homeDir, homeDir: homeDir)
+        if abs == homeDir { return "$HOME" }
+        if abs.hasPrefix(homeDir + "/") {
+            return "$HOME" + abs.dropFirst(homeDir.count)
+        }
+        return abs
     }
 
     /// Render a path as `~/...` if it's under the home dir, else the absolute path.

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -1,0 +1,264 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.shared", category: "cli-installer")
+
+public enum CLIInstallState: Equatable {
+    case notInstalled
+    case installed(target: String)
+    case stale(currentTarget: String)
+}
+
+public struct CLIInstallResult: Equatable {
+    public let symlinkPath: String
+    public let target: String
+    public let onPath: Bool
+    public let suggestedShellRC: String?
+    public let exportLine: String?
+
+    public init(
+        symlinkPath: String,
+        target: String,
+        onPath: Bool,
+        suggestedShellRC: String?,
+        exportLine: String?
+    ) {
+        self.symlinkPath = symlinkPath
+        self.target = target
+        self.onPath = onPath
+        self.suggestedShellRC = suggestedShellRC
+        self.exportLine = exportLine
+    }
+}
+
+public enum CLIInstallerError: Error, Equatable {
+    case daemonExecutablePathUnavailable
+    case cliBinaryNotFound(searched: String)
+    case symlinkCreationFailed(String)
+}
+
+public struct CLIInstaller {
+    public let symlinkPath: String
+    public let pathProbe: () -> String?
+    public let homeDir: String
+    public let shellPath: String
+
+    public init(
+        symlinkPath: String? = nil,
+        homeDir: String = NSHomeDirectory(),
+        shellPath: String = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
+        pathProbe: (() -> String?)? = nil
+    ) {
+        self.homeDir = homeDir
+        self.symlinkPath = symlinkPath ?? (homeDir as NSString).appendingPathComponent(".local/bin/tbd")
+        self.shellPath = shellPath
+        self.pathProbe = pathProbe ?? { Self.defaultLoginShellPathProbe(shellPath: shellPath) }
+    }
+
+    /// Compute the TBDCLI path given the daemon's executable path.
+    public static func cliPath(forDaemonExecutable daemonPath: String) -> String {
+        let dir = (daemonPath as NSString).deletingLastPathComponent
+        return (dir as NSString).appendingPathComponent("TBDCLI")
+    }
+
+    /// Inspect the symlink. Pass the expected target (resolved daemon-sibling
+    /// path) to determine staleness. If `expectedTarget` is nil, only checks
+    /// that the symlink exists and points at a real file.
+    public func currentState(expectedTarget: String?) -> CLIInstallState {
+        let fm = FileManager.default
+        let attrs = try? fm.attributesOfItem(atPath: symlinkPath)
+        guard let attrs, attrs[.type] as? FileAttributeType == .typeSymbolicLink else {
+            // Either missing entirely, or a non-symlink we'd need to overwrite.
+            if (attrs?[.type] as? FileAttributeType) != nil {
+                return .stale(currentTarget: symlinkPath)
+            }
+            return .notInstalled
+        }
+        let destination: String
+        do {
+            destination = try fm.destinationOfSymbolicLink(atPath: symlinkPath)
+        } catch {
+            return .notInstalled
+        }
+
+        let resolvedDest = Self.absolutize(
+            destination,
+            relativeTo: (symlinkPath as NSString).deletingLastPathComponent,
+            homeDir: homeDir
+        )
+
+        if let expectedTarget {
+            let expectedAbs = Self.absolutize(expectedTarget, relativeTo: homeDir, homeDir: homeDir)
+            if resolvedDest == expectedAbs && fm.fileExists(atPath: resolvedDest) {
+                return .installed(target: resolvedDest)
+            }
+            return .stale(currentTarget: resolvedDest)
+        } else {
+            if fm.fileExists(atPath: resolvedDest) {
+                return .installed(target: resolvedDest)
+            }
+            return .stale(currentTarget: resolvedDest)
+        }
+    }
+
+    /// Create or replace the symlink to point at `target`. Idempotent.
+    public func install(target: String) throws -> CLIInstallResult {
+        let fm = FileManager.default
+        let parent = (symlinkPath as NSString).deletingLastPathComponent
+        if !fm.fileExists(atPath: parent) {
+            do {
+                try fm.createDirectory(atPath: parent, withIntermediateDirectories: true)
+            } catch {
+                throw CLIInstallerError.symlinkCreationFailed("create parent: \(error.localizedDescription)")
+            }
+        }
+
+        // Remove any existing entry (symlink or file). Use lstat so we don't
+        // follow a broken symlink and miss the removal.
+        var st = stat()
+        if lstat(symlinkPath, &st) == 0 {
+            do {
+                try fm.removeItem(atPath: symlinkPath)
+            } catch {
+                throw CLIInstallerError.symlinkCreationFailed("remove existing: \(error.localizedDescription)")
+            }
+        }
+
+        do {
+            try fm.createSymbolicLink(atPath: symlinkPath, withDestinationPath: target)
+        } catch {
+            throw CLIInstallerError.symlinkCreationFailed(error.localizedDescription)
+        }
+
+        let pathInfo = pathStatus()
+        return CLIInstallResult(
+            symlinkPath: symlinkPath,
+            target: target,
+            onPath: pathInfo.onPath,
+            suggestedShellRC: pathInfo.onPath ? nil : pathInfo.shellRC,
+            exportLine: pathInfo.onPath ? nil : pathInfo.exportLine
+        )
+    }
+
+    /// Compute current path status (whether the symlink's parent dir is on the
+    /// user's login-shell PATH, plus suggested rc / export line if not).
+    public func pathStatus() -> (onPath: Bool, shellRC: String, exportLine: String) {
+        let binDir = (symlinkPath as NSString).deletingLastPathComponent
+        let probed = pathProbe()
+        let onPath = Self.directoryIsOnPath(binDir, pathString: probed, homeDir: homeDir)
+        let (rc, line) = Self.shellRCAndExport(forShellPath: shellPath, binDir: binDir, homeDir: homeDir)
+        return (onPath, rc, line)
+    }
+
+    // MARK: - Helpers
+
+    static func directoryIsOnPath(_ dir: String, pathString: String?, homeDir: String) -> Bool {
+        guard let pathString, !pathString.isEmpty else { return false }
+        let entries = pathString.split(separator: ":").map(String.init)
+        let normalizedDir = absolutize(dir, relativeTo: homeDir, homeDir: homeDir)
+        for entry in entries {
+            let normalized = absolutize(entry, relativeTo: homeDir, homeDir: homeDir)
+            if normalized == normalizedDir { return true }
+        }
+        return false
+    }
+
+    static func shellRCAndExport(forShellPath shellPath: String, binDir: String, homeDir: String) -> (rc: String, exportLine: String) {
+        let shellName = (shellPath as NSString).lastPathComponent.lowercased()
+        let displayBinDir = displayPath(binDir, homeDir: homeDir)
+        switch shellName {
+        case "fish":
+            let rc = "~/.config/fish/config.fish"
+            let line: String
+            if displayBinDir == "~/.local/bin" {
+                line = "set -gx PATH $HOME/.local/bin $PATH"
+            } else {
+                line = "set -gx PATH \(displayBinDir) $PATH"
+            }
+            return (rc, line)
+        case "bash":
+            let rc = "~/.bash_profile"
+            let line: String
+            if displayBinDir == "~/.local/bin" {
+                line = "export PATH=\"$HOME/.local/bin:$PATH\""
+            } else {
+                line = "export PATH=\"\(displayBinDir):$PATH\""
+            }
+            return (rc, line)
+        default:
+            let rc = "~/.zshrc"
+            let line: String
+            if displayBinDir == "~/.local/bin" {
+                line = "export PATH=\"$HOME/.local/bin:$PATH\""
+            } else {
+                line = "export PATH=\"\(displayBinDir):$PATH\""
+            }
+            return (rc, line)
+        }
+    }
+
+    /// Render a path as `~/...` if it's under the home dir, else the absolute path.
+    static func displayPath(_ path: String, homeDir: String) -> String {
+        let abs = absolutize(path, relativeTo: homeDir, homeDir: homeDir)
+        if abs == homeDir { return "~" }
+        if abs.hasPrefix(homeDir + "/") {
+            return "~" + abs.dropFirst(homeDir.count)
+        }
+        return abs
+    }
+
+    static func expandTilde(_ path: String, homeDir: String) -> String {
+        if path == "~" { return homeDir }
+        if path.hasPrefix("~/") {
+            return homeDir + String(path.dropFirst(1))
+        }
+        return path
+    }
+
+    static func absolutize(_ path: String, relativeTo base: String, homeDir: String = NSHomeDirectory()) -> String {
+        let expanded = expandTilde(path, homeDir: homeDir)
+        let nsPath = expanded as NSString
+        if nsPath.isAbsolutePath {
+            return nsPath.standardizingPath
+        }
+        let combined = (base as NSString).appendingPathComponent(expanded)
+        return (combined as NSString).standardizingPath
+    }
+
+    /// Spawn the user's login shell to print PATH. Returns nil on any failure.
+    public static func defaultLoginShellPathProbe(shellPath: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shellPath)
+        process.arguments = ["-ilc", "echo $PATH"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()  // discard
+
+        do {
+            try process.run()
+        } catch {
+            logger.warning("Login-shell PATH probe failed to launch \(shellPath, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+
+        // Best-effort 2-second timeout.
+        let deadline = Date().addingTimeInterval(2.0)
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if process.isRunning {
+            process.terminate()
+            logger.warning("Login-shell PATH probe timed out")
+            return nil
+        }
+
+        guard let data = try? pipe.fileHandleForReading.readToEnd(),
+              let output = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        let firstLine = output.split(whereSeparator: { $0 == "\n" || $0 == "\r" }).first.map(String.init) ?? ""
+        let trimmed = firstLine.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+

--- a/Sources/TBDShared/CLIInstaller.swift
+++ b/Sources/TBDShared/CLIInstaller.swift
@@ -136,6 +136,10 @@ public struct CLIInstaller: Sendable {
         )
 
         if let expectedTarget {
+            // expectedTarget is always absolute (callers pass an absolute
+            // path resolved from the daemon's executable). `relativeTo`
+            // is therefore inert — pass `homeDir` only because absolutize
+            // requires the parameter.
             let expectedAbs = Self.absolutize(expectedTarget, relativeTo: homeDir, homeDir: homeDir)
             if resolvedDest == expectedAbs && fm.fileExists(atPath: resolvedDest) {
                 return .installed(target: resolvedDest)

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -531,8 +531,19 @@ public struct DaemonStatusResult: Codable, Sendable {
     public let version: String
     public let uptime: TimeInterval
     public let connectedClients: Int
-    public init(version: String, uptime: TimeInterval, connectedClients: Int) {
-        self.version = version; self.uptime = uptime; self.connectedClients = connectedClients
+    /// Absolute path to the running daemon's executable. Optional for backward
+    /// compatibility — older daemons won't include this field.
+    public let executablePath: String?
+    public init(
+        version: String,
+        uptime: TimeInterval,
+        connectedClients: Int,
+        executablePath: String? = nil
+    ) {
+        self.version = version
+        self.uptime = uptime
+        self.connectedClients = connectedClients
+        self.executablePath = executablePath
     }
 }
 

--- a/Tests/TBDDaemonTests/WorktreeReviveReorderTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveReorderTests.swift
@@ -1,29 +1,27 @@
-import XCTest
+import Testing
 @testable import TBDDaemonLib
 import TBDShared
 
-final class WorktreeReviveReorderTests: XCTestCase {
-    func testReorderFloatsPreferredSessionFirst() {
-        let stored = ["a", "b", "c"]
-        let preferred = "b"
-        let result = reorderSessions(stored: stored, preferred: preferred)
-        XCTAssertEqual(result, ["b", "a", "c"])
-    }
+@Test func reorderFloatsPreferredSessionFirst() {
+    let stored = ["a", "b", "c"]
+    let preferred = "b"
+    let result = reorderSessions(stored: stored, preferred: preferred)
+    #expect(result == ["b", "a", "c"])
+}
 
-    func testNilPreferredKeepsOrder() {
-        let stored = ["a", "b", "c"]
-        let result = reorderSessions(stored: stored, preferred: String?.none)
-        XCTAssertEqual(result, ["a", "b", "c"])
-    }
+@Test func nilPreferredKeepsOrder() {
+    let stored = ["a", "b", "c"]
+    let result = reorderSessions(stored: stored, preferred: String?.none)
+    #expect(result == ["a", "b", "c"])
+}
 
-    func testUnknownPreferredKeepsOrder() {
-        let stored = ["a", "b", "c"]
-        let result = reorderSessions(stored: stored, preferred: "z")
-        XCTAssertEqual(result, ["a", "b", "c"])
-    }
+@Test func unknownPreferredKeepsOrder() {
+    let stored = ["a", "b", "c"]
+    let result = reorderSessions(stored: stored, preferred: "z")
+    #expect(result == ["a", "b", "c"])
+}
 
-    func testNilStoredStaysNil() {
-        let result = reorderSessions(stored: [String]?.none, preferred: "anything")
-        XCTAssertNil(result)
-    }
+@Test func nilStoredStaysNil() {
+    let result = reorderSessions(stored: [String]?.none, preferred: "anything")
+    #expect(result == nil)
 }

--- a/Tests/TBDSharedTests/CLIInstallerTests.swift
+++ b/Tests/TBDSharedTests/CLIInstallerTests.swift
@@ -159,6 +159,35 @@ private func makeFile(_ path: String) throws {
     #expect(dest == target)
 }
 
+@Test func installRefusesToReplaceDirectory() async throws {
+    // FileManager.removeItem deletes directories recursively. If a directory
+    // is unexpectedly at the install path, install() must refuse rather than
+    // silently rm -rf based on a "Replace the file" confirmation.
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/cli"
+    try makeFile(target)
+    let symlink = home.path + "/.local/bin/tbd"
+    // Create a directory at the symlink path with a file inside (to verify
+    // we wouldn't have silently lost it).
+    try FileManager.default.createDirectory(atPath: symlink, withIntermediateDirectories: true)
+    try makeFile(symlink + "/important.txt")
+
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { nil })
+    do {
+        _ = try await installer.install(target: target)
+        Issue.record("Expected install to throw when a directory exists at the path")
+    } catch let error as CLIInstallerError {
+        if case .symlinkCreationFailed(let reason) = error {
+            #expect(reason.contains("directory"))
+        } else {
+            Issue.record("Wrong CLIInstallerError case: \(error)")
+        }
+    }
+    // The directory and its contents must still be there.
+    #expect(FileManager.default.fileExists(atPath: symlink + "/important.txt"))
+}
+
 @Test func installReplacesExistingSymlink() async throws {
     let home = try TempHome()
     defer { home.cleanup() }

--- a/Tests/TBDSharedTests/CLIInstallerTests.swift
+++ b/Tests/TBDSharedTests/CLIInstallerTests.swift
@@ -239,17 +239,32 @@ private func makeFile(_ path: String) throws {
     let result = try await installer.install(target: target)
     #expect(result.onPath == false)
     #expect(result.suggestedShellRC == "~/.config/fish/config.fish")
-    #expect(result.exportLine == "set -gx PATH $HOME/.local/bin $PATH")
+    #expect(result.exportLine == "set -gx PATH \"$HOME/.local/bin\" $PATH")
 }
 
-@Test func fishExportLineQuotesNonDefaultBinDirToHandleSpaces() {
+@Test func fishExportLineUsesHomeAndDoubleQuotesForNonDefaultBinDirWithSpaces() {
+    // Tilde is NOT expanded inside fish single quotes, and $HOME is NOT
+    // expanded inside single quotes either — so we use $HOME inside double
+    // quotes, which both expands and preserves spaces.
     let (rc, line) = CLIInstaller.shellRCAndExport(
         forShellPath: "/usr/local/bin/fish",
         binDir: "/Users/me/Library/Application Support/tbd/bin",
         homeDir: "/Users/me"
     )
     #expect(rc == "~/.config/fish/config.fish")
-    #expect(line == "set -gx PATH '~/Library/Application Support/tbd/bin' $PATH")
+    #expect(line == "set -gx PATH \"$HOME/Library/Application Support/tbd/bin\" $PATH")
+}
+
+@Test func bashExportLineUsesHomeForPathsOutsideHome() {
+    // $HOME prefix only applies under the home dir; absolute paths elsewhere
+    // are embedded as-is and the surrounding double quotes keep them intact.
+    let (rc, line) = CLIInstaller.shellRCAndExport(
+        forShellPath: "/bin/bash",
+        binDir: "/opt/tbd/bin",
+        homeDir: "/Users/me"
+    )
+    #expect(rc == "~/.bash_profile")
+    #expect(line == "export PATH=\"/opt/tbd/bin:$PATH\"")
 }
 
 @Test func pathProbeReturningNilTreatedAsOffPath() async throws {

--- a/Tests/TBDSharedTests/CLIInstallerTests.swift
+++ b/Tests/TBDSharedTests/CLIInstallerTests.swift
@@ -113,7 +113,7 @@ private func makeFile(_ path: String) throws {
 
 // MARK: - install
 
-@Test func installCreatesParentDirectoryAndSymlink() throws {
+@Test func installCreatesParentDirectoryAndSymlink() async throws {
     let home = try TempHome()
     defer { home.cleanup() }
     let target = home.path + "/build/TBDCLI"
@@ -121,7 +121,7 @@ private func makeFile(_ path: String) throws {
     let symlink = home.path + "/.local/bin/tbd"
 
     let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { "/usr/bin:/bin" })
-    let result = try installer.install(target: target)
+    let result = try await installer.install(target: target)
     #expect(result.symlinkPath == symlink)
     #expect(result.target == target)
 
@@ -129,7 +129,7 @@ private func makeFile(_ path: String) throws {
     #expect(dest == target)
 }
 
-@Test func installReplacesExistingSymlink() throws {
+@Test func installReplacesExistingSymlink() async throws {
     let home = try TempHome()
     defer { home.cleanup() }
     let oldTarget = home.path + "/old-cli"
@@ -144,14 +144,14 @@ private func makeFile(_ path: String) throws {
     try FileManager.default.createSymbolicLink(atPath: symlink, withDestinationPath: oldTarget)
 
     let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { "/usr/bin" })
-    _ = try installer.install(target: newTarget)
+    _ = try await installer.install(target: newTarget)
     let dest = try FileManager.default.destinationOfSymbolicLink(atPath: symlink)
     #expect(dest == newTarget)
 }
 
 // MARK: - PATH detection / on-PATH branch
 
-@Test func installReportsOnPathWhenBinDirIsPresent() throws {
+@Test func installReportsOnPathWhenBinDirIsPresent() async throws {
     let home = try TempHome()
     defer { home.cleanup() }
     let target = home.path + "/cli"
@@ -159,17 +159,17 @@ private func makeFile(_ path: String) throws {
     let symlink = home.path + "/.local/bin/tbd"
 
     let homePath = home.path
-    let probe: @Sendable () -> String? = {
+    let probe: @Sendable () async -> String? = {
         "/usr/bin:\(homePath)/.local/bin:/sbin"
     }
     let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: probe)
-    let result = try installer.install(target: target)
+    let result = try await installer.install(target: target)
     #expect(result.onPath == true)
     #expect(result.suggestedShellRC == nil)
     #expect(result.exportLine == nil)
 }
 
-@Test func installReportsOnPathWhenBinDirAppearsTildeExpanded() throws {
+@Test func installReportsOnPathWhenBinDirAppearsTildeExpanded() async throws {
     let home = try TempHome()
     defer { home.cleanup() }
     let target = home.path + "/cli"
@@ -177,15 +177,15 @@ private func makeFile(_ path: String) throws {
     let symlink = home.path + "/.local/bin/tbd"
 
     // Path string contains the tilde-prefixed form — should still match.
-    let probe: @Sendable () -> String? = { "/usr/bin:~/.local/bin:/sbin" }
+    let probe: @Sendable () async -> String? = { "/usr/bin:~/.local/bin:/sbin" }
     let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: probe)
-    let result = try installer.install(target: target)
+    let result = try await installer.install(target: target)
     #expect(result.onPath == true)
 }
 
 // MARK: - PATH detection / off-PATH branch
 
-@Test func installReportsOffPathAndZshRCByDefault() throws {
+@Test func installReportsOffPathAndZshRCByDefault() async throws {
     let home = try TempHome()
     defer { home.cleanup() }
     let target = home.path + "/cli"
@@ -198,13 +198,13 @@ private func makeFile(_ path: String) throws {
         shellPath: "/bin/zsh",
         pathProbe: { "/usr/bin:/bin" }
     )
-    let result = try installer.install(target: target)
+    let result = try await installer.install(target: target)
     #expect(result.onPath == false)
     #expect(result.suggestedShellRC == "~/.zshrc")
     #expect(result.exportLine == "export PATH=\"$HOME/.local/bin:$PATH\"")
 }
 
-@Test func installReportsOffPathBashProfileForBash() throws {
+@Test func installReportsOffPathBashProfileForBash() async throws {
     let home = try TempHome()
     defer { home.cleanup() }
     let target = home.path + "/cli"
@@ -217,13 +217,13 @@ private func makeFile(_ path: String) throws {
         shellPath: "/bin/bash",
         pathProbe: { "/usr/bin:/bin" }
     )
-    let result = try installer.install(target: target)
+    let result = try await installer.install(target: target)
     #expect(result.onPath == false)
     #expect(result.suggestedShellRC == "~/.bash_profile")
     #expect(result.exportLine == "export PATH=\"$HOME/.local/bin:$PATH\"")
 }
 
-@Test func installReportsOffPathFishConfigForFish() throws {
+@Test func installReportsOffPathFishConfigForFish() async throws {
     let home = try TempHome()
     defer { home.cleanup() }
     let target = home.path + "/cli"
@@ -236,13 +236,23 @@ private func makeFile(_ path: String) throws {
         shellPath: "/usr/local/bin/fish",
         pathProbe: { "/usr/bin:/bin" }
     )
-    let result = try installer.install(target: target)
+    let result = try await installer.install(target: target)
     #expect(result.onPath == false)
     #expect(result.suggestedShellRC == "~/.config/fish/config.fish")
     #expect(result.exportLine == "set -gx PATH $HOME/.local/bin $PATH")
 }
 
-@Test func pathProbeReturningNilTreatedAsOffPath() throws {
+@Test func fishExportLineQuotesNonDefaultBinDirToHandleSpaces() {
+    let (rc, line) = CLIInstaller.shellRCAndExport(
+        forShellPath: "/usr/local/bin/fish",
+        binDir: "/Users/me/Library/Application Support/tbd/bin",
+        homeDir: "/Users/me"
+    )
+    #expect(rc == "~/.config/fish/config.fish")
+    #expect(line == "set -gx PATH '~/Library/Application Support/tbd/bin' $PATH")
+}
+
+@Test func pathProbeReturningNilTreatedAsOffPath() async throws {
     let home = try TempHome()
     defer { home.cleanup() }
     let target = home.path + "/cli"
@@ -250,7 +260,7 @@ private func makeFile(_ path: String) throws {
     let symlink = home.path + "/.local/bin/tbd"
 
     let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { nil })
-    let result = try installer.install(target: target)
+    let result = try await installer.install(target: target)
     #expect(result.onPath == false)
     #expect(result.exportLine != nil)
 }

--- a/Tests/TBDSharedTests/CLIInstallerTests.swift
+++ b/Tests/TBDSharedTests/CLIInstallerTests.swift
@@ -83,6 +83,17 @@ private func makeFile(_ path: String) throws {
     #expect(state == .stale(currentTarget: other))
 }
 
+@Test func currentStateNonSymlinkWhenRegularFileExistsAtPath() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let symlink = home.path + "/.local/bin/tbd"
+    try makeFile(symlink)
+
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { nil })
+    let state = installer.currentState(expectedTarget: "/some/target")
+    #expect(state == .nonSymlink)
+}
+
 @Test func currentStateStaleWhenSymlinkTargetMissing() throws {
     let home = try TempHome()
     defer { home.cleanup() }
@@ -147,8 +158,9 @@ private func makeFile(_ path: String) throws {
     try makeFile(target)
     let symlink = home.path + "/.local/bin/tbd"
 
-    let probe: () -> String? = {
-        "/usr/bin:\(home.path)/.local/bin:/sbin"
+    let homePath = home.path
+    let probe: @Sendable () -> String? = {
+        "/usr/bin:\(homePath)/.local/bin:/sbin"
     }
     let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: probe)
     let result = try installer.install(target: target)
@@ -165,7 +177,7 @@ private func makeFile(_ path: String) throws {
     let symlink = home.path + "/.local/bin/tbd"
 
     // Path string contains the tilde-prefixed form — should still match.
-    let probe: () -> String? = { "/usr/bin:~/.local/bin:/sbin" }
+    let probe: @Sendable () -> String? = { "/usr/bin:~/.local/bin:/sbin" }
     let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: probe)
     let result = try installer.install(target: target)
     #expect(result.onPath == true)

--- a/Tests/TBDSharedTests/CLIInstallerTests.swift
+++ b/Tests/TBDSharedTests/CLIInstallerTests.swift
@@ -1,0 +1,244 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+private struct TempHome {
+    let url: URL
+    var path: String { url.path }
+
+    init() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-cli-installer-tests")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        self.url = base
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func makeFile(_ path: String) throws {
+    let dir = (path as NSString).deletingLastPathComponent
+    try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+    FileManager.default.createFile(atPath: path, contents: Data())
+}
+
+// MARK: - cliPath(forDaemonExecutable:)
+
+@Test func cliPathDerivedFromSiblingOfDaemon() {
+    let result = CLIInstaller.cliPath(forDaemonExecutable: "/Users/me/.build/debug/TBDDaemon")
+    #expect(result == "/Users/me/.build/debug/TBDCLI")
+}
+
+@Test func cliPathHandlesAlternateDaemonName() {
+    let result = CLIInstaller.cliPath(forDaemonExecutable: "/opt/tbd/bin/tbdd")
+    #expect(result == "/opt/tbd/bin/TBDCLI")
+}
+
+// MARK: - currentState
+
+@Test func currentStateNotInstalledWhenSymlinkAbsent() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let installer = CLIInstaller(homeDir: home.path, pathProbe: { nil })
+    let state = installer.currentState(expectedTarget: "/some/target")
+    #expect(state == .notInstalled)
+}
+
+@Test func currentStateInstalledWhenSymlinkPointsAtExpectedExistingTarget() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/cli-target"
+    try makeFile(target)
+    let symlink = home.path + "/.local/bin/tbd"
+    try FileManager.default.createDirectory(
+        atPath: (symlink as NSString).deletingLastPathComponent,
+        withIntermediateDirectories: true
+    )
+    try FileManager.default.createSymbolicLink(atPath: symlink, withDestinationPath: target)
+
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { nil })
+    let state = installer.currentState(expectedTarget: target)
+    #expect(state == .installed(target: target))
+}
+
+@Test func currentStateStaleWhenSymlinkPointsElsewhere() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let expected = home.path + "/expected-cli"
+    let other = home.path + "/other-cli"
+    try makeFile(expected)
+    try makeFile(other)
+    let symlink = home.path + "/.local/bin/tbd"
+    try FileManager.default.createDirectory(
+        atPath: (symlink as NSString).deletingLastPathComponent,
+        withIntermediateDirectories: true
+    )
+    try FileManager.default.createSymbolicLink(atPath: symlink, withDestinationPath: other)
+
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { nil })
+    let state = installer.currentState(expectedTarget: expected)
+    #expect(state == .stale(currentTarget: other))
+}
+
+@Test func currentStateStaleWhenSymlinkTargetMissing() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/cli-target"
+    // Note: do NOT create the file — the symlink will dangle.
+    let symlink = home.path + "/.local/bin/tbd"
+    try FileManager.default.createDirectory(
+        atPath: (symlink as NSString).deletingLastPathComponent,
+        withIntermediateDirectories: true
+    )
+    try FileManager.default.createSymbolicLink(atPath: symlink, withDestinationPath: target)
+
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { nil })
+    let state = installer.currentState(expectedTarget: target)
+    #expect(state == .stale(currentTarget: target))
+}
+
+// MARK: - install
+
+@Test func installCreatesParentDirectoryAndSymlink() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/build/TBDCLI"
+    try makeFile(target)
+    let symlink = home.path + "/.local/bin/tbd"
+
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { "/usr/bin:/bin" })
+    let result = try installer.install(target: target)
+    #expect(result.symlinkPath == symlink)
+    #expect(result.target == target)
+
+    let dest = try FileManager.default.destinationOfSymbolicLink(atPath: symlink)
+    #expect(dest == target)
+}
+
+@Test func installReplacesExistingSymlink() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let oldTarget = home.path + "/old-cli"
+    let newTarget = home.path + "/new-cli"
+    try makeFile(oldTarget)
+    try makeFile(newTarget)
+    let symlink = home.path + "/.local/bin/tbd"
+    try FileManager.default.createDirectory(
+        atPath: (symlink as NSString).deletingLastPathComponent,
+        withIntermediateDirectories: true
+    )
+    try FileManager.default.createSymbolicLink(atPath: symlink, withDestinationPath: oldTarget)
+
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { "/usr/bin" })
+    _ = try installer.install(target: newTarget)
+    let dest = try FileManager.default.destinationOfSymbolicLink(atPath: symlink)
+    #expect(dest == newTarget)
+}
+
+// MARK: - PATH detection / on-PATH branch
+
+@Test func installReportsOnPathWhenBinDirIsPresent() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/cli"
+    try makeFile(target)
+    let symlink = home.path + "/.local/bin/tbd"
+
+    let probe: () -> String? = {
+        "/usr/bin:\(home.path)/.local/bin:/sbin"
+    }
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: probe)
+    let result = try installer.install(target: target)
+    #expect(result.onPath == true)
+    #expect(result.suggestedShellRC == nil)
+    #expect(result.exportLine == nil)
+}
+
+@Test func installReportsOnPathWhenBinDirAppearsTildeExpanded() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/cli"
+    try makeFile(target)
+    let symlink = home.path + "/.local/bin/tbd"
+
+    // Path string contains the tilde-prefixed form — should still match.
+    let probe: () -> String? = { "/usr/bin:~/.local/bin:/sbin" }
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: probe)
+    let result = try installer.install(target: target)
+    #expect(result.onPath == true)
+}
+
+// MARK: - PATH detection / off-PATH branch
+
+@Test func installReportsOffPathAndZshRCByDefault() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/cli"
+    try makeFile(target)
+    let symlink = home.path + "/.local/bin/tbd"
+
+    let installer = CLIInstaller(
+        symlinkPath: symlink,
+        homeDir: home.path,
+        shellPath: "/bin/zsh",
+        pathProbe: { "/usr/bin:/bin" }
+    )
+    let result = try installer.install(target: target)
+    #expect(result.onPath == false)
+    #expect(result.suggestedShellRC == "~/.zshrc")
+    #expect(result.exportLine == "export PATH=\"$HOME/.local/bin:$PATH\"")
+}
+
+@Test func installReportsOffPathBashProfileForBash() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/cli"
+    try makeFile(target)
+    let symlink = home.path + "/.local/bin/tbd"
+
+    let installer = CLIInstaller(
+        symlinkPath: symlink,
+        homeDir: home.path,
+        shellPath: "/bin/bash",
+        pathProbe: { "/usr/bin:/bin" }
+    )
+    let result = try installer.install(target: target)
+    #expect(result.onPath == false)
+    #expect(result.suggestedShellRC == "~/.bash_profile")
+    #expect(result.exportLine == "export PATH=\"$HOME/.local/bin:$PATH\"")
+}
+
+@Test func installReportsOffPathFishConfigForFish() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/cli"
+    try makeFile(target)
+    let symlink = home.path + "/.local/bin/tbd"
+
+    let installer = CLIInstaller(
+        symlinkPath: symlink,
+        homeDir: home.path,
+        shellPath: "/usr/local/bin/fish",
+        pathProbe: { "/usr/bin:/bin" }
+    )
+    let result = try installer.install(target: target)
+    #expect(result.onPath == false)
+    #expect(result.suggestedShellRC == "~/.config/fish/config.fish")
+    #expect(result.exportLine == "set -gx PATH $HOME/.local/bin $PATH")
+}
+
+@Test func pathProbeReturningNilTreatedAsOffPath() throws {
+    let home = try TempHome()
+    defer { home.cleanup() }
+    let target = home.path + "/cli"
+    try makeFile(target)
+    let symlink = home.path + "/.local/bin/tbd"
+
+    let installer = CLIInstaller(symlinkPath: symlink, homeDir: home.path, pathProbe: { nil })
+    let result = try installer.install(target: target)
+    #expect(result.onPath == false)
+    #expect(result.exportLine != nil)
+}

--- a/Tests/TBDSharedTests/CLIInstallerTests.swift
+++ b/Tests/TBDSharedTests/CLIInstallerTests.swift
@@ -111,6 +111,36 @@ private func makeFile(_ path: String) throws {
     #expect(state == .stale(currentTarget: target))
 }
 
+// MARK: - launchPromptKind
+
+@Test func launchPromptKindIsNilWhenInstalled() {
+    let state: CLIInstallState = .installed(target: "/bin/tbd")
+    #expect(state.launchPromptKind(userPreviouslyDismissed: false) == nil)
+    #expect(state.launchPromptKind(userPreviouslyDismissed: true) == nil)
+}
+
+@Test func launchPromptKindMissingWhenNotInstalledAndNotDismissed() {
+    let state: CLIInstallState = .notInstalled
+    #expect(state.launchPromptKind(userPreviouslyDismissed: false) == .missing)
+}
+
+@Test func launchPromptKindNilWhenNotInstalledAndPreviouslyDismissed() {
+    let state: CLIInstallState = .notInstalled
+    #expect(state.launchPromptKind(userPreviouslyDismissed: true) == nil)
+}
+
+@Test func launchPromptKindStaleAlwaysSurfacedRegardlessOfDismissal() {
+    let state: CLIInstallState = .stale(currentTarget: "/old/tbd")
+    #expect(state.launchPromptKind(userPreviouslyDismissed: false) == .stale(current: "/old/tbd"))
+    #expect(state.launchPromptKind(userPreviouslyDismissed: true) == .stale(current: "/old/tbd"))
+}
+
+@Test func launchPromptKindNonSymlinkAlwaysSurfacedRegardlessOfDismissal() {
+    let state: CLIInstallState = .nonSymlink
+    #expect(state.launchPromptKind(userPreviouslyDismissed: false) == .nonSymlink)
+    #expect(state.launchPromptKind(userPreviouslyDismissed: true) == .nonSymlink)
+}
+
 // MARK: - install
 
 @Test func installCreatesParentDirectoryAndSymlink() async throws {


### PR DESCRIPTION
## Summary
- TBDApp's system prompt tells Claude sessions about `tbd worktree create`, `tbd terminal create`, etc. — but the project never put `tbd` on PATH, so those commands failed with "command not found" in any fresh shell.
- Adds a launch-time check and an "Install Command-Line Tool…" menu item that symlinks `~/.local/bin/tbd` at the running daemon's sibling `TBDCLI`. Re-resolves on every launch, so it follows whichever worktree's daemon is currently active.
- After install, if `~/.local/bin` isn't on the user's login-shell PATH, a follow-up dialog shows the exact export line for their shell (zsh / bash / fish). No sudo, no rc-file editing.

## Test plan
- [x] `swift build` clean
- [x] `swift test` — all 446 tests pass (14 new in `CLIInstallerTests`)
- [ ] `rm -f ~/.local/bin/tbd`, run `scripts/restart.sh` from this worktree, verify the launch prompt appears and clicking Install creates the symlink
- [ ] Use the "Install Command-Line Tool…" menu item from a healthy state — verify the "already installed" dialog reports the correct target
- [ ] In a fresh terminal (with `~/.local/bin` on PATH), confirm `tbd worktree list` works