### PR TITLE
Feat: Rename, reorder, and remember tabs

### DIFF
--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -101,7 +101,7 @@ extension AppState {
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
             tabs[worktreeID, default: []].append(tab)
             let index = (tabs[worktreeID]?.count ?? 1) - 1
-            activeTabIndices[worktreeID] = index
+            setActiveTab(worktreeID: worktreeID, tabIndex: index)
             historyActiveWorktrees.remove(worktreeID)
         } catch {
             handleConnectionError(error)

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -132,7 +132,7 @@ extension AppState {
             terminals[worktreeID, default: []].append(newTerminal)
             let newTab = Tab(id: newTerminal.id, content: .terminal(terminalID: newTerminal.id))
             tabs[worktreeID, default: []].append(newTab)
-            activeTabIndices[worktreeID] = (tabs[worktreeID]?.count ?? 1) - 1
+            setActiveTab(worktreeID: worktreeID, tabIndex: (tabs[worktreeID]?.count ?? 1) - 1)
         } catch {
             logger.error("Failed to swap profile on terminal: \(error, privacy: .public)")
             showAlert("Failed to swap profile: \(error.localizedDescription)", isError: true)

--- a/Sources/TBDApp/AppState+Notes.swift
+++ b/Sources/TBDApp/AppState+Notes.swift
@@ -12,7 +12,7 @@ extension AppState {
         do {
             let note = try await daemonClient.createNote(worktreeID: worktreeID)
             notes[worktreeID, default: []].append(note)
-            let tab = Tab(id: note.id, content: .note(noteID: note.id), label: note.title)
+            let tab = Tab(id: note.id, content: .note(noteID: note.id), label: nil)
             tabs[worktreeID, default: []].append(tab)
         } catch {
             logger.error("Failed to create note: \(error)")
@@ -26,12 +26,6 @@ extension AppState {
             let updated = try await daemonClient.updateNote(noteID: noteID, title: title, content: content)
             if let idx = notes[worktreeID]?.firstIndex(where: { $0.id == noteID }) {
                 notes[worktreeID]?[idx] = updated
-            }
-            // Update tab label if title changed
-            if let newTitle = title {
-                if let tabIdx = tabs[worktreeID]?.firstIndex(where: { $0.id == noteID }) {
-                    tabs[worktreeID]?[tabIdx].label = newTitle
-                }
             }
         } catch {
             logger.error("Failed to update note: \(error)")

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -31,9 +31,37 @@ extension AppState {
                 tabs[worktreeID] = arr
                 applyStoredOrder(worktreeID: worktreeID)
             }
+            // Hydrate the persisted active tab. Must run AFTER applyStoredOrder
+            // so the resolved index reflects the persisted order. If the stored
+            // ID no longer exists (tab was deleted), gracefully fall through and
+            // leave activeTabIndices unchanged (defaults to 0 at the view layer).
+            if let activeID = response.activeTabID,
+               let arr = tabs[worktreeID],
+               let idx = arr.firstIndex(where: { $0.id == activeID }) {
+                activeTabIndices[worktreeID] = idx
+            }
         } catch {
             logger.error("loadTabStates failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
             handleConnectionError(error)
+        }
+    }
+
+    // MARK: - Active tab persistence
+
+    /// Update the in-memory active tab index for a worktree AND persist the
+    /// underlying tab.id to the daemon. Use this anywhere the UI changes the
+    /// active selection so the choice survives a restart.
+    func setActiveTab(worktreeID: UUID, tabIndex: Int) {
+        activeTabIndices[worktreeID] = tabIndex
+        guard let arr = tabs[worktreeID], arr.indices.contains(tabIndex) else { return }
+        let tabID = arr[tabIndex].id
+        Task {
+            do {
+                try await daemonClient.setActiveTab(worktreeID: worktreeID, tabID: tabID)
+            } catch {
+                logger.error("setActiveTab persist failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+                handleConnectionError(error)
+            }
         }
     }
 

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -1,0 +1,131 @@
+import Foundation
+import SwiftUI
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "AppState+Tabs")
+
+/// Edge of a tab where a drop should insert the dragged tab.
+enum DropEdge: Sendable, Equatable {
+    case leading, trailing
+}
+
+extension AppState {
+
+    // MARK: - Tab metadata loading
+
+    /// Pull stored label overrides and tab order from the daemon for a worktree.
+    /// Called the first time a worktree's tabs appear in memory.
+    func loadTabStates(worktreeID: UUID) async {
+        do {
+            let response = try await daemonClient.listTabs(worktreeID: worktreeID)
+            worktreeTabOrders[worktreeID] = response.order
+            // Apply stored labels to any in-memory tabs that already exist.
+            if var arr = tabs[worktreeID] {
+                let labelByID = Dictionary(uniqueKeysWithValues: response.tabs.map { ($0.id, $0.label) })
+                for i in arr.indices {
+                    if let label = labelByID[arr[i].id] {
+                        arr[i].label = label
+                    }
+                }
+                tabs[worktreeID] = arr
+                applyStoredOrder(worktreeID: worktreeID)
+            }
+        } catch {
+            logger.error("loadTabStates failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+            handleConnectionError(error)
+        }
+    }
+
+    /// Sort `tabs[worktreeID]` against `worktreeTabOrders[worktreeID]`. Unknown
+    /// tab IDs (e.g. newly-created since last save) go to the end, preserving
+    /// their current relative order.
+    func applyStoredOrder(worktreeID: UUID) {
+        guard let storedOrder = worktreeTabOrders[worktreeID], !storedOrder.isEmpty,
+              var arr = tabs[worktreeID] else { return }
+        let storedIndex = Dictionary(uniqueKeysWithValues: storedOrder.enumerated().map { ($1, $0) })
+        // Capture which tab.id is currently active so we can re-point activeTabIndices.
+        let activeID: UUID? = activeTabIndices[worktreeID].flatMap { idx in
+            arr.indices.contains(idx) ? arr[idx].id : nil
+        }
+        // Stable sort: known first (by stored position), unknown after (in input order).
+        // Use enumerated original index as a tiebreaker so unknown tabs keep their input order.
+        let withIndex = arr.enumerated().map { (origIdx: $0.offset, tab: $0.element) }
+        let sorted = withIndex.sorted { a, b in
+            switch (storedIndex[a.tab.id], storedIndex[b.tab.id]) {
+            case let (ai?, bi?): return ai < bi
+            case (_?, nil):      return true
+            case (nil, _?):      return false
+            case (nil, nil):     return a.origIdx < b.origIdx
+            }
+        }
+        arr = sorted.map(\.tab)
+        tabs[worktreeID] = arr
+        // Keep active index pointing at the same tab.id.
+        if let activeID, let newIdx = arr.firstIndex(where: { $0.id == activeID }) {
+            activeTabIndices[worktreeID] = newIdx
+        }
+    }
+
+    // MARK: - Rename
+
+    /// Rename a tab. Empty / whitespace-only string clears the override
+    /// (tab reverts to auto-derived label). Same-as-displayed is a no-op.
+    func renameTab(tabID: UUID, worktreeID: UUID, newLabel: String) async {
+        let trimmed = newLabel.trimmingCharacters(in: .whitespaces)
+        guard var arr = tabs[worktreeID],
+              let idx = arr.firstIndex(where: { $0.id == tabID }) else { return }
+        let newValue: String? = trimmed.isEmpty ? nil : trimmed
+        // No-op if value is identical to what's stored.
+        if arr[idx].label == newValue {
+            return
+        }
+        arr[idx].label = newValue
+        tabs[worktreeID] = arr
+        do {
+            try await daemonClient.setTabLabel(tabID: tabID, worktreeID: worktreeID, label: newValue)
+        } catch {
+            logger.error("renameTab persist failed for \(tabID, privacy: .public): \(error, privacy: .public)")
+            handleConnectionError(error)
+        }
+    }
+
+    // MARK: - Reorder
+
+    /// Move `draggedID` to land next to `targetID`. `edge == .leading` inserts
+    /// before the target; `.trailing` inserts after. Dropping a tab on itself
+    /// is a no-op. Active selection follows the moved tab.
+    func reorderTab(draggedID: UUID, in worktreeID: UUID,
+                    relativeTo targetID: UUID, edge: DropEdge) {
+        guard draggedID != targetID,
+              var arr = tabs[worktreeID],
+              let from = arr.firstIndex(where: { $0.id == draggedID }) else { return }
+        // Capture which tab.id is currently active so we can re-point activeTabIndices.
+        let activeID: UUID? = activeTabIndices[worktreeID].flatMap { idx in
+            arr.indices.contains(idx) ? arr[idx].id : nil
+        }
+        let item = arr.remove(at: from)
+        // Look up target's index *after* removal (it may have shifted left by 1).
+        guard let targetIdx = arr.firstIndex(where: { $0.id == targetID }) else {
+            // Target gone (rare race). Restore and bail.
+            arr.insert(item, at: from)
+            return
+        }
+        let insertAt = (edge == .trailing) ? targetIdx + 1 : targetIdx
+        arr.insert(item, at: insertAt)
+        tabs[worktreeID] = arr
+        worktreeTabOrders[worktreeID] = arr.map(\.id)
+        if let activeID, let newIdx = arr.firstIndex(where: { $0.id == activeID }) {
+            activeTabIndices[worktreeID] = newIdx
+        }
+        let snapshot = arr.map(\.id)
+        Task {
+            do {
+                try await daemonClient.setTabOrder(worktreeID: worktreeID, tabIDs: snapshot)
+            } catch {
+                logger.error("reorderTab persist failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+                handleConnectionError(error)
+            }
+        }
+    }
+}

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -99,7 +99,11 @@ extension AppState {
 
     /// Rename a tab. Empty / whitespace-only string clears the override
     /// (tab reverts to auto-derived label). Same-as-displayed is a no-op.
-    func renameTab(tabID: UUID, worktreeID: UUID, newLabel: String) async {
+    ///
+    /// Synchronous so the in-memory label mutation and SwiftUI's exit-from-edit-mode
+    /// re-render batch into a single frame — otherwise the tab briefly flashes the
+    /// pre-rename label before the update lands. Persistence is fire-and-forget.
+    func renameTab(tabID: UUID, worktreeID: UUID, newLabel: String) {
         let trimmed = newLabel.trimmingCharacters(in: .whitespaces)
         guard var arr = tabs[worktreeID],
               let idx = arr.firstIndex(where: { $0.id == tabID }) else { return }
@@ -110,11 +114,13 @@ extension AppState {
         }
         arr[idx].label = newValue
         tabs[worktreeID] = arr
-        do {
-            try await daemonClient.setTabLabel(tabID: tabID, worktreeID: worktreeID, label: newValue)
-        } catch {
-            logger.error("renameTab persist failed for \(tabID, privacy: .public): \(error, privacy: .public)")
-            handleConnectionError(error)
+        Task {
+            do {
+                try await daemonClient.setTabLabel(tabID: tabID, worktreeID: worktreeID, label: newValue)
+            } catch {
+                logger.error("renameTab persist failed for \(tabID, privacy: .public): \(error, privacy: .public)")
+                handleConnectionError(error)
+            }
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -167,6 +167,8 @@ final class AppState: ObservableObject {
     }
     @Published var tabs: [UUID: [Tab]] = [:]
     @Published var activeTabIndices: [UUID: Int] = [:]
+    @Published var worktreeTabOrders: [UUID: [UUID]] = [:]
+    @Published var draggingTabID: UUID? = nil
     @Published var repoFilter: UUID? = nil
     @Published var pendingWorktreeIDs: Set<UUID> = []
     @Published var suspendingTerminalIDs: Set<UUID> = []

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -711,6 +711,7 @@ final class AppState: ObservableObject {
     /// terminals that aren't already represented (either as a tab root or
     /// embedded in another tab's split layout).
     private func reconcileTabs(worktreeID: UUID, terminals: [Terminal]) {
+        let alreadyLoadedOrder = worktreeTabOrders[worktreeID] != nil
         var currentTabs = tabs[worktreeID] ?? []
         let terminalIDs = Set(terminals.map(\.id))
 
@@ -746,6 +747,10 @@ final class AppState: ObservableObject {
         }
 
         tabs[worktreeID] = currentTabs
+        applyStoredOrder(worktreeID: worktreeID)
+        if !alreadyLoadedOrder {
+            Task { await loadTabStates(worktreeID: worktreeID) }
+        }
     }
 
     /// Reconcile note tabs — remove tabs whose note no longer exists,
@@ -769,10 +774,11 @@ final class AppState: ObservableObject {
 
         // Add tabs for notes not already represented
         for note in notes where !noteIDsInTabs.contains(note.id) {
-            currentTabs.append(Tab(id: note.id, content: .note(noteID: note.id), label: note.title))
+            currentTabs.append(Tab(id: note.id, content: .note(noteID: note.id), label: nil))
         }
 
         tabs[worktreeID] = currentTabs
+        applyStoredOrder(worktreeID: worktreeID)
     }
 
     /// Poll all cached PR statuses from the daemon (background, every ~30s).

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -696,6 +696,33 @@ actor DaemonClient {
         )
     }
 
+    // MARK: - Tabs
+
+    /// List per-tab metadata + stored tab order for a worktree.
+    func listTabs(worktreeID: UUID) async throws -> TabListResponse {
+        return try await callAsync(
+            method: RPCMethod.tabList,
+            params: TabListParams(worktreeID: worktreeID),
+            resultType: TabListResponse.self
+        )
+    }
+
+    /// Set or clear a tab's custom label. `label = nil` clears the override.
+    func setTabLabel(tabID: UUID, worktreeID: UUID, label: String?) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.tabSetLabel,
+            params: TabSetLabelParams(tabID: tabID, worktreeID: worktreeID, label: label)
+        )
+    }
+
+    /// Set the stored tab order for a worktree.
+    func setTabOrder(worktreeID: UUID, tabIDs: [UUID]) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.tabSetOrder,
+            params: TabSetOrderParams(worktreeID: worktreeID, tabIDs: tabIDs)
+        )
+    }
+
     /// List notes, optionally filtered by worktree.
     func listNotes(worktreeID: UUID? = nil) async throws -> [Note] {
         return try await callAsync(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -723,6 +723,15 @@ actor DaemonClient {
         )
     }
 
+    /// Persist the worktree's active tab so it survives app restart.
+    /// `tabID = nil` clears the stored selection.
+    func setActiveTab(worktreeID: UUID, tabID: UUID?) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.worktreeSetActiveTab,
+            params: WorktreeSetActiveTabParams(worktreeID: worktreeID, tabID: tabID)
+        )
+    }
+
     /// List notes, optionally filtered by worktree.
     func listNotes(worktreeID: UUID? = nil) async throws -> [Note] {
         return try await callAsync(

--- a/Sources/TBDApp/Sidebar/InlineTextField.swift
+++ b/Sources/TBDApp/Sidebar/InlineTextField.swift
@@ -12,6 +12,12 @@ struct InlineTextField: NSViewRepresentable {
     var onKeyDown: ((_ key: UInt16) -> Bool)?
     /// Called when Tab or Space is pressed. Return true to consume the event.
     var onSpecialKey: ((_ key: SpecialKey) -> Bool)?
+    /// Font to apply to the NSTextField. Defaults to the system size.
+    var font: NSFont? = nil
+    /// When true, the entire text is selected on first focus (instead of
+    /// preserving the cursor at `cursorPosition`). Use for type-to-replace
+    /// rename flows; leave false for click-to-position editing.
+    var selectAllOnFocus: Bool = false
 
     enum SpecialKey {
         case tab, space
@@ -24,7 +30,7 @@ struct InlineTextField: NSViewRepresentable {
         field.isBordered = false
         field.drawsBackground = false
         field.focusRingType = .none
-        field.font = .systemFont(ofSize: NSFont.systemFontSize)
+        field.font = font ?? .systemFont(ofSize: NSFont.systemFontSize)
         field.cell?.isScrollable = true
         field.cell?.wraps = false
         field.cell?.lineBreakMode = .byClipping
@@ -56,8 +62,16 @@ struct InlineTextField: NSViewRepresentable {
                 if needsFocus {
                     nsView.window?.makeFirstResponder(nsView)
                 }
-                // Set cursor position after focus is established and text is updated
-                if needsFocus || textChanged {
+                // On first focus of this editing session, optionally select all so
+                // the user can type-to-replace. After that, fall back to cursor
+                // positioning (so re-focus after losing focus doesn't lose the cursor).
+                if needsFocus, selectAllOnFocus, !context.coordinator.didInitialSelectAll {
+                    if let editor = nsView.currentEditor() {
+                        let utf16Count = (editor.string as NSString).length
+                        editor.selectedRange = NSRange(location: 0, length: utf16Count)
+                        context.coordinator.didInitialSelectAll = true
+                    }
+                } else if needsFocus || textChanged {
                     if let editor = nsView.currentEditor() {
                         let utf16Count = (editor.string as NSString).length
                         let pos = min(cursorPosition, utf16Count)
@@ -82,6 +96,7 @@ struct InlineTextField: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: InlineTextField
         var monitor: Any?
+        var didInitialSelectAll: Bool = false
 
         init(_ parent: InlineTextField) {
             self.parent = parent

--- a/Sources/TBDApp/Sidebar/RenameableLabel.swift
+++ b/Sources/TBDApp/Sidebar/RenameableLabel.swift
@@ -16,6 +16,15 @@ struct RenameableLabel<DisplayContent: View>: View {
     var onCancel: () -> Void = {}
     var onStartEditing: () -> Void = {}
     var onStopEditing: () -> Void = {}
+    /// Font for the inline editor. Default mirrors the sidebar's 13pt system font.
+    var editorFont: NSFont? = nil
+    /// When true, the entire text is selected the first time the editor gains focus.
+    var selectAllOnEnterEditing: Bool = false
+    /// When true, committing an empty string still calls `onCommit("")`. Use this for
+    /// renames where "clear" is a meaningful action (e.g. clearing an override to fall
+    /// back to a computed default). Default false preserves the safer behavior of
+    /// treating empty-on-Enter like a cancel.
+    var allowsEmptyCommit: Bool = false
     @ViewBuilder let displayContent: () -> DisplayContent
 
     @State private var editText = ""
@@ -59,7 +68,9 @@ struct RenameableLabel<DisplayContent: View>: View {
                     guard emojiQuery != nil, let emoji = selectedEmoji() else { return false }
                     replaceColonQuery(with: emoji)
                     return true
-                }
+                },
+                font: editorFont,
+                selectAllOnFocus: selectAllOnEnterEditing
             )
             .onChange(of: editText) { _, _ in
                 updateEmojiQuery()
@@ -97,7 +108,12 @@ struct RenameableLabel<DisplayContent: View>: View {
         let trimmed = editText.trimmingCharacters(in: .whitespaces)
         isEditing = false
         onStopEditing()
-        guard !trimmed.isEmpty, trimmed != text else { return }
+        if trimmed.isEmpty {
+            // Treat empty as "clear" when the caller opted in; otherwise cancel.
+            if allowsEmptyCommit { onCommit("") }
+            return
+        }
+        guard trimmed != text else { return }
         onCommit(trimmed)
     }
 

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -1,6 +1,25 @@
 import AppKit
 import SwiftUI
 import TBDShared
+import UniformTypeIdentifiers
+
+/// Transferable payload identifying a tab during drag/drop. App-only — never crosses the wire.
+struct TabDragPayload: Codable, Transferable {
+    let tabID: UUID
+
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .tbdTabDrag)
+    }
+}
+
+extension UTType {
+    static let tbdTabDrag = UTType(exportedAs: "com.tbd.app.tab-drag")
+}
+
+private struct TabWidthPreference: PreferenceKey {
+    static let defaultValue: CGFloat = 100
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
 
 // MARK: - TabBar
 
@@ -8,6 +27,7 @@ import TBDShared
 /// Replaces the former TerminalTabBar.
 struct TabBar: View {
     let tabs: [Tab]
+    let worktreeID: UUID
     @Binding var activeTabIndex: Int
     var onAddShell: () -> Void = {}
     var onAddClaude: () -> Void = {}
@@ -34,6 +54,7 @@ struct TabBar: View {
                 TabBarItem(
                     tab: tab,
                     index: index,
+                    worktreeID: worktreeID,
                     isSelected: index == activeTabIndex,
                     terminal: terminalForTab(tab.id),
                     onSelect: { activeTabIndex = index },
@@ -170,6 +191,7 @@ private class MenuCoordinator: NSObject {
 private struct TabBarItem: View {
     let tab: Tab
     let index: Int
+    let worktreeID: UUID
     let isSelected: Bool
     let terminal: Terminal?
     let onSelect: () -> Void
@@ -180,6 +202,9 @@ private struct TabBarItem: View {
 
     @State private var isHovering = false
     @State private var isHoveringClose = false
+    @State private var isEditing: Bool = false
+    @State private var dropEdge: DropEdge? = nil
+    @State private var measuredWidth: CGFloat = 100
     @AppStorage("codeViewer.showSidebar") private var showSidebar = false
     @EnvironmentObject private var appState: AppState
 
@@ -190,6 +215,11 @@ private struct TabBarItem: View {
     private var isCodeViewer: Bool {
         if case .codeViewer = tab.content { return true }
         return false
+    }
+
+    private var isRenameable: Bool {
+        if case .codeViewer = tab.content { return false }
+        return true
     }
 
     private var isClaudeTerminal: Bool {
@@ -228,11 +258,36 @@ private struct TabBarItem: View {
                         .frame(width: 14)
                         .padding(.trailing, 3)
 
-                    Text(tabLabel)
+                    if isEditing {
+                        RenameableLabel(
+                            text: tabLabel,
+                            isEditing: $isEditing,
+                            onCommit: { newText in
+                                Task {
+                                    await appState.renameTab(
+                                        tabID: tab.id,
+                                        worktreeID: worktreeID,
+                                        newLabel: newText
+                                    )
+                                }
+                            },
+                            displayContent: {
+                                Text(tabLabel)
+                                    .font(.system(size: 11))
+                                    .lineLimit(1)
+                                    .fixedSize()
+                                    .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))
+                            }
+                        )
                         .font(.system(size: 11))
-                        .lineLimit(1)
-                        .fixedSize()
-                        .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))
+                        .frame(minWidth: 40)
+                    } else {
+                        Text(tabLabel)
+                            .font(.system(size: 11))
+                            .lineLimit(1)
+                            .fixedSize()
+                            .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))
+                    }
                 }
             }
             .buttonStyle(.plain)
@@ -264,10 +319,63 @@ private struct TabBarItem: View {
                 ? Color(nsColor: .controlBackgroundColor)
                 : (isHovering ? Color.primary.opacity(0.04) : Color.clear)
         )
+        .background(
+            GeometryReader { geo in
+                Color.clear.preference(key: TabWidthPreference.self, value: geo.size.width)
+            }
+        )
+        .onPreferenceChange(TabWidthPreference.self) { measuredWidth = $0 }
         .animation(.easeInOut(duration: 0.1), value: isHovering)
         .contextMenu { contextMenuContent }
         .onHover { hovering in
             isHovering = hovering
+        }
+        .simultaneousGesture(
+            TapGesture(count: 2).onEnded {
+                guard isRenameable else { return }
+                if !isSelected { onSelect() }
+                isEditing = true
+            }
+        )
+        .opacity(appState.draggingTabID == tab.id ? 0.4 : 1)
+        .overlay(alignment: dropEdge == .leading ? .leading : .trailing) {
+            if dropEdge != nil {
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(Color.accentColor)
+                    .frame(width: 2)
+                    .padding(.vertical, 2)
+                    .transition(.opacity)
+            }
+        }
+        .draggable(TabDragPayload(tabID: tab.id)) {
+            // Drag preview: a translucent copy of the tab content.
+            HStack(spacing: 0) {
+                tabIconView.frame(width: 14).padding(.trailing, 3)
+                Text(tabLabel).font(.system(size: 11)).lineLimit(1).fixedSize()
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .cornerRadius(4)
+            .opacity(0.85)
+            .onAppear { appState.draggingTabID = tab.id }
+        }
+        .dropDestination(for: TabDragPayload.self) { payloads, location in
+            defer { dropEdge = nil; appState.draggingTabID = nil }
+            guard let payload = payloads.first,
+                  payload.tabID != tab.id else { return false }
+            let edge: DropEdge = (location.x < measuredWidth / 2) ? .leading : .trailing
+            appState.reorderTab(
+                draggedID: payload.tabID,
+                in: worktreeID,
+                relativeTo: tab.id,
+                edge: edge
+            )
+            return true
+        } isTargeted: { targeted in
+            if !targeted {
+                dropEdge = nil
+            }
         }
     }
 
@@ -355,6 +463,14 @@ private struct TabBarItem: View {
             Divider()
         }
 
+        if isRenameable {
+            Button("Rename Tab") {
+                if !isSelected { onSelect() }
+                isEditing = true
+            }
+            Divider()
+        }
+
         Button(action: onClose) {
             Label("Close Tab", systemImage: "xmark")
         }
@@ -436,7 +552,11 @@ private struct TabBarItem: View {
             return url.host ?? "Web"
         case .codeViewer(_, let path):
             return URL(fileURLWithPath: path).lastPathComponent
-        case .note:
+        case .note(let noteID):
+            let allNotes = appState.notes.values.flatMap { $0 }
+            if let title = allNotes.first(where: { $0.id == noteID })?.title, !title.isEmpty {
+                return title
+            }
             return "Note \(index + 1)"
         case .liveTranscript:
             return "Transcript"

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -21,6 +21,62 @@ private struct TabWidthPreference: PreferenceKey {
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
 }
 
+/// DropDelegate so we can read `info.location` during hover via `dropUpdated`,
+/// which is the only API path that gives us cursor position before drop time.
+/// Drives the leading/trailing insertion indicator on the targeted tab.
+private struct TabDropDelegate: DropDelegate {
+    let targetTabID: UUID
+    let worktreeID: UUID
+    let measuredWidth: CGFloat
+    @Binding var dropEdge: DropEdge?
+    let appState: AppState
+
+    private func edge(for location: CGPoint) -> DropEdge {
+        location.x < measuredWidth / 2 ? .leading : .trailing
+    }
+
+    func dropEntered(info: DropInfo) {
+        dropEdge = edge(for: info.location)
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        dropEdge = edge(for: info.location)
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) {
+        dropEdge = nil
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let dropEdgeValue = edge(for: info.location)
+        let providers = info.itemProviders(for: [UTType.tbdTabDrag])
+        guard let provider = providers.first else {
+            dropEdge = nil
+            appState.draggingTabID = nil
+            return false
+        }
+        provider.loadDataRepresentation(forTypeIdentifier: UTType.tbdTabDrag.identifier) { data, _ in
+            Task { @MainActor in
+                defer {
+                    dropEdge = nil
+                    appState.draggingTabID = nil
+                }
+                guard let data,
+                      let payload = try? JSONDecoder().decode(TabDragPayload.self, from: data),
+                      payload.tabID != targetTabID else { return }
+                appState.reorderTab(
+                    draggedID: payload.tabID,
+                    in: worktreeID,
+                    relativeTo: targetTabID,
+                    edge: dropEdgeValue
+                )
+            }
+        }
+        return true
+    }
+}
+
 // MARK: - TabBar
 
 /// Generic tab bar that renders Tab items with type-appropriate icons and labels.
@@ -28,6 +84,7 @@ private struct TabWidthPreference: PreferenceKey {
 struct TabBar: View {
     let tabs: [Tab]
     let worktreeID: UUID
+    @EnvironmentObject private var appState: AppState
     @Binding var activeTabIndex: Int
     var onAddShell: () -> Void = {}
     var onAddClaude: () -> Void = {}
@@ -86,6 +143,14 @@ struct TabBar: View {
         .padding(.horizontal, 0)
         .frame(height: 30)
         .background(Color(nsColor: .windowBackgroundColor))
+        // Catch-all so dropping a tab on the +/history button or empty
+        // strip space still clears `draggingTabID`. Returns false (no
+        // reorder), but ends the visual "dragging" state. Per-tab drop
+        // delegates above handle real reorders.
+        .onDrop(of: [UTType.tbdTabDrag], isTargeted: nil) { _ in
+            appState.draggingTabID = nil
+            return false
+        }
     }
 }
 
@@ -348,6 +413,7 @@ private struct TabBarItem: View {
                     .transition(.opacity)
             }
         }
+        .animation(.easeInOut(duration: 0.1), value: dropEdge)
         .draggable(TabDragPayload(tabID: tab.id)) {
             // Drag preview: a translucent copy of the tab content.
             HStack(spacing: 0) {
@@ -361,23 +427,19 @@ private struct TabBarItem: View {
             .opacity(0.85)
             .onAppear { appState.draggingTabID = tab.id }
         }
-        .dropDestination(for: TabDragPayload.self) { payloads, location in
-            defer { dropEdge = nil; appState.draggingTabID = nil }
-            guard let payload = payloads.first,
-                  payload.tabID != tab.id else { return false }
-            let edge: DropEdge = (location.x < measuredWidth / 2) ? .leading : .trailing
-            appState.reorderTab(
-                draggedID: payload.tabID,
-                in: worktreeID,
-                relativeTo: tab.id,
-                edge: edge
+        // Use onDrop+DropDelegate (instead of .dropDestination) so we get
+        // info.location during hover via dropUpdated, which is required to
+        // render the leading/trailing insertion indicator before drop time.
+        .onDrop(
+            of: [UTType.tbdTabDrag],
+            delegate: TabDropDelegate(
+                targetTabID: tab.id,
+                worktreeID: worktreeID,
+                measuredWidth: measuredWidth,
+                dropEdge: $dropEdge,
+                appState: appState
             )
-            return true
-        } isTargeted: { targeted in
-            if !targeted {
-                dropEdge = nil
-            }
-        }
+        )
     }
 
     private func formatProfileHeader(_ profileID: UUID?) -> String {

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -426,6 +426,10 @@ private struct TabBarItem: View {
             .cornerRadius(4)
             .opacity(0.85)
             .onAppear { appState.draggingTabID = tab.id }
+            // Drag preview is dismissed on any drag end — drop, drop-outside-window,
+            // Escape, drop on a non-target. Covers cancel paths that neither the
+            // per-tab delegate nor the outer catch-all see.
+            .onDisappear { appState.draggingTabID = nil }
         }
         // Use onDrop+DropDelegate (instead of .dropDestination) so we get
         // info.location during hover via dropUpdated, which is required to

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -263,14 +263,15 @@ private struct TabBarItem: View {
                             text: tabLabel,
                             isEditing: $isEditing,
                             onCommit: { newText in
-                                Task {
-                                    await appState.renameTab(
-                                        tabID: tab.id,
-                                        worktreeID: worktreeID,
-                                        newLabel: newText
-                                    )
-                                }
+                                appState.renameTab(
+                                    tabID: tab.id,
+                                    worktreeID: worktreeID,
+                                    newLabel: newText
+                                )
                             },
+                            editorFont: .systemFont(ofSize: 11),
+                            selectAllOnEnterEditing: true,
+                            allowsEmptyCommit: true,
                             displayContent: {
                                 Text(tabLabel)
                                     .font(.system(size: 11))
@@ -280,7 +281,7 @@ private struct TabBarItem: View {
                             }
                         )
                         .font(.system(size: 11))
-                        .frame(minWidth: 40)
+                        .frame(width: max(60, measuredWidth - 50))
                     } else {
                         Text(tabLabel)
                             .font(.system(size: 11))

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -107,7 +107,7 @@ struct SingleWorktreeView: View {
     private var activeTabIndex: Int {
         get { appState.activeTabIndices[worktreeID] ?? 0 }
         nonmutating set {
-            appState.activeTabIndices[worktreeID] = newValue
+            appState.setActiveTab(worktreeID: worktreeID, tabIndex: newValue)
             appState.historyActiveWorktrees.remove(worktreeID)
         }
     }

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -140,6 +140,7 @@ struct SingleWorktreeView: View {
                 if !worktreeTabs.isEmpty {
                     TabBar(
                         tabs: worktreeTabs,
+                        worktreeID: worktreeID,
                         activeTabIndex: Binding(
                             get: { activeTabIndex },
                             set: { activeTabIndex = $0 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -354,6 +354,18 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v19_tabs_and_order") { db in
+            try db.create(table: "tab") { t in
+                t.column("id", .text).primaryKey()
+                t.column("worktreeID", .text).notNull()
+                t.column("label", .text)         // nullable = use auto-derived
+                t.column("createdAt", .datetime).notNull()
+            }
+            try db.alter(table: "worktree") { t in
+                t.add(column: "tabOrder", .text).notNull().defaults(to: "[]")
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -19,6 +19,7 @@ public final class TBDDatabase: Sendable {
     public let modelProfileUsage: ModelProfileUsageStore
     public let config: ConfigStore
     public let meta: TBDMetaStore
+    public let tabs: TabStore
 
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
     public init(path: String) throws {
@@ -40,6 +41,7 @@ public final class TBDDatabase: Sendable {
         self.modelProfileUsage = ModelProfileUsageStore(writer: pool)
         self.config = ConfigStore(writer: pool)
         self.meta = TBDMetaStore(writer: pool)
+        self.tabs = TabStore(writer: pool)
         try Self.migrate(writer: pool)
     }
 
@@ -58,6 +60,7 @@ public final class TBDDatabase: Sendable {
         self.modelProfileUsage = ModelProfileUsageStore(writer: queue)
         self.config = ConfigStore(writer: queue)
         self.meta = TBDMetaStore(writer: queue)
+        self.tabs = TabStore(writer: queue)
         try Self.migrate(writer: queue)
     }
 

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -369,6 +369,12 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v20_worktree_active_tab") { db in
+            try db.alter(table: "worktree") { t in
+                t.add(column: "activeTabID", .text)  // nullable
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/TabStore.swift
+++ b/Sources/TBDDaemon/Database/TabStore.swift
@@ -30,6 +30,13 @@ struct TabRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
 
 /// CRUD for tab metadata. Rows are sparse — only present when a tab has
 /// user-set metadata (currently just a custom label).
+///
+/// NOTE: The `tab` table has no FK to `worktree`, so worktree-level
+/// cleanups are explicit — see `deleteForWorktree(...)` and the call
+/// sites in `WorktreeLifecycle+Archive.swift`, `WorktreeLifecycle+Reconcile.swift`,
+/// and the per-row deletes in `handleTerminalDelete` / `handleNoteDelete`.
+/// When adding a new code path that removes worktrees or their underlying
+/// terminals/notes, mirror those deletes here too.
 public struct TabStore: Sendable {
     let writer: any DatabaseWriter
 
@@ -51,7 +58,6 @@ public struct TabStore: Sendable {
                 // would otherwise reset it. Use upsert semantics manually.
                 if var existing = try TabRecord.fetchOne(db, key: tabID.uuidString) {
                     existing.label = label
-                    existing.worktreeID = worktreeID.uuidString
                     try existing.update(db)
                 } else {
                     try record.insert(db)

--- a/Sources/TBDDaemon/Database/TabStore.swift
+++ b/Sources/TBDDaemon/Database/TabStore.swift
@@ -1,0 +1,90 @@
+import Foundation
+import GRDB
+import TBDShared
+
+/// GRDB Record type for the `tab` table.
+struct TabRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "tab"
+
+    var id: String
+    var worktreeID: String
+    var label: String?
+    var createdAt: Date
+
+    init(from state: TabState) {
+        self.id = state.id.uuidString
+        self.worktreeID = state.worktreeID.uuidString
+        self.label = state.label
+        self.createdAt = state.createdAt
+    }
+
+    func toModel() -> TabState {
+        TabState(
+            id: UUID(uuidString: id)!,
+            worktreeID: UUID(uuidString: worktreeID)!,
+            label: label,
+            createdAt: createdAt
+        )
+    }
+}
+
+/// CRUD for tab metadata. Rows are sparse — only present when a tab has
+/// user-set metadata (currently just a custom label).
+public struct TabStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Insert or update the label for a tab. Passing `nil` deletes the row.
+    public func setLabel(tabID: UUID, worktreeID: UUID, label: String?) async throws {
+        _ = try await writer.write { db in
+            if let label {
+                let record = TabRecord(from: TabState(
+                    id: tabID,
+                    worktreeID: worktreeID,
+                    label: label,
+                    createdAt: Date()
+                ))
+                // Preserve original createdAt if a row exists; INSERT OR REPLACE
+                // would otherwise reset it. Use upsert semantics manually.
+                if var existing = try TabRecord.fetchOne(db, key: tabID.uuidString) {
+                    existing.label = label
+                    existing.worktreeID = worktreeID.uuidString
+                    try existing.update(db)
+                } else {
+                    try record.insert(db)
+                }
+            } else {
+                try TabRecord.deleteOne(db, key: tabID.uuidString)
+            }
+        }
+    }
+
+    /// List all tab states for a worktree (only those with overrides).
+    public func listForWorktree(worktreeID: UUID) async throws -> [TabState] {
+        try await writer.read { db in
+            try TabRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .fetchAll(db)
+                .map { $0.toModel() }
+        }
+    }
+
+    /// Delete a tab row by ID (used as cleanup when a terminal/note is deleted).
+    public func delete(tabID: UUID) async throws {
+        _ = try await writer.write { db in
+            try TabRecord.deleteOne(db, key: tabID.uuidString)
+        }
+    }
+
+    /// Delete all tab rows for a worktree (used when a worktree is removed).
+    public func deleteForWorktree(worktreeID: UUID) async throws {
+        _ = try await writer.write { db in
+            try TabRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .deleteAll(db)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -21,6 +21,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var sortOrder: Int
     var archivedHeadSHA: String?
     var tabOrder: String  // JSON array of UUID strings, e.g. "[]" or "[\"...\",\"...\"]"
+    var activeTabID: String?
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -41,6 +42,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
                 data: JSONEncoder().encode(sessions), encoding: .utf8)
         }
         self.tabOrder = "[]"  // overwritten by GRDB when fetched; only "new worktree" path uses this initializer
+        self.activeTabID = nil  // new worktrees start with no stored selection
     }
 
     func toModel() -> Worktree {
@@ -363,6 +365,28 @@ public struct WorktreeStore: Sendable {
             try db.execute(
                 sql: "UPDATE worktree SET tabOrder = ? WHERE id = ?",
                 arguments: [json, worktreeID.uuidString]
+            )
+        }
+    }
+
+    /// Read the `activeTabID` column for a worktree. Returns nil for missing
+    /// worktrees, NULL columns, or strings that don't decode as a UUID.
+    public func getActiveTabID(worktreeID: UUID) async throws -> UUID? {
+        try await writer.read { db in
+            guard let record = try WorktreeRecord.fetchOne(db, key: worktreeID.uuidString),
+                  let raw = record.activeTabID else {
+                return nil
+            }
+            return UUID(uuidString: raw)
+        }
+    }
+
+    /// Set or clear (`nil`) the persisted active tab UUID for a worktree.
+    public func setActiveTabID(worktreeID: UUID, tabID: UUID?) async throws {
+        _ = try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE worktree SET activeTabID = ? WHERE id = ?",
+                arguments: [tabID?.uuidString, worktreeID.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -20,6 +20,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var archivedClaudeSessions: String?
     var sortOrder: Int
     var archivedHeadSHA: String?
+    var tabOrder: String  // JSON array of UUID strings, e.g. "[]" or "[\"...\",\"...\"]"
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -39,6 +40,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             self.archivedClaudeSessions = try? String(
                 data: JSONEncoder().encode(sessions), encoding: .utf8)
         }
+        self.tabOrder = "[]"  // overwritten by GRDB when fetched; only "new worktree" path uses this initializer
     }
 
     func toModel() -> Worktree {
@@ -341,5 +343,40 @@ public struct WorktreeStore: Sendable {
                 .filter(Column("repoID") == repoID.uuidString)
                 .deleteAll(db)
         }
+    }
+
+    /// Read the `tabOrder` JSON column for a worktree, decoded into UUIDs.
+    /// Returns an empty array if the worktree has no stored order yet.
+    public func getTabOrder(worktreeID: UUID) async throws -> [UUID] {
+        try await writer.read { db in
+            guard let record = try WorktreeRecord.fetchOne(db, key: worktreeID.uuidString) else {
+                return []
+            }
+            return Self.decodeTabOrder(record.tabOrder)
+        }
+    }
+
+    /// Replace the `tabOrder` JSON column for a worktree.
+    public func setTabOrder(worktreeID: UUID, tabIDs: [UUID]) async throws {
+        let json = Self.encodeTabOrder(tabIDs)
+        _ = try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE worktree SET tabOrder = ? WHERE id = ?",
+                arguments: [json, worktreeID.uuidString]
+            )
+        }
+    }
+
+    private static func decodeTabOrder(_ json: String) -> [UUID] {
+        guard let data = json.data(using: .utf8) else { return [] }
+        guard let strings = try? JSONDecoder().decode([String].self, from: data) else { return [] }
+        return strings.compactMap(UUID.init(uuidString:))
+    }
+
+    private static func encodeTabOrder(_ ids: [UUID]) -> String {
+        let strings = ids.map(\.uuidString)
+        guard let data = try? JSONEncoder().encode(strings),
+              let s = String(data: data, encoding: .utf8) else { return "[]" }
+        return s
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -93,6 +93,7 @@ extension WorktreeLifecycle {
 
         // Delete terminals from db
         try await db.terminals.deleteForWorktree(worktreeID: worktreeID)
+        try await db.tabs.deleteForWorktree(worktreeID: worktreeID)
         for terminal in terminals {
             await pendingQuestions.clear(terminalID: terminal.id)
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -112,6 +112,7 @@ extension WorktreeLifecycle {
                 }
             }
             try await db.terminals.deleteForWorktree(worktreeID: wt.id)
+            try await db.tabs.deleteForWorktree(worktreeID: wt.id)
             for terminal in terminals {
                 await pendingQuestions.clear(terminalID: terminal.id)
             }

--- a/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
@@ -44,6 +44,7 @@ extension RPCRouter {
     func handleNoteDelete(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(NoteDeleteParams.self, from: paramsData)
         try await db.notes.delete(id: params.noteID)
+        try await db.tabs.delete(tabID: params.noteID)
         return .ok()
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TabHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TabHandlers.swift
@@ -1,0 +1,37 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+
+    // MARK: - Tab Handlers
+
+    func handleTabSetLabel(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TabSetLabelParams.self, from: paramsData)
+        try await db.tabs.setLabel(
+            tabID: params.tabID,
+            worktreeID: params.worktreeID,
+            label: params.label
+        )
+        return .ok()
+    }
+
+    func handleTabSetOrder(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TabSetOrderParams.self, from: paramsData)
+        // Reject duplicates — order arrays must be a set in disguise.
+        if Set(params.tabIDs).count != params.tabIDs.count {
+            return RPCResponse(error: "tab.setOrder: duplicate tab IDs not allowed")
+        }
+        try await db.worktrees.setTabOrder(
+            worktreeID: params.worktreeID,
+            tabIDs: params.tabIDs
+        )
+        return .ok()
+    }
+
+    func handleTabList(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TabListParams.self, from: paramsData)
+        let tabs = try await db.tabs.listForWorktree(worktreeID: params.worktreeID)
+        let order = try await db.worktrees.getTabOrder(worktreeID: params.worktreeID)
+        return try RPCResponse(result: TabListResponse(tabs: tabs, order: order))
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TabHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TabHandlers.swift
@@ -32,6 +32,13 @@ extension RPCRouter {
         let params = try decoder.decode(TabListParams.self, from: paramsData)
         let tabs = try await db.tabs.listForWorktree(worktreeID: params.worktreeID)
         let order = try await db.worktrees.getTabOrder(worktreeID: params.worktreeID)
-        return try RPCResponse(result: TabListResponse(tabs: tabs, order: order))
+        let activeTabID = try await db.worktrees.getActiveTabID(worktreeID: params.worktreeID)
+        return try RPCResponse(result: TabListResponse(tabs: tabs, order: order, activeTabID: activeTabID))
+    }
+
+    func handleWorktreeSetActiveTab(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeSetActiveTabParams.self, from: paramsData)
+        try await db.worktrees.setActiveTabID(worktreeID: params.worktreeID, tabID: params.tabID)
+        return .ok()
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -258,6 +258,7 @@ extension RPCRouter {
 
         // Delete from DB
         try await db.terminals.delete(id: params.terminalID)
+        try await db.tabs.delete(tabID: params.terminalID)
         await pendingQuestions.clear(terminalID: params.terminalID)
 
         subscriptions.broadcast(delta: .terminalRemoved(TerminalIDDelta(

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -221,6 +221,8 @@ public final class RPCRouter: Sendable {
                 return try await handleTabSetOrder(request.paramsData)
             case RPCMethod.tabList:
                 return try await handleTabList(request.paramsData)
+            case RPCMethod.worktreeSetActiveTab:
+                return try await handleWorktreeSetActiveTab(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -215,6 +215,12 @@ public final class RPCRouter: Sendable {
                 return try await handleDaemonLegacyHooksStatus()
             case RPCMethod.daemonRemoveLegacyGlobalHooks:
                 return try await handleDaemonRemoveLegacyGlobalHooks()
+            case RPCMethod.tabSetLabel:
+                return try await handleTabSetLabel(request.paramsData)
+            case RPCMethod.tabSetOrder:
+                return try await handleTabSetOrder(request.paramsData)
+            case RPCMethod.tabList:
+                return try await handleTabList(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -535,3 +535,21 @@ public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable 
         }
     }
 }
+
+// MARK: - Tab Metadata
+
+/// Per-tab metadata persisted in the daemon DB. A row exists only when
+/// a tab has user-set metadata; absence means "use auto-derived defaults".
+public struct TabState: Codable, Sendable, Equatable, Identifiable {
+    public let id: UUID
+    public var worktreeID: UUID
+    public var label: String?
+    public var createdAt: Date
+
+    public init(id: UUID, worktreeID: UUID, label: String? = nil, createdAt: Date = Date()) {
+        self.id = id
+        self.worktreeID = worktreeID
+        self.label = label
+        self.createdAt = createdAt
+    }
+}

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -148,6 +148,7 @@ public enum RPCMethod {
     public static let tabSetLabel = "tab.setLabel"
     public static let tabSetOrder = "tab.setOrder"
     public static let tabList     = "tab.list"
+    public static let worktreeSetActiveTab = "worktree.setActiveTab"
 }
 
 // MARK: - Legacy Hook Detection / Removal
@@ -859,8 +860,19 @@ public struct TabListParams: Codable, Sendable {
 public struct TabListResponse: Codable, Sendable {
     public let tabs: [TabState]   // only tabs with overrides
     public let order: [UUID]      // contents of worktree.tab_order; [] if never reordered
-    public init(tabs: [TabState], order: [UUID]) {
+    public let activeTabID: UUID?  // persisted active tab UUID, nil if never set
+    public init(tabs: [TabState], order: [UUID], activeTabID: UUID? = nil) {
         self.tabs = tabs
         self.order = order
+        self.activeTabID = activeTabID
+    }
+}
+
+public struct WorktreeSetActiveTabParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let tabID: UUID?  // nil clears the stored selection
+    public init(worktreeID: UUID, tabID: UUID?) {
+        self.worktreeID = worktreeID
+        self.tabID = tabID
     }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -145,6 +145,9 @@ public enum RPCMethod {
     public static let setMainAreaSize = "app.setMainAreaSize"
     public static let daemonLegacyHooksStatus = "daemon.legacyHooksStatus"
     public static let daemonRemoveLegacyGlobalHooks = "daemon.removeLegacyGlobalHooks"
+    public static let tabSetLabel = "tab.setLabel"
+    public static let tabSetOrder = "tab.setOrder"
+    public static let tabList     = "tab.list"
 }
 
 // MARK: - Legacy Hook Detection / Removal
@@ -823,5 +826,41 @@ public struct TerminalAskUserQuestionClearedParams: Codable, Sendable {
     public init(terminalID: UUID, toolUseID: String) {
         self.terminalID = terminalID
         self.toolUseID = toolUseID
+    }
+}
+
+// MARK: - Tab Params
+
+public struct TabSetLabelParams: Codable, Sendable {
+    public let tabID: UUID
+    public let worktreeID: UUID
+    public let label: String?  // nil = clear override (delete row)
+    public init(tabID: UUID, worktreeID: UUID, label: String?) {
+        self.tabID = tabID
+        self.worktreeID = worktreeID
+        self.label = label
+    }
+}
+
+public struct TabSetOrderParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let tabIDs: [UUID]
+    public init(worktreeID: UUID, tabIDs: [UUID]) {
+        self.worktreeID = worktreeID
+        self.tabIDs = tabIDs
+    }
+}
+
+public struct TabListParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public init(worktreeID: UUID) { self.worktreeID = worktreeID }
+}
+
+public struct TabListResponse: Codable, Sendable {
+    public let tabs: [TabState]   // only tabs with overrides
+    public let order: [UUID]      // contents of worktree.tab_order; [] if never reordered
+    public init(tabs: [TabState], order: [UUID]) {
+        self.tabs = tabs
+        self.order = order
     }
 }

--- a/Tests/TBDAppTests/TabReorderTests.swift
+++ b/Tests/TBDAppTests/TabReorderTests.swift
@@ -1,0 +1,121 @@
+import Testing
+import Foundation
+@testable import TBDApp
+import TBDShared
+
+// DaemonClient is a concrete actor (no protocol), so we can't inject a stub.
+// These tests verify pure-Swift state mutations on AppState — the persistence
+// path (setTabLabel / setTabOrder) is covered by daemon-side tests in
+// `Tests/TBDDaemonTests/TabRPCHandlersTests.swift`.
+
+@MainActor
+@Test func reorderMovesTabAndPreservesActiveSelection() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let ids = [UUID(), UUID(), UUID()]
+    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    state.activeTabIndices[worktreeID] = 0  // first tab active
+    // Move first tab to after the third (.trailing of last)
+    state.reorderTab(
+        draggedID: ids[0],
+        in: worktreeID,
+        relativeTo: ids[2],
+        edge: .trailing
+    )
+    let newOrder = state.tabs[worktreeID]!.map(\.id)
+    #expect(newOrder == [ids[1], ids[2], ids[0]])
+    // Active index should now point at the same tab.id (was ids[0], still ids[0])
+    let activeIdx = state.activeTabIndices[worktreeID]!
+    #expect(state.tabs[worktreeID]![activeIdx].id == ids[0])
+    // worktreeTabOrders should reflect the new order
+    #expect(state.worktreeTabOrders[worktreeID] == [ids[1], ids[2], ids[0]])
+}
+
+@MainActor
+@Test func reorderDropOnSelfIsNoOp() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let ids = [UUID(), UUID()]
+    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    state.reorderTab(draggedID: ids[0], in: worktreeID, relativeTo: ids[0], edge: .leading)
+    #expect(state.tabs[worktreeID]!.map(\.id) == ids)
+}
+
+@MainActor
+@Test func reorderLeadingEdgeInsertsBeforeTarget() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let ids = [UUID(), UUID(), UUID()]
+    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    // Move third tab to before the first (.leading of first)
+    state.reorderTab(
+        draggedID: ids[2],
+        in: worktreeID,
+        relativeTo: ids[0],
+        edge: .leading
+    )
+    let newOrder = state.tabs[worktreeID]!.map(\.id)
+    #expect(newOrder == [ids[2], ids[0], ids[1]])
+}
+
+@MainActor
+@Test func renameTabWithEmptyStringClearsLabel() async {
+    let state = AppState()
+    let worktreeID = UUID()
+    let tabID = UUID()
+    state.tabs[worktreeID] = [Tab(id: tabID, content: .terminal(terminalID: tabID), label: "old")]
+    // Daemon RPC will fail (no daemon running in tests) but the synchronous
+    // in-memory mutation still happens first.
+    await state.renameTab(tabID: tabID, worktreeID: worktreeID, newLabel: "   ")
+    #expect(state.tabs[worktreeID]!.first?.label == nil)
+}
+
+@MainActor
+@Test func renameTabTrimsAndUpdatesInMemory() async {
+    let state = AppState()
+    let worktreeID = UUID()
+    let tabID = UUID()
+    state.tabs[worktreeID] = [Tab(id: tabID, content: .terminal(terminalID: tabID), label: nil)]
+    await state.renameTab(tabID: tabID, worktreeID: worktreeID, newLabel: "  Hello  ")
+    #expect(state.tabs[worktreeID]!.first?.label == "Hello")
+}
+
+@MainActor
+@Test func applyStoredOrderReordersTabsToMatchStoredOrder() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let ids = [UUID(), UUID(), UUID()]
+    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    // Stored order is reversed.
+    state.worktreeTabOrders[worktreeID] = [ids[2], ids[1], ids[0]]
+    state.applyStoredOrder(worktreeID: worktreeID)
+    #expect(state.tabs[worktreeID]!.map(\.id) == [ids[2], ids[1], ids[0]])
+}
+
+@MainActor
+@Test func applyStoredOrderPlacesUnknownIDsAtEnd() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let known = [UUID(), UUID()]
+    let newTab = UUID()
+    // Tabs include a new tab (newTab) that wasn't in the stored order.
+    state.tabs[worktreeID] = [known[0], newTab, known[1]].map {
+        Tab(id: $0, content: .terminal(terminalID: $0), label: nil)
+    }
+    state.worktreeTabOrders[worktreeID] = [known[1], known[0]]
+    state.applyStoredOrder(worktreeID: worktreeID)
+    let result = state.tabs[worktreeID]!.map(\.id)
+    // Known tabs come first in stored order; unknown tab goes to the end.
+    #expect(result == [known[1], known[0], newTab])
+}
+
+@MainActor
+@Test func applyStoredOrderIsNoOpWhenStoredOrderEmpty() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let ids = [UUID(), UUID(), UUID()]
+    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    // No worktreeTabOrders entry — applyStoredOrder should not mutate.
+    state.applyStoredOrder(worktreeID: worktreeID)
+    #expect(state.tabs[worktreeID]!.map(\.id) == ids)
+}

--- a/Tests/TBDAppTests/TabReorderTests.swift
+++ b/Tests/TBDAppTests/TabReorderTests.swift
@@ -119,3 +119,27 @@ import TBDShared
     state.applyStoredOrder(worktreeID: worktreeID)
     #expect(state.tabs[worktreeID]!.map(\.id) == ids)
 }
+
+@MainActor
+@Test func setActiveTabUpdatesInMemoryIndex() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let ids = [UUID(), UUID(), UUID()]
+    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    // The daemon RPC will fail (no daemon running) but the synchronous
+    // in-memory mutation still happens first.
+    state.setActiveTab(worktreeID: worktreeID, tabIndex: 2)
+    #expect(state.activeTabIndices[worktreeID] == 2)
+}
+
+@MainActor
+@Test func setActiveTabIgnoresOutOfBoundsIndexForPersistButStillStoresIndex() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let ids = [UUID(), UUID()]
+    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    // Out-of-bounds index — helper still updates the dictionary so the view
+    // layer can recover; the persist path bails before constructing a tab ID.
+    state.setActiveTab(worktreeID: worktreeID, tabIndex: 99)
+    #expect(state.activeTabIndices[worktreeID] == 99)
+}

--- a/Tests/TBDAppTests/TabReorderTests.swift
+++ b/Tests/TBDAppTests/TabReorderTests.swift
@@ -59,24 +59,24 @@ import TBDShared
 }
 
 @MainActor
-@Test func renameTabWithEmptyStringClearsLabel() async {
+@Test func renameTabWithEmptyStringClearsLabel() {
     let state = AppState()
     let worktreeID = UUID()
     let tabID = UUID()
     state.tabs[worktreeID] = [Tab(id: tabID, content: .terminal(terminalID: tabID), label: "old")]
     // Daemon RPC will fail (no daemon running in tests) but the synchronous
     // in-memory mutation still happens first.
-    await state.renameTab(tabID: tabID, worktreeID: worktreeID, newLabel: "   ")
+    state.renameTab(tabID: tabID, worktreeID: worktreeID, newLabel: "   ")
     #expect(state.tabs[worktreeID]!.first?.label == nil)
 }
 
 @MainActor
-@Test func renameTabTrimsAndUpdatesInMemory() async {
+@Test func renameTabTrimsAndUpdatesInMemory() {
     let state = AppState()
     let worktreeID = UUID()
     let tabID = UUID()
     state.tabs[worktreeID] = [Tab(id: tabID, content: .terminal(terminalID: tabID), label: nil)]
-    await state.renameTab(tabID: tabID, worktreeID: worktreeID, newLabel: "  Hello  ")
+    state.renameTab(tabID: tabID, worktreeID: worktreeID, newLabel: "  Hello  ")
     #expect(state.tabs[worktreeID]!.first?.label == "Hello")
 }
 

--- a/Tests/TBDDaemonTests/MigrationV19Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV19Tests.swift
@@ -22,4 +22,69 @@ import GRDB
         let tabs = try await db.tabs.listForWorktree(worktreeID: wt.id)
         #expect(tabs.isEmpty)
     }
+
+    @Test func setLabelInsertsRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v19a-repo", displayName: "V19a", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v19a-repo/wt", tmuxServer: "tbd-v19a"
+        )
+        let tabID = UUID()
+        try await db.tabs.setLabel(tabID: tabID, worktreeID: wt.id, label: "Custom Name")
+        let tabs = try await db.tabs.listForWorktree(worktreeID: wt.id)
+        #expect(tabs.count == 1)
+        #expect(tabs.first?.label == "Custom Name")
+        #expect(tabs.first?.id == tabID)
+    }
+
+    @Test func setLabelNilDeletesRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v19b-repo", displayName: "V19b", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v19b-repo/wt", tmuxServer: "tbd-v19b"
+        )
+        let tabID = UUID()
+        try await db.tabs.setLabel(tabID: tabID, worktreeID: wt.id, label: "X")
+        try await db.tabs.setLabel(tabID: tabID, worktreeID: wt.id, label: nil)
+        let tabs = try await db.tabs.listForWorktree(worktreeID: wt.id)
+        #expect(tabs.isEmpty)
+    }
+
+    @Test func setLabelReplacesExistingRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v19c-repo", displayName: "V19c", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v19c-repo/wt", tmuxServer: "tbd-v19c"
+        )
+        let tabID = UUID()
+        try await db.tabs.setLabel(tabID: tabID, worktreeID: wt.id, label: "First")
+        try await db.tabs.setLabel(tabID: tabID, worktreeID: wt.id, label: "Second")
+        let tabs = try await db.tabs.listForWorktree(worktreeID: wt.id)
+        #expect(tabs.count == 1)
+        #expect(tabs.first?.label == "Second")
+    }
+
+    @Test func deleteForWorktreeRemovesAll() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v19d-repo", displayName: "V19d", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v19d-repo/wt", tmuxServer: "tbd-v19d"
+        )
+        try await db.tabs.setLabel(tabID: UUID(), worktreeID: wt.id, label: "A")
+        try await db.tabs.setLabel(tabID: UUID(), worktreeID: wt.id, label: "B")
+        try await db.tabs.deleteForWorktree(worktreeID: wt.id)
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).isEmpty)
+    }
 }

--- a/Tests/TBDDaemonTests/MigrationV19Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV19Tests.swift
@@ -87,4 +87,20 @@ import GRDB
         try await db.tabs.deleteForWorktree(worktreeID: wt.id)
         #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).isEmpty)
     }
+
+    @Test func tabOrderRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v19e-repo", displayName: "V19e", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v19e-repo/wt", tmuxServer: "tbd-v19e"
+        )
+        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id).isEmpty)
+        let ids = [UUID(), UUID(), UUID()]
+        try await db.worktrees.setTabOrder(worktreeID: wt.id, tabIDs: ids)
+        let fetched = try await db.worktrees.getTabOrder(worktreeID: wt.id)
+        #expect(fetched == ids)
+    }
 }

--- a/Tests/TBDDaemonTests/MigrationV19Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV19Tests.swift
@@ -1,0 +1,25 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct MigrationV19Tests {
+
+    @Test func v19CreatesTabTableAndTabOrderColumn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v19-repo", displayName: "V19", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v19-repo/wt", tmuxServer: "tbd-v19"
+        )
+        // tab_order defaults to empty array literal.
+        let order = try await db.worktrees.getTabOrder(worktreeID: wt.id)
+        #expect(order.isEmpty)
+        // tab table exists and is empty.
+        let tabs = try await db.tabs.listForWorktree(worktreeID: wt.id)
+        #expect(tabs.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/MigrationV20Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV20Tests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct MigrationV20Tests {
+
+    @Test func v20AddsActiveTabIDColumnDefaultingToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v20-repo", displayName: "V20", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v20-repo/wt", tmuxServer: "tbd-v20"
+        )
+        // Newly created worktrees have no stored active tab.
+        let activeID = try await db.worktrees.getActiveTabID(worktreeID: wt.id)
+        #expect(activeID == nil)
+    }
+
+    @Test func setActiveTabIDPersistsAndRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v20a-repo", displayName: "V20a", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v20a-repo/wt", tmuxServer: "tbd-v20a"
+        )
+        let tabID = UUID()
+        try await db.worktrees.setActiveTabID(worktreeID: wt.id, tabID: tabID)
+        let fetched = try await db.worktrees.getActiveTabID(worktreeID: wt.id)
+        #expect(fetched == tabID)
+    }
+
+    @Test func setActiveTabIDNilClearsStoredValue() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v20b-repo", displayName: "V20b", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v20b-repo/wt", tmuxServer: "tbd-v20b"
+        )
+        let tabID = UUID()
+        try await db.worktrees.setActiveTabID(worktreeID: wt.id, tabID: tabID)
+        try await db.worktrees.setActiveTabID(worktreeID: wt.id, tabID: nil)
+        let fetched = try await db.worktrees.getActiveTabID(worktreeID: wt.id)
+        #expect(fetched == nil)
+    }
+
+    @Test func getActiveTabIDReturnsNilForUnknownWorktree() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let fetched = try await db.worktrees.getActiveTabID(worktreeID: UUID())
+        #expect(fetched == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/TabRPCHandlersTests.swift
+++ b/Tests/TBDDaemonTests/TabRPCHandlersTests.swift
@@ -110,4 +110,54 @@ import Foundation
         #expect(!resp.success)
         #expect(resp.error != nil)
     }
+
+    @Test func deletingTerminalDeletesItsTabRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/cleanup-t-repo-\(UUID().uuidString)",
+            displayName: "C", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/cleanup-t-repo/wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-cleanup-t"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1"
+        )
+        try await db.tabs.setLabel(tabID: terminal.id, worktreeID: wt.id, label: "Mine")
+
+        let router = makeRouter(db: db)
+        let req = try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: terminal.id)
+        )
+        _ = await router.handle(req)
+        let tabs = try await db.tabs.listForWorktree(worktreeID: wt.id)
+        #expect(tabs.isEmpty)
+    }
+
+    @Test func deletingNoteDeletesItsTabRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/cleanup-n-repo-\(UUID().uuidString)",
+            displayName: "C", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/cleanup-n-repo/wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-cleanup-n"
+        )
+        let note = try await db.notes.create(worktreeID: wt.id)
+        try await db.tabs.setLabel(tabID: note.id, worktreeID: wt.id, label: "MyNote")
+
+        let router = makeRouter(db: db)
+        let req = try RPCRequest(
+            method: RPCMethod.noteDelete,
+            params: NoteDeleteParams(noteID: note.id)
+        )
+        _ = await router.handle(req)
+        let tabs = try await db.tabs.listForWorktree(worktreeID: wt.id)
+        #expect(tabs.isEmpty)
+    }
 }

