### PR TITLE
Feat: Let agents in different TBD sessions share context via #channels

### DIFF
--- a/Sources/TBDCLI/Commands/ChannelsCommand.swift
+++ b/Sources/TBDCLI/Commands/ChannelsCommand.swift
@@ -1,0 +1,105 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct ChannelsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "channels",
+        abstract: "Inter-session message channels",
+        subcommands: [
+            ChannelsPostCommand.self,
+            // read / tail / list / archive added in later tasks
+        ]
+    )
+}
+
+// MARK: - post
+
+struct ChannelsPostCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "post",
+        abstract: "Post a message to a channel"
+    )
+
+    @Argument(help: "Channel name (e.g. 'help', 'api-questions'). Use without leading '#'.")
+    var name: String
+
+    @Argument(help: "Message body. Use '-' to read from stdin.")
+    var body: String
+
+    @Option(name: .long, help: "Override terminal ID (defaults to TBD_TERMINAL_ID env)")
+    var terminalID: String?
+
+    @Option(name: .long, help: "Override sender session ID (requires --from-label)")
+    var fromSession: String?
+
+    @Option(name: .long, help: "Override sender display label (requires --from-session)")
+    var fromLabel: String?
+
+    func validate() throws {
+        if (fromSession != nil) != (fromLabel != nil) {
+            throw ValidationError("--from-session and --from-label must be specified together")
+        }
+    }
+
+    mutating func run() async throws {
+        // Resolve body from stdin if requested
+        var resolvedBody = body
+        if body == "-" {
+            let data = FileHandle.standardInput.readDataToEndOfFile()
+            guard let text = String(data: data, encoding: .utf8) else {
+                FileHandle.standardError.write(Data("error: failed to read stdin as UTF-8\n".utf8))
+                throw ExitCode.failure
+            }
+            resolvedBody = text
+        }
+
+        // Resolve terminalID
+        var resolvedTerminalID: UUID?
+        if let s = terminalID {
+            guard let id = UUID(uuidString: s) else {
+                FileHandle.standardError.write(Data("error: invalid --terminal-id\n".utf8))
+                throw ExitCode.failure
+            }
+            resolvedTerminalID = id
+        } else if fromSession == nil {
+            // Auto-detect from env
+            guard let envID = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+                  let id = UUID(uuidString: envID) else {
+                FileHandle.standardError.write(Data("""
+                    error: TBD_TERMINAL_ID not set in environment.
+                    This command must run inside a TBD-managed terminal,
+                    or pass --terminal-id, or --from-session and --from-label.\n
+                    """.utf8))
+                throw ExitCode.failure
+            }
+            resolvedTerminalID = id
+        }
+
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            FileHandle.standardError.write(Data("error: TBD daemon is not running\n".utf8))
+            throw ExitCode.failure
+        }
+
+        do {
+            let result: ChannelsPostResult = try client.call(
+                method: RPCMethod.channelsPost,
+                params: ChannelsPostParams(
+                    name: name,
+                    body: resolvedBody,
+                    terminalID: resolvedTerminalID,
+                    fromSession: fromSession,
+                    fromLabel: fromLabel
+                ),
+                resultType: ChannelsPostResult.self
+            )
+            // Friendly output: include a copy-pasteable read suggestion.
+            print("Posted to #\(name) (seq \(result.seq))")
+            print("→ tbd channels read \(name) --seq \(result.seq)")
+        } catch {
+            FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+    }
+}

--- a/Sources/TBDCLI/Commands/ChannelsCommand.swift
+++ b/Sources/TBDCLI/Commands/ChannelsCommand.swift
@@ -1,4 +1,6 @@
 import ArgumentParser
+import Darwin
+import Dispatch
 import Foundation
 import TBDShared
 
@@ -9,7 +11,8 @@ struct ChannelsCommand: AsyncParsableCommand {
         subcommands: [
             ChannelsPostCommand.self,
             ChannelsReadCommand.self,
-            // tail / list / archive added in later tasks
+            ChannelsTailCommand.self,
+            // list / archive added in later tasks
         ]
     )
 }
@@ -175,5 +178,91 @@ struct ChannelsReadCommand: AsyncParsableCommand {
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let ts = formatter.string(from: m.ts)
         return "[\(ts)] (seq \(m.seq)) \(m.fromLabel): \(m.body)"
+    }
+}
+
+// MARK: - tail
+
+struct ChannelsTailCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "tail",
+        abstract: "Stream new messages from a channel as they arrive"
+    )
+
+    @Argument(help: "Channel name (without leading '#').")
+    var name: String
+
+    @Flag(name: .long, help: "Keep watching after the current end of file")
+    var follow: Bool = false
+
+    @Flag(name: .long, help: "Show all existing messages before tailing")
+    var fromStart: Bool = false
+
+    mutating func run() async throws {
+        let normalized = try validateChannelName(name)
+        let url = TBDConstants.channelsDir.appendingPathComponent("\(normalized).jsonl")
+
+        // Ensure the file exists so we have something to open. (If the
+        // channel hasn't been posted to yet, --follow would otherwise wait
+        // forever on a non-existent file.)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            FileManager.default.createFile(atPath: url.path, contents: nil)
+        }
+
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        if !fromStart {
+            try handle.seekToEnd()
+        }
+
+        // Print whatever is already there if --from-start.
+        try printNewLines(handle: handle)
+
+        if !follow { return }
+
+        // SIGINT must be ignored *before* installing the dispatch source, or
+        // the default handler can fire between setup steps.
+        signal(SIGINT, SIG_IGN)
+        let signalSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+        signalSource.setEventHandler { Darwin.exit(0) }
+        signalSource.resume()
+
+        // Watch for VNODE_WRITE | VNODE_EXTEND on the file.
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: handle.fileDescriptor,
+            eventMask: [.write, .extend],
+            queue: .global(qos: .utility)
+        )
+        let stream = AsyncStream<Void> { continuation in
+            source.setEventHandler { continuation.yield(()) }
+            source.setCancelHandler { continuation.finish() }
+            source.resume()
+        }
+
+        for await _ in stream {
+            try printNewLines(handle: handle)
+        }
+    }
+
+    private func printNewLines(handle: FileHandle) throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        // Read whatever is available now.
+        guard let chunk = try handle.read(upToCount: Int.max), !chunk.isEmpty else { return }
+        var lineStart = 0
+        for (idx, byte) in chunk.enumerated() where byte == 0x0A {
+            let lineData = chunk.subdata(in: lineStart..<idx)
+            lineStart = idx + 1
+            guard let msg = try? ChannelMessage.decodeLine(lineData) else { continue }
+            let ts = formatter.string(from: msg.ts)
+            print("[\(ts)] (seq \(msg.seq)) \(msg.fromLabel): \(msg.body)")
+        }
+        // Anything after the last newline is a partial write in progress;
+        // the next event will see it complete.
     }
 }

--- a/Sources/TBDCLI/Commands/ChannelsCommand.swift
+++ b/Sources/TBDCLI/Commands/ChannelsCommand.swift
@@ -200,6 +200,7 @@ struct ChannelsTailCommand: AsyncParsableCommand {
     var fromStart: Bool = false
 
     mutating func run() async throws {
+        setbuf(stdout, nil)  // line-buffer-or-immediate stdout so piped readers see output
         let normalized = try validateChannelName(name)
         let url = TBDConstants.channelsDir.appendingPathComponent("\(normalized).jsonl")
 

--- a/Sources/TBDCLI/Commands/ChannelsCommand.swift
+++ b/Sources/TBDCLI/Commands/ChannelsCommand.swift
@@ -224,14 +224,14 @@ struct ChannelsTailCommand: AsyncParsableCommand {
             return
         }
 
-        // --follow: the file must exist for DispatchSource to watch it.
-        // Create it if absent so we don't wait forever on a non-existent file.
-        if !FileManager.default.fileExists(atPath: url.path) {
-            try FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            FileManager.default.createFile(atPath: url.path, contents: nil)
+        // --follow requires the channel file to exist. We do NOT create it
+        // here — that would silently produce a ghost channel with no
+        // `channel_index` row, identical to the bug fixed for the non-follow
+        // branch. The user must `tbd channels post <name> "…"` first to
+        // materialize the channel.
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            FileHandle.standardError.write(Data("error: no such channel #\(normalized) (post to create it first)\n".utf8))
+            throw ExitCode.failure
         }
 
         let handle = try FileHandle(forReadingFrom: url)

--- a/Sources/TBDCLI/Commands/ChannelsCommand.swift
+++ b/Sources/TBDCLI/Commands/ChannelsCommand.swift
@@ -100,8 +100,11 @@ struct ChannelsPostCommand: AsyncParsableCommand {
                 resultType: ChannelsPostResult.self
             )
             // Friendly output: include a copy-pasteable read suggestion.
-            print("Posted to #\(name) (seq \(result.seq))")
-            print("→ tbd channels read \(name) --seq \(result.seq)")
+            // Use the canonical (normalized) name from the daemon, not the
+            // raw `name` the user typed, so the suggestion matches what
+            // `tbd channels list` shows.
+            print("Posted to #\(result.name) (seq \(result.seq))")
+            print("→ tbd channels read \(result.name) --seq \(result.seq)")
         } catch {
             FileHandle.standardError.write(Data("error: \(error)\n".utf8))
             throw ExitCode.failure

--- a/Sources/TBDCLI/Commands/ChannelsCommand.swift
+++ b/Sources/TBDCLI/Commands/ChannelsCommand.swift
@@ -12,7 +12,8 @@ struct ChannelsCommand: AsyncParsableCommand {
             ChannelsPostCommand.self,
             ChannelsReadCommand.self,
             ChannelsTailCommand.self,
-            // list / archive added in later tasks
+            ChannelsListCommand.self,
+            ChannelsArchiveCommand.self,
         ]
     )
 }
@@ -264,5 +265,106 @@ struct ChannelsTailCommand: AsyncParsableCommand {
         }
         // Anything after the last newline is a partial write in progress;
         // the next event will see it complete.
+    }
+}
+
+// MARK: - list
+
+struct ChannelsListCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List channels"
+    )
+
+    @Flag(name: .long, help: "List archived channels instead of active ones")
+    var archived: Bool = false
+
+    mutating func run() async throws {
+        if archived {
+            try printArchived()
+            return
+        }
+
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            FileHandle.standardError.write(Data("error: TBD daemon is not running\n".utf8))
+            throw ExitCode.failure
+        }
+
+        let result: ChannelsListResult = try client.call(
+            method: RPCMethod.channelsList,
+            params: ChannelsListParams(includeArchived: false),
+            resultType: ChannelsListResult.self
+        )
+
+        if result.channels.isEmpty {
+            print("No channels yet. Post one with `tbd channels post <name> <body>`.")
+            return
+        }
+
+        let nameWidth = max(4, result.channels.map { $0.name.count }.max() ?? 0)
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime]
+        print("\(pad("NAME", nameWidth))  COUNT  LAST")
+        for ch in result.channels {
+            let count = String(ch.messageCount)
+            let last = ch.lastMessageAt.map { fmt.string(from: $0) } ?? "—"
+            print("\(pad(ch.name, nameWidth))  \(pad(count, 5))  \(last)")
+        }
+    }
+
+    private func printArchived() throws {
+        let dir = TBDConstants.channelsArchiveDir
+        guard FileManager.default.fileExists(atPath: dir.path) else {
+            print("No archived channels.")
+            return
+        }
+        let entries = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            .filter { $0.hasSuffix(".jsonl") }
+            .sorted()
+        if entries.isEmpty {
+            print("No archived channels.")
+            return
+        }
+        print("ARCHIVED CHANNEL FILES:")
+        for entry in entries {
+            print("  \(dir.appendingPathComponent(entry).path)")
+        }
+    }
+
+    private func pad(_ s: String, _ width: Int) -> String {
+        s + String(repeating: " ", count: max(0, width - s.count))
+    }
+}
+
+// MARK: - archive
+
+struct ChannelsArchiveCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "archive",
+        abstract: "Archive a channel (move to ~/tbd/channels/_archive/)"
+    )
+
+    @Argument(help: "Channel name (without leading '#').")
+    var name: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            FileHandle.standardError.write(Data("error: TBD daemon is not running\n".utf8))
+            throw ExitCode.failure
+        }
+
+        do {
+            let result: ChannelsArchiveResult = try client.call(
+                method: RPCMethod.channelsArchive,
+                params: ChannelsArchiveParams(name: name),
+                resultType: ChannelsArchiveResult.self
+            )
+            print("Archived #\(name) → \(result.archivedPath)")
+        } catch {
+            FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
     }
 }

