### PR TITLE
Feat: Show AskUserQuestion in the transcript while it's still pending

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
                 "TBDDaemonLib",
             ],
             path: "Sources/TBDDaemon",
-            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Conductor", "Keychain", "Claude", "ModelProfile", "Daemon.swift", "PIDFile.swift"],
+            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Conductor", "Keychain", "Claude", "ModelProfile", "AskUserQuestion", "Daemon.swift", "PIDFile.swift"],
             sources: ["main.swift"]
         ),
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -83,5 +83,12 @@ let package = Package(
                 "TBDApp",
             ]
         ),
+        .testTarget(
+            name: "TBDCLITests",
+            dependencies: [
+                "TBDCLI",
+                "TBDShared",
+            ]
+        ),
     ]
 )

--- a/Sources/TBDApp/Panes/Transcript/AskUserQuestionCard.swift
+++ b/Sources/TBDApp/Panes/Transcript/AskUserQuestionCard.swift
@@ -199,7 +199,7 @@ private struct QuestionBubble: View {
     let timestamp: Date?
     let selectedIndices: Set<Int>
 
-    @State private var expanded = false
+    @State private var expanded = true
 
     private var hasHeader: Bool {
         if let h = question.header, !h.isEmpty, h != question.question {

--- a/Sources/TBDCLI/Commands/AskUserQuestionEventCommand.swift
+++ b/Sources/TBDCLI/Commands/AskUserQuestionEventCommand.swift
@@ -1,0 +1,141 @@
+import ArgumentParser
+import Foundation
+import os
+import TBDShared
+
+private let cliLogger = Logger(subsystem: "com.tbd.cli", category: "askUserQuestion")
+
+/// Bridges Claude Code's `PreToolUse:AskUserQuestion` and
+/// `PostToolUse:AskUserQuestion` hooks into TBD. Reads stdin (Claude pipes
+/// the hook payload here), extracts `tool_use_id` and `tool_input`, and
+/// RPCs the daemon so the transcript pane can render a synthetic
+/// "Waiting for response…" card before the assistant message lands in the
+/// JSONL.
+///
+/// All failure paths exit 0 silently — Claude prints hook stderr to the
+/// user's terminal, so any noise here would be surfaced as a hook error
+/// message. We'd rather degrade silently than spam the chat.
+struct AskUserQuestionEventCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "ask-user-question",
+        abstract: "Internal: bridge Claude Code's AskUserQuestion hooks into TBD",
+        shouldDisplay: false,
+        subcommands: [PreSubcommand.self, PostSubcommand.self]
+    )
+
+    struct PreSubcommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(commandName: "pre", shouldDisplay: false)
+        mutating func run() async throws {
+            await AskUserQuestionEventCommand.run(mode: .pre)
+        }
+    }
+
+    struct PostSubcommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(commandName: "post", shouldDisplay: false)
+        mutating func run() async throws {
+            await AskUserQuestionEventCommand.run(mode: .post)
+        }
+    }
+
+    enum Mode { case pre, post }
+
+    static func run(mode: Mode) async {
+        guard let terminalIDString = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+              let terminalID = UUID(uuidString: terminalIDString) else {
+            cliLogger.debug("\(mode == .pre ? "pre" : "post") suppressed reason=noTerminalID")
+            return
+        }
+
+        let data = FileHandle.standardInput.readDataToEndOfFile()
+        guard !data.isEmpty, data.count <= 1 << 20 else {
+            cliLogger.debug("\(mode == .pre ? "pre" : "post") suppressed reason=emptyOrOversizedStdin bytes=\(data.count, privacy: .public)")
+            return
+        }
+
+        let parsed: AskUserQuestionPayloadParser.Parsed
+        do {
+            parsed = try AskUserQuestionPayloadParser.parse(data)
+        } catch {
+            cliLogger.debug("\(mode == .pre ? "pre" : "post") suppressed reason=decodeFailed err=\(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        if AskUserQuestionPayloadParser.isSubagentTranscript(parsed.transcriptPath) {
+            cliLogger.debug("\(mode == .pre ? "pre" : "post") suppressed reason=subagent toolUseID=\(parsed.toolUseID, privacy: .public)")
+            return
+        }
+
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            cliLogger.debug("\(mode == .pre ? "pre" : "post") suppressed reason=daemonDown")
+            return
+        }
+
+        do {
+            switch mode {
+            case .pre:
+                try client.callVoid(
+                    method: RPCMethod.terminalAskUserQuestionPending,
+                    params: TerminalAskUserQuestionPendingParams(
+                        terminalID: terminalID,
+                        toolUseID: parsed.toolUseID,
+                        inputJSON: parsed.toolInputJSON,
+                        timestampMillis: Int64(Date().timeIntervalSince1970 * 1000)
+                    )
+                )
+                cliLogger.debug("pre delivered toolUseID=\(parsed.toolUseID, privacy: .public) terminalID=\(terminalID.uuidString, privacy: .public)")
+            case .post:
+                try client.callVoid(
+                    method: RPCMethod.terminalAskUserQuestionCleared,
+                    params: TerminalAskUserQuestionClearedParams(
+                        terminalID: terminalID,
+                        toolUseID: parsed.toolUseID
+                    )
+                )
+                cliLogger.debug("post delivered toolUseID=\(parsed.toolUseID, privacy: .public) terminalID=\(terminalID.uuidString, privacy: .public)")
+            }
+        } catch {
+            cliLogger.debug("\(mode == .pre ? "pre" : "post") suppressed reason=rpcFailed err=\(error.localizedDescription, privacy: .public)")
+        }
+    }
+}
+
+/// Pure parsing helpers, factored out so tests don't need stdin/env/RPC.
+enum AskUserQuestionPayloadParser {
+    struct Parsed: Equatable {
+        let toolUseID: String
+        let toolInputJSON: String
+        let transcriptPath: String?
+    }
+
+    enum ParseError: Error { case invalidJSON, missingToolUseID }
+
+    static func parse(_ data: Data) throws -> Parsed {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ParseError.invalidJSON
+        }
+        guard let toolUseID = obj["tool_use_id"] as? String, !toolUseID.isEmpty else {
+            throw ParseError.missingToolUseID
+        }
+        let toolInputJSON: String
+        if let toolInput = obj["tool_input"],
+           let toolInputData = try? JSONSerialization.data(withJSONObject: toolInput, options: [.sortedKeys]),
+           let str = String(data: toolInputData, encoding: .utf8) {
+            toolInputJSON = str
+        } else {
+            toolInputJSON = "{}"
+        }
+        let transcriptPath = obj["transcript_path"] as? String
+        return Parsed(toolUseID: toolUseID, toolInputJSON: toolInputJSON, transcriptPath: transcriptPath)
+    }
+
+    /// Subagent JSONLs live under `.../subagents/<agent-id>.jsonl`. If the
+    /// PreToolUse payload's `transcript_path` contains the `/subagents/`
+    /// segment we suppress the RPC entirely — the synthetic merge only
+    /// renders into the top-level items list, and a top-level synthetic
+    /// for a subagent question would render in the wrong place.
+    static func isSubagentTranscript(_ transcriptPath: String?) -> Bool {
+        guard let path = transcriptPath, !path.isEmpty else { return false }
+        return path.contains("/subagents/")
+    }
+}

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -14,6 +14,7 @@ struct TBDCommand: AsyncParsableCommand {
             ConductorCommand.self,
             NotifyCommand.self,
             SessionEventCommand.self,
+            AskUserQuestionEventCommand.self,
             DaemonCommand.self,
             HooksCommand.self,
             SetupHooksCommand.self,

--- a/Sources/TBDDaemon/AskUserQuestion/PendingQuestionStore.swift
+++ b/Sources/TBDDaemon/AskUserQuestion/PendingQuestionStore.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// One in-flight `AskUserQuestion` capture relayed by the
+/// `PreToolUse:AskUserQuestion` hook bridge. `inputJSON` is the verbatim
+/// `tool_input` object from the hook payload, re-serialized with sorted
+/// keys — the SwiftUI card decodes it the same way it decodes JSONL-backed
+/// tool-use input.
+public struct PendingAskUserQuestion: Sendable, Equatable {
+    public let toolUseID: String
+    public let inputJSON: String
+    public let timestamp: Date
+    public init(toolUseID: String, inputJSON: String, timestamp: Date) {
+        self.toolUseID = toolUseID
+        self.inputJSON = inputJSON
+        self.timestamp = timestamp
+    }
+}
+
+/// Holds the daemon's view of pending `AskUserQuestion`s, keyed on
+/// `(terminalID, toolUseID)`. Memory-only; daemon restart wipes the store.
+/// The merger inside `handleTerminalTranscript` reads from this and
+/// removes entries once a matching `tool_use_id` appears in the JSONL —
+/// see `RPCRouter+TerminalHandlers.swift`.
+public actor PendingQuestionStore {
+    public struct Key: Hashable, Sendable {
+        public let terminalID: UUID
+        public let toolUseID: String
+    }
+
+    private var pending: [Key: PendingAskUserQuestion] = [:]
+
+    public init() {}
+
+    public func set(terminalID: UUID, _ value: PendingAskUserQuestion) {
+        let key = Key(terminalID: terminalID, toolUseID: value.toolUseID)
+        pending[key] = value
+    }
+
+    public func clear(terminalID: UUID, toolUseID: String) {
+        pending.removeValue(forKey: Key(terminalID: terminalID, toolUseID: toolUseID))
+    }
+
+    public func clear(terminalID: UUID) {
+        pending = pending.filter { $0.key.terminalID != terminalID }
+    }
+
+    public func entries(forTerminal terminalID: UUID) -> [PendingAskUserQuestion] {
+        pending
+            .filter { $0.key.terminalID == terminalID }
+            .values
+            .sorted { $0.timestamp < $1.timestamp }
+    }
+
+    /// Reap entries older than `maxAge` relative to `now`. Called once
+    /// per `handleTerminalTranscript` to keep stranded entries (e.g.
+    /// user-installed PreToolUse hook returned `decision: "block"`) from
+    /// living forever.
+    public func gcExpired(now: Date, maxAge: Duration) {
+        let maxAgeSeconds = TimeInterval(maxAge.components.seconds)
+            + TimeInterval(maxAge.components.attoseconds) / 1e18
+        let cutoff = now.addingTimeInterval(-maxAgeSeconds)
+        pending = pending.filter { $0.value.timestamp >= cutoff }
+    }
+}

--- a/Sources/TBDDaemon/AskUserQuestion/PendingQuestionStore.swift
+++ b/Sources/TBDDaemon/AskUserQuestion/PendingQuestionStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 
 /// One in-flight `AskUserQuestion` capture relayed by the
 /// `PreToolUse:AskUserQuestion` hook bridge. `inputJSON` is the verbatim
@@ -60,5 +61,50 @@ public actor PendingQuestionStore {
             + TimeInterval(maxAge.components.attoseconds) / 1e18
         let cutoff = now.addingTimeInterval(-maxAgeSeconds)
         pending = pending.filter { $0.value.timestamp >= cutoff }
+    }
+}
+
+/// Pure merge function: combines JSONL-derived items with pending
+/// AskUserQuestion entries and reports which pending entries are
+/// satisfied by JSONL matches. Pulled out of the RPC handler so it can
+/// be tested without an RPCRouter.
+public enum AskUserQuestionMerger {
+    public struct Result: Equatable {
+        public let items: [TranscriptItem]
+        /// Pending tool_use_ids that already have a matching JSONL item
+        /// and should be removed from the store. Caller does the removal.
+        public let satisfiedToolUseIDs: [String]
+    }
+
+    public static func merge(
+        jsonlItems: [TranscriptItem],
+        pending: [PendingAskUserQuestion]
+    ) -> Result {
+        var jsonlIDs = Set<String>()
+        for item in jsonlItems {
+            if case let .toolCall(id, _, _, _, _, _, _, _) = item {
+                jsonlIDs.insert(id)
+            }
+        }
+
+        var merged = jsonlItems
+        var satisfied: [String] = []
+        for p in pending {
+            if jsonlIDs.contains(p.toolUseID) {
+                satisfied.append(p.toolUseID)
+                continue
+            }
+            merged.append(.toolCall(
+                id: p.toolUseID,
+                name: "AskUserQuestion",
+                inputJSON: p.inputJSON,
+                inputTruncatedTo: nil,
+                result: nil,
+                subagent: nil,
+                timestamp: p.timestamp,
+                usage: nil
+            ))
+        }
+        return Result(items: merged, satisfiedToolUseIDs: satisfied)
     }
 }

