### PR TITLE
Feat: Copy absolute path from file rows, viewer tabs, and transcripts

### DIFF
--- a/Sources/TBDApp/FileViewer/FileViewerPanel.swift
+++ b/Sources/TBDApp/FileViewer/FileViewerPanel.swift
@@ -2,6 +2,15 @@ import AppKit
 import SwiftUI
 import TBDShared
 
+private func copyPathToPasteboard(_ path: String) {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(path, forType: .string)
+}
+
+private func absolutePath(worktreePath: String, relativePath: String) -> String {
+    URL(fileURLWithPath: worktreePath).appendingPathComponent(relativePath).path
+}
+
 // MARK: - Data Model
 
 struct GitFileStatus: Identifiable {
@@ -328,6 +337,11 @@ private struct GitFileRow: View {
             onFileClick(file.path, cmdClick)
         }
         .onHover { isHovered = $0 }
+        .contextMenu {
+            Button("Copy Path") {
+                copyPathToPasteboard(absolutePath(worktreePath: worktreePath, relativePath: file.path))
+            }
+        }
     }
 }
 
@@ -407,5 +421,10 @@ private struct BranchFileRow: View {
             onFileClick(file.path, cmdClick)
         }
         .onHover { isHovered = $0 }
+        .contextMenu {
+            Button("Copy Path") {
+                copyPathToPasteboard(absolutePath(worktreePath: worktreePath, relativePath: file.path))
+            }
+        }
     }
 }

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import TBDShared
 
@@ -94,6 +95,12 @@ struct HistoryPaneView: View {
                     .contentShape(Rectangle())
                     .onTapGesture {
                         Task { await appState.selectSession(summary, worktreeID: worktreeID) }
+                    }
+                    .contextMenu {
+                        Button("Copy Conversation Path") {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(summary.filePath, forType: .string)
+                        }
                     }
                     .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
                     .listRowBackground(
@@ -326,6 +333,12 @@ struct SessionTranscriptView: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
+            .contextMenu {
+                Button("Copy Conversation Path") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(summary.filePath, forType: .string)
+                }
+            }
 
             Divider()
 

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import TBDShared
 
@@ -282,8 +283,36 @@ private struct TabBarItem: View {
         entry.profile.name
     }
 
+    /// Absolute path on disk for tab content that has a backing file
+    /// (codeViewer points at the file directly; liveTranscript points at
+    /// the resolved Claude session JSONL via the underlying terminal).
+    private var copyablePath: String? {
+        switch tab.content {
+        case .codeViewer(_, let path):
+            return path.isEmpty ? nil : path
+        case .liveTranscript(_, let terminalID):
+            let allTerminals = appState.terminals.values.flatMap { $0 }
+            return allTerminals.first { $0.id == terminalID }?.transcriptPath
+        default:
+            return nil
+        }
+    }
+
+    private var copyPathLabel: String {
+        if case .liveTranscript = tab.content { return "Copy Conversation Path" }
+        return "Copy Path"
+    }
+
     @ViewBuilder
     private var contextMenuContent: some View {
+        if let path = copyablePath {
+            Button(copyPathLabel) {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(path, forType: .string)
+            }
+            Divider()
+        }
+
         if isClaudeTerminal {
             Button(formatProfileHeader(terminal?.profileID)) {}
                 .disabled(true)


### PR DESCRIPTION
## Summary
- Right-click "Copy Path" on any row in the right-side file panel (Staged / Changes / Untracked / Branch) — copies the absolute path on disk, not the worktree-relative one.
- Same on the tab header for code/markdown viewer tabs, and "Copy Conversation Path" on live transcript tabs (uses the terminal's resolved Claude session JSONL).
- And on history-pane session rows + the open transcript's header bar — pulls `summary.filePath` straight to the pasteboard so you can `cat` / open the JSONL without hunting through `~/.claude/projects/`.

## Test plan
- [ ] Right-click a file in Staged/Changes/Untracked/Branch → "Copy Path" → paste, verify it's the absolute path
- [ ] Right-click a code viewer tab → "Copy Path" → paste, verify it matches the file
- [ ] Right-click a markdown tab in reader mode → "Copy Path" works the same
- [ ] Right-click a Live Transcript tab → "Copy Conversation Path" → paste, verify it's the `.jsonl` under `~/.claude/projects/...`
- [ ] In the History pane, right-click a session row → "Copy Conversation Path" → matches the JSONL on disk
- [ ] Right-click the open transcript header → same result

[📋 Copy File Path Menus](https://cheapsteak.github.io/tbd/open/?worktree=B75C99BE-FA14-4140-958D-5970368D6007)