### PR TITLE
Feat: Rename projects from the sidebar with :emoji: autocomplete

### DIFF
--- a/Sources/TBDApp/AppState+Repos.swift
+++ b/Sources/TBDApp/AppState+Repos.swift
@@ -51,6 +51,21 @@ extension AppState {
         }
     }
 
+    /// Rename a repo's display name. Updates local state optimistically before issuing the RPC.
+    func renameRepo(id: UUID, displayName: String) async {
+        if let idx = repos.firstIndex(where: { $0.id == id }) {
+            var repo = repos[idx]
+            repo.displayName = displayName
+            repos[idx] = repo
+        }
+        do {
+            try await daemonClient.renameRepo(id: id, displayName: displayName)
+        } catch {
+            logger.error("Failed to rename repo: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
     /// Update per-repo instruction fields. Returns true on success.
     @discardableResult
     func updateRepoInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async -> Bool {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -362,6 +362,14 @@ actor DaemonClient {
         )
     }
 
+    /// Rename a repo's display name.
+    func renameRepo(id: UUID, displayName: String) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.repoRename,
+            params: RepoRenameParams(repoID: id, displayName: displayName)
+        )
+    }
+
     /// Update per-repo instruction fields.
     func repoUpdateInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async throws -> Repo {
         return try await callAsync(

--- a/Sources/TBDApp/Sidebar/RenameableLabel.swift
+++ b/Sources/TBDApp/Sidebar/RenameableLabel.swift
@@ -1,0 +1,148 @@
+// Sources/TBDApp/Sidebar/RenameableLabel.swift
+import SwiftUI
+
+/// Inline-editable label with `:emoji:` autocomplete support.
+/// When `isEditing` is true, displays a TextField with emoji autocomplete;
+/// otherwise displays static text via `displayContent`.
+///
+/// The caller is responsible for:
+///   - flipping `isEditing` to true to enter edit mode
+///   - providing the static display via `displayContent`
+///   - persisting on `onCommit`
+struct RenameableLabel<DisplayContent: View>: View {
+    let text: String
+    @Binding var isEditing: Bool
+    let onCommit: (String) -> Void
+    var onCancel: () -> Void = {}
+    var onStartEditing: () -> Void = {}
+    var onStopEditing: () -> Void = {}
+    @ViewBuilder let displayContent: () -> DisplayContent
+
+    @State private var editText = ""
+    @State private var cursorPosition = 0
+    @State private var isTextFieldFocused = false
+    @State private var emojiQuery: String?
+    @State private var emojiSelectedIndex = 0
+    @State private var frecency = EmojiFrecency.load()
+
+    var body: some View {
+        if isEditing {
+            InlineTextField(
+                text: $editText,
+                cursorPosition: $cursorPosition,
+                isFocused: $isTextFieldFocused,
+                onSubmit: {
+                    if emojiQuery != nil, let emoji = selectedEmoji() {
+                        replaceColonQuery(with: emoji)
+                    } else {
+                        commit()
+                    }
+                },
+                onCancel: {
+                    if emojiQuery != nil {
+                        emojiQuery = nil
+                    } else {
+                        cancel()
+                    }
+                },
+                onKeyDown: { keyCode in
+                    guard emojiQuery != nil else { return false }
+                    switch keyCode {
+                    case 125: emojiSelectedIndex += 7; return true   // down
+                    case 126: emojiSelectedIndex = max(0, emojiSelectedIndex - 7); return true // up
+                    case 124: emojiSelectedIndex += 1; return true   // right
+                    case 123: emojiSelectedIndex = max(0, emojiSelectedIndex - 1); return true // left
+                    default: return false
+                    }
+                },
+                onSpecialKey: { _ in
+                    guard emojiQuery != nil, let emoji = selectedEmoji() else { return false }
+                    replaceColonQuery(with: emoji)
+                    return true
+                }
+            )
+            .onChange(of: editText) { _, newValue in
+                updateEmojiQuery(newValue)
+            }
+            .onChange(of: isTextFieldFocused) { _, focused in
+                if !focused {
+                    emojiQuery = nil
+                    commit()
+                }
+            }
+            .onAppear {
+                editText = text
+                onStartEditing()
+                isTextFieldFocused = true
+                // Re-assert focus after a delay to win any focus race with terminal views
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    isTextFieldFocused = true
+                }
+            }
+            .background(
+                EmojiPanelAnchor(
+                    isPresented: emojiQuery != nil,
+                    query: emojiQuery ?? "",
+                    selectedIndex: $emojiSelectedIndex,
+                    onSelect: { emoji in replaceColonQuery(with: emoji) }
+                )
+            )
+        } else {
+            displayContent()
+        }
+    }
+
+    private func commit() {
+        let trimmed = editText.trimmingCharacters(in: .whitespaces)
+        isEditing = false
+        onStopEditing()
+        guard !trimmed.isEmpty, trimmed != text else { return }
+        onCommit(trimmed)
+    }
+
+    private func cancel() {
+        isEditing = false
+        onStopEditing()
+        onCancel()
+    }
+
+    // MARK: - Emoji autocomplete
+
+    private var activeColonRange: Range<String.Index>? {
+        let utf16Pos = min(cursorPosition, editText.utf16.count)
+        let cursorIndex = String.Index(utf16Offset: utf16Pos, in: editText)
+        let beforeCursor = editText[editText.startIndex..<cursorIndex]
+        guard let colonIndex = beforeCursor.lastIndex(of: ":") else { return nil }
+        let between = editText[editText.index(after: colonIndex)..<cursorIndex]
+        if between.contains(" ") || between.contains(":") { return nil }
+        return colonIndex..<cursorIndex
+    }
+
+    private func updateEmojiQuery(_ text: String) {
+        if let range = activeColonRange {
+            emojiQuery = String(editText[editText.index(after: range.lowerBound)..<range.upperBound])
+            emojiSelectedIndex = 0
+        } else {
+            emojiQuery = nil
+        }
+    }
+
+    private func replaceColonQuery(with emoji: String) {
+        guard let range = activeColonRange else { return }
+        let newCursorUTF16 = editText[editText.startIndex..<range.lowerBound].utf16.count + emoji.utf16.count
+        editText.replaceSubrange(range, with: emoji)
+        cursorPosition = newCursorUTF16
+        emojiQuery = nil
+        frecency.record(emoji)
+    }
+
+    private func selectedEmoji() -> String? {
+        guard let query = emojiQuery else { return nil }
+        let results = query.isEmpty
+            ? frecency.defaults()
+            : frecency.search(query, limit: 21)
+        guard !results.isEmpty else { return nil }
+        let index = min(emojiSelectedIndex, results.count - 1)
+        return results[index].emoji
+    }
+}

--- a/Sources/TBDApp/Sidebar/RenameableLabel.swift
+++ b/Sources/TBDApp/Sidebar/RenameableLabel.swift
@@ -61,8 +61,8 @@ struct RenameableLabel<DisplayContent: View>: View {
                     return true
                 }
             )
-            .onChange(of: editText) { _, newValue in
-                updateEmojiQuery(newValue)
+            .onChange(of: editText) { _, _ in
+                updateEmojiQuery()
             }
             .onChange(of: isTextFieldFocused) { _, focused in
                 if !focused {
@@ -70,7 +70,8 @@ struct RenameableLabel<DisplayContent: View>: View {
                     commit()
                 }
             }
-            .onAppear {
+            .onChange(of: isEditing, initial: true) { _, editing in
+                guard editing else { return }
                 editText = text
                 onStartEditing()
                 isTextFieldFocused = true
@@ -118,7 +119,7 @@ struct RenameableLabel<DisplayContent: View>: View {
         return colonIndex..<cursorIndex
     }
 
-    private func updateEmojiQuery(_ text: String) {
+    private func updateEmojiQuery() {
         if let range = activeColonRange {
             emojiQuery = String(editText[editText.index(after: range.lowerBound)..<range.upperBound])
             emojiSelectedIndex = 0

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -29,6 +29,7 @@ struct RepoSectionView: View {
     @EnvironmentObject var appState: AppState
 
     @State private var isExpanded = true
+    @State private var isEditing = false
 
     var mainWorktree: Worktree? {
         (appState.worktrees[repo.id] ?? [])
@@ -51,13 +52,23 @@ struct RepoSectionView: View {
             .buttonStyle(HoverPressButtonStyle())
             .help(isExpanded ? "Collapse" : "Expand")
 
-            Text(repo.displayName)
-                .font(.headline)
-                .foregroundStyle(
-                    repo.status == .missing
-                        ? AnyShapeStyle(Color.secondary.opacity(0.5))
-                        : AnyShapeStyle(appState.selectedRepoID == repo.id ? HierarchicalShapeStyle.primary : HierarchicalShapeStyle.secondary)
-                )
+            RenameableLabel(
+                text: repo.displayName,
+                isEditing: $isEditing,
+                onCommit: { newName in
+                    Task {
+                        await appState.renameRepo(id: repo.id, displayName: newName)
+                    }
+                }
+            ) {
+                Text(repo.displayName)
+                    .font(.headline)
+                    .foregroundStyle(
+                        repo.status == .missing
+                            ? AnyShapeStyle(Color.secondary.opacity(0.5))
+                            : AnyShapeStyle(appState.selectedRepoID == repo.id ? HierarchicalShapeStyle.primary : HierarchicalShapeStyle.secondary)
+                    )
+            }
 
             if repo.status == .missing {
                 Text("[missing]")
@@ -84,6 +95,11 @@ struct RepoSectionView: View {
         .contentShape(Rectangle())
         .onTapGesture {
             appState.selectRepo(id: repo.id)
+        }
+        .contextMenu {
+            Button("Rename...") {
+                isEditing = true
+            }
         }
         .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
         .tag(repo.id)

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -6,12 +6,6 @@ struct WorktreeRowView: View {
     var isMain: Bool = false
     @EnvironmentObject var appState: AppState
     @State private var isEditing = false
-    @State private var editText = ""
-    @State private var cursorPosition = 0
-    @State private var isTextFieldFocused = false
-    @State private var emojiQuery: String?
-    @State private var emojiSelectedIndex = 0
-    @State private var frecency = EmojiFrecency.load()
     @State private var isNameTruncated = false
 
     private var isPending: Bool {
@@ -118,59 +112,23 @@ struct WorktreeRowView: View {
         HStack(spacing: 6) {
             rowIcons()
                 .allowsHitTesting(false)
-            if isEditing {
-                InlineTextField(
-                    text: $editText,
-                    cursorPosition: $cursorPosition,
-                    isFocused: $isTextFieldFocused,
-                    onSubmit: {
-                        if emojiQuery != nil, let emoji = selectedEmoji() {
-                            replaceColonQuery(with: emoji)
-                        } else {
-                            commitRename()
+            RenameableLabel(
+                text: worktree.displayName,
+                isEditing: $isEditing,
+                onCommit: { newName in
+                    // Optimistic local update so the UI reflects the new name before the RPC returns
+                    for repoID in appState.worktrees.keys {
+                        if let idx = appState.worktrees[repoID]?.firstIndex(where: { $0.id == worktree.id }) {
+                            appState.worktrees[repoID]?[idx].displayName = newName
                         }
-                    },
-                    onCancel: {
-                        if emojiQuery != nil {
-                            emojiQuery = nil
-                        } else {
-                            cancelRename()
-                        }
-                    },
-                    onKeyDown: { keyCode in
-                        guard emojiQuery != nil else { return false }
-                        switch keyCode {
-                        case 125: emojiSelectedIndex += 7; return true  // down
-                        case 126: emojiSelectedIndex = max(0, emojiSelectedIndex - 7); return true // up
-                        case 124: emojiSelectedIndex += 1; return true  // right
-                        case 123: emojiSelectedIndex = max(0, emojiSelectedIndex - 1); return true // left
-                        default: return false
-                        }
-                    },
-                    onSpecialKey: { key in
-                        guard emojiQuery != nil, let emoji = selectedEmoji() else { return false }
-                        replaceColonQuery(with: emoji)
-                        return true
                     }
-                )
-                .onChange(of: editText) { _, newValue in
-                    updateEmojiQuery(newValue)
-                }
-                .onChange(of: isTextFieldFocused) { _, focused in
-                    if !focused {
-                        emojiQuery = nil
-                        commitRename()
+                    Task {
+                        await appState.renameWorktree(id: worktree.id, displayName: newName)
                     }
-                }
-                .background(
-                    EmojiPanelAnchor(
-                        isPresented: emojiQuery != nil,
-                        query: emojiQuery ?? "",
-                        selectedIndex: $emojiSelectedIndex,
-                        onSelect: { emoji in replaceColonQuery(with: emoji) }
-                    )
-                )
-            } else {
+                },
+                onStartEditing: { appState.isRenamingWorktree = true },
+                onStopEditing: { appState.isRenamingWorktree = false }
+            ) {
                 VStack(alignment: .leading, spacing: 2) {
                     ExpandingTextField(
                         text: worktree.displayName,
@@ -237,82 +195,7 @@ struct WorktreeRowView: View {
 
     func startRename() {
         guard !isMain else { return }
-        editText = worktree.displayName
         isEditing = true
-        isTextFieldFocused = true
-        appState.isRenamingWorktree = true
-        // Re-assert focus after a delay to win any focus race with terminal views
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            isTextFieldFocused = true
-        }
-    }
-
-    private func commitRename() {
-        let trimmed = editText.trimmingCharacters(in: .whitespaces)
-        isEditing = false
-        appState.isRenamingWorktree = false
-        guard !trimmed.isEmpty, trimmed != worktree.displayName else { return }
-        // Update local model immediately so the UI reflects the new name
-        for repoID in appState.worktrees.keys {
-            if let idx = appState.worktrees[repoID]?.firstIndex(where: { $0.id == worktree.id }) {
-                appState.worktrees[repoID]?[idx].displayName = trimmed
-            }
-        }
-        // Then persist to daemon
-        Task {
-            await appState.renameWorktree(id: worktree.id, displayName: trimmed)
-        }
-    }
-
-    private func cancelRename() {
-        isEditing = false
-        appState.isRenamingWorktree = false
-    }
-
-    // MARK: - Emoji autocomplete
-
-    /// Find the `:` before the cursor with no space between it and the cursor.
-    private var activeColonRange: Range<String.Index>? {
-        let text = editText
-        // Clamp cursor to valid UTF-16 range, convert to String.Index
-        let utf16Pos = min(cursorPosition, text.utf16.count)
-        let cursorIndex = String.Index(utf16Offset: utf16Pos, in: text)
-        // Search backwards from cursor for `:`
-        let beforeCursor = text[text.startIndex..<cursorIndex]
-        guard let colonIndex = beforeCursor.lastIndex(of: ":") else { return nil }
-        // Check no space between colon and cursor
-        let between = text[text.index(after: colonIndex)..<cursorIndex]
-        if between.contains(" ") || between.contains(":") { return nil }
-        return colonIndex..<cursorIndex
-    }
-
-    private func updateEmojiQuery(_ text: String) {
-        if let range = activeColonRange {
-            let query = String(editText[editText.index(after: range.lowerBound)..<range.upperBound])
-            emojiQuery = query
-            emojiSelectedIndex = 0
-        } else {
-            emojiQuery = nil
-        }
-    }
-
-    private func replaceColonQuery(with emoji: String) {
-        guard let range = activeColonRange else { return }
-        let newCursorUTF16 = editText[editText.startIndex..<range.lowerBound].utf16.count + emoji.utf16.count
-        editText.replaceSubrange(range, with: emoji)
-        cursorPosition = newCursorUTF16
-        emojiQuery = nil
-        frecency.record(emoji)
-    }
-
-    private func selectedEmoji() -> String? {
-        guard let query = emojiQuery else { return nil }
-        let results = query.isEmpty
-            ? frecency.defaults()
-            : frecency.search(query, limit: 21)
-        guard !results.isEmpty else { return nil }
-        let index = min(emojiSelectedIndex, results.count - 1)
-        return results[index].emoji
     }
 
     private func loadIcon(_ name: String) -> NSImage? {

--- a/Sources/TBDCLI/Commands/RepoCommands.swift
+++ b/Sources/TBDCLI/Commands/RepoCommands.swift
@@ -6,7 +6,7 @@ struct RepoCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "repo",
         abstract: "Manage repositories",
-        subcommands: [RepoAdd.self, RepoRemove.self, RepoList.self, RepoRelocate.self]
+        subcommands: [RepoAdd.self, RepoRemove.self, RepoList.self, RepoRelocate.self, RepoRename.self]
     )
 }
 
@@ -157,6 +157,41 @@ struct RepoRelocate: AsyncParsableCommand {
             if !result.worktreesFailed.isEmpty {
                 print("  Failed worktrees:   \(result.worktreesFailed.count) (marked .failed; manual cleanup required)")
             }
+        }
+    }
+}
+
+// MARK: - repo rename
+
+struct RepoRename: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "rename",
+        abstract: "Rename a repository's display name"
+    )
+
+    @Argument(help: "Repository ID")
+    var id: String
+
+    @Argument(help: "New display name")
+    var newName: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        guard let repoID = UUID(uuidString: id) else {
+            throw CLIError.invalidArgument("Invalid repository ID: \(id)")
+        }
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.repoRename,
+            params: RepoRenameParams(repoID: repoID, displayName: newName)
+        )
+
+        if json {
+            printJSON(["status": "renamed", "id": id, "displayName": newName])
+        } else {
+            print("Repository renamed to: \(newName)")
         }
     }
 }

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -136,6 +136,17 @@ public struct RepoStore: Sendable {
         }
     }
 
+    /// Rename a repo's display name.
+    public func rename(id: UUID, displayName: String) async throws {
+        try await writer.write { db in
+            guard var record = try RepoRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Repo not found")
+            }
+            record.displayName = displayName
+            try record.update(db)
+        }
+    }
+
     /// Set or clear the model profile override for a repo.
     public func setProfileOverride(id: UUID, profileID: UUID?) async throws {
         try await writer.write { db in

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -133,6 +133,11 @@ extension RPCRouter {
 
     func handleRepoRename(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(RepoRenameParams.self, from: paramsData)
+
+        guard try await db.repos.get(id: params.repoID) != nil else {
+            return RPCResponse(error: "Repository not found: \(params.repoID)")
+        }
+
         try await db.repos.rename(id: params.repoID, displayName: params.displayName)
 
         subscriptions.broadcast(delta: .repoRenamed(RepoRenameDelta(

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -130,4 +130,15 @@ extension RPCRouter {
 
         return try RPCResponse(result: updated)
     }
+
+    func handleRepoRename(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(RepoRenameParams.self, from: paramsData)
+        try await db.repos.rename(id: params.repoID, displayName: params.displayName)
+
+        subscriptions.broadcast(delta: .repoRenamed(RepoRenameDelta(
+            repoID: params.repoID, displayName: params.displayName
+        )))
+
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -77,6 +77,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRepoUpdateInstructions(request.paramsData)
             case RPCMethod.repoRelocate:
                 return try await handleRepoRelocate(request.paramsData)
+            case RPCMethod.repoRename:
+                return try await handleRepoRename(request.paramsData)
             case RPCMethod.worktreeCreate:
                 return try await handleWorktreeCreate(request.paramsData)
             case RPCMethod.worktreeList:

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -133,6 +133,7 @@ public enum RPCMethod {
     public static let terminalSwapProfile = "terminal.swapProfile"
     public static let appSetForegroundState = "app.setForegroundState"
     public static let repoRelocate = "repo.relocate"
+    public static let repoRename = "repo.rename"
     public static let sessionList = "session.list"
     public static let sessionMessages = "session.messages"
     public static let setMainAreaSize = "app.setMainAreaSize"
@@ -336,6 +337,14 @@ public struct RepoRelocateResult: Codable, Sendable {
         self.repo = repo
         self.worktreesRepaired = worktreesRepaired
         self.worktreesFailed = worktreesFailed
+    }
+}
+
+public struct RepoRenameParams: Codable, Sendable {
+    public let repoID: UUID
+    public let displayName: String
+    public init(repoID: UUID, displayName: String) {
+        self.repoID = repoID; self.displayName = displayName
     }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -11,6 +11,7 @@ public enum StateDelta: Codable, Sendable {
     case notificationReceived(NotificationDelta)
     case repoAdded(RepoDelta)
     case repoRemoved(RepoIDDelta)
+    case repoRenamed(RepoRenameDelta)
     case terminalCreated(TerminalDelta)
     case terminalRemoved(TerminalIDDelta)
     case worktreeConflictsChanged(WorktreeConflictDelta)
@@ -74,6 +75,15 @@ public struct RepoDelta: Codable, Sendable {
 public struct RepoIDDelta: Codable, Sendable {
     public let repoID: UUID
     public init(repoID: UUID) { self.repoID = repoID }
+}
+
+/// Delta payload for repo rename.
+public struct RepoRenameDelta: Codable, Sendable {
+    public let repoID: UUID
+    public let displayName: String
+    public init(repoID: UUID, displayName: String) {
+        self.repoID = repoID; self.displayName = displayName
+    }
 }
 
 /// Delta payload for terminal creation.

--- a/Tests/TBDDaemonTests/RepoStoreTests.swift
+++ b/Tests/TBDDaemonTests/RepoStoreTests.swift
@@ -27,4 +27,21 @@ import Foundation
         let fetched = try await db.repos.get(id: repo.id)
         #expect(fetched?.path == "/tmp/new")
     }
+
+    @Test func repoStoreRenamesDisplayName() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID())", displayName: "old", defaultBranch: "main"
+        )
+        try await db.repos.rename(id: repo.id, displayName: "✨ new")
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.displayName == "✨ new")
+    }
+
+    @Test func repoStoreRenameThrowsForUnknownID() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        await #expect(throws: Error.self) {
+            try await db.repos.rename(id: UUID(), displayName: "anything")
+        }
+    }
 }

--- a/docs/superpowers/specs/2026-05-04-rename-projects-design.md
+++ b/docs/superpowers/specs/2026-05-04-rename-projects-design.md
@@ -1,0 +1,99 @@
+# Rename Projects in the Worktree List
+
+**Date:** 2026-05-04
+**Status:** Approved
+
+## Goal
+
+Let users rename projects (repos) shown in the sidebar's worktree list, using the same emoji-friendly inline input UX that already exists for worktree rename. Display-name only — no on-disk or git changes.
+
+## UX
+
+- Right-click on a repo's section header opens a context menu that includes **"Rename..."** (this is the only entry point for rename, to avoid conflicting with the existing click-to-expand/collapse on the header).
+- Selecting "Rename..." swaps the section header's `Text` for an inline `TextField` in place.
+- Typing `:query:` triggers the same emoji autocomplete panel used for worktree rename, with frecency-ranked suggestions.
+- **Enter** commits, **Esc** cancels, blur commits — mirroring worktree rename.
+- Empty / whitespace-only input cancels with no rename, matching worktree rename behavior.
+- The rest of the header continues to expand/collapse the section as before. Single-click and double-click on the header do not enter rename mode.
+
+## Component extraction: `RenameableLabel`
+
+To avoid duplicating ~120 lines of inline-edit + emoji autocomplete logic, extract a reusable component.
+
+**New file:** `Sources/TBDApp/Sidebar/RenameableLabel.swift`
+
+Encapsulates:
+- Display text vs. edit-mode toggle
+- `TextField` + focus management
+- `:emoji:` autocomplete panel (the logic currently around lines 272-316 of `WorktreeRowView.swift`)
+- Enter / Esc / blur handling
+
+Approximate public surface:
+
+```swift
+RenameableLabel(
+    text: String,
+    isEditing: Binding<Bool>,
+    font: Font,
+    onCommit: (String) -> Void,
+    emojiFrecency: EmojiFrecency
+)
+```
+
+Both `WorktreeRowView` and `RepoSectionView` consume it. `WorktreeRowView` keeps its outer row chrome (status icons, etc.) and delegates only the editable-name portion to `RenameableLabel`.
+
+## Data flow
+
+### Database / Store
+
+`Sources/TBDDaemon/Database/RepoStore.swift`:
+
+- Add `func rename(id: UUID, displayName: String) throws` — single-column update on `repo.displayName`, mirroring `WorktreeStore.rename`.
+- No migration needed; the `displayName` column already exists on the `repo` table.
+
+### Shared protocol
+
+`Sources/TBDShared/RPCProtocol.swift`:
+
+- New method name: `"repo.rename"`.
+- New params type: `RepoRenameParams { repoID: UUID; displayName: String }`.
+
+### RPC handler
+
+`Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift` (create if absent, else extend):
+
+- Handler calls `db.repos.rename()` and broadcasts `RepoRenameDelta`.
+
+### State delta
+
+`Sources/TBDShared/StateDelta.swift`:
+
+- New `RepoRenameDelta { repoID: UUID; displayName: String }`.
+- App-side application path updates the repo in the `AppState` cache so the sidebar re-renders.
+
+### App side
+
+`Sources/TBDApp/AppState+Repos.swift` (create if absent, else extend the appropriate file):
+
+- `func renameRepo(id: UUID, displayName: String)` — sends the RPC and optimistically updates local state, consistent with how `renameWorktree` works.
+
+### CLI
+
+Add `tbd repo rename <name-or-id> <new-name>` parallel to `tbd worktree rename`. Cheap to add, useful for scripting and parity.
+
+## Testing
+
+Per the CLAUDE.md branching-conditional rule and to maintain parity with worktree rename:
+
+- `RepoStoreTests` — verify `rename()` updates the column; verify rename of a nonexistent ID throws the expected error.
+- RPC-level test in the same style as the existing worktree rename RPC tests (if any) verifying the handler dispatches the delta.
+- Manual smoke checks:
+  - Rename a repo via the right-click menu and confirm the sidebar updates immediately.
+  - Verify other open TBD windows receive the delta.
+  - Verify the new name persists across `scripts/restart.sh`.
+
+## Out of scope
+
+- Repo rename does not affect the on-disk path or git remote — display name only.
+- No bulk rename, no undo stack, no rename history.
+- The `renamePrompt` column on `repo` (an LLM-rename suggestion prompt for *worktrees*, not the repo's own display name) is unrelated and untouched.


### PR DESCRIPTION
## Summary
- Right-click a project header in the sidebar → **Rename...** to edit the display name inline, with the same `:emoji:` autocomplete (frecency-ranked) used by worktree rename.
- Pulled the inline-edit + emoji picker out of `WorktreeRowView` into a reusable `RenameableLabel` component so both worktree and project rename share one implementation.
- Added matching `tbd repo rename <id> <new-name>` CLI for parity with `tbd worktree rename`.

Display-name only — no on-disk path, git remote, or worktree slot changes. Reuses the existing `repo.displayName` column, no migration.

Spec: `docs/superpowers/specs/2026-05-04-rename-projects-design.md`

## Test plan
- [ ] Right-click a repo header → "Rename..." appears
- [ ] Click it → inline text field with current name; type `:rocket:` → emoji autocomplete shows; arrow keys navigate; Enter inserts
- [ ] Enter without active picker commits; Esc cancels; clicking elsewhere blurs and commits
- [ ] New name persists across `scripts/restart.sh`
- [ ] `tbd repo rename <uuid> "🎯 New Name"` works end-to-end
- [ ] Worktree rename still behaves identically (RenameableLabel refactor regression check)

## Notes
- Tests for `RepoStore.rename` were written but not executed in this branch — pre-existing `WorktreeReviveReorderTests.swift` (from #87) imports XCTest, which won't compile on Command Line Tools alone. Worth a separate cleanup to migrate to Swift Testing.
- Noticed a pre-existing crash in `tbd repo list` (non-`--json`): `String(format: "%-36s ...", uuidString as NSString, ...)` — `%s` expects a C string, passing `NSString` segfaults in `_platform_strlen`. Unrelated to this branch (lives since `de3b521`); flagging for a separate fix.

open in TBD: \`tbd://open?worktree=281EF37E-8278-4BBD-952F-0048BD831247\`