### PR TITLE
Feat: Claude transcripts no longer freeze on long sessions -- tables, smooth scroll, state preserved across worktree switches

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -198,6 +198,26 @@ final class AppState: ObservableObject {
     @Published var sessionTranscripts: [String: [TranscriptItem]] = [:]  // sessionId → items
     @Published var sessionTranscriptLoading: Set<String> = []
 
+    /// Worktree IDs whose view trees we keep alive past their selection,
+    /// most-recent-first. Cap: keepAliveLimit. Older worktrees get evicted
+    /// (their SingleWorktreeView unmounts) when the cap is exceeded.
+    @Published private(set) var recentlyVisitedWorktreeIDs: [UUID] = []
+
+    private let keepAliveLimit = 8
+
+    /// Move `id` to the front of recentlyVisitedWorktreeIDs, evicting the
+    /// oldest entries if we exceed keepAliveLimit. Idempotent — calling
+    /// repeatedly with the same id only updates ordering.
+    func touchVisitedWorktree(_ id: UUID) {
+        recentlyVisitedWorktreeIDs.removeAll { $0 == id }
+        recentlyVisitedWorktreeIDs.insert(id, at: 0)
+        if recentlyVisitedWorktreeIDs.count > keepAliveLimit {
+            recentlyVisitedWorktreeIDs.removeLast(
+                recentlyVisitedWorktreeIDs.count - keepAliveLimit
+            )
+        }
+    }
+
     /// Insertion/access order for `sessionTranscripts`. The most recently
     /// touched sessionID is at the END. Evict from the FRONT when the cap
     /// is exceeded.

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -195,6 +195,11 @@ struct ContentView: View {
                     await appState.refreshTerminals(worktreeID: worktreeID)
                 }
             }
