### PR TITLE
Feat: Jump from transcript Read/Write/Edit cards to the file viewer

### DIFF
--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -217,6 +217,10 @@ struct PanePlaceholder: View {
             NotePaneView(noteID: noteID, worktreeID: worktree.id)
         case .liveTranscript(_, let terminalID):
             LiveTranscriptPaneView(terminalID: terminalID, worktreeID: worktree.id)
+                .environment(\.openFilePreview, { path in
+                    let newContent = PaneContent.codeViewer(id: UUID(), path: path)
+                    layout = layout.splitPane(id: content.paneID, direction: .horizontal, newContent: newContent)
+                })
         }
     }
 

--- a/Sources/TBDApp/Panes/Transcript/ActivityRowChrome.swift
+++ b/Sources/TBDApp/Panes/Transcript/ActivityRowChrome.swift
@@ -86,3 +86,23 @@ struct TruncationFooter: View {
         .padding(.top, 4)
     }
 }
+
+/// Button that opens a file path in a new code-viewer split pane.
+struct PreviewFileButton: View {
+    let path: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: "doc.text.magnifyingglass")
+                Text("Preview file").foregroundStyle(.tint)
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 4)
+        .help("Open \(path) in viewer")
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/EditCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/EditCard.swift
@@ -15,6 +15,7 @@ struct EditCard: View {
     @State private var expanded = true
     @State private var fullInputJSON: String? = nil
     @EnvironmentObject var appState: AppState
+    @Environment(\.openFilePreview) private var openFilePreview
 
     private struct EditHunk: Decodable, Equatable {
         let old_string: String
@@ -96,9 +97,18 @@ struct EditCard: View {
                         if idx < hunks.count - 1 { Divider() }
                     }
                 }
-                if let cap = inputTruncatedTo, fullInputJSON == nil, terminalID != nil {
-                    TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
-                        Task { await fetchFullInput() }
+                let showTruncation = inputTruncatedTo != nil && fullInputJSON == nil && terminalID != nil
+                let showPreview = parsedInput?.file_path != nil && openFilePreview != nil
+                if showPreview || showTruncation {
+                    HStack(spacing: 12) {
+                        if showPreview, let path = parsedInput?.file_path, let open = openFilePreview {
+                            PreviewFileButton(path: path) { open(path) }
+                        }
+                        if showTruncation, let cap = inputTruncatedTo {
+                            TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
+                                Task { await fetchFullInput() }
+                            }
+                        }
                     }
                 }
             }

--- a/Sources/TBDApp/Panes/Transcript/EditCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/EditCard.swift
@@ -38,6 +38,11 @@ struct EditCard: View {
         return try? Self.decoder.decode(EditInput.self, from: data)
     }
 
