### PR TITLE
DX: Cache full .build/ + restore source mtimes for ~3x faster CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       # culprit; SPM actually emits `file-system: device-agnostic` so llbuild
       # zeroes device+inode before equality. mtime drift was the real issue.)
       - name: Restore source mtimes from git commit times
-        uses: chetan/git-restore-mtime-action@v2
+        uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2
 
       - name: Capture Swift toolchain version
         run: echo "SWIFT_VERSION=$(xcrun swift --version | head -1)" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,19 +15,35 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # git-restore-mtime needs full history
+
+      # Restore source-file mtimes to their last git commit times BEFORE the
+      # cache restore. Without this, fresh checkout writes every source mtime
+      # to "now", which looks newer than what llbuild recorded in the cached
+      # `.build/`, so it rebuilds from scratch. (PR #82 trimmed `.build/` from
+      # the cache under the wrong assumption that fresh-VM inodes were the
+      # culprit; SPM actually emits `file-system: device-agnostic` so llbuild
+      # zeroes device+inode before equality. mtime drift was the real issue.)
+      - name: Restore source mtimes from git commit times
+        uses: chetan/git-restore-mtime-action@v2
 
       - name: Capture Swift toolchain version
         run: echo "SWIFT_VERSION=$(xcrun swift --version | head -1)" >> $GITHUB_ENV
 
-      - name: Cache SwiftPM dependencies
+      - name: Cache SwiftPM build artifacts and dependencies
         uses: actions/cache@v4
         with:
           path: |
-            .build/checkouts
+            .build
             ~/Library/Caches/org.swift.swiftpm
-          key: spm-deps-${{ runner.os }}-${{ env.SWIFT_VERSION }}-${{ hashFiles('Package.resolved') }}
+          # Primary key changes per source revision so we always know what we
+          # restored. restore-keys falls back to the most recent matching
+          # cache; llbuild's incremental build then only recompiles what
+          # actually differs.
+          key: spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-${{ hashFiles('Package.resolved', 'Sources/**/*.swift', 'Tests/**/*.swift') }}
           restore-keys: |
-            spm-deps-${{ runner.os }}-${{ env.SWIFT_VERSION }}-
+            spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-
 
       - name: Test
         run: swift test --parallel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           # restored. restore-keys falls back to the most recent matching
           # cache; llbuild's incremental build then only recompiles what
           # actually differs.
-          key: spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-${{ hashFiles('Package.resolved', 'Sources/**/*.swift', 'Tests/**/*.swift') }}
+          key: spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-${{ hashFiles('Package.swift', 'Package.resolved', 'Sources/**/*.swift', 'Tests/**/*.swift') }}
           restore-keys: |
             spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-
 


### PR DESCRIPTION
## Summary

Re-include `.build` in the cache (reverts the trim from #82) and restore source-file mtimes from git commit times before the cache step. Warm-run wall clock drops **~240s → ~79s** based on direct measurement.

## Why #82's trim was wrong

PR #82 trimmed `.build/` from the cache assuming `actions/cache` restoring on a fresh VM gave artifacts new inodes that broke llbuild's `FileInfo::operator==`. Verifying in source shows that's not how SPM drives llbuild:

- [`swift-package-manager/Sources/LLBuildManifest/LLBuildManifestWriter.swift:24`](https://github.com/swiftlang/swift-package-manager/blob/main/Sources/LLBuildManifest/LLBuildManifestWriter.swift#L24) emits `file-system: device-agnostic` in every llbuild manifest.
- [`swift-llbuild/lib/BuildSystem/BuildSystem.cpp:4042`](https://github.com/swiftlang/swift-llbuild/blob/main/lib/BuildSystem/BuildSystem.cpp#L4042) parses that and switches to `DeviceAgnosticFileSystem`.
- [`swift-llbuild/include/llbuild/Basic/FileSystem.h:142`](https://github.com/swiftlang/swift-llbuild/blob/main/include/llbuild/Basic/FileSystem.h#L142) `DeviceAgnosticFileSystem::getFileInfo` zeroes `info.device` and `info.inode` before equality is checked.

So inodes were never the problem. mtime was. `git checkout` writes every source-file mtime to "now" on a fresh runner, which looks newer than what llbuild recorded in the cached `.build/`, so it rebuilds. `chetan/git-restore-mtime-action@v2` sets source mtimes to their last git commit times — deterministic across runners, so a restored `.build/` keeps its incremental relationship to the sources.

PR #80's \`find .build -exec touch +\` was also wrong-direction — it touched *artifact* mtimes to "now", which doesn't match llbuild's recorded state either. The right move is to make *source* mtimes deterministic.

## Measured (experiment branch \`tbd/ci-shard-experiment\`)

| Config                                   | Wall  |
|------------------------------------------|-------|
| Current main (deps-only cache)           | ~240s |
| Full \`.build/\` cache, no mtime restore   | 166s  |
| Full \`.build/\` cache + git-restore-mtime | **79s** |

Cold runs (cache miss, e.g. first build of a new branch) stay slow — this only helps warm runs, which is the common case.

## Test plan

- [ ] CI on this PR: first run cold-misses and seeds the cache (~5m+).
- [ ] Push an empty commit; second run should hit the warm cache and land in the ~80s range, vs ~4m today.
- [ ] Confirm \`Restore source mtimes\` step runs in 1–2s.
- [ ] After merge, monitor a few main builds — \`restore-keys\` should pull a partial-match cache and incrementally compile only the files that changed.