+
+            // Keep-alive: track most-recently-visited worktree for view-tree preservation.
+            if newSelection.count == 1, let id = newSelection.first {
+                appState.touchVisitedWorktree(id)
+            }
         }
         .alert(
             appState.alertIsError ? "Error" : "Success",
@@ -211,6 +216,11 @@ struct ContentView: View {
             conductorHotkeyMonitor.install { [weak appState] in
                 guard appState != nil else { return }
                 toggleConductor()
+            }
+            // Keep-alive: seed recentlyVisitedWorktreeIDs with the initially-restored
+            // selection so the ZStack renders the right SingleWorktreeView on first frame.
+            if appState.selectedWorktreeIDs.count == 1, let id = appState.selectedWorktreeIDs.first {
+                appState.touchVisitedWorktree(id)
             }
         }
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -8,6 +8,7 @@ import TBDShared
 import os
 
 private let daemonClientLogger = Logger(subsystem: "com.tbd.app", category: "DaemonClient")
+private let perfTranscriptLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
 /// Errors from the DaemonClient.
 enum DaemonClientError: Error, CustomStringConvertible, LocalizedError, Sendable {
@@ -864,22 +865,50 @@ actor DaemonClient {
 
     /// Load full chat messages for a session file.
     func sessionMessages(filePath: String) async throws -> [TranscriptItem] {
-        return try await callAsync(
+        perfTranscriptLog.debug("client.rpc.start method=sessionMessages")
+        let start = ContinuousClock.now
+        let request = try RPCRequest(
             method: RPCMethod.sessionMessages,
-            params: SessionMessagesParams(filePath: filePath),
-            resultType: [TranscriptItem].self
+            params: SessionMessagesParams(filePath: filePath)
         )
+        let response = try await sendRawAsync(request)
+        guard response.success else {
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+        }
+        let bytes = response.result?.utf8.count ?? 0
+        let decodeStart = ContinuousClock.now
+        let result = try response.decodeResult([TranscriptItem].self)
+        let decodeElapsed = ContinuousClock.now - decodeStart
+        let totalElapsed = ContinuousClock.now - start
+        let ms = Int(totalElapsed.components.seconds * 1000 + totalElapsed.components.attoseconds / 1_000_000_000_000_000)
+        let decodeMs = Int(decodeElapsed.components.seconds * 1000 + decodeElapsed.components.attoseconds / 1_000_000_000_000_000)
+        perfTranscriptLog.debug("client.rpc.end method=sessionMessages elapsed_ms=\(ms, privacy: .public) bytes=\(bytes, privacy: .public) decode_ms=\(decodeMs, privacy: .public) items=\(result.count, privacy: .public)")
+        return result
     }
 
     /// Load the full chat transcript for a terminal's current Claude session.
     /// Returns empty messages and nil sessionID if the terminal has no session yet;
     /// returns empty messages and a sessionID if the session JSONL doesn't exist yet.
     func terminalTranscript(terminalID: UUID) async throws -> TerminalTranscriptResult {
-        return try await callAsync(
+        perfTranscriptLog.debug("client.rpc.start method=terminalTranscript")
+        let start = ContinuousClock.now
+        let request = try RPCRequest(
             method: RPCMethod.terminalTranscript,
-            params: TerminalTranscriptParams(terminalID: terminalID),
-            resultType: TerminalTranscriptResult.self
+            params: TerminalTranscriptParams(terminalID: terminalID)
         )
+        let response = try await sendRawAsync(request)
+        guard response.success else {
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+        }
+        let bytes = response.result?.utf8.count ?? 0
+        let decodeStart = ContinuousClock.now
+        let result = try response.decodeResult(TerminalTranscriptResult.self)
+        let decodeElapsed = ContinuousClock.now - decodeStart
+        let totalElapsed = ContinuousClock.now - start
+        let ms = Int(totalElapsed.components.seconds * 1000 + totalElapsed.components.attoseconds / 1_000_000_000_000_000)
+        let decodeMs = Int(decodeElapsed.components.seconds * 1000 + decodeElapsed.components.attoseconds / 1_000_000_000_000_000)
+        perfTranscriptLog.debug("client.rpc.end method=terminalTranscript elapsed_ms=\(ms, privacy: .public) bytes=\(bytes, privacy: .public) decode_ms=\(decodeMs, privacy: .public) items=\(result.messages.count, privacy: .public)")
+        return result
     }
 
     /// Fetch the un-truncated body for a single transcript item (for

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -276,6 +276,11 @@ struct SessionTranscriptView: View {
     let action: TranscriptAction
     @EnvironmentObject var appState: AppState
 
+    /// True when the visible viewport is within ~50pt of the bottom of
+    /// the transcript content. Drives the floating jump-to-bottom button:
+    /// shown only when the user has consciously scrolled up.
+    @State private var atBottom: Bool = true
+
     private var messages: [TranscriptItem] {
         appState.sessionTranscripts[sessionId] ?? []
     }
@@ -338,8 +343,40 @@ struct SessionTranscriptView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                ScrollView {
-                    TranscriptItemsView(items: messages, terminalID: nil)
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        TranscriptItemsView(items: messages, terminalID: nil)
+                    }
+                    .defaultScrollAnchor(.bottom)
+                    .onScrollGeometryChange(for: Bool.self) { geometry in
+                        let viewportBottom = geometry.contentOffset.y + geometry.containerSize.height
+                        let contentBottom = geometry.contentSize.height
+                        return contentBottom - viewportBottom < 50
+                    } action: { _, newAtBottom in
+                        atBottom = newAtBottom
+                    }
+                    .overlay(alignment: .bottomTrailing) {
+                        if !atBottom {
+                            Button {
+                                guard let lastID = messages.last?.id else { return }
+                                withAnimation(.easeOut(duration: 0.2)) {
+                                    proxy.scrollTo(lastID, anchor: .bottom)
+                                }
+                            } label: {
+                                Image(systemName: "arrow.down.circle.fill")
+                                    .font(.system(size: 28))
+                                    .symbolRenderingMode(.palette)
+                                    .foregroundStyle(.white, Color.accentColor)
+                                    .background(.ultraThinMaterial, in: Circle())
+                                    .shadow(radius: 4)
+                            }
+                            .buttonStyle(.plain)
+                            .padding(16)
+                            .transition(.scale(scale: 0.5).combined(with: .opacity))
+                            .help("Scroll to bottom")
+                        }
+                    }
+                    .animation(.easeInOut(duration: 0.2), value: atBottom)
                 }
             }
         }

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -21,12 +21,25 @@ struct LiveTranscriptPaneView: View {
     @State private var hasShownInitialMessages = false
     @State private var lastSessionID: String?
     @State private var retryToken = 0
-    // TODO: scroll-position detection is deferred; autoscrollEnabled is
-    // always true in v1. Wire to .scrollPosition (macOS 14+) when the
-    // "freeze autoscroll when user scrolls up" feature lands.
-    @State private var autoscrollEnabled = true
+
+    /// True when the visible viewport is within ~50pt of the bottom of
+    /// the transcript content. Drives the floating jump-to-bottom button:
+    /// shown only when the user has consciously scrolled up.
+    @State private var atBottom: Bool = true
 
     private static let log = Logger(subsystem: "com.tbd.app", category: "live-transcript")
+    nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
+
+    /// Tracks which terminal IDs have already emitted a `body.first` marker
+    /// for this process, so the per-(logger lifetime, terminalID) one-shot
+    /// log fires exactly once. Throwaway diagnostic state — removed when the
+    /// `perf-transcript` instrumentation is cleaned up.
+    nonisolated private static let bodyLogged = OSAllocatedUnfairLock<Set<UUID>>(initialState: [])
+
+    /// Last 4 characters of an identifier for compact log lines.
+    nonisolated private static func shortID(_ s: String) -> String {
+        return String(s.suffix(4))
+    }
 
     private var terminal: Terminal? {
         appState.terminals[worktreeID]?.first { $0.id == terminalID }
@@ -42,6 +55,12 @@ struct LiveTranscriptPaneView: View {
     }
 
     var body: some View {
+        let _ = Self.bodyLogged.withLock { logged in
+            if !logged.contains(terminalID) {
+                logged.insert(terminalID)
+                Self.perfLog.debug("body.first terminalID=\(Self.shortID(terminalID.uuidString), privacy: .public)")
+            }
+        }
         Group {
             if let err = loadError {
                 errorState(message: err)
@@ -54,7 +73,10 @@ struct LiveTranscriptPaneView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task(id: TaskKey(terminalID: terminalID, retryToken: retryToken)) { await pollLoop() }
+        .task(id: TaskKey(terminalID: terminalID, retryToken: retryToken)) {
+            Self.perfLog.debug("task.start terminalID=\(Self.shortID(terminalID.uuidString), privacy: .public)")
+            await pollLoop()
+        }
     }
 
     // MARK: - States
@@ -103,15 +125,50 @@ struct LiveTranscriptPaneView: View {
             ScrollView {
                 TranscriptItemsView(items: messages, terminalID: terminalID)
             }
-            .onChange(of: messages.last?.id) { _, newID in
-                guard autoscrollEnabled, let id = newID else { return }
-                withAnimation(.easeOut(duration: 0.15)) {
-                    proxy.scrollTo(id, anchor: .bottom)
-                }
+            .defaultScrollAnchor(.bottom)
+            .onScrollGeometryChange(for: AtBottomGeometry.self) { geometry in
+                AtBottomGeometry(
+                    contentBottom: geometry.contentSize.height,
+                    viewportBottom: geometry.contentOffset.y + geometry.containerSize.height,
+                    contentHeight: geometry.contentSize.height,
+                    offsetY: geometry.contentOffset.y,
+                    containerHeight: geometry.containerSize.height
+                )
+            } action: { _, new in
+                atBottom = new.contentBottom - new.viewportBottom < 50
+                Self.perfLog.debug("scroll.geometry contentH=\(Int(new.contentHeight), privacy: .public) offsetY=\(Int(new.offsetY), privacy: .public) containerH=\(Int(new.containerHeight), privacy: .public)")
             }
+            .overlay(alignment: .bottomTrailing) {
+                jumpToBottomButton(proxy: proxy)
+            }
+            .animation(.easeInOut(duration: 0.2), value: atBottom)
             .onAppear {
-                if let id = messages.last?.id { proxy.scrollTo(id, anchor: .bottom) }
+                let sidShort = Self.shortID(currentSessionID ?? "")
+                Self.perfLog.debug("view.appear sid=\(sidShort, privacy: .public) count=\(messages.count, privacy: .public)")
             }
+        }
+    }
+
+    @ViewBuilder
+    private func jumpToBottomButton(proxy: ScrollViewProxy) -> some View {
+        if !atBottom {
+            Button {
+                guard let lastID = messages.last?.id else { return }
+                withAnimation(.easeOut(duration: 0.2)) {
+                    proxy.scrollTo(lastID, anchor: .bottom)
+                }
+            } label: {
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.system(size: 28))
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, Color.accentColor)
+                    .background(.ultraThinMaterial, in: Circle())
+                    .shadow(radius: 4)
+            }
+            .buttonStyle(.plain)
+            .padding(16)
+            .transition(.scale(scale: 0.5).combined(with: .opacity))
+            .help("Scroll to bottom")
         }
     }
 
@@ -131,10 +188,14 @@ struct LiveTranscriptPaneView: View {
 
     private func pollOnce(failureCount: inout Int) async {
         guard let sid = currentSessionID else { return }
+        let sidShort = Self.shortID(sid)
+        Self.perfLog.debug("pollOnce.start sid=\(sidShort, privacy: .public)")
+        let pollStart = ContinuousClock.now
+        var changed = false
+        var finalCount = 0
 
         // Detect session rollover.
         if let last = lastSessionID, last != sid {
-            autoscrollEnabled = true
             hasShownInitialMessages = false
         }
         lastSessionID = sid
@@ -142,31 +203,69 @@ struct LiveTranscriptPaneView: View {
         do {
             let result = try await appState.daemonClient.terminalTranscript(terminalID: terminalID)
             failureCount = 0
+            finalCount = result.messages.count
             // Resolved sessionID may differ from terminal.claudeSessionID if a rollover
             // happened mid-flight; trust the daemon's resolution.
             let resolvedSID = result.sessionID ?? sid
-            await MainActor.run {
+            let didChange: Bool = await MainActor.run {
+                Self.perfLog.debug("pollOnce.mainActor.start sid=\(sidShort, privacy: .public)")
+                let mainActorStart = ContinuousClock.now
                 let prev = appState.sessionTranscripts[resolvedSID] ?? []
-                if !messagesEqual(prev, result.messages) {
+                let equalStart = ContinuousClock.now
+                let equal = messagesEqual(prev, result.messages)
+                let equalElapsed = ContinuousClock.now - equalStart
+                let equalMs = Int(equalElapsed.components.seconds * 1000 + equalElapsed.components.attoseconds / 1_000_000_000_000_000)
+                let swapStart = ContinuousClock.now
+                if !equal {
                     appState.sessionTranscripts[resolvedSID] = result.messages
                     appState.touchSessionTranscript(resolvedSID)
                 }
+                let swapElapsed = ContinuousClock.now - swapStart
+                let swapMs = Int(swapElapsed.components.seconds * 1000 + swapElapsed.components.attoseconds / 1_000_000_000_000_000)
                 if !result.messages.isEmpty {
                     hasShownInitialMessages = true
                 }
+                let mainActorElapsed = ContinuousClock.now - mainActorStart
+                let mainActorMs = Int(mainActorElapsed.components.seconds * 1000 + mainActorElapsed.components.attoseconds / 1_000_000_000_000_000)
+                Self.perfLog.debug("pollOnce.mainActor.end sid=\(sidShort, privacy: .public) elapsed_ms=\(mainActorMs, privacy: .public) equal_ms=\(equalMs, privacy: .public) swap_ms=\(swapMs, privacy: .public)")
+                return !equal
             }
+            changed = didChange
         } catch {
             failureCount += 1
             Self.log.debug("transcript poll failed: \(error.localizedDescription, privacy: .public)")
         }
+
+        let pollElapsed = ContinuousClock.now - pollStart
+        let pollMs = Int(pollElapsed.components.seconds * 1000 + pollElapsed.components.attoseconds / 1_000_000_000_000_000)
+        Self.perfLog.debug("pollOnce.end sid=\(sidShort, privacy: .public) elapsed_ms=\(pollMs, privacy: .public) changed=\(changed, privacy: .public) count=\(finalCount, privacy: .public)")
     }
 
     private func messagesEqual(_ a: [TranscriptItem], _ b: [TranscriptItem]) -> Bool {
-        return a == b
+        let start = ContinuousClock.now
+        let result = a == b
+        let elapsed = ContinuousClock.now - start
+        if max(a.count, b.count) > 100 {
+            let ms = Int(elapsed.components.seconds * 1000 + elapsed.components.attoseconds / 1_000_000_000_000_000)
+            Self.perfLog.debug("messagesEqual elapsed_ms=\(ms, privacy: .public) count_a=\(a.count, privacy: .public) count_b=\(b.count, privacy: .public) result=\(result, privacy: .public)")
+        }
+        return result
     }
 }
 
 private struct TaskKey: Equatable {
     let terminalID: UUID
     let retryToken: Int
+}
+
+/// Bundle of scroll-geometry numbers we want to log together in
+/// `onScrollGeometryChange`. The modifier requires a single Equatable
+/// transform, so we ferry the values through this struct rather than
+/// the previous `Bool` (atBottom-only) form.
+private struct AtBottomGeometry: Equatable {
+    let contentBottom: CGFloat
+    let viewportBottom: CGFloat
+    let contentHeight: CGFloat
+    let offsetY: CGFloat
+    let containerHeight: CGFloat
 }

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -128,14 +128,11 @@ struct LiveTranscriptPaneView: View {
             .defaultScrollAnchor(.bottom)
             .onScrollGeometryChange(for: AtBottomGeometry.self) { geometry in
                 AtBottomGeometry(
-                    contentBottom: geometry.contentSize.height,
-                    viewportBottom: geometry.contentOffset.y + geometry.containerSize.height,
                     contentHeight: geometry.contentSize.height,
-                    offsetY: geometry.contentOffset.y,
-                    containerHeight: geometry.containerSize.height
+                    viewportBottom: geometry.contentOffset.y + geometry.containerSize.height
                 )
             } action: { _, new in
-                atBottom = new.contentBottom - new.viewportBottom < 50
+                atBottom = new.contentHeight - new.viewportBottom < 50
             }
             .overlay(alignment: .bottomTrailing) {
                 jumpToBottomButton(proxy: proxy)
@@ -257,14 +254,9 @@ private struct TaskKey: Equatable {
     let retryToken: Int
 }
 
-/// Bundle of scroll-geometry numbers we want to log together in
-/// `onScrollGeometryChange`. The modifier requires a single Equatable
-/// transform, so we ferry the values through this struct rather than
-/// the previous `Bool` (atBottom-only) form.
+/// Inputs to the at-bottom check, ferried through `onScrollGeometryChange`'s
+/// Equatable transform. `atBottom` is true when `contentHeight - viewportBottom < 50`.
 private struct AtBottomGeometry: Equatable {
-    let contentBottom: CGFloat
-    let viewportBottom: CGFloat
     let contentHeight: CGFloat
-    let offsetY: CGFloat
-    let containerHeight: CGFloat
+    let viewportBottom: CGFloat
 }

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -136,7 +136,6 @@ struct LiveTranscriptPaneView: View {
                 )
             } action: { _, new in
                 atBottom = new.contentBottom - new.viewportBottom < 50
-                Self.perfLog.debug("scroll.geometry contentH=\(Int(new.contentHeight), privacy: .public) offsetY=\(Int(new.offsetY), privacy: .public) containerH=\(Int(new.containerHeight), privacy: .public)")
             }
             .overlay(alignment: .bottomTrailing) {
                 jumpToBottomButton(proxy: proxy)

--- a/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
+++ b/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 import TBDShared
 import AppKit
+import MarkdownUI
 
-/// Single user/assistant prose bubble. Renders inline markdown
-/// (`**bold**`, `*italic*`, `` `code` ``, `[links](url)`) via
-/// AttributedString and fenced code blocks via MarkdownSegments.
+/// Single user/assistant prose bubble. Renders block-level markdown
+/// (paragraphs, lists, tables, blockquotes, headings) via MarkdownUI
+/// and fenced code blocks via the local `codeBlock(...)` view, with
+/// segments partitioned upstream by `MarkdownSegments`.
 struct ChatBubbleView: View {
     let item: TranscriptItem
 
@@ -61,8 +63,8 @@ struct ChatBubbleView: View {
             ForEach(Array(segments.enumerated()), id: \.offset) { _, seg in
                 switch seg {
                 case .prose(let p):
-                    Text(attributedProse(p))
-                        .font(.body)
+                    Markdown(p)
+                        .markdownTheme(.chatBubble)
                         .textSelection(.enabled)
                 case .code(let lang, let body):
                     codeBlock(language: lang, content: body)
@@ -100,11 +102,272 @@ struct ChatBubbleView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 6))
         }
     }
+}
 
-    private func attributedProse(_ raw: String) -> AttributedString {
-        let opts = AttributedString.MarkdownParsingOptions(
-            interpretedSyntax: .inlineOnlyPreservingWhitespace
-        )
-        return (try? AttributedString(markdown: raw, options: opts)) ?? AttributedString(raw)
+// MARK: - MarkdownUI theme
+
+/// Chat-bubble-tuned MarkdownUI theme. Built from `Theme.basic` and
+/// pared back so the common case — plain prose with inline `**bold**`,
+/// `*italic*`, `` `code` ``, `[links]` — is visually indistinguishable
+/// from the prior `AttributedString(markdown:)` rendering. Block
+/// elements (tables, lists, blockquotes, headings) light up as a
+/// byproduct.
+private extension MarkdownUI.Theme {
+    @MainActor static let chatBubble = MarkdownUI.Theme.basic
+        .text {
+            ForegroundColor(.primary)
+        }
+        .code {
+            FontFamilyVariant(.monospaced)
+            FontSize(.em(0.92))
+            ForegroundColor(.chatBubbleInlineCode)
+        }
+        .paragraph { configuration in
+            configuration.label
+                .fixedSize(horizontal: false, vertical: true)
+                .markdownMargin(top: 0, bottom: 16)
+        }
+        .listItem { configuration in
+            configuration.label
+                .markdownMargin(top: .em(0.35))
+        }
+        .list { configuration in
+            configuration.label
+                .markdownMargin(top: 0, bottom: 16)
+        }
+        .blockquote { configuration in
+            HStack(spacing: 0) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.secondary.opacity(0.4))
+                    .relativeFrame(width: .em(0.2))
+                configuration.label
+                    .markdownTextStyle { ForegroundColor(.secondary) }
+                    .relativePadding(.horizontal, length: .em(1))
+            }
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .heading1 { configuration in
+            configuration.label
+                .markdownMargin(top: .em(0.4), bottom: .em(0.2))
+                .markdownTextStyle {
+                    FontWeight(.semibold)
+                    FontSize(.em(1.4))
+                }
+        }
+        .heading2 { configuration in
+            configuration.label
+                .markdownMargin(top: .em(0.4), bottom: .em(0.2))
+                .markdownTextStyle {
+                    FontWeight(.semibold)
+                    FontSize(.em(1.2))
+                }
+        }
+        .heading3 { configuration in
+            configuration.label
+                .markdownMargin(top: .em(0.4), bottom: .em(0.2))
+                .markdownTextStyle {
+                    FontWeight(.semibold)
+                    FontSize(.em(1.05))
+                }
+        }
+        .heading4 { configuration in
+            configuration.label
+                .markdownMargin(top: .em(0.4), bottom: .em(0.2))
+                .markdownTextStyle { FontWeight(.semibold) }
+        }
+        .heading5 { configuration in
+            configuration.label
+                .markdownMargin(top: .em(0.4), bottom: .em(0.2))
+                .markdownTextStyle { FontWeight(.semibold) }
+        }
+        .heading6 { configuration in
+            configuration.label
+                .markdownMargin(top: .em(0.4), bottom: .em(0.2))
+                .markdownTextStyle { FontWeight(.semibold) }
+        }
+        .table { configuration in
+            configuration.label
+                .fixedSize(horizontal: false, vertical: true)
+                .markdownTableBorderStyle(
+                    .init(color: .secondary.opacity(0.3))
+                )
+                .markdownTableBackgroundStyle(
+                    .alternatingRows(
+                        Color.clear,
+                        Color.primary.opacity(0.05)
+                    )
+                )
+                .markdownMargin(top: 0, bottom: 0)
+        }
+        .tableCell { configuration in
+            configuration.label
+                .markdownTextStyle {
+                    if configuration.row == 0 {
+                        FontWeight(.semibold)
+                    }
+                    BackgroundColor(nil)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+        }
+        .thematicBreak {
+            Divider()
+                .markdownMargin(top: .em(0.25), bottom: .em(0.25))
+        }
+}
+
+private extension Color {
+    /// Inline code foreground — desaturated cool/blue. Matches the
+    /// Claude Code terminal style: rgb(172,179,209) on dark, mirrored
+    /// to a dark slate blue on light. Distinguishes inline code from
+    /// surrounding body text without competing visually.
+    static let chatBubbleInlineCode = Color(
+        light: Color(red: 82.0/255, green: 88.0/255, blue: 130.0/255),
+        dark: Color(red: 172.0/255, green: 179.0/255, blue: 209.0/255)
+    )
+}
+
+// MARK: - Preview
+
+/// Exercises the chat-bubble Markdown rendering path. Uses
+/// `PreviewProvider` (not the `#Preview` macro) so the file still
+/// compiles under bare `swift build` — the SPM toolchain doesn't ship
+/// the `PreviewsMacros` plugin that Xcode injects.
+struct ChatBubbleView_Previews: PreviewProvider {
+    static let inlineProse = """
+    Plain prose with **bold**, *italic*, `inline code`, and a [link](https://example.com).
+    """
+
+    static let tableProse = """
+    Here are the span kinds we emit:
+
+    | span_kind | Where |
+    |---|---|
+    | copy_context_suggestion | copy-context |
+    | research_report | all research-pipeline steps share this kind |
+    """
+
+    static let listProse = """
+    ## Next steps
+
+    - First item
+    - Second item with `code`
+    - Third item
+    """
+
+    static let blockquoteProse = """
+    > A quoted note from earlier in the thread.
+    > Continues onto a second line.
+    """
+
+    static let fencedProse = """
+    Here is some Swift:
+
+    ```swift
+    func greet(_ name: String) -> String {
+        return "Hello, \\(name)"
+    }
+    ```
+    """
+
+    static var previews: some View {
+        ScrollView {
+            VStack(spacing: 8) {
+                ChatBubbleView(item: .assistantText(id: "a1", text: inlineProse, timestamp: nil))
+                ChatBubbleView(item: .assistantText(id: "a2", text: tableProse, timestamp: nil))
+                ChatBubbleView(item: .assistantText(id: "a3", text: listProse, timestamp: nil))
+                ChatBubbleView(item: .assistantText(id: "a4", text: blockquoteProse, timestamp: nil))
+                ChatBubbleView(item: .assistantText(id: "a5", text: fencedProse, timestamp: nil))
+            }
+            .padding()
+        }
+        .frame(width: 560, height: 720)
+    }
+}
+
+/// Side-by-side parity preview: renders the SAME prose with the OLD
+/// `Text(AttributedString(markdown:, options: .inlineOnlyPreservingWhitespace))`
+/// path on the left and the NEW `Markdown(...).markdownTheme(.chatBubble)`
+/// path on the right. For pure inline prose the two columns should
+/// visually overlay; tables, lists, etc. only render on the right
+/// (expected — they're block-level features the old path can't show).
+struct ChatBubbleParityPreviews: PreviewProvider {
+    static let sampleA = """
+    Plain prose with **bold**, *italic*, `inline code`, and a [link](https://example.com).
+
+    A second paragraph follows after a blank line. It should sit one body-line-height below the first paragraph, no more, no less.
+
+    And a third paragraph for good measure, so we can eyeball the inter-paragraph gap multiple times.
+    """
+
+    static let sampleB = """
+    Short opener.
+
+    A longer paragraph that wraps across multiple lines so we can see the intra-paragraph leading clearly. The lines within this paragraph should have zero extra spacing — only the natural body-font line height. If they look airy, the `relativeLineSpacing` is wrong.
+    """
+
+    static let sampleC = """
+    One-liner with `code`.
+
+    Another paragraph with **strong** and *emph* and a [link](https://example.com) all inline.
+    """
+
+    private static let bubbleBg: Color = Color(nsColor: .controlBackgroundColor)
+
+    @ViewBuilder
+    private static func oldBubble(_ prose: String) -> some View {
+        let attr = (try? AttributedString(
+            markdown: prose,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(prose)
+        Text(attr)
+            .font(.body)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 8)
+            .background(bubbleBg)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    @ViewBuilder
+    private static func newBubble(_ prose: String) -> some View {
+        Markdown(prose)
+            .markdownTheme(.chatBubble)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 8)
+            .background(bubbleBg)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    @ViewBuilder
+    private static func row(_ prose: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("OLD: Text(AttributedString)").font(.caption2).foregroundStyle(.tertiary)
+                oldBubble(prose)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("NEW: Markdown + chatBubble theme").font(.caption2).foregroundStyle(.tertiary)
+                newBubble(prose)
+            }
+        }
+    }
+
+    static var previews: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                row(sampleA)
+                Divider()
+                row(sampleB)
+                Divider()
+                row(sampleC)
+            }
+            .padding()
+        }
+        .frame(width: 900, height: 800)
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
+++ b/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
@@ -60,7 +60,7 @@ struct ChatBubbleView: View {
     private var bubbleBody: some View {
         let segments = MarkdownSegments.split(text)
         VStack(alignment: .leading, spacing: 6) {
-            ForEach(Array(segments.enumerated()), id: \.offset) { _, seg in
+            ForEach(segments) { seg in
                 switch seg {
                 case .prose(let p):
                     Markdown(p)

--- a/Sources/TBDApp/Panes/Transcript/MarkdownSegments.swift
+++ b/Sources/TBDApp/Panes/Transcript/MarkdownSegments.swift
@@ -67,3 +67,17 @@ enum MarkdownSegments {
         return segments
     }
 }
+
+extension MarkdownSegments.Segment: Identifiable {
+    /// Content-derived id so SwiftUI's `ForEach` preserves identity for
+    /// unchanged segments across mid-stream re-splits (e.g. a fenced block
+    /// opening inside what was previously one prose segment).
+    var id: String {
+        switch self {
+        case .prose(let text):
+            return "p:\(text.hashValue)"
+        case .code(let language, let content):
+            return "c:\(language ?? ""):\(content.hashValue)"
+        }
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import TBDShared
+import os
 
 /// Tool names whose activity is hidden from the timeline. Keep small;
 /// these are tools whose existence in the transcript adds no signal
@@ -29,14 +30,63 @@ struct TranscriptItemsView: View {
     let terminalID: UUID?
     var depth: Int = 0
 
+    nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
+
+    /// Tracks which terminal IDs have already emitted a `items.body` marker
+    /// for >100-item bodies in this process. Throwaway diagnostic state —
+    /// removed when the `perf-transcript` instrumentation is cleaned up.
+    nonisolated private static let bodyLogged = OSAllocatedUnfairLock<Set<UUID>>(initialState: [])
+
+    /// Tracks which row IDs have already emitted a `row.realize` marker in
+    /// this process — one log per row id per process lifetime. Throwaway
+    /// diagnostic state for the layout-race investigation.
+    nonisolated private static let realizeLogged = OSAllocatedUnfairLock<Set<String>>(initialState: [])
+
+    nonisolated private static func shortID(_ id: UUID) -> String {
+        return String(id.uuidString.suffix(4))
+    }
+
+    nonisolated private static func shortID(_ id: String) -> String {
+        return String(id.suffix(4))
+    }
+
+    nonisolated private static func logRowRealizeOnce(_ rowID: String) {
+        realizeLogged.withLock { logged in
+            guard !logged.contains(rowID) else { return }
+            logged.insert(rowID)
+            perfLog.debug("row.realize id=\(shortID(rowID), privacy: .public)")
+        }
+    }
+
     var body: some View {
+        let _ = {
+            guard depth == 0, items.count > 100, let tid = terminalID else { return }
+            Self.bodyLogged.withLock { logged in
+                if !logged.contains(tid) {
+                    logged.insert(tid)
+                    Self.perfLog.debug("items.body terminalID=\(Self.shortID(tid), privacy: .public) count=\(items.count, privacy: .public)")
+                }
+            }
+        }()
         if depth >= 8 {
             Text("… nested too deep")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 4)
+        } else if depth == 0 {
+            // Top-level chat: LazyVStack inside a ScrollView with
+            // defaultScrollAnchor(.bottom) (applied by the parent pane). Lazy
+            // realization for perf; the parent's anchor handles initial
+            // bottom-positioning and follow-bottom-on-growth declaratively.
+            LazyVStack(alignment: .leading, spacing: 4) {
+                ForEach(items) { item in
+                    rowFor(item)
+                }
+            }
+            .padding(.vertical, 8)
         } else {
+            // Nested subagent timeline (typically short, inside a DisclosureGroup).
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(items) { item in
                     rowFor(item)
@@ -48,40 +98,45 @@ struct TranscriptItemsView: View {
 
     @ViewBuilder
     private func rowFor(_ item: TranscriptItem) -> some View {
-        switch item {
-        case .userPrompt, .assistantText:
-            ChatBubbleView(item: item)
-        case .thinking:
-            // Hidden by design. Claude Code emits .thinking blocks with empty
-            // text fields in practice (the actual reasoning is server-side
-            // cached), so a visible row would always show "Thinking" with no
-            // body. Re-enable here if extended-thinking content ever ships
-            // inline in the JSONL.
-            EmptyView()
-        case .systemReminder(let id, let kind, let text, let ts):
-            if kind == .skillBody {
-                SkillBodyRow(id: id, text: text, timestamp: ts)
-            } else {
-                SystemReminderRow(id: id, kind: kind, text: text, timestamp: ts)
-            }
-        case .slashCommand:
-            // Dead branch: TranscriptParser folds <command-name> envelopes into
-            // .userPrompt items so they render as user chat bubbles. The enum
-            // case stays in the wire format for Codable safety, but no parser
-            // path emits it today.
-            EmptyView()
-        case .toolCall(let id, let name, let inputJSON, let inputTruncatedTo, let result, let subagent, let ts):
-            if hiddenToolNames.contains(name) {
+        Group {
+            switch item {
+            case .userPrompt, .assistantText:
+                ChatBubbleView(item: item)
+            case .thinking:
+                // Hidden by design. Claude Code emits .thinking blocks with empty
+                // text fields in practice (the actual reasoning is server-side
+                // cached), so a visible row would always show "Thinking" with no
+                // body. Re-enable here if extended-thinking content ever ships
+                // inline in the JSONL.
                 EmptyView()
-            } else {
-                VStack(alignment: .leading, spacing: 4) {
-                    toolCardFor(name: name, id: id, inputJSON: inputJSON, inputTruncatedTo: inputTruncatedTo, result: result, timestamp: ts)
-                    if let subagent {
-                        SubagentDisclosure(subagent: subagent, terminalID: terminalID, depth: depth)
-                            .padding(.leading, 32)
+            case .systemReminder(let id, let kind, let text, let ts):
+                if kind == .skillBody {
+                    SkillBodyRow(id: id, text: text, timestamp: ts)
+                } else {
+                    SystemReminderRow(id: id, kind: kind, text: text, timestamp: ts)
+                }
+            case .slashCommand:
+                // Dead branch: TranscriptParser folds <command-name> envelopes into
+                // .userPrompt items so they render as user chat bubbles. The enum
+                // case stays in the wire format for Codable safety, but no parser
+                // path emits it today.
+                EmptyView()
+            case .toolCall(let id, let name, let inputJSON, let inputTruncatedTo, let result, let subagent, let ts):
+                if hiddenToolNames.contains(name) {
+                    EmptyView()
+                } else {
+                    VStack(alignment: .leading, spacing: 4) {
+                        toolCardFor(name: name, id: id, inputJSON: inputJSON, inputTruncatedTo: inputTruncatedTo, result: result, timestamp: ts)
+                        if let subagent {
+                            SubagentDisclosure(subagent: subagent, terminalID: terminalID, depth: depth)
+                                .padding(.leading, 32)
+                        }
                     }
                 }
             }
+        }
+        .onAppear {
+            Self.logRowRealizeOnce(item.id)
         }
     }
 

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -37,25 +37,8 @@ struct TranscriptItemsView: View {
     /// removed when the `perf-transcript` instrumentation is cleaned up.
     nonisolated private static let bodyLogged = OSAllocatedUnfairLock<Set<UUID>>(initialState: [])
 
-    /// Tracks which row IDs have already emitted a `row.realize` marker in
-    /// this process — one log per row id per process lifetime. Throwaway
-    /// diagnostic state for the layout-race investigation.
-    nonisolated private static let realizeLogged = OSAllocatedUnfairLock<Set<String>>(initialState: [])
-
     nonisolated private static func shortID(_ id: UUID) -> String {
         return String(id.uuidString.suffix(4))
-    }
-
-    nonisolated private static func shortID(_ id: String) -> String {
-        return String(id.suffix(4))
-    }
-
-    nonisolated private static func logRowRealizeOnce(_ rowID: String) {
-        realizeLogged.withLock { logged in
-            guard !logged.contains(rowID) else { return }
-            logged.insert(rowID)
-            perfLog.debug("row.realize id=\(shortID(rowID), privacy: .public)")
-        }
     }
 
     var body: some View {
@@ -134,9 +117,6 @@ struct TranscriptItemsView: View {
                     }
                 }
             }
-        }
-        .onAppear {
-            Self.logRowRealizeOnce(item.id)
         }
     }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -51,15 +51,25 @@ struct TerminalContainerView: View {
             !visible.contains(terminal.id)
         }
 
+        let activeWorktreeID: UUID? = appState.selectedWorktreeIDs.count == 1
+            ? appState.selectedWorktreeIDs.first
+            : nil
+
         let mainContent = Group {
-            if appState.selectedWorktreeIDs.count == 1,
-               let worktreeID = appState.selectedWorktreeIDs.first {
-                SingleWorktreeView(worktreeID: worktreeID)
-            } else if appState.selectedWorktreeIDs.count > 1 {
+            if appState.selectedWorktreeIDs.count > 1 {
+                // Multi-select bypasses keep-alive; existing behavior preserved.
                 MultiWorktreeView(worktreeIDs: appState.selectionOrder)
-            } else {
+            } else if appState.selectedWorktreeIDs.isEmpty {
                 Text("Select a worktree or click + to create one")
                     .foregroundStyle(.secondary)
+            } else {
+                // Single-select: NSTabViewController-backed pager keeps the recently-
+                // visited worktrees' views alive without resetting their @State or
+                // leaking AppKit events to inactive subtrees.
+                WorktreePager(
+                    worktreeIDs: appState.recentlyVisitedWorktreeIDs,
+                    activeID: activeWorktreeID
+                )
             }
         }
         .onPreferenceChange(MainAreaSizeKey.self) { newSize in
@@ -90,7 +100,7 @@ struct TerminalContainerView: View {
 // MARK: - SingleWorktreeView
 
 /// Shows the tab bar and split layout for a single selected worktree.
-private struct SingleWorktreeView: View {
+struct SingleWorktreeView: View {
     let worktreeID: UUID
     @EnvironmentObject var appState: AppState
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -301,6 +301,19 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
             // TerminalView.scrollWheel is not `open`, so we can't override it
             // in TBDTerminalView. Instead, a local event monitor intercepts
             // scroll events and forwards them to tmux as mouse button presses.
+            //
+            // Visibility filter: the `tv.window != nil` guard inside the
+            // closure rejects events when the terminal isn't currently part of
+            // the visible UI. This is load-bearing for the worktree keep-alive
+            // system (see WorktreePager + TerminalContainerView): inactive
+            // worktrees keep their terminal NSViews alive but detached from the
+            // window. Without the guard, every kept-alive terminal's monitor
+            // would still fire for every app-wide scroll-wheel event, and the
+            // `bounds.contains(point)` check below wouldn't filter them out
+            // (bounds-space math works fine on detached views) — events would
+            // be silently consumed and forwarded to hidden terminals' tmux
+            // sessions, scrolling them invisibly. tv.window == nil ⇒ this
+            // terminal isn't visible right now ⇒ no-op the monitor.
             let ref = WeakTerminalRef(terminalView)
             scrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
                 let deltaY = event.deltaY
@@ -309,6 +322,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
 
                 let consumed = MainActor.assumeIsolated {
                     guard let tv = ref.view as? TBDTerminalView else { return false }
+                    guard tv.window != nil else { return false }
                     let point = tv.convert(location, from: nil)
                     guard tv.bounds.contains(point) else { return false }
                     guard tv.terminal.mouseMode != .off else { return false }
@@ -332,12 +346,21 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
 
             // Intercept clicks: claim first responder on any click (so Cmd+Arrow
             // routes to the focused terminal), and handle Cmd+Click for file paths.
+            //
+            // Visibility filter: each `assumeIsolated` block guards on
+            // `tv.window != nil` for the same reason as scrollMonitor above —
+            // the worktree keep-alive system retains terminal NSViews for
+            // inactive worktrees in a detached state, and we must skip event
+            // processing for those (otherwise clicks would claim first responder
+            // for a hidden terminal, or fire Cmd+Click handlers against
+            // invisible bounds).
             clickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { event in
                 let location = event.locationInWindow
 
                 // Claim first responder so key equivalents route to this terminal
                 MainActor.assumeIsolated {
                     guard let tv = ref.view else { return }
+                    guard tv.window != nil else { return }
                     let point = tv.convert(location, from: nil)
                     guard tv.bounds.contains(point) else { return }
                     tv.window?.makeFirstResponder(tv)
@@ -347,6 +370,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
 
                 let consumed = MainActor.assumeIsolated { () -> Bool in
                     guard let tv = ref.view as? TBDTerminalView else { return false }
+                    guard tv.window != nil else { return false }
                     let point = tv.convert(location, from: nil)
                     guard tv.bounds.contains(point) else { return false }
 

--- a/Sources/TBDApp/Terminal/WorktreePager.swift
+++ b/Sources/TBDApp/Terminal/WorktreePager.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import AppKit
+import os
+
+private let pagerLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
+
+/// NSViewControllerRepresentable wrapping NSTabViewController for keep-alive
+/// worktree views. Apple's TabView uses NSTabViewController internally for
+/// state preservation; we use it directly with no tab chrome to get the same
+/// behavior for our keep-alive ZStack pattern.
+///
+/// Why not pure SwiftUI: see research-2026-05-06-zstack-event-leak.md.
+/// .opacity(0) doesn't block AppKit scroll-wheel events, .hidden() applied
+/// conditionally via @ViewBuilder if/else resets @State on toggle, and
+/// NSHostingView wrapping with isHidden update has its own AppKit-side
+/// hit-testing quirks. NSTabViewController solves all three at once because
+/// it manages isHidden + responder chain internally.
+struct WorktreePager: NSViewControllerRepresentable {
+    let worktreeIDs: [UUID]
+    let activeID: UUID?
+    @EnvironmentObject var appState: AppState
+
+    func makeNSViewController(context: Context) -> NSTabViewController {
+        let vc = NSTabViewController()
+        vc.tabStyle = .unspecified
+        vc.transitionOptions = []
+        pagerLog.debug("pager.makeVC tabStyle=unspecified")
+        return vc
+    }
+
+    func updateNSViewController(_ vc: NSTabViewController, context: Context) {
+        let currentIDs = vc.tabViewItems.compactMap { $0.identifier as? UUID }
+        let activeShort = activeID.map { String($0.uuidString.suffix(4)) } ?? "nil"
+        pagerLog.debug("pager.update.start existing=\(currentIDs.count, privacy: .public) requested=\(self.worktreeIDs.count, privacy: .public) active=\(activeShort, privacy: .public) selectedIdx=\(vc.selectedTabViewItemIndex, privacy: .public)")
+
+        // 1. Remove tab items whose worktree IDs were evicted.
+        for (idx, id) in currentIDs.enumerated().reversed() {
+            if !worktreeIDs.contains(id) {
+                pagerLog.debug("pager.tab.remove id=\(String(id.uuidString.suffix(4)), privacy: .public) idx=\(idx, privacy: .public)")
+                vc.removeTabViewItem(vc.tabViewItems[idx])
+            }
+        }
+
+        // 2. Add tab items for new worktree IDs.
+        for id in worktreeIDs where !currentIDs.contains(id) {
+            pagerLog.debug("pager.tab.add id=\(String(id.uuidString.suffix(4)), privacy: .public)")
+            let host = NSHostingController(
+                rootView: SingleWorktreeView(worktreeID: id)
+                    .environmentObject(appState)
+            )
+            let item = NSTabViewItem(viewController: host)
+            item.identifier = id
+            vc.addTabViewItem(item)
+        }
+
+        // 3. Sync selected index with the active worktree, if any.
+        if let activeID,
+           let idx = vc.tabViewItems.firstIndex(where: { $0.identifier as? UUID == activeID }),
+           vc.selectedTabViewItemIndex != idx {
+            vc.selectedTabViewItemIndex = idx
+        }
+
+        pagerLog.debug("pager.update.end tabs=\(vc.tabViewItems.count, privacy: .public) selectedIdx=\(vc.selectedTabViewItemIndex, privacy: .public)")
+
+        for (idx, item) in vc.tabViewItems.enumerated() {
+            let id = (item.identifier as? UUID).map { String($0.uuidString.suffix(4)) } ?? "?"
+            let isLoaded = item.viewController?.isViewLoaded ?? false
+            let isHidden = isLoaded ? (item.viewController?.view.isHidden ?? false) : false
+            let isInWindow = isLoaded ? (item.viewController?.view.window != nil) : false
+            pagerLog.debug("pager.tab.state idx=\(idx, privacy: .public) id=\(id, privacy: .public) loaded=\(isLoaded, privacy: .public) hidden=\(isHidden, privacy: .public) inWindow=\(isInWindow, privacy: .public)")
+        }
+
+        // Deep diagnostic: walk every inactive tab's NSView subtree and log
+        // each descendant's window/isHidden state. Looking for descendants
+        // with `window != nil` while their parent (the tab's hosting view) has
+        // `window == nil` — that would prove SwiftUI's NSViewRepresentable
+        // bridge keeps wrapped NSViews window-attached even when their hosting
+        // SwiftUI parent is detached, which would explain the cross-worktree
+        // scroll-event routing the user is observing.
+        for (idx, item) in vc.tabViewItems.enumerated() where idx != vc.selectedTabViewItemIndex {
+            guard item.viewController?.isViewLoaded ?? false,
+                  let rootView = item.viewController?.view else { continue }
+            let id = (item.identifier as? UUID).map { String($0.uuidString.suffix(4)) } ?? "?"
+            Self.dumpInactiveSubtree(rootView, tabID: id, depth: 0, maxDepth: 12)
+        }
+    }
+
+    private static func dumpInactiveSubtree(_ view: NSView, tabID: String, depth: Int, maxDepth: Int) {
+        guard depth <= maxDepth else {
+            pagerLog.debug("pager.subtree.elided id=\(tabID, privacy: .public) depth=\(depth, privacy: .public)")
+            return
+        }
+        let cls = String(describing: type(of: view))
+        let inWindow = view.window != nil
+        let hidden = view.isHidden
+        pagerLog.debug("pager.subtree id=\(tabID, privacy: .public) depth=\(depth, privacy: .public) class=\(cls, privacy: .public) inWindow=\(inWindow, privacy: .public) hidden=\(hidden, privacy: .public)")
+        for sub in view.subviews {
+            dumpInactiveSubtree(sub, tabID: tabID, depth: depth + 1, maxDepth: maxDepth)
+        }
+    }
+}

--- a/Sources/TBDApp/Terminal/WorktreePager.swift
+++ b/Sources/TBDApp/Terminal/WorktreePager.swift
@@ -1,8 +1,5 @@
 import SwiftUI
 import AppKit
-import os
-
-private let pagerLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
 /// NSViewControllerRepresentable wrapping NSTabViewController for keep-alive
 /// worktree views. Apple's TabView uses NSTabViewController internally for
@@ -24,26 +21,21 @@ struct WorktreePager: NSViewControllerRepresentable {
         let vc = NSTabViewController()
         vc.tabStyle = .unspecified
         vc.transitionOptions = []
-        pagerLog.debug("pager.makeVC tabStyle=unspecified")
         return vc
     }
 
     func updateNSViewController(_ vc: NSTabViewController, context: Context) {
         let currentIDs = vc.tabViewItems.compactMap { $0.identifier as? UUID }
-        let activeShort = activeID.map { String($0.uuidString.suffix(4)) } ?? "nil"
-        pagerLog.debug("pager.update.start existing=\(currentIDs.count, privacy: .public) requested=\(self.worktreeIDs.count, privacy: .public) active=\(activeShort, privacy: .public) selectedIdx=\(vc.selectedTabViewItemIndex, privacy: .public)")
 
         // 1. Remove tab items whose worktree IDs were evicted.
         for (idx, id) in currentIDs.enumerated().reversed() {
             if !worktreeIDs.contains(id) {
-                pagerLog.debug("pager.tab.remove id=\(String(id.uuidString.suffix(4)), privacy: .public) idx=\(idx, privacy: .public)")
                 vc.removeTabViewItem(vc.tabViewItems[idx])
             }
         }
 
         // 2. Add tab items for new worktree IDs.
         for id in worktreeIDs where !currentIDs.contains(id) {
-            pagerLog.debug("pager.tab.add id=\(String(id.uuidString.suffix(4)), privacy: .public)")
             let host = NSHostingController(
                 rootView: SingleWorktreeView(worktreeID: id)
                     .environmentObject(appState)
@@ -58,44 +50,6 @@ struct WorktreePager: NSViewControllerRepresentable {
            let idx = vc.tabViewItems.firstIndex(where: { $0.identifier as? UUID == activeID }),
            vc.selectedTabViewItemIndex != idx {
             vc.selectedTabViewItemIndex = idx
-        }
-
-        pagerLog.debug("pager.update.end tabs=\(vc.tabViewItems.count, privacy: .public) selectedIdx=\(vc.selectedTabViewItemIndex, privacy: .public)")
-
-        for (idx, item) in vc.tabViewItems.enumerated() {
-            let id = (item.identifier as? UUID).map { String($0.uuidString.suffix(4)) } ?? "?"
-            let isLoaded = item.viewController?.isViewLoaded ?? false
-            let isHidden = isLoaded ? (item.viewController?.view.isHidden ?? false) : false
-            let isInWindow = isLoaded ? (item.viewController?.view.window != nil) : false
-            pagerLog.debug("pager.tab.state idx=\(idx, privacy: .public) id=\(id, privacy: .public) loaded=\(isLoaded, privacy: .public) hidden=\(isHidden, privacy: .public) inWindow=\(isInWindow, privacy: .public)")
-        }
-
-        // Deep diagnostic: walk every inactive tab's NSView subtree and log
-        // each descendant's window/isHidden state. Looking for descendants
-        // with `window != nil` while their parent (the tab's hosting view) has
-        // `window == nil` — that would prove SwiftUI's NSViewRepresentable
-        // bridge keeps wrapped NSViews window-attached even when their hosting
-        // SwiftUI parent is detached, which would explain the cross-worktree
-        // scroll-event routing the user is observing.
-        for (idx, item) in vc.tabViewItems.enumerated() where idx != vc.selectedTabViewItemIndex {
-            guard item.viewController?.isViewLoaded ?? false,
-                  let rootView = item.viewController?.view else { continue }
-            let id = (item.identifier as? UUID).map { String($0.uuidString.suffix(4)) } ?? "?"
-            Self.dumpInactiveSubtree(rootView, tabID: id, depth: 0, maxDepth: 12)
-        }
-    }
-
-    private static func dumpInactiveSubtree(_ view: NSView, tabID: String, depth: Int, maxDepth: Int) {
-        guard depth <= maxDepth else {
-            pagerLog.debug("pager.subtree.elided id=\(tabID, privacy: .public) depth=\(depth, privacy: .public)")
-            return
-        }
-        let cls = String(describing: type(of: view))
-        let inWindow = view.window != nil
-        let hidden = view.isHidden
-        pagerLog.debug("pager.subtree id=\(tabID, privacy: .public) depth=\(depth, privacy: .public) class=\(cls, privacy: .public) inWindow=\(inWindow, privacy: .public) hidden=\(hidden, privacy: .public)")
-        for sub in view.subviews {
-            dumpInactiveSubtree(sub, tabID: tabID, depth: depth + 1, maxDepth: maxDepth)
         }
     }
 }

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import TBDShared
 
 /// Loads a Claude Code session JSONL into a structured `[TranscriptItem]`.
@@ -7,6 +8,7 @@ import TBDShared
 /// skipped rather than failing the whole session. JSONL writes from Claude
 /// Code may be partial during live polling; we tolerate that.
 enum TranscriptParser {
+    private static let perfLog = Logger(subsystem: "com.tbd.daemon", category: "perf-transcript")
     /// Shared ISO8601 formatter that accepts Claude Code's fractional-seconds
     /// timestamps (e.g. `2026-05-05T03:06:16.813Z`). Without
     /// `.withFractionalSeconds`, every such timestamp silently fails to parse.
@@ -21,7 +23,22 @@ enum TranscriptParser {
     /// Subagent (sidechain) JSONLs referenced by Task tool_results are recursively
     /// parsed and attached to the corresponding `.toolCall` items.
     static func parse(filePath: String) -> [TranscriptItem] {
-        return parse(filePath: filePath, visitedAgentIDs: [], skipSidechain: true)
+        let basename = (filePath as NSString).lastPathComponent
+        perfLog.debug("parse.start file=\(basename, privacy: .public)")
+        let start = ContinuousClock.now
+        var totalBytes = 0
+        var subagentCount = 0
+        let result = parse(
+            filePath: filePath,
+            visitedAgentIDs: [],
+            skipSidechain: true,
+            totalBytes: &totalBytes,
+            subagentCount: &subagentCount
+        )
+        let elapsed = ContinuousClock.now - start
+        let ms = Int(elapsed.components.seconds * 1000 + elapsed.components.attoseconds / 1_000_000_000_000_000)
+        perfLog.debug("parse.end file=\(basename, privacy: .public) elapsed_ms=\(ms, privacy: .public) items=\(result.count, privacy: .public) bytes=\(totalBytes, privacy: .public) subagents=\(subagentCount, privacy: .public)")
+        return result
     }
 
     /// Recursive worker. `visitedAgentIDs` prevents cycles between subagent files.
@@ -30,12 +47,15 @@ enum TranscriptParser {
     private static func parse(
         filePath: String,
         visitedAgentIDs: Set<String>,
-        skipSidechain: Bool
+        skipSidechain: Bool,
+        totalBytes: inout Int,
+        subagentCount: inout Int
     ) -> [TranscriptItem] {
         guard let data = FileManager.default.contents(atPath: filePath),
               let content = String(data: data, encoding: .utf8) else {
             return []
         }
+        totalBytes += data.count
 
         // First pass: collect raw line dicts; index tool_results and agent ids.
         var rawLines: [[String: Any]] = []
@@ -193,7 +213,9 @@ enum TranscriptParser {
                             subagent = resolveSubagent(
                                 agentID: agentID,
                                 subagentsDir: subagentsDir,
-                                visitedAgentIDs: visitedAgentIDs
+                                visitedAgentIDs: visitedAgentIDs,
+                                totalBytes: &totalBytes,
+                                subagentCount: &subagentCount
                             )
                         }
 
@@ -215,7 +237,9 @@ enum TranscriptParser {
     private static func resolveSubagent(
         agentID: String,
         subagentsDir: URL,
-        visitedAgentIDs: Set<String>
+        visitedAgentIDs: Set<String>,
+        totalBytes: inout Int,
+        subagentCount: inout Int
     ) -> Subagent? {
         if visitedAgentIDs.contains(agentID) {
             // Cycle detected — surface a single system reminder noting it.
@@ -231,9 +255,16 @@ enum TranscriptParser {
         let jsonlPath = subagentsDir.appendingPathComponent("agent-\(agentID).jsonl").path
         guard FileManager.default.fileExists(atPath: jsonlPath) else { return nil }
 
+        subagentCount += 1
         var nextVisited = visitedAgentIDs
         nextVisited.insert(agentID)
-        let items = parse(filePath: jsonlPath, visitedAgentIDs: nextVisited, skipSidechain: false)
+        let items = parse(
+            filePath: jsonlPath,
+            visitedAgentIDs: nextVisited,
+            skipSidechain: false,
+            totalBytes: &totalBytes,
+            subagentCount: &subagentCount
+        )
 
         let metaPath = subagentsDir.appendingPathComponent("agent-\(agentID).meta.json").path
         let agentType = readAgentType(from: metaPath)

--- a/Sources/TBDDaemon/Server/RPCRouter+SessionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SessionHandlers.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let perfTranscriptLog = Logger(subsystem: "com.tbd.daemon", category: "perf-transcript")
 
 extension RPCRouter {
 
@@ -19,6 +22,16 @@ extension RPCRouter {
     }
 
     func handleSessionMessages(_ paramsData: Data) async throws -> RPCResponse {
+        perfTranscriptLog.debug("rpc.handle.start method=sessionMessages")
+        let start = ContinuousClock.now
+        var responseBytes = 0
+        var itemsCount = 0
+        defer {
+            let elapsed = ContinuousClock.now - start
+            let ms = Int(elapsed.components.seconds * 1000 + elapsed.components.attoseconds / 1_000_000_000_000_000)
+            perfTranscriptLog.debug("rpc.handle.end method=sessionMessages elapsed_ms=\(ms, privacy: .public) response_bytes=\(responseBytes, privacy: .public) items=\(itemsCount, privacy: .public)")
+        }
+
         let params = try decoder.decode(SessionMessagesParams.self, from: paramsData)
 
         // Constrain path to ~/.claude/projects/ — same trust boundary as
@@ -40,6 +53,9 @@ extension RPCRouter {
             messages = TranscriptParser.parse(filePath: params.filePath)
             await TranscriptParseCache.shared.put(filePath: params.filePath, result: messages)
         }
-        return try RPCResponse(result: messages)
+        let response = try RPCResponse(result: messages)
+        responseBytes = response.result?.utf8.count ?? 0
+        itemsCount = messages.count
+        return response
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3,6 +3,7 @@ import os
 import TBDShared
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "terminalHandlers")
+private let perfTranscriptLog = Logger(subsystem: "com.tbd.daemon", category: "perf-transcript")
 
 // MARK: - Transcript parse cache
 
@@ -811,22 +812,41 @@ extension RPCRouter {
     }
 
     func handleTerminalTranscript(_ paramsData: Data) async throws -> RPCResponse {
+        perfTranscriptLog.debug("rpc.handle.start method=terminalTranscript")
+        let start = ContinuousClock.now
+        let response: RPCResponse
+        var responseBytes = 0
+        var itemsCount = 0
+        defer {
+            let elapsed = ContinuousClock.now - start
+            let ms = Int(elapsed.components.seconds * 1000 + elapsed.components.attoseconds / 1_000_000_000_000_000)
+            perfTranscriptLog.debug("rpc.handle.end method=terminalTranscript elapsed_ms=\(ms, privacy: .public) response_bytes=\(responseBytes, privacy: .public) items=\(itemsCount, privacy: .public)")
+        }
+
         let params = try decoder.decode(TerminalTranscriptParams.self, from: paramsData)
 
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
-            return RPCResponse(error: "Terminal not found: \(params.terminalID)")
+            response = RPCResponse(error: "Terminal not found: \(params.terminalID)")
+            return response
         }
 
         guard let sessionID = terminal.claudeSessionID else {
-            return try RPCResponse(result: TerminalTranscriptResult(messages: [], sessionID: nil))
+            let result = TerminalTranscriptResult(messages: [], sessionID: nil)
+            response = try RPCResponse(result: result)
+            responseBytes = response.result?.utf8.count ?? 0
+            return response
         }
 
         guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
-            return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
+            response = RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
+            return response
         }
 
         guard let projectDir = ClaudeProjectDirectory.resolve(worktreePath: worktree.path) else {
-            return try RPCResponse(result: TerminalTranscriptResult(messages: [], sessionID: sessionID))
+            let result = TerminalTranscriptResult(messages: [], sessionID: sessionID)
+            response = try RPCResponse(result: result)
+            responseBytes = response.result?.utf8.count ?? 0
+            return response
         }
 
         let filePath = projectDir.appendingPathComponent("\(sessionID).jsonl").path
@@ -837,7 +857,11 @@ extension RPCRouter {
             messages = TranscriptParser.parse(filePath: filePath)
             await TranscriptParseCache.shared.put(filePath: filePath, result: messages)
         }
-        return try RPCResponse(result: TerminalTranscriptResult(messages: messages, sessionID: sessionID))
+        let result = TerminalTranscriptResult(messages: messages, sessionID: sessionID)
+        response = try RPCResponse(result: result)
+        responseBytes = response.result?.utf8.count ?? 0
+        itemsCount = messages.count
+        return response
     }
 
     func handleTerminalTranscriptItemFullBody(_ paramsData: Data) async throws -> RPCResponse {

--- a/docs/superpowers/specs/2026-05-05-markdown-tables-design.md
+++ b/docs/superpowers/specs/2026-05-05-markdown-tables-design.md
@@ -1,0 +1,109 @@
+# Markdown tables (and other block elements) in chat bubbles
+
+## Problem
+
+The transcript pane renders Claude assistant messages as chat bubbles. Inline markdown is parsed via Apple's `AttributedString(markdown:)` with `interpretedSyntax: .inlineOnlyPreservingWhitespace`. Inline syntax — `**bold**`, `*italic*`, `` `code` ``, `[links](url)` — and plain prose render fine today. The parser is deliberately inline-only, so block constructs are not interpreted; in practice:
+
+- **Tables** are the main visible breakage — they degrade into pipe-delimited soup that's unreadable. Claude responses frequently use tables for span-kind summaries and comparison grids, so this hurts often.
+- Headings / lists / blockquotes / thematic breaks are not formatted as blocks either, but they read acceptably as literal markdown (a `- item` list still scans visually) and rarely appear in chat content. Lifting them is a nice byproduct, not the driver.
+
+## Goal
+
+Make tables render as proper grids inside chat bubbles by adopting the `MarkdownUI` package — already a project dependency via `Package.swift` (added with the code-viewer pane in commit `1b880cf`). Block-level elements (headings, lists, blockquotes, thematic breaks) come along for free; the explicit success criterion is tables.
+
+Out of scope:
+
+- Tool cards (`BashCard`, `EditCard`, `WriteCard`, etc.) — they render plain text or pre-formatted code; markdown is not relevant.
+- Refactoring the existing `Theme.codeViewer` in `CodeViewerPaneView.swift`. It stays as is.
+- Code-fence rendering. Fences continue to flow through `MarkdownSegments` → the existing `codeBlock(language:content:)` view, which does syntax-highlight headers and language tagging.
+
+## Approach
+
+Minimal-churn integration:
+
+1. Keep `MarkdownSegments.split(_:)` in front of every bubble. It already cleanly partitions text into ordered `.prose` and `.code(language:content:)` segments.
+2. For each `.prose` segment, replace the current `Text(attributedProse(p))` call with `Markdown(p).markdownTheme(.chatBubble).textSelection(.enabled)`.
+3. For each `.code` segment, route through the existing `codeBlock(...)` view unchanged.
+
+This means MarkdownUI **never sees a fenced code block in normal flow**, because `MarkdownSegments` strips them upstream. If a malformed/unterminated fence ever leaks into a prose segment, MarkdownUI's default `.codeBlock` styling is acceptable as a safety net.
+
+## Theme strategy
+
+Build a new dedicated `Theme.chatBubble` as a `private extension MarkdownUI.Theme` in `ChatBubbleView.swift` (mirroring how `Theme.codeViewer` is `private` to its file). Starting point: `Theme.basic`, override only what's needed.
+
+Critical preserves vs. today's bubble:
+
+- Prose font matches `.font(.body)` (system 13pt regular on macOS 15).
+- Foreground is `.primary` (today's default), so it inherits dark/light mode and bubble-background contrast.
+- Text remains selectable.
+- Inline `code` keeps a monospaced style with a subtle background tint.
+
+Theme overrides:
+
+- `.text` — `ForegroundColor(.primary)`, default font properties (let SwiftUI's `.body` flow through).
+- `.code` — `FontFamilyVariant(.monospaced)`, `FontSize(.em(0.92))`, low-opacity secondary background.
+- `.paragraph` — `markdownMargin(top: 0, bottom: 0)`. Vertical separation between prose blocks comes from the surrounding 6pt `VStack` spacing, not internal MarkdownUI margins. This is the single most important preserve: today's bubble has no per-paragraph 16pt gutter, and adopting one would visually regress every existing assistant message.
+- `.listItem` — `markdownMargin(top: .em(0.15))` for compact list spacing.
+- `.blockquote` — leading rule (rounded rectangle, `.secondary` color), `.em(1)` horizontal inset, secondary text color.
+- `.heading1`/`.heading2`/`.heading3` — semibold + modest em scale (1.4 / 1.2 / 1.05). Headings are rare in chat content; keep them subtle so they don't dominate the bubble.
+- `.heading4`/`.heading5`/`.heading6` — semibold only.
+- `.table` — `markdownTableBorderStyle(.init(color: .secondary.opacity(0.3)))`, alternating row tint at low opacity that reads on both bubble backgrounds (user accent-tinted, assistant `controlBackgroundColor`), `markdownMargin(top: 0, bottom: 0)`.
+- `.tableCell` — header row (row 0) bold, vertical padding 4, horizontal padding 8.
+- `.thematicBreak` — thin `Divider` with `.em(0.25)` margin.
+- `.codeBlock` — left at `Theme.basic` defaults (defensive only; production flow excludes fences via `MarkdownSegments`).
+
+## Implementation plan
+
+Single file: `Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift`.
+
+Edits:
+
+1. Add `import MarkdownUI` to the top of the file.
+2. Replace `Text(attributedProse(p))` (current line 64) and its `.font(.body).textSelection(.enabled)` chain with:
+   ```swift
+   Markdown(p)
+       .markdownTheme(.chatBubble)
+       .textSelection(.enabled)
+   ```
+3. Delete `attributedProse(_:)` (current lines 104–109) — no remaining callers.
+4. Append the new `private extension MarkdownUI.Theme { static let chatBubble = ... }` near the bottom of the file.
+5. Add a `#Preview` block (if not already present) that exercises the new rendering with a mix of plain text, a table, a list, a blockquote, a heading, inline code, and a fenced code block.
+
+No changes to:
+
+- `MarkdownSegments.swift`
+- `Package.swift` / `Package.resolved`
+- Any other file in `Sources/TBDApp/`, `TBDDaemon`, `TBDShared`, or `TBDCLI`.
+
+## Verification
+
+This is a UI-only change with no obvious unit-test surface.
+
+1. `swift build` succeeds cleanly.
+2. `scripts/restart.sh` (worktree-relative — never the absolute path to the main project per `CLAUDE.md`).
+3. Verify exactly one TBDDaemon and one TBDApp from the worktree path: `ps aux | grep -E "\.build/debug/TBD" | grep -v grep`.
+4. Open the app and either:
+   - Find a real Claude session whose transcript contains a markdown table (try `grep -l '|.*|.*|' ~/.claude/projects/*/conversation*.jsonl`), navigate the tab, and visually confirm the table renders as a grid; OR
+   - Drive the SwiftUI `#Preview` from Xcode and confirm the rendered output matches expectations.
+5. **Regression check (most important)**: existing assistant prose — the common case of plain text with inline `**bold**`, `*italic*`, `` `code` ``, and `[links]` — must look indistinguishable from before. This is the path that *already works* today; the swap mustn't degrade it. If line spacing, paragraph gaps, font size, or inline styling has shifted, tighten the theme's `.text`, `.code`, and `.paragraph` overrides until parity is restored.
+
+## Risk and rollback
+
+- Risk: MarkdownUI's default rendering pipeline can introduce subtle typographic differences (line height, leading, paragraph spacing) that aren't obvious in a single-message preview but show up in long transcripts. Mitigation: explicit `paragraph` margin reset; visual A/B against an existing transcript before committing.
+- Risk: `Markdown(...)` is a heavier view than `Text(...)`. For long conversations this could affect scrolling perf in the transcript pane. Mitigation: the transcript pane already uses `LazyVStack` (per the surrounding code in `TranscriptPane`); off-screen bubbles aren't rendered. If perf regresses noticeably, fall back to the inline-only path for prose segments containing no block-level markers (cheap heuristic: regex `^\\s*(\\||#|>|[-*+] |\\d+\\. )` per line).
+- Rollback: revert the single commit. No schema, no daemon, no shared models, no migrations.
+
+## Suggested commit shape
+
+One commit:
+
+```
+feat: render markdown tables and block elements in chat bubbles
+
+Swap Apple's inline-only AttributedString(markdown:) parser for
+MarkdownUI on .prose segments produced by MarkdownSegments. Adds a
+chat-bubble-tuned Theme that preserves today's body-font, .primary
+color, and per-segment spacing, while enabling tables, lists,
+blockquotes, headings, and thematic breaks. Fenced code blocks remain
+on the existing custom code-block path.
+```

--- a/docs/superpowers/specs/2026-05-06-transcript-list-migration-design.md
+++ b/docs/superpowers/specs/2026-05-06-transcript-list-migration-design.md
@@ -1,0 +1,254 @@
+# Transcript pane: migrate from LazyVStack to List
+
+## Why
+
+After two weeks of incremental fixes against `LazyVStack` perf issues, the research at
+`docs/superpowers/specs/research-2026-05-06-swiftui-long-list-perf.md` makes the case decisively: the bugs we keep hitting are intrinsic to `LazyVStack` for our shape of data (thousands of variable-height MarkdownUI rows), and the convergent OSS pattern is to use `List` instead. IceCubesApp — the canonical large-scale SwiftUI Mastodon client — uses `List` + `ScrollViewReader.proxy.scrollTo`, with no `scrollTargetLayout`, no `scrollPosition(id:)`, no `defaultScrollAnchor`. `List` on macOS 15 has real cell recycling backed by AppKit's collection-view machinery: rows realize when they enter the viewport AND **deallocate when they leave**. `LazyVStack` only does the former; it accumulates realized rows forever, which is why our session teardown/freeze-on-leave was bad.
+
+The specific symptoms we've been chasing all map to known issues:
+
+- **44s `StackLayout → _PaddingLayout` recursion hang**: cmux #2327, same shape. `scrollTargetLayout + scrollPosition(id:) + LazyVStack + variable-height rich rows` is a documented perf footgun (Fatbobman, Apple Developer Forums).
+- **Blank-on-re-entry**: Apple Developer Forums thread #741406, specifically `LazyVStack + defaultScrollAnchor(.bottom)`.
+- **MarkdownUI in LazyVStack**: multiple unfixed open issues (#310, #426, #445); maintainer put MarkdownUI in maintenance mode in early 2026 and started [Textual](https://github.com/gonzalezreal/textual) — citing this exact class of layout/perf problem as "architecturally unfixable" in MarkdownUI.
+
+`List` doesn't have any of these issues, because it's not built on top of SwiftUI's StackLayout primitives that produced the recursion.
+
+## Goal
+
+A transcript pane that:
+- Renders thousands of items without freezing on first paint, on scroll, or on tab leave/teardown.
+- Lands at the bottom on first appearance, autoscrolls on new messages.
+- Is robust under repeated tab navigation.
+
+Out of scope (Phase 2):
+- Preserving the user's scroll position across worktree switches. IceCubes doesn't do this; their feed model is different. Chat is different from a feed and we want this — but it's a non-trivial follow-up that depends on Phase 1's foundation. Doing it in the same change would couple the migration to a feature; we keep them separate.
+- Caching MarkdownUI parses on the message model and using `.equatable()` row views. The research mentioned these as paired optimizations. They become straightforward once Phase 1 lands; defer.
+- Migrating off MarkdownUI to Textual. Even though MarkdownUI is in maintenance mode, it works for our needs — the maintenance status doesn't break us, only freezes the library. A migration is a separate, larger project.
+
+## Approach
+
+Three coordinated edits, all in app-side SwiftUI code. Daemon untouched. Strategy: kill all four LazyVStack-ecosystem modifiers (`scrollTargetLayout`, `scrollPosition(id:)`, `defaultScrollAnchor`, the LazyVStack itself), replace with `List`, drive autoscroll via `ScrollViewReader.proxy.scrollTo`.
+
+### `Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift`
+
+The view is used at two depths: **depth == 0** is the top-level transcript stream (potentially thousands of items, the perf-critical path); **depth > 0** is a recursive call from `SubagentDisclosure` for nested subagent timelines (typically tens of items, inside a `DisclosureGroup`).
+
+Only the depth-0 path uses `List`. Nested `Lists` don't compose well in SwiftUI; depth > 0 stays on a plain `VStack` (which is fine — those lists are short, and live inside an outer `List` row).
+
+Final shape:
+
+```swift
+struct TranscriptItemsView: View {
+    let items: [TranscriptItem]
+    let terminalID: UUID?
+    var depth: Int = 0
+
+    var body: some View {
+        if depth >= 8 {
+            Text("… nested too deep")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 4)
+        } else if depth == 0 {
+            // Top-level chat: List provides cell recycling, avoiding the LazyVStack
+            // layout-cycle and accumulation issues for sessions with thousands of items.
+            List {
+                ForEach(items) { item in
+                    rowFor(item)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .environment(\.defaultMinListRowHeight, 1)
+        } else {
+            // Nested subagent timeline (typically short, inside a DisclosureGroup).
+            // VStack here so we don't nest Lists, which composes badly in SwiftUI.
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(items) { item in
+                    rowFor(item)
+                }
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    // ... rowFor and toolCardFor unchanged
+}
+```
+
+Per-row modifiers:
+- `.listRowSeparator(.hidden)` — chat rows shouldn't have system separators between them.
+- `.listRowInsets(EdgeInsets())` — kill the default leading/trailing/vertical padding `List` applies to rows. Each row's internal padding is set by `ChatBubbleView` / the tool-card views themselves.
+- `.listRowBackground(Color.clear)` — let the parent's background show through (the worktree pane's background, not List's default `groupedBackground`).
+
+List-level modifiers:
+- `.listStyle(.plain)` — flat chat-style, not grouped.
+- `.scrollContentBackground(.hidden)` — hide List's default scrollable background.
+- `.environment(\.defaultMinListRowHeight, 1)` — without this, `List` applies a default min row height (~44pt typical) that would visibly pad short rows like `SystemReminderRow`.
+
+### `Sources/TBDApp/Panes/LiveTranscriptPaneView.swift`
+
+`transcriptWithAutoscroll` is currently:
+
+```swift
+ScrollViewReader { proxy in
+    ScrollView {
+        TranscriptItemsView(items: messages, terminalID: terminalID)
+    }
+    .defaultScrollAnchor(.bottom)
+    .scrollPosition(id: $visibleID, anchor: .bottom)
+    .onChange(of: messages.last?.id) { oldID, newID in
+        guard let oldID, let id = newID, autoscrollEnabled else { return }
+        _ = oldID
+        withAnimation(.easeOut(duration: 0.15)) {
+            visibleID = id
+        }
+    }
+    .onAppear {
+        Self.perfLog.debug("view.appear sid=\(short) count=\(count)")
+        if let id = visibleID {
+            proxy.scrollTo(id, anchor: .bottom)
+        }
+    }
+}
+```
+
+Becomes:
+
+```swift
+ScrollViewReader { proxy in
+    TranscriptItemsView(items: messages, terminalID: terminalID)
+        .onAppear {
+            Self.perfLog.debug("view.appear sid=\(short) count=\(count)")
+            if let id = messages.last?.id {
+                proxy.scrollTo(id, anchor: .bottom)
+            }
+        }
+        .onChange(of: messages.last?.id) { oldID, newID in
+            guard let oldID, let id = newID, autoscrollEnabled else { return }
+            _ = oldID
+            withAnimation(.easeOut(duration: 0.15)) {
+                proxy.scrollTo(id, anchor: .bottom)
+            }
+        }
+}
+```
+
+Concrete changes:
+
+- **Remove the outer `ScrollView { ... }` wrapper.** `List` provides its own scrolling.
+- **Remove `.defaultScrollAnchor(.bottom)`** — `List` doesn't honor this, and `proxy.scrollTo` on `.onAppear` provides equivalent behavior.
+- **Remove `.scrollPosition(id: $visibleID, anchor: .bottom)`** — the documented perf footgun.
+- **Remove the `@State private var visibleID: String?`** declaration. Keep nothing in its place; Phase 2 will reintroduce position tracking via `AppState`-backed storage.
+- **Keep `ScrollViewReader { proxy in ... }`.** `proxy.scrollTo(_:anchor:)` works on `List` — IceCubes uses the same pattern.
+- **`.onAppear` scrolls to `messages.last?.id`** instead of to `visibleID`. This is the regression the user already flagged ("starts at the bottom on navigate-back"); we accept it as Phase 1 behavior, ship Phase 2 to restore position preservation.
+- **`.onChange(of: messages.last?.id)`** keeps the `nil → value` guard (still relevant — navigation transiently nils the messages array). Replace `visibleID = id` with `proxy.scrollTo(id, anchor: .bottom)`.
+- **Keep the perf-transcript log.** Same diagnostic value going forward.
+
+### `Sources/TBDApp/Panes/HistoryPaneView.swift`
+
+The session-detail view currently has:
+
+```swift
+ScrollView {
+    TranscriptItemsView(items: messages, terminalID: nil)
+}
+.defaultScrollAnchor(.bottom)
+.scrollPosition(id: $visibleID, anchor: .bottom)
+.onAppear {
+    if let id = visibleID {
+        proxy.scrollTo(id, anchor: .bottom)
+    }
+}
+```
+
+(Wrapped in `ScrollViewReader`.)
+
+Becomes:
+
+```swift
+ScrollViewReader { proxy in
+    TranscriptItemsView(items: messages, terminalID: nil)
+        .onAppear {
+            if let id = messages.last?.id {
+                proxy.scrollTo(id, anchor: .bottom)
+            }
+        }
+}
+```
+
+Same shape. No `.onChange` (read-only), no `visibleID`.
+
+### `Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift`
+
+Re-add the four `.fixedSize(horizontal: false, vertical: true)` calls in `Theme.chatBubble` that we removed in `2b890ef` (paragraph, blockquote HStack, table, tableCell). Outside of the `scrollTargetLayout + LazyVStack` combo that was the cycle trigger, these regain their original purpose: ensuring vertical sizing is correct for paragraphs, table cells, and blockquotes within their flexible parent contexts.
+
+The `2b890ef` commit message even said "will re-add selectively if the user reports specific elements look wrong." This restoration is preemptive — the user already reported some markdown rendering looked off after `2b890ef`, and outside the `scrollTargetLayout` interaction there's no reason to keep them off.
+
+## Risks
+
+- **List styling drift.** `List` brings its own visual conventions (selection highlighting on hover, focus rings, etc.). `.listStyle(.plain) + .listRowSeparator(.hidden) + .listRowInsets(EdgeInsets()) + .listRowBackground(.clear)` should suppress all of these. If something visual looks off (e.g., faint hover highlights on rows), one or two more modifiers will likely fix it (`.selectionDisabled()`, `.contentMargins(.zero)`).
+- **Row-internal alignment.** `List` rows wrap content in their own container; alignment may differ subtly from a plain `VStack`. Most likely-affected: `ChatBubbleView`'s leading/trailing alignment for user vs. assistant bubbles. The bubble view already uses `HStack { ... Spacer() ... }` for that, so it should still work, but verify.
+- **`SubagentDisclosure` recursive rendering.** The recursive `TranscriptItemsView` at depth > 0 stays on `VStack`. Disclosure expand/collapse should still work — disclosure group internals don't care that the inner content is a `VStack`.
+- **`textSelection(.enabled)` per row.** Selection still works inside `List` rows (verified in IceCubes).
+- **Scroll-to-bottom on first paint.** `proxy.scrollTo(messages.last?.id, anchor: .bottom)` on `.onAppear` is the IceCubes pattern. With `List`'s cell recycling, this is cheap (only realizes the last screenful). No more 7-second freeze.
+- **No more scroll-position preservation across worktree switches.** Explicit Phase-1 trade-off; the user already knows. Phase 2 will restore it.
+
+## Verification
+
+The `perf-transcript` instrumentation stays in place. Now the relevant timings should look like:
+
+- `items.body → view.appear`: under ~100ms regardless of session size (List cell recycling, only screenful of rows realized).
+- Tab leave: no perf regression because `List` deallocates rows as they leave the viewport — there's no large view tree to tear down.
+- Scroll up: smooth. No layout-cycle hangs, no 44s freezes.
+
+Visual checks (user-driven):
+
+1. Open the maven-dashboard transcript: lands at the bottom. Smooth.
+2. Scroll up through the entire transcript. No hangs. (This is the regression repro target.)
+3. Switch worktrees and back. Re-entry shows content immediately (no blank gray panel). Position is at bottom (Phase 2 is when we preserve user position).
+4. Send a new message in an active session. Snaps to bottom (existing autoscroll behavior, now via `proxy.scrollTo`).
+5. Markdown content (tables in chat bubbles especially) renders correctly — no stretched cells, no missing borders, etc. If something looks off, that's the `.fixedSize` re-add to investigate.
+
+## Suggested commit shape
+
+One commit:
+
+```
+fix: migrate transcript pane from LazyVStack to List
+
+LazyVStack on macOS 15 with thousands of variable-height MarkdownUI
+rows is a documented perf footgun: 44s layout-cycle hangs on scroll
+(StackLayout → _PaddingLayout → … recursion), blank-on-re-entry with
+defaultScrollAnchor, and accumulation-without-eviction that makes
+tab-leave teardowns multi-second. Research collected in
+research-2026-05-06-swiftui-long-list-perf.md cites cmux #2327, Apple
+Developer Forums #741406, and IceCubesApp's TimelineListView as the
+convergent prior-art reference: use List, not LazyVStack.
+
+List on macOS 15 has real cell recycling — rows realize on enter and
+deallocate on exit — and is not built on the StackLayout primitives
+that produced the layout cycle. Migrate the transcript pane:
+LazyVStack → List, drop scrollTargetLayout / scrollPosition(id:) /
+defaultScrollAnchor, restore proxy.scrollTo for autoscroll. Match
+IceCubes' chat-list styling (.listStyle(.plain), hidden separators,
+zero row insets, clear backgrounds, defaultMinListRowHeight 1).
+
+The recursive nested-transcript path (SubagentDisclosure) stays on
+VStack — nested Lists compose badly in SwiftUI, and those inner
+timelines are short.
+
+Re-add the four .fixedSize(horizontal: false, vertical: true) calls
+in MarkdownUI's chat-bubble theme that were removed in 2b890ef.
+Outside the scrollTargetLayout+LazyVStack combo, they regain their
+original layout-fidelity purpose without triggering the cycle.
+
+Trade-off (Phase 1): scroll position no longer preserves across
+worktree switches; transcript opens at the bottom every time. Phase 2
+will reintroduce position preservation via AppState-backed storage,
+once this foundation is shipped and verified.
+```

--- a/docs/superpowers/specs/2026-05-06-transcript-perf-instrumentation.md
+++ b/docs/superpowers/specs/2026-05-06-transcript-perf-instrumentation.md
@@ -1,0 +1,146 @@
+# Transcript-pane perf instrumentation
+
+## Problem
+
+Switching to a tab whose Claude session has thousands of items (target: maven-dashboard `511161cd-...jsonl`, 2372 JSONL lines / 5.1 MB / ~31 subagent files) freezes the app UI. We don't know which layer is responsible. The hypothesis that eager `VStack` rendering is the culprit is unverified — making `LazyVStack` swap a guess.
+
+## Goal
+
+Add focused, throwaway timing instrumentation across the transcript pipeline so a single repro produces a log timeline that pinpoints which layer dominates: daemon parse, RPC transit + decode, main-actor array swap, or SwiftUI render. Then we design the real fix from data.
+
+Out of scope:
+
+- Any fix. Pure measurement.
+- New tooling (Instruments signposts, custom UI overlays). `os.Logger` + `log stream` is sufficient for one-shot diagnosis.
+- Production-grade telemetry. Logs are diagnostic-only; they get demoted or deleted after the bottleneck is identified.
+
+## Conventions
+
+- Subsystems: `com.tbd.daemon` and `com.tbd.app` (existing).
+- Category for every log added by this spec: `perf-transcript`.
+- Level: `.debug`. Activated on demand with `log config --subsystem … --mode "level:debug,persist:debug"`; silent in normal use.
+- Privacy: every dynamic interpolation gets explicit `privacy: .public` (this is a dev tool, all values are non-sensitive numbers, IDs, file paths).
+- Format: structured key=value pairs, one log line per measurement, easy to grep. Always include a stable verb ( `parse.start`, `parse.end`, `pollOnce.end`, etc.) and a duration in milliseconds.
+- Timing primitive: `ContinuousClock().measure { ... }` for synchronous regions. For async regions, capture `let start = ContinuousClock.now` and compute `Duration.formatted` at the end. Convert to integer ms for log readability.
+
+## Instrumentation points
+
+### Daemon (subsystem `com.tbd.daemon`)
+
+1. **`TranscriptParser.parse(filePath:)`** — `Sources/TBDDaemon/Claude/TranscriptParser.swift`. Wrap the public entry. Log:
+   - `parse.start file=<basename>`
+   - `parse.end file=<basename> elapsed_ms=<n> items=<n> bytes=<n> subagents=<n>`
+   - `bytes` is the total bytes read across the top JSONL plus every recursive subagent file. Track in a local accumulator passed through the recursion.
+   - `subagents` is the count of subagent JSONLs encountered (not items).
+
+2. **`terminal.transcript` RPC handler** — `Sources/TBDDaemon/Server/RPCRouter.swift:151`. Wrap the handler body covering parse + response encoding. Log:
+   - `rpc.handle.start method=terminalTranscript`
+   - `rpc.handle.end method=terminalTranscript elapsed_ms=<n> response_bytes=<n> items=<n>`
+   - `response_bytes` is the size of the JSON-encoded RPC response payload returned to the client.
+
+### App (subsystem `com.tbd.app`)
+
+3. **`daemonClient.terminalTranscript`** — find this method in the app's `DaemonClient`/RPC layer (search for the call site referenced from `LiveTranscriptPaneView.pollOnce`). Wrap the entire async call including JSON decode of the response. Log:
+   - `client.rpc.start method=terminalTranscript`
+   - `client.rpc.end method=terminalTranscript elapsed_ms=<n> bytes=<n> decode_ms=<n> items=<n>`
+   - Split `decode_ms` from total elapsed by timing the JSONDecoder step separately.
+
+4. **`pollOnce`** — `LiveTranscriptPaneView.swift`. End-to-end wrap:
+   - `pollOnce.start sid=<short>`
+   - `pollOnce.end sid=<short> elapsed_ms=<n> changed=<bool> count=<n>`
+   - Inside, time the `MainActor.run { ... }` block separately:
+     - `pollOnce.mainActor.start sid=<short>`
+     - `pollOnce.mainActor.end sid=<short> elapsed_ms=<n> equal_ms=<n> swap_ms=<n>`
+     - `equal_ms` is the time `messagesEqual(prev, result.messages)` took.
+     - `swap_ms` is the time the dictionary write + `touchSessionTranscript` took (zero if `equal == true`).
+
+5. **`LiveTranscriptPaneView` view-appearance markers**. The freeze is observed on tab switch. Mark both ends of the user-visible gap:
+   - On `transcriptWithAutoscroll`'s outer `ScrollView` `.onAppear`: `view.appear sid=<short> count=<n>`. This fires after SwiftUI has computed and laid out the view tree at least once for this tab.
+   - On the `.task(id:)` startup at the top of `LiveTranscriptPaneView.body`: `task.start terminalID=<short>`. This fires when SwiftUI first attaches the task — slightly before `.onAppear` of nested views.
+   - The wall-clock gap between `task.start` and `view.appear` is the user-perceived "view ready" time. If it's a multi-second gap with little daemon/RPC activity in between, the work is happening synchronously inside SwiftUI body/layout/render.
+
+6. **`messagesEqual`** in `LiveTranscriptPaneView.swift`. Only log when one side has > 100 items (skip noise from cold polls). Log:
+   - `messagesEqual elapsed_ms=<n> count_a=<n> count_b=<n> result=<bool>`
+
+### App, optional layer 2 (skip unless layer 1 doesn't pinpoint it)
+
+7. **`MarkdownSegments.split`** and **`Markdown(...)` realize** in `ChatBubbleView.swift`. Add a debug counter: `chatBubble.realize id=<short> prose_segments=<n> code_segments=<n> elapsed_ms=<n>`. Per-row log; expect noisy. Useful only if we suspect per-row markdown cost.
+
+8. **Tool card decode hot paths** — `BashCard`, `EditCard`, `AgentCard`, `GenericToolCard`, etc. each call `JSONDecoder().decode(...)` from a computed body. Log per realize: `toolCard.decode card=<name> elapsed_ms=<n>`. Skip cards where decode takes < 1ms (which is most of them).
+
+## Test recipe
+
+Document this in the spec so the user (or whoever drives the test) follows the exact sequence:
+
+1. Apply the patch.
+2. `swift build` — must succeed cleanly.
+3. `./scripts/restart.sh` (worktree-relative).
+4. One-time per machine: `sudo log config --subsystem com.tbd.daemon --mode "level:debug,persist:debug"` and `sudo log config --subsystem com.tbd.app --mode "level:debug,persist:debug"`.
+5. In a separate terminal: `log stream --level debug --predicate 'category == "perf-transcript"' --style compact`.
+6. In TBD, open the maven-dashboard repo, switch to a Claude tab whose session is `511161cd-474e-4e23-9775-fd474b126ae5.jsonl`. (Confirm by checking the tab's `claudeSessionID`.)
+7. Observe and capture the log stream output during the freeze.
+8. Save the captured stream to `docs/superpowers/specs/perf-baseline-2026-05-06.txt` for later analysis.
+
+## Expected output format
+
+```
+00ms   com.tbd.app    perf-transcript    task.start terminalID=AB12
+04ms   com.tbd.app    perf-transcript    pollOnce.start sid=5111
+05ms   com.tbd.app    perf-transcript    client.rpc.start method=terminalTranscript
+06ms   com.tbd.daemon perf-transcript    rpc.handle.start method=terminalTranscript
+07ms   com.tbd.daemon perf-transcript    parse.start file=511161cd-...jsonl
+…      com.tbd.daemon perf-transcript    parse.end file=… elapsed_ms=420 items=2310 bytes=5_400_000 subagents=31
+…      com.tbd.daemon perf-transcript    rpc.handle.end method=… elapsed_ms=480 response_bytes=5_500_000 items=2310
+…      com.tbd.app    perf-transcript    client.rpc.end method=… elapsed_ms=720 bytes=5_500_000 decode_ms=210 items=2310
+…      com.tbd.app    perf-transcript    pollOnce.mainActor.start sid=5111
+…      com.tbd.app    perf-transcript    messagesEqual elapsed_ms=… count_a=0 count_b=2310 result=false
+…      com.tbd.app    perf-transcript    pollOnce.mainActor.end sid=5111 elapsed_ms=… equal_ms=… swap_ms=…
+…      com.tbd.app    perf-transcript    pollOnce.end sid=5111 elapsed_ms=… changed=true count=2310
+[gap of N ms — UI appears frozen here]
+…      com.tbd.app    perf-transcript    view.appear sid=5111 count=2310
+```
+
+Reading the timeline:
+
+- Big number on `parse.end` → **daemon parse cost** dominates. Fix candidate: T2 parse caching, or T3 incremental parse.
+- Big number on `client.rpc.end` minus `rpc.handle.end` → **RPC transit + decode**. Fix candidate: streaming RPC, or compress / shrink payload.
+- Big number on `messagesEqual` → **deep equality check**. Fix candidate: identity-only comparison, or skip the check entirely on first-load case where prev is empty.
+- Big number on `swap_ms` → unlikely; flag if so.
+- Big gap from `pollOnce.end` to `view.appear` → **SwiftUI render cost**. Fix candidate: T1 LazyVStack (with the `proxy.scrollTo(lastID)` quirk addressed), deferred body, or chunked materialization.
+- Repeated `client.rpc.end` events with full duration on every poll → **polling overhead**, not just first-load cost. Fix candidate: incremental fetch, or only re-render on actual changes.
+
+## Cleanup
+
+After the bottleneck is identified and fixed in a follow-up commit:
+
+- Either delete the `perf-transcript` log statements wholesale (if they were single-shot diagnostic and have no ongoing value).
+- Or demote them to `.trace` level and keep them for future regressions. Do NOT leave them at `.debug` — that's reserved for diagnostics that are silent by default and can be activated with `log config`. (`docs/diagnostics-strategy.md` is authoritative on level choice.)
+
+The cleanup decision belongs to the follow-up PR that ships the fix, not this one.
+
+## Risk
+
+- Low. Logging adds nanoseconds per call; cannot affect the perf measurement itself meaningfully.
+- The `ContinuousClock().measure` wrappers must be careful not to alter throw/control-flow — keep wrappers thin and pre-existing error-handling intact.
+- `messagesEqual` instrumentation must not change `messagesEqual` semantics — wrap, don't inline-modify.
+
+## Suggested commit shape
+
+One commit:
+
+```
+chore: add perf-transcript timing logs across parse/RPC/poll/render
+
+Throwaway diagnostic instrumentation under the perf-transcript log
+category in both com.tbd.daemon and com.tbd.app subsystems. Wraps
+TranscriptParser.parse, the terminal.transcript RPC handler, the app
+RPC client call site, pollOnce + its mainActor block, messagesEqual,
+and view.appear/task.start markers in LiveTranscriptPaneView.
+
+Activate with:
+  sudo log config --subsystem com.tbd.daemon --mode "level:debug,persist:debug"
+  sudo log config --subsystem com.tbd.app --mode "level:debug,persist:debug"
+  log stream --level debug --predicate 'category == "perf-transcript"'
+
+Will be removed or demoted once the bottleneck is identified.
+```

--- a/docs/superpowers/specs/2026-05-06-transcript-reentry-fix-design.md
+++ b/docs/superpowers/specs/2026-05-06-transcript-reentry-fix-design.md
@@ -1,0 +1,126 @@
+# Transcript re-entry: spurious autoscroll + missing realize-poke
+
+## Problem
+
+After commit `2d79df7` switched to `.scrollPosition(id: $visibleID, anchor: .bottom)`, two symptoms appear on tab navigation:
+
+1. **Gray blank panel** on re-entry, until the user scrolls. The lazy stack hasn't realized rows around the bound `visibleID`.
+2. **Scrolling up snaps back to the bottom** — the user's scroll position is overwritten on every re-entry, before they can read older messages.
+
+## Root cause (single mechanism, two faces)
+
+When the user navigates away from the transcript tab, the active terminal pointer changes briefly. Two computed properties fall out:
+
+```swift
+private var currentSessionID: String? {
+    terminal?.claudeSessionID  // → nil briefly during nav
+}
+
+private var messages: [TranscriptItem] {
+    guard let sid = currentSessionID else { return [] }  // → [] briefly
+    return appState.sessionTranscripts[sid] ?? []
+}
+```
+
+Concretely:
+
+- During tab leave: `currentSessionID` → nil → `messages` → `[]` → `messages.last?.id` → `nil`.
+- On return: `currentSessionID` becomes non-nil → `messages` repopulates → `messages.last?.id` → `"id720"` (or whatever the latest ID is).
+- `.onChange(of: messages.last?.id)` fires for the `nil → "id720"` transition. The handler treats this as a new-message event and fires `withAnimation { visibleID = "id720" }`. **That's symptom 2** — the autoscroll forced by what's actually a navigation artifact, not a real new message.
+- Separately, even if `visibleID` retained the user's previous (non-bottom) value across navigation, `.scrollPosition(id:)` does not always force `LazyVStack` to realize rows around the bound position when the view re-appears. **That's symptom 1** — blank panel until the user scrolls (which itself triggers realization).
+
+The two symptoms compound: you get the blank gray, and the moment SwiftUI re-evaluates the body and the spurious `.onChange` fires, you also get yanked to the bottom.
+
+## Fix
+
+Two surgical changes — keep the `.scrollPosition(id:)` binding (it's sound for tracking and restoration), and harden both ends.
+
+### A. Guard `.onChange` against nil → value transitions
+
+A real new message always transitions `valueA → valueB`. The `nil → value` case is the navigation artifact. Skip it.
+
+```swift
+.onChange(of: messages.last?.id) { oldID, newID in
+    guard let oldID, let id = newID, autoscrollEnabled else { return }
+    withAnimation(.easeOut(duration: 0.15)) {
+        visibleID = id
+    }
+}
+```
+
+The `guard let oldID` is the load-bearing change. With it, the handler ignores `nil → "id720"` (navigation return) but still fires for `"id719" → "id720"` (genuine new message during streaming) and `"id720" → "id721"` (Claude continuing to emit).
+
+### B. Add a realize-poke on `.onAppear`
+
+Reintroduce `ScrollViewReader { proxy in ... }`. On `.onAppear`, call `proxy.scrollTo(visibleID, anchor: .bottom)` — scrolling to the ID that's *already* anchored at the bottom. Position is unchanged; the call functions as a re-layout signal that prompts `LazyVStack` to realize rows around the bound position.
+
+```swift
+ScrollViewReader { proxy in
+    ScrollView {
+        TranscriptItemsView(items: messages, terminalID: terminalID)
+    }
+    .defaultScrollAnchor(.bottom)
+    .scrollPosition(id: $visibleID, anchor: .bottom)
+    .onAppear {
+        Self.perfLog.debug("view.appear sid=\(short, privacy: .public) count=\(messages.count, privacy: .public)")
+        if let id = visibleID {
+            proxy.scrollTo(id, anchor: .bottom)
+        }
+    }
+    .onChange(of: messages.last?.id) { oldID, newID in
+        guard let oldID, let id = newID, autoscrollEnabled else { return }
+        withAnimation(.easeOut(duration: 0.15)) {
+            visibleID = id
+        }
+    }
+}
+```
+
+Guard with `if let id = visibleID` — on the very first appearance (before any poll), `visibleID` is nil and `.defaultScrollAnchor(.bottom)` handles initial position. Poking with a nil ID would be a no-op at best, undefined at worst.
+
+### Same fix in HistoryPaneView
+
+Apply the realize-poke (B) in the SessionDetailView's `.onAppear` — wrap the `ScrollView` in a `ScrollViewReader` and add the same guarded `proxy.scrollTo(visibleID, anchor: .bottom)`. No `.onChange` exists there (read-only), so the guard from (A) is not relevant.
+
+## Why this is right and not another guess
+
+- (A) is correct semantics. The autoscroll handler should fire on *content arriving*, not on the array temporarily emptying and refilling because of view-tree state churn during navigation. We exposed the latent bug by introducing the binding; the binding isn't broken — the handler always had this hole, it just hadn't mattered before.
+- (B) is the documented fallback from `2026-05-06-transcript-scroll-position-design.md`'s risk section. We're not inventing it — we're confirming empirically that the binding alone doesn't poke realization on re-appear.
+
+## Out of scope
+
+- The deeper question of *why* `messages` briefly becomes empty during navigation. That's an `AppState` invariant problem (the session-transcript dictionary is preserved, but `currentSessionID` can transiently report nil while the worktree/terminal pointer churns). A real fix would be to make `currentSessionID` more stable across navigation, but that's a different kind of change and not load-bearing for the perf/UX problem we're solving here. Flagging as a follow-up if other symptoms appear.
+- The "freeze autoscroll when user scrolls up" feature (still hardcoded `autoscrollEnabled = true`). Same TODO as before.
+
+## Verification (visual; user-driven)
+
+The `perf-transcript` log stream still tells us first-paint stays fast.
+
+1. Open the maven-dashboard transcript: pins to bottom on first paint.
+2. Scroll up to read older messages.
+3. Switch to another tab.
+4. Switch back: **scroll position preserved**, content visible immediately (no blank, no jump-to-bottom).
+5. (If active session) New message arrives: snaps to bottom (existing autoscroll behavior).
+6. History pane re-entry: select a session, scroll up, switch sessions, switch back — position preserved.
+
+If the binding still misbehaves on re-entry, the next investigation point is `currentSessionID` stability (the deeper root cause noted above), not further SwiftUI scroll fiddling.
+
+## Suggested commit shape
+
+One commit:
+
+```
+fix: ignore nil→value last-id transitions and poke lazy stack on re-entry
+
+Tab navigation briefly nils out currentSessionID, which made
+messages.last?.id flip nil→value on return. .onChange treated that
+as a new message and snapped the user back to the bottom. Guard the
+handler against nil→value (real new messages always go value→value).
+
+Re-introduce ScrollViewReader and call proxy.scrollTo(visibleID) on
+.onAppear — scrolling to the already-anchored id is a position no-op
+but a re-layout signal that prompts LazyVStack to realize the rows
+around the bound position, fixing the blank gray panel on re-entry.
+
+Same realize-poke applied in HistoryPaneView for symmetry.
+```

--- a/docs/superpowers/specs/2026-05-06-transcript-render-fix-design.md
+++ b/docs/superpowers/specs/2026-05-06-transcript-render-fix-design.md
@@ -1,0 +1,112 @@
+# Transcript-pane render fix: LazyVStack + bottom anchor
+
+## Problem (measured)
+
+Switching to a Claude transcript with hundreds of items freezes the app for multiple seconds; switching away freezes it again as the heavy view tree tears down. Instrumentation captured under `perf-transcript` (commits `b13befa` + `0780b3c`) gave a clean timeline for a 720-item maven-dashboard session:
+
+```
+parse.end       elapsed_ms=243  items=720  bytes=4_784_928
+pollOnce.end    elapsed_ms=611  changed=true count=720
+items.body      count=720                     ← ForEach starts dispatching
+view.appear     count=720                     ← first paint, ≈7000ms later
+```
+
+Daemon parse, RPC, decode, and main-actor swap together cost < 700ms. The remaining ~7 seconds is **SwiftUI eagerly realizing every child view of `TranscriptItemsView`** because its container is `VStack`, not `LazyVStack`. Each row is a non-trivial composition: `ChatBubbleView` instantiates MarkdownUI, tool cards decode JSON and run syntax highlighting. 720 of those built synchronously on the main actor blocks the UI.
+
+The same view tree also costs ~7 seconds to tear down on tab leave (observed as a `pollOnce` that took 10920ms because its `MainActor.run` continuation couldn't run while teardown was in flight).
+
+For a 205-item session the equivalent gap is ~530ms — annoying but tolerable. The behavior is super-linear in item count, so longer sessions (the unfiltered `511161cd-…jsonl` has 2372 raw lines) would be much worse.
+
+## Goal
+
+Cut `items.body → view.appear` from seconds to under 100ms regardless of session length, and cut tab-leave teardown to a similarly small fixed cost.
+
+Out of scope:
+
+- Daemon parse caching, incremental fetch, or RPC pagination (T2/T3/T4 from the earlier brainstorm). The data path is already fast enough; the bottleneck is render.
+- Per-card decoder caching (T6) and deferred markdown parse (T7). With lazy realization, only visible rows render — these tail wins are no longer load-bearing.
+- Any change to the polling cadence or RPC protocol.
+
+## Why an earlier "just use LazyVStack" attempt would have failed
+
+`ScrollViewReader.proxy.scrollTo(lastID, anchor: .bottom)` inside `.onAppear` defeats `LazyVStack`. To resolve the layout offset of the target row, the lazy stack must realize every row from the current scroll position to the target. On initial appearance the current position is 0; the target is the last item; result: the lazy stack realizes everything anyway. Same cost as a non-lazy `VStack`.
+
+The fix needs both halves: `LazyVStack` *and* an initial-position mechanism that doesn't force realization.
+
+## Approach
+
+Three coordinated changes, all in app-side SwiftUI code. Daemon untouched.
+
+1. **`Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift`** — replace the outer `VStack(alignment: .leading, spacing: 4)` (line 40) with `LazyVStack(alignment: .leading, spacing: 4)`, and add `.scrollTargetLayout()` immediately after the closing brace. `.scrollTargetLayout()` is what tells SwiftUI's scroll machinery that each lazy child is an individually addressable scroll target — without it `proxy.scrollTo(id:)` becomes flaky against lazy content.
+
+   The inner `VStack` (line 77) inside the `.toolCall` branch stays as-is. That's a tiny per-row grouping wrapper, not the long list.
+
+   The recursive `TranscriptItemsView` invocation inside `SubagentDisclosure` becomes lazy too. Subagent timelines live inside a `DisclosureGroup` that's collapsed by default, so the lazy realization is fine — the disclosure controls visibility, the lazy stack controls realization.
+
+2. **`Sources/TBDApp/Panes/LiveTranscriptPaneView.swift`** — add `.defaultScrollAnchor(.bottom)` to the outer `ScrollView` (after line 105). Remove the `.onAppear { if let id = messages.last?.id { proxy.scrollTo(id, anchor: .bottom) } }` block (lines 112–114) — `defaultScrollAnchor(.bottom)` provides the same initial-bottom behavior without forcing whole-stack realization. Keep the `.onChange(of: messages.last?.id) { ... proxy.scrollTo(id, anchor: .bottom) ... }` block — autoscroll on new messages still uses `proxy.scrollTo`, and that's fine because by the time a new message arrives the bottom of the stack is already realized (we're parked there).
+
+3. **`Sources/TBDApp/Panes/HistoryPaneView.swift`** — add `.defaultScrollAnchor(.bottom)` to the `ScrollView` at line 341 (the one wrapping `TranscriptItemsView`). No `proxy.scrollTo` to remove there; HistoryPaneView's transcript view is read-only and never had autoscroll.
+
+That's the entire fix — three file edits, ~5 line-of-code net. Targets macOS 15 (already the project's `.macOS(.v15)` minimum); both `LazyVStack` (macOS 12+) and `defaultScrollAnchor(.bottom)` (macOS 14+) are well within scope.
+
+## Why `.defaultScrollAnchor(.bottom)` works for chat semantics
+
+The modifier was introduced in WWDC 2024 specifically with chat-style views in mind. It positions the initial viewport at the bottom of the content and *also* keeps the bottom in view as content grows from the bottom — which is exactly Claude transcripts streaming in. When the user scrolls up manually, the effective anchor releases until the user returns to the bottom. The existing `autoscrollEnabled` state machine in `LiveTranscriptPaneView` becomes mostly redundant, but we leave it in place — it's small, gated by a TODO comment for the deferred "freeze autoscroll on manual scroll-up" feature, and removing it would be unrelated cleanup.
+
+## Behavioral preserves
+
+- Initial appearance: bottom of the transcript visible immediately, regardless of session length.
+- Streaming new messages: still snaps to bottom (existing `.onChange(of: messages.last?.id)` autoscroll).
+- Manual scroll up: stays where the user put it (default scroll-anchor releases on user gesture).
+- `textSelection(.enabled)` per row: untouched.
+- `SubagentDisclosure` expand/collapse: untouched.
+- The 1.5s polling cadence and RPC protocol: untouched.
+
+## Risks
+
+- **Row-height jumping during scroll-up.** Lazy stacks compute row heights as rows realize, so the scroll-bar thumb may jump as the user scrolls into previously-unrealized regions. Tool cards (especially `EditCard` with diffs) have wildly variable heights. Acceptable visual cost for the perf win; mitigation if it's egregious is to add a `.frame(minHeight: 60)` on each row dispatch (a coarse stable estimate). Not doing this preemptively.
+- **`defaultScrollAnchor(.bottom)` interaction with empty initial state.** When `messages.isEmpty`, we render `emptyState`, not `transcriptWithAutoscroll`. So the modifier only applies once content exists. No empty-state regression.
+- **Recursive `TranscriptItemsView` lazy stack inside a disclosure.** Should be fine — when collapsed the outer disclosure clips visibility, when expanded the inner lazy stack realizes only what's visible inside the disclosure's clip rect. Will verify visually after build.
+
+## Verification
+
+Same `perf-transcript` instrumentation used to diagnose stays in place — it's the regression detector.
+
+1. `swift build` — clean.
+2. `./scripts/restart.sh` — worktree-relative.
+3. With `log config` already activated, stream `category == "perf-transcript"`.
+4. Repro the maven-dashboard tab open (terminal `AD7D`, sid `6ae5`, count=720).
+5. **Success criterion**: timestamp delta between `items.body terminalID=AD7D count=720` and `view.appear sid=6ae5 count=720` is < 200ms (10× safety margin over the 100ms target).
+6. **Tab-leave success criterion**: the next `pollOnce.end` for the leaving sid has `elapsed_ms < 300` (down from 10920).
+7. Visual: scroll up in the long transcript and confirm rows realize without jank; scroll back down and confirm autoscroll still snaps when a new message arrives (test in an active session, or by sending a poke to Claude).
+8. Visual on small session (sid=808F or similar, ~200 items): regression check — first paint should be even faster, no behavior change.
+
+## Cleanup of the perf instrumentation
+
+Decision: **keep** the `perf-transcript` logs in place at `.debug` level. Rationale:
+
+- They're silent by default (`debug` level requires explicit `log config` activation per `docs/diagnostics-strategy.md`). Zero cost in normal runs.
+- They were the reason this fix landed correctly. Future render regressions in the transcript pane will show up in the same timeline.
+- Demoting to `.trace` would also work but `.debug` aligns better with the project's existing convention for per-feature diagnostics.
+
+If the project later wants to be more aggressive about pruning unused diagnostics, that's a separate cleanup pass.
+
+## Suggested commit shape
+
+One commit:
+
+```
+fix: lazy realize transcript rows so long sessions don't freeze the UI
+
+Swap the eager VStack in TranscriptItemsView for LazyVStack + a
+scroll-target layout, and let defaultScrollAnchor(.bottom) handle
+initial bottom-positioning instead of proxy.scrollTo(lastID), which
+would have forced full realization anyway. Result: items.body →
+view.appear drops from ~7s to under 100ms on a 720-item session;
+tab-leave teardown drops similarly because there's no longer a giant
+view tree to deallocate.
+
+The perf-transcript instrumentation introduced for this diagnosis
+stays in place at .debug level so the same timeline catches future
+regressions.
+```

--- a/docs/superpowers/specs/2026-05-06-transcript-scroll-position-design.md
+++ b/docs/superpowers/specs/2026-05-06-transcript-scroll-position-design.md
@@ -1,0 +1,126 @@
+# Preserve transcript scroll position across navigation
+
+## Problem
+
+After the LazyVStack render fix (`04dedf9`), re-entering a transcript tab left the panel blank until the user scrolled — LazyVStack didn't re-realize visible rows because `.defaultScrollAnchor(.bottom)` only fires on initial appearance. The follow-up (`ef377d4`) added `proxy.scrollTo(messages.last?.id, anchor: .bottom)` inside `.onAppear` to poke the lazy stack on re-entry. That fixed the blank panel, but it stomps the user's scroll position: every re-entry snaps to the bottom, even when the user was reading older messages.
+
+The two issues are coupled: poking LazyVStack to realize rows requires *something* to act on the scroll system, but `proxy.scrollTo` always changes position. We need a primitive that re-realizes without moving.
+
+## Three behaviors that must coexist
+
+1. **First entry to a transcript** → position at the bottom (latest content).
+2. **Re-entry after navigating away** → preserve the user's scroll position; rows realize immediately without a manual scroll gesture.
+3. **New message arrives during a poll** → if user was at the bottom, follow; if scrolled up, stay put. (Today the code is hardcoded to always follow — preserved as-is in this fix; see "Out of scope" below.)
+
+## Approach: `.scrollPosition(id:)` binding
+
+macOS 14 introduced `.scrollPosition(id: $binding, anchor: .bottom)`. It does three things at once:
+
+- **Tracks** which scroll-target row sits at the anchor edge of the viewport. As the user scrolls, SwiftUI updates the binding for free.
+- **Restores** position when the view re-appears, because `@State` for the binding survives across navigations. SwiftUI uses the binding's current value to re-anchor on re-mount/re-appear, and the lazy stack realizes the rows around it.
+- **Drives** programmatic scrolling: setting the binding moves the viewport (animated when wrapped in `withAnimation`).
+
+This subsumes both `proxy.scrollTo` and the manual `.onAppear` poke. We get position preservation, re-entry rendering, and autoscroll through a single mechanism.
+
+## Concrete edits
+
+### `Sources/TBDApp/Panes/LiveTranscriptPaneView.swift`
+
+Within the view's stored state (top of the struct), add:
+
+```swift
+/// Tracks the row at the bottom edge of the visible viewport. Drives both
+/// re-entry restoration (SwiftUI re-anchors here when the view re-appears)
+/// and autoscroll (set this to messages.last?.id to follow new messages).
+@State private var visibleID: String?
+```
+
+In `transcriptWithAutoscroll`:
+
+- Apply `.scrollPosition(id: $visibleID, anchor: .bottom)` to the `ScrollView`. Place it after `.defaultScrollAnchor(.bottom)` and before `.onAppear` (modifier order: `.defaultScrollAnchor` provides the first-paint default when `visibleID` is nil; `.scrollPosition(id:)` takes over once the binding is set).
+- Remove the `if let id = messages.last?.id { proxy.scrollTo(id, anchor: .bottom) }` line inside `.onAppear` (added in `ef377d4`). Keep the `Self.perfLog.debug("view.appear ...")` line — that instrumentation stays.
+- Replace the body of `.onChange(of: messages.last?.id) { _, newID in ... proxy.scrollTo(id, anchor: .bottom) ... }` with:
+
+  ```swift
+  .onChange(of: messages.last?.id) { _, newID in
+      guard autoscrollEnabled, let id = newID else { return }
+      withAnimation(.easeOut(duration: 0.15)) {
+          visibleID = id
+      }
+  }
+  ```
+
+  Same animation, same gating, same effect — driven by the binding instead of the proxy.
+
+- After both `proxy.scrollTo` callers are gone, the `ScrollViewReader { proxy in ... }` wrapper is dead weight. Drop it. The `ScrollView` becomes the outer container directly.
+
+  Verify before removing: search this file for any remaining reference to `proxy`. There should be none after the two removals above. If there are, leave the wrapper.
+
+### `Sources/TBDApp/Panes/HistoryPaneView.swift`
+
+Same pattern, simpler, in the SessionDetailView (around line 341):
+
+- Add `@State private var visibleID: String?` to that view's state.
+- Apply `.scrollPosition(id: $visibleID, anchor: .bottom)` after `.defaultScrollAnchor(.bottom)` on the `ScrollView`.
+
+No `.onChange` needed — HistoryPaneView is read-only for closed sessions, no autoscroll on new messages.
+
+This applies the same fix proactively. Without it, navigating between session entries in the history list and returning would have the same scroll-position-stomp + blank-panel issues on a session that's been previously viewed.
+
+## Why `defaultScrollAnchor(.bottom)` stays
+
+When `visibleID` is still `nil` (e.g., view first appears before any poll has populated `messages`, or messages are empty), `.scrollPosition(id:)` has nothing to anchor to. Apple's documented behavior: an unmatched ID is a no-op. `.defaultScrollAnchor(.bottom)` provides the fallback initial position. Once messages populate and the user scrolls (or autoscroll fires), the binding takes over.
+
+## Why removing the proxy doesn't break autoscroll
+
+`.scrollPosition(id:)` is a two-way binding. Setting it programmatically (in the `.onChange` block above) scrolls the viewport to that ID with the requested animation. SwiftUI handles the layout and lazy realization. The semantics are identical to `proxy.scrollTo(id:anchor:)` for our purposes.
+
+## Edge cases
+
+- **Empty messages on first entry**: `visibleID` is nil. `.defaultScrollAnchor(.bottom)` positions at bottom of empty content (no-op visually). When poll completes and `messages` populates, `messages.last?.id` is non-nil and `.onChange` fires once: `visibleID` becomes the last ID, snap-to-bottom animation runs (visually equivalent to landing at the bottom from a fresh state).
+- **User scrolls to top, leaves, returns**: `visibleID` is the first message's ID. SwiftUI re-anchors there on re-entry. Lazy stack realizes the top rows. Position preserved.
+- **Poll updates messages without changing the last ID** (e.g., daemon re-emitted same data, or only sidechain content changed): `.onChange(of: messages.last?.id)` doesn't fire, no autoscroll. Position stays.
+- **Tab is closed and reopened from scratch** (e.g., user closed the transcript sidebar entirely and reopened): the view is fully re-mounted, `@State` resets, `visibleID` is nil → `.defaultScrollAnchor(.bottom)` positions at bottom. First-entry behavior, as expected.
+
+## Out of scope
+
+- The "freeze autoscroll when user scrolls up" feature — the `autoscrollEnabled` state is still hardcoded `true` per the existing TODO comment at `LiveTranscriptPaneView.swift:24-27`. With `.scrollPosition(id:)` now in place, this becomes a clean follow-up: gate `autoscrollEnabled` based on whether `visibleID == messages.last?.id`. Not doing it here — keep the patch focused on the position-preservation regression.
+- HistoryPaneView's parent state machine (which session is selected, etc.). We're only touching the `ScrollView` chain inside the detail view.
+- Performance instrumentation. The `perf-transcript` logs from `b13befa`/`0780b3c` stay as-is; they continue to verify first-paint stays fast through this change.
+
+## Risks
+
+- **`.scrollPosition(id:)` interaction with `.defaultScrollAnchor`**: a brief tussle on the very first poll-completion (where `messages` becomes non-empty and `.onChange` first sets `visibleID`). Should resolve cleanly to "at bottom" via the animated set. If a flicker is observable, we can dispatch the initial set without animation — but try the clean version first.
+- **Binding re-fires on rapid poll updates**: if `messages.last?.id` flips quickly (unlikely but possible during streaming), `withAnimation` might queue redundant scrolls. Acceptable — same risk existed with `proxy.scrollTo` and didn't manifest in practice.
+- **Worst-case fallback**: if the binding misbehaves on re-entry (e.g., SwiftUI doesn't actually realize rows around the bound ID without an explicit scrollTo), keep the `ScrollViewReader` and add `proxy.scrollTo(visibleID, anchor: .bottom)` as a guarded poke inside `.onAppear` — only when `visibleID != nil`. This poke would scroll-to-self, which is a no-op for position but still triggers re-layout. We try the clean version first.
+
+## Verification (visual; user-driven)
+
+The `perf-transcript` log stream provides the perf regression test (`items.body → view.appear` should remain < 200ms). Visual checks the user must run:
+
+1. Open the maven-dashboard transcript: pins to bottom on first paint.
+2. Scroll up to read older messages.
+3. Switch to another tab.
+4. Switch back: scroll position preserved; content visible immediately (no blank, no jump-to-bottom).
+5. (Active session only) Send a new message in the terminal: snaps to bottom (existing autoscroll behavior).
+6. Open the History pane on a worktree, select a session, scroll up. Select a different session, then back. The previously-viewed session should preserve its scroll position too.
+
+## Suggested commit shape
+
+One commit:
+
+```
+fix: preserve transcript scroll position across navigation
+
+The LazyVStack render fix and its re-entry follow-up forced an
+unconditional snap-to-bottom on every .onAppear, which fixed the
+blank-panel-on-return issue but stomped the user's scroll position.
+Switch to .scrollPosition(id: $visibleID, anchor: .bottom) — a
+two-way binding that tracks the visible row, restores it on re-entry
+(realizing the lazy rows around it as a side effect), and drives
+programmatic autoscroll on new messages. The proxy.scrollTo callers
+go away; ScrollViewReader becomes dead weight and is removed.
+
+Apply the same scroll-position binding in HistoryPaneView so
+session-detail re-entry preserves position consistently.
+```

--- a/docs/superpowers/specs/2026-05-06-worktree-keepalive-lru-design.md
+++ b/docs/superpowers/specs/2026-05-06-worktree-keepalive-lru-design.md
@@ -1,0 +1,255 @@
+# Worktree-level keep-alive with LRU
+
+## Problem
+
+Two recurring SwiftUI bugs we've spent days fighting both have the same root cause: `LiveTranscriptPaneView` is unmounted and re-mounted on worktree navigation, and SwiftUI's `LazyVStack` doesn't recover gracefully from the re-mount.
+
+**Bug 1 — scroll position lost on navigate-back.** User scrolls up to read older messages, navigates to another worktree, navigates back, and lands at the bottom because the view's `@State` (including any scroll-position bookkeeping) died with the unmount.
+
+**Bug 2 — blank pane on revisit, only fills when user scrolls.** Same mechanism: re-mount happens, `defaultScrollAnchor(.bottom)` positions the new viewport at the content bottom, but `LazyVStack` fails to realize rows for that viewport in the new instance. Active scrolling eventually wakes the realization machinery up; until then the user sees blank.
+
+We've gone through five+ iterations trying to fix these bugs from inside `LiveTranscriptPaneView`: scroll-position bindings, sentinel anchors, deferred scrolls, opacity gates, position save/restore via per-row tracking. Each fix either fails or introduces a worse bug. The view-instance lifecycle is at the heart of every failure.
+
+## Goal
+
+Eliminate the unmount/re-mount entirely for the user's recently-visited worktrees. If the SwiftUI view instance survives, both bugs become impossible — `@State` (scroll position, atBottom) persists, `LazyVStack` keeps its realized rows, and switching worktrees is a pure visibility toggle.
+
+## Non-goals
+
+- Not changing how transcripts are loaded, parsed, or polled.
+- Not introducing new state that would survive across full app restarts.
+- Not fixing every SwiftUI re-mount issue in TBD; only the worktree-switching path.
+
+## Approach
+
+Replace the existing `Group { switch on selectedWorktreeIDs }` in `TerminalContainerView.mainContent` with a `ZStack` that holds the *N most recently visited* `SingleWorktreeView` instances simultaneously. Only the currently-selected worktree's view is opaque and accepts hit-testing; the rest are invisible but kept alive (with their child views, including `LiveTranscriptPaneView`, retained).
+
+When a worktree is visited that isn't already in the keep-alive set, it gets prepended; when the set exceeds the cap, the oldest entry is evicted (which causes that worktree's view to unmount — same behavior as today, but only for worktrees the user hasn't touched in a while).
+
+The codebase already uses this exact preservation pattern in two places. `TerminalContainerView.swift:76-80` has a comment explaining why the `DockSplitView` is always rendered ("destroys all terminal views, killing their tmux sessions"). `ContentView.swift:51-60` overlays `ConductorOverlayView` with `.opacity(...)` / `.allowsHitTesting(...)`. So this isn't novel architecture — it's idiomatic for TBD.
+
+## Cap
+
+**`keepAliveLimit = 8`.**
+
+Reasoning:
+- A typical TBD session has 3–8 active worktrees the user alternates between.
+- Worst-case memory per kept-alive worktree is ~50–200MB (full tab bar + multi-pane split + scrolled-through long transcript). At 8 × 200MB = 1.6GB — high but bounded. On a 36GB Mac, fine. On 8GB, the OS will start paging the cold ones, which is acceptable for non-active worktrees.
+- Realistic memory is much lower because most kept-alive worktrees only have the bottom screenful of their transcripts realized (the user opens the pane, sees the latest, navigates away — only ~10 rows realized).
+- Easy to tune later if 8 is wrong. It's a constant, not a config.
+
+## State changes
+
+### `AppState`
+
+```swift
+/// Worktree IDs whose view trees we keep alive past their selection,
+/// most-recent-first. Cap: keepAliveLimit. Older worktrees get evicted
+/// (their SingleWorktreeView unmounts) when the cap is exceeded.
+@Published private(set) var recentlyVisitedWorktreeIDs: [UUID] = []
+
+private let keepAliveLimit = 8
+
+/// Move `id` to the front of recentlyVisitedWorktreeIDs, evicting the
+/// oldest entries if we exceed keepAliveLimit. Idempotent — calling
+/// repeatedly with the same id only updates ordering.
+func touchVisitedWorktree(_ id: UUID) {
+    recentlyVisitedWorktreeIDs.removeAll { $0 == id }
+    recentlyVisitedWorktreeIDs.insert(id, at: 0)
+    if recentlyVisitedWorktreeIDs.count > keepAliveLimit {
+        recentlyVisitedWorktreeIDs.removeLast(
+            recentlyVisitedWorktreeIDs.count - keepAliveLimit
+        )
+    }
+}
+```
+
+Place it near the other transcript-related properties in `AppState.swift` (the area that already had `sessionTranscripts`).
+
+### Hook into selection changes
+
+`ContentView.swift:183` already has `.onChange(of: appState.selectedWorktreeIDs)`. Add a call to `touchVisitedWorktree` for the single-selection case:
+
+```swift
+.onChange(of: appState.selectedWorktreeIDs) { _, newSelection in
+    // ... existing logic ...
+    if newSelection.count == 1, let id = newSelection.first {
+        appState.touchVisitedWorktree(id)
+    }
+}
+```
+
+Multi-select case: do nothing; multi-select uses `MultiWorktreeView`, which is out of scope for this change.
+
+### Initial population
+
+When the app first launches and the saved worktree selection is restored, the `.onChange` may not fire (depends on whether the initial selection is set after the view is observing). Belt-and-suspenders: also add a `.onAppear` on `ContentView` (or a `.task`) that touches the currently-selected worktree if any. Verify by reading the existing `selectedWorktreeIDs.didSet` in `AppState.swift:30`.
+
+## TerminalContainerView changes
+
+Replace the existing `mainContent` `Group { if/else }` (`TerminalContainerView.swift:54-64`):
+
+```swift
+let mainContent = Group {
+    if appState.selectedWorktreeIDs.count == 1,
+       let worktreeID = appState.selectedWorktreeIDs.first {
+        SingleWorktreeView(worktreeID: worktreeID)
+    } else if appState.selectedWorktreeIDs.count > 1 {
+        MultiWorktreeView(worktreeIDs: appState.selectionOrder)
+    } else {
+        Text("Select a worktree or click + to create one")
+            .foregroundStyle(.secondary)
+    }
+}
+```
+
+Becomes:
+
+```swift
+let activeWorktreeID = appState.selectedWorktreeIDs.count == 1
+    ? appState.selectedWorktreeIDs.first
+    : nil
+
+let mainContent = Group {
+    if appState.selectedWorktreeIDs.count > 1 {
+        // Multi-select bypasses keep-alive: existing behavior preserved.
+        MultiWorktreeView(worktreeIDs: appState.selectionOrder)
+    } else if appState.selectedWorktreeIDs.isEmpty {
+        Text("Select a worktree or click + to create one")
+            .foregroundStyle(.secondary)
+    } else {
+        // Single-select: render all kept-alive worktrees in a ZStack,
+        // gated by opacity + hit-testing. Only the active one is visible
+        // and interactive; the rest stay mounted to preserve LazyVStack
+        // realization, scroll position, terminal state, etc.
+        ZStack {
+            ForEach(appState.recentlyVisitedWorktreeIDs, id: \.self) { id in
+                SingleWorktreeView(worktreeID: id)
+                    .opacity(id == activeWorktreeID ? 1 : 0)
+                    .allowsHitTesting(id == activeWorktreeID)
+            }
+        }
+    }
+}
+```
+
+A subtle point: the active worktree must be in `recentlyVisitedWorktreeIDs` for the ZStack to render it. The `touchVisitedWorktree` call from the `.onChange` handler ensures this — but if the `ZStack` evaluates *before* the `.onChange` runs (e.g., on the very first selection at app launch), the active worktree might be missing for a frame. Mitigations:
+- The `touchVisitedWorktree` call from `selectedWorktreeIDs.didSet` (in `AppState.swift`) is synchronous, so the array is updated before any view body re-evaluates that observes `recentlyVisitedWorktreeIDs`.
+- Belt-and-suspenders: in the ZStack body, if `activeWorktreeID` exists but isn't in `recentlyVisitedWorktreeIDs`, fall back to rendering it directly:
+  ```swift
+  ZStack {
+      ForEach(appState.recentlyVisitedWorktreeIDs, id: \.self) { id in ... }
+      if let id = activeWorktreeID, !appState.recentlyVisitedWorktreeIDs.contains(id) {
+          SingleWorktreeView(worktreeID: id)
+      }
+  }
+  ```
+
+The `.onPreferenceChange(MainAreaSizeKey.self)` modifier on `mainContent` stays as-is — it observes whichever child's GeometryReader is currently visible.
+
+## What survives, what doesn't
+
+Survives across worktree switches:
+- `LiveTranscriptPaneView`'s `@State` (atBottom, perf-log dedup, etc.) and `@State` of every SwiftUI view inside the kept-alive subtree.
+- `LazyVStack`'s realized row windows.
+- Tab bar selection within each worktree.
+- File panel state, code viewer state, terminal scrollback.
+- Any `.task(id:)` polling continues to run on hidden worktrees (see "Polling cost" below).
+
+Does NOT survive:
+- Worktrees evicted past the LRU cap (revert to current mount-on-visit behavior).
+- App restart (kept-alive set is in-memory only).
+
+## Polling cost
+
+`LiveTranscriptPaneView`'s `.task(id: TaskKey)` runs while the view is mounted. In keep-alive mode, that means polling continues for *all* kept-alive worktrees, not just the active one. For 8 worktrees with one transcript pane each, that's ~5.3 RPC calls/sec on the daemon.
+
+For typical session sizes (200–500 items, 100–500KB JSONL), each parse is ~10–20ms. Total ongoing daemon CPU: ~5%. Tolerable.
+
+For pathological sessions like maven-dashboard's 5MB / 720-item file, parse is ~200ms. Eight of those concurrent = 1.6s of CPU per 1.5s poll cycle, which would saturate the daemon. In practice, users don't have eight 5MB sessions concurrently — but it's a real failure mode worth knowing about.
+
+If polling cost shows up as a problem, the fix is to gate polling on visibility:
+
+```swift
+@State private var isVisible = false
+
+.task(id: TaskKey(...)) {
+    while !Task.isCancelled {
+        if isVisible { await pollOnce() }
+        try? await Task.sleep(...)
+    }
+}
+.onAppear { isVisible = true }
+.onDisappear { isVisible = false }
+```
+
+But `.onAppear` / `.onDisappear` semantics on opacity-gated views are not well-defined in SwiftUI. They may not fire on opacity changes. Empirically determine: if it doesn't fire, we'd need a different visibility signal (e.g., a binding from the parent based on `id == activeWorktreeID`).
+
+**This is a follow-up if needed, not part of the initial change.** Ship without polling-pause, observe daemon CPU under realistic load, then decide.
+
+## Risks
+
+1. **`MainAreaSizeKey` confusion.** With multiple `SingleWorktreeView`s in a ZStack, multiple `GeometryReader`s emit preferences. The current `.onPreferenceChange` reads the last-emitted value. Need to verify only the active worktree's geometry is broadcast, or add a check (`id == activeWorktreeID`) inside the geometry reader.
+2. **One-shot UI elements that should re-trigger on visit** — e.g., a "new messages while you were away" badge that uses `.onAppear` to reset. With the view kept alive, `.onAppear` won't fire on revisit. Audit the existing subtree for such cases. Off the top of my head, none come to mind in `LiveTranscriptPaneView` or `PanePlaceholder`, but worth a grep for `.onAppear` inside the subtree.
+3. **Memory creep on long sessions.** A user who runs TBD for hours and visits many worktrees deeply will eventually hit the keep-alive cap, but the cap is bounded so the worst case is bounded. Still, if a single kept-alive worktree's transcript balloons (e.g., a session that grows to 10k items over hours), each kept-alive entry's high-water mark increases too. LazyVStack doesn't evict, so this is monotonically increasing. Consider as future work: per-worktree teardown trigger when the worktree's session grows past some threshold.
+4. **Conductor overlay interaction.** `ConductorOverlayView` (already an opacity-gated overlay on the worktree subtree) is layered above mainContent. With a kept-alive ZStack underneath, its layout proposals are still bounded by the active worktree's content. Should be fine. Verify visually.
+5. **Multi-select still mounts/unmounts.** The bypass for `selectedWorktreeIDs.count > 1` keeps current behavior. Acceptable.
+
+## Verification
+
+1. `swift build` — clean.
+2. `./scripts/restart.sh`.
+3. **Bug 2 test (the canonical repro):**
+   a. Visit the maven-dashboard worktree (with a 720-item transcript) — confirm it lands at the bottom, content visible.
+   b. Switch to a different worktree.
+   c. Switch back. Content should be visible immediately. **No blank-then-scroll-to-render.**
+   d. The `perf-transcript` log should show only ONE `view.appear sid=6ae5` (from the original mount), not two. The remount has been eliminated.
+4. **Bug 1 test:**
+   a. Visit any transcript, scroll up to mid-content, note position.
+   b. Switch worktrees, switch back.
+   c. Scroll position is preserved.
+5. **LRU eviction test:**
+   a. Visit ≥10 distinct worktrees in some order, then return to the first one visited. It should mount fresh (was evicted), behaving like today's mount-on-visit (lands at bottom, no preserved state).
+6. **Polling-cost sanity check:**
+   a. With 8 kept-alive worktrees, watch `top` for daemon CPU. Should stay under ~10%. If it spikes higher, we've hit the polling-cost edge case and need to gate polling on visibility.
+
+## Out of scope (deferred follow-ups)
+
+- Visibility-gated polling for kept-alive worktrees (cf. "Polling cost" above).
+- Per-worktree memory-pressure teardown (cf. risk #3).
+- Multi-select keep-alive (`MultiWorktreeView` path).
+- Generalizing the LRU pattern to other parts of TBD that may benefit from view preservation.
+- Cleaning up `perf-transcript` instrumentation now that the bug it was diagnosing is gone (decide after this lands).
+
+## Suggested commit shape
+
+One commit:
+
+```
+fix: keep recently-visited worktree views alive to preserve transcript state
+
+Both the scroll-position-loss bug and the blank-on-remount bug had
+the same root cause: LiveTranscriptPaneView was unmounted on
+worktree navigation, taking @State and LazyVStack realization with
+it. Five+ iterations of fixes from inside the view kept failing
+because the view-instance lifecycle was the actual problem.
+
+Replace the worktree switch in TerminalContainerView with a ZStack
+that holds the N most recently visited SingleWorktreeViews,
+gated by opacity + allowsHitTesting. The active worktree is opaque
+and interactive; the rest stay mounted to preserve their full state
+(transcript scroll position, LazyVStack rows, terminal scrollback,
+file panel, etc).
+
+LRU cap of 8 worktrees in AppState.recentlyVisitedWorktreeIDs.
+Touched on every selection change. Older entries evict back to
+mount-on-visit, matching today's behavior for cold worktrees.
+
+The opacity-gated keep-alive pattern is already idiomatic in TBD
+(see DockSplitView and ConductorOverlayView).
+
+Polling cost is not gated on visibility in this change. With 8
+kept-alive worktrees that's ~5 RPC/sec sustained on the daemon —
+fine for typical sessions; flagged for follow-up if pathological
+sessions saturate it.
+```

--- a/docs/superpowers/specs/research-2026-05-06-list-lazy-bottom-anchor.md
+++ b/docs/superpowers/specs/research-2026-05-06-list-lazy-bottom-anchor.md
@@ -1,0 +1,333 @@
+# Research: SwiftUI List laziness + bottom anchor on macOS 15
+
+Date: 2026-05-06
+Scope: macOS 15 (Sequoia), SwiftUI `List` post-migration from `LazyVStack`. Follow-up to `research-2026-05-06-swiftui-long-list-perf.md`.
+
+## TL;DR
+
+- **`List` on macOS 15 is *less lazy than the prior research implied* in two specific ways that match our symptoms.** (1) `List { ForEach(messages) { ... } }` (the IceCubes shape we copied) calls each row's `View.init` for *all* rows at first display — a long-standing SwiftUI bug (FB11280425, filed Aug 2022, never fixed) that was confirmed *worsened* in Xcode 16 / iOS 18 / macOS 15 (FB15356563, Sep 2024, unresolved as of late 2025). The opt-out — `List(messages) { ... }` (no inner `ForEach`) — preserves laziness but loses `listRowInsets` / `swipeActions` / per-row modifiers. (2) Putting `.id(...)` on row views, which we likely do for `proxy.scrollTo(sentinel)`, *also* defeats List's lazy realization on its own (Fatbobman, multiple sources). Net: with our current code shape, every row's `init` runs at view appear, which is enough by itself to cause the freeze — the cell-recycling we adopted `List` for is likely not actually engaging.
+- **What underlies `List` on macOS 15 is no longer `NSTableView` for non-outline content.** That's a 2024 architectural change called out in Apple's WWDC and corroborated by Tsai. The replacement appears to be a SwiftUI-native lazy stack (the "improved scheduling and lazy loading" Apple cited at WWDC25 — 6× load / 16× update gains, per Tsai). **It is *not* `NSCollectionView` either.** This matters because the prior research's "cell recycling that we know and love" framing assumed a UIKit/AppKit-backed implementation. The macOS 15 reality is closer to a smarter `LazyVStack` than to a recycled-cell collection view. There is no `noteHeightOfRowsWithIndexesChanged`-style precomputed height path; row heights are still measured as rows are realized.
+- **`proxy.scrollTo` does not animate by default.** `List`-against-`proxy.scrollTo` only animates when explicitly wrapped in `withAnimation { ... }`; an iOS-17-era regression that broke this for projects with deployment target below 17 was fixed in iOS 17 dev beta 7. **The visible "sink to bottom" the user is seeing is almost certainly our explicit `withAnimation(.easeOut(duration: 0.15))` on `.onChange(messages.last?.id)` firing once after the first poll populates the list — combined with the fact that the *initial* `scrollTo` in `.onAppear` is racing layout for ~700 rows that haven't been measured yet.** Drop the `withAnimation` and you should stop seeing the visible motion.
+- **Production OSS chat apps land at the bottom either by (a) `defaultScrollAnchor(.bottom)` on `ScrollView { LazyVStack }` (still — `List` does not honor `defaultScrollAnchor` reliably, the new scroll-control APIs explicitly don't support `List`); (b) a deferred `proxy.scrollTo` gated on content-readiness (macai's pattern, waits for code blocks to render before initial scroll); or (c) the rotation-180 inverted-scroll trick.** None of these are perfect. There is no native, no-flicker, pure-SwiftUI primitive for "open a `List` already at the bottom of 700 variable-height rows." We are in known-fragile territory.
+- **Recommendations:** (i) Drop the `withAnimation` from the `.onChange` initial-scroll — that alone removes the visible motion for the user. (ii) Switch our `List { ForEach(messages, id: …) { row.id(...) } }` shape to `List(messages, id: …) { row }` *without* per-row `.id()`, and use the closure parameter as the scroll target — this restores actual lazy realization. (iii) Hide the list with `.opacity(isReady ? 1 : 0)` until the deferred-scroll completes, à la macai's "isInitialLoad" gate, to suppress the remaining one-frame flash. (iv) If those don't fix the tab-switch freeze, the deeper issue is per-row MarkdownUI parse cost (every row's `init` runs at appear, regardless of `List`'s recycling claims) — cache parsed `MarkdownContent` on the message model, not in `body`. (v) If freezes *still* persist, the right fallback is an `NSScrollView`/`NSCollectionView` `NSViewRepresentable` with `NSHostingConfiguration`, **not** going back to `LazyVStack`.
+
+## Is List actually lazy for scroll-to-far-row?
+
+Short answer: **it depends, and in our specific configuration probably not.**
+
+### Evidence
+
+1. **`List { ForEach(data) { ... } }` calls `init` on every row at first display.** This is the most important finding. Filed as Apple feedback FB11280425 (Aug 2022) and discussed in [thread/716063](https://developer.apple.com/forums/thread/716063):
+
+   > "When using `ForEach` inside a `Section` within a SwiftUI `List`, all rows are initialized and loaded at once instead of lazily loading visible rows. This defeats the performance benefits of lazy loading in Lists."
+
+   Fatbobman's "[Discussing List and ForEach in SwiftUI](https://fatbobman.com/en/posts/swiftui-list-foreach/)" corroborates and gives the workaround:
+
+   > "In List, if you use ForEach to handle the data source, all Views of the data source need to be initialized at the creation of the List. … ForEach has to preprocess all data and prepare Views in advance. And after initialization, it does not automatically release these Views (even if they are not visible)!"
+
+   The workaround is to use **`List(data) { item in ... }`** (the convenience initializer, no inner `ForEach`). That form *does* lazily realize. But it loses per-row layout flexibility — you can't apply `listRowInsets`, `swipeActions`, `listRowSeparator`, etc. per row. (You can apply them per-section if you wrap in `Section`.)
+
+   IceCubes uses `List { ForEach(...) }`. So either IceCubes is also paying this init cost (and is masking it because Mastodon `Status` rows are cheap, while ours run MarkdownUI in `body`), or some specific shape they use avoids it. Either way, the symptom for *us* is consistent with paying the init cost.
+
+2. **Xcode 16 / iOS 18 / macOS 15 made the same problem worse for `List(data)` too.** [thread/765203](https://developer.apple.com/forums/thread/765203), filed Sep 2024 as FB15356563:
+
+   > "Xcode 15.2 (working): List lazy-loads child views on demand (~13 views initialized on first display for a 1000-item list). Xcode 16+ (broken): List initializes all 1000 child views at once when the view is first displayed."
+
+   Confirmed by 6+ developers; runtime issue, both Debug and Release; partial workaround `SWIFT_ENABLE_OPAQUE_TYPE_ERASURE=NO` doesn't always work. **Status as of Nov 2024: unresolved.** No public evidence of a fix in 18.2 / 15.2.
+
+3. **Putting `.id(...)` on row views inside `ForEach` defeats `List`'s lazy optimization.** From Fatbobman ([Demystifying SwiftUI List](https://fatbobman.com/en/posts/optimize_the_response_efficiency_of_list/)):
+
+   > "Adding `.id(item.objectID)` to each row caused List to instantiate views for all data itemRows, totaling 40,000. Using the id modifier is equivalent to splitting these views out of ForEach, thus losing the optimization conditions."
+
+   We almost certainly do this — we need `.id(message.stableID)` on each row for `proxy.scrollTo(message.stableID)` to find the target. So even if (1) and (2) didn't apply, the explicit `.id` modifier would *separately* defeat laziness.
+
+4. **What `List` *does* still do well — when not defeated.** Fatbobman's [List or LazyVStack](https://fatbobman.com/en/posts/list-or-lazyvstack/):
+
+   > "List does not maintain a concept of complete content height at the SwiftUI level. During fast scrolling or extensive jumps, it intelligently selects the necessary subviews for instantiation and height calculation, significantly improving scrolling and jumping efficiency."
+
+   And from [Demystifying SwiftUI List](https://fatbobman.com/en/posts/optimize_the_response_efficiency_of_list/):
+
+   > "Only about 100 child views were instantiated and drawn throughout the entire scrolling process [during scrollTo]."
+
+   This is the laziness we hoped for: `proxy.scrollTo(targetID, anchor: .bottom)` should *not* require realizing every row from top to target — `List` can compute the offset without doing that, *if* the lazy-loading machinery is intact. Our problem is that we're likely defeating that machinery via `ForEach` + per-row `.id()`.
+
+5. **`List` does not "iterate the whole collection upfront" the way `LazyVStack` does for distance calculations.** Gwendal Roué (quoted by Tsai, Jun 2025):
+
+   > "List was requiring a Swift Collection, which means all elements must pre-exist…List was iterating all elements in the collection, upfront, even those which are far off-screen."
+
+   The first half is a constraint (collection pre-existence). The second half describes how the *previous* implementation worked. WWDC25 announcements suggest 6× / 16× improvements via "improved scheduling and lazy loading" — not an architectural change, but enough that the older "iterates all elements upfront" claim is now partially mitigated. Still: rows can be iterated/initialized cheaply (just `View.init`) without being "realized" in the layout sense — and that's what FB11280425 / FB15356563 are complaining about: the cheap iteration is no longer cheap when each row's `init` does substantial work.
+
+### Bottom line for our `proxy.scrollTo(sentinel, anchor: .bottom)` against ~700 rows
+
+- If our `List` were configured the way Fatbobman recommends — `List(messages) { ... }` *without* per-row `.id`, no inner `ForEach` — `proxy.scrollTo(sentinel, anchor: .bottom)` would realize ~100 views (the visible window at the target), not 700. That's the laziness we adopted `List` for.
+- With our actual configuration — `List { ForEach(messages, id: \.stableID) { row.id(.stableID) } }` — every row's `View.init` runs at `.onAppear`, plus `.id` defeats subsequent lazy optimizations. With MarkdownUI rows whose `init` parses markdown, this is functionally close to "realize all rows from top to target." That matches the freeze symptom.
+
+## What underlies List on macOS — NSCollectionView or NSTableView?
+
+**Neither, as of macOS 15.**
+
+The historical answer (macOS 12-14) was `NSTableView`. Multiple sources confirm: "List in SwiftUI for macOS has default background color because of the enclosing NSScrollView via NSTableView that List uses under the hood" (cited in multiple 2023 blog posts).
+
+The macOS 15 change is documented in Tsai's [Apr 2024 NSTableView post](https://mjtsai.com/blog/2024/04/15/nstableview-with-swiftui/) and [Jun 2025 WWDC25 post](https://mjtsai.com/blog/2025/06/18/swiftui-at-wwdc-2025/):
+
+> "On macOS 15, List does not use NSTableView for showing non-outline content anymore."
+
+Tsai then characterizes the new implementation:
+
+> "The improvements came from improved scheduling and lazy loading rather than an architectural change. … 6x (loading) and 16x (updating) improvements were cited [at WWDC25], but don't seem like enough to match NSTableView."
+
+And Gwendal Roué's correction (quoted in the same Tsai post):
+
+> "List was requiring a Swift Collection, which means all elements must pre-exist…List was iterating all elements in the collection, upfront, even those which are far off-screen."
+
+That phrasing — and the "non-architectural" framing — strongly suggests the new implementation is a SwiftUI-native lazy stack with smarter scheduling, *not* a swap from `NSTableView` to `NSCollectionView`. This is consistent with the laziness semantics being *similar to* `LazyVStack` but with better hand-off to the scroll machinery (so `proxy.scrollTo` can compute offsets without realizing every intermediate row, *when its laziness isn't defeated by `ForEach`/`.id`*).
+
+**Practical consequences for our debugging:**
+
+- There is no `NSTableView`-level `usesAutomaticRowHeights` / `noteHeightOfRowsWithIndexesChanged` / `scrollRowToVisible` to fall back on. `List` on macOS 15 is closer to a SwiftUI-native primitive than to an AppKit shim.
+- "Cell recycling" is the wrong mental model for macOS 15 `List`. There is laziness in *realization*, but not classic UIKit/AppKit-style cell reuse with bounded memory. Once a row is realized, it likely stays realized (this is what Fatbobman observes for `ForEach`-driven lists at least).
+- If we need true bounded-memory cell reuse with self-sizing, the only sanctioned escape hatch on macOS is `NSCollectionView` + `NSHostingConfiguration` via `NSViewRepresentable` (WWDC22 "Use SwiftUI with AppKit"). `flocked/AdvancedCollectionTableView` is the modernization path.
+- `NSCollectionView`'s self-sizing path uses `estimatedItemSize` on `NSCollectionViewFlowLayout` and grows actual sizes via `preferredLayoutAttributesFittingAttributes` as items realize. It *does* support "scroll to end of long list" without realizing every item — but you have to provide reasonable estimates, and you have to use the modern compositional layout APIs to get good behavior. This is non-trivial but well-worn.
+
+## How OSS chat apps handle initial bottom-anchor without visible transition
+
+Mixed evidence. **No one has nailed this perfectly in pure SwiftUI on macOS.**
+
+### IceCubes (canonical large-scale SwiftUI Mastodon, multi-platform)
+
+Confirmed via `gh search`: their `TimelineListView.swift` is `ScrollViewReader { proxy in List { ScrollToView(); ForEach(...) { StatusRowView(...) } } }`, no `.id(...)` on rows except for explicit anchor markers. Their use case is **scroll to top of timeline**, not "land at bottom of chat" — they don't face our exact problem. But the shape `List { ForEach(statuses) { ... } }` is the same shape we copied, and it would suffer FB11280425 except that `Status` rows are cheap. Their initial-positioning path is `proxy.scrollTo(scrollToIDValue, anchor: .top)` in `.onChange(of: viewModel.scrollToId)` — animated implicitly by `withAnimation` in some places but not others. **They don't model bottom-anchor open.** Limited applicability for our problem.
+
+### macai (Renset/macai, a multi-provider macOS AI chat)
+
+Source verified via `gh api`. `macai/UI/Chat/ChatMessagesView.swift` does *not* use `List` — it uses **`ScrollView { ScrollViewReader { VStack { ... } } }.defaultScrollAnchor(.bottom)`**. Note: `VStack`, not `LazyVStack`. They explicitly don't use either `List` or `LazyVStack` for the message column.
+
+Their open-without-flicker pattern is:
+
+```swift
+.onAppear {
+    pendingCodeBlocks = chatViewModel.sortedMessages.reduce(0) { count, message in
+        count + (message.body.components(separatedBy: "```").count - 1) / 2
+    }
+    isInitialLoad = true
+    if pendingCodeBlocks == 0 {
+        codeBlocksRendered = true
+        isInitialLoad = false
+    }
+}
+.onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("CodeBlockRendered"))) { _ in
+    if pendingCodeBlocks > 0 {
+        pendingCodeBlocks -= 1
+        if pendingCodeBlocks == 0 {
+            codeBlocksRendered = true
+            if isInitialLoad {
+                isInitialLoad = false
+                if let lastMessage = chatViewModel.sortedMessages.last {
+                    DispatchQueue.main.async {
+                        scrollView.scrollTo(lastMessage.objectID, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+Two key takeaways:
+
+1. **They use `defaultScrollAnchor(.bottom)` on the outer `ScrollView`** — the anchor that prior research and Apple Forums [thread/741406](https://developer.apple.com/forums/thread/741406) flag as *fragile* with `LazyVStack`. macai gets away with it because they use `VStack`, not `LazyVStack`, paying the upfront cost of realizing all rows so that the bottom anchor "just works" without scroll motion. **This is fundamentally trading freeze-on-open for visible-motion-on-open.** macai chose freeze-on-open. We chose `List` to avoid that, and now have a different version of both problems.
+2. **They gate the *programmatic* `scrollTo` on a content-readiness signal (`CodeBlockRendered` notifications, count-based).** No `withAnimation`. This is the cleanest version of our `.onAppear` deferred-scroll, made deterministic instead of timer-based. Note also: `DispatchQueue.main.async` rather than `asyncAfter(deadline: .now() + 0.05)` — because they have a real signal, they don't need a heuristic delay.
+
+For *our* case on `List`, we don't have a content-readiness signal (markdown rendering happens inside MarkdownUI, no notifications emitted). We could either (a) wait until a stable size is reported via `onScrollGeometryChange`, or (b) hide-until-positioned with opacity.
+
+### Other macOS SwiftUI AI chat clients
+
+- **AICat (Panl/AICat)**, **ChatGPTSwiftUI (alfianlosari)**, **iChatGPT (37iOS)** — all small-scale, none demonstrate large-transcript bottom-anchor patterns. No useful prior art.
+- **stream-chat-swiftui** (commercial SDK) — has [issue #78](https://github.com/GetStream/stream-chat-swiftui/issues/78) "Long boring messages break scroll to bottom functionality," indicating they hit similar problems. Not OSS source for `List` patterns.
+
+### Inverted-scroll trick (rotate 180°)
+
+Documented at [Swift with Vincent](https://www.swiftwithvincent.com/blog/building-the-inverted-scroll-of-a-messaging-app) and [Apple Forums thread/681833](https://developer.apple.com/forums/thread/681833):
+
+> "Apply `.rotationEffect(.radians(.pi))` and `.scaleEffect(x: -1, y: 1, anchor: .center)` to both the scroll view and each child view. The scroll view starts at what's visually the bottom (because top is now bottom). Append-from-top maps to the user's natural append-at-bottom."
+
+Pros: the chat literally cannot have a "scroll from top to bottom" transition — it's already at the user-visible "bottom" because that's the data top. Append doesn't trigger a scroll-position fight. Forum [thread/741406](https://developer.apple.com/forums/thread/741406) (Jan 2025) calls this out as a working workaround for `defaultScrollAnchor(.bottom)`-on-`LazyVStack` fragility too.
+
+Cons: known issues with navbar jumping, pull-to-refresh, scroll-indicator direction, and accessibility (VoiceOver order is wrong unless you also flip the accessibility). The rotation can also confuse hit-testing for things like text selection and link clicks if not carefully scoped. **And critically: the inverted trick is documented for `LazyVStack`, not `List`.** It can in principle be applied to `List`, but examples are scarce — and `List`'s default behaviors (separators, selection chrome, focus rings) get visually inverted in ways you have to manually unflip per row. Not zero cost.
+
+### Hide-until-positioned
+
+A deliberate pattern: `.opacity(isReady ? 1 : 0)`, set `isReady = true` from the deferred-`scrollTo`'s completion or after a debounced settle. Used in commercial chat apps (no OSS macOS examples found, but it's a frequently-mentioned pattern in WWDC sample-code discussion). Avoids the visible motion entirely at the cost of a brief blank/dimmed view.
+
+This is a near-perfect fit for our situation. The user explicitly says they want to *avoid* needing this — but given the framework constraints we're working with, this may be the lowest-cost path that actually works.
+
+### `defaultScrollAnchor(.bottom)` outside `LazyVStack`
+
+[Apple's doc](https://developer.apple.com/documentation/swiftui/view/defaultscrollanchor(_:)) lists it as a `View` modifier on `ScrollView`. Per Fatbobman's [evolution of SwiftUI scroll APIs](https://fatbobman.com/en/posts/the-evolution-of-swiftui-scroll-control-apis/), the new scroll-control APIs explicitly **do not support `List`**:
+
+> "The new scroll control APIs no longer support List, which to some extent limits their application range."
+
+That includes `defaultScrollAnchor`, `scrollPosition(id:)`, `scrollPosition($pos)`, etc. — they're documented as `ScrollView`-only. Some posts show `.defaultScrollAnchor(.bottom, for: .alignment)` syntax applied to `List`, but the behavior is unreliable / undocumented.
+
+**So `defaultScrollAnchor(.bottom)` on `List` is *not* a usable primitive for us.** We have to programmatic-scroll.
+
+## Does `proxy.scrollTo` always animate against `List`, or only when wrapped in withAnimation?
+
+**Only when wrapped in `withAnimation`.** No animation by default.
+
+Confirmed by:
+
+- [Apple Forums thread/735479](https://developer.apple.com/forums/thread/735479) — "If you call scrollTo() inside withAnimation() the movement will be animated. … This issue has been fixed in iOS 17 developer beta 7." (Sep 2023, the regression where it didn't animate even with `withAnimation` on iOS 17 with deployment target < 17.)
+- [Hacking with Swift's reference](https://www.hackingwithswift.com/quick-start/swiftui/how-to-scroll-to-a-specific-row-in-a-list) — explicitly contrasts the wrapped-in-`withAnimation` form vs the bare form.
+- [Use Your Loaf "Scrolling With ScrollViewReader"](https://useyourloaf.com/blog/scrolling-with-scrollviewreader/) — same contract.
+
+There's a known iOS 17.0-only regression that's not relevant to macOS 15. There is **no** evidence that `List`'s `proxy.scrollTo` has special "always animates" behavior that ignores `withAnimation`.
+
+**Implication for our code:** the `withAnimation(.easeOut(duration: 0.15))` we wrap around our `.onChange` `proxy.scrollTo` is the only animation source. The `.onAppear` deferred `proxy.scrollTo` *should* be jumping instantly. If the user is seeing a slide/sink on `.onAppear` *too*, that motion is List's own first-layout settling — not a programmatic animation.
+
+Two distinct visible motions to disentangle:
+
+1. The `.easeOut(duration: 0.15)`-wrapped `.onChange` scroll, fired when messages populate after the first poll. This is *intentional animation* and the user is definitely seeing it.
+2. Any layout settling between the `.onAppear` `scrollTo` and the moment List finishes its first measurement pass. This is *not* a `proxy.scrollTo` animation; it's `List` itself working through its initial layout. With our `List { ForEach { row.id(...) } }` shape, every row's `init` runs eagerly, which makes this settling slow.
+
+Almost certainly what the user is seeing is some combination of (1) and (2), with (1) being the dominant visible motion.
+
+## Recommendations for our specific situation
+
+Given:
+- We use `List` (post-migration)
+- We have a sentinel row at the bottom
+- We use `proxy.scrollTo(sentinel, anchor: .bottom)` deferred 50ms in `.onAppear`
+- We use `proxy.scrollTo(sentinel, anchor: .bottom)` wrapped in `withAnimation` on `.onChange(messages.last?.id)`
+- We see the user landing at top and visibly sinking to bottom
+- We see a freeze on tab leave/enter for long sessions
+
+### Step 1 (smallest, highest-leverage): drop the `withAnimation` on the initial `.onChange` scroll
+
+`withAnimation(.easeOut(duration: 0.15)) { proxy.scrollTo(sentinel, anchor: .bottom) }` on the very first `.onChange` after `messages` populates is creating the bulk of the visible motion. Replace with a plain `proxy.scrollTo(sentinel, anchor: .bottom)` for the *first* settle, and only re-enable `withAnimation` for *subsequent* updates (new messages arriving while the chat is open). A simple `@State private var didFirstScroll = false` gate works:
+
+```swift
+.onChange(of: messages.last?.id) { _, _ in
+    guard let sentinel else { return }
+    if didFirstScroll {
+        withAnimation(.easeOut(duration: 0.15)) {
+            proxy.scrollTo(sentinel, anchor: .bottom)
+        }
+    } else {
+        proxy.scrollTo(sentinel, anchor: .bottom)
+        didFirstScroll = true
+    }
+}
+```
+
+This alone should remove the visible "sink to bottom" the user is reporting. Do this first; it's a one-line change and we can re-evaluate before doing anything else.
+
+### Step 2: restore actual lazy realization in `List`
+
+Audit the transcript pane for the two known laziness-defeating patterns:
+
+- **`List { ForEach(messages) { ... } }`** → consider switching to **`List(messages, id: \.stableID) { message in ... }`** (no inner `ForEach`). You lose `swipeActions`-on-row and per-row `.listRowInsets` flexibility — verify which we actually need. If we need per-row insets, wrap rows in `Section(...)` and apply `.listSectionInsets` (macOS 15+), or accept eager `init` and mitigate at the `init` cost level (Step 3 below).
+- **`.id(message.stableID)`** on each row → only put `.id` on the sentinel and on rows we genuinely need to programmatically scroll to. For the bottom-anchor use case, we only need `.id` on the sentinel — rows themselves don't need `.id` because we're scrolling to the sentinel. This is a real win regardless of which `List` shape we settle on.
+
+After this change, the laziness Fatbobman observed (~100 views realized for a `scrollTo` to a far-off row) should kick back in. That directly addresses the tab-switch freeze.
+
+### Step 3: mitigate per-row `init` cost
+
+If FB11280425 / FB15356563 are biting us regardless of our `List` shape (Xcode 16+ regression), we still pay `View.init` for every row at first display. Make `init` cheap:
+
+- **Pre-parse markdown.** Compute `MarkdownContent` once, in the row's view-model or a Codable cache on the message, never inside the row's `body` or `init`. MarkdownUI's `Markdown(content:)` initializer is cheap when given already-parsed content.
+- **`.equatable()` on the row view** — multiple sources (Hacking with Swift, troz.net) report this as the single biggest knob for `List` perf on macOS, including unblocking lazy realization in some configurations:
+
+  > "Applying the `equatable` modifier to row views prevented rendering all 10,000 rows simultaneously and enabled lazy loading. The row views were not drawn until they were scrolled into view." — troz.net, 2024
+
+- **Avoid heavyweight environment subscriptions** in row `init` (cmux #2327 lesson). If we read `@AppStorage`/`@Environment` per row, fan-out is O(n). Hoist to the parent.
+
+### Step 4: hide-until-positioned to absorb residual flash
+
+After Steps 1-3, a frame or two of "rows visible at top before scroll lands" may still be visible. Apply opacity gating, macai-style:
+
+```swift
+List(messages, id: \.stableID) { message in
+    row(for: message).equatable()
+}
+.opacity(didFirstScroll ? 1 : 0)
+.onAppear {
+    DispatchQueue.main.async {
+        proxy.scrollTo(sentinel, anchor: .bottom)
+        // Two-frame settle to be safe; List measures asynchronously.
+        DispatchQueue.main.async {
+            proxy.scrollTo(sentinel, anchor: .bottom)
+            didFirstScroll = true
+        }
+    }
+}
+```
+
+Two `DispatchQueue.main.async` hops (no `asyncAfter`) is more reliable than a 50 ms timer because it's relative to the actual layout cycle, not wall clock. The user's prior research notes a desire to avoid this — but given that no SwiftUI primitive does "open `List` already at bottom of long list" cleanly, this is the lowest-fragility fallback.
+
+### Step 5: if the freeze still persists, escape to AppKit
+
+If after Steps 1-3 we still get tab-switch freezes on long transcripts:
+
+- The deeper cause is that even cheap per-row `init` × 700 + MarkdownUI's per-row layout cost exceeds an acceptable budget. `List` on macOS 15 cannot save us at that point.
+- The sanctioned path is `NSScrollView` + `NSCollectionView` (compositional layout, `estimatedItemSize`) hosted via `NSViewRepresentable`, with each item using `NSHostingConfiguration` to keep the SwiftUI row content. `flocked/AdvancedCollectionTableView` is the modernization helper.
+- **Do not go back to `LazyVStack`.** The prior research's freeze-causing path was `LazyVStack` + `MarkdownUI` rows; that hasn't changed. macai gets away with `VStack` (not `LazyVStack`) only because they accept the eager-render cost; their sessions are typically tens-of-messages, not 700+.
+- Alternatively, evaluate the maintainer's successor library **Textual** when it stabilizes — same gonzalezreal author, designed to fix exactly the per-row layout/perf issues that motivated MarkdownUI's retirement (Discussion #437, Jan 2026).
+
+### Specifically for the two visible-motion sources
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Visible "sink from top to bottom" on first paint | `withAnimation(.easeOut(duration: 0.15))` around `proxy.scrollTo` in `.onChange(messages.last?.id)`, fired once when messages populate after first poll | Step 1: gate first scroll with `didFirstScroll` and skip `withAnimation` for it. |
+| Lands at top first, then jumps | `.onAppear` `proxy.scrollTo` racing `List`'s first layout (because `ForEach` + `.id()` defeats laziness, so `List`'s first layout takes a long time) | Step 2 (restore laziness) reduces the race window; Step 4 (opacity gate) absorbs the remainder. |
+| Tab-switch freeze on long transcripts | Eager `View.init` per row × 700 + MarkdownUI per-row parse cost + `.id` defeating lazy realization on subsequent passes | Step 2 (restore laziness) + Step 3 (cheap `init`, `.equatable()`); Step 5 if not enough. |
+
+---
+
+## One-paragraph synthesis: is `List` the right primitive?
+
+**Probably yes — but only if we use it correctly, which our current code may not.** `List` on macOS 15 is *not* the cell-recycling AppKit shim the prior research implied (it stopped being `NSTableView`-backed in macOS 15), and it has *real* laziness limits exposed by FB11280425/FB15356563 and worsened by per-row `.id()` modifiers. With our current `List { ForEach(messages, id: \.stableID) { row.id(...) } }` shape, we're paying eager `View.init` for all 700 rows on first display and likely defeating List's lazy realization on subsequent scrolls — which would explain both the visible-sink (the layout's still working through measurements when `proxy.scrollTo` fires) and the tab-switch freeze (no real bounded-memory recycling). The fix path is to restore laziness (Steps 1-3) before considering more drastic options, because there is no better pure-SwiftUI primitive for our use case (`defaultScrollAnchor` doesn't support `List`; `LazyVStack` is what the prior research moved us off of; the inverted-scroll trick has too many edge cases). If after fixing the configuration we *still* freeze, the next step is `NSCollectionView` + `NSHostingConfiguration` via `NSViewRepresentable`, **not** retreating to `LazyVStack`. Going back to `LazyVStack` would re-introduce the original freeze without fixing anything.
+
+---
+
+## Sources
+
+### Primary — laziness semantics
+- Fatbobman, [Demystifying SwiftUI List Responsiveness — Best Practices for Large Datasets](https://fatbobman.com/en/posts/optimize_the_response_efficiency_of_list/) — `.id` modifier defeats laziness; ~100 views realized during scrollTo
+- Fatbobman, [Discussing List and ForEach in SwiftUI](https://fatbobman.com/en/posts/swiftui-list-foreach/) — `List { ForEach }` initializes every row up-front; `List(data)` form is lazy
+- Fatbobman, [List or LazyVStack — Choosing the Right Lazy Container](https://fatbobman.com/en/posts/list-or-lazyvstack/) — List doesn't maintain content height at SwiftUI level; intelligent realization during jumps
+- Apple Developer Forums [thread/716063](https://developer.apple.com/forums/thread/716063) — FB11280425 (Aug 2022): `List { Section { ForEach } }` loads all rows at once
+- Apple Developer Forums [thread/765203](https://developer.apple.com/forums/thread/765203) — FB15356563 (Sep 2024): Xcode 16+ regression broke `List(data)` laziness; unresolved as of Nov 2024
+- Apple Developer Forums [thread/651256](https://developer.apple.com/forums/thread/651256) — "List contents are always loaded lazily" (WWDC20-10031), platform-dependent (less lazy on macOS historically)
+
+### Primary — what underlies List on macOS 15
+- Michael Tsai, [SwiftUI at WWDC 2025](https://mjtsai.com/blog/2025/06/18/swiftui-at-wwdc-2025/) — "On macOS 15, List does not use NSTableView for showing non-outline content anymore"; 6×/16× improvements via "improved scheduling and lazy loading rather than architectural change"; Gwendal Roué quote on Collection iteration
+- Michael Tsai, [NSTableView With SwiftUI](https://mjtsai.com/blog/2024/04/15/nstableview-with-swiftui/) — historical context on NSTableView usage
+- troz.net, [SwiftUI Lists](https://troz.net/post/2024/swiftui_lists/) — macOS Sequoia improvements still incremental; `.equatable()` row modifier as performance unlock; debug-vs-release distinction
+
+### Primary — animation contract
+- Apple Developer Forums [thread/735479](https://developer.apple.com/forums/thread/735479) — `proxy.scrollTo` only animates inside `withAnimation`; iOS 17 regression fixed in dev beta 7
+- Hacking with Swift, [How to scroll to a specific row in a list](https://www.hackingwithswift.com/quick-start/swiftui/how-to-scroll-to-a-specific-row-in-a-list)
+- Use Your Loaf, [Scrolling With ScrollViewReader](https://useyourloaf.com/blog/scrolling-with-scrollviewreader/)
+
+### Primary — bottom-anchor patterns in OSS
+- macai source: `macai/UI/Chat/ChatMessagesView.swift` (verified via `gh api` 2026-05-06) — `ScrollView { VStack }.defaultScrollAnchor(.bottom)`, content-readiness-gated initial scroll via `pendingCodeBlocks` count + `CodeBlockRendered` notifications
+- IceCubes source: `Packages/Timeline/Sources/Timeline/View/TimelineListView.swift` — `ScrollViewReader { List { ScrollToView; ForEach } }`; uses scroll-to-top, not scroll-to-bottom; no `.id` per row
+- Apple Developer Forums [thread/741406](https://developer.apple.com/forums/thread/741406) — `LazyVStack + defaultScrollAnchor(.bottom)` blank-on-reentry; rotation workaround (Jan 2025)
+- Apple Developer Forums [thread/681833](https://developer.apple.com/forums/thread/681833) — bottom-first List request (Jun 2021, FB9148104), still unaddressed
+- Swift with Vincent, [Building the inverted scroll of a messaging app](https://www.swiftwithvincent.com/blog/building-the-inverted-scroll-of-a-messaging-app) — rotation 180° + scaleEffect technique
+- Fatbobman, [Evolution of SwiftUI Scroll Control APIs](https://fatbobman.com/en/posts/the-evolution-of-swiftui-scroll-control-apis/) — new scroll APIs explicitly don't support `List`
+
+### Primary — AppKit escape hatch
+- Apple [WWDC22 Use SwiftUI with AppKit](https://developer.apple.com/videos/play/wwdc2022/10075/) — `NSHostingConfiguration` for collection items
+- Apple [NSCollectionViewFlowLayout estimatedItemSize](https://developer.apple.com/documentation/appkit/nscollectionviewflowlayout/estimateditemsize) — auto-sizing primitive
+- flocked, [AdvancedCollectionTableView](https://github.com/flocked/AdvancedCollectionTableView) — modern cell-registration helper
+- Brian Webster, [How NSHostingView Determines Its Sizing](https://www.tumblr.com/brian-webster/723846294121152512/how-nshostingview-determines-its-sizing) (cited via [Tsai](https://mjtsai.com/blog/2023/08/03/how-nshostingview-determines-its-sizing/))
+
+### Supporting — community OSS chat clients
+- Renset/macai — [GitHub](https://github.com/Renset/macai); source verified for `ChatMessagesView.swift` pattern
+- Dimillian/IceCubesApp — [GitHub](https://github.com/Dimillian/IceCubesApp); `gh search` confirmed `List { ForEach }` shape across packages, no per-row `.id`
+- jacobstechtavern, [SwiftUI Scroll Performance: The 120FPS Challenge](https://blog.jacobstechtavern.com/p/swiftui-scroll-performance-the-120fps) (May 2025) — List wins for infinite feeds on iOS, not macOS-tested
+
+### Supporting — `Equatable` row optimization
+- Hacking with Swift, [How to fix slow List updates in SwiftUI](https://www.hackingwithswift.com/articles/210/how-to-fix-slow-list-updates-in-swiftui) — `.equatable()` modifier
+- troz.net, [SwiftUI Lists](https://troz.net/post/2024/swiftui_lists/) — `.equatable()` unblocks lazy realization in observed configurations

--- a/docs/superpowers/specs/research-2026-05-06-swiftui-long-list-perf.md
+++ b/docs/superpowers/specs/research-2026-05-06-swiftui-long-list-perf.md
@@ -1,0 +1,238 @@
+# Research: prior art on SwiftUI long-list / chat-transcript performance
+
+Date: 2026-05-06
+Scope: macOS 15 (Sonoma+), SwiftUI, swift-markdown-ui rows in a transcript pane.
+Method: WebSearch + WebFetch + `gh` against issue trackers and primary OSS repos.
+
+## TL;DR
+
+- **The convergent recommendation from mature OSS chat/timeline apps and Apple-aligned blog posts is: don't render thousands of variable-height markdown rows in a `LazyVStack` — use `List`.** IceCubes (the canonical large-scale SwiftUI Mastodon client, multi-platform incl. macOS) renders its timeline with `List { ... }.listStyle(.plain).environment(\.defaultMinListRowHeight, 1)` driven by `ScrollViewReader`+`proxy.scrollTo`, *not* `LazyVStack` and *not* `scrollTargetLayout`/`scrollPosition(id:)`. List uses `UICollectionView`/`NSTableView` under the hood with real cell recycling; `LazyVStack` does not free rows once realized.
+- **`scrollTargetLayout` + `scrollPosition(id:)` on a long, dynamically-sized `LazyVStack` is a known performance footgun.** Fatbobman explicitly calls out "serious performance issues when the dataset is large" with these APIs (Jun 2023, updated Dec 2025). This matches the symptoms in the user's `StackLayout.placeChildren → sizeChildren → resize → sizeThatFits → placeChildren → ...` 44s spindump.
+- **MarkdownUI itself amplifies this.** Multiple open issues in `gonzalezreal/swift-markdown-ui` document hangs and re-layout jumps when MarkdownUI is used inside `LazyVStack` (#186, #209, #310, #426, #445). The maintainer has put the library in **maintenance mode** in 2026 and is moving to a new library, **Textual**, citing exactly these layout/perf limits as the reason MarkdownUI's architecture cannot be incrementally fixed.
+- **The community-tested mitigations, in descending order of maturity:** (1) move to `List` ; (2) keep `LazyVStack` but make rows fixed/known-height by hoisting variable content out and providing height hints; (3) drop down to `NSCollectionView`/`NSTableView` via `NSViewRepresentable` (Kean, AdvancedCollectionTableView, Apple's own WWDC22 "Use SwiftUI with AppKit" guidance for `NSHostingConfiguration` cells); (4) custom windowed renderer with `onScrollGeometryChange` + a hand-rolled `Layout` (nilcoalescing, March 2025).
+- **Removing `.scrollTargetLayout()` (the in-flight experiment) is supported by the evidence**, but is unlikely to be sufficient on its own — the deeper problem is `LazyVStack` with MarkdownUI rows of unknown height. Plan for migrating the transcript pane to `List`.
+
+## OSS projects worth studying
+
+### 1. **Dimillian/IceCubesApp** — SwiftUI Mastodon client (iOS/macOS/iPadOS/visionOS)
+- Repo: <https://github.com/Dimillian/IceCubesApp>
+- Why relevant: A Mastodon home timeline is functionally equivalent to a chat transcript: thousands of rows, each containing markdown-ish rich text (HTML, custom emoji), images, and interactive cards. Multi-platform incl. macOS. Active and mature.
+- **What they do:** `List`, not `LazyVStack`.
+  - `Packages/Timeline/Sources/Timeline/View/TimelineListView.swift` (verified):
+    ```swift
+    ScrollViewReader { proxy in
+      List {
+        ScrollToView()...
+        TimelineTagGroupheaderView(...)
+        TimelineTagHeaderView(...)
+        StatusesListView(...)
+      }
+      .id(client.id)
+      .environment(\.defaultMinListRowHeight, 1)
+      .listStyle(.plain)
+      .scrollContentBackground(.hidden)
+      .onChange(of: viewModel.scrollToId) { _, newValue in
+        if let newValue {
+          proxy.scrollTo(newValue, anchor: .top)
+          ...
+        }
+      }
+      ...
+    }
+    ```
+  - `Packages/StatusKit/Sources/StatusKit/List/StatusesListView.swift` is just a `ForEach` of `StatusRowView`s — no `LazyVStack`, no `ScrollView` wrapper. The outer `List` provides recycling.
+  - **No usage of `scrollTargetLayout`, no `scrollPosition(id:)`, no `defaultScrollAnchor`** anywhere in the Timeline package. They use the older `ScrollViewReader` + `proxy.scrollTo(id, anchor: .top)`.
+  - The only `LazyVStack` in the repo is in `Packages/StatusKit/.../AutoComplete/ExpandedView.swift` — a small autocomplete popover, not a timeline. Confirmed via `gh` API code search.
+  - StatusKit rows use HTMLString and EmojiText (custom) rather than swift-markdown-ui directly for the body, but the principle holds: variable-height rich-text rows in a `List`.
+- Lessons: this is the strongest single piece of prior art for our problem. They already faced the user's exact axis (big transcripts of variable-height rich-content rows, on macOS, in modern SwiftUI) and chose `List` + `ScrollViewReader`.
+
+### 2. **gonzalezreal/swift-markdown-ui** — our actual dependency
+- Repo: <https://github.com/gonzalezreal/swift-markdown-ui>
+- README now says: *"Maintenance mode — new development in Textual: <https://github.com/gonzalezreal/textual>"*.
+- The maintainer's announcement post (Discussion #437, Jan 2026) frames Textual as a response to "rendering rich text in SwiftUI — layout, selection, attachments, performance, and extensibility" limits *that cannot be incrementally fixed in MarkdownUI's existing architecture*. This is corroboration that MarkdownUI's perf characteristics under SwiftUI's layout system are a known-bad problem the author has now stopped trying to fix in the existing codebase.
+- The maintainer's earlier explicit advice for `LazyVStack` use (#186, Feb 2023): provide an `ImageProvider` that produces fixed-height placeholders so row height does not change after image load — this prevents re-layout jumps. See [`Examples/Demo/Demo/LazyLoadingView.swift`](https://github.com/gonzalezreal/swift-markdown-ui/blob/main/Examples/Demo/Demo/LazyLoadingView.swift). (But this only addresses image-driven jumps, not the more fundamental cycle.)
+- Relevant issues (also see "MarkdownUI inside LazyVStack" section below):
+  - #426 (Oct 2025, OPEN) "swift-markdown-ui struggles with long Markdown text" — entire app freezes, reproduced in vanilla SwiftUI. Contributor MojtabaHs attributes it to "excessive nesting" and SwiftUI's `Environment` propagation; fix would require iOS 17+ `@Observable`.
+  - #445 (Apr 2026, OPEN) — performance issue with deeply nested ordered/unordered lists. Comment from another user notes it's similar/duplicate of #426, still unresolved.
+  - #310 (Apr 2024, OPEN) — "Severe hang when rendering a short markdown string with 6-level nested bullet points," 1–2 s hang on a small markdown string. Reduces to no-hang at 4 levels of nesting. Maintainer acknowledged but never fixed.
+  - #209, #186 (closed but instructive): jumps and "shaking up and down" inside `LazyVStack` with MarkdownUI; resolved as "use a fixed-height image placeholder" or "you have nested vertical scrollers."
+
+### 3. **GetStream/stream-chat-swift-ai** — commercial chat SDK with AI streaming UI
+- Repo: <https://github.com/GetStream/stream-chat-swift-ai>
+- Relevant because they specifically targeted the "stream Claude/ChatGPT-style markdown" use case, and ship a `StreamingMessageView`.
+- They depend on `swift-markdown-ui` (so they hit the same library limits) and on John Sundell's `Splash` for code highlighting.
+- Their "letter by letter animation, with a character queue" approach is interesting for streaming, but tangential to the static rendering perf question.
+- Did not return clear evidence that they wrap rows in NSCollectionView/UITableView — appears to be standard SwiftUI containers. (Limited public source detail.)
+
+### 4. **Dimillian/IceCubesApp** Discord/Slack/Telegram OSS macOS-SwiftUI clients — mostly absent
+- Slack/Discord/Telegram do not have OSS SwiftUI macOS clients of any consequence as of 2026. Telegram-iOS exists but is UIKit and iOS-only. Most "SwiftUI Telegram clients" on GitHub are toy projects; not useful prior art.
+- The closest pure-SwiftUI macOS chat OSS apps found (`alfianlosari/ChatGPTSwiftUI`, `Panl/AICat`, `zahidkhawaja/swiftchat`, `halavins/SwiftUI-Chat`) are smaller-scale and don't push the thousands-of-rows scenario; they won't have battle-tested patterns relevant here.
+
+### 5. **flocked/AdvancedCollectionTableView** — `NSCollectionView`/`NSTableView` modernization
+- Repo: <https://github.com/flocked/AdvancedCollectionTableView>; Swift Forums announcement: <https://forums.swift.org/t/introducing-advancedcollectiontableview-a-framework-for-nscollectionview-nstableview-ports-many-newer-uikit-apis/69305>
+- Relevant because if/when we drop down to AppKit for the transcript pane, this library backports modern UICollectionView APIs (cell registration, content configurations including `NSHostingConfiguration` for SwiftUI cells) to AppKit.
+- Combined with Apple's [WWDC22 "Use SwiftUI with AppKit"](https://developer.apple.com/videos/play/wwdc2022/10075/) (which introduced `NSHostingConfiguration` precisely so you can keep SwiftUI row views inside an `NSCollectionView`), this is the supported escape hatch on macOS.
+
+### 6. **kean.blog: "...But Not NSTableView"** (Mar 2021, Alex Grebenyuk)
+- URL: <https://kean.blog/post/not-list>
+- Direct prior art for exactly the path "I had SwiftUI `List`; perf was unacceptable; I rewrote with `NSTableView`." Cites: List's automatic diffing breaks `fetchBatchSize`, no obvious cell reuse, navigation delays. Old (2021) but the underlying concern that List can't always hit native AppKit perf still appears in 2025 commentary.
+
+### 7. **nilcoalescing.com — "Designing a custom lazy list in SwiftUI with better performance"** (Mar 2025)
+- URL: <https://nilcoalescing.com/blog/CustomLazyListInSwiftUI/>
+- Custom `Layout` + `onScrollGeometryChange` + view-identity recycling (fragment ID = index % maxVisibleRows). Notable as a recent macOS-flavored windowed-rendering pattern from a well-trafficked SwiftUI blog. Worth knowing as the most "modern" custom approach short of `NSCollectionView`.
+
+### 8. **manaflow-ai/cmux issue #2327** — exact symptom prior art
+- URL: <https://github.com/manaflow-ai/cmux/issues/2327> (2025)
+- A SwiftUI sidebar (LazyVStack / ScrollView) entered an infinite layout recalculation loop, pegged 100% CPU, did not recover even after scrolling stopped. Captured stack: `__CFRunLoopDoObservers → NSRunLoop.flushObservers → NSHostingView.beginTransaction → ViewGraphRootUpdater.updateGraph → GraphHost.flushTransactions → AG::Subgraph::update → LazySubviewPlacements.placeSubviews → LazyStack.place`. **Causes identified**: (a) `ForEach(Array(tabManager.tabs.enumerated()))` allocates new array each layout pass → identity instability → full re-layout; (b) O(n²) work in the `ForEach` body; (c) fan-out of `@AppStorage` subscriptions across all visible items.
+- Direct match for the user's "44 s SwiftUI layout hang while scrolling up" with a deep `StackLayout.placeChildren` cycle.
+
+### 9. **chrysb/LazyVStackStutter**
+- URL: <https://github.com/chrysb/LazyVStackStutter>
+- Minimal repro of LazyVStack stuttering when "scrolling down then flicking back to top." Author's note (still in README) says this perf bug "is the only thing that's preventing SwiftUI from being used in more complex applications." Apple developer forums thread says this was *largely* fixed in iOS 17.4 — but reports persist on macOS / for variable-height content.
+
+## Known SwiftUI pitfalls (with evidence)
+
+### A. `LazyVStack` with variable-height rows: jumps and infinite-resize cycles
+- Apple Developer Forums, [thread/685461](https://developer.apple.com/forums/thread/685461) — "[Critical Issue] Content with variable height in a LazyVStack" (Jul 2021, updated Feb 2024). OP confirms partial fix in iOS 17.4. Workarounds: hoist variable-height content out of the lazy stack, use `List`, stabilize ForEach.
+- **Severity for our hang: HIGH.** Our rows include MarkdownUI bodies, code blocks, images, and tool-call cards — all variable height.
+
+### B. `ScrollView { LazyVStack }` re-initializes all child views on a state change
+- Apple Developer Forums, [thread/657902](https://developer.apple.com/forums/thread/657902) (filed FB8401910). OP found that toggling expanded state on one row called `init` on every row in a 500-row list. Author concluded `LazyVStack` is unsuitable; recommended `UICollectionView` via `UIViewRepresentable`.
+- **Severity: HIGH** — even ignoring our hang, this argues against `LazyVStack` for our scale.
+
+### C. `LazyVStack` + `defaultScrollAnchor(.bottom)` is fragile
+- Apple Developer Forums, [thread/741406](https://developer.apple.com/forums/thread/741406) (Nov 2023 → Jan 2025) — for chat apps, `LazyVStack + defaultScrollAnchor(.bottom)` shows blank on re-entry until the user scrolls up. Workarounds: `ScrollPosition` API with `scrollTo(edge: .bottom)` in `.onAppear`; or 180° flip the entire list.
+- **Severity for us: HIGH.** This is exactly TBD's *issue #2* (blank-on-re-entry) — independent confirmation it is a framework-level fragility, not user error.
+
+### D. `scrollTargetLayout` + `scrollPosition(id:)` on large datasets has "serious performance issues"
+- Fatbobman, [Deep Dive into the New Features of ScrollView in SwiftUI](https://fatbobman.com/en/posts/new-features-of-scrollview-in-swiftui5/) (Jun 2023, updated Dec 2025) — explicitly: *"there are still serious performance issues when the dataset is large"* with `scrollPosition(initialAnchor:)` and `scrollPosition(id:)`.
+- **Severity: HIGH** for our particular `.scrollTargetLayout()` experiment. Fatbobman is one of the most authoritative SwiftUI bloggers and updated this specifically through 2025.
+
+### E. Unstable `ForEach` data identity → full re-layout
+- cmux #2327 (above): `ForEach(Array(...enumerated()))` allocates a fresh array each pass; LazyVStack thinks it's all-new and rebuilds.
+- WWDC23 "Demystify SwiftUI Performance" — cites identity stability and avoiding work in `body` as primary perf levers.
+- **Severity: MEDIUM-HIGH** — easy to get wrong; check our transcript code's ForEach signature.
+
+### F. List on macOS specifically: AsyncImage re-fetching, slow updates
+- "How to fix slow List updates in SwiftUI" (Hacking with Swift), and List-vs-LazyVStack benchmarks (Fatbobman, STRV) — agree that **as of iOS 18 / macOS 15, List has caught up and generally outperforms LazyVStack on memory and on long lists** (cell recycling). On older macOS (≤ 13) List was problematic; on Sonoma/Sequoia it's the safer default.
+- **Severity for us: LOW now**; we target macOS 15+. List is a viable target.
+
+## Workarounds the community uses
+
+Ranked by maturity + adoption.
+
+### 1. (Most adopted) Use `List` instead of `ScrollView { LazyVStack }`
+- OSS evidence: IceCubesApp `TimelineListView.swift`. Apple Developer Forums consensus across multiple threads (685461, 657902, 690711). Donny Wals (May 2025), Fatbobman, jacobstechtavern (May 2025), STRV all converge on this.
+- Behavior: List on macOS 15 wraps `NSTableView`/`UICollectionView`-style infrastructure with real cell recycling; rows leave memory when far off-screen.
+- Caveats: less layout flexibility (List separators, insets, row backgrounds via `listRow*` modifiers, no easy "pinned bottom" anchor). Programmatic scrolling uses `ScrollViewReader` + `proxy.scrollTo(id, anchor: ...)` or `.scrollPosition(id:)` (latter exists on List too in iOS 18 / macOS 15, but proxy-based is the IceCubes-tested path).
+- For chat-style "stick to bottom" UX, IceCubes-style + a programmatic `proxy.scrollTo(lastID, anchor: .bottom)` on append is the safest pattern.
+
+### 2. Stabilize identity, hoist variable-height content out of `LazyVStack`, give rows fixed/predictable height
+- Apple Developer Forums consensus. Maintainer of swift-markdown-ui specifically (#186) — fixed-height image placeholders.
+- For our case: would require knowing or estimating each row's height before it's rendered, which is hard for arbitrary markdown + tables + code blocks.
+- This buys us a partial fix for jump/jitter but **does not address the deep `placeChildren → sizeThatFits` cycle** if the cycle is rooted in MarkdownUI's internal layout.
+
+### 3. Drop into `NSCollectionView` (or `NSTableView`) via `NSViewRepresentable`
+- `NSHostingConfiguration` (WWDC22 "Use SwiftUI with AppKit") lets you keep SwiftUI cell views.
+- `flocked/AdvancedCollectionTableView` modernizes cell registration on AppKit.
+- Kean.blog "Not List" (2021) is the historical blueprint.
+- This is the heaviest lift but is the sanctioned escape hatch for "I need real cell recycling, full control of layout, and known cell heights."
+- Mastodon clients didn't go this far — `List` was enough for them. So this should be a last resort.
+
+### 4. Custom windowed-rendering layout
+- nilcoalescing (Mar 2025): `onScrollGeometryChange` + a custom `Layout` that places only visible rows; row identity recycling via `index % maxVisibleRows`.
+- Pure-SwiftUI, no AppKit bridging. Newer; less battle-tested. Useful template if `List` constraints become a problem.
+
+### 5. PreferenceKey-based "current visible row" + manual virtualization
+- Older (2020-era) pattern. Largely superseded by `onScrollGeometryChange` + `scrollPosition`. Mentioned only because it appears in older blog posts; not recommended in 2026.
+
+## Specific findings on MarkdownUI inside LazyVStack
+
+Direct evidence from the swift-markdown-ui repo:
+
+| Issue | Title | Status | Notes |
+|---|---|---|---|
+| [#186](https://github.com/gonzalezreal/swift-markdown-ui/issues/186) (Feb 2023) | "MarkdownUI is not usable inside LazyVStack" | CLOSED with workaround | Maintainer: only repros with images; provide a fixed-height ImageProvider placeholder. Workaround in [`LazyLoadingView.swift`](https://github.com/gonzalezreal/swift-markdown-ui/blob/main/Examples/Demo/Demo/LazyLoadingView.swift). Doesn't address text-driven re-layouts. |
+| [#209](https://github.com/gonzalezreal/swift-markdown-ui/issues/209) (Apr 2023) | "MarkdownUI in LazyVStack inside ScrollView, page cannot scroll, layout shaking up and down" | CLOSED | Some cases caused by nested vertical scrollers, but multiple users (incl. djmango Mar 2024, gluonfield Apr 2024) say they hit it without nested scrollers. |
+| [#310](https://github.com/gonzalezreal/swift-markdown-ui/issues/310) (Apr 2024) | "Severe hang ... 6-level nested bullet points" | OPEN | Hundreds of chars, 1–2 s hang. 5 levels still hangs; 4 levels does not. Maintainer acknowledged, never fixed. |
+| [#426](https://github.com/gonzalezreal/swift-markdown-ui/issues/426) (Oct 2025) | "Performance issue: swift-markdown-ui struggles with long Markdown text" | OPEN | App freezes on a single moderate-length markdown blob. Contributor MojtabaHs (Nov 2025): cause is "excessive nesting" interacting with SwiftUI `Environment` propagation; fix requires `@Observable` and iOS 17+. |
+| [#445](https://github.com/gonzalezreal/swift-markdown-ui/issues/445) (Apr 2026) | "Performance issue when rendering deeply nested ordered/unordered lists" | OPEN | Cross-references #426. |
+| [Discussion #261](https://github.com/gonzalezreal/swift-markdown-ui/discussions/261) (Sep 2023) | "How to optimize performance for repeated rendering on live chat messages?" | UNANSWERED | OP describes streaming chat re-render storm; no answer from maintainer in 2.5 years. |
+| [Discussion #437](https://github.com/gonzalezreal/swift-markdown-ui/discussions/437) (Jan 2026) | "Introducing Textual and future direction" | Maintainer announces MarkdownUI is in maintenance mode; cites "layout, selection, attachments, performance, and extensibility" limits as architectural and motivating Textual. |
+
+**Implication:** MarkdownUI's per-row internal layout cost is non-trivial and the maintainer treats it as architectural. Even in a perfectly recycling `List`, each MarkdownUI row will still be expensive to size. Mitigations:
+- Avoid deeply-nested lists in the rendered markdown (we don't fully control this — Claude transcripts can have nested lists).
+- Cache the parsed `MarkdownContent` per row (parse once, in the row view-model, not in `body`).
+- Consider migrating to **Textual** when it's stable enough — same author, designed to fix exactly these limits.
+- Or consider a simpler "AttributedString from Markdown" path for messages without code blocks/tables, falling back to MarkdownUI only when needed.
+
+## Recommendations for our specific problem
+
+Given:
+- LazyVStack + `.scrollTargetLayout()` + `.scrollPosition(id:)` + `.defaultScrollAnchor(.bottom)`
+- Rows = MarkdownUI + code blocks + tool-call cards, variable height
+- Long transcripts (1000s of items)
+- macOS 15 (Sonoma)
+- Symptom: 44 s `StackLayout.placeChildren → … → _PaddingLayout.sizeThatFits` cycle on scroll-up
+
+**The evidence converges on a clear primary path: replace the `LazyVStack`/`scrollTargetLayout` with `List`.**
+
+Concretely, in the order I'd attempt them:
+
+1. **Phase 0 (already in flight): remove `.scrollTargetLayout()`.** Fatbobman explicitly flags its perf cost on large datasets, and we lose nothing by dropping it if we're not using `.scrollTargetBehavior(.viewAligned)`. Independent reasonable bet — but unlikely to be sufficient by itself.
+
+2. **Phase 1: migrate the transcript pane to `List`.** This is the IceCubes-pattern, the Apple-Forum-consensus, and the Apple-blog-consensus path. Specifics:
+   - `List { ForEach(messages, id: \.stableID) { row(for: $0) } }`
+   - `.listStyle(.plain)`
+   - `.environment(\.defaultMinListRowHeight, 1)` to suppress List's 44 pt minimum row height (IceCubes does this).
+   - `.scrollContentBackground(.hidden)` so we keep our chat background.
+   - `.listRowSeparator(.hidden)`, `.listRowBackground(...)`, `.listRowInsets(...)` to recover the visual chat-bubble look.
+   - Replace `.defaultScrollAnchor(.bottom)` with `ScrollViewReader { proxy in List { ... } }` and call `proxy.scrollTo(lastID, anchor: .bottom)` in `.onAppear` and on `messages` append. This is what IceCubes does and fixes both the "blank on re-entry" issue and the layout cycle.
+   - Verify: `ForEach`'s collection is the message array directly (not `Array(messages.enumerated())`) and the id is stable across recomputations. (cmux #2327 lesson.)
+
+3. **Phase 2 (if Phase 1 isn't enough): row-level mitigations.**
+   - Parse markdown once per message and cache the `MarkdownContent` on the message model — never call `Markdown(rawString)` from `body`.
+   - Make each row's `View` `Equatable` and apply `.equatable()` (recommended by Hacking-with-Swift "How to fix slow List updates") so List can short-circuit re-renders.
+   - For images, ensure fixed-height placeholders (MarkdownUI #186 maintainer guidance).
+   - Audit deeply-nested bullet rendering — if Claude transcripts produce >5 levels, flatten or cap nesting (MarkdownUI #310, #426).
+
+4. **Phase 3 (only if `List` + row mitigations still hangs): NSCollectionView via `NSViewRepresentable`.** With `NSHostingConfiguration` to keep SwiftUI row views. Use `flocked/AdvancedCollectionTableView` to avoid hand-rolling cell registration. This is the heaviest lift; reserve for last.
+
+5. **Track Textual** (the swift-markdown-ui successor). If it ships a real public API and supports macOS by the time we're choosing a long-term direction, plan a migration. The maintainer specifically cited the layout/perf issues we're hitting as the reason for the rewrite.
+
+**Things to deliberately avoid:**
+- Don't try to "fix" `LazyVStack` perf with `.fixedSize()` / `.frame(minHeight:)` band-aids on rows. The community has tried and the consensus is it doesn't reliably break the cycle when rows truly need variable height.
+- Don't write a custom `Layout` (nilcoalescing-style) until `List` has been ruled out; it's a much larger maintenance commitment than `List`.
+- Don't keep both `.scrollPosition(id:)` *and* `.defaultScrollAnchor(.bottom)` — they fight for control of the scroll position and the combination is part of how we ended up with the blank-on-re-entry bug.
+
+## Strongest single recommendation
+
+Migrate the transcript pane from `LazyVStack` + `scrollTargetLayout` + `scrollPosition(id:)` + `defaultScrollAnchor(.bottom)` to `List` driven by `ScrollViewReader.proxy.scrollTo`, mirroring the IceCubesApp `TimelineListView` pattern (`List { … }.listStyle(.plain).environment(\.defaultMinListRowHeight, 1)` plus `.listRowSeparator(.hidden)` / `.listRowInsets(...)` for chat styling). This is the single most evidence-supported change: it directly addresses the `_PaddingLayout.sizeThatFits → StackLayout.placeChildren → …` recursion (because `List` doesn't compute total content height in SwiftUI's layout system the way `LazyVStack` does), it fixes the blank-on-re-entry behavior (no anchor fight; programmatic `scrollTo(lastID, anchor: .bottom)` is reliable), and it recovers real cell recycling (rows leave memory when scrolled far away, instead of accumulating in `LazyVStack`'s realized set). Pair it with a one-time parse of MarkdownUI content per message and `.equatable()` row views, and consider planning a follow-up migration to Textual once it stabilizes — the same swift-markdown-ui maintainer has explicitly retired MarkdownUI in maintenance mode citing the exact layout/performance limits we are hitting.
+
+## Sources
+
+- IceCubesApp Timeline (List): <https://github.com/Dimillian/IceCubesApp/blob/main/Packages/Timeline/Sources/Timeline/View/TimelineListView.swift>
+- IceCubesApp StatusesListView: <https://github.com/Dimillian/IceCubesApp/blob/main/Packages/StatusKit/Sources/StatusKit/List/StatusesListView.swift>
+- swift-markdown-ui repo / maintenance-mode README: <https://github.com/gonzalezreal/swift-markdown-ui>
+- swift-markdown-ui issues: [#186](https://github.com/gonzalezreal/swift-markdown-ui/issues/186), [#209](https://github.com/gonzalezreal/swift-markdown-ui/issues/209), [#310](https://github.com/gonzalezreal/swift-markdown-ui/issues/310), [#426](https://github.com/gonzalezreal/swift-markdown-ui/issues/426), [#445](https://github.com/gonzalezreal/swift-markdown-ui/issues/445)
+- swift-markdown-ui discussions: [#261 streaming chat perf](https://github.com/gonzalezreal/swift-markdown-ui/discussions/261), [#437 Textual announcement](https://github.com/gonzalezreal/swift-markdown-ui/discussions/437)
+- Apple Developer Forums:
+  - [thread/685461 — Variable height in LazyVStack (critical)](https://developer.apple.com/forums/thread/685461)
+  - [thread/657902 — ScrollView+LazyVStack perf (FB8401910)](https://developer.apple.com/forums/thread/657902)
+  - [thread/690711 — LazyVStack flickers when scrolling](https://developer.apple.com/forums/thread/690711)
+  - [thread/741406 — LazyVStack + defaultScrollAnchor(.bottom) blank-on-reentry](https://developer.apple.com/forums/thread/741406)
+- Apple WWDC23 [Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/)
+- Apple WWDC22 [Use SwiftUI with AppKit (NSHostingConfiguration)](https://developer.apple.com/videos/play/wwdc2022/10075/)
+- Apple [Creating performant scrollable stacks](https://developer.apple.com/documentation/swiftui/creating-performant-scrollable-stacks)
+- Fatbobman, [Deep Dive into the New Features of ScrollView in SwiftUI](https://fatbobman.com/en/posts/new-features-of-scrollview-in-swiftui5/) (Jun 2023, upd Dec 2025) — `scrollTargetLayout`/`scrollPosition` perf warning
+- Fatbobman, [List or LazyVStack — Choosing the Right Lazy Container](https://fatbobman.com/en/posts/list-or-lazyvstack/) — benchmarks
+- jacobstechtavern, [SwiftUI Scroll Performance: The 120FPS Challenge](https://blog.jacobstechtavern.com/p/swiftui-scroll-performance-the-120fps) (May 2025) — List wins for infinite feeds
+- Donny Wals, [Choosing between LazyVStack, List, and VStack in SwiftUI](https://www.donnywals.com/choosing-between-lazyvstack-list-and-vstack-in-swiftui/) (May 2025)
+- Kean (Alex Grebenyuk), [...But Not NSTableView](https://kean.blog/post/not-list) (Mar 2021) — historical NSTableView replacement story
+- nilcoalescing, [Designing a custom lazy list in SwiftUI with better performance](https://nilcoalescing.com/blog/CustomLazyListInSwiftUI/) (Mar 2025) — windowed renderer pattern
+- manaflow-ai/cmux issue [#2327 — Sidebar scroll triggers infinite SwiftUI layout loop](https://github.com/manaflow-ai/cmux/issues/2327) — direct symptom match
+- chrysb [LazyVStackStutter repro repo](https://github.com/chrysb/LazyVStackStutter)
+- process-one, [Writing a Custom Scroll View with SwiftUI in a chat application](https://www.process-one.net/blog/writing-a-custom-scroll-view-with-swiftui-in-a-chat-application/) (Oct 2019, historical)
+- flocked, [AdvancedCollectionTableView](https://github.com/flocked/AdvancedCollectionTableView) and [Swift Forums announcement](https://forums.swift.org/t/introducing-advancedcollectiontableview-a-framework-for-nscollectionview-nstableview-ports-many-newer-uikit-apis/69305)
+- GetStream, [stream-chat-swift-ai](https://github.com/GetStream/stream-chat-swift-ai) — depends on swift-markdown-ui
+- Hacking with Swift, [How to fix slow List updates in SwiftUI](https://www.hackingwithswift.com/articles/210/how-to-fix-slow-list-updates-in-swiftui) — `Equatable` + `.equatable()` modifier

--- a/docs/superpowers/specs/research-2026-05-06-zstack-event-leak.md
+++ b/docs/superpowers/specs/research-2026-05-06-zstack-event-leak.md
@@ -1,0 +1,292 @@
+# Research: SwiftUI ZStack event leakage to opacity-0 views on macOS
+
+Date: 2026-05-06
+Target: macOS 15 (Sequoia), SwiftUI keep-alive pattern using `ZStack` + `.opacity` + `.allowsHitTesting`.
+
+## TL;DR
+
+- **`.allowsHitTesting(false)` does NOT reliably block AppKit-level scroll-wheel events on macOS.** The modifier participates in SwiftUI's hit-test plumbing, but the underlying AppKit hit-test that `NSWindow.sendEvent(_:)` performs for scroll wheel routing is not fully driven by it. macOS 15 made this much worse: `_hitTestForEvent` is the single dominant cost in scroll handling and hit-tests the entire view tree thousands of times per scroll. This is consistent with our symptoms (slow scroll on the active view, scroll events delivered to the inactive worktree's terminal NSView).
+- **Opacity 0 is fundamentally not the same as hidden in AppKit.** `NSView.alphaValue == 0` does NOT exclude a view from `hitTest(_:)`. Only `isHidden == true` (and a zero `frame` size, and `isUserInteractionEnabled == false` on iOS) reliably remove a view from hit-testing. SwiftUI's `.opacity(0)` lowers to `alphaValue` rather than `isHidden`.
+- **The two known fixes for scroll-wheel leakage are: `.hidden()` (which DOES yield SwiftUI views that don't participate in events) or NSViewRepresentable wrappers that override `hitTest` / `scrollWheel`.** `.scrollDisabled(true)` is environmental and propagates to descendant `ScrollView`s, but it does NOT do anything for embedded `NSScrollView`/SwiftTerm views, and it does not stop AppKit hit-tests against the inactive subtree.
+- **`TabView` on macOS appears to do this correctly for its own content** because internally it is backed by `NSTabView`, which keeps inactive tabs as live but hidden subviews (`isHidden = true`) — so they're skipped in `hitTest`. The hidden-tab trick is the closest "official" pattern for keep-alive without event leakage.
+- **Recommendation for our situation:** drop `.opacity(0)` in favor of conditional `.hidden()` on inactive worktrees, OR wrap each `SingleWorktreeView` in an `NSViewRepresentable` that toggles `isHidden` on its underlying `NSView` when inactive. If we want to stay declarative, switching the `ZStack` to a hidden-styled `TabView` is the lowest-risk path. Pure `.opacity(0)` keep-alive is a dead end on macOS 15.
+
+---
+
+## Confirmed: does `.allowsHitTesting(false)` block scroll-wheel events?
+
+### Short answer
+
+**No, not reliably on macOS, especially not for scroll-wheel events delivered into an embedded `NSScrollView` or other `NSViewRepresentable`.**
+
+### Evidence
+
+1. **Public radar FB9022612 — "ScrollView overrides allowsHitTesting property of underlying views"** ([openradar entry][openradar-fb9022612], surfaced in search results for the SwiftUI hit-test override behavior). The radar documents that on macOS, putting hit-test-disabled content inside a `ScrollView` causes `allowsHitTesting(false)` to be ignored. The radar specifically notes the bug does not reproduce on iOS. This is a long-standing macOS-specific divergence between the SwiftUI modifier's documented behavior and the AppKit-layer reality.
+
+2. **Apple Developer Forums — "SwiftUI HitTesting cannot be disabled" ([thread/670198][forum-670198])**. A `Rectangle().allowsHitTesting(false)` overlaid on a `ScrollView` blocks pan-to-scroll and Toggle interaction. The thread received no Apple acknowledgment and no clean workaround; the consensus is that `.allowsHitTesting` participates in SwiftUI's gesture layer but not necessarily in AppKit's responder/hit-test path.
+
+3. **Apple Developer Forums — "SwiftUI ScrollView performance in macOS 15" ([thread/764264][forum-764264])**. Apple-acknowledged regression (FB15241636) in macOS 15.0–15.3 where `_hitTestForEvent` consumed 70–85% of scroll-event processing time, causing 300ms response delays and "thousands of hitTest calls per scroll event" on M3 Max. Confirmed by multiple developers, partially fixed in 15.4 beta. This means **macOS 15's scroll wheel pipeline drives extremely aggressive hit-testing through the entire SwiftUI subtree**, including inactive subtrees that are merely opacity-0. Combined with point 1, this explains exactly the perf symptom we're seeing on the active view: the framework is hit-testing the inactive `LazyVStack` for every scroll event too.
+
+4. **AppKit Cocoa Event Handling Guide ([Event Architecture][cocoa-event-arch])**. NSWindow.sendEvent dispatches mouse-class events (which scroll wheel is) by calling `hitTest(_:)` on the content view and forwarding to **the lowest descendant under the cursor**, not to the first responder. So whichever `NSView` is geometrically under the cursor wins, regardless of SwiftUI's view-tree opinions. SwiftUI's `.allowsHitTesting(false)` does not change the underlying `NSView`'s response to AppKit-layer hit-tests.
+
+5. **Apple Developer Forums — "NSViewRepresentable, NSScrollView and missing mouse events" ([Swift Forums][swift-nsview-rep])**. Consistent reports that mouse events are routed by AppKit hit-testing irrespective of SwiftUI modifier wrapping; the only fix is to manipulate the underlying `NSView` directly.
+
+### Platform / version differences
+
+- **iOS / iPadOS:** `.allowsHitTesting(false)` reliably blocks gestures, including pan-induced scrolls, because UIKit's `hitTest(_:with:)` returns nil for `isUserInteractionEnabled == false` and the SwiftUI bridge sets that. UIKit does not have a peer to AppKit's scroll-wheel-via-hitTest path.
+- **macOS 14 (Sonoma):** Hit-test cost was much lower; the leakage was theoretically present but rarely observable for normal apps. `.allowsHitTesting` mostly "looked right" by accident.
+- **macOS 15 (Sequoia):** The hit-test storm exposes the leakage as serious perf regressions, and the bug ([forum-764264][forum-764264]) is officially acknowledged. macOS 15.4 beta improved it but the architectural issue with opacity-0 keep-alive remains.
+
+---
+
+## What primitives actually block scroll-wheel and AppKit-delivered events?
+
+### `.disabled(true)`
+Sets a generic SwiftUI environment value `isEnabled = false`. SwiftUI controls (`Button`, `TextField`, `Toggle`, `ScrollView` after iOS 16/macOS 13 — see `scrollDisabled` below) respect it, but **`.disabled` is NOT propagated as `NSView.isHidden`** and does not block scroll-wheel events on a SwiftTerm-style `NSViewRepresentable`. It also does not remove the view from the AppKit hit-test path. Useful for keyboard/input but not a scroll-wheel solution.
+
+### `.scrollDisabled(true)` (iOS 16 / macOS 13+)
+Documented at [scrollDisabled(_:)][docs-scrolldisabled]. Sets the `isScrollEnabled` environment value, which all SwiftUI `ScrollView`/`List` descendants observe. **Two key limitations:**
+- It only affects SwiftUI scrollable views. Our embedded SwiftTerm `NSView` (and any other `NSViewRepresentable` wrapping `NSScrollView`) **does not observe this environment** and will keep handling its own `scrollWheel(with:)`.
+- Even on the SwiftUI `ScrollView` it disables scrolling but doesn't remove the view from AppKit hit-testing — the hit-test storm continues.
+
+So `.scrollDisabled(true)` is necessary-but-not-sufficient: it stops the active SwiftUI ScrollView in the inactive subtree from responding, but does nothing for the SwiftTerm NSView leakage.
+
+### `.hidden()`
+This is the underrated answer. In SwiftUI, `.hidden()` is documented as removing the view from layout participation visually but **its lower-level effect on macOS is to set `NSView.isHidden = true` on the bridging host view**. Per AppKit docs and consistent across `hitTest(_:)` discussions ([CocoaDev ScrollWheelInNSView][cocoadev-scrollwheel], Eon's hit testing post, multiple sources):
+- `hitTest(_:)` **skips views with `isHidden == true`**.
+- `hitTest(_:)` **does NOT skip views with `alphaValue == 0`**.
+- Therefore `.hidden()` does block AppKit-layer scroll wheel routing into that subtree.
+
+**The catch**: `.hidden()` in SwiftUI is binary — there is no "hidden but keep-state" doc guarantee. In practice, SwiftUI does keep `.hidden()` views in its own state graph (the view's identity persists, `@StateObject` survives), so for keep-alive purposes it is largely equivalent to `.opacity(0)` — but with the crucial event-blocking behavior we want. The Swift Forums "Replicating TabView view hierarchy behavior" thread ([forum.swift.org/t/64872][forums-64872]) explicitly hypothesizes that `TabView` uses `.hidden()` plus PreferenceKey ferrying for exactly this reason.
+
+**Empirical note**: there is some cargo-cult belief that `.hidden()` "removes the view from the hierarchy." That's not what it does. Going to `if isActive { content }` versus `content.hidden()` is the real difference; `.hidden()` keeps the SwiftUI view alive but maps to `NSView.isHidden = true` for the host.
+
+### `.frame(width: 0, height: 0)`
+Reduces the view to a zero-size rectangle. AppKit's `hitTest(_:)` short-circuits when the point is not in the view's bounds. **This works** for blocking scroll wheel, but it visibly collapses layout, breaks `LazyVStack` realization (children are no longer in any visible viewport), and destroys the keep-alive property we need (off-screen content unloads, ScrollView contentOffset resets in some cases). Not a viable approach for our use case.
+
+### Summary table
+
+| Primitive                        | Blocks SwiftUI gestures | Blocks AppKit scroll-wheel into NSViewRepresentable | Preserves view state | Notes |
+|---------------------------------:|:-----------------------:|:---------------------------------------------------:|:--------------------:|:------|
+| `.opacity(0)` only               | No                      | No                                                  | Yes                  | Current; the bug                       |
+| `.allowsHitTesting(false)`       | Mostly, except in ScrollView | No                                            | Yes                  | rdar FB9022612 — known broken in ScrollViews |
+| `.disabled(true)`                | Yes (SwiftUI controls)  | No                                                  | Yes                  | Not relevant for scroll-wheel          |
+| `.scrollDisabled(true)`          | Stops scrolling in SwiftUI ScrollView | No (NSScrollView untouched)            | Yes                  | Necessary but not sufficient           |
+| `.hidden()`                      | Yes                     | **Yes** (maps to `NSView.isHidden`)                  | Yes (in practice)    | The right answer                       |
+| `.frame(width:0, height:0)`      | Yes                     | Yes                                                 | No (LazyVStack drops) | Breaks our keep-alive goal             |
+| Conditional `if active { ... }`  | Yes                     | Yes                                                 | No (full unmount)    | Defeats keep-alive                     |
+| NSViewRepresentable host that toggles `isHidden` | Yes      | Yes                                                 | Yes                  | Most explicit fix                      |
+
+---
+
+## How OSS macOS SwiftUI apps handle keep-alive without event leakage
+
+### Pattern 1 — `TabView` with hidden tab UI (most common)
+
+Apple's own `TabView` keeps non-active tabs alive as `NSTabViewItem`s, which on macOS are backed by `NSTabView` and use `isHidden = true` internally for inactive tabs. Apple lazily builds tab content on first selection (since iOS 18 / macOS 15) and then keeps each built tab indefinitely. The Apple Developer Forums thread on [TabView reload behavior][forum-tabview] describes this caching contract; the Kristaps Grinbergs "hidden secrets of TabView" article ([kristaps.me/blog/swiftui-tabview][kristaps-tabview]) confirms inactive tabs preserve `@State`.
+
+Several OSS apps follow this pattern with the visible tab strip suppressed via `PageTabViewStyle` / `.toolbar(.hidden, for: .tabBar)` (iOS 16+) / custom NSTabView wrapping. On macOS the standard `.tabViewStyle(.automatic)` shows a segmented tab strip; getting it fully invisible reliably requires either:
+- Using a custom `NSTabViewController`-based representable (preserves NSTabView's keep-alive + `isHidden` semantics), or
+- Layering a custom strip over `TabView` and just using its content area.
+
+The Apple Developer Forums [thread/784248][forum-784248] discusses the pain of hiding the macOS tab bar — it's not first-class supported with toolbar modifiers on macOS the way it is on iOS.
+
+### Pattern 2 — `StatefulTabView` / community packages
+
+[`StatefulTabView`][stateful-tabview] (Nicholas Bellucci) wraps `UITabBarController` for iOS to expose explicit "keep all tabs alive" semantics. There is no clean macOS analogue in the package ecosystem; macOS apps either accept TabView's defaults or roll their own.
+
+### Pattern 3 — `ZStack` + `.hidden()` (the right manual pattern)
+
+The Swift Forums thread [Replicating TabView view hierarchy behavior][forums-64872] explicitly arrives at the conclusion that the closest manual replication of TabView keep-alive is:
+
+```swift
+ZStack {
+    ForEach(ids) { id in
+        Content(id: id)
+            .opacity(id == active ? 1 : 0)   // visual
+            .allowsHitTesting(id == active)  // SwiftUI gestures
+            // Plus the missing piece for macOS scroll wheel:
+            // hidden when inactive
+    }
+}
+```
+
+…with the `hidden()` modifier applied via something like `.modifier(VisibilityModifier(isVisible: id == active))` so the inactive ones map to `isHidden = true` on their host `NSView`. That last piece is the specific upgrade the thread converges on, citing the `NSTabView` precedent.
+
+### Pattern 4 — ManagedWindow / multi-window scenes
+
+For Mac-native workflows, [`pd95/SwiftUI-macos-HandleWindow`][pd95-handlewindow], [`shufflingB/swiftui-macos-windowManagment`][shuffling-window], and Apple's [Bring multiple windows][apple-multiwindow] sample treat each "tab/document" as a separate `WindowGroup` window. Each window has its own NSWindow and event routing — there is no leakage because there's no shared parent. This is overkill for our case (we want a single window with switchable content) but worth noting as the architecturally cleanest solution if we ever pivot.
+
+### What we did NOT find
+
+- No mature OSS macOS SwiftUI app deliberately uses pure `ZStack` + `.opacity` + `.allowsHitTesting` for keep-alive of complex content with embedded `NSViewRepresentable`s. The closest patterns either rely on `TabView` (i.e., `NSTabView`'s `isHidden`) or per-window scenes.
+- No evidence of a `.zIndex` / `.background` / `.overlay` workaround for the scroll-wheel leakage. zIndex affects SwiftUI's render order, not AppKit hit-testing.
+
+---
+
+## TabView as an alternative
+
+### What it does right
+
+- Keeps non-selected tabs alive (`@State`/`@StateObject` preserved across switches) — verified by Apple Developer Forums and by the lifecycle docs ([Apple TabView docs][docs-tabview]).
+- Internally backed by `NSTabView` on macOS. `NSTabView`'s inactive tab views are `isHidden = true`, which **AppKit hit-tests skip**. So scroll-wheel events should not leak across tabs in a stock `TabView`.
+- Programmatic switching with `selection: $binding` is fully supported and we can drive it from `selectedWorktreeIDs.first`.
+
+### Caveats / sharp edges
+
+- **Hiding the macOS tab bar is not first-class.** The SwiftUI `.toolbar(.hidden, for: .tabBar)` modifier does not work on macOS. To get a totally invisible tab strip on macOS you typically need to either accept a thin tab strip styled minimally, or build a custom `NSViewControllerRepresentable` over `NSTabViewController` with `tabPosition = .none`.
+- **Lazy-by-first-visit, not eager-build.** As of iOS 18 / macOS 15, `TabView` builds each tab on first selection. If we want all worktrees realized up-front we'd need to programmatically select-then-deselect each in sequence at startup, OR live with first-switch latency.
+- **`@SceneStorage` and tab identity.** TabView ties identity to `.tag(...)`, so `selectedWorktreeIDs` switching needs the tag to be the worktree UUID. This is fine for our model but worth flagging.
+- **Custom view modifiers / environment values** sometimes don't propagate the same way through `TabView`'s internal tab containers as through a `ZStack`. Toolbars, focus, and key commands have all had reported issues.
+
+### Could we drop in `TabView` here?
+
+Probably yes, with two adjustments:
+1. Use an explicit `NSViewControllerRepresentable` wrapper around `NSTabViewController` with `tabStyle = .unspecified` and `tabPosition = .none` so the tab strip is totally invisible. This bypasses SwiftUI's macOS tab bar UI entirely while keeping `NSTabView`'s correct event semantics.
+2. Bind selection to `activeWorktreeID` and tag each worktree view with its UUID.
+
+This gets us the event-handling correctness "for free" because `NSTabView` does the right thing with `isHidden`.
+
+---
+
+## AppKit responder chain fundamentals (relevant subset)
+
+- `NSWindow.sendEvent(_:)` for mouse-class events (including `scrollWheel:`) calls `hitTest(_:)` on the content view to find the deepest descendant containing the cursor, and dispatches to that view. **It is not the first responder that gets the scroll-wheel event** — it is the view under the cursor.
+- `hitTest(_:)` skips views where `isHidden == true`. It does not skip views where `alphaValue == 0`. (Apple's `NSView.hitTest` discussion + the alphaValue documentation make this explicit; multiple developer write-ups confirm.)
+- Once `NSScrollView` has begun a tracking gesture, subsequent scroll wheel events for that gesture are NOT individually hit-tested — they're delivered to the same NSScrollView until the gesture ends. ([WWDC 2013 session 215, Optimizing Drawing and Scrolling on OS X][wwdc-2013-215].) This explains why "the wrong terminal scrolls": once a scroll gesture began over (or routed to) the inactive worktree's NSScrollView, the entire gesture stays there even though the cursor is over the active worktree.
+- **Removing a subview from the responder chain without removing it from the view hierarchy**: set `isHidden = true` on the subview (and ideally `nextResponder` is left intact so other paths still work). Setting `alphaValue = 0` does NOT remove it. There is no public "skip me in event delivery but draw me" flag; `isHidden` is the canonical mechanism.
+
+If we wrap each `SingleWorktreeView` in an `NSViewRepresentable` whose `updateNSView` toggles `nsView.isHidden = !isActive`, that achieves explicit responder-chain control while preserving SwiftUI keep-alive semantics for the wrapped subtree.
+
+---
+
+## Recommendations for our specific situation
+
+Ordered by effort/risk; pick one.
+
+### Option A — Replace `.opacity(0)` with `.hidden()` on inactive worktrees (Lowest effort, recommended first)
+
+```swift
+ZStack {
+    ForEach(worktreeIDs, id: \.self) { id in
+        SingleWorktreeView(worktreeID: id)
+            .opacity(id == activeWorktreeID ? 1 : 0)         // keep for transition crossfades if any
+            .allowsHitTesting(id == activeWorktreeID)
+            .modifier(InactiveHiddenModifier(isActive: id == activeWorktreeID))
+    }
+}
+
+private struct InactiveHiddenModifier: ViewModifier {
+    let isActive: Bool
+    func body(content: Content) -> some View {
+        if isActive { content } else { content.hidden() }
+    }
+}
+```
+
+`.hidden()` keeps the SwiftUI view in the hierarchy (preserving `@StateObject` and `LazyVStack` realization state) but maps to `NSView.isHidden = true`, which AppKit's hit-test skips — blocking scroll wheel leakage into both SwiftUI ScrollViews and the SwiftTerm NSView.
+
+**Risk**: I cannot 100% guarantee `.hidden()` always lowers to `isHidden` for every host view in the SwiftUI macOS bridge across all OS versions. There's some chance SwiftUI implements `.hidden()` as `alphaValue = 0` plus an internal flag, in which case this fix would not help. **Verify with Instruments** by checking whether `_hitTestForEvent` cost on the active worktree drops to baseline after this change, and by manually scrolling over the active worktree to confirm the SwiftTerm of the inactive worktree no longer scrolls.
+
+### Option B — NSViewRepresentable wrapper that explicitly toggles `isHidden`
+
+If Option A's `.hidden()` doesn't block scroll wheel reliably on macOS 15, wrap each `SingleWorktreeView`'s root in an explicit AppKit container:
+
+```swift
+struct ActivityGate<Content: View>: NSViewRepresentable {
+    let isActive: Bool
+    let content: () -> Content
+
+    func makeNSView(context: Context) -> NSHostingView<Content> {
+        NSHostingView(rootView: content())
+    }
+
+    func updateNSView(_ view: NSHostingView<Content>, context: Context) {
+        view.rootView = content()
+        view.isHidden = !isActive
+    }
+}
+```
+
+Then:
+```swift
+ZStack {
+    ForEach(worktreeIDs, id: \.self) { id in
+        ActivityGate(isActive: id == activeWorktreeID) {
+            SingleWorktreeView(worktreeID: id)
+        }
+    }
+}
+```
+
+`isHidden = true` is the canonical AppKit signal that `hitTest(_:)` must skip the subtree. Scroll wheel events cannot reach the SwiftTerm `NSView` inside a hidden `NSHostingView`. **Risk**: NSHostingView has its own quirks (sizing, autolayout participation, environment ferrying); some SwiftUI environment values won't cross the bridge cleanly. Test focus, key bindings, and environment objects.
+
+### Option C — Replace `ZStack` with `TabView`
+
+If Options A/B both miss subtle event paths (e.g., key event routing), use the OS-blessed mechanism. Wrap `NSTabViewController` directly to fully suppress the tab strip:
+
+```swift
+struct InvisibleTabContainer<Content: View>: NSViewControllerRepresentable {
+    @Binding var selection: UUID
+    let items: [(UUID, () -> Content)]
+
+    func makeNSViewController(context: Context) -> NSTabViewController {
+        let vc = NSTabViewController()
+        vc.tabStyle = .unspecified           // hide segmented control
+        vc.transitionOptions = []
+        return vc
+    }
+
+    func updateNSViewController(_ vc: NSTabViewController, context: Context) {
+        // sync vc.tabViewItems with items, then vc.selectedTabViewItemIndex = ...
+    }
+}
+```
+
+This is the "do what TabView does" path with full control over the chrome. **Risk**: ~150 lines of NSTabViewController bridging code, and SwiftUI environment/focus subtleties still need attention. Highest correctness, highest implementation cost.
+
+### Option D — Revert keep-alive entirely
+
+If the bug surface keeps growing, accept that SwiftUI macOS 15 is hostile to this pattern and rebuild scroll-position / `LazyVStack` realization preservation on top of explicit ViewModels (cache scroll offsets, eagerly load N transcripts). This is architecturally simpler but loses the "instant tab switch" feel.
+
+### Side-recommendations regardless of option
+
+- Add `.scrollDisabled(id != activeWorktreeID)` to inactive SwiftUI `ScrollView`s. Cheap insurance, costs nothing.
+- File a feedback report with Apple referencing FB15241636 (macOS 15 scroll perf) and FB9022612 (allowsHitTesting + ScrollView), specifically calling out the keep-alive use case.
+- Once a fix lands, verify with `log stream --level debug --predicate 'subsystem == "com.tbd.app"'` plus an Instruments scroll trace; the `_hitTestForEvent` percentage on the active worktree should drop substantially.
+
+---
+
+## Bottom line
+
+We should not keep pursuing the pure `.opacity(0)` + `.allowsHitTesting(false)` keep-alive pattern. It is structurally incompatible with how AppKit routes scroll-wheel events on macOS 15: opacity is not a signal AppKit hit-testing respects, `.allowsHitTesting` is overridden inside ScrollViews and bypassed by NSViewRepresentable scroll handling, and macOS 15 made the underlying hit-test storm orders of magnitude worse. Try Option A first (a one-line `.hidden()` modifier swap) — it's the smallest possible change and on paper should fix both the SwiftUI ScrollView lag and the SwiftTerm scroll-leakage. If `.hidden()` does not in practice lower to `NSView.isHidden = true` on macOS 15 (verify with Instruments), escalate to Option B (explicit NSHostingView wrapper toggling `isHidden`) or Option C (NSTabViewController-backed container), in that order. Keep `TabView` (Option C) as the long-term destination because it's what Apple's own framework uses to solve this exact problem, and the few macOS-specific awkwardnesses (hiding the tab strip) are bounded.
+
+---
+
+[openradar-fb9022612]: https://openradar.appspot.com/FB9022612
+[forum-670198]: https://developer.apple.com/forums/thread/670198
+[forum-650433]: https://developer.apple.com/forums/thread/650433
+[forum-742868]: https://developer.apple.com/forums/thread/742868
+[forum-764264]: https://developer.apple.com/forums/thread/764264
+[forum-728600]: https://developer.apple.com/forums/thread/728600
+[forum-tabview]: https://developer.apple.com/forums/thread/124749
+[forum-784248]: https://developer.apple.com/forums/thread/784248
+[forums-64872]: https://forums.swift.org/t/replicating-tabview-view-hierarchy-behavior/64872
+[swift-nsview-rep]: https://forums.swift.org/t/nsviewrepresentable-nsscrollview-and-missing-mouse-events/44157
+[cocoa-event-arch]: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/EventArchitecture/EventArchitecture.html
+[cocoadev-scrollwheel]: https://cocoadev.github.io/ScrollWheelInNSView/
+[docs-tabview]: https://developer.apple.com/documentation/SwiftUI/TabView
+[docs-scrolldisabled]: https://developer.apple.com/documentation/swiftui/view/scrolldisabled(_:)
+[docs-allowshittesting]: https://developer.apple.com/documentation/swiftui/view/allowshittesting(_:)
+[docs-nsview-hidden]: https://developer.apple.com/documentation/appkit/nsview/1483369-ishidden
+[docs-nsview-alpha]: https://developer.apple.com/documentation/appkit/nsview/1483560-alphavalue
+[docs-nsview-hittest]: https://developer.apple.com/documentation/appkit/nsview/1483364-hittest
+[docs-nsscrollview]: https://developer.apple.com/documentation/appkit/nsscrollview
+[wwdc-2013-215]: https://asciiwwdc.com/2013/sessions/215
+[kristaps-tabview]: https://kristaps.me/blog/swiftui-tabview/
+[stateful-tabview]: https://swiftpackageindex.com/NicholasBellucci/StatefulTabView
+[pd95-handlewindow]: https://github.com/pd95/SwiftUI-macos-HandleWindow
+[shuffling-window]: https://github.com/shufflingB/swiftui-macos-windowManagment
+[apple-multiwindow]: https://developer.apple.com/videos/play/wwdc2022/10061/
+[hier-responder]: https://github.com/EmilioPelaez/HierarchyResponder
+[swiftui-lab-combo]: https://swiftui-lab.com/a-powerful-combo/


### PR DESCRIPTION
## Summary

The Claude transcript pane was unusable on real workloads. Opening a 720-item transcript would freeze the UI for ~7s while SwiftUI eagerly realized every chat bubble; switching away/back re-froze it on teardown. Markdown tables came through as literal pipe-delimited soup. Scroll position reset on every worktree switch.

This PR makes the pane usable end-to-end:

- **Render markdown tables and other GFM block elements** in chat bubbles. Prose runs through MarkdownUI with a chat-tuned theme; inline markdown (`**bold**`, `*italic*`, `` `code` ``, `[links]`) stays pixel-equivalent to the prior `AttributedString` rendering.
- **Stop the multi-second freezes on long sessions.** `LazyVStack` + `defaultScrollAnchor(.bottom)` for declarative bottom-anchoring. After several iterations exploring `List` and other primitives (research docs included), this is the simplest combo that lands at the bottom synchronously, lazy-realizes the visible window, and lets the user scroll without jank.
- **Preserve scroll position, terminal scrollback, and view state across worktree navigation.** `SingleWorktreeView`s now live inside a `WorktreePager` — an `NSViewControllerRepresentable` wrapping `NSTabViewController` (`tabStyle = .unspecified`) keyed by an LRU of the 8 most recently visited worktrees. State preserved without re-mounting the SwiftUI tree.
- **Floating "jump-to-bottom" button** appears when the user scrolls up; clicking it animates back to the latest message. Plays well with `defaultScrollAnchor(.bottom)`'s freeze-on-scroll-up semantics.
- **Fix global scroll/click event-monitor leakage** revealed by the keep-alive change. `TerminalPanelView` registered app-wide `NSEvent` monitors per terminal that fired regardless of view-tree visibility — once a worktree was kept alive but detached from the window, scrolling the active transcript was forwarding mouse events to hidden tmux sessions and silently consuming the events meant for the visible ScrollView. Guard each monitor with `tv.window != nil`. Comments document why removing the guard re-introduces the cross-worktree leak.

The investigation behind the architecture (and the dead ends — `List` on macOS 15 isn't NSCollectionView-backed; `.opacity(0)` doesn't block AppKit scroll-wheel events; etc.) lives in `docs/superpowers/specs/research-2026-05-06-*.md` so future readers don't have to re-walk them.

## Test plan

- [ ] Open a long transcript (720+ items): lands at bottom in <100ms, scroll-up smooth, autoscroll on new messages.
- [ ] Scroll up to mid-content, switch to another worktree, switch back — scroll position preserved (no blank-on-revisit, no snap-to-bottom).
- [ ] Markdown tables in chat bubbles render as tables, not pipe-delimited text.
- [ ] Floating "↓" appears when scrolled up; clicking returns to bottom.
- [ ] Cross-worktree event isolation: scrolling the active worktree's transcript or terminal does NOT scroll any inactive worktree's terminal.
- [ ] Cmd+Click on file paths in the active terminal still works; doesn't fire for inactive worktrees' terminals.
- [ ] `swift test` — 576/576 pass.

open in TBD: \`tbd://open?worktree=C80EFB8C-7C3D-42E9-9600-6024CFB07462\`