### PR TITLE
Feat: Hide and remove repos from the sidebar

### DIFF
--- a/Sources/TBDApp/AppState+Repos.swift
+++ b/Sources/TBDApp/AppState+Repos.swift
@@ -51,6 +51,22 @@ extension AppState {
         }
     }
 
+    /// Toggle whether a repo is hidden from the default sidebar view.
+    /// Updates local state optimistically before issuing the RPC.
+    func setRepoHidden(id: UUID, hidden: Bool) async {
+        if let idx = repos.firstIndex(where: { $0.id == id }) {
+            var repo = repos[idx]
+            repo.hidden = hidden
+            repos[idx] = repo
+        }
+        do {
+            try await daemonClient.setRepoHidden(id: id, hidden: hidden)
+        } catch {
+            logger.error("Failed to set repo hidden: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
     /// Rename a repo's display name. Updates local state optimistically before issuing the RPC.
     func renameRepo(id: UUID, displayName: String) async {
         if let idx = repos.firstIndex(where: { $0.id == id }) {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -371,6 +371,14 @@ actor DaemonClient {
         )
     }
 
+    /// Toggle whether a repo is hidden from the sidebar by default.
+    func setRepoHidden(id: UUID, hidden: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.repoSetHidden,
+            params: RepoSetHiddenParams(repoID: id, hidden: hidden)
+        )
+    }
+
     /// Update per-repo instruction fields.
     func repoUpdateInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async throws -> Repo {
         return try await callAsync(

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -33,6 +33,7 @@ struct RepoSectionView: View {
     @State private var isHeaderHovered = false
     @State private var isSectionHovered = false
     @State private var hoverDebounceTask: Task<Void, Error>?
+    @State private var showRemoveConfirm = false
 
     private static func startsWithEmoji(_ name: String) -> Bool {
         guard let first = name.first else { return false }
@@ -64,6 +65,25 @@ struct RepoSectionView: View {
         (appState.worktrees[repo.id] ?? [])
             .filter { $0.status == .active || $0.status == .creating }
             .sorted { $0.sortOrder < $1.sortOrder }
+    }
+
+    private var activeWorktreeCount: Int {
+        (appState.worktrees[repo.id] ?? [])
+            .filter { $0.status == .active || $0.status == .creating }
+            .count
+    }
+
+    private var removeButtonLabel: String {
+        activeWorktreeCount > 0 ? "Archive Worktrees & Remove" : "Remove"
+    }
+
+    private var removeConfirmMessage: String {
+        let base = "This unregisters the repo from TBD. Your git repository and files on disk are not touched."
+        if activeWorktreeCount > 0 {
+            let plural = activeWorktreeCount == 1 ? "worktree" : "worktrees"
+            return "\(activeWorktreeCount) active \(plural) will be archived first.\n\n\(base)"
+        }
+        return base
     }
 
     var body: some View {
@@ -139,6 +159,22 @@ struct RepoSectionView: View {
             Button("Rename...") {
                 isEditing = true
             }
+            Divider()
+            Button("Remove from List...", role: .destructive) {
+                showRemoveConfirm = true
+            }
+        }
+        .confirmationDialog(
+            "Remove \(repo.displayName) from list?",
+            isPresented: $showRemoveConfirm,
+            titleVisibility: .visible
+        ) {
+            Button(removeButtonLabel, role: .destructive) {
+                Task { await appState.removeRepo(repoID: repo.id, force: activeWorktreeCount > 0) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(removeConfirmMessage)
         }
         .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
         .listRowSeparator(.hidden)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -159,6 +159,9 @@ struct RepoSectionView: View {
             Button("Rename...") {
                 isEditing = true
             }
+            Button(repo.hidden ? "Unhide" : "Hide") {
+                Task { await appState.setRepoHidden(id: repo.id, hidden: !repo.hidden) }
+            }
             Divider()
             Button("Remove from List...", role: .destructive) {
                 showRemoveConfirm = true

--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -4,18 +4,23 @@ import TBDShared
 
 struct SidebarView: View {
     @EnvironmentObject var appState: AppState
+    @AppStorage("sidebar.showHiddenRepos") private var showHiddenRepos: Bool = false
 
     var filteredRepos: [Repo] {
+        let base: [Repo]
         if let filterID = appState.repoFilter {
-            return appState.repos.filter { $0.id == filterID }
+            base = appState.repos.filter { $0.id == filterID }
+        } else {
+            base = appState.repos
         }
-        return appState.repos
+        return showHiddenRepos ? base : base.filter { !$0.hidden }
     }
 
     var body: some View {
         List(selection: $appState.selectedWorktreeIDs) {
             ForEach(filteredRepos) { repo in
                 RepoSectionView(repo: repo)
+                    .opacity(repo.hidden ? 0.55 : 1.0)
             }
         }
         .listStyle(.plain)
@@ -24,7 +29,7 @@ struct SidebarView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
                 Divider()
-                HStack {
+                HStack(spacing: 4) {
                     Button(action: addRepo) {
                         Label("Add Repository", systemImage: "plus.rectangle")
                             .font(.subheadline)
@@ -32,12 +37,41 @@ struct SidebarView: View {
                     .buttonStyle(.plain)
                     .foregroundStyle(.secondary)
                     Spacer()
+                    filterMenu
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
             }
             .background(.bar)
         }
+    }
+
+    private var hiddenCount: Int {
+        appState.repos.filter { $0.hidden }.count
+    }
+
+    private var filterMenu: some View {
+        Menu {
+            Toggle(isOn: $showHiddenRepos) {
+                if hiddenCount > 0 {
+                    Text("Show hidden repos (\(hiddenCount))")
+                } else {
+                    Text("Show hidden repos")
+                }
+            }
+        } label: {
+            Image(systemName: showHiddenRepos
+                  ? "line.3.horizontal.decrease.circle.fill"
+                  : "line.3.horizontal.decrease.circle")
+                .font(.system(size: 14))
+                .foregroundStyle(.secondary)
+                .frame(width: 20, height: 20)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Filter")
     }
 
     private func addRepo() {

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -348,6 +348,12 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v18_repo_hidden") { db in
+            try db.alter(table: "repo") { t in
+                t.add(column: "hidden", .boolean).notNull().defaults(to: false)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -18,6 +18,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var worktree_slot: String?
     var worktree_root: String?
     var status: String
+    var hidden: Bool
 
     init(from repo: Repo) {
         self.id = repo.id.uuidString
@@ -32,6 +33,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.worktree_slot = repo.worktreeSlot
         self.worktree_root = repo.worktreeRoot
         self.status = repo.status.rawValue
+        self.hidden = repo.hidden
     }
 
     func toModel() -> Repo {
@@ -47,7 +49,8 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             profileOverrideID: profile_override_id.flatMap(UUID.init(uuidString:)),
             worktreeSlot: worktree_slot,
             worktreeRoot: worktree_root,
-            status: RepoStatus(rawValue: status) ?? .ok
+            status: RepoStatus(rawValue: status) ?? .ok,
+            hidden: hidden
         )
     }
 }
@@ -163,6 +166,16 @@ public struct RepoStore: Sendable {
             try db.execute(
                 sql: "UPDATE repo SET profile_override_id = NULL WHERE profile_override_id = ?",
                 arguments: [profileID.uuidString]
+            )
+        }
+    }
+
+    /// Set whether a repo is hidden from the sidebar by default.
+    public func setHidden(id: UUID, hidden: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET hidden = ? WHERE id = ?",
+                arguments: [hidden, id.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -139,6 +139,11 @@ extension RPCRouter {
         }
 
         try await db.repos.setHidden(id: params.repoID, hidden: params.hidden)
+
+        subscriptions.broadcast(delta: .repoHiddenChanged(RepoHiddenDelta(
+            repoID: params.repoID, hidden: params.hidden
+        )))
+
         return .ok()
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -131,6 +131,17 @@ extension RPCRouter {
         return try RPCResponse(result: updated)
     }
 
+    func handleRepoSetHidden(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(RepoSetHiddenParams.self, from: paramsData)
+
+        guard try await db.repos.get(id: params.repoID) != nil else {
+            return RPCResponse(error: "Repository not found: \(params.repoID)")
+        }
+
+        try await db.repos.setHidden(id: params.repoID, hidden: params.hidden)
+        return .ok()
+    }
+
     func handleRepoRename(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(RepoRenameParams.self, from: paramsData)
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -82,6 +82,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRepoRelocate(request.paramsData)
             case RPCMethod.repoRename:
                 return try await handleRepoRename(request.paramsData)
+            case RPCMethod.repoSetHidden:
+                return try await handleRepoSetHidden(request.paramsData)
             case RPCMethod.worktreeCreate:
                 return try await handleWorktreeCreate(request.paramsData)
             case RPCMethod.worktreeList:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -18,13 +18,14 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
     public var worktreeSlot: String?
     public var worktreeRoot: String?
     public var status: RepoStatus
+    public var hidden: Bool
 
     public init(id: UUID = UUID(), path: String, remoteURL: String? = nil,
                 displayName: String, defaultBranch: String = "main", createdAt: Date = Date(),
                 renamePrompt: String? = nil, customInstructions: String? = nil,
                 profileOverrideID: UUID? = nil,
                 worktreeSlot: String? = nil, worktreeRoot: String? = nil,
-                status: RepoStatus = .ok) {
+                status: RepoStatus = .ok, hidden: Bool = false) {
         self.id = id
         self.path = path
         self.remoteURL = remoteURL
@@ -37,12 +38,13 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         self.worktreeSlot = worktreeSlot
         self.worktreeRoot = worktreeRoot
         self.status = status
+        self.hidden = hidden
     }
 
     enum CodingKeys: String, CodingKey {
         case id, path, remoteURL, displayName, defaultBranch, createdAt
         case renamePrompt, customInstructions, profileOverrideID
-        case worktreeSlot, worktreeRoot, status
+        case worktreeSlot, worktreeRoot, status, hidden
     }
 
     public init(from decoder: Decoder) throws {
@@ -59,6 +61,7 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         worktreeSlot = try c.decodeIfPresent(String.self, forKey: .worktreeSlot)
         worktreeRoot = try c.decodeIfPresent(String.self, forKey: .worktreeRoot)
         status = try c.decodeIfPresent(RepoStatus.self, forKey: .status) ?? .ok
+        hidden = try c.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -137,6 +137,7 @@ public enum RPCMethod {
     public static let appSetForegroundState = "app.setForegroundState"
     public static let repoRelocate = "repo.relocate"
     public static let repoRename = "repo.rename"
+    public static let repoSetHidden = "repo.setHidden"
     public static let sessionList = "session.list"
     public static let sessionMessages = "session.messages"
     public static let setMainAreaSize = "app.setMainAreaSize"
@@ -387,6 +388,14 @@ public struct RepoRenameParams: Codable, Sendable {
     public let displayName: String
     public init(repoID: UUID, displayName: String) {
         self.repoID = repoID; self.displayName = displayName
+    }
+}
+
+public struct RepoSetHiddenParams: Codable, Sendable {
+    public let repoID: UUID
+    public let hidden: Bool
+    public init(repoID: UUID, hidden: Bool) {
+        self.repoID = repoID; self.hidden = hidden
     }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -12,6 +12,7 @@ public enum StateDelta: Codable, Sendable {
     case repoAdded(RepoDelta)
     case repoRemoved(RepoIDDelta)
     case repoRenamed(RepoRenameDelta)
+    case repoHiddenChanged(RepoHiddenDelta)
     case terminalCreated(TerminalDelta)
     case terminalRemoved(TerminalIDDelta)
     case worktreeConflictsChanged(WorktreeConflictDelta)
@@ -100,6 +101,15 @@ public struct RepoRenameDelta: Codable, Sendable {
     public let displayName: String
     public init(repoID: UUID, displayName: String) {
         self.repoID = repoID; self.displayName = displayName
+    }
+}
+
+/// Delta payload for repo hidden-flag change.
+public struct RepoHiddenDelta: Codable, Sendable {
+    public let repoID: UUID
+    public let hidden: Bool
+    public init(repoID: UUID, hidden: Bool) {
+        self.repoID = repoID; self.hidden = hidden
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds a destructive "Remove from List..." entry to the repo right-click menu, with a confirmation dialog that clarifies the on-disk repo isn't touched and warns when active worktrees will be cascade-archived first.
- Adds a "Hide / Unhide" toggle to the same menu, persisted via a new `hidden` column on the `repo` table (migration `v18_repo_hidden`) and a new `repo.setHidden` RPC.
- Adds an icon-only filter menu next to *Add Repository* in the sidebar bottom bar. Single entry "Show hidden repos" is off by default (persisted via `@AppStorage`); when on, hidden repos appear at 55% opacity.

## Test plan
- [ ] Right-click a repo → **Hide**. Repo disappears from the sidebar. Open the new filter menu → toggle "Show hidden repos" — repo reappears dimmed.
- [ ] With it shown dimmed, right-click → **Unhide**. Repo returns to normal opacity. Toggle filter off, repo still visible (no longer hidden).
- [ ] Right-click a repo with no active worktrees → **Remove from List...** → confirm. Repo disappears from sidebar; the on-disk git repo is untouched.
- [ ] Right-click a repo with 1+ active worktrees → **Remove from List...** Dialog says "N active worktree(s) will be archived first" and the destructive button reads "Archive Worktrees & Remove". Confirm and verify worktrees end up archived and the repo is gone.
- [ ] Quit and relaunch the app: hidden flag and "Show hidden repos" toggle both persist.

open in TBD: \`tbd://open?worktree=64BC6FE7-9BC7-43C1-B9D2-0009A79D5D7F\`