--- a/Sources/TBDDaemon/Conductor/ConductorManager.swift
+++ b/Sources/TBDDaemon/Conductor/ConductorManager.swift
@@ -5,11 +5,17 @@ import TBDShared
 public final class ConductorManager: Sendable {
     let db: TBDDatabase
     let tmux: TmuxManager
+    let pendingQuestions: PendingQuestionStore
     private let _suggestions = OSAllocatedUnfairLock(initialState: [String: ConductorSuggestion]())
 
-    public init(db: TBDDatabase, tmux: TmuxManager) {
+    public init(
+        db: TBDDatabase,
+        tmux: TmuxManager,
+        pendingQuestions: PendingQuestionStore = PendingQuestionStore()
+    ) {
         self.db = db
         self.tmux = tmux
+        self.pendingQuestions = pendingQuestions
     }
 
     // MARK: - Suggestions
@@ -125,6 +131,7 @@ public final class ConductorManager: Sendable {
             }
             // Window is dead — clean up stale terminal record
             try await db.terminals.delete(id: existingTerminalID)
+            await pendingQuestions.clear(terminalID: existingTerminalID)
             try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: nil)
         }
 
@@ -191,6 +198,7 @@ public final class ConductorManager: Sendable {
                 windowID: terminal.tmuxWindowID
             )
             try await db.terminals.delete(id: terminalID)
+            await pendingQuestions.clear(terminalID: terminalID)
         }
 
         try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: nil)

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -137,10 +137,12 @@ public final class Daemon: Sendable {
             repos: database.repos,
             config: database.config
         )
+        let pendingQuestions = PendingQuestionStore()
         let lifecycle = WorktreeLifecycle(
             db: database, git: git, tmux: tmux, hooks: hooks,
             subscriptions: subs,
-            modelProfileResolver: modelProfileResolver
+            modelProfileResolver: modelProfileResolver,
+            pendingQuestions: pendingQuestions
         )
         let prManager = PRStatusManager()
 
