### PR TITLE
Fix: Don't /exit Claude sessions on daemon reconnect when auto-suspend is off

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -444,9 +444,11 @@ final class AppState: ObservableObject {
             await refreshClaudeTokens()
             startSubscription()
             await refreshPRStatuses()
-            Task {
+            let suspendEnabled = AppState.autoSuspendClaudeEnabled
+            Task { [selectedWorktreeIDs] in
                 try? await daemonClient.worktreeSelectionChanged(
-                    selectedWorktreeIDs: selectedWorktreeIDs
+                    selectedWorktreeIDs: selectedWorktreeIDs,
+                    suspendEnabled: suspendEnabled
                 )
             }
         } else {
@@ -838,6 +840,18 @@ final class AppState: ObservableObject {
     /// Whether the WIP main-area resize broadcast is enabled. Default false.
     private var terminalAutoResizeEnabled: Bool {
         UserDefaults.standard.bool(forKey: Self.terminalAutoResizeKey)
+    }
+
+    /// UserDefaults key mirroring the `@AppStorage("autoSuspendClaude")`
+    /// toggle in ContentView/SettingsView. Read from non-View contexts (e.g.
+    /// the daemon-reconnect path) to avoid sending `suspendEnabled=true`
+    /// when the user has the toggle off.
+    static let autoSuspendClaudeKey = "autoSuspendClaude"
+
+    /// Whether auto-suspend is enabled. Defaults to true when the user has
+    /// never touched the toggle, matching the `@AppStorage` defaults.
+    static var autoSuspendClaudeEnabled: Bool {
+        UserDefaults.standard.object(forKey: autoSuspendClaudeKey) as? Bool ?? true
     }
 
     /// Convert the current `mainAreaSize` (pixels) into tmux cell dimensions

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -6,7 +6,7 @@ struct ContentView: View {
     @EnvironmentObject var appState: AppState
     @AppStorage("filePanel.isVisible") private var showFilePanel = true
     @AppStorage("filePanel.width") private var filePanelWidth: Double = 280
-    @AppStorage("autoSuspendClaude") private var autoSuspendClaude: Bool = true
+    @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspendClaude: Bool = true
     @State private var conductorHotkeyMonitor = ConductorHotkeyMonitor()
     @State private var contentAreaHeight: CGFloat = 600
     /// Saved first responder to restore when conductor hides.

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -530,7 +530,7 @@ actor DaemonClient {
     }
 
     /// Notify the daemon which worktrees are currently selected in the app.
-    func worktreeSelectionChanged(selectedWorktreeIDs: Set<UUID>, suspendEnabled: Bool = true) async throws {
+    func worktreeSelectionChanged(selectedWorktreeIDs: Set<UUID>, suspendEnabled: Bool) async throws {
         try await callVoidAsync(
             method: RPCMethod.worktreeSelectionChanged,
             params: WorktreeSelectionChangedParams(selectedWorktreeIDs: Array(selectedWorktreeIDs), suspendEnabled: suspendEnabled)

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -28,7 +28,7 @@ struct SettingsView: View {
 struct GeneralSettingsTab: View {
     @AppStorage("enableNotifications") private var enableNotifications: Bool = true
     @AppStorage("skipPermissions") private var skipPermissions: Bool = true
-    @AppStorage("autoSuspendClaude") private var autoSuspend: Bool = true
+    @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = true
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""

--- a/Tests/TBDAppTests/AutoSuspendPreferenceTests.swift
+++ b/Tests/TBDAppTests/AutoSuspendPreferenceTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tests for the `autoSuspendClaude` UserDefaults helper that the
+/// daemon-reconnect path in `AppState.connectAndLoadInitialState()` reads to
+/// build the `worktree.selectionChanged` RPC params. Regression coverage for
+/// a bug where the reconnect path ignored the toggle and always sent
+/// `suspendEnabled=true`, causing real Claude sessions to receive `/exit`.
+
+@MainActor
+@Suite("Auto-suspend Claude preference")
+struct AutoSuspendPreferenceTests {
+    private let key = AppState.autoSuspendClaudeKey
+
+    private func withPreference(_ value: Bool?, _ body: () throws -> Void) rethrows {
+        let prior = UserDefaults.standard.object(forKey: key)
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        defer {
+            if let prior {
+                UserDefaults.standard.set(prior, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+        try body()
+    }
+
+    @Test("returns true when toggle is on")
+    func enabledWhenOn() throws {
+        try withPreference(true) {
+            #expect(AppState.autoSuspendClaudeEnabled == true)
+        }
+    }
+
+    @Test("returns false when toggle is off — the regressed branch")
+    func disabledWhenOff() throws {
+        try withPreference(false) {
+            #expect(AppState.autoSuspendClaudeEnabled == false)
+        }
+    }
+
+    @Test("defaults to true when the user has never touched the toggle")
+    func defaultsToTrueWhenUnset() throws {
+        try withPreference(nil) {
+            #expect(AppState.autoSuspendClaudeEnabled == true)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Real Claude sessions were getting `/exit`'d even with the auto-suspend toolbar toggle turned **off**. Every daemon reconnect (app start, daemon restart, sleep/wake, socket blip) sent `worktree.selectionChanged` with `suspendEnabled=true`, ignoring the user's preference.

**Root cause:** `AppState.connectAndLoadInitialState()` called `daemonClient.worktreeSelectionChanged(selectedWorktreeIDs:)` without passing `suspendEnabled`, falling through to `DaemonClient`'s `= true` default. The `SuspendResumeCoordinator` then scheduled suspends for any worktrees that "departed" between the daemon's in-memory `lastKnownSelection` and the app's current selection.

**Fix:**
- Added `AppState.autoSuspendClaudeEnabled` static helper that reads `@AppStorage("autoSuspendClaude")` from a non-View context (defaulting to `true` when unset, matching the existing `@AppStorage` defaults).
- The reconnect path now passes the user's preference explicitly.
- Removed the `= true` default from `DaemonClient.worktreeSelectionChanged` so the compiler enforces every callsite is intentional. Silent defaults that override user preference are exactly what bit us here.

**Out of scope (follow-up):** `SuspendResumeCoordinator.scheduleResume` at `Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift:218` also gates on `suspendEnabled`, which means manually-suspended terminals never auto-resume on focus when the toggle is off. Separate fix.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — full suite (431 tests) passes; new `AutoSuspendPreferenceTests` covers all three branches (toggle on, toggle off, never-set defaults to true)
- [ ] Manual smoke:
  - `scripts/restart.sh` from worktree
  - Turn auto-suspend OFF in the toolbar
  - Switch between worktrees
  - Restart the daemon (`pkill TBDDaemon`)
  - `tail -f /tmp/tbd-suspend.log` — confirm reconnect-driven `selectionChanged` lines now show `suspendEnabled=false` and no `SUSPENDING ...: sending /exit` lines appear