### PR TITLE
Reliability: Poll for suspendedAt cleared, drop fixed 5s sleep in resume tests

### DIFF
--- a/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
@@ -53,10 +53,10 @@ struct SuspendResumeCoordinatorTests {
 
         await coordinator.selectionChanged(to: [worktreeID], suspendEnabled: true)
 
-        try await Task.sleep(for: .seconds(5))
-
-        let after = try await db.terminals.get(id: terminalID)
-        #expect(after?.suspendedAt == nil, "Resume should clear suspendedAt when suspendEnabled is true")
+        let cleared = try await waitUntil {
+            try await db.terminals.get(id: terminalID)?.suspendedAt == nil
+        }
+        #expect(cleared, "Resume should clear suspendedAt when suspendEnabled is true")
     }
 
     @Test func manualSuspendSkipsAlreadySuspended() async throws {
@@ -142,10 +142,11 @@ struct SuspendResumeCoordinatorTests {
         let coordinator = SuspendResumeCoordinator(db: db, tmux: tmux, modelProfileResolver: resolver)
 
         await coordinator.selectionChanged(to: [wt.id], suspendEnabled: true)
-        try await Task.sleep(for: .seconds(5))
 
-        let after = try await db.terminals.get(id: terminal.id)
-        #expect(after?.suspendedAt == nil)
+        let cleared = try await waitUntil {
+            try await db.terminals.get(id: terminal.id)?.suspendedAt == nil
+        }
+        #expect(cleared, "Resume should clear suspendedAt when suspendEnabled is true")
 
         // Find the createWindow invocation (it's the only dryRun call recorded here).
         let snap = recorded.snapshot()
@@ -174,10 +175,11 @@ struct SuspendResumeCoordinatorTests {
         let coordinator = SuspendResumeCoordinator(db: db, tmux: tmux, modelProfileResolver: nil)
 
         await coordinator.selectionChanged(to: [worktreeID], suspendEnabled: true)
-        try await Task.sleep(for: .seconds(5))
 
-        let after = try await db.terminals.get(id: terminalID)
-        #expect(after?.suspendedAt == nil)
+        let cleared = try await waitUntil {
+            try await db.terminals.get(id: terminalID)?.suspendedAt == nil
+        }
+        #expect(cleared, "Resume should clear suspendedAt when suspendEnabled is true")
 
         let joined = recorded.snapshot().map { $0.joined(separator: " ") }
         let resumeArg = joined.first { $0.contains("claude --resume") }
@@ -216,6 +218,24 @@ struct SuspendResumeCoordinatorTests {
 
         let after = try await db.terminals.get(id: terminal.id)
         #expect(after?.suspendedAt == nil, "Terminal should NOT be suspended when suspendEnabled is false")
+    }
+
+    /// Polls `condition` every 50ms until it returns true, up to `timeout`.
+    /// Use this when awaiting fire-and-forget actor work that has no
+    /// synchronization point — `Task.sleep(.seconds(N))` is brittle under
+    /// `swift test --parallel` load where scheduling delays can stretch
+    /// nominally sub-second work to many seconds.
+    private func waitUntil(
+        timeout: Duration = .seconds(30),
+        pollInterval: Duration = .milliseconds(50),
+        _ condition: () async throws -> Bool
+    ) async throws -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if try await condition() { return true }
+            try await Task.sleep(for: pollInterval)
+        }
+        return try await condition()
     }
 }
 


### PR DESCRIPTION
## Summary

Three resume tests in `SuspendResumeCoordinatorTests` slept a fixed 5s after `selectionChanged()` and then asserted `suspendedAt == nil`. `selectionChanged` is fire-and-forget by design (background Tasks on the actor that eventually call `clearSuspended`) — so the test had no real synchronization point, just a guess.

Under `swift test --parallel` load in CI, scheduler latency stretches the resume chain past 5s in some runs. One observed failing run took 8.4s wall time for nominally <100ms of work — and the most-flaky test (`resumeInjectsTokenWhenResolverProvided`) is exactly the one with the most extra await hops (`loadByID` → `profiles.get` + `touchLastUsed` before reaching `clearSuspended`), giving it the smallest margin.

The failure was confirmed by inspecting the original CI run attempt: `suspendedAt` still held the original `setSuspended` timestamp at assertion time, proving the resume Task simply hadn't run to completion yet.

## Fix

Replace the 5s sleep + assert pattern in the three resume tests with `waitUntil` — polls every 50ms up to 30s for `suspendedAt == nil`. Resilient to scheduler delays without inflating happy-path runtime.

Production code is unchanged — fire-and-forget is intentional in `selectionChanged` (real users have no synchronization point either).

The two negative-case tests (`resumeSkippedWhenSuspendDisabled`, `suspendSkippedWhenDisabled`) keep their fixed sleeps — they're verifying nothing happens, where polling doesn't apply.

## Test plan

- [ ] CI Test workflow passes on first attempt across multiple runs
- [ ] No new sleeps elsewhere in the test file

[fix-suspend-resume-flake](https://cheapsteak.github.io/tbd/open/?worktree=9FECC36D-8021-4F42-924A-140447C4B5BD)