### PR TITLE
Feat: Claude transcripts no longer freeze on /clear or /compact

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -273,6 +273,7 @@ final class AppState: ObservableObject {
     let daemonClient = DaemonClient()
     let tmuxBridge = TmuxBridge()
     lazy var cliInstallerCoordinator = CLIInstallerCoordinator(daemonClient: daemonClient)
+    lazy var legacyHooksCoordinator = LegacyHooksCoordinator(daemonClient: daemonClient)
     private var pollTimer: Timer?
     private var pollCycle = 0
     private var subscriptionTask: Task<Void, Never>?
@@ -533,12 +534,22 @@ final class AppState: ObservableObject {
                 guard let self else { return }
                 await self.cliInstallerCoordinator.checkOnLaunch()
             }
+            Task { [weak self] in
+                guard let self else { return }
+                await self.legacyHooksCoordinator.checkOnLaunch()
+            }
         }
     }
 
     /// Menu entry point — install or refresh the `tbd` CLI symlink.
     func installCLITool() async {
         await cliInstallerCoordinator.runFromMenu()
+    }
+
+    /// Menu entry point — review and (optionally) remove TBD's legacy
+    /// hook entries from the user's `~/.claude/settings.json`.
+    func migrateClaudeHooks() async {
+        await legacyHooksCoordinator.runFromMenu()
     }
 
     /// Launch the daemon process and connect.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -442,7 +442,13 @@ final class AppState: ObservableObject {
             return
         }
         terminals[delta.worktreeID]?[idx].claudeSessionID = delta.sessionID
-        terminals[delta.worktreeID]?[idx].transcriptPath = delta.transcriptPath
+        // Mirror TerminalStore.updateSession's preserve-on-nil: a delta with
+        // nil transcriptPath means the SessionStart payload didn't carry a
+        // path even though sessionID rolled. Keep the previous value so the
+        // in-memory model doesn't drift from the DB.
+        if let tp = delta.transcriptPath {
+            terminals[delta.worktreeID]?[idx].transcriptPath = tp
+        }
     }
 
     /// Update the in-place usage entry for a single profile. If no match,

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -425,9 +425,23 @@ final class AppState: ObservableObject {
             applyModelProfileUsageDelta(usage)
         case .modelProfilesChanged:
             Task { [weak self] in await self?.loadModelProfiles() }
+        case .terminalSessionUpdated(let d):
+            applyTerminalSessionDelta(d)
         default:
             break
         }
+    }
+
+    /// Apply a Claude session rollover (post-`/clear` / `/compact` / startup)
+    /// directly to the in-memory Terminal so LiveTranscriptPaneView re-targets
+    /// without waiting for the next 2s `terminal.list` poll. Silently ignores
+    /// terminals we don't know about — the next refresh will reconcile.
+    private func applyTerminalSessionDelta(_ delta: TerminalSessionDelta) {
+        guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
+            return
+        }
+        terminals[delta.worktreeID]?[idx].claudeSessionID = delta.sessionID
+        terminals[delta.worktreeID]?[idx].transcriptPath = delta.transcriptPath
     }
 
     /// Update the in-place usage entry for a single profile. If no match,

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -928,4 +928,25 @@ actor DaemonClient {
             params: AppSetForegroundStateParams(isForeground: isForeground)
         )
     }
+
+    /// Read-only scan of the user's settings.json files for legacy TBD hook
+    /// entries (the ones now superseded by the spawn-time --settings overlay).
+    func legacyHooksStatus() async throws -> LegacyHooksStatusResult {
+        return try await callNoParamsAsync(
+            method: RPCMethod.daemonLegacyHooksStatus,
+            resultType: LegacyHooksStatusResult.self
+        )
+    }
+
+    /// Remove TBD's legacy entries from ~/.claude/settings.json. The daemon
+    /// runs the write through SettingsJSONSafety (pristine backup, atomic,
+    /// roundtrip-validated). Repo-level files are NEVER auto-modified.
+    func removeLegacyGlobalHooks() async throws -> RemoveLegacyGlobalHooksResult {
+        let request = RPCRequest(method: RPCMethod.daemonRemoveLegacyGlobalHooks)
+        let response = try await sendRawAsync(request)
+        guard response.success else {
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+        }
+        return try response.decodeResult(RemoveLegacyGlobalHooksResult.self)
+    }
 }

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -11,6 +11,11 @@ struct TBDCommands: Commands {
                     await appState.installCLITool()
                 }
             }
+            Button("Migrate Claude Hooks…") {
+                Task { @MainActor in
+                    await appState.migrateClaudeHooks()
+                }
+            }
         }
 
         // Worktree commands

--- a/Sources/TBDApp/LegacyHooksCoordinator.swift
+++ b/Sources/TBDApp/LegacyHooksCoordinator.swift
@@ -105,6 +105,13 @@ final class LegacyHooksCoordinator {
         alert.addButton(withTitle: "Remove")
         alert.addButton(withTitle: "Not Now")
         alert.addButton(withTitle: "Show File…")
+        // HIG: destructive action shouldn't be the Return-key default.
+        // Move the keyEquivalent off "Remove" and onto "Not Now" so muscle-
+        // memory Return-presses don't trigger the destructive path. The
+        // pristine-backup mechanism makes accidental removal recoverable,
+        // but the friction is still worth adding.
+        alert.buttons[0].keyEquivalent = ""
+        alert.buttons[1].keyEquivalent = "\r"
         let response = alert.runModal()
         switch response {
         case .alertFirstButtonReturn:

--- a/Sources/TBDApp/LegacyHooksCoordinator.swift
+++ b/Sources/TBDApp/LegacyHooksCoordinator.swift
@@ -39,6 +39,10 @@ final class LegacyHooksCoordinator {
     /// same app session, even if a daemon reconnect happens.
     func checkOnLaunch() async {
         guard !hasCheckedThisSession else { return }
+        // Latch immediately so a second concurrent caller can't slip past
+        // the guard during the daemonClient await below. Mirrors CLI
+        // installer's pattern: only the first invocation per session runs.
+        hasCheckedThisSession = true
         let status: LegacyHooksStatusResult
         do {
             status = try await daemonClient.legacyHooksStatus()
@@ -46,7 +50,6 @@ final class LegacyHooksCoordinator {
             logger.warning("daemon.legacyHooksStatus failed: \(error.localizedDescription, privacy: .public)")
             return
         }
-        hasCheckedThisSession = true
 
         if status.globalEntries.isEmpty {
             // Re-arm dismissal so a later reinstall surfaces the prompt

--- a/Sources/TBDApp/LegacyHooksCoordinator.swift
+++ b/Sources/TBDApp/LegacyHooksCoordinator.swift
@@ -92,6 +92,21 @@ final class LegacyHooksCoordinator {
             )
             return
         }
+        // Repo-only case: presentDialog renders Remove/Not Now/Show File…
+        // but Remove only acts on global entries. Show an info alert that
+        // names the affected repo files instead, so the menu path doesn't
+        // dangle a button that does nothing.
+        if status.globalEntries.isEmpty {
+            let body = "TBD doesn't auto-modify repo settings (often git-tracked). "
+                + "Edit these manually:\n\n"
+                + status.repoEntries.keys.sorted().map { "• \($0)" }.joined(separator: "\n")
+            presentAlert(
+                style: .informational,
+                title: "Repo-level legacy hooks need manual cleanup",
+                body: body
+            )
+            return
+        }
         await presentDialog(status: status, recordDismissalOnDecline: false)
     }
 

--- a/Sources/TBDApp/LegacyHooksCoordinator.swift
+++ b/Sources/TBDApp/LegacyHooksCoordinator.swift
@@ -1,0 +1,192 @@
+import Foundation
+import AppKit
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "legacy-hooks")
+
+/// Coordinates the one-time migration prompt that asks the user whether
+/// TBD should remove its legacy global hook entries from
+/// `~/.claude/settings.json` (the entries now superseded by the spawn-time
+/// `--settings <overlay>` injection introduced in this PR).
+///
+/// Mirrors the shape of `CLIInstallerCoordinator`:
+///   - `checkOnLaunch()` runs once per app session, gated by a UserDefaults
+///     dismissal key. Repo-level entries are surfaced informationally; only
+///     the global file is auto-modifiable.
+///   - `runFromMenu()` is the explicit entry point — bypasses the dismissal
+///     latch.
+///   - On observing a clean state (no global entries), the dismissal latch
+///     is cleared, so a future legacy reinstall (e.g., the user runs an old
+///     `tbd setup-hooks --global` script) re-arms the prompt.
+@MainActor
+final class LegacyHooksCoordinator {
+    private let daemonClient: DaemonClient
+
+    private var hasCheckedThisSession = false
+
+    private static let dismissedKey = "com.tbd.app.legacyHooks.dismissed"
+    private var dismissed: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.dismissedKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.dismissedKey) }
+    }
+
+    init(daemonClient: DaemonClient) {
+        self.daemonClient = daemonClient
+    }
+
+    /// One-time launch check. Skips on subsequent invocations within the
+    /// same app session, even if a daemon reconnect happens.
+    func checkOnLaunch() async {
+        guard !hasCheckedThisSession else { return }
+        let status: LegacyHooksStatusResult
+        do {
+            status = try await daemonClient.legacyHooksStatus()
+        } catch {
+            logger.warning("daemon.legacyHooksStatus failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        hasCheckedThisSession = true
+
+        if status.globalEntries.isEmpty {
+            // Re-arm dismissal so a later reinstall surfaces the prompt
+            // again — matches CLIInstallerCoordinator's behavior on
+            // `.installed`.
+            if dismissed {
+                logger.info("legacy hooks clean — clearing prior dismissal")
+                dismissed = false
+            }
+            return
+        }
+
+        guard !dismissed else {
+            logger.debug("legacy hooks present but user previously dismissed prompt")
+            return
+        }
+
+        await presentDialog(status: status, recordDismissalOnDecline: true)
+    }
+
+    /// Menu entry point — always presents the dialog regardless of
+    /// dismissal state. Declining here does NOT record a dismissal.
+    func runFromMenu() async {
+        let status: LegacyHooksStatusResult
+        do {
+            status = try await daemonClient.legacyHooksStatus()
+        } catch {
+            presentAlert(
+                style: .warning,
+                title: "Couldn't read legacy hook status",
+                body: error.localizedDescription
+            )
+            return
+        }
+        if status.globalEntries.isEmpty && status.repoEntries.isEmpty {
+            presentAlert(
+                style: .informational,
+                title: "No legacy TBD hooks detected",
+                body: "Your Claude Code settings are already up to date — TBD provisions hooks automatically when it spawns Claude."
+            )
+            return
+        }
+        await presentDialog(status: status, recordDismissalOnDecline: false)
+    }
+
+    // MARK: - Private
+
+    private func presentDialog(status: LegacyHooksStatusResult, recordDismissalOnDecline: Bool) async {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Migrate TBD's Claude hooks?"
+        alert.informativeText = buildBody(status: status)
+        alert.addButton(withTitle: "Remove")
+        alert.addButton(withTitle: "Not Now")
+        alert.addButton(withTitle: "Show File…")
+        let response = alert.runModal()
+        switch response {
+        case .alertFirstButtonReturn:
+            await performRemove()
+        case .alertSecondButtonReturn:
+            if recordDismissalOnDecline {
+                logger.info("user dismissed legacy-hooks prompt — not auto-prompting next launch")
+                dismissed = true
+            }
+        case .alertThirdButtonReturn:
+            // Reveal global settings.json in Finder. We always reveal the
+            // global file since that's the one TBD can modify; repo files
+            // are user-managed.
+            let url = URL(fileURLWithPath: LegacyHookSettingsPath.global)
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        default:
+            break
+        }
+    }
+
+    private func performRemove() async {
+        do {
+            let result = try await daemonClient.removeLegacyGlobalHooks()
+            // Clear dismissal so the prompt re-arms if the entries reappear.
+            dismissed = false
+            let body: String
+            if result.removedCount == 0 {
+                body = "No matching entries were found in ~/.claude/settings.json. Nothing was changed."
+            } else if let backup = result.backupPath {
+                body = "Removed \(result.removedCount) entr\(result.removedCount == 1 ? "y" : "ies") from ~/.claude/settings.json. A backup of your original file is saved at \(backup)."
+            } else {
+                body = "Removed \(result.removedCount) entr\(result.removedCount == 1 ? "y" : "ies") from ~/.claude/settings.json."
+            }
+            presentAlert(style: .informational, title: "Legacy hooks removed", body: body)
+        } catch {
+            presentAlert(
+                style: .warning,
+                title: "Couldn't update Claude settings",
+                body: """
+                TBD didn't modify the file — please check ~/.claude/settings.json manually and report this to TBD.
+
+                Error: \(error.localizedDescription)
+                """
+            )
+        }
+    }
+
+    private func buildBody(status: LegacyHooksStatusResult) -> String {
+        var lines: [String] = []
+        if !status.globalEntries.isEmpty {
+            let n = status.globalEntries.count
+            lines.append("TBD found \(n) legacy hook entr\(n == 1 ? "y" : "ies") in your global Claude settings (\(LegacyHookSettingsPath.global)).")
+            lines.append("")
+            lines.append("These are no longer needed — TBD now installs hooks per-spawn via the --settings overlay file at \(LegacyHookSettingsPath.overlayHint), so the global entries can fire twice or stick around if you stop using TBD.")
+            lines.append("")
+            lines.append("• Remove: TBD will atomically rewrite the global file (a backup is saved next to it).")
+            lines.append("• Not Now: keep the entries; we'll ask again next launch.")
+            lines.append("• Show File…: reveal the global file in Finder so you can inspect it.")
+        }
+        if !status.repoEntries.isEmpty {
+            lines.append("")
+            lines.append("Repo-level settings files also contain legacy entries. TBD will NOT modify these for you — please review them yourself:")
+            for path in status.repoEntries.keys.sorted() {
+                lines.append("  • \(path)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func presentAlert(style: NSAlert.Style, title: String, body: String) {
+        let alert = NSAlert()
+        alert.alertStyle = style
+        alert.messageText = title
+        alert.informativeText = body
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}
+
+/// Constants the coordinator surfaces in the dialog body. Kept separate so
+/// the overlay hint stays in sync if we ever move the file.
+enum LegacyHookSettingsPath {
+    static let global: String = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".claude")
+        .appendingPathComponent("settings.json")
+        .path
+    static let overlayHint = "~/tbd/runtime/claude-overlay.json"
+}

--- a/Sources/TBDCLI/Commands/HooksCommand.swift
+++ b/Sources/TBDCLI/Commands/HooksCommand.swift
@@ -1,0 +1,110 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+/// Top-level `tbd hooks` group. Today exposes only `status`; over time
+/// other subcommands (e.g. `regenerate`, `clean-repo`) can land here.
+struct HooksCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "hooks",
+        abstract: "Inspect and manage TBD's Claude Code hook integration",
+        subcommands: [HooksStatusCommand.self],
+        defaultSubcommand: HooksStatusCommand.self
+    )
+}
+
+/// Prints the overlay path, active entries (parsed from the overlay file),
+/// and any legacy entries the daemon detects in ~/.claude/settings.json or
+/// per-repo settings files. Useful for users to verify state without
+/// inspecting JSON manually.
+struct HooksStatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show TBD's Claude hook overlay state and any legacy entries"
+    )
+
+    mutating func run() async throws {
+        // 1. Overlay block (parsed from the file we own).
+        let overlayPath = TBDConstants.configDir
+            .appendingPathComponent("runtime")
+            .appendingPathComponent("claude-overlay.json")
+            .path
+        print("Overlay file: \(overlayPath)")
+        if FileManager.default.fileExists(atPath: overlayPath) {
+            if let data = try? Data(contentsOf: URL(fileURLWithPath: overlayPath)),
+               let dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+               let hooks = dict["hooks"] as? [String: Any] {
+                let events = hooks.keys.sorted()
+                if events.isEmpty {
+                    print("  (no hooks registered in overlay)")
+                } else {
+                    for event in events {
+                        let matchers = (hooks[event] as? [[String: Any]]) ?? []
+                        let count = matchers.reduce(0) { acc, m in
+                            acc + ((m["hooks"] as? [[String: Any]])?.count ?? 1)
+                        }
+                        print("  \(event): \(count) hook\(count == 1 ? "" : "s")")
+                    }
+                }
+            } else {
+                print("  (overlay file present but unparseable)")
+            }
+        } else {
+            print("  (not yet written — start the daemon to generate it)")
+        }
+
+        // 2. Legacy block — query the daemon. If the daemon isn't running we
+        //    fall back to a local-only scan so the command still gives useful
+        //    information.
+        print("")
+        print("Legacy entries in user settings.json files:")
+        let client = SocketClient()
+        if client.isDaemonRunning {
+            do {
+                let result: LegacyHooksStatusResult = try client.call(
+                    method: RPCMethod.daemonLegacyHooksStatus,
+                    params: EmptyParams(),
+                    resultType: LegacyHooksStatusResult.self
+                )
+                printLegacyResult(result)
+            } catch {
+                print("  daemon RPC failed: \(error)")
+            }
+        } else {
+            print("  (daemon not running — run `tbdd` to enable full status)")
+        }
+    }
+
+    private func printLegacyResult(_ result: LegacyHooksStatusResult) {
+        if result.globalEntries.isEmpty && result.repoEntries.isEmpty {
+            print("  (none — your settings.json is clean)")
+            return
+        }
+        if !result.globalEntries.isEmpty {
+            print("  Global (~/.claude/settings.json): \(result.globalEntries.count) entr\(result.globalEntries.count == 1 ? "y" : "ies")")
+            for e in result.globalEntries {
+                print("    [\(e.event)] \(truncate(e.command))")
+            }
+        }
+        if !result.repoEntries.isEmpty {
+            print("  Repo-level entries:")
+            for path in result.repoEntries.keys.sorted() {
+                let entries = result.repoEntries[path] ?? []
+                print("    \(path): \(entries.count) entr\(entries.count == 1 ? "y" : "ies")")
+                for e in entries {
+                    print("      [\(e.event)] \(truncate(e.command))")
+                }
+            }
+        }
+        print("")
+        print("  Use the TBD app menu (\"Migrate Claude Hooks…\") to remove global entries safely.")
+    }
+
+    private func truncate(_ s: String, max: Int = 80) -> String {
+        s.count > max ? String(s.prefix(max)) + "…" : s
+    }
+}
+
+/// Empty params struct for RPCs that take no parameters but for which the
+/// generic `call` helper still expects an Encodable.
+private struct EmptyParams: Codable {}

--- a/Sources/TBDCLI/Commands/HooksCommand.swift
+++ b/Sources/TBDCLI/Commands/HooksCommand.swift
@@ -53,9 +53,10 @@ struct HooksStatusCommand: AsyncParsableCommand {
             print("  (not yet written — start the daemon to generate it)")
         }
 
-        // 2. Legacy block — query the daemon. If the daemon isn't running we
-        //    fall back to a local-only scan so the command still gives useful
-        //    information.
+        // 2. Legacy block — query the daemon. The scanner lives in TBDDaemon
+        //    and isn't reachable from this module, so when the daemon is down
+        //    we just print a hint to start it rather than re-implementing the
+        //    scan locally.
         print("")
         print("Legacy entries in user settings.json files:")
         let client = SocketClient()

--- a/Sources/TBDCLI/Commands/SessionEventCommand.swift
+++ b/Sources/TBDCLI/Commands/SessionEventCommand.swift
@@ -39,15 +39,8 @@ struct SessionEventCommand: AsyncParsableCommand {
 
         // 2. Read stdin (Claude pipes the hook payload here). Bound the
         //    read at 1 MiB to avoid a runaway hook flooding the CLI process.
-        let stdin = FileHandle.standardInput
-        let maxBytes = 1 << 20
-        var data = Data()
-        while data.count < maxBytes {
-            let chunk = stdin.availableData
-            if chunk.isEmpty { break }
-            data.append(chunk)
-        }
-        guard !data.isEmpty,
+        let data = FileHandle.standardInput.readDataToEndOfFile()
+        guard !data.isEmpty, data.count <= 1 << 20,
               let payload = try? JSONDecoder().decode(HookPayload.self, from: data),
               let sessionID = payload.session_id, !sessionID.isEmpty else {
             return

--- a/Sources/TBDCLI/Commands/SessionEventCommand.swift
+++ b/Sources/TBDCLI/Commands/SessionEventCommand.swift
@@ -15,7 +15,8 @@ import TBDShared
 struct SessionEventCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "session-event",
-        abstract: "Internal: bridge Claude Code's SessionStart hook into TBD"
+        abstract: "Internal: bridge Claude Code's SessionStart hook into TBD",
+        shouldDisplay: false
     )
 
     /// JSON payload Claude Code emits to stdin for SessionStart hooks.
@@ -37,8 +38,11 @@ struct SessionEventCommand: AsyncParsableCommand {
             return
         }
 
-        // 2. Read stdin (Claude pipes the hook payload here). Bound the
-        //    read at 1 MiB to avoid a runaway hook flooding the CLI process.
+        // 2. Read stdin (Claude pipes the hook payload here). The 1 MiB
+        //    cap below limits *processing*, not the read itself —
+        //    readDataToEndOfFile() allocates the full buffer first. In
+        //    practice Claude controls the payload, so this is fine; the
+        //    cap exists as a defensive guard against a runaway producer.
         let data = FileHandle.standardInput.readDataToEndOfFile()
         guard !data.isEmpty, data.count <= 1 << 20,
               let payload = try? JSONDecoder().decode(HookPayload.self, from: data),

--- a/Sources/TBDCLI/Commands/SessionEventCommand.swift
+++ b/Sources/TBDCLI/Commands/SessionEventCommand.swift
@@ -1,0 +1,77 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+/// Bridges Claude Code's `SessionStart` hook into TBD. Reads the hook payload
+/// from stdin (Claude pipes a JSON object with fields like `session_id`,
+/// `transcript_path`, `source`, `cwd`), reads `$TBD_TERMINAL_ID` from the env
+/// (set by the daemon at spawn time), and forwards the data to the daemon
+/// via the `terminal.sessionEvent` RPC.
+///
+/// All failure paths are silent and exit 0 — Claude prints stderr from hooks
+/// to the user's terminal, so any noise here would be surfaced as a hook
+/// error message. The transcript pane simply won't update if the bridge
+/// can't deliver the event; we'd rather degrade silently than spam the chat.
+struct SessionEventCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "session-event",
+        abstract: "Internal: bridge Claude Code's SessionStart hook into TBD"
+    )
+
+    /// JSON payload Claude Code emits to stdin for SessionStart hooks.
+    /// We parse only the fields we need, treat all of them as optional,
+    /// and ignore anything else. Future Claude payload extensions are
+    /// additive — they shouldn't break this command.
+    private struct HookPayload: Decodable {
+        let session_id: String?
+        let transcript_path: String?
+        let source: String?
+    }
+
+    mutating func run() async throws {
+        // 1. Resolve terminal ID from env. Without this, we can't route the
+        //    event — silent exit (the hook is also configured globally and
+        //    fires for non-TBD-spawned Claude sessions).
+        guard let terminalIDString = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+              let terminalID = UUID(uuidString: terminalIDString) else {
+            return
+        }
+
+        // 2. Read stdin (Claude pipes the hook payload here). Bound the
+        //    read at 1 MiB to avoid a runaway hook flooding the CLI process.
+        let stdin = FileHandle.standardInput
+        let maxBytes = 1 << 20
+        var data = Data()
+        while data.count < maxBytes {
+            let chunk = stdin.availableData
+            if chunk.isEmpty { break }
+            data.append(chunk)
+        }
+        guard !data.isEmpty,
+              let payload = try? JSONDecoder().decode(HookPayload.self, from: data),
+              let sessionID = payload.session_id, !sessionID.isEmpty else {
+            return
+        }
+
+        // 3. Daemon-down → silent exit. The hook will fire again on the next
+        //    session event after the daemon starts (or, in the worst case,
+        //    the legacy fallback in handleTerminalTranscript still works).
+        let client = SocketClient()
+        guard client.isDaemonRunning else { return }
+
+        // 4. Fire the RPC. Ignore the response — hook is best-effort.
+        do {
+            try client.callVoid(
+                method: RPCMethod.terminalSessionEvent,
+                params: TerminalSessionEventParams(
+                    terminalID: terminalID,
+                    sessionID: sessionID,
+                    transcriptPath: payload.transcript_path,
+                    source: payload.source
+                )
+            )
+        } catch {
+            return
+        }
+    }
+}