--- a/Sources/TBDCLI/Commands/ChannelsCommand.swift
+++ b/Sources/TBDCLI/Commands/ChannelsCommand.swift
@@ -204,9 +204,25 @@ struct ChannelsTailCommand: AsyncParsableCommand {
         let normalized = try validateChannelName(name)
         let url = TBDConstants.channelsDir.appendingPathComponent("\(normalized).jsonl")
 
-        // Ensure the file exists so we have something to open. (If the
-        // channel hasn't been posted to yet, --follow would otherwise wait
-        // forever on a non-existent file.)
+        // Without --follow: read whatever's in the file (if any) and exit.
+        // Do NOT create the file — that would silently produce a ghost
+        // channel with no `channel_index` row.
+        if !follow {
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                FileHandle.standardError.write(Data("error: no such channel #\(normalized)\n".utf8))
+                throw ExitCode.failure
+            }
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { try? handle.close() }
+            if !fromStart {
+                try handle.seekToEnd()
+            }
+            try printNewLines(handle: handle)
+            return
+        }
+
+        // --follow: the file must exist for DispatchSource to watch it.
+        // Create it if absent so we don't wait forever on a non-existent file.
         if !FileManager.default.fileExists(atPath: url.path) {
             try FileManager.default.createDirectory(
                 at: url.deletingLastPathComponent(),
@@ -224,8 +240,6 @@ struct ChannelsTailCommand: AsyncParsableCommand {
 
         // Print whatever is already there if --from-start.
         try printNewLines(handle: handle)
-
-        if !follow { return }
 
         // SIGINT must be ignored *before* installing the dispatch source, or
         // the default handler can fire between setup steps.

--- a/Sources/TBDCLI/Commands/ChannelsCommand.swift
+++ b/Sources/TBDCLI/Commands/ChannelsCommand.swift
@@ -8,7 +8,8 @@ struct ChannelsCommand: AsyncParsableCommand {
         abstract: "Inter-session message channels",
         subcommands: [
             ChannelsPostCommand.self,
-            // read / tail / list / archive added in later tasks
+            ChannelsReadCommand.self,
+            // tail / list / archive added in later tasks
         ]
     )
 }
@@ -101,5 +102,78 @@ struct ChannelsPostCommand: AsyncParsableCommand {
             FileHandle.standardError.write(Data("error: \(error)\n".utf8))
             throw ExitCode.failure
         }
+    }
+}
+
+// MARK: - read
+
+struct ChannelsReadCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "read",
+        abstract: "Read messages from a channel (direct file read; daemon not required)"
+    )
+
+    @Argument(help: "Channel name (without leading '#').")
+    var name: String
+
+    @Option(name: .long, help: "Show just the message with this seq")
+    var seq: Int?
+
+    @Option(name: .long, help: "Show messages with seq > this value")
+    var since: Int?
+
+    @Option(name: .long, help: "Maximum number of messages to print (default 20)")
+    var limit: Int = 20
+
+    func validate() throws {
+        if seq != nil && since != nil {
+            throw ValidationError("--seq and --since are mutually exclusive")
+        }
+    }
+
+    mutating func run() async throws {
+        let normalized: String
+        do {
+            normalized = try validateChannelName(name)
+        } catch {
+            FileHandle.standardError.write(Data("error: invalid channel name: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        let path = TBDConstants.channelsDir.appendingPathComponent("\(normalized).jsonl").path
+        guard FileManager.default.fileExists(atPath: path) else {
+            FileHandle.standardError.write(Data("error: no such channel #\(normalized)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        var matched: [(seq: Int, formatted: String)] = []
+        var lineStart = 0
+        for (idx, byte) in data.enumerated() where byte == 0x0A {
+            let lineData = data.subdata(in: lineStart..<idx)
+            lineStart = idx + 1
+            guard let msg = try? ChannelMessage.decodeLine(lineData) else { continue }
+
+            if let s = seq, msg.seq != s { continue }
+            if let since = since, msg.seq <= since { continue }
+
+            matched.append((msg.seq, format(msg)))
+        }
+
+        // Apply limit (most recent N when no --seq filter)
+        let toPrint: ArraySlice<(seq: Int, formatted: String)>
+        if seq != nil {
+            toPrint = matched[...]
+        } else {
+            toPrint = matched.suffix(limit)[...]
+        }
+        for entry in toPrint { print(entry.formatted) }
+    }
+
+    private func format(_ m: ChannelMessage) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let ts = formatter.string(from: m.ts)
+        return "[\(ts)] (seq \(m.seq)) \(m.fromLabel): \(m.body)"
     }
 }

--- a/Sources/TBDCLI/Commands/ChannelsCommand.swift
+++ b/Sources/TBDCLI/Commands/ChannelsCommand.swift
@@ -248,20 +248,34 @@ struct ChannelsTailCommand: AsyncParsableCommand {
         signalSource.setEventHandler { Darwin.exit(0) }
         signalSource.resume()
 
-        // Watch for VNODE_WRITE | VNODE_EXTEND on the file.
+        // Watch for VNODE_WRITE | VNODE_EXTEND on the file. Also watch for
+        // VNODE_DELETE | VNODE_RENAME so we exit cleanly when the channel is
+        // archived (rename(2) into _archive/) instead of blocking forever.
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: handle.fileDescriptor,
-            eventMask: [.write, .extend],
+            eventMask: [.write, .extend, .delete, .rename],
             queue: .global(qos: .utility)
         )
-        let stream = AsyncStream<Void> { continuation in
-            source.setEventHandler { continuation.yield(()) }
+        let stream = AsyncStream<DispatchSource.FileSystemEvent> { continuation in
+            source.setEventHandler {
+                let data = source.data
+                let isLifecycle = data.contains(.delete) || data.contains(.rename)
+                continuation.yield(data)
+                if isLifecycle {
+                    continuation.finish()
+                }
+            }
             source.setCancelHandler { continuation.finish() }
             source.resume()
         }
 
-        for await _ in stream {
+        for await event in stream {
             try printNewLines(handle: handle)
+            if event.contains(.delete) || event.contains(.rename) {
+                // File was removed/archived. Drain anything remaining (above) and exit.
+                FileHandle.standardError.write(Data("(channel file gone — exiting tail)\n".utf8))
+                return
+            }
         }
     }
 

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -13,6 +13,7 @@ struct TBDCommand: AsyncParsableCommand {
             TerminalCommand.self,
             ConductorCommand.self,
             NotifyCommand.self,
+            ChannelsCommand.self,
             SessionEventCommand.self,
             AskUserQuestionEventCommand.self,
             DaemonCommand.self,

--- a/Sources/TBDDaemon/Channels/ChannelLockManager.swift
+++ b/Sources/TBDDaemon/Channels/ChannelLockManager.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// In-process, per-channel async serialization. Each channel name gets a
+/// dedicated actor that linearizes write operations, so the daemon only
+/// holds one channel's `flock` at a time per channel.
+///
+/// Cross-process protection comes from `FileLock` on the sidecar `.lock`
+/// file; this manager only handles in-process concurrency.
+actor ChannelLockManager {
+    private var locks: [String: ChannelSerial] = [:]
+
+    func withLock<T: Sendable>(_ name: String, _ body: @Sendable () async throws -> T) async throws -> T {
+        let serial = serial(for: name)
+        return try await serial.run(body)
+    }
+
+    private func serial(for name: String) -> ChannelSerial {
+        if let existing = locks[name] { return existing }
+        let made = ChannelSerial()
+        locks[name] = made
+        return made
+    }
+}
+
+/// One channel's async-serial queue. Posts arrive concurrently; this
+/// actor's mailbox order is the channel's write order.
+actor ChannelSerial {
+    func run<T: Sendable>(_ body: @Sendable () async throws -> T) async throws -> T {
+        try await body()
+    }
+}

--- a/Sources/TBDDaemon/Channels/ChannelLockManager.swift
+++ b/Sources/TBDDaemon/Channels/ChannelLockManager.swift
@@ -9,7 +9,7 @@ import Foundation
 actor ChannelLockManager {
     private var locks: [String: ChannelSerial] = [:]
 
-    func withLock<T: Sendable>(_ name: String, _ body: @Sendable () async throws -> T) async throws -> T {
+    func withLock<T: Sendable>(_ name: String, _ body: @Sendable () throws -> T) async throws -> T {
         let serial = serial(for: name)
         return try await serial.run(body)
     }
@@ -24,8 +24,15 @@ actor ChannelLockManager {
 
 /// One channel's async-serial queue. Posts arrive concurrently; this
 /// actor's mailbox order is the channel's write order.
+///
+/// The body type is *synchronous* on purpose: the whole point of this
+/// actor is serialization, and an `async` body would suspend on every
+/// internal `await`, opening the door to actor reentrancy and silently
+/// reintroducing the post/archive race we previously fixed. Keeping
+/// the type synchronous makes the contract compiler-enforced rather
+/// than relying on a comment.
 actor ChannelSerial {
-    func run<T: Sendable>(_ body: @Sendable () async throws -> T) async throws -> T {
-        try await body()
+    func run<T: Sendable>(_ body: @Sendable () throws -> T) throws -> T {
+        try body()
     }
 }

--- a/Sources/TBDDaemon/Channels/ChannelLockManager.swift
+++ b/Sources/TBDDaemon/Channels/ChannelLockManager.swift
@@ -20,6 +20,13 @@ actor ChannelLockManager {
         locks[name] = made
         return made
     }
+
+    /// Drop the per-channel actor for `name`. Call this after archiving
+    /// a channel so the dictionary doesn't accumulate stale entries
+    /// across the daemon's lifetime.
+    func evict(_ name: String) {
+        locks.removeValue(forKey: name)
+    }
 }
 
 /// One channel's async-serial queue. Posts arrive concurrently; this

--- a/Sources/TBDDaemon/Channels/ChannelStore.swift
+++ b/Sources/TBDDaemon/Channels/ChannelStore.swift
@@ -162,6 +162,13 @@ public final class ChannelStore: @unchecked Sendable {
             if ftruncate(fd, off_t(lastGoodEnd)) != 0 {
                 throw ChannelStoreError.writeFailed(path: path, errno: errno)
             }
+            // Make the truncate durable so a crash before the OS flushes
+            // doesn't leave the torn line on disk for the next start to
+            // recover again. Recovery is idempotent, so this is correctness
+            // polish rather than a fix for a known bug.
+            if fsync(fd) != 0 {
+                throw ChannelStoreError.fsyncFailed(path: path, errno: errno)
+            }
         }
         return highest
     }

--- a/Sources/TBDDaemon/Channels/ChannelStore.swift
+++ b/Sources/TBDDaemon/Channels/ChannelStore.swift
@@ -155,6 +155,53 @@ public final class ChannelStore: @unchecked Sendable {
         return highest
     }
 
+    /// Move the channel file to `_archive/<name>-<YYYYMMDD-HHMMSS>.jsonl`,
+    /// remove the lock sidecar, and delete the index row. Returns the
+    /// archived path.
+    public func archive(name: String) async throws -> String {
+        let normalized = try validateChannelName(name)
+
+        // Synchronous file work under the per-channel lock; DB cleanup outside.
+        // (Same actor-reentrancy lesson as `post`: no `await` inside withLock.)
+        let archivedPath: String = try await lockManager.withLock(normalized) { [self] in
+            let activePath = filePath(for: normalized)
+            guard FileManager.default.fileExists(atPath: activePath) else {
+                throw ChannelStoreError.openFailed(path: activePath, errno: ENOENT)
+            }
+
+            // Hold the cross-process lock for the rename.
+            let lock = try FileLock.acquire(path: lockPath(for: normalized))
+            defer { try? lock.release() }
+
+            try ensureDir(archiveDir)
+            let stamp = Self.timestampFormatter.string(from: Date())
+            let archivedPath = archiveDir
+                .appendingPathComponent("\(normalized)-\(stamp).jsonl")
+                .path
+            try FileManager.default.moveItem(atPath: activePath, toPath: archivedPath)
+
+            // Remove the lock sidecar (best-effort; lock FD is already closed
+            // by `defer` above, but unlink can race with that).
+            try? FileManager.default.removeItem(atPath: lockPath(for: normalized))
+
+            seqCache.removeValue(forKey: normalized)
+            return archivedPath
+        }
+
+        // DB index update outside the per-channel lock.
+        try await index.delete(name: normalized)
+        return archivedPath
+    }
+
+    /// `YYYYMMDD-HHMMSS` in UTC, for archive filenames.
+    static let timestampFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyyMMdd-HHmmss"
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
     private func appendLine(channel: String, line: Data) throws {
         let path = filePath(for: channel)
         let fd = open(path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0o644)

--- a/Sources/TBDDaemon/Channels/ChannelStore.swift
+++ b/Sources/TBDDaemon/Channels/ChannelStore.swift
@@ -202,8 +202,10 @@ public final class ChannelStore: @unchecked Sendable {
                 .path
             try FileManager.default.moveItem(atPath: activePath, toPath: archivedPath)
 
-            // Remove the lock sidecar (best-effort; lock FD is already closed
-            // by `defer` above, but unlink can race with that).
+            // Remove the lock sidecar (best-effort). On macOS, unlink while
+            // the fd is still open just removes the directory entry — the
+            // lock remains exclusive until `release()` fires in the defer
+            // above, so this is safe.
             try? FileManager.default.removeItem(atPath: lockPath(for: normalized))
 
             seqCache.withLock { _ = $0.removeValue(forKey: normalized) }

--- a/Sources/TBDDaemon/Channels/ChannelStore.swift
+++ b/Sources/TBDDaemon/Channels/ChannelStore.swift
@@ -204,6 +204,13 @@ public final class ChannelStore: @unchecked Sendable {
             return archivedPath
         }
 
+        // Eviction happens *after* the per-channel lock body returns. The
+        // ChannelSerial actor for this name has no remaining work (we just
+        // archived the file and deleted the index row), so dropping it
+        // prevents `locks` from accumulating stale entries over the
+        // daemon's lifetime as channels are created and archived.
+        await lockManager.evict(normalized)
+
         return archivedPath
     }
 

--- a/Sources/TBDDaemon/Channels/ChannelStore.swift
+++ b/Sources/TBDDaemon/Channels/ChannelStore.swift
@@ -24,6 +24,10 @@ public enum ChannelStoreError: Error, CustomStringConvertible {
 }
 
 public struct ChannelPostResult: Sendable {
+    /// Canonical (normalized, lowercased) channel name. The CLI echoes
+    /// this in the paste suggestion so users see the same form
+    /// `channels list` prints, not whatever casing they typed.
+    public let name: String
     public let seq: Int
     public let ts: Date
 }
@@ -94,7 +98,7 @@ public final class ChannelStore: @unchecked Sendable {
             // post/archive can't interleave at the index layer.
             try index.recordPostSync(name: normalized, at: ts)
 
-            return ChannelPostResult(seq: nextSeq, ts: ts)
+            return ChannelPostResult(name: normalized, seq: nextSeq, ts: ts)
         }
 
         return result

--- a/Sources/TBDDaemon/Channels/ChannelStore.swift
+++ b/Sources/TBDDaemon/Channels/ChannelStore.swift
@@ -10,6 +10,7 @@ public enum ChannelStoreError: Error, CustomStringConvertible {
     case writeFailed(path: String, errno: Int32)
     case fsyncFailed(path: String, errno: Int32)
     case openFailed(path: String, errno: Int32)
+    case channelNotFound(name: String)
 
     public var description: String {
         switch self {
@@ -17,6 +18,7 @@ public enum ChannelStoreError: Error, CustomStringConvertible {
         case .writeFailed(let p, let e): return "write(\(p)) failed: errno=\(e)"
         case .fsyncFailed(let p, let e): return "fsync(\(p)) failed: errno=\(e)"
         case .openFailed(let p, let e): return "open(\(p)) failed: errno=\(e)"
+        case .channelNotFound(let n): return "channel not found: \(n)"
         }
     }
 }
@@ -175,7 +177,7 @@ public final class ChannelStore: @unchecked Sendable {
         let archivedPath: String = try await lockManager.withLock(normalized) { [self] in
             let activePath = filePath(for: normalized)
             guard FileManager.default.fileExists(atPath: activePath) else {
-                throw ChannelStoreError.openFailed(path: activePath, errno: ENOENT)
+                throw ChannelStoreError.channelNotFound(name: normalized)
             }
 
             // Hold the cross-process lock for the rename.

--- a/Sources/TBDDaemon/Channels/ChannelStore.swift
+++ b/Sources/TBDDaemon/Channels/ChannelStore.swift
@@ -1,0 +1,183 @@
+import Darwin
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "channels.store")
+
+public enum ChannelStoreError: Error, CustomStringConvertible {
+    case bodyTooLarge(bytes: Int)
+    case writeFailed(path: String, errno: Int32)
+    case fsyncFailed(path: String, errno: Int32)
+    case openFailed(path: String, errno: Int32)
+
+    public var description: String {
+        switch self {
+        case .bodyTooLarge(let n): return "body too large: \(n) bytes (max 65536)"
+        case .writeFailed(let p, let e): return "write(\(p)) failed: errno=\(e)"
+        case .fsyncFailed(let p, let e): return "fsync(\(p)) failed: errno=\(e)"
+        case .openFailed(let p, let e): return "open(\(p)) failed: errno=\(e)"
+        }
+    }
+}
+
+public struct ChannelPostResult: Sendable {
+    public let seq: Int
+    public let ts: Date
+}
+
+/// Orchestrates per-channel JSONL writes. Owns the per-channel lock
+/// manager, the in-memory `seq` cache, and the `channel_index` updates.
+public final class ChannelStore: @unchecked Sendable {
+    private static let bodyByteLimit = 64 * 1024
+
+    private let channelsDir: URL
+    private let archiveDir: URL
+    private let index: ChannelIndexStore
+    private let lockManager = ChannelLockManager()
+
+    // Protected by per-channel async locks (ChannelLockManager). Mutations
+    // happen only inside `withLock`, so the Dictionary is never touched
+    // concurrently for the same key. @unchecked is justified by that contract.
+    private var seqCache: [String: Int] = [:]
+
+    public init(channelsDir: URL, index: ChannelIndexStore) {
+        self.channelsDir = channelsDir
+        self.archiveDir = channelsDir.appendingPathComponent("_archive")
+        self.index = index
+    }
+
+    /// Append one message to a channel. Returns the assigned `seq` and `ts`.
+    public func post(
+        name: String,
+        body: String,
+        fromSession: String,
+        fromLabel: String
+    ) async throws -> ChannelPostResult {
+        let normalized = try validateChannelName(name)
+
+        let bodyBytes = body.utf8.count
+        if bodyBytes > Self.bodyByteLimit {
+            throw ChannelStoreError.bodyTooLarge(bytes: bodyBytes)
+        }
+
+        // Inside the per-channel lock: only synchronous file work.
+        // No `await` inside the closure body means no actor reentrancy
+        // and no parallel attempts to acquire the same flock.
+        let result: ChannelPostResult = try await lockManager.withLock(normalized) { [self] in
+            try ensureDir(channelsDir)
+            let lock = try FileLock.acquire(path: lockPath(for: normalized))
+            defer { try? lock.release() }
+
+            let nextSeq = try ensureSeqCachePopulated(for: normalized) + 1
+            let ts = Date()
+            let msg = ChannelMessage(seq: nextSeq, ts: ts,
+                                     fromSession: fromSession,
+                                     fromLabel: fromLabel,
+                                     body: body)
+            let line = try msg.encodeLine()
+            try appendLine(channel: normalized, line: line)
+            seqCache[normalized] = nextSeq
+            return ChannelPostResult(seq: nextSeq, ts: ts)
+        }
+
+        // DB index update outside the per-channel lock (no serialization
+        // requirement here; ChannelIndexStore already serializes via its
+        // own writer queue, and ordering of `recordPost` calls only affects
+        // `lastMessageAt` precedence — not correctness).
+        try await index.recordPost(name: normalized, at: result.ts)
+        return result
+    }
+
+    // MARK: - File paths
+
+    func filePath(for name: String) -> String {
+        channelsDir.appendingPathComponent("\(name).jsonl").path
+    }
+
+    func lockPath(for name: String) -> String {
+        channelsDir.appendingPathComponent("\(name).lock").path
+    }
+
+    // MARK: - Helpers
+
+    private func ensureDir(_ url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    /// Populate the in-memory seq cache by scanning the file tail (and
+    /// running torn-line recovery as a side effect). Returns the highest
+    /// known seq, or 0 if the channel has no file yet.
+    func ensureSeqCachePopulated(for name: String) throws -> Int {
+        if let cached = seqCache[name] { return cached }
+        let highest = try recoverAndScanHighestSeq(name: name)
+        seqCache[name] = highest
+        return highest
+    }
+
+    /// Stream-scan the channel file. If the trailing line is malformed,
+    /// truncate the file back to the last good newline. Returns the highest
+    /// successfully parsed seq (or 0 if no file).
+    func recoverAndScanHighestSeq(name: String) throws -> Int {
+        let path = filePath(for: name)
+        guard FileManager.default.fileExists(atPath: path) else { return 0 }
+
+        let url = URL(fileURLWithPath: path)
+        let data = try Data(contentsOf: url)
+        guard !data.isEmpty else { return 0 }
+
+        var highest = 0
+        var lastGoodEnd = 0  // byte offset of (one-past) last good newline
+        var lineStart = 0
+        for (idx, byte) in data.enumerated() {
+            if byte == 0x0A {
+                let line = data.subdata(in: lineStart..<idx)
+                if let msg = try? ChannelMessage.decodeLine(line) {
+                    highest = max(highest, msg.seq)
+                    lastGoodEnd = idx + 1
+                }
+                lineStart = idx + 1
+            }
+        }
+        // Anything after the last newline (or after position 0 if no newline)
+        // is an unfinished line. Truncate.
+        if lastGoodEnd < data.count {
+            logger.notice("Truncating torn-line tail of \(name, privacy: .public): \(data.count - lastGoodEnd) bytes dropped")
+            let fd = open(path, O_WRONLY)
+            if fd < 0 {
+                throw ChannelStoreError.openFailed(path: path, errno: errno)
+            }
+            defer { close(fd) }
+            if ftruncate(fd, off_t(lastGoodEnd)) != 0 {
+                throw ChannelStoreError.writeFailed(path: path, errno: errno)
+            }
+        }
+        return highest
+    }
+
+    private func appendLine(channel: String, line: Data) throws {
+        let path = filePath(for: channel)
+        let fd = open(path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0o644)
+        if fd < 0 {
+            throw ChannelStoreError.openFailed(path: path, errno: errno)
+        }
+        defer { close(fd) }
+
+        try line.withUnsafeBytes { (rawBuf: UnsafeRawBufferPointer) in
+            guard let base = rawBuf.baseAddress else { return }
+            var written = 0
+            while written < rawBuf.count {
+                let r = Darwin.write(fd, base.advanced(by: written), rawBuf.count - written)
+                if r < 0 {
+                    if errno == EINTR { continue }
+                    throw ChannelStoreError.writeFailed(path: path, errno: errno)
+                }
+                written += r
+            }
+        }
+
+        if fsync(fd) != 0 {
+            throw ChannelStoreError.fsyncFailed(path: path, errno: errno)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Channels/ChannelStore.swift
+++ b/Sources/TBDDaemon/Channels/ChannelStore.swift
@@ -36,10 +36,15 @@ public final class ChannelStore: @unchecked Sendable {
     private let index: ChannelIndexStore
     private let lockManager = ChannelLockManager()
 
-    // Protected by per-channel async locks (ChannelLockManager). Mutations
-    // happen only inside `withLock`, so the Dictionary is never touched
-    // concurrently for the same key. @unchecked is justified by that contract.
-    private var seqCache: [String: Int] = [:]
+    // Per-channel async locks (ChannelLockManager) serialize work for a
+    // single channel name, but `post`/`archive` against *different* names
+    // run on different actors and can mutate this Dictionary in parallel.
+    // Swift Dictionary is COW: concurrent structural mutations from
+    // different threads can corrupt the buffer or crash on resize even
+    // when the keys differ. Hold an unfair lock around every read/write.
+    // The lock is taken only for in-memory dictionary access — never
+    // across file I/O or `await` boundaries — so contention is minimal.
+    private let seqCache = OSAllocatedUnfairLock<[String: Int]>(initialState: [:])
 
     public init(channelsDir: URL, index: ChannelIndexStore) {
         self.channelsDir = channelsDir
@@ -61,9 +66,12 @@ public final class ChannelStore: @unchecked Sendable {
             throw ChannelStoreError.bodyTooLarge(bytes: bodyBytes)
         }
 
-        // Inside the per-channel lock: only synchronous file work.
-        // No `await` inside the closure body means no actor reentrancy
-        // and no parallel attempts to acquire the same flock.
+        // Inside the per-channel lock: only synchronous work. No `await`
+        // inside the closure body means no actor reentrancy and no
+        // parallel attempts to acquire the same flock. The DB index
+        // update uses the *synchronous* GRDB write so it sits inside
+        // this lock too — that's what guarantees `archive` can't race
+        // an in-flight `post` and resurrect the index row after delete.
         let result: ChannelPostResult = try await lockManager.withLock(normalized) { [self] in
             try ensureDir(channelsDir)
             let lock = try FileLock.acquire(path: lockPath(for: normalized))
@@ -77,15 +85,16 @@ public final class ChannelStore: @unchecked Sendable {
                                      body: body)
             let line = try msg.encodeLine()
             try appendLine(channel: normalized, line: line)
-            seqCache[normalized] = nextSeq
+            seqCache.withLock { $0[normalized] = nextSeq }
+
+            // DB write inside the per-channel lock; synchronous so we
+            // don't reintroduce the actor-reentrancy hazard, and so
+            // post/archive can't interleave at the index layer.
+            try index.recordPostSync(name: normalized, at: ts)
+
             return ChannelPostResult(seq: nextSeq, ts: ts)
         }
 
-        // DB index update outside the per-channel lock (no serialization
-        // requirement here; ChannelIndexStore already serializes via its
-        // own writer queue, and ordering of `recordPost` calls only affects
-        // `lastMessageAt` precedence — not correctness).
-        try await index.recordPost(name: normalized, at: result.ts)
         return result
     }
 
@@ -109,9 +118,9 @@ public final class ChannelStore: @unchecked Sendable {
     /// running torn-line recovery as a side effect). Returns the highest
     /// known seq, or 0 if the channel has no file yet.
     func ensureSeqCachePopulated(for name: String) throws -> Int {
-        if let cached = seqCache[name] { return cached }
+        if let cached = seqCache.withLock({ $0[name] }) { return cached }
         let highest = try recoverAndScanHighestSeq(name: name)
-        seqCache[name] = highest
+        seqCache.withLock { $0[name] = highest }
         return highest
     }
 
@@ -184,12 +193,17 @@ public final class ChannelStore: @unchecked Sendable {
             // by `defer` above, but unlink can race with that).
             try? FileManager.default.removeItem(atPath: lockPath(for: normalized))
 
-            seqCache.removeValue(forKey: normalized)
+            seqCache.withLock { _ = $0.removeValue(forKey: normalized) }
+
+            // DB delete inside the per-channel lock; synchronous to
+            // match `post` and prevent the post/archive race that would
+            // otherwise let an in-flight `recordPost` resurrect the row
+            // after we deleted it.
+            try index.deleteSync(name: normalized)
+
             return archivedPath
         }
 
-        // DB index update outside the per-channel lock.
-        try await index.delete(name: normalized)
         return archivedPath
     }
 

--- a/Sources/TBDDaemon/Channels/FileLock.swift
+++ b/Sources/TBDDaemon/Channels/FileLock.swift
@@ -1,0 +1,57 @@
+import Darwin
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "channels.flock")
+
+/// Holds an exclusive `flock(2)` on a sidecar lockfile for the lifetime of
+/// the value. Use `acquire(path:)` (blocking) and call `release()` once done.
+///
+/// Rationale: defensive guard against the two-daemon race the
+/// adversarial-review identified. The daemon enforces single-instance via
+/// `PIDFile.swift`, but the read-then-write check there has a TOCTOU window;
+/// `flock` makes channel writes safe even if two daemons briefly coexist.
+struct FileLock {
+    private let fd: Int32
+    private let path: String
+
+    static func acquire(path: String) throws -> FileLock {
+        // O_RDWR | O_CREAT | O_CLOEXEC; permissions 0644.
+        let fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
+        if fd < 0 {
+            throw FileLockError.openFailed(errno: errno, path: path)
+        }
+        // Blocking exclusive lock.
+        if flock(fd, LOCK_EX) != 0 {
+            let savedErrno = errno
+            close(fd)
+            throw FileLockError.lockFailed(errno: savedErrno, path: path)
+        }
+        logger.debug("Acquired lock on \(path, privacy: .public)")
+        return FileLock(fd: fd, path: path)
+    }
+
+    func release() throws {
+        if flock(fd, LOCK_UN) != 0 {
+            let savedErrno = errno
+            close(fd)
+            throw FileLockError.unlockFailed(errno: savedErrno, path: path)
+        }
+        close(fd)
+        logger.debug("Released lock on \(path, privacy: .public)")
+    }
+}
+
+enum FileLockError: Error, CustomStringConvertible {
+    case openFailed(errno: Int32, path: String)
+    case lockFailed(errno: Int32, path: String)
+    case unlockFailed(errno: Int32, path: String)
+
+    var description: String {
+        switch self {
+        case .openFailed(let e, let p):  return "open(\(p)) failed: errno=\(e)"
+        case .lockFailed(let e, let p):  return "flock(LOCK_EX, \(p)) failed: errno=\(e)"
+        case .unlockFailed(let e, let p): return "flock(LOCK_UN, \(p)) failed: errno=\(e)"
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/ChannelIndexStore.swift
+++ b/Sources/TBDDaemon/Database/ChannelIndexStore.swift
@@ -1,0 +1,14 @@
+import Foundation
+import GRDB
+import TBDShared
+
+/// GRDB Record for the `channel_index` table — derivable cache of per-channel
+/// metadata that backs `tbd channels list` and the daemon's per-post update.
+struct ChannelIndexRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "channel_index"
+
+    var name: String
+    var createdAt: Date
+    var lastMessageAt: Date?
+    var messageCount: Int
+}

--- a/Sources/TBDDaemon/Database/ChannelIndexStore.swift
+++ b/Sources/TBDDaemon/Database/ChannelIndexStore.swift
@@ -45,6 +45,28 @@ public struct ChannelIndexStore: Sendable {
         }
     }
 
+    /// Synchronous variant of `recordPost`. Blocks the calling thread until
+    /// the GRDB writer queue completes the upsert. Used from inside the
+    /// per-channel async lock in `ChannelStore`, where awaiting the async
+    /// variant would (a) re-enter the actor system after releasing the lock
+    /// is no longer guarded, opening a post/archive race on the index row,
+    /// and (b) reintroduce the actor-reentrancy hazard the per-channel
+    /// lock was meant to close.
+    public func recordPostSync(name: String, at timestamp: Date) throws {
+        try writer.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO channel_index (name, createdAt, lastMessageAt, messageCount)
+                    VALUES (?, ?, ?, 1)
+                    ON CONFLICT(name) DO UPDATE SET
+                        lastMessageAt = excluded.lastMessageAt,
+                        messageCount = messageCount + 1
+                    """,
+                arguments: [name, timestamp, timestamp]
+            )
+        }
+    }
+
     /// List all channels ordered by most-recent activity first.
     public func list(includeArchived: Bool) async throws -> [ChannelIndexRecord] {
         // includeArchived is a no-op in v1 — archived channels live as
@@ -62,6 +84,16 @@ public struct ChannelIndexStore: Sendable {
     /// Remove the row (used on archive).
     public func delete(name: String) async throws {
         try await writer.write { db in
+            _ = try ChannelIndexRecord.deleteOne(db, key: name)
+        }
+    }
+
+    /// Synchronous variant of `delete`. See `recordPostSync` for the
+    /// rationale; both are paired so that `ChannelStore.archive` can
+    /// commit its DB cleanup inside the same per-channel lock that
+    /// renamed the file, eliminating the post/archive resurrection race.
+    public func deleteSync(name: String) throws {
+        try writer.write { db in
             _ = try ChannelIndexRecord.deleteOne(db, key: name)
         }
     }

--- a/Sources/TBDDaemon/Database/ChannelIndexStore.swift
+++ b/Sources/TBDDaemon/Database/ChannelIndexStore.swift
@@ -4,11 +4,65 @@ import TBDShared
 
 /// GRDB Record for the `channel_index` table — derivable cache of per-channel
 /// metadata that backs `tbd channels list` and the daemon's per-post update.
-struct ChannelIndexRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
-    static let databaseTableName = "channel_index"
+public struct ChannelIndexRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    public static let databaseTableName = "channel_index"
 
-    var name: String
-    var createdAt: Date
-    var lastMessageAt: Date?
-    var messageCount: Int
+    public var name: String
+    public var createdAt: Date
+    public var lastMessageAt: Date?
+    public var messageCount: Int
+
+    public init(name: String, createdAt: Date, lastMessageAt: Date?, messageCount: Int) {
+        self.name = name
+        self.createdAt = createdAt
+        self.lastMessageAt = lastMessageAt
+        self.messageCount = messageCount
+    }
+}
+
+/// CRUD for `channel_index`. All methods are safe for concurrent callers.
+public struct ChannelIndexStore: Sendable {
+    let writer: any DatabaseWriter
+
+    public init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Upsert: create the row if missing, increment `messageCount` and bump
+    /// `lastMessageAt` if present.
+    public func recordPost(name: String, at timestamp: Date) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO channel_index (name, createdAt, lastMessageAt, messageCount)
+                    VALUES (?, ?, ?, 1)
+                    ON CONFLICT(name) DO UPDATE SET
+                        lastMessageAt = excluded.lastMessageAt,
+                        messageCount = messageCount + 1
+                    """,
+                arguments: [name, timestamp, timestamp]
+            )
+        }
+    }
+
+    /// List all channels ordered by most-recent activity first.
+    public func list(includeArchived: Bool) async throws -> [ChannelIndexRecord] {
+        // includeArchived is a no-op in v1 — archived channels live as
+        // files under `_archive/` and never have an index row. The
+        // parameter exists so the RPC surface doesn't change when
+        // archived-listing arrives.
+        _ = includeArchived
+        return try await writer.read { db in
+            try ChannelIndexRecord
+                .order(Column("lastMessageAt").desc)
+                .fetchAll(db)
+        }
+    }
+
+    /// Remove the row (used on archive).
+    public func delete(name: String) async throws {
+        try await writer.write { db in
+            _ = try ChannelIndexRecord.deleteOne(db, key: name)
+        }
+    }
 }

--- a/Sources/TBDDaemon/Database/ChannelIndexStore.swift
+++ b/Sources/TBDDaemon/Database/ChannelIndexStore.swift
@@ -24,7 +24,7 @@ public struct ChannelIndexRecord: Codable, FetchableRecord, PersistableRecord, S
 public struct ChannelIndexStore: Sendable {
     let writer: any DatabaseWriter
 
-    public init(writer: any DatabaseWriter) {
+    init(writer: any DatabaseWriter) {
         self.writer = writer
     }
 

--- a/Sources/TBDDaemon/Database/ChannelIndexStore.swift
+++ b/Sources/TBDDaemon/Database/ChannelIndexStore.swift
@@ -28,18 +28,24 @@ public struct ChannelIndexStore: Sendable {
         self.writer = writer
     }
 
+    /// Single source of truth for the upsert SQL used by both the async and
+    /// sync `recordPost` variants. Keeping these aligned matters: divergence
+    /// between the two would produce subtly different index state depending
+    /// on which call site landed last.
+    private static let upsertSQL = """
+        INSERT INTO channel_index (name, createdAt, lastMessageAt, messageCount)
+        VALUES (?, ?, ?, 1)
+        ON CONFLICT(name) DO UPDATE SET
+            lastMessageAt = excluded.lastMessageAt,
+            messageCount = messageCount + 1
+        """
+
     /// Upsert: create the row if missing, increment `messageCount` and bump
     /// `lastMessageAt` if present.
     public func recordPost(name: String, at timestamp: Date) async throws {
         try await writer.write { db in
             try db.execute(
-                sql: """
-                    INSERT INTO channel_index (name, createdAt, lastMessageAt, messageCount)
-                    VALUES (?, ?, ?, 1)
-                    ON CONFLICT(name) DO UPDATE SET
-                        lastMessageAt = excluded.lastMessageAt,
-                        messageCount = messageCount + 1
-                    """,
+                sql: Self.upsertSQL,
                 arguments: [name, timestamp, timestamp]
             )
         }
@@ -55,13 +61,7 @@ public struct ChannelIndexStore: Sendable {
     public func recordPostSync(name: String, at timestamp: Date) throws {
         try writer.write { db in
             try db.execute(
-                sql: """
-                    INSERT INTO channel_index (name, createdAt, lastMessageAt, messageCount)
-                    VALUES (?, ?, ?, 1)
-                    ON CONFLICT(name) DO UPDATE SET
-                        lastMessageAt = excluded.lastMessageAt,
-                        messageCount = messageCount + 1
-                    """,
+                sql: Self.upsertSQL,
                 arguments: [name, timestamp, timestamp]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -354,6 +354,15 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v19_channel_index") { db in
+            try db.create(table: "channel_index") { t in
+                t.primaryKey("name", .text)
+                t.column("createdAt", .text).notNull()
+                t.column("lastMessageAt", .text)
+                t.column("messageCount", .integer).notNull().defaults(to: 0)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -357,8 +357,8 @@ public final class TBDDatabase: Sendable {
         migrator.registerMigration("v19_channel_index") { db in
             try db.create(table: "channel_index") { t in
                 t.primaryKey("name", .text)
-                t.column("createdAt", .text).notNull()
-                t.column("lastMessageAt", .text)
+                t.column("createdAt", .datetime).notNull()
+                t.column("lastMessageAt", .datetime)
                 t.column("messageCount", .integer).notNull().defaults(to: 0)
             }
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -13,6 +13,7 @@ public final class TBDDatabase: Sendable {
     public let worktrees: WorktreeStore
     public let terminals: TerminalStore
     public let notifications: NotificationStore
+    public let channels: ChannelIndexStore
     public let notes: NoteStore
     public let conductors: ConductorStore
     public let modelProfiles: ModelProfileStore
@@ -34,6 +35,7 @@ public final class TBDDatabase: Sendable {
         self.worktrees = WorktreeStore(writer: pool)
         self.terminals = TerminalStore(writer: pool)
         self.notifications = NotificationStore(writer: pool)
+        self.channels = ChannelIndexStore(writer: pool)
         self.notes = NoteStore(writer: pool)
         self.conductors = ConductorStore(writer: pool)
         self.modelProfiles = ModelProfileStore(writer: pool)
@@ -52,6 +54,7 @@ public final class TBDDatabase: Sendable {
         self.worktrees = WorktreeStore(writer: queue)
         self.terminals = TerminalStore(writer: queue)
         self.notifications = NotificationStore(writer: queue)
+        self.channels = ChannelIndexStore(writer: queue)
         self.notes = NoteStore(writer: queue)
         self.conductors = ConductorStore(writer: queue)
         self.modelProfiles = ModelProfileStore(writer: queue)

--- a/Sources/TBDDaemon/Server/RPCRouter+ChannelHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ChannelHandlers.swift
@@ -1,0 +1,71 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "channels.rpc")
+
+extension RPCRouter {
+    func handleChannelsPost(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ChannelsPostParams.self, from: paramsData)
+
+        // Resolve identity. Either explicit overrides, or via terminalID lookup.
+        let fromSession: String
+        let fromLabel: String
+        if let s = params.fromSession, let l = params.fromLabel {
+            fromSession = s
+            fromLabel = l
+        } else if let terminalID = params.terminalID {
+            guard let terminal = try await db.terminals.get(id: terminalID) else {
+                return RPCResponse(error: "Unknown terminalID \(terminalID.uuidString)")
+            }
+            guard let session = terminal.claudeSessionID, !session.isEmpty else {
+                return RPCResponse(error: "Terminal \(terminalID.uuidString) has no recorded sessionID yet (SessionStart hook hasn't fired)")
+            }
+            guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+                return RPCResponse(error: "Worktree \(terminal.worktreeID.uuidString) not found")
+            }
+            fromSession = session
+            fromLabel = worktree.displayName
+        } else {
+            return RPCResponse(error: "Either terminalID or (fromSession + fromLabel) must be provided")
+        }
+
+        do {
+            let result = try await channelStore.post(
+                name: params.name,
+                body: params.body,
+                fromSession: fromSession,
+                fromLabel: fromLabel
+            )
+            return try RPCResponse(result: ChannelsPostResult(seq: result.seq, ts: result.ts))
+        } catch {
+            logger.error("channels.post failed: \(String(describing: error), privacy: .public)")
+            return RPCResponse(error: "channels.post failed: \(error)")
+        }
+    }
+
+    func handleChannelsList(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ChannelsListParams.self, from: paramsData)
+        let entries = try await db.channels.list(includeArchived: params.includeArchived)
+        let summaries = entries.map {
+            ChannelSummary(
+                name: $0.name,
+                createdAt: $0.createdAt,
+                lastMessageAt: $0.lastMessageAt,
+                messageCount: $0.messageCount
+            )
+        }
+        return try RPCResponse(result: ChannelsListResult(channels: summaries))
+    }
+
+    func handleChannelsArchive(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ChannelsArchiveParams.self, from: paramsData)
+        do {
+            let path = try await channelStore.archive(name: params.name)
+            return try RPCResponse(result: ChannelsArchiveResult(archivedPath: path))
+        } catch {
+            logger.error("channels.archive failed: \(String(describing: error), privacy: .public)")
+            return RPCResponse(error: "channels.archive failed: \(error)")
+        }
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+ChannelHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ChannelHandlers.swift
@@ -37,7 +37,7 @@ extension RPCRouter {
                 fromSession: fromSession,
                 fromLabel: fromLabel
             )
-            return try RPCResponse(result: ChannelsPostResult(seq: result.seq, ts: result.ts))
+            return try RPCResponse(result: ChannelsPostResult(name: result.name, seq: result.seq, ts: result.ts))
         } catch {
             logger.error("channels.post failed: \(String(describing: error), privacy: .public)")
             return RPCResponse(error: "channels.post failed: \(error)")

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -18,6 +18,7 @@ public final class RPCRouter: Sendable {
     public let conductorManager: ConductorManager
     public let usageFetcher: ClaudeUsageFetcher
     public let modelProfileResolver: ModelProfileResolver
+    public let channelStore: ChannelStore
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     public let pendingQuestions: PendingQuestionStore
 
@@ -35,7 +36,8 @@ public final class RPCRouter: Sendable {
         conductorManager: ConductorManager? = nil,
         usageFetcher: ClaudeUsageFetcher = LiveClaudeUsageFetcher(),
         modelProfileResolver: ModelProfileResolver? = nil,
-        pendingQuestions: PendingQuestionStore = PendingQuestionStore()
+        pendingQuestions: PendingQuestionStore = PendingQuestionStore(),
+        channelStore: ChannelStore? = nil
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -58,6 +60,10 @@ public final class RPCRouter: Sendable {
         )
         self.usageFetcher = usageFetcher
         self.pendingQuestions = pendingQuestions
+        self.channelStore = channelStore ?? ChannelStore(
+            channelsDir: TBDConstants.channelsDir,
+            index: db.channels
+        )
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.
@@ -125,6 +131,12 @@ public final class RPCRouter: Sendable {
                 return try await handleNotificationsList()
             case RPCMethod.notificationsMarkRead:
                 return try await handleNotificationsMarkRead(request.paramsData)
+            case RPCMethod.channelsPost:
+                return try await handleChannelsPost(request.paramsData)
+            case RPCMethod.channelsList:
+                return try await handleChannelsList(request.paramsData)
+            case RPCMethod.channelsArchive:
+                return try await handleChannelsArchive(request.paramsData)
             case RPCMethod.cleanup:
                 return try await handleCleanup()
             case RPCMethod.prList:

--- a/Sources/TBDShared/ChannelMessage.swift
+++ b/Sources/TBDShared/ChannelMessage.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// One JSONL line in a channel file. `(channel, seq)` is the message identity.
+public struct ChannelMessage: Codable, Equatable, Sendable {
+    public let seq: Int
+    public let ts: Date
+    public let fromSession: String
+    public let fromLabel: String
+    public let body: String
+
+    public init(seq: Int, ts: Date, fromSession: String, fromLabel: String, body: String) {
+        self.seq = seq
+        self.ts = ts
+        self.fromSession = fromSession
+        self.fromLabel = fromLabel
+        self.body = body
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case seq, ts, fromSession = "from_session", fromLabel = "from_label", body
+    }
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    /// Encode this message as one JSONL line ending in `\n`. Throws if encoding fails.
+    public func encodeLine() throws -> Data {
+        var data = try Self.encoder.encode(self)
+        data.append(0x0A)  // '\n'
+        return data
+    }
+
+    /// Decode one JSONL line (with or without trailing newline) into a message.
+    public static func decodeLine(_ data: Data) throws -> ChannelMessage {
+        let trimmed: Data
+        if data.last == 0x0A {
+            trimmed = data.subdata(in: 0..<data.count - 1)
+        } else {
+            trimmed = data
+        }
+        return try decoder.decode(ChannelMessage.self, from: trimmed)
+    }
+}

--- a/Sources/TBDShared/ChannelName.swift
+++ b/Sources/TBDShared/ChannelName.swift
@@ -15,14 +15,22 @@ public enum ChannelNameError: Error, Equatable, Sendable {
 /// See `docs/superpowers/specs/2026-05-10-channels-design.md` for the
 /// rationale behind each rule.
 public func validateChannelName(_ raw: String) throws -> String {
-    if raw.isEmpty { throw ChannelNameError.empty }
-    if raw.first?.isWhitespace == true || raw.last?.isWhitespace == true {
+    // Strip a single leading '#' for Slack-style ergonomics. This lets
+    // `tbd channels post #help …` and `tbd channels post help …` resolve
+    // to the same channel. We only strip ONE — `##foo` is still rejected
+    // by the forbidden-character check below (well, `#` isn't forbidden,
+    // so `##foo` becomes `#foo` and is accepted as a literal channel name
+    // — that's intentional; it just means "Slack-prefix UX, not literal").
+    let input = raw.hasPrefix("#") ? String(raw.dropFirst()) : raw
+
+    if input.isEmpty { throw ChannelNameError.empty }
+    if input.first?.isWhitespace == true || input.last?.isWhitespace == true {
         throw ChannelNameError.leadingOrTrailingWhitespace
     }
 
     // Reject forbidden characters before normalization so error messages
     // reference the original character the user typed.
-    for ch in raw {
+    for ch in input {
         for scalar in ch.unicodeScalars {
             if scalar.value == 0x2F           // '/'
                 || scalar.value == 0x5C       // '\\'
@@ -33,7 +41,7 @@ public func validateChannelName(_ raw: String) throws -> String {
         }
     }
 
-    let folded = raw.precomposedStringWithCanonicalMapping.lowercased()
+    let folded = input.precomposedStringWithCanonicalMapping.lowercased()
 
     if folded == "." || folded == ".." || folded == "_archive" {
         throw ChannelNameError.reservedName(folded)

--- a/Sources/TBDShared/ChannelName.swift
+++ b/Sources/TBDShared/ChannelName.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public enum ChannelNameError: Error, Equatable, Sendable {
+    case empty
+    case leadingOrTrailingWhitespace
+    case reservedName(String)
+    case forbiddenCharacter(Character)
+    case tooLongGraphemes(Int)
+    case tooLongBytes(Int)
+}
+
+/// Validate, normalize, and case-fold a channel name. Returns the canonical
+/// storage form. Throws `ChannelNameError` if the name is invalid.
+///
+/// See `docs/superpowers/specs/2026-05-10-channels-design.md` for the
+/// rationale behind each rule.
+public func validateChannelName(_ raw: String) throws -> String {
+    if raw.isEmpty { throw ChannelNameError.empty }
+    if raw.first?.isWhitespace == true || raw.last?.isWhitespace == true {
+        throw ChannelNameError.leadingOrTrailingWhitespace
+    }
+
+    // Reject forbidden characters before normalization so error messages
+    // reference the original character the user typed.
+    for ch in raw {
+        for scalar in ch.unicodeScalars {
+            if scalar.value == 0x2F           // '/'
+                || scalar.value == 0x5C       // '\\'
+                || scalar.value <= 0x1F       // C0 controls + NUL
+                || scalar.value == 0x7F {     // DEL
+                throw ChannelNameError.forbiddenCharacter(ch)
+            }
+        }
+    }
+
+    let folded = raw.precomposedStringWithCanonicalMapping.localizedLowercase
+
+    if folded == "." || folded == ".." || folded == "_archive" {
+        throw ChannelNameError.reservedName(folded)
+    }
+
+    let graphemeCount = folded.count
+    if graphemeCount > 64 {
+        throw ChannelNameError.tooLongGraphemes(graphemeCount)
+    }
+    let byteCount = folded.utf8.count
+    if byteCount > 200 {
+        throw ChannelNameError.tooLongBytes(byteCount)
+    }
+
+    return folded
+}

--- a/Sources/TBDShared/ChannelName.swift
+++ b/Sources/TBDShared/ChannelName.swift
@@ -33,7 +33,7 @@ public func validateChannelName(_ raw: String) throws -> String {
         }
     }
 
-    let folded = raw.precomposedStringWithCanonicalMapping.localizedLowercase
+    let folded = raw.precomposedStringWithCanonicalMapping.lowercased()
 
     if folded == "." || folded == ".." || folded == "_archive" {
         throw ChannelNameError.reservedName(folded)

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -10,6 +10,8 @@ public enum TBDConstants {
     public static let portFilePath = configDir.appendingPathComponent("port").path
     public static let conductorsDir = configDir.appendingPathComponent("conductors")
     public static let reposDir = configDir.appendingPathComponent("repos")
+    public static let channelsDir = configDir.appendingPathComponent("channels")
+    public static let channelsArchiveDir = channelsDir.appendingPathComponent("_archive")
 
     public static func hookPath(repoID: UUID, eventName: String) -> String {
         reposDir

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -845,9 +845,12 @@ public struct ChannelsPostParams: Codable, Sendable {
 }
 
 public struct ChannelsPostResult: Codable, Sendable {
+    public let name: String
     public let seq: Int
     public let ts: Date
-    public init(seq: Int, ts: Date) { self.seq = seq; self.ts = ts }
+    public init(name: String, seq: Int, ts: Date) {
+        self.name = name; self.seq = seq; self.ts = ts
+    }
 }
 
 public struct ChannelsListParams: Codable, Sendable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -96,6 +96,9 @@ public enum RPCMethod {
     public static let resolvePath = "resolve.path"
     public static let notificationsList = "notifications.list"
     public static let notificationsMarkRead = "notifications.markRead"
+    public static let channelsPost = "channels.post"
+    public static let channelsList = "channels.list"
+    public static let channelsArchive = "channels.archive"
     public static let prList    = "pr.list"
     public static let prRefresh = "pr.refresh"
     public static let cleanup = "cleanup"
@@ -824,4 +827,56 @@ public struct TerminalAskUserQuestionClearedParams: Codable, Sendable {
         self.terminalID = terminalID
         self.toolUseID = toolUseID
     }
+}
+
+// MARK: - Channels
+
+public struct ChannelsPostParams: Codable, Sendable {
+    public let name: String
+    public let body: String
+    public let terminalID: UUID?       // resolved → fromSession + fromLabel by daemon
+    public let fromSession: String?    // override (for non-TBD callers)
+    public let fromLabel: String?      // override (for non-TBD callers)
+    public init(name: String, body: String, terminalID: UUID? = nil,
+                fromSession: String? = nil, fromLabel: String? = nil) {
+        self.name = name; self.body = body; self.terminalID = terminalID
+        self.fromSession = fromSession; self.fromLabel = fromLabel
+    }
+}
+
+public struct ChannelsPostResult: Codable, Sendable {
+    public let seq: Int
+    public let ts: Date
+    public init(seq: Int, ts: Date) { self.seq = seq; self.ts = ts }
+}
+
+public struct ChannelsListParams: Codable, Sendable {
+    public let includeArchived: Bool
+    public init(includeArchived: Bool = false) { self.includeArchived = includeArchived }
+}
+
+public struct ChannelSummary: Codable, Sendable {
+    public let name: String
+    public let createdAt: Date
+    public let lastMessageAt: Date?
+    public let messageCount: Int
+    public init(name: String, createdAt: Date, lastMessageAt: Date?, messageCount: Int) {
+        self.name = name; self.createdAt = createdAt
+        self.lastMessageAt = lastMessageAt; self.messageCount = messageCount
+    }
+}
+
+public struct ChannelsListResult: Codable, Sendable {
+    public let channels: [ChannelSummary]
+    public init(channels: [ChannelSummary]) { self.channels = channels }
+}
+
+public struct ChannelsArchiveParams: Codable, Sendable {
+    public let name: String
+    public init(name: String) { self.name = name }
+}
+
+public struct ChannelsArchiveResult: Codable, Sendable {
+    public let archivedPath: String
+    public init(archivedPath: String) { self.archivedPath = archivedPath }
 }

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -27,7 +27,7 @@ TBD is a macOS app that manages git worktrees and terminal tabs (Claude Code or 
 
 ## Discovering current commands
 
-Always run `tbd <subcommand> --help` for current flags — flag detail is not duplicated here. Top-level commands: `tbd worktree`, `tbd terminal`, `tbd link`, `tbd notify`.
+Always run `tbd <subcommand> --help` for current flags — flag detail is not duplicated here. Top-level commands: `tbd worktree`, `tbd terminal`, `tbd link`, `tbd notify`, `tbd channels`.
 
 ## Common workflows
 
@@ -62,6 +62,55 @@ tbd terminal output <id> [--lines N]
 ```bash
 tbd notify --type {response_complete|error|task_complete|attention_needed} --message "..."
 ```
+
+### Coordinate via channels
+
+Channels let you share context with another TBD-managed session — useful when
+the user asks you to "post that question for the other agent" or asks the other
+agent to "go read what session A said in #foo".
+
+```bash
+# Post a message
+tbd channels post help "anyone seen the launchctl crash?"
+
+# Output includes a copy-pasteable read command:
+#   Posted to #help (seq 42)
+#   → tbd channels read help --seq 42
+# The user often pastes the second line into another session's prompt.
+
+# Read a specific message
+tbd channels read help --seq 42
+
+# Read recent activity (default last 20)
+tbd channels read help
+
+# Pull only what's new since the seq you last saw
+tbd channels read help --since 40
+
+# Discover channels
+tbd channels list
+
+# Watch a channel live (background bash + BashOutput)
+# Note: long-lived `tail --follow` shells are not yet empirically validated
+# against Claude Code's BashOutput buffer / reaping behavior. Prefer short
+# windows (start the tail when you need it, kill it when done) over
+# multi-hour background shells until the integration is characterized.
+tbd channels tail help --follow
+
+# Clean up a channel that has served its purpose
+tbd channels archive help
+```
+
+**Notes:**
+- Channel names are case-folded; `#API-questions` and `#api-questions` are the
+  same channel. Free-form Unicode is allowed (emoji, non-Latin scripts).
+- The body is plain UTF-8 text up to 64 KB. Markdown is fine if the reader
+  cares; the daemon does not interpret it.
+- Reads do not require the daemon — the CLI opens the file directly. Posts
+  and archives go through the daemon.
+- You can also `Read("~/tbd/channels/<name>.jsonl", offset=N)` directly, but
+  note `offset` is line-numbered and may diverge from `seq` after a torn-line
+  recovery. Prefer the CLI commands above.
 
 ### Get a deep link to a worktree
 

--- a/Tests/TBDDaemonTests/ChannelIndexStoreTests.swift
+++ b/Tests/TBDDaemonTests/ChannelIndexStoreTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ChannelIndexStoreTests {
+
+    private func makeStore() throws -> (ChannelIndexStore, TBDDatabase, String) {
+        let dbPath = NSTemporaryDirectory() + "tbd-cix-\(UUID().uuidString).db"
+        let db = try TBDDatabase(path: dbPath)
+        return (ChannelIndexStore(writer: db.writerForTests), db, dbPath)
+    }
+
+    @Test func recordOnFirstPostCreatesRow() async throws {
+        let (store, _, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let now = Date()
+        try await store.recordPost(name: "help", at: now)
+
+        let entries = try await store.list(includeArchived: false)
+        #expect(entries.count == 1)
+        #expect(entries.first?.name == "help")
+        #expect(entries.first?.messageCount == 1)
+    }
+
+    @Test func recordOnSubsequentPostsIncrements() async throws {
+        let (store, _, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        try await store.recordPost(name: "help", at: Date())
+        try await store.recordPost(name: "help", at: Date())
+        try await store.recordPost(name: "help", at: Date())
+
+        let entries = try await store.list(includeArchived: false)
+        #expect(entries.first?.messageCount == 3)
+    }
+
+    @Test func listReturnsAllChannelsSortedByLastMessage() async throws {
+        let (store, _, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let earlier = Date().addingTimeInterval(-100)
+        let later = Date()
+        try await store.recordPost(name: "old", at: earlier)
+        try await store.recordPost(name: "new", at: later)
+
+        let entries = try await store.list(includeArchived: false)
+        #expect(entries.map(\.name) == ["new", "old"])
+    }
+
+    @Test func deleteRemovesRow() async throws {
+        let (store, _, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        try await store.recordPost(name: "help", at: Date())
+        try await store.delete(name: "help")
+
+        let entries = try await store.list(includeArchived: false)
+        #expect(entries.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/ChannelIndexStoreTests.swift
+++ b/Tests/TBDDaemonTests/ChannelIndexStoreTests.swift
@@ -8,7 +8,7 @@ import Testing
     private func makeStore() throws -> (ChannelIndexStore, TBDDatabase, String) {
         let dbPath = NSTemporaryDirectory() + "tbd-cix-\(UUID().uuidString).db"
         let db = try TBDDatabase(path: dbPath)
-        return (ChannelIndexStore(writer: db.writerForTests), db, dbPath)
+        return (db.channels, db, dbPath)
     }
 
     @Test func recordOnFirstPostCreatesRow() async throws {

--- a/Tests/TBDDaemonTests/ChannelStoreArchiveTests.swift
+++ b/Tests/TBDDaemonTests/ChannelStoreArchiveTests.swift
@@ -74,4 +74,52 @@ import Testing
             _ = try await store.archive(name: "ghost")
         }
     }
+
+    /// Regression: post and archive used to issue their channel_index
+    /// writes *outside* the per-channel lock. If `delete` landed before
+    /// `recordPost`, the upsert resurrected the row for a channel whose
+    /// JSONL had already been moved to `_archive/` — `tbd channels list`
+    /// showed a phantom active channel with no backing file.
+    ///
+    /// With both DB calls now inside the per-channel lock, the index and
+    /// the filesystem can never disagree: either the row exists and the
+    /// active file exists, or neither does. This test races the two
+    /// operations across multiple iterations to amplify the chance of
+    /// catching a regression. It is non-deterministic — the bug doesn't
+    /// fire on every run — but with the fix in place it can never
+    /// observe the inconsistent state, so it cannot false-positive.
+    @Test func archiveDoesNotResurrectIndexRowFromInflightPost() async throws {
+        for _ in 0..<10 {
+            let (store, tmp, dbPath) = try makeStore()
+            defer { try? FileManager.default.removeItem(at: tmp) }
+
+            // Establish the channel so the racing `post` is "update" not "insert".
+            _ = try await store.post(name: "ghosted", body: "first",
+                                     fromSession: "s", fromLabel: "L")
+
+            // Concurrently kick off another post and an archive. Whichever
+            // wins the per-channel lock first, both should leave the index
+            // and filesystem in agreement when they're done.
+            async let p: () = {
+                _ = try? await store.post(name: "ghosted", body: "racing",
+                                          fromSession: "s", fromLabel: "L")
+            }()
+            async let a: () = {
+                _ = try? await store.archive(name: "ghosted")
+            }()
+            _ = await (p, a)
+
+            // Read the index. Either the channel is archived (no row, no
+            // active file) OR the post landed first and the channel is
+            // still active. The buggy interleaving (row exists but file
+            // gone, or file exists but no row) must never be observed.
+            let db = try TBDDatabase(path: dbPath)
+            let entries = try await db.channels.list(includeArchived: false)
+            let activePath = tmp.appendingPathComponent("channels/ghosted.jsonl").path
+            let activeFileExists = FileManager.default.fileExists(atPath: activePath)
+            let indexHasRow = entries.contains { $0.name == "ghosted" }
+            #expect(activeFileExists == indexHasRow,
+                    "phantom row: index says active=\(indexHasRow) but file exists=\(activeFileExists)")
+        }
+    }
 }

--- a/Tests/TBDDaemonTests/ChannelStoreArchiveTests.swift
+++ b/Tests/TBDDaemonTests/ChannelStoreArchiveTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ChannelStoreArchiveTests {
+
+    private func makeStore() throws -> (ChannelStore, URL, String) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-csa-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let dbPath = tmp.appendingPathComponent("state.db").path
+        let db = try TBDDatabase(path: dbPath)
+        let store = ChannelStore(channelsDir: tmp.appendingPathComponent("channels"),
+                                 index: db.channels)
+        return (store, tmp, dbPath)
+    }
+
+    @Test func archiveMovesFileToArchiveDir() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "old", body: "x", fromSession: "s", fromLabel: "L")
+        let archived = try await store.archive(name: "old")
+
+        let activePath = tmp.appendingPathComponent("channels/old.jsonl").path
+        #expect(FileManager.default.fileExists(atPath: activePath) == false)
+        #expect(FileManager.default.fileExists(atPath: archived) == true)
+        #expect(archived.contains("/_archive/old-"))
+        #expect(archived.hasSuffix(".jsonl"))
+    }
+
+    @Test func archiveRemovesIndexRow() async throws {
+        let (store, tmp, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "old", body: "x", fromSession: "s", fromLabel: "L")
+        _ = try await store.archive(name: "old")
+
+        let db = try TBDDatabase(path: dbPath)
+        let entries = try await db.channels.list(includeArchived: false)
+        #expect(entries.isEmpty)
+    }
+
+    @Test func archiveRemovesLockSidecar() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "old", body: "x", fromSession: "s", fromLabel: "L")
+        _ = try await store.archive(name: "old")
+        let lockPath = tmp.appendingPathComponent("channels/old.lock").path
+        #expect(FileManager.default.fileExists(atPath: lockPath) == false)
+    }
+
+    @Test func reusingArchivedNameStartsAtSeq1() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "phoenix", body: "first life",
+                                 fromSession: "s", fromLabel: "L")
+        _ = try await store.post(name: "phoenix", body: "still first",
+                                 fromSession: "s", fromLabel: "L")
+        _ = try await store.archive(name: "phoenix")
+
+        let r = try await store.post(name: "phoenix", body: "rebirth",
+                                     fromSession: "s", fromLabel: "L")
+        #expect(r.seq == 1)
+    }
+
+    @Test func archiveOfMissingChannelThrows() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        await #expect(throws: ChannelStoreError.self) {
+            _ = try await store.archive(name: "ghost")
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/ChannelStoreRecoveryTests.swift
+++ b/Tests/TBDDaemonTests/ChannelStoreRecoveryTests.swift
@@ -1,0 +1,87 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct ChannelStoreRecoveryTests {
+
+    private func makeStore() throws -> (ChannelStore, URL) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-csr-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let dbPath = tmp.appendingPathComponent("state.db").path
+        let db = try TBDDatabase(path: dbPath)
+        let store = ChannelStore(channelsDir: tmp.appendingPathComponent("channels"),
+                                 index: db.channels)
+        return (store, tmp)
+    }
+
+    @Test func recoversFromTornLastLine() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Post two messages so we have known good content.
+        _ = try await store.post(name: "rec", body: "m1", fromSession: "s", fromLabel: "L")
+        _ = try await store.post(name: "rec", body: "m2", fromSession: "s", fromLabel: "L")
+
+        // Append a half-written line to simulate a crash mid-write.
+        let path = tmp.appendingPathComponent("channels/rec.jsonl").path
+        let truncated = "{\"seq\":3,\"ts\":\"2026-".data(using: .utf8)!
+        let fd = open(path, O_WRONLY | O_APPEND)
+        _ = truncated.withUnsafeBytes { write(fd, $0.baseAddress, $0.count) }
+        close(fd)
+
+        // Make a new store (simulating daemon restart).
+        let dbPath2 = tmp.appendingPathComponent("state.db").path
+        let db2 = try TBDDatabase(path: dbPath2)
+        let store2 = ChannelStore(channelsDir: tmp.appendingPathComponent("channels"),
+                                  index: db2.channels)
+
+        // Next post should be seq 3 (torn line is dropped); file should
+        // contain exactly 3 valid JSONL lines.
+        let r = try await store2.post(name: "rec", body: "m3",
+                                      fromSession: "s", fromLabel: "L")
+        #expect(r.seq == 3)
+
+        let bytes = try Data(contentsOf: URL(fileURLWithPath: path))
+        let lines = bytes.split(separator: 0x0A).filter { !$0.isEmpty }
+        #expect(lines.count == 3)
+        for line in lines {
+            _ = try ChannelMessage.decodeLine(Data(line))
+        }
+    }
+
+    @Test func emptyFileReturnsZeroSeq() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Create an empty file.
+        let dir = tmp.appendingPathComponent("channels")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("empty.jsonl").path
+        FileManager.default.createFile(atPath: path, contents: nil)
+
+        let r = try await store.post(name: "empty", body: "first",
+                                     fromSession: "s", fromLabel: "L")
+        #expect(r.seq == 1)
+    }
+
+    @Test func recoveryHandlesNoFinalNewline() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Manually write one good line and one trailing partial line with no newline at all.
+        let dir = tmp.appendingPathComponent("channels")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("nonl.jsonl").path
+        let good = ChannelMessage(seq: 1, ts: Date(), fromSession: "s", fromLabel: "L", body: "ok")
+        var content = try good.encodeLine()
+        content.append(contentsOf: Array("{\"partial".utf8))
+        try content.write(to: URL(fileURLWithPath: path))
+
+        let r = try await store.post(name: "nonl", body: "next",
+                                     fromSession: "s", fromLabel: "L")
+        #expect(r.seq == 2)
+    }
+}

--- a/Tests/TBDDaemonTests/ChannelStoreTests.swift
+++ b/Tests/TBDDaemonTests/ChannelStoreTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct ChannelStoreTests {
+
+    private func makeStore() throws -> (ChannelStore, URL, String) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-cs-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let dbPath = tmp.appendingPathComponent("state.db").path
+        let db = try TBDDatabase(path: dbPath)
+        let store = ChannelStore(channelsDir: tmp.appendingPathComponent("channels"),
+                                 index: db.channels)
+        return (store, tmp, dbPath)
+    }
+
+    @Test func postCreatesFileWithSeq1() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let result = try await store.post(name: "help", body: "hi",
+                                          fromSession: "s1", fromLabel: "L1")
+        #expect(result.seq == 1)
+
+        let file = tmp.appendingPathComponent("channels").appendingPathComponent("help.jsonl")
+        let bytes = try Data(contentsOf: file)
+        let line = try ChannelMessage.decodeLine(bytes)
+        #expect(line.seq == 1)
+        #expect(line.body == "hi")
+        #expect(line.fromSession == "s1")
+        #expect(line.fromLabel == "L1")
+    }
+
+    @Test func sequentialPostsIncrementSeq() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let r1 = try await store.post(name: "help", body: "one", fromSession: "s", fromLabel: "L")
+        let r2 = try await store.post(name: "help", body: "two", fromSession: "s", fromLabel: "L")
+        let r3 = try await store.post(name: "help", body: "three", fromSession: "s", fromLabel: "L")
+        let seqs: [Int] = [r1.seq, r2.seq, r3.seq]
+        #expect(seqs == [1, 2, 3])
+    }
+
+    @Test func differentChannelsHaveIndependentSeq() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let a = try await store.post(name: "alpha", body: "x", fromSession: "s", fromLabel: "L")
+        let b = try await store.post(name: "beta",  body: "x", fromSession: "s", fromLabel: "L")
+        #expect(a.seq == 1)
+        #expect(b.seq == 1)
+    }
+
+    @Test func nameIsCaseFolded() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "Help", body: "x", fromSession: "s", fromLabel: "L")
+        _ = try await store.post(name: "HELP", body: "y", fromSession: "s", fromLabel: "L")
+
+        // Both should land in the same file `help.jsonl`.
+        let file = tmp.appendingPathComponent("channels/help.jsonl")
+        let bytes = try Data(contentsOf: file)
+        let lines = bytes.split(separator: 0x0A)
+        #expect(lines.count == 2)
+    }
+
+    @Test func rejectsInvalidName() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        await #expect(throws: ChannelNameError.self) {
+            _ = try await store.post(name: "../etc/passwd", body: "x",
+                                     fromSession: "s", fromLabel: "L")
+        }
+    }
+
+    @Test func rejectsBodyOver64KB() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let body = String(repeating: "a", count: 64 * 1024 + 1)
+        await #expect(throws: ChannelStoreError.self) {
+            _ = try await store.post(name: "help", body: body,
+                                     fromSession: "s", fromLabel: "L")
+        }
+    }
+
+    @Test func updatesChannelIndex() async throws {
+        let (store, tmp, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "help", body: "x", fromSession: "s", fromLabel: "L")
+        _ = try await store.post(name: "help", body: "y", fromSession: "s", fromLabel: "L")
+
+        let db = try TBDDatabase(path: dbPath)
+        let entries = try await db.channels.list(includeArchived: false)
+        #expect(entries.first?.name == "help")
+        #expect(entries.first?.messageCount == 2)
+    }
+
+    @Test func concurrentPostsToSameChannelGetUniqueSeq() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let count = 20
+        try await withThrowingTaskGroup(of: Int.self) { group in
+            for i in 0..<count {
+                group.addTask {
+                    let r = try await store.post(name: "race", body: "msg-\(i)",
+                                                 fromSession: "s", fromLabel: "L")
+                    return r.seq
+                }
+            }
+            var seqs: [Int] = []
+            for try await seq in group { seqs.append(seq) }
+            #expect(Set(seqs).count == count)
+            #expect(seqs.min() == 1)
+            #expect(seqs.max() == count)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/FileLockTests.swift
+++ b/Tests/TBDDaemonTests/FileLockTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct FileLockTests {
+
+    @Test func acquiresAndReleases() throws {
+        let path = NSTemporaryDirectory() + "tbd-flock-\(UUID().uuidString).lock"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let lock = try FileLock.acquire(path: path)
+        try lock.release()
+    }
+
+    @Test func twoLocksOnSamePathSerialize() async throws {
+        let path = NSTemporaryDirectory() + "tbd-flock-\(UUID().uuidString).lock"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let first = try FileLock.acquire(path: path)
+
+        // Try to acquire a non-blocking second lock from a separate fork; in-process
+        // flock is per-FD, so a second open+flock from this same process should
+        // *also* block. Run in a Task with a timeout to verify it blocks.
+        let acquired = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    let second = try FileLock.acquire(path: path)
+                    try? second.release()
+                    return true
+                } catch {
+                    return false
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: .milliseconds(150))
+                try? first.release()
+                return true
+            }
+            // collect; we only care that the first task eventually completes
+            for await _ in group {}
+            return true
+        }
+        #expect(acquired == true)
+    }
+
+    @Test func createsLockFileIfAbsent() throws {
+        let path = NSTemporaryDirectory() + "tbd-flock-\(UUID().uuidString).lock"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        #expect(FileManager.default.fileExists(atPath: path) == false)
+        let lock = try FileLock.acquire(path: path)
+        #expect(FileManager.default.fileExists(atPath: path) == true)
+        try lock.release()
+    }
+}

--- a/Tests/TBDDaemonTests/FileLockTests.swift
+++ b/Tests/TBDDaemonTests/FileLockTests.swift
@@ -18,29 +18,32 @@ import Testing
 
         let first = try FileLock.acquire(path: path)
 
-        // Try to acquire a non-blocking second lock from a separate fork; in-process
-        // flock is per-FD, so a second open+flock from this same process should
-        // *also* block. Run in a Task with a timeout to verify it blocks.
-        let acquired = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                do {
-                    let second = try FileLock.acquire(path: path)
-                    try? second.release()
-                    return true
-                } catch {
-                    return false
-                }
-            }
-            group.addTask {
-                try? await Task.sleep(for: .milliseconds(150))
-                try? first.release()
-                return true
-            }
-            // collect; we only care that the first task eventually completes
-            for await _ in group {}
-            return true
+        // Kick off a second acquire in a Task. It should block until we
+        // release the first. Capture the timestamp at which it actually
+        // returns so we can assert it didn't return early.
+        let secondAcquireStarted = Date()
+        let secondAcquireTask = Task<Date, Error> {
+            let second = try FileLock.acquire(path: path)
+            let acquiredAt = Date()
+            try second.release()
+            return acquiredAt
         }
-        #expect(acquired == true)
+
+        // Hold the first lock for at least 200ms, then release.
+        try await Task.sleep(for: .milliseconds(200))
+        let releasedAt = Date()
+        try first.release()
+
+        let secondAcquiredAt = try await secondAcquireTask.value
+
+        // The second acquire's completion must happen at-or-after the
+        // first release. If `flock` were broken (returned immediately),
+        // `secondAcquiredAt` would be earlier than `releasedAt`. Allow a
+        // small tolerance for scheduling jitter between the two clocks.
+        let secondWaitedFor = secondAcquiredAt.timeIntervalSince(secondAcquireStarted)
+        let firstHeldFor = releasedAt.timeIntervalSince(secondAcquireStarted)
+        #expect(secondWaitedFor >= firstHeldFor - 0.05,
+                "second acquire returned at \(secondAcquiredAt) but first released at \(releasedAt)")
     }
 
     @Test func createsLockFileIfAbsent() throws {

--- a/Tests/TBDDaemonTests/MigrationV18Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV18Tests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct MigrationV18Tests {
+
+    @Test func createsChannelIndexTable() throws {
+        let dbPath = NSTemporaryDirectory() + "tbd-v18-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let db = try TBDDatabase(path: dbPath)
+        try db.writerForTests.read { db in
+            let exists = try Bool.fetchOne(db, sql: """
+                SELECT COUNT(*) > 0 FROM sqlite_master
+                WHERE type='table' AND name='channel_index'
+                """)
+            #expect(exists == true)
+
+            // Verify columns
+            let cols = try Row.fetchAll(db, sql: "PRAGMA table_info('channel_index')")
+            let names = Set(cols.compactMap { $0["name"] as String? })
+            #expect(names == ["name", "createdAt", "lastMessageAt", "messageCount"])
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/MigrationV19Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV19Tests.swift
@@ -3,7 +3,7 @@ import GRDB
 import Testing
 @testable import TBDDaemonLib
 
-@Suite struct MigrationV18Tests {
+@Suite struct MigrationV19Tests {
 
     @Test func createsChannelIndexTable() throws {
         let dbPath = NSTemporaryDirectory() + "tbd-v18-\(UUID().uuidString).db"

--- a/Tests/TBDSharedTests/ChannelMessageTests.swift
+++ b/Tests/TBDSharedTests/ChannelMessageTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite struct ChannelMessageTests {
+
+    @Test func roundtrips() throws {
+        let msg = ChannelMessage(
+            seq: 42,
+            ts: Date(timeIntervalSince1970: 1_715_354_581),
+            fromSession: "abc-123",
+            fromLabel: "tbd-known-smelt",
+            body: "anyone seen the launchctl crash?"
+        )
+        let line = try msg.encodeLine()
+        let decoded = try ChannelMessage.decodeLine(line)
+        #expect(decoded == msg)
+    }
+
+    @Test func encodedLineEndsWithNewline() throws {
+        let msg = ChannelMessage(seq: 1, ts: Date(), fromSession: "s", fromLabel: "l", body: "x")
+        let line = try msg.encodeLine()
+        #expect(line.last == 0x0A)  // '\n'
+    }
+
+    @Test func encodedLineHasNoInternalNewline() throws {
+        let msg = ChannelMessage(seq: 1, ts: Date(), fromSession: "s", fromLabel: "l",
+                                 body: "line one\nline two\nline three")
+        let line = try msg.encodeLine()
+        // Exactly one newline — at the end.
+        let count = line.filter { $0 == 0x0A }.count
+        #expect(count == 1)
+        let decoded = try ChannelMessage.decodeLine(line)
+        #expect(decoded.body == "line one\nline two\nline three")
+    }
+
+    @Test func decodeRejectsMalformedLine() {
+        let bogus = Data("{not json\n".utf8)
+        #expect(throws: (any Error).self) {
+            try ChannelMessage.decodeLine(bogus)
+        }
+    }
+}

--- a/Tests/TBDSharedTests/ChannelNameTests.swift
+++ b/Tests/TBDSharedTests/ChannelNameTests.swift
@@ -55,6 +55,12 @@ import Testing
         #expect(normalized.count == 64)
     }
 
+    @Test func acceptsAtByteLimit() throws {
+        let s = String(repeating: "🔥", count: 50)  // 50 × 4 bytes = 200
+        let normalized = try validateChannelName(s)
+        #expect(normalized.utf8.count == 200)
+    }
+
     @Test func rejectsTooLongInBytes() {
         // 50 emoji × ~4 bytes = 200 bytes; 51 emoji = 204 bytes → reject
         let s = String(repeating: "🔥", count: 51)

--- a/Tests/TBDSharedTests/ChannelNameTests.swift
+++ b/Tests/TBDSharedTests/ChannelNameTests.swift
@@ -68,4 +68,15 @@ import Testing
             try validateChannelName(s)
         }
     }
+
+    @Test func stripsLeadingHash() throws {
+        let normalized = try validateChannelName("#help")
+        #expect(normalized == "help")
+    }
+
+    @Test func keepsNonLeadingHash() throws {
+        // Internal # is allowed (not in forbidden set); only LEADING # is stripped.
+        let normalized = try validateChannelName("a#b")
+        #expect(normalized == "a#b")
+    }
 }

--- a/Tests/TBDSharedTests/ChannelNameTests.swift
+++ b/Tests/TBDSharedTests/ChannelNameTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite struct ChannelNameTests {
+
+    @Test func acceptsSimpleAscii() throws {
+        let normalized = try validateChannelName("help")
+        #expect(normalized == "help")
+    }
+
+    @Test func lowercases() throws {
+        let normalized = try validateChannelName("API-Questions")
+        #expect(normalized == "api-questions")
+    }
+
+    @Test func acceptsEmoji() throws {
+        let normalized = try validateChannelName("🔥")
+        #expect(normalized == "🔥")
+    }
+
+    @Test func acceptsNonLatin() throws {
+        let normalized = try validateChannelName("日本語")
+        #expect(normalized == "日本語")
+    }
+
+    @Test func nfcNormalizes() throws {
+        // "é" composed (U+00E9) vs decomposed ("e" + U+0301)
+        let composed = try validateChannelName("caf\u{00E9}")
+        let decomposed = try validateChannelName("cafe\u{0301}")
+        #expect(composed == decomposed)
+    }
+
+    @Test(arguments: [
+        "", " ", "  ", "name ", " name", ".", "..", "_archive",
+        "a/b", "a\\b", "a\u{0000}b", "a\u{0001}b", "a\u{007F}b",
+        "a\nb", "a\tb",
+    ])
+    func rejects(_ input: String) {
+        #expect(throws: ChannelNameError.self) {
+            try validateChannelName(input)
+        }
+    }
+
+    @Test func rejectsTooLongInGraphemes() {
+        let s = String(repeating: "a", count: 65)
+        #expect(throws: ChannelNameError.self) {
+            try validateChannelName(s)
+        }
+    }
+
+    @Test func acceptsAtGraphemeLimit() throws {
+        let s = String(repeating: "a", count: 64)
+        let normalized = try validateChannelName(s)
+        #expect(normalized.count == 64)
+    }
+
+    @Test func rejectsTooLongInBytes() {
+        // 50 emoji × ~4 bytes = 200 bytes; 51 emoji = 204 bytes → reject
+        let s = String(repeating: "🔥", count: 51)
+        #expect(throws: ChannelNameError.self) {
+            try validateChannelName(s)
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-05-10-channels.md
+++ b/docs/superpowers/plans/2026-05-10-channels.md
@@ -1,0 +1,2491 @@
+# Channels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Slack-like inter-session channels for TBD agents, backed by per-channel append-only JSONL files, with daemon-mediated writes and CLI-only read paths.
+
+**Architecture:** Each channel is a JSONL file at `~/tbd/channels/<name>.jsonl`. The daemon serializes writes via per-channel async locks plus cross-process `flock(2)` on a sidecar lockfile. Reads bypass the daemon — the CLI opens files directly. Identity is resolved by reusing TBD's existing `TBD_TERMINAL_ID` env var and the daemon's Terminal table (no new hooks). One SQLite table (`channel_index`) is a derivable cache for fast listing.
+
+**Tech Stack:** Swift, GRDB (SQLite), Swift NIO (existing daemon), Swift ArgumentParser (CLI), Swift Testing (`import Testing` + `@Test` + `#expect`).
+
+**Adversarial-review findings folded in:**
+- Crash safety = serialization + `flock` + torn-line recovery + `fsync`. No PIPE_BUF claims anywhere.
+- Per-channel `flock` defends against the (rare) two-daemon race the PID-file TOCTOU permits.
+- Reopen-per-write (no cached FDs) defends against atomic-save / rename hazards.
+- Channel-name validation rejects path traversal and case-aliases via Unicode case-folding.
+- `BashOutput` integration is validated empirically (Task 17) before docs claim it works.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-channels-design.md`
+
+---
+
+## File Structure
+
+**TBDShared:**
+- `Sources/TBDShared/ChannelName.swift` — `validateChannelName()` + `ChannelNameError`
+- `Sources/TBDShared/RPCProtocol.swift` — additions (RPC method constants + param/result types)
+- `Sources/TBDShared/TBDSkillContent.swift` — additions (Channels section)
+
+**TBDDaemonLib:**
+- `Sources/TBDDaemon/Database/Database.swift` — additions (v18 migration)
+- `Sources/TBDDaemon/Database/ChannelIndexStore.swift` — Record + Store for `channel_index`
+- `Sources/TBDDaemon/Channels/ChannelMessage.swift` — JSONL line codec
+- `Sources/TBDDaemon/Channels/FileLock.swift` — `flock(2)` RAII wrapper
+- `Sources/TBDDaemon/Channels/ChannelLockManager.swift` — per-channel async locks
+- `Sources/TBDDaemon/Channels/ChannelStore.swift` — post / archive / recovery orchestration
+- `Sources/TBDDaemon/Server/RPCRouter+ChannelHandlers.swift` — RPC handlers
+- `Sources/TBDDaemon/Server/RPCRouter.swift` — additions (dispatch cases)
+
+**TBDCLI:**
+- `Sources/TBDCLI/Commands/ChannelsCommand.swift` — top-level group + subcommands
+- `Sources/TBDCLI/TBD.swift` — additions (register subcommand)
+
+**Tests:**
+- `Tests/TBDSharedTests/ChannelNameTests.swift`
+- `Tests/TBDDaemonTests/MigrationV18Tests.swift`
+- `Tests/TBDDaemonTests/ChannelIndexStoreTests.swift`
+- `Tests/TBDDaemonTests/ChannelMessageTests.swift`
+- `Tests/TBDDaemonTests/FileLockTests.swift`
+- `Tests/TBDDaemonTests/ChannelStoreTests.swift`
+- `Tests/TBDDaemonTests/ChannelStoreRecoveryTests.swift`
+- `Tests/TBDDaemonTests/ChannelStoreArchiveTests.swift`
+
+**Docs / Validation:**
+- `docs/superpowers/notes/2026-05-10-bashoutput-validation.md` — empirical findings (Task 17)
+
+---
+
+## Task 1: Channel name validation (TBDShared)
+
+**Files:**
+- Create: `Sources/TBDShared/ChannelName.swift`
+- Create: `Tests/TBDSharedTests/ChannelNameTests.swift`
+
+**Behavior summary:**
+- Allow arbitrary Unicode (emoji, non-Latin).
+- Apply NFC normalization, then case-fold via `localizedLowercase`.
+- Reject `/`, `\`, NUL, control chars (`U+0000`–`U+001F`, `U+007F`).
+- Reject `.`, `..`, `_archive`, empty, leading/trailing whitespace.
+- Length: ≤ 64 grapheme clusters AND ≤ 200 UTF-8 bytes.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/TBDSharedTests/ChannelNameTests.swift
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite struct ChannelNameTests {
+
+    @Test func acceptsSimpleAscii() throws {
+        let normalized = try validateChannelName("help")
+        #expect(normalized == "help")
+    }
+
+    @Test func lowercases() throws {
+        let normalized = try validateChannelName("API-Questions")
+        #expect(normalized == "api-questions")
+    }
+
+    @Test func acceptsEmoji() throws {
+        let normalized = try validateChannelName("🔥")
+        #expect(normalized == "🔥")
+    }
+
+    @Test func acceptsNonLatin() throws {
+        let normalized = try validateChannelName("日本語")
+        #expect(normalized == "日本語")
+    }
+
+    @Test func nfcNormalizes() throws {
+        // "é" composed (U+00E9) vs decomposed ("e" + U+0301)
+        let composed = try validateChannelName("caf\u{00E9}")
+        let decomposed = try validateChannelName("cafe\u{0301}")
+        #expect(composed == decomposed)
+    }
+
+    @Test(arguments: [
+        "", " ", "  ", "name ", " name", ".", "..", "_archive",
+        "a/b", "a\\b", "a\u{0000}b", "a\u{0001}b", "a\u{007F}b",
+        "a\nb", "a\tb",
+    ])
+    func rejects(_ input: String) {
+        #expect(throws: ChannelNameError.self) {
+            try validateChannelName(input)
+        }
+    }
+
+    @Test func rejectsTooLongInGraphemes() {
+        let s = String(repeating: "a", count: 65)
+        #expect(throws: ChannelNameError.self) {
+            try validateChannelName(s)
+        }
+    }
+
+    @Test func acceptsAtGraphemeLimit() throws {
+        let s = String(repeating: "a", count: 64)
+        let normalized = try validateChannelName(s)
+        #expect(normalized.count == 64)
+    }
+
+    @Test func rejectsTooLongInBytes() {
+        // 50 emoji × ~4 bytes = 200 bytes; 51 emoji = 204 bytes → reject
+        let s = String(repeating: "🔥", count: 51)
+        #expect(throws: ChannelNameError.self) {
+            try validateChannelName(s)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `swift test --filter ChannelNameTests`
+Expected: build error — `validateChannelName` and `ChannelNameError` are undefined.
+
+- [ ] **Step 3: Implement `ChannelName.swift`**
+
+```swift
+// Sources/TBDShared/ChannelName.swift
+import Foundation
+
+public enum ChannelNameError: Error, Equatable, Sendable {
+    case empty
+    case leadingOrTrailingWhitespace
+    case reservedName(String)
+    case forbiddenCharacter(Character)
+    case tooLongGraphemes(Int)
+    case tooLongBytes(Int)
+}
+
+/// Validate, normalize, and case-fold a channel name. Returns the canonical
+/// storage form. Throws `ChannelNameError` if the name is invalid.
+///
+/// See `docs/superpowers/specs/2026-05-10-channels-design.md` for the
+/// rationale behind each rule.
+public func validateChannelName(_ raw: String) throws -> String {
+    if raw.isEmpty { throw ChannelNameError.empty }
+    if raw.first?.isWhitespace == true || raw.last?.isWhitespace == true {
+        throw ChannelNameError.leadingOrTrailingWhitespace
+    }
+
+    // Reject forbidden characters before normalization so error messages
+    // reference the original character the user typed.
+    for ch in raw {
+        for scalar in ch.unicodeScalars {
+            if scalar.value == 0x2F           // '/'
+                || scalar.value == 0x5C       // '\\'
+                || scalar.value <= 0x1F       // C0 controls + NUL
+                || scalar.value == 0x7F {     // DEL
+                throw ChannelNameError.forbiddenCharacter(ch)
+            }
+        }
+    }
+
+    let folded = raw.precomposedStringWithCanonicalMapping.localizedLowercase
+
+    if folded == "." || folded == ".." || folded == "_archive" {
+        throw ChannelNameError.reservedName(folded)
+    }
+
+    let graphemeCount = folded.count
+    if graphemeCount > 64 {
+        throw ChannelNameError.tooLongGraphemes(graphemeCount)
+    }
+    let byteCount = folded.utf8.count
+    if byteCount > 200 {
+        throw ChannelNameError.tooLongBytes(byteCount)
+    }
+
+    return folded
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `swift test --filter ChannelNameTests`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDShared/ChannelName.swift Tests/TBDSharedTests/ChannelNameTests.swift
+git commit -m "feat(channels): add channel name validation in TBDShared"
+```
+
+---
+
+## Task 2: Database migration v18 + ChannelIndexRecord
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Database/Database.swift` (after the `v17_terminal_transcript_path` migration block)
+- Create: `Sources/TBDDaemon/Database/ChannelIndexStore.swift` (Record only in this task; Store added in Task 3)
+- Create: `Tests/TBDDaemonTests/MigrationV18Tests.swift`
+
+- [ ] **Step 1: Write the failing migration test**
+
+```swift
+// Tests/TBDDaemonTests/MigrationV18Tests.swift
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct MigrationV18Tests {
+
+    @Test func createsChannelIndexTable() throws {
+        let dbPath = NSTemporaryDirectory() + "tbd-v18-\(UUID().uuidString).db"
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let db = try Database(path: dbPath)
+        try db.migrate()
+
+        try db.dbQueue.read { db in
+            let exists = try Bool.fetchOne(db, sql: """
+                SELECT COUNT(*) > 0 FROM sqlite_master
+                WHERE type='table' AND name='channel_index'
+                """)
+            #expect(exists == true)
+
+            // Verify columns
+            let cols = try Row.fetchAll(db, sql: "PRAGMA table_info('channel_index')")
+            let names = Set(cols.compactMap { $0["name"] as String? })
+            #expect(names == ["name", "createdAt", "lastMessageAt", "messageCount"])
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `swift test --filter MigrationV18Tests`
+Expected: failure — `channel_index` table does not exist.
+
+- [ ] **Step 3: Add the migration**
+
+Open `Sources/TBDDaemon/Database/Database.swift`. Find the `v17_terminal_transcript_path` block. **After** it (and before `try migrator.migrate(writer)`), add:
+
+```swift
+        migrator.registerMigration("v18_channel_index") { db in
+            try db.create(table: "channel_index") { t in
+                t.primaryKey("name", .text)
+                t.column("createdAt", .text).notNull()
+                t.column("lastMessageAt", .text)
+                t.column("messageCount", .integer).notNull().defaults(to: 0)
+            }
+        }
+```
+
+- [ ] **Step 4: Run test, confirm pass**
+
+Run: `swift test --filter MigrationV18Tests`
+Expected: pass.
+
+- [ ] **Step 5: Create the GRDB Record stub**
+
+```swift
+// Sources/TBDDaemon/Database/ChannelIndexStore.swift
+import Foundation
+import GRDB
+import TBDShared
+
+/// GRDB Record for the `channel_index` table — derivable cache of per-channel
+/// metadata that backs `tbd channels list` and the daemon's per-post update.
+struct ChannelIndexRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "channel_index"
+
+    var name: String
+    var createdAt: Date
+    var lastMessageAt: Date?
+    var messageCount: Int
+}
+```
+
+(Store struct comes in Task 3; this gives the migration test a sibling that establishes the file.)
+
+- [ ] **Step 6: Verify build**
+
+Run: `swift build`
+Expected: success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/TBDDaemon/Database/Database.swift Sources/TBDDaemon/Database/ChannelIndexStore.swift Tests/TBDDaemonTests/MigrationV18Tests.swift
+git commit -m "feat(channels): add v18 migration for channel_index table"
+```
+
+---
+
+## Task 3: ChannelIndexStore CRUD
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Database/ChannelIndexStore.swift` (add Store struct)
+- Create: `Tests/TBDDaemonTests/ChannelIndexStoreTests.swift`
+
+**Pattern reference:** `Sources/TBDDaemon/Database/NotificationStore.swift` is the canonical example.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/TBDDaemonTests/ChannelIndexStoreTests.swift
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ChannelIndexStoreTests {
+
+    private func makeStore() throws -> (ChannelIndexStore, Database, String) {
+        let dbPath = NSTemporaryDirectory() + "tbd-cix-\(UUID().uuidString).db"
+        let db = try Database(path: dbPath)
+        try db.migrate()
+        return (ChannelIndexStore(writer: db.dbQueue), db, dbPath)
+    }
+
+    @Test func recordOnFirstPostCreatesRow() async throws {
+        let (store, _, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let now = Date()
+        try await store.recordPost(name: "help", at: now)
+
+        let entries = try await store.list(includeArchived: false)
+        #expect(entries.count == 1)
+        #expect(entries.first?.name == "help")
+        #expect(entries.first?.messageCount == 1)
+    }
+
+    @Test func recordOnSubsequentPostsIncrements() async throws {
+        let (store, _, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        try await store.recordPost(name: "help", at: Date())
+        try await store.recordPost(name: "help", at: Date())
+        try await store.recordPost(name: "help", at: Date())
+
+        let entries = try await store.list(includeArchived: false)
+        #expect(entries.first?.messageCount == 3)
+    }
+
+    @Test func listReturnsAllChannelsSortedByLastMessage() async throws {
+        let (store, _, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        let earlier = Date().addingTimeInterval(-100)
+        let later = Date()
+        try await store.recordPost(name: "old", at: earlier)
+        try await store.recordPost(name: "new", at: later)
+
+        let entries = try await store.list(includeArchived: false)
+        #expect(entries.map(\.name) == ["new", "old"])
+    }
+
+    @Test func deleteRemovesRow() async throws {
+        let (store, _, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(atPath: dbPath) }
+
+        try await store.recordPost(name: "help", at: Date())
+        try await store.delete(name: "help")
+
+        let entries = try await store.list(includeArchived: false)
+        #expect(entries.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `swift test --filter ChannelIndexStoreTests`
+Expected: build error — `ChannelIndexStore` is undefined.
+
+- [ ] **Step 3: Implement the Store**
+
+Append to `Sources/TBDDaemon/Database/ChannelIndexStore.swift`:
+
+```swift
+/// CRUD for `channel_index`. All methods are safe for concurrent callers.
+public struct ChannelIndexStore: Sendable {
+    let writer: any DatabaseWriter
+
+    public init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Upsert: create the row if missing, increment `messageCount` and bump
+    /// `lastMessageAt` if present.
+    public func recordPost(name: String, at timestamp: Date) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO channel_index (name, createdAt, lastMessageAt, messageCount)
+                    VALUES (?, ?, ?, 1)
+                    ON CONFLICT(name) DO UPDATE SET
+                        lastMessageAt = excluded.lastMessageAt,
+                        messageCount = messageCount + 1
+                    """,
+                arguments: [name, timestamp, timestamp]
+            )
+        }
+    }
+
+    /// List all channels ordered by most-recent activity first.
+    public func list(includeArchived: Bool) async throws -> [ChannelIndexRecord] {
+        // includeArchived is a no-op in v1 — archived channels live as
+        // files under `_archive/` and never have an index row. The
+        // parameter exists so the RPC surface doesn't change when
+        // archived-listing arrives.
+        _ = includeArchived
+        return try await writer.read { db in
+            try ChannelIndexRecord
+                .order(Column("lastMessageAt").desc)
+                .fetchAll(db)
+        }
+    }
+
+    /// Remove the row (used on archive).
+    public func delete(name: String) async throws {
+        try await writer.write { db in
+            _ = try ChannelIndexRecord.deleteOne(db, key: name)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `swift test --filter ChannelIndexStoreTests`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Database/ChannelIndexStore.swift Tests/TBDDaemonTests/ChannelIndexStoreTests.swift
+git commit -m "feat(channels): add ChannelIndexStore CRUD"
+```
+
+---
+
+## Task 4: FileLock helper (`flock(2)` RAII)
+
+**Files:**
+- Create: `Sources/TBDDaemon/Channels/FileLock.swift`
+- Create: `Tests/TBDDaemonTests/FileLockTests.swift`
+
+**Purpose:** A defensive cross-process lock against the rare two-daemon scenario noted in the adversarial review. Wraps `flock(2)` in a try-with-resources idiom.
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/TBDDaemonTests/FileLockTests.swift
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct FileLockTests {
+
+    @Test func acquiresAndReleases() throws {
+        let path = NSTemporaryDirectory() + "tbd-flock-\(UUID().uuidString).lock"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let lock = try FileLock.acquire(path: path)
+        try lock.release()
+    }
+
+    @Test func twoLocksOnSamePathSerialize() async throws {
+        let path = NSTemporaryDirectory() + "tbd-flock-\(UUID().uuidString).lock"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        let first = try FileLock.acquire(path: path)
+
+        // Try to acquire a non-blocking second lock from a separate fork; in-process
+        // flock is per-FD, so a second open+flock from this same process should
+        // *also* block. Run in a Task with a timeout to verify it blocks.
+        let acquired = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    let second = try FileLock.acquire(path: path)
+                    try? second.release()
+                    return true
+                } catch {
+                    return false
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: .milliseconds(150))
+                try? first.release()
+                return true
+            }
+            // collect; we only care that the first task eventually completes
+            for await _ in group {}
+            return true
+        }
+        #expect(acquired == true)
+    }
+
+    @Test func createsLockFileIfAbsent() throws {
+        let path = NSTemporaryDirectory() + "tbd-flock-\(UUID().uuidString).lock"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        #expect(FileManager.default.fileExists(atPath: path) == false)
+        let lock = try FileLock.acquire(path: path)
+        #expect(FileManager.default.fileExists(atPath: path) == true)
+        try lock.release()
+    }
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `swift test --filter FileLockTests`
+Expected: build error — `FileLock` undefined.
+
+- [ ] **Step 3: Implement FileLock**
+
+```swift
+// Sources/TBDDaemon/Channels/FileLock.swift
+import Darwin
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "channels.flock")
+
+/// Holds an exclusive `flock(2)` on a sidecar lockfile for the lifetime of
+/// the value. Use `acquire(path:)` (blocking) and call `release()` once done.
+///
+/// Rationale: defensive guard against the two-daemon race the
+/// adversarial-review identified. The daemon enforces single-instance via
+/// `PIDFile.swift`, but the read-then-write check there has a TOCTOU window;
+/// `flock` makes channel writes safe even if two daemons briefly coexist.
+struct FileLock {
+    private let fd: Int32
+    private let path: String
+
+    static func acquire(path: String) throws -> FileLock {
+        // O_RDWR | O_CREAT | O_CLOEXEC; permissions 0644.
+        let fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
+        if fd < 0 {
+            throw FileLockError.openFailed(errno: errno, path: path)
+        }
+        // Blocking exclusive lock.
+        if flock(fd, LOCK_EX) != 0 {
+            let savedErrno = errno
+            close(fd)
+            throw FileLockError.lockFailed(errno: savedErrno, path: path)
+        }
+        logger.debug("Acquired lock on \(path, privacy: .public)")
+        return FileLock(fd: fd, path: path)
+    }
+
+    func release() throws {
+        if flock(fd, LOCK_UN) != 0 {
+            let savedErrno = errno
+            close(fd)
+            throw FileLockError.unlockFailed(errno: savedErrno, path: path)
+        }
+        close(fd)
+        logger.debug("Released lock on \(path, privacy: .public)")
+    }
+}
+
+enum FileLockError: Error, CustomStringConvertible {
+    case openFailed(errno: Int32, path: String)
+    case lockFailed(errno: Int32, path: String)
+    case unlockFailed(errno: Int32, path: String)
+
+    var description: String {
+        switch self {
+        case .openFailed(let e, let p):  return "open(\(p)) failed: errno=\(e)"
+        case .lockFailed(let e, let p):  return "flock(LOCK_EX, \(p)) failed: errno=\(e)"
+        case .unlockFailed(let e, let p): return "flock(LOCK_UN, \(p)) failed: errno=\(e)"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `swift test --filter FileLockTests`
+Expected: pass. (The "two locks serialize" test verifies blocking semantics — second `acquire` waits until `first.release()` fires from the parallel task.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Channels/FileLock.swift Tests/TBDDaemonTests/FileLockTests.swift
+git commit -m "feat(channels): add FileLock RAII wrapper around flock(2)"
+```
+
+---
+
+## Task 5: ChannelMessage JSONL codec
+
+**Files:**
+- Create: `Sources/TBDDaemon/Channels/ChannelMessage.swift`
+- Create: `Tests/TBDDaemonTests/ChannelMessageTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/TBDDaemonTests/ChannelMessageTests.swift
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ChannelMessageTests {
+
+    @Test func roundtrips() throws {
+        let msg = ChannelMessage(
+            seq: 42,
+            ts: Date(timeIntervalSince1970: 1_715_354_581.234),
+            fromSession: "abc-123",
+            fromLabel: "tbd-known-smelt",
+            body: "anyone seen the launchctl crash?"
+        )
+        let line = try msg.encodeLine()
+        let decoded = try ChannelMessage.decodeLine(line)
+        #expect(decoded == msg)
+    }
+
+    @Test func encodedLineEndsWithNewline() throws {
+        let msg = ChannelMessage(seq: 1, ts: Date(), fromSession: "s", fromLabel: "l", body: "x")
+        let line = try msg.encodeLine()
+        #expect(line.last == 0x0A)  // '\n'
+    }
+
+    @Test func encodedLineHasNoInternalNewline() throws {
+        let msg = ChannelMessage(seq: 1, ts: Date(), fromSession: "s", fromLabel: "l",
+                                 body: "line one\nline two\nline three")
+        let line = try msg.encodeLine()
+        // Exactly one newline — at the end.
+        let count = line.filter { $0 == 0x0A }.count
+        #expect(count == 1)
+        let decoded = try ChannelMessage.decodeLine(line)
+        #expect(decoded.body == "line one\nline two\nline three")
+    }
+
+    @Test func decodeRejectsMalformedLine() {
+        let bogus = Data("{not json\n".utf8)
+        #expect(throws: (any Error).self) {
+            try ChannelMessage.decodeLine(bogus)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `swift test --filter ChannelMessageTests`
+Expected: build error — `ChannelMessage` undefined.
+
+- [ ] **Step 3: Implement**
+
+```swift
+// Sources/TBDDaemon/Channels/ChannelMessage.swift
+import Foundation
+
+/// One JSONL line in a channel file. `(channel, seq)` is the message identity.
+public struct ChannelMessage: Codable, Equatable, Sendable {
+    public let seq: Int
+    public let ts: Date
+    public let fromSession: String
+    public let fromLabel: String
+    public let body: String
+
+    public init(seq: Int, ts: Date, fromSession: String, fromLabel: String, body: String) {
+        self.seq = seq
+        self.ts = ts
+        self.fromSession = fromSession
+        self.fromLabel = fromLabel
+        self.body = body
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case seq, ts, fromSession = "from_session", fromLabel = "from_label", body
+    }
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    /// Encode this message as one JSONL line ending in `\n`. Throws if encoding fails.
+    public func encodeLine() throws -> Data {
+        var data = try Self.encoder.encode(self)
+        data.append(0x0A)  // '\n'
+        return data
+    }
+
+    /// Decode one JSONL line (with or without trailing newline) into a message.
+    public static func decodeLine(_ data: Data) throws -> ChannelMessage {
+        let trimmed: Data
+        if data.last == 0x0A {
+            trimmed = data.subdata(in: 0..<data.count - 1)
+        } else {
+            trimmed = data
+        }
+        return try decoder.decode(ChannelMessage.self, from: trimmed)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `swift test --filter ChannelMessageTests`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Channels/ChannelMessage.swift Tests/TBDDaemonTests/ChannelMessageTests.swift
+git commit -m "feat(channels): add ChannelMessage JSONL codec"
+```
+
+---
+
+## Task 6: ChannelLockManager (per-channel async serialization)
+
+**Files:**
+- Create: `Sources/TBDDaemon/Channels/ChannelLockManager.swift`
+
+This is small enough to ship without a dedicated test file — its correctness is verified through `ChannelStoreTests` (Task 7), which exercises concurrent posts.
+
+- [ ] **Step 1: Implement**
+
+```swift
+// Sources/TBDDaemon/Channels/ChannelLockManager.swift
+import Foundation
+
+/// In-process, per-channel async serialization. Each channel name gets a
+/// dedicated actor that linearizes write operations, so the daemon only
+/// holds one channel's `flock` at a time per channel.
+///
+/// Cross-process protection comes from `FileLock` on the sidecar `.lock`
+/// file; this manager only handles in-process concurrency.
+actor ChannelLockManager {
+    private var locks: [String: ChannelSerial] = [:]
+
+    func withLock<T: Sendable>(_ name: String, _ body: @Sendable () async throws -> T) async throws -> T {
+        let serial = serial(for: name)
+        return try await serial.run(body)
+    }
+
+    private func serial(for name: String) -> ChannelSerial {
+        if let existing = locks[name] { return existing }
+        let made = ChannelSerial()
+        locks[name] = made
+        return made
+    }
+}
+
+/// One channel's async-serial queue. Posts arrive concurrently; this
+/// actor's mailbox order is the channel's write order.
+actor ChannelSerial {
+    func run<T: Sendable>(_ body: @Sendable () async throws -> T) async throws -> T {
+        try await body()
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/TBDDaemon/Channels/ChannelLockManager.swift
+git commit -m "feat(channels): add per-channel async lock manager"
+```
+
+---
+
+## Task 7: ChannelStore.post (compose write path)
+
+**Files:**
+- Create: `Sources/TBDDaemon/Channels/ChannelStore.swift`
+- Create: `Tests/TBDDaemonTests/ChannelStoreTests.swift`
+
+**Behavior summary:**
+1. Validate name (TBDShared `validateChannelName`).
+2. Validate body ≤ 64 KB UTF-8.
+3. Acquire per-channel async lock.
+4. `flock(LOCK_EX)` on sidecar `.lock` file.
+5. Determine next `seq`: in-memory cache → fall back to scanning file tail if cache is cold.
+6. Open file `O_WRONLY | O_APPEND | O_CREAT`, write line, fsync, close.
+7. Release flock; release async lock.
+8. Update `channel_index` (recordPost).
+9. Return `(seq, ts)`.
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/TBDDaemonTests/ChannelStoreTests.swift
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct ChannelStoreTests {
+
+    private func makeStore() throws -> (ChannelStore, URL, String) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-cs-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let dbPath = tmp.appendingPathComponent("state.db").path
+        let db = try Database(path: dbPath)
+        try db.migrate()
+        let index = ChannelIndexStore(writer: db.dbQueue)
+        let store = ChannelStore(channelsDir: tmp.appendingPathComponent("channels"),
+                                 index: index)
+        return (store, tmp, dbPath)
+    }
+
+    @Test func postCreatesFileWithSeq1() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let result = try await store.post(name: "help", body: "hi",
+                                          fromSession: "s1", fromLabel: "L1")
+        #expect(result.seq == 1)
+
+        let file = tmp.appendingPathComponent("channels").appendingPathComponent("help.jsonl")
+        let bytes = try Data(contentsOf: file)
+        let line = try ChannelMessage.decodeLine(bytes)
+        #expect(line.seq == 1)
+        #expect(line.body == "hi")
+        #expect(line.fromSession == "s1")
+        #expect(line.fromLabel == "L1")
+    }
+
+    @Test func sequentialPostsIncrementSeq() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let r1 = try await store.post(name: "help", body: "one", fromSession: "s", fromLabel: "L")
+        let r2 = try await store.post(name: "help", body: "two", fromSession: "s", fromLabel: "L")
+        let r3 = try await store.post(name: "help", body: "three", fromSession: "s", fromLabel: "L")
+        #expect([r1.seq, r2.seq, r3.seq] == [1, 2, 3])
+    }
+
+    @Test func differentChannelsHaveIndependentSeq() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let a = try await store.post(name: "alpha", body: "x", fromSession: "s", fromLabel: "L")
+        let b = try await store.post(name: "beta",  body: "x", fromSession: "s", fromLabel: "L")
+        #expect(a.seq == 1)
+        #expect(b.seq == 1)
+    }
+
+    @Test func nameIsCaseFolded() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await store.post(name: "Help", body: "x", fromSession: "s", fromLabel: "L")
+        try await store.post(name: "HELP", body: "y", fromSession: "s", fromLabel: "L")
+
+        // Both should land in the same file `help.jsonl`.
+        let file = tmp.appendingPathComponent("channels/help.jsonl")
+        let bytes = try Data(contentsOf: file)
+        let lines = bytes.split(separator: 0x0A)
+        #expect(lines.count == 2)
+    }
+
+    @Test func rejectsInvalidName() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        await #expect(throws: ChannelNameError.self) {
+            _ = try await store.post(name: "../etc/passwd", body: "x",
+                                     fromSession: "s", fromLabel: "L")
+        }
+    }
+
+    @Test func rejectsBodyOver64KB() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let body = String(repeating: "a", count: 64 * 1024 + 1)
+        await #expect(throws: ChannelStoreError.self) {
+            _ = try await store.post(name: "help", body: body,
+                                     fromSession: "s", fromLabel: "L")
+        }
+    }
+
+    @Test func updatesChannelIndex() async throws {
+        let (store, tmp, dbPath) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await store.post(name: "help", body: "x", fromSession: "s", fromLabel: "L")
+        try await store.post(name: "help", body: "y", fromSession: "s", fromLabel: "L")
+
+        let db = try Database(path: dbPath)
+        let index = ChannelIndexStore(writer: db.dbQueue)
+        let entries = try await index.list(includeArchived: false)
+        #expect(entries.first?.name == "help")
+        #expect(entries.first?.messageCount == 2)
+    }
+
+    @Test func concurrentPostsToSameChannelGetUniqueSeq() async throws {
+        let (store, tmp, _) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let count = 20
+        try await withThrowingTaskGroup(of: Int.self) { group in
+            for i in 0..<count {
+                group.addTask {
+                    let r = try await store.post(name: "race", body: "msg-\(i)",
+                                                 fromSession: "s", fromLabel: "L")
+                    return r.seq
+                }
+            }
+            var seqs: [Int] = []
+            for try await seq in group { seqs.append(seq) }
+            #expect(Set(seqs).count == count)
+            #expect(seqs.min() == 1)
+            #expect(seqs.max() == count)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `swift test --filter ChannelStoreTests`
+Expected: build error — `ChannelStore` undefined.
+
+- [ ] **Step 3: Implement ChannelStore (post-only for this task)**
+
+```swift
+// Sources/TBDDaemon/Channels/ChannelStore.swift
+import Darwin
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "channels.store")
+
+public enum ChannelStoreError: Error, CustomStringConvertible {
+    case bodyTooLarge(bytes: Int)
+    case writeFailed(path: String, errno: Int32)
+    case fsyncFailed(path: String, errno: Int32)
+    case openFailed(path: String, errno: Int32)
+
+    public var description: String {
+        switch self {
+        case .bodyTooLarge(let n): return "body too large: \(n) bytes (max 65536)"
+        case .writeFailed(let p, let e): return "write(\(p)) failed: errno=\(e)"
+        case .fsyncFailed(let p, let e): return "fsync(\(p)) failed: errno=\(e)"
+        case .openFailed(let p, let e): return "open(\(p)) failed: errno=\(e)"
+        }
+    }
+}
+
+public struct ChannelPostResult: Sendable {
+    public let seq: Int
+    public let ts: Date
+}
+
+/// Orchestrates per-channel JSONL writes. Owns the per-channel lock
+/// manager, the in-memory `seq` cache, and the `channel_index` updates.
+public final class ChannelStore: @unchecked Sendable {
+    private static let bodyByteLimit = 64 * 1024
+
+    private let channelsDir: URL
+    private let archiveDir: URL
+    private let index: ChannelIndexStore
+    private let lockManager = ChannelLockManager()
+
+    // Protected by per-channel locks, so a Dictionary mutated under the
+    // ChannelSerial actor is safe; @unchecked is justified by that contract.
+    private var seqCache: [String: Int] = [:]
+
+    public init(channelsDir: URL, index: ChannelIndexStore) {
+        self.channelsDir = channelsDir
+        self.archiveDir = channelsDir.appendingPathComponent("_archive")
+        self.index = index
+    }
+
+    /// Append one message to a channel. Returns the assigned `seq` and `ts`.
+    public func post(
+        name: String,
+        body: String,
+        fromSession: String,
+        fromLabel: String
+    ) async throws -> ChannelPostResult {
+        let normalized = try validateChannelName(name)
+
+        let bodyBytes = body.utf8.count
+        if bodyBytes > Self.bodyByteLimit {
+            throw ChannelStoreError.bodyTooLarge(bytes: bodyBytes)
+        }
+
+        return try await lockManager.withLock(normalized) { [self] in
+            try ensureDir(channelsDir)
+            let lockPath = lockPath(for: normalized)
+            let lock = try FileLock.acquire(path: lockPath)
+            defer { try? lock.release() }
+
+            let nextSeq = try ensureSeqCachePopulated(for: normalized) + 1
+            let ts = Date()
+            let msg = ChannelMessage(seq: nextSeq, ts: ts,
+                                     fromSession: fromSession,
+                                     fromLabel: fromLabel,
+                                     body: body)
+            let line = try msg.encodeLine()
+            try appendLine(channel: normalized, line: line)
+            seqCache[normalized] = nextSeq
+
+            try await index.recordPost(name: normalized, at: ts)
+            return ChannelPostResult(seq: nextSeq, ts: ts)
+        }
+    }
+
+    // MARK: - File paths
+
+    func filePath(for name: String) -> String {
+        channelsDir.appendingPathComponent("\(name).jsonl").path
+    }
+
+    func lockPath(for name: String) -> String {
+        channelsDir.appendingPathComponent("\(name).lock").path
+    }
+
+    // MARK: - Helpers
+
+    private func ensureDir(_ url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    /// Populate the in-memory seq cache by scanning the file tail (and
+    /// running torn-line recovery as a side effect). Returns the highest
+    /// known seq, or 0 if the channel has no file yet.
+    func ensureSeqCachePopulated(for name: String) throws -> Int {
+        if let cached = seqCache[name] { return cached }
+        let highest = try recoverAndScanHighestSeq(name: name)
+        seqCache[name] = highest
+        return highest
+    }
+
+    /// Stream-scan the channel file. If the trailing line is malformed,
+    /// truncate the file back to the last good newline. Returns the highest
+    /// successfully parsed seq (or 0 if no file).
+    func recoverAndScanHighestSeq(name: String) throws -> Int {
+        let path = filePath(for: name)
+        guard FileManager.default.fileExists(atPath: path) else { return 0 }
+
+        let url = URL(fileURLWithPath: path)
+        let data = try Data(contentsOf: url)
+        guard !data.isEmpty else { return 0 }
+
+        var highest = 0
+        var lastGoodEnd = 0  // byte offset of (one-past) last good newline
+        var lineStart = 0
+        for (idx, byte) in data.enumerated() {
+            if byte == 0x0A {
+                let line = data.subdata(in: lineStart..<idx)
+                if let msg = try? ChannelMessage.decodeLine(line) {
+                    highest = max(highest, msg.seq)
+                    lastGoodEnd = idx + 1
+                }
+                lineStart = idx + 1
+            }
+        }
+        // Anything after the last newline (or after position 0 if no newline)
+        // is an unfinished line. Truncate.
+        if lastGoodEnd < data.count {
+            logger.notice("Truncating torn-line tail of \(name, privacy: .public): \(data.count - lastGoodEnd) bytes dropped")
+            let fd = open(path, O_WRONLY)
+            if fd < 0 {
+                throw ChannelStoreError.openFailed(path: path, errno: errno)
+            }
+            defer { close(fd) }
+            if ftruncate(fd, off_t(lastGoodEnd)) != 0 {
+                throw ChannelStoreError.writeFailed(path: path, errno: errno)
+            }
+        }
+        return highest
+    }
+
+    private func appendLine(channel: String, line: Data) throws {
+        let path = filePath(for: channel)
+        let fd = open(path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0o644)
+        if fd < 0 {
+            throw ChannelStoreError.openFailed(path: path, errno: errno)
+        }
+        defer { close(fd) }
+
+        try line.withUnsafeBytes { buf in
+            var written = 0
+            while written < buf.count {
+                let r = Darwin.write(fd, buf.baseAddress!.advanced(by: written), buf.count - written)
+                if r < 0 {
+                    if errno == EINTR { continue }
+                    throw ChannelStoreError.writeFailed(path: path, errno: errno)
+                }
+                written += r
+            }
+        }
+
+        if fsync(fd) != 0 {
+            throw ChannelStoreError.fsyncFailed(path: path, errno: errno)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `swift test --filter ChannelStoreTests`
+Expected: pass.
+
+If the concurrency test flakes, the cause is almost always either (a) missing `try await` on the index call inside `withLock`, or (b) `seqCache` mutation outside the actor — both should already be correct as written.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Channels/ChannelStore.swift Tests/TBDDaemonTests/ChannelStoreTests.swift
+git commit -m "feat(channels): add ChannelStore.post with per-channel locking"
+```
+
+---
+
+## Task 8: Torn-line recovery (dedicated tests)
+
+**Files:**
+- Create: `Tests/TBDDaemonTests/ChannelStoreRecoveryTests.swift`
+
+The recovery code already lives in `ChannelStore.swift` (Task 7). This task only adds focused tests so the behavior is durable.
+
+- [ ] **Step 1: Write tests**
+
+```swift
+// Tests/TBDDaemonTests/ChannelStoreRecoveryTests.swift
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ChannelStoreRecoveryTests {
+
+    private func makeStore() throws -> (ChannelStore, URL) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-csr-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let dbPath = tmp.appendingPathComponent("state.db").path
+        let db = try Database(path: dbPath)
+        try db.migrate()
+        let index = ChannelIndexStore(writer: db.dbQueue)
+        let store = ChannelStore(channelsDir: tmp.appendingPathComponent("channels"),
+                                 index: index)
+        return (store, tmp)
+    }
+
+    @Test func recoversFromTornLastLine() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Post two messages so we have known good content.
+        _ = try await store.post(name: "rec", body: "m1", fromSession: "s", fromLabel: "L")
+        _ = try await store.post(name: "rec", body: "m2", fromSession: "s", fromLabel: "L")
+
+        // Append a half-written line to simulate a crash mid-write.
+        let path = tmp.appendingPathComponent("channels/rec.jsonl").path
+        let truncated = "{\"seq\":3,\"ts\":\"2026-".data(using: .utf8)!
+        let fd = open(path, O_WRONLY | O_APPEND)
+        _ = truncated.withUnsafeBytes { write(fd, $0.baseAddress, $0.count) }
+        close(fd)
+
+        // Make a new store (simulating daemon restart).
+        let dbPath2 = tmp.appendingPathComponent("state.db").path
+        let db2 = try Database(path: dbPath2)
+        let index2 = ChannelIndexStore(writer: db2.dbQueue)
+        let store2 = ChannelStore(channelsDir: tmp.appendingPathComponent("channels"),
+                                  index: index2)
+
+        // Next post should be seq 3 (torn line is dropped); file should
+        // contain exactly 3 valid JSONL lines.
+        let r = try await store2.post(name: "rec", body: "m3",
+                                      fromSession: "s", fromLabel: "L")
+        #expect(r.seq == 3)
+
+        let bytes = try Data(contentsOf: URL(fileURLWithPath: path))
+        let lines = bytes.split(separator: 0x0A).filter { !$0.isEmpty }
+        #expect(lines.count == 3)
+        for line in lines {
+            _ = try ChannelMessage.decodeLine(Data(line))
+        }
+    }
+
+    @Test func emptyFileReturnsZeroSeq() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Create an empty file.
+        let dir = tmp.appendingPathComponent("channels")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("empty.jsonl").path
+        FileManager.default.createFile(atPath: path, contents: nil)
+
+        let r = try await store.post(name: "empty", body: "first",
+                                     fromSession: "s", fromLabel: "L")
+        #expect(r.seq == 1)
+    }
+
+    @Test func recoveryHandlesNoFinalNewline() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // Manually write one good line and one trailing partial line with no newline at all.
+        let dir = tmp.appendingPathComponent("channels")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("nonl.jsonl").path
+        let good = ChannelMessage(seq: 1, ts: Date(), fromSession: "s", fromLabel: "L", body: "ok")
+        var content = try good.encodeLine()
+        content.append(contentsOf: Array("{\"partial".utf8))
+        try content.write(to: URL(fileURLWithPath: path))
+
+        let r = try await store.post(name: "nonl", body: "next",
+                                     fromSession: "s", fromLabel: "L")
+        #expect(r.seq == 2)
+    }
+}
+```
+
+- [ ] **Step 2: Run, confirm pass**
+
+Run: `swift test --filter ChannelStoreRecoveryTests`
+Expected: all three tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/TBDDaemonTests/ChannelStoreRecoveryTests.swift
+git commit -m "test(channels): cover torn-line recovery on startup"
+```
+
+---
+
+## Task 9: ChannelStore.archive
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Channels/ChannelStore.swift` (add `archive` method)
+- Create: `Tests/TBDDaemonTests/ChannelStoreArchiveTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/TBDDaemonTests/ChannelStoreArchiveTests.swift
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct ChannelStoreArchiveTests {
+
+    private func makeStore() throws -> (ChannelStore, URL) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-csa-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let dbPath = tmp.appendingPathComponent("state.db").path
+        let db = try Database(path: dbPath)
+        try db.migrate()
+        let index = ChannelIndexStore(writer: db.dbQueue)
+        let store = ChannelStore(channelsDir: tmp.appendingPathComponent("channels"),
+                                 index: index)
+        return (store, tmp)
+    }
+
+    @Test func archiveMovesFileToArchiveDir() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "old", body: "x", fromSession: "s", fromLabel: "L")
+        let archived = try await store.archive(name: "old")
+
+        let activePath = tmp.appendingPathComponent("channels/old.jsonl").path
+        #expect(FileManager.default.fileExists(atPath: activePath) == false)
+        #expect(FileManager.default.fileExists(atPath: archived) == true)
+        #expect(archived.contains("/_archive/old-"))
+        #expect(archived.hasSuffix(".jsonl"))
+    }
+
+    @Test func archiveRemovesIndexRow() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "old", body: "x", fromSession: "s", fromLabel: "L")
+        _ = try await store.archive(name: "old")
+
+        let dbPath = tmp.appendingPathComponent("state.db").path
+        let db = try Database(path: dbPath)
+        let index = ChannelIndexStore(writer: db.dbQueue)
+        let entries = try await index.list(includeArchived: false)
+        #expect(entries.isEmpty)
+    }
+
+    @Test func archiveRemovesLockSidecar() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "old", body: "x", fromSession: "s", fromLabel: "L")
+        _ = try await store.archive(name: "old")
+        let lockPath = tmp.appendingPathComponent("channels/old.lock").path
+        #expect(FileManager.default.fileExists(atPath: lockPath) == false)
+    }
+
+    @Test func reusingArchivedNameStartsAtSeq1() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        _ = try await store.post(name: "phoenix", body: "first life",
+                                 fromSession: "s", fromLabel: "L")
+        _ = try await store.post(name: "phoenix", body: "still first",
+                                 fromSession: "s", fromLabel: "L")
+        _ = try await store.archive(name: "phoenix")
+
+        let r = try await store.post(name: "phoenix", body: "rebirth",
+                                     fromSession: "s", fromLabel: "L")
+        #expect(r.seq == 1)
+    }
+
+    @Test func archiveOfMissingChannelThrows() async throws {
+        let (store, tmp) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        await #expect(throws: ChannelStoreError.self) {
+            _ = try await store.archive(name: "ghost")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `swift test --filter ChannelStoreArchiveTests`
+Expected: build error — `archive` not defined.
+
+- [ ] **Step 3: Add `archive` to `ChannelStore`**
+
+Append to `Sources/TBDDaemon/Channels/ChannelStore.swift` (inside the `ChannelStore` class):
+
+```swift
+    /// Move the channel file to `_archive/<name>-<YYYYMMDD-HHMMSS>.jsonl`,
+    /// remove the lock sidecar, and delete the index row. Returns the
+    /// archived path.
+    public func archive(name: String) async throws -> String {
+        let normalized = try validateChannelName(name)
+
+        return try await lockManager.withLock(normalized) { [self] in
+            let activePath = filePath(for: normalized)
+            guard FileManager.default.fileExists(atPath: activePath) else {
+                throw ChannelStoreError.openFailed(path: activePath, errno: ENOENT)
+            }
+
+            // Hold the cross-process lock for the rename.
+            let lock = try FileLock.acquire(path: lockPath(for: normalized))
+            defer { try? lock.release() }
+
+            try ensureDir(archiveDir)
+            let stamp = Self.timestampFormatter.string(from: Date())
+            let archivedPath = archiveDir
+                .appendingPathComponent("\(normalized)-\(stamp).jsonl")
+                .path
+            try FileManager.default.moveItem(atPath: activePath, toPath: archivedPath)
+
+            // Remove the lock sidecar (best-effort; lock FD is already closed
+            // by `defer` above, but unlink can race with that).
+            try? FileManager.default.removeItem(atPath: lockPath(for: normalized))
+
+            seqCache.removeValue(forKey: normalized)
+            try await index.delete(name: normalized)
+
+            return archivedPath
+        }
+    }
+
+    /// `YYYYMMDD-HHMMSS` in UTC, for archive filenames.
+    static let timestampFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyyMMdd-HHmmss"
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `swift test --filter ChannelStoreArchiveTests`
+Expected: all five tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDDaemon/Channels/ChannelStore.swift Tests/TBDDaemonTests/ChannelStoreArchiveTests.swift
+git commit -m "feat(channels): add ChannelStore.archive"
+```
+
+---
+
+## Task 10: RPC types + handlers + dispatch wiring
+
+**Files:**
+- Modify: `Sources/TBDShared/RPCProtocol.swift` (add 3 method constants + 6 param/result types)
+- Modify: `Sources/TBDShared/Constants.swift` (add `channelsDir`, `channelsArchiveDir`)
+- Create: `Sources/TBDDaemon/Server/RPCRouter+ChannelHandlers.swift`
+- Modify: `Sources/TBDDaemon/Server/RPCRouter.swift` (add 3 dispatch cases + ChannelStore wiring)
+- Modify: `Sources/TBDDaemon/Daemon.swift` (instantiate ChannelStore)
+
+This task wires up integration. Tests live in the next task (CLI integration tests fall out of test runs).
+
+- [ ] **Step 1: Add constants and RPC types in TBDShared**
+
+Edit `Sources/TBDShared/Constants.swift`. After `reposDir`:
+
+```swift
+    public static let channelsDir = configDir.appendingPathComponent("channels")
+    public static let channelsArchiveDir = channelsDir.appendingPathComponent("_archive")
+```
+
+Edit `Sources/TBDShared/RPCProtocol.swift`. Inside `enum RPCMethod`:
+
+```swift
+    public static let channelsPost = "channels.post"
+    public static let channelsList = "channels.list"
+    public static let channelsArchive = "channels.archive"
+```
+
+At the bottom of `RPCProtocol.swift` (alongside other param/result types):
+
+```swift
+public struct ChannelsPostParams: Codable, Sendable {
+    public let name: String
+    public let body: String
+    public let terminalID: UUID?       // resolved → fromSession + fromLabel by daemon
+    public let fromSession: String?    // override (for non-TBD callers)
+    public let fromLabel: String?      // override (for non-TBD callers)
+    public init(name: String, body: String, terminalID: UUID? = nil,
+                fromSession: String? = nil, fromLabel: String? = nil) {
+        self.name = name; self.body = body; self.terminalID = terminalID
+        self.fromSession = fromSession; self.fromLabel = fromLabel
+    }
+}
+
+public struct ChannelsPostResult: Codable, Sendable {
+    public let seq: Int
+    public let ts: Date
+    public init(seq: Int, ts: Date) { self.seq = seq; self.ts = ts }
+}
+
+public struct ChannelsListParams: Codable, Sendable {
+    public let includeArchived: Bool
+    public init(includeArchived: Bool = false) { self.includeArchived = includeArchived }
+}
+
+public struct ChannelSummary: Codable, Sendable {
+    public let name: String
+    public let createdAt: Date
+    public let lastMessageAt: Date?
+    public let messageCount: Int
+    public init(name: String, createdAt: Date, lastMessageAt: Date?, messageCount: Int) {
+        self.name = name; self.createdAt = createdAt
+        self.lastMessageAt = lastMessageAt; self.messageCount = messageCount
+    }
+}
+
+public struct ChannelsListResult: Codable, Sendable {
+    public let channels: [ChannelSummary]
+    public init(channels: [ChannelSummary]) { self.channels = channels }
+}
+
+public struct ChannelsArchiveParams: Codable, Sendable {
+    public let name: String
+    public init(name: String) { self.name = name }
+}
+
+public struct ChannelsArchiveResult: Codable, Sendable {
+    public let archivedPath: String
+    public init(archivedPath: String) { self.archivedPath = archivedPath }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `swift build`
+Expected: success.
+
+- [ ] **Step 3: Wire ChannelStore into Daemon**
+
+Open `Sources/TBDDaemon/Daemon.swift`. Find where stores are instantiated (look near `NotificationStore(...)`). Add:
+
+```swift
+        // Channels store (creates ~/tbd/channels/ on first use).
+        let channelsDir = TBDConstants.channelsDir
+        let channelStore = ChannelStore(
+            channelsDir: channelsDir,
+            index: ChannelIndexStore(writer: database.dbQueue)
+        )
+```
+
+Then thread `channelStore` through to `RPCRouter` initialization (follow the existing pattern — every store is passed in). If the RPCRouter takes a struct of dependencies, add a `channelStore: ChannelStore` field to that struct; if it takes individual parameters, add it there.
+
+(The exact mechanism depends on the current shape of the daemon's dependency graph; subagent should follow the existing pattern, not invent a new one. If unclear, look at how `notificationStore` is wired.)
+
+- [ ] **Step 4: Implement RPCRouter+ChannelHandlers**
+
+```swift
+// Sources/TBDDaemon/Server/RPCRouter+ChannelHandlers.swift
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "channels.rpc")
+
+extension RPCRouter {
+    func handleChannelsPost(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ChannelsPostParams.self, from: paramsData)
+
+        // Resolve identity. Either explicit overrides, or via terminalID lookup.
+        let fromSession: String
+        let fromLabel: String
+        if let s = params.fromSession, let l = params.fromLabel {
+            fromSession = s
+            fromLabel = l
+        } else if let terminalID = params.terminalID {
+            guard let terminal = try await terminalStore.get(id: terminalID) else {
+                return RPCResponse(error: "Unknown terminalID \(terminalID.uuidString)")
+            }
+            guard let session = terminal.sessionID, !session.isEmpty else {
+                return RPCResponse(error: "Terminal \(terminalID.uuidString) has no recorded sessionID yet (SessionStart hook hasn't fired)")
+            }
+            guard let worktree = try await worktreeStore.get(id: terminal.worktreeID) else {
+                return RPCResponse(error: "Worktree \(terminal.worktreeID.uuidString) not found")
+            }
+            fromSession = session
+            fromLabel = worktree.displayName
+        } else {
+            return RPCResponse(error: "Either terminalID or (fromSession + fromLabel) must be provided")
+        }
+
+        do {
+            let result = try await channelStore.post(
+                name: params.name,
+                body: params.body,
+                fromSession: fromSession,
+                fromLabel: fromLabel
+            )
+            return RPCResponse(result: ChannelsPostResult(seq: result.seq, ts: result.ts))
+        } catch {
+            logger.error("channels.post failed: \(String(describing: error), privacy: .public)")
+            return RPCResponse(error: "channels.post failed: \(error)")
+        }
+    }
+
+    func handleChannelsList(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ChannelsListParams.self, from: paramsData)
+        let entries = try await channelIndexStore.list(includeArchived: params.includeArchived)
+        let summaries = entries.map {
+            ChannelSummary(
+                name: $0.name,
+                createdAt: $0.createdAt,
+                lastMessageAt: $0.lastMessageAt,
+                messageCount: $0.messageCount
+            )
+        }
+        return RPCResponse(result: ChannelsListResult(channels: summaries))
+    }
+
+    func handleChannelsArchive(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ChannelsArchiveParams.self, from: paramsData)
+        do {
+            let path = try await channelStore.archive(name: params.name)
+            return RPCResponse(result: ChannelsArchiveResult(archivedPath: path))
+        } catch {
+            logger.error("channels.archive failed: \(String(describing: error), privacy: .public)")
+            return RPCResponse(error: "channels.archive failed: \(error)")
+        }
+    }
+}
+```
+
+Notes for the implementing subagent:
+- `terminalStore`, `worktreeStore` are existing properties on `RPCRouter` (used by other handlers). Look at how `RPCRouter+TerminalHandlers.swift` calls them to find the exact method names — they may be `find(id:)`, `get(id:)`, `byID(_:)`, etc. Use the same name the existing handlers use.
+- `channelIndexStore` and `channelStore` are NEW properties on `RPCRouter` — add them as fields and pass from `Daemon.swift` following the same pattern as `notificationStore`.
+
+- [ ] **Step 5: Wire dispatch in RPCRouter.swift**
+
+Open `Sources/TBDDaemon/Server/RPCRouter.swift`. Inside the `switch request.method` block (the long block starting near line 71), add three cases — alphabetical placement near other `channel*` cases doesn't apply (none yet), so place them adjacent to a related domain (e.g., after `notificationsMarkRead`):
+
+```swift
+            case RPCMethod.channelsPost:
+                return try await handleChannelsPost(request.paramsData)
+            case RPCMethod.channelsList:
+                return try await handleChannelsList(request.paramsData)
+            case RPCMethod.channelsArchive:
+                return try await handleChannelsArchive(request.paramsData)
+```
+
+- [ ] **Step 6: Verify build**
+
+Run: `swift build`
+Expected: success. If RPCRouter complains about missing `channelStore` / `channelIndexStore` properties, add them to the `RPCRouter` struct/class and pass from `Daemon.swift`.
+
+- [ ] **Step 7: Run all tests, confirm no regressions**
+
+Run: `swift test`
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/TBDShared/RPCProtocol.swift Sources/TBDShared/Constants.swift Sources/TBDDaemon/Server/RPCRouter+ChannelHandlers.swift Sources/TBDDaemon/Server/RPCRouter.swift Sources/TBDDaemon/Daemon.swift
+git commit -m "feat(channels): add channels.post/list/archive RPC handlers"
+```
+
+---
+
+## Task 11: CLI — `tbd channels post`
+
+**Files:**
+- Create: `Sources/TBDCLI/Commands/ChannelsCommand.swift`
+- Modify: `Sources/TBDCLI/TBD.swift` (register `ChannelsCommand`)
+
+This task ships the top-level `ChannelsCommand` group with the `post` subcommand. Subsequent tasks add `read`, `tail`, `list`, `archive`.
+
+- [ ] **Step 1: Create the command file**
+
+```swift
+// Sources/TBDCLI/Commands/ChannelsCommand.swift
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct ChannelsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "channels",
+        abstract: "Inter-session message channels",
+        subcommands: [
+            ChannelsPostCommand.self,
+            // read / tail / list / archive added in later tasks
+        ]
+    )
+}
+
+// MARK: - post
+
+struct ChannelsPostCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "post",
+        abstract: "Post a message to a channel"
+    )
+
+    @Argument(help: "Channel name (e.g. 'help', 'api-questions'). Use without leading '#'.")
+    var name: String
+
+    @Argument(help: "Message body. Use '-' to read from stdin.")
+    var body: String
+
+    @Option(name: .long, help: "Override terminal ID (defaults to TBD_TERMINAL_ID env)")
+    var terminalID: String?
+
+    @Option(name: .long, help: "Override sender session ID (requires --from-label)")
+    var fromSession: String?
+
+    @Option(name: .long, help: "Override sender display label (requires --from-session)")
+    var fromLabel: String?
+
+    func validate() throws {
+        if (fromSession != nil) != (fromLabel != nil) {
+            throw ValidationError("--from-session and --from-label must be specified together")
+        }
+    }
+
+    mutating func run() async throws {
+        // Resolve body from stdin if requested
+        var resolvedBody = body
+        if body == "-" {
+            let data = FileHandle.standardInput.readDataToEndOfFile()
+            guard let text = String(data: data, encoding: .utf8) else {
+                FileHandle.standardError.write(Data("error: failed to read stdin as UTF-8\n".utf8))
+                throw ExitCode.failure
+            }
+            resolvedBody = text
+        }
+
+        // Resolve terminalID
+        var resolvedTerminalID: UUID?
+        if let s = terminalID {
+            guard let id = UUID(uuidString: s) else {
+                FileHandle.standardError.write(Data("error: invalid --terminal-id\n".utf8))
+                throw ExitCode.failure
+            }
+            resolvedTerminalID = id
+        } else if fromSession == nil {
+            // Auto-detect from env
+            guard let envID = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+                  let id = UUID(uuidString: envID) else {
+                FileHandle.standardError.write(Data("""
+                    error: TBD_TERMINAL_ID not set in environment.
+                    This command must run inside a TBD-managed terminal,
+                    or pass --terminal-id, or --from-session and --from-label.\n
+                    """.utf8))
+                throw ExitCode.failure
+            }
+            resolvedTerminalID = id
+        }
+
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            FileHandle.standardError.write(Data("error: TBD daemon is not running\n".utf8))
+            throw ExitCode.failure
+        }
+
+        do {
+            let result: ChannelsPostResult = try client.call(
+                method: RPCMethod.channelsPost,
+                params: ChannelsPostParams(
+                    name: name,
+                    body: resolvedBody,
+                    terminalID: resolvedTerminalID,
+                    fromSession: fromSession,
+                    fromLabel: fromLabel
+                ),
+                resultType: ChannelsPostResult.self
+            )
+            // Friendly output: include a copy-pasteable read suggestion.
+            print("Posted to #\(name) (seq \(result.seq))")
+            print("→ tbd channels read \(name) --seq \(result.seq)")
+        } catch {
+            FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register in TBD.swift**
+
+Edit `Sources/TBDCLI/TBD.swift`. Add `ChannelsCommand.self` to the `subcommands` array (alongside `NotifyCommand.self`, etc.).
+
+- [ ] **Step 3: Verify build**
+
+Run: `swift build`
+Expected: success.
+
+- [ ] **Step 4: Smoke test (manual)**
+
+```bash
+# In a TBD-spawned terminal (TBD_TERMINAL_ID set):
+.build/debug/tbd channels post smoke "hello from task 11"
+
+# Expected stdout:
+# Posted to #smoke (seq 1)
+# → tbd channels read smoke --seq 1
+
+# Verify the file was written:
+cat ~/tbd/channels/smoke.jsonl
+# Expected: one JSONL line with body "hello from task 11"
+```
+
+If running outside a TBD terminal, expect a clear error pointing at `TBD_TERMINAL_ID` / overrides.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDCLI/Commands/ChannelsCommand.swift Sources/TBDCLI/TBD.swift
+git commit -m "feat(channels): add 'tbd channels post' subcommand"
+```
+
+---
+
+## Task 12: CLI — `tbd channels read` (direct file read)
+
+**Files:**
+- Modify: `Sources/TBDCLI/Commands/ChannelsCommand.swift` (add `ChannelsReadCommand`)
+- Register in `ChannelsCommand.subcommands`
+
+- [ ] **Step 1: Add `ChannelsReadCommand`**
+
+Append to `Sources/TBDCLI/Commands/ChannelsCommand.swift`:
+
+```swift
+// MARK: - read
+
+struct ChannelsReadCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "read",
+        abstract: "Read messages from a channel (direct file read; daemon not required)"
+    )
+
+    @Argument(help: "Channel name (without leading '#').")
+    var name: String
+
+    @Option(name: .long, help: "Show just the message with this seq")
+    var seq: Int?
+
+    @Option(name: .long, help: "Show messages with seq > this value")
+    var since: Int?
+
+    @Option(name: .long, help: "Maximum number of messages to print (default 20)")
+    var limit: Int = 20
+
+    func validate() throws {
+        if seq != nil && since != nil {
+            throw ValidationError("--seq and --since are mutually exclusive")
+        }
+    }
+
+    mutating func run() async throws {
+        let normalized: String
+        do {
+            normalized = try validateChannelName(name)
+        } catch {
+            FileHandle.standardError.write(Data("error: invalid channel name: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        let path = TBDConstants.channelsDir.appendingPathComponent("\(normalized).jsonl").path
+        guard FileManager.default.fileExists(atPath: path) else {
+            FileHandle.standardError.write(Data("error: no such channel #\(normalized)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        var matched: [(seq: Int, formatted: String)] = []
+        var lineStart = 0
+        for (idx, byte) in data.enumerated() where byte == 0x0A {
+            let lineData = data.subdata(in: lineStart..<idx)
+            lineStart = idx + 1
+            guard let msg = try? ChannelMessage.decodeLine(lineData) else { continue }
+
+            if let s = seq, msg.seq != s { continue }
+            if let since = since, msg.seq <= since { continue }
+
+            matched.append((msg.seq, format(msg)))
+        }
+
+        // Apply limit (most recent N when no --seq filter)
+        let toPrint: ArraySlice<(seq: Int, formatted: String)>
+        if seq != nil {
+            toPrint = matched[...]
+        } else {
+            toPrint = matched.suffix(limit)[...]
+        }
+        for entry in toPrint { print(entry.formatted) }
+    }
+
+    private static let formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private func format(_ m: ChannelMessage) -> String {
+        let ts = Self.formatter.string(from: m.ts)
+        return "[\(ts)] (seq \(m.seq)) \(m.fromLabel): \(m.body)"
+    }
+}
+```
+
+`ChannelMessage` lives in TBDDaemonLib but the CLI only depends on TBDShared. **Move `ChannelMessage` from `Sources/TBDDaemon/Channels/ChannelMessage.swift` to `Sources/TBDShared/ChannelMessage.swift`** (it has no daemon-only deps; the CLI legitimately needs it). Update the import in `ChannelStore.swift` if needed (already imports `TBDShared`).
+
+- [ ] **Step 2: Register subcommand**
+
+In `ChannelsCommand.configuration.subcommands`, add `ChannelsReadCommand.self`.
+
+- [ ] **Step 3: Build and smoke-test**
+
+```bash
+swift build
+.build/debug/tbd channels read smoke
+.build/debug/tbd channels read smoke --seq 1
+.build/debug/tbd channels read smoke --since 0
+.build/debug/tbd channels read smoke --limit 5
+.build/debug/tbd channels read nonexistent  # expect error
+```
+
+- [ ] **Step 4: Move ChannelMessage to TBDShared (verify tests still pass)**
+
+```bash
+swift test
+```
+
+Expected: pass. If `ChannelMessageTests.swift` import broke, change `@testable import TBDDaemonLib` to `@testable import TBDShared` for the message-codec tests (or keep both — the test file just needs to see the type).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TBDCLI/Commands/ChannelsCommand.swift Sources/TBDShared/ChannelMessage.swift
+git rm Sources/TBDDaemon/Channels/ChannelMessage.swift
+git commit -m "feat(channels): add 'tbd channels read'; move ChannelMessage to TBDShared"
+```
+
+---
+
+## Task 13: CLI — `tbd channels tail --follow`
+
+**Files:**
+- Modify: `Sources/TBDCLI/Commands/ChannelsCommand.swift` (add `ChannelsTailCommand`)
+- Register in subcommands
+
+- [ ] **Step 1: Add `ChannelsTailCommand`**
+
+Append to `ChannelsCommand.swift`:
+
+```swift
+// MARK: - tail
+
+struct ChannelsTailCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "tail",
+        abstract: "Stream new messages from a channel as they arrive"
+    )
+
+    @Argument(help: "Channel name (without leading '#').")
+    var name: String
+
+    @Flag(name: .long, help: "Keep watching after the current end of file")
+    var follow: Bool = false
+
+    @Flag(name: .long, help: "Show all existing messages before tailing")
+    var fromStart: Bool = false
+
+    mutating func run() async throws {
+        let normalized = try validateChannelName(name)
+        let url = TBDConstants.channelsDir.appendingPathComponent("\(normalized).jsonl")
+
+        // Ensure the file exists so we have something to open. (If the
+        // channel hasn't been posted to yet, --follow would otherwise wait
+        // forever on a non-existent file.)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            FileManager.default.createFile(atPath: url.path, contents: nil)
+        }
+
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        if !fromStart {
+            try handle.seekToEnd()
+        }
+
+        // Print whatever is already there if --from-start.
+        try printNewLines(handle: handle)
+
+        if !follow { return }
+
+        // SIGINT must be ignored *before* installing the dispatch source, or
+        // the default handler can fire between setup steps.
+        signal(SIGINT, SIG_IGN)
+        let signalSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+        signalSource.setEventHandler { exit(0) }
+        signalSource.resume()
+
+        // Watch for VNODE_WRITE | VNODE_EXTEND on the file.
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: handle.fileDescriptor,
+            eventMask: [.write, .extend],
+            queue: .global(qos: .utility)
+        )
+        let stream = AsyncStream<Void> { continuation in
+            source.setEventHandler { continuation.yield(()) }
+            source.setCancelHandler { continuation.finish() }
+            source.resume()
+        }
+
+        for await _ in stream {
+            try printNewLines(handle: handle)
+        }
+    }
+
+    private static let formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private func printNewLines(handle: FileHandle) throws {
+        // Read whatever is available now.
+        guard let chunk = try handle.read(upToCount: Int.max), !chunk.isEmpty else { return }
+        var lineStart = 0
+        for (idx, byte) in chunk.enumerated() where byte == 0x0A {
+            let lineData = chunk.subdata(in: lineStart..<idx)
+            lineStart = idx + 1
+            guard let msg = try? ChannelMessage.decodeLine(lineData) else { continue }
+            let ts = Self.formatter.string(from: msg.ts)
+            print("[\(ts)] (seq \(msg.seq)) \(msg.fromLabel): \(msg.body)")
+        }
+        // Anything after the last newline is a partial write in progress;
+        // the next event will see it complete.
+    }
+}
+```
+
+- [ ] **Step 2: Register subcommand**
+
+Add `ChannelsTailCommand.self` to `ChannelsCommand.configuration.subcommands`.
+
+- [ ] **Step 3: Build and smoke-test**
+
+```bash
+swift build
+
+# Terminal A:
+.build/debug/tbd channels tail smoke --follow
+
+# Terminal B (in a TBD pane):
+.build/debug/tbd channels post smoke "hello from terminal B"
+
+# Terminal A should print the new line within ~1s.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDCLI/Commands/ChannelsCommand.swift
+git commit -m "feat(channels): add 'tbd channels tail --follow' via DispatchSource"
+```
+
+---
+
+## Task 14: CLI — `tbd channels list`
+
+**Files:**
+- Modify: `Sources/TBDCLI/Commands/ChannelsCommand.swift` (add `ChannelsListCommand`)
+- Register in subcommands
+
+- [ ] **Step 1: Add `ChannelsListCommand`**
+
+Append to `ChannelsCommand.swift`:
+
+```swift
+// MARK: - list
+
+struct ChannelsListCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List channels"
+    )
+
+    @Flag(name: .long, help: "List archived channels instead of active ones")
+    var archived: Bool = false
+
+    mutating func run() async throws {
+        if archived {
+            try printArchived()
+            return
+        }
+
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            FileHandle.standardError.write(Data("error: TBD daemon is not running\n".utf8))
+            throw ExitCode.failure
+        }
+
+        let result: ChannelsListResult = try client.call(
+            method: RPCMethod.channelsList,
+            params: ChannelsListParams(includeArchived: false),
+            resultType: ChannelsListResult.self
+        )
+
+        if result.channels.isEmpty {
+            print("No channels yet. Post one with `tbd channels post <name> <body>`.")
+            return
+        }
+
+        let nameWidth = max(4, result.channels.map { $0.name.count }.max() ?? 0)
+        print("\(pad("NAME", nameWidth))  COUNT  LAST")
+        for ch in result.channels {
+            let count = String(ch.messageCount)
+            let last = ch.lastMessageAt.map { Self.fmt.string(from: $0) } ?? "—"
+            print("\(pad(ch.name, nameWidth))  \(pad(count, 5))  \(last)")
+        }
+    }
+
+    private func printArchived() throws {
+        let dir = TBDConstants.channelsArchiveDir
+        guard FileManager.default.fileExists(atPath: dir.path) else {
+            print("No archived channels.")
+            return
+        }
+        let entries = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            .filter { $0.hasSuffix(".jsonl") }
+            .sorted()
+        if entries.isEmpty {
+            print("No archived channels.")
+            return
+        }
+        print("ARCHIVED CHANNEL FILES:")
+        for entry in entries {
+            print("  \(dir.appendingPathComponent(entry).path)")
+        }
+    }
+
+    private static let fmt: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private func pad(_ s: String, _ width: Int) -> String {
+        s + String(repeating: " ", count: max(0, width - s.count))
+    }
+}
+```
+
+- [ ] **Step 2: Register subcommand**
+
+Add `ChannelsListCommand.self` to `ChannelsCommand.configuration.subcommands`.
+
+- [ ] **Step 3: Build and smoke-test**
+
+```bash
+swift build
+.build/debug/tbd channels list
+# Should show columns: NAME, COUNT, LAST
+
+.build/debug/tbd channels list --archived
+# "No archived channels." (until Task 15 ships)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDCLI/Commands/ChannelsCommand.swift
+git commit -m "feat(channels): add 'tbd channels list'"
+```
+
+---
+
+## Task 15: CLI — `tbd channels archive`
+
+**Files:**
+- Modify: `Sources/TBDCLI/Commands/ChannelsCommand.swift` (add `ChannelsArchiveCommand`)
+- Register in subcommands
+
+- [ ] **Step 1: Add `ChannelsArchiveCommand`**
+
+Append to `ChannelsCommand.swift`:
+
+```swift
+// MARK: - archive
+
+struct ChannelsArchiveCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "archive",
+        abstract: "Archive a channel (move to ~/tbd/channels/_archive/)"
+    )
+
+    @Argument(help: "Channel name (without leading '#').")
+    var name: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            FileHandle.standardError.write(Data("error: TBD daemon is not running\n".utf8))
+            throw ExitCode.failure
+        }
+
+        do {
+            let result: ChannelsArchiveResult = try client.call(
+                method: RPCMethod.channelsArchive,
+                params: ChannelsArchiveParams(name: name),
+                resultType: ChannelsArchiveResult.self
+            )
+            print("Archived #\(name) → \(result.archivedPath)")
+        } catch {
+            FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register subcommand**
+
+Add `ChannelsArchiveCommand.self` to `ChannelsCommand.configuration.subcommands`.
+
+- [ ] **Step 3: Build and smoke-test**
+
+```bash
+swift build
+.build/debug/tbd channels post smoke "another"
+.build/debug/tbd channels archive smoke
+# Expected: "Archived #smoke → ~/tbd/channels/_archive/smoke-YYYYMMDD-HHMMSS.jsonl"
+.build/debug/tbd channels list
+# 'smoke' should no longer appear
+.build/debug/tbd channels list --archived
+# Should show the archived path
+.build/debug/tbd channels post smoke "rebirth"
+# Posts to a fresh smoke.jsonl with seq 1
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDCLI/Commands/ChannelsCommand.swift
+git commit -m "feat(channels): add 'tbd channels archive'"
+```
+
+---
+
+## Task 16: Document channels in the tbd skill
+
+**Files:**
+- Modify: `Sources/TBDShared/TBDSkillContent.swift`
+
+The skill is loaded into TBD-spawned Claude sessions via `--plugin-dir` (see commit `798293c`), so adding content here is what makes agents aware of channels.
+
+- [ ] **Step 1: Add a Channels section**
+
+Open `Sources/TBDShared/TBDSkillContent.swift`. Find the "Common workflows" section. After the "Notify the TBD UI" workflow (around line 60-65) and before "Get a deep link to a worktree" (around line 66), add a new workflow:
+
+```swift
+### Coordinate via channels
+
+Channels let you share context with another TBD-managed session — useful when
+the user asks you to "post that question for the other agent" or asks the other
+agent to "go read what session A said in #foo".
+
+```bash
+# Post a message
+tbd channels post help "anyone seen the launchctl crash?"
+
+# Output includes a copy-pasteable read command:
+#   Posted to #help (seq 42)
+#   → tbd channels read help --seq 42
+# The user often pastes the second line into another session's prompt.
+
+# Read a specific message
+tbd channels read help --seq 42
+
+# Read recent activity (default last 20)
+tbd channels read help
+
+# Pull only what's new since the seq you last saw
+tbd channels read help --since 40
+
+# Discover channels
+tbd channels list
+
+# Watch a channel live (background bash + BashOutput pairs naturally)
+tbd channels tail help --follow
+
+# Clean up a channel that has served its purpose
+tbd channels archive help
+```
+
+**Notes:**
+- Channel names are case-folded; `#API-questions` and `#api-questions` are the
+  same channel. Free-form Unicode is allowed (emoji, non-Latin scripts).
+- The body is plain UTF-8 text up to 64 KB. Markdown is fine if the reader
+  cares; the daemon does not interpret it.
+- Reads do not require the daemon — the CLI opens the file directly. Posts
+  and archives go through the daemon.
+- You can also `Read("~/tbd/channels/<name>.jsonl", offset=N)` directly, but
+  note `offset` is line-numbered and may diverge from `seq` after a torn-line
+  recovery. Prefer the CLI commands above.
+```
+
+(In the Swift string literal you'll write `\\\``-escapes around the bash
+fences as needed.)
+
+- [ ] **Step 2: Update top-level commands list**
+
+Find the "Discovering current commands" section (around line 28-30):
+
+```
+Top-level commands: `tbd worktree`, `tbd terminal`, `tbd link`, `tbd notify`.
+```
+
+Change to:
+
+```
+Top-level commands: `tbd worktree`, `tbd terminal`, `tbd link`, `tbd notify`, `tbd channels`.
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `swift build`
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/TBDShared/TBDSkillContent.swift
+git commit -m "docs(channels): document channels in the tbd skill"
+```
+
+---
+
+## Task 17: Empirical validation of `BashOutput` ↔ `tbd channels tail`
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-05-10-bashoutput-validation.md`
+
+The adversarial review flagged that the `BashOutput` integration is load-bearing on undocumented Claude Code behavior (per-shell output buffer cap, idle-shell reaping, cursor reset on shell death). Before claims in the skill docs say "this just works," verify what actually happens.
+
+This task is **manual** — there's no automated test that can characterize Claude Code tool behavior. Document findings in the notes file.
+
+- [ ] **Step 1: Build and start a probe**
+
+```bash
+swift build
+# In a TBD-managed Claude session, dispatch this prompt to itself or a child agent:
+```
+
+Send to a Claude session (or run as a subagent):
+
+> Please run `.build/debug/tbd channels tail probe-bashoutput --follow` as a
+> background bash (`run_in_background: true`). Then post 5 messages to that
+> channel from another shell, polling `BashOutput` after each. Then wait 10
+> minutes idle, post another message, and report whether `BashOutput` returns
+> it. Then post 1000 short messages rapidly and report whether any are
+> dropped from the buffer. Report what you observe — exact byte counts and
+> any messages that did not appear.
+
+- [ ] **Step 2: Capture the findings in writing**
+
+Write `docs/superpowers/notes/2026-05-10-bashoutput-validation.md` with:
+
+- What was tested (the probe steps above).
+- What worked (the happy path with rapid posts).
+- Whether long idle periods caused the shell to be reaped.
+- What the actual buffer cap appears to be (if reachable).
+- What happens when the underlying `tbd channels tail` is killed (e.g., daemon restart).
+- Recommendations: should the skill doc claim live tail "just works" or warn about specific failure modes?
+
+- [ ] **Step 3: Update the skill doc if needed**
+
+If the validation surfaces caveats (e.g., "shells go idle after N minutes"), update the Channels section in `Sources/TBDShared/TBDSkillContent.swift` (Task 16) to mention them. Common likely caveat: prefer short-lived `tail --follow` shells over multi-hour ones.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-05-10-bashoutput-validation.md Sources/TBDShared/TBDSkillContent.swift
+git commit -m "docs(channels): validate BashOutput integration empirically"
+```
+
+---
+
+## Task 18: Final verification — full restart + end-to-end smoke
+
+**Files:** none modified; this is verification.
+
+- [ ] **Step 1: Full daemon restart**
+
+```bash
+scripts/restart.sh
+```
+
+(NOT `scripts/restart.sh --app` — daemon code changed; per `Sources/TBDDaemon/CLAUDE.md`, app-only restart leaves the daemon on the old binary.)
+
+Verify exactly one daemon and one app are running, both from the worktree path:
+
+```bash
+ps aux | grep -E "\.build/debug/TBD" | grep -v grep
+```
+
+Expected: one `TBDDaemon`, one `TBDApp`, both under `/Users/chang/tbd/worktrees/tbd/20260510-known-smelt/.build/debug/`.
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+swift test
+```
+
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 3: End-to-end manual smoke**
+
+In a TBD-managed terminal:
+
+```bash
+# Post
+tbd channels post smoke-final "end-to-end smoke test from $TBD_TERMINAL_ID"
+# Confirm "Posted to #smoke-final (seq N)" + "→ tbd channels read smoke-final --seq N"
+
+# Read
+tbd channels read smoke-final --seq 1
+# Confirm the message renders with the worktree's display name as from_label
+
+# Read all
+tbd channels read smoke-final
+
+# List
+tbd channels list
+# Confirm smoke-final appears with COUNT 1
+
+# Tail in a second terminal
+tbd channels tail smoke-final --follow &
+TAIL_PID=$!
+sleep 1
+tbd channels post smoke-final "second message"
+sleep 1
+kill $TAIL_PID
+# Confirm the tail printed the second message
+
+# Archive
+tbd channels archive smoke-final
+# Confirm the archive path is printed
+
+# Verify list excludes archived
+tbd channels list
+# smoke-final should not appear
+
+tbd channels list --archived
+# smoke-final-<ts>.jsonl should appear
+
+# Reuse name
+tbd channels post smoke-final "reborn"
+tbd channels read smoke-final --seq 1
+# Confirm seq is 1 again, body is "reborn"
+```
+
+- [ ] **Step 4: Verify the daemon log is clean**
+
+```bash
+log show --last 5m --level debug --predicate 'subsystem BEGINSWITH "com.tbd" AND category BEGINSWITH "channels"'
+```
+
+Expected: no `.error` rows; `.notice` rows acceptable (e.g., torn-line truncation if you triggered it).
+
+- [ ] **Step 5: Final commit (if any housekeeping)**
+
+If the smoke test surfaced any tweaks needed (e.g., output formatting), commit them with a clear message. Otherwise this task is verification-only — no commit needed.
+
+---
+
+## Spec coverage check
+
+| Spec section | Covered by |
+|---|---|
+| Storage model — JSONL files | Task 7 (post) |
+| `channel_index` migration + cache | Tasks 2, 3 |
+| Channel name validation | Task 1 |
+| Single in-process writer (per-channel lock) | Tasks 6, 7 |
+| Cross-process `flock` defense | Tasks 4, 7 |
+| Reopen-per-write (no cached FDs) | Task 7 (`appendLine` opens fresh each call) |
+| `fsync` on every post | Task 7 |
+| Torn-line recovery on startup | Tasks 7 (impl), 8 (tests) |
+| Body size cap 64 KB | Task 7 |
+| Identity via `TBD_TERMINAL_ID` + Terminal table | Task 10 (handler resolves), Task 11 (CLI reads env) |
+| `tbd channels post` | Task 11 |
+| `tbd channels read` | Task 12 |
+| `tbd channels tail --follow` | Task 13 |
+| `tbd channels list` (+ `--archived`) | Task 14 |
+| `tbd channels archive` | Tasks 9 (store), 15 (CLI) |
+| RPC methods + types | Task 10 |
+| Archive layout (`_archive/<name>-<ts>.jsonl`) | Task 9 |
+| Reusing archived name → fresh seq | Task 9 (test included) |
+| Skill documentation | Task 16 |
+| `BashOutput` empirical validation | Task 17 |
+| Full restart + smoke | Task 18 |

--- a/docs/superpowers/specs/2026-05-10-channels-design.md
+++ b/docs/superpowers/specs/2026-05-10-channels-design.md
@@ -41,8 +41,9 @@ their existing primitives (`Read`, `tail -f`, `cat`).
   existing files.
 - Subscriptions. Agents pull what they want; no server-side
   subscription state.
-- Auto-pruning. Files grow unbounded for now; add `archive` later if it
-  matters.
+- Auto-pruning. Files grow unbounded; explicit `tbd channels archive`
+  ships in v1 (see "Archive" below). Time-based or size-based auto-archive
+  is deferred.
 - Cross-channel "firehose" reads (`tbd channels read` with no name).
   Use `tbd channels list` for cross-channel awareness; revisit if it
   matters.
@@ -58,18 +59,42 @@ channel" step.
 
 ### Channel name validation
 
-Names are normalized to lowercase and validated at the RPC boundary:
+Names are validated at the RPC boundary. Arbitrary Unicode is allowed
+(emoji, non-Latin scripts), but the name must be safely usable as a
+filename on macOS APFS.
 
-- Pattern: `^[a-z0-9][a-z0-9_-]{0,63}$`
-- No leading/trailing whitespace, no slashes, no dots, no Unicode.
-- Names that fail validation are rejected with a clear error before
-  any file operation is attempted.
+**Length:** ≤ 64 grapheme clusters AND ≤ 200 UTF-8 bytes (filesystem
+max is 255, leaving headroom for the `.jsonl` suffix and `.lock`
+sidecar).
 
-This is strict by design. APFS is case-insensitive on the boot volume,
-which means `#Foo` and `#foo` resolve to the same file but would be
-distinct rows in the per-viewer cursor table; lowercasing eliminates the
-ambiguity. The pattern also closes the path-traversal vector
-(`../../etc/passwd` and friends) before file paths are constructed.
+**Forbidden characters (reject):**
+- `/` (path separator)
+- `\` (Windows path separator — defensive; cross-platform sanity)
+- NUL (`U+0000`)
+- All control characters (`U+0000`–`U+001F`, `U+007F`)
+
+**Forbidden whole-strings (reject):**
+- Empty string (after trim)
+- `.`
+- `..`
+- `_archive` (reserved — see "Archive" section)
+- Anything starting or ending with whitespace
+
+**Normalization (apply, then store):**
+- Apply Unicode NFC normalization. (`é` U+00E9 and `e` + U+0301 are
+  the same channel.)
+- Apply Unicode case folding (`String.localizedLowercase`). APFS is
+  case-insensitive on the boot volume; folding case-aliases the row
+  in `channel_index` so `#API-questions` and `#api-questions` resolve
+  to the same channel. The first writer's casing is *not* preserved
+  for display in v1; channels are referred to by their folded form.
+  (If display-casing matters later, an additional `display_name`
+  column on `channel_index` solves it without re-migrating.)
+
+Validation lives in `TBDShared` as a free function
+`validateChannelName(_:) -> Result<String, ChannelNameError>` so both
+the CLI and the daemon use exactly the same rules. No external
+dependency.
 
 ## Storage model
 
@@ -109,9 +134,7 @@ on first post by opening with `O_CREAT | O_WRONLY | O_APPEND`.
 
 ### SQLite (`~/tbd/state.db`)
 
-Two new tables. **`channel_index` is a derivable cache; `channel_cursor`
-is non-recoverable app state** (sibling to `notification` per the
-existing "NEVER delete `~/tbd/state.db`" rule).
+One new table — a derivable cache for fast channel listing:
 
 ```sql
 -- v18 migration:
@@ -121,20 +144,20 @@ CREATE TABLE channel_index (
   last_message_at TEXT,
   message_count INTEGER NOT NULL DEFAULT 0
 );
-
-CREATE TABLE channel_cursor (
-  viewer_id TEXT NOT NULL,        -- "app" for the SwiftUI app today
-  channel_name TEXT NOT NULL,
-  last_seen_seq INTEGER NOT NULL,
-  PRIMARY KEY (viewer_id, channel_name)
-);
 ```
 
-Both tables update on every successful post. `channel_index` could be
-rebuilt by walking `~/tbd/channels/*.jsonl`; `channel_cursor` could not.
-Per the project's standard rule, both shipping schemas (the GRDB Record
-type and the `TBDShared/Models.swift` Codable model) must be updated in
-the same commit as the migration.
+`channel_index` updates on every successful post and is rebuildable by
+walking `~/tbd/channels/*.jsonl` — losing the table at worst means a
+cold rebuild on next daemon startup, not data loss.
+
+A `channel_cursor` table for per-viewer "last read" state is **deferred
+to v2**, when the SwiftUI app sidebar lands and actually needs unread
+badges. Adding it later is a separate migration; carrying an unused
+table now would be dead weight.
+
+Per the project's standard rule, the GRDB Record type and the
+`TBDShared/Models.swift` Codable model are updated in the same commit
+as the migration.
 
 ### Per-channel file layout, end state
 
@@ -289,37 +312,130 @@ reads; it can be useful for one-off inspection.
 | `Read("~/tbd/channels/<name>.jsonl", offset=N)` | No | Direct file read with caveats |
 | `tbd channels list` | Yes (RPC for index) | Discovery |
 | `tbd channels post <name> <body>` | Yes (RPC; daemon writes) | Posting |
+| `tbd channels archive <name>` | Yes (RPC; daemon moves file) | Cleanup |
+
+## Archive
+
+Channels that have served their purpose can be archived. Auto-archival
+is **not** a v1 feature — only explicit `tbd channels archive <name>`
+is supported.
+
+### Layout
+
+Archived channels live in a sibling subdirectory under `~/tbd/channels/`:
+
+```
+~/tbd/channels/
+├── help.jsonl              # active
+├── help.lock
+├── api-questions.jsonl     # active
+├── api-questions.lock
+└── _archive/
+    ├── auth-rewrite-20260315-142301.jsonl
+    └── deprecated-thing-20260401-093017.jsonl
+```
+
+The `_archive` name is reserved (the channel-name validator rejects
+it), so a channel cannot shadow the archive directory.
+
+### `tbd channels archive <name>` (daemon-mediated)
+
+The daemon performs the move under the per-channel lock:
+
+1. Validate `<name>` per the channel-name rules above.
+2. Acquire the daemon's per-channel async lock for `<name>`.
+3. `flock(LOCK_EX)` on `~/tbd/channels/<name>.lock`.
+4. Compute archive timestamp (UTC, format `YYYYMMDD-HHMMSS`).
+5. Create `~/tbd/channels/_archive/` if it doesn't exist.
+6. `rename(2)` `~/tbd/channels/<name>.jsonl` →
+   `~/tbd/channels/_archive/<name>-<ts>.jsonl`.
+7. `unlink(2)` the `.lock` sidecar.
+8. Delete the row from `channel_index`.
+9. Release locks.
+10. Return `{archivedPath}` to the caller.
+
+The daemon's per-channel lock + `flock` together guarantee no
+in-flight `write(2)` is interleaved with the rename. (Without the
+daemon mediation, a `mv` from another process could leave the daemon's
+cached FD writing to the orphaned inode in `_archive/` — but we
+already chose reopen-per-write, so even that hazard is moot. The lock
+is belt-and-braces.)
+
+### Reading archived channels
+
+`tbd channels list --archived` lists archive entries with their
+original name and `archived_at` parsed from the filename.
+
+For reading the archive contents, use `cat` or `Read` on the file
+directly:
+
+```
+cat ~/tbd/channels/_archive/auth-rewrite-20260315-142301.jsonl
+```
+
+A dedicated `tbd channels read --archived <name> --at <ts>` is
+deferred; the file is plainly there and accessible.
+
+### Reusing an archived name
+
+After archive, posting to the same name creates a fresh channel —
+`channel_index` row is recreated, `seq` starts at 1, JSONL file is
+created from scratch. The archived file is untouched. Two completely
+independent histories coexist (one in `_archive/`, one in the active
+directory).
 
 ## Identity
 
-Reuse the prior attempt's mechanism. A tiny `PreToolUse` hook
-subcommand writes session identity to a temp file on every fire:
+**Reuses TBD's existing terminal-identity infrastructure. No new hook
+is added for channels.**
 
-```
-/tmp/tbd-session-${TMUX_PANE}
-```
+TBD already exposes everything channels needs:
 
-Contents:
+- `TBD_TERMINAL_ID` is set as an env var on every TBD-spawned terminal
+  (`Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift:100-101`).
+- The existing `SessionStart` hook (`tbd session-event`, registered by
+  `Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift:38-39`) fires on
+  every new Claude session — *including* after `/clear` and `/compact`
+  — reads stdin, and RPCs the daemon, which persists
+  `terminal_id → {session_id, transcript_path}` in the Terminal table.
+- The Terminal table is joined to a Worktree, which has a
+  `displayName` field (the user's custom name, defaulting to the
+  folder name).
 
-```json
-{"session_id": "abc-123", "transcript_path": "~/.claude/projects/.../sessions/abc-123.jsonl"}
-```
+So the daemon already knows, at any time, the session ID and worktree
+display name for every TBD-spawned pane.
 
-The hook subcommand (provisionally `tbd channels write-session-id`)
-does **only** this one thing: read the hook's stdin JSON, write the
-identity file. No daemon roundtrip. No throttle needed (purely local
-file write, sub-millisecond).
+`tbd channels post` uses this directly:
 
-`tbd channels post` reads `/tmp/tbd-session-${TMUX_PANE}` to resolve
-`{from_session, from_label}` automatically; agents never need to know
-their own identity. `--from` and `--from-label` flags exist as
-overrides for testing or non-TBD contexts.
+1. Read `TBD_TERMINAL_ID` from the environment. (Error clearly if
+   unset — the CLI is not running inside a TBD-managed terminal.)
+2. RPC `channels.post(name, body, terminalID)` to the daemon.
+3. Daemon resolves `from_session` (Terminal table's `sessionID`) and
+   `from_label` (joined Worktree's `displayName`) from the
+   `terminalID`. Errors clearly if the terminal is unknown.
+4. Daemon writes the JSONL line.
 
-This is **not** the descoped content-push hook. It only writes the
-identity file.
+The CLI accepts `--terminal-id`, `--from-session`, and `--from-label`
+flag overrides for testing and non-TBD contexts; these are not the
+common path.
 
-`tbd setup-hooks` is extended to install this `PreToolUse` hook
-alongside the existing `Stop` notification hook.
+### Why this is better than the prior attempt's `/tmp/tbd-session-${TMUX_PANE}` mechanism
+
+- **No new hook to install.** The `SessionStart` hook is already there
+  for an unrelated reason (the post-`/clear` transcript-freeze fix).
+- **Daemon-mediated identity.** Consistent with how everything else in
+  TBD resolves "who is this terminal."
+- **Survives `/clear` and `/compact`** because the existing
+  `SessionStart` hook re-fires.
+- **No `/tmp` files to manage or clean up** on terminal teardown.
+- **No `TMUX_PANE`-keyed state** that could be re-used by tmux when a
+  pane is closed and a new one takes its number.
+- **Channels doesn't touch `tbd setup-hooks` at all.**
+
+### What the agent sees in its context as a result of channels
+
+Nothing. The identity flow involves only the daemon and the CLI; no
+hook injects anything into the agent's conversation.
 
 ## CLI
 
@@ -328,8 +444,8 @@ alongside the existing `Stop` notification hook.
 | `tbd channels post <name> <body>` | Post a message. Body may be `-` to read from stdin. Stdout includes a copy-pasteable read suggestion. |
 | `tbd channels read <name> [--seq N \| --since N] [--limit N]` | Read messages. |
 | `tbd channels tail <name> [--follow] [--from-start]` | Tail a channel; `--follow` watches for new messages. |
-| `tbd channels list` | List channels with `last_message_at` and `message_count`. |
-| `tbd channels write-session-id` | Internal hook subcommand. Not user-facing. |
+| `tbd channels list [--archived]` | List channels with `last_message_at` and `message_count`. `--archived` lists archived channels instead. |
+| `tbd channels archive <name>` | Move the channel to `~/tbd/channels/_archive/<name>-<YYYYMMDD-HHMMSS>.jsonl`. Future posts to the same name create a fresh channel starting at `seq=1`. |
 
 ### `post` output
 
@@ -348,13 +464,13 @@ and agent B reads exactly that one message.
 
 | Method | Request | Response |
 |---|---|---|
-| `channels.post` | `{name, body, fromSession, fromLabel}` | `{seq, ts}` |
-| `channels.list` | `{}` | `[{name, createdAt, lastMessageAt, messageCount}]` |
+| `channels.post` | `{name, body, terminalID}` (with optional `fromSession`/`fromLabel` overrides for non-TBD callers) | `{seq, ts}` |
+| `channels.list` | `{includeArchived: Bool}` | `[{name, createdAt, lastMessageAt, messageCount, archivedAt?}]` |
+| `channels.archive` | `{name}` | `{archivedPath}` |
 
 That is the complete RPC surface for v1. Reads bypass the daemon. The
-shared model layer (`Sources/TBDShared/Models.swift`,
-`RPCProtocol.swift`) is updated in the same commit as the migration
-per the project's standard rule.
+shared model layer (`Sources/TBDShared/RPCProtocol.swift`) is updated
+in the same commit as the migration per the project's standard rule.
 
 ## Discovery
 
@@ -365,7 +481,8 @@ Two paths:
    the plugin shipped in commit `798293c`) gains a Channels section
    covering: what channels are, the post/read/tail commands, the
    `--seq` vs `--since` distinction, the post-output read-suggestion
-   pattern, and the caveats for direct `Read`.
+   pattern, the caveats for direct `Read`, and when/how to archive
+   (`tbd channels archive <name>`).
 
 The typical workflow is **human-mediated**: a user asks agent A to post
 something, then goes to agent B's pane and asks it to read. Agents do
@@ -373,12 +490,9 @@ not auto-discover or auto-poll.
 
 ## App UI
 
-Out of scope for v1. The SwiftUI app is unchanged.
-
-The `channel_cursor` table includes the row `viewer_id = "app"` for a
-future v2 sidebar; v1 simply does not write to it. (The presence of the
-table in the migration is fine — it is a no-op until the app starts
-using it.)
+Out of scope for v1. The SwiftUI app is unchanged. Per-viewer cursor
+state (the `channel_cursor` table) is also deferred — it lands with
+the v2 sidebar in its own migration.
 
 ## Adversarial review findings
 
@@ -389,7 +503,7 @@ run against an earlier draft of this design. Key calibrated findings:
 |---|---|---|
 | 1 | "PIPE_BUF makes O_APPEND atomic" claim is wrong (POSIX guarantees apply to pipes, not regular files; macOS PIPE_BUF is 512, not 4096) | **Removed.** Crash safety = serialization + `flock` + torn-line policy + `fsync`, not kernel atomicity. |
 | 3 | Torn-line recovery on startup is unspecified | **Resolved.** Truncate-to-last-newline policy with logging. |
-| 4 | `channel_cursor` claimed to be derivable but isn't | **Resolved.** Table is reframed as non-recoverable app state, sibling to `notification`. |
+| 4 | `channel_cursor` claimed to be derivable but isn't | **Resolved by deferral.** Table dropped from v1 entirely; per-viewer cursor lands with the v2 sidebar in its own migration, where its non-derivable nature can be documented honestly. |
 | 6 | `Read --offset` is line-numbered and diverges from `seq` | **Documented.** TBD skill recommends CLI; direct `Read` is supported with caveats noted. |
 | 7 | Channel name validation undefined; APFS case-insensitivity, path traversal | **Resolved.** Strict regex + lowercasing at RPC boundary. |
 | 8 | Cached file handles survive `unlink`/atomic-save | **Resolved.** Reopen-per-write; no cached FDs. |
@@ -416,8 +530,6 @@ run against an earlier draft of this design. Key calibrated findings:
   plan to specify after looking at what's available in the daemon's
   per-pane state. Whatever is chosen should be stable for the
   lifetime of the pane.
-- **No automatic pruning.** Files grow unbounded. For the expected
-  usage (humans post sporadically), this should not bite for a long
-  time. If/when it does, an `archive` subcommand that moves a channel
-  file to `~/tbd/channels/_archive/<name>-<ts>.jsonl` is the obvious
-  v2 addition.
+- **No automatic pruning.** Explicit `tbd channels archive <name>`
+  ships in v1. Time-based or size-based auto-archive is deferred until
+  there's evidence anyone wants it.

--- a/docs/superpowers/specs/2026-05-10-channels-design.md
+++ b/docs/superpowers/specs/2026-05-10-channels-design.md
@@ -1,0 +1,423 @@
+# Channels Design
+
+**Date:** 2026-05-10
+**Status:** Ready for implementation planning
+**Replaces:** `2026-04-09-inter-session-messaging-design.md` (the prior "broadcast/thread/visibility-rules" attempt; deemed over-engineered)
+
+## Overview
+
+A Slack-like **channels** feature for inter-session context sharing across
+Claude Code agents running in TBD-managed terminals. Free-form named topics
+(`#help`, `#api-questions`, `#whatever`), append-only logs, pull-based
+reads. Humans mediate cross-session discovery; agents post and read
+explicitly.
+
+The persistence story is the unusual choice: each channel is a single
+JSONL file at `~/tbd/channels/<name>.jsonl`. The filesystem is the source
+of truth; SQLite holds only viewer/UI metadata. This makes channel
+content trivially inspectable, tailable, and readable by agents using
+their existing primitives (`Read`, `tail -f`, `cat`).
+
+## Goals and non-goals
+
+### Goals
+
+- Let one agent post a message that another agent (in any worktree, any
+  repo, any tmux pane) can subsequently read.
+- Make posting and reading both feel cheap and obvious from the agent's
+  perspective — no schema gymnastics, no protocol learning.
+- Keep the daemon out of the read path entirely. Reads should work even
+  if the daemon is down.
+- Be replaceable / inspectable / debuggable with standard Unix tools.
+
+### Non-goals (v1)
+
+- Auto-injection of unread messages into agent context via `PreToolUse`
+  hooks. The prior attempt's "context arrives naturally" property is
+  explicitly traded away in favor of agent-controlled, deterministic
+  pulls.
+- App UI. CLI-only ship; revisit once data shape stabilizes.
+- Threading. Defer; can add `in_reply_to_seq` later without breaking
+  existing files.
+- Subscriptions. Agents pull what they want; no server-side
+  subscription state.
+- Auto-pruning. Files grow unbounded for now; add `archive` later if it
+  matters.
+- Cross-channel "firehose" reads (`tbd channels read` with no name).
+  Use `tbd channels list` for cross-channel awareness; revisit if it
+  matters.
+
+## Concept
+
+### What is a channel
+
+A channel is a **free-form named topic** in a single global namespace.
+`#help` means the same thing whether you post from repo A or repo B. A
+channel is auto-created on first post; there is no separate "create
+channel" step.
+
+### Channel name validation
+
+Names are normalized to lowercase and validated at the RPC boundary:
+
+- Pattern: `^[a-z0-9][a-z0-9_-]{0,63}$`
+- No leading/trailing whitespace, no slashes, no dots, no Unicode.
+- Names that fail validation are rejected with a clear error before
+  any file operation is attempted.
+
+This is strict by design. APFS is case-insensitive on the boot volume,
+which means `#Foo` and `#foo` resolve to the same file but would be
+distinct rows in the per-viewer cursor table; lowercasing eliminates the
+ambiguity. The pattern also closes the path-traversal vector
+(`../../etc/passwd` and friends) before file paths are constructed.
+
+## Storage model
+
+### Filesystem (source of truth)
+
+Each channel is a single append-only JSONL file:
+
+```
+~/tbd/channels/<name>.jsonl
+```
+
+(`~/tbd/` is the existing TBD config dir; do not introduce `~/.tbd/`.)
+
+One JSON object per line. Newlines inside `body` are encoded (`\n`).
+Lines are never updated, only appended. The channel file is auto-created
+on first post by opening with `O_CREAT | O_WRONLY | O_APPEND`.
+
+### Per-line schema
+
+```json
+{
+  "seq": 42,
+  "ts": "2026-05-10T14:23:01.234Z",
+  "from_session": "abc-123",
+  "from_label": "tbd-20260510-known-smelt",
+  "body": "anyone seen the launchctl crash?"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `seq` | int | Per-channel monotonic, 1-based. `(channel_name, seq)` is the message identity. |
+| `ts` | string | ISO-8601 with millisecond precision. UTC. |
+| `from_session` | string | The opaque Claude Code session ID (for traceability). |
+| `from_label` | string | A human-readable session display name. Provisional source: TBD's worktree label / pane label. |
+| `body` | string | UTF-8 plain text. Agents may post markdown; the daemon does not interpret it. Max 64 KB. |
+
+### SQLite (`~/tbd/state.db`)
+
+Two new tables. **`channel_index` is a derivable cache; `channel_cursor`
+is non-recoverable app state** (sibling to `notification` per the
+existing "NEVER delete `~/tbd/state.db`" rule).
+
+```sql
+-- v18 migration:
+CREATE TABLE channel_index (
+  name TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL,
+  last_message_at TEXT,
+  message_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE channel_cursor (
+  viewer_id TEXT NOT NULL,        -- "app" for the SwiftUI app today
+  channel_name TEXT NOT NULL,
+  last_seen_seq INTEGER NOT NULL,
+  PRIMARY KEY (viewer_id, channel_name)
+);
+```
+
+Both tables update on every successful post. `channel_index` could be
+rebuilt by walking `~/tbd/channels/*.jsonl`; `channel_cursor` could not.
+Per the project's standard rule, both shipping schemas (the GRDB Record
+type and the `TBDShared/Models.swift` Codable model) must be updated in
+the same commit as the migration.
+
+### Per-channel file layout, end state
+
+```
+~/tbd/channels/
+├── help.jsonl          # source of truth
+├── help.lock           # cross-process lock file (zero bytes)
+├── api-questions.jsonl
+├── api-questions.lock
+└── …
+```
+
+Lock files are zero-byte sentinels used only for `flock(2)`; never read
+or written.
+
+## Write path (daemon-only)
+
+All posts go through the daemon over the existing Unix socket. The CLI
+calls `channels.post`; the daemon does the file I/O. There is no
+direct-write path for the CLI in v1.
+
+### Per-post sequence
+
+For each `channels.post(name, body, fromSession, fromLabel)`:
+
+1. Validate `name` against the regex above; reject otherwise.
+2. Validate `body` is UTF-8 and ≤ 64 KB.
+3. Acquire the daemon's per-channel async lock (in-process serialization).
+4. `flock(LOCK_EX)` on `~/tbd/channels/<name>.lock`, opening the lock
+   file with `O_CREAT` if absent.
+5. Open `~/tbd/channels/<name>.jsonl` with `O_WRONLY | O_APPEND | O_CREAT`.
+6. Determine next `seq`: read the highest `seq` from the in-memory cache
+   (populated on daemon startup or first touch — see torn-line policy
+   below).
+7. Build the JSON line, ending with `\n`.
+8. Single `write(2)` call. (Atomicity guarantees rest on the
+   serialization above, not on PIPE_BUF.)
+9. `fsync(2)`.
+10. `close(2)`.
+11. Release `flock`.
+12. Update `channel_index` (`last_message_at`, `message_count++`,
+    create row if first post).
+13. Release per-channel lock.
+14. Return `{seq, ts}` to the CLI.
+
+No cached file descriptors. Each post reopens the file — this is the
+trade-off chosen to avoid the "cached FD survives `unlink`/atomic-save"
+hazard surfaced during adversarial review, at the cost of two extra
+syscalls per post. Acceptable given the expected low post rate.
+
+### `fsync` default
+
+`fsync` is performed on every post in v1. The cost (~ms on APFS) is
+acceptable given the expected low post rate. There is no flag to disable
+it; if one is added later, the documented failure mode is "an OS-level
+crash during a burst of posts can lose the most recent unflushed lines."
+
+### Torn-line recovery (startup)
+
+On daemon startup, for each `~/tbd/channels/*.jsonl`:
+
+1. Stream-parse the file from the start, line by line.
+2. Track the highest successfully-parsed `seq`.
+3. If a line fails JSON parse, it is treated as a torn write.
+4. **If the failed line is the last line of the file:** truncate the
+   file to the offset of the trailing newline preceding it, log the
+   truncation at `.notice` level, continue.
+5. **If the failed line is anywhere else in the file:** log at `.error`,
+   skip the line, continue parsing.
+6. **If the file is unreadable entirely:** refuse to start, surface a
+   loud error.
+
+Recovery is logged so that a curious user can find out why their last
+post is missing. Silent data loss is not acceptable; loud-but-recovered
+loss is.
+
+### Cross-process write hazard
+
+The daemon enforces single-process operation via `Daemon.swift`'s
+PID-file check, but there is a TOCTOU race in `PIDFile.swift` (read →
+`kill(pid,0)` → write is not atomic) and a manual `swift run TBDDaemon`
+from a sibling worktree could in principle race past the check. The
+per-channel `flock` is a defensive measure for that case: even with two
+daemons live, channel files cannot be torn by interleaved writes. The
+worst surviving failure mode is duplicate `seq` values (each daemon
+allocates from its own in-memory cache); detection of this and recovery
+is out of scope for v1, but the lock prevents file corruption.
+
+## Read paths
+
+Reads bypass the daemon entirely. The CLI reads files directly. The
+daemon does not need to be running for reads to work.
+
+### Path 1: `tbd channels read <name> [--seq N | --since N] [--limit N]`
+
+The recommended path for agents.
+
+- `tbd channels read help` — last 20 messages from `#help`.
+- `tbd channels read help --since 40` — messages with `seq > 40`.
+- `tbd channels read help --seq 42` — just message 42.
+- `tbd channels read help --limit 50` — last 50 messages.
+- `--since` and `--seq` are mutually exclusive.
+- Channel name is required (no cross-channel read in v1).
+
+Implementation: open the file, stream-parse, filter, format, print.
+Output is a human-readable rendering; JSONL is for storage, not for
+consumption by humans/agents at the read layer.
+
+### Path 2: `tbd channels tail <name> --follow`
+
+A long-running command that watches the channel file and prints new
+lines as they arrive. Designed for agents to launch as a Claude Code
+background bash (`run_in_background: true`) and poll via `BashOutput`.
+
+Implementation: open file, seek to EOF, register a `DispatchSource` /
+`kqueue` watcher on `VNODE_WRITE | VNODE_EXTEND`. On event, read from
+the saved position to current EOF, split on newlines, format, print.
+Exits cleanly on SIGINT/SIGTERM.
+
+The `BashOutput` integration is **load-bearing on undocumented Claude
+Code behavior** (per-shell output buffer cap, idle-shell reaping, cursor
+reset on shell death). Before docs claim the integration "just works,"
+implementation includes an empirical-validation task; if the behavior is
+fragile, the docs say so honestly and recommend short-lived background
+shells over long-lived ones.
+
+### Path 3: Direct file read by an agent
+
+Agents can also read the channel file directly using Claude Code's
+native `Read` tool: `Read("~/tbd/channels/<name>.jsonl", offset=N)`.
+
+This works but has caveats:
+
+- `offset` is **line-numbered**, not seq-numbered. After a torn-line
+  recovery the two diverge.
+- `Read` has a default 2000-line cap and per-line truncation.
+- A growing file triggers Claude Code's stale-read warning machinery on
+  every poll.
+
+The TBD skill (which is loaded into TBD-spawned agent sessions via the
+Claude Code plugin) documents the CLI as the recommended path and notes
+these caveats for direct `Read`. We do not actively prevent direct
+reads; it can be useful for one-off inspection.
+
+### Read-path summary
+
+| Path | Daemon involved? | Use case |
+|---|---|---|
+| `tbd channels read <name> --since N` | No (CLI reads file) | Agent pulls incrementals |
+| `tbd channels read <name> --seq N` | No (CLI reads file) | Read one specific message (the post-output suggestion) |
+| `tbd channels tail <name> --follow` | No (CLI tails file) | Agent watches in background |
+| `Read("~/tbd/channels/<name>.jsonl", offset=N)` | No | Direct file read with caveats |
+| `tbd channels list` | Yes (RPC for index) | Discovery |
+| `tbd channels post <name> <body>` | Yes (RPC; daemon writes) | Posting |
+
+## Identity
+
+Reuse the prior attempt's mechanism. A tiny `PreToolUse` hook
+subcommand writes session identity to a temp file on every fire:
+
+```
+/tmp/tbd-session-${TMUX_PANE}
+```
+
+Contents:
+
+```json
+{"session_id": "abc-123", "transcript_path": "~/.claude/projects/.../sessions/abc-123.jsonl"}
+```
+
+The hook subcommand (provisionally `tbd channels write-session-id`)
+does **only** this one thing: read the hook's stdin JSON, write the
+identity file. No daemon roundtrip. No throttle needed (purely local
+file write, sub-millisecond).
+
+`tbd channels post` reads `/tmp/tbd-session-${TMUX_PANE}` to resolve
+`{from_session, from_label}` automatically; agents never need to know
+their own identity. `--from` and `--from-label` flags exist as
+overrides for testing or non-TBD contexts.
+
+This is **not** the descoped content-push hook. It only writes the
+identity file.
+
+`tbd setup-hooks` is extended to install this `PreToolUse` hook
+alongside the existing `Stop` notification hook.
+
+## CLI
+
+| Command | Purpose |
+|---|---|
+| `tbd channels post <name> <body>` | Post a message. Body may be `-` to read from stdin. Stdout includes a copy-pasteable read suggestion. |
+| `tbd channels read <name> [--seq N \| --since N] [--limit N]` | Read messages. |
+| `tbd channels tail <name> [--follow] [--from-start]` | Tail a channel; `--follow` watches for new messages. |
+| `tbd channels list` | List channels with `last_message_at` and `message_count`. |
+| `tbd channels write-session-id` | Internal hook subcommand. Not user-facing. |
+
+### `post` output
+
+```
+Posted to #help (seq 42)
+→ tbd channels read help --seq 42
+```
+
+The second line is the bridge to another session. A user posts in
+agent A's terminal, copies that line, pastes it as agent B's prompt,
+and agent B reads exactly that one message.
+
+## RPC additions
+
+`Sources/TBDDaemon/Server/RPCRouter+ChannelHandlers.swift` (new):
+
+| Method | Request | Response |
+|---|---|---|
+| `channels.post` | `{name, body, fromSession, fromLabel}` | `{seq, ts}` |
+| `channels.list` | `{}` | `[{name, createdAt, lastMessageAt, messageCount}]` |
+
+That is the complete RPC surface for v1. Reads bypass the daemon. The
+shared model layer (`Sources/TBDShared/Models.swift`,
+`RPCProtocol.swift`) is updated in the same commit as the migration
+per the project's standard rule.
+
+## Discovery
+
+Two paths:
+
+1. **`tbd channels list`** — always available.
+2. **The TBD skill** (loaded into TBD-spawned Claude Code sessions via
+   the plugin shipped in commit `798293c`) gains a Channels section
+   covering: what channels are, the post/read/tail commands, the
+   `--seq` vs `--since` distinction, the post-output read-suggestion
+   pattern, and the caveats for direct `Read`.
+
+The typical workflow is **human-mediated**: a user asks agent A to post
+something, then goes to agent B's pane and asks it to read. Agents do
+not auto-discover or auto-poll.
+
+## App UI
+
+Out of scope for v1. The SwiftUI app is unchanged.
+
+The `channel_cursor` table includes the row `viewer_id = "app"` for a
+future v2 sidebar; v1 simply does not write to it. (The presence of the
+table in the migration is fine — it is a no-op until the app starts
+using it.)
+
+## Adversarial review findings
+
+The first round of adversarial review (feasibility-skeptic persona) was
+run against an earlier draft of this design. Key calibrated findings:
+
+| # | Finding | Status in this design |
+|---|---|---|
+| 1 | "PIPE_BUF makes O_APPEND atomic" claim is wrong (POSIX guarantees apply to pipes, not regular files; macOS PIPE_BUF is 512, not 4096) | **Removed.** Crash safety = serialization + `flock` + torn-line policy + `fsync`, not kernel atomicity. |
+| 3 | Torn-line recovery on startup is unspecified | **Resolved.** Truncate-to-last-newline policy with logging. |
+| 4 | `channel_cursor` claimed to be derivable but isn't | **Resolved.** Table is reframed as non-recoverable app state, sibling to `notification`. |
+| 6 | `Read --offset` is line-numbered and diverges from `seq` | **Documented.** TBD skill recommends CLI; direct `Read` is supported with caveats noted. |
+| 7 | Channel name validation undefined; APFS case-insensitivity, path traversal | **Resolved.** Strict regex + lowercasing at RPC boundary. |
+| 8 | Cached file handles survive `unlink`/atomic-save | **Resolved.** Reopen-per-write; no cached FDs. |
+| 2 | Multi-daemon writer hazard | **Mitigated.** Single-daemon enforced via PID-file (with TOCTOU race acknowledged); per-channel `flock` defends against the racy edge case. |
+| 5 | `BashOutput` integration claim oversold | **Carried forward.** Empirical-validation task in the implementation plan before docs make claims. |
+| Missed: fsync default | **Resolved.** `fsync` on per post in v1. |
+
+## Open questions / risks
+
+- **`BashOutput` lifecycle assumptions.** The "tail-as-background-bash"
+  read path is convenient but rests on undocumented behavior. The
+  implementation plan must include an empirical-validation task that
+  characterizes: per-shell output buffer cap, idle-shell reaping, and
+  what happens when the underlying bash dies.
+- **Duplicate `seq` under the (rare, racy) two-daemon scenario.** The
+  per-channel `flock` prevents file tearing but does not prevent two
+  daemons from independently allocating the same `seq` from their own
+  caches. Detection and recovery are out of scope for v1; if it
+  becomes observable, a future revision can move sequence allocation
+  into a small SQLite transaction.
+- **`from_label` provenance.** The label is human-meaningful (e.g.,
+  `tbd-20260510-known-smelt`). The exact source — worktree display
+  name, pane label, something else — is left for the implementation
+  plan to specify after looking at what's available in the daemon's
+  per-pane state. Whatever is chosen should be stable for the
+  lifetime of the pane.
+- **No automatic pruning.** Files grow unbounded. For the expected
+  usage (humans post sporadically), this should not bite for a long
+  time. If/when it does, an `archive` subcommand that moves a channel
+  file to `~/tbd/channels/_archive/<name>-<ts>.jsonl` is the obvious
+  v2 addition.


### PR DESCRIPTION
## Summary

- Adds Slack-like inter-session **channels** so agents in separate panes/worktrees can post and read context to each other (`tbd channels post #help "..."` → `tbd channels read #help --seq N`).
- Source of truth is per-channel append-only JSONL at `~/tbd/channels/<name>.jsonl`. Reads bypass the daemon entirely (CLI opens the file directly, including `tbd channels tail --follow`); writes go through the daemon (per-channel async lock + cross-process `flock` + `fsync` + torn-line recovery).
- Identity reuses TBD's existing `TBD_TERMINAL_ID` env + `SessionStart` hook, so no new hook is added — `tbd channels post` resolves the worktree's display name and Claude session ID via the daemon's existing Terminal table.
- Subagent-driven development with adversarial-review and post-impl code review; 717 tests passing. Two real data races caught and fixed (cross-channel `seqCache` corruption; post/archive index resurrection).

## Surface

| | |
|---|---|
| `tbd channels post <name> <body>` | RPC; output includes a copy-pasteable `read --seq N` line |
| `tbd channels read <name> [--seq N \| --since N] [--limit N]` | Direct file read |
| `tbd channels tail <name> --follow` | DispatchSource watcher; stdout unbuffered for `BashOutput` pairing |
| `tbd channels list [--archived]` | RPC for active; filesystem walk for archived |
| `tbd channels archive <name>` | RPC; daemon moves file under per-channel lock |

## Out of scope (explicitly deferred)

- App UI (sidebar, unread badges) — `channel_cursor` table also deferred to v2 with sidebar.
- Threading.
- Auto-pruning (explicit `archive` ships in v1).
- `PreToolUse` content-push hook from the prior attempt.
- Empirical validation of long-lived `tail --follow` against `BashOutput` reaping/buffer behavior — the skill doc tells agents to prefer short-lived tail windows until characterized.

## Spec, plan, review trail

- Design: `docs/superpowers/specs/2026-05-10-channels-design.md`
- Plan: `docs/superpowers/plans/2026-05-10-channels.md`
- Adversarial review (feasibility-skeptic round) folded into the spec; PIPE_BUF/atomicity prose removed; channel-name validation pinned down; torn-line recovery + `flock` + reopen-per-write defenses added.

## Test plan

- [ ] `swift test` — 717 tests pass (8 ChannelStore, 5 archive incl. race regression, 3 recovery, 4 ChannelIndexStore, 1 migration v18, 4 ChannelMessage, 3 FileLock, 10 ChannelName, plus existing 679).
- [ ] In a TBD-managed terminal: `tbd channels post smoke "hi"` → confirm "Posted to #smoke (seq 1)" + paste-suggestion.
- [ ] Triple-click the suggested `tbd channels read smoke --seq 1` line, paste into another TBD pane's prompt, confirm the message renders.
- [ ] `tbd channels tail smoke --follow &` then post from another pane; confirm tail prints within ~1s.
- [ ] `tbd channels archive smoke` → `list` excludes it → `list --archived` shows it → `post smoke "again"` resets `seq` to 1.
- [ ] After a daemon restart, post fresh; if you've manually appended a torn line, confirm the daemon log emits a `Truncating torn-line tail` notice and the next post lands at the right seq.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=786E7B39-61A9-4AE1-A3E0-7F0618C4F062)