### PR TITLE
Fix: Stop NSHostingController from collapsing the AppKit sidebar split to a 46pt sliver

### DIFF
--- a/Sources/TBDApp/Sidebar/AppKitSplitView.swift
+++ b/Sources/TBDApp/Sidebar/AppKitSplitView.swift
@@ -10,6 +10,16 @@ import SwiftUI
 /// the sidebar and never restoring it. Wrapping `NSSplitViewController` directly with
 /// `canCollapse = false` on the sidebar item makes the layout deterministic.
 ///
+/// Why each `NSHostingController` gets `sizingOptions = []`: by default an
+/// `NSHostingController` installs `.minSize`, `.intrinsicContentSize`, and `.maxSize`
+/// constraints sourced from the SwiftUI content. The intrinsic-size constraint
+/// leaks back up through the split view controller's view and into the
+/// `NSViewControllerRepresentable`'s SwiftUI host, which then sizes the entire
+/// split to that small value (~46 pt) and centers it vertically with empty space
+/// above and below. Clearing `sizingOptions` suppresses those constraints so the
+/// split fills whatever frame SwiftUI hands the representable. Background:
+/// https://mjtsai.com/blog/2023/08/03/how-nshostingview-determines-its-sizing/
+///
 /// `AppState` is passed explicitly and re-injected as an environment object on every
 /// `NSHostingController` rootView. `EnvironmentObject` does not auto-cross the
 /// SwiftUI -> AppKit -> SwiftUI boundary; skipping the re-injection would crash at
@@ -37,6 +47,7 @@ struct AppKitSplitView<Sidebar: View, Detail: View>: NSViewControllerRepresentab
         let sidebarHost = NSHostingController(
             rootView: EnvironmentInjector(appState: appState, content: sidebar())
         )
+        sidebarHost.sizingOptions = []
         context.coordinator.sidebarHost = sidebarHost
         let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebarHost)
         sidebarItem.canCollapse = false
@@ -54,6 +65,7 @@ struct AppKitSplitView<Sidebar: View, Detail: View>: NSViewControllerRepresentab
         let detailHost = NSHostingController(
             rootView: EnvironmentInjector(appState: appState, content: detail())
         )
+        detailHost.sizingOptions = []
         context.coordinator.detailHost = detailHost
         let detailItem = NSSplitViewItem(viewController: detailHost)
         detailItem.canCollapse = false


### PR DESCRIPTION
## Summary
After replacing `NavigationSplitView` with an `NSSplitViewController` wrapped in `NSViewControllerRepresentable` in #119, every fresh launch rendered the sidebar + detail squeezed into a thin band (~46 pt tall) floating at the vertical center of the window, with massive empty space above and below.

Root cause: `NSHostingController` ships with `sizingOptions = [.minSize, .intrinsicContentSize, .maxSize]` by default. The intrinsic-size constraint propagates up through the split-view controller's view into the SwiftUI representable's host, which obediently sizes the entire split to the small intrinsic value and centers the rest. Setting `sizingOptions = []` on each pane's hosting controller suppresses those constraints, so the split fills whatever frame SwiftUI hands the representable.

## Test plan
- [ ] Quit any running TBDApp, `defaults delete TBDApp` to ensure no persisted state masks anything, relaunch.
- [ ] Sidebar fills the full window height with worktrees rendered top-to-bottom.
- [ ] Detail pane fills the full window height with the empty-state prompt centered.
- [ ] Wake-from-sleep behavior from #119 still holds — sidebar doesn't auto-collapse.
- [ ] Resize the window narrow then wide; sidebar respects `minimumThickness=220` / `maximumThickness=400`.

Background: https://mjtsai.com/blog/2023/08/03/how-nshostingview-determines-its-sizing/

open in TBD: \`tbd://open?worktree=AC023F83-737F-4A55-9A07-78F7646E2645\`