### PR TITLE
Fix: Stop expanded transcript cards from freezing the UI

### DIFF
--- a/Sources/TBDApp/Diagnostics/HangWatchdog.swift
+++ b/Sources/TBDApp/Diagnostics/HangWatchdog.swift
@@ -75,9 +75,11 @@ final class HangWatchdog: @unchecked Sendable {
     // MARK: Configuration
 
     /// Threshold in milliseconds beyond which a stall is reported as a hang.
-    /// 1500 ms is comfortably above the worst non-hang transcript layout pause
-    /// we've measured but well below the 17 s hangs in `crash.log`.
-    static let defaultThresholdMs: UInt64 = 1500
+    /// 1000 ms catches sub-second hangs like the 1.05 s sample on 2026-05-10
+    /// (issue #129) — at the previous 1500 ms threshold that event slipped
+    /// past our own diagnostics even though the macOS hang reporter caught
+    /// it. Still well above any expected steady-state main-thread pause.
+    static let defaultThresholdMs: UInt64 = 1000
 
     /// Background tick interval. 250 ms gives sub-half-second detection of
     /// onset and recovery without meaningful battery cost — the timer just

--- a/Sources/TBDApp/Panes/Transcript/BashCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/BashCard.swift
@@ -68,7 +68,9 @@ struct BashCard: View {
                                 .padding(8)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .frame(maxHeight: commandContainerExpanded ? .infinity : 120)
+                        // Finite cap (not .infinity) so _FlexFrameLayout short-circuits inside
+                        // LazyVStack — see #129. .infinity forces per-row content measurement.
+                        .frame(maxHeight: commandContainerExpanded ? 600 : 120)
                         .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
 
@@ -102,7 +104,9 @@ struct BashCard: View {
                                 .padding(8)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .frame(maxHeight: containerExpanded ? .infinity : 120)
+                        // Finite cap (not .infinity) so _FlexFrameLayout short-circuits inside
+                        // LazyVStack — see #129. .infinity forces per-row content measurement.
+                        .frame(maxHeight: containerExpanded ? 600 : 120)
                         .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
 

--- a/Sources/TBDApp/Panes/Transcript/BashCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/BashCard.swift
@@ -70,7 +70,7 @@ struct BashCard: View {
                         }
                         // Finite cap (not .infinity) so _FlexFrameLayout short-circuits inside
                         // LazyVStack — see #129. .infinity forces per-row content measurement.
-                        .frame(maxHeight: commandContainerExpanded ? 600 : 120)
+                        .frame(maxHeight: commandContainerExpanded ? TranscriptCardLayout.expandedMaxHeight : TranscriptCardLayout.collapsedMaxHeight)
                         .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
 
@@ -106,7 +106,7 @@ struct BashCard: View {
                         }
                         // Finite cap (not .infinity) so _FlexFrameLayout short-circuits inside
                         // LazyVStack — see #129. .infinity forces per-row content measurement.
-                        .frame(maxHeight: containerExpanded ? 600 : 120)
+                        .frame(maxHeight: containerExpanded ? TranscriptCardLayout.expandedMaxHeight : TranscriptCardLayout.collapsedMaxHeight)
                         .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
 

--- a/Sources/TBDApp/Panes/Transcript/TranscriptCardLayout.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptCardLayout.swift
@@ -1,0 +1,16 @@
+import CoreGraphics
+
+/// Shared layout constants for transcript row cards (BashCard, WriteCard, …).
+/// Centralized so tuning the expanded cap doesn't require touching every card.
+/// The expanded cap is intentionally finite (not .infinity) so _FlexFrameLayout
+/// short-circuits inside LazyVStack — see issue #129.
+enum TranscriptCardLayout {
+    /// Max height of an expanded scrollable card body. Generous for typical
+    /// bash/write output; bounded so the LazyVStack containing the card
+    /// doesn't recursively measure the inner ScrollView's full content.
+    static let expandedMaxHeight: CGFloat = 600
+
+    /// Max height of a collapsed scrollable card body. Roughly six lines of
+    /// caption-monospaced text — enough to preview without dominating the row.
+    static let collapsedMaxHeight: CGFloat = 120
+}

--- a/Sources/TBDApp/Panes/Transcript/WriteCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/WriteCard.swift
@@ -61,7 +61,9 @@ struct WriteCard: View {
                                 .padding(8)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .frame(maxHeight: containerExpanded ? .infinity : 120)
+                        // Finite cap (not .infinity) so _FlexFrameLayout short-circuits inside
+                        // LazyVStack — see #129. .infinity forces per-row content measurement.
+                        .frame(maxHeight: containerExpanded ? 600 : 120)
                         .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
 

--- a/Sources/TBDApp/Panes/Transcript/WriteCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/WriteCard.swift
@@ -63,7 +63,7 @@ struct WriteCard: View {
                         }
                         // Finite cap (not .infinity) so _FlexFrameLayout short-circuits inside
                         // LazyVStack — see #129. .infinity forces per-row content measurement.
-                        .frame(maxHeight: containerExpanded ? 600 : 120)
+                        .frame(maxHeight: containerExpanded ? TranscriptCardLayout.expandedMaxHeight : TranscriptCardLayout.collapsedMaxHeight)
                         .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
 

--- a/Tests/TBDAppTests/HangWatchdogTests.swift
+++ b/Tests/TBDAppTests/HangWatchdogTests.swift
@@ -10,10 +10,10 @@ import Testing
 /// quadrants of the state machine.
 @Suite("HangWatchdog")
 struct HangWatchdogTests {
-    /// 1500 ms threshold matches `HangWatchdog.defaultThresholdMs`. Tests that
+    /// 1000 ms threshold matches `HangWatchdog.defaultThresholdMs`. Tests that
     /// follow choose stall values clearly above/below this so a small drift
     /// in the constant doesn't silently break the suite.
-    private let thresholdMs: UInt64 = 1500
+    private let thresholdMs: UInt64 = 1000
 
     @Test func healthy_belowThreshold_isNoop() {
         // wasHung=false, stall<threshold — first tick of a healthy app.


### PR DESCRIPTION
## Summary

The transcript pane intermittently freezes for ~1+ second after a new message lands or on scroll, especially in long sessions. A macOS hang report sampled today showed all 11 main-thread samples stuck in SwiftUI layout: `LazyVStack.place` → per-row `_FlexFrameLayout.sizeThatFits` → recursive `ScrollViewLayoutComputer.Engine.sizeThatFits` → `StyledTextLayoutEngine`.

Root cause: `BashCard` and `WriteCard` use `.frame(maxHeight: containerExpanded ? .infinity : 120)` on the inner output ScrollView. Inside a `LazyVStack` row, `.infinity` strips the upper bound, so `_FlexFrameLayout` cannot short-circuit — every row's inner ScrollView content gets fully measured during layout. Cost is super-linear with transcript length.

This PR:

- **Caps the expanded scroll height at 600 pt** (5x the collapsed 120) in `BashCard.swift` (command + result containers) and `WriteCard.swift`. Bounded enough for `_FlexFrameLayout` to short-circuit; generous enough for typical bash/write output. If 600 turns out to feel cramped we can tune up — but going back to `.infinity` reintroduces the hang.
- **Tightens `HangWatchdog.defaultThresholdMs` 1500 → 1000** so sub-second hangs like today's 1.05 s sample land in our own `os.Logger` (`subsystem com.tbd.app, category hang-watchdog`) instead of only in macOS hang reports the user has to hand-collect. Existing test's local constant + comment updated to match; stall values (100/3000/5000 ms) still bracket cleanly.

Issue #129 tracks the broader umbrella (more steps to consider, including a strategic move to `List` per `docs/superpowers/specs/research-2026-05-06-swiftui-long-list-perf.md`). This PR is the quick-win subset.

## Test plan

- [ ] `scripts/restart.sh` (worktree-relative, per CLAUDE.md) and verify `ps aux | grep TBDApp` shows the new binary
- [ ] Open a long bash-heavy transcript; expand a few BashCards; confirm no UI freeze on scroll or new message
- [ ] Confirm expanded BashCard/WriteCard caps at ~600 pt and scrolls internally past that
- [ ] Stream `log stream --level info --predicate 'subsystem == "com.tbd.app" AND category == "hang-watchdog"'` and confirm sub-second hangs (if any reproduce) now show up
- [ ] No regression in the existing 17 s text-selection-storm fix (PR #120) — text selection on hovered row still works

## Notes

- `swift build` clean.
- `swift test` not run — the existing test target fails in this toolchain with `no such module 'Testing'`, a pre-existing issue confirmed by stashing changes and re-running. The HangWatchdog test edits are doc/value-only so this PR doesn't widen the gap.
- Empirical perf measurement (re-sampling on a long transcript before/after) is left for the verification step above; the change is small and well-grounded in the spindump signature.

Refs #129

open in TBD: `tbd://open?worktree=D917BD15-077C-41E4-82E8-FFF69A960D3E`