### PR TITLE
Feat: One viewer pane, not five — and it auto-refreshes when the file changes

### DIFF
--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -258,6 +258,11 @@ struct CodeViewerPaneView: View {
                 selectedFiles = [path]
             }
         }
+        .onChange(of: path) { _, newPath in
+            if !newPath.isEmpty && FileManager.default.fileExists(atPath: newPath) {
+                selectedFiles = [newPath]
+            }
+        }
     }
 
     private var emptyState: some View {

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -312,15 +312,22 @@ private struct FilePreviewView: View {
     let filePath: String
     let showSourceCode: Bool
 
+    @StateObject private var watcher = FileWatcher()
+
     var body: some View {
-        if !showSourceCode && isRenderableFile(filePath) {
-            RenderedContentView(filePath: filePath)
-        } else if isImageFile(filePath) {
-            ImagePreviewView(filePath: filePath)
-        } else if isTextFile(filePath) {
-            HighlightedCodeView(filePath: filePath)
-        } else {
-            BinaryFallbackView(filePath: filePath)
+        Group {
+            if !showSourceCode && isRenderableFile(filePath) {
+                RenderedContentView(filePath: filePath, revision: watcher.revision)
+            } else if isImageFile(filePath) {
+                ImagePreviewView(filePath: filePath, revision: watcher.revision)
+            } else if isTextFile(filePath) {
+                HighlightedCodeView(filePath: filePath, revision: watcher.revision)
+            } else {
+                BinaryFallbackView(filePath: filePath)
+            }
+        }
+        .task(id: filePath) {
+            watcher.observe(filePath)
         }
     }
 }
@@ -329,6 +336,7 @@ private struct FilePreviewView: View {
 
 private struct RenderedContentView: View {
     let filePath: String
+    let revision: Int
     @State private var content: String?
     @State private var loadError: String?
 
@@ -357,7 +365,7 @@ private struct RenderedContentView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .task(id: filePath) {
+        .task(id: "\(filePath)#\(revision)") {
             await loadContent()
         }
     }
@@ -383,6 +391,7 @@ private struct RenderedContentView: View {
 
 private struct ImagePreviewView: View {
     let filePath: String
+    let revision: Int
     @State private var image: NSImage?
 
     var body: some View {
@@ -405,7 +414,7 @@ private struct ImagePreviewView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .task(id: filePath) {
+        .task(id: "\(filePath)#\(revision)") {
             image = NSImage(contentsOfFile: filePath)
         }
     }
@@ -441,6 +450,7 @@ private struct BinaryFallbackView: View {
 
 private struct HighlightedCodeView: View {
     let filePath: String
+    let revision: Int
     @State private var attributedContent: NSAttributedString?
     @State private var loadError: String?
 
@@ -462,7 +472,7 @@ private struct HighlightedCodeView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .task(id: filePath) {
+        .task(id: "\(filePath)#\(revision)") {
             await loadAndHighlight()
         }
     }

--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -313,25 +313,41 @@ private func isTextFile(_ path: String) -> Bool {
 
 /// Routes to the appropriate preview based on file type:
 /// images → native NSImage, text → syntax-highlighted code, binary → "Open in Finder" fallback.
+///
+/// File-watching plumbing intentionally avoids `@StateObject` /
+/// `ObservableObject` / `@Published` — see the doc-comment on
+/// `FileWatcher` for the SIGTRAP that taught us why. The watcher lives in
+/// `@State` (which stores reference types stably across re-renders) and
+/// pokes the view via a callback that bumps `revision`, an Int observed
+/// by SwiftUI as ordinary `@State`.
 private struct FilePreviewView: View {
     let filePath: String
     let showSourceCode: Bool
 
-    @StateObject private var watcher = FileWatcher()
+    @State private var watcher = FileWatcher()
+    @State private var revision: Int = 0
 
     var body: some View {
         Group {
             if !showSourceCode && isRenderableFile(filePath) {
-                RenderedContentView(filePath: filePath, revision: watcher.revision)
+                RenderedContentView(filePath: filePath, revision: revision)
             } else if isImageFile(filePath) {
-                ImagePreviewView(filePath: filePath, revision: watcher.revision)
+                ImagePreviewView(filePath: filePath, revision: revision)
             } else if isTextFile(filePath) {
-                HighlightedCodeView(filePath: filePath, revision: watcher.revision)
+                HighlightedCodeView(filePath: filePath, revision: revision)
             } else {
                 BinaryFallbackView(filePath: filePath)
             }
         }
         .task(id: filePath) {
+            // Wire the callback fresh each time filePath changes. The
+            // callback bumps revision on the main actor; SwiftUI re-renders
+            // the leaf view, whose .task(id: "<path>#<rev>") reloads.
+            watcher.onChange = {
+                Task { @MainActor in
+                    revision &+= 1
+                }
+            }
             watcher.observe(filePath)
         }
     }

--- a/Sources/TBDApp/Panes/FileWatcher.swift
+++ b/Sources/TBDApp/Panes/FileWatcher.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Darwin
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "fileWatcher")
+
+/// Observes a single file on disk and bumps `revision` (debounced ~150ms)
+/// whenever the file changes. Survives atomic saves (rename/delete) by
+/// re-opening the watcher on the same path after a small delay.
+///
+/// Lifecycle invariants:
+/// 1. The file descriptor is closed exactly once, by the dispatch source's
+///    cancel handler. `cancel()` is invoked from `stop()` (path change /
+///    explicit stop) and from `deinit` (view teardown). No path leaks an
+///    FD; no path double-closes.
+/// 2. All event/cancel/Task closures capture `self` weakly — the source's
+///    handlers and the in-flight `Task`s never keep the watcher alive past
+///    its owning view.
+/// 3. `observe(path:)` is idempotent on the same path; on a different path
+///    it calls `stop()` first.
+///
+/// Hosted as a `@StateObject` on `FilePreviewView` so SwiftUI manages its
+/// lifetime deterministically — when the pane is closed (or the displayed
+/// path changes such that the view's identity flips), `deinit` runs and
+/// the source is cancelled.
+@MainActor
+final class FileWatcher: ObservableObject {
+
+    /// Bumped each time the file changes (after debouncing). Views key
+    /// their `.task(id:)` on `"\(path)#\(revision)"` to trigger reloads.
+    @Published private(set) var revision: Int = 0
+
+    private var source: DispatchSourceFileSystemObject?
+    private var watchedPath: String?
+    private var debounceTask: Task<Void, Never>?
+    private var reopenTask: Task<Void, Never>?
+
+    /// DEBUG-only counter for lifecycle balance assertions in tests.
+    /// Backed by an unfair lock so init/deinit can read and mutate from
+    /// any isolation context (deinit may run off the main actor).
+    #if DEBUG
+    nonisolated private static let _liveCountLock = OSAllocatedUnfairLock<Int>(initialState: 0)
+    nonisolated static var liveCount: Int { _liveCountLock.withLock { $0 } }
+    #endif
+
+    init() {
+        #if DEBUG
+        Self._liveCountLock.withLock { $0 += 1 }
+        #endif
+    }
+
+    deinit {
+        // `source.cancel()` and `Task.cancel()` are safe to call from any
+        // thread / isolation context. The source's cancel handler runs on
+        // its dispatch queue and closes the FD exactly once.
+        debounceTask?.cancel()
+        reopenTask?.cancel()
+        source?.cancel()
+        #if DEBUG
+        Self._liveCountLock.withLock { $0 -= 1 }
+        #endif
+    }
+
+    func observe(_ path: String) {
+        guard path != watchedPath else { return }
+        stop()
+        startWatching(path)
+    }
+
+    func stop() {
+        debounceTask?.cancel(); debounceTask = nil
+        reopenTask?.cancel(); reopenTask = nil
+        source?.cancel()           // triggers cancel handler → close(fd)
+        source = nil
+        watchedPath = nil
+    }
+
+    // MARK: - Private
+
+    private func startWatching(_ path: String) {
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else {
+            // File doesn't exist (or we can't open it). Remember the intent
+            // anyway so a later observe(samePath) is still a no-op; the
+            // existing one-shot loaders in the leaf views will surface the
+            // read error.
+            watchedPath = path
+            logger.debug("FileWatcher: open(\(path, privacy: .public)) failed errno=\(errno)")
+            return
+        }
+
+        let queue = DispatchQueue.global(qos: .utility)
+        let src = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .delete, .rename, .revoke],
+            queue: queue
+        )
+
+        src.setEventHandler { [weak self] in
+            // Capture the mask while we're on the dispatch queue; hop to
+            // the main actor to mutate watcher state.
+            let mask = src.data
+            Task { @MainActor [weak self] in
+                self?.handleEvent(mask: mask, path: path)
+            }
+        }
+
+        src.setCancelHandler {
+            // FD closed exactly once, here, regardless of who triggered
+            // cancellation (stop / deinit / re-open).
+            close(fd)
+        }
+
+        self.source = src
+        self.watchedPath = path
+        src.resume()
+    }
+
+    private func handleEvent(mask: DispatchSource.FileSystemEvent, path: String) {
+        // Atomic save: vim/VS Code/Prettier write a temp file then rename
+        // it over the original. The original inode is now gone even though
+        // the path still resolves to a file.
+        if mask.contains(.delete) || mask.contains(.rename) || mask.contains(.revoke) {
+            reopenTask?.cancel()
+            reopenTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(50))
+                guard !Task.isCancelled,
+                      let self,
+                      self.watchedPath == path
+                else { return }
+                self.stop()
+                self.startWatching(path)
+                self.revision &+= 1
+            }
+            return
+        }
+
+        // Write/extend: trailing-edge debounce a revision bump.
+        debounceTask?.cancel()
+        debounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled, let self else { return }
+            self.revision &+= 1
+        }
+    }
+}

--- a/Sources/TBDApp/Panes/FileWatcher.swift
+++ b/Sources/TBDApp/Panes/FileWatcher.swift
@@ -4,11 +4,36 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.app", category: "fileWatcher")
 
-/// Observes a single file on disk and bumps `revision` (debounced ~150ms)
-/// whenever the file changes. Survives atomic saves (rename/delete) by
-/// re-opening the watcher on the same path after a small delay.
+/// Observes a single file on disk and invokes `onChange` (debounced ~150ms,
+/// hopped onto the main actor) whenever the file changes. Survives atomic
+/// saves (rename/delete) by re-opening the watcher on the same path after a
+/// small delay.
 ///
-/// Lifecycle invariants:
+/// ## Why this is *not* `@MainActor` or `ObservableObject`
+///
+/// An earlier design exposed `@Published var revision: Int` on a
+/// `@MainActor`-isolated `ObservableObject` and was hosted as a
+/// `@StateObject` on `FilePreviewView`. Closing the code-viewer pane crashed
+/// the app with `EXC_BREAKPOINT` (SIGTRAP). The OS log showed
+/// `BUG IN CLIENT OF LIBDISPATCH: Block was expected to execute on queue
+/// [com.apple.main-thread]` on two non-main worker threads, immediately
+/// preceded by SwiftUI's "NSHostingView is being laid out reentrantly while
+/// rendering its SwiftUI content" warning. The earliest crash trace pointed
+/// straight at `swift_release` inside `AGGraphSetOutputValue` during
+/// `GraphHost.updatePreferences()` — the Combine + `@StateObject` teardown
+/// was running off the main thread during a failed-layout-pass recovery,
+/// tripping `dispatchPrecondition(.onQueue(.main))` inside Combine's
+/// internals.
+///
+/// The fix: keep the watcher a plain reference type with no actor isolation
+/// and no Combine publishers. SwiftUI observes a separate `@State var
+/// revision: Int` on the host view; the watcher just calls `onChange` on the
+/// main actor when the file changes, and the view bumps its own revision.
+/// No `@StateObject`, no `@Published`, no Combine subscription teardown
+/// during view destruction.
+///
+/// ## Lifecycle invariants
+///
 /// 1. The file descriptor is closed exactly once, by the dispatch source's
 ///    cancel handler. `cancel()` is invoked from `stop()` (path change /
 ///    explicit stop) and from `deinit` (view teardown). No path leaks an
@@ -18,26 +43,33 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "fileWatcher")
 ///    its owning view.
 /// 3. `observe(path:)` is idempotent on the same path; on a different path
 ///    it calls `stop()` first.
-///
-/// Hosted as a `@StateObject` on `FilePreviewView` so SwiftUI manages its
-/// lifetime deterministically — when the pane is closed (or the displayed
-/// path changes such that the view's identity flips), `deinit` runs and
-/// the source is cancelled.
-@MainActor
-final class FileWatcher: ObservableObject {
+/// 4. All mutable state (`source`, `watchedPath`, debounce/reopen tasks,
+///    `onChange`) is guarded by `OSAllocatedUnfairLock<State>` so callers
+///    may invoke `observe`/`stop` from any isolation context, and `deinit`
+///    (which Swift always treats as `nonisolated`) can tear down safely
+///    from whatever thread released the last reference.
+final class FileWatcher: @unchecked Sendable {
 
-    /// Bumped each time the file changes (after debouncing). Views key
-    /// their `.task(id:)` on `"\(path)#\(revision)"` to trigger reloads.
-    @Published private(set) var revision: Int = 0
+    /// Bundled mutable state, all guarded by `state.withLock { ... }`.
+    fileprivate struct State {
+        var onChange: (@Sendable () -> Void)?
+        var source: DispatchSourceFileSystemObject?
+        var watchedPath: String?
+        var debounceTask: Task<Void, Never>?
+        var reopenTask: Task<Void, Never>?
+    }
 
-    private var source: DispatchSourceFileSystemObject?
-    private var watchedPath: String?
-    private var debounceTask: Task<Void, Never>?
-    private var reopenTask: Task<Void, Never>?
+    /// Invoked on the main actor each time the watched file changes (after
+    /// debouncing). Set by the owning view; the watcher hops onto the main
+    /// actor before invoking it.
+    var onChange: (@Sendable () -> Void)? {
+        get { state.withLock { $0.onChange } }
+        set { state.withLock { $0.onChange = newValue } }
+    }
+
+    private let state = OSAllocatedUnfairLock<State>(initialState: State())
 
     /// DEBUG-only counter for lifecycle balance assertions in tests.
-    /// Backed by an unfair lock so init/deinit can read and mutate from
-    /// any isolation context (deinit may run off the main actor).
     #if DEBUG
     nonisolated private static let _liveCountLock = OSAllocatedUnfairLock<Int>(initialState: 0)
     nonisolated static var liveCount: Int { _liveCountLock.withLock { $0 } }
@@ -52,39 +84,61 @@ final class FileWatcher: ObservableObject {
     deinit {
         // `source.cancel()` and `Task.cancel()` are safe to call from any
         // thread / isolation context. The source's cancel handler runs on
-        // its dispatch queue and closes the FD exactly once.
-        debounceTask?.cancel()
-        reopenTask?.cancel()
-        source?.cancel()
+        // its dispatch queue and closes the FD exactly once. We grab the
+        // lock briefly to hand off ownership of the cancellable resources
+        // to local vars, then release the lock before cancelling — that
+        // way the dispatch source's release (which can run its cancel
+        // handler on the GCD queue) doesn't reenter under our lock.
+        let (debounce, reopen, src): (Task<Void, Never>?, Task<Void, Never>?, DispatchSourceFileSystemObject?) =
+            state.withLock { s in
+                let trio = (s.debounceTask, s.reopenTask, s.source)
+                s.debounceTask = nil
+                s.reopenTask = nil
+                s.source = nil
+                s.watchedPath = nil
+                s.onChange = nil
+                return trio
+            }
+        debounce?.cancel()
+        reopen?.cancel()
+        src?.cancel()
         #if DEBUG
         Self._liveCountLock.withLock { $0 -= 1 }
         #endif
     }
 
     func observe(_ path: String) {
-        guard path != watchedPath else { return }
-        stop()
-        startWatching(path)
+        state.withLock { s in
+            guard path != s.watchedPath else { return }
+            stopLocked(&s)
+            startWatchingLocked(&s, path: path)
+        }
     }
 
     func stop() {
-        debounceTask?.cancel(); debounceTask = nil
-        reopenTask?.cancel(); reopenTask = nil
-        source?.cancel()           // triggers cancel handler → close(fd)
-        source = nil
-        watchedPath = nil
+        state.withLock { s in
+            stopLocked(&s)
+        }
     }
 
-    // MARK: - Private
+    // MARK: - Private (caller holds the lock)
 
-    private func startWatching(_ path: String) {
+    private func stopLocked(_ s: inout State) {
+        s.debounceTask?.cancel(); s.debounceTask = nil
+        s.reopenTask?.cancel(); s.reopenTask = nil
+        s.source?.cancel()           // triggers cancel handler → close(fd)
+        s.source = nil
+        s.watchedPath = nil
+    }
+
+    private func startWatchingLocked(_ s: inout State, path: String) {
         let fd = open(path, O_EVTONLY)
         guard fd >= 0 else {
             // File doesn't exist (or we can't open it). Remember the intent
             // anyway so a later observe(samePath) is still a no-op; the
             // existing one-shot loaders in the leaf views will surface the
             // read error.
-            watchedPath = path
+            s.watchedPath = path
             logger.debug("FileWatcher: open(\(path, privacy: .public)) failed errno=\(errno)")
             return
         }
@@ -97,12 +151,10 @@ final class FileWatcher: ObservableObject {
         )
 
         src.setEventHandler { [weak self] in
-            // Capture the mask while we're on the dispatch queue; hop to
-            // the main actor to mutate watcher state.
+            // Capture the mask while we're on the dispatch queue; hop into
+            // the watcher (under its lock) on whichever queue we're on.
             let mask = src.data
-            Task { @MainActor [weak self] in
-                self?.handleEvent(mask: mask, path: path)
-            }
+            self?.handleEvent(mask: mask, path: path)
         }
 
         src.setCancelHandler {
@@ -111,8 +163,8 @@ final class FileWatcher: ObservableObject {
             close(fd)
         }
 
-        self.source = src
-        self.watchedPath = path
+        s.source = src
+        s.watchedPath = path
         src.resume()
     }
 
@@ -121,26 +173,54 @@ final class FileWatcher: ObservableObject {
         // it over the original. The original inode is now gone even though
         // the path still resolves to a file.
         if mask.contains(.delete) || mask.contains(.rename) || mask.contains(.revoke) {
-            reopenTask?.cancel()
-            reopenTask = Task { @MainActor [weak self] in
-                try? await Task.sleep(for: .milliseconds(50))
-                guard !Task.isCancelled,
-                      let self,
-                      self.watchedPath == path
-                else { return }
-                self.stop()
-                self.startWatching(path)
-                self.revision &+= 1
-            }
+            scheduleReopen(path: path)
             return
         }
 
-        // Write/extend: trailing-edge debounce a revision bump.
-        debounceTask?.cancel()
-        debounceTask = Task { @MainActor [weak self] in
+        // Write/extend: trailing-edge debounce a notification.
+        scheduleDebouncedNotify()
+    }
+
+    private func scheduleReopen(path: String) {
+        let newTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled, let self else { return }
+            let cb: (@Sendable () -> Void)? = self.state.withLock { s in
+                guard s.watchedPath == path else { return nil }
+                self.stopLocked(&s)
+                self.startWatchingLocked(&s, path: path)
+                return s.onChange
+            }
+            if let cb {
+                await MainActor.run { cb() }
+            }
+        }
+        state.withLock { s in
+            // If we're racing with a `stop()` that already happened, the
+            // path won't match in the body above — the task will be a
+            // benign no-op. We still record it so that a subsequent
+            // `stop()`/deinit cancels it promptly.
+            guard s.watchedPath == path else {
+                newTask.cancel()
+                return
+            }
+            s.reopenTask?.cancel()
+            s.reopenTask = newTask
+        }
+    }
+
+    private func scheduleDebouncedNotify() {
+        let newTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(150))
             guard !Task.isCancelled, let self else { return }
-            self.revision &+= 1
+            let cb: (@Sendable () -> Void)? = self.state.withLock { $0.onChange }
+            if let cb {
+                await MainActor.run { cb() }
+            }
+        }
+        state.withLock { s in
+            s.debounceTask?.cancel()
+            s.debounceTask = newTask
         }
     }
 }

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -35,10 +35,26 @@ struct PanePlaceholder: View {
             paneBody
         }
         .onPreferenceChange(HasRenderableContentKey.self) { newValue in
-            if newValue && !hasRenderableContent {
-                showSourceCode = false
+            // Defer @State writes to the next runloop tick.
+            //
+            // SwiftUI propagates preference values during its layout / render
+            // pass — and on pane teardown the preference resets to its
+            // default, which fires this handler *while* the host view is
+            // mid-layout. Mutating @State synchronously here re-invalidates
+            // the view inside the same pass, producing
+            // "NSHostingView is being laid out reentrantly while rendering
+            // its SwiftUI content" and (with our FilePreviewView changes
+            // adding @StateObject + .task teardown work in the same phase)
+            // a SIGTRAP in GraphHost.updatePreferences.
+            //
+            // Hopping to the next main-actor turn lets the current layout
+            // pass finish, then schedules a normal subsequent render.
+            Task { @MainActor in
+                if newValue && !hasRenderableContent {
+                    showSourceCode = false
+                }
+                hasRenderableContent = newValue
             }
-            hasRenderableContent = newValue
         }
     }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -241,8 +241,7 @@ struct PanePlaceholder: View {
                     worktreePath: worktree.path,
                     remoteURL: appState.repos.first(where: { $0.id == worktree.repoID })?.remoteURL,
                     onFilePathClicked: { path in
-                        let newContent = PaneContent.codeViewer(id: UUID(), path: path)
-                        layout = layout.splitPane(id: terminalID, direction: .horizontal, newContent: newContent)
+                        layout = routeFileClick(into: layout, terminalID: terminalID, path: path)
                     },
                     onTerminalNotification: { title, body in
                         debugLog("OSC 777: \(title) — \(body)")

--- a/Sources/TBDApp/Panes/ViewerRouting.swift
+++ b/Sources/TBDApp/Panes/ViewerRouting.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Decides where a terminal-link click should land.
+///
+/// If the tab's layout already contains a `.codeViewer` pane, this returns
+/// the layout with that pane's `path` swapped (preserving the pane's `paneID`
+/// so SwiftUI keeps the view identity stable, including any `@StateObject`
+/// it owns — notably the `FileWatcher`).
+///
+/// Otherwise it falls back to splitting horizontally from the clicked terminal,
+/// matching the original behavior at `PanePlaceholder.swift:243-245`.
+func routeFileClick(into layout: LayoutNode, terminalID: UUID, path: String) -> LayoutNode {
+    let isViewer: (PaneContent) -> Bool = { content in
+        if case .codeViewer = content { return true } else { return false }
+    }
+
+    if let viewerID = layout.firstPaneID(where: isViewer),
+       let updated = layout.replacingContent(
+           at: viewerID,
+           with: .codeViewer(id: viewerID, path: path)
+       )
+    {
+        return updated
+    }
+
+    return layout.splitPane(
+        id: terminalID,
+        direction: .horizontal,
+        newContent: .codeViewer(id: UUID(), path: path)
+    )
+}

--- a/Sources/TBDApp/Terminal/LayoutNode.swift
+++ b/Sources/TBDApp/Terminal/LayoutNode.swift
@@ -105,6 +105,50 @@ indirect enum LayoutNode: Equatable, Sendable {
     }
 }
 
+// MARK: - Pane lookup / replacement helpers
+
+extension LayoutNode {
+    /// Returns the id of the first pane (in pre-order, left-to-right traversal)
+    /// whose content matches the predicate, or nil if none match.
+    func firstPaneID(where predicate: (PaneContent) -> Bool) -> UUID? {
+        switch self {
+        case .pane(let content):
+            return predicate(content) ? content.paneID : nil
+        case .split(_, let children, _):
+            for child in children {
+                if let found = child.firstPaneID(where: predicate) {
+                    return found
+                }
+            }
+            return nil
+        }
+    }
+
+    /// Returns a copy of the tree with the pane identified by `paneID` replaced
+    /// by `newContent`. Sibling panes and split ratios are preserved exactly.
+    /// Returns nil if no pane has that id.
+    func replacingContent(at paneID: UUID, with newContent: PaneContent) -> LayoutNode? {
+        switch self {
+        case .pane(let content):
+            return content.paneID == paneID ? .pane(newContent) : nil
+
+        case .split(let direction, let children, let ratios):
+            var newChildren = children
+            var replaced = false
+            for (index, child) in children.enumerated() {
+                if let updated = child.replacingContent(at: paneID, with: newContent) {
+                    newChildren[index] = updated
+                    replaced = true
+                    break
+                }
+            }
+            return replaced
+                ? .split(direction: direction, children: newChildren, ratios: ratios)
+                : nil
+        }
+    }
+}
+
 // MARK: - Codable (manual conformance for indirect enum)
 
 extension LayoutNode: Codable {

--- a/Tests/TBDAppTests/FileWatcherTests.swift
+++ b/Tests/TBDAppTests/FileWatcherTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+
+@Suite("FileWatcher")
+struct FileWatcherTests {
+
+    /// Creates and immediately releases many FileWatchers. If any of them
+    /// kept an internal retain cycle (e.g. handler closure capturing self
+    /// strongly, Task holding self), liveCount would not return to its
+    /// starting value.
+    @MainActor
+    @Test func liveCountReturnsToZeroAfterRelease() async {
+        let baseline = FileWatcher.liveCount
+
+        do {
+            var watchers: [FileWatcher] = []
+            for _ in 0..<50 {
+                watchers.append(FileWatcher())
+            }
+            #expect(FileWatcher.liveCount == baseline + 50)
+            watchers.removeAll()
+        }
+
+        // Allow any deferred deallocations to settle on the main actor.
+        await Task.yield()
+        #expect(FileWatcher.liveCount == baseline)
+    }
+
+    @MainActor
+    @Test func liveCountReturnsToZeroAfterObserveOnTempFile() async {
+        let baseline = FileWatcher.liveCount
+
+        // Create a real temp file so observe() actually opens an FD and
+        // creates a dispatch source — we want to confirm the source's
+        // strong refs to closures don't keep self alive.
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("filewatcher-test-\(UUID().uuidString).txt")
+        FileManager.default.createFile(atPath: tmpURL.path, contents: Data("hi".utf8))
+        defer { try? FileManager.default.removeItem(at: tmpURL) }
+
+        do {
+            let w = FileWatcher()
+            w.observe(tmpURL.path)
+            #expect(FileWatcher.liveCount == baseline + 1)
+            // w goes out of scope here
+            _ = w
+        }
+
+        // Give GCD a moment to run the cancel handler / release closures.
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(FileWatcher.liveCount == baseline)
+    }
+
+    @MainActor
+    @Test func observeIsIdempotentOnSamePath() {
+        let w = FileWatcher()
+        w.observe("/some/path")
+        let r1 = w.revision
+        w.observe("/some/path") // same path — should be a no-op
+        #expect(w.revision == r1)
+    }
+
+    @MainActor
+    @Test func stopIsIdempotent() {
+        let w = FileWatcher()
+        w.observe("/some/path")
+        w.stop()
+        w.stop() // should not crash
+    }
+}

--- a/Tests/TBDAppTests/FileWatcherTests.swift
+++ b/Tests/TBDAppTests/FileWatcherTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Testing
 
 @testable import TBDApp
@@ -59,12 +60,16 @@ struct FileWatcherTests {
         // comment on FileWatcher for why). The observable signal we have
         // here is "did onChange fire?", which it should NOT for a no-op
         // re-observe of the same (non-existent) path.
-        var fireCount = 0
+        //
+        // `onChange` is `@Sendable`, so the counter has to be safe to
+        // mutate from any isolation. A lock-backed counter keeps the
+        // assertion semantics while satisfying Swift 6 strict concurrency.
+        let fireCount = OSAllocatedUnfairLock<Int>(initialState: 0)
         let w = FileWatcher()
-        w.onChange = { fireCount += 1 }
+        w.onChange = { fireCount.withLock { $0 += 1 } }
         w.observe("/some/path")
         w.observe("/some/path") // same path — should be a no-op
-        #expect(fireCount == 0)
+        #expect(fireCount.withLock { $0 } == 0)
     }
 
     @MainActor

--- a/Tests/TBDAppTests/FileWatcherTests.swift
+++ b/Tests/TBDAppTests/FileWatcherTests.swift
@@ -55,11 +55,16 @@ struct FileWatcherTests {
 
     @MainActor
     @Test func observeIsIdempotentOnSamePath() {
+        // FileWatcher no longer exposes `revision` directly (see doc
+        // comment on FileWatcher for why). The observable signal we have
+        // here is "did onChange fire?", which it should NOT for a no-op
+        // re-observe of the same (non-existent) path.
+        var fireCount = 0
         let w = FileWatcher()
+        w.onChange = { fireCount += 1 }
         w.observe("/some/path")
-        let r1 = w.revision
         w.observe("/some/path") // same path — should be a no-op
-        #expect(w.revision == r1)
+        #expect(fireCount == 0)
     }
 
     @MainActor

--- a/Tests/TBDAppTests/LayoutNodeTests.swift
+++ b/Tests/TBDAppTests/LayoutNodeTests.swift
@@ -249,4 +249,153 @@ struct LayoutNodeTests {
         let decoded = try JSONDecoder().decode(LayoutNode.self, from: data)
         #expect(decoded == node)
     }
+
+    // MARK: - firstPaneID
+
+    @Test func firstPaneID_returnsRootIDWhenRootMatches() {
+        let id = UUID()
+        let node = LayoutNode.pane(.codeViewer(id: id, path: "/a"))
+
+        let result = node.firstPaneID(where: {
+            if case .codeViewer = $0 { return true } else { return false }
+        })
+
+        #expect(result == id)
+    }
+
+    @Test func firstPaneID_returnsNilWhenNoneMatch() {
+        let node = LayoutNode.pane(.terminal(terminalID: UUID()))
+
+        let result = node.firstPaneID(where: {
+            if case .codeViewer = $0 { return true } else { return false }
+        })
+
+        #expect(result == nil)
+    }
+
+    @Test func firstPaneID_walksLeftThenRight() {
+        let leftID = UUID()
+        let rightID = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.codeViewer(id: leftID, path: "/left")),
+                .pane(.codeViewer(id: rightID, path: "/right")),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = node.firstPaneID(where: {
+            if case .codeViewer = $0 { return true } else { return false }
+        })
+
+        #expect(result == leftID)
+    }
+
+    @Test func firstPaneID_findsNestedMatch() {
+        let terminalID = UUID()
+        let viewerID = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .split(
+                    direction: .vertical,
+                    children: [
+                        .pane(.terminal(terminalID: UUID())),
+                        .pane(.codeViewer(id: viewerID, path: "/nested")),
+                    ],
+                    ratios: [0.5, 0.5]
+                ),
+            ],
+            ratios: [0.6, 0.4]
+        )
+
+        let result = node.firstPaneID(where: {
+            if case .codeViewer = $0 { return true } else { return false }
+        })
+
+        #expect(result == viewerID)
+    }
+
+    // MARK: - replacingContent
+
+    @Test func replacingContent_returnsNilWhenIDMissing() {
+        let node = LayoutNode.pane(.terminal(terminalID: UUID()))
+
+        let result = node.replacingContent(
+            at: UUID(),
+            with: .codeViewer(id: UUID(), path: "/x")
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test func replacingContent_replacesAtRoot() {
+        let id = UUID()
+        let node = LayoutNode.pane(.codeViewer(id: id, path: "/old"))
+        let newContent = PaneContent.codeViewer(id: id, path: "/new")
+
+        let result = node.replacingContent(at: id, with: newContent)
+
+        #expect(result == .pane(newContent))
+    }
+
+    @Test func replacingContent_replacesInsideSplitPreservingSiblingsAndRatios() {
+        let terminalID = UUID()
+        let viewerID = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(.codeViewer(id: viewerID, path: "/old")),
+            ],
+            ratios: [0.7, 0.3]
+        )
+        let newContent = PaneContent.codeViewer(id: viewerID, path: "/new")
+
+        let result = node.replacingContent(at: viewerID, with: newContent)
+
+        #expect(result == .split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(newContent),
+            ],
+            ratios: [0.7, 0.3]
+        ))
+    }
+
+    @Test func replacingContent_replacesInNestedSplit() {
+        let terminalID = UUID()
+        let viewerID = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .split(
+                    direction: .vertical,
+                    children: [
+                        .pane(.terminal(terminalID: UUID())),
+                        .pane(.codeViewer(id: viewerID, path: "/old")),
+                    ],
+                    ratios: [0.4, 0.6]
+                ),
+            ],
+            ratios: [0.5, 0.5]
+        )
+        let newContent = PaneContent.codeViewer(id: viewerID, path: "/new")
+
+        let result = node.replacingContent(at: viewerID, with: newContent)
+
+        guard case .split(_, let topChildren, let topRatios) = result,
+              case .split(_, let nestedChildren, let nestedRatios) = topChildren[1]
+        else {
+            Issue.record("Expected nested split structure")
+            return
+        }
+        #expect(topRatios == [0.5, 0.5])
+        #expect(nestedRatios == [0.4, 0.6])
+        #expect(nestedChildren[1] == .pane(newContent))
+    }
 }

