### PR TITLE
fix: sever FloatingPanel child-window link to stop crash

### DIFF
--- a/Sources/TBDApp/Sidebar/FloatingPanel.swift
+++ b/Sources/TBDApp/Sidebar/FloatingPanel.swift
@@ -29,6 +29,14 @@ final class FloatingPanel: NSPanel {
     }
 
     /// Show the panel below the given view, aligned to its leading edge.
+    ///
+    /// The parent window is used only for screen-coordinate conversion; we deliberately
+    /// do *not* call `addChildWindow` here. Establishing a child-window relationship
+    /// couples this panel's constraint invalidations into the parent split-view
+    /// window's per-cycle update-pass budget, which can blow past the AppKit threshold
+    /// and trigger an `NSGenericException` ("more Update Constraints in Window passes
+    /// than there are views in the window"). The panel's `.popUpMenu` level is enough
+    /// to keep it above other content without parenting.
     func show(relativeTo view: NSView) {
         guard let window = view.window else { return }
         let viewFrame = view.convert(view.bounds, to: nil)
@@ -44,12 +52,14 @@ final class FloatingPanel: NSPanel {
         setFrame(NSRect(origin: origin, size: size), display: true)
 
         if !isVisible {
-            window.addChildWindow(self, ordered: .above)
             orderFront(nil)
         }
     }
 
     func dismiss() {
+        // `parent` is always nil now (we no longer call `addChildWindow`), so this is
+        // a defensive no-op left in place to stay safe if a future change ever
+        // reintroduces parenting.
         parent?.removeChildWindow(self)
         orderOut(nil)
     }


### PR DESCRIPTION
## Summary

TBDApp keeps crashing with `NSGenericException` "more Update Constraints in Window passes than there are views in the window", referencing a 232x175 borderless panel at off-screen position `{0, -196}`. Forensic logs at `~/Library/Logs/TBD/last-exception.txt` confirm this signature points at the emoji-picker / inline-rename autocomplete `FloatingPanel` introduced in `c57d8c8`.

`FloatingPanel.show()` calls `parentWindow.addChildWindow(self, ordered: .above)`. That child-window relationship couples the panel's constraint chatter (every SwiftUI body re-evaluation in the picker posts `setNeedsUpdateConstraints` upward) into the parent split-view window's per-cycle constraint-update budget. Eventually that budget overflows and AppKit raises.

This is the same architectural pattern that bit us with `ExpandingRow`. PRs #92 and #97 didn't catch this instance because they targeted that other component — different panel, same coupling shape — and the failed-fix history on the parallel symptom (`acb057f`, `b770ef3`, `3fa2cc6`) culminated in #97 deleting `ExpandingRow` outright. The emoji picker is still desired UX, so here we keep the panel and sever just the parenting.

## Why not `.popover`

`c57d8c8` chose `NSPanel` over `.popover` deliberately:
1. `.popover` has a ~200ms fade animation SwiftUI cannot disable — laggy for a typing autocomplete.
2. `.popover` steals focus from the rename text field, forcing an `isInsertingEmoji` hack and a refocus dance.

We are not reintroducing those.

## What this fix does

- Drops `window.addChildWindow(self, ordered: .above)` from `FloatingPanel.show()`. The panel becomes an independent floating window. Its `.popUpMenu` level still keeps it visually above other content, and the `.nonactivatingPanel` flag preserves focus in the parent rename field, so keyboard input continues to flow.
- Keeps `parent?.removeChildWindow(self)` in `dismiss()` as a defensive no-op (`parent` is now always nil).
- Retains the `view.window` lookup in `show(relativeTo:)` because it is still required for `convertToScreen`.

The `EmojiPanelAnchor.Coordinator` already nils out `coordinator.panel` on dismiss and in `dismantleNSView`, so the `NSHostingView` and its SwiftUI binding subscriptions are released when the picker is hidden. No change needed there.

## Test plan

- [ ] `swift build` clean (verified locally).
- [ ] `scripts/restart.sh` from this worktree; both `TBDDaemon` and `TBDApp` running from the worktree path.
- [ ] Rename a worktree, type `:smile`, confirm the emoji picker appears at the expected position.
- [ ] Arrow keys and Enter still move selection / commit; mouse click on an emoji still works.
- [ ] Picker dismisses on selection, Escape, and clicking elsewhere.
- [ ] Focus stays in the rename text field while the picker is open (no focus flicker, no extra refocus dance needed).
- [ ] `~/Library/Logs/TBD/last-exception.txt` does not gain a new entry from a smoke session that previously reproduced the crash.
- [ ] After a system sleep / wake cycle, opening and dismissing the picker repeatedly does not produce the constraint-budget exception.