### PR TITLE
Refactor: Drop colored band dot next to transcript token count

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
+++ b/Sources/TBDApp/Panes/Transcript/ContextUsageBadge.swift
@@ -3,62 +3,40 @@ import SwiftUI
 /// Diminutive subscript line shown beneath the latest top-level assistant
 /// item in the transcript viewer. Displays the total prompt size
 /// (input + cache_creation + cache_read tokens) of that turn's API call
-/// as `Nk tokens` in muted gray, prefixed by a small colored dot whose
-/// color signals the band:
-///
-/// - `<190k`  → `.secondary`
-/// - `>=190k` → yellow
-/// - `>=260k` → orange
-/// - `>=300k` → red
+/// as `Nk tokens` in muted gray.
 ///
 /// See `docs/transcript-context-usage.md` for the underlying mechanism.
 struct ContextUsageBadge: View {
     let total: Int
 
     var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "circle.fill")
-                .imageScale(.small)
-                .frame(width: 14)
-                .foregroundStyle(Self.color(for: total))
-            Text(Self.formatted(total))
-                .foregroundStyle(.secondary)
-        }
-        .font(.system(size: 9))
-        .fontWeight(.regular)
-        .opacity(0.7)
+        Text(Self.formatted(total))
+            .foregroundStyle(.secondary)
+            .font(.system(size: 9))
+            .fontWeight(.regular)
+            .opacity(0.7)
     }
 
     /// Whole-thousands abbreviation, e.g. 124_300 -> "124k tokens".
     nonisolated static func formatted(_ total: Int) -> String {
         "\(total / 1000)k tokens"
     }
-
-    nonisolated static func color(for total: Int) -> Color {
-        switch total {
-        case ..<190_000:  return .secondary
-        case ..<260_000:  return .yellow
-        case ..<300_000:  return .orange
-        default:          return .red
-        }
-    }
 }
 
 // MARK: - Preview
 
-/// Exercises the four threshold bands. Uses `PreviewProvider` (not the
-/// `#Preview` macro) so the file still compiles under bare `swift build`
-/// — the SPM toolchain doesn't ship the `PreviewsMacros` plugin that
-/// Xcode injects.
+/// Uses `PreviewProvider` (not the `#Preview` macro) so the file still
+/// compiles under bare `swift build` — the SPM toolchain doesn't ship the
+/// `PreviewsMacros` plugin that Xcode injects.
 struct ContextUsageBadge_Previews: PreviewProvider {
     static var previews: some View {
         VStack(alignment: .leading, spacing: 4) {
-            ContextUsageBadge(total: 12_345)      // muted
-            ContextUsageBadge(total: 200_000)     // yellow
-            ContextUsageBadge(total: 270_000)     // orange
-            ContextUsageBadge(total: 350_000)     // red
+            ContextUsageBadge(total: 12_345)
+            ContextUsageBadge(total: 200_000)
+            ContextUsageBadge(total: 270_000)
+            ContextUsageBadge(total: 350_000)
         }
         .padding()
-        .previewDisplayName("ContextUsageBadge — bands")
+        .previewDisplayName("ContextUsageBadge")
     }
 }

--- a/Tests/TBDAppTests/ContextUsageBadgeTests.swift
+++ b/Tests/TBDAppTests/ContextUsageBadgeTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 import Testing
 
 @testable import TBDApp
@@ -11,15 +10,5 @@ struct ContextUsageBadgeTests {
         #expect(ContextUsageBadge.formatted(999) == "0k tokens")
         #expect(ContextUsageBadge.formatted(124_300) == "124k tokens")
         #expect(ContextUsageBadge.formatted(1_500_000) == "1500k tokens")
-    }
-
-    @Test func color_thresholds() {
-        #expect(ContextUsageBadge.color(for: 0) == .secondary)
-        #expect(ContextUsageBadge.color(for: 189_999) == .secondary)
-        #expect(ContextUsageBadge.color(for: 190_000) == .yellow)
-        #expect(ContextUsageBadge.color(for: 259_999) == .yellow)
-        #expect(ContextUsageBadge.color(for: 260_000) == .orange)
-        #expect(ContextUsageBadge.color(for: 299_999) == .orange)
-        #expect(ContextUsageBadge.color(for: 300_000) == .red)
     }
 }


### PR DESCRIPTION
## Summary
- Removes the threshold-colored dot that prefixed the `Nk tokens` line beneath the latest assistant turn in the transcript viewer.
- The token count now stands alone in muted gray; the `color(for:)` band helper goes away with it.

## Test plan
- [ ] Open a transcript with a recent assistant turn — only the muted "Nk tokens" text shows beneath it, no leading dot.
- [ ] `swift build` succeeds.

open in TBD: \`tbd://open?worktree=6F4DBDBC-C3A3-4A30-A9B1-9BFA431D7AA3\`