### PR TITLE
Fix: Eliminate flaky daemon git tests caused by silent empty-stdout race

### DIFF
--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -236,35 +236,26 @@ public struct GitManager: Sendable {
             let stdoutAccumulator = PipeDataAccumulator()
             let stderrAccumulator = PipeDataAccumulator()
             stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
-                let chunk = handle.availableData
-                if chunk.isEmpty {
+                if !stdoutAccumulator.readAvailable(from: handle) {
                     handle.readabilityHandler = nil
-                } else {
-                    stdoutAccumulator.append(chunk)
                 }
             }
             stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-                let chunk = handle.availableData
-                if chunk.isEmpty {
+                if !stderrAccumulator.readAvailable(from: handle) {
                     handle.readabilityHandler = nil
-                } else {
-                    stderrAccumulator.append(chunk)
                 }
             }
 
             process.terminationHandler = { _ in
-                // Detach handlers and drain anything still buffered.
+                // Detach handlers; `finish` blocks on the same lock the readability
+                // handler holds, so any in-flight read+append completes before we snapshot.
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
                 stderrPipe.fileHandleForReading.readabilityHandler = nil
-                if let tail = try? stdoutPipe.fileHandleForReading.readToEnd(), !tail.isEmpty {
-                    stdoutAccumulator.append(tail)
-                }
-                if let tail = try? stderrPipe.fileHandleForReading.readToEnd(), !tail.isEmpty {
-                    stderrAccumulator.append(tail)
-                }
+                let stdoutData = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
+                let stderrData = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
 
-                let stdout = String(data: stdoutAccumulator.snapshot(), encoding: .utf8) ?? ""
-                let stderr = String(data: stderrAccumulator.snapshot(), encoding: .utf8) ?? ""
+                let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+                let stderr = String(data: stderrData, encoding: .utf8) ?? ""
 
                 if process.terminationStatus != 0 {
                     continuation.resume(throwing: GitError(
@@ -330,21 +321,38 @@ public struct GitManager: Sendable {
     }
 }
 
-/// Thread-safe accumulator for incremental pipe reads. The readability handler
-/// fires on a background dispatch queue, so concurrent appends need a lock.
+/// Thread-safe accumulator for incremental pipe reads.
+///
+/// Invariant: `availableData`/`readToEnd` and the corresponding append happen
+/// under the same lock as `finish`. This prevents `terminationHandler` from
+/// snapshotting between a readability handler's read and its append, which
+/// would silently drop the in-flight chunk.
 private final class PipeDataAccumulator: @unchecked Sendable {
     private let lock = NSLock()
     private var data = Data()
 
-    func append(_ chunk: Data) {
-        lock.lock()
-        data.append(chunk)
-        lock.unlock()
-    }
-
-    func snapshot() -> Data {
+    /// Reads any available data from `handle` and appends it atomically.
+    /// Returns `false` on EOF (empty read), `true` otherwise.
+    func readAvailable(from handle: FileHandle) -> Bool {
         lock.lock()
         defer { lock.unlock() }
+        let chunk = handle.availableData
+        if chunk.isEmpty {
+            return false
+        }
+        data.append(chunk)
+        return true
+    }
+
+    /// Drains any remaining buffered data from `handle` and returns the full
+    /// accumulated buffer. Acquiring the lock blocks until any in-flight
+    /// `readAvailable` call has completed its append.
+    func finish(handle: FileHandle) -> Data {
+        lock.lock()
+        defer { lock.unlock() }
+        if let tail = try? handle.readToEnd(), !tail.isEmpty {
+            data.append(tail)
+        }
         return data
     }
 }

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -38,13 +38,24 @@ public struct GitManager: Sendable {
             let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
             // refs/remotes/origin/main -> main
             if let lastSlash = trimmed.lastIndex(of: "/") {
-                return String(trimmed[trimmed.index(after: lastSlash)...])
+                let branch = String(trimmed[trimmed.index(after: lastSlash)...])
+                if !branch.isEmpty {
+                    return branch
+                }
             }
         }
 
         // Fall back to local HEAD branch
         let result = try await run(arguments: ["symbolic-ref", "--short", "HEAD"], at: repoPath)
-        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            throw GitError(
+                command: "git symbolic-ref --short HEAD",
+                exitCode: 0,
+                stderr: "git symbolic-ref --short HEAD succeeded but returned empty output (likely a pipe-drain race upstream)"
+            )
+        }
+        return trimmed
     }
 
     /// Returns the URL of the `origin` remote, or `nil` if none is configured.
@@ -69,7 +80,15 @@ public struct GitManager: Sendable {
     /// Returns the HEAD SHA for a branch or ref.
     public func headSHA(repoPath: String, ref: String = "HEAD") async throws -> String {
         let output = try await run(arguments: ["rev-parse", ref], at: repoPath)
-        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            throw GitError(
+                command: "git rev-parse \(ref)",
+                exitCode: 0,
+                stderr: "git rev-parse \(ref) succeeded but returned empty output (likely a pipe-drain race upstream)"
+            )
+        }
+        return trimmed
     }
 
     /// Returns `true` if there are uncommitted changes (staged or unstaged).
@@ -114,7 +133,15 @@ public struct GitManager: Sendable {
     /// Returns the HEAD SHA of a worktree directory.
     public func headSHA(worktreePath: String) async throws -> String {
         let output = try await run(arguments: ["rev-parse", "HEAD"], at: worktreePath)
-        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            throw GitError(
+                command: "git rev-parse HEAD",
+                exitCode: 0,
+                stderr: "git rev-parse HEAD succeeded but returned empty output (likely a pipe-drain race upstream)"
+            )
+        }
+        return trimmed
     }
 
     /// Returns true if the given branch / ref name resolves in the repo.

--- a/Tests/TBDDaemonTests/GitManagerTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTests.swift
@@ -67,6 +67,39 @@ struct GitManagerTests {
         cleanup()
     }
 
+    /// Regression test for a race in `GitManager.run()` where the readability handler
+    /// did `availableData` and `accumulator.append` in two non-atomic steps,
+    /// allowing `terminationHandler` to snapshot between them and drop the chunk.
+    /// Manifested as fast commands like `git rev-parse HEAD` returning "" with exit 0.
+    /// Without the fix, this test reliably catches the race within ~200 iterations.
+    @Test func concurrentHeadSHADoesNotRace() async throws {
+        let repoPath = repoDir.path
+        let expected = try await git.headSHA(repoPath: repoPath)
+        #expect(expected.count == 40)
+        #expect(!expected.isEmpty)
+
+        let iterations = 200
+        let results = await withTaskGroup(of: String.self) { group -> [String] in
+            for _ in 0..<iterations {
+                group.addTask {
+                    (try? await self.git.headSHA(repoPath: repoPath)) ?? ""
+                }
+            }
+            var collected: [String] = []
+            for await sha in group {
+                collected.append(sha)
+            }
+            return collected
+        }
+
+        #expect(results.count == iterations)
+        for sha in results {
+            #expect(sha.count == 40, "Expected 40-char SHA, got \(sha.count) chars: '\(sha)'")
+            #expect(sha == expected, "Expected '\(expected)', got '\(sha)'")
+        }
+        cleanup()
+    }
+
     // MARK: - Helpers
 
     func cleanup() {

--- a/Tests/TBDDaemonTests/GitManagerTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTests.swift
@@ -100,6 +100,38 @@ struct GitManagerTests {
         cleanup()
     }
 
+    /// Sibling regression test for the same `GitManager.run()` pipe-drain race,
+    /// exercised through `detectDefaultBranch`. An empty branch name flows into
+    /// `git worktree add ... -b <branch> ''` and produces the
+    /// `fatal: not a valid object name: ''` failure observed in `worktreeRemove`.
+    @Test func concurrentDetectDefaultBranchDoesNotRace() async throws {
+        let repoPath = repoDir.path
+        let expected = try await git.detectDefaultBranch(repoPath: repoPath)
+        #expect(!expected.isEmpty)
+        #expect(["main", "master"].contains(expected))
+
+        let iterations = 200
+        let results = await withTaskGroup(of: String.self) { group -> [String] in
+            for _ in 0..<iterations {
+                group.addTask {
+                    (try? await self.git.detectDefaultBranch(repoPath: repoPath)) ?? ""
+                }
+            }
+            var collected: [String] = []
+            for await branch in group {
+                collected.append(branch)
+            }
+            return collected
+        }
+
+        #expect(results.count == iterations)
+        for branch in results {
+            #expect(!branch.isEmpty, "Expected non-empty branch name, got empty string")
+            #expect(branch == expected, "Expected '\(expected)', got '\(branch)'")
+        }
+        cleanup()
+    }
+
     // MARK: - Helpers
 
     func cleanup() {


### PR DESCRIPTION
## Summary

Three different daemon git tests have flaked across recent CI runs (`testReviveFallsBackToSHAWhenBranchMissing`, `testBackfillRepairsRenamedBranch`, `worktreeRemove`) — different files, different assertions, same root cause: `GitManager.run()` was occasionally returning empty stdout from a successful git command (exit 0).

**The race.** The readability handler did `let chunk = handle.availableData` and *then* `accumulator.append(chunk)` as two separate steps. If `terminationHandler` ran between them, it cleared the readability handler, called `readToEnd()` (which returned empty because `availableData` had already consumed the bytes), snapshotted the accumulator without the in-flight chunk, and resumed the continuation with truncated/empty stdout.

**The fallout.** Empty stdout from `git rev-parse HEAD` got persisted as an empty `archivedHeadSHA` (so the SHA-fallback revive path threw `branchMissingNoFallback`); empty stdout from `git symbolic-ref --short HEAD` got passed to `git worktree add ... -b <name>` as an empty base, producing `fatal: not a valid object name: ''`. All three failure modes bottom out at the same buggy helper.

**The fix.**
- 313f6e9 — Make read+append atomic under one lock and have `terminationHandler` acquire it before draining the tail. In-flight readability handlers always finish appending before the snapshot is taken.
- c0fde5e — Defense-in-depth empty guards on `headSHA(repoPath:, ref:)`, `headSHA(worktreePath:)`, and `detectDefaultBranch(repoPath:)` so a future regression in `run()` throws loudly at the call site instead of silently writing empty SHAs to the DB.

Background: this surfaced from #105's CI runs.

## Test plan

- [x] New `concurrentHeadSHADoesNotRace` and `concurrentDetectDefaultBranchDoesNotRace` stress tests fire 200 concurrent calls and assert every result is the expected non-empty value
- [x] `swift test --filter GitManagerTests` — 7/7 pass, looped 5x with `--parallel`, no flakes
- [x] `swift test --filter ArchivedReviveBranchRenameTests` — 9/9 pass

open in TBD: \`tbd://open?worktree=0B7DCE23-3C84-42FC-847D-9738D0009FFD\`