--- a/Tests/TBDDaemonTests/TabRPCHandlersTests.swift
+++ b/Tests/TBDDaemonTests/TabRPCHandlersTests.swift
@@ -137,6 +137,50 @@ import Foundation
         #expect(tabs.isEmpty)
     }
 
+    @Test func setActiveTabPersistsAndTabListReturnsIt() async throws {
+        let (db, worktreeID) = try await makeFixture()
+        let router = makeRouter(db: db)
+        let tabID = UUID()
+
+        // Initially tab.list reports activeTabID = nil.
+        let initialListReq = try RPCRequest(
+            method: RPCMethod.tabList,
+            params: TabListParams(worktreeID: worktreeID)
+        )
+        let initialResp = await router.handle(initialListReq)
+        #expect(initialResp.success)
+        let initialDecoded = try initialResp.decodeResult(TabListResponse.self)
+        #expect(initialDecoded.activeTabID == nil)
+
+        // worktree.setActiveTab writes the ID.
+        let setReq = try RPCRequest(
+            method: RPCMethod.worktreeSetActiveTab,
+            params: WorktreeSetActiveTabParams(worktreeID: worktreeID, tabID: tabID)
+        )
+        let setResp = await router.handle(setReq)
+        #expect(setResp.success)
+        #expect(setResp.error == nil)
+
+        // Subsequent tab.list returns it.
+        let listReq = try RPCRequest(
+            method: RPCMethod.tabList,
+            params: TabListParams(worktreeID: worktreeID)
+        )
+        let listResp = await router.handle(listReq)
+        let decoded = try listResp.decodeResult(TabListResponse.self)
+        #expect(decoded.activeTabID == tabID)
+
+        // nil clears.
+        let clearReq = try RPCRequest(
+            method: RPCMethod.worktreeSetActiveTab,
+            params: WorktreeSetActiveTabParams(worktreeID: worktreeID, tabID: nil)
+        )
+        _ = await router.handle(clearReq)
+        let clearedResp = await router.handle(listReq)
+        let clearedDecoded = try clearedResp.decodeResult(TabListResponse.self)
+        #expect(clearedDecoded.activeTabID == nil)
+    }
+
     @Test func deletingNoteDeletesItsTabRow() async throws {
         let db = try TBDDatabase(inMemory: true)
         let repo = try await db.repos.create(

--- a/Tests/TBDDaemonTests/TabRPCHandlersTests.swift
+++ b/Tests/TBDDaemonTests/TabRPCHandlersTests.swift
@@ -1,0 +1,113 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct TabRPCHandlersTests {
+
+    private func makeRouter(db: TBDDatabase) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+    }
+
+    private func makeFixture() async throws -> (TBDDatabase, UUID) {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/tabrpc-repo-\(UUID().uuidString)",
+            displayName: "T",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/tabrpc-repo/wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-tabrpc"
+        )
+        return (db, wt.id)
+    }
+
+    @Test func setLabelThenListReturnsIt() async throws {
+        let (db, worktreeID) = try await makeFixture()
+        let router = makeRouter(db: db)
+        let tabID = UUID()
+
+        // setLabel
+        let setReq = try RPCRequest(
+            method: RPCMethod.tabSetLabel,
+            params: TabSetLabelParams(tabID: tabID, worktreeID: worktreeID, label: "My Tab")
+        )
+        let setResp = await router.handle(setReq)
+        #expect(setResp.success)
+        #expect(setResp.error == nil)
+
+        // list
+        let listReq = try RPCRequest(
+            method: RPCMethod.tabList,
+            params: TabListParams(worktreeID: worktreeID)
+        )
+        let listResp = await router.handle(listReq)
+        #expect(listResp.success)
+        let decoded = try listResp.decodeResult(TabListResponse.self)
+        #expect(decoded.tabs.count == 1)
+        #expect(decoded.tabs.first?.label == "My Tab")
+        #expect(decoded.tabs.first?.id == tabID)
+        #expect(decoded.order.isEmpty)
+    }
+
+    @Test func setLabelNilClearsRow() async throws {
+        let (db, worktreeID) = try await makeFixture()
+        let router = makeRouter(db: db)
+        let tabID = UUID()
+        let req = try RPCRequest(
+            method: RPCMethod.tabSetLabel,
+            params: TabSetLabelParams(tabID: tabID, worktreeID: worktreeID, label: nil)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        #expect(resp.error == nil)
+        let tabs = try await db.tabs.listForWorktree(worktreeID: worktreeID)
+        #expect(tabs.isEmpty)
+    }
+
+    @Test func setOrderPersistsAndListReturnsIt() async throws {
+        let (db, worktreeID) = try await makeFixture()
+        let router = makeRouter(db: db)
+        let ids = [UUID(), UUID(), UUID()]
+        let req = try RPCRequest(
+            method: RPCMethod.tabSetOrder,
+            params: TabSetOrderParams(worktreeID: worktreeID, tabIDs: ids)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        #expect(resp.error == nil)
+
+        let listReq = try RPCRequest(
+            method: RPCMethod.tabList,
+            params: TabListParams(worktreeID: worktreeID)
+        )
+        let listResp = await router.handle(listReq)
+        let decoded = try listResp.decodeResult(TabListResponse.self)
+        #expect(decoded.order == ids)
+    }
+
+    @Test func setOrderRejectsDuplicates() async throws {
+        let (db, worktreeID) = try await makeFixture()
+        let router = makeRouter(db: db)
+        let dup = UUID()
+        let req = try RPCRequest(
+            method: RPCMethod.tabSetOrder,
+            params: TabSetOrderParams(worktreeID: worktreeID, tabIDs: [dup, dup])
+        )
+        let resp = await router.handle(req)
+        #expect(!resp.success)
+        #expect(resp.error != nil)
+    }
+}

--- a/docs/superpowers/specs/2026-05-11-tab-rename-reorder-design.md
+++ b/docs/superpowers/specs/2026-05-11-tab-rename-reorder-design.md
@@ -1,0 +1,308 @@
+# Tab Rename & Reorder
+
+Date: 2026-05-11
+
+## Summary
+
+Let users rename tabs in the main content panel's tab strip (double-click or right-click → Rename) and reorder them by drag. Both changes persist across app restart via the daemon's SQLite DB.
+
+## Background
+
+Today the tab strip in `Sources/TBDApp/TabBar.swift` shows auto-derived labels:
+
+- Claude terminals: `"<ProfileName> <N>"` based on position among same-profile terminals
+- Codex / shell terminals: `"Terminal <N>"`
+- Notes: the note's `title`
+- Webviews: URL host
+- Code-viewers: file basename
+- Live transcripts: `"Transcript"`
+
+`Tab.label: String?` already exists in `Sources/TBDApp/Terminal/PaneContent.swift` and falls through to the auto-derived label when nil. Tab labels and ordering are kept only in `AppState.tabs: [UUID: [Tab]]` — entirely in-memory, lost on app restart. Note tabs additionally have their `label` overwritten from the note's `title` (`AppState+Notes.swift` line 33).
+
+## Goals
+
+- Users can rename any tab except code-viewer tabs.
+- Users can drag tabs left/right within a worktree's tab strip to reorder.
+- Both rename and reorder survive app restart.
+- New tabs (created from a fresh terminal, note, etc.) still appear at the end of the strip; user-set order is preserved for everything else.
+- Note tab labels decouple from note titles (the tab gets its own label; the note keeps its own title).
+
+## Non-goals
+
+- Renaming code-viewer tabs (they always show the file basename).
+- Dragging tabs between worktrees, or detaching a tab into a new window.
+- Reordering the `+` (new-tab) and history buttons in the tab strip.
+- Live-syncing tab metadata between multiple TBDApp instances.
+
+## Reference: iTerm2
+
+iTerm2 has a `titleOverride: NSString?` on `PTYTab` (saved in arrangements, reverts to auto-derived when nil) — that's the same pattern as our `Tab.label: String?`. iTerm2 has no inline rename UI; titles come from escape sequences or scripts/API. Tab order in iTerm2 is encoded as the natural NSArray order in `TERMINAL_ARRANGEMENT_TABS` (no separate sort-order field). Drag is implemented in `PSMTabBarControl`, a custom `NSView` that hooks `-[NSTabView moveTabViewItem:toIndex:]`. Layout (splits) is a recursive plist dict on the tab — they don't normalize splits into a separate store. Persistence is lazy: arrangements only write on explicit save events, not per-change.
+
+We borrow: `titleOverride` semantics, array-order persistence, lazy writes. We diverge: SwiftUI `.draggable` instead of `PSMTabBarControl`; SQLite-backed daemon instead of `NSUserDefaults` arrangements.
+
+## Architecture
+
+### Storage
+
+A new sparse `tabs` table — a row exists only when a tab has user-set metadata (a custom label). Tab *order* is stored as a single JSON array on the existing `worktrees` row.
+
+Migration (next sequential `vN+1.swift` in `Sources/TBDDaemon/Database/`):
+
+```sql
+CREATE TABLE tabs (
+    id          TEXT PRIMARY KEY,        -- == Tab.id (UUID)
+    worktree_id TEXT NOT NULL,
+    label       TEXT,                    -- NULL = use auto-derived
+    created_at  REAL NOT NULL
+);
+ALTER TABLE worktrees ADD COLUMN tab_order TEXT NOT NULL DEFAULT '[]';
+```
+
+`tab_order` holds a JSON array of UUID strings, e.g. `["e3a1...","9c44...",...]`. Unknown IDs are tolerated (sorted to the end on reconcile).
+
+Layouts (splits within a tab) stay in `UserDefaults` under `com.tbd.app.layouts`. This change does not touch layout persistence.
+
+### Shared model
+
+`Sources/TBDShared/Models.swift` gains:
+
+```swift
+public struct TabState: Codable, Sendable, Equatable, Identifiable {
+    public let id: UUID
+    public var worktreeID: UUID
+    public var label: String?
+    public var createdAt: Date
+
+    public init(id: UUID, worktreeID: UUID, label: String? = nil, createdAt: Date = Date()) {
+        self.id = id
+        self.worktreeID = worktreeID
+        self.label = label
+        self.createdAt = createdAt
+    }
+}
+
+public struct TabDragPayload: Codable, Sendable, Transferable {
+    public let tabID: UUID
+    // Transferable conformance with UTType "com.tbd.app.tab-drag"
+}
+```
+
+All fields have defaults or are optional so older JSON decodes cleanly (per project DB rule in `CLAUDE.md`).
+
+### RPC surface
+
+New methods in `Sources/TBDShared/RPCProtocol.swift`:
+
+```swift
+public static let tabSetLabel = "tab.setLabel"
+public static let tabSetOrder = "tab.setOrder"
+public static let tabList     = "tab.list"
+```
+
+Request shapes:
+
+```swift
+public struct TabSetLabelRequest: Codable, Sendable {
+    public let tabID: UUID
+    public let worktreeID: UUID
+    public let label: String?  // nil = clear override (delete row)
+}
+
+public struct TabSetOrderRequest: Codable, Sendable {
+    public let worktreeID: UUID
+    public let tabIDs: [UUID]
+}
+
+public struct TabListRequest: Codable, Sendable {
+    public let worktreeID: UUID
+}
+
+public struct TabListResponse: Codable, Sendable {
+    public let tabs: [TabState]   // only tabs with overrides; empty when none
+    public let order: [UUID]      // contents of worktrees.tab_order; [] if never reordered
+}
+```
+
+`tab.list` is called once per worktree on first appearance in `AppState.tabs[worktreeID]` and seeds the in-memory caches.
+
+### Daemon
+
+In `Sources/TBDDaemon/Database/`:
+
+- `TabRow` GRDB record matching the `tabs` table.
+- `WorktreeRow` gains `tabOrder: String` (default `"[]"`).
+- `Database.setTabLabel(tabID:worktreeID:label:)`:
+  - If `label == nil` → `DELETE FROM tabs WHERE id = ?`.
+  - Else → `INSERT OR REPLACE INTO tabs(id, worktree_id, label, created_at) VALUES (?,?,?,?)`.
+- `Database.getTabsByWorktree(worktreeID:)` → `[TabRow]`.
+- `Database.setTabOrder(worktreeID:tabIDs:)` → JSON-encode and update `worktrees.tab_order`.
+- `Database.getTabOrder(worktreeID:)` → JSON-decode `worktrees.tab_order` into `[UUID]`.
+
+In the RPC handler:
+
+- Decode requests, call the DB methods, return success/response.
+- Validation for `tab.setOrder`: reject if `tabIDs` contains duplicates. We do **not** require the list to exactly match the current set of tabs (tabs come and go; tolerated drift is preferable to spurious rejections).
+
+Cleanup hooks (in the existing terminal- and note-delete code paths):
+
+- On `terminal.delete` (or whichever path removes a terminal): `DELETE FROM tabs WHERE id = ?` with the terminal's UUID.
+- On `note.delete`: same with the note's UUID.
+
+No subscription/push for tab metadata — only one TBDApp instance writes, and reads happen on launch or worktree selection.
+
+### App-side: AppState
+
+New file `Sources/TBDApp/AppState+Tabs.swift`:
+
+```swift
+@Published var worktreeTabOrders: [UUID: [UUID]] = [:]
+@Published var draggingTabID: UUID? = nil
+
+func loadTabStates(worktreeID: UUID) async
+func renameTab(tabID: UUID, worktreeID: UUID, newLabel: String) async
+func reorderTab(draggedID: UUID, in worktreeID: UUID,
+                relativeTo targetID: UUID, edge: DropEdge)
+```
+
+`renameTab`:
+
+1. Trim whitespace from `newLabel`.
+2. Resolve the currently displayed label (custom if set, else auto-derived from `tabLabel` logic).
+3. If trimmed text equals the currently displayed label → no-op (no RPC).
+4. If trimmed is empty → set `tab.label = nil` in `tabs[worktreeID]` and call `daemonClient.setTabLabel(..., label: nil)`.
+5. Else → set `tab.label = trimmed` and call `daemonClient.setTabLabel(..., label: trimmed)`.
+
+`reorderTab` (body sketched in §3 of the design discussion):
+
+1. Locate `from` and `target` indices in `tabs[worktreeID]`.
+2. Remove `from`, insert at the target index (`+1` for `.trailing` edge).
+3. Mutate `tabs[worktreeID]` and update `activeTabIndices[worktreeID]` so the currently-active tab.id stays selected.
+4. Fire-and-forget `daemonClient.setTabOrder(worktreeID, arr.map(\.id))`.
+
+`reconcileTabs` and `reconcileNoteTabs` in `AppState.swift` apply stored order as a final step:
+
+```swift
+let storedOrder = worktreeTabOrders[worktreeID] ?? []
+let storedIndex = Dictionary(uniqueKeysWithValues: storedOrder.enumerated().map { ($1, $0) })
+currentTabs.sort { (a, b) in
+    let ai = storedIndex[a.id] ?? Int.max
+    let bi = storedIndex[b.id] ?? Int.max
+    return ai < bi
+}
+```
+
+`AppState+Notes.swift` drops the line that mirrors `note.title` into `tab.label` (line 33 today). New note tabs are created with `label: nil`. The tab label fallback for `.note` content is added in `TabBar.swift`'s `tabLabel` property: when `tab.label` is nil, look up the note in `appState.notes[worktreeID]` and use its `title`.
+
+### App-side: TabBar UI
+
+In `Sources/TBDApp/TabBar.swift` (`TabBarItem`):
+
+Rename:
+
+- `@State private var isEditing: Bool = false` on `TabBarItem`.
+- Replace the static `Text(tabLabel)` with a `RenameableLabel` (from `Sources/TBDApp/Sidebar/RenameableLabel.swift`) when `isEditing == true`. Static `Text` otherwise.
+- Triggers:
+  - `.onTapGesture(count: 2)` on the tab text area enters edit mode, except when `tab.content == .codeViewer(...)`.
+  - "Rename Tab" `Button` added to `contextMenuContent`, gated on the same content-type check.
+- `RenameableLabel` is initialized with `text:` = currently displayed label so the user types over the visible text. On commit, call `appState.renameTab(...)`.
+- During edit: the close button (`xmark`) is hidden; the tab becomes active if it wasn't already; tab is `.fixedSize()` so it auto-grows.
+
+Reorder:
+
+- `.draggable(TabDragPayload(tabID: tab.id), preview: { /* ghosted tab content */ })` on the tab.
+- On drag start, set `appState.draggingTabID = tab.id`; clear on drop / cancel.
+- The dragged tab renders at 40% opacity when `appState.draggingTabID == tab.id`.
+- Each tab is `.dropDestination(for: TabDragPayload.self)`:
+  - Compute `DropEdge` (`enum DropEdge { case leading, trailing }`, defined in `TabBar.swift`) from the local drop `CGPoint.x` vs tab width midpoint.
+  - On valid drop: call `appState.reorderTab(...)`.
+  - On `isTargeted` change: update `@State private var dropEdge: DropEdge?` so only one tab shows the indicator at a time.
+- Insertion indicator: a 2pt-wide `RoundedRectangle` in `Color.accentColor`, full tab height, overlaid on the targeted tab's leading or trailing edge. Animated `easeInOut(duration: 0.1)`.
+- The `+` button and history button are **not** drop destinations.
+
+Drop UTType (`com.tbd.app.tab-drag`) is registered in `Info.plist`-equivalent location for the bundled `.app`. (Worktree CLAUDE.md note: the app runs from `.build/debug/TBD.app` assembled by `scripts/restart.sh` — drop registration goes in the same plist the bundle script generates.)
+
+## Data flow
+
+### Rename
+
+1. User double-clicks a tab (or right-clicks → Rename).
+2. `TabBarItem.isEditing = true`, `RenameableLabel` takes focus with the current displayed label preselected.
+3. User types, presses Enter (or blurs).
+4. `RenameableLabel.onCommit(trimmed)` → `appState.renameTab(tabID:, worktreeID:, newLabel:)`.
+5. AppState applies the rules above, updates `tabs[worktreeID]` in-memory, fires `daemonClient.setTabLabel(...)`.
+6. Daemon writes (or deletes) the row in `tabs`.
+
+### Reorder
+
+1. User starts a drag on a tab → `draggingTabID` set, dragged tab dimmed.
+2. User moves cursor over another tab → that tab's `dropEdge` flips to `.leading` or `.trailing` based on the cursor's x; insertion indicator renders.
+3. User releases → `dropDestination` closure runs `appState.reorderTab(...)`.
+4. AppState mutates `tabs[worktreeID]`, fires `daemonClient.setTabOrder(...)`.
+5. Daemon JSON-encodes the array and writes `worktrees.tab_order`.
+
+### App launch / worktree first visit
+
+1. AppState already loads worktrees/terminals/notes.
+2. When a worktree first appears in `AppState.tabs`, AppState calls `daemonClient.listTabs(worktreeID:)`.
+3. Response seeds `worktreeTabOrders[worktreeID]` and per-tab `label` overrides.
+4. Subsequent `reconcileTabs` / `reconcileNoteTabs` calls apply the stored order at the end and use the seeded labels.
+
+## Edge cases
+
+- **Rename to empty / whitespace-only** → clear override (`label = nil`, DB row deleted). Tab reverts to auto-derived label.
+- **Rename to same value as displayed** → no-op (no RPC, no in-memory change).
+- **Drag onto self or current slot** → no-op.
+- **Drag onto `+` button or history button** → drop rejected, tab snaps back.
+- **Drop outside tab strip** → SwiftUI default cancel, tab snaps back.
+- **Reorder while a tab is mid-edit** — guarded by SwiftUI's normal interaction routing; the dragged tab's `RenameableLabel` loses focus, which commits the in-progress edit (`RenameableLabel.onChange(of: isTextFieldFocused)` already handles this).
+- **Tab whose terminal/note was deleted while app was offline** → next reconcile drops the tab; daemon's `terminal.delete` / `note.delete` already cleaned the `tabs` row.
+- **Unknown UUIDs in stored `tab_order`** (e.g. tab existed at write-time, gone now) → sorted to the end via `Int.max` sentinel, no error.
+- **Code-viewer tab** → double-click ignored, "Rename Tab" not shown in context menu. Still reorderable.
+- **Note tab decoupling**: if a note's title was previously mirrored into `tab.label` (pre-migration), that label stays on first run; user clearing it reverts to the live note title.
+
+## Testing
+
+Per project rule "add a test for each branch":
+
+| Layer | Test |
+|---|---|
+| Migration | Round-trip from prior version: `tabs` table present, `worktrees.tab_order` defaults to `'[]'` |
+| Database | `setTabLabel` with non-empty inserts row; with nil deletes row |
+| Database | `setTabOrder` round-trips JSON correctly; preserves order |
+| Database | `getTabOrder` returns `[]` for a worktree with no overrides |
+| RPC | `tab.setOrder` rejects request with duplicate UUIDs |
+| RPC | `tab.list` returns labels + order for a worktree, empty when unset |
+| Cleanup | Deleting a terminal removes its `tabs` row |
+| Cleanup | Deleting a note removes its `tabs` row |
+| AppState | `renameTab` with empty string sets `label = nil` and calls RPC with nil |
+| AppState | `renameTab` with same-as-displayed value is a no-op (no RPC) |
+| AppState | `renameTab` with new value updates `tabs[worktreeID]` and calls RPC with trimmed value |
+| AppState | `reorderTab` updates order and preserves `activeTabIndices` pointing at same `tab.id` |
+| Reconcile | New terminal appears at end of strip when user-ordered tabs already present |
+| Reconcile | Tab whose terminal disappeared is dropped on next reconcile |
+| Note decoupling | Renaming a note no longer mutates its tab's `label`; renaming the tab leaves `note.title` untouched |
+
+Manual UI verification (after `scripts/restart.sh`):
+
+- Double-click enters edit; Esc cancels; Enter commits; empty + Enter clears override.
+- Right-click → "Rename Tab" works.
+- Drag tab left/right of another tab — insertion indicator on the correct edge.
+- Drag onto `+` or history button — no drop, tab returns.
+- Code-viewer tabs: double-click and context menu item suppressed.
+- Restart app — custom labels and tab order persist.
+
+## Files touched
+
+- `Sources/TBDDaemon/Database/Database.swift` — migration, queries.
+- `Sources/TBDDaemon/Database/TabRow.swift` (new) — GRDB record.
+- `Sources/TBDDaemon/Database/WorktreeRow.swift` (or equivalent) — add `tabOrder` field.
+- `Sources/TBDDaemon/RPCHandler.swift` (or equivalent) — dispatch the three new methods.
+- `Sources/TBDShared/Models.swift` — `TabState`, `TabDragPayload`.
+- `Sources/TBDShared/RPCProtocol.swift` — method names, request/response structs.
+- `Sources/TBDApp/DaemonClient.swift` — `listTabs`, `setTabLabel`, `setTabOrder` clients.
+- `Sources/TBDApp/AppState+Tabs.swift` (new) — `renameTab`, `reorderTab`, `loadTabStates`, `draggingTabID`.
+- `Sources/TBDApp/AppState.swift` — apply stored order in `reconcileTabs` / `reconcileNoteTabs`.
+- `Sources/TBDApp/AppState+Notes.swift` — drop the line that mirrors `note.title` into `tab.label`.
+- `Sources/TBDApp/TabBar.swift` — `isEditing` state, `RenameableLabel` swap, double-click trigger, context menu item, `.draggable` / `.dropDestination`, insertion indicator, dimmed dragged tab.
+- `Sources/TBDApp/Terminal/PaneContent.swift` — no change (existing `Tab.label: String?` is reused).
+- Bundle plist (assembled by `scripts/restart.sh`) — register `com.tbd.app.tab-drag` UTType.

--- a/docs/superpowers/specs/2026-05-11-tab-rename-reorder-design.md
+++ b/docs/superpowers/specs/2026-05-11-tab-rename-reorder-design.md
@@ -34,6 +34,10 @@ Today the tab strip in `Sources/TBDApp/TabBar.swift` shows auto-derived labels:
 - Reordering the `+` (new-tab) and history buttons in the tab strip.
 - Live-syncing tab metadata between multiple TBDApp instances.
 
+## Follow-ups (deferred)
+
+- **Persist active-tab focus per worktree.** Today `AppState.activeTabIndices: [UUID: Int]` stores which tab is focused in each worktree, but it's in-memory only and resets on app launch. A future change can add an `active_tab_id: TEXT` column on the `worktree` table (storing the `Tab.id` UUID, not a positional index, so it stays correct across reorders) and an `app.setActiveTab` RPC. The current change's data model intentionally leaves this column off — defer until there's a user request for tab focus to survive restart.
+
 ## Reference: iTerm2
 
 iTerm2 has a `titleOverride: NSString?` on `PTYTab` (saved in arrangements, reverts to auto-derived when nil) — that's the same pattern as our `Tab.label: String?`. iTerm2 has no inline rename UI; titles come from escape sequences or scripts/API. Tab order in iTerm2 is encoded as the natural NSArray order in `TERMINAL_ARRANGEMENT_TABS` (no separate sort-order field). Drag is implemented in `PSMTabBarControl`, a custom `NSView` that hooks `-[NSTabView moveTabViewItem:toIndex:]`. Layout (splits) is a recursive plist dict on the tab — they don't normalize splits into a separate store. Persistence is lazy: arrangements only write on explicit save events, not per-change.

--- a/docs/superpowers/specs/2026-05-11-tab-rename-reorder-design.md
+++ b/docs/superpowers/specs/2026-05-11-tab-rename-reorder-design.md
@@ -34,9 +34,15 @@ Today the tab strip in `Sources/TBDApp/TabBar.swift` shows auto-derived labels:
 - Reordering the `+` (new-tab) and history buttons in the tab strip.
 - Live-syncing tab metadata between multiple TBDApp instances.
 
-## Follow-ups (deferred)
+## Active-tab focus persistence (scoped in)
 
-- **Persist active-tab focus per worktree.** Today `AppState.activeTabIndices: [UUID: Int]` stores which tab is focused in each worktree, but it's in-memory only and resets on app launch. A future change can add an `active_tab_id: TEXT` column on the `worktree` table (storing the `Tab.id` UUID, not a positional index, so it stays correct across reorders) and an `app.setActiveTab` RPC. The current change's data model intentionally leaves this column off — defer until there's a user request for tab focus to survive restart.
+Today `AppState.activeTabIndices: [UUID: Int]` stores which tab is focused in each worktree, but it's in-memory only and resets on app launch. With reorder support landing, we also persist the active tab so a user's exact workspace state survives restart.
+
+**Schema:** add `activeTabID: TEXT` (nullable) on the `worktree` table — same migration is fine, but since v19 is already shipped, this uses a new migration `v20_worktree_active_tab`. We store the `Tab.id` UUID (not a positional index) so the value stays correct across reorders.
+
+**RPC:** new method `worktree.setActiveTab` with params `{ worktreeID: UUID, tabID: UUID? }`. nil clears the stored value (e.g., on close of the last tab).
+
+**App-side wiring:** `tab.list` response gains an `activeTabID: UUID?` field. On worktree first appearance, after `loadTabStates` hydrates `worktreeTabOrders`, also resolve `activeTabID` → set `activeTabIndices[worktreeID]` to the matching position. When the user clicks a different tab, write through to the daemon (fire-and-forget). Persisted active tab gracefully degrades: if the stored `activeTabID` no longer exists in the worktree's reconciled tabs, fall back to index 0.
 
 ## Reference: iTerm2
 


### PR DESCRIPTION
## Summary
- Double-click (or right-click → Rename Tab) a tab to give it a custom label; drag to reorder within the strip
- Custom labels, tab order, and active-tab focus persist per worktree via the daemon DB (migrations v19 + v20)
- Code-viewer tabs intentionally aren't renameable; note-tab labels now decouple from the underlying note's title

## Test plan
- [ ] Double-click a tab → field shows current label preselected; type a name and press Enter; tab updates immediately (no flash)
- [ ] Right-click a tab → "Rename Tab" present (suppressed for code-viewer tabs)
- [ ] Double-click → clear the field → Enter → tab reverts to auto-derived label (e.g. "Claude 1", "Note 2")
- [ ] Drag a tab left/right of another → accent-colored insertion bar shows on the correct edge; release → tab moves
- [ ] Drag a tab onto the `+` or history button → drop rejected, tab snaps back
- [ ] Set a different active tab in each of two worktrees
- [ ] Restart the app (`pkill -f TBDApp; scripts/restart.sh`) → custom labels, tab order, and active tab all persist

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=BCFCF46E-744C-4D91-AF4D-88DF24B657A7)