### PR TITLE
Reliability: Stop the sidebar from collapsing on wake-from-sleep

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -180,6 +180,7 @@ struct ContentView: View {
 
             StatusBarView()
         }
+        .frame(minWidth: 800, minHeight: 500)
         .onChange(of: appState.selectedWorktreeIDs) { oldSelection, newSelection in
             markSelectedWorktreesAsRead(newSelection)
             let newlySelected = newSelection.subtracting(oldSelection)

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -19,50 +19,50 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            NavigationSplitView {
-                SidebarView()
-            } detail: {
-                if !appState.isConnected {
-                    disconnectedView
-                } else if appState.repos.isEmpty {
-                    emptyStateView
-                } else if let repoID = appState.selectedRepoID {
-                    RepoDetailView(repoID: repoID)
-                } else if appState.selectedWorktreeIDs.isEmpty {
-                    Text("Select a worktree or click + to create one")
-                        .foregroundStyle(.secondary)
-                } else {
-                    HStack(spacing: 0) {
-                        TerminalContainerView()
-                        if showFilePanel, let worktree = selectedWorktree, !worktree.path.isEmpty {
-                            FilePanelDivider(panelWidth: Binding(
-                                get: { CGFloat(filePanelWidth) },
-                                set: { filePanelWidth = Double($0) }
-                            ))
-                            FileViewerPanel(worktree: worktree)
-                                .frame(width: CGFloat(filePanelWidth))
-                                .id(worktree.id)
+            AppKitSplitView(
+                appState: appState,
+                sidebar: { SidebarView() },
+                detail: {
+                    if !appState.isConnected {
+                        disconnectedView
+                    } else if appState.repos.isEmpty {
+                        emptyStateView
+                    } else if let repoID = appState.selectedRepoID {
+                        RepoDetailView(repoID: repoID)
+                    } else if appState.selectedWorktreeIDs.isEmpty {
+                        Text("Select a worktree or click + to create one")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        HStack(spacing: 0) {
+                            TerminalContainerView()
+                            if showFilePanel, let worktree = selectedWorktree, !worktree.path.isEmpty {
+                                FilePanelDivider(panelWidth: Binding(
+                                    get: { CGFloat(filePanelWidth) },
+                                    set: { filePanelWidth = Double($0) }
+                                ))
+                                FileViewerPanel(worktree: worktree)
+                                    .frame(width: CGFloat(filePanelWidth))
+                                    .id(worktree.id)
+                            }
                         }
-                    }
-                    .background(GeometryReader { geometry in
-                        Color.clear.preference(key: ContentHeightKey.self, value: geometry.size.height)
-                    })
-                    .onPreferenceChange(ContentHeightKey.self) { contentAreaHeight = $0 }
-                    .overlay(alignment: .top) {
-                        if let terminal = appState.currentConductorTerminal {
-                            ConductorOverlayView(
-                                terminal: terminal,
-                                tmuxServer: TBDConstants.conductorsTmuxServer,
-                                parentHeight: contentAreaHeight
-                            )
-                            .opacity(appState.showConductor ? 1 : 0)
-                            .allowsHitTesting(appState.showConductor)
+                        .background(GeometryReader { geometry in
+                            Color.clear.preference(key: ContentHeightKey.self, value: geometry.size.height)
+                        })
+                        .onPreferenceChange(ContentHeightKey.self) { contentAreaHeight = $0 }
+                        .overlay(alignment: .top) {
+                            if let terminal = appState.currentConductorTerminal {
+                                ConductorOverlayView(
+                                    terminal: terminal,
+                                    tmuxServer: TBDConstants.conductorsTmuxServer,
+                                    parentHeight: contentAreaHeight
+                                )
+                                .opacity(appState.showConductor ? 1 : 0)
+                                .allowsHitTesting(appState.showConductor)
+                            }
                         }
                     }
                 }
-            }
-            .navigationSplitViewStyle(.prominentDetail)
-            .toolbar(removing: .sidebarToggle)
+            )
             .toolbar {
                 ToolbarItemGroup(placement: .navigation) {
                     Button {

--- a/Sources/TBDApp/Sidebar/AppKitSplitView.swift
+++ b/Sources/TBDApp/Sidebar/AppKitSplitView.swift
@@ -30,6 +30,7 @@ struct AppKitSplitView<Sidebar: View, Detail: View>: NSViewControllerRepresentab
 
     func makeNSViewController(context: Context) -> NSSplitViewController {
         let splitVC = NSSplitViewController()
+        splitVC.splitView.autosaveName = "main.sidebar"
 
         let sidebarHost = NSHostingController(
             rootView: AnyView(sidebar().environmentObject(appState))

--- a/Sources/TBDApp/Sidebar/AppKitSplitView.swift
+++ b/Sources/TBDApp/Sidebar/AppKitSplitView.swift
@@ -11,30 +11,33 @@ import SwiftUI
 /// `canCollapse = false` on the sidebar item makes the layout deterministic.
 ///
 /// `AppState` is passed explicitly and re-injected as an environment object on every
-/// `NSHostingController` rootView (both at make and update time). `EnvironmentObject`
-/// does not auto-cross the SwiftUI -> AppKit -> SwiftUI boundary; skipping the
-/// re-injection would crash at runtime with "No ObservableObject of type AppState
-/// found" the first time the hosted SwiftUI views read state.
+/// `NSHostingController` rootView. `EnvironmentObject` does not auto-cross the
+/// SwiftUI -> AppKit -> SwiftUI boundary; skipping the re-injection would crash at
+/// runtime with "No ObservableObject of type AppState found".
 ///
-/// Generics note: we erase sidebar/detail to `AnyView` inside `updateNSViewController`
-/// when reassigning `rootView`. The alternative (preserving the concrete `Sidebar` /
-/// `Detail` generic types in the `NSHostingController<...>` cast) compiles, but the
-/// resulting `as? NSHostingController<ModifiedContent<Sidebar, ...>>` casts are very
-/// fragile to any future change to the `.environmentObject(...)` chain. AnyView
-/// erasure trades a negligible amount of view diffing efficiency for code that is
-/// readable and won't silently break when the wrapping modifiers change.
+/// Identity-preserving update path: rootView is reassigned with the same static type
+/// (`EnvironmentInjector<Sidebar>` / `EnvironmentInjector<Detail>`) on every update,
+/// so SwiftUI matches views by type identity and runs its normal structural reconcile.
+/// The earlier draft of this file used `AnyView` erasure inside `updateNSViewController`,
+/// which forced SwiftUI into a heuristic reconcile and surfaced as a "performed a
+/// reentrant operation in its NSTableView delegate" warning on the sidebar `List`.
 struct AppKitSplitView<Sidebar: View, Detail: View>: NSViewControllerRepresentable {
     let appState: AppState
     @ViewBuilder let sidebar: () -> Sidebar
     @ViewBuilder let detail: () -> Detail
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
 
     func makeNSViewController(context: Context) -> NSSplitViewController {
         let splitVC = NSSplitViewController()
         splitVC.splitView.autosaveName = "main.sidebar"
 
         let sidebarHost = NSHostingController(
-            rootView: AnyView(sidebar().environmentObject(appState))
+            rootView: EnvironmentInjector(appState: appState, content: sidebar())
         )
+        context.coordinator.sidebarHost = sidebarHost
         let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebarHost)
         sidebarItem.canCollapse = false
         sidebarItem.minimumThickness = 220
@@ -49,8 +52,9 @@ struct AppKitSplitView<Sidebar: View, Detail: View>: NSViewControllerRepresentab
         )
 
         let detailHost = NSHostingController(
-            rootView: AnyView(detail().environmentObject(appState))
+            rootView: EnvironmentInjector(appState: appState, content: detail())
         )
+        context.coordinator.detailHost = detailHost
         let detailItem = NSSplitViewItem(viewController: detailHost)
         detailItem.canCollapse = false
 
@@ -61,18 +65,29 @@ struct AppKitSplitView<Sidebar: View, Detail: View>: NSViewControllerRepresentab
     }
 
     func updateNSViewController(_ splitVC: NSSplitViewController, context: Context) {
-        // Re-render hosted SwiftUI views so that observable state changes
-        // (e.g. AppState mutations) propagate. We re-attach the environment
-        // object on every update because the AnyView wrapping would otherwise
-        // hide the previously-injected EnvironmentObject from the new rootView.
-        let items = splitVC.splitViewItems
-        guard items.count == 2 else { return }
+        // Reassign rootView with the same static wrapper type so SwiftUI can
+        // match the view tree by identity and run a normal structural reconcile.
+        // Required for state read by the closures (e.g. ContentView's @AppStorage
+        // showFilePanel / filePanelWidth) to propagate into the hosted tree.
+        context.coordinator.sidebarHost?.rootView =
+            EnvironmentInjector(appState: appState, content: sidebar())
+        context.coordinator.detailHost?.rootView =
+            EnvironmentInjector(appState: appState, content: detail())
+    }
 
-        if let sidebarHost = items[0].viewController as? NSHostingController<AnyView> {
-            sidebarHost.rootView = AnyView(sidebar().environmentObject(appState))
-        }
-        if let detailHost = items[1].viewController as? NSHostingController<AnyView> {
-            detailHost.rootView = AnyView(detail().environmentObject(appState))
-        }
+    final class Coordinator {
+        fileprivate var sidebarHost: NSHostingController<EnvironmentInjector<Sidebar>>?
+        fileprivate var detailHost: NSHostingController<EnvironmentInjector<Detail>>?
+    }
+}
+
+/// Spellable wrapper around `.environmentObject(...)` so the hosted rootView has
+/// a concrete, generic-friendly type that the Coordinator can hold without
+/// resorting to `AnyView` erasure.
+private struct EnvironmentInjector<Content: View>: View {
+    let appState: AppState
+    let content: Content
+    var body: some View {
+        content.environmentObject(appState)
     }
 }

--- a/Sources/TBDApp/Sidebar/AppKitSplitView.swift
+++ b/Sources/TBDApp/Sidebar/AppKitSplitView.swift
@@ -1,0 +1,77 @@
+import AppKit
+import SwiftUI
+
+/// AppKit-backed two-pane split view that replaces SwiftUI's `NavigationSplitView`.
+///
+/// Why this exists: SwiftUI's `NavigationSplitView` (with `.prominentDetail` style and
+/// `.toolbar(removing: .sidebarToggle)`) auto-collapses the sidebar when the window
+/// gets narrow and gives the user no way to bring it back. After wake-from-sleep,
+/// macOS reports a transient ~200x200 window size; SwiftUI reacts by auto-collapsing
+/// the sidebar and never restoring it. Wrapping `NSSplitViewController` directly with
+/// `canCollapse = false` on the sidebar item makes the layout deterministic.
+///
+/// `AppState` is passed explicitly and re-injected as an environment object on every
+/// `NSHostingController` rootView (both at make and update time). `EnvironmentObject`
+/// does not auto-cross the SwiftUI -> AppKit -> SwiftUI boundary; skipping the
+/// re-injection would crash at runtime with "No ObservableObject of type AppState
+/// found" the first time the hosted SwiftUI views read state.
+///
+/// Generics note: we erase sidebar/detail to `AnyView` inside `updateNSViewController`
+/// when reassigning `rootView`. The alternative (preserving the concrete `Sidebar` /
+/// `Detail` generic types in the `NSHostingController<...>` cast) compiles, but the
+/// resulting `as? NSHostingController<ModifiedContent<Sidebar, ...>>` casts are very
+/// fragile to any future change to the `.environmentObject(...)` chain. AnyView
+/// erasure trades a negligible amount of view diffing efficiency for code that is
+/// readable and won't silently break when the wrapping modifiers change.
+struct AppKitSplitView<Sidebar: View, Detail: View>: NSViewControllerRepresentable {
+    let appState: AppState
+    @ViewBuilder let sidebar: () -> Sidebar
+    @ViewBuilder let detail: () -> Detail
+
+    func makeNSViewController(context: Context) -> NSSplitViewController {
+        let splitVC = NSSplitViewController()
+
+        let sidebarHost = NSHostingController(
+            rootView: AnyView(sidebar().environmentObject(appState))
+        )
+        let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebarHost)
+        sidebarItem.canCollapse = false
+        sidebarItem.minimumThickness = 220
+        sidebarItem.maximumThickness = 400
+        // Holding priority above the default makes the sidebar resist resize
+        // pressure less than the detail pane — i.e. on window resize the
+        // detail keeps its width preference and the sidebar absorbs the delta
+        // (within its min/max). +1 over .defaultLow puts us just above the
+        // detail item's implicit holding priority.
+        sidebarItem.holdingPriority = NSLayoutConstraint.Priority(
+            rawValue: NSLayoutConstraint.Priority.defaultLow.rawValue + 1
+        )
+
+        let detailHost = NSHostingController(
+            rootView: AnyView(detail().environmentObject(appState))
+        )
+        let detailItem = NSSplitViewItem(viewController: detailHost)
+        detailItem.canCollapse = false
+
+        splitVC.addSplitViewItem(sidebarItem)
+        splitVC.addSplitViewItem(detailItem)
+
+        return splitVC
+    }
+
+    func updateNSViewController(_ splitVC: NSSplitViewController, context: Context) {
+        // Re-render hosted SwiftUI views so that observable state changes
+        // (e.g. AppState mutations) propagate. We re-attach the environment
+        // object on every update because the AnyView wrapping would otherwise
+        // hide the previously-injected EnvironmentObject from the new rootView.
+        let items = splitVC.splitViewItems
+        guard items.count == 2 else { return }
+
+        if let sidebarHost = items[0].viewController as? NSHostingController<AnyView> {
+            sidebarHost.rootView = AnyView(sidebar().environmentObject(appState))
+        }
+        if let detailHost = items[1].viewController as? NSHostingController<AnyView> {
+            detailHost.rootView = AnyView(detail().environmentObject(appState))
+        }
+    }
+}

--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -36,18 +36,6 @@ struct SidebarView: View {
             }
             .background(.bar)
         }
-        .toolbar {
-            ToolbarItem(placement: .automatic) {
-                Picker("Filter", selection: $appState.repoFilter) {
-                    Text("All Repos").tag(UUID?.none)
-                    Divider()
-                    ForEach(appState.repos) { repo in
-                        Text(repo.displayName).tag(UUID?.some(repo.id))
-                    }
-                }
-                .pickerStyle(.menu)
-            }
-        }
     }
 
     private func addRepo() {

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -327,6 +327,7 @@ struct TBDAppMain: App {
                 }
         }
         .defaultSize(width: 1200, height: 800)
+        .windowResizability(.contentMinSize)
         .commands {
             TBDCommands(appState: appState)
             ModelProfileMenu(appState: appState)


### PR DESCRIPTION
## Summary

The worktree-list sidebar would randomly hide itself, especially after the Mac woke from sleep, with no UI to bring it back. Root cause: SwiftUI's `NavigationSplitView` (with `.prominentDetail` style and `.toolbar(removing: .sidebarToggle)`) auto-collapses the sidebar at narrow widths. On wake, macOS reports a transient ~200×200 window size; SwiftUI eagerly collapses, then never restores when the window grows back. Auto-collapse is sticky.

This PR is staged in two commits so each is independently revertable:

- **Stage 1** (`6a550c7`): Hard minimum window size — `.windowResizability(.contentMinSize)` on the scene + `.frame(minWidth: 800, minHeight: 500)` on the root content. The bogus tiny size now can't land in the first place. Defensive fix that may by itself eliminate the wake symptom; worth keeping regardless.
- **Stage 2** (`09d32fe`): Replace `NavigationSplitView` with an `NSViewControllerRepresentable` wrapping `NSSplitViewController`. The sidebar split item gets `canCollapse = false`, `minimumThickness = 220`, `maximumThickness = 400`. Layout is now deterministic — SwiftUI cannot auto-collapse what AppKit refuses to collapse. Also removes a redundant `.toolbar { Picker }` from `SidebarView` that was already declared in `ContentView` and would have stopped propagating from inside an `NSHostingController` anyway.

A parallel sister-session investigation (worktree `20260509-friendly-chicken`) independently landed on the same diagnosis and AppKit answer — this PR consolidates both threads.

**Deferred follow-up (not this PR):** Replacing the SwiftUI `List(.sidebar)` inside `SidebarView` with a raw `NSOutlineView` to reach Tower-grade row density. PR #117 already shipped the chevron / "+" / font-size wins on the SwiftUI side; the row-height ceiling needs AppKit. The `NSSplitViewController` wrap from this PR is the natural foundation. Estimated 4–8h when there's appetite.

## Test plan

After pulling, run `scripts/restart.sh` from the worktree, then verify:

- [ ] Sidebar is visible on launch.
- [ ] Drag the window narrow — it stops at 800×500, sidebar stays put.
- [ ] Sleep / wake the Mac — sidebar is still visible.
- [ ] Worktree selection works: single-click, Cmd-click multi-select.
- [ ] Drag-to-reorder worktrees within a repo (`.onMove` in `RepoSectionView`).
- [ ] Hover-revealed chevron on the repo header (PR #117 work).
- [ ] Hover-revealed "+" on the main worktree row (PR #117 work).
- [ ] Inline rename via double-click and the context menu.
- [ ] "Add Repository" button in the bottom safe-area inset still triggers the open panel.
- [ ] Repo-filter Picker in the window toolbar still filters the sidebar.
- [ ] Toolbar items unchanged: back/forward, auto-suspend, conductor, filter, PR button (when applicable), file-panel toggle (⌘⇧E).
- [ ] Terminal panes resize correctly when the window is resized (PTY reflow).
- [ ] Sidebar source-list vibrancy still applies.

## Notes for reviewers

- `EnvironmentObject` does not auto-cross the SwiftUI → AppKit → SwiftUI boundary. `AppKitSplitView` re-injects `appState` as an environment object on every `NSHostingController` rootView, in both `makeNSViewController` and `updateNSViewController`. Skipping either would crash at runtime.
- `updateNSViewController` reassigns `rootView` via `AnyView` erasure. The concrete-generic alternative compiles but produces casts that silently break if the wrapping `.environmentObject(...)` modifier chain ever changes. Negligible diffing cost; large readability win.
- Did not override `splitView.dividerStyle` — `NSSplitViewItem(sidebarWithViewController:)` configures source-list-appropriate defaults.

open in TBD: \`tbd://open?worktree=CDB7B3FA-55F9-4E46-A65E-CE435AB168F5\`