### PR TITLE
Feat: Right-click transcript pane header to copy conversation path

### DIFF
--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -87,6 +87,16 @@ struct PanePlaceholder: View {
         .onHover { hovering in
             isHeaderHovering = hovering
         }
+        .applyTranscriptCopyPathContextMenu(path: transcriptPath)
+    }
+
+    /// Resolved Claude session JSONL path for liveTranscript panes; nil otherwise.
+    private var transcriptPath: String? {
+        if case .liveTranscript(_, let terminalID) = content {
+            let path = terminal(for: terminalID)?.transcriptPath
+            return (path?.isEmpty ?? true) ? nil : path
+        }
+        return nil
     }
 
     @ViewBuilder
@@ -372,6 +382,27 @@ struct PanePlaceholder: View {
             direction: direction,
             newContent: .terminal(terminalID: newTerminal.id)
         )
+    }
+}
+
+// MARK: - Transcript Copy Path Context Menu
+
+private extension View {
+    /// Attach the "Copy Conversation Path" context menu only when a transcript
+    /// path is available — non-transcript panes get no contextMenu at all so
+    /// right-click is a true no-op rather than showing an empty menu.
+    @ViewBuilder
+    func applyTranscriptCopyPathContextMenu(path: String?) -> some View {
+        if let path {
+            self.contextMenu {
+                Button("Copy Conversation Path") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(path, forType: .string)
+                }
+            }
+        } else {
+            self
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Right-click a live transcript pane's toolbar to copy the underlying Claude session JSONL path, mirroring the existing tab-level menu so the path is reachable without first hunting for the matching tab.
- Non-transcript panes get no contextMenu modifier at all (true no-op rather than an empty popover).

## Test plan
- [ ] Open a worktree with a Claude terminal that has an active session.
- [ ] Open a live transcript pane on that terminal.
- [ ] Right-click anywhere on the transcript pane's toolbar (the strip with the bubble icon and label) and pick "Copy Conversation Path".
- [ ] Paste — the path should be the absolute `.jsonl` for that session.
- [ ] Right-click on a terminal/code-viewer/note pane toolbar — no menu should appear.

open in TBD: `tbd://open?worktree=BA7F0048-35F9-403C-8D89-83E92F1003FD`