### PR TITLE
fix: revive archived worktrees with renamed/missing branches

### DIFF
--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -143,6 +143,8 @@ extension AppState {
             await refreshArchivedWorktrees(repoID: snapshot.repoID)
         } catch {
             revivingArchived.removeValue(forKey: worktreeID)
+            logger.error("reviveWithSession failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+            showAlert("Couldn't revive worktree: \(error.localizedDescription)", isError: true)
             handleConnectionError(error)
         }
     }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -92,6 +92,7 @@ extension AppState {
         } catch {
             revivingArchived.removeValue(forKey: id)
             logger.error("Failed to revive worktree: \(error)")
+            showAlert("Couldn't revive worktree: \(error.localizedDescription)", isError: true)
             handleConnectionError(error)
         }
     }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -166,6 +166,11 @@ public final class Daemon: Sendable {
             print("[Daemon] Warning: Failed to list repos for reconciliation: \(error)")
         }
 
+        // 11a. Backfill archived worktrees whose branch is missing — repairs
+        // rows whose branch was renamed before archive captured the new name.
+        // Idempotent and best-effort; never throws.
+        await ArchivedWorktreeBackfill(db: database, git: git).run()
+
         // 11b. Validate repo health — flips repos with stale paths to .missing.
         //      Must come *after* reconcile so newly-discovered worktrees see the
         //      correct status, and *before* the periodic tasks so users get accurate

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -329,6 +329,14 @@ public final class TBDDatabase: Sendable {
             try db.execute(sql: "ALTER TABLE model_profile_usage RENAME COLUMN token_id TO profile_id")
         }
 
