### PR TITLE
Fix: Stop swift test from /exit'ing live Claude sessions via UserDefaults leak

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -515,7 +515,7 @@ final class AppState: ObservableObject {
             await loadModelProfiles()
             startSubscription()
             await refreshPRStatuses()
-            let suspendEnabled = AppState.autoSuspendClaudeEnabled()
+            let suspendEnabled = AppState.autoSuspendClaudeEnabled(defaults: userDefaults)
             Task { [selectedWorktreeIDs] in
                 try? await daemonClient.worktreeSelectionChanged(
                     selectedWorktreeIDs: selectedWorktreeIDs,

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -283,7 +283,13 @@ final class AppState: ObservableObject {
     private var memoryPressureSource: DispatchSourceMemoryPressure?
     private var focusObservers: [NSObjectProtocol] = []
 
-    init() {
+    /// UserDefaults domain this AppState reads instance-level preferences from.
+    /// Production uses `.standard`; tests inject a per-suite `UserDefaults(suiteName:)`
+    /// so they never clobber the developer's running app preferences.
+    let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
         restoreLayouts()
         if let saved = UserDefaults.standard.object(forKey: Self.dockRatioKey) as? Double {
             dockRatio = max(0.1, min(0.6, CGFloat(saved)))
@@ -509,7 +515,7 @@ final class AppState: ObservableObject {
             await loadModelProfiles()
             startSubscription()
             await refreshPRStatuses()
-            let suspendEnabled = AppState.autoSuspendClaudeEnabled
+            let suspendEnabled = AppState.autoSuspendClaudeEnabled()
             Task { [selectedWorktreeIDs] in
                 try? await daemonClient.worktreeSelectionChanged(
                     selectedWorktreeIDs: selectedWorktreeIDs,
@@ -925,7 +931,7 @@ final class AppState: ObservableObject {
 
     /// Whether the WIP main-area resize broadcast is enabled. Default false.
     private var terminalAutoResizeEnabled: Bool {
-        UserDefaults.standard.bool(forKey: Self.terminalAutoResizeKey)
+        userDefaults.bool(forKey: Self.terminalAutoResizeKey)
     }
 
     /// UserDefaults key mirroring the `@AppStorage("autoSuspendClaude")`
@@ -936,8 +942,10 @@ final class AppState: ObservableObject {
 
     /// Whether auto-suspend is enabled. Defaults to true when the user has
     /// never touched the toggle, matching the `@AppStorage` defaults.
-    static var autoSuspendClaudeEnabled: Bool {
-        UserDefaults.standard.object(forKey: autoSuspendClaudeKey) as? Bool ?? true
+    /// Tests pass a private `UserDefaults(suiteName:)` so they never mutate
+    /// the developer's live app preferences.
+    static func autoSuspendClaudeEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: autoSuspendClaudeKey) as? Bool ?? true
     }
 
     /// Convert the current `mainAreaSize` (pixels) into tmux cell dimensions

--- a/Tests/TBDAppTests/AutoSuspendPreferenceTests.swift
+++ b/Tests/TBDAppTests/AutoSuspendPreferenceTests.swift
@@ -7,47 +7,55 @@ import Testing
 /// build the `worktree.selectionChanged` RPC params. Regression coverage for
 /// a bug where the reconnect path ignored the toggle and always sent
 /// `suspendEnabled=true`, causing real Claude sessions to receive `/exit`.
+///
+/// Isolation matters: TBDApp ships as an unbundled SPM executable, so its
+/// `UserDefaults.standard` domain is `TBDApp.plist` in the developer's home
+/// — the SAME domain a running production TBDApp reads via `@AppStorage`.
+/// An earlier version of these tests mutated `.standard`, which clobbered the
+/// live app's preferences mid-test and triggered a real Claude `/exit`. Every
+/// test below now drives the helper through a per-test `UserDefaults(suiteName:)`
+/// so `.standard` is never touched.
 
 @MainActor
 @Suite("Auto-suspend Claude preference")
 struct AutoSuspendPreferenceTests {
     private let key = AppState.autoSuspendClaudeKey
 
-    private func withPreference(_ value: Bool?, _ body: () throws -> Void) rethrows {
-        let prior = UserDefaults.standard.object(forKey: key)
-        if let value {
-            UserDefaults.standard.set(value, forKey: key)
-        } else {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
+    /// Build an isolated UserDefaults domain, run the body with it, and tear
+    /// the domain down afterwards so nothing persists across tests.
+    private func withIsolatedDefaults(
+        seed: Bool?,
+        _ body: (UserDefaults) -> Void
+    ) {
+        let suiteName = "TBDAppTests.AutoSuspend.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
         defer {
-            if let prior {
-                UserDefaults.standard.set(prior, forKey: key)
-            } else {
-                UserDefaults.standard.removeObject(forKey: key)
-            }
+            defaults.removePersistentDomain(forName: suiteName)
         }
-        try body()
+        if let seed {
+            defaults.set(seed, forKey: key)
+        }
+        body(defaults)
     }
 
     @Test("returns true when toggle is on")
-    func enabledWhenOn() throws {
-        try withPreference(true) {
-            #expect(AppState.autoSuspendClaudeEnabled == true)
+    func enabledWhenOn() {
+        withIsolatedDefaults(seed: true) { defaults in
+            #expect(AppState.autoSuspendClaudeEnabled(defaults: defaults) == true)
         }
     }
 
     @Test("returns false when toggle is off — the regressed branch")
-    func disabledWhenOff() throws {
-        try withPreference(false) {
-            #expect(AppState.autoSuspendClaudeEnabled == false)
+    func disabledWhenOff() {
+        withIsolatedDefaults(seed: false) { defaults in
+            #expect(AppState.autoSuspendClaudeEnabled(defaults: defaults) == false)
         }
     }
 
     @Test("defaults to true when the user has never touched the toggle")
-    func defaultsToTrueWhenUnset() throws {
-        try withPreference(nil) {
-            #expect(AppState.autoSuspendClaudeEnabled == true)
+    func defaultsToTrueWhenUnset() {
+        withIsolatedDefaults(seed: nil) { defaults in
+            #expect(AppState.autoSuspendClaudeEnabled(defaults: defaults) == true)
         }
     }
 }

--- a/Tests/TBDAppTests/TerminalAutoResizeFlagTests.swift
+++ b/Tests/TBDAppTests/TerminalAutoResizeFlagTests.swift
@@ -6,31 +6,37 @@ import Testing
 /// the main-area resize broadcast to the daemon and the per-create cell
 /// dimensions sent with `terminal.create` / `worktree.create` RPCs. Off by
 /// default; on flips the broadcast back on.
+///
+/// Isolation matters: TBDApp ships as an unbundled SPM executable, so its
+/// `UserDefaults.standard` domain is `TBDApp.plist` in the developer's home
+/// — the SAME domain a running production TBDApp reads via `@AppStorage`.
+/// An earlier version of these tests mutated `.standard`, which clobbered the
+/// live app's preferences mid-test and triggered a real Claude `/exit`. Every
+/// test below now constructs `AppState(userDefaults:)` with a per-test
+/// `UserDefaults(suiteName:)` so `.standard` is never touched.
 
 @MainActor
 @Suite("Terminal auto-resize flag")
 struct TerminalAutoResizeFlagTests {
     private let key = AppState.terminalAutoResizeKey
 
-    private func withFlag(_ enabled: Bool, _ body: () throws -> Void) rethrows {
-        let prior = UserDefaults.standard.object(forKey: key)
-        UserDefaults.standard.set(enabled, forKey: key)
+    /// Build an isolated UserDefaults domain seeded with the flag value,
+    /// hand the body an `AppState` wired to that domain, then tear the
+    /// domain down so nothing persists across tests.
+    private func withFlag(_ enabled: Bool, _ body: (AppState) throws -> Void) rethrows {
+        let suiteName = "TBDAppTests.TerminalAutoResize.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
         defer {
-            // Restore prior state so tests don't bleed into each other or
-            // into the developer's running app instance.
-            if let prior {
-                UserDefaults.standard.set(prior, forKey: key)
-            } else {
-                UserDefaults.standard.removeObject(forKey: key)
-            }
+            defaults.removePersistentDomain(forName: suiteName)
         }
-        try body()
+        defaults.set(enabled, forKey: key)
+        let state = AppState(userDefaults: defaults)
+        try body(state)
     }
 
     @Test("returns (nil, nil) when flag is off so daemon falls back to its 220×50 default")
-    func mainAreaTerminalSizeOff() throws {
-        try withFlag(false) {
-            let state = AppState()
+    func mainAreaTerminalSizeOff() {
+        withFlag(false) { state in
             // The defaults seed mainAreaSize at 1120x776, which would
             // otherwise produce a real cell count — verify the flag wins.
             state.mainAreaSize = CGSize(width: 1200, height: 800)
@@ -45,8 +51,7 @@ struct TerminalAutoResizeFlagTests {
 
     @Test("returns real cell counts when flag is on")
     func mainAreaTerminalSizeOn() throws {
-        try withFlag(true) {
-            let state = AppState()
+        try withFlag(true) { state in
             state.mainAreaSize = CGSize(width: 1200, height: 800)
             let size = state.mainAreaTerminalSize()
             // Exact cell metrics depend on the platform monospaced font, so


### PR DESCRIPTION
## Summary

- TBDApp ships as an unbundled SPM executable, so `UserDefaults.standard` lives in the `TBDApp` plist domain — the same domain a running production TBDApp reads via `@AppStorage`.
- `AutoSuspendPreferenceTests` and `TerminalAutoResizeFlagTests` mutated `.standard` directly. Running `swift test` while the app was open briefly flipped `autoSuspendClaude=true`; the live `@AppStorage` reacted, and the next selection change sent `worktreeSelectionChanged(suspendEnabled: true)` to the daemon, which then `/exit`'d the departing worktree's Claude session. (That's how today's "🐌 Investigate Transcript Hangs" session got suspended.)
- Make the helpers take a `UserDefaults` argument (defaulted to `.standard` for production) and rewrite the tests to drive isolated `UserDefaults(suiteName:)` instances that are torn down per test. `.standard` is never touched.

## Test plan

- [ ] `swift test --filter AutoSuspendPreferenceTests` passes (3 tests)
- [ ] `swift test --filter TerminalAutoResizeFlagTests` passes (2 tests)
- [ ] With the TBDApp running and `autoSuspendClaude` toggle OFF: run `swift test` and confirm `defaults read TBDApp autoSuspendClaude` still reads `0` (or whatever it was) after the suite completes, and no `SUSPENDING` line appears in `/tmp/tbd-suspend.log`.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=95B648D5-6B4A-4198-A136-9CBD5D3B96B7)