@@ -153,7 +155,8 @@ public final class Daemon: Sendable {
             startTime: startTime,
             subscriptions: subs,
             prManager: prManager,
-            modelProfileResolver: modelProfileResolver
+            modelProfileResolver: modelProfileResolver,
+            pendingQuestions: pendingQuestions
         )
         self.router = rpcRouter
 

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -44,6 +44,18 @@ public enum ClaudeHookOverlay {
     static let stopCommand =
         #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
 
+    /// Bridges the `PreToolUse:AskUserQuestion` hook into TBD. Captures the
+    /// tool input and tool_use_id so the transcript pane can render the
+    /// question before Claude flushes the assistant message to the JSONL.
+    static let askUserQuestionPreCommand =
+        #"tbd ask-user-question pre 2>/dev/null || true"#
+
+    /// Bridges the `PostToolUse:AskUserQuestion` hook into TBD. Defensive
+    /// only — see RPCRouter+TerminalHandlers.swift for why we rely on JSONL
+    /// dedupe rather than eager cleanup.
+    static let askUserQuestionPostCommand =
+        #"tbd ask-user-question post 2>/dev/null || true"#
+
     /// Build the JSON-encoded overlay body.
     public static func generateBody() throws -> Data {
         let body: [String: Any] = [
@@ -60,6 +72,22 @@ public enum ClaudeHookOverlay {
                     [
                         "hooks": [
                             ["type": "command", "command": stopCommand]
+                        ]
+                    ]
+                ],
+                "PreToolUse": [
+                    [
+                        "matcher": "AskUserQuestion",
+                        "hooks": [
+                            ["type": "command", "command": askUserQuestionPreCommand]
+                        ]
+                    ]
+                ],
+                "PostToolUse": [
+                    [
+                        "matcher": "AskUserQuestion",
+                        "hooks": [
+                            ["type": "command", "command": askUserQuestionPostCommand]
                         ]
                     ]
                 ]

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -93,6 +93,9 @@ extension WorktreeLifecycle {
 
         // Delete terminals from db
         try await db.terminals.deleteForWorktree(worktreeID: worktreeID)
+        for terminal in terminals {
+            await pendingQuestions.clear(terminalID: terminal.id)
+        }
 
         return (worktree, repo)
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -112,6 +112,9 @@ extension WorktreeLifecycle {
                 }
             }
             try await db.terminals.deleteForWorktree(worktreeID: wt.id)
+            for terminal in terminals {
+                await pendingQuestions.clear(terminalID: terminal.id)
+            }
             try await db.worktrees.archive(id: wt.id)
         }
 
@@ -153,6 +156,7 @@ extension WorktreeLifecycle {
                     let alive = await tmux.windowExists(server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
                     if !alive {
                         try? await db.terminals.delete(id: terminal.id)
+                        await pendingQuestions.clear(terminalID: terminal.id)
                     }
                 } else {
                     do {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -52,6 +52,7 @@ public struct WorktreeLifecycle: Sendable {
     public let hooks: HookResolver
     public let subscriptions: StateSubscriptionManager?
     public let modelProfileResolver: ModelProfileResolver?
+    public let pendingQuestions: PendingQuestionStore
 
     /// The user's default shell (from $SHELL, falls back to /bin/zsh)
     var defaultShell: String {
@@ -64,7 +65,8 @@ public struct WorktreeLifecycle: Sendable {
         tmux: TmuxManager,
         hooks: HookResolver,
         subscriptions: StateSubscriptionManager? = nil,
-        modelProfileResolver: ModelProfileResolver? = nil
+        modelProfileResolver: ModelProfileResolver? = nil,
+        pendingQuestions: PendingQuestionStore = PendingQuestionStore()
     ) {
         self.db = db
         self.git = git
@@ -72,5 +74,6 @@ public struct WorktreeLifecycle: Sendable {
         self.hooks = hooks
         self.subscriptions = subscriptions
         self.modelProfileResolver = modelProfileResolver
+        self.pendingQuestions = pendingQuestions
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+AskUserQuestionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AskUserQuestionHandlers.swift
@@ -1,0 +1,34 @@
+import Foundation
+import os
+import TBDShared
+
+private let askUserQuestionLog = Logger(subsystem: "com.tbd.daemon", category: "askUserQuestion")
+
+extension RPCRouter {
+    /// Stores the pending question payload for a terminal so the merger
+    /// inside `handleTerminalTranscript` can synthesize a transcript item
+    /// before the assistant `tool_use` line is flushed to the JSONL.
+    func handleTerminalAskUserQuestionPending(_ paramsData: Data) async throws -> RPCResponse {
+        let p = try decoder.decode(TerminalAskUserQuestionPendingParams.self, from: paramsData)
+        let pending = PendingAskUserQuestion(
+            toolUseID: p.toolUseID,
+            inputJSON: p.inputJSON,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(p.timestampMillis) / 1000)
+        )
+        await pendingQuestions.set(terminalID: p.terminalID, pending)
+        askUserQuestionLog.debug("pending stored terminalID=\(p.terminalID.uuidString, privacy: .public) toolUseID=\(p.toolUseID, privacy: .public)")
+        return .ok()
+    }
+
+    /// Defensive cleanup path — no-op today. The merger performs lazy
+    /// cleanup when it observes the matching `tool_use_id` in the JSONL,
+    /// which avoids the flicker that eager PostToolUse cleanup would
+    /// introduce (Claude flushes the JSONL line slightly after PostToolUse
+    /// returns). Keeping the wire format reserved so a future change to
+    /// eager cleanup needn't ship a protocol break.
+    func handleTerminalAskUserQuestionCleared(_ paramsData: Data) async throws -> RPCResponse {
+        let p = try decoder.decode(TerminalAskUserQuestionClearedParams.self, from: paramsData)
+        askUserQuestionLog.debug("cleared received (no-op) terminalID=\(p.terminalID.uuidString, privacy: .public) toolUseID=\(p.toolUseID, privacy: .public)")
+        return .ok()
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -931,13 +931,22 @@ extension RPCRouter {
             }
             filePath = projectDir.appendingPathComponent("\(sessionID).jsonl").path
         }
-        let messages: [TranscriptItem]
+        let parsed: [TranscriptItem]
         if let cached = await TranscriptParseCache.shared.get(filePath: filePath) {
-            messages = cached
+            parsed = cached
         } else {
-            messages = TranscriptParser.parse(filePath: filePath)
-            await TranscriptParseCache.shared.put(filePath: filePath, result: messages)
+            parsed = TranscriptParser.parse(filePath: filePath)
+            await TranscriptParseCache.shared.put(filePath: filePath, result: parsed)
         }
+
+        await pendingQuestions.gcExpired(now: Date(), maxAge: .seconds(900))
+        let entries = await pendingQuestions.entries(forTerminal: params.terminalID)
+        let merged = AskUserQuestionMerger.merge(jsonlItems: parsed, pending: entries)
+        for satisfiedID in merged.satisfiedToolUseIDs {
+            await pendingQuestions.clear(terminalID: params.terminalID, toolUseID: satisfiedID)
+        }
+        let messages = merged.items
+
         let result = TerminalTranscriptResult(messages: messages, sessionID: sessionID)
         response = try RPCResponse(result: result)
         responseBytes = response.result?.utf8.count ?? 0

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -258,6 +258,7 @@ extension RPCRouter {
 
         // Delete from DB
         try await db.terminals.delete(id: params.terminalID)
+        await pendingQuestions.clear(terminalID: params.terminalID)
 
         subscriptions.broadcast(delta: .terminalRemoved(TerminalIDDelta(
             terminalID: terminal.id

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -34,7 +34,8 @@ public final class RPCRouter: Sendable {
         prManager: PRStatusManager = PRStatusManager(),
         conductorManager: ConductorManager? = nil,
         usageFetcher: ClaudeUsageFetcher = LiveClaudeUsageFetcher(),
-        modelProfileResolver: ModelProfileResolver? = nil
+        modelProfileResolver: ModelProfileResolver? = nil,
+        pendingQuestions: PendingQuestionStore = PendingQuestionStore()
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -52,9 +53,11 @@ public final class RPCRouter: Sendable {
         self.suspendResumeCoordinator = SuspendResumeCoordinator(
             db: db, tmux: tmux, modelProfileResolver: resolvedModelProfileResolver
         )
-        self.conductorManager = conductorManager ?? ConductorManager(db: db, tmux: tmux)
+        self.conductorManager = conductorManager ?? ConductorManager(
+            db: db, tmux: tmux, pendingQuestions: pendingQuestions
+        )
         self.usageFetcher = usageFetcher
-        self.pendingQuestions = PendingQuestionStore()
+        self.pendingQuestions = pendingQuestions
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -19,6 +19,7 @@ public final class RPCRouter: Sendable {
     public let usageFetcher: ClaudeUsageFetcher
     public let modelProfileResolver: ModelProfileResolver
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
+    public let pendingQuestions: PendingQuestionStore
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -53,6 +54,7 @@ public final class RPCRouter: Sendable {
         )
         self.conductorManager = conductorManager ?? ConductorManager(db: db, tmux: tmux)
         self.usageFetcher = usageFetcher
+        self.pendingQuestions = PendingQuestionStore()
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.
@@ -154,6 +156,10 @@ public final class RPCRouter: Sendable {
                 return try await handleTerminalTranscript(request.paramsData)
             case RPCMethod.terminalTranscriptItemFullBody:
                 return try await handleTerminalTranscriptItemFullBody(request.paramsData)
+            case RPCMethod.terminalAskUserQuestionPending:
+                return try await handleTerminalAskUserQuestionPending(request.paramsData)
+            case RPCMethod.terminalAskUserQuestionCleared:
+                return try await handleTerminalAskUserQuestionCleared(request.paramsData)
             case RPCMethod.conductorSetup:
                 return try await handleConductorSetup(request.paramsData)
             case RPCMethod.conductorStart:

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -134,6 +134,8 @@ public enum RPCMethod {
     public static let modelProfileHealthCheck = "modelProfile.healthCheck"
     public static let terminalSwapProfile = "terminal.swapProfile"
     public static let terminalSessionEvent = "terminal.sessionEvent"
+    public static let terminalAskUserQuestionPending = "terminal.askUserQuestionPending"
+    public static let terminalAskUserQuestionCleared = "terminal.askUserQuestionCleared"
     public static let appSetForegroundState = "app.setForegroundState"
     public static let repoRelocate = "repo.relocate"
     public static let repoRename = "repo.rename"
@@ -781,5 +783,36 @@ public struct TerminalSessionEventParams: Codable, Sendable {
         self.sessionID = sessionID
         self.transcriptPath = transcriptPath
         self.source = source
+    }
+}
+
+/// PreToolUse:AskUserQuestion hook bridge — fires when Claude is about to
+/// render the question picker. The daemon stores this payload and uses it
+/// to synthesize a transcript item while the assistant `tool_use` line is
+/// still missing from the JSONL.
+public struct TerminalAskUserQuestionPendingParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let toolUseID: String
+    public let inputJSON: String
+    public let timestampMillis: Int64
+    public init(terminalID: UUID, toolUseID: String, inputJSON: String, timestampMillis: Int64) {
+        self.terminalID = terminalID
+        self.toolUseID = toolUseID
+        self.inputJSON = inputJSON
+        self.timestampMillis = timestampMillis
+    }
+}
+
+/// PostToolUse:AskUserQuestion hook bridge — fires after the user has
+/// answered. The handler is intentionally a no-op today; the merger
+/// performs lazy cleanup when it observes the matching `tool_use` line in
+/// the JSONL. Keeping the wire format reserved means a future change to
+/// eager cleanup won't ship a protocol break.
+public struct TerminalAskUserQuestionClearedParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let toolUseID: String
+    public init(terminalID: UUID, toolUseID: String) {
+        self.terminalID = terminalID
+        self.toolUseID = toolUseID
     }
 }

--- a/Tests/TBDCLITests/AskUserQuestionEventCommandTests.swift
+++ b/Tests/TBDCLITests/AskUserQuestionEventCommandTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import TBDCLI
+
+@Suite("AskUserQuestionPayloadParser")
+struct AskUserQuestionEventCommandTests {
+    private static let mainAgentPayload = #"""
+    {
+      "session_id": "B88113CA-EAF0-41D7-AEF7-C4AB2FB449CF",
+      "transcript_path": "/Users/x/.claude/projects/-Users-x-foo/B88113CA-EAF0-41D7-AEF7-C4AB2FB449CF.jsonl",
+      "cwd": "/Users/x/foo",
+      "hook_event_name": "PreToolUse",
+      "tool_name": "AskUserQuestion",
+      "tool_input": { "questions": [{"question": "?", "options": [{"label": "A"}]}] },
+      "tool_use_id": "toolu_01ABCXYZ"
+    }
+    """#
+
+    private static let subagentPayload = #"""
+    {
+      "session_id": "subagent-sid",
+      "transcript_path": "/Users/x/.claude/projects/-Users-x-foo/PARENT/subagents/agent-abc.jsonl",
+      "cwd": "/Users/x/foo",
+      "hook_event_name": "PreToolUse",
+      "tool_name": "AskUserQuestion",
+      "tool_input": { "questions": [] },
+      "tool_use_id": "toolu_subagent"
+    }
+    """#
+
+    @Test func decode_main_agent_payload_extracts_fields() throws {
+        let data = Data(Self.mainAgentPayload.utf8)
+        let parsed = try AskUserQuestionPayloadParser.parse(data)
+        #expect(parsed.toolUseID == "toolu_01ABCXYZ")
+        #expect(parsed.transcriptPath
+            == "/Users/x/.claude/projects/-Users-x-foo/B88113CA-EAF0-41D7-AEF7-C4AB2FB449CF.jsonl")
+        let obj = try JSONSerialization.jsonObject(with: Data(parsed.toolInputJSON.utf8))
+        #expect((obj as? [String: Any]) != nil)
+    }
+
+    @Test func is_subagent_transcript_detects_subagents_segment() {
+        #expect(AskUserQuestionPayloadParser.isSubagentTranscript(
+            "/Users/x/.claude/projects/-Users-x-foo/PARENT/subagents/agent-abc.jsonl"))
+        #expect(!AskUserQuestionPayloadParser.isSubagentTranscript(
+            "/Users/x/.claude/projects/-Users-x-foo/B88113CA-401C-47EE-843E-4BACB67AE5FA.jsonl"))
+    }
+
+    @Test func is_subagent_transcript_nil_path_is_not_subagent() {
+        #expect(!AskUserQuestionPayloadParser.isSubagentTranscript(nil))
+    }
+
+    @Test func decode_malformed_json_throws() {
+        #expect(throws: (any Error).self) {
+            try AskUserQuestionPayloadParser.parse(Data("not json".utf8))
+        }
+    }
+
+    @Test func decode_missing_tool_use_id_throws() {
+        let bad = #"{"tool_input": {}}"#
+        #expect(throws: (any Error).self) {
+            try AskUserQuestionPayloadParser.parse(Data(bad.utf8))
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/AskUserQuestionMergeTests.swift
+++ b/Tests/TBDDaemonTests/AskUserQuestionMergeTests.swift
@@ -1,0 +1,97 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct AskUserQuestionMergeTests {
+    private static func toolCall(_ id: String, name: String = "AskUserQuestion") -> TranscriptItem {
+        .toolCall(
+            id: id, name: name, inputJSON: "{}",
+            inputTruncatedTo: nil, result: nil, subagent: nil,
+            timestamp: nil, usage: nil
+        )
+    }
+
+    private static func pending(_ id: String) -> PendingAskUserQuestion {
+        PendingAskUserQuestion(
+            toolUseID: id,
+            inputJSON: "{\"questions\":[]}",
+            timestamp: Date(timeIntervalSince1970: 1000)
+        )
+    }
+
+    @Test func pendingPresent_NoJSONLMatch_AppendsSynthetic() {
+        let jsonl: [TranscriptItem] = [
+            Self.toolCall("toolu_real_other", name: "Bash")
+        ]
+        let result = AskUserQuestionMerger.merge(
+            jsonlItems: jsonl,
+            pending: [Self.pending("toolu_pending")]
+        )
+        #expect(result.items.count == 2)
+        if case let .toolCall(id, name, _, truncated, res, sub, _, usage) = result.items[1] {
+            #expect(id == "toolu_pending")
+            #expect(name == "AskUserQuestion")
+            #expect(truncated == nil)
+            #expect(res == nil)
+            #expect(sub == nil)
+            #expect(usage == nil)
+        } else {
+            Issue.record("expected synthetic toolCall as last item, got \(result.items[1])")
+        }
+        #expect(result.satisfiedToolUseIDs == [])
+    }
+
+    @Test func pendingPresent_JSONLMatch_SuppressesSyntheticAndReportsSatisfied() {
+        let jsonl: [TranscriptItem] = [
+            Self.toolCall("toolu_real_other", name: "Bash"),
+            Self.toolCall("toolu_pending")
+        ]
+        let result = AskUserQuestionMerger.merge(
+            jsonlItems: jsonl,
+            pending: [Self.pending("toolu_pending")]
+        )
+        #expect(result.items.count == 2, "synthetic must not be appended when JSONL matches")
+        #expect(result.satisfiedToolUseIDs == ["toolu_pending"])
+    }
+
+    @Test func noPending_ReturnsJSONLByteIdentical() {
+        let jsonl: [TranscriptItem] = [
+            Self.toolCall("toolu_a"),
+            Self.toolCall("toolu_b", name: "Bash")
+        ]
+        let result = AskUserQuestionMerger.merge(jsonlItems: jsonl, pending: [])
+        #expect(result.items == jsonl)
+        #expect(result.satisfiedToolUseIDs == [])
+    }
+
+    @Test func twoPendingDifferentToolIDs_BothAppearWhenNoMatch() {
+        let result = AskUserQuestionMerger.merge(
+            jsonlItems: [],
+            pending: [Self.pending("toolu_a"), Self.pending("toolu_b")]
+        )
+        #expect(result.items.count == 2)
+        let ids = result.items.compactMap { item -> String? in
+            if case let .toolCall(id, _, _, _, _, _, _, _) = item { return id }
+            return nil
+        }
+        #expect(Set(ids) == ["toolu_a", "toolu_b"])
+    }
+
+    @Test func mixedMatch_SuppressesMatchedOnly() {
+        let jsonl: [TranscriptItem] = [
+            Self.toolCall("toolu_a")
+        ]
+        let result = AskUserQuestionMerger.merge(
+            jsonlItems: jsonl,
+            pending: [Self.pending("toolu_a"), Self.pending("toolu_b")]
+        )
+        #expect(result.items.count == 2)
+        #expect(result.satisfiedToolUseIDs == ["toolu_a"])
+        if case let .toolCall(id, _, _, _, _, _, _, _) = result.items[1] {
+            #expect(id == "toolu_b")
+        } else {
+            Issue.record("expected toolu_b synthetic, got \(result.items[1])")
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayAskUserQuestionTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayAskUserQuestionTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+
+@Suite struct ClaudeHookOverlayAskUserQuestionTests {
+    private func decode(_ data: Data) throws -> [String: Any] {
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return try #require(obj)
+    }
+
+    @Test func preToolUseAskUserQuestionEntryIsPresent() throws {
+        let data = try ClaudeHookOverlay.generateBody()
+        let obj = try decode(data)
+        let hooks = try #require(obj["hooks"] as? [String: Any])
+        let pre = try #require(hooks["PreToolUse"] as? [[String: Any]])
+        #expect(pre.count == 1)
+        #expect(pre[0]["matcher"] as? String == "AskUserQuestion")
+        let commands = try #require(pre[0]["hooks"] as? [[String: Any]])
+        #expect(commands.count == 1)
+        #expect(commands[0]["type"] as? String == "command")
+        let cmd = try #require(commands[0]["command"] as? String)
+        #expect(cmd.contains("tbd ask-user-question pre"), "got: \(cmd)")
+    }
+
+    @Test func postToolUseAskUserQuestionEntryIsPresent() throws {
+        let data = try ClaudeHookOverlay.generateBody()
+        let obj = try decode(data)
+        let hooks = try #require(obj["hooks"] as? [String: Any])
+        let post = try #require(hooks["PostToolUse"] as? [[String: Any]])
+        #expect(post.count == 1)
+        #expect(post[0]["matcher"] as? String == "AskUserQuestion")
+        let commands = try #require(post[0]["hooks"] as? [[String: Any]])
+        let cmd = try #require(commands[0]["command"] as? String)
+        #expect(cmd.contains("tbd ask-user-question post"), "got: \(cmd)")
+    }
+
+    @Test func existingSessionStartAndStopHooksUnchanged() throws {
+        let data = try ClaudeHookOverlay.generateBody()
+        let obj = try decode(data)
+        let hooks = try #require(obj["hooks"] as? [String: Any])
+        #expect(hooks["SessionStart"] != nil, "SessionStart hook regressed")
+        #expect(hooks["Stop"] != nil, "Stop hook regressed")
+    }
+}

--- a/Tests/TBDDaemonTests/PendingQuestionStoreTests.swift
+++ b/Tests/TBDDaemonTests/PendingQuestionStoreTests.swift
@@ -1,0 +1,100 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+
+@Suite struct PendingQuestionStoreTests {
+    @Test func setThenEntriesReturnsStoredValue() async {
+        let store = PendingQuestionStore()
+        let terminalID = UUID()
+        let pending = PendingAskUserQuestion(
+            toolUseID: "toolu_test1",
+            inputJSON: "{\"questions\":[]}",
+            timestamp: Date(timeIntervalSince1970: 1000)
+        )
+        await store.set(terminalID: terminalID, pending)
+        let entries = await store.entries(forTerminal: terminalID)
+        #expect(entries.count == 1)
+        #expect(entries.first?.toolUseID == "toolu_test1")
+    }
+
+    @Test func twoSetsSameTerminalDifferentToolIDsCoexist() async {
+        let store = PendingQuestionStore()
+        let terminalID = UUID()
+        await store.set(terminalID: terminalID, PendingAskUserQuestion(
+            toolUseID: "toolu_a", inputJSON: "{}", timestamp: Date()))
+        await store.set(terminalID: terminalID, PendingAskUserQuestion(
+            toolUseID: "toolu_b", inputJSON: "{}", timestamp: Date()))
+        let entries = await store.entries(forTerminal: terminalID)
+        #expect(entries.count == 2)
+        #expect(Set(entries.map { $0.toolUseID }) == ["toolu_a", "toolu_b"])
+    }
+
+    @Test func clearMatchingToolUseIDRemovesOnlyThatEntry() async {
+        let store = PendingQuestionStore()
+        let terminalID = UUID()
+        await store.set(terminalID: terminalID, PendingAskUserQuestion(
+            toolUseID: "toolu_a", inputJSON: "{}", timestamp: Date(timeIntervalSince1970: 1)))
+        await store.set(terminalID: terminalID, PendingAskUserQuestion(
+            toolUseID: "toolu_b", inputJSON: "{}", timestamp: Date(timeIntervalSince1970: 2)))
+        await store.clear(terminalID: terminalID, toolUseID: "toolu_a")
+        let entries = await store.entries(forTerminal: terminalID)
+        #expect(entries.map { $0.toolUseID } == ["toolu_b"])
+    }
+
+    @Test func clearMismatchedToolUseIDIsNoOp() async {
+        let store = PendingQuestionStore()
+        let terminalID = UUID()
+        await store.set(terminalID: terminalID, PendingAskUserQuestion(
+            toolUseID: "toolu_a", inputJSON: "{}", timestamp: Date()))
+        await store.clear(terminalID: terminalID, toolUseID: "toolu_missing")
+        let entries = await store.entries(forTerminal: terminalID)
+        #expect(entries.count == 1)
+    }
+
+    @Test func clearTerminalRemovesAllEntries() async {
+        let store = PendingQuestionStore()
+        let terminalID = UUID()
+        await store.set(terminalID: terminalID, PendingAskUserQuestion(
+            toolUseID: "toolu_a", inputJSON: "{}", timestamp: Date()))
+        await store.set(terminalID: terminalID, PendingAskUserQuestion(
+            toolUseID: "toolu_b", inputJSON: "{}", timestamp: Date()))
+        await store.clear(terminalID: terminalID)
+        let entries = await store.entries(forTerminal: terminalID)
+        #expect(entries == [])
+    }
+
+    @Test func gcExpiredRemovesEntriesOlderThanMaxAge() async {
+        let store = PendingQuestionStore()
+        let terminalID = UUID()
+        let now = Date(timeIntervalSince1970: 10_000)
+        let oldEntry = PendingAskUserQuestion(
+            toolUseID: "toolu_old",
+            inputJSON: "{}",
+            timestamp: now.addingTimeInterval(-1000)
+        )
+        let freshEntry = PendingAskUserQuestion(
+            toolUseID: "toolu_fresh",
+            inputJSON: "{}",
+            timestamp: now.addingTimeInterval(-10)
+        )
+        await store.set(terminalID: terminalID, oldEntry)
+        await store.set(terminalID: terminalID, freshEntry)
+        await store.gcExpired(now: now, maxAge: .seconds(60))
+        let entries = await store.entries(forTerminal: terminalID)
+        #expect(entries.map { $0.toolUseID } == ["toolu_fresh"])
+    }
+
+    @Test func entriesIsolatedByTerminalID() async {
+        let store = PendingQuestionStore()
+        let a = UUID()
+        let b = UUID()
+        await store.set(terminalID: a, PendingAskUserQuestion(
+            toolUseID: "toolu_a", inputJSON: "{}", timestamp: Date()))
+        await store.set(terminalID: b, PendingAskUserQuestion(
+            toolUseID: "toolu_b", inputJSON: "{}", timestamp: Date()))
+        let aEntries = await store.entries(forTerminal: a)
+        let bEntries = await store.entries(forTerminal: b)
+        #expect(aEntries.map { $0.toolUseID } == ["toolu_a"])
+        #expect(bEntries.map { $0.toolUseID } == ["toolu_b"])
+    }
+}

--- a/docs/superpowers/specs/2026-05-09-pending-askuserquestion-rendering-design.md
+++ b/docs/superpowers/specs/2026-05-09-pending-askuserquestion-rendering-design.md
@@ -1,0 +1,244 @@
+# Pending AskUserQuestion Rendering — Design
+
+## Problem
+
+When Claude Code asks an `AskUserQuestion`, the assistant `tool_use` line is **not** appended to the JSONL transcript file until the user has answered. Verified empirically: in
+`~/.claude/projects/-Users-chang-projects-maven-dashboard/1D7BF9A8-401C-47EE-843E-4BACB67AE5FA.jsonl`, the session was in `status: "waiting"` / `waitingFor: "approve AskUserQuestion"` while the file's last `AskUserQuestion` entry already had a matching `tool_result`. The currently-asked question existed in the running Claude process but not on disk.
+
+Consequence in TBD's transcript pane: a pending question is invisible until the user has selected an option in the terminal — exactly when seeing the question is most useful.
+
+## Goal
+
+Render the question (header, prompt, options) inside the TBD transcript pane as soon as Claude asks it, with a "Waiting for response…" affordance until the user answers. When the answer arrives, the rendering must transition seamlessly to the JSONL-backed render of the same question with no flicker, duplicates, or layout jumps.
+
+## Non-Goals
+
+- **Answering from inside TBD.** Routing keystrokes back through tmux into the Claude TUI is a separate, larger problem.
+- **Tmux screen-scrape fallback.** If the hook didn't fire (daemon was down, hook overlay not picked up by an already-running session), the synthetic card will not appear. The user still sees the question in the terminal pane itself; the transcript pane just won't show it until JSONL catches up after the answer. This is the same degraded-but-correct behavior we have today.
+- **Other pending states.** This design covers `AskUserQuestion` only. It does not attempt to surface permission prompts (`approve Bash`, etc.) — those have a different UX shape.
+
+## Signal Source
+
+Anthropic's hook system fires `PreToolUse:AskUserQuestion` **before** Claude renders the picker, with the full tool input (the `questions` array, including options and headers) and the assigned `tool_use_id`. The matching `PostToolUse:AskUserQuestion` fires after the user answers, before Claude resumes.
+
+This is structured, version-stable, and addressable per matcher — strictly better than the alternatives:
+
+- The session file `~/.claude/sessions/<pid>.json` carries `status: "waiting"` and `waitingFor: "approve AskUserQuestion"` but never the question content.
+- Tmux pane capture has the rendered TUI but parsing it is brittle to formatting changes.
+- The JSONL records `attachment.type: "hook_success"` lines after PreToolUse hooks run, but these don't carry `tool_input`.
+
+## Architecture
+
+### 1. Hook overlay entries
+
+Extend `ClaudeHookOverlay.generateBody()` (`Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift`) with two new hook registrations alongside the existing `SessionStart` and `Stop` entries:
+
+```jsonc
+"PreToolUse": [
+  {
+    "matcher": "AskUserQuestion",
+    "hooks": [
+      { "type": "command", "command": "tbd ask-user-question pre 2>/dev/null || true" }
+    ]
+  }
+],
+"PostToolUse": [
+  {
+    "matcher": "AskUserQuestion",
+    "hooks": [
+      { "type": "command", "command": "tbd ask-user-question post 2>/dev/null || true" }
+    ]
+  }
+]
+```
+
+Same overlay file (`~/tbd/runtime/claude-overlay.json`), same `--settings` injection path through `ClaudeSpawnCommandBuilder`, same per-spawn scope. No changes to the user's `~/.claude/settings.json`. No changes for non-TBD-spawned Claude sessions.
+
+The overlay is regenerated on every daemon startup, so the new hooks take effect on the next worktree open after upgrade. Already-running Claude sessions started under the old overlay continue working unchanged — they just won't get pending-question cards until they restart through TBD.
+
+### 2. New CLI subcommand: `tbd ask-user-question`
+
+Add `Sources/TBDCLI/Commands/AskUserQuestionEventCommand.swift`, modeled directly on `SessionEventCommand`. Two subcommands:
+
+- `tbd ask-user-question pre` — invoked from `PreToolUse`. Reads stdin, decodes Claude's hook payload (`tool_use_id`, `tool_input`, plus the standard envelope fields), reads `TBD_TERMINAL_ID` from env, RPCs `terminal.askUserQuestionPending`. Silent on every error path; exit 0 always.
+- `tbd ask-user-question post` — invoked from `PostToolUse`. Same shape, RPCs `terminal.askUserQuestionCleared`.
+
+Both commands cap stdin at 1 MiB matching `SessionEventCommand`. Both return immediately if `TBD_TERMINAL_ID` is missing or malformed (covers non-TBD-spawned sessions that somehow inherit the overlay).
+
+The PreToolUse stdin payload, per Claude Code's hook contract, includes `tool_input` as a structured JSON object containing the questions array. The CLI command re-serializes `tool_input` with `JSONSerialization` (sorted keys) into a string and passes it through. The daemon does no further interpretation — it stores the JSON verbatim and lets the SwiftUI card decode it the same way it decodes JSONL-backed input.
+
+### 3. RPC additions
+
+In `Sources/TBDShared/RPCProtocol.swift`:
+
+```swift
+public static let terminalAskUserQuestionPending = "terminal.askUserQuestionPending"
+public static let terminalAskUserQuestionCleared = "terminal.askUserQuestionCleared"
+
+public struct TerminalAskUserQuestionPendingParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let toolUseID: String
+    public let inputJSON: String
+    public let timestampMillis: Int64
+}
+
+public struct TerminalAskUserQuestionClearedParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let toolUseID: String
+}
+```
+
+Both return void (`.ok()`). No client-side response handling needed.
+
+### 4. Daemon state store
+
+New file `Sources/TBDDaemon/AskUserQuestion/PendingQuestionStore.swift`:
+
+```swift
+actor PendingQuestionStore {
+    private var pending: [UUID: PendingAskUserQuestion] = [:]
+    func set(terminalID: UUID, _ value: PendingAskUserQuestion)
+    func clear(terminalID: UUID, toolUseID: String)
+    func clear(terminalID: UUID)              // called on terminal-close
+    func get(terminalID: UUID) -> PendingAskUserQuestion?
+}
+
+struct PendingAskUserQuestion: Sendable {
+    let toolUseID: String
+    let inputJSON: String
+    let timestamp: Date
+}
+```
+
+Single instance held by the daemon, injected into the relevant RPC handlers. Memory-only — daemon restart wipes it, which is correct behavior: after a daemon restart, the JSONL is the only authoritative source and any in-flight question will simply not get a synthetic card until answered. This is acceptable degradation.
+
+`clear(terminalID:)` (no toolUseID) is invoked from terminal-close paths so a closed pane never leaves a phantom card on the next reopen.
+
+### 5. RPC handlers
+
+New file `Sources/TBDDaemon/Server/RPCRouter+AskUserQuestionHandlers.swift`:
+
+```swift
+func handleTerminalAskUserQuestionPending(_ paramsData: Data) async throws -> RPCResponse {
+    let p = try decoder.decode(TerminalAskUserQuestionPendingParams.self, from: paramsData)
+    await pendingQuestions.set(
+        terminalID: p.terminalID,
+        PendingAskUserQuestion(
+            toolUseID: p.toolUseID,
+            inputJSON: p.inputJSON,
+            timestamp: Date(timeIntervalSince1970: TimeInterval(p.timestampMillis) / 1000)
+        )
+    )
+    return .ok()
+}
+
+func handleTerminalAskUserQuestionCleared(_ paramsData: Data) async throws -> RPCResponse {
+    let p = try decoder.decode(TerminalAskUserQuestionClearedParams.self, from: paramsData)
+    await pendingQuestions.clear(terminalID: p.terminalID, toolUseID: p.toolUseID)
+    return .ok()
+}
+```
+
+Wire into `RPCRouter.route(...)` next to existing terminal handlers.
+
+### 6. Transcript merge
+
+In `handleTerminalTranscript` (`Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`), after `messages = TranscriptParser.parse(...)` (or cache hit), perform the synthetic-item merge before building the response:
+
+```swift
+var finalMessages = messages
+if let pending = await pendingQuestions.get(terminalID: params.terminalID) {
+    let alreadyInJSONL = messages.contains { item in
+        if case let .toolCall(id, _, _, _, _, _, _, _) = item {
+            return id == pending.toolUseID
+        }
+        return false
+    }
+    if !alreadyInJSONL {
+        finalMessages.append(.toolCall(
+            id: pending.toolUseID,
+            name: "AskUserQuestion",
+            inputJSON: pending.inputJSON,
+            inputTruncatedTo: nil,
+            result: nil,
+            subagent: nil,
+            timestamp: pending.timestamp,
+            usage: nil
+        ))
+    }
+}
+```
+
+The cache (`TranscriptParseCache`) continues to cache the JSONL-derived items only; the synthetic merge happens post-cache-lookup so pending-state changes are reflected on every poll without cache invalidation.
+
+The dedupe key is `tool_use_id`, which Claude assigns once and reuses in both the PreToolUse hook payload and the eventual JSONL `tool_use` block. A real JSONL line landing for the same `tool_use_id` always wins.
+
+### 7. Terminal-close cleanup
+
+In the terminal lifecycle paths that already exist (closing a terminal, archiving a worktree), call `pendingQuestions.clear(terminalID:)`. This is a single line in each cleanup site.
+
+### 8. UI
+
+No changes. `AskUserQuestionCard` in `Sources/TBDApp/Panes/Transcript/AskUserQuestionCard.swift` already handles `result: nil` by rendering the question bubble plus a `WaitingForResponseRow` ("Waiting for response…" with spinner). Once the answer arrives via JSONL, the synthetic item is suppressed and the JSONL-backed card renders the answer bubble in the same slot. Layout is consistent because both renders go through the same `AskUserQuestionCard`.
+
+## Live update cadence
+
+The App's `LiveTranscriptPaneView` polls `terminal.transcript` on a fixed interval. The synthetic card therefore appears on the first poll after the PreToolUse hook fires — sub-second under normal conditions. No additional push channel is needed.
+
+## Tests
+
+Per project policy on branching conditionals, every new branch gets a test on each side.
+
+**`ClaudeHookOverlay` JSON snapshot**
+- `generateBody()` output contains the new `PreToolUse` and `PostToolUse` entries with `matcher: "AskUserQuestion"` and the expected commands.
+- Existing `SessionStart` and `Stop` entries are unchanged.
+
+**`AskUserQuestionEventCommand` payload parsing**
+- Given a representative PreToolUse stdin payload (real shape captured from a live session), the command extracts `tool_use_id` and a re-serialized `tool_input` JSON.
+- Missing `TBD_TERMINAL_ID`: command exits silently.
+- Malformed JSON: command exits silently.
+- Stdin > 1 MiB: command exits silently.
+
+**`PendingQuestionStore`**
+- `set` then `get` returns the stored value.
+- `clear(terminalID:toolUseID:)` for the matching toolUseID removes the entry; mismatched toolUseID is a no-op.
+- `clear(terminalID:)` removes the entry regardless of toolUseID.
+
+**Transcript merge (the branching gate)**
+- Pending state present, no matching JSONL item → synthetic `toolCall` appended at tail.
+- Pending state present, JSONL contains a `tool_use` with the same `tool_use_id` → no synthetic appended (real wins).
+- Pending state absent → output byte-identical to `TranscriptParser.parse(filePath:)` (the gated-off ungated-behavior check).
+- Synthetic appended once cleared by `terminal.askUserQuestionCleared` → next call returns no synthetic.
+
+**RPC round-trip**
+- `terminal.askUserQuestionPending` then `terminal.transcript` returns a transcript including the synthetic.
+- Then `terminal.askUserQuestionCleared` then `terminal.transcript` returns a transcript without the synthetic.
+
+## Restart and verification per CLAUDE.md
+
+After daemon-side or shared-code changes, restart the worktree with `scripts/restart.sh` (the worktree's own copy, not the main project's), then verify exactly one `TBDDaemon` and one `TBDApp` are running from this worktree path with `ps aux | grep -E "\.build/debug/TBD"`.
+
+Manual verification: open a TBD-spawned Claude session, ask Claude to invoke `AskUserQuestion`, confirm the card appears in the transcript pane with "Waiting for response…" before answering, answer in the terminal, confirm the card transitions to the answered state without flicker.
+
+## Risks and mitigations
+
+- **Hook didn't fire (daemon was down when PreToolUse triggered).** Synthetic card won't appear; user sees the question in the terminal pane only. Same degraded behavior as today. Acceptable.
+- **PostToolUse failed to fire (daemon down between Pre and Post).** JSONL dedupe handles it: when the assistant `tool_use` lands in JSONL after the answer, the synthetic is suppressed by `tool_use_id` match.
+- **Stale pending entry from a crashed Claude session.** Daemon restart wipes the in-memory store. Terminal-close also clears the entry. The only stuck-state path is "Claude crashed, daemon kept running, terminal still open." Manageable scope; if it becomes common, add a TTL.
+- **Hook overlay merge order.** Claude merges `--settings` array entries with the user's settings.json by concatenation + dedupe. Adding new matchers cannot conflict with user hooks on the same matcher — both run. Confirmed by the existing `SessionStart` overlay coexisting with user hooks.
+
+## Files touched
+
+- `Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift` — extend `generateBody()`.
+- `Sources/TBDCLI/Commands/AskUserQuestionEventCommand.swift` — new.
+- `Sources/TBDCLI/TBDCLI.swift` (or wherever subcommands are registered) — register new command.
+- `Sources/TBDShared/RPCProtocol.swift` — new method names + param structs.
+- `Sources/TBDDaemon/AskUserQuestion/PendingQuestionStore.swift` — new actor.
+- `Sources/TBDDaemon/Server/RPCRouter+AskUserQuestionHandlers.swift` — new handlers.
+- `Sources/TBDDaemon/Server/RPCRouter.swift` — route the two new methods.
+- `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift` — synthetic merge in `handleTerminalTranscript`; inject `PendingQuestionStore`.
+- `Sources/TBDDaemon/Daemon.swift` (or composition root) — instantiate `PendingQuestionStore`, wire to RPCRouter.
+- Terminal-close paths (existing files) — call `pendingQuestions.clear(terminalID:)`.
+- `Tests/TBDDaemonTests/` and `Tests/TBDCLITests/` — tests above.
+
+No SwiftUI files modified.

--- a/docs/superpowers/specs/2026-05-09-pending-askuserquestion-rendering-design.md
+++ b/docs/superpowers/specs/2026-05-09-pending-askuserquestion-rendering-design.md
@@ -16,6 +16,7 @@ Render the question (header, prompt, options) inside the TBD transcript pane as 
 - **Answering from inside TBD.** Routing keystrokes back through tmux into the Claude TUI is a separate, larger problem.
 - **Tmux screen-scrape fallback.** If the hook didn't fire (daemon was down, hook overlay not picked up by an already-running session), the synthetic card will not appear. The user still sees the question in the terminal pane itself; the transcript pane just won't show it until JSONL catches up after the answer. This is the same degraded-but-correct behavior we have today.
 - **Other pending states.** This design covers `AskUserQuestion` only. It does not attempt to surface permission prompts (`approve Bash`, etc.) — those have a different UX shape.
+- **Subagent (Task) AskUserQuestion.** When a Task subagent calls `AskUserQuestion`, the eventual real `tool_use` lands nested inside the parent `toolCall`'s `Subagent.items`, not at the top level. Top-level dedupe + top-level placement would render the synthetic incorrectly. Subagent questions therefore degrade to today's behavior (visible only after answer). Recursing into `Subagent.items` for dedupe and rendering the synthetic in the correct nested slot is tracked as a follow-up. We can detect this at the CLI bridge by inspecting `cwd` / `transcript_path` from the hook payload against the parent terminal's main JSONL — if they diverge (subagent transcripts live under a `subagents/` sibling), the bridge does not RPC the daemon at all. This keeps the synthetic out of the top-level items list for subagent calls.
 
 ## Signal Source
 
@@ -26,6 +27,26 @@ This is structured, version-stable, and addressable per matcher — strictly bet
 - The session file `~/.claude/sessions/<pid>.json` carries `status: "waiting"` and `waitingFor: "approve AskUserQuestion"` but never the question content.
 - Tmux pane capture has the rendered TUI but parsing it is brittle to formatting changes.
 - The JSONL records `attachment.type: "hook_success"` lines after PreToolUse hooks run, but these don't carry `tool_input`.
+
+### Empirically verified payload shape
+
+Captured live from Claude Code 2.1.138 by installing a `cat > file` hook on `PreToolUse:AskUserQuestion`:
+
+```json
+{
+  "session_id": "B88113CA-EAF0-41D7-AEF7-C4AB2FB449CF",
+  "transcript_path": "/Users/chang/.claude/projects/.../<sid>.jsonl",
+  "cwd": "...",
+  "permission_mode": "bypassPermissions",
+  "effort": { "level": "high" },
+  "hook_event_name": "PreToolUse",
+  "tool_name": "AskUserQuestion",
+  "tool_input": { "questions": [ { "question": "...", "header": "...", "options": [ ... ], "multiSelect": false } ] },
+  "tool_use_id": "toolu_01JLbNo3vYeQp2TVif7Cd8Mn"
+}
+```
+
+Confirms the load-bearing assumption: `tool_use_id` is present on PreToolUse for this matcher, in the same `toolu_…` format that the assistant `tool_use.id` later carries into the JSONL. Exact-string match works as a dedupe key.
 
 ## Architecture
 
@@ -61,11 +82,15 @@ The overlay is regenerated on every daemon startup, so the new hooks take effect
 Add `Sources/TBDCLI/Commands/AskUserQuestionEventCommand.swift`, modeled directly on `SessionEventCommand`. Two subcommands:
 
 - `tbd ask-user-question pre` — invoked from `PreToolUse`. Reads stdin, decodes Claude's hook payload (`tool_use_id`, `tool_input`, plus the standard envelope fields), reads `TBD_TERMINAL_ID` from env, RPCs `terminal.askUserQuestionPending`. Silent on every error path; exit 0 always.
-- `tbd ask-user-question post` — invoked from `PostToolUse`. Same shape, RPCs `terminal.askUserQuestionCleared`.
+- `tbd ask-user-question post` — invoked from `PostToolUse`. Same shape, RPCs `terminal.askUserQuestionCleared` (which is a no-op today; see §3).
 
 Both commands cap stdin at 1 MiB matching `SessionEventCommand`. Both return immediately if `TBD_TERMINAL_ID` is missing or malformed (covers non-TBD-spawned sessions that somehow inherit the overlay).
 
-The PreToolUse stdin payload, per Claude Code's hook contract, includes `tool_input` as a structured JSON object containing the questions array. The CLI command re-serializes `tool_input` with `JSONSerialization` (sorted keys) into a string and passes it through. The daemon does no further interpretation — it stores the JSON verbatim and lets the SwiftUI card decode it the same way it decodes JSONL-backed input.
+The PreToolUse stdin payload includes `tool_input` as a structured JSON object containing the questions array (empirically verified — see §Signal Source). The CLI command re-serializes `tool_input` with `JSONSerialization` (sorted keys) into a string and passes it through. The daemon does no further interpretation — it stores the JSON verbatim and lets the SwiftUI card decode it the same way it decodes JSONL-backed input.
+
+**Subagent detection.** Before issuing the RPC, the `pre` subcommand compares the payload's `transcript_path` to a hint about the parent terminal's expected JSONL path. If the path lives under a `subagents/` subdirectory of the project, the subagent-question case (see §Non-Goals), the CLI exits silently without RPCing. This keeps subagent questions out of the synthetic-merge path entirely. Tests cover both branches (main-agent path: RPC fires; subagent path: no RPC).
+
+**Observability.** Each subcommand emits exactly one `logger.debug` line via `os.Logger` (subsystem `com.tbd.cli`, category `askUserQuestion`) — `"pre delivered toolUseID=… terminalID=…"` or `"pre suppressed reason=subagent|noTerminalID|rpcFailed"`. Per project policy, debug-level logs are silent by default and surfaced via `log stream --level debug`. This is the only diagnostic path; hook stderr stays empty so nothing leaks into the user's terminal.
 
 ### 3. RPC additions
 
@@ -90,17 +115,22 @@ public struct TerminalAskUserQuestionClearedParams: Codable, Sendable {
 
 Both return void (`.ok()`). No client-side response handling needed.
 
+PostToolUse is intentionally a defensive signal only — see §6 for why we don't clear on PostToolUse. The `…Cleared` RPC exists so the daemon could choose to drop a pending entry early in the rare case of a same-cycle redundant question, but the *default* merger path doesn't call it. Concretely, `handleTerminalAskUserQuestionCleared` is a no-op today (logs only); we keep the wire format reserved so we don't have to ship a protocol change if we later want it.
+
 ### 4. Daemon state store
 
 New file `Sources/TBDDaemon/AskUserQuestion/PendingQuestionStore.swift`:
 
 ```swift
 actor PendingQuestionStore {
-    private var pending: [UUID: PendingAskUserQuestion] = [:]
+    private var pending: [Key: PendingAskUserQuestion] = [:]
+    struct Key: Hashable, Sendable { let terminalID: UUID; let toolUseID: String }
+
     func set(terminalID: UUID, _ value: PendingAskUserQuestion)
     func clear(terminalID: UUID, toolUseID: String)
     func clear(terminalID: UUID)              // called on terminal-close
-    func get(terminalID: UUID) -> PendingAskUserQuestion?
+    func entries(forTerminal: UUID) -> [PendingAskUserQuestion]
+    func gcExpired(now: Date, maxAge: Duration)
 }
 
 struct PendingAskUserQuestion: Sendable {
@@ -110,9 +140,13 @@ struct PendingAskUserQuestion: Sendable {
 }
 ```
 
-Single instance held by the daemon, injected into the relevant RPC handlers. Memory-only — daemon restart wipes it, which is correct behavior: after a daemon restart, the JSONL is the only authoritative source and any in-flight question will simply not get a synthetic card until answered. This is acceptable degradation.
+Keyed on `(terminalID, toolUseID)` rather than `terminalID` alone — so two pending questions on the same terminal coexist (rare, but happens during session restore/replay, or if a hook bug double-fires). Stored as a list returned by `entries(forTerminal:)`; merger iterates them.
 
-`clear(terminalID:)` (no toolUseID) is invoked from terminal-close paths so a closed pane never leaves a phantom card on the next reopen.
+Memory-only — daemon restart wipes it. After a daemon restart, the JSONL is the only authoritative source and any in-flight question simply doesn't get a synthetic card until answered. Acceptable degradation.
+
+`clear(terminalID:)` (no toolUseID) is invoked from terminal-close paths so a closed pane never leaves a phantom entry on the next reopen.
+
+**TTL.** Stranded entries (e.g., a user-installed PreToolUse hook on the same matcher returned `decision: "block"`, so no answer ever comes; or daemon-vs-Claude lifetime mismatch) are reaped via `gcExpired` called from `handleTerminalTranscript` with `maxAge: .seconds(900)` (15 min). Cheap — runs O(entries) per poll, entries are tiny.
 
 ### 5. RPC handlers
 
@@ -141,41 +175,61 @@ func handleTerminalAskUserQuestionCleared(_ paramsData: Data) async throws -> RP
 
 Wire into `RPCRouter.route(...)` next to existing terminal handlers.
 
-### 6. Transcript merge
+### 6. Transcript merge — and lazy cleanup that avoids flicker
 
-In `handleTerminalTranscript` (`Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`), after `messages = TranscriptParser.parse(...)` (or cache hit), perform the synthetic-item merge before building the response:
+In `handleTerminalTranscript` (`Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`), after `messages = TranscriptParser.parse(...)` (or cache hit), perform GC + merge before building the response:
 
 ```swift
+await pendingQuestions.gcExpired(now: Date(), maxAge: .seconds(900))
+
+let jsonlIDs: Set<String> = {
+    var ids = Set<String>()
+    for item in messages {
+        if case let .toolCall(id, _, _, _, _, _, _, _) = item { ids.insert(id) }
+    }
+    return ids
+}()
+
 var finalMessages = messages
-if let pending = await pendingQuestions.get(terminalID: params.terminalID) {
-    let alreadyInJSONL = messages.contains { item in
-        if case let .toolCall(id, _, _, _, _, _, _, _) = item {
-            return id == pending.toolUseID
-        }
-        return false
+for pending in await pendingQuestions.entries(forTerminal: params.terminalID) {
+    if jsonlIDs.contains(pending.toolUseID) {
+        // JSONL caught up. Drop the entry now — keeps the store small,
+        // avoids ever surfacing a "ghost" synthetic for an answered question.
+        await pendingQuestions.clear(terminalID: params.terminalID,
+                                     toolUseID: pending.toolUseID)
+        continue
     }
-    if !alreadyInJSONL {
-        finalMessages.append(.toolCall(
-            id: pending.toolUseID,
-            name: "AskUserQuestion",
-            inputJSON: pending.inputJSON,
-            inputTruncatedTo: nil,
-            result: nil,
-            subagent: nil,
-            timestamp: pending.timestamp,
-            usage: nil
-        ))
-    }
+    finalMessages.append(.toolCall(
+        id: pending.toolUseID,
+        name: "AskUserQuestion",
+        inputJSON: pending.inputJSON,
+        inputTruncatedTo: nil,   // synthetic input is always uncapped
+        result: nil,
+        subagent: nil,
+        timestamp: pending.timestamp,
+        usage: nil
+    ))
 }
 ```
 
 The cache (`TranscriptParseCache`) continues to cache the JSONL-derived items only; the synthetic merge happens post-cache-lookup so pending-state changes are reflected on every poll without cache invalidation.
 
-The dedupe key is `tool_use_id`, which Claude assigns once and reuses in both the PreToolUse hook payload and the eventual JSONL `tool_use` block. A real JSONL line landing for the same `tool_use_id` always wins.
+**Why lazy cleanup avoids flicker.** A naive design clears pending state when the PostToolUse hook fires. But Claude flushes the assistant `tool_use` line to JSONL slightly *after* PostToolUse returns. A poll landing in that gap would show the synthetic disappear and then the real card appear with the answer — a visible flicker. Lazy cleanup means the synthetic stays visible (with "Waiting for response…") until the JSONL line lands, at which point the real card replaces it in the same render slot. PostToolUse becomes a defensive-only signal — see §3.
+
+The dedupe key is `tool_use_id`, which Claude assigns once and reuses in both the PreToolUse hook payload (empirically verified, see §Signal Source) and the eventual JSONL `tool_use` block.
+
+**`inputTruncatedTo` is always `nil` on synthetic items.** The CLI bridge never caps the JSON; the merger never sets the field. This keeps the synthetic out of the truncation-footer code path in `AskUserQuestionCard` (which would otherwise call `terminal.transcriptItemFullBody` with a `tool_use_id` that doesn't exist in JSONL yet, getting back "Output no longer available.").
 
 ### 7. Terminal-close cleanup
 
-In the terminal lifecycle paths that already exist (closing a terminal, archiving a worktree), call `pendingQuestions.clear(terminalID:)`. This is a single line in each cleanup site.
+Call `pendingQuestions.clear(terminalID:)` from every code path that terminates a terminal so the store can't grow phantom entries. The exhaustive list — verified by grepping for terminal teardown sites in `Sources/TBDDaemon/` — is:
+
+- Worktree archive (`Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift`).
+- `tbd terminal close` / explicit terminal close (`RPCRouter+TerminalHandlers.swift` close handlers).
+- Tmux session death detection (the existing watcher that detects tmux-side closes and updates terminal status).
+- Daemon shutdown (memory-only store, so no action needed — process exit clears it).
+
+Each non-shutdown site adds one line. Tests cover each path's call into the clear method.
 
 ### 8. UI
 
@@ -194,25 +248,31 @@ Per project policy on branching conditionals, every new branch gets a test on ea
 - Existing `SessionStart` and `Stop` entries are unchanged.
 
 **`AskUserQuestionEventCommand` payload parsing**
-- Given a representative PreToolUse stdin payload (real shape captured from a live session), the command extracts `tool_use_id` and a re-serialized `tool_input` JSON.
+- Given a representative PreToolUse stdin payload (real shape captured from a live session — checked into the test fixtures), the command extracts `tool_use_id` and a re-serialized `tool_input` JSON.
 - Missing `TBD_TERMINAL_ID`: command exits silently.
 - Malformed JSON: command exits silently.
 - Stdin > 1 MiB: command exits silently.
+- Subagent transcript path (`transcript_path` under `/subagents/`): command exits silently without RPCing the daemon.
+- Main-agent transcript path: command issues the RPC.
 
 **`PendingQuestionStore`**
-- `set` then `get` returns the stored value.
+- `set` then `entries(forTerminal:)` returns the stored value.
 - `clear(terminalID:toolUseID:)` for the matching toolUseID removes the entry; mismatched toolUseID is a no-op.
-- `clear(terminalID:)` removes the entry regardless of toolUseID.
+- `clear(terminalID:)` removes all entries for that terminal regardless of toolUseID.
+- Two `set` calls on the same terminal with different toolUseIDs → both entries present.
+- `gcExpired(now:, maxAge:)` removes entries older than `maxAge`; younger entries are kept.
 
 **Transcript merge (the branching gate)**
-- Pending state present, no matching JSONL item → synthetic `toolCall` appended at tail.
-- Pending state present, JSONL contains a `tool_use` with the same `tool_use_id` → no synthetic appended (real wins).
+- Pending state present, no matching JSONL item → synthetic `toolCall` appended at tail with `inputTruncatedTo: nil`, `result: nil`, `subagent: nil`.
+- Pending state present, JSONL contains a `tool_use` with the same `tool_use_id` → no synthetic appended (real wins) AND the entry is removed from `PendingQuestionStore` by the merger (lazy cleanup).
 - Pending state absent → output byte-identical to `TranscriptParser.parse(filePath:)` (the gated-off ungated-behavior check).
-- Synthetic appended once cleared by `terminal.askUserQuestionCleared` → next call returns no synthetic.
+- Two pending entries on the same terminal with different `toolUseID`s → both appear in the output (keying preserves both).
+- Pending entry older than 15 minutes → reaped by `gcExpired`, not surfaced.
 
 **RPC round-trip**
 - `terminal.askUserQuestionPending` then `terminal.transcript` returns a transcript including the synthetic.
-- Then `terminal.askUserQuestionCleared` then `terminal.transcript` returns a transcript without the synthetic.
+- A second `terminal.transcript` call once the JSONL contains the real `tool_use`+`tool_result` → no synthetic; pending store is empty for that terminalID.
+- `terminal.askUserQuestionCleared` is a no-op today; test asserts `entries(forTerminal:)` is unchanged after calling it (the wire format reservation, not behavior).
 
 ## Restart and verification per CLAUDE.md
 
@@ -223,9 +283,11 @@ Manual verification: open a TBD-spawned Claude session, ask Claude to invoke `As
 ## Risks and mitigations
 
 - **Hook didn't fire (daemon was down when PreToolUse triggered).** Synthetic card won't appear; user sees the question in the terminal pane only. Same degraded behavior as today. Acceptable.
-- **PostToolUse failed to fire (daemon down between Pre and Post).** JSONL dedupe handles it: when the assistant `tool_use` lands in JSONL after the answer, the synthetic is suppressed by `tool_use_id` match.
-- **Stale pending entry from a crashed Claude session.** Daemon restart wipes the in-memory store. Terminal-close also clears the entry. The only stuck-state path is "Claude crashed, daemon kept running, terminal still open." Manageable scope; if it becomes common, add a TTL.
-- **Hook overlay merge order.** Claude merges `--settings` array entries with the user's settings.json by concatenation + dedupe. Adding new matchers cannot conflict with user hooks on the same matcher — both run. Confirmed by the existing `SessionStart` overlay coexisting with user hooks.
+- **Flicker on answer (PostToolUse clears too early).** Mitigated by lazy cleanup inside the merger — pending state lives until the JSONL match is observed, so the synthetic stays on-screen continuously through the transition.
+- **Stale pending entry.** Two pressure-release valves: `gcExpired` (15-minute TTL) handles the "user-installed PreToolUse blocked the call" case where no answer/JSONL ever lands; terminal-close paths handle the "user killed the terminal mid-question" case; daemon restart handles everything else.
+- **Hook overlay merge order vs. user hooks on the same matcher.** Claude merges `--settings` array entries with the user's settings.json by concatenation + dedupe. If the user has their own `PreToolUse:AskUserQuestion` hook, both run. If theirs returns `decision: "block"`, Claude skips the tool call entirely — our pending entry strands until TTL reaps it. Acceptable failure mode.
+- **Concurrent same-terminal questions.** Keying on `(terminalID, toolUseID)` rather than `terminalID` alone means two pending questions coexist; merger surfaces both. Order in the items list reflects pending-store insertion order; identical to JSONL ordering once they flush.
+- **Subagent (Task) AskUserQuestion.** The CLI bridge suppresses the RPC for subagent transcripts (see §Non-Goals and §2 in Architecture), so the synthetic never appears at the top level. Subagent questions are visible only after answer — same as today.
 
 ## Files touched
 


### PR DESCRIPTION
## Summary

- Claude Code doesn't flush an assistant `tool_use` line to the JSONL until *after* the user answers an `AskUserQuestion`. So today TBD's transcript pane is silent while a question is open — you can only read the question by switching to the terminal pane. This PR closes that gap.
- Adds `PreToolUse:AskUserQuestion` and `PostToolUse:AskUserQuestion` matchers to TBD's per-spawn `--settings` overlay. A new `tbd ask-user-question pre|post` CLI subcommand bridges hook stdin into the daemon, which holds the question in an in-memory `PendingQuestionStore` actor keyed on `(terminalID, toolUseID)`. `handleTerminalTranscript` synthesizes a `.toolCall(result: nil)` item whose `tool_use_id` doesn't already appear in the JSONL — the existing `AskUserQuestionCard` already renders that with a "Waiting for response…" row, so no UI changes were needed.
- Dedupe is lazy: pending entries are cleared only when the merger observes a matching `tool_use_id` in the JSONL, which means the synthetic card stays visible until the real one is ready to take its place — no flicker on transition. PostToolUse is intentionally a no-op signal. Stranded entries (e.g., user-installed hook blocks the call) are reaped on a 15-minute TTL. Subagent (Task) AskUserQuestion is suppressed at the CLI bridge and remains visible only after answer — tracked as a follow-up.
- Drive-by: AskUserQuestion options now render expanded by default in the transcript card (no chevron click needed).

The PreToolUse payload shape (`tool_use_id` is present) was verified empirically by capturing live stdin from Claude Code 2.1.138 — see the spec for the captured JSON.

## Test plan

- [ ] Spawn a fresh Claude session in a TBD-managed terminal. Ask it to use `AskUserQuestion`. Before answering, confirm the transcript pane shows the question bubble with all options visible and a "Waiting for response…" row beneath.
- [ ] Pick an option. Confirm the "Waiting for response…" row replaces in-place with the answer bubble — no flicker, no duplicate cards, no layout jump.
- [ ] Stream debug logs while reproducing: `log stream --level debug --predicate 'subsystem BEGINSWITH "com.tbd" AND category == "askUserQuestion"'`. Expect `pre delivered` → `pending stored` → `cleared received (no-op)` → `post delivered` for each AskUserQuestion cycle.
- [ ] Verify daemon-side unit tests: `swift test --filter PendingQuestionStoreTests` (7 tests) and `--filter AskUserQuestionMergeTests` (5 tests).
- [ ] Verify the overlay file after restart contains the new entries: `cat ~/tbd/runtime/claude-overlay.json | python3 -m json.tool | grep -A 5 -E 'PreToolUse|PostToolUse'`.
- [ ] Negative path: trigger an AskUserQuestion from inside a Task subagent. Confirm `pre suppressed reason=subagent` appears in the log and no synthetic card is rendered in the parent terminal's transcript (this is the documented degradation).
- [ ] Close a terminal that has a pending AskUserQuestion. Confirm no phantom card appears on the next terminal-create in the same worktree.

open in TBD: \`tbd://open?worktree=D0502156-4BA5-4F89-9611-053F3C5E06BE\`