### PR TITLE
Refactor: FileWatcher emits changes as AsyncStream<Void>

### DIFF
--- a/Sources/TBDApp/Panes/CodeViewerPaneView.swift
+++ b/Sources/TBDApp/Panes/CodeViewerPaneView.swift
@@ -316,16 +316,17 @@ private func isTextFile(_ path: String) -> Bool {
 ///
 /// File-watching plumbing intentionally avoids `@StateObject` /
 /// `ObservableObject` / `@Published` — see the doc-comment on
-/// `FileWatcher` for the SIGTRAP that taught us why. The watcher lives in
-/// `@State` (which stores reference types stably across re-renders) and
-/// pokes the view via a callback that bumps `revision`, an Int observed
-/// by SwiftUI as ordinary `@State`.
+/// `FileWatcher` for the SIGTRAP that taught us why. The watcher exposes
+/// changes as an `AsyncStream<Void>` consumed inside `.task(id: filePath)`;
+/// when the task is cancelled (path change, view teardown) the stream's
+/// `onTermination` cancels the dispatch source, closing the FD via its
+/// cancel handler. SwiftUI just observes the `revision` Int.
 private struct FilePreviewView: View {
     let filePath: String
     let showSourceCode: Bool
 
-    @State private var watcher = FileWatcher()
     @State private var revision: Int = 0
+    private let watcher = FileWatcher()
 
     var body: some View {
         Group {
@@ -340,15 +341,16 @@ private struct FilePreviewView: View {
             }
         }
         .task(id: filePath) {
-            // Wire the callback fresh each time filePath changes. The
-            // callback bumps revision on the main actor; SwiftUI re-renders
-            // the leaf view, whose .task(id: "<path>#<rev>") reloads.
-            watcher.onChange = {
-                Task { @MainActor in
-                    revision &+= 1
-                }
+            // Each filePath change starts a fresh stream. Iterating it
+            // inside `.task` ties FD lifetime to this view: when the task
+            // is cancelled (path change, view teardown), the stream's
+            // iterator is dropped, `onTermination` fires, and the dispatch
+            // source is cancelled — which closes the FD via its cancel
+            // handler. SwiftUI re-renders the leaf view on each yield, and
+            // its `.task(id: "<path>#<rev>")` reloads the file contents.
+            for await _ in watcher.changes(for: filePath) {
+                revision &+= 1
             }
-            watcher.observe(filePath)
         }
     }
 }

--- a/Sources/TBDApp/Panes/FileWatcher.swift
+++ b/Sources/TBDApp/Panes/FileWatcher.swift
@@ -157,12 +157,11 @@ private final class StreamState: @unchecked Sendable {
             close(fd)
         }
 
-        // Install the new source under the lock, cancelling any previous
-        // source in case startWatching is called from a reopen path.
+        // Install the new source under the lock, returning either the
+        // previous epoch's source (so we can cancel it below) or — if
+        // terminate() already ran — the freshly-built `src` itself, so
+        // the same teardown step closes its FD.
         let previousSource: DispatchSourceFileSystemObject? = inner.withLock { i -> DispatchSourceFileSystemObject? in
-            // Don't install if we've already terminated — race with
-            // onTermination firing while we were mid-open. Cancel the
-            // freshly-built source ourselves so its FD doesn't leak.
             if i.terminated {
                 return src
             }
@@ -171,14 +170,17 @@ private final class StreamState: @unchecked Sendable {
             return prev
         }
 
-        if inner.withLock({ $0.terminated }) {
-            // We raced with terminate(); the source we just stashed-then-
-            // returned is the one we need to cancel ourselves. (See above.)
-            previousSource?.cancel()
-            return true
-        }
-
-        // Cancel the previous epoch (if any) and start the new one.
+        // Always cancel any previous epoch's source AND resume `src`. The
+        // resume is the load-bearing detail: per GCD docs, "if a source
+        // was suspended at the time `dispatch_source_cancel()` was called,
+        // the cancellation handler will be submitted after the source is
+        // resumed." Without resume() on every path, a path where another
+        // thread cancels `src` while it's still suspended (race with
+        // terminate(), or the `terminated`-at-install case above) would
+        // never run the cancel handler — leaking the FD.
+        //
+        // Resuming an already-cancelled source is harmless: GCD dispatches
+        // the cancel handler and delivers no events.
         previousSource?.cancel()
         src.resume()
         return true

--- a/Sources/TBDApp/Panes/FileWatcher.swift
+++ b/Sources/TBDApp/Panes/FileWatcher.swift
@@ -77,7 +77,7 @@ final class FileWatcher: Sendable {
                 #endif
             }
 
-            if !box.startWatching(path: path) {
+            if !box.startWatching() {
                 continuation.finish()
             }
         }
@@ -123,12 +123,12 @@ private final class StreamState: @unchecked Sendable {
         self.continuation = continuation
     }
 
-    /// Open `path` and start a dispatch source for it. Returns `false` if
-    /// `open()` failed (caller should `continuation.finish()`).
-    func startWatching(path: String) -> Bool {
-        let fd = open(path, O_EVTONLY)
+    /// Open `self.path` and start a dispatch source for it. Returns `false`
+    /// if `open()` failed (caller should `continuation.finish()`).
+    func startWatching() -> Bool {
+        let fd = open(self.path, O_EVTONLY)
         guard fd >= 0 else {
-            logger.debug("FileWatcher: open(\(path, privacy: .public)) failed errno=\(errno)")
+            logger.debug("FileWatcher: open(\(self.path, privacy: .public)) failed errno=\(errno)")
             return false
         }
 
@@ -236,7 +236,7 @@ private final class StreamState: @unchecked Sendable {
         // Bail out fast if the stream is already gone.
         if inner.withLock({ $0.terminated }) { return }
 
-        if startWatching(path: path) {
+        if startWatching() {
             // Successful re-open — surface a single event so consumers
             // (e.g. file viewers) re-load the freshly-saved content.
             yieldIfActive()

--- a/Sources/TBDApp/Panes/FileWatcher.swift
+++ b/Sources/TBDApp/Panes/FileWatcher.swift
@@ -4,143 +4,132 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.app", category: "fileWatcher")
 
-/// Observes a single file on disk and invokes `onChange` (debounced ~150ms,
-/// hopped onto the main actor) whenever the file changes. Survives atomic
-/// saves (rename/delete) by re-opening the watcher on the same path after a
-/// small delay.
+/// Observes a single file on disk and yields a debounced (~150ms) `Void`
+/// each time the file changes. Survives atomic saves (rename/delete) by
+/// re-opening the watcher on the same path after a small delay.
 ///
-/// ## Why this is *not* `@MainActor` or `ObservableObject`
+/// ## Why `AsyncStream` rather than a callback
 ///
-/// An earlier design exposed `@Published var revision: Int` on a
-/// `@MainActor`-isolated `ObservableObject` and was hosted as a
-/// `@StateObject` on `FilePreviewView`. Closing the code-viewer pane crashed
-/// the app with `EXC_BREAKPOINT` (SIGTRAP). The OS log showed
-/// `BUG IN CLIENT OF LIBDISPATCH: Block was expected to execute on queue
-/// [com.apple.main-thread]` on two non-main worker threads, immediately
-/// preceded by SwiftUI's "NSHostingView is being laid out reentrantly while
-/// rendering its SwiftUI content" warning. The earliest crash trace pointed
-/// straight at `swift_release` inside `AGGraphSetOutputValue` during
-/// `GraphHost.updatePreferences()` — the Combine + `@StateObject` teardown
-/// was running off the main thread during a failed-layout-pass recovery,
-/// tripping `dispatchPrecondition(.onQueue(.main))` inside Combine's
-/// internals.
+/// An earlier `@StateObject` + `@MainActor ObservableObject` + `@Published`
+/// design crashed during view teardown (Combine subscription release on a
+/// non-main thread). The fix that shipped in PR #108 reduced the watcher to
+/// a plain `Sendable` reference type with an `onChange` callback, owned via
+/// `@State` on the host view. That works, but the lifetime story is
+/// imperative — the host has to wire `onChange` and call `observe` /
+/// `stop` itself, and the watcher stays alive across `.task` cancellations.
 ///
-/// The fix: keep the watcher a plain reference type with no actor isolation
-/// and no Combine publishers. SwiftUI observes a separate `@State var
-/// revision: Int` on the host view; the watcher just calls `onChange` on the
-/// main actor when the file changes, and the view bumps its own revision.
-/// No `@StateObject`, no `@Published`, no Combine subscription teardown
-/// during view destruction.
+/// This refinement, modeled on Point-Free's `FileStorage` PersistenceKey
+/// pattern, ties the file descriptor's lifetime to a single
+/// `AsyncStream<Void>`:
+///
+/// - Each call to `changes(for:)` opens its own FD, builds its own
+///   dispatch source, and returns a fresh stream. No shared state, no
+///   `observe`/`stop` API.
+/// - When the consuming `.task` is cancelled (path change, view teardown)
+///   the stream's iterator is dropped, which fires
+///   `continuation.onTermination`. That cancels the dispatch source, whose
+///   cancel handler closes the FD exactly once.
+/// - Atomic saves (vim `:w`, prettier, etc.) on the watched inode trigger a
+///   re-open of the same path after ~50ms. The old source is cancelled
+///   (closing its FD) before the new one starts, so we never leak.
 ///
 /// ## Lifecycle invariants
 ///
-/// 1. The file descriptor is closed exactly once, by the dispatch source's
-///    cancel handler. `cancel()` is invoked from `stop()` (path change /
-///    explicit stop) and from `deinit` (view teardown). No path leaks an
-///    FD; no path double-closes.
-/// 2. All event/cancel/Task closures capture `self` weakly — the source's
-///    handlers and the in-flight `Task`s never keep the watcher alive past
-///    its owning view.
-/// 3. `observe(path:)` is idempotent on the same path; on a different path
-///    it calls `stop()` first.
-/// 4. All mutable state (`source`, `watchedPath`, debounce/reopen tasks,
-///    `onChange`) is guarded by `OSAllocatedUnfairLock<State>` so callers
-///    may invoke `observe`/`stop` from any isolation context, and `deinit`
-///    (which Swift always treats as `nonisolated`) can tear down safely
-///    from whatever thread released the last reference.
-final class FileWatcher: @unchecked Sendable {
+/// 1. `open(path, O_EVTONLY)` — read-only event subscription, no other modes.
+/// 2. `close(fd)` is called exactly once per opened FD, only from the
+///    dispatch source's cancel handler.
+/// 3. All exit paths funnel through `continuation.onTermination`:
+///    - Consumer drops the iterator (`break` out of `for await`).
+///    - Consuming `.task` is cancelled (host view torn down, `.task(id:)`
+///      identity changes).
+///    - The watcher itself calls `continuation.finish()` (re-open failed).
+///    Each of those cancels the current dispatch source, which closes the
+///    FD via its cancel handler.
+/// 4. The dispatch event handler holds a weak reference to the per-stream
+///    `StreamState` box. When the stream terminates, the box is released,
+///    and any in-flight handler call becomes a no-op.
+final class FileWatcher: Sendable {
 
-    /// Bundled mutable state, all guarded by `state.withLock { ... }`.
-    fileprivate struct State {
-        var onChange: (@Sendable () -> Void)?
-        var source: DispatchSourceFileSystemObject?
-        var watchedPath: String?
-        var debounceTask: Task<Void, Never>?
-        var reopenTask: Task<Void, Never>?
+    /// Yields a debounced (~150ms trailing-edge) `Void` each time `path`
+    /// changes on disk. The stream's lifetime owns the file descriptor: when
+    /// the consuming `.task` is cancelled (or the iterator is dropped), the
+    /// continuation's onTermination callback cancels the dispatch source,
+    /// which closes the FD via its cancel handler.
+    ///
+    /// Atomic-save aware: a `.delete` / `.rename` / `.revoke` event on the
+    /// watched inode triggers a re-open of the same path after ~50ms. If
+    /// the re-open fails (file genuinely gone) the stream is finished.
+    func changes(for path: String) -> AsyncStream<Void> {
+        AsyncStream<Void>(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            let box = StreamState(path: path, continuation: continuation)
+
+            #if DEBUG
+            Self._liveStreamCountLock.withLock { $0 += 1 }
+            #endif
+
+            // First open. If it fails, finish the stream right away.
+            // (We still register onTermination so the DEBUG counter is
+            // balanced and `finish()` is idempotent.)
+            continuation.onTermination = { _ in
+                box.terminate()
+                #if DEBUG
+                Self._liveStreamCountLock.withLock { $0 -= 1 }
+                #endif
+            }
+
+            if !box.startWatching(path: path) {
+                continuation.finish()
+            }
+        }
     }
-
-    /// Invoked on the main actor each time the watched file changes (after
-    /// debouncing). Set by the owning view; the watcher hops onto the main
-    /// actor before invoking it.
-    var onChange: (@Sendable () -> Void)? {
-        get { state.withLock { $0.onChange } }
-        set { state.withLock { $0.onChange = newValue } }
-    }
-
-    private let state = OSAllocatedUnfairLock<State>(initialState: State())
 
     /// DEBUG-only counter for lifecycle balance assertions in tests.
+    /// Increments when a stream is created, decrements when its
+    /// `onTermination` fires (consumer dropped iterator or `.task` was
+    /// cancelled or `finish()` was called).
     #if DEBUG
-    nonisolated private static let _liveCountLock = OSAllocatedUnfairLock<Int>(initialState: 0)
-    nonisolated static var liveCount: Int { _liveCountLock.withLock { $0 } }
+    nonisolated private static let _liveStreamCountLock = OSAllocatedUnfairLock<Int>(initialState: 0)
+    nonisolated static var liveStreamCount: Int { _liveStreamCountLock.withLock { $0 } }
     #endif
+}
 
-    init() {
-        #if DEBUG
-        Self._liveCountLock.withLock { $0 += 1 }
-        #endif
+// MARK: - StreamState (per-stream lifetime box)
+
+/// Mutable state for a single in-flight `changes(for:)` stream. Guarded by
+/// `OSAllocatedUnfairLock` so the dispatch event handler (running on a
+/// global utility queue) and the `onTermination` callback (running on
+/// whatever thread released the iterator) can both touch it safely.
+///
+/// The box itself is held strongly by the dispatch source's event handler
+/// closure for as long as the source is alive. When `terminate()` cancels
+/// the source, the source's GCD-side strong references go away, the cancel
+/// handler runs (closing the FD), and the box becomes eligible for
+/// deallocation.
+private final class StreamState: @unchecked Sendable {
+    fileprivate struct Inner {
+        var source: DispatchSourceFileSystemObject?
+        var debounceTask: Task<Void, Never>?
+        var reopenTask: Task<Void, Never>?
+        /// Set once `terminate()` has run; further events are ignored.
+        var terminated: Bool = false
     }
 
-    deinit {
-        // `source.cancel()` and `Task.cancel()` are safe to call from any
-        // thread / isolation context. The source's cancel handler runs on
-        // its dispatch queue and closes the FD exactly once. We grab the
-        // lock briefly to hand off ownership of the cancellable resources
-        // to local vars, then release the lock before cancelling — that
-        // way the dispatch source's release (which can run its cancel
-        // handler on the GCD queue) doesn't reenter under our lock.
-        let (debounce, reopen, src): (Task<Void, Never>?, Task<Void, Never>?, DispatchSourceFileSystemObject?) =
-            state.withLock { s in
-                let trio = (s.debounceTask, s.reopenTask, s.source)
-                s.debounceTask = nil
-                s.reopenTask = nil
-                s.source = nil
-                s.watchedPath = nil
-                s.onChange = nil
-                return trio
-            }
-        debounce?.cancel()
-        reopen?.cancel()
-        src?.cancel()
-        #if DEBUG
-        Self._liveCountLock.withLock { $0 -= 1 }
-        #endif
+    private let inner = OSAllocatedUnfairLock<Inner>(initialState: Inner())
+    private let path: String
+    private let continuation: AsyncStream<Void>.Continuation
+
+    init(path: String, continuation: AsyncStream<Void>.Continuation) {
+        self.path = path
+        self.continuation = continuation
     }
 
-    func observe(_ path: String) {
-        state.withLock { s in
-            guard path != s.watchedPath else { return }
-            stopLocked(&s)
-            startWatchingLocked(&s, path: path)
-        }
-    }
-
-    func stop() {
-        state.withLock { s in
-            stopLocked(&s)
-        }
-    }
-
-    // MARK: - Private (caller holds the lock)
-
-    private func stopLocked(_ s: inout State) {
-        s.debounceTask?.cancel(); s.debounceTask = nil
-        s.reopenTask?.cancel(); s.reopenTask = nil
-        s.source?.cancel()           // triggers cancel handler → close(fd)
-        s.source = nil
-        s.watchedPath = nil
-    }
-
-    private func startWatchingLocked(_ s: inout State, path: String) {
+    /// Open `path` and start a dispatch source for it. Returns `false` if
+    /// `open()` failed (caller should `continuation.finish()`).
+    func startWatching(path: String) -> Bool {
         let fd = open(path, O_EVTONLY)
         guard fd >= 0 else {
-            // File doesn't exist (or we can't open it). Remember the intent
-            // anyway so a later observe(samePath) is still a no-op; the
-            // existing one-shot loaders in the leaf views will surface the
-            // read error.
-            s.watchedPath = path
             logger.debug("FileWatcher: open(\(path, privacy: .public)) failed errno=\(errno)")
-            return
+            return false
         }
 
         let queue = DispatchQueue.global(qos: .utility)
@@ -150,77 +139,136 @@ final class FileWatcher: @unchecked Sendable {
             queue: queue
         )
 
-        src.setEventHandler { [weak self] in
-            // Capture the mask while we're on the dispatch queue; hop into
-            // the watcher (under its lock) on whichever queue we're on.
+        // Capture the source weakly via a local — the source is kept alive
+        // by `inner.source` plus its own GCD-side retain. Capture self
+        // weakly so the box is not kept alive by the dispatch source past
+        // the consumer dropping the stream (after which the source is
+        // already cancelled and the handler will not fire again).
+        src.setEventHandler { [weak self, weak src] in
+            guard let self, let src else { return }
             let mask = src.data
-            self?.handleEvent(mask: mask, path: path)
+            self.handleEvent(mask: mask)
         }
 
         src.setCancelHandler {
             // FD closed exactly once, here, regardless of who triggered
-            // cancellation (stop / deinit / re-open).
+            // cancellation (terminate / atomic-save reopen / stream
+            // consumer dropping the iterator).
             close(fd)
         }
 
-        s.source = src
-        s.watchedPath = path
+        // Install the new source under the lock, cancelling any previous
+        // source in case startWatching is called from a reopen path.
+        let previousSource: DispatchSourceFileSystemObject? = inner.withLock { i -> DispatchSourceFileSystemObject? in
+            // Don't install if we've already terminated — race with
+            // onTermination firing while we were mid-open. Cancel the
+            // freshly-built source ourselves so its FD doesn't leak.
+            if i.terminated {
+                return src
+            }
+            let prev = i.source
+            i.source = src
+            return prev
+        }
+
+        if inner.withLock({ $0.terminated }) {
+            // We raced with terminate(); the source we just stashed-then-
+            // returned is the one we need to cancel ourselves. (See above.)
+            previousSource?.cancel()
+            return true
+        }
+
+        // Cancel the previous epoch (if any) and start the new one.
+        previousSource?.cancel()
         src.resume()
+        return true
     }
 
-    private func handleEvent(mask: DispatchSource.FileSystemEvent, path: String) {
+    /// Called by the dispatch source's event handler. The source/queue keep
+    /// the box alive long enough to safely touch `inner` here.
+    private func handleEvent(mask: DispatchSource.FileSystemEvent) {
         // Atomic save: vim/VS Code/Prettier write a temp file then rename
         // it over the original. The original inode is now gone even though
         // the path still resolves to a file.
         if mask.contains(.delete) || mask.contains(.rename) || mask.contains(.revoke) {
-            scheduleReopen(path: path)
+            scheduleReopen()
             return
         }
-
         // Write/extend: trailing-edge debounce a notification.
         scheduleDebouncedNotify()
     }
 
-    private func scheduleReopen(path: String) {
-        let newTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(50))
+    private func scheduleDebouncedNotify() {
+        let task = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(150))
             guard !Task.isCancelled, let self else { return }
-            let cb: (@Sendable () -> Void)? = self.state.withLock { s in
-                guard s.watchedPath == path else { return nil }
-                self.stopLocked(&s)
-                self.startWatchingLocked(&s, path: path)
-                return s.onChange
-            }
-            if let cb {
-                await MainActor.run { cb() }
-            }
+            self.yieldIfActive()
         }
-        state.withLock { s in
-            // If we're racing with a `stop()` that already happened, the
-            // path won't match in the body above — the task will be a
-            // benign no-op. We still record it so that a subsequent
-            // `stop()`/deinit cancels it promptly.
-            guard s.watchedPath == path else {
-                newTask.cancel()
+        inner.withLock { i in
+            if i.terminated {
+                task.cancel()
                 return
             }
-            s.reopenTask?.cancel()
-            s.reopenTask = newTask
+            i.debounceTask?.cancel()
+            i.debounceTask = task
         }
     }
 
-    private func scheduleDebouncedNotify() {
-        let newTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(150))
+    private func scheduleReopen() {
+        let task = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
             guard !Task.isCancelled, let self else { return }
-            let cb: (@Sendable () -> Void)? = self.state.withLock { $0.onChange }
-            if let cb {
-                await MainActor.run { cb() }
+            self.performReopen()
+        }
+        inner.withLock { i in
+            if i.terminated {
+                task.cancel()
+                return
             }
+            i.reopenTask?.cancel()
+            i.reopenTask = task
         }
-        state.withLock { s in
-            s.debounceTask?.cancel()
-            s.debounceTask = newTask
+    }
+
+    private func performReopen() {
+        // Bail out fast if the stream is already gone.
+        if inner.withLock({ $0.terminated }) { return }
+
+        if startWatching(path: path) {
+            // Successful re-open — surface a single event so consumers
+            // (e.g. file viewers) re-load the freshly-saved content.
+            yieldIfActive()
+        } else {
+            // File genuinely gone (or unreadable). Finish the stream.
+            // `terminate()` will run via `onTermination` and clean up.
+            continuation.finish()
         }
+    }
+
+    private func yieldIfActive() {
+        let active = inner.withLock { !$0.terminated }
+        guard active else { return }
+        continuation.yield()
+    }
+
+    /// Called from `continuation.onTermination`. Cancels the dispatch
+    /// source (which closes the FD via its cancel handler) and any
+    /// outstanding tasks. Safe to call from any thread; idempotent.
+    func terminate() {
+        let (src, debounce, reopen): (DispatchSourceFileSystemObject?, Task<Void, Never>?, Task<Void, Never>?) =
+            inner.withLock { i in
+                if i.terminated {
+                    return (nil, nil, nil)
+                }
+                i.terminated = true
+                let trio = (i.source, i.debounceTask, i.reopenTask)
+                i.source = nil
+                i.debounceTask = nil
+                i.reopenTask = nil
+                return trio
+            }
+        debounce?.cancel()
+        reopen?.cancel()
+        src?.cancel()
     }
 }

--- a/Tests/TBDAppTests/FileWatcherTests.swift
+++ b/Tests/TBDAppTests/FileWatcherTests.swift
@@ -7,35 +7,34 @@ import Testing
 @Suite("FileWatcher")
 struct FileWatcherTests {
 
-    /// Creates and immediately releases many FileWatchers. If any of them
-    /// kept an internal retain cycle (e.g. handler closure capturing self
-    /// strongly, Task holding self), liveCount would not return to its
-    /// starting value.
+    /// Construct many watchers without ever calling `changes(for:)`.
+    /// `FileWatcher` itself is now a stateless factory, so this should be
+    /// trivially balanced — no FDs opened, no streams alive.
     @MainActor
-    @Test func liveCountReturnsToZeroAfterRelease() async {
-        let baseline = FileWatcher.liveCount
-
+    @Test func factoryConstructionIsStateless() async {
+        let baseline = FileWatcher.liveStreamCount
         do {
             var watchers: [FileWatcher] = []
             for _ in 0..<50 {
                 watchers.append(FileWatcher())
             }
-            #expect(FileWatcher.liveCount == baseline + 50)
+            // Constructing a FileWatcher must not start any stream.
+            #expect(FileWatcher.liveStreamCount == baseline)
             watchers.removeAll()
         }
-
-        // Allow any deferred deallocations to settle on the main actor.
         await Task.yield()
-        #expect(FileWatcher.liveCount == baseline)
+        #expect(FileWatcher.liveStreamCount == baseline)
     }
 
+    /// Start a stream against a real temp file, drop the iterator, and
+    /// confirm the stream's `onTermination` ran (live count returns to
+    /// baseline). This covers the core invariant: any path that drops the
+    /// iterator must drive cleanup, including the dispatch source's cancel
+    /// handler closing the FD.
     @MainActor
-    @Test func liveCountReturnsToZeroAfterObserveOnTempFile() async {
-        let baseline = FileWatcher.liveCount
+    @Test func liveStreamCountReturnsToBaselineAfterIteratorDrops() async {
+        let baseline = FileWatcher.liveStreamCount
 
-        // Create a real temp file so observe() actually opens an FD and
-        // creates a dispatch source — we want to confirm the source's
-        // strong refs to closures don't keep self alive.
         let tmpURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("filewatcher-test-\(UUID().uuidString).txt")
         FileManager.default.createFile(atPath: tmpURL.path, contents: Data("hi".utf8))
@@ -43,40 +42,73 @@ struct FileWatcherTests {
 
         do {
             let w = FileWatcher()
-            w.observe(tmpURL.path)
-            #expect(FileWatcher.liveCount == baseline + 1)
-            // w goes out of scope here
-            _ = w
+            var iterator = w.changes(for: tmpURL.path).makeAsyncIterator()
+            #expect(FileWatcher.liveStreamCount == baseline + 1)
+            // Dropping `iterator` here triggers continuation.onTermination
+            // (no consumer left to receive yields).
+            _ = iterator
         }
 
-        // Give GCD a moment to run the cancel handler / release closures.
-        try? await Task.sleep(for: .milliseconds(50))
-        #expect(FileWatcher.liveCount == baseline)
+        // Give GCD a moment to run the cancel handler and the
+        // onTermination callback.
+        for _ in 0..<10 {
+            if FileWatcher.liveStreamCount == baseline { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(FileWatcher.liveStreamCount == baseline)
     }
 
+    /// Cancelling the consuming `Task` (the SwiftUI `.task` analogue) must
+    /// also drive the stream's onTermination — that's the most common
+    /// real-world cleanup path.
     @MainActor
-    @Test func observeIsIdempotentOnSamePath() {
-        // FileWatcher no longer exposes `revision` directly (see doc
-        // comment on FileWatcher for why). The observable signal we have
-        // here is "did onChange fire?", which it should NOT for a no-op
-        // re-observe of the same (non-existent) path.
-        //
-        // `onChange` is `@Sendable`, so the counter has to be safe to
-        // mutate from any isolation. A lock-backed counter keeps the
-        // assertion semantics while satisfying Swift 6 strict concurrency.
-        let fireCount = OSAllocatedUnfairLock<Int>(initialState: 0)
+    @Test func cancellingConsumingTaskTerminatesStream() async {
+        let baseline = FileWatcher.liveStreamCount
+
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("filewatcher-test-\(UUID().uuidString).txt")
+        FileManager.default.createFile(atPath: tmpURL.path, contents: Data("hi".utf8))
+        defer { try? FileManager.default.removeItem(at: tmpURL) }
+
         let w = FileWatcher()
-        w.onChange = { fireCount.withLock { $0 += 1 } }
-        w.observe("/some/path")
-        w.observe("/some/path") // same path — should be a no-op
-        #expect(fireCount.withLock { $0 } == 0)
+        let path = tmpURL.path
+        let task = Task {
+            for await _ in w.changes(for: path) {
+                // Nothing to do — we just need a live consumer.
+            }
+        }
+        // Yield to let the Task actually start iterating.
+        await Task.yield()
+        #expect(FileWatcher.liveStreamCount >= baseline + 1)
+
+        task.cancel()
+        _ = await task.value
+
+        for _ in 0..<10 {
+            if FileWatcher.liveStreamCount == baseline { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(FileWatcher.liveStreamCount == baseline)
     }
 
+    /// Opening a non-existent path must finish the stream cleanly — no
+    /// hang, no leak. The for-await loop should exit immediately.
     @MainActor
-    @Test func stopIsIdempotent() {
+    @Test func nonExistentPathFinishesStreamImmediately() async {
+        let baseline = FileWatcher.liveStreamCount
         let w = FileWatcher()
-        w.observe("/some/path")
-        w.stop()
-        w.stop() // should not crash
+        let bogus = "/definitely/does/not/exist/\(UUID().uuidString)"
+
+        var receivedAny = false
+        for await _ in w.changes(for: bogus) {
+            receivedAny = true
+        }
+        #expect(receivedAny == false)
+
+        for _ in 0..<10 {
+            if FileWatcher.liveStreamCount == baseline { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(FileWatcher.liveStreamCount == baseline)
     }
 }

--- a/Tests/TBDAppTests/FileWatcherTests.swift
+++ b/Tests/TBDAppTests/FileWatcherTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import TBDApp
 
-@Suite("FileWatcher")
+@Suite("FileWatcher", .serialized)
 struct FileWatcherTests {
 
     /// Construct many watchers without ever calling `changes(for:)`.


### PR DESCRIPTION
## Summary

- Replaces `FileWatcher`'s `onChange: (@Sendable () -> Void)?` callback (shipped in #108) with a single API: `changes(for:) -> AsyncStream<Void>`. Each call opens its own FD, builds its own dispatch source, and returns a fresh stream. There is no shared `observe`/`stop` state, no `onChange` to wire, no view-owned lifetime to track.
- Cleanup is the stream's `continuation.onTermination`: when the consuming `.task` is cancelled (path change, view teardown) or the iterator is dropped, the dispatch source is cancelled, which closes the FD exactly once via its cancel handler. That's the only place `close(fd)` runs.
- Atomic-save handling unchanged: a `.delete` / `.rename` / `.revoke` event on the watched inode triggers a re-open of the same path after ~50ms (and yields once on success); failure to re-open finishes the stream cleanly. 150ms trailing-edge debounce on `.write` / `.extend` unchanged.

## Why this refactor

Follow-up to #108. The callback design that shipped there is the correct simplification of an earlier (crashing) `@StateObject` + `@MainActor ObservableObject` + `@Published` design. It works — it's the same pattern used by GitHub Copilot for Xcode's `SingleFileWatcher` and cmux's `FileExplorerDirectoryWatcher`.

This PR is the next refinement, modeled on Point-Free's `FileStorage` PersistenceKey: wrap a `DispatchSourceFileSystemObject` in an `AsyncStream` and tie the FD's lifetime to `continuation.onTermination`. For our specific case (one watcher per `FilePreviewView`, consumed via SwiftUI's `.task(id:)`), AsyncStream is a natural fit:

```swift
.task(id: filePath) {
    for await _ in watcher.changes(for: filePath) {
        revision &+= 1
    }
}
```

The cancellation story is bulletproof — there's no `deinit`-on-wrong-thread risk to even worry about, because cleanup runs from `onTermination` on whatever thread released the iterator, and `source.cancel()` is documented as safe to call from anywhere.

## What changed

- `Sources/TBDApp/Panes/FileWatcher.swift` — full rewrite. `FileWatcher` is now a `Sendable` factory with a single method `changes(for:)`; per-stream state lives in a private `StreamState` box guarded by `OSAllocatedUnfairLock`. DEBUG-only `liveStreamCount` replaces `liveCount`.
- `Sources/TBDApp/Panes/CodeViewerPaneView.swift` — `FilePreviewView` swapped to `for await _ in watcher.changes(for: filePath)` inside its `.task(id: filePath)`. The `watcher` itself is now a stateless `private let` (no `@State` needed since it has no per-instance state).
- `Tests/TBDAppTests/FileWatcherTests.swift` — `observeIsIdempotentOnSamePath` removed (no `observe`/`onChange` API). New stream-lifecycle tests covering: stateless construction, iterator-drop cleanup, consuming-task-cancel cleanup, non-existent-path finishes immediately. All assert lifecycle balance via `FileWatcher.liveStreamCount` (DEBUG only).

## Behaviorally equivalent

- 150ms trailing-edge debounce: preserved.
- 50ms atomic-save reopen: preserved.
- `O_EVTONLY` FD, single `close(fd)` from cancel handler: preserved.
- Weak captures in event handlers: preserved.
- The closing tests from the existing suite (lifecycle balance after observe-on-temp-file) remain conceptually intact — the new `liveStreamCountReturnsToBaselineAfterIteratorDrops` is the same property in stream form.

No other behavioral changes. Routing (`LayoutNode.firstPaneID` / `replacingContent` / `routeFileClick` / `PanePlaceholder` wiring) and the preference-change deferral in `PanePlaceholder.onPreferenceChange` are untouched.

## Test plan

- [x] `swift build` clean (warnings unchanged from main).
- [ ] CI runs the unit tests on this PR (local `swift test` is broken on this machine due to a CommandLineTools / Testing-framework runtime quirk, unrelated to this PR — same situation as #108).
- [ ] Smoke: open a worktree, click a `.md` file, `echo >> file.md` and `vim :w` externally → viewer updates within ~150ms.
- [ ] Smoke: cmd-click a different file → viewer swaps content; old stream's onTermination cancels the previous source.
- [ ] Smoke: close the viewer pane → no SIGTRAP.

Follow-up to #108.

open in TBD: `tbd://open?worktree=C81B77A1-5276-454E-AFA2-6095700E435C`