+    private var resolvedFilePath: String? {
+        if let p = decodeInput()?.file_path { return p }
+        return ToolInputFilePath.extract(from: fullInputJSON ?? inputJSON)
+    }
+
     var body: some View {
         let parsedInput = decodeInput()
         let language: String? = {
@@ -98,10 +103,11 @@ struct EditCard: View {
                     }
                 }
                 let showTruncation = inputTruncatedTo != nil && fullInputJSON == nil && terminalID != nil
-                let showPreview = parsedInput?.file_path != nil && openFilePreview != nil
+                let previewPath = resolvedFilePath
+                let showPreview = previewPath != nil && openFilePreview != nil
                 if showPreview || showTruncation {
                     HStack(spacing: 12) {
-                        if showPreview, let path = parsedInput?.file_path, let open = openFilePreview {
+                        if showPreview, let path = previewPath, let open = openFilePreview {
                             PreviewFileButton(path: path) { open(path) }
                         }
                         if showTruncation, let cap = inputTruncatedTo {

--- a/Sources/TBDApp/Panes/Transcript/FilePreviewEnvironment.swift
+++ b/Sources/TBDApp/Panes/Transcript/FilePreviewEnvironment.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// Environment closure that opens a file path in a new code-viewer split.
+private struct OpenFilePreviewKey: EnvironmentKey {
+    static let defaultValue: (@MainActor (String) -> Void)? = nil
+}
+
+extension EnvironmentValues {
+    var openFilePreview: (@MainActor (String) -> Void)? {
+        get { self[OpenFilePreviewKey.self] }
+        set { self[OpenFilePreviewKey.self] = newValue }
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/FilePreviewEnvironment.swift
+++ b/Sources/TBDApp/Panes/Transcript/FilePreviewEnvironment.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 /// Environment closure that opens a file path in a new code-viewer split.
@@ -9,5 +10,24 @@ extension EnvironmentValues {
     var openFilePreview: (@MainActor (String) -> Void)? {
         get { self[OpenFilePreviewKey.self] }
         set { self[OpenFilePreviewKey.self] = newValue }
+    }
+}
+
+/// Best-effort extraction of `file_path` from a possibly-truncated tool input
+/// JSON string. Returns nil if the field is absent or appears escaped.
+/// Used so the Preview File button can render before full JSON is fetched.
+enum ToolInputFilePath {
+    private static let regex = try! NSRegularExpression(
+        pattern: #""file_path"\s*:\s*"((?:[^"\\]|\\.)*)""#
+    )
+    static func extract(from json: String) -> String? {
+        let range = NSRange(json.startIndex..., in: json)
+        guard let m = regex.firstMatch(in: json, range: range), m.numberOfRanges >= 2,
+              let r = Range(m.range(at: 1), in: json) else { return nil }
+        let raw = String(json[r])
+        // Only handle the unescaped-path case. If we see a backslash, give up
+        // and let full-input fetch fix it later — paths with escapes are rare.
+        if raw.contains("\\") { return nil }
+        return raw
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/ReadCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/ReadCard.swift
@@ -13,6 +13,7 @@ struct ReadCard: View {
     @State private var expanded = false
     @State private var fullResultText: String? = nil
     @EnvironmentObject var appState: AppState
+    @Environment(\.openFilePreview) private var openFilePreview
 
     private struct Input: Decodable {
         let file_path: String
@@ -62,9 +63,18 @@ struct ReadCard: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
                     .clipShape(RoundedRectangle(cornerRadius: 4))
-                if let cap = r.truncatedTo, fullResultText == nil, terminalID != nil {
-                    TruncationFooter(truncatedTo: cap, currentLength: r.text.count) {
-                        Task { await fetchFull() }
+                let showTruncation = r.truncatedTo != nil && fullResultText == nil && terminalID != nil
+                let showPreview = parsedInput?.file_path != nil && openFilePreview != nil
+                if showPreview || showTruncation {
+                    HStack(spacing: 12) {
+                        if showPreview, let path = parsedInput?.file_path, let open = openFilePreview {
+                            PreviewFileButton(path: path) { open(path) }
+                        }
+                        if showTruncation, let cap = r.truncatedTo {
+                            TruncationFooter(truncatedTo: cap, currentLength: r.text.count) {
+                                Task { await fetchFull() }
+                            }
+                        }
                     }
                 }
             } else {

--- a/Sources/TBDApp/Panes/Transcript/WriteCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/WriteCard.swift
@@ -24,6 +24,11 @@ struct WriteCard: View {
         return try? Self.decoder.decode(Input.self, from: data)
     }
 
+    private var resolvedFilePath: String? {
+        if let p = decodeInput()?.file_path { return p }
+        return ToolInputFilePath.extract(from: fullInputJSON ?? inputJSON)
+    }
+
     private func lineCount(for parsed: Input?) -> Int {
         guard let content = parsed?.content, !content.isEmpty else { return 0 }
         return content.split(separator: "\n", omittingEmptySubsequences: false).count
@@ -76,10 +81,11 @@ struct WriteCard: View {
                     }
                 }
                 let showTruncation = inputTruncatedTo != nil && fullInputJSON == nil && terminalID != nil
-                let showPreview = parsedInput?.file_path != nil && openFilePreview != nil
+                let previewPath = resolvedFilePath
+                let showPreview = previewPath != nil && openFilePreview != nil
                 if showPreview || showTruncation {
                     HStack(spacing: 12) {
-                        if showPreview, let path = parsedInput?.file_path, let open = openFilePreview {
+                        if showPreview, let path = previewPath, let open = openFilePreview {
                             PreviewFileButton(path: path) { open(path) }
                         }
                         if showTruncation, let cap = inputTruncatedTo {

--- a/Sources/TBDApp/Panes/Transcript/WriteCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/WriteCard.swift
@@ -13,6 +13,7 @@ struct WriteCard: View {
     @State private var containerExpanded = false
     @State private var fullInputJSON: String? = nil
     @EnvironmentObject var appState: AppState
+    @Environment(\.openFilePreview) private var openFilePreview
 
     private struct Input: Decodable { let file_path: String; let content: String }
 
@@ -74,9 +75,18 @@ struct WriteCard: View {
                         .help(containerExpanded ? "Collapse container" : "Expand container")
                     }
                 }
-                if let cap = inputTruncatedTo, fullInputJSON == nil, terminalID != nil {
-                    TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
-                        Task { await fetchFullInput() }
+                let showTruncation = inputTruncatedTo != nil && fullInputJSON == nil && terminalID != nil
+                let showPreview = parsedInput?.file_path != nil && openFilePreview != nil
+                if showPreview || showTruncation {
+                    HStack(spacing: 12) {
+                        if showPreview, let path = parsedInput?.file_path, let open = openFilePreview {
+                            PreviewFileButton(path: path) { open(path) }
+                        }
+                        if showTruncation, let cap = inputTruncatedTo {
+                            TruncationFooter(truncatedTo: cap, currentLength: inputJSON.count) {
+                                Task { await fetchFullInput() }
+                            }
+                        }
                     }
                 }
             }

--- a/Tests/TBDAppTests/ToolInputFilePathTests.swift
+++ b/Tests/TBDAppTests/ToolInputFilePathTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+
+@Suite("ToolInputFilePath")
+struct ToolInputFilePathTests {
+    @Test func well_formed_json() {
+        let json = #"{"file_path":"/Users/me/foo.swift","content":"hello"}"#
+        #expect(ToolInputFilePath.extract(from: json) == "/Users/me/foo.swift")
+    }
+
+    @Test func truncated_mid_content() {
+        // Truncated inside the `content` string — JSON is structurally invalid,
+        // but `file_path` already serialized in full.
+        let json = #"{"file_path":"/Users/me/big.txt","content":"line1\nline2\nline3"#
+        #expect(ToolInputFilePath.extract(from: json) == "/Users/me/big.txt")
+    }
+
+    @Test func file_path_after_other_field() {
+        let json = #"{"old_string":"foo","file_path":"/tmp/x.swift","new_string":"bar"}"#
+        #expect(ToolInputFilePath.extract(from: json) == "/tmp/x.swift")
+    }
+
+    @Test func missing_file_path_returns_nil() {
+        let json = #"{"command":"ls -la","description":"list"}"#
+        #expect(ToolInputFilePath.extract(from: json) == nil)
+    }
+
+    @Test func escaped_path_returns_nil() {
+        // We bail out on backslashes; let full-input fetch resolve it.
+        let json = #"{"file_path":"/tmp/with\"quote.swift","content":"x"}"#
+        #expect(ToolInputFilePath.extract(from: json) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a **Preview file** button to Read, Write, Edit, and MultiEdit cards in the live transcript pane. Clicking it opens that file in a code-viewer split next to the transcript — same routing terminal Cmd+Click already uses.
- The button sits next to **Show full output** in the same footer slot. It's always visible when the card has a parsable `file_path`; "Show full output" still only appears when the body was truncated.
- Plumbed via a SwiftUI `openFilePreview` environment value injected by `PanePlaceholder` on the `.liveTranscript` branch, so cards don't need to thread a closure through `TranscriptItemsView` / `SubagentDisclosure`.

## Test plan
- [ ] Restart with `scripts/restart.sh`, open a Claude terminal with a session that has Read/Write/Edit activity, open a transcript split.
- [ ] Expand a Read card — see "Preview file" in the footer; click it; verify a code-viewer pane opens beside the transcript with the file loaded.
- [ ] Repeat for a Write card (default-expanded) and an Edit/MultiEdit card.
- [ ] Trigger a truncated card (large Write input) — verify "Preview file" and "Show full output" sit side-by-side and both work.
- [ ] Confirm subagent-nested Read/Write/Edit cards also show the button.

open in TBD: \`tbd://open?worktree=0DC6BCA2-4065-4104-82EA-9955730AF602\`