--- a/Tests/TBDAppTests/ViewerRoutingTests.swift
+++ b/Tests/TBDAppTests/ViewerRoutingTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+
+@Suite("ViewerRouting")
+struct ViewerRoutingTests {
+
+    @Test func routeFileClick_splitsWhenNoExistingViewer() {
+        let terminalID = UUID()
+        let layout = LayoutNode.pane(.terminal(terminalID: terminalID))
+
+        let result = routeFileClick(into: layout, terminalID: terminalID, path: "/a.md")
+
+        guard case .split(let dir, let children, _) = result else {
+            Issue.record("Expected split result"); return
+        }
+        #expect(dir == .horizontal)
+        #expect(children.count == 2)
+        #expect(children[0] == .pane(.terminal(terminalID: terminalID)))
+        guard case .pane(.codeViewer(_, let path)) = children[1] else {
+            Issue.record("Expected codeViewer leaf"); return
+        }
+        #expect(path == "/a.md")
+    }
+
+    @Test func routeFileClick_replacesPathOnExistingViewerKeepingID() {
+        let terminalID = UUID()
+        let viewerID = UUID()
+        let layout = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(.codeViewer(id: viewerID, path: "/old.md")),
+            ],
+            ratios: [0.6, 0.4]
+        )
+
+        let result = routeFileClick(into: layout, terminalID: terminalID, path: "/new.md")
+
+        guard case .split(_, let children, let ratios) = result,
+              case .pane(.codeViewer(let id, let path)) = children[1]
+        else {
+            Issue.record("Expected codeViewer in right child"); return
+        }
+        #expect(id == viewerID, "paneID must be preserved across path replacement")
+        #expect(path == "/new.md")
+        #expect(ratios == [0.6, 0.4], "split ratios must be preserved")
+    }
+
+    @Test func routeFileClick_findsAndReplacesNestedViewer() {
+        let terminalID = UUID()
+        let viewerID = UUID()
+        let layout = LayoutNode.split(
+            direction: .vertical,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .split(
+                    direction: .horizontal,
+                    children: [
+                        .pane(.terminal(terminalID: UUID())),
+                        .pane(.codeViewer(id: viewerID, path: "/old")),
+                    ],
+                    ratios: [0.5, 0.5]
+                ),
+            ],
+            ratios: [0.7, 0.3]
+        )
+
+        let result = routeFileClick(into: layout, terminalID: terminalID, path: "/new")
+
+        guard case .split(_, let topChildren, _) = result,
+              case .split(_, let nested, _) = topChildren[1],
+              case .pane(.codeViewer(let id, let path)) = nested[1]
+        else {
+            Issue.record("Expected nested codeViewer"); return
+        }
+        #expect(id == viewerID)
+        #expect(path == "/new")
+    }
+}

