### PR TITLE
Fix: Stop transcript pane from blanking after new messages

### DIFF
--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -288,10 +288,6 @@ struct SessionTranscriptView: View {
     /// shown only when the user has consciously scrolled up.
     @State private var atBottom: Bool = true
 
-    /// Tracks the row at the bottom edge of the viewport. Drives re-entry
-    /// restoration via `.scrollPosition(id:)`.
-    @State private var visibleID: String?
-
     private var messages: [TranscriptItem] {
         appState.sessionTranscripts[sessionId] ?? []
     }
@@ -365,7 +361,6 @@ struct SessionTranscriptView: View {
                         TranscriptItemsView(items: messages, terminalID: nil)
                     }
                     .defaultScrollAnchor(.bottom)
-                    .scrollPosition(id: $visibleID, anchor: .bottom)
                     .onScrollGeometryChange(for: Bool.self) { geometry in
                         let viewportBottom = geometry.contentOffset.y + geometry.containerSize.height
                         let contentBottom = geometry.contentSize.height
@@ -395,11 +390,6 @@ struct SessionTranscriptView: View {
                         }
                     }
                     .animation(.easeInOut(duration: 0.2), value: atBottom)
-                    .onAppear {
-                        if let id = visibleID {
-                            proxy.scrollTo(id, anchor: .bottom)
-                        }
-                    }
                 }
             }
         }

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -288,6 +288,10 @@ struct SessionTranscriptView: View {
     /// shown only when the user has consciously scrolled up.
     @State private var atBottom: Bool = true
 
+    /// Tracks the row at the bottom edge of the viewport. Drives re-entry
+    /// restoration via `.scrollPosition(id:)`.
+    @State private var visibleID: String?
+
     private var messages: [TranscriptItem] {
         appState.sessionTranscripts[sessionId] ?? []
     }
@@ -361,6 +365,7 @@ struct SessionTranscriptView: View {
                         TranscriptItemsView(items: messages, terminalID: nil)
                     }
                     .defaultScrollAnchor(.bottom)
+                    .scrollPosition(id: $visibleID, anchor: .bottom)
                     .onScrollGeometryChange(for: Bool.self) { geometry in
                         let viewportBottom = geometry.contentOffset.y + geometry.containerSize.height
                         let contentBottom = geometry.contentSize.height
@@ -390,6 +395,11 @@ struct SessionTranscriptView: View {
                         }
                     }
                     .animation(.easeInOut(duration: 0.2), value: atBottom)
+                    .onAppear {
+                        if let id = visibleID {
+                            proxy.scrollTo(id, anchor: .bottom)
+                        }
+                    }
                 }
             }
         }

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -27,6 +27,10 @@ struct LiveTranscriptPaneView: View {
     /// shown only when the user has consciously scrolled up.
     @State private var atBottom: Bool = true
 
+    /// Tracks the row at the bottom edge of the viewport. Drives re-entry
+    /// restoration via `.scrollPosition(id:)` and autoscroll on new messages.
+    @State private var visibleID: String?
+
     private static let log = Logger(subsystem: "com.tbd.app", category: "live-transcript")
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
@@ -126,6 +130,7 @@ struct LiveTranscriptPaneView: View {
                 TranscriptItemsView(items: messages, terminalID: terminalID)
             }
             .defaultScrollAnchor(.bottom)
+            .scrollPosition(id: $visibleID, anchor: .bottom)
             .onScrollGeometryChange(for: AtBottomGeometry.self) { geometry in
                 AtBottomGeometry(
                     contentHeight: geometry.contentSize.height,
@@ -149,6 +154,15 @@ struct LiveTranscriptPaneView: View {
                     snap.focusedTerminalIDShort = tidShort
                     snap.transcriptItemCount = count
                     snap.paneLabel = "liveTranscript"
+                }
+                if let id = visibleID {
+                    proxy.scrollTo(id, anchor: .bottom)
+                }
+            }
+            .onChange(of: messages.last?.id) { oldID, newID in
+                guard let _ = oldID, let id = newID else { return }
+                withAnimation(.easeOut(duration: 0.15)) {
+                    visibleID = id
                 }
             }
             .onChange(of: messages.count) { _, newCount in

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -160,7 +160,7 @@ struct LiveTranscriptPaneView: View {
                 }
             }
             .onChange(of: messages.last?.id) { oldID, newID in
-                guard let _ = oldID, let id = newID else { return }
+                guard let _ = oldID, let id = newID, atBottom else { return }
                 withAnimation(.easeOut(duration: 0.15)) {
                     visibleID = id
                 }


### PR DESCRIPTION
## Summary

- After a new message arrived in the live transcript pane (often right after the user submitted a prompt in the terminal), the pane intermittently went blank — scrolling up a short distance brought content back.
- Root cause: the `ScrollView` relied solely on `.defaultScrollAnchor(.bottom)` paired with a `LazyVStack`. There was no `.scrollPosition(id:)` binding and no explicit autoscroll on append, so on content growth the lazy stack's row realization fell out of sync with the scroll offset. The viewport landed past the realized rows; manual scroll forced re-realization.
- Fix follows two existing specs that were never landed (`docs/superpowers/specs/2026-05-06-transcript-scroll-position-design.md` and `2026-05-06-transcript-reentry-fix-design.md`): a `@State visibleID` + `.scrollPosition(id: $visibleID, anchor: .bottom)` on `LiveTranscriptPaneView` and `HistoryPaneView`'s `SessionTranscriptView`. New messages drive autoscroll via `.onChange(of: messages.last?.id)` with a `guard let _ = oldID` nil→value guard (avoids a spurious snap when `messages` transiently empties during nav churn). An `.onAppear` `proxy.scrollTo(visibleID, anchor: .bottom)` acts as a position-no-op realize-poke so the lazy stack realizes rows around the bound id on re-entry.

## Test plan

- [ ] `scripts/restart.sh`, open a Claude terminal, switch to the live transcript pane.
- [ ] Submit a new message in the terminal; transcript should keep showing content (no blank flash) and follow to the new last row.
- [ ] Scroll up to older messages, switch to another tab, switch back — scroll position is preserved, no blank panel.
- [ ] Open the History pane on a worktree with prior sessions, scroll a session up, switch sessions and back — position preserved.

open in TBD: \`tbd://open?worktree=70B550D1-79E7-4489-BB01-D1522F645A5F\`