### PR TITLE
Feat: Hide sidebar chevron and + behind hover to reclaim horizontal space

### DIFF
--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -30,6 +30,28 @@ struct RepoSectionView: View {
 
     @State private var isExpanded = true
     @State private var isEditing = false
+    @State private var isHeaderHovered = false
+    @State private var isSectionHovered = false
+    @State private var hoverDebounceTask: Task<Void, Never>?
+
+    private func onSectionHoverChange(_ hovering: Bool) {
+        if hovering {
+            hoverDebounceTask?.cancel()
+            hoverDebounceTask = nil
+            if !isSectionHovered {
+                isSectionHovered = true
+            }
+        } else {
+            hoverDebounceTask?.cancel()
+            let task = Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 80_000_000)
+                if !Task.isCancelled {
+                    isSectionHovered = false
+                }
+            }
+            hoverDebounceTask = task
+        }
+    }
 
     var mainWorktree: Worktree? {
         (appState.worktrees[repo.id] ?? [])
@@ -44,14 +66,6 @@ struct RepoSectionView: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Button(action: { isExpanded.toggle() }) {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(.caption)
-                    .frame(width: 20, height: 20)
-            }
-            .buttonStyle(HoverPressButtonStyle())
-            .help(isExpanded ? "Collapse" : "Expand")
-
             RenameableLabel(
                 text: repo.displayName,
                 isEditing: $isEditing,
@@ -62,7 +76,7 @@ struct RepoSectionView: View {
                 }
             ) {
                 Text(repo.displayName)
-                    .font(.headline)
+                    .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(
                         repo.status == .missing
                             ? AnyShapeStyle(Color.secondary.opacity(0.5))
@@ -83,18 +97,28 @@ struct RepoSectionView: View {
 
             Spacer()
 
-            Button(action: createWorktree) {
-                Image(systemName: "plus")
-                    .font(.caption)
-                    .frame(width: 20, height: 20)
+            Group {
+                if isHeaderHovered {
+                    Button(action: { isExpanded.toggle() }) {
+                        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                            .font(.caption)
+                            .frame(width: 20, height: 20)
+                    }
+                    .buttonStyle(HoverPressButtonStyle())
+                    .help(isExpanded ? "Collapse" : "Expand")
+                } else {
+                    Color.clear
+                }
             }
-            .buttonStyle(HoverPressButtonStyle())
-            .help("New worktree")
-            .disabled(repo.status == .missing)
+            .frame(width: 20, height: 20)
         }
         .contentShape(Rectangle())
         .onTapGesture {
             appState.selectRepo(id: repo.id)
+        }
+        .onHover { hovering in
+            isHeaderHovered = hovering
+            onSectionHoverChange(hovering)
         }
         .contextMenu {
             Button("Rename...") {
@@ -106,13 +130,33 @@ struct RepoSectionView: View {
 
         if isExpanded {
             if let main = mainWorktree {
-                WorktreeRowView(worktree: main, isMain: true)
-                    .listRowInsets(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 0))
-                    .tag(main.id)
+                HStack(spacing: 0) {
+                    WorktreeRowView(worktree: main, isMain: true)
+                    Spacer()
+                    Group {
+                        if isSectionHovered {
+                            Button(action: createWorktree) {
+                                Image(systemName: "plus")
+                                    .font(.caption)
+                                    .frame(width: 20, height: 20)
+                            }
+                            .buttonStyle(HoverPressButtonStyle())
+                            .help("New worktree")
+                            .disabled(repo.status == .missing)
+                        } else {
+                            Color.clear
+                        }
+                    }
+                    .frame(width: 20, height: 20)
+                }
+                .onHover { onSectionHoverChange($0) }
+                .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                .tag(main.id)
             }
             ForEach(worktrees) { worktree in
                 WorktreeRowView(worktree: worktree)
-                    .listRowInsets(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 0))
+                    .onHover { onSectionHoverChange($0) }
+                    .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
                     .tag(worktree.id)
             }
             .onMove { source, destination in

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -132,7 +132,7 @@ struct RepoSectionView: View {
             if let main = mainWorktree {
                 HStack(spacing: 0) {
                     WorktreeRowView(worktree: main, isMain: true)
-                    Spacer()
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     Group {
                         if isSectionHovered {
                             Button(action: createWorktree) {

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -32,7 +32,7 @@ struct RepoSectionView: View {
     @State private var isEditing = false
     @State private var isHeaderHovered = false
     @State private var isSectionHovered = false
-    @State private var hoverDebounceTask: Task<Void, Never>?
+    @State private var hoverDebounceTask: Task<Void, Error>?
 
     private func onSectionHoverChange(_ hovering: Bool) {
         if hovering {
@@ -43,13 +43,10 @@ struct RepoSectionView: View {
             }
         } else {
             hoverDebounceTask?.cancel()
-            let task = Task { @MainActor in
-                try? await Task.sleep(nanoseconds: 80_000_000)
-                if !Task.isCancelled {
-                    isSectionHovered = false
-                }
+            hoverDebounceTask = Task { @MainActor in
+                try await Task.sleep(nanoseconds: 80_000_000)
+                isSectionHovered = false
             }
-            hoverDebounceTask = task
         }
     }
 

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -156,8 +156,6 @@ struct WorktreeRowView: View {
                 appState.selectedWorktreeIDs = [worktree.id]
             }
         }
-        .padding(.vertical, 2)
-        .padding(.horizontal, 4)
         .help(isEditing ? "" : worktree.displayName)
         .background(
             RoundedRectangle(cornerRadius: 4)


### PR DESCRIPTION
## Summary
- Repo header row: chevron moved from leading to trailing edge, only visible on hover of the header. The leading chevron and trailing `+` are gone, so project names get the full width of the row.
- Main worktree row: `+` moved here at the trailing edge, visible whenever any row in the repo section is hovered (80ms debounce so it doesn't flicker as the cursor crosses adjacent List cells).
- Project name font shrunk from `.headline` (13pt semibold) to `.system(size: 11, weight: .semibold)` to read more like a sidebar group header.
- Removed our explicit `.padding(.vertical, 2)` and `.padding(.horizontal, 4)` from worktree rows, and zeroed our `listRowInsets` leading from 4 to 0. (System `.listStyle(.sidebar)` row padding is unchanged — that's a separate, harder problem.)
- Hover-revealed buttons sit in a 20×20 placeholder so toggling visibility doesn't shift row content.

## Test plan
- [ ] Hover a project header row — chevron appears at the trailing edge; clicking it expands/collapses the section.
- [ ] Move the cursor off the project header — chevron disappears; project name is unindented and uses the full row width.
- [ ] Hover any row inside a project (header, main, child worktree) — `+` appears on the main worktree row's trailing edge.
- [ ] Move the cursor between adjacent rows in the same section — `+` stays visible (no flicker).
- [ ] Move the cursor out of the section entirely — `+` disappears after ~80ms.
- [ ] Click `+` on the main row — creates a new worktree (same behavior as the old leading `+`).
- [ ] Right-click a project header — context menu still offers "Rename...".
- [ ] Click a worktree row — selection still works (single, cmd-click multi-select, click-to-rename when already selected).
- [ ] `+` is disabled if the repo is `.missing`.

open in TBD: \`tbd://open?worktree=E83C5596-3226-43B8-A8DA-2F8BADA7DDF9\`