### PR TITLE
DX: Tell TBD windows apart -- show worktree label instead of version in dev builds

### DIFF
--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -12,6 +12,19 @@ struct StatusBarView: View {
         return (worktree.path, worktree.repoID)
     }
 
+    private var footerLabel: (text: String, tooltip: String?) {
+        let version = "v\(TBDConstants.version)"
+        guard let execPath = Bundle.main.executablePath,
+              let buildRange = execPath.range(of: "/.build/") else {
+            return (version, nil)
+        }
+        let worktreePath = String(execPath[..<buildRange.lowerBound])
+        guard let worktree = appState.worktrees.values.flatMap({ $0 }).first(where: { $0.path == worktreePath }) else {
+            return (version, nil)
+        }
+        return (worktree.displayName, version)
+    }
+
     var body: some View {
         HStack {
             Circle()
@@ -22,8 +35,15 @@ struct StatusBarView: View {
             if let info = selectedWorktreeInfo {
                 OpenInEditorButton(path: info.path, repoID: info.repoID)
             }
-            Text("v\(TBDConstants.version)")
-                .foregroundStyle(.secondary)
+            let footer = footerLabel
+            if let tooltip = footer.tooltip {
+                Text(footer.text)
+                    .foregroundStyle(.secondary)
+                    .help(tooltip)
+            } else {
+                Text(footer.text)
+                    .foregroundStyle(.secondary)
+            }
         }
         .font(.caption)
         .padding(.horizontal)

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -15,7 +15,7 @@ struct StatusBarView: View {
     private var footerLabel: (text: String, tooltip: String?) {
         let version = "v\(TBDConstants.version)"
         guard let execPath = Bundle.main.executablePath,
-              let buildRange = execPath.range(of: "/.build/") else {
+              let buildRange = execPath.range(of: "/.build/", options: .backwards) else {
             return (version, nil)
         }
         let worktreePath = String(execPath[..<buildRange.lowerBound])


### PR DESCRIPTION
## Summary
- Replaces `v0.1.0` in the status bar footer with the running worktree's display name when TBD is launched from a dev build, so you can tell multiple TBD windows apart at a glance.
- Detection is path-based: `Bundle.main.executablePath` is split on `/.build/` to derive the worktree path, then matched against `appState.worktrees`. Installed/release builds (no `/.build/` in the exec path) keep showing the version string unchanged.
- The version is preserved as a `.help()` tooltip on hover, so it's still one mouseover away.

## Test plan
- [ ] In this worktree, run `scripts/restart.sh` and confirm the footer shows the worktree's display name (e.g. "🏷 Dev Build Worktree Label").
- [ ] Hover the label and confirm `v0.1.0` appears as a tooltip.
- [ ] Rename the worktree via the sidebar and confirm the footer updates live.
- [ ] (Manual) Build a copy outside `.build/` and confirm it still shows `v0.1.0` with no tooltip.

open in TBD: \`tbd://open?worktree=1BDD2DEB-C226-4D5A-9C51-2D685CD3332F\`