--- a/docs/superpowers/specs/2026-05-07-single-viewer-file-watch-design.md
+++ b/docs/superpowers/specs/2026-05-07-single-viewer-file-watch-design.md
@@ -1,0 +1,281 @@
+# Single Viewer + Live File Watching
+
+## Problem
+
+Clicking a relative file path in a terminal pane (cmd-click, OSC-8, etc.) currently calls `splitPane(...)` from `Sources/TBDApp/Panes/PanePlaceholder.swift:243-245`. Every click appends a new pane to the layout, so clicking N relative links produces N viewer panes, each squeezed smaller than the last.
+
+A second, related gap: the code viewer reads file contents once via `.task(id: filePath)` and never updates when the file changes on disk. Editing the same file in another tool requires re-clicking the link to see the latest content.
+
+## Goals
+
+1. **At most one code-viewer pane per tab.** Subsequent terminal-link clicks in the same tab replace that pane's contents instead of splitting.
+2. **Auto-refresh on disk changes.** Any code-viewer pane (terminal flow, sidebar flow, future markdown-link flow) reflects edits to the watched file within ~150 ms.
+3. **No leaked file watchers, file descriptors, or async tasks** under any combination of pane open / close / path-change cycles.
+
+## Non-goals
+
+- Replacing or repurposing the existing markdown `OpenURLAction` in `RenderedContentView` (`NSWorkspace.shared.open`) — that is a separate flow for in-document links and is left untouched.
+- Sharing a single watcher across multiple viewers of the same path (no central pool — see "Rejected alternatives").
+- Showing a dedicated UI state when a watched file is deleted; the existing "Could not read file" error suffices.
+- Multi-pane "tile of viewers" layouts. A future cmd-click escape hatch could add this; out of scope.
+
+## Decisions captured during brainstorming
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Behavior on link click when a viewer already exists in the tab | Replace the existing pane's path, keep its size and position |
+| 2 | Behavior after the user closes the viewer | Next click re-creates by splitting from the clicked terminal (today's first-time behavior) |
+| 3 | Reach of the file watcher | Applies to all code-viewer panes regardless of how they were opened |
+| 4 | Atomic-save handling | Detect rename/delete, retry-open the same path after a short delay |
+| 5 | Refresh debounce | ~150 ms trailing-edge |
+| 6 | Cross-tab routing | Out of scope. One viewer per tab. Different tabs each get their own. |
+
+## Architecture overview
+
+Two narrow, independent changes:
+
+1. **Single-viewer routing** — pure additions to `LayoutNode` (a value type) plus a small free function `routeFileClick`. `PanePlaceholder.swift`'s `onFilePathClicked` callback delegates to that function.
+2. **`FileWatcher` class** — a new `final class FileWatcher: ObservableObject` owning a `DispatchSourceFileSystemObject`. `CodeViewerPaneView` holds one as `@StateObject`; its leaf content views (`RenderedContentView`, `HighlightedCodeView`, `ImagePreviewView`) take a `revision: Int` from `watcher.revision` and key their `.task` on `"\(filePath)#\(revision)"` so they reload when the watcher fires.
+
+The two changes are wired together through one fact: when the routing change replaces a viewer's content, it **keeps the same `paneID`**, so SwiftUI's view identity is stable and the `@StateObject` watcher is reused (re-targeted via `observe(newPath)`). One pane lifetime → one `FileWatcher` instance, regardless of how many files are clicked.
+
+## Component 1: Single-viewer routing
+
+### New helpers on `LayoutNode`
+
+```swift
+extension LayoutNode {
+    /// Returns the id of the first pane (in pre-order traversal) whose content
+    /// matches the predicate, or nil if none match.
+    func firstPaneID(where predicate: (PaneContent) -> Bool) -> UUID?
+
+    /// Returns a copy of the tree with the pane identified by `paneID`
+    /// replaced by `newContent`. Returns nil if no pane has that id.
+    /// Other panes and split ratios are preserved exactly.
+    func replacingContent(at paneID: UUID, with newContent: PaneContent) -> LayoutNode?
+}
+```
+
+Both are pure recursive walks. No I/O, no side effects, fully unit-testable against constructed trees.
+
+### Routing function
+
+```swift
+// Sources/TBDApp/Panes/ViewerRouting.swift
+func routeFileClick(into layout: LayoutNode, terminalID: UUID, path: String) -> LayoutNode {
+    let isViewer: (PaneContent) -> Bool = {
+        if case .codeViewer = $0 { return true } else { return false }
+    }
+    if let viewerID = layout.firstPaneID(where: isViewer),
+       let updated = layout.replacingContent(
+           at: viewerID,
+           with: .codeViewer(id: viewerID, path: path)
+       ) {
+        return updated
+    }
+    return layout.splitPane(
+        id: terminalID,
+        direction: .horizontal,
+        newContent: .codeViewer(id: UUID(), path: path)
+    )
+}
+```
+
+Crucial detail: the replacement reuses `viewerID` as the new content's id. `PaneContent.codeViewer` carries an id field; `LayoutNode` keys panes by it; SwiftUI uses it as the view identity. Stable id → stable view → stable `@StateObject`.
+
+### Callback site
+
+`Sources/TBDApp/Panes/PanePlaceholder.swift:243-245` becomes:
+
+```swift
+onFilePathClicked: { path in
+    layout = routeFileClick(into: layout, terminalID: terminalID, path: path)
+}
+```
+
+No other call sites change. The sidebar's "open as code viewer" flow in `FileViewerPanel.swift` already uses tab/replace semantics on `appState.tabs` and is left as-is.
+
+## Component 2: `FileWatcher`
+
+### Type
+
+```swift
+@MainActor
+final class FileWatcher: ObservableObject {
+    @Published private(set) var revision: Int = 0
+
+    private var source: DispatchSourceFileSystemObject?
+    private var watchedPath: String?
+    private var debounceTask: Task<Void, Never>?
+    private var reopenTask: Task<Void, Never>?
+
+    #if DEBUG
+    static let liveCount = OSAllocatedUnfairLock(initialState: 0)
+    #endif
+
+    init() {
+        #if DEBUG
+        FileWatcher.liveCount.withLock { $0 += 1 }
+        #endif
+    }
+
+    func observe(_ path: String) {
+        guard path != watchedPath else { return }
+        stop()
+        startWatching(path)
+    }
+
+    func stop() {
+        debounceTask?.cancel(); debounceTask = nil
+        reopenTask?.cancel(); reopenTask = nil
+        source?.cancel()           // triggers cancel handler → close(fd)
+        source = nil
+        watchedPath = nil
+    }
+
+    deinit {
+        debounceTask?.cancel()
+        reopenTask?.cancel()
+        source?.cancel()
+        #if DEBUG
+        FileWatcher.liveCount.withLock { $0 -= 1 }
+        #endif
+    }
+
+    private func startWatching(_ path: String) { /* see below */ }
+    private func handleEvent(mask: DispatchSource.FileSystemEvent, path: String) { /* see below */ }
+}
+```
+
+### `startWatching`
+
+```swift
+private func startWatching(_ path: String) {
+    let fd = open(path, O_EVTONLY)
+    guard fd >= 0 else {
+        watchedPath = path     // remember intent; if file appears later, re-targeting still works
+        return
+    }
+    let queue = DispatchQueue.global(qos: .utility)
+    let src = DispatchSource.makeFileSystemObjectSource(
+        fileDescriptor: fd,
+        eventMask: [.write, .extend, .delete, .rename, .revoke],
+        queue: queue
+    )
+    src.setEventHandler { [weak self] in
+        let mask = src.data
+        Task { @MainActor [weak self] in
+            self?.handleEvent(mask: mask, path: path)
+        }
+    }
+    src.setCancelHandler {
+        close(fd)              // FD closed exactly once, here, only here
+    }
+    self.source = src
+    self.watchedPath = path
+    src.resume()
+}
+```
+
+### `handleEvent`
+
+```swift
+private func handleEvent(mask: DispatchSource.FileSystemEvent, path: String) {
+    if mask.contains(.delete) || mask.contains(.rename) || mask.contains(.revoke) {
+        // Atomic save: editor wrote a temp file and renamed over us.
+        // Tear down the now-stale source/FD, retry-open after a small delay.
+        reopenTask?.cancel()
+        reopenTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled, let self, self.watchedPath == path else { return }
+            self.stop()
+            self.startWatching(path)
+            self.revision &+= 1
+        }
+        return
+    }
+
+    // Write/extend: debounce a revision bump.
+    debounceTask?.cancel()
+    debounceTask = Task { @MainActor [weak self] in
+        try? await Task.sleep(for: .milliseconds(150))
+        guard !Task.isCancelled, let self else { return }
+        self.revision &+= 1
+    }
+}
+```
+
+### Wiring into `CodeViewerPaneView`
+
+```swift
+struct CodeViewerPaneView: View {
+    let filePath: String
+    @StateObject private var watcher = FileWatcher()
+
+    var body: some View {
+        // ...existing chrome / sidebar / content branching...
+        contentView
+            .task(id: filePath) { watcher.observe(filePath) }
+    }
+}
+```
+
+The leaf content views — `RenderedContentView`, `HighlightedCodeView`, `ImagePreviewView` — gain a `revision: Int` parameter and key their existing `.task(id: ...)` on `"\(filePath)#\(revision)"` instead of `filePath`. That triggers their existing one-shot loaders to re-run on each watcher fire. No other change to their internals.
+
+## Leak prevention
+
+| Vector | Guard |
+|---|---|
+| Source's event handler retains `self` | `[weak self]` in event/cancel/debounce/reopen closures |
+| `Task` retains `self` while sleeping | `[weak self]` plus `cancel()` in `stop()` and `deinit` |
+| New `FileWatcher` per click | `@StateObject` (one-time init per view identity) **and** the routing change keeps `paneID` stable across path replacements, so SwiftUI doesn't tear the view down |
+| Repeated `observe()` leaks old source | Idempotent on same path; calls `stop()` first on different path |
+| Watcher outlives its pane | `LayoutNode.removePane` removes the node → SwiftUI tears down view → `@StateObject` released → `deinit` runs → source cancelled |
+| FD leak | FD is closed *only* by the source's cancel handler. Cancel is invoked from `stop()` (path change, explicit stop) and `deinit` (view teardown) — no path leaks an FD; no path double-closes |
+
+## Testing strategy
+
+### Unit tests (must pass in CI)
+
+- **`LayoutNodeTests`** — extend the existing test file:
+  - `firstPaneID` returns nil on no match, root pane id on root match, walks left-then-right, finds nested matches.
+  - `replacingContent` returns nil on missing id, replaces at root, replaces in either side of a split, preserves split direction and ratios, preserves sibling panes byte-for-byte.
+- **`ViewerRoutingTests`**:
+  - No existing viewer → returns `splitPane` result with a fresh viewer id.
+  - One existing viewer → returns the tree with that viewer's `path` field replaced and id preserved.
+  - Multiple viewers (a layout that somehow has more than one) → replaces the first found; others untouched.
+- **`FileWatcherTests`** (in DEBUG):
+  - Create 50 `FileWatcher`s in an `autoreleasepool`, call `observe("/some/path")`, let them deallocate. Assert `FileWatcher.liveCount == 0` afterward. Catches retain-cycle regressions.
+  - Watcher with no events: `revision` stays 0.
+  - `observe(path)` then `observe(samePath)` — no source recreation (verified via a debug hook or by counting `init` of an injected source factory; if too invasive, verify only that `revision` doesn't bump spuriously).
+  - `observe(path)` then `observe(differentPath)` — old source cancelled before new one starts (assert via cancel callback observability).
+
+### Manual verification (run before commit)
+
+1. Open a worktree, open a terminal pane, `ls`, cmd-click a `.md` file. Viewer opens to the right.
+2. cmd-click a second file. Viewer **content swaps**, pane keeps size.
+3. Repeat for 5+ files. Pane never gets smaller; `log stream --predicate 'subsystem BEGINSWITH "com.tbd" AND category == "fileWatcher"'` shows 1 init, 0 deinit.
+4. Edit the displayed file in another editor (vim, then VS Code). Pane refreshes within ~200ms each save.
+5. Close the viewer pane via its close button. Logs show 1 deinit. Re-click a relative link — viewer is recreated by splitting from the terminal.
+6. Open viewer + close pane in a tight loop 50 times. Final live-count is 0.
+7. Run Instruments → Leaks → record the manual flow. No leaks reported.
+
+## Files touched
+
+- `Sources/TBDApp/Terminal/LayoutNode.swift` — add `firstPaneID(where:)` and `replacingContent(at:with:)` extensions.
+- `Sources/TBDApp/Panes/ViewerRouting.swift` — **new file**, contains the free function `routeFileClick`.
+- `Sources/TBDApp/Panes/PanePlaceholder.swift:243-245` — replace the body of the `onFilePathClicked` closure with a call to `routeFileClick`.
+- `Sources/TBDApp/Panes/FileWatcher.swift` — **new file**, the `FileWatcher` class.
+- `Sources/TBDApp/Panes/CodeViewerPaneView.swift` — add `@StateObject private var watcher = FileWatcher()`, plumb `watcher.revision` into the three leaf content views, change their `.task(id:)` keys.
+- `Tests/TBDAppTests/LayoutNodeTests.swift` (or equivalent existing test file) — new cases for the two helpers.
+- `Tests/TBDAppTests/ViewerRoutingTests.swift` — **new file**.
+- `Tests/TBDAppTests/FileWatcherTests.swift` — **new file** (DEBUG only).
+
+## Rejected alternatives
+
+- **Promote the viewer to a fixed dock outside the layout tree.** Cleaner conceptually but a real refactor: existing close/move/split menus, layout serialization, and the FileViewerPanel sidebar's "open as code viewer" flow all route through the layout tree today. Replacing them is a lot of work for the same observable result.
+- **`LayoutNode.viewerSlot` placeholder variant.** A hybrid that picks up the worst of both — extra state to sync but still inside the tree.
+- **Central `FileWatcherPool` keyed by path.** Would let multiple viewers of the same file share a watcher. In practice we have at most one viewer per tab and rarely the same file in two tabs. The pool would add reference counting, deregistration callbacks, and a global to leak — *more* leak surface, not less. Skipped.
+- **`FSEventStream` on the parent directory.** Survives atomic saves naturally, but emits more events to filter and is heavier per directory. The vnode-source + retry approach is lighter and equally correct for this use case.
+- **`NSFilePresenter`.** Designed for coordinated I/O; far heavier than needed; unrelated semantics.
+- **Reload immediately with no debounce.** Causes flicker during multi-event saves (Prettier, vim's :w). 150ms trailing edge is the standard fix.


### PR DESCRIPTION
## Summary
- Cmd-clicking N relative file paths in a terminal used to open N viewer panes, each one squeezed smaller than the last. Now there is at most one code-viewer pane per tab — subsequent clicks swap its content (preserving the pane's id, size, and position) instead of splitting again. After an explicit close, the next click splits a fresh pane as before.
- Whichever file the viewer is showing is now watched on disk and live-refreshes within ~150ms of any external write — debounced, atomic-save aware (vim `:w`, prettier, etc.), with FD and watcher cleanup tied to the SwiftUI view's lifetime.
- Two fixes for crashes the new lifecycle work surfaced: a pre-existing latent reentrancy in `PanePlaceholder.onPreferenceChange` (synchronous `@State` writes inside the preference-graph callback) deferred to the next runloop tick; and a Combine-on-non-main teardown crash from `@StateObject` + `@MainActor ObservableObject` + `@Published` resolved by making `FileWatcher` a plain `Sendable` class with a callback, owned via `@State` (which matches the pattern used by GitHub Copilot for Xcode and cmux for the same problem).

Spec at `docs/superpowers/specs/2026-05-07-single-viewer-file-watch-design.md` walks the design and the leak-prevention reasoning. Unit tests added for `LayoutNode.firstPaneID` / `replacingContent`, `routeFileClick`, and `FileWatcher` lifecycle balance.

## Test plan
- [x] Open a worktree, terminal, cmd-click 5 different `.md` files in sequence → exactly one viewer pane, size unchanged across clicks.
- [x] With a file in the viewer, externally edit it (`echo >>` and `vim :w` to cover atomic saves) → viewer updates within ~150ms each time.
- [x] Close the viewer pane via its X button → no SIGTRAP. Cmd-click another file → fresh viewer splits open.
- [x] `swift build` clean. `swift test` runs the new unit suites in CI (local runner is broken on this machine due to a CommandLineTools / Testing-framework runtime quirk, unrelated to this PR).

open in TBD: \`tbd://open?worktree=C81B77A1-5276-454E-AFA2-6095700E435C\`