### PR TITLE
Perf: Stop big Write inputs from duplicating MBs across two transcript caches

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/AgentCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/AgentCard.swift
@@ -8,12 +8,14 @@ import TBDShared
 struct AgentCard: View {
     let id: String
     let inputJSON: String
+    let inputTruncatedTo: Int?
     let result: ToolResult?
     let timestamp: Date?
     let terminalID: UUID?
 
     @State private var expanded = false
     @State private var fullResultText: String? = nil
+    @State private var fullInputJSON: String? = nil
     @EnvironmentObject var appState: AppState
 
     private struct Input: Decodable {
@@ -25,7 +27,7 @@ struct AgentCard: View {
     private static let decoder = JSONDecoder()
 
     private func decodeInput() -> Input? {
-        guard let data = inputJSON.data(using: .utf8) else { return nil }
+        guard let data = (fullInputJSON ?? inputJSON).data(using: .utf8) else { return nil }
         return try? Self.decoder.decode(Input.self, from: data)
     }
 
@@ -81,6 +83,11 @@ struct AgentCard: View {
                         .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
                 }
+                if let cap = inputTruncatedTo, fullInputJSON == nil, terminalID != nil {
+                    TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
+                        Task { await fetchFullInput() }
+                    }
+                }
                 if let r = result {
                     Text(fullResultText ?? r.text)
                         .font(.system(.caption, design: .monospaced))
@@ -109,6 +116,13 @@ struct AgentCard: View {
         guard let terminalID else { return }
         if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(terminalID: terminalID, itemID: id) {
             await MainActor.run { fullResultText = r.text }
+        }
+    }
+
+    private func fetchFullInput() async {
+        guard let terminalID else { return }
+        if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(terminalID: terminalID, itemID: "\(id)#input") {
+            await MainActor.run { fullInputJSON = r.text }
         }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/AgentCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/AgentCard.swift
@@ -22,9 +22,11 @@ struct AgentCard: View {
         let subagent_type: String?
     }
 
+    private static let decoder = JSONDecoder()
+
     private func decodeInput() -> Input? {
         guard let data = inputJSON.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(Input.self, from: data)
+        return try? Self.decoder.decode(Input.self, from: data)
     }
 
     private func headerSummary(for parsed: Input?) -> String {

--- a/Sources/TBDApp/Panes/Transcript/BashCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/BashCard.swift
@@ -4,12 +4,14 @@ import TBDShared
 struct BashCard: View {
     let id: String
     let inputJSON: String
+    let inputTruncatedTo: Int?
     let result: ToolResult?
     let timestamp: Date?
     let terminalID: UUID?
 
     @State private var expanded = false
     @State private var fullResultText: String? = nil
+    @State private var fullInputJSON: String? = nil
     @State private var containerExpanded = false
     @State private var commandContainerExpanded = false
     @EnvironmentObject var appState: AppState
@@ -19,7 +21,7 @@ struct BashCard: View {
     private static let decoder = JSONDecoder()
 
     private func decodeInput() -> Input? {
-        guard let data = inputJSON.data(using: .utf8) else { return nil }
+        guard let data = (fullInputJSON ?? inputJSON).data(using: .utf8) else { return nil }
         return try? Self.decoder.decode(Input.self, from: data)
     }
 
@@ -85,6 +87,11 @@ struct BashCard: View {
                         .help(commandContainerExpanded ? "Collapse container" : "Expand container")
                     }
                 }
+                if let cap = inputTruncatedTo, fullInputJSON == nil, terminalID != nil {
+                    TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
+                        Task { await fetchFullInput() }
+                    }
+                }
                 if let r = result {
                     ZStack(alignment: .topTrailing) {
                         ScrollView(.vertical) {
@@ -132,6 +139,13 @@ struct BashCard: View {
         guard let terminalID else { return }
         if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(terminalID: terminalID, itemID: id) {
             await MainActor.run { fullResultText = r.text }
+        }
+    }
+
+    private func fetchFullInput() async {
+        guard let terminalID else { return }
+        if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(terminalID: terminalID, itemID: "\(id)#input") {
+            await MainActor.run { fullInputJSON = r.text }
         }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/BashCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/BashCard.swift
@@ -16,9 +16,11 @@ struct BashCard: View {
 
     private struct Input: Decodable { let command: String; let description: String? }
 
+    private static let decoder = JSONDecoder()
+
     private func decodeInput() -> Input? {
         guard let data = inputJSON.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(Input.self, from: data)
+        return try? Self.decoder.decode(Input.self, from: data)
     }
 
     private func headerSummary(for parsed: Input?) -> String {

--- a/Sources/TBDApp/Panes/Transcript/EditCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/EditCard.swift
@@ -84,21 +84,21 @@ struct EditCard: View {
                 }
             }
         } body: {
-            if result?.isError == true, let r = result {
-                Text(r.text)
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.red)
-                    .textSelection(.enabled)
-            } else {
-                VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 8) {
+                if result?.isError == true, let r = result {
+                    Text(r.text)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
+                } else {
                     ForEach(Array(hunks.enumerated()), id: \.offset) { idx, hunk in
                         diffHunk(hunk, language: language)
                         if idx < hunks.count - 1 { Divider() }
                     }
-                    if let cap = inputTruncatedTo, fullInputJSON == nil, terminalID != nil {
-                        TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
-                            Task { await fetchFullInput() }
-                        }
+                }
+                if let cap = inputTruncatedTo, fullInputJSON == nil, terminalID != nil {
+                    TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
+                        Task { await fetchFullInput() }
                     }
                 }
             }

--- a/Sources/TBDApp/Panes/Transcript/EditCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/EditCard.swift
@@ -7,11 +7,13 @@ struct EditCard: View {
     let id: String
     let name: String           // "Edit" or "MultiEdit"
     let inputJSON: String
+    let inputTruncatedTo: Int?
     let result: ToolResult?
     let timestamp: Date?
     let terminalID: UUID?
 
     @State private var expanded = true
+    @State private var fullInputJSON: String? = nil
     @EnvironmentObject var appState: AppState
 
     private struct EditHunk: Decodable, Equatable {
@@ -31,7 +33,7 @@ struct EditCard: View {
     private static let decoder = JSONDecoder()
 
     private func decodeInput() -> EditInput? {
-        guard let data = inputJSON.data(using: .utf8) else { return nil }
+        guard let data = (fullInputJSON ?? inputJSON).data(using: .utf8) else { return nil }
         return try? Self.decoder.decode(EditInput.self, from: data)
     }
 
@@ -93,8 +95,20 @@ struct EditCard: View {
                         diffHunk(hunk, language: language)
                         if idx < hunks.count - 1 { Divider() }
                     }
+                    if let cap = inputTruncatedTo, fullInputJSON == nil, terminalID != nil {
+                        TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
+                            Task { await fetchFullInput() }
+                        }
+                    }
                 }
             }
+        }
+    }
+
+    private func fetchFullInput() async {
+        guard let terminalID else { return }
+        if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(terminalID: terminalID, itemID: "\(id)#input") {
+            await MainActor.run { fullInputJSON = r.text }
         }
     }
 

--- a/Sources/TBDApp/Panes/Transcript/GenericToolCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/GenericToolCard.swift
@@ -6,12 +6,14 @@ struct GenericToolCard: View {
     let id: String
     let name: String
     let inputJSON: String
+    let inputTruncatedTo: Int?
     let result: ToolResult?
     let timestamp: Date?
     let terminalID: UUID?
 
     @State private var expanded = false
     @State private var fullResultText: String? = nil
+    @State private var fullInputJSON: String? = nil
     @EnvironmentObject var appState: AppState
 
     private var displayName: String {
@@ -43,8 +45,9 @@ struct GenericToolCard: View {
             }
         } body: {
             VStack(alignment: .leading, spacing: 8) {
-                if !inputJSON.isEmpty && inputJSON != "{}" {
-                    Text(prettyJSON(inputJSON))
+                let displayedInput = fullInputJSON ?? inputJSON
+                if !displayedInput.isEmpty && displayedInput != "{}" {
+                    Text(prettyJSON(displayedInput))
                         .font(.system(.caption, design: .monospaced))
                         .foregroundStyle(.secondary)
                         .textSelection(.enabled)
@@ -52,6 +55,11 @@ struct GenericToolCard: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
+                    if let cap = inputTruncatedTo, fullInputJSON == nil, terminalID != nil {
+                        TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
+                            Task { await fetchFullInput() }
+                        }
+                    }
                 }
                 if let r = result {
                     Text(fullResultText ?? r.text)
@@ -96,6 +104,13 @@ struct GenericToolCard: View {
             await MainActor.run { fullResultText = result.text }
         } catch {
             // Keep showing truncated version on error.
+        }
+    }
+
+    private func fetchFullInput() async {
+        guard let terminalID else { return }
+        if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(terminalID: terminalID, itemID: "\(id)#input") {
+            await MainActor.run { fullInputJSON = r.text }
         }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/GlobCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/GlobCard.swift
@@ -14,9 +14,11 @@ struct GlobCard: View {
 
     private struct Input: Decodable { let pattern: String; let path: String? }
 
+    private static let decoder = JSONDecoder()
+
     private func decodeInput() -> Input? {
         guard let data = inputJSON.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(Input.self, from: data)
+        return try? Self.decoder.decode(Input.self, from: data)
     }
 
     var body: some View {

--- a/Sources/TBDApp/Panes/Transcript/GrepCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/GrepCard.swift
@@ -14,9 +14,11 @@ struct GrepCard: View {
 
     private struct Input: Decodable { let pattern: String; let path: String? }
 
+    private static let decoder = JSONDecoder()
+
     private func decodeInput() -> Input? {
         guard let data = inputJSON.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(Input.self, from: data)
+        return try? Self.decoder.decode(Input.self, from: data)
     }
 
     var body: some View {

--- a/Sources/TBDApp/Panes/Transcript/ReadCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/ReadCard.swift
@@ -20,9 +20,11 @@ struct ReadCard: View {
         let limit: Int?
     }
 
+    private static let decoder = JSONDecoder()
+
     private func decodeInput() -> Input? {
         guard let data = inputJSON.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(Input.self, from: data)
+        return try? Self.decoder.decode(Input.self, from: data)
     }
 
     var body: some View {

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -14,7 +14,7 @@ func isHiddenInTranscript(_ item: TranscriptItem) -> Bool {
     switch item {
     case .thinking:
         return true
-    case .toolCall(_, let name, _, _, _, _):
+    case .toolCall(_, let name, _, _, _, _, _):
         return hiddenToolNames.contains(name)
     default:
         return false
@@ -70,12 +70,12 @@ struct TranscriptItemsView: View {
             // case stays in the wire format for Codable safety, but no parser
             // path emits it today.
             EmptyView()
-        case .toolCall(let id, let name, let inputJSON, let result, let subagent, let ts):
+        case .toolCall(let id, let name, let inputJSON, let inputTruncatedTo, let result, let subagent, let ts):
             if hiddenToolNames.contains(name) {
                 EmptyView()
             } else {
                 VStack(alignment: .leading, spacing: 4) {
-                    toolCardFor(name: name, id: id, inputJSON: inputJSON, result: result, timestamp: ts)
+                    toolCardFor(name: name, id: id, inputJSON: inputJSON, inputTruncatedTo: inputTruncatedTo, result: result, timestamp: ts)
                     if let subagent {
                         SubagentDisclosure(subagent: subagent, terminalID: terminalID, depth: depth)
                             .padding(.leading, 32)
@@ -86,22 +86,22 @@ struct TranscriptItemsView: View {
     }
 
     @ViewBuilder
-    private func toolCardFor(name: String, id: String, inputJSON: String, result: ToolResult?, timestamp: Date?) -> some View {
+    private func toolCardFor(name: String, id: String, inputJSON: String, inputTruncatedTo: Int?, result: ToolResult?, timestamp: Date?) -> some View {
         switch name {
         case "Read":
             ReadCard(id: id, inputJSON: inputJSON, result: result, timestamp: timestamp, terminalID: terminalID)
         case "Edit", "MultiEdit":
-            EditCard(id: id, name: name, inputJSON: inputJSON, result: result, timestamp: timestamp, terminalID: terminalID)
+            EditCard(id: id, name: name, inputJSON: inputJSON, inputTruncatedTo: inputTruncatedTo, result: result, timestamp: timestamp, terminalID: terminalID)
         case "Write":
-            WriteCard(id: id, inputJSON: inputJSON, result: result, timestamp: timestamp, terminalID: terminalID)
+            WriteCard(id: id, inputJSON: inputJSON, inputTruncatedTo: inputTruncatedTo, result: result, timestamp: timestamp, terminalID: terminalID)
         case "Bash":
-            BashCard(id: id, inputJSON: inputJSON, result: result, timestamp: timestamp, terminalID: terminalID)
+            BashCard(id: id, inputJSON: inputJSON, inputTruncatedTo: inputTruncatedTo, result: result, timestamp: timestamp, terminalID: terminalID)
         case "Grep":
             GrepCard(id: id, inputJSON: inputJSON, result: result, timestamp: timestamp, terminalID: terminalID)
         case "Glob":
             GlobCard(id: id, inputJSON: inputJSON, result: result, timestamp: timestamp, terminalID: terminalID)
         case "Task", "Agent":
-            AgentCard(id: id, inputJSON: inputJSON, result: result, timestamp: timestamp, terminalID: terminalID)
+            AgentCard(id: id, inputJSON: inputJSON, inputTruncatedTo: inputTruncatedTo, result: result, timestamp: timestamp, terminalID: terminalID)
         default:
             GenericToolCard(id: id, name: name, inputJSON: inputJSON, result: result, timestamp: timestamp, terminalID: terminalID)
         }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -103,7 +103,7 @@ struct TranscriptItemsView: View {
         case "Task", "Agent":
             AgentCard(id: id, inputJSON: inputJSON, inputTruncatedTo: inputTruncatedTo, result: result, timestamp: timestamp, terminalID: terminalID)
         default:
-            GenericToolCard(id: id, name: name, inputJSON: inputJSON, result: result, timestamp: timestamp, terminalID: terminalID)
+            GenericToolCard(id: id, name: name, inputJSON: inputJSON, inputTruncatedTo: inputTruncatedTo, result: result, timestamp: timestamp, terminalID: terminalID)
         }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/WriteCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/WriteCard.swift
@@ -40,7 +40,9 @@ struct WriteCard: View {
                 Text(parsedInput?.file_path ?? "…")
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Text("\(lineCount(for: parsedInput)) lines").font(.caption2).foregroundStyle(.tertiary)
+                let count = lineCount(for: parsedInput)
+                let prefix = (inputTruncatedTo != nil && fullInputJSON == nil) ? "≥" : ""
+                Text("\(prefix)\(count) lines").font(.caption2).foregroundStyle(.tertiary)
             }
         } body: {
             VStack(alignment: .leading, spacing: 8) {

--- a/Sources/TBDApp/Panes/Transcript/WriteCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/WriteCard.swift
@@ -4,12 +4,14 @@ import TBDShared
 struct WriteCard: View {
     let id: String
     let inputJSON: String
+    let inputTruncatedTo: Int?
     let result: ToolResult?
     let timestamp: Date?
     let terminalID: UUID?
 
     @State private var expanded = true
     @State private var containerExpanded = false
+    @State private var fullInputJSON: String? = nil
     @EnvironmentObject var appState: AppState
 
     private struct Input: Decodable { let file_path: String; let content: String }
@@ -17,7 +19,7 @@ struct WriteCard: View {
     private static let decoder = JSONDecoder()
 
     private func decodeInput() -> Input? {
-        guard let data = inputJSON.data(using: .utf8) else { return nil }
+        guard let data = (fullInputJSON ?? inputJSON).data(using: .utf8) else { return nil }
         return try? Self.decoder.decode(Input.self, from: data)
     }
 
@@ -41,34 +43,48 @@ struct WriteCard: View {
                 Text("\(lineCount(for: parsedInput)) lines").font(.caption2).foregroundStyle(.tertiary)
             }
         } body: {
-            if let content = parsedInput?.content {
-                ZStack(alignment: .topTrailing) {
-                    ScrollView(.vertical) {
-                        Text(content)
-                            .font(.system(.caption, design: .monospaced))
-                            .textSelection(.enabled)
-                            .padding(8)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .frame(maxHeight: containerExpanded ? .infinity : 120)
-                    .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            VStack(alignment: .leading, spacing: 8) {
+                if let content = parsedInput?.content {
+                    ZStack(alignment: .topTrailing) {
+                        ScrollView(.vertical) {
+                            Text(content)
+                                .font(.system(.caption, design: .monospaced))
+                                .textSelection(.enabled)
+                                .padding(8)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .frame(maxHeight: containerExpanded ? .infinity : 120)
+                        .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
 
-                    Button(action: { containerExpanded.toggle() }) {
-                        Image(systemName: containerExpanded
-                            ? "arrow.down.right.and.arrow.up.left"
-                            : "arrow.up.left.and.arrow.down.right")
-                            .font(.caption2)
-                            .padding(4)
-                            .background(Color(nsColor: .windowBackgroundColor).opacity(0.9))
-                            .clipShape(Circle())
+                        Button(action: { containerExpanded.toggle() }) {
+                            Image(systemName: containerExpanded
+                                ? "arrow.down.right.and.arrow.up.left"
+                                : "arrow.up.left.and.arrow.down.right")
+                                .font(.caption2)
+                                .padding(4)
+                                .background(Color(nsColor: .windowBackgroundColor).opacity(0.9))
+                                .clipShape(Circle())
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                        .padding(4)
+                        .help(containerExpanded ? "Collapse container" : "Expand container")
                     }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .padding(4)
-                    .help(containerExpanded ? "Collapse container" : "Expand container")
+                }
+                if let cap = inputTruncatedTo, fullInputJSON == nil, terminalID != nil {
+                    TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
+                        Task { await fetchFullInput() }
+                    }
                 }
             }
+        }
+    }
+
+    private func fetchFullInput() async {
+        guard let terminalID else { return }
+        if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(terminalID: terminalID, itemID: "\(id)#input") {
+            await MainActor.run { fullInputJSON = r.text }
         }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/WriteCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/WriteCard.swift
@@ -14,9 +14,11 @@ struct WriteCard: View {
 
     private struct Input: Decodable { let file_path: String; let content: String }
 
+    private static let decoder = JSONDecoder()
+
     private func decodeInput() -> Input? {
         guard let data = inputJSON.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(Input.self, from: data)
+        return try? Self.decoder.decode(Input.self, from: data)
     }
 
     private func lineCount(for parsed: Input?) -> Int {

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -174,9 +174,15 @@ enum TranscriptParser {
                     case "tool_use":
                         let toolID = (block["id"] as? String) ?? blockID
                         let name = (block["name"] as? String) ?? ""
-                        let input = block["input"] ?? [:]
-                        let inputData = (try? JSONSerialization.data(withJSONObject: input, options: [.sortedKeys])) ?? Data()
+                        let rawInput = block["input"] ?? [:]
+                        let originalData = (try? JSONSerialization.data(withJSONObject: rawInput, options: [.sortedKeys])) ?? Data()
+                        let originalJSON = String(data: originalData, encoding: .utf8) ?? "{}"
+                        let (truncatedInput, didTruncate) = truncateInputStrings(rawInput)
+                        let inputData = didTruncate
+                            ? ((try? JSONSerialization.data(withJSONObject: truncatedInput, options: [.sortedKeys])) ?? originalData)
+                            : originalData
                         let inputJSON = String(data: inputData, encoding: .utf8) ?? "{}"
+                        let inputTruncatedTo: Int? = didTruncate ? originalJSON.count : nil
                         let result = toolResultsByID[toolID]
 
                         var subagent: Subagent? = nil
@@ -190,6 +196,7 @@ enum TranscriptParser {
 
                         items.append(.toolCall(
                             id: toolID, name: name, inputJSON: inputJSON,
+                            inputTruncatedTo: inputTruncatedTo,
                             result: result, subagent: subagent, timestamp: timestamp
                         ))
                     default:
@@ -278,6 +285,36 @@ enum TranscriptParser {
         return (capped, originalCount)
     }
 
+    /// Walks `input` recursively and replaces any string value exceeding the
+    /// configured caps with its truncated form. Returns (newInput, anyTruncated).
+    static func truncateInputStrings(_ input: Any) -> (Any, Bool) {
+        if let s = input as? String {
+            let (capped, originalCount) = truncate(s)
+            return (capped, originalCount != capped.count)
+        }
+        if let dict = input as? [String: Any] {
+            var out: [String: Any] = [:]
+            var anyTrunc = false
+            for (k, v) in dict {
+                let (newV, t) = truncateInputStrings(v)
+                out[k] = newV
+                if t { anyTrunc = true }
+            }
+            return (out, anyTrunc)
+        }
+        if let arr = input as? [Any] {
+            var out: [Any] = []
+            var anyTrunc = false
+            for v in arr {
+                let (newV, t) = truncateInputStrings(v)
+                out.append(newV)
+                if t { anyTrunc = true }
+            }
+            return (out, anyTrunc)
+        }
+        return (input, false)
+    }
+
     static func extractUserText(from json: [String: Any]) -> String? {
         guard let message = json["message"] as? [String: Any] else { return nil }
         if let s = message["content"] as? String { return s }
@@ -303,6 +340,7 @@ enum TranscriptParser {
     /// Returns the un-truncated body text for an item id, or nil if not found.
     /// itemID forms:
     ///  - `tool_use_id` (e.g. "toolu_abc") → returns the matching tool_result content
+    ///  - `<tool_use_id>#input` → returns the un-truncated `tool_use.input` JSON
     ///  - `<lineUUID>#<blockIndex>` → returns the assistant block's text/thinking
     ///  - bare `lineUUID` → returns the user message content
     static func lookupFullBody(filePath: String, itemID: String) -> String? {
@@ -311,10 +349,20 @@ enum TranscriptParser {
             return nil
         }
 
-        // Parse the composite id form first.
+        // Detect the `#input` suffix variant first — when present, we ONLY scan
+        // assistant tool_use blocks for a matching id and return their full input
+        // JSON. Other branches are skipped because the unsuffixed id would
+        // otherwise fall into the tool_result / uuid scans.
+        let inputSuffix = "#input"
+        let isInputLookup = itemID.hasSuffix(inputSuffix)
+        let toolUseIDForInput: String? = isInputLookup
+            ? String(itemID.dropLast(inputSuffix.count))
+            : nil
+
+        // Parse the composite id form for the non-input branches.
         let lineUUID: String
         let blockIndex: Int?
-        if let hashIdx = itemID.firstIndex(of: "#") {
+        if !isInputLookup, let hashIdx = itemID.firstIndex(of: "#") {
             lineUUID = String(itemID[..<hashIdx])
             blockIndex = Int(itemID[itemID.index(after: hashIdx)...])
         } else {
@@ -325,6 +373,23 @@ enum TranscriptParser {
         for line in content.components(separatedBy: "\n") where !line.isEmpty {
             guard let lineData = line.data(using: .utf8),
                   let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+                continue
+            }
+
+            if let toolUseID = toolUseIDForInput {
+                // Only scan assistant tool_use blocks; ignore tool_result/uuid branches.
+                if let message = json["message"] as? [String: Any],
+                   let array = message["content"] as? [[String: Any]] {
+                    for block in array where block["type"] as? String == "tool_use" {
+                        if (block["id"] as? String) == toolUseID {
+                            let input = block["input"] ?? [:]
+                            if let data = try? JSONSerialization.data(withJSONObject: input, options: [.sortedKeys]),
+                               let s = String(data: data, encoding: .utf8) {
+                                return s
+                            }
+                        }
+                    }
+                }
                 continue
             }
 

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -175,14 +175,17 @@ enum TranscriptParser {
                         let toolID = (block["id"] as? String) ?? blockID
                         let name = (block["name"] as? String) ?? ""
                         let rawInput = block["input"] ?? [:]
-                        let originalData = (try? JSONSerialization.data(withJSONObject: rawInput, options: [.sortedKeys])) ?? Data()
-                        let originalJSON = String(data: originalData, encoding: .utf8) ?? "{}"
                         let (truncatedInput, didTruncate) = truncateInputStrings(rawInput)
-                        let inputData = didTruncate
-                            ? ((try? JSONSerialization.data(withJSONObject: truncatedInput, options: [.sortedKeys])) ?? originalData)
-                            : originalData
+                        let inputData = (try? JSONSerialization.data(
+                            withJSONObject: didTruncate ? truncatedInput : rawInput,
+                            options: [.sortedKeys])) ?? Data()
                         let inputJSON = String(data: inputData, encoding: .utf8) ?? "{}"
-                        let inputTruncatedTo: Int? = didTruncate ? originalJSON.count : nil
+                        let inputTruncatedTo: Int? = {
+                            guard didTruncate,
+                                  let d = try? JSONSerialization.data(withJSONObject: rawInput, options: [.sortedKeys]),
+                                  let s = String(data: d, encoding: .utf8) else { return nil }
+                            return s.count
+                        }()
                         let result = toolResultsByID[toolID]
 
                         var subagent: Subagent? = nil

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -461,6 +461,7 @@ public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable 
     case userPrompt(id: String, text: String, timestamp: Date?)
     case assistantText(id: String, text: String, timestamp: Date?)
     case toolCall(id: String, name: String, inputJSON: String,
+                  inputTruncatedTo: Int?,
                   result: ToolResult?, subagent: Subagent?, timestamp: Date?)
     case thinking(id: String, text: String, timestamp: Date?)
     case systemReminder(id: String, kind: SystemKind, text: String, timestamp: Date?)
@@ -470,7 +471,7 @@ public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable 
         switch self {
         case .userPrompt(let id, _, _): return id
         case .assistantText(let id, _, _): return id
-        case .toolCall(let id, _, _, _, _, _): return id
+        case .toolCall(let id, _, _, _, _, _, _): return id
         case .thinking(let id, _, _): return id
         case .systemReminder(let id, _, _, _): return id
         case .slashCommand(let id, _, _, _): return id
@@ -481,7 +482,7 @@ public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable 
         switch self {
         case .userPrompt(_, _, let t),
              .assistantText(_, _, let t),
-             .toolCall(_, _, _, _, _, let t),
+             .toolCall(_, _, _, _, _, _, let t),
              .thinking(_, _, let t),
              .systemReminder(_, _, _, let t),
              .slashCommand(_, _, _, let t):

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -58,7 +58,7 @@ struct TranscriptParserTests {
 
         let items = TranscriptParser.parse(filePath: tmp)
         #expect(items.count == 1, "tool_result should fold into the tool_use, not be its own item")
-        if case .toolCall(_, _, _, let r, _, _) = items[0] {
+        if case .toolCall(_, _, _, _, let r, _, _) = items[0] {
             #expect(r?.text == "file contents")
             #expect(r?.isError == false)
         } else {
@@ -73,7 +73,7 @@ struct TranscriptParserTests {
 
         let items = TranscriptParser.parse(filePath: tmp)
         #expect(items.count == 1)
-        if case .toolCall(_, _, _, let r, _, _) = items[0] {
+        if case .toolCall(_, _, _, _, let r, _, _) = items[0] {
             #expect(r == nil, "in-flight tool call should have nil result")
         } else {
             Issue.record("expected .toolCall")
@@ -120,7 +120,7 @@ struct TranscriptParserTests {
 
         let items = TranscriptParser.parse(filePath: parentPath)
         #expect(items.count == 1)
-        guard case .toolCall(_, let name, _, _, let subagent, _) = items[0] else {
+        guard case .toolCall(_, let name, _, _, _, let subagent, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(name == "Task")
@@ -150,7 +150,7 @@ struct TranscriptParserTests {
             .write(toFile: subDir.appendingPathComponent("agent-AM.meta.json").path, atomically: true, encoding: .utf8)
 
         let items = TranscriptParser.parse(filePath: parentPath)
-        guard case .toolCall(_, _, _, _, let subagent, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, _, let subagent, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(subagent?.agentType == "feature-dev:code-reviewer")
@@ -170,7 +170,7 @@ struct TranscriptParserTests {
         try parent.write(toFile: parentPath, atomically: true, encoding: .utf8)
 
         let items = TranscriptParser.parse(filePath: parentPath)
-        guard case .toolCall(_, _, _, _, let subagent, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, _, let subagent, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(subagent == nil, "missing subagent file → nil subagent, parent still renders")
@@ -204,9 +204,9 @@ struct TranscriptParserTests {
         ].joined(separator: "\n").write(toFile: subDir.appendingPathComponent("agent-AINNER.jsonl").path, atomically: true, encoding: .utf8)
 
         let items = TranscriptParser.parse(filePath: parentPath)
-        guard case .toolCall(_, _, _, _, let outer, _) = items[0],
+        guard case .toolCall(_, _, _, _, _, let outer, _) = items[0],
               let outerItems = outer?.items, outerItems.count >= 2,
-              case .toolCall(_, _, _, _, let inner, _) = outerItems[1] else {
+              case .toolCall(_, _, _, _, _, let inner, _) = outerItems[1] else {
             Issue.record("recursive structure mismatched"); return
         }
         #expect(inner?.agentID == "AINNER")
@@ -223,7 +223,7 @@ struct TranscriptParserTests {
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
         let items = TranscriptParser.parse(filePath: tmp)
-        guard case .toolCall(_, _, _, let r, _, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, let r, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(r?.text.count == 2000)
@@ -241,7 +241,7 @@ struct TranscriptParserTests {
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
         let items = TranscriptParser.parse(filePath: tmp)
-        guard case .toolCall(_, _, _, let r, _, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, let r, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(r?.text.split(separator: "\n").count == 20)
@@ -257,7 +257,7 @@ struct TranscriptParserTests {
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
         let items = TranscriptParser.parse(filePath: tmp)
-        guard case .toolCall(_, _, _, let r, _, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, let r, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(r?.text == "short")
@@ -340,6 +340,68 @@ struct TranscriptParserTests {
             itemID: "toolu_nope"
         )
         #expect(miss == nil)
+    }
+
+    @Test func inputTruncatesLargeStringField() throws {
+        let big = String(repeating: "a", count: 3000)
+        let line = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"timestamp\":\"2026-05-05T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"Write\",\"input\":{\"file_path\":\"/x.swift\",\"content\":\"\(big)\"}}]}}"
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        guard case .toolCall(_, _, let inputJSON, let inputTruncatedTo, _, _, _) = items[0] else {
+            Issue.record("expected .toolCall"); return
+        }
+        #expect(inputTruncatedTo != nil, "large input field should set inputTruncatedTo")
+        #expect(inputJSON.count < 3000, "truncated inputJSON should be smaller than original payload")
+        // The recorded original JSON length should match the count we report.
+        if let trunc = inputTruncatedTo {
+            #expect(trunc > inputJSON.count, "inputTruncatedTo should be the original full-JSON char count")
+        }
+    }
+
+    @Test func inputNotTruncatedWhenSmall() throws {
+        let line = #"{"type":"assistant","uuid":"a1","timestamp":"2026-05-05T10:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Write","input":{"file_path":"x.swift","content":"ok"}}]}}"#
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        guard case .toolCall(_, _, _, let inputTruncatedTo, _, _, _) = items[0] else {
+            Issue.record("expected .toolCall"); return
+        }
+        #expect(inputTruncatedTo == nil, "small inputs should not set inputTruncatedTo")
+    }
+
+    @Test func multiEditNestedStringIsTruncated() throws {
+        let big = String(repeating: "a", count: 3000)
+        let line = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"timestamp\":\"2026-05-05T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"MultiEdit\",\"input\":{\"file_path\":\"/x.swift\",\"edits\":[{\"old_string\":\"foo\",\"new_string\":\"\(big)\"}]}}]}}"
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        guard case .toolCall(_, _, let inputJSON, let inputTruncatedTo, _, _, _) = items[0] else {
+            Issue.record("expected .toolCall"); return
+        }
+        #expect(inputTruncatedTo != nil, "nested oversized string should trigger truncation")
+        let needle = String(repeating: "a", count: 2500)
+        #expect(!inputJSON.contains(needle), "the nested array element's string should have been truncated below 2500 chars")
+    }
+
+    @Test func lookupFullBodyWithInputSuffix() throws {
+        let big = String(repeating: "a", count: 3000)
+        let line = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"timestamp\":\"2026-05-05T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_xyz\",\"name\":\"Write\",\"input\":{\"file_path\":\"/x.swift\",\"content\":\"\(big)\"}}]}}"
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let hit = TranscriptParser.lookupFullBody(filePath: tmp, itemID: "toolu_xyz#input")
+        #expect(hit != nil, "lookupFullBody with #input suffix should resolve")
+        guard let hit else { return }
+        #expect(hit.count > 2000, "result should include the full un-truncated content (\(hit.count) chars)")
+        #expect(hit.contains(big), "result should contain the full original 3000-char content string")
+        // Sanity-check the result is JSON (parses to a dict).
+        let data = hit.data(using: .utf8) ?? Data()
+        let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed != nil, "result should be valid JSON")
     }
 
     // MARK: - helpers

--- a/Tests/TBDSharedTests/TranscriptItemTests.swift
+++ b/Tests/TBDSharedTests/TranscriptItemTests.swift
@@ -35,12 +35,13 @@ struct TranscriptItemTests {
         )
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(TranscriptItem.self, from: data)
-        guard case .toolCall(let id, let name, let inputJSON, _, let r, let sub, _) = decoded else {
+        guard case .toolCall(let id, let name, let inputJSON, let inputTruncatedTo, let r, let sub, _) = decoded else {
             Issue.record("expected .toolCall"); return
         }
         #expect(id == "toolu_1")
         #expect(name == "Read")
         #expect(inputJSON == "{\"file_path\":\"/x\"}")
+        #expect(inputTruncatedTo == nil)
         #expect(r?.text == "stdout")
         #expect(sub == nil)
     }
@@ -54,16 +55,17 @@ struct TranscriptItemTests {
         )
         let sub = Subagent(agentID: "agent_x", agentType: "feature-dev:code-explorer", items: [inner])
         let outer: TranscriptItem = .toolCall(
-            id: "toolu_outer", name: "Task", inputJSON: "{}",
-            inputTruncatedTo: nil,
+            id: "toolu_outer", name: "Task", inputJSON: "{\"prompt\":\"…\"}",
+            inputTruncatedTo: 50_000,
             result: ToolResult(text: "done", truncatedTo: nil, isError: false),
             subagent: sub, timestamp: nil
         )
         let data = try JSONEncoder().encode(outer)
         let decoded = try JSONDecoder().decode(TranscriptItem.self, from: data)
-        guard case .toolCall(_, _, _, _, _, let s, _) = decoded else {
+        guard case .toolCall(_, _, _, let outerTruncated, _, let s, _) = decoded else {
             Issue.record("expected .toolCall"); return
         }
+        #expect(outerTruncated == 50_000)
         #expect(s?.agentID == "agent_x")
         #expect(s?.items.count == 1)
     }

--- a/Tests/TBDSharedTests/TranscriptItemTests.swift
+++ b/Tests/TBDSharedTests/TranscriptItemTests.swift
@@ -30,11 +30,12 @@ struct TranscriptItemTests {
         let result = ToolResult(text: "stdout", truncatedTo: nil, isError: false)
         let original: TranscriptItem = .toolCall(
             id: "toolu_1", name: "Read", inputJSON: "{\"file_path\":\"/x\"}",
+            inputTruncatedTo: nil,
             result: result, subagent: nil, timestamp: nil
         )
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(TranscriptItem.self, from: data)
-        guard case .toolCall(let id, let name, let inputJSON, let r, let sub, _) = decoded else {
+        guard case .toolCall(let id, let name, let inputJSON, _, let r, let sub, _) = decoded else {
             Issue.record("expected .toolCall"); return
         }
         #expect(id == "toolu_1")
@@ -47,18 +48,20 @@ struct TranscriptItemTests {
     @Test func roundtrip_toolCall_with_subagent_with_nested_toolcall() throws {
         let inner: TranscriptItem = .toolCall(
             id: "toolu_inner", name: "Bash", inputJSON: "{}",
+            inputTruncatedTo: nil,
             result: ToolResult(text: "ok", truncatedTo: nil, isError: false),
             subagent: nil, timestamp: nil
         )
         let sub = Subagent(agentID: "agent_x", agentType: "feature-dev:code-explorer", items: [inner])
         let outer: TranscriptItem = .toolCall(
             id: "toolu_outer", name: "Task", inputJSON: "{}",
+            inputTruncatedTo: nil,
             result: ToolResult(text: "done", truncatedTo: nil, isError: false),
             subagent: sub, timestamp: nil
         )
         let data = try JSONEncoder().encode(outer)
         let decoded = try JSONDecoder().decode(TranscriptItem.self, from: data)
-        guard case .toolCall(_, _, _, _, let s, _) = decoded else {
+        guard case .toolCall(_, _, _, _, _, let s, _) = decoded else {
             Issue.record("expected .toolCall"); return
         }
         #expect(s?.agentID == "agent_x")

--- a/docs/superpowers/specs/2026-05-05-transcript-input-cap-design.md
+++ b/docs/superpowers/specs/2026-05-05-transcript-input-cap-design.md
@@ -1,0 +1,138 @@
+# Transcript: cap tool-call input size
+
+Follow-up to PR #99. Tool *results* in the transcript are size-capped
+(`bodyCharCap=2000`, `bodyLineCap=20`) but tool *inputs* are passed through
+verbatim. A single `Write` of a real source file can carry hundreds of KB
+through the daemon→app `terminal.transcript` channel and is then held in
+the app's `sessionTranscripts` LRU and the daemon's `TranscriptParseCache`,
+each sized for 50 sessions. Several `Write`s in one session = several MB
+duplicated across both caches and re-sent on every 1.5s poll.
+
+## Goal
+
+Apply the same truncation contract to inputs that already exists for
+results: cap large string fields in the input dict, surface a
+`TruncationFooter` in cards, fetch the full body on demand via the
+existing `terminal.transcriptItemFullBody` RPC.
+
+## Design
+
+### Parser: per-field truncation
+
+In `Sources/TBDDaemon/Claude/TranscriptParser.swift`, the path that
+serializes `inputJSON` for a tool-use block walks the input dict before
+serializing and replaces any string value exceeding `bodyCharCap` chars
+or `bodyLineCap` lines with its truncated form, reusing the existing
+`truncate(_:)` helper. After truncation, the dict is JSON-serialized as
+today (sortedKeys). Result: the `inputJSON` string is always valid JSON
+and always ≤ a bounded size (cap × number of string fields), so cards
+keep parsing without changes.
+
+Recursion: nested arrays and dicts are walked too (covers
+`MultiEdit.edits[*].old_string`/`new_string` and any future tool with
+nested string fields).
+
+### Wire change: `inputTruncatedTo`
+
+`Sources/TBDShared/Models.swift` — extend `TranscriptItem.toolCall`:
+
+```swift
+case toolCall(id: String, name: String, inputJSON: String,
+              inputTruncatedTo: Int?,
+              result: ToolResult?, subagent: Subagent?, timestamp: Date?)
+```
+
+Semantics: `inputTruncatedTo` is the char count of the *original full
+inputJSON* (before any per-field truncation), set iff any field was
+truncated, otherwise `nil`. Mirrors `ToolResult.truncatedTo`.
+
+`TranscriptItem` is auto-synthesized Codable. The new positional-but-
+labeled associated value is optional, so old encoded items decode as
+`nil` (same pattern used when `subagent: Subagent?` was added). All
+constructors and `switch case .toolCall(...)` sites need the extra
+binding.
+
+### Full-body RPC: `<tool_use_id>#input` suffix
+
+Reuse `terminal.transcriptItemFullBody`. Extend
+`TranscriptParser.lookupFullBody(filePath:itemID:)` with one new branch:
+
+- itemID has form `<tool_use_id>#input` → split on `#`, scan assistant
+  lines' `content` array for `tool_use` blocks where `id` matches the
+  prefix, re-serialize that block's `input` dict using the same options
+  (`.sortedKeys`) and return the full string.
+
+No RPC signature change. App calls
+`daemonClient.transcriptItemFullBody(filePath:, itemID: "\(toolUseID)#input")`
+and re-parses the returned string.
+
+### Cards: opt-in plumbing
+
+Four cards display content that can be large. Each adds:
+
+1. `let inputTruncatedTo: Int?` parameter (passed from
+   `TranscriptItemView`).
+2. `@State private var fullInputJSON: String? = nil`.
+3. Compute `effectiveInputJSON = fullInputJSON ?? inputJSON`; existing
+   `decodeInput()` consumes that.
+4. Below the body, when `inputTruncatedTo != nil && fullInputJSON == nil
+   && terminalID != nil`, render `TruncationFooter(truncatedTo:
+   inputTruncatedTo!, currentLength: inputJSON.count)` whose action
+   fetches via RPC and assigns `fullInputJSON`.
+
+Cards in scope:
+
+- `WriteCard` — `content` field is the file body. Primary win.
+- `EditCard` — `old_string`, `new_string`, and `MultiEdit.edits[*]`.
+- `AgentCard` — `prompt` field; subagent prompts run 5–10KB.
+- `BashCard` — `command` is usually short but rare long heredocs/scripts
+  benefit from the cap.
+
+Cards out of scope: `ReadCard`, `GrepCard`, `GlobCard` — inputs are paths
+and patterns, never large.
+
+### `TranscriptItemView` wiring
+
+`Sources/TBDApp/Panes/Transcript/TranscriptItemView.swift` (or wherever
+`.toolCall` is destructured) passes the new `inputTruncatedTo` to each
+card initializer.
+
+## Caps
+
+Same constants for inputs as for results: `bodyCharCap=2000`,
+`bodyLineCap=20`. No per-tool tuning. Rationale: consistent UX, single
+knob to tune, and the affected fields (file content, prompts, edit
+hunks) all benefit from the same scale.
+
+## Backward compatibility
+
+- Old encoded `TranscriptItem.toolCall` rows decode with
+  `inputTruncatedTo = nil`. No-op for cards.
+- `TranscriptParseCache` entries cached before the upgrade decode the
+  same way; on next parse they get the new field populated.
+- Old daemons with new app: the field is missing from the wire payload,
+  decodes as `nil`, no truncation footer shows. No crash.
+- New daemon with old app: old app ignores the unknown field via Codable
+  defaults. No crash.
+
+## Testing
+
+`Tests/TBDDaemonTests/TranscriptParserTests.swift`:
+
+- New test: a synthetic JSONL line with a tool_use whose `input.content`
+  is 5000 chars yields a `TranscriptItem.toolCall` with truncated
+  `inputJSON` and non-nil `inputTruncatedTo` equal to the pre-truncation
+  full-JSON char count.
+- New test: a tool_use with all-small inputs yields
+  `inputTruncatedTo == nil`.
+- New test: `MultiEdit` with one large `new_string` inside `edits[]`
+  truncates the nested string and sets `inputTruncatedTo`.
+- New test: `lookupFullBody(filePath:, itemID: "\(toolUseID)#input")`
+  returns the full un-truncated input JSON.
+
+## Out of scope
+
+- No new tool-card types. Truncation only retrofits existing cards.
+- No change to caps for results.
+- No change to the LRU sizing — this fix reduces memory pressure within
+  the existing 50-session window.


### PR DESCRIPTION
## Summary

Two follow-ups from PR #99's bot review.

- **Tool-call inputs were unbounded.** Tool *results* in the transcript are size-capped, but inputs were serialized verbatim — a single `Write` of a real source file pushed hundreds of KB through the daemon→app `terminal.transcript` channel and stuck in both the daemon's `TranscriptParseCache` (50 sessions) and the app's `sessionTranscripts` LRU (50 sessions), getting re-sent on every 1.5s poll. Several `Write`s in one session = several MB duplicated, on every tick. Now the parser walks each tool input dict and truncates large string values using the existing `bodyCharCap`/`bodyLineCap`. The `inputJSON` stays valid JSON so cards keep parsing; a new `inputTruncatedTo: Int?` mirrors `ToolResult.truncatedTo`. The existing `terminal.transcriptItemFullBody` RPC gains a `<tool_use_id>#input` itemID form for on-demand fetch. `WriteCard`/`EditCard`/`AgentCard`/`BashCard` show the same `TruncationFooter` they already use for results.
- **`JSONDecoder` was being re-allocated on every render** for six tool cards. Hoisted to `private static let decoder = JSONDecoder()`, matching `EditCard`'s existing pattern.

Spec: [`docs/superpowers/specs/2026-05-05-transcript-input-cap-design.md`](docs/superpowers/specs/2026-05-05-transcript-input-cap-design.md)

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 580 tests pass, including 4 new parser tests (`inputTruncatesLargeStringField`, `inputNotTruncatedWhenSmall`, `multiEditNestedStringIsTruncated`, `lookupFullBodyWithInputSuffix`)
- [x] `scripts/restart.sh` — daemon and app come up cleanly
- [ ] Drive a real `Write` of a large file in the app; confirm the truncation footer appears below the file body and tapping it loads full content
- [ ] Drive a `Task`/Agent invocation with a multi-KB prompt; confirm same behavior on `AgentCard`

open in TBD: \`tbd://open?worktree=9ADCC356-D87B-45D5-83FA-2C4B5D10F7CD\`