### PR TITLE
Feat: Surface +new-worktree in the sidebar repo header

### DIFF
--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -126,6 +126,7 @@ struct RepoSectionView: View {
             .frame(width: 20, height: 20)
         }
         .frame(height: 22, alignment: .bottom)
+        .background(Color.white.opacity(0.0001))
         .contentShape(Rectangle())
         .onTapGesture {
             appState.selectRepo(id: repo.id)
@@ -146,6 +147,7 @@ struct RepoSectionView: View {
         if let main = mainWorktree {
             WorktreeRowView(worktree: main, isMain: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.white.opacity(0.0001))
                 .onHover { onSectionHoverChange($0) }
                 .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
                 .listRowSeparator(.hidden)
@@ -154,6 +156,8 @@ struct RepoSectionView: View {
         }
         ForEach(worktrees) { worktree in
             WorktreeRowView(worktree: worktree)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.white.opacity(0.0001))
                 .onHover { onSectionHoverChange($0) }
                 .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
                 .listRowSeparator(.hidden)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -28,9 +28,7 @@ struct RepoSectionView: View {
     let repo: Repo
     @EnvironmentObject var appState: AppState
 
-    @State private var isExpanded = true
     @State private var isEditing = false
-    @State private var isHeaderHovered = false
     @State private var isSectionHovered = false
     @State private var hoverDebounceTask: Task<Void, Error>?
 
@@ -112,14 +110,15 @@ struct RepoSectionView: View {
             Spacer()
 
             Group {
-                if isHeaderHovered {
-                    Button(action: { isExpanded.toggle() }) {
-                        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                if isSectionHovered {
+                    Button(action: createWorktree) {
+                        Image(systemName: "plus")
                             .font(.caption)
                             .frame(width: 20, height: 20)
                     }
                     .buttonStyle(HoverPressButtonStyle())
-                    .help(isExpanded ? "Collapse" : "Expand")
+                    .help("New worktree")
+                    .disabled(repo.status == .missing)
                 } else {
                     Color.clear
                 }
@@ -132,7 +131,6 @@ struct RepoSectionView: View {
             appState.selectRepo(id: repo.id)
         }
         .onHover { hovering in
-            isHeaderHovered = hovering
             onSectionHoverChange(hovering)
         }
         .contextMenu {
@@ -145,44 +143,25 @@ struct RepoSectionView: View {
         .listRowBackground(Color.clear)
         .tag(repo.id)
 
-        if isExpanded {
-            if let main = mainWorktree {
-                HStack(spacing: 0) {
-                    WorktreeRowView(worktree: main, isMain: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Group {
-                        if isSectionHovered {
-                            Button(action: createWorktree) {
-                                Image(systemName: "plus")
-                                    .font(.caption)
-                                    .frame(width: 20, height: 20)
-                            }
-                            .buttonStyle(HoverPressButtonStyle())
-                            .help("New worktree")
-                            .disabled(repo.status == .missing)
-                        } else {
-                            Color.clear
-                        }
-                    }
-                    .frame(width: 20, height: 20)
-                }
+        if let main = mainWorktree {
+            WorktreeRowView(worktree: main, isMain: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .onHover { onSectionHoverChange($0) }
                 .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
                 .tag(main.id)
-            }
-            ForEach(worktrees) { worktree in
-                WorktreeRowView(worktree: worktree)
-                    .onHover { onSectionHoverChange($0) }
-                    .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
-                    .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
-                    .tag(worktree.id)
-            }
-            .onMove { source, destination in
-                appState.reorderWorktrees(repoID: repo.id, fromOffsets: source, toOffset: destination)
-            }
+        }
+        ForEach(worktrees) { worktree in
+            WorktreeRowView(worktree: worktree)
+                .onHover { onSectionHoverChange($0) }
+                .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+                .listRowSeparator(.hidden)
+            .listRowBackground(Color.clear)
+                .tag(worktree.id)
+        }
+        .onMove { source, destination in
+            appState.reorderWorktrees(repoID: repo.id, fromOffsets: source, toOffset: destination)
         }
     }
 


### PR DESCRIPTION
## Summary
- Removes the expand/collapse chevron from each repo header row in the sidebar — it was the only toggle for `isExpanded`, so removing it means repos are simply always expanded.
- Moves the + (new worktree) button from the main worktree row into the slot the chevron used to occupy, so the header's hover affordance now does the action people actually use.
- Fixes a SwiftUI hover-detection gap: `onHover` only fires on rendered surfaces, so blank space in rows wasn't triggering the reveal. A near-transparent background + `frame(maxWidth: .infinity)` gives every row a continuous hit surface across its full width.

## Test plan
- [ ] Hover anywhere on a repo header row (over text or blank space) → `+` reveals; click adds a new worktree.
- [ ] Hover anywhere on the main worktree row or any other worktree row → still reveals the `+` in the header above (section-hover propagation).
- [ ] Repo with `status == .missing`: `+` is visible but disabled.
- [ ] No chevron is visible anywhere in the sidebar.

open in TBD: \`tbd://open?worktree=604048C7-2DF3-48AA-AB66-CDCA69995E0F\`