### PR TITLE
Fix: Cmd+click on OSC 8 hyperlinks no longer opens two viewer panes

### DIFF
--- a/Sources/TBDApp/Panes/ViewerRouting.swift
+++ b/Sources/TBDApp/Panes/ViewerRouting.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "ViewerRouting")
 
 /// Decides where a terminal-link click should land.
 ///
@@ -20,9 +23,11 @@ func routeFileClick(into layout: LayoutNode, terminalID: UUID, path: String) -> 
            with: .codeViewer(id: viewerID, path: path)
        )
     {
+        logger.debug("routeFileClick[swap]: viewerID=\(viewerID, privacy: .public) path=\(path, privacy: .public)")
         return updated
     }
 
+    logger.debug("routeFileClick[split]: terminalID=\(terminalID, privacy: .public) path=\(path, privacy: .public)")
     return layout.splitPane(
         id: terminalID,
         direction: .horizontal,

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -215,12 +215,16 @@ class TBDTerminalView: TerminalView {
     /// payload. SwiftTerm's `mouseUp` will dispatch these via
     /// `requestOpenLink`, so our local mouseDown monitor must not also handle
     /// them — otherwise a single cmd+click opens two viewer panes.
+    ///
+    /// `CharData.getPayload()` is `Any?` — SwiftTerm also uses it for sixel
+    /// and iTerm2 inline image data. Cast to `String` so non-OSC-8 payloads
+    /// (graphics) don't short-circuit our path-detection path.
     func hasOSC8Payload(atWindowLocation windowPoint: CGPoint) -> Bool {
         guard let pos = gridPosition(atWindowLocation: windowPoint) else { return false }
         let terminal = getTerminal()
         guard let line = terminal.getLine(row: pos.row) else { return false }
         guard pos.col < line.count else { return false }
-        return line[pos.col].getPayload() != nil
+        return line[pos.col].getPayload() as? String != nil
     }
 
     /// Extracts a file path from the terminal buffer at the given window-coordinate point.
@@ -319,25 +323,16 @@ class TBDTerminalView: TerminalView {
     }
 
     /// Extracts a clickable URL from the terminal buffer at the given window-coordinate point.
-    /// Checks for OSC 8 hyperlink payloads first, then falls back to pattern matching
-    /// for common link patterns like "PR #123".
+    /// OSC 8 hyperlinks are dispatched by SwiftTerm's `mouseUp` /
+    /// `requestOpenLink` path (see `hasOSC8Payload`); this function handles
+    /// the residual non-OSC-8 patterns we recognize, currently just
+    /// `PR #123`.
     func extractHyperlinkURL(atWindowLocation windowPoint: CGPoint) -> String? {
         guard let pos = gridPosition(atWindowLocation: windowPoint) else { return nil }
-        let col = pos.col
         let row = pos.row
         let terminal = getTerminal()
 
         guard let line = terminal.getLine(row: row) else { return nil }
-        guard col < line.count else { return nil }
-
-        // Check for OSC 8 payload first
-        if let payload = line[col].getPayload() as? String {
-            let parts = payload.split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false)
-            if parts.count > 1 {
-                let url = String(parts[1])
-                if !url.isEmpty { return url }
-            }
-        }
 
         // Build visible text from line (translateToString may return empty for status bar lines)
         var visibleText = ""

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -211,6 +211,18 @@ class TBDTerminalView: TerminalView {
         term.sendEvent(buttonFlags: releaseFlags, x: col, y: row)
     }
 
+    /// True if the cell at the given window point carries an OSC 8 hyperlink
+    /// payload. SwiftTerm's `mouseUp` will dispatch these via
+    /// `requestOpenLink`, so our local mouseDown monitor must not also handle
+    /// them — otherwise a single cmd+click opens two viewer panes.
+    func hasOSC8Payload(atWindowLocation windowPoint: CGPoint) -> Bool {
+        guard let pos = gridPosition(atWindowLocation: windowPoint) else { return false }
+        let terminal = getTerminal()
+        guard let line = terminal.getLine(row: pos.row) else { return false }
+        guard pos.col < line.count else { return false }
+        return line[pos.col].getPayload() != nil
+    }
+
     /// Extracts a file path from the terminal buffer at the given window-coordinate point.
     func extractFilePath(atWindowLocation windowPoint: CGPoint) -> String? {
         guard let pos = gridPosition(atWindowLocation: windowPoint) else { return nil }

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -374,18 +374,28 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
                     let point = tv.convert(location, from: nil)
                     guard tv.bounds.contains(point) else { return false }
 
+                    // OSC 8 hyperlinks are handled by SwiftTerm's mouseUp path
+                    // (requestOpenLink). If we also fired here on mouseDown,
+                    // a single cmd+click would route through both paths and
+                    // open two viewer panes.
+                    if tv.hasOSC8Payload(atWindowLocation: location) {
+                        logger.debug("file-click: skipping mouseDown handling — OSC 8 payload present, deferring to requestOpenLink")
+                        return false
+                    }
+
                     if let filePath = tv.extractFilePath(atWindowLocation: location) {
+                        logger.debug("file-click[mouseDown/path]: \(filePath, privacy: .public)")
                         tv.onFilePathClicked?(filePath)
                         return true
                     }
-                    // Fall back to hyperlink detection (OSC 8 or pattern matching)
+                    // Fall back to hyperlink detection (PR pattern; OSC 8 was
+                    // already short-circuited above).
                     if let urlString = tv.extractHyperlinkURL(atWindowLocation: location) {
-                        // Try to resolve as a file path first (OSC 8 payload may be relative or file:// URL)
                         if let resolved = tv.resolveAsFilePath(urlString) {
+                            logger.debug("file-click[mouseDown/hyperlink-as-file]: \(resolved, privacy: .public)")
                             tv.onFilePathClicked?(resolved)
                             return true
                         }
-                        // Only open as external URL if it has a real scheme
                         if urlString.contains("://"), let url = URL(string: urlString) {
                             NSWorkspace.shared.open(url)
                             return true
@@ -473,6 +483,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
                 // Try to resolve as a file path (absolute, file://, or relative to worktree)
                 if let tv = source as? TBDTerminalView,
                    let resolved = tv.resolveAsFilePath(link) {
+                    logger.debug("file-click[requestOpenLink/file]: \(resolved, privacy: .public) raw=\(link, privacy: .public)")
                     tv.onFilePathClicked?(resolved)
                     return
                 }


### PR DESCRIPTION
## Summary

- **Symptom**: cmd+clicking a relative file link in a TBD terminal sometimes opens **two** code-viewer panes instead of one. Reproducible with any OSC 8 hyperlink whose visible text is also a real path (Claude Code emits these for tool results).
- **Root cause**: a single cmd+click was getting handled by two paths in `Sources/TBDApp/Terminal/TerminalPanelView.swift`. Our local `NSEvent` mouseDown monitor matched the visible text via `extractFilePath()` and fired `onFilePathClicked` (consuming mouseDown). But our monitor only intercepts mouseDown — `mouseUp` flowed through to SwiftTerm, whose `mouseUp` saw the OSC 8 payload + cmd modifier and called `requestOpenLink`, firing `onFilePathClicked` a second time. The "sometimes" comes from `linkHighlightMode = .hoverWithModifier` (Mac default): the second fire only happens when the link gets hover-highlighted before mouseUp.
- **Fix**: when the click cell carries an OSC 8 payload, the mouseDown monitor returns without consuming so SwiftTerm owns that click via `requestOpenLink`. Plain-text paths and `PR #123` matches still go through our monitor unchanged. Also wires `os.Logger` diagnostics on every fire path and on `routeFileClick`'s split-vs-swap branches so future occurrences are traceable.

## Test plan

- [ ] In any TBD terminal pane, run `printf '\e]8;;file://%s/Sources/TBDApp/Panes/ViewerRouting.swift\e\\%s\e]8;;\e\\\n' "$(pwd)" "Sources/TBDApp/Panes/ViewerRouting.swift"` to print a clickable link.
- [ ] Hover the cursor over the link with cmd held until it underlines, then click. Confirm exactly **one** viewer pane opens (pre-fix this would open two).
- [ ] Repeat without prior hover (fast cmd+click). Confirm one pane still opens (no regression for fast clickers — SwiftTerm's `mouseUp` calls `updateHoverLink` before `linkForClick`, so the highlight range is set in time).
- [ ] Cmd+click a plain-text path printed by `ls` or similar. Confirm it still opens (mouseDown monitor path).
- [ ] Cmd+click a `PR #123` reference. Confirm it still opens GitHub (PR-pattern path).
- [ ] Tail the logs to verify single-fire: `log stream --level debug --predicate 'subsystem BEGINSWITH "com.tbd" AND (category == "TerminalPanel" OR category == "ViewerRouting")'` — should show one `requestOpenLink/file` and one `routeFileClick[split]` (or `[swap]` on subsequent clicks) per click.

open in TBD: `tbd://open?worktree=E9FD18C8-A443-44A7-80DD-E6AC3B049ECA`