### PR TITLE
Feat: Show Claude context size in the transcript viewer (skip /context)

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
+++ b/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
@@ -17,7 +17,7 @@ struct ChatBubbleView: View {
     private var text: String {
         switch item {
         case .userPrompt(_, let t, _): return t
-        case .assistantText(_, let t, _): return t
+        case .assistantText(_, let t, _, _): return t
         default: return ""
         }
     }

--- a/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
+++ b/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Diminutive subscript line shown beneath the latest top-level assistant
+/// item in the transcript viewer. Displays the total prompt size
+/// (input + cache_creation + cache_read tokens) of that turn's API call,
+/// formatted as `Nk tokens` with thresholds:
+///
+/// - `<190k`  → muted (`.secondary`)
+/// - `>=190k` → yellow
+/// - `>=260k` → orange
+/// - `>=300k` → red
+///
+/// See `docs/transcript-context-usage.md` for the underlying mechanism.
+struct ContextUsageBadge: View {
+    let total: Int
+
+    var body: some View {
+        Text(Self.formatted(total))
+            .font(.caption2)
+            .foregroundStyle(Self.color(for: total))
+    }
+
+    /// Whole-thousands abbreviation, e.g. 124_300 -> "124k tokens".
+    static func formatted(_ total: Int) -> String {
+        "\(total / 1000)k tokens"
+    }
+
+    static func color(for total: Int) -> Color {
+        switch total {
+        case ..<190_000:  return .secondary
+        case ..<260_000:  return .yellow
+        case ..<300_000:  return .orange
+        default:          return .red
+        }
+    }
+}
+
+// MARK: - Preview
+
+/// Exercises the four threshold bands. Uses `PreviewProvider` (not the
+/// `#Preview` macro) so the file still compiles under bare `swift build`
+/// — the SPM toolchain doesn't ship the `PreviewsMacros` plugin that
+/// Xcode injects.
+struct ContextUsageBadge_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ContextUsageBadge(total: 12_345)      // muted
+            ContextUsageBadge(total: 200_000)     // yellow
+            ContextUsageBadge(total: 270_000)     // orange
+            ContextUsageBadge(total: 350_000)     // red
+        }
+        .padding()
+        .previewDisplayName("ContextUsageBadge — bands")
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
+++ b/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
@@ -16,9 +16,10 @@ struct ContextUsageBadge: View {
     let total: Int
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 6) {
             Image(systemName: "circle.fill")
                 .imageScale(.small)
+                .frame(width: 14)
                 .foregroundStyle(Self.color(for: total))
             Text(Self.formatted(total))
                 .foregroundStyle(.secondary)

--- a/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
+++ b/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
@@ -17,6 +17,7 @@ struct ContextUsageBadge: View {
     var body: some View {
         Text(Self.formatted(total))
             .font(.caption2)
+            .fontWeight(.regular)
             .foregroundStyle(Self.color(for: total))
     }
 

--- a/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
+++ b/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
@@ -30,11 +30,11 @@ struct ContextUsageBadge: View {
     }
 
     /// Whole-thousands abbreviation, e.g. 124_300 -> "124k tokens".
-    static func formatted(_ total: Int) -> String {
+    nonisolated static func formatted(_ total: Int) -> String {
         "\(total / 1000)k tokens"
     }
 
-    static func color(for total: Int) -> Color {
+    nonisolated static func color(for total: Int) -> Color {
         switch total {
         case ..<190_000:  return .secondary
         case ..<260_000:  return .yellow

--- a/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
+++ b/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 /// Diminutive subscript line shown beneath the latest top-level assistant
 /// item in the transcript viewer. Displays the total prompt size
-/// (input + cache_creation + cache_read tokens) of that turn's API call,
-/// formatted as `Nk tokens` with thresholds:
+/// (input + cache_creation + cache_read tokens) of that turn's API call
+/// as `Nk tokens` in muted gray, prefixed by a small colored dot whose
+/// color signals the band:
 ///
-/// - `<190k`  → muted (`.secondary`)
+/// - `<190k`  → `.secondary`
 /// - `>=190k` → yellow
 /// - `>=260k` → orange
 /// - `>=300k` → red
@@ -15,10 +16,14 @@ struct ContextUsageBadge: View {
     let total: Int
 
     var body: some View {
-        Text(Self.formatted(total))
-            .font(.caption2)
-            .fontWeight(.regular)
-            .foregroundStyle(Self.color(for: total))
+        HStack(spacing: 4) {
+            Image(systemName: "circle.fill")
+                .foregroundStyle(Self.color(for: total))
+            Text(Self.formatted(total))
+                .foregroundStyle(.secondary)
+        }
+        .font(.caption2)
+        .fontWeight(.regular)
     }
 
     /// Whole-thousands abbreviation, e.g. 124_300 -> "124k tokens".

--- a/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
+++ b/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
@@ -18,12 +18,14 @@ struct ContextUsageBadge: View {
     var body: some View {
         HStack(spacing: 4) {
             Image(systemName: "circle.fill")
+                .imageScale(.small)
                 .foregroundStyle(Self.color(for: total))
             Text(Self.formatted(total))
                 .foregroundStyle(.secondary)
         }
-        .font(.caption2)
+        .font(.system(size: 9))
         .fontWeight(.regular)
+        .opacity(0.7)
     }
 
     /// Whole-thousands abbreviation, e.g. 124_300 -> "124k tokens".

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -71,7 +71,10 @@ struct TranscriptItemsView: View {
             // Skip hidden tool calls (TodoWrite/TaskUpdate/etc) — those render
             // as EmptyView, so attaching the badge there would leave it
             // floating below nothing. The badge follows the latest *visible*
-            // assistant item instead.
+            // assistant item instead. Trade-off: when the most recent turn is
+            // entirely hidden tools, the badge shows the prior visible turn's
+            // token count, which lags reality by one turn until the next
+            // visible item lands.
             let latestUsageItemID = items.reversed().first {
                 $0.usage != nil && !isHiddenInTranscript($0)
             }?.id

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -15,7 +15,7 @@ func isHiddenInTranscript(_ item: TranscriptItem) -> Bool {
     switch item {
     case .thinking:
         return true
-    case .toolCall(_, let name, _, _, _, _, _):
+    case .toolCall(_, let name, _, _, _, _, _, _):
         return hiddenToolNames.contains(name)
     default:
         return false
@@ -104,7 +104,7 @@ struct TranscriptItemsView: View {
                 // case stays in the wire format for Codable safety, but no parser
                 // path emits it today.
                 EmptyView()
-            case .toolCall(let id, let name, let inputJSON, let inputTruncatedTo, let result, let subagent, let ts):
+            case .toolCall(let id, let name, let inputJSON, let inputTruncatedTo, let result, let subagent, let ts, _):
                 if hiddenToolNames.contains(name) {
                     EmptyView()
                 } else {

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -68,7 +68,13 @@ struct TranscriptItemsView: View {
             // top-level items array is sidechain-free by construction (the
             // parser drops sidechain lines), so a simple reverse scan is
             // correct without further filtering.
-            let latestUsageItemID = items.reversed().first { $0.usage != nil }?.id
+            // Skip hidden tool calls (TodoWrite/TaskUpdate/etc) — those render
+            // as EmptyView, so attaching the badge there would leave it
+            // floating below nothing. The badge follows the latest *visible*
+            // assistant item instead.
+            let latestUsageItemID = items.reversed().first {
+                $0.usage != nil && !isHiddenInTranscript($0)
+            }?.id
             LazyVStack(alignment: .leading, spacing: 4) {
                 ForEach(items) { item in
                     rowFor(item)

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -62,9 +62,21 @@ struct TranscriptItemsView: View {
             // defaultScrollAnchor(.bottom) (applied by the parent pane). Lazy
             // realization for perf; the parent's anchor handles initial
             // bottom-positioning and follow-bottom-on-growth declaratively.
+            //
+            // Walk items in reverse to find the most recent one carrying a
+            // TokenUsage — that's where the ContextUsageBadge attaches. The
+            // top-level items array is sidechain-free by construction (the
+            // parser drops sidechain lines), so a simple reverse scan is
+            // correct without further filtering.
+            let latestUsageItemID = items.reversed().first { $0.usage != nil }?.id
             LazyVStack(alignment: .leading, spacing: 4) {
                 ForEach(items) { item in
                     rowFor(item)
+                    if item.id == latestUsageItemID, let usage = item.usage {
+                        ContextUsageBadge(total: usage.contextTotal)
+                            .padding(.leading, 12)
+                            .padding(.top, 2)
+                    }
                 }
             }
             .padding(.vertical, 8)

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -169,11 +169,12 @@ enum TranscriptParser {
 
             if typeStr == "assistant" {
                 guard let message = json["message"] as? [String: Any] else { continue }
+                let usage = extractUsage(from: message)
 
                 // String-content fallback (matches existing scanner behavior).
                 if let s = message["content"] as? String {
                     if !s.isEmpty {
-                        items.append(.assistantText(id: "\(lineUUID)#0", text: s, timestamp: timestamp))
+                        items.append(.assistantText(id: "\(lineUUID)#0", text: s, timestamp: timestamp, usage: usage))
                     }
                     continue
                 }
@@ -189,7 +190,7 @@ enum TranscriptParser {
                     case "text":
                         let text = (block["text"] as? String) ?? ""
                         if !text.isEmpty {
-                            items.append(.assistantText(id: blockID, text: text, timestamp: timestamp))
+                            items.append(.assistantText(id: blockID, text: text, timestamp: timestamp, usage: usage))
                         }
                     case "tool_use":
                         let toolID = (block["id"] as? String) ?? blockID
@@ -222,7 +223,8 @@ enum TranscriptParser {
                         items.append(.toolCall(
                             id: toolID, name: name, inputJSON: inputJSON,
                             inputTruncatedTo: inputTruncatedTo,
-                            result: result, subagent: subagent, timestamp: timestamp
+                            result: result, subagent: subagent, timestamp: timestamp,
+                            usage: usage
                         ))
                     default:
                         continue
@@ -232,6 +234,23 @@ enum TranscriptParser {
         }
 
         return items
+    }
+
+    /// Extract a `TokenUsage` from `message.usage` if all three input-token
+    /// fields are present. Output tokens, cache breakdowns, and other fields
+    /// are ignored — we only care about the prompt-size signal.
+    private static func extractUsage(from message: [String: Any]) -> TokenUsage? {
+        guard let usage = message["usage"] as? [String: Any],
+              let input = usage["input_tokens"] as? Int,
+              let cacheCreation = usage["cache_creation_input_tokens"] as? Int,
+              let cacheRead = usage["cache_read_input_tokens"] as? Int else {
+            return nil
+        }
+        return TokenUsage(
+            inputTokens: input,
+            cacheCreationTokens: cacheCreation,
+            cacheReadTokens: cacheRead
+        )
     }
 
     private static func resolveSubagent(

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -241,11 +241,15 @@ enum TranscriptParser {
     /// are ignored — we only care about the prompt-size signal.
     private static func extractUsage(from message: [String: Any]) -> TokenUsage? {
         guard let usage = message["usage"] as? [String: Any],
-              let input = usage["input_tokens"] as? Int,
-              let cacheCreation = usage["cache_creation_input_tokens"] as? Int,
-              let cacheRead = usage["cache_read_input_tokens"] as? Int else {
+              let input = usage["input_tokens"] as? Int else {
             return nil
         }
+        // Cache fields are optional in the Anthropic API: users without
+        // prompt caching enabled emit `usage` blocks that omit them
+        // entirely. Default to 0 so the badge still surfaces a token count
+        // for those sessions.
+        let cacheCreation = usage["cache_creation_input_tokens"] as? Int ?? 0
+        let cacheRead = usage["cache_read_input_tokens"] as? Int ?? 0
         return TokenUsage(
             inputTokens: input,
             cacheCreationTokens: cacheCreation,

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -457,12 +457,34 @@ public struct Subagent: Codable, Sendable, Equatable {
     }
 }
 
+/// Token-count snapshot from a single Claude API response, captured per
+/// assistant JSONL line. The three fields together represent the size of
+/// the prompt sent on that request — see docs/transcript-context-usage.md
+/// for the meaning of each.
+public struct TokenUsage: Codable, Sendable, Equatable {
+    public let inputTokens: Int
+    public let cacheCreationTokens: Int
+    public let cacheReadTokens: Int
+
+    public init(inputTokens: Int, cacheCreationTokens: Int, cacheReadTokens: Int) {
+        self.inputTokens = inputTokens
+        self.cacheCreationTokens = cacheCreationTokens
+        self.cacheReadTokens = cacheReadTokens
+    }
+
+    /// Total prompt size for this request — what `/context` reports.
+    public var contextTotal: Int {
+        inputTokens + cacheCreationTokens + cacheReadTokens
+    }
+}
+
 public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable {
     case userPrompt(id: String, text: String, timestamp: Date?)
-    case assistantText(id: String, text: String, timestamp: Date?)
+    case assistantText(id: String, text: String, timestamp: Date?, usage: TokenUsage? = nil)
     case toolCall(id: String, name: String, inputJSON: String,
                   inputTruncatedTo: Int?,
-                  result: ToolResult?, subagent: Subagent?, timestamp: Date?)
+                  result: ToolResult?, subagent: Subagent?, timestamp: Date?,
+                  usage: TokenUsage? = nil)
     case thinking(id: String, text: String, timestamp: Date?)
     case systemReminder(id: String, kind: SystemKind, text: String, timestamp: Date?)
     case slashCommand(id: String, name: String, args: String?, timestamp: Date?)
@@ -470,8 +492,8 @@ public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable 
     public var id: String {
         switch self {
         case .userPrompt(let id, _, _): return id
-        case .assistantText(let id, _, _): return id
-        case .toolCall(let id, _, _, _, _, _, _): return id
+        case .assistantText(let id, _, _, _): return id
+        case .toolCall(let id, _, _, _, _, _, _, _): return id
         case .thinking(let id, _, _): return id
         case .systemReminder(let id, _, _, _): return id
         case .slashCommand(let id, _, _, _): return id
@@ -481,12 +503,23 @@ public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable 
     public var timestamp: Date? {
         switch self {
         case .userPrompt(_, _, let t),
-             .assistantText(_, _, let t),
-             .toolCall(_, _, _, _, _, _, let t),
+             .assistantText(_, _, let t, _),
+             .toolCall(_, _, _, _, _, _, let t, _),
              .thinking(_, _, let t),
              .systemReminder(_, _, _, let t),
              .slashCommand(_, _, _, let t):
             return t
+        }
+    }
+
+    /// The `TokenUsage` stamped on items derived from an assistant API call,
+    /// `nil` for all other item kinds. Used by `TranscriptItemsView` to find
+    /// the latest item whose context size is worth surfacing in the UI.
+    public var usage: TokenUsage? {
+        switch self {
+        case .assistantText(_, _, _, let u): return u
+        case .toolCall(_, _, _, _, _, _, _, let u): return u
+        default: return nil
         }
     }
 }

--- a/Tests/TBDAppTests/ContextUsageBadgeTests.swift
+++ b/Tests/TBDAppTests/ContextUsageBadgeTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import TBDApp
+
+@Suite("ContextUsageBadge")
+struct ContextUsageBadgeTests {
+    @Test func formatted_floor_thousands_with_tokens_suffix() {
+        #expect(ContextUsageBadge.formatted(0) == "0k tokens")
+        #expect(ContextUsageBadge.formatted(999) == "0k tokens")
+        #expect(ContextUsageBadge.formatted(124_300) == "124k tokens")
+        #expect(ContextUsageBadge.formatted(1_500_000) == "1500k tokens")
+    }
+
+    @Test func color_thresholds() {
+        #expect(ContextUsageBadge.color(for: 0) == .secondary)
+        #expect(ContextUsageBadge.color(for: 189_999) == .secondary)
+        #expect(ContextUsageBadge.color(for: 190_000) == .yellow)
+        #expect(ContextUsageBadge.color(for: 259_999) == .yellow)
+        #expect(ContextUsageBadge.color(for: 260_000) == .orange)
+        #expect(ContextUsageBadge.color(for: 299_999) == .orange)
+        #expect(ContextUsageBadge.color(for: 300_000) == .red)
+    }
+}

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -404,6 +404,65 @@ struct TranscriptParserTests {
         #expect(parsed != nil, "result should be valid JSON")
     }
 
+    @Test func extracts_usage_from_assistant_line() throws {
+        let line = """
+        {"type":"assistant","uuid":"a1","timestamp":"2026-05-05T10:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":5,"cache_creation_input_tokens":1000,"cache_read_input_tokens":40000,"output_tokens":7}}}
+        """
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 1)
+        let usage = items[0].usage
+        #expect(usage?.inputTokens == 5)
+        #expect(usage?.cacheCreationTokens == 1000)
+        #expect(usage?.cacheReadTokens == 40000)
+        #expect(usage?.contextTotal == 41005)
+    }
+
+    @Test func usage_stamped_on_every_item_from_same_assistant_line() throws {
+        let line = """
+        {"type":"assistant","uuid":"a1","timestamp":"2026-05-05T10:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"calling a tool"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/x"}}],"usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":3,"output_tokens":4}}}
+        """
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 2)
+        #expect(items[0].usage?.contextTotal == 6)
+        #expect(items[1].usage?.contextTotal == 6)
+    }
+
+    @Test func usage_nil_when_absent() throws {
+        let line = #"{"type":"assistant","uuid":"a1","timestamp":"2026-05-05T10:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}"#
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 1)
+        #expect(items[0].usage == nil)
+    }
+
+    @Test func sidechain_lines_drop_at_top_level_regression_guard() throws {
+        // Locks in the existing TranscriptParser behavior that top-level
+        // sidechain lines are dropped — the latest-usage badge logic relies
+        // on the top-level items array being sidechain-free by construction.
+        let lines = [
+            #"{"type":"assistant","uuid":"a1","isSidechain":true,"timestamp":"2026-05-05T10:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"sidechain"}],"usage":{"input_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1}}}"#,
+            #"{"type":"assistant","uuid":"a2","timestamp":"2026-05-05T10:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"main"}],"usage":{"input_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1}}}"#,
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 1, "sidechain line must not produce a top-level item")
+        if case .assistantText(_, let text, _, _) = items[0] {
+            #expect(text == "main")
+        } else {
+            Issue.record("expected only the main assistant text item")
+        }
+    }
+
     // MARK: - helpers
 
     private func writeTempJSONL(_ contents: String) throws -> String {

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -28,7 +28,7 @@ struct TranscriptParserTests {
     @Test func parses_assistant_text() throws {
         let items = TranscriptParser.parse(filePath: fixturePath)
         let assistantTexts = items.compactMap { item -> String? in
-            if case .assistantText(_, let t, _) = item { return t }
+            if case .assistantText(_, let t, _, _) = item { return t }
             return nil
         }
         #expect(!assistantTexts.isEmpty)
@@ -58,7 +58,7 @@ struct TranscriptParserTests {
 
         let items = TranscriptParser.parse(filePath: tmp)
         #expect(items.count == 1, "tool_result should fold into the tool_use, not be its own item")
-        if case .toolCall(_, _, _, _, let r, _, _) = items[0] {
+        if case .toolCall(_, _, _, _, let r, _, _, _) = items[0] {
             #expect(r?.text == "file contents")
             #expect(r?.isError == false)
         } else {
@@ -73,7 +73,7 @@ struct TranscriptParserTests {
 
         let items = TranscriptParser.parse(filePath: tmp)
         #expect(items.count == 1)
-        if case .toolCall(_, _, _, _, let r, _, _) = items[0] {
+        if case .toolCall(_, _, _, _, let r, _, _, _) = items[0] {
             #expect(r == nil, "in-flight tool call should have nil result")
         } else {
             Issue.record("expected .toolCall")
@@ -120,7 +120,7 @@ struct TranscriptParserTests {
 
         let items = TranscriptParser.parse(filePath: parentPath)
         #expect(items.count == 1)
-        guard case .toolCall(_, let name, _, _, _, let subagent, _) = items[0] else {
+        guard case .toolCall(_, let name, _, _, _, let subagent, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(name == "Task")
@@ -150,7 +150,7 @@ struct TranscriptParserTests {
             .write(toFile: subDir.appendingPathComponent("agent-AM.meta.json").path, atomically: true, encoding: .utf8)
 
         let items = TranscriptParser.parse(filePath: parentPath)
-        guard case .toolCall(_, _, _, _, _, let subagent, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, _, let subagent, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(subagent?.agentType == "feature-dev:code-reviewer")
@@ -170,7 +170,7 @@ struct TranscriptParserTests {
         try parent.write(toFile: parentPath, atomically: true, encoding: .utf8)
 
         let items = TranscriptParser.parse(filePath: parentPath)
-        guard case .toolCall(_, _, _, _, _, let subagent, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, _, let subagent, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(subagent == nil, "missing subagent file → nil subagent, parent still renders")
@@ -204,9 +204,9 @@ struct TranscriptParserTests {
         ].joined(separator: "\n").write(toFile: subDir.appendingPathComponent("agent-AINNER.jsonl").path, atomically: true, encoding: .utf8)
 
         let items = TranscriptParser.parse(filePath: parentPath)
-        guard case .toolCall(_, _, _, _, _, let outer, _) = items[0],
+        guard case .toolCall(_, _, _, _, _, let outer, _, _) = items[0],
               let outerItems = outer?.items, outerItems.count >= 2,
-              case .toolCall(_, _, _, _, _, let inner, _) = outerItems[1] else {
+              case .toolCall(_, _, _, _, _, let inner, _, _) = outerItems[1] else {
             Issue.record("recursive structure mismatched"); return
         }
         #expect(inner?.agentID == "AINNER")
@@ -223,7 +223,7 @@ struct TranscriptParserTests {
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
         let items = TranscriptParser.parse(filePath: tmp)
-        guard case .toolCall(_, _, _, _, let r, _, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, let r, _, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(r?.text.count == 2000)
@@ -241,7 +241,7 @@ struct TranscriptParserTests {
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
         let items = TranscriptParser.parse(filePath: tmp)
-        guard case .toolCall(_, _, _, _, let r, _, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, let r, _, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(r?.text.split(separator: "\n").count == 20)
@@ -257,7 +257,7 @@ struct TranscriptParserTests {
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
         let items = TranscriptParser.parse(filePath: tmp)
-        guard case .toolCall(_, _, _, _, let r, _, _) = items[0] else {
+        guard case .toolCall(_, _, _, _, let r, _, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(r?.text == "short")
@@ -349,7 +349,7 @@ struct TranscriptParserTests {
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
         let items = TranscriptParser.parse(filePath: tmp)
-        guard case .toolCall(_, _, let inputJSON, let inputTruncatedTo, _, _, _) = items[0] else {
+        guard case .toolCall(_, _, let inputJSON, let inputTruncatedTo, _, _, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(inputTruncatedTo != nil, "large input field should set inputTruncatedTo")
@@ -366,7 +366,7 @@ struct TranscriptParserTests {
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
         let items = TranscriptParser.parse(filePath: tmp)
-        guard case .toolCall(_, _, _, let inputTruncatedTo, _, _, _) = items[0] else {
+        guard case .toolCall(_, _, _, let inputTruncatedTo, _, _, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(inputTruncatedTo == nil, "small inputs should not set inputTruncatedTo")
@@ -379,7 +379,7 @@ struct TranscriptParserTests {
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
         let items = TranscriptParser.parse(filePath: tmp)
-        guard case .toolCall(_, _, let inputJSON, let inputTruncatedTo, _, _, _) = items[0] else {
+        guard case .toolCall(_, _, let inputJSON, let inputTruncatedTo, _, _, _, _) = items[0] else {
             Issue.record("expected .toolCall"); return
         }
         #expect(inputTruncatedTo != nil, "nested oversized string should trigger truncation")

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -443,6 +443,22 @@ struct TranscriptParserTests {
         #expect(items[0].usage == nil)
     }
 
+    @Test func usage_extracted_when_only_input_tokens_present() throws {
+        // Users without prompt caching emit `usage` blocks that omit the
+        // cache fields. Those sessions must still surface a token count.
+        let line = #"{"type":"assistant","uuid":"a1","timestamp":"2026-05-05T10:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":42,"output_tokens":7}}}"#
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 1)
+        let usage = items[0].usage
+        #expect(usage?.inputTokens == 42)
+        #expect(usage?.cacheCreationTokens == 0)
+        #expect(usage?.cacheReadTokens == 0)
+        #expect(usage?.contextTotal == 42)
+    }
+
     @Test func sidechain_lines_drop_at_top_level_regression_guard() throws {
         // Locks in the existing TranscriptParser behavior that top-level
         // sidechain lines are dropped — the latest-usage badge logic relies

--- a/Tests/TBDSharedTests/TranscriptItemTests.swift
+++ b/Tests/TBDSharedTests/TranscriptItemTests.swift
@@ -19,7 +19,7 @@ struct TranscriptItemTests {
         let original: TranscriptItem = .assistantText(id: "a1", text: "ok", timestamp: nil)
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(TranscriptItem.self, from: data)
-        guard case .assistantText(let id, let text, _) = decoded else {
+        guard case .assistantText(let id, let text, _, _) = decoded else {
             Issue.record("expected .assistantText"); return
         }
         #expect(id == "a1")
@@ -35,7 +35,7 @@ struct TranscriptItemTests {
         )
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(TranscriptItem.self, from: data)
-        guard case .toolCall(let id, let name, let inputJSON, let inputTruncatedTo, let r, let sub, _) = decoded else {
+        guard case .toolCall(let id, let name, let inputJSON, let inputTruncatedTo, let r, let sub, _, _) = decoded else {
             Issue.record("expected .toolCall"); return
         }
         #expect(id == "toolu_1")
@@ -62,7 +62,7 @@ struct TranscriptItemTests {
         )
         let data = try JSONEncoder().encode(outer)
         let decoded = try JSONDecoder().decode(TranscriptItem.self, from: data)
-        guard case .toolCall(_, _, _, let outerTruncated, _, let s, _) = decoded else {
+        guard case .toolCall(_, _, _, let outerTruncated, _, let s, _, _) = decoded else {
             Issue.record("expected .toolCall"); return
         }
         #expect(outerTruncated == 50_000)

--- a/docs/superpowers/specs/2026-05-08-context-usage-display-design.md
+++ b/docs/superpowers/specs/2026-05-08-context-usage-display-design.md
@@ -1,0 +1,143 @@
+# Context Usage Display in Transcript Viewer
+
+## Goal
+
+Show how many tokens the current Claude Code session is carrying, surfaced under the most recent assistant item in the transcript viewer. The number is reference info — diminutive, not primary content — so the user can see "session is getting big" without running `/context`.
+
+Background and the underlying mechanism are documented in `docs/transcript-context-usage.md`. This spec covers only the implementation in TBD.
+
+## Decisions
+
+- **Token count only.** No window/denominator and no percent. The Claude Code transcript JSONL does not carry a context-window value, and we cannot reliably distinguish Opus 4.7's 200K and 1M variants from `message.model` alone (both write `claude-opus-4-7`). Showing a fabricated denominator would be misleading.
+- **Format:** `124k tokens` — abbreviated whole-thousands, with the literal word "tokens" appended. No decimal.
+- **Color thresholds:**
+  - `< 190_000` → muted gray (`.secondary`)
+  - `>= 190_000` → yellow
+  - `>= 260_000` → orange
+  - `>= 300_000` → red
+- **Placement:** A single tiny line below the bubble or card of the most recent non-sidechain item that carries usage data. No badges on older items; no per-turn history; no sparkline; no status-bar version.
+- **Sidechain handling:** Subagent / sidechain assistant lines (top-level `isSidechain: true`) are skipped when picking "latest." They run in a separate context window, so their usage values are not meaningful to the parent session's display.
+- **Scope:** Both `LiveTranscriptPaneView` (live polled session) and `HistoryPaneView` (static historical view). The single shared rendering path in `TranscriptItemsView` makes this one change.
+- **Latest-item rule (A1):** If the most recent assistant turn is tool-only (no text content), the badge attaches to the tool card it produced, not to the previous text bubble. The placement always reflects the most recent API call.
+
+## Architecture
+
+### Data model (`Sources/TBDShared/Models.swift`)
+
+New struct:
+
+```swift
+public struct TokenUsage: Codable, Sendable, Equatable {
+    public let inputTokens: Int
+    public let cacheCreationTokens: Int
+    public let cacheReadTokens: Int
+    public var contextTotal: Int {
+        inputTokens + cacheCreationTokens + cacheReadTokens
+    }
+}
+```
+
+Extend `TranscriptItem`:
+
+- `.assistantText` and `.toolCall` gain two new fields:
+  - `usage: TokenUsage?` (nil for items not derived from an assistant API call, or assistant lines that lack a `usage` block defensively)
+  - `isSidechain: Bool` (defaults to `false`)
+- These are **optional/defaulted** so existing serialized `TranscriptItem` values still decode — same compatibility rule the project applies to DB migrations (per `CLAUDE.md` Database section), applied here to the in-memory enum.
+
+### Parser (`Sources/TBDDaemon/Claude/TranscriptParser.swift`)
+
+When processing a JSONL line where `type == "assistant"`:
+
+1. Decode `message.usage` into a `TokenUsage`. Only the three fields we care about are mapped; the rest of the `usage` blob is ignored. Missing or malformed → `nil`.
+2. Read the top-level `isSidechain` boolean (defaults to `false` if absent).
+3. Stamp both onto every `.assistantText` and `.toolCall` item produced from that line.
+
+The duplication is intentional and cheap: a single assistant API call can produce one text item plus several tool_use items, and stamping the same `TokenUsage` on each one keeps the model uniform without introducing a separate "metadata index." Total memory cost is bounded by transcript length × ~32 bytes per stamped item.
+
+No changes to `TerminalTranscriptResult` or any RPC shape — usage rides with the existing items array.
+
+### Rendering (`Sources/TBDApp/Panes/Transcript/`)
+
+New file: `ContextUsageBadge.swift`
+
+```swift
+struct ContextUsageBadge: View {
+    let total: Int
+    var body: some View {
+        Text("\(total / 1000)k tokens")
+            .font(.caption2)
+            .foregroundStyle(color(for: total))
+    }
+
+    private func color(for total: Int) -> Color {
+        switch total {
+        case ..<190_000:  return .secondary
+        case ..<260_000:  return .yellow
+        case ..<300_000:  return .orange
+        default:          return .red
+        }
+    }
+}
+```
+
+`TranscriptItemsView` changes:
+
+- At the top of `body`, compute `let latestUsageItemID: String? = items.reversed().first { !$0.isSidechain && $0.usage != nil }?.id`. This walk is over the data array, not the materialized views, so it is unaffected by `LazyVStack`. The walk is O(n) per body evaluation, which is fine for a few hundred items at the 1.5s polling cadence.
+- In the per-item `ForEach`, after the existing item view (`ChatBubbleView`, `BashCard`, `ReadCard`, `EditCard`, `WriteCard`, `GrepCard`, `GlobCard`, `GenericToolCard`, `AgentCard`), conditionally render the badge:
+  ```swift
+  if item.id == latestUsageItemID, let usage = item.usage {
+      ContextUsageBadge(total: usage.contextTotal)
+          .padding(.leading, /* match bubble/card leading inset */)
+  }
+  ```
+- The badge is leading-aligned and indented to the bubble/card's leading edge so it visually reads as a tail of the item rather than a floating element. Exact inset matches whatever the existing item view uses (likely a shared constant in `TranscriptItemsView` or `ChatBubbleView`).
+
+`LiveTranscriptPaneView` and `HistoryPaneView` both delegate transcript rendering to `TranscriptItemsView`, so they pick up the badge with no further changes.
+
+### Lazy-stack interaction
+
+`TranscriptItemsView` uses `LazyVStack`. When a new assistant turn arrives:
+
+1. The polled `[TranscriptItem]` updates.
+2. `body` re-evaluates → `latestUsageItemID` recomputes.
+3. On-screen items re-evaluate naturally; the previously-latest item (if visible) drops its badge, the new latest item shows one.
+4. Off-screen items don't re-evaluate, but when they later scroll back into view they instantiate against the current `latestUsageItemID` and correctly do not render the badge.
+
+The badge changes the latest item's height. With the existing scroll-to-bottom behavior, this should follow naturally if the user is anchored to bottom; if they are scrolled up reading, the change happens to an off-screen item and does not move the viewport. Worth confirming once during manual verification, not designing around.
+
+## Testing
+
+### Parser unit tests (`Tests/TBDDaemonTests/TranscriptParserTests.swift`)
+
+- Assistant line with a `usage` block produces items whose `usage` is populated with the correct field values.
+- Assistant line with no `usage` (defensive) produces items with `usage == nil`.
+- Assistant line with `isSidechain: true` produces items with `isSidechain == true`; default lines have `isSidechain == false`.
+
+These cover each branch of the parser's gating logic per the `CLAUDE.md` rule on testing branching conditionals.
+
+### Helper unit tests
+
+If an app-level test target exists, test `ContextUsageBadge`'s formatting and color logic:
+
+- `formatted(0)` → `"0k tokens"`, `formatted(999)` → `"0k tokens"`, `formatted(124_300)` → `"124k tokens"`, `formatted(1_500_000)` → `"1500k tokens"`.
+- `color(for:)` boundary cases: 0, 189_999, 190_000, 259_999, 260_000, 299_999, 300_000.
+
+If no app-level test target exists in TBDApp, drop these — the formatting and color logic is too small to justify standing one up, and manual verification covers it.
+
+### Manual verification
+
+After `scripts/restart.sh`:
+
+1. Open a worktree with an active long Claude Code session. Confirm the badge appears under the last non-sidechain item (whether bubble or tool card).
+2. Verify color transitions. If a real high-token session is unavailable, temporarily lower the thresholds in `ContextUsageBadge` and reload to confirm yellow/orange/red render correctly.
+3. Trigger a sidechain (subagent) call and confirm the badge stays on the parent session's last main-thread item — does not jump to the subagent.
+4. Open `HistoryPaneView` for a past session and confirm the badge renders identically there.
+5. Confirm scroll anchoring: when scrolled to the bottom, new turns + their badges keep the bottom in view; when scrolled up, new turns do not jerk the viewport.
+
+## Out of scope
+
+- Window/denominator display, percent display.
+- Per-turn sparklines or any historical visualization of context growth.
+- Hooks consuming this data (covered separately in `docs/transcript-context-usage.md`).
+- Subagent context display in subagent disclosure cards. If we want to surface a subagent's own usage in the future, that's a follow-up.
+- Auto-compact warnings / notifications (would be a separate hook-driven feature).

--- a/docs/superpowers/specs/2026-05-08-context-usage-display-design.md
+++ b/docs/superpowers/specs/2026-05-08-context-usage-display-design.md
@@ -16,7 +16,7 @@ Background and the underlying mechanism are documented in `docs/transcript-conte
   - `>= 260_000` → orange
   - `>= 300_000` → red
 - **Placement:** A single tiny line below the bubble or card of the most recent non-sidechain item that carries usage data. No badges on older items; no per-turn history; no sparkline; no status-bar version.
-- **Sidechain handling:** Subagent / sidechain assistant lines (top-level `isSidechain: true`) are skipped when picking "latest." They run in a separate context window, so their usage values are not meaningful to the parent session's display.
+- **Sidechain handling:** Subagent / sidechain assistant lines (top-level `isSidechain: true`) are skipped when picking "latest." They run in a separate context window, so their usage values are not meaningful to the parent session's display. The parser already drops top-level sidechain lines (`TranscriptParser.parse` line ~126, `if skipSidechain, json["isSidechain"] as? Bool == true { continue }`), so the top-level items array is sidechain-free by construction. Subagent-nested items are reached via recursive `TranscriptItemsView` at `depth > 0` inside `SubagentDisclosure`; we suppress the badge there by gating render on `depth == 0`.
 - **Scope:** Both `LiveTranscriptPaneView` (live polled session) and `HistoryPaneView` (static historical view). The single shared rendering path in `TranscriptItemsView` makes this one change.
 - **Latest-item rule (A1):** If the most recent assistant turn is tool-only (no text content), the badge attaches to the tool card it produced, not to the previous text bubble. The placement always reflects the most recent API call.
 
@@ -39,20 +39,20 @@ public struct TokenUsage: Codable, Sendable, Equatable {
 
 Extend `TranscriptItem`:
 
-- `.assistantText` and `.toolCall` gain two new fields:
+- `.assistantText` and `.toolCall` gain one new field:
   - `usage: TokenUsage?` (nil for items not derived from an assistant API call, or assistant lines that lack a `usage` block defensively)
-  - `isSidechain: Bool` (defaults to `false`)
-- These are **optional/defaulted** so existing serialized `TranscriptItem` values still decode — same compatibility rule the project applies to DB migrations (per `CLAUDE.md` Database section), applied here to the in-memory enum.
+- This is **optional** so existing serialized `TranscriptItem` values still decode — same compatibility rule the project applies to DB migrations (per `CLAUDE.md` Database section), applied here to the in-memory enum.
+
+No `isSidechain` field is needed: the parser drops top-level sidechain lines, and subagent-nested items are filtered out at render time via the `depth == 0` gate.
 
 ### Parser (`Sources/TBDDaemon/Claude/TranscriptParser.swift`)
 
 When processing a JSONL line where `type == "assistant"`:
 
 1. Decode `message.usage` into a `TokenUsage`. Only the three fields we care about are mapped; the rest of the `usage` blob is ignored. Missing or malformed → `nil`.
-2. Read the top-level `isSidechain` boolean (defaults to `false` if absent).
-3. Stamp both onto every `.assistantText` and `.toolCall` item produced from that line.
+2. Stamp the `usage` value onto every `.assistantText` and `.toolCall` item produced from that line.
 
-The duplication is intentional and cheap: a single assistant API call can produce one text item plus several tool_use items, and stamping the same `TokenUsage` on each one keeps the model uniform without introducing a separate "metadata index." Total memory cost is bounded by transcript length × ~32 bytes per stamped item.
+The duplication is intentional and cheap: a single assistant API call can produce one text item plus several tool_use items, and stamping the same `TokenUsage` on each one keeps the model uniform without introducing a separate "metadata index." Total memory cost is bounded by transcript length × ~24 bytes per stamped item.
 
 No changes to `TerminalTranscriptResult` or any RPC shape — usage rides with the existing items array.
 
@@ -82,7 +82,8 @@ struct ContextUsageBadge: View {
 
 `TranscriptItemsView` changes:
 
-- At the top of `body`, compute `let latestUsageItemID: String? = items.reversed().first { !$0.isSidechain && $0.usage != nil }?.id`. This walk is over the data array, not the materialized views, so it is unaffected by `LazyVStack`. The walk is O(n) per body evaluation, which is fine for a few hundred items at the 1.5s polling cadence.
+- The badge is only rendered when `depth == 0` (top-level transcript). Subagent-nested rendering at `depth > 0` skips the latest-usage walk entirely, so subagent context never shows a badge.
+- At the top of the `depth == 0` branch, compute `let latestUsageItemID: String? = items.reversed().first { $0.usage != nil }?.id`. This walk is over the data array, not the materialized views, so it is unaffected by `LazyVStack`. The walk is O(n) per body evaluation, which is fine for a few hundred items at the 1.5s polling cadence.
 - In the per-item `ForEach`, after the existing item view (`ChatBubbleView`, `BashCard`, `ReadCard`, `EditCard`, `WriteCard`, `GrepCard`, `GlobCard`, `GenericToolCard`, `AgentCard`), conditionally render the badge:
   ```swift
   if item.id == latestUsageItemID, let usage = item.usage {
@@ -111,7 +112,7 @@ The badge changes the latest item's height. With the existing scroll-to-bottom b
 
 - Assistant line with a `usage` block produces items whose `usage` is populated with the correct field values.
 - Assistant line with no `usage` (defensive) produces items with `usage == nil`.
-- Assistant line with `isSidechain: true` produces items with `isSidechain == true`; default lines have `isSidechain == false`.
+- A top-level assistant line with `isSidechain: true` produces no items at all (existing parser drop behavior — covered by an explicit test to lock it in as a regression guard for the badge logic).
 
 These cover each branch of the parser's gating logic per the `CLAUDE.md` rule on testing branching conditionals.
 

--- a/docs/transcript-context-usage.md
+++ b/docs/transcript-context-usage.md
@@ -1,0 +1,92 @@
+# Reading Context Usage from Claude Code Transcripts
+
+Claude Code does not expose a CLI command, RPC, or hook for "how full is the context window right now." But every assistant turn in the on-disk transcript records the exact token counts the API used, so the transcript viewer can derive context usage by reading the file.
+
+## Where the data lives
+
+Each session writes a JSONL file to:
+
+```
+~/.claude/projects/<slugified-cwd>/<sessionId>.jsonl
+```
+
+One line per event. Assistant turns carry a `message.usage` object populated from the Anthropic API response:
+
+```json
+{
+  "type": "assistant",
+  "message": {
+    "usage": {
+      "input_tokens": 1,
+      "cache_creation_input_tokens": 1077,
+      "cache_read_input_tokens": 41667,
+      "output_tokens": 261,
+      "cache_creation": {
+        "ephemeral_5m_input_tokens": 0,
+        "ephemeral_1h_input_tokens": 1077
+      }
+    }
+  }
+}
+```
+
+User messages, tool results, and system events do **not** carry `usage` — only assistant turns do.
+
+## Computing context used
+
+The number `/context` shows is the total prompt size sent on the most recent request:
+
+```
+context_used = input_tokens + cache_creation_input_tokens + cache_read_input_tokens
+```
+
+`output_tokens` is the model's reply and is **not** part of the prompt size — exclude it from the "context used" figure.
+
+To get the latest value, scan the JSONL backwards (or forwards, taking the last hit) for an `assistant` line with a `message.usage` object and apply the formula above.
+
+## When assistant lines are written
+
+An assistant line is written **every time the API returns a response**, not once per user prompt. A single user message typically produces several assistant lines if the turn involves tools:
+
+```
+user message
+  → assistant line (text + tool_use)        ← usage snapshot #1
+tool_result (recorded as a "user" line)
+  → assistant line (more tool_use)          ← usage snapshot #2
+tool_result
+  → assistant line (final text)             ← usage snapshot #3
+```
+
+Each line's `usage` reflects the prompt as it was for *that* API call. Within one user turn the numbers climb monotonically — call #2's prompt includes call #1's output plus the tool result, call #3's includes everything before it, and so on. The viewer can poll the file during a long tool-heavy turn and watch context grow in near real time.
+
+Two structural notes that matter for rendering:
+
+- **Tool results are stored as `type: "user"` lines** with a `tool_result` content block, even though the user didn't type them. They carry no `usage`. Don't render them as user chat bubbles.
+- **Sidechain / subagent calls** appear in the same JSONL with `isSidechain: true` and their own `usage` values. They run in a separate context window from the parent session, so don't fold their usage into the parent's "context used" figure — show them separately or skip them when computing the headline number.
+
+## Semantics: it's a per-request snapshot, not a running total
+
+Each assistant turn's `usage` records the size of *that one API request*. Every turn re-sends the system prompt + every prior message, so consecutive turns overlap massively — **don't sum them**. The latest turn's value already represents "everything in context as of that request."
+
+The number is immutable once written. Re-reading the file later returns the same value.
+
+## Caveats for the UI
+
+- **Lag vs. live.** The recorded value reflects the last request the model answered. Between then and now, the user may have typed a new message, tools may have produced output, and new `<system-reminder>` blocks may have been injected. The next turn will be larger. Show the value as "as of last response," not "right now."
+- **Compaction resets it.** Auto-compact rewrites the prompt, so post-compact turns show a much smaller number. This is a real drop, not a bug — the viewer should render it as such (e.g. a step-down in a sparkline rather than smoothing across it).
+- **Window size is model-dependent.** The denominator (200K, 1M, etc.) comes from the model name on the same assistant message, not from `usage` itself. Read `message.model` and map it to the limit.
+- **Cache splits are informational.** `cache_read_input_tokens` is the bulk of context once a session warms up; `cache_creation_input_tokens` is the newly added portion that just got cached; `input_tokens` is whatever wasn't cacheable. They all count toward the window equally — the split only matters for cost/latency display.
+
+## Hooks can read the same data
+
+Claude Code hooks (`Stop`, `SubagentStop`, `PostToolUse`, `PreCompact`, `Notification`, etc.) do not receive `usage` in their stdin payload, but every hook event includes a `transcript_path` field pointing at this same JSONL file. A hook script can read it, scan backward for the last `type: "assistant"` line, and compute context size with the formula above — exactly the same logic the viewer uses. Good fits:
+
+- `Stop` — log final context size per turn.
+- `PreCompact` — record the pre-compact size for a "compacted at X tokens" trail.
+- `Notification` — warn the user when context crosses a threshold.
+
+Worth factoring the parser into a shared helper so the viewer and any hook scripts agree on what counts.
+
+## Viewer surface
+
+Show `context_used / window_size` only on the **latest** assistant line, collocated with that message — no per-turn history, no sparkline, no display on older messages. Render it diminutively (small, muted) since it's reference info, not primary content. Older assistant lines all carry their own `usage` too, but those values are stale and would just clutter the transcript.


### PR DESCRIPTION
## Summary
- Adds a tiny `Nk tokens` line beneath the most recent visible assistant item, with a small leading dot that shifts color through bands: gray `<190k` → yellow `≥190k` → orange `≥260k` → red `≥300k`. Same number `/context` reports, but visible without leaving the chat.
- Sourced from `message.usage` in the session JSONL (`input_tokens + cache_creation_input_tokens + cache_read_input_tokens`). The parser already drops top-level sidechain lines; the renderer additionally gates on `depth == 0` so subagent-nested timelines never show their own badge, and skips hidden tool calls (TodoWrite/TaskUpdate/etc.) so the badge never floats below an empty row.
- Spec at `docs/superpowers/specs/2026-05-08-context-usage-display-design.md`; underlying mechanism documented in `docs/transcript-context-usage.md` for anyone wiring up hooks against the same data.

## Test plan
- [ ] Open a long active session in TBD; confirm the badge appears under the latest visible item (chat bubble or tool card) and updates as the session grows.
- [ ] Confirm older messages do not carry the badge.
- [ ] Open the History pane for a past session; confirm the badge renders the same way.
- [ ] Expand a subagent disclosure; confirm no nested badge appears.
- [ ] Visually verify the color thresholds (190k yellow, 260k orange, 300k red) against a high-token session.

open in TBD: \`tbd://open?worktree=42A29C83-B18E-4559-A0C2-478A116306EE\`