--- a/Sources/TBDCLI/Commands/SetupHooksCommand.swift
+++ b/Sources/TBDCLI/Commands/SetupHooksCommand.swift
@@ -43,6 +43,9 @@ struct SetupHooksCommand: AsyncParsableCommand {
     }
 
     /// Read existing settings, merge the Stop hook, and write back.
+    /// Wrapped in the SettingsJSONSafety helpers (pristine backup, roundtrip
+    /// validation, atomic write) so a malformed write can't corrupt the
+    /// user's settings.json mid-edit.
     private func installHooks(at path: String) throws {
         var settings: [String: Any] = [:]
 
@@ -95,8 +98,32 @@ struct SetupHooksCommand: AsyncParsableCommand {
         hooks["Stop"] = stopHooks
         settings["hooks"] = hooks
 
-        // Write back
+        // Pristine backup before TBD's first ever mutation. Idempotent — only
+        // creates the backup if it doesn't already exist.
+        try SettingsJSONSafety.ensureBackup(of: path)
+
+        // Serialize the proposed bytes once; the safety helper round-trips
+        // them and runs an invariant before atomically writing.
         let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
-        try data.write(to: URL(fileURLWithPath: path))
+        try SettingsJSONSafety.atomicWriteValidated(
+            proposedBytes: data,
+            targetPath: path
+        ) { dict in
+            // Sanity-check: the result has a `hooks` dict, the Stop array
+            // contains our entry, and no stray null at top-level.
+            guard let parsedHooks = dict["hooks"] as? [String: Any] else {
+                throw SettingsJSONSafety.Error.invariantFailed("Missing hooks dict")
+            }
+            guard let parsedStop = parsedHooks["Stop"] as? [[String: Any]] else {
+                throw SettingsJSONSafety.Error.invariantFailed("Missing Stop hooks array")
+            }
+            let containsTBD = parsedStop.contains { matcher in
+                let inner = matcher["hooks"] as? [[String: Any]] ?? []
+                return inner.contains { ($0["command"] as? String)?.contains("tbd notify") == true }
+            }
+            guard containsTBD else {
+                throw SettingsJSONSafety.Error.invariantFailed("tbd notify entry missing after merge")
+            }
+        }
     }
 }

--- a/Sources/TBDCLI/Commands/SetupHooksCommand.swift
+++ b/Sources/TBDCLI/Commands/SetupHooksCommand.swift
@@ -2,128 +2,43 @@ import ArgumentParser
 import Foundation
 import TBDShared
 
+/// Deprecated. TBD now provisions Claude hooks automatically when it spawns
+/// Claude Code (via the `--settings` overlay at
+/// `~/tbd/runtime/claude-overlay.json`). The user's `~/.claude/settings.json`
+/// is no longer touched.
+///
+/// We keep this command around as a no-op so external scripts and docs
+/// pointing at `tbd setup-hooks --global` don't immediately break — they
+/// just print a migration hint and exit 0.
 struct SetupHooksCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "setup-hooks",
-        abstract: "Set up Claude Code hooks for TBD notifications"
+        abstract: "Deprecated — hooks are now provisioned automatically",
+        shouldDisplay: false
     )
 
-    @Flag(name: .long, help: "Install hooks globally in ~/.claude/settings.json")
+    @Flag(name: .long, help: "Deprecated; ignored.")
     var global = false
 
-    @Option(name: .long, help: "Install hooks for a specific repo (path to repo root)")
+    @Option(name: .long, help: "Deprecated; ignored.")
     var repo: String?
 
