### PR TITLE
Feat: Collapse worktree rows per repo with a hover-revealed chevron

### DIFF
--- a/Sources/TBDApp/AppState+Repos.swift
+++ b/Sources/TBDApp/AppState+Repos.swift
@@ -67,6 +67,22 @@ extension AppState {
         }
     }
 
+    /// Toggle whether a repo section is expanded in the sidebar.
+    /// Updates local state optimistically before issuing the RPC.
+    func setRepoExpanded(id: UUID, expanded: Bool) async {
+        if let idx = repos.firstIndex(where: { $0.id == id }) {
+            var repo = repos[idx]
+            repo.expanded = expanded
+            repos[idx] = repo
+        }
+        do {
+            try await daemonClient.setRepoExpanded(id: id, expanded: expanded)
+        } catch {
+            logger.error("Failed to set repo expanded: \(error)")
+            handleConnectionError(error)
+        }
+    }
+
     /// Rename a repo's display name. Updates local state optimistically before issuing the RPC.
     func renameRepo(id: UUID, displayName: String) async {
         if let idx = repos.firstIndex(where: { $0.id == id }) {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -379,6 +379,14 @@ actor DaemonClient {
         )
     }
 
+    /// Toggle whether a repo section is expanded in the sidebar.
+    func setRepoExpanded(id: UUID, expanded: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.repoSetExpanded,
+            params: RepoSetExpandedParams(repoID: id, expanded: expanded)
+        )
+    }
+
     /// Update per-repo instruction fields.
     func repoUpdateInstructions(repoID: UUID, renamePrompt: String?, customInstructions: String?) async throws -> Repo {
         return try await callAsync(

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -30,6 +30,7 @@ struct RepoSectionView: View {
 
     @State private var isEditing = false
     @State private var isSectionHovered = false
+    @State private var isChevronHovered = false
     @State private var hoverDebounceTask: Task<Void, Error>?
     @State private var showRemoveConfirm = false
 
@@ -94,7 +95,8 @@ struct RepoSectionView: View {
                     .frame(width: 18, height: 18)
                     .contentShape(Rectangle())
             }
-            .buttonStyle(HoverPressButtonStyle())
+            .buttonStyle(.plain)
+            .onHover { isChevronHovered = $0 }
             .help(repo.expanded ? "Collapse" : "Expand")
             RenameableLabel(
                 text: repo.displayName,
@@ -115,6 +117,7 @@ struct RepoSectionView: View {
                             : AnyShapeStyle(appState.selectedRepoID == repo.id ? HierarchicalShapeStyle.primary : HierarchicalShapeStyle.secondary)
                     )
             }
+            .padding(.leading, -4)
 
             if repo.status == .missing {
                 Text("[missing]")
@@ -191,6 +194,7 @@ struct RepoSectionView: View {
                 WorktreeRowView(worktree: main, isMain: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.white.opacity(0.0001))
+                    .opacity(isChevronHovered ? 0.5 : 1.0)
                     .onHover { onSectionHoverChange($0) }
                     .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
                     .listRowSeparator(.hidden)
@@ -201,6 +205,7 @@ struct RepoSectionView: View {
                 WorktreeRowView(worktree: worktree)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.white.opacity(0.0001))
+                    .opacity(isChevronHovered ? 0.5 : 1.0)
                     .onHover { onSectionHoverChange($0) }
                     .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
                     .listRowSeparator(.hidden)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -87,14 +87,32 @@ struct RepoSectionView: View {
     var body: some View {
         HStack(spacing: 4) {
             if !Self.startsWithEmoji(repo.displayName) {
-                Image(systemName: "folder")
-                    .font(.system(size: 11))
-                    .foregroundStyle(
-                        repo.status == .missing
-                            ? AnyShapeStyle(Color.secondary.opacity(0.5))
-                            : AnyShapeStyle(HierarchicalShapeStyle.secondary)
-                    )
-                    .frame(width: 18, height: 18)
+                if isSectionHovered {
+                    Button {
+                        Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
+                    } label: {
+                        Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 11))
+                            .foregroundStyle(
+                                repo.status == .missing
+                                    ? AnyShapeStyle(Color.secondary.opacity(0.5))
+                                    : AnyShapeStyle(HierarchicalShapeStyle.secondary)
+                            )
+                            .frame(width: 18, height: 18)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(HoverPressButtonStyle())
+                    .help(repo.expanded ? "Collapse" : "Expand")
+                } else {
+                    Image(systemName: "folder")
+                        .font(.system(size: 11))
+                        .foregroundStyle(
+                            repo.status == .missing
+                                ? AnyShapeStyle(Color.secondary.opacity(0.5))
+                                : AnyShapeStyle(HierarchicalShapeStyle.secondary)
+                        )
+                        .frame(width: 18, height: 18)
+                }
             }
             RenameableLabel(
                 text: repo.displayName,
@@ -155,6 +173,9 @@ struct RepoSectionView: View {
             onSectionHoverChange(hovering)
         }
         .contextMenu {
+            Button(repo.expanded ? "Collapse" : "Expand") {
+                Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
+            }
             Button("Rename...") {
                 isEditing = true
             }
@@ -183,28 +204,30 @@ struct RepoSectionView: View {
         .listRowBackground(Color.clear)
         .tag(repo.id)
 
-        if let main = mainWorktree {
-            WorktreeRowView(worktree: main, isMain: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color.white.opacity(0.0001))
-                .onHover { onSectionHoverChange($0) }
-                .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
-                .listRowSeparator(.hidden)
+        if repo.expanded {
+            if let main = mainWorktree {
+                WorktreeRowView(worktree: main, isMain: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.white.opacity(0.0001))
+                    .onHover { onSectionHoverChange($0) }
+                    .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+                    .tag(main.id)
+            }
+            ForEach(worktrees) { worktree in
+                WorktreeRowView(worktree: worktree)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.white.opacity(0.0001))
+                    .onHover { onSectionHoverChange($0) }
+                    .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+                    .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
-                .tag(main.id)
-        }
-        ForEach(worktrees) { worktree in
-            WorktreeRowView(worktree: worktree)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color.white.opacity(0.0001))
-                .onHover { onSectionHoverChange($0) }
-                .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
-                .listRowSeparator(.hidden)
-            .listRowBackground(Color.clear)
-                .tag(worktree.id)
-        }
-        .onMove { source, destination in
-            appState.reorderWorktrees(repoID: repo.id, fromOffsets: source, toOffset: destination)
+                    .tag(worktree.id)
+            }
+            .onMove { source, destination in
+                appState.reorderWorktrees(repoID: repo.id, fromOffsets: source, toOffset: destination)
+            }
         }
     }
 

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -38,6 +38,18 @@ struct RepoSectionView: View {
         return first.unicodeScalars.contains { $0.properties.isEmoji && $0.value > 0x7F }
     }
 
+    private static func leadingEmoji(_ name: String) -> String? {
+        guard startsWithEmoji(name), let first = name.first else { return nil }
+        return String(first)
+    }
+
+    private static func nameWithoutLeadingEmoji(_ name: String) -> String {
+        guard startsWithEmoji(name) else { return name }
+        var rest = name.dropFirst()
+        if rest.first == " " { rest = rest.dropFirst() }
+        return String(rest)
+    }
+
     private func onSectionHoverChange(_ hovering: Bool) {
         if hovering {
             hoverDebounceTask?.cancel()
@@ -86,25 +98,11 @@ struct RepoSectionView: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            if !Self.startsWithEmoji(repo.displayName) {
-                if isSectionHovered {
-                    Button {
-                        Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
-                    } label: {
-                        Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
-                            .font(.system(size: 11))
-                            .foregroundStyle(
-                                repo.status == .missing
-                                    ? AnyShapeStyle(Color.secondary.opacity(0.5))
-                                    : AnyShapeStyle(HierarchicalShapeStyle.secondary)
-                            )
-                            .frame(width: 18, height: 18)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(HoverPressButtonStyle())
-                    .help(repo.expanded ? "Collapse" : "Expand")
-                } else {
-                    Image(systemName: "folder")
+            if isSectionHovered {
+                Button {
+                    Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
+                } label: {
+                    Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
                         .font(.system(size: 11))
                         .foregroundStyle(
                             repo.status == .missing
@@ -112,7 +110,23 @@ struct RepoSectionView: View {
                                 : AnyShapeStyle(HierarchicalShapeStyle.secondary)
                         )
                         .frame(width: 18, height: 18)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(HoverPressButtonStyle())
+                .help(repo.expanded ? "Collapse" : "Expand")
+            } else if let emoji = Self.leadingEmoji(repo.displayName) {
+                Text(emoji)
+                    .font(.system(size: 12))
+                    .frame(width: 18, height: 18)
+            } else {
+                Image(systemName: "folder")
+                    .font(.system(size: 11))
+                    .foregroundStyle(
+                        repo.status == .missing
+                            ? AnyShapeStyle(Color.secondary.opacity(0.5))
+                            : AnyShapeStyle(HierarchicalShapeStyle.secondary)
+                    )
+                    .frame(width: 18, height: 18)
             }
             RenameableLabel(
                 text: repo.displayName,
@@ -123,7 +137,7 @@ struct RepoSectionView: View {
                     }
                 }
             ) {
-                Text(repo.displayName)
+                Text(Self.nameWithoutLeadingEmoji(repo.displayName))
                     .font(.system(size: 12, weight: .semibold))
                     .lineLimit(1)
                     .truncationMode(.tail)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -194,7 +194,7 @@ struct RepoSectionView: View {
                 WorktreeRowView(worktree: main, isMain: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.white.opacity(0.0001))
-                    .opacity(isChevronHovered ? 0.75 : 1.0)
+                    .opacity(isChevronHovered ? 0.7 : 1.0)
                     .onHover { onSectionHoverChange($0) }
                     .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
                     .listRowSeparator(.hidden)
@@ -205,7 +205,7 @@ struct RepoSectionView: View {
                 WorktreeRowView(worktree: worktree)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.white.opacity(0.0001))
-                    .opacity(isChevronHovered ? 0.75 : 1.0)
+                    .opacity(isChevronHovered ? 0.7 : 1.0)
                     .onHover { onSectionHoverChange($0) }
                     .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
                     .listRowSeparator(.hidden)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -117,7 +117,7 @@ struct RepoSectionView: View {
                             : AnyShapeStyle(appState.selectedRepoID == repo.id ? HierarchicalShapeStyle.primary : HierarchicalShapeStyle.secondary)
                     )
             }
-            .padding(.leading, -4)
+            .padding(.leading, -2)
 
             if repo.status == .missing {
                 Text("[missing]")

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -33,23 +33,6 @@ struct RepoSectionView: View {
     @State private var hoverDebounceTask: Task<Void, Error>?
     @State private var showRemoveConfirm = false
 
-    private static func startsWithEmoji(_ name: String) -> Bool {
-        guard let first = name.first else { return false }
-        return first.unicodeScalars.contains { $0.properties.isEmoji && $0.value > 0x7F }
-    }
-
-    private static func leadingEmoji(_ name: String) -> String? {
-        guard startsWithEmoji(name), let first = name.first else { return nil }
-        return String(first)
-    }
-
-    private static func nameWithoutLeadingEmoji(_ name: String) -> String {
-        guard startsWithEmoji(name) else { return name }
-        var rest = name.dropFirst()
-        if rest.first == " " { rest = rest.dropFirst() }
-        return String(rest)
-    }
-
     private func onSectionHoverChange(_ hovering: Bool) {
         if hovering {
             hoverDebounceTask?.cancel()
@@ -98,28 +81,10 @@ struct RepoSectionView: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            if isSectionHovered {
-                Button {
-                    Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
-                } label: {
-                    Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
-                        .font(.system(size: 11))
-                        .foregroundStyle(
-                            repo.status == .missing
-                                ? AnyShapeStyle(Color.secondary.opacity(0.5))
-                                : AnyShapeStyle(HierarchicalShapeStyle.secondary)
-                        )
-                        .frame(width: 18, height: 18)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(HoverPressButtonStyle())
-                .help(repo.expanded ? "Collapse" : "Expand")
-            } else if let emoji = Self.leadingEmoji(repo.displayName) {
-                Text(emoji)
-                    .font(.system(size: 12))
-                    .frame(width: 18, height: 18)
-            } else {
-                Image(systemName: "folder")
+            Button {
+                Task { await appState.setRepoExpanded(id: repo.id, expanded: !repo.expanded) }
+            } label: {
+                Image(systemName: repo.expanded ? "chevron.down" : "chevron.right")
                     .font(.system(size: 11))
                     .foregroundStyle(
                         repo.status == .missing
@@ -127,7 +92,10 @@ struct RepoSectionView: View {
                             : AnyShapeStyle(HierarchicalShapeStyle.secondary)
                     )
                     .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
             }
+            .buttonStyle(HoverPressButtonStyle())
+            .help(repo.expanded ? "Collapse" : "Expand")
             RenameableLabel(
                 text: repo.displayName,
                 isEditing: $isEditing,
@@ -137,7 +105,7 @@ struct RepoSectionView: View {
                     }
                 }
             ) {
-                Text(Self.nameWithoutLeadingEmoji(repo.displayName))
+                Text(repo.displayName)
                     .font(.system(size: 12, weight: .semibold))
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -213,7 +181,7 @@ struct RepoSectionView: View {
         } message: {
             Text(removeConfirmMessage)
         }
-        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+        .listRowInsets(EdgeInsets(top: 0, leading: -2, bottom: 0, trailing: 0))
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
         .tag(repo.id)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -194,7 +194,7 @@ struct RepoSectionView: View {
                 WorktreeRowView(worktree: main, isMain: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.white.opacity(0.0001))
-                    .opacity(isChevronHovered ? 0.5 : 1.0)
+                    .opacity(isChevronHovered ? 0.75 : 1.0)
                     .onHover { onSectionHoverChange($0) }
                     .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
                     .listRowSeparator(.hidden)
@@ -205,7 +205,7 @@ struct RepoSectionView: View {
                 WorktreeRowView(worktree: worktree)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.white.opacity(0.0001))
-                    .opacity(isChevronHovered ? 0.5 : 1.0)
+                    .opacity(isChevronHovered ? 0.75 : 1.0)
                     .onHover { onSectionHoverChange($0) }
                     .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
                     .listRowSeparator(.hidden)

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -375,6 +375,12 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v21_repo_expanded") { db in
+            try db.alter(table: "repo") { t in
+                t.add(column: "expanded", .boolean).notNull().defaults(to: true)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -19,6 +19,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var worktree_root: String?
     var status: String
     var hidden: Bool
+    var expanded: Bool
 
     init(from repo: Repo) {
         self.id = repo.id.uuidString
@@ -34,6 +35,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.worktree_root = repo.worktreeRoot
         self.status = repo.status.rawValue
         self.hidden = repo.hidden
+        self.expanded = repo.expanded
     }
 
     func toModel() -> Repo {
@@ -50,7 +52,8 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             worktreeSlot: worktree_slot,
             worktreeRoot: worktree_root,
             status: RepoStatus(rawValue: status) ?? .ok,
-            hidden: hidden
+            hidden: hidden,
+            expanded: expanded
         )
     }
 }
@@ -176,6 +179,17 @@ public struct RepoStore: Sendable {
             try db.execute(
                 sql: "UPDATE repo SET hidden = ? WHERE id = ?",
                 arguments: [hidden, id.uuidString]
+            )
+        }
+    }
+
+    /// Set whether the repo section is expanded in the sidebar (worktree
+    /// rows visible). Defaults to true; persisted across app restarts.
+    public func setExpanded(id: UUID, expanded: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET expanded = ? WHERE id = ?",
+                arguments: [expanded, id.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -147,6 +147,22 @@ extension RPCRouter {
         return .ok()
     }
 
+    func handleRepoSetExpanded(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(RepoSetExpandedParams.self, from: paramsData)
+
+        guard try await db.repos.get(id: params.repoID) != nil else {
+            return RPCResponse(error: "Repository not found: \(params.repoID)")
+        }
+
+        try await db.repos.setExpanded(id: params.repoID, expanded: params.expanded)
+
+        subscriptions.broadcast(delta: .repoExpandedChanged(RepoExpandedDelta(
+            repoID: params.repoID, expanded: params.expanded
+        )))
+
+        return .ok()
+    }
+
     func handleRepoRename(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(RepoRenameParams.self, from: paramsData)
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -89,6 +89,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRepoRename(request.paramsData)
             case RPCMethod.repoSetHidden:
                 return try await handleRepoSetHidden(request.paramsData)
+            case RPCMethod.repoSetExpanded:
+                return try await handleRepoSetExpanded(request.paramsData)
             case RPCMethod.worktreeCreate:
                 return try await handleWorktreeCreate(request.paramsData)
             case RPCMethod.worktreeList:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -19,13 +19,18 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
     public var worktreeRoot: String?
     public var status: RepoStatus
     public var hidden: Bool
+    /// Whether the repo's worktree rows are shown in the sidebar. Defaults to
+    /// expanded (true). Collapsing hides the main worktree row and all child
+    /// worktree rows beneath the repo header.
+    public var expanded: Bool
 
     public init(id: UUID = UUID(), path: String, remoteURL: String? = nil,
                 displayName: String, defaultBranch: String = "main", createdAt: Date = Date(),
                 renamePrompt: String? = nil, customInstructions: String? = nil,
                 profileOverrideID: UUID? = nil,
                 worktreeSlot: String? = nil, worktreeRoot: String? = nil,
-                status: RepoStatus = .ok, hidden: Bool = false) {
+                status: RepoStatus = .ok, hidden: Bool = false,
+                expanded: Bool = true) {
         self.id = id
         self.path = path
         self.remoteURL = remoteURL
@@ -39,12 +44,13 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         self.worktreeRoot = worktreeRoot
         self.status = status
         self.hidden = hidden
+        self.expanded = expanded
     }
 
     enum CodingKeys: String, CodingKey {
         case id, path, remoteURL, displayName, defaultBranch, createdAt
         case renamePrompt, customInstructions, profileOverrideID
-        case worktreeSlot, worktreeRoot, status, hidden
+        case worktreeSlot, worktreeRoot, status, hidden, expanded
     }
 
     public init(from decoder: Decoder) throws {
@@ -62,6 +68,7 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         worktreeRoot = try c.decodeIfPresent(String.self, forKey: .worktreeRoot)
         status = try c.decodeIfPresent(RepoStatus.self, forKey: .status) ?? .ok
         hidden = try c.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
+        expanded = try c.decodeIfPresent(Bool.self, forKey: .expanded) ?? true
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -140,6 +140,7 @@ public enum RPCMethod {
     public static let repoRelocate = "repo.relocate"
     public static let repoRename = "repo.rename"
     public static let repoSetHidden = "repo.setHidden"
+    public static let repoSetExpanded = "repo.setExpanded"
     public static let sessionList = "session.list"
     public static let sessionMessages = "session.messages"
     public static let setMainAreaSize = "app.setMainAreaSize"
@@ -402,6 +403,14 @@ public struct RepoSetHiddenParams: Codable, Sendable {
     public let hidden: Bool
     public init(repoID: UUID, hidden: Bool) {
         self.repoID = repoID; self.hidden = hidden
+    }
+}
+
+public struct RepoSetExpandedParams: Codable, Sendable {
+    public let repoID: UUID
+    public let expanded: Bool
+    public init(repoID: UUID, expanded: Bool) {
+        self.repoID = repoID; self.expanded = expanded
     }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -13,6 +13,7 @@ public enum StateDelta: Codable, Sendable {
     case repoRemoved(RepoIDDelta)
     case repoRenamed(RepoRenameDelta)
     case repoHiddenChanged(RepoHiddenDelta)
+    case repoExpandedChanged(RepoExpandedDelta)
     case terminalCreated(TerminalDelta)
     case terminalRemoved(TerminalIDDelta)
     case worktreeConflictsChanged(WorktreeConflictDelta)
@@ -110,6 +111,15 @@ public struct RepoHiddenDelta: Codable, Sendable {
     public let hidden: Bool
     public init(repoID: UUID, hidden: Bool) {
         self.repoID = repoID; self.hidden = hidden
+    }
+}
+
+/// Delta payload for repo expand/collapse change.
+public struct RepoExpandedDelta: Codable, Sendable {
+    public let repoID: UUID
+    public let expanded: Bool
+    public init(repoID: UUID, expanded: Bool) {
+        self.repoID = repoID; self.expanded = expanded
     }
 }
 

--- a/Tests/TBDAppTests/RepoExpandedAppStateTests.swift
+++ b/Tests/TBDAppTests/RepoExpandedAppStateTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// DaemonClient is a concrete actor with no test stub. These tests only verify
+// the synchronous, optimistic local-state mutation in `setRepoExpanded` —
+// the daemon call afterwards will fail with no daemon present and be swallowed.
+// The view's render gate (worktree rows hidden when `repo.expanded == false`)
+// reads directly from the same `Repo.expanded` field, so verifying the
+// mutation covers both branches of the gate.
+
+@MainActor
+@Test func appState_setRepoExpanded_collapseUpdatesLocalState() async {
+    let state = AppState()
+    let repoID = UUID()
+    state.repos = [
+        Repo(id: repoID, path: "/tmp/x", displayName: "x", expanded: true)
+    ]
+    // Sanity: default branch — worktree rows would render.
+    #expect(state.repos[0].expanded == true)
+
+    await state.setRepoExpanded(id: repoID, expanded: false)
+
+    // Gated branch: rows hidden.
+    #expect(state.repos[0].expanded == false)
+}
+
+@MainActor
+@Test func appState_setRepoExpanded_expandUpdatesLocalState() async {
+    let state = AppState()
+    let repoID = UUID()
+    state.repos = [
+        Repo(id: repoID, path: "/tmp/x", displayName: "x", expanded: false)
+    ]
+    #expect(state.repos[0].expanded == false)
+
+    await state.setRepoExpanded(id: repoID, expanded: true)
+
+    // Ungated branch: rows render again.
+    #expect(state.repos[0].expanded == true)
+}
+
+@Test func repo_defaultIsExpanded() {
+    let repo = Repo(path: "/tmp/x", displayName: "x")
+    #expect(repo.expanded == true)
+}
+
+@Test func repo_decodesMissingExpandedAsTrue() throws {
+    // Old JSON shape (no `expanded` field) must decode as expanded so
+    // existing daemon installs don't suddenly collapse every repo.
+    let json = """
+    {
+      "id": "\(UUID().uuidString)",
+      "path": "/tmp/old",
+      "displayName": "old",
+      "defaultBranch": "main",
+      "createdAt": 0,
+      "status": "ok",
+      "hidden": false
+    }
+    """.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    let repo = try decoder.decode(Repo.self, from: json)
+    #expect(repo.expanded == true)
+}

--- a/Tests/TBDDaemonTests/RepoStoreTests.swift
+++ b/Tests/TBDDaemonTests/RepoStoreTests.swift
@@ -44,4 +44,31 @@ import Foundation
             try await db.repos.rename(id: UUID(), displayName: "anything")
         }
     }
+
+    // MARK: - Expand/collapse persistence
+
+    @Test func repoStoreDefaultExpandedIsTrue() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID())", displayName: "x", defaultBranch: "main"
+        )
+        // Newly created repos must start expanded so worktree rows are visible.
+        #expect(repo.expanded == true)
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.expanded == true)
+    }
+
+    @Test func repoStoreCollapsedRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID())", displayName: "x", defaultBranch: "main"
+        )
+        try await db.repos.setExpanded(id: repo.id, expanded: false)
+        let collapsed = try await db.repos.get(id: repo.id)
+        #expect(collapsed?.expanded == false)
+
+        try await db.repos.setExpanded(id: repo.id, expanded: true)
+        let expanded = try await db.repos.get(id: repo.id)
+        #expect(expanded?.expanded == true)
+    }
 }


### PR DESCRIPTION
## Summary
- Each repo header now has an always-visible chevron in place of the folder icon — `chevron.down` when the section is expanded, `chevron.right` when collapsed. Click toggles whether the main + worktree rows render. Display name renders verbatim, so any leading emoji stays put as part of the name. (Earlier passes tried hover-swap and emoji-slot tricks; both violated principle-of-least-surprise and were dropped — see commit history.) The repo header row is shifted 2pt left so the chevron lines up visually with the worktree content beneath.
- State persists across restarts via a new `expanded` column on repos (migration `v21_repo_expanded`, defaults to true) and a new `repo_set_expanded` RPC mirroring the existing `repo_set_hidden` flow — daemon, app, shared model, and state-delta broadcast all updated together.
- Tests cover both branches of the gated render: GRDB round-trip on the persistence side and AppState optimistic mutation on the UI side, including a legacy-JSON decode test that defaults missing `expanded` to true so existing installs don't suddenly collapse everything.

## Test plan
- [ ] `swift test --filter RepoStoreTests` and `swift test --filter RepoExpandedAppStateTests` pass.
- [ ] Sidebar shows a chevron next to every repo name (folder icon is gone). Click it — worktree rows hide, chevron flips to `chevron.right`. Click again to re-expand.
- [ ] Right-click the repo row — "Collapse" / "Expand" item appears at the top of the menu and works.
- [ ] Quit and relaunch the app — collapsed repos stay collapsed.
- [ ] Emoji-named repos still display their emoji as the first character of the name (no slot-swapping).

[📁 Folder Icon Toggle](https://cheapsteak.github.io/tbd/open/?worktree=B8603AB8-830D-4854-A879-FDCA3A639C37)