+        // Track HEAD SHA captured at archive time so revive can fall back when
+        // the archived branch was renamed/deleted on disk before archive captured it.
+        migrator.registerMigration("v16_archived_head_sha") { db in
+            try db.alter(table: "worktree") { t in
+                t.add(column: "archivedHeadSHA", .text)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -174,9 +174,14 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Archive a worktree (set status to archived and record the timestamp).
-    /// Optionally saves Claude session IDs in the same transaction so they survive terminal deletion.
+    /// Optionally saves Claude session IDs and the captured HEAD SHA in the
+    /// same transaction so they survive terminal deletion and crashes.
     /// Refuses to archive worktrees with `.main` status.
-    public func archive(id: UUID, claudeSessionIDs: [String]? = nil) async throws {
+    public func archive(
+        id: UUID,
+        claudeSessionIDs: [String]? = nil,
+        archivedHeadSHA: String? = nil
+    ) async throws {
         try await writer.write { db in
             guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Worktree not found")
@@ -192,6 +197,9 @@ public struct WorktreeStore: Sendable {
             if let sessions = claudeSessionIDs, !sessions.isEmpty {
                 record.archivedClaudeSessions = try String(
                     data: JSONEncoder().encode(sessions), encoding: .utf8)
+            }
+            if let sha = archivedHeadSHA {
+                record.archivedHeadSHA = sha
             }
             try record.update(db)
         }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -19,6 +19,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var tmuxServer: String
     var archivedClaudeSessions: String?
     var sortOrder: Int
+    var archivedHeadSHA: String?
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -33,6 +34,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.archivedAt = wt.archivedAt
         self.tmuxServer = wt.tmuxServer
         self.sortOrder = wt.sortOrder
+        self.archivedHeadSHA = wt.archivedHeadSHA
         if let sessions = wt.archivedClaudeSessions {
             self.archivedClaudeSessions = try? String(
                 data: JSONEncoder().encode(sessions), encoding: .utf8)
@@ -58,7 +60,8 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             archivedAt: archivedAt,
             tmuxServer: tmuxServer,
             archivedClaudeSessions: sessions,
-            sortOrder: sortOrder
+            sortOrder: sortOrder,
+            archivedHeadSHA: archivedHeadSHA
         )
     }
 }
@@ -252,6 +255,17 @@ public struct WorktreeStore: Sendable {
                 throw DatabaseError(message: "Worktree not found")
             }
             record.path = path
+            try record.update(db)
+        }
+    }
+
+    /// Update the archived HEAD SHA for a worktree (captured at archive time).
+    public func updateArchivedHeadSHA(id: UUID, sha: String?) async throws {
+        try await writer.write { db in
+            guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Worktree not found")
+            }
+            record.archivedHeadSHA = sha
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -101,6 +101,38 @@ public struct GitManager: Sendable {
         _ = try await run(arguments: ["worktree", "add", worktreePath, branch], at: repoPath)
     }
 
+    /// Adds a worktree at `worktreePath`, creating a new branch pointing at the given SHA.
+    /// Used as a fallback when the original branch was renamed/deleted but we have the
+    /// archived HEAD SHA to recover the commit.
+    public func worktreeAddNewBranch(repoPath: String, worktreePath: String, branch: String, sha: String) async throws {
+        _ = try await run(
+            arguments: ["worktree", "add", "-b", branch, worktreePath, sha],
+            at: repoPath
+        )
+    }
+
+    /// Returns the HEAD SHA of a worktree directory.
+    public func headSHA(worktreePath: String) async throws -> String {
+        let output = try await run(arguments: ["rev-parse", "HEAD"], at: worktreePath)
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Returns true if the given branch / ref name resolves in the repo.
+    public func refExists(repoPath: String, ref: String) async -> Bool {
+        do {
+            _ = try await run(arguments: ["rev-parse", "--verify", "--quiet", ref], at: repoPath)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Returns the raw output of `git log -g --all --pretty=%H %gs` for reflog mining.
+    /// Used by the archived-worktree backfill to discover branch renames.
+    public func reflogAll(repoPath: String) async throws -> String {
+        return try await run(arguments: ["log", "-g", "--all", "--pretty=%H %gs"], at: repoPath)
+    }
+
     /// Removes a worktree at the given path.
     public func worktreeRemove(repoPath: String, worktreePath: String) async throws {
         _ = try await run(arguments: ["worktree", "remove", worktreePath, "--force"], at: repoPath)

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -230,11 +230,41 @@ public struct GitManager: Sendable {
 
             let commandDescription = "git " + arguments.joined(separator: " ")
 
+            // Drain pipes incrementally to prevent deadlock when output exceeds the
+            // OS pipe buffer (~64KB). Without this, the child process blocks on
+            // write and `terminationHandler` never fires.
+            let stdoutAccumulator = PipeDataAccumulator()
+            let stderrAccumulator = PipeDataAccumulator()
+            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                if chunk.isEmpty {
+                    handle.readabilityHandler = nil
+                } else {
+                    stdoutAccumulator.append(chunk)
+                }
+            }
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                if chunk.isEmpty {
+                    handle.readabilityHandler = nil
+                } else {
+                    stderrAccumulator.append(chunk)
+                }
+            }
+
             process.terminationHandler = { _ in
-                let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-                let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-                let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
-                let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+                // Detach handlers and drain anything still buffered.
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                if let tail = try? stdoutPipe.fileHandleForReading.readToEnd(), !tail.isEmpty {
+                    stdoutAccumulator.append(tail)
+                }
+                if let tail = try? stderrPipe.fileHandleForReading.readToEnd(), !tail.isEmpty {
+                    stderrAccumulator.append(tail)
+                }
+
+                let stdout = String(data: stdoutAccumulator.snapshot(), encoding: .utf8) ?? ""
+                let stderr = String(data: stderrAccumulator.snapshot(), encoding: .utf8) ?? ""
 
                 if process.terminationStatus != 0 {
                     continuation.resume(throwing: GitError(
@@ -297,5 +327,24 @@ public struct GitManager: Sendable {
         }
 
         return results
+    }
+}
+
+/// Thread-safe accumulator for incremental pipe reads. The readability handler
+/// fires on a background dispatch queue, so concurrent appends need a lock.
+private final class PipeDataAccumulator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ chunk: Data) {
+        lock.lock()
+        data.append(chunk)
+        lock.unlock()
+    }
+
+    func snapshot() -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
+++ b/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
@@ -1,0 +1,161 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "archivedBackfill")
+
+/// One-shot recovery for archived worktree rows whose `branch` no longer exists
+/// in the underlying repo (e.g. the user ran `git branch -m` inside the worktree
+/// before archive, and the rename never made it into the DB).
+///
+/// Strategy: for each archived worktree, verify the branch resolves; if not,
+/// mine the reflog (`git log -g --all --pretty=%H %gs`) for entries shaped like
+/// `Branch: renamed refs/heads/<old> to refs/heads/<new>`. If we find a rename
+/// chain and the destination branch currently exists, update the DB row to the
+/// new branch and populate `archivedHeadSHA` from that branch's HEAD.
+///
+/// Idempotent: rows with a resolvable branch are skipped — running twice is a
+/// no-op for already-fixed rows. Never deletes rows; never throws to the caller.
+public struct ArchivedWorktreeBackfill: Sendable {
+    public let db: TBDDatabase
+    public let git: GitManager
+
+    public init(db: TBDDatabase, git: GitManager) {
+        self.db = db
+        self.git = git
+    }
+
+    /// Run the backfill across all repos. Errors are logged, never propagated.
+    public func run() async {
+        let repos: [Repo]
+        do {
+            repos = try await db.repos.list()
+        } catch {
+            logger.warning("backfill: failed to list repos: \(error, privacy: .public)")
+            return
+        }
+
+        for repo in repos where repo.status != .missing {
+            await runForRepo(repo: repo)
+        }
+    }
+
+    /// Run the backfill for a single repo. `internal` so tests can drive it directly.
+    func runForRepo(repo: Repo) async {
+        let archived: [Worktree]
+        do {
+            archived = try await db.worktrees.list(repoID: repo.id, status: .archived)
+        } catch {
+            logger.warning("backfill: failed to list archived worktrees for \(repo.displayName, privacy: .public): \(error, privacy: .public)")
+            return
+        }
+
+        guard !archived.isEmpty else { return }
+
+        // Lazily mine the reflog only if at least one row needs repair —
+        // skip the git call entirely on the common (no-broken-rows) path.
+        var renameMap: [String: String]? = nil
+
+        logger.debug("backfill: repo=\(repo.displayName, privacy: .public) archivedCount=\(archived.count, privacy: .public)")
+
+        for wt in archived {
+            let branchOK = await git.refExists(repoPath: repo.path, ref: wt.branch)
+            logger.debug("backfill:   wt=\(wt.name, privacy: .public) branch=\(wt.branch, privacy: .public) exists=\(branchOK, privacy: .public)")
+            if branchOK {
+                continue
+            }
+
+            // First broken row in this repo — mine the reflog now.
+            if renameMap == nil {
+                renameMap = await mineReflogRenames(repoPath: repo.path)
+            }
+
+            await attemptRepair(worktree: wt, repo: repo, renameMap: renameMap ?? [:])
+        }
+    }
+
+    private func attemptRepair(worktree: Worktree, repo: Repo, renameMap: [String: String]) async {
+        // Walk the rename chain (a → b → c) until we hit a branch that no
+        // longer appears as a key (i.e. the latest known name).
+        var current = worktree.branch
+        var visited: Set<String> = [current]
+        while let next = renameMap[current], !visited.contains(next) {
+            visited.insert(next)
+            current = next
+        }
+
+        guard current != worktree.branch else {
+            logger.warning("backfill: worktree \(worktree.id, privacy: .public) branch '\(worktree.branch, privacy: .public)' missing and no rename found in reflog")
+            return
+        }
+
+        let newExists = await git.refExists(repoPath: repo.path, ref: current)
+        guard newExists else {
+            logger.warning("backfill: worktree \(worktree.id, privacy: .public) reflog suggests rename '\(worktree.branch, privacy: .public)' → '\(current, privacy: .public)' but renamed branch is also missing")
+            return
+        }
+
+        do {
+            try await db.worktrees.updateBranch(id: worktree.id, branch: current)
+        } catch {
+            logger.warning("backfill: failed to update branch for \(worktree.id, privacy: .public): \(error, privacy: .public)")
+            return
+        }
+
+        // Populate archivedHeadSHA from the renamed branch's HEAD if not already set.
+        if worktree.archivedHeadSHA == nil {
+            do {
+                let sha = try await git.headSHA(repoPath: repo.path, ref: current)
+                try await db.worktrees.updateArchivedHeadSHA(id: worktree.id, sha: sha)
+            } catch {
+                logger.warning("backfill: failed to populate archivedHeadSHA for \(worktree.id, privacy: .public) (branch \(current, privacy: .public)): \(error, privacy: .public)")
+            }
+        }
+
+        logger.info("backfill: repaired worktree \(worktree.id, privacy: .public) branch '\(worktree.branch, privacy: .public)' → '\(current, privacy: .public)'")
+    }
+
+    /// Parse `git log -g --all --pretty='%H %gs'` output for branch-rename
+    /// entries. Returns a map from old → new branch name.
+    ///
+    /// Reflog message shape:
+    ///   Branch: renamed refs/heads/<old> to refs/heads/<new>
+    func mineReflogRenames(repoPath: String) async -> [String: String] {
+        let output: String
+        do {
+            output = try await git.reflogAll(repoPath: repoPath)
+        } catch {
+            logger.warning("backfill: reflog read failed in \(repoPath, privacy: .public): \(error, privacy: .public)")
+            return [:]
+        }
+
+        return Self.parseReflogRenames(output)
+    }
+
+    /// Pure parser — public for tests.
+    public static func parseReflogRenames(_ output: String) -> [String: String] {
+        var map: [String: String] = [:]
+        let prefix = "refs/heads/"
+        let needle = "Branch: renamed "
+        let separator = " to "
+
+        for line in output.split(separator: "\n") {
+            // Format: "<sha> Branch: renamed refs/heads/<old> to refs/heads/<new>"
+            guard let renameRange = line.range(of: needle) else { continue }
+            let tail = line[renameRange.upperBound...]
+            guard let sepRange = tail.range(of: separator) else { continue }
+            let oldRef = String(tail[..<sepRange.lowerBound])
+            let newRef = String(tail[sepRange.upperBound...])
+            guard oldRef.hasPrefix(prefix), newRef.hasPrefix(prefix) else { continue }
+            let old = String(oldRef.dropFirst(prefix.count))
+            let new = String(newRef.dropFirst(prefix.count))
+            // Latest reflog entries come first; if we encounter a chain we
+            // want the most recent mapping for a given key. Since we're
+            // iterating top-down, only set if missing.
+            if map[old] == nil {
+                map[old] = new
+            }
+        }
+        return map
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
+++ b/Sources/TBDDaemon/Lifecycle/ArchivedWorktreeBackfill.swift
@@ -102,7 +102,12 @@ public struct ArchivedWorktreeBackfill: Sendable {
             return
         }
 
-        // Populate archivedHeadSHA from the renamed branch's HEAD if not already set.
+        // Populate archivedHeadSHA from the renamed branch's *current* HEAD —
+        // not the commit the worktree was on at archive time, which we can't
+        // recover after the fact. If the user committed on the renamed branch
+        // post-archive, a later SHA-fallback revive will land on the newer
+        // commit. Acceptable: the fallback only fires when the branch is also
+        // gone, and a slightly newer starting point beats outright failure.
         if worktree.archivedHeadSHA == nil {
             do {
                 let sha = try await git.headSHA(repoPath: repo.path, ref: current)
@@ -133,6 +138,12 @@ public struct ArchivedWorktreeBackfill: Sendable {
     }
 
     /// Pure parser — public for tests.
+    ///
+    /// The needle is case-sensitive: git's reflog message for `git branch -m`
+    /// has been `"Branch: renamed ..."` (capital B) for many years, but isn't
+    /// formally guaranteed. If git ever changes the message, the parser
+    /// silently returns an empty map and the backfill leaves rows untouched —
+    /// in line with the best-effort, never-throws contract.
     public static func parseReflogRenames(_ output: String) -> [String: String] {
         var map: [String: String] = [:]
         let prefix = "refs/heads/"

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let archiveLogger = Logger(subsystem: "com.tbd.daemon", category: "archive")
 
 /// Reorders `stored` so `preferred` is first, preserving the relative order of
 /// the rest. Returns `stored` unchanged when `preferred` is nil, when `stored`
@@ -37,6 +40,50 @@ extension WorktreeLifecycle {
         let claudeSessionIDs = terminals
             .sorted(by: { $0.createdAt < $1.createdAt })
             .compactMap { $0.claudeSessionID }
+
+        // Sync the branch in DB with what git reports for the worktree path,
+        // so a rename done inside the worktree (e.g. `git branch -m`) is
+        // captured before we lose the live worktree. Without this, revive
+        // would later try to check out a stale branch that no longer exists.
+        var resolvedBranch = worktree.branch
+        // git canonicalizes worktree paths (e.g. /var → /private/var on macOS),
+        // so compare resolved-symlink forms when matching against `worktree.path`.
+        let resolvedWtPath = (URL(fileURLWithPath: worktree.path).resolvingSymlinksInPath()).path
+        if let gitWorktrees = try? await git.worktreeList(repoPath: repo.path),
+           let gitWt = gitWorktrees.first(where: {
+               let resolvedGitPath = (URL(fileURLWithPath: $0.path).resolvingSymlinksInPath()).path
+               return resolvedGitPath == resolvedWtPath
+           }),
+           !gitWt.branch.isEmpty,
+           gitWt.branch != worktree.branch {
+            do {
+                try await db.worktrees.updateBranch(id: worktreeID, branch: gitWt.branch)
+                resolvedBranch = gitWt.branch
+                archiveLogger.info("archive: updated branch for \(worktreeID, privacy: .public) from '\(worktree.branch, privacy: .public)' to '\(gitWt.branch, privacy: .public)' (git worktree list)")
+            } catch {
+                archiveLogger.warning("archive: failed to update branch for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+            }
+        }
+
+        // Capture HEAD SHA from the live worktree directory while it still
+        // exists on disk. Persisted as a fallback for revive when the branch
+        // has been renamed or deleted.
+        var capturedSHA: String? = nil
+        if FileManager.default.fileExists(atPath: worktree.path) {
+            do {
+                capturedSHA = try await git.headSHA(worktreePath: worktree.path)
+            } catch {
+                archiveLogger.warning("archive: failed to capture HEAD SHA for \(worktreeID, privacy: .public) at \(worktree.path, privacy: .public): \(error, privacy: .public)")
+            }
+        }
+        if let sha = capturedSHA {
+            do {
+                try await db.worktrees.updateArchivedHeadSHA(id: worktreeID, sha: sha)
+            } catch {
+                archiveLogger.warning("archive: failed to persist archivedHeadSHA for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+            }
+        }
+        _ = resolvedBranch
 
         // Update DB status and save sessions in one transaction
         try await db.worktrees.archive(id: worktreeID, claudeSessionIDs: claudeSessionIDs)
@@ -133,12 +180,28 @@ extension WorktreeLifecycle {
             throw WorktreeLifecycleError.worktreeAlreadyRegistered(worktree.path)
         }
 
-        // Re-add the git worktree using the existing branch
-        try await git.worktreeAddExisting(
-            repoPath: repo.path,
-            worktreePath: worktree.path,
-            branch: worktree.branch
-        )
+        // Re-add the git worktree. Prefer the existing branch; fall back to
+        // a new branch pointing at the captured archived HEAD SHA when the
+        // branch is no longer present (renamed/deleted before archive ran).
+        let branchExists = await git.refExists(repoPath: repo.path, ref: worktree.branch)
+        if branchExists {
+            try await git.worktreeAddExisting(
+                repoPath: repo.path,
+                worktreePath: worktree.path,
+                branch: worktree.branch
+            )
+        } else if let sha = worktree.archivedHeadSHA, !sha.isEmpty {
+            archiveLogger.info("revive: branch '\(worktree.branch, privacy: .public)' missing for \(worktreeID, privacy: .public), recreating from archived SHA \(sha, privacy: .public)")
+            try await git.worktreeAddNewBranch(
+                repoPath: repo.path,
+                worktreePath: worktree.path,
+                branch: worktree.branch,
+                sha: sha
+            )
+        } else {
+            archiveLogger.error("revive: branch '\(worktree.branch, privacy: .public)' missing for \(worktreeID, privacy: .public) and no archivedHeadSHA — cannot recover")
+            throw WorktreeLifecycleError.branchMissingNoFallback(branch: worktree.branch)
+        }
 
         // If the caller asked to prefer a specific session, float it to the
         // front of the stored list and persist the new order so a subsequent

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -74,16 +74,14 @@ extension WorktreeLifecycle {
                 archiveLogger.warning("archive: failed to capture HEAD SHA for \(worktreeID, privacy: .public) at \(worktree.path, privacy: .public): \(error, privacy: .public)")
             }
         }
-        if let sha = capturedSHA {
-            do {
-                try await db.worktrees.updateArchivedHeadSHA(id: worktreeID, sha: sha)
-            } catch {
-                archiveLogger.warning("archive: failed to persist archivedHeadSHA for \(worktreeID, privacy: .public): \(error, privacy: .public)")
-            }
-        }
 
-        // Update DB status and save sessions in one transaction
-        try await db.worktrees.archive(id: worktreeID, claudeSessionIDs: claudeSessionIDs)
+        // Status flip, session save, and SHA persist all in one transaction —
+        // a crash mid-archive can't leave the row half-updated.
+        try await db.worktrees.archive(
+            id: worktreeID,
+            claudeSessionIDs: claudeSessionIDs,
+            archivedHeadSHA: capturedSHA
+        )
 
         // Kill all tmux windows for this worktree
         for terminal in terminals {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -45,7 +45,6 @@ extension WorktreeLifecycle {
         // so a rename done inside the worktree (e.g. `git branch -m`) is
         // captured before we lose the live worktree. Without this, revive
         // would later try to check out a stale branch that no longer exists.
-        var resolvedBranch = worktree.branch
         // git canonicalizes worktree paths (e.g. /var → /private/var on macOS),
         // so compare resolved-symlink forms when matching against `worktree.path`.
         let resolvedWtPath = (URL(fileURLWithPath: worktree.path).resolvingSymlinksInPath()).path
@@ -58,7 +57,6 @@ extension WorktreeLifecycle {
            gitWt.branch != worktree.branch {
             do {
                 try await db.worktrees.updateBranch(id: worktreeID, branch: gitWt.branch)
-                resolvedBranch = gitWt.branch
                 archiveLogger.info("archive: updated branch for \(worktreeID, privacy: .public) from '\(worktree.branch, privacy: .public)' to '\(gitWt.branch, privacy: .public)' (git worktree list)")
             } catch {
                 archiveLogger.warning("archive: failed to update branch for \(worktreeID, privacy: .public): \(error, privacy: .public)")
@@ -83,7 +81,6 @@ extension WorktreeLifecycle {
                 archiveLogger.warning("archive: failed to persist archivedHeadSHA for \(worktreeID, privacy: .public): \(error, privacy: .public)")
             }
         }
-        _ = resolvedBranch
 
         // Update DB status and save sessions in one transaction
         try await db.worktrees.archive(id: worktreeID, claudeSessionIDs: claudeSessionIDs)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -2,7 +2,7 @@ import Foundation
 import TBDShared
 
 /// Errors that can occur during worktree lifecycle operations.
-public enum WorktreeLifecycleError: Error, CustomStringConvertible {
+public enum WorktreeLifecycleError: Error, CustomStringConvertible, LocalizedError {
     case repoNotFound(UUID)
     case worktreeNotFound(UUID)
     case worktreeNotArchived(UUID)
@@ -11,6 +11,9 @@ public enum WorktreeLifecycleError: Error, CustomStringConvertible {
     case invalidOperation(String)
     case worktreePathAlreadyExists(String)
     case worktreeAlreadyRegistered(String)
+    /// The archived worktree's branch no longer exists and we have no captured
+    /// HEAD SHA to fall back to — there's no safe way to recreate the working tree.
+    case branchMissingNoFallback(branch: String)
 
     public var description: String {
         switch self {
@@ -30,8 +33,12 @@ public enum WorktreeLifecycleError: Error, CustomStringConvertible {
             return "Cannot revive worktree: a file or directory already exists at \(path). Remove or move it and try again."
         case .worktreeAlreadyRegistered(let path):
             return "Cannot revive worktree: git already has a worktree registered at \(path). Run `git worktree remove \(path)` (or `git worktree prune`) from the main repo and try again."
+        case .branchMissingNoFallback(let branch):
+            return "Cannot revive worktree: branch '\(branch)' no longer exists in the repository, and no archived HEAD SHA was captured to fall back to. The branch may have been renamed or deleted before this worktree was archived."
         }
     }
+
+    public var errorDescription: String? { description }
 }
 
 /// Orchestrates the full lifecycle of worktrees: create, archive, revive, and reconcile.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let routerLogger = Logger(subsystem: "com.tbd.daemon", category: "rpcRouter")
 
 /// Maps RPC method names to handler functions.
 /// Decodes raw JSON params, dispatches to the appropriate subsystem, and returns an RPCResponse.
@@ -197,6 +200,7 @@ public final class RPCRouter: Sendable {
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }
         } catch {
+            routerLogger.error("RPC \(request.method, privacy: .public) failed: \(error, privacy: .public)")
             return RPCResponse(error: "\(error)")
         }
     }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -80,6 +80,9 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public var tmuxServer: String
     public var archivedClaudeSessions: [String]?
     public var sortOrder: Int = 0
+    /// HEAD SHA captured at archive time. Used as a fallback when reviving a
+    /// worktree whose branch was renamed or deleted before archive ran.
+    public var archivedHeadSHA: String?
     /// Transient enrichment populated by the daemon's `worktree.list` handler
     /// for archived worktrees: count of actual session JSONL files in the
     /// resolved Claude project directory. Not persisted in the DB. nil when
@@ -92,6 +95,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 hasConflicts: Bool = false,
                 createdAt: Date = Date(), archivedAt: Date? = nil, tmuxServer: String,
                 archivedClaudeSessions: [String]? = nil, sortOrder: Int = 0,
+                archivedHeadSHA: String? = nil,
                 liveClaudeSessionCount: Int? = nil) {
         self.id = id
         self.repoID = repoID
@@ -106,6 +110,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.tmuxServer = tmuxServer
         self.archivedClaudeSessions = archivedClaudeSessions
         self.sortOrder = sortOrder
+        self.archivedHeadSHA = archivedHeadSHA
         self.liveClaudeSessionCount = liveClaudeSessionCount
     }
 
@@ -124,6 +129,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         tmuxServer = try c.decode(String.self, forKey: .tmuxServer)
         archivedClaudeSessions = try c.decodeIfPresent([String].self, forKey: .archivedClaudeSessions)
         sortOrder = try c.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
+        archivedHeadSHA = try c.decodeIfPresent(String.self, forKey: .archivedHeadSHA)
         liveClaudeSessionCount = try c.decodeIfPresent(Int.self, forKey: .liveClaudeSessionCount)
     }
 }

--- a/Tests/TBDDaemonTests/ArchivedReviveBranchRenameTests.swift
+++ b/Tests/TBDDaemonTests/ArchivedReviveBranchRenameTests.swift
@@ -1,0 +1,298 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Helpers (private to this file to avoid colliding with helpers in
+// WorktreeLifecycleTests, which are file-private over there).
+
+private func sh(_ command: String, at dir: URL) async throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = ["-c", command]
+    process.currentDirectoryURL = dir
+    process.environment = [
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
+        "HOME": NSHomeDirectory(),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+    ]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+    process.waitUntilExit()
+    if process.terminationStatus != 0 {
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        throw NSError(domain: "shell", code: Int(process.terminationStatus),
+                      userInfo: [NSLocalizedDescriptionKey: "\(command)\n\(output)"])
+    }
+}
+
+private func makeRepo() async throws -> (tempDir: URL, repoDir: URL) {
+    let tempDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-test-\(UUID().uuidString)")
+    let repoDir = tempDir.appendingPathComponent("repo")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    try await sh("git init -b main && git commit --allow-empty -m 'init'", at: repoDir)
+    return (tempDir, repoDir)
+}
+
+private func makeRepoRow(db: TBDDatabase, tempDir: URL, repoDir: URL) async throws -> Repo {
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+    let override = tempDir.appendingPathComponent(".tbd/worktrees").path
+    try await db.repos.updateWorktreeRoot(id: repo.id, path: override)
+    return try await db.repos.get(id: repo.id)!
+}
+
+// MARK: - Archive captures branch + SHA
+
+@Test func testArchiveCapturesRenamedBranch() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+    let originalBranch = wt.branch
+
+    // Rename the branch from inside the worktree (simulates user `git branch -m`).
+    let newBranch = "renamed-\(UUID().uuidString.prefix(6))"
+    try await sh("git branch -m \(newBranch)", at: URL(fileURLWithPath: wt.path))
+
+    // Archive — should detect the rename and persist the new branch.
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    let archived = try await db.worktrees.get(id: wt.id)
+    #expect(archived?.branch == newBranch)
+    #expect(archived?.branch != originalBranch)
+}
+
+@Test func testArchiveCapturesHeadSHA() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+    let expectedSHA = try await GitManager().headSHA(worktreePath: wt.path)
+
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    let archived = try await db.worktrees.get(id: wt.id)
+    #expect(archived?.archivedHeadSHA == expectedSHA)
+    #expect(archived?.archivedHeadSHA?.isEmpty == false)
+}
+
+// MARK: - Revive happy path / fallback / unrecoverable
+
+@Test func testReviveUsesLiveBranchWhenPresent() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
+    #expect(revived.status == .active)
+    #expect(FileManager.default.fileExists(atPath: revived.path))
+}
+
+@Test func testReviveFallsBackToSHAWhenBranchMissing() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+    // Capture SHA before archive.
+    let sha = try await GitManager().headSHA(worktreePath: wt.path)
+
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    // Now mutate the DB row: rename the branch in the DB to a value that
+    // doesn't exist in git, leaving archivedHeadSHA intact. This simulates
+    // the buggy case where the user renamed before archive but archive
+    // captured the renamed name correctly — except later that branch was
+    // also deleted (or here, was never created). To trigger the SHA
+    // fallback path we need the DB branch to NOT exist in git.
+    let bogus = "tbd/never-existed-\(UUID().uuidString.prefix(6))"
+    try await db.worktrees.updateBranch(id: wt.id, branch: bogus)
+    try await db.worktrees.updateArchivedHeadSHA(id: wt.id, sha: sha)
+
+    let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
+    #expect(revived.status == .active)
+    #expect(FileManager.default.fileExists(atPath: revived.path))
+
+    // The new worktree should be on the (newly created) bogus branch, with HEAD == sha.
+    let revivedSHA = try await GitManager().headSHA(worktreePath: revived.path)
+    #expect(revivedSHA == sha)
+}
+
+@Test func testReviveThrowsBranchMissingNoFallback() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    // Wipe both the branch (rename to something non-existent) and the SHA.
+    let bogus = "tbd/never-existed-\(UUID().uuidString.prefix(6))"
+    try await db.worktrees.updateBranch(id: wt.id, branch: bogus)
+    try await db.worktrees.updateArchivedHeadSHA(id: wt.id, sha: nil)
+
+    do {
+        _ = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
+        Issue.record("expected branchMissingNoFallback to throw")
+    } catch let error as WorktreeLifecycleError {
+        guard case .branchMissingNoFallback(let branch) = error else {
+            Issue.record("wrong WorktreeLifecycleError case: \(error)")
+            return
+        }
+        #expect(branch == bogus)
+        let desc = error.localizedDescription
+        #expect(desc.contains(bogus))
+        #expect(desc.lowercased().contains("branch"))
+    }
+}
+
+// MARK: - Backfill
+
+@Test func testBackfillReflogParser() {
+    let sample = """
+    abc123 commit: hello
+    def456 Branch: renamed refs/heads/old-name to refs/heads/new-name
+    111222 Branch: renamed refs/heads/another-old to refs/heads/another-new
+    333444 commit: unrelated
+    """
+    let map = ArchivedWorktreeBackfill.parseReflogRenames(sample)
+    #expect(map["old-name"] == "new-name")
+    #expect(map["another-old"] == "another-new")
+    #expect(map.count == 2)
+}
+
+@Test func testBackfillRepairsRenamedBranch() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let git = GitManager()
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: git, tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // Build a worktree, rename its branch in git, archive (the archive
+    // capture will pick up the rename — so we then simulate the legacy buggy
+    // state by rolling the DB branch back to the original name).
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    let originalBranch = wt.branch
+    let renamedBranch = "renamed-\(UUID().uuidString.prefix(6))"
+    try await sh("git branch -m \(renamedBranch)", at: URL(fileURLWithPath: wt.path))
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    // Roll the DB row back so it has the *old* branch name. This mimics the
+    // legacy bug where archive ran on rows whose branch was already stale.
+    try await db.worktrees.updateBranch(id: wt.id, branch: originalBranch)
+    try await db.worktrees.updateArchivedHeadSHA(id: wt.id, sha: nil)
+
+    let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+    await backfill.run()
+
+    let repaired = try await db.worktrees.get(id: wt.id)
+    #expect(repaired?.branch == renamedBranch)
+    #expect(repaired?.archivedHeadSHA != nil)
+    #expect(repaired?.archivedHeadSHA?.isEmpty == false)
+
+    // Idempotency: a second run should not change anything.
+    let beforeSecond = repaired
+    await backfill.run()
+    let afterSecond = try await db.worktrees.get(id: wt.id)
+    #expect(afterSecond?.branch == beforeSecond?.branch)
+    #expect(afterSecond?.archivedHeadSHA == beforeSecond?.archivedHeadSHA)
+}
+
+@Test func testBackfillLeavesUnrecoverableRows() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let git = GitManager()
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: git, tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    // Smash the branch to something that never appears anywhere in the reflog.
+    let bogus = "tbd/never-existed-\(UUID().uuidString.prefix(6))"
+    try await db.worktrees.updateBranch(id: wt.id, branch: bogus)
+    let priorSHA = try await db.worktrees.get(id: wt.id)?.archivedHeadSHA
+
+    let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+    await backfill.run()
+
+    // Branch should remain bogus — backfill never deletes or invents.
+    let after = try await db.worktrees.get(id: wt.id)
+    #expect(after?.branch == bogus)
+    #expect(after?.archivedHeadSHA == priorSHA)
+}
+
+@Test func testBackfillNoOpForValidRows() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let git = GitManager()
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: git, tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    let beforeBranch = try await db.worktrees.get(id: wt.id)?.branch
+    let beforeSHA = try await db.worktrees.get(id: wt.id)?.archivedHeadSHA
+
+    let backfill = ArchivedWorktreeBackfill(db: db, git: git)
+    await backfill.run()
+
+    let after = try await db.worktrees.get(id: wt.id)
+    #expect(after?.branch == beforeBranch)
+    #expect(after?.archivedHeadSHA == beforeSHA)
+}


### PR DESCRIPTION
## Summary

Clicking **Revive with this session** on archived worktrees failed silently when the worktree's branch had been renamed before archive. The daemon RPC returned:

```
git worktree add /path tbd/20260430-assistant-clam
fatal: invalid reference: tbd/20260430-assistant-clam
```

…because branch-rename detection only ran for **active** worktrees in `refreshGitStatuses`. Renames performed in the brief window before archive (e.g. the user's "rename `tbd/*` branch on first turn" automation) were lost, and the app silently swallowed the `git worktree add` error.

## Changes

- **Schema**: migration v15 adds `archivedHeadSHA` column to `worktree`.
- **Archive capture**: `beginArchiveWorktree` snapshots the live branch (path-matched against `git worktree list`) and HEAD SHA before flipping the row to archived.
- **Revive fallback**: `reviveWorktree` now uses `git worktree add -b <branch> <path> <sha>` when the original branch is missing but a captured SHA exists. If neither is available, throws a typed `WorktreeLifecycleError.branchMissingNoFallback` with informative `errorDescription`.
- **App-side errors**: `reviveWithSession` and `reviveWorktree` in `AppState` now log and surface via `showAlert`.
- **Daemon-side errors**: `RPCRouter` dispatch failures log via `os.Logger(subsystem: "com.tbd.daemon", category: "rpcRouter")`.
- **One-shot backfill**: `ArchivedWorktreeBackfill` runs once at daemon startup, mining `git log -g --all` for `Branch: renamed refs/heads/<old> to refs/heads/<new>` entries to repair already-broken archived rows. Idempotent, never deletes rows, never throws.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter ArchivedReviveBranchRenameTests` — 9/9 passing (archive capture, revive happy path, SHA fallback, typed error, backfill parser, repair, idempotency, unrecoverable rows)
- [ ] Reproduce original error against an actual broken archived row, then verify revive succeeds after this fix
- [ ] After daemon restart, confirm backfill repairs known-broken rows in `~/tbd/state.db` (`20260430-assistant-clam`, `20260430-negative-ocelot`, `20260504-equal-giraffe`, etc.)

## Verification recipe

```bash
# Trigger the original failure (archived worktree with renamed branch):
PORT=$(cat ~/tbd/port)
curl -s -X POST "http://127.0.0.1:$PORT/rpc" -H 'Content-Type: application/json' \
  -d '{"method":"worktree.revive","params":"{\"worktreeID\":\"<UUID>\",\"cols\":120,\"rows\":40,\"preferredSessionID\":\"<SID>\"}"}'
```