-    func validate() throws {
-        if !global && repo == nil {
-            throw ValidationError("Specify --global or --repo <path>")
-        }
-    }
-
     mutating func run() async throws {
-        if global {
-            let settingsPath = FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".claude")
-                .appendingPathComponent("settings.json")
-            try installHooks(at: settingsPath.path)
-            print("Global hooks installed at \(settingsPath.path)")
-        }
+        let stderr = FileHandle.standardError
+        let msg = """
+        `tbd setup-hooks` is deprecated.
 
-        if let repo = repo {
-            let repoPath = resolvePath(repo)
-            let settingsPath = URL(fileURLWithPath: repoPath)
-                .appendingPathComponent(".claude")
-                .appendingPathComponent("settings.json")
-            // Ensure .claude directory exists
-            let claudeDir = URL(fileURLWithPath: repoPath).appendingPathComponent(".claude")
-            try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
-            try installHooks(at: settingsPath.path)
-            print("Repo hooks installed at \(settingsPath.path)")
-        }
-    }
+        Hooks are now provisioned automatically when TBD spawns Claude — the
+        daemon writes a settings overlay at ~/tbd/runtime/claude-overlay.json
+        and passes it via `claude --settings <overlay>` at spawn time. Your
+        ~/.claude/settings.json is no longer modified.
 
-    /// Read existing settings, merge the Stop hook, and write back.
-    /// Wrapped in the SettingsJSONSafety helpers (pristine backup, roundtrip
-    /// validation, atomic write) so a malformed write can't corrupt the
-    /// user's settings.json mid-edit.
-    private func installHooks(at path: String) throws {
-        var settings: [String: Any] = [:]
+        Run `tbd hooks status` to verify the overlay state and check whether
+        any legacy entries from previous TBD versions still need cleanup.
 
-        // Read existing settings if file exists
-        if FileManager.default.fileExists(atPath: path) {
-            let data = try Data(contentsOf: URL(fileURLWithPath: path))
-            if let existing = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                settings = existing
-            }
-        }
-
-        // Get or create hooks dictionary
-        var hooks = settings["hooks"] as? [String: Any] ?? [:]
-
-        // Get or create the Stop hooks array
-        var stopHooks = hooks["Stop"] as? [[String: Any]] ?? []
-
-        // The hook command we want to add
-        let tbdNotifyCommand = #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
-
-        let correctEntry: [String: Any] = [
-            "hooks": [
-                [
-                    "type": "command",
-                    "command": tbdNotifyCommand,
-                ] as [String: Any],
-            ],
-        ]
-
-        // Migrate legacy bare-format entries and check if hook already exists
-        var found = false
-        for (i, matcher) in stopHooks.enumerated() {
-            if let innerHooks = matcher["hooks"] as? [[String: Any]] {
-                if innerHooks.contains(where: { ($0["command"] as? String)?.contains("tbd notify") == true }) {
-                    // Update the command even if format is correct (command may have changed)
-                    stopHooks[i] = correctEntry
-                    found = true
-                }
-            } else if let command = matcher["command"] as? String, command.contains("tbd notify") {
-                // Legacy bare format — migrate in place
-                stopHooks[i] = correctEntry
-                found = true
-            }
-        }
-
-        if !found {
-            stopHooks.append(correctEntry)
-        }
-
-        hooks["Stop"] = stopHooks
-        settings["hooks"] = hooks
-
-        // Pristine backup before TBD's first ever mutation. Idempotent — only
-        // creates the backup if it doesn't already exist.
-        try SettingsJSONSafety.ensureBackup(of: path)
-
-        // Serialize the proposed bytes once; the safety helper round-trips
-        // them and runs an invariant before atomically writing.
-        let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
-        try SettingsJSONSafety.atomicWriteValidated(
-            proposedBytes: data,
-            targetPath: path
-        ) { dict in
-            // Sanity-check: the result has a `hooks` dict, the Stop array
-            // contains our entry, and no stray null at top-level.
-            guard let parsedHooks = dict["hooks"] as? [String: Any] else {
-                throw SettingsJSONSafety.Error.invariantFailed("Missing hooks dict")
-            }
-            guard let parsedStop = parsedHooks["Stop"] as? [[String: Any]] else {
-                throw SettingsJSONSafety.Error.invariantFailed("Missing Stop hooks array")
-            }
-            let containsTBD = parsedStop.contains { matcher in
-                let inner = matcher["hooks"] as? [[String: Any]] ?? []
-                return inner.contains { ($0["command"] as? String)?.contains("tbd notify") == true }
-            }
-            guard containsTBD else {
-                throw SettingsJSONSafety.Error.invariantFailed("tbd notify entry missing after merge")
-            }
+        """
+        if let data = msg.data(using: .utf8) {
+            stderr.write(data)
         }
     }
 }

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -13,6 +13,7 @@ struct TBDCommand: AsyncParsableCommand {
             TerminalCommand.self,
             ConductorCommand.self,
             NotifyCommand.self,
+            SessionEventCommand.self,
             DaemonCommand.self,
             SetupHooksCommand.self,
             SkillCommand.self,

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -15,6 +15,7 @@ struct TBDCommand: AsyncParsableCommand {
             NotifyCommand.self,
             SessionEventCommand.self,
             DaemonCommand.self,
+            HooksCommand.self,
             SetupHooksCommand.self,
             SkillCommand.self,
             CleanupCommand.self,

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -40,13 +40,29 @@ enum ClaudeSpawnCommandBuilder {
         profileBaseURL: String? = nil,
         profileModel: String? = nil,
         cmd: String?,
-        shellFallback: String
+        shellFallback: String,
+        settingsOverlayPath: String? = nil
     ) -> Result {
+        // Optional --settings flag merged into the claude invocation.
+        // Claude's --settings flag MERGES with ~/.claude/settings.json
+        // (array settings concatenated + deduplicated). So we can ship
+        // a TBD-owned overlay carrying the SessionStart hook etc. without
+        // touching the user's settings.json. Only emitted when an overlay
+        // path was supplied AND it exists on disk — otherwise the spawn
+        // would fail with "settings file not found".
+        let settingsFlag: String
+        if let p = settingsOverlayPath,
+           FileManager.default.fileExists(atPath: p) {
+            settingsFlag = " --settings \(SystemPromptBuilder.shellEscape(p))"
+        } else {
+            settingsFlag = ""
+        }
+
         let base: String
         if let resumeID {
-            base = "claude --resume \(resumeID) --dangerously-skip-permissions"
+            base = "claude --resume \(resumeID) --dangerously-skip-permissions\(settingsFlag)"
         } else if let sessionID = freshSessionID {
-            var b = "claude --session-id \(sessionID) --dangerously-skip-permissions"
+            var b = "claude --session-id \(sessionID) --dangerously-skip-permissions\(settingsFlag)"
             if let prompt = appendSystemPrompt {
                 b += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
             }

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -3,8 +3,11 @@ import TBDShared
 
 /// Builds the shell command string for spawning (or respawning) a claude terminal.
 ///
-/// Pure function — no DB, no Keychain, no tmux. Easy to unit-test. The caller is
-/// responsible for resolving the token secret (if any) before invoking.
+/// Pure function — no DB, no Keychain, no tmux. The only filesystem touch
+/// is via the injectable `fileExists` parameter, which defaults to
+/// `FileManager.default.fileExists(atPath:)`. Tests can pass a closure to
+/// keep the function fully hermetic. The caller is responsible for
+/// resolving the token secret (if any) before invoking.
 ///
 /// Behavior:
 /// - `resumeID` non-nil → `claude --resume <id> --dangerously-skip-permissions`
@@ -41,7 +44,8 @@ enum ClaudeSpawnCommandBuilder {
         profileModel: String? = nil,
         cmd: String?,
         shellFallback: String,
-        settingsOverlayPath: String? = nil
+        settingsOverlayPath: String? = nil,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
     ) -> Result {
         // Optional --settings flag merged into the claude invocation.
         // Claude's --settings flag MERGES with ~/.claude/settings.json
@@ -51,8 +55,7 @@ enum ClaudeSpawnCommandBuilder {
         // path was supplied AND it exists on disk — otherwise the spawn
         // would fail with "settings file not found".
         let settingsFlag: String
-        if let p = settingsOverlayPath,
-           FileManager.default.fileExists(atPath: p) {
+        if let p = settingsOverlayPath, fileExists(p) {
             settingsFlag = " --settings \(SystemPromptBuilder.shellEscape(p))"
         } else {
             settingsFlag = ""

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -40,30 +40,6 @@ public final class Daemon: Sendable {
         unsetenv("TBD_PROMPT_RENAME")
     }
 
-    /// Resolve the absolute path to the TBDCLI binary that sits alongside
-    /// this daemon executable. Returns nil when the executable path can't
-    /// be determined — callers should fall back to bare `tbd` on PATH.
-    ///
-    /// Why we bother: the user's `~/.local/bin/tbd` symlink can be stale
-    /// (pointing at a different worktree's older build), so PATH lookup is
-    /// unreliable for hook commands. The daemon's own sibling binary is
-    /// guaranteed to be the version that wrote the overlay.
-    static func resolveSiblingCLIPath() -> String? {
-        // `Bundle.main.executableURL` is the most reliable source — it
-        // resolves through symlinks and any wrapping bundle. Fall back to
-        // argv[0] only if the bundle API somehow returns nil (shouldn't
-        // happen for SPM executables, but cheap insurance).
-        let daemonPath: String
-        if let url = Bundle.main.executableURL {
-            daemonPath = url.path
-        } else if let arg0 = CommandLine.arguments.first, !arg0.isEmpty {
-            daemonPath = arg0
-        } else {
-            return nil
-        }
-        return CLIInstaller.cliPath(forDaemonExecutable: daemonPath)
-    }
-
     /// Start the daemon: create config directory, clean up stale state,
     /// initialize database and all managers, start servers, reconcile worktrees.
     public func start() async throws {
@@ -104,13 +80,7 @@ public final class Daemon: Sendable {
         // Claude sessions register the SessionStart + Stop hooks. Idempotent;
         // failures degrade gracefully to the legacy cwd-based transcript
         // resolution (the bridge just won't fire).
-        //
-        // Bake the absolute path to the daemon's sibling TBDCLI binary into
-        // the hook commands. Otherwise the hooks rely on `tbd` being on PATH,
-        // which on this machine often resolves to a stale symlink pointing at
-        // the main-project build (predates `session-event`) and silently
-        // exits non-zero.
-        ClaudeHookOverlay.writeOverlay(cliPath: Daemon.resolveSiblingCLIPath())
+        ClaudeHookOverlay.writeOverlay()
 
         // 4a. Scrub inherited TBD_* env vars before any tmux server is spawned.
         // The daemon may have been launched from inside a TBD-spawned shell (e.g.

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -40,6 +40,30 @@ public final class Daemon: Sendable {
         unsetenv("TBD_PROMPT_RENAME")
     }
 
+    /// Resolve the absolute path to the TBDCLI binary that sits alongside
+    /// this daemon executable. Returns nil when the executable path can't
+    /// be determined — callers should fall back to bare `tbd` on PATH.
+    ///
+    /// Why we bother: the user's `~/.local/bin/tbd` symlink can be stale
+    /// (pointing at a different worktree's older build), so PATH lookup is
+    /// unreliable for hook commands. The daemon's own sibling binary is
+    /// guaranteed to be the version that wrote the overlay.
+    static func resolveSiblingCLIPath() -> String? {
+        // `Bundle.main.executableURL` is the most reliable source — it
+        // resolves through symlinks and any wrapping bundle. Fall back to
+        // argv[0] only if the bundle API somehow returns nil (shouldn't
+        // happen for SPM executables, but cheap insurance).
+        let daemonPath: String
+        if let url = Bundle.main.executableURL {
+            daemonPath = url.path
+        } else if let arg0 = CommandLine.arguments.first, !arg0.isEmpty {
+            daemonPath = arg0
+        } else {
+            return nil
+        }
+        return CLIInstaller.cliPath(forDaemonExecutable: daemonPath)
+    }
+
     /// Start the daemon: create config directory, clean up stale state,
     /// initialize database and all managers, start servers, reconcile worktrees.
     public func start() async throws {
@@ -80,7 +104,13 @@ public final class Daemon: Sendable {
         // Claude sessions register the SessionStart + Stop hooks. Idempotent;
         // failures degrade gracefully to the legacy cwd-based transcript
         // resolution (the bridge just won't fire).
-        ClaudeHookOverlay.writeOverlay()
+        //
+        // Bake the absolute path to the daemon's sibling TBDCLI binary into
+        // the hook commands. Otherwise the hooks rely on `tbd` being on PATH,
+        // which on this machine often resolves to a stale symlink pointing at
+        // the main-project build (predates `session-event`) and silently
+        // exits non-zero.
+        ClaudeHookOverlay.writeOverlay(cliPath: Daemon.resolveSiblingCLIPath())
 
         // 4a. Scrub inherited TBD_* env vars before any tmux server is spawned.
         // The daemon may have been launched from inside a TBD-spawned shell (e.g.

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -76,6 +76,12 @@ public final class Daemon: Sendable {
                 .error("Failed to write fallback skill file: \(String(describing: error), privacy: .public)")
         }
 
+        // Refresh the TBD-owned Claude settings overlay so newly spawned
+        // Claude sessions register the SessionStart + Stop hooks. Idempotent;
+        // failures degrade gracefully to the legacy cwd-based transcript
+        // resolution (the bridge just won't fire).
+        ClaudeHookOverlay.writeOverlay()
+
         // 4a. Scrub inherited TBD_* env vars before any tmux server is spawned.
         // The daemon may have been launched from inside a TBD-spawned shell (e.g.
         // `scripts/restart.sh` run from a terminal pane), which exports per-worktree

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -337,6 +337,17 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        // Persist the absolute JSONL path Claude reports via the SessionStart
+        // hook. Lets the transcript handler stay accurate across `/clear` and
+        // `/compact` rollovers where the session ID changes mid-stream and the
+        // jsonl can land in a different `~/.claude/projects/` directory than
+        // the worktree's cwd would suggest.
+        migrator.registerMigration("v17_terminal_transcript_path") { db in
+            try db.alter(table: "terminal") { t in
+                t.add(column: "transcriptPath", .text)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -61,7 +61,13 @@ public struct TerminalStore: Sendable {
     }
 
     /// Create a new terminal record.
+    ///
+    /// `id` is optional. Callers that need to know the terminal ID *before*
+    /// the tmux window is spawned (so it can be injected as `TBD_TERMINAL_ID`
+    /// in the spawned env, used by the SessionStart hook bridge) can pre-mint
+    /// a UUID and pass it here. Defaults to a fresh UUID otherwise.
     public func create(
+        id: UUID = UUID(),
         worktreeID: UUID,
         tmuxWindowID: String,
         tmuxPaneID: String,
@@ -70,6 +76,7 @@ public struct TerminalStore: Sendable {
         profileID: UUID? = nil
     ) async throws -> Terminal {
         let terminal = Terminal(
+            id: id,
             worktreeID: worktreeID,
             tmuxWindowID: tmuxWindowID,
             tmuxPaneID: tmuxPaneID,

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -184,7 +184,14 @@ public struct TerminalStore: Sendable {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.claudeSessionID = sessionID
-            record.transcriptPath = transcriptPath
+            // Only overwrite when the caller supplied a path. A SessionStart
+            // payload that omits `transcript_path` (theoretical — Claude
+            // currently always sends it) shouldn't clobber a previously
+            // captured path; the existing value still points at the right
+            // file as long as sessionID matches.
+            if let transcriptPath = transcriptPath {
+                record.transcriptPath = transcriptPath
+            }
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -17,6 +17,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var suspendedAt: Date?
     var suspendedSnapshot: String?
     var profile_id: String?
+    var transcriptPath: String?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -30,6 +31,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.suspendedAt = terminal.suspendedAt
         self.suspendedSnapshot = terminal.suspendedSnapshot
         self.profile_id = terminal.profileID?.uuidString
+        self.transcriptPath = terminal.transcriptPath
     }
 
     func toModel() -> Terminal {
@@ -44,7 +46,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             claudeSessionID: claudeSessionID,
             suspendedAt: suspendedAt,
             suspendedSnapshot: suspendedSnapshot,
-            profileID: profile_id.flatMap(UUID.init(uuidString:))
+            profileID: profile_id.flatMap(UUID.init(uuidString:)),
+            transcriptPath: transcriptPath
         )
     }
 }
@@ -159,6 +162,22 @@ public struct TerminalStore: Sendable {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.claudeSessionID = sessionID
+            try record.update(db)
+        }
+    }
+
+    /// Update the Claude session ID and the absolute JSONL transcript path for
+    /// a terminal in one write. Used by the SessionStart hook bridge so the
+    /// transcript handler can target the exact file Claude is writing without
+    /// re-deriving the project directory from cwd (which is fragile across
+    /// `/clear` and `/compact` rollovers).
+    public func updateSession(id: UUID, sessionID: String, transcriptPath: String?) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.claudeSessionID = sessionID
+            record.transcriptPath = transcriptPath
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -197,6 +197,7 @@ public struct TerminalStore: Sendable {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.claudeSessionID = nil
+            record.transcriptPath = nil
             record.suspendedAt = nil
             record.suspendedSnapshot = nil
             record.label = "shell"

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -35,58 +35,31 @@ public enum ClaudeHookOverlay {
     /// The shell command for the SessionStart hook. Reads stdin (Claude's
     /// hook payload) into `tbd session-event`, which RPCs the daemon. The
     /// command tolerates `tbd` not being on PATH — silent failure is fine.
-    ///
-    /// Pass an absolute path to TBDCLI to bypass PATH entirely (avoids the
-    /// stale-symlink-on-PATH bug where `tbd` resolves to a different
-    /// worktree's older binary that doesn't know `session-event`). When
-    /// `cliPath` is nil/empty, fall back to bare `tbd` for backward compat.
-    static func sessionStartCommand(cliPath: String?) -> String {
-        let bin = shellQuote(cliPath) ?? "tbd"
-        return "\(bin) session-event 2>/dev/null || true"
-    }
+    static let sessionStartCommand =
+        #"tbd session-event 2>/dev/null || true"#
 
     /// The shell command for the Stop hook. Mirrors the legacy
     /// `setup-hooks --global` command so TBD can replace it without
     /// regressing notification behavior.
-    ///
-    /// Same rationale as `sessionStartCommand` for `cliPath`: bake an
-    /// absolute path so we don't share the broken `tbd` PATH symlink.
-    static func stopCommand(cliPath: String?) -> String {
-        let bin = shellQuote(cliPath) ?? "tbd"
-        return #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); "# +
-            #"\#(bin) notify --type response_complete --message "$MSG" 2>/dev/null || true"#
-    }
-
-    /// Single-quote-wrap a path for safe shell embedding. Returns nil when
-    /// the input is nil/empty so callers can fall back to bare `tbd`.
-    /// Embedded single quotes are escaped via the standard `'\''` trick.
-    static func shellQuote(_ path: String?) -> String? {
-        guard let path, !path.isEmpty else { return nil }
-        let escaped = path.replacingOccurrences(of: "'", with: #"'\''"#)
-        return "'\(escaped)'"
-    }
+    static let stopCommand =
+        #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
 
     /// Build the JSON-encoded overlay body.
-    ///
-    /// `cliPath` should be the absolute path to the daemon's sibling TBDCLI
-    /// binary (see `CLIInstaller.cliPath(forDaemonExecutable:)`). When nil,
-    /// falls back to bare `tbd` (PATH lookup) — accepting the stale-symlink
-    /// risk so notifications still have a chance to fire.
-    public static func generateBody(cliPath: String? = nil) throws -> Data {
+    public static func generateBody() throws -> Data {
         let body: [String: Any] = [
             "hooks": [
                 "SessionStart": [
                     [
                         "matcher": "*",
                         "hooks": [
-                            ["type": "command", "command": sessionStartCommand(cliPath: cliPath)]
+                            ["type": "command", "command": sessionStartCommand]
                         ]
                     ]
                 ],
                 "Stop": [
                     [
                         "hooks": [
-                            ["type": "command", "command": stopCommand(cliPath: cliPath)]
+                            ["type": "command", "command": stopCommand]
                         ]
                     ]
                 ]
@@ -101,24 +74,17 @@ public enum ClaudeHookOverlay {
     /// Write the overlay to `overlayPath`, creating the parent directory if
     /// needed. Atomic so a crash mid-write can't leave a half-written file
     /// that breaks the next Claude spawn. Returns true on success.
-    ///
-    /// `cliPath` is the absolute path to TBDCLI. When nil/empty, the overlay
-    /// falls back to bare `tbd` and a warning is logged — the caller's
-    /// responsibility to pass a real path on every healthy startup.
     @discardableResult
-    public static func writeOverlay(cliPath: String? = nil) -> Bool {
-        if cliPath == nil || cliPath?.isEmpty == true {
-            logger.warning("Writing Claude overlay without absolute CLI path; falling back to bare `tbd` on PATH (may resolve to a stale symlink).")
-        }
+    public static func writeOverlay() -> Bool {
         do {
-            let data = try generateBody(cliPath: cliPath)
+            let data = try generateBody()
             let parent = (overlayPath as NSString).deletingLastPathComponent
             try FileManager.default.createDirectory(
                 atPath: parent,
                 withIntermediateDirectories: true
             )
             try data.write(to: URL(fileURLWithPath: overlayPath), options: .atomic)
-            logger.info("Wrote Claude overlay at \(overlayPath, privacy: .public) (cli=\(cliPath ?? "<bare tbd>", privacy: .public))")
+            logger.info("Wrote Claude overlay at \(overlayPath, privacy: .public)")
             return true
         } catch {
             logger.error("Failed to write Claude overlay: \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -35,31 +35,58 @@ public enum ClaudeHookOverlay {
     /// The shell command for the SessionStart hook. Reads stdin (Claude's
     /// hook payload) into `tbd session-event`, which RPCs the daemon. The
     /// command tolerates `tbd` not being on PATH — silent failure is fine.
-    static let sessionStartCommand =
-        #"tbd session-event 2>/dev/null || true"#
+    ///
+    /// Pass an absolute path to TBDCLI to bypass PATH entirely (avoids the
+    /// stale-symlink-on-PATH bug where `tbd` resolves to a different
+    /// worktree's older binary that doesn't know `session-event`). When
+    /// `cliPath` is nil/empty, fall back to bare `tbd` for backward compat.
+    static func sessionStartCommand(cliPath: String?) -> String {
+        let bin = shellQuote(cliPath) ?? "tbd"
+        return "\(bin) session-event 2>/dev/null || true"
+    }
 
     /// The shell command for the Stop hook. Mirrors the legacy
     /// `setup-hooks --global` command so TBD can replace it without
     /// regressing notification behavior.
-    static let stopCommand =
-        #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
+    ///
+    /// Same rationale as `sessionStartCommand` for `cliPath`: bake an
+    /// absolute path so we don't share the broken `tbd` PATH symlink.
+    static func stopCommand(cliPath: String?) -> String {
+        let bin = shellQuote(cliPath) ?? "tbd"
+        return #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); "# +
+            #"\#(bin) notify --type response_complete --message "$MSG" 2>/dev/null || true"#
+    }
+
+    /// Single-quote-wrap a path for safe shell embedding. Returns nil when
+    /// the input is nil/empty so callers can fall back to bare `tbd`.
+    /// Embedded single quotes are escaped via the standard `'\''` trick.
+    static func shellQuote(_ path: String?) -> String? {
+        guard let path, !path.isEmpty else { return nil }
+        let escaped = path.replacingOccurrences(of: "'", with: #"'\''"#)
+        return "'\(escaped)'"
+    }
 
     /// Build the JSON-encoded overlay body.
-    public static func generateBody() throws -> Data {
+    ///
+    /// `cliPath` should be the absolute path to the daemon's sibling TBDCLI
+    /// binary (see `CLIInstaller.cliPath(forDaemonExecutable:)`). When nil,
+    /// falls back to bare `tbd` (PATH lookup) — accepting the stale-symlink
+    /// risk so notifications still have a chance to fire.
+    public static func generateBody(cliPath: String? = nil) throws -> Data {
         let body: [String: Any] = [
             "hooks": [
                 "SessionStart": [
                     [
                         "matcher": "*",
                         "hooks": [
-                            ["type": "command", "command": sessionStartCommand]
+                            ["type": "command", "command": sessionStartCommand(cliPath: cliPath)]
                         ]
                     ]
                 ],
                 "Stop": [
                     [
                         "hooks": [
-                            ["type": "command", "command": stopCommand]
+                            ["type": "command", "command": stopCommand(cliPath: cliPath)]
                         ]
                     ]
                 ]
@@ -74,17 +101,24 @@ public enum ClaudeHookOverlay {
     /// Write the overlay to `overlayPath`, creating the parent directory if
     /// needed. Atomic so a crash mid-write can't leave a half-written file
     /// that breaks the next Claude spawn. Returns true on success.
+    ///
+    /// `cliPath` is the absolute path to TBDCLI. When nil/empty, the overlay
+    /// falls back to bare `tbd` and a warning is logged — the caller's
+    /// responsibility to pass a real path on every healthy startup.
     @discardableResult
-    public static func writeOverlay() -> Bool {
+    public static func writeOverlay(cliPath: String? = nil) -> Bool {
+        if cliPath == nil || cliPath?.isEmpty == true {
+            logger.warning("Writing Claude overlay without absolute CLI path; falling back to bare `tbd` on PATH (may resolve to a stale symlink).")
+        }
         do {
-            let data = try generateBody()
+            let data = try generateBody(cliPath: cliPath)
             let parent = (overlayPath as NSString).deletingLastPathComponent
             try FileManager.default.createDirectory(
                 atPath: parent,
                 withIntermediateDirectories: true
             )
             try data.write(to: URL(fileURLWithPath: overlayPath), options: .atomic)
-            logger.info("Wrote Claude overlay at \(overlayPath, privacy: .public)")
+            logger.info("Wrote Claude overlay at \(overlayPath, privacy: .public) (cli=\(cliPath ?? "<bare tbd>", privacy: .public))")
             return true
         } catch {
             logger.error("Failed to write Claude overlay: \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -1,0 +1,100 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-overlay")
+
+/// Generates and maintains the TBD-owned Claude Code settings overlay file.
+///
+/// Claude Code's `--settings <path>` flag merges array settings (like the
+/// `hooks` dict's matchers) with the user's `~/.claude/settings.json` —
+/// concatenated and deduplicated, not replaced. That means TBD can ship
+/// its own overlay file pinned at spawn time without touching the user's
+/// settings.json at all.
+///
+/// The overlay registers two hooks:
+/// - `SessionStart` (matcher `*`): calls `tbd session-event`, which
+///   relays the new session ID + transcript path to the daemon. This is
+///   what fixes the post-`/clear`/`/compact` transcript freeze.
+/// - `Stop`: calls `tbd notify` for response-complete notifications,
+///   matching the legacy globally-installed hook.
+///
+/// The overlay is regenerated on every daemon startup so changes to the
+/// shape (new hooks, new commands) take effect on the next worktree open.
+/// Idempotent — repeated writes with the same content are safe.
+public enum ClaudeHookOverlay {
+    /// Path of the TBD-owned overlay file. Lives under `~/tbd/runtime/` so
+    /// it cohabits with state.db and other daemon-managed files.
+    public static let overlayPath: String = {
+        TBDConstants.configDir
+            .appendingPathComponent("runtime")
+            .appendingPathComponent("claude-overlay.json")
+            .path
+    }()
+
+    /// The shell command for the SessionStart hook. Reads stdin (Claude's
+    /// hook payload) into `tbd session-event`, which RPCs the daemon. The
+    /// command tolerates `tbd` not being on PATH — silent failure is fine.
+    static let sessionStartCommand =
+        #"tbd session-event 2>/dev/null || true"#
+
+    /// The shell command for the Stop hook. Mirrors the legacy
+    /// `setup-hooks --global` command so TBD can replace it without
+    /// regressing notification behavior.
+    static let stopCommand =
+        #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
+
+    /// Build the JSON-encoded overlay body.
+    public static func generateBody() throws -> Data {
+        let body: [String: Any] = [
+            "hooks": [
+                "SessionStart": [
+                    [
+                        "matcher": "*",
+                        "hooks": [
+                            ["type": "command", "command": sessionStartCommand]
+                        ]
+                    ]
+                ],
+                "Stop": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": stopCommand]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        return try JSONSerialization.data(
+            withJSONObject: body,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+    }
+
+    /// Write the overlay to `overlayPath`, creating the parent directory if
+    /// needed. Atomic so a crash mid-write can't leave a half-written file
+    /// that breaks the next Claude spawn. Returns true on success.
+    @discardableResult
+    public static func writeOverlay() -> Bool {
+        do {
+            let data = try generateBody()
+            let parent = (overlayPath as NSString).deletingLastPathComponent
+            try FileManager.default.createDirectory(
+                atPath: parent,
+                withIntermediateDirectories: true
+            )
+            try data.write(to: URL(fileURLWithPath: overlayPath), options: .atomic)
+            logger.info("Wrote Claude overlay at \(overlayPath, privacy: .public)")
+            return true
+        } catch {
+            logger.error("Failed to write Claude overlay: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Verify the overlay exists. Used by `tbd hooks status` and as a
+    /// belt-and-braces check before we add `--settings` to the spawn command.
+    public static func overlayExists() -> Bool {
+        FileManager.default.fileExists(atPath: overlayPath)
+    }
+}

--- a/Sources/TBDDaemon/Hooks/LegacyHookScanner.swift
+++ b/Sources/TBDDaemon/Hooks/LegacyHookScanner.swift
@@ -1,0 +1,168 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "legacy-hook-scanner")
+
+/// Detects and (optionally) removes legacy TBD-installed hook entries from
+/// `~/.claude/settings.json` and per-repo `<repo>/.claude/settings.json`.
+///
+/// "Legacy" means: any hook entry whose `command` string contains
+/// `"tbd notify"` or `"tbd session-event"`. We can't tell from the
+/// settings.json alone whether the entry was installed by `tbd setup-hooks`,
+/// hand-edited by the user, or sourced elsewhere — but the substring is a
+/// good-enough signal for surfacing a one-time migration prompt, and the
+/// removal path only ever runs when the user clicks "Remove" in the dialog.
+///
+/// All removals run through `SettingsJSONSafety` (pristine backup, atomic
+/// write, roundtrip validation).
+public enum LegacyHookScanner {
+
+    /// Substrings that identify a TBD-installed hook entry.
+    static let markerSubstrings: [String] = ["tbd notify", "tbd session-event"]
+
+    /// Walk a parsed settings dict and return every hook entry whose
+    /// `command` contains one of the marker substrings.
+    public static func detectEntries(in settings: [String: Any]) -> [LegacyHookEntry] {
+        guard let hooks = settings["hooks"] as? [String: Any] else { return [] }
+        var found: [LegacyHookEntry] = []
+        for (event, raw) in hooks {
+            guard let matchers = raw as? [[String: Any]] else { continue }
+            for matcher in matchers {
+                if let inner = matcher["hooks"] as? [[String: Any]] {
+                    for entry in inner {
+                        if let cmd = entry["command"] as? String,
+                           markerSubstrings.contains(where: { cmd.contains($0) }) {
+                            found.append(LegacyHookEntry(event: event, command: cmd))
+                        }
+                    }
+                } else if let cmd = matcher["command"] as? String,
+                          markerSubstrings.contains(where: { cmd.contains($0) }) {
+                    // Older bare-format entries.
+                    found.append(LegacyHookEntry(event: event, command: cmd))
+                }
+            }
+        }
+        return found
+    }
+
+    /// Read a settings.json from disk and return detected entries, or [] if
+    /// the file is missing/unreadable/non-JSON.
+    public static func detectEntries(at path: String) -> [LegacyHookEntry] {
+        guard FileManager.default.fileExists(atPath: path),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            return []
+        }
+        return detectEntries(in: dict)
+    }
+
+    /// Mutate a parsed settings dict in place, removing every hook entry
+    /// matching our marker substrings. Returns the number of entries
+    /// removed (count of `entry` objects, not matcher groups).
+    @discardableResult
+    public static func stripEntries(from settings: inout [String: Any]) -> Int {
+        guard var hooks = settings["hooks"] as? [String: Any] else { return 0 }
+        var removed = 0
+        for (event, raw) in hooks {
+            guard var matchers = raw as? [[String: Any]] else { continue }
+            var newMatchers: [[String: Any]] = []
+            for matcher in matchers {
+                if let inner = matcher["hooks"] as? [[String: Any]] {
+                    let kept = inner.filter { entry in
+                        guard let cmd = entry["command"] as? String else { return true }
+                        let drop = markerSubstrings.contains(where: { cmd.contains($0) })
+                        if drop { removed += 1 }
+                        return !drop
+                    }
+                    if !kept.isEmpty {
+                        var copy = matcher
+                        copy["hooks"] = kept
+                        newMatchers.append(copy)
+                    }
+                } else if let cmd = matcher["command"] as? String,
+                          markerSubstrings.contains(where: { cmd.contains($0) }) {
+                    removed += 1
+                    // drop entirely
+                } else {
+                    newMatchers.append(matcher)
+                }
+            }
+            matchers = newMatchers
+            if matchers.isEmpty {
+                hooks.removeValue(forKey: event)
+            } else {
+                hooks[event] = matchers
+            }
+        }
+        settings["hooks"] = hooks
+        return removed
+    }
+
+    /// Path to the user's global Claude settings.
+    public static var globalSettingsPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude")
+            .appendingPathComponent("settings.json")
+            .path
+    }
+
+    /// Repo-level settings paths for every repo registered in the TBD DB.
+    /// Returns only paths that actually exist on disk.
+    public static func repoSettingsPaths(repoPaths: [String],
+                                         fileManager: FileManager = .default) -> [String] {
+        repoPaths.compactMap { repoPath in
+            let candidate = URL(fileURLWithPath: repoPath)
+                .appendingPathComponent(".claude")
+                .appendingPathComponent("settings.json")
+                .path
+            return fileManager.fileExists(atPath: candidate) ? candidate : nil
+        }
+    }
+
+    /// Remove every detected legacy entry from the global settings file. No-op
+    /// if there's nothing to remove. Wraps the write in `SettingsJSONSafety`
+    /// (pristine backup, atomic write, roundtrip validation). Returns the
+    /// number of entries removed and the backup file path (if a backup was
+    /// just created — nil means a prior backup already existed or the file
+    /// was missing).
+    @discardableResult
+    public static func removeGlobalEntries(at path: String = globalSettingsPath) throws -> RemoveLegacyGlobalHooksResult {
+        guard FileManager.default.fileExists(atPath: path) else {
+            return RemoveLegacyGlobalHooksResult(removedCount: 0, backupPath: nil)
+        }
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        guard var settings = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            // File exists but isn't a JSON object — refuse to touch it.
+            throw SettingsJSONSafety.Error.roundtripFailed("Existing settings.json is not a JSON object")
+        }
+        let removed = stripEntries(from: &settings)
+        if removed == 0 {
+            return RemoveLegacyGlobalHooksResult(removedCount: 0, backupPath: nil)
+        }
+        let createdBackup = try SettingsJSONSafety.ensureBackup(of: path)
+        let proposed = try JSONSerialization.data(
+            withJSONObject: settings,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try SettingsJSONSafety.atomicWriteValidated(
+            proposedBytes: proposed,
+            targetPath: path
+        ) { dict in
+            // Invariant: the marker substrings must be GONE from any
+            // `command` field in the resulting structure. Belt-and-braces
+            // against a future regression in stripEntries.
+            let leftover = detectEntries(in: dict)
+            if !leftover.isEmpty {
+                throw SettingsJSONSafety.Error.invariantFailed(
+                    "Strip pass left \(leftover.count) marker entries behind"
+                )
+            }
+        }
+        logger.info("Removed \(removed, privacy: .public) legacy global hook entries from \(path, privacy: .public)")
+        return RemoveLegacyGlobalHooksResult(
+            removedCount: removed,
+            backupPath: createdBackup ? path + SettingsJSONSafety.backupSuffix : nil
+        )
+    }
+}

--- a/Sources/TBDDaemon/Hooks/LegacyHookScanner.swift
+++ b/Sources/TBDDaemon/Hooks/LegacyHookScanner.swift
@@ -65,7 +65,7 @@ public enum LegacyHookScanner {
         guard var hooks = settings["hooks"] as? [String: Any] else { return 0 }
         var removed = 0
         for (event, raw) in hooks {
-            guard var matchers = raw as? [[String: Any]] else { continue }
+            guard let matchers = raw as? [[String: Any]] else { continue }
             var newMatchers: [[String: Any]] = []
             for matcher in matchers {
                 if let inner = matcher["hooks"] as? [[String: Any]] {
@@ -88,11 +88,10 @@ public enum LegacyHookScanner {
                     newMatchers.append(matcher)
                 }
             }
-            matchers = newMatchers
-            if matchers.isEmpty {
+            if newMatchers.isEmpty {
                 hooks.removeValue(forKey: event)
             } else {
-                hooks[event] = matchers
+                hooks[event] = newMatchers
             }
         }
         settings["hooks"] = hooks

--- a/Sources/TBDDaemon/Hooks/LegacyHookScanner.swift
+++ b/Sources/TBDDaemon/Hooks/LegacyHookScanner.swift
@@ -94,7 +94,13 @@ public enum LegacyHookScanner {
                 hooks[event] = newMatchers
             }
         }
-        settings["hooks"] = hooks
+        // If we stripped every event, drop the empty `hooks: {}` rather
+        // than leaving a vestigial section in the user's settings.json.
+        if hooks.isEmpty {
+            settings.removeValue(forKey: "hooks")
+        } else {
+            settings["hooks"] = hooks
+        }
         return removed
     }
 

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -387,12 +387,21 @@ public actor SuspendResumeCoordinator {
             profileBaseURL: resolvedProfile?.baseURL,
             profileModel: resolvedProfile?.model,
             cmd: nil,
-            shellFallback: defaultShell
+            shellFallback: defaultShell,
+            settingsOverlayPath: ClaudeHookOverlay.overlayPath
         )
+        // Inject TBD_WORKTREE_ID + TBD_TERMINAL_ID into the resumed pane so
+        // notifications and the SessionStart hook bridge attribute to the
+        // right terminal even after the post-resume session-id rollover.
+        let resumeEnv: [String: String] = [
+            "TBD_WORKTREE_ID": worktree.id.uuidString,
+            "TBD_TERMINAL_ID": terminal.id.uuidString,
+        ]
         do {
             let window = try await tmux.createWindow(
                 server: server, session: "main",
                 cwd: worktree.path, shellCommand: spawn.command,
+                env: resumeEnv,
                 sensitiveEnv: spawn.sensitiveEnv
             )
             try await db.terminals.updateTmuxIDs(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -245,6 +245,7 @@ extension WorktreeLifecycle {
         }
 
         // Create terminal 1: claude (or shell if skipClaude)
+        let plannedTerminalID1 = UUID()
         let claudeCommand: String
         let claudeSensitiveEnv: [String: String]
         let claudeSessionID: String?
@@ -269,22 +270,31 @@ extension WorktreeLifecycle {
                 profileBaseURL: resolvedProfile?.baseURL,
                 profileModel: resolvedProfile?.model,
                 cmd: nil,
-                shellFallback: defaultShell
+                shellFallback: defaultShell,
+                settingsOverlayPath: ClaudeHookOverlay.overlayPath
             )
             claudeCommand = spawn.command
             claudeSensitiveEnv = spawn.sensitiveEnv
             pinnedProfileID = resolvedProfile?.profileID
         }
+        // Inject TBD_TERMINAL_ID + TBD_WORKTREE_ID so the SessionStart hook
+        // bridge can route session events to the right terminal.
+        let claudeEnv: [String: String] = [
+            "TBD_WORKTREE_ID": worktreeID.uuidString,
+            "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
+        ]
         let window1 = try await tmux.createWindow(
             server: tmuxServer,
             session: "main",
             cwd: worktreePath,
             shellCommand: claudeCommand,
+            env: claudeEnv,
             sensitiveEnv: claudeSensitiveEnv,
             cols: resolvedCols,
             rows: resolvedRows
         )
         _ = try await db.terminals.create(
+            id: plannedTerminalID1,
             worktreeID: worktreeID,
             tmuxWindowID: window1.windowID,
             tmuxPaneID: window1.paneID,
@@ -318,6 +328,7 @@ extension WorktreeLifecycle {
         // Restore additional archived Claude sessions (beyond the first which was used above)
         if !skipClaude, let sessions = archivedClaudeSessions, sessions.count > 1 {
             for sessionID in sessions.dropFirst() {
+                let plannedID = UUID()
                 let spawn = ClaudeSpawnCommandBuilder.build(
                     resumeID: nil,
                     freshSessionID: sessionID,
@@ -328,18 +339,25 @@ extension WorktreeLifecycle {
                     profileBaseURL: resolvedProfile?.baseURL,
                     profileModel: resolvedProfile?.model,
                     cmd: nil,
-                    shellFallback: defaultShell
+                    shellFallback: defaultShell,
+                    settingsOverlayPath: ClaudeHookOverlay.overlayPath
                 )
+                let perTermEnv: [String: String] = [
+                    "TBD_WORKTREE_ID": worktreeID.uuidString,
+                    "TBD_TERMINAL_ID": plannedID.uuidString,
+                ]
                 let window = try await tmux.createWindow(
                     server: tmuxServer,
                     session: "main",
                     cwd: worktreePath,
                     shellCommand: spawn.command,
+                    env: perTermEnv,
                     sensitiveEnv: spawn.sensitiveEnv,
                     cols: resolvedCols,
                     rows: resolvedRows
                 )
                 _ = try await db.terminals.create(
+                    id: plannedID,
                     worktreeID: worktreeID,
                     tmuxWindowID: window.windowID,
                     tmuxPaneID: window.paneID,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -239,6 +239,10 @@ extension WorktreeLifecycle {
         // with — which would misattribute notifications to a different
         // worktree. Applies to all branches below (claude, codex, shell/cmd).
         env["TBD_WORKTREE_ID"] = worktree.id.uuidString
+        // Persist the terminal ID into the spawned env so the SessionStart
+        // hook bridge can route session events for `/clear`/`/compact`
+        // rollovers without depending on cwd-based heuristics.
+        env["TBD_TERMINAL_ID"] = terminal.id.uuidString
 
         if let sessionID = terminal.claudeSessionID {
             // Claude terminal — resume existing session with persisted profile
@@ -256,7 +260,8 @@ extension WorktreeLifecycle {
                 profileBaseURL: resolvedProfile?.baseURL,
                 profileModel: resolvedProfile?.model,
                 cmd: nil,
-                shellFallback: defaultShell
+                shellFallback: defaultShell,
+                settingsOverlayPath: ClaudeHookOverlay.overlayPath
             )
         } else if terminal.label == "Codex" {
             // Codex terminal — detected by label "Codex" (set during terminal creation).

--- a/Sources/TBDDaemon/Server/RPCRouter+LegacyHookHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+LegacyHookHandlers.swift
@@ -1,0 +1,51 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "legacy-hooks")
+
+extension RPCRouter {
+
+    /// Read-only scan of `~/.claude/settings.json` plus every registered
+    /// repo's `<repo>/.claude/settings.json` for hook entries whose
+    /// `command` field contains `tbd notify` or `tbd session-event`.
+    /// Returns a structured list the app uses to decide whether to surface
+    /// the migration prompt and to populate the dialog body.
+    public func handleDaemonLegacyHooksStatus() async throws -> RPCResponse {
+        let global = LegacyHookScanner.detectEntries(at: LegacyHookScanner.globalSettingsPath)
+        var repoMap: [String: [LegacyHookEntry]] = [:]
+        let repos = (try? await db.repos.list()) ?? []
+        let candidatePaths = LegacyHookScanner.repoSettingsPaths(repoPaths: repos.map { $0.path })
+        for path in candidatePaths {
+            let entries = LegacyHookScanner.detectEntries(at: path)
+            if !entries.isEmpty {
+                repoMap[path] = entries
+            }
+        }
+        return try RPCResponse(result: LegacyHooksStatusResult(
+            globalEntries: global,
+            repoEntries: repoMap
+        ))
+    }
+
+    /// Mutating: remove every legacy global entry from
+    /// `~/.claude/settings.json`. Atomic + backed-up + validated via
+    /// `SettingsJSONSafety`. Repo-level files are NEVER touched.
+    public func handleDaemonRemoveLegacyGlobalHooks() async throws -> RPCResponse {
+        do {
+            let result = try LegacyHookScanner.removeGlobalEntries()
+            return try RPCResponse(result: result)
+        } catch let e as SettingsJSONSafety.Error {
+            logger.error("removeLegacyGlobalHooks safety error: \(String(describing: e), privacy: .public)")
+            switch e {
+            case .backupFailed(let m): return RPCResponse(error: "backup_failed: \(m)")
+            case .roundtripFailed(let m): return RPCResponse(error: "roundtrip_failed: \(m)")
+            case .writeFailed(let m): return RPCResponse(error: "write_failed: \(m)")
+            case .invariantFailed(let m): return RPCResponse(error: "invariant_failed: \(m)")
+            }
+        } catch {
+            logger.error("removeLegacyGlobalHooks unexpected: \(error.localizedDescription, privacy: .public)")
+            return RPCResponse(error: "remove_failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -89,9 +89,16 @@ extension RPCRouter {
         // Look up repo once for system prompt env vars and Claude session setup
         let repo = try await db.repos.get(id: worktree.repoID)
 
+        // Pre-mint the terminal ID so we can inject it into the spawned env
+        // as TBD_TERMINAL_ID. Claude's SessionStart hook (registered via the
+        // TBD overlay file) reads this env var to route session events back
+        // to the right terminal record.
+        let plannedTerminalID = UUID()
+
         // Build env vars available in all TBD terminals
         var env = SystemPromptBuilder.promptLayers(repo: repo, worktree: worktree)
         env["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
+        env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
 
         // Codex branch: minimal launch with isolated CODEX_HOME. No session
         // tracking, no system prompt injection, no token resolution. Session
@@ -106,6 +113,7 @@ extension RPCRouter {
             let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
+            codexEnv["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
             codexEnv["CODEX_HOME"] = codexHome.path
 
             let window = try await tmux.createWindow(
@@ -119,6 +127,7 @@ extension RPCRouter {
             )
 
             let terminal = try await db.terminals.create(
+                id: plannedTerminalID,
                 worktreeID: params.worktreeID,
                 tmuxWindowID: window.windowID,
                 tmuxPaneID: window.paneID,
@@ -195,7 +204,8 @@ extension RPCRouter {
             profileBaseURL: resolvedProfile?.baseURL,
             profileModel: resolvedProfile?.model,
             cmd: params.cmd,
-            shellFallback: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+            shellFallback: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
+            settingsOverlayPath: isClaudeType ? ClaudeHookOverlay.overlayPath : nil
         )
 
         let window = try await tmux.createWindow(
@@ -210,6 +220,7 @@ extension RPCRouter {
         )
 
         let terminal = try await db.terminals.create(
+            id: plannedTerminalID,
             worktreeID: params.worktreeID,
             tmuxWindowID: window.windowID,
             tmuxPaneID: window.paneID,
@@ -500,8 +511,10 @@ extension RPCRouter {
         // produce "no conversation found" and chaotic behavior, so we instead
         // spawn a brand-new session and skip the recapture.
         let repo = try await db.repos.get(id: worktree.repoID)
+        let plannedTerminalID = UUID()
         var env = SystemPromptBuilder.promptLayers(repo: repo, worktree: worktree)
         env["TBD_WORKTREE_ID"] = worktree.id.uuidString
+        env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
 
         let blank = ClaudeSessionScanner.isSessionBlank(
             sessionID: sessionID,
@@ -525,7 +538,8 @@ extension RPCRouter {
                 profileBaseURL: resolved?.baseURL,
                 profileModel: resolved?.model,
                 cmd: nil,
-                shellFallback: ""
+                shellFallback: "",
+                settingsOverlayPath: ClaudeHookOverlay.overlayPath
             )
             storedSessionID = resumeID
             scheduleRecapture = true
@@ -544,7 +558,8 @@ extension RPCRouter {
                 profileBaseURL: resolved?.baseURL,
                 profileModel: resolved?.model,
                 cmd: nil,
-                shellFallback: ""
+                shellFallback: "",
+                settingsOverlayPath: ClaudeHookOverlay.overlayPath
             )
             storedSessionID = newSessionID
             scheduleRecapture = false
@@ -567,6 +582,7 @@ extension RPCRouter {
         )
 
         let newTerminal = try await db.terminals.create(
+            id: plannedTerminalID,
             worktreeID: worktree.id,
             tmuxWindowID: window.windowID,
             tmuxPaneID: window.paneID,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -811,6 +811,57 @@ extension RPCRouter {
         return try RPCResponse(result: result)
     }
 
+    /// Bridge for the Claude SessionStart hook. The CLI relays the hook
+    /// payload (session_id, transcript_path, source) plus the spawn-time
+    /// `TBD_TERMINAL_ID` env to this method. We persist both fields and
+    /// broadcast a delta so the app's transcript pane re-targets the new
+    /// session file. Unknown terminal IDs are treated as a soft no-op (the
+    /// terminal may have been deleted between hook fire and arrival).
+    func handleTerminalSessionEvent(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalSessionEventParams.self, from: paramsData)
+
+        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+            // Soft success — caller is a fire-and-forget hook, returning an
+            // error would just spam stderr inside Claude.
+            logger.debug("sessionEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
+            return .ok()
+        }
+
+        // Sanitize: an empty transcriptPath shouldn't overwrite an existing
+        // good value with nil (treat as "not provided"). A non-absolute path
+        // is also rejected since that's never how Claude reports it.
+        let cleanedPath: String? = {
+            guard let p = params.transcriptPath, !p.isEmpty else { return nil }
+            guard p.hasPrefix("/") else {
+                logger.warning("sessionEvent: ignoring non-absolute transcriptPath \(p, privacy: .public)")
+                return nil
+            }
+            return p
+        }()
+
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: params.sessionID,
+            transcriptPath: cleanedPath
+        )
+
+        // Invalidate cached transcript parse for the OLD session file (if any)
+        // so a quick re-poll doesn't return stale entries.
+        // (TranscriptParseCache keys on filePath, so the new path naturally
+        // misses cache and re-parses — no explicit invalidation needed.)
+
+        let source = params.source ?? "unknown"
+        logger.info("sessionEvent: terminal \(terminal.id.uuidString, privacy: .public) -> session \(params.sessionID, privacy: .public) (source=\(source, privacy: .public))")
+
+        subscriptions.broadcast(delta: .terminalSessionUpdated(TerminalSessionDelta(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            sessionID: params.sessionID,
+            transcriptPath: cleanedPath
+        )))
+        return .ok()
+    }
+
     func handleTerminalTranscript(_ paramsData: Data) async throws -> RPCResponse {
         perfTranscriptLog.debug("rpc.handle.start method=terminalTranscript")
         let start = ContinuousClock.now
@@ -842,14 +893,25 @@ extension RPCRouter {
             return response
         }
 
-        guard let projectDir = ClaudeProjectDirectory.resolve(worktreePath: worktree.path) else {
-            let result = TerminalTranscriptResult(messages: [], sessionID: sessionID)
-            response = try RPCResponse(result: result)
-            responseBytes = response.result?.utf8.count ?? 0
-            return response
+        // Prefer the absolute path captured by the SessionStart hook — it's
+        // immune to `/clear` and `/compact` rollovers that change the
+        // ~/.claude/projects/ subdir away from the cwd-derived guess. Fall
+        // back to the legacy projectDir+sessionID resolution for terminals
+        // that haven't received a hook event yet (older terminals, or
+        // sessions that were already running before the overlay hook was
+        // registered).
+        let filePath: String
+        if let storedPath = terminal.transcriptPath, !storedPath.isEmpty {
+            filePath = storedPath
+        } else {
+            guard let projectDir = ClaudeProjectDirectory.resolve(worktreePath: worktree.path) else {
+                let result = TerminalTranscriptResult(messages: [], sessionID: sessionID)
+                response = try RPCResponse(result: result)
+                responseBytes = response.result?.utf8.count ?? 0
+                return response
+            }
+            filePath = projectDir.appendingPathComponent("\(sessionID).jsonl").path
         }
-
-        let filePath = projectDir.appendingPathComponent("\(sessionID).jsonl").path
         let messages: [TranscriptItem]
         if let cached = await TranscriptParseCache.shared.get(filePath: filePath) {
             messages = cached
@@ -871,13 +933,28 @@ extension RPCRouter {
             return RPCResponse(error: "Terminal not found: \(params.terminalID)")
         }
         guard let sessionID = terminal.claudeSessionID,
-              let worktree = try await db.worktrees.get(id: terminal.worktreeID),
-              let projectDir = ClaudeProjectDirectory.resolve(worktreePath: worktree.path) else {
+              let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
             return try RPCResponse(result: TerminalTranscriptItemFullBodyResult(text: "Output no longer available."))
         }
 
-        var paths = [projectDir.appendingPathComponent("\(sessionID).jsonl").path]
-        let subagentsDir = projectDir.appendingPathComponent(sessionID).appendingPathComponent("subagents")
+        // Prefer hook-reported path; derive the subagents directory from
+        // either the stored path's parent or the legacy projectDir.
+        let primaryPath: String
+        let subagentsDir: URL
+        if let storedPath = terminal.transcriptPath, !storedPath.isEmpty {
+            primaryPath = storedPath
+            let parent = (storedPath as NSString).deletingLastPathComponent
+            subagentsDir = URL(fileURLWithPath: parent)
+                .appendingPathComponent(sessionID)
+                .appendingPathComponent("subagents")
+        } else {
+            guard let projectDir = ClaudeProjectDirectory.resolve(worktreePath: worktree.path) else {
+                return try RPCResponse(result: TerminalTranscriptItemFullBodyResult(text: "Output no longer available."))
+            }
+            primaryPath = projectDir.appendingPathComponent("\(sessionID).jsonl").path
+            subagentsDir = projectDir.appendingPathComponent(sessionID).appendingPathComponent("subagents")
+        }
+        var paths = [primaryPath]
         if let subFiles = try? FileManager.default.contentsOfDirectory(at: subagentsDir, includingPropertiesForKeys: nil) {
             paths.append(contentsOf: subFiles
                 .filter { $0.pathExtension == "jsonl" }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -106,6 +106,8 @@ public final class RPCRouter: Sendable {
                 return try await handleTerminalSetPin(request.paramsData)
             case RPCMethod.terminalSwapProfile:
                 return try await handleTerminalSwapProfile(request.paramsData)
+            case RPCMethod.terminalSessionEvent:
+                return try await handleTerminalSessionEvent(request.paramsData)
             case RPCMethod.notify:
                 return try await handleNotify(request.paramsData)
             case RPCMethod.daemonStatus:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -204,6 +204,10 @@ public final class RPCRouter: Sendable {
                 return try await handleSkillStatus(request.paramsData)
             case RPCMethod.skillInstall:
                 return try await handleSkillInstall(request.paramsData)
+            case RPCMethod.daemonLegacyHooksStatus:
+                return try await handleDaemonLegacyHooksStatus()
+            case RPCMethod.daemonRemoveLegacyGlobalHooks:
+                return try await handleDaemonRemoveLegacyGlobalHooks()
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -146,12 +146,19 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public var suspendedAt: Date?
     public var suspendedSnapshot: String?
     public var profileID: UUID?
+    /// Absolute path to the JSONL file Claude is writing for the current
+    /// session, captured via the SessionStart hook. Persisted so the
+    /// transcript handler can re-target accurately across `/clear` and
+    /// `/compact` rollovers (where Claude may pick a different
+    /// `~/.claude/projects/` subdirectory than cwd would suggest).
+    public var transcriptPath: String?
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
                 pinnedAt: Date? = nil, claudeSessionID: String? = nil,
                 suspendedAt: Date? = nil, suspendedSnapshot: String? = nil,
-                profileID: UUID? = nil) {
+                profileID: UUID? = nil,
+                transcriptPath: String? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -163,6 +170,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.suspendedAt = suspendedAt
         self.suspendedSnapshot = suspendedSnapshot
         self.profileID = profileID
+        self.transcriptPath = transcriptPath
     }
 
     public init(from decoder: Decoder) throws {
@@ -178,6 +186,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         suspendedAt = try c.decodeIfPresent(Date.self, forKey: .suspendedAt)
         suspendedSnapshot = try c.decodeIfPresent(String.self, forKey: .suspendedSnapshot)
         profileID = try c.decodeIfPresent(UUID.self, forKey: .profileID)
+        transcriptPath = try c.decodeIfPresent(String.self, forKey: .transcriptPath)
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -142,6 +142,45 @@ public enum RPCMethod {
     public static let setMainAreaSize = "app.setMainAreaSize"
     public static let skillStatus = "skill.status"
     public static let skillInstall = "skill.install"
+    public static let daemonLegacyHooksStatus = "daemon.legacyHooksStatus"
+    public static let daemonRemoveLegacyGlobalHooks = "daemon.removeLegacyGlobalHooks"
+}
+
+// MARK: - Legacy Hook Detection / Removal
+
+/// One detected legacy entry — surfaced to the user so they know what TBD
+/// proposes to remove (or, for repo-level entries, what they can edit
+/// themselves).
+public struct LegacyHookEntry: Codable, Sendable, Equatable {
+    /// "Stop", "SessionStart", etc. — the matcher event name.
+    public let event: String
+    /// Captured `command` string from the matched entry (truncated upstream
+    /// if needed so the dialog stays readable).
+    public let command: String
+    public init(event: String, command: String) {
+        self.event = event
+        self.command = command
+    }
+}
+
+public struct LegacyHooksStatusResult: Codable, Sendable {
+    public let globalEntries: [LegacyHookEntry]
+    /// Repo-level entries keyed by repo settings.json path. Surfaced
+    /// informationally; TBD never auto-modifies repo files.
+    public let repoEntries: [String: [LegacyHookEntry]]
+    public init(globalEntries: [LegacyHookEntry], repoEntries: [String: [LegacyHookEntry]]) {
+        self.globalEntries = globalEntries
+        self.repoEntries = repoEntries
+    }
+}
+
+public struct RemoveLegacyGlobalHooksResult: Codable, Sendable {
+    public let removedCount: Int
+    public let backupPath: String?
+    public init(removedCount: Int, backupPath: String?) {
+        self.removedCount = removedCount
+        self.backupPath = backupPath
+    }
 }
 
 // MARK: - Main Area Size

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -133,6 +133,7 @@ public enum RPCMethod {
     public static let modelProfileFetchUsage = "modelProfile.fetchUsage"
     public static let modelProfileHealthCheck = "modelProfile.healthCheck"
     public static let terminalSwapProfile = "terminal.swapProfile"
+    public static let terminalSessionEvent = "terminal.sessionEvent"
     public static let appSetForegroundState = "app.setForegroundState"
     public static let repoRelocate = "repo.relocate"
     public static let repoRename = "repo.rename"
@@ -762,5 +763,24 @@ public struct TerminalTranscriptItemFullBodyResult: Codable, Sendable {
     public let text: String
     public init(text: String) {
         self.text = text
+    }
+}
+
+// MARK: - Terminal Session Event (Claude SessionStart hook bridge)
+
+/// Payload reported by the SessionStart hook (relayed via `tbd session-event`).
+/// `source` is one of the values Claude Code emits: `startup`, `resume`,
+/// `clear`, `compact`. We pass it through opaquely so future Claude
+/// hook payload changes don't immediately break this bridge.
+public struct TerminalSessionEventParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let sessionID: String
+    public let transcriptPath: String?
+    public let source: String?
+    public init(terminalID: UUID, sessionID: String, transcriptPath: String?, source: String?) {
+        self.terminalID = terminalID
+        self.sessionID = sessionID
+        self.transcriptPath = transcriptPath
+        self.source = source
     }
 }

--- a/Sources/TBDShared/SettingsJSONWriter.swift
+++ b/Sources/TBDShared/SettingsJSONWriter.swift
@@ -50,6 +50,12 @@ public enum SettingsJSONSafety {
     /// over the parsed dictionary. The invariant closure should throw on
     /// any structural mismatch; that throw is mapped into
     /// `Error.invariantFailed` and the on-disk file is NOT modified.
+    ///
+    /// `fileManager` is used only for parent-directory existence checks and
+    /// `createDirectory`; the final write goes through `Data.write(to:)`,
+    /// which always hits real I/O. Tests can pass an in-memory file manager
+    /// to mock the directory probe but should still expect real bytes on
+    /// disk afterwards.
     public static func atomicWriteValidated(
         proposedBytes: Data,
         targetPath: String,

--- a/Sources/TBDShared/SettingsJSONWriter.swift
+++ b/Sources/TBDShared/SettingsJSONWriter.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Safety layers for any TBD code path that mutates a Claude Code-style
+/// `settings.json` file. The helpers are pure — no I/O on construction —
+/// so they are safe to use from CLI commands, the daemon, and unit tests.
+///
+/// Three layers:
+/// 1. **Pristine backup**: before the FIRST mutation TBD ever makes to
+///    the target file, we copy it to `<path>.tbd-backup`. The backup is
+///    only created if it does not already exist, so a user's true
+///    pre-TBD original is preserved forever, immune to repeated bugs.
+/// 2. **Roundtrip validation**: callers serialize their proposed JSON
+///    and pass the bytes here; we re-parse them and run the caller's
+///    invariant closure. If it throws, the write is aborted — the
+///    original file stays untouched.
+/// 3. **Atomic write**: `Data.write(options: .atomic)` so a crash mid-
+///    write can't leave a half-written file.
+public enum SettingsJSONSafety {
+
+    public enum Error: Swift.Error, Equatable, Sendable {
+        case backupFailed(String)
+        case roundtripFailed(String)
+        case writeFailed(String)
+        case invariantFailed(String)
+    }
+
+    /// Suffix appended to settings.json paths to derive the backup path.
+    public static let backupSuffix = ".tbd-backup"
+
+    /// Copy `sourcePath` to `sourcePath + backupSuffix` only if the backup
+    /// file does not already exist. Returns true if a new backup was
+    /// created, false if a prior backup already existed (or if the
+    /// source itself is missing — there's nothing to back up).
+    @discardableResult
+    public static func ensureBackup(of sourcePath: String,
+                                    fileManager: FileManager = .default) throws -> Bool {
+        let backupPath = sourcePath + backupSuffix
+        if fileManager.fileExists(atPath: backupPath) { return false }
+        guard fileManager.fileExists(atPath: sourcePath) else { return false }
+        do {
+            try fileManager.copyItem(atPath: sourcePath, toPath: backupPath)
+            return true
+        } catch {
+            throw Error.backupFailed("Could not copy \(sourcePath) to \(backupPath): \(error.localizedDescription)")
+        }
+    }
+
+    /// Atomic-write the proposed bytes to `targetPath` after running both
+    /// JSON-roundtrip validation and a caller-supplied invariant closure
+    /// over the parsed dictionary. The invariant closure should throw on
+    /// any structural mismatch; that throw is mapped into
+    /// `Error.invariantFailed` and the on-disk file is NOT modified.
+    public static func atomicWriteValidated(
+        proposedBytes: Data,
+        targetPath: String,
+        invariant: ([String: Any]) throws -> Void
+    ) throws {
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: proposedBytes, options: [])
+        } catch {
+            throw Error.roundtripFailed(error.localizedDescription)
+        }
+        guard let dict = parsed as? [String: Any] else {
+            throw Error.roundtripFailed("Top-level value is not a JSON object")
+        }
+        do {
+            try invariant(dict)
+        } catch let e as Error {
+            throw e
+        } catch {
+            throw Error.invariantFailed(error.localizedDescription)
+        }
+        do {
+            // Ensure parent directory exists.
+            let parent = (targetPath as NSString).deletingLastPathComponent
+            if !FileManager.default.fileExists(atPath: parent) {
+                try FileManager.default.createDirectory(
+                    atPath: parent,
+                    withIntermediateDirectories: true
+                )
+            }
+            try proposedBytes.write(to: URL(fileURLWithPath: targetPath), options: .atomic)
+        } catch {
+            throw Error.writeFailed(error.localizedDescription)
+        }
+    }
+}

--- a/Sources/TBDShared/SettingsJSONWriter.swift
+++ b/Sources/TBDShared/SettingsJSONWriter.swift
@@ -53,6 +53,7 @@ public enum SettingsJSONSafety {
     public static func atomicWriteValidated(
         proposedBytes: Data,
         targetPath: String,
+        fileManager: FileManager = .default,
         invariant: ([String: Any]) throws -> Void
     ) throws {
         let parsed: Any
@@ -74,8 +75,8 @@ public enum SettingsJSONSafety {
         do {
             // Ensure parent directory exists.
             let parent = (targetPath as NSString).deletingLastPathComponent
-            if !FileManager.default.fileExists(atPath: parent) {
-                try FileManager.default.createDirectory(
+            if !fileManager.fileExists(atPath: parent) {
+                try fileManager.createDirectory(
                     atPath: parent,
                     withIntermediateDirectories: true
                 )

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -19,6 +19,23 @@ public enum StateDelta: Codable, Sendable {
     case worktreeReordered(RepoIDDelta)
     case modelProfileUsageUpdated(ModelProfileUsage)
     case modelProfilesChanged
+    case terminalSessionUpdated(TerminalSessionDelta)
+}
+
+/// Delta payload for Claude session ID/transcript path rollover, fired when
+/// the SessionStart hook bridge reports a new session for an existing
+/// terminal (e.g., post-`/clear`, `/compact`, or initial startup).
+public struct TerminalSessionDelta: Codable, Sendable {
+    public let terminalID: UUID
+    public let worktreeID: UUID
+    public let sessionID: String
+    public let transcriptPath: String?
+    public init(terminalID: UUID, worktreeID: UUID, sessionID: String, transcriptPath: String?) {
+        self.terminalID = terminalID
+        self.worktreeID = worktreeID
+        self.sessionID = sessionID
+        self.transcriptPath = transcriptPath
+    }
 }
 
 /// Delta payload for worktree creation/revival.

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -4,153 +4,30 @@ import Testing
 
 @Suite struct ClaudeHookOverlayTests {
 
-    // MARK: - Helpers
-
-    /// Decode the overlay body and pull out the SessionStart + Stop command
-    /// strings. Returns (sessionStart, stop) or nil if the shape is wrong.
-    private func extractCommands(from data: Data) throws -> (String, String)? {
-        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        guard let hooks = parsed?["hooks"] as? [String: Any] else { return nil }
-        let sessionStart = hooks["SessionStart"] as? [[String: Any]]
-        let inner = sessionStart?.first?["hooks"] as? [[String: Any]]
-        let cmd0 = inner?.first?["command"] as? String
-        let stop = hooks["Stop"] as? [[String: Any]]
-        let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
-        let stopCmd = stopHooks?.first?["command"] as? String
-        guard let cmd0, let stopCmd else { return nil }
-        return (cmd0, stopCmd)
-    }
-
-    // MARK: - Shape
-
     @Test func generateBodyHasExpectedShape() throws {
-        let data = try ClaudeHookOverlay.generateBody(cliPath: "/abs/TBDCLI")
+        let data = try ClaudeHookOverlay.generateBody()
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let hooks = parsed?["hooks"] as? [String: Any]
         #expect(hooks != nil)
-        // SessionStart entry registers `<cli> session-event` with a `*` matcher.
+        // SessionStart entry registers `tbd session-event` with a `*` matcher.
         let sessionStart = hooks?["SessionStart"] as? [[String: Any]]
         let matcher0 = sessionStart?.first?["matcher"] as? String
         #expect(matcher0 == "*")
         let inner = sessionStart?.first?["hooks"] as? [[String: Any]]
         let cmd0 = inner?.first?["command"] as? String
-        #expect(cmd0?.contains("session-event") == true)
+        #expect(cmd0?.contains("tbd session-event") == true)
 
-        // Stop entry registers `<cli> notify`.
+        // Stop entry registers `tbd notify`.
         let stop = hooks?["Stop"] as? [[String: Any]]
         let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
         let stopCmd = stopHooks?.first?["command"] as? String
-        #expect(stopCmd?.contains("notify") == true)
+        #expect(stopCmd?.contains("tbd notify") == true)
     }
 
     @Test func roundtripsAsValidJSON() throws {
-        let data = try ClaudeHookOverlay.generateBody(cliPath: "/abs/TBDCLI")
+        let data = try ClaudeHookOverlay.generateBody()
         // Must round-trip — a malformed overlay file would crash Claude
         // Code's settings loader. JSONSerialization throws on invalid JSON.
         _ = try JSONSerialization.jsonObject(with: data, options: [])
-    }
-
-    // MARK: - Absolute-path baking
-
-    @Test func bakesAbsolutePathIntoBothHooks() throws {
-        let cli = "/Users/chang/tbd/worktrees/foo/.build/debug/TBDCLI"
-        let data = try ClaudeHookOverlay.generateBody(cliPath: cli)
-        let cmds = try extractCommands(from: data)
-        #expect(cmds != nil)
-        // Both hooks invoke the absolute path, not bare `tbd`.
-        #expect(cmds?.0.contains(cli) == true)
-        #expect(cmds?.1.contains(cli) == true)
-        // Specifically, the absolute path should appear *as the binary*, not
-        // bare `tbd`. The simplest signature: the command starts with a
-        // single-quoted absolute path.
-        #expect(cmds?.0.hasPrefix("'\(cli)'") == true)
-        #expect(cmds?.1.contains("'\(cli)' notify") == true)
-    }
-
-    @Test func absolutePathIsShellQuoted() throws {
-        // A path with a space must round-trip through JSON encoding *and*
-        // come out as a single shell token. Use single-quote wrapping.
-        let pathWithSpace = "/tmp/path with spaces/TBDCLI"
-        let data = try ClaudeHookOverlay.generateBody(cliPath: pathWithSpace)
-        let cmds = try extractCommands(from: data)
-        #expect(cmds != nil)
-        // Single-quoted form keeps the whole path as one shell argument.
-        #expect(cmds?.0.contains("'\(pathWithSpace)'") == true)
-        #expect(cmds?.1.contains("'\(pathWithSpace)'") == true)
-
-        // Defense in depth: parse the command back out and verify it would
-        // round-trip cleanly through `sh -c` as a single token. We don't
-        // shell-execute here (the binary doesn't exist) — we just confirm
-        // the quoting structure: the path is wrapped in matching `'...'`
-        // and contains no unescaped single quotes inside.
-        let cmd = cmds!.0
-        // Strip the suffix to get just the quoted path.
-        let suffix = " session-event 2>/dev/null || true"
-        #expect(cmd.hasSuffix(suffix))
-        let quoted = String(cmd.dropLast(suffix.count))
-        #expect(quoted.hasPrefix("'") && quoted.hasSuffix("'"))
-        // Inside the quotes, there are no `'` chars (the path under test
-        // doesn't contain any).
-        let inside = String(quoted.dropFirst().dropLast())
-        #expect(inside == pathWithSpace)
-    }
-
-    @Test func embeddedSingleQuoteSurvives() throws {
-        // Pathological input — paths with literal `'` are rare but valid.
-        // The standard `'\''` trick must produce a shell-parseable command.
-        let weirdPath = "/tmp/it's/TBDCLI"
-        let data = try ClaudeHookOverlay.generateBody(cliPath: weirdPath)
-        let cmds = try extractCommands(from: data)
-        #expect(cmds != nil)
-        // The `'` should be escaped as `'\''` inside the wrapping quotes.
-        #expect(cmds?.0.contains(#"'/tmp/it'\''s/TBDCLI'"#) == true)
-    }
-
-    // MARK: - Fallback branch
-
-    @Test func nilCliPathFallsBackToBareTbd() throws {
-        let data = try ClaudeHookOverlay.generateBody(cliPath: nil)
-        let cmds = try extractCommands(from: data)
-        #expect(cmds != nil)
-        #expect(cmds?.0 == "tbd session-event 2>/dev/null || true")
-        #expect(cmds?.1.hasPrefix("MSG=") == true)
-        #expect(cmds?.1.contains("tbd notify --type response_complete") == true)
-        // Make sure no stray quoting was added when falling back.
-        #expect(cmds?.0.contains("'") == false)
-    }
-
-    @Test func emptyCliPathFallsBackToBareTbd() throws {
-        // Empty string is treated the same as nil — defensive against
-        // accidental "" from a misbehaving caller.
-        let data = try ClaudeHookOverlay.generateBody(cliPath: "")
-        let cmds = try extractCommands(from: data)
-        #expect(cmds?.0 == "tbd session-event 2>/dev/null || true")
-        #expect(cmds?.1.contains("tbd notify") == true)
-    }
-
-    @Test func writeOverlayWithNilFallsBackAndStillWrites() throws {
-        // Redirect overlay path to a temp file via override of the constant
-        // is overkill for this test — instead, call writeOverlay() and
-        // verify it succeeded and that the on-disk content reflects the
-        // bare-`tbd` fallback. We restore the file afterwards.
-        let path = ClaudeHookOverlay.overlayPath
-        let fm = FileManager.default
-        // Snapshot existing content so the test doesn't perturb a running
-        // daemon's overlay (the daemon will rewrite on next restart anyway,
-        // but the snapshot keeps the test idempotent for repeated runs).
-        let snapshot = try? Data(contentsOf: URL(fileURLWithPath: path))
-        defer {
-            if let snapshot {
-                try? snapshot.write(to: URL(fileURLWithPath: path))
-            } else {
-                try? fm.removeItem(atPath: path)
-            }
-        }
-
-        let ok = ClaudeHookOverlay.writeOverlay(cliPath: nil)
-        #expect(ok)
-        let onDisk = try Data(contentsOf: URL(fileURLWithPath: path))
-        let cmds = try extractCommands(from: onDisk)
-        #expect(cmds?.0 == "tbd session-event 2>/dev/null || true")
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -4,30 +4,153 @@ import Testing
 
 @Suite struct ClaudeHookOverlayTests {
 
+    // MARK: - Helpers
+
+    /// Decode the overlay body and pull out the SessionStart + Stop command
+    /// strings. Returns (sessionStart, stop) or nil if the shape is wrong.
+    private func extractCommands(from data: Data) throws -> (String, String)? {
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard let hooks = parsed?["hooks"] as? [String: Any] else { return nil }
+        let sessionStart = hooks["SessionStart"] as? [[String: Any]]
+        let inner = sessionStart?.first?["hooks"] as? [[String: Any]]
+        let cmd0 = inner?.first?["command"] as? String
+        let stop = hooks["Stop"] as? [[String: Any]]
+        let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
+        let stopCmd = stopHooks?.first?["command"] as? String
+        guard let cmd0, let stopCmd else { return nil }
+        return (cmd0, stopCmd)
+    }
+
+    // MARK: - Shape
+
     @Test func generateBodyHasExpectedShape() throws {
-        let data = try ClaudeHookOverlay.generateBody()
+        let data = try ClaudeHookOverlay.generateBody(cliPath: "/abs/TBDCLI")
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let hooks = parsed?["hooks"] as? [String: Any]
         #expect(hooks != nil)
-        // SessionStart entry registers `tbd session-event` with a `*` matcher.
+        // SessionStart entry registers `<cli> session-event` with a `*` matcher.
         let sessionStart = hooks?["SessionStart"] as? [[String: Any]]
         let matcher0 = sessionStart?.first?["matcher"] as? String
         #expect(matcher0 == "*")
         let inner = sessionStart?.first?["hooks"] as? [[String: Any]]
         let cmd0 = inner?.first?["command"] as? String
-        #expect(cmd0?.contains("tbd session-event") == true)
+        #expect(cmd0?.contains("session-event") == true)
 
-        // Stop entry registers `tbd notify`.
+        // Stop entry registers `<cli> notify`.
         let stop = hooks?["Stop"] as? [[String: Any]]
         let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
         let stopCmd = stopHooks?.first?["command"] as? String
-        #expect(stopCmd?.contains("tbd notify") == true)
+        #expect(stopCmd?.contains("notify") == true)
     }
 
     @Test func roundtripsAsValidJSON() throws {
-        let data = try ClaudeHookOverlay.generateBody()
+        let data = try ClaudeHookOverlay.generateBody(cliPath: "/abs/TBDCLI")
         // Must round-trip — a malformed overlay file would crash Claude
         // Code's settings loader. JSONSerialization throws on invalid JSON.
         _ = try JSONSerialization.jsonObject(with: data, options: [])
+    }
+
+    // MARK: - Absolute-path baking
+
+    @Test func bakesAbsolutePathIntoBothHooks() throws {
+        let cli = "/Users/chang/tbd/worktrees/foo/.build/debug/TBDCLI"
+        let data = try ClaudeHookOverlay.generateBody(cliPath: cli)
+        let cmds = try extractCommands(from: data)
+        #expect(cmds != nil)
+        // Both hooks invoke the absolute path, not bare `tbd`.
+        #expect(cmds?.0.contains(cli) == true)
+        #expect(cmds?.1.contains(cli) == true)
+        // Specifically, the absolute path should appear *as the binary*, not
+        // bare `tbd`. The simplest signature: the command starts with a
+        // single-quoted absolute path.
+        #expect(cmds?.0.hasPrefix("'\(cli)'") == true)
+        #expect(cmds?.1.contains("'\(cli)' notify") == true)
+    }
+
+    @Test func absolutePathIsShellQuoted() throws {
+        // A path with a space must round-trip through JSON encoding *and*
+        // come out as a single shell token. Use single-quote wrapping.
+        let pathWithSpace = "/tmp/path with spaces/TBDCLI"
+        let data = try ClaudeHookOverlay.generateBody(cliPath: pathWithSpace)
+        let cmds = try extractCommands(from: data)
+        #expect(cmds != nil)
+        // Single-quoted form keeps the whole path as one shell argument.
+        #expect(cmds?.0.contains("'\(pathWithSpace)'") == true)
+        #expect(cmds?.1.contains("'\(pathWithSpace)'") == true)
+
+        // Defense in depth: parse the command back out and verify it would
+        // round-trip cleanly through `sh -c` as a single token. We don't
+        // shell-execute here (the binary doesn't exist) — we just confirm
+        // the quoting structure: the path is wrapped in matching `'...'`
+        // and contains no unescaped single quotes inside.
+        let cmd = cmds!.0
+        // Strip the suffix to get just the quoted path.
+        let suffix = " session-event 2>/dev/null || true"
+        #expect(cmd.hasSuffix(suffix))
+        let quoted = String(cmd.dropLast(suffix.count))
+        #expect(quoted.hasPrefix("'") && quoted.hasSuffix("'"))
+        // Inside the quotes, there are no `'` chars (the path under test
+        // doesn't contain any).
+        let inside = String(quoted.dropFirst().dropLast())
+        #expect(inside == pathWithSpace)
+    }
+
+    @Test func embeddedSingleQuoteSurvives() throws {
+        // Pathological input — paths with literal `'` are rare but valid.
+        // The standard `'\''` trick must produce a shell-parseable command.
+        let weirdPath = "/tmp/it's/TBDCLI"
+        let data = try ClaudeHookOverlay.generateBody(cliPath: weirdPath)
+        let cmds = try extractCommands(from: data)
+        #expect(cmds != nil)
+        // The `'` should be escaped as `'\''` inside the wrapping quotes.
+        #expect(cmds?.0.contains(#"'/tmp/it'\''s/TBDCLI'"#) == true)
+    }
+
+    // MARK: - Fallback branch
+
+    @Test func nilCliPathFallsBackToBareTbd() throws {
+        let data = try ClaudeHookOverlay.generateBody(cliPath: nil)
+        let cmds = try extractCommands(from: data)
+        #expect(cmds != nil)
+        #expect(cmds?.0 == "tbd session-event 2>/dev/null || true")
+        #expect(cmds?.1.hasPrefix("MSG=") == true)
+        #expect(cmds?.1.contains("tbd notify --type response_complete") == true)
+        // Make sure no stray quoting was added when falling back.
+        #expect(cmds?.0.contains("'") == false)
+    }
+
+    @Test func emptyCliPathFallsBackToBareTbd() throws {
+        // Empty string is treated the same as nil — defensive against
+        // accidental "" from a misbehaving caller.
+        let data = try ClaudeHookOverlay.generateBody(cliPath: "")
+        let cmds = try extractCommands(from: data)
+        #expect(cmds?.0 == "tbd session-event 2>/dev/null || true")
+        #expect(cmds?.1.contains("tbd notify") == true)
+    }
+
+    @Test func writeOverlayWithNilFallsBackAndStillWrites() throws {
+        // Redirect overlay path to a temp file via override of the constant
+        // is overkill for this test — instead, call writeOverlay() and
+        // verify it succeeded and that the on-disk content reflects the
+        // bare-`tbd` fallback. We restore the file afterwards.
+        let path = ClaudeHookOverlay.overlayPath
+        let fm = FileManager.default
+        // Snapshot existing content so the test doesn't perturb a running
+        // daemon's overlay (the daemon will rewrite on next restart anyway,
+        // but the snapshot keeps the test idempotent for repeated runs).
+        let snapshot = try? Data(contentsOf: URL(fileURLWithPath: path))
+        defer {
+            if let snapshot {
+                try? snapshot.write(to: URL(fileURLWithPath: path))
+            } else {
+                try? fm.removeItem(atPath: path)
+            }
+        }
+
+        let ok = ClaudeHookOverlay.writeOverlay(cliPath: nil)
+        #expect(ok)
+        let onDisk = try Data(contentsOf: URL(fileURLWithPath: path))
+        let cmds = try extractCommands(from: onDisk)
+        #expect(cmds?.0 == "tbd session-event 2>/dev/null || true")
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ClaudeHookOverlayTests {
+
+    @Test func generateBodyHasExpectedShape() throws {
+        let data = try ClaudeHookOverlay.generateBody()
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let hooks = parsed?["hooks"] as? [String: Any]
+        #expect(hooks != nil)
+        // SessionStart entry registers `tbd session-event` with a `*` matcher.
+        let sessionStart = hooks?["SessionStart"] as? [[String: Any]]
+        let matcher0 = sessionStart?.first?["matcher"] as? String
+        #expect(matcher0 == "*")
+        let inner = sessionStart?.first?["hooks"] as? [[String: Any]]
+        let cmd0 = inner?.first?["command"] as? String
+        #expect(cmd0?.contains("tbd session-event") == true)
+
+        // Stop entry registers `tbd notify`.
+        let stop = hooks?["Stop"] as? [[String: Any]]
+        let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
+        let stopCmd = stopHooks?.first?["command"] as? String
+        #expect(stopCmd?.contains("tbd notify") == true)
+    }
+
+    @Test func roundtripsAsValidJSON() throws {
+        let data = try ClaudeHookOverlay.generateBody()
+        // Must round-trip — a malformed overlay file would crash Claude
+        // Code's settings loader. JSONSerialization throws on invalid JSON.
+        _ = try JSONSerialization.jsonObject(with: data, options: [])
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -217,4 +217,108 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv["ANTHROPIC_BASE_URL"] == nil)
         #expect(r.sensitiveEnv["ANTHROPIC_MODEL"] == nil)
     }
+
+    // MARK: - settingsOverlayPath branch
+
+    @Test("settings overlay path absent → no --settings flag in command")
+    func settingsOverlayNotPassed() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            settingsOverlayPath: nil
+        )
+        #expect(!r.command.contains("--settings"))
+    }
+
+    @Test("settings overlay path supplied but file missing → no --settings flag")
+    func settingsOverlayMissingFile() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            settingsOverlayPath: "/tmp/this-path-cannot-possibly-exist-\(UUID().uuidString)/overlay.json"
+        )
+        #expect(!r.command.contains("--settings"))
+    }
+
+    @Test("settings overlay path with existing file → --settings flag emitted")
+    func settingsOverlayWithExistingFile() throws {
+        let tmpFile = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString).json")
+        try "{}".data(using: .utf8)!.write(to: tmpFile)
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            settingsOverlayPath: tmpFile.path
+        )
+        #expect(r.command.contains("--settings"))
+        #expect(r.command.contains(tmpFile.path))
+    }
+
+    @Test("--settings flag also applied to fresh-session spawns")
+    func settingsOverlayOnFreshSession() throws {
+        let tmpFile = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-overlay-fresh-\(UUID().uuidString).json")
+        try "{}".data(using: .utf8)!.write(to: tmpFile)
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            settingsOverlayPath: tmpFile.path
+        )
+        #expect(r.command.contains("--session-id sid"))
+        #expect(r.command.contains("--settings"))
+    }
+
+    @Test("--settings is NOT emitted in cmd or shell-fallback branches")
+    func settingsOverlayIgnoredForCmdBranch() throws {
+        let tmpFile = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-overlay-cmd-\(UUID().uuidString).json")
+        try "{}".data(using: .utf8)!.write(to: tmpFile)
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+        // cmd path returns the verbatim cmd, no --settings injection
+        let r1 = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: "codex --full-auto",
+            shellFallback: "/bin/zsh",
+            settingsOverlayPath: tmpFile.path
+        )
+        #expect(r1.command == "codex --full-auto")
+        // shell fallback path likewise verbatim
+        let r2 = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            settingsOverlayPath: tmpFile.path
+        )
+        #expect(r2.command == "/bin/zsh")
+    }
 }

--- a/Tests/TBDDaemonTests/LegacyHookScannerTests.swift
+++ b/Tests/TBDDaemonTests/LegacyHookScannerTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct LegacyHookScannerTests {
+
+    @Test func detectsTBDNotifyEntryInWrappedFormat() {
+        let settings: [String: Any] = [
+            "hooks": [
+                "Stop": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": "tbd notify --type response_complete"]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        let entries = LegacyHookScanner.detectEntries(in: settings)
+        #expect(entries.count == 1)
+        #expect(entries.first?.event == "Stop")
+    }
+
+    @Test func detectsTBDNotifyEntryInBareFormat() {
+        let settings: [String: Any] = [
+            "hooks": [
+                "Stop": [
+                    ["type": "command", "command": "tbd notify"]
+                ]
+            ]
+        ]
+        let entries = LegacyHookScanner.detectEntries(in: settings)
+        #expect(entries.count == 1)
+    }
+
+    @Test func detectsSessionEventEntry() {
+        let settings: [String: Any] = [
+            "hooks": [
+                "SessionStart": [
+                    ["hooks": [["type": "command", "command": "tbd session-event"]]]
+                ]
+            ]
+        ]
+        let entries = LegacyHookScanner.detectEntries(in: settings)
+        #expect(entries.count == 1)
+        #expect(entries.first?.event == "SessionStart")
+    }
+
+    @Test func ignoresUnrelatedEntries() {
+        let settings: [String: Any] = [
+            "hooks": [
+                "Stop": [
+                    ["hooks": [["type": "command", "command": "echo hi"]]]
+                ]
+            ]
+        ]
+        let entries = LegacyHookScanner.detectEntries(in: settings)
+        #expect(entries.isEmpty)
+    }
+
+    @Test func stripsWrappedAndBareEntries() {
+        var settings: [String: Any] = [
+            "hooks": [
+                "Stop": [
+                    ["hooks": [["type": "command", "command": "tbd notify --type response_complete"]]],
+                    ["hooks": [["type": "command", "command": "echo keep me"]]],
+                    ["type": "command", "command": "tbd notify --type error"]
+                ],
+                "SessionStart": [
+                    ["matcher": "*", "hooks": [["type": "command", "command": "tbd session-event"]]]
+                ]
+            ],
+            "model": "claude-opus"
+        ]
+        let removed = LegacyHookScanner.stripEntries(from: &settings)
+        #expect(removed == 3)
+
+        let hooks = settings["hooks"] as? [String: Any] ?? [:]
+        let stop = hooks["Stop"] as? [[String: Any]] ?? []
+        // The non-tbd matcher should still be present.
+        #expect(stop.count == 1)
+        // The SessionStart key should have been removed because the only
+        // entry in it was a TBD entry.
+        #expect(hooks["SessionStart"] == nil)
+        // Unrelated top-level keys preserved.
+        #expect(settings["model"] as? String == "claude-opus")
+    }
+
+    @Test func removeGlobalEntriesIsNoOpWhenFileMissing() throws {
+        let path = NSTemporaryDirectory() + "tbd-legacy-missing-\(UUID().uuidString).json"
+        let result = try LegacyHookScanner.removeGlobalEntries(at: path)
+        #expect(result.removedCount == 0)
+        #expect(result.backupPath == nil)
+    }
+
+    @Test func removeGlobalEntriesWritesBackupOnce() throws {
+        let path = NSTemporaryDirectory() + "tbd-legacy-\(UUID().uuidString).json"
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            try? FileManager.default.removeItem(atPath: path + SettingsJSONSafety.backupSuffix)
+        }
+        let original: [String: Any] = [
+            "hooks": [
+                "Stop": [
+                    ["hooks": [["type": "command", "command": "tbd notify"]]]
+                ]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: original)
+        try data.write(to: URL(fileURLWithPath: path))
+
+        let r1 = try LegacyHookScanner.removeGlobalEntries(at: path)
+        #expect(r1.removedCount == 1)
+        #expect(r1.backupPath == path + SettingsJSONSafety.backupSuffix)
+        #expect(FileManager.default.fileExists(atPath: r1.backupPath!))
+
+        // After removal, the file no longer contains marker entries.
+        let after = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: after) as? [String: Any] ?? [:]
+        #expect(LegacyHookScanner.detectEntries(in: parsed).isEmpty)
+
+        // Re-running is a no-op on the live file but the backup must
+        // still preserve the FIRST original.
+        let r2 = try LegacyHookScanner.removeGlobalEntries(at: path)
+        #expect(r2.removedCount == 0)
+        let backupBytes = try Data(contentsOf: URL(fileURLWithPath: path + SettingsJSONSafety.backupSuffix))
+        let backupDict = try JSONSerialization.jsonObject(with: backupBytes) as? [String: Any] ?? [:]
+        // Original (legacy entry) preserved in the backup.
+        #expect(!LegacyHookScanner.detectEntries(in: backupDict).isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/MigrationV17Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV17Tests.swift
@@ -1,0 +1,82 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct MigrationV17Tests {
+
+    @Test func v17AddsNullableTranscriptPathColumn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        // Create a repo + worktree + terminal to verify the new column exists
+        // and round-trips through the GRDB record.
+        let repo = try await db.repos.create(
+            path: "/tmp/v17-repo", displayName: "V17", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v17-repo/wt", tmuxServer: "tbd-v17"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude"
+        )
+        // New column should default to nil for pre-existing inserts.
+        let fetched = try await db.terminals.get(id: terminal.id)
+        #expect(fetched?.transcriptPath == nil)
+    }
+
+    @Test func updateSessionPersistsTranscriptPath() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v17b-repo", displayName: "V17b", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v17b-repo/wt", tmuxServer: "tbd-v17b"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude",
+            claudeSessionID: "old-session"
+        )
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "new-session",
+            transcriptPath: "/Users/me/.claude/projects/-x/new.jsonl"
+        )
+        let fetched = try await db.terminals.get(id: terminal.id)
+        #expect(fetched?.claudeSessionID == "new-session")
+        #expect(fetched?.transcriptPath == "/Users/me/.claude/projects/-x/new.jsonl")
+    }
+
+    @Test func updateSessionWithNilTranscriptPathClearsIt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v17c-repo", displayName: "V17c", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v17c-repo/wt", tmuxServer: "tbd-v17c"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1", tmuxPaneID: "%1"
+        )
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "s1",
+            transcriptPath: "/tmp/path1.jsonl"
+        )
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "s2",
+            transcriptPath: nil
+        )
+        let fetched = try await db.terminals.get(id: terminal.id)
+        #expect(fetched?.claudeSessionID == "s2")
+        #expect(fetched?.transcriptPath == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/MigrationV17Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV17Tests.swift
@@ -52,7 +52,12 @@ import GRDB
         #expect(fetched?.transcriptPath == "/Users/me/.claude/projects/-x/new.jsonl")
     }
 
-    @Test func updateSessionWithNilTranscriptPathClearsIt() async throws {
+    @Test func updateSessionWithNilTranscriptPathPreservesPrior() async throws {
+        // updateSession leaves transcriptPath untouched when called with nil
+        // so a SessionStart payload that omits/rejects `transcript_path`
+        // doesn't blow away a previously-captured good path. See
+        // TerminalSessionEventHandlerTests.nilPathPreservesExisting for the
+        // end-to-end RPC coverage; this guards the store-layer behavior.
         let db = try TBDDatabase(inMemory: true)
         let repo = try await db.repos.create(
             path: "/tmp/v17c-repo", displayName: "V17c", defaultBranch: "main"
@@ -77,6 +82,6 @@ import GRDB
         )
         let fetched = try await db.terminals.get(id: terminal.id)
         #expect(fetched?.claudeSessionID == "s2")
-        #expect(fetched?.transcriptPath == nil)
+        #expect(fetched?.transcriptPath == "/tmp/path1.jsonl")
     }
 }

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -47,7 +47,7 @@ struct TerminalSessionEventHandlerTests {
         return (terminal, wt)
     }
 
-    @Test("updates sessionID + transcriptPath and broadcasts delta")
+    @Test("updates sessionID + transcriptPath in DB on a fresh SessionStart")
     func updatesSessionAndBroadcasts() async throws {
         let (terminal, _) = try await makeTerminal(initialSession: "old-id")
         let request = try RPCRequest(

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("terminal.sessionEvent handler")
+struct TerminalSessionEventHandlerTests {
+    let db: TBDDatabase
+    let router: RPCRouter
+
+    init() throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+    }
+
+    private func makeTerminal(initialSession: String? = nil) async throws -> (Terminal, Worktree) {
+        let repo = try await db.repos.create(
+            path: "/tmp/se-repo-\(UUID().uuidString)",
+            displayName: "se-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "main",
+            path: "/tmp/se-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-se"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "claude",
+            claudeSessionID: initialSession
+        )
+        return (terminal, wt)
+    }
+
+    @Test("updates sessionID + transcriptPath and broadcasts delta")
+    func updatesSessionAndBroadcasts() async throws {
+        let (terminal, _) = try await makeTerminal(initialSession: "old-id")
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "new-id",
+                transcriptPath: "/Users/me/.claude/projects/-x/new-id.jsonl",
+                source: "clear"
+            )
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let updated = try await db.terminals.get(id: terminal.id)
+        #expect(updated?.claudeSessionID == "new-id")
+        #expect(updated?.transcriptPath == "/Users/me/.claude/projects/-x/new-id.jsonl")
+    }
+
+    @Test("ignores non-absolute transcriptPath but still updates sessionID")
+    func ignoresNonAbsolutePath() async throws {
+        let (terminal, _) = try await makeTerminal()
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "abc",
+                transcriptPath: "relative/path.jsonl",
+                source: "startup"
+            )
+        )
+        _ = await router.handle(request)
+        let updated = try await db.terminals.get(id: terminal.id)
+        #expect(updated?.claudeSessionID == "abc")
+        #expect(updated?.transcriptPath == nil)
+    }
+
+    @Test("treats empty transcriptPath as not-provided")
+    func treatsEmptyPathAsAbsent() async throws {
+        let (terminal, _) = try await makeTerminal()
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "s",
+                transcriptPath: "",
+                source: nil
+            )
+        )
+        _ = await router.handle(request)
+        let updated = try await db.terminals.get(id: terminal.id)
+        #expect(updated?.claudeSessionID == "s")
+        #expect(updated?.transcriptPath == nil)
+    }
+
+    @Test("unknown terminalID is a soft no-op (success, no error)")
+    func unknownTerminalSoftSuccess() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: UUID(),
+                sessionID: "x",
+                transcriptPath: nil,
+                source: nil
+            )
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        #expect(response.error == nil)
+    }
+
+    @Test("transcript handler prefers stored transcriptPath over cwd resolution")
+    func transcriptHandlerPrefersStoredPath() async throws {
+        // Write a synthetic JSONL at a path the legacy cwd-derived resolution
+        // would never find (a /tmp directory unrelated to the worktree path).
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-se-prefer-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        let storedPath = tmpDir.appendingPathComponent("session.jsonl").path
+        // A minimal user message line so TranscriptParser produces at least one item.
+        let line = #"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]},"uuid":"abc","timestamp":"2025-01-01T00:00:00Z"}"#
+        try (line + "\n").data(using: .utf8)!.write(to: URL(fileURLWithPath: storedPath))
+
+        let (terminal, _) = try await makeTerminal()
+
+        // Tell the daemon about the stored path via sessionEvent.
+        let evt = try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "logical-session-id",
+                transcriptPath: storedPath,
+                source: "startup"
+            )
+        )
+        _ = await router.handle(evt)
+
+        // Now ask for the transcript — it should resolve via storedPath, not
+        // via ClaudeProjectDirectory.resolve(worktreePath:) (which would fail
+        // for our /tmp/se-wt-* path since no ~/.claude/projects/ entry exists).
+        let req = try RPCRequest(
+            method: RPCMethod.terminalTranscript,
+            params: TerminalTranscriptParams(terminalID: terminal.id)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(TerminalTranscriptResult.self)
+        #expect(result.sessionID == "logical-session-id")
+        #expect(!result.messages.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -103,6 +103,36 @@ struct TerminalSessionEventHandlerTests {
         #expect(updated?.transcriptPath == nil)
     }
 
+    @Test("nil/rejected transcriptPath preserves a previously-stored path")
+    func nilPathPreservesExisting() async throws {
+        let (terminal, _) = try await makeTerminal()
+        // First event sets a valid path.
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "s1",
+                transcriptPath: "/abs/s1.jsonl",
+                source: "startup"
+            )
+        ))
+        // Second event has a rejected (non-absolute) path. sessionID
+        // updates; transcriptPath stays at the previously-stored value
+        // rather than getting zeroed back to nil.
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminal.id,
+                sessionID: "s2",
+                transcriptPath: "relative/path.jsonl",
+                source: "clear"
+            )
+        ))
+        let updated = try await db.terminals.get(id: terminal.id)
+        #expect(updated?.claudeSessionID == "s2")
+        #expect(updated?.transcriptPath == "/abs/s1.jsonl")
+    }
+
     @Test("unknown terminalID is a soft no-op (success, no error)")
     func unknownTerminalSoftSuccess() async throws {
         let request = try RPCRequest(

--- a/Tests/TBDSharedTests/SettingsJSONSafetyTests.swift
+++ b/Tests/TBDSharedTests/SettingsJSONSafetyTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite struct SettingsJSONSafetyTests {
+
+    private func makeTempPath() -> String {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-safety-\(UUID().uuidString).json")
+            .path
+    }
+
+    @Test func ensureBackupCopiesOnceThenSkipsSubsequentCalls() throws {
+        let src = makeTempPath()
+        defer {
+            try? FileManager.default.removeItem(atPath: src)
+            try? FileManager.default.removeItem(atPath: src + SettingsJSONSafety.backupSuffix)
+        }
+        try #"{"hooks":{}}"#.data(using: .utf8)!.write(to: URL(fileURLWithPath: src))
+        // First call → creates backup.
+        let first = try SettingsJSONSafety.ensureBackup(of: src)
+        #expect(first)
+        #expect(FileManager.default.fileExists(atPath: src + SettingsJSONSafety.backupSuffix))
+        // Mutate the source file.
+        try #"{"hooks":{"Stop":[]}}"#.data(using: .utf8)!.write(to: URL(fileURLWithPath: src))
+        // Second call → should NOT overwrite the original backup.
+        let second = try SettingsJSONSafety.ensureBackup(of: src)
+        #expect(!second)
+        let backup = try String(contentsOfFile: src + SettingsJSONSafety.backupSuffix, encoding: .utf8)
+        #expect(backup == #"{"hooks":{}}"#)
+    }
+
+    @Test func ensureBackupNoOpWhenSourceMissing() throws {
+        let src = makeTempPath()
+        let result = try SettingsJSONSafety.ensureBackup(of: src)
+        #expect(!result)
+        #expect(!FileManager.default.fileExists(atPath: src + SettingsJSONSafety.backupSuffix))
+    }
+
+    @Test func atomicWriteSucceedsAndPersistsBytes() throws {
+        let target = makeTempPath()
+        defer { try? FileManager.default.removeItem(atPath: target) }
+        let bytes = #"{"a":1}"#.data(using: .utf8)!
+        try SettingsJSONSafety.atomicWriteValidated(
+            proposedBytes: bytes,
+            targetPath: target,
+            invariant: { _ in }
+        )
+        let written = try Data(contentsOf: URL(fileURLWithPath: target))
+        #expect(written == bytes)
+    }
+
+    @Test func atomicWriteRejectsMalformedJSON() throws {
+        let target = makeTempPath()
+        defer { try? FileManager.default.removeItem(atPath: target) }
+        let bytes = "not json".data(using: .utf8)!
+        do {
+            try SettingsJSONSafety.atomicWriteValidated(
+                proposedBytes: bytes,
+                targetPath: target,
+                invariant: { _ in }
+            )
+            Issue.record("Expected roundtrip failure")
+        } catch SettingsJSONSafety.Error.roundtripFailed {
+            // expected
+        }
+        // Target file must NOT have been written.
+        #expect(!FileManager.default.fileExists(atPath: target))
+    }
+
+    @Test func atomicWriteAbortsWhenInvariantThrows() throws {
+        let target = makeTempPath()
+        defer { try? FileManager.default.removeItem(atPath: target) }
+        // Pre-existing file we can compare against — must remain untouched.
+        try #"{"existing":true}"#.data(using: .utf8)!.write(to: URL(fileURLWithPath: target))
+        let bytes = #"{"hooks":{}}"#.data(using: .utf8)!
+        do {
+            try SettingsJSONSafety.atomicWriteValidated(
+                proposedBytes: bytes,
+                targetPath: target,
+                invariant: { _ in
+                    throw SettingsJSONSafety.Error.invariantFailed("synthetic")
+                }
+            )
+            Issue.record("Expected invariant failure")
+        } catch SettingsJSONSafety.Error.invariantFailed {
+            // expected
+        }
+        let onDisk = try String(contentsOfFile: target, encoding: .utf8)
+        #expect(onDisk == #"{"existing":true}"#)
+    }
+
+    @Test func atomicWriteRejectsNonObjectTopLevel() throws {
+        let target = makeTempPath()
+        defer { try? FileManager.default.removeItem(atPath: target) }
+        let arrayBytes = "[]".data(using: .utf8)!
+        do {
+            try SettingsJSONSafety.atomicWriteValidated(
+                proposedBytes: arrayBytes,
+                targetPath: target,
+                invariant: { _ in }
+            )
+            Issue.record("Expected roundtrip failure for array top-level")
+        } catch SettingsJSONSafety.Error.roundtripFailed {
+            // expected
+        }
+        #expect(!FileManager.default.fileExists(atPath: target))
+    }
+}


### PR DESCRIPTION
## Summary

- TBD's transcript pane was source-of-truthing off Claude Code's session JSONL. When the user ran `/clear` (or `/compact`), Claude rolled to a new sessionId in a new file, but TBD never noticed — the pane stayed glued to the now-frozen pre-clear file. Confirmed empirically: the PID-keyed `~/.claude/sessions/<pid>.json` doesn't update on `/clear` either, so polling that wouldn't have helped.
- Routes the canonical signal (Claude's `SessionStart` hook with the `clear`/`compact`/`startup`/`resume` matchers) into TBD via a daemon-owned `--settings` overlay at `~/tbd/runtime/claude-overlay.json`. A new `tbd session-event` CLI bridges the hook payload into a `terminal.sessionEvent` RPC, which updates the DB and broadcasts a delta. The transcript pane already re-targets on sessionID change, so the existing UI plumbing carries the rest.
- New terminals also persist Claude's `transcript_path` directly on the terminal record, sidestepping the project-dir encoding rules that we observed Claude Code retarget unpredictably (e.g., into a totally different project dir when its internal worktree tool kicks in).
- Bonus consolidation: the existing notification `Stop` hook moves into the same overlay, so notifications now work out of the box for any TBD-spawned Claude — no manual `tbd setup-hooks` required. `tbd setup-hooks` is deprecated to a no-op message; `tbd hooks status` is the new inspector.
- Existing users with a legacy `tbd setup-hooks --global` install can opt into removing those entries via a new "Migrate Claude Hooks…" app menu (mirrors the CLI installer's interactive pattern). Settings.json mutations go through atomic write + roundtrip-validation + a one-time pristine `~/.claude/settings.json.tbd-backup`.

## Test plan

- [ ] Spawn a fresh Claude terminal in a TBD worktree, send a message, run `/clear`, send another message. Transcript pane should re-target to the new session within the next poll cycle (~1.5s).
- [ ] `tbd hooks status` shows the overlay path with both `SessionStart` and `Stop` hooks listed, and surfaces any legacy entries it detects in user/repo settings.
- [ ] If you have legacy entries: TBD app menu → "Migrate Claude Hooks…" → verify dialog copy, the `Show File…` button, and the `Remove` flow (writes pristine backup, atomic write, validation).
- [ ] `swift test` passes for the new suites: `MigrationV17Tests`, `TerminalSessionEventHandlerTests`, `ClaudeHookOverlayTests`, `LegacyHookScannerTests`, `SettingsJSONSafetyTests`, `ClaudeSpawnCommandBuilderTests`.

## Known limitations

- Claude processes spawned before this PR's overlay was installed won't pick up the new behavior — they were launched without `--settings`. Respawn to test against them.
- The hook commands in the overlay use bare `tbd`, so a stale `tbd` symlink on PATH (especially `/usr/local/bin/tbd` from older installs) will silently fail with exit 64. The CLI installer prompt at app launch addresses `~/.local/bin/tbd`; if you have a higher-priority root-owned symlink, `sudo rm /usr/local/bin/tbd` and let `~/.local/bin/tbd` take over.
- `swift test` full suite hangs on exit (pre-existing — `AppState.startPolling()`'s timer keeps the runloop alive). Targeted suites all run cleanly. Worth a separate cleanup ticket.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B634D5A9-C7C7-428E-85DA-56AED40E5E54)