### PR TITLE
Feat: Install TBD as a Claude skill — survives resume, reaches shell tabs

### DIFF
--- a/Sources/TBDApp/AppState+Skill.swift
+++ b/Sources/TBDApp/AppState+Skill.swift
@@ -1,0 +1,29 @@
+import Foundation
+import TBDShared
+import os
+
+extension AppState {
+    private static let skillLogger = Logger(subsystem: "com.tbd.app", category: "skill")
+
+    /// Refresh the cached skill status. Called on app activation and after install.
+    @MainActor
+    func refreshSkillStatus() async {
+        do {
+            let result = try await daemonClient.skillStatus()
+            self.skillStatus = result
+        } catch {
+            Self.skillLogger.error("refreshSkillStatus error: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Install or update the skill, then refresh status so the menu reflects the new state.
+    @MainActor
+    func installSkill() async {
+        do {
+            _ = try await daemonClient.installSkill()
+        } catch {
+            Self.skillLogger.error("installSkill error: \(String(describing: error), privacy: .public)")
+        }
+        await refreshSkillStatus()
+    }
+}

--- a/Sources/TBDApp/AppState+Skill.swift
+++ b/Sources/TBDApp/AppState+Skill.swift
@@ -17,11 +17,14 @@ extension AppState {
     }
 
     /// Install or update the skill, then refresh status so the menu reflects the new state.
+    /// Stores any install error in `skillInstallError` so the menu can surface it.
     @MainActor
     func installSkill() async {
         do {
             _ = try await daemonClient.installSkill()
+            self.skillInstallError = nil
         } catch {
+            self.skillInstallError = String(describing: error)
             Self.skillLogger.error("installSkill error: \(String(describing: error), privacy: .public)")
         }
         await refreshSkillStatus()

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -226,6 +226,9 @@ final class AppState: ObservableObject {
     @Published var alertMessage: String? = nil
     @Published var alertIsError: Bool = false
 
+    /// Cached skill installation status; refreshed on app activation and after install.
+    @Published var skillStatus: SkillStatusResult? = nil
+
     let daemonClient = DaemonClient()
     let tmuxBridge = TmuxBridge()
     private var pollTimer: Timer?
@@ -255,6 +258,9 @@ final class AppState: ObservableObject {
             await connectAndLoadInitialState()
             startPolling()
         }
+        Task { @MainActor in
+            await self.refreshSkillStatus()
+        }
     }
 
     // Note: AppState is singleton-lifetime in this app, so we deliberately
@@ -281,6 +287,10 @@ final class AppState: ObservableObject {
                 } catch {
                     logger.warning("setAppForegroundState(true) failed: \(error)")
                 }
+            }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                await self.refreshSkillStatus()
             }
         }
         let resigned = center.addObserver(

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -228,6 +228,7 @@ final class AppState: ObservableObject {
 
     /// Cached skill installation status; refreshed on app activation and after install.
     @Published var skillStatus: SkillStatusResult? = nil
+    @Published var skillInstallError: String? = nil
 
     let daemonClient = DaemonClient()
     let tmuxBridge = TmuxBridge()

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -509,6 +509,24 @@ actor DaemonClient {
         )
     }
 
+    /// Get the current skill installation status.
+    func skillStatus(harness: Harness = .claudeCode) async throws -> SkillStatusResult {
+        return try await callAsync(
+            method: RPCMethod.skillStatus,
+            params: SkillStatusParams(harness: harness),
+            resultType: SkillStatusResult.self
+        )
+    }
+
+    /// Install or update the skill in the user's harness.
+    func installSkill(harness: Harness = .claudeCode) async throws -> SkillInstallResultRPC {
+        return try await callAsync(
+            method: RPCMethod.skillInstall,
+            params: SkillInstallParams(harness: harness),
+            resultType: SkillInstallResultRPC.self
+        )
+    }
+
     /// List unread notifications grouped by worktree (highest severity per worktree).
     func listNotifications() async throws -> [UUID: NotificationType] {
         let result = try await callNoParamsAsync(method: RPCMethod.notificationsList, resultType: NotificationsListResult.self)

--- a/Sources/TBDApp/MenuBar/SkillMenu.swift
+++ b/Sources/TBDApp/MenuBar/SkillMenu.swift
@@ -28,12 +28,15 @@ private struct SkillMenuContent: View {
             Button("Install TBD Skill…") {
                 Task { @MainActor in
                     await appState.installSkill()
-                    let post = appState.skillStatus
                     let alert = NSAlert()
-                    if let s = post, s.status == .upToDate {
+                    if let err = appState.skillInstallError {
+                        alert.alertStyle = .warning
+                        alert.messageText = "Couldn't install TBD skill"
+                        alert.informativeText = "\(err)\n\nIf the TBD daemon isn't running, restart it with scripts/restart.sh, then try again."
+                    } else if let s = appState.skillStatus, s.status == .upToDate {
                         alert.messageText = "TBD skill installed"
                         alert.informativeText = "Installed at \(s.harnessPath)"
-                    } else if let s = post, s.status == .harnessNotDetected {
+                    } else if let s = appState.skillStatus, s.status == .harnessNotDetected {
                         alert.alertStyle = .warning
                         alert.messageText = "Claude Code not detected"
                         alert.informativeText = "TBD couldn't find ~/.claude/. Install Claude Code, then try again."

--- a/Sources/TBDApp/MenuBar/SkillMenu.swift
+++ b/Sources/TBDApp/MenuBar/SkillMenu.swift
@@ -22,31 +22,45 @@ struct SkillMenu: Commands {
 private struct SkillMenuContent: View {
     @EnvironmentObject var appState: AppState
 
+    /// Build and run the post-install/update alert. Inspects `appState.skillInstallError`
+    /// and `appState.skillStatus` to choose between success / harness-missing / generic-error
+    /// messages. `successTitle` is the message text shown when the post-call status is `.upToDate`
+    /// — e.g. "TBD skill installed" vs "TBD skill updated".
+    @MainActor
+    private func showPostInstallAlert(successTitle: String) {
+        let alert = NSAlert()
+        if let err = appState.skillInstallError {
+            alert.alertStyle = .warning
+            alert.messageText = "Couldn't install TBD skill"
+            alert.informativeText = "\(err)\n\nIf the TBD daemon isn't running, restart it with scripts/restart.sh, then try again."
+        } else if let s = appState.skillStatus, s.status == .upToDate {
+            alert.messageText = successTitle
+            alert.informativeText = s.harnessPath
+        } else if let s = appState.skillStatus, s.status == .harnessNotDetected {
+            alert.alertStyle = .warning
+            alert.messageText = "Claude Code not detected"
+            alert.informativeText = "TBD couldn't find ~/.claude/. Install Claude Code, then try again."
+        } else {
+            alert.alertStyle = .warning
+            alert.messageText = "Couldn't install TBD skill"
+            alert.informativeText = "Check Console.app (subsystem com.tbd.app, category skill) for details."
+        }
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
     var body: some View {
         switch appState.skillStatus?.status {
+        // `nil` means "status not loaded yet" — typically a brief window on app
+        // cold-start before the first `refreshSkillStatus()` returns. We treat it
+        // the same as `.notInstalled` so the user can click through; if something
+        // is actually wrong (daemon down, etc.), the post-install error alert
+        // surfaces it with a restart hint.
         case .none, .some(.notInstalled):
             Button("Install TBD Skill…") {
                 Task { @MainActor in
                     await appState.installSkill()
-                    let alert = NSAlert()
-                    if let err = appState.skillInstallError {
-                        alert.alertStyle = .warning
-                        alert.messageText = "Couldn't install TBD skill"
-                        alert.informativeText = "\(err)\n\nIf the TBD daemon isn't running, restart it with scripts/restart.sh, then try again."
-                    } else if let s = appState.skillStatus, s.status == .upToDate {
-                        alert.messageText = "TBD skill installed"
-                        alert.informativeText = "Installed at \(s.harnessPath)"
-                    } else if let s = appState.skillStatus, s.status == .harnessNotDetected {
-                        alert.alertStyle = .warning
-                        alert.messageText = "Claude Code not detected"
-                        alert.informativeText = "TBD couldn't find ~/.claude/. Install Claude Code, then try again."
-                    } else {
-                        alert.alertStyle = .warning
-                        alert.messageText = "Couldn't install TBD skill"
-                        alert.informativeText = "Check Console.app (subsystem com.tbd.app, category skill) for details."
-                    }
-                    alert.addButton(withTitle: "OK")
-                    alert.runModal()
+                    showPostInstallAlert(successTitle: "TBD skill installed")
                 }
             }
         case .some(.upToDate):
@@ -62,15 +76,15 @@ private struct SkillMenuContent: View {
         case .some(.outdated):
             Button("Update TBD Skill…") {
                 Task { @MainActor in
-                    let alert = NSAlert()
-                    alert.messageText = "Update TBD skill?"
-                    alert.informativeText = "This will overwrite \(appState.skillStatus?.harnessPath ?? "")."
-                    alert.addButton(withTitle: "Update")
-                    alert.addButton(withTitle: "Cancel")
-                    let response = alert.runModal()
-                    if response == .alertFirstButtonReturn {
-                        await appState.installSkill()
-                    }
+                    let confirm = NSAlert()
+                    confirm.messageText = "Update TBD skill?"
+                    confirm.informativeText = "This will overwrite \(appState.skillStatus?.harnessPath ?? "")."
+                    confirm.addButton(withTitle: "Update")
+                    confirm.addButton(withTitle: "Cancel")
+                    let response = confirm.runModal()
+                    guard response == .alertFirstButtonReturn else { return }
+                    await appState.installSkill()
+                    showPostInstallAlert(successTitle: "TBD skill updated")
                 }
             }
         case .some(.harnessNotDetected):

--- a/Sources/TBDApp/MenuBar/SkillMenu.swift
+++ b/Sources/TBDApp/MenuBar/SkillMenu.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import AppKit
+import TBDShared
+
+/// Menu bar item for installing / updating the TBD skill in the user's harness.
+/// Three states (mirrors PR #90's CLI installer pattern):
+///  - not installed: "Install TBD Skill…"
+///  - installed and up to date: "TBD Skill: Installed ✓" (clickable; shows path)
+///  - installed but outdated: "Update TBD Skill…"
+/// If the harness root (~/.claude/) is missing, the item is disabled with a tooltip.
+struct SkillMenu: Commands {
+    @ObservedObject var appState: AppState
+
+    var body: some Commands {
+        CommandMenu("TBD") {
+            SkillMenuContent()
+                .environmentObject(appState)
+        }
+    }
+}
+
+private struct SkillMenuContent: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        switch appState.skillStatus?.status {
+        case .none, .some(.notInstalled):
+            Button("Install TBD Skill…") {
+                Task { @MainActor in
+                    await appState.installSkill()
+                    if let status = appState.skillStatus, status.status == .upToDate {
+                        let alert = NSAlert()
+                        alert.messageText = "TBD skill installed"
+                        alert.informativeText = "Installed at \(status.harnessPath)"
+                        alert.addButton(withTitle: "OK")
+                        alert.runModal()
+                    }
+                }
+            }
+        case .some(.upToDate):
+            Button("TBD Skill: Installed ✓") {
+                if let path = appState.skillStatus?.harnessPath {
+                    let alert = NSAlert()
+                    alert.messageText = "TBD skill is installed"
+                    alert.informativeText = path
+                    alert.addButton(withTitle: "OK")
+                    alert.runModal()
+                }
+            }
+        case .some(.outdated):
+            Button("Update TBD Skill…") {
+                Task { @MainActor in
+                    let alert = NSAlert()
+                    alert.messageText = "Update TBD skill?"
+                    alert.informativeText = "This will overwrite \(appState.skillStatus?.harnessPath ?? "")."
+                    alert.addButton(withTitle: "Update")
+                    alert.addButton(withTitle: "Cancel")
+                    let response = alert.runModal()
+                    if response == .alertFirstButtonReturn {
+                        await appState.installSkill()
+                    }
+                }
+            }
+        case .some(.harnessNotDetected):
+            Button("Install TBD Skill…") {}
+                .disabled(true)
+                .help("Claude Code not detected (~/.claude/ is missing).")
+        }
+    }
+}

--- a/Sources/TBDApp/MenuBar/SkillMenu.swift
+++ b/Sources/TBDApp/MenuBar/SkillMenu.swift
@@ -28,13 +28,22 @@ private struct SkillMenuContent: View {
             Button("Install TBD Skill…") {
                 Task { @MainActor in
                     await appState.installSkill()
-                    if let status = appState.skillStatus, status.status == .upToDate {
-                        let alert = NSAlert()
+                    let post = appState.skillStatus
+                    let alert = NSAlert()
+                    if let s = post, s.status == .upToDate {
                         alert.messageText = "TBD skill installed"
-                        alert.informativeText = "Installed at \(status.harnessPath)"
-                        alert.addButton(withTitle: "OK")
-                        alert.runModal()
+                        alert.informativeText = "Installed at \(s.harnessPath)"
+                    } else if let s = post, s.status == .harnessNotDetected {
+                        alert.alertStyle = .warning
+                        alert.messageText = "Claude Code not detected"
+                        alert.informativeText = "TBD couldn't find ~/.claude/. Install Claude Code, then try again."
+                    } else {
+                        alert.alertStyle = .warning
+                        alert.messageText = "Couldn't install TBD skill"
+                        alert.informativeText = "Check Console.app (subsystem com.tbd.app, category skill) for details."
                     }
+                    alert.addButton(withTitle: "OK")
+                    alert.runModal()
                 }
             }
         case .some(.upToDate):

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -329,6 +329,7 @@ struct TBDAppMain: App {
         .commands {
             TBDCommands(appState: appState)
             ModelProfileMenu(appState: appState)
+            SkillMenu(appState: appState)
         }
 
         Settings {

--- a/Sources/TBDCLI/Commands/SkillCommand.swift
+++ b/Sources/TBDCLI/Commands/SkillCommand.swift
@@ -1,0 +1,82 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct SkillCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "skill",
+        abstract: "Manage the TBD agent skill installed in your harness",
+        subcommands: [SkillStatusCommand.self, SkillInstallCommand.self]
+    )
+}
+
+struct SkillStatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show whether the TBD skill is installed and up to date"
+    )
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            FileHandle.standardError.write(Data("TBD daemon is not running.\n".utf8))
+            throw ExitCode(2)
+        }
+
+        let req = try RPCRequest(method: RPCMethod.skillStatus, params: SkillStatusParams())
+        let resp = try client.send(req)
+        guard resp.success, let resultJSON = resp.result else {
+            FileHandle.standardError.write(Data("Error: \(resp.error ?? "unknown")\n".utf8))
+            throw ExitCode(1)
+        }
+        let result = try JSONDecoder().decode(SkillStatusResult.self, from: Data(resultJSON.utf8))
+
+        // Stdout: the path. Stderr: the human-readable status.
+        print(result.harnessPath)
+        let label: String
+        switch result.status {
+        case .upToDate: label = "installed (up to date)"
+        case .outdated: label = "installed (outdated)"
+        case .notInstalled: label = "not installed"
+        case .harnessNotDetected: label = "harness not detected"
+        }
+        FileHandle.standardError.write(Data("status: \(label)\n".utf8))
+
+        // Exit code: 0 only when fully current.
+        if result.status != .upToDate {
+            throw ExitCode(1)
+        }
+    }
+}
+
+struct SkillInstallCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "install",
+        abstract: "Install or update the TBD skill in your harness"
+    )
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            FileHandle.standardError.write(Data("TBD daemon is not running.\n".utf8))
+            throw ExitCode(2)
+        }
+
+        let req = try RPCRequest(method: RPCMethod.skillInstall, params: SkillInstallParams())
+        let resp = try client.send(req)
+        guard resp.success, let resultJSON = resp.result else {
+            FileHandle.standardError.write(Data("Error: \(resp.error ?? "unknown")\n".utf8))
+            throw ExitCode(1)
+        }
+        let result = try JSONDecoder().decode(SkillInstallResultRPC.self, from: Data(resultJSON.utf8))
+
+        print(result.path)
+        let label: String
+        switch result.action {
+        case .installed: label = "installed"
+        case .updated: label = "updated"
+        case .noop: label = "already up to date"
+        }
+        FileHandle.standardError.write(Data("\(label)\n".utf8))
+    }
+}

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -15,6 +15,7 @@ struct TBDCommand: AsyncParsableCommand {
             NotifyCommand.self,
             DaemonCommand.self,
             SetupHooksCommand.self,
+            SkillCommand.self,
             CleanupCommand.self,
             LinkCommand.self,
         ]

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TBDShared
+import os
 
 /// Top-level daemon orchestrator.
 ///
@@ -63,6 +64,17 @@ public final class Daemon: Sendable {
 
         // 4. Write PID file
         try pidFile.write()
+
+        // Drop the canonical TBD skill body to the failsafe path so any
+        // Claude session can `Read` it even when no harness skill is registered.
+        // Failures here are non-fatal — the slim system-prompt pointer can still
+        // reference the path, and a missing file is recoverable on next boot.
+        do {
+            try SkillFileWriter().writeFallback()
+        } catch {
+            Logger(subsystem: "com.tbd.daemon", category: "skill")
+                .error("Failed to write fallback skill file: \(String(describing: error), privacy: .public)")
+        }
 
         // 4a. Scrub inherited TBD_* env vars before any tmux server is spawned.
         // The daemon may have been launched from inside a TBD-spawned shell (e.g.

--- a/Sources/TBDDaemon/Lifecycle/SkillFileWriter.swift
+++ b/Sources/TBDDaemon/Lifecycle/SkillFileWriter.swift
@@ -1,0 +1,39 @@
+import Foundation
+import TBDShared
+import os
+
+/// Writes the canonical TBD skill body to the failsafe path under
+/// Application Support. Called once at daemon startup. Failures are
+/// logged but never thrown to the caller — the legacy injection still
+/// works without this file.
+struct SkillFileWriter {
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "skill")
+
+    let applicationSupportRoot: String
+
+    init(applicationSupportRoot: String? = nil) {
+        if let explicit = applicationSupportRoot {
+            self.applicationSupportRoot = explicit
+        } else {
+            // ~/Library/Application Support
+            let urls = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            self.applicationSupportRoot = urls.first?.path
+                ?? (FileManager.default.homeDirectoryForCurrentUser.path + "/Library/Application Support")
+        }
+    }
+
+    /// Absolute path the daemon writes to, e.g.
+    /// `/Users/chang/Library/Application Support/TBD/skill/SKILL.md`.
+    func fallbackPath() -> String {
+        applicationSupportRoot + "/TBD/skill/SKILL.md"
+    }
+
+    /// Write the canonical body, creating parent directories as needed.
+    func writeFallback() throws {
+        let path = fallbackPath()
+        let dir = (path as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try TBDSkillContent.body.write(toFile: path, atomically: true, encoding: .utf8)
+        Self.logger.info("Wrote fallback skill file to \(path, privacy: .public)")
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+++ b/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
@@ -11,46 +11,22 @@ enum SystemPromptBuilder {
 
     static let defaultRenamePrompt = RepoConstants.defaultRenamePrompt
 
-    static let builtInTBDContext = """
-        You are running inside a TBD-managed worktree. TBD is a macOS worktree + terminal manager.
-
-        Available CLI commands:
-        - tbd worktree rename "<worktree-name>" "<display-name>" — rename the worktree display name
-        - tbd worktree create [--repo <path-or-id>] [--folder <dir>] [--branch <name>] [--name "<display>"] — create a new worktree
-        - tbd worktree list [--repo <id>] — list worktrees
-        - tbd link [<worktree>] — print a tbd://open URL for a worktree (no arg = current); clicking opens TBD on that worktree, survives renames
-        - tbd terminal create <worktree> [--type claude|shell] [--cmd <command>] — create a new terminal tab
-        - tbd terminal send --terminal <id> --text <text> [--submit] — send text to a terminal (--submit presses Enter)
-        - tbd terminal output <terminal-id> [--lines N] — read terminal output
-        - tbd notify --type <type> [--message <msg>] — send notifications to TBD UI
-          Types: response_complete, error, task_complete, attention_needed
-
-        Environment variables:
-        - TBD_WORKTREE_ID — UUID of the current worktree (auto-set in all TBD terminals)
-        - TBD_PROMPT_CONTEXT — Built-in TBD context (this text), for passing to spawned sessions
-        - TBD_PROMPT_INSTRUCTIONS — Per-repo custom instructions (set if configured)
-        - TBD_PROMPT_RENAME — Worktree rename prompt (set if worktree hasn't been renamed yet)
-
-        Spawning a new Claude tab in the current worktree:
-          tbd terminal create "$TBD_WORKTREE_ID" --type claude --prompt-file - <<'EOF'
-          your task here
-          EOF
-
-        Creating a new worktree with an initial task for its default Claude tab:
-          tbd worktree create --prompt-file - <<'EOF'
-          your task here
-          EOF
-
-        When using --prompt or --prompt-file to spawn a new worktree or Claude tab, write a
-        thorough briefing — the new session starts with zero context from your conversation.
-        Include what you're trying to accomplish, what you've already learned or ruled out,
-        relevant file paths and line numbers, and enough surrounding context that the new
-        session can make judgment calls rather than follow narrow instructions. Use
-        --prompt-file - with a heredoc for multi-line prompts to avoid shell escaping issues.
-
-        Using --cmd for full control (env vars expand in the new shell):
-          tbd terminal create "$TBD_WORKTREE_ID" --cmd 'claude --append-system-prompt "$TBD_PROMPT_CONTEXT"'
-        """
+    /// Slim pointer injected via `--append-system-prompt` on fresh Claude
+    /// sessions. The full TBD reference content lives in the `tbd` skill
+    /// (registered at `~/.claude/skills/tbd/SKILL.md` after the user clicks
+    /// "Install TBD Skill" in the menu) and at the failsafe path resolved below.
+    static var builtInTBDContext: String {
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?.path
+            ?? (FileManager.default.homeDirectoryForCurrentUser.path + "/Library/Application Support")
+        let fallback = appSupport + "/TBD/skill/SKILL.md"
+        return """
+            You are running inside a TBD-managed worktree (a macOS worktree + terminal manager).
+            A `tbd` skill should be available — invoke it for worktree/terminal actions.
+            If unavailable, read its content directly from \(fallback).
+            """
+    }
 
     /// Returns the individual prompt layers as env-var-name → value pairs.
     /// Used both to set env vars in terminals and to build the combined `--append-system-prompt`.

--- a/Sources/TBDDaemon/Server/RPCRouter+SkillHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SkillHandlers.swift
@@ -1,0 +1,32 @@
+import Foundation
+import TBDShared
+import os
+
+extension RPCRouter {
+    private static let skillLogger = Logger(subsystem: "com.tbd.daemon", category: "skill")
+
+    func handleSkillStatus(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(SkillStatusParams.self, from: paramsData)
+        let installer = SkillInstaller()
+        let status = installer.status(harness: params.harness)
+        let result = SkillStatusResult(
+            harness: params.harness,
+            status: status,
+            harnessPath: installer.targetPath(for: params.harness),
+            daemonHash: TBDSkillContent.bodyHash()
+        )
+        return try RPCResponse(result: result)
+    }
+
+    func handleSkillInstall(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(SkillInstallParams.self, from: paramsData)
+        let installer = SkillInstaller()
+        do {
+            let result = try installer.install(harness: params.harness)
+            Self.skillLogger.info("Skill install action=\(result.action.rawValue, privacy: .public) path=\(result.path, privacy: .public)")
+            return try RPCResponse(result: SkillInstallResultRPC(action: result.action, path: result.path))
+        } catch SkillInstallerError.harnessNotDetected(let harness) {
+            return RPCResponse(error: "Harness not detected: \(harness.rawValue)")
+        }
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -189,6 +189,10 @@ public final class RPCRouter: Sendable {
                 return try await handleSessionMessages(request.paramsData)
             case RPCMethod.stateSubscribe:
                 return RPCResponse(error: "state.subscribe must be handled by SocketServer")
+            case RPCMethod.skillStatus:
+                return try await handleSkillStatus(request.paramsData)
+            case RPCMethod.skillInstall:
+                return try await handleSkillInstall(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -136,6 +136,8 @@ public enum RPCMethod {
     public static let sessionList = "session.list"
     public static let sessionMessages = "session.messages"
     public static let setMainAreaSize = "app.setMainAreaSize"
+    public static let skillStatus = "skill.status"
+    public static let skillInstall = "skill.install"
 }
 
 // MARK: - Main Area Size
@@ -666,5 +668,43 @@ public struct ConversationMessage: Codable, Sendable {
     public let content: String
     public init(role: String, content: String) {
         self.role = role; self.content = content
+    }
+}
+
+// MARK: - Skill RPC payloads
+
+public struct SkillStatusParams: Codable, Sendable {
+    public let harness: Harness
+    public init(harness: Harness = .claudeCode) {
+        self.harness = harness
+    }
+}
+
+public struct SkillStatusResult: Codable, Sendable {
+    public let harness: Harness
+    public let status: SkillStatus
+    public let harnessPath: String
+    public let daemonHash: String
+    public init(harness: Harness, status: SkillStatus, harnessPath: String, daemonHash: String) {
+        self.harness = harness
+        self.status = status
+        self.harnessPath = harnessPath
+        self.daemonHash = daemonHash
+    }
+}
+
+public struct SkillInstallParams: Codable, Sendable {
+    public let harness: Harness
+    public init(harness: Harness = .claudeCode) {
+        self.harness = harness
+    }
+}
+
+public struct SkillInstallResultRPC: Codable, Sendable {
+    public let action: SkillInstallResult.Action
+    public let path: String
+    public init(action: SkillInstallResult.Action, path: String) {
+        self.action = action
+        self.path = path
     }
 }

--- a/Sources/TBDShared/SkillInstaller.swift
+++ b/Sources/TBDShared/SkillInstaller.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// Harnesses we can install the skill into. V1 ships only Claude Code; the
+/// enum exists so adding `.codex` / `.gemini` later is mechanical.
+public enum Harness: String, Sendable, Codable {
+    case claudeCode
+}
+
+/// Result of a `status` call.
+public enum SkillStatus: String, Sendable, Codable, Equatable {
+    /// The harness's root config dir does not exist (e.g., `~/.claude/`).
+    case harnessNotDetected
+    /// The harness is detected but the skill file is not present.
+    case notInstalled
+    /// The skill file exists and matches the running daemon's content.
+    case upToDate
+    /// The skill file exists but differs from the running daemon's content.
+    case outdated
+}
+
+/// Result of an `install` call.
+public struct SkillInstallResult: Sendable, Codable, Equatable {
+    public enum Action: String, Sendable, Codable, Equatable {
+        case installed   // file did not exist before
+        case updated     // file existed and differed; overwritten
+        case noop        // file existed and already matched
+    }
+    public let action: Action
+    public let path: String
+}
+
+public enum SkillInstallerError: Error, Equatable {
+    case harnessNotDetected(Harness)
+}
+
+/// Minimal file-system abstraction so the installer can be unit-tested without
+/// touching the real `~/`.
+public protocol SkillFileSystem: Sendable {
+    func fileExists(atPath path: String) -> Bool
+    func readUTF8(atPath path: String) throws -> String
+    func writeUTF8(_ contents: String, atPath path: String) throws
+    func createDirectory(atPath path: String, withIntermediateDirectories: Bool) throws
+    func isDirectory(atPath path: String) -> Bool
+}
+
+/// Real-FS implementation used in production.
+public struct DefaultSkillFileSystem: SkillFileSystem {
+    public init() {}
+
+    public func fileExists(atPath path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+
+    public func readUTF8(atPath path: String) throws -> String {
+        try String(contentsOfFile: path, encoding: .utf8)
+    }
+
+    public func writeUTF8(_ contents: String, atPath path: String) throws {
+        try contents.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    public func createDirectory(atPath path: String, withIntermediateDirectories: Bool) throws {
+        try FileManager.default.createDirectory(
+            atPath: path,
+            withIntermediateDirectories: withIntermediateDirectories
+        )
+    }
+
+    public func isDirectory(atPath path: String) -> Bool {
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
+        return exists && isDir.boolValue
+    }
+}
+
+/// Pure logic for installing the TBD skill. No daemon, no DB, no `os.Logger`.
+public struct SkillInstaller: Sendable {
+    private let fileSystem: SkillFileSystem
+    private let claudeSkillsRoot: String
+
+    /// Default home-relative paths used in production.
+    public static func defaultClaudeSkillsRoot() -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return home + "/.claude/skills"
+    }
+
+    public init(
+        fileSystem: SkillFileSystem = DefaultSkillFileSystem(),
+        claudeSkillsRoot: String = SkillInstaller.defaultClaudeSkillsRoot()
+    ) {
+        self.fileSystem = fileSystem
+        self.claudeSkillsRoot = claudeSkillsRoot
+    }
+
+    public func targetPath(for harness: Harness) -> String {
+        switch harness {
+        case .claudeCode:
+            return claudeSkillsRoot + "/tbd/SKILL.md"
+        }
+    }
+
+    private func harnessRootPath(for harness: Harness) -> String {
+        switch harness {
+        case .claudeCode:
+            // `~/.claude/` — parent of `~/.claude/skills/`.
+            // Strip "/skills" suffix off claudeSkillsRoot.
+            return (claudeSkillsRoot as NSString).deletingLastPathComponent
+        }
+    }
+
+    public func status(harness: Harness) -> SkillStatus {
+        let root = harnessRootPath(for: harness)
+        guard fileSystem.isDirectory(atPath: root) else {
+            return .harnessNotDetected
+        }
+        let target = targetPath(for: harness)
+        guard fileSystem.fileExists(atPath: target) else {
+            return .notInstalled
+        }
+        let installed = (try? fileSystem.readUTF8(atPath: target)) ?? ""
+        return installed == TBDSkillContent.body ? .upToDate : .outdated
+    }
+
+    @discardableResult
+    public func install(harness: Harness) throws -> SkillInstallResult {
+        let current = status(harness: harness)
+        if current == .harnessNotDetected {
+            throw SkillInstallerError.harnessNotDetected(harness)
+        }
+        let target = targetPath(for: harness)
+        let parentDir = (target as NSString).deletingLastPathComponent
+        try fileSystem.createDirectory(atPath: parentDir, withIntermediateDirectories: true)
+
+        let action: SkillInstallResult.Action
+        switch current {
+        case .upToDate:
+            action = .noop
+        case .outdated:
+            try fileSystem.writeUTF8(TBDSkillContent.body, atPath: target)
+            action = .updated
+        case .notInstalled:
+            try fileSystem.writeUTF8(TBDSkillContent.body, atPath: target)
+            action = .installed
+        case .harnessNotDetected:
+            // Already thrown above; keep exhaustive switch happy.
+            throw SkillInstallerError.harnessNotDetected(harness)
+        }
+        return SkillInstallResult(action: action, path: target)
+    }
+}

--- a/Sources/TBDShared/SkillInstaller.swift
+++ b/Sources/TBDShared/SkillInstaller.swift
@@ -76,35 +76,33 @@ public struct DefaultSkillFileSystem: SkillFileSystem {
 /// Pure logic for installing the TBD skill. No daemon, no DB, no `os.Logger`.
 public struct SkillInstaller: Sendable {
     private let fileSystem: SkillFileSystem
-    private let claudeSkillsRoot: String
+    private let claudeRoot: String
 
-    /// Default home-relative paths used in production.
-    public static func defaultClaudeSkillsRoot() -> String {
+    /// Default home-relative path to the Claude Code root config dir.
+    public static func defaultClaudeRoot() -> String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return home + "/.claude/skills"
+        return home + "/.claude"
     }
 
     public init(
         fileSystem: SkillFileSystem = DefaultSkillFileSystem(),
-        claudeSkillsRoot: String = SkillInstaller.defaultClaudeSkillsRoot()
+        claudeRoot: String = SkillInstaller.defaultClaudeRoot()
     ) {
         self.fileSystem = fileSystem
-        self.claudeSkillsRoot = claudeSkillsRoot
+        self.claudeRoot = claudeRoot
     }
 
     public func targetPath(for harness: Harness) -> String {
         switch harness {
         case .claudeCode:
-            return claudeSkillsRoot + "/tbd/SKILL.md"
+            return claudeRoot + "/skills/tbd/SKILL.md"
         }
     }
 
     private func harnessRootPath(for harness: Harness) -> String {
         switch harness {
         case .claudeCode:
-            // `~/.claude/` — parent of `~/.claude/skills/`.
-            // Strip "/skills" suffix off claudeSkillsRoot.
-            return (claudeSkillsRoot as NSString).deletingLastPathComponent
+            return claudeRoot
         }
     }
 

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -79,7 +79,7 @@ Use `--prompt-file -` with a heredoc to avoid shell escaping issues.
 ## Env vars set in TBD-managed terminals
 
 - `TBD_WORKTREE_ID` — current worktree UUID.
-- `TBD_PROMPT_CONTEXT` — the same content as this skill, for piping into spawned shells.
+- `TBD_PROMPT_CONTEXT` — short pointer that names this skill and the absolute path to its fallback file (~/Library/Application Support/TBD/skill/SKILL.md). The skill body itself is not in env — read it from that path or via your harness's skill mechanism.
 - `TBD_PROMPT_INSTRUCTIONS` — per-repo custom instructions (if configured).
 
 ## Outside a TBD terminal

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -1,0 +1,97 @@
+import Foundation
+import CryptoKit
+
+/// Canonical content for the `tbd` skill. Single source of truth — written to
+/// the fallback file at daemon startup, written to `~/.claude/skills/tbd/SKILL.md`
+/// when the user clicks "Install" in the app menu, and referenced (by absolute
+/// path) from the slim system-prompt pointer that fresh Claude sessions get.
+public enum TBDSkillContent {
+
+    public static let body: String = """
+---
+name: tbd
+description: Drive TBD (a macOS worktree + terminal manager). Use when the user asks to create a worktree, spawn a Claude or shell session in another tab, send input to a terminal, read terminal output, link to a worktree, or send a UI notification — or whenever running inside a TBD-managed terminal (TBD_WORKTREE_ID env var is set).
+---
+
+# TBD
+
+TBD is a macOS app that manages git worktrees and terminal tabs (Claude Code or shell). Sessions running inside a TBD-managed terminal have `TBD_WORKTREE_ID` set in env.
+
+## When to use this skill
+
+- The user asks to spawn an agent, create a new worktree, send a message to another terminal, or notify the UI.
+- You're running inside TBD (`TBD_WORKTREE_ID` is set) and need to coordinate with the user's other tabs.
+
+## Discovering current commands
+
+Always run `tbd <subcommand> --help` for current flags — flag detail is not duplicated here. Top-level commands: `tbd worktree`, `tbd terminal`, `tbd link`, `tbd notify`.
+
+## Common workflows
+
+### Spawn a new Claude tab in the current worktree
+
+New sessions you spawn start with NO conversation history. Brief them like a colleague who just walked into the room.
+
+```bash
+tbd terminal create "$TBD_WORKTREE_ID" --type claude --prompt-file - <<'EOF'
+Goal, what you've ruled out, file paths/lines, enough surrounding context
+that the new session can make judgment calls rather than follow narrow steps.
+EOF
+```
+
+### Create a new worktree with an initial task
+
+```bash
+tbd worktree create --prompt-file - <<'EOF'
+briefing here
+EOF
+```
+
+### Send input to an existing terminal / read its output
+
+```bash
+tbd terminal send --terminal <id> --text "..." [--submit]
+tbd terminal output <id> [--lines N]
+```
+
+### Notify the TBD UI
+
+```bash
+tbd notify --type {response_complete|error|task_complete|attention_needed} --message "..."
+```
+
+### Get a deep link to a worktree
+
+```bash
+tbd link [<worktree>]   # no arg = current
+```
+
+## Briefing requirements when spawning sessions
+
+Always include:
+- What you're trying to accomplish.
+- What you've already tried or ruled out.
+- Relevant file paths with line numbers.
+- Enough context for the new session to make judgment calls, not just follow narrow steps.
+
+Use `--prompt-file -` with a heredoc to avoid shell escaping issues.
+
+## Env vars set in TBD-managed terminals
+
+- `TBD_WORKTREE_ID` — current worktree UUID.
+- `TBD_PROMPT_CONTEXT` — the same content as this skill, for piping into spawned shells.
+- `TBD_PROMPT_INSTRUCTIONS` — per-repo custom instructions (if configured).
+
+## Outside a TBD terminal
+
+If `TBD_WORKTREE_ID` isn't set, run `tbd worktree list` to find an ID, or `tbd worktree create` to make one. The CLI works from any shell on the same machine as the TBD daemon.
+"""
+
+    /// SHA256 of `body`, hex-encoded (lowercase, 64 chars). Used to detect
+    /// whether an installed skill file matches the running daemon's content.
+    public static func bodyHash() -> String {
+        let data = Data(body.utf8)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Tests/TBDDaemonTests/SkillFileWriterTests.swift
+++ b/Tests/TBDDaemonTests/SkillFileWriterTests.swift
@@ -1,0 +1,38 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Test func writesFallbackFileAtTargetPath() throws {
+    let tempRoot = NSTemporaryDirectory() + "tbd-skill-test-\(UUID().uuidString)"
+    defer { try? FileManager.default.removeItem(atPath: tempRoot) }
+
+    let writer = SkillFileWriter(applicationSupportRoot: tempRoot)
+    try writer.writeFallback()
+
+    let target = tempRoot + "/TBD/skill/SKILL.md"
+    #expect(FileManager.default.fileExists(atPath: target))
+
+    let written = try String(contentsOfFile: target, encoding: .utf8)
+    #expect(written == TBDSkillContent.body)
+}
+
+@Test func overwritesExistingFile() throws {
+    let tempRoot = NSTemporaryDirectory() + "tbd-skill-test-\(UUID().uuidString)"
+    defer { try? FileManager.default.removeItem(atPath: tempRoot) }
+
+    let dir = tempRoot + "/TBD/skill"
+    try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+    try "stale".write(toFile: dir + "/SKILL.md", atomically: true, encoding: .utf8)
+
+    let writer = SkillFileWriter(applicationSupportRoot: tempRoot)
+    try writer.writeFallback()
+
+    let written = try String(contentsOfFile: dir + "/SKILL.md", encoding: .utf8)
+    #expect(written == TBDSkillContent.body)
+}
+
+@Test func fallbackPathMatchesExpectedShape() {
+    let writer = SkillFileWriter(applicationSupportRoot: "/var/test")
+    #expect(writer.fallbackPath() == "/var/test/TBD/skill/SKILL.md")
+}

--- a/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
+++ b/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
@@ -116,7 +116,7 @@ struct SystemPromptBuilderTests {
         let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
         #expect(result != nil)
         #expect(result!.contains("TBD-managed worktree"))
-        #expect(result!.contains("tbd notify"))
+        #expect(result!.contains("`tbd` skill"))
     }
 
     @Test("build includes general instructions when set")
@@ -144,5 +144,44 @@ struct SystemPromptBuilderTests {
         #expect(result != nil)
         #expect(!result!.contains("   \n  "))
         #expect(result!.contains("TBD-managed worktree"))
+    }
+
+    // MARK: - Slim context (skill pointer)
+
+    @Test("builtInTBDContext names the tbd skill")
+    func slimContextNamesSkill() {
+        let ctx = SystemPromptBuilder.builtInTBDContext
+        #expect(ctx.contains("`tbd` skill"))
+    }
+
+    @Test("builtInTBDContext references absolute fallback path")
+    func slimContextReferencesFallbackPath() {
+        let ctx = SystemPromptBuilder.builtInTBDContext
+        #expect(ctx.contains("/Library/Application Support/TBD/skill/SKILL.md"))
+    }
+
+    @Test("builtInTBDContext is short (no longer a full CLI reference)")
+    func slimContextIsShort() {
+        // Generous upper bound — flag if anyone re-bloats this string.
+        #expect(SystemPromptBuilder.builtInTBDContext.count < 600)
+    }
+
+    @Test("builtInTBDContext no longer enumerates every subcommand")
+    func slimContextDoesNotEnumerateAllCommands() {
+        let ctx = SystemPromptBuilder.builtInTBDContext
+        #expect(!ctx.contains("tbd terminal send"))
+        #expect(!ctx.contains("tbd terminal output"))
+        #expect(!ctx.contains("--prompt-file"))
+    }
+
+    @Test("fresh session includes the slim pointer")
+    func freshSessionIncludesSlimPointer() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "test-wt", displayName: "🔐 Auth Fix",
+                          branch: "tbd/test-wt", path: "/test/.tbd/worktrees/test-wt",
+                          tmuxServer: "tbd-test")
+        let prompt = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(prompt != nil)
+        #expect(prompt?.contains("`tbd` skill") == true)
     }
 }

--- a/Tests/TBDDaemonTests/WorktreeReviveReorderTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveReorderTests.swift
@@ -1,29 +1,27 @@
-import XCTest
+import Testing
 @testable import TBDDaemonLib
 import TBDShared
 
-final class WorktreeReviveReorderTests: XCTestCase {
-    func testReorderFloatsPreferredSessionFirst() {
-        let stored = ["a", "b", "c"]
-        let preferred = "b"
-        let result = reorderSessions(stored: stored, preferred: preferred)
-        XCTAssertEqual(result, ["b", "a", "c"])
-    }
+@Test func reorderFloatsPreferredSessionFirst() {
+    let stored = ["a", "b", "c"]
+    let preferred = "b"
+    let result = reorderSessions(stored: stored, preferred: preferred)
+    #expect(result == ["b", "a", "c"])
+}
 
-    func testNilPreferredKeepsOrder() {
-        let stored = ["a", "b", "c"]
-        let result = reorderSessions(stored: stored, preferred: String?.none)
-        XCTAssertEqual(result, ["a", "b", "c"])
-    }
+@Test func nilPreferredKeepsOrder() {
+    let stored = ["a", "b", "c"]
+    let result = reorderSessions(stored: stored, preferred: String?.none)
+    #expect(result == ["a", "b", "c"])
+}
 
-    func testUnknownPreferredKeepsOrder() {
-        let stored = ["a", "b", "c"]
-        let result = reorderSessions(stored: stored, preferred: "z")
-        XCTAssertEqual(result, ["a", "b", "c"])
-    }
+@Test func unknownPreferredKeepsOrder() {
+    let stored = ["a", "b", "c"]
+    let result = reorderSessions(stored: stored, preferred: "z")
+    #expect(result == ["a", "b", "c"])
+}
 
-    func testNilStoredStaysNil() {
-        let result = reorderSessions(stored: [String]?.none, preferred: "anything")
-        XCTAssertNil(result)
-    }
+@Test func nilStoredStaysNil() {
+    let result = reorderSessions(stored: [String]?.none, preferred: "anything")
+    #expect(result == nil)
 }

--- a/Tests/TBDSharedTests/SkillInstallerTests.swift
+++ b/Tests/TBDSharedTests/SkillInstallerTests.swift
@@ -31,14 +31,14 @@ final class FakeFileSystem: SkillFileSystem, @unchecked Sendable {
     }
 }
 
-private func make(installed claudeRoot: Bool = true) -> (SkillInstaller, FakeFileSystem) {
+private func make(installed claudeRootExists: Bool = true) -> (SkillInstaller, FakeFileSystem) {
     let fs = FakeFileSystem()
-    if claudeRoot {
+    if claudeRootExists {
         fs.directories.insert("/home/u/.claude")
     }
     let installer = SkillInstaller(
         fileSystem: fs,
-        claudeSkillsRoot: "/home/u/.claude/skills"
+        claudeRoot: "/home/u/.claude"
     )
     return (installer, fs)
 }

--- a/Tests/TBDSharedTests/SkillInstallerTests.swift
+++ b/Tests/TBDSharedTests/SkillInstallerTests.swift
@@ -1,0 +1,111 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+/// In-memory file system for testing.
+final class FakeFileSystem: SkillFileSystem, @unchecked Sendable {
+    var files: [String: String] = [:]
+    var directories: Set<String> = []
+
+    func fileExists(atPath path: String) -> Bool {
+        files[path] != nil || directories.contains(path)
+    }
+
+    func readUTF8(atPath path: String) throws -> String {
+        guard let s = files[path] else {
+            throw NSError(domain: "FakeFS", code: 1)
+        }
+        return s
+    }
+
+    func writeUTF8(_ contents: String, atPath path: String) throws {
+        files[path] = contents
+    }
+
+    func createDirectory(atPath path: String, withIntermediateDirectories: Bool) throws {
+        directories.insert(path)
+    }
+
+    func isDirectory(atPath path: String) -> Bool {
+        directories.contains(path)
+    }
+}
+
+private func make(installed claudeRoot: Bool = true) -> (SkillInstaller, FakeFileSystem) {
+    let fs = FakeFileSystem()
+    if claudeRoot {
+        fs.directories.insert("/home/u/.claude")
+    }
+    let installer = SkillInstaller(
+        fileSystem: fs,
+        claudeSkillsRoot: "/home/u/.claude/skills"
+    )
+    return (installer, fs)
+}
+
+@Test func statusReportsHarnessNotDetectedWhenClaudeRootMissing() {
+    let (installer, _) = make(installed: false)
+    let status = installer.status(harness: .claudeCode)
+    #expect(status == .harnessNotDetected)
+}
+
+@Test func statusReportsNotInstalledWhenFileAbsent() {
+    let (installer, _) = make()
+    let status = installer.status(harness: .claudeCode)
+    #expect(status == .notInstalled)
+}
+
+@Test func statusReportsUpToDateWhenContentMatches() {
+    let (installer, fs) = make()
+    fs.files["/home/u/.claude/skills/tbd/SKILL.md"] = TBDSkillContent.body
+    let status = installer.status(harness: .claudeCode)
+    #expect(status == .upToDate)
+}
+
+@Test func statusReportsOutdatedWhenContentDiffers() {
+    let (installer, fs) = make()
+    fs.files["/home/u/.claude/skills/tbd/SKILL.md"] = "different"
+    let status = installer.status(harness: .claudeCode)
+    #expect(status == .outdated)
+}
+
+@Test func installWritesFileWhenNotInstalled() throws {
+    let (installer, fs) = make()
+    let result = try installer.install(harness: .claudeCode)
+    #expect(result.action == .installed)
+    #expect(result.path == "/home/u/.claude/skills/tbd/SKILL.md")
+    #expect(fs.files["/home/u/.claude/skills/tbd/SKILL.md"] == TBDSkillContent.body)
+}
+
+@Test func installCreatesParentDirectoryIfMissing() throws {
+    let (installer, fs) = make()
+    _ = try installer.install(harness: .claudeCode)
+    #expect(fs.directories.contains("/home/u/.claude/skills/tbd"))
+}
+
+@Test func installOverwritesWhenOutdated() throws {
+    let (installer, fs) = make()
+    fs.files["/home/u/.claude/skills/tbd/SKILL.md"] = "stale content"
+    let result = try installer.install(harness: .claudeCode)
+    #expect(result.action == .updated)
+    #expect(fs.files["/home/u/.claude/skills/tbd/SKILL.md"] == TBDSkillContent.body)
+}
+
+@Test func installIsNoopWhenAlreadyUpToDate() throws {
+    let (installer, fs) = make()
+    fs.files["/home/u/.claude/skills/tbd/SKILL.md"] = TBDSkillContent.body
+    let result = try installer.install(harness: .claudeCode)
+    #expect(result.action == .noop)
+}
+
+@Test func installThrowsWhenHarnessNotDetected() {
+    let (installer, _) = make(installed: false)
+    #expect(throws: SkillInstallerError.self) {
+        _ = try installer.install(harness: .claudeCode)
+    }
+}
+
+@Test func harnessTargetPathIsExpected() {
+    let (installer, _) = make()
+    #expect(installer.targetPath(for: .claudeCode) == "/home/u/.claude/skills/tbd/SKILL.md")
+}

--- a/Tests/TBDSharedTests/TBDSkillContentTests.swift
+++ b/Tests/TBDSharedTests/TBDSkillContentTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Test func bodyStartsWithYAMLFrontmatter() {
+    let body = TBDSkillContent.body
+    #expect(body.hasPrefix("---\n"))
+    // Frontmatter terminator
+    let rest = body.dropFirst("---\n".count)
+    #expect(rest.contains("\n---\n"))
+}
+
+@Test func bodyContainsRequiredFrontmatterFields() {
+    let body = TBDSkillContent.body
+    #expect(body.contains("name: tbd"))
+    #expect(body.contains("description:"))
+}
+
+@Test func bodyContainsExpectedWorkflowSections() {
+    let body = TBDSkillContent.body
+    #expect(body.contains("## Common workflows"))
+    #expect(body.contains("tbd terminal create"))
+    #expect(body.contains("tbd worktree create"))
+    #expect(body.contains("tbd notify"))
+    #expect(body.contains("tbd link"))
+    #expect(body.contains("tbd terminal send"))
+    #expect(body.contains("tbd terminal output"))
+}
+
+@Test func bodyDelegatesFlagDetailToHelp() {
+    let body = TBDSkillContent.body
+    // Versioning-drift mitigation: instruct the model to use --help for current flags.
+    #expect(body.contains("--help"))
+}
+
+@Test func bodyHashIsStableAcrossCalls() {
+    #expect(TBDSkillContent.bodyHash() == TBDSkillContent.bodyHash())
+}
+
+@Test func bodyHashIsHexEncoded64Chars() {
+    let hash = TBDSkillContent.bodyHash()
+    #expect(hash.count == 64)
+    #expect(hash.allSatisfy { $0.isHexDigit })
+}

--- a/docs/superpowers/specs/2026-05-03-tbd-skill-design.md
+++ b/docs/superpowers/specs/2026-05-03-tbd-skill-design.md
@@ -1,0 +1,188 @@
+# TBD Actions as an Installable Skill
+
+**Date:** 2026-05-03
+**Status:** Design
+
+## Problem
+
+TBD currently teaches Claude sessions about its CLI by injecting `--append-system-prompt` at spawn time. The prompt body is `builtInTBDContext` in `Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift:14-53`. This mechanism has five known weaknesses:
+
+1. **Resumes silently lose it.** `SystemPromptBuilder.build()` returns nil when `isResume=true` (`SystemPromptBuilder.swift:80`), so `claude --resume <uuid>` never re-injects. Sessions originally created before a TBD feature shipped stay permanently context-less for that feature.
+2. **Compaction can summarize it away** on long sessions.
+3. **Shell-type terminals never get it** — only sessions TBD spawns directly via `claude --append-system-prompt` benefit. Manual `claude` invocations in shell tabs are blind.
+4. **Updating the prompt requires a daemon rebuild.** The prompt is a Swift constant baked into the binary, not a file the model can read fresh.
+5. **It is Claude-Code-only.** Future codex / gemini support would need separate spawn paths and prompt-injection plumbing.
+
+## Goals
+
+- Make TBD's CLI knowledge available to agent harnesses as a discoverable, on-demand **skill**, so it survives resume and compaction and reaches every kind of terminal.
+- Keep the canonical content **hot-updatable** — editing one place in the daemon source updates the body without daemon-internal coupling that requires rebuilding consumers.
+- Provide a **failsafe** path so the model can read the content even if no skill is registered with the harness.
+- **Ship V1 for Claude Code** while leaving codex / gemini as a clean future extension.
+- Match the install UX shape of PR #90 (CLI symlink installer): status-aware menu item, explicit user click, no silent writes to the user's harness config.
+
+## Non-Goals
+
+- Auto-installing into `~/.claude/skills/` without user action.
+- Codex / Gemini install targets in V1 (designed for, not shipped).
+- Auto-update on TBD upgrade (user clicks Update; no background overwrite).
+- User-customization markers / generated-block delimiters in the skill file (Q4 option C). Out of scope until a real user complains.
+- Project-scoped skills. TBD is a system-level tool; user-global is the only sensible scope.
+
+## Design
+
+### One canonical source of truth
+
+A new Swift file `Sources/TBDShared/TBDSkillContent.swift` holds:
+
+- `body: String` — the full skill markdown including YAML frontmatter.
+- `bodyHash() -> String` — SHA256 of `body`, hex-encoded. Used for "is the installed copy current?" checks.
+
+This replaces the role of `builtInTBDContext` as the canonical reference text. `builtInTBDContext` itself stays as a property of `SystemPromptBuilder` but is rewritten to a one-line pointer (see "Slim legacy injection" below).
+
+### Three places the content lands
+
+1. **Fallback file — always written.** Path: `~/Library/Application Support/TBD/skill/SKILL.md`. Daemon writes this on every startup, unconditionally. Resolved via `FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)`. Failures (permissions, disk full) are logged via `os.Logger` (subsystem `com.tbd.daemon`, category `skill`) but do not crash the daemon — the slim injection still works. This file is the failsafe the legacy injection points to.
+2. **Harness skill — written on user click.** Path: `~/.claude/skills/tbd/SKILL.md`. Written only when the user clicks "Install" or "Update" in the menu (or runs `tbd skill install`). Parent directory `~/.claude/skills/tbd/` is created if missing. `~/.claude/` itself is NOT created — its absence means Claude Code is not installed and the menu item is disabled with a tooltip.
+3. **Slim legacy injection** — see next section.
+
+### Slim legacy injection
+
+`SystemPromptBuilder.builtInTBDContext` is replaced with a short pointer (~3 lines):
+
+```
+You are running inside a TBD-managed worktree (a macOS worktree + terminal manager).
+A `tbd` skill should be available — invoke it for worktree/terminal actions.
+If unavailable, read its content directly from /Users/<user>/Library/Application Support/TBD/skill/SKILL.md.
+```
+
+The fallback path is resolved at injection build time to its concrete absolute form (e.g., `/Users/chang/Library/Application Support/TBD/skill/SKILL.md`) using `FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)`. The `<user>` shown above is illustrative; the real injected string contains the resolved path. Resume sessions still skip injection (`build()` continues to return nil when `isResume=true`) — same behavior as today. The slim pointer is only added on fresh sessions.
+
+Rationale for keeping resume-skip behavior: the slim pointer's value comes from being injected when no other context exists. On resume, the user's prior session text is the load-bearing context, and the skill is registered (or the file is on disk) for the model to find on its own.
+
+### Skill body content
+
+Frontmatter — this is the description the harness matches against to decide skill relevance:
+
+```yaml
+---
+name: tbd
+description: Drive TBD (a macOS worktree + terminal manager). Use when the user asks to create a worktree, spawn a Claude or shell session in another tab, send input to a terminal, read terminal output, link to a worktree, or send a UI notification — or whenever running inside a TBD-managed terminal (TBD_WORKTREE_ID env var is set).
+---
+```
+
+Body, ~50–70 lines, workflow-oriented (not a flag dump):
+
+1. **What TBD is** — one paragraph. macOS app, manages git worktrees + terminal tabs (claude/shell), `TBD_WORKTREE_ID` set inside.
+2. **Discovering current commands** — explicit instruction to run `tbd <cmd> --help` for current flags. Versioning-drift mitigation: the body documents shape and intent; `--help` is authoritative for flag specifics.
+3. **Common workflows** (5 tasks, each one example block):
+   - Spawn a new Claude tab in the current worktree (heredoc + briefing)
+   - Create a new worktree with an initial task
+   - Send input to an existing terminal / read its output
+   - Notify the TBD UI (with the four valid types)
+   - Get a deep link to a worktree
+4. **Briefing requirements when spawning sessions** — preserved verbatim from today's injection: spawned sessions start with zero context, include goal/ruled-out/paths/judgment-context, use `--prompt-file -` heredoc.
+5. **Env vars set in TBD-managed terminals** — `TBD_WORKTREE_ID`, `TBD_PROMPT_CONTEXT`, `TBD_PROMPT_INSTRUCTIONS`. Brief.
+6. **Outside a TBD terminal** — short note: if `TBD_WORKTREE_ID` isn't set, use `tbd worktree list` to find an ID, or `tbd worktree create` from anywhere on the same machine.
+
+What's NOT in the body:
+- Per-flag enumeration (delegated to `--help`)
+- Architecture details (daemon, RPC, tmux internals — irrelevant to driving the CLI)
+- Notes about deep links / LaunchServices internals
+
+### Menu UX (mirrors PR #90 pattern)
+
+Three menu states, re-evaluated on app activation by polling `skillStatus` RPC:
+
+| Daemon hash vs file | File exists? | Menu item label | Action on click |
+|---|---|---|---|
+| n/a | no | **Install TBD Skill…** | Write file, show "Installed at `~/.claude/skills/tbd/SKILL.md`" dialog |
+| match | yes | **TBD Skill: Installed ✓** | Disabled / informational; clicking shows path |
+| mismatch | yes | **Update TBD Skill…** | Confirm dialog ("This will overwrite ~/.claude/skills/tbd/SKILL.md"), then write |
+
+If `~/.claude/` does not exist: menu item is disabled with tooltip "Claude Code not detected".
+
+Update detection uses content-hash compare (Q4 option A). User edits to the installed file will show as "Update available"; clicking Update overwrites them. Acceptable for V1 — design intent is that user customization happens in their own skills, not by patching ours.
+
+### CLI parity
+
+`Sources/TBDCLI/Commands/` gains `skill` subcommand:
+
+- `tbd skill install` — installs or updates `~/.claude/skills/tbd/SKILL.md`. Prints absolute path on stdout on success, status on stderr.
+- `tbd skill status` — prints status (`not-installed` / `installed` / `outdated`) and the path. Exit code 0 for installed-and-current; non-zero otherwise so it composes in shell scripts.
+
+Same logic as the menu, scriptable, useful for headless / no-app users.
+
+### RPC surface
+
+Additions to `Sources/TBDShared/RPCProtocol.swift`:
+
+```swift
+case skillStatus      // -> { harnessPath, exists, hashMatch, daemonHash, fileHash? }
+case skillInstall     // -> { harnessPath, action: "installed" | "updated" | "noop" }
+```
+
+Daemon-side handlers in a new `Sources/TBDDaemon/Server/RPCRouter+SkillHandlers.swift` (parallel to PR #90's terminal handler additions). Pure delegation to `SkillInstaller` in TBDShared.
+
+### Components
+
+| File | Purpose |
+|---|---|
+| `Sources/TBDShared/TBDSkillContent.swift` (new) | Canonical body string + hash function |
+| `Sources/TBDShared/SkillInstaller.swift` (new) | Pure logic: status check, install, update. Takes a `Harness` enum (`.claudeCode` only in V1) |
+| `Sources/TBDShared/RPCProtocol.swift` | Add `skillStatus` and `skillInstall` cases |
+| `Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift` | `builtInTBDContext` becomes the slim pointer; resolves fallback path absolutely |
+| `Sources/TBDDaemon/Lifecycle/SkillFileWriter.swift` (new) | Writes fallback file at daemon boot, idempotent |
+| `Sources/TBDDaemon/Server/RPCRouter+SkillHandlers.swift` (new) | RPC handlers for `skillStatus` / `skillInstall` |
+| `Sources/TBDApp/SkillInstallerCoordinator.swift` (new) | Menu state + click handlers; polls daemon on app activation |
+| `Sources/TBDApp/AppState.swift` | Wire in coordinator (parallel to PR #90's CLI installer wiring) |
+| `Sources/TBDCLI/Commands/Skill.swift` (new) | `tbd skill install` / `tbd skill status` subcommands |
+
+### Data flow
+
+```
+Daemon boot
+  └─ SkillFileWriter.writeFallback() → ~/Library/Application Support/TBD/skill/SKILL.md
+
+App launch / activation
+  └─ SkillInstallerCoordinator.refresh()
+       └─ RPC skillStatus → { harnessPath, exists, hashMatch, daemonHash }
+            └─ Menu renders "Install…" / "Installed ✓" / "Update…"
+
+User clicks Install/Update
+  └─ RPC skillInstall
+       └─ SkillInstaller.install(harness: .claudeCode)
+            └─ Writes ~/.claude/skills/tbd/SKILL.md
+       └─ Coordinator re-renders menu
+```
+
+### Future-proofing
+
+`SkillInstaller` accepts a `Harness` enum:
+
+```swift
+enum Harness {
+    case claudeCode
+    // future: .codex, .gemini
+}
+```
+
+Each case maps to:
+- A target install path (e.g., `~/.claude/skills/tbd/SKILL.md` for `.claudeCode`)
+- A detector for whether the harness is installed (e.g., `~/.claude/` exists)
+- (If needed) a content adapter that transforms the canonical body into harness-specific format
+
+V1 ships with one case. Adding codex / gemini later is mechanical: new enum case, new path resolver, new adapter if format differs. RPC signature stays stable; menu grows a submenu when more than one harness is detected.
+
+## Testing
+
+- `Tests/TBDSharedTests/SkillInstallerTests.swift` (new): pure-logic tests parallel to `CLIInstallerTests`. Cover status detection (not installed / installed-current / installed-outdated), install transitions, update transitions, missing parent dir creation, refusal when `~/.claude/` is absent.
+- `Tests/TBDSharedTests/TBDSkillContentTests.swift` (new): hash is stable across calls; body parses as valid YAML frontmatter (cheap regex check); body contains the expected workflow section headings.
+- `Tests/TBDDaemonTests/SystemPromptBuilderTests.swift` (extend or add): verifies the slim pointer is what's emitted now, fallback path is absolute, `build()` still returns nil on resume.
+- Per CLAUDE.md branching-conditional rule: tests for both "skill installed" and "skill not installed" branches of menu state evaluation.
+
+## Open Questions
+
+1. **Menu placement** — TBD app menu, dedicated "Tools" submenu, or alongside the existing "Install Command-Line Tool…"? PR #90's pattern would suggest the latter. Defer to implementation; trivial to move.
+2. **Generated-by header in the skill file** — should the body include a `<!-- generated by TBD vX.Y.Z -->` comment? Adds forensic value but complicates hash semantics if not excluded from the hash. Lean: skip for V1.
+3. **`tbd skill install` exit codes / output** — confirmed shape: stdout = absolute path on success; stderr = human-readable status; exit 0 only for installed-and-current on `status`. Check this matches existing CLI conventions in TBDCLI before implementation.


### PR DESCRIPTION
## Summary

- TBD's `--append-system-prompt` injection has five known weaknesses: it's skipped on `claude --resume`, it can be compacted away on long sessions, it never reaches shell-type terminals, updating it requires a daemon rebuild, and it's Claude-Code-only. Resumed sessions silently lose TBD CLI knowledge forever.
- Ships a `tbd` Claude Code skill as the canonical, hot-updatable source of TBD's CLI reference. Menu item ("Install TBD Skill…" / "Update…" / "Installed ✓") writes it to `~/.claude/skills/tbd/SKILL.md`. CLI parity via `tbd skill install` / `tbd skill status`.
- Daemon writes an always-fresh fallback copy to `~/Library/Application Support/TBD/skill/SKILL.md` on every boot, so even sessions whose harness has no skill registered can `Read` the content directly. The legacy `--append-system-prompt` injection shrinks from ~40 lines to a 3-line pointer that names the skill and the absolute fallback path.
- Designed for codex/gemini extension later — `Harness` enum is single-case (`.claudeCode`) for V1; new harnesses become a new case + path resolver.

## Architecture

- **`TBDShared`** — `TBDSkillContent` (canonical body + SHA256 hash) and `SkillInstaller` (pure logic over an injected `SkillFileSystem`, all 4 status branches + 3 install actions tested).
- **`TBDDaemon`** — `SkillFileWriter` runs at boot (non-fatal); `RPCRouter+SkillHandlers` exposes `skill.status` / `skill.install`; `SystemPromptBuilder` slimmed to a pointer that resolves the absolute fallback path at access time (resume still skips, same as today).
- **`TBDApp`** — `DaemonClient` typed methods, `AppState.skillStatus` `@Published`, refresh on `didBecomeActive` + once at init, `SkillMenu` (Commands + nested View, mirrors `ClaudeTokenMenu` pattern). Install errors surface as alerts (not just logs).
- **`TBDCLI`** — `tbd skill status` (exit 0 only when up-to-date, scriptable), `tbd skill install` (path on stdout, status on stderr).

Spec: `docs/superpowers/specs/2026-05-03-tbd-skill-design.md`

Drive-by: migrated `WorktreeReviveReorderTests` from XCTest to swift-testing — pre-existing import was blocking `swift test` for the whole package.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 456/456 pass (37 new)
- [ ] `scripts/restart.sh`; verify exactly one TBDDaemon + one TBDApp from the worktree path
- [ ] `ls "$HOME/Library/Application Support/TBD/skill/SKILL.md"` — fallback file exists after restart, starts with `---\nname: tbd\n…`
- [ ] `.build/debug/TBDCLI skill status` — prints harness path, "not installed" on stderr, exit 1
- [ ] `.build/debug/TBDCLI skill install` — writes `~/.claude/skills/tbd/SKILL.md`; second `status` prints "installed (up to date)", exit 0
- [ ] Open TBD app menu — "TBD" menu item reflects state (Install / Installed ✓ / Update). Edit the installed file by one byte, cmd-tab away+back; menu flips to "Update TBD Skill…"
- [ ] `rm -rf ~/.claude/`; menu item shows disabled with "Claude Code not detected" tooltip
- [ ] In a fresh Claude tab spawned in this worktree, ask "What's the absolute path of your TBD skill fallback file?" — model answers with the absolute fallback path (slim pointer is doing its job)