### PR TITLE
Perf: Stop SwiftUI re-measuring the entire transcript on every scroll

### DIFF
--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -360,29 +360,31 @@ struct SessionTranscriptView: View {
                     ScrollView {
                         TranscriptItemsView(items: messages, terminalID: nil, atBottom: $atBottom)
                     }
-                    .defaultScrollAnchor(.bottom)
+                    .defaultScrollAnchor(.bottom, for: .initialOffset)
                     .overlay(alignment: .bottomTrailing) {
-                        if !atBottom {
-                            Button {
-                                guard let lastID = lastRenderedNodeID(for: messages) else { return }
-                                withAnimation(.easeOut(duration: 0.2)) {
-                                    proxy.scrollTo(lastID, anchor: .bottom)
+                        Group {
+                            if !atBottom {
+                                Button {
+                                    guard let lastID = lastRenderedNodeID(for: messages) else { return }
+                                    withAnimation(.easeOut(duration: 0.2)) {
+                                        proxy.scrollTo(lastID, anchor: .bottom)
+                                    }
+                                } label: {
+                                    Image(systemName: "arrow.down.circle.fill")
+                                        .font(.system(size: 28))
+                                        .symbolRenderingMode(.palette)
+                                        .foregroundStyle(.white, Color.accentColor)
+                                        .background(.ultraThinMaterial, in: Circle())
+                                        .shadow(radius: 4)
                                 }
-                            } label: {
-                                Image(systemName: "arrow.down.circle.fill")
-                                    .font(.system(size: 28))
-                                    .symbolRenderingMode(.palette)
-                                    .foregroundStyle(.white, Color.accentColor)
-                                    .background(.ultraThinMaterial, in: Circle())
-                                    .shadow(radius: 4)
+                                .buttonStyle(.plain)
+                                .padding(16)
+                                .transition(.scale(scale: 0.5).combined(with: .opacity))
+                                .help("Scroll to bottom")
                             }
-                            .buttonStyle(.plain)
-                            .padding(16)
-                            .transition(.scale(scale: 0.5).combined(with: .opacity))
-                            .help("Scroll to bottom")
                         }
+                        .animation(.easeInOut(duration: 0.2), value: atBottom)
                     }
-                    .animation(.easeInOut(duration: 0.2), value: atBottom)
                 }
             }
         }

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -27,10 +27,6 @@ struct LiveTranscriptPaneView: View {
     /// shown only when the user has consciously scrolled up.
     @State private var atBottom: Bool = true
 
-    /// Tracks the row at the bottom edge of the viewport. Drives re-entry
-    /// restoration via `.scrollPosition(id:)` and autoscroll on new messages.
-    @State private var visibleID: String?
-
     private static let log = Logger(subsystem: "com.tbd.app", category: "live-transcript")
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
@@ -129,12 +125,11 @@ struct LiveTranscriptPaneView: View {
             ScrollView {
                 TranscriptItemsView(items: messages, terminalID: terminalID, atBottom: $atBottom)
             }
-            .defaultScrollAnchor(.bottom)
-            .scrollPosition(id: $visibleID, anchor: .bottom)
+            .defaultScrollAnchor(.bottom, for: .initialOffset)
             .overlay(alignment: .bottomTrailing) {
                 jumpToBottomButton(proxy: proxy)
+                    .animation(.easeInOut(duration: 0.2), value: atBottom)
             }
-            .animation(.easeInOut(duration: 0.2), value: atBottom)
             .onAppear {
                 let sidShort = Self.shortID(currentSessionID ?? "")
                 Self.perfLog.debug("view.appear sid=\(sidShort, privacy: .public) count=\(messages.count, privacy: .public)")
@@ -147,18 +142,15 @@ struct LiveTranscriptPaneView: View {
                     snap.transcriptItemCount = count
                     snap.paneLabel = "liveTranscript"
                 }
-                if let id = visibleID {
-                    let scrollInterval = TranscriptSignposts.signposter.beginInterval("transcript.scrollTo")
-                    proxy.scrollTo(id, anchor: .bottom)
-                    TranscriptSignposts.signposter.endInterval("transcript.scrollTo", scrollInterval)
-                }
             }
             .onChange(of: messages.last?.id) { oldID, newID in
                 guard let _ = oldID, let _ = newID, atBottom else { return }
                 guard let targetID = lastRenderedNodeID(for: messages) else { return }
+                let scrollInterval = TranscriptSignposts.signposter.beginInterval("transcript.scrollTo")
                 withAnimation(.easeOut(duration: 0.15)) {
-                    visibleID = targetID
+                    proxy.scrollTo(targetID, anchor: .bottom)
                 }
+                TranscriptSignposts.signposter.endInterval("transcript.scrollTo", scrollInterval)
             }
             .onChange(of: messages.count) { _, newCount in
                 let tidShort = String(terminalID.uuidString.suffix(4))

--- a/docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-brief.md
+++ b/docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-brief.md
@@ -1,0 +1,237 @@
+# Research brief: SwiftUI transcript pane hang, post-PR-#134 — flex-frame layout cycle
+
+**Date:** 2026-05-11
+**Author:** Claude (investigating issue cheapsteak/tbd#129)
+**Audience:** Reviewer LLM/human being asked to **critique an existing analysis and propose alternatives** for a SwiftUI hang in the TBD transcript pane.
+
+This is a peer-review brief, not a cold-start research request. A Claude general-purpose agent has already produced an analysis (summarized below). We want a second opinion that **challenges, refines, or extends** that analysis. If you think the leading hypothesis is wrong, say so concretely and propose what's right.
+
+> Sibling: a similar brief was produced for the prior signature (`_ViewList_Group.estimatedCount` recursion); see [`2026-05-11-transcript-hang-research-brief.md`](2026-05-11-transcript-hang-research-brief.md). PR #134 — born from that brief — landed today and successfully killed that signature. This brief is about what's left.
+
+## TL;DR
+
+- **PR #134 worked for its targeted signature** (`_ViewList_Group.estimatedCount` recursion: ≥40 deep / 67% CPU → **0 occurrences**).
+- **A different signature is now dominant**: `StackLayout.placeChildren1 ↔ _FlexFrameLayout.sizeThatFits ↔ _PaddingLayout.sizeThatFits` cycle, ~4 layers deep × 12/12 samples.
+- **Claude's leading hypothesis**: `.scrollPosition(id: $visibleID, anchor: .bottom)` on a `ScrollView { LazyVStack }` is forcing continuous content-height accounting, which drives the per-row layout fix-point search. Single-line removal as the falsification test.
+- **What we want from you**: is that hypothesis right? Is there a cheaper or more diagnostic test? Anything Claude missed?
+
+## Bug class history (compressed)
+
+`TranscriptItemsView` (`Sources/TBDApp/Panes/Transcript/`) renders a SwiftUI chat-style transcript inside `ScrollView { LazyVStack { ForEach } }` on macOS 15. Heterogeneous rows: user prompts, MarkdownUI chat bubbles, ~9 kinds of tool-call cards. Long sessions (50–1000+ items). Recurring 1s–17s main-thread hangs for weeks. Each fix closes one stack signature; a new one appears. Prior fixes (do not re-propose):
+
+| When | What | Outcome |
+|---|---|---|
+| 2026-05-09 | Gated `.textSelection(.enabled)` on hover (PR #120). | Closed 17s `StyledTextLayoutEngine` storm. |
+| 2026-05-11 morning | Capped `BashCard`/`WriteCard` inner-ScrollView heights at 600pt (PR #130). | Closed 5/10 signature. |
+| 2026-05-11 today | **PR #134 (merged):** pre-flattened `[TranscriptRenderNode]` outside `body`, dropped `.onScrollGeometryChange(... contentSize.height ...)`, collapsed `SubagentDisclosure` to single non-interactive row, added `OSSignposter`. | Closed `_ViewList_Group.estimatedCount` recursion entirely. |
+
+Full research-doc prior art collected at `docs/superpowers/specs/research-2026-05-06-swiftui-long-list-perf.md`. The `List` migration is documented as the structural fallback (`docs/superpowers/specs/2026-05-06-transcript-list-migration-design.md`) and explicitly still on the table for this round, but only if cheaper options don't work — `List` costs us `.defaultScrollAnchor(.bottom)` flash-free first paint and contiguous drag-select across rows.
+
+## New hang signature (post-PR-#134)
+
+Captured 2026-05-11 16:37, **1.18s hang, 1.100s main-thread CPU, 12 stackshots, ~23 min into a session.** Full spindump at `/Users/chang/tbd/worktrees/tbd/20260511-patient-tarantula/freeze.2.log` (18MB).
+
+### Frame counts
+
+- `_ViewList_Group.estimatedCount` / `ForEachList.estimatedCount`: **0 occurrences.** (Pre-#134: ≥40 deep, dominant.)
+- `StackLayout.placeChildren1`: 7 occurrences.
+- `_FlexFrameLayout.sizeThatFits` + `_PaddingLayout.sizeThatFits`: 12/12 samples each.
+- `GeometryReader.Child.updateValue → TBDApp + 1464048`: 1/12 sample. **Claude located this** — `Sources/TBDApp/Terminal/TerminalContainerView.swift:215` (`.background(GeometryReader { ... preference(MainAreaSizeKey) })`). Claude characterized it as **noise**, not cause: it's downstream of the transcript layout cycle dirtying ancestors, not driving it. Worth verifying.
+
+### Verbatim stack (deepest cycle path, lines 275–360 of freeze.2.log; ~12 deep in some samples)
+
+```
+NSHostingView.beginTransaction
+  → GraphHost.flushTransactions
+  → AG::Subgraph::update / AG::Graph::UpdateStack::update
+  →   _LazyLayout_Subviews.applyNodes
+  →     ForEachList.applyNodes → ForEachState.applyNodes
+  →       StackPlacement.placeSection
+  →         LazyHVStack<>.lengthAndSpacing                   ← outer LazyVStack
+  →           ViewLayoutEngine.sizeThatFits
+  →             StackLayout.placeChildren1                   ← TranscriptRow's VStack
+  →               StackLayout.sizeChildrenIdeally
+  →                 _FlexFrameLayout.sizeThatFits            ← .frame(maxWidth: .infinity)
+  →                   StackLayout.placeChildren1             ← inner VStack (ActivityRowChrome)
+  →                     _PaddingLayout.sizeThatFits          ← .padding(.horizontal, 12)
+  →                       _PaddingLayout.sizeThatFits        ← .padding(.vertical, 4)
+  →                         ViewLayoutEngine.sizeThatFits
+  →                           StackLayout.placeChildren1     ← cycle continues ~4 layers
+```
+
+Same recursion family as **[cmux #2327](https://github.com/manaflow-ai/cmux/issues/2327)** documented in the research doc: nested flex-frame interactions inside a parent stack layout producing a place-children/size-children/re-place-children cycle.
+
+## Current code state (post-merge)
+
+### `TranscriptItemsView.swift` body (lines ~67–110, abridged)
+
+```swift
+struct TranscriptItemsView: View {
+    let items: [TranscriptItem]
+    let terminalID: UUID?
+    var atBottom: Binding<Bool>? = nil
+    @State private var hoveredItemID: String? = nil
+
+    var body: some View {
+        let intervalState = TranscriptSignposts.signposter.beginInterval("transcript.items.body")
+        defer { TranscriptSignposts.signposter.endInterval("transcript.items.body", intervalState) }
+        return bodyView
+    }
+
+    @ViewBuilder private var bodyView: some View {
+        let nodes = transcriptRenderNodes(from: items)
+        // ... bodyLogged perf marker ...
+        LazyVStack(alignment: .leading, spacing: 4) {
+            ForEach(nodes) { node in
+                TranscriptRow(node: node, terminalID: terminalID)
+                    .environment(\.transcriptTextSelection, hoveredItemID == node.id)
+                    .onHover { if $0 { hoveredItemID = node.id } }
+            }
+            // 1pt sentinel — replaces old onScrollGeometryChange 50pt threshold
+            Color.clear
+                .frame(height: 1)
+                .onAppear { atBottom?.wrappedValue = true }
+                .onDisappear { atBottom?.wrappedValue = false }
+        }
+        .padding(.vertical, 8)
+    }
+}
+```
+
+### `TranscriptRow.swift` (the new PR #134 wrapper)
+
+```swift
+struct TranscriptRow: View {
+    let node: TranscriptRenderNode
+    let terminalID: UUID?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {     // ← new wrapper added by #134
+            content
+            if let usage = node.badgeUsage {
+                ContextUsageBadge(total: usage.contextTotal)
+                    .padding(.leading, 12).padding(.top, 2)
+            }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        switch node.kind {
+        case .chatBubble(let item):                   ChatBubbleView(item: item)
+        case .systemReminder(let id, let kind, let text, let ts):
+            SystemReminderRow(id: id, kind: kind, text: text, timestamp: ts)
+        case .skillBody(let id, let text, let ts):
+            SkillBodyRow(id: id, text: text, timestamp: ts)
+        case .toolCall(...):                          toolCard(...)
+        case .subagentSummary(_, let count, let agentType):
+            SubagentSummaryRow(count: count, agentType: agentType)
+        }
+    }
+    // ... toolCard internal switch over 9 tool names ...
+}
+```
+
+### `LiveTranscriptPaneView.swift` outer (lines ~127–135)
+
+```swift
+ScrollViewReader { proxy in
+    ScrollView {
+        TranscriptItemsView(items: messages, terminalID: terminalID, atBottom: $atBottom)
+    }
+    .defaultScrollAnchor(.bottom)
+    .scrollPosition(id: $visibleID, anchor: .bottom)    // ← Claude's leading suspect
+    .overlay(alignment: .bottomTrailing) {
+        jumpToBottomButton(proxy: proxy)
+    }
+    .animation(.easeInOut(duration: 0.2), value: atBottom)
+    .onAppear {
+        // ... HangWatchdog.recordContext ...
+        if let id = visibleID {
+            proxy.scrollTo(id, anchor: .bottom)
+        }
+    }
+    .onChange(of: messages.last?.id) { _, newID in
+        guard let _ = oldID, let _ = newID, atBottom else { return }
+        guard let targetID = lastRenderedNodeID(for: messages) else { return }
+        withAnimation(.easeOut(duration: 0.15)) {
+            visibleID = targetID
+        }
+    }
+}
+```
+
+`.scrollPosition(id:)` writes the user's anchored row into `visibleID`; `.defaultScrollAnchor(.bottom)` provides the initial-position hint. **Both currently coexist.**
+
+### `.frame(maxWidth: .infinity)` cardinality
+
+Claude grepped `Panes/Transcript/` and found **21 callsites** — every chat bubble, every tool-card body, every `ActivityRowChrome.body`, every `AskUserQuestionCard` panel — each one a `_FlexFrameLayout` node that appears as a frame in the cycle. Stacked `.padding(...)` modifiers on top add one round-trip per layer to the fix-point search.
+
+## Claude's analysis (summary)
+
+### Root-cause hypothesis
+
+**Layout fixed-point search inside LazyVStack.** SwiftUI's `LazyVStack` (a `StackLayout`) sizes a child by (1) proposing a width, (2) asking the child to fit, (3) reconciling alignment. A child rooted in `VStack { ... }.frame(maxWidth: .infinity)` is a `_FlexFrameLayout` containing another `StackLayout`. With `maxWidth: .infinity`, the child can't commit a width until its own children fit — so each `.padding(...)` wrapper introduces another round-trip. With 21 per-row flex frames, each row's layout pass bounces through `StackLayout ↔ _FlexFrameLayout ↔ _PaddingLayout` repeatedly. `.scrollPosition(id:, anchor: .bottom)` then *forces SwiftUI to know the anchored row's exact y-position*, which requires sizing every row from `visibleID` to end on every transaction. That sizing cost is what's hanging.
+
+### PR #134 culpability
+
+**~75% pre-existing, ~25% amplified by the new `TranscriptRow` `VStack` wrapper.** Evidence:
+- `_FlexFrameLayout.sizeThatFits` and `_PaddingLayout.sizeThatFits` were *visible* in the pre-#134 12:18 freeze (~8/12 samples each), just masked by the dominant `estimatedCount` work. Now they're the top remaining cost.
+- The new wrapper adds 1 `StackLayout` layer per row; the cycle was always there, now it's 4-deep instead of 3-deep.
+- `.scrollPosition(id:)` and the 21 `.frame(maxWidth:.infinity)` callsites all predate #134.
+
+So #134 didn't cause this — it exposed the always-latent cycle by removing the bigger cost on top. (The row-wrapper amplification is a small *bonus* fix-back opportunity if Fix A doesn't fully clear the cycle.)
+
+### Candidate fixes (ranked)
+
+| # | Fix | Confidence | Effort |
+|---|---|---|---|
+| **A** | **Drop `.scrollPosition(id:)`, keep `.defaultScrollAnchor(.bottom)`** + remove `visibleID` state and its two `onChange` writers. Use `ScrollViewReader.proxy.scrollTo` for autoscroll (already in place). | **High** | 1-line removal + dead-state cleanup |
+| B | Add `.fixedSize(horizontal: false, vertical: true)` on `TranscriptRow.body`'s outer `VStack`. | Medium (cycle is width-shaped, not height-shaped) | 1 line |
+| C | Hoist `.frame(maxWidth: .infinity)` from per-row to LazyVStack level + remove from 21 callsites. | Med-high impact, med-high risk (visual regressions, esp. ChatBubbleView right-alignment) | 21-callsite refactor |
+| D | `TranscriptRow: Equatable` + `.equatable()`. | Medium for re-render churn, low for layout cycle (skips `body`, not `sizeThatFits`) | 5 lines |
+| E | `List` migration (structural fix). | High that it works; existing design doc has the plan. | Medium (1 commit per design doc) |
+| F | Replace `if usage { Badge }` conditional with always-rendered + opacity/overlay (kills `_ConditionalContent` row-shape flips on every new message). | Low-Medium | 5 lines |
+
+### Proposed 1-day test (Fix A)
+
+1. Baseline spindump on a 500+ item transcript scrolled up.
+2. Remove `.scrollPosition(id:)` + dead `visibleID` state + 2 `onChange` writers.
+3. Verification spindump after restart.
+4. **Pass**: `grep -c "StackLayout.UnmanagedImplementation" freeze.*.log` drops ≥50%, recursion depth from ~4 to ≤2.
+5. Functional: re-entry behavior (loses "remembered scroll position" — re-opens at bottom), autoscroll on new message, jump-to-bottom button. **Trade-off acceptable.**
+
+## What we want from you (the reviewer)
+
+Critique Claude's analysis. Specifically:
+
+1. **Is Fix A the leading candidate, or should something else be first?** Cite reasoning. If Claude's hypothesis about `.scrollPosition(id:)` forcing continuous content-height accounting is wrong or oversimplified, explain why. (Apple DTS reply on [forums #770682](https://developer.apple.com/forums/thread/770682) confirms `.scrollPosition` doesn't work on `List` — does it actually force *continuous* size accounting on `LazyVStack`, or only on initial position resolution? Cite SwiftUI internals or Apple docs.)
+
+2. **Is there a cheaper or more diagnostic test than Fix A?** The frame-count + recursion-depth grep is rough — would a more precise instrument (Instruments, SwiftUI track, `OSSignposter` overlap with one of our existing regions) tell us more without code change first?
+
+3. **Is the `TranscriptRow` wrapper's ~25% amplification estimate plausible?** Could the new `VStack(alignment: .leading, spacing: 2)` actually be the *primary* contributor, not a secondary one? Falsifying test?
+
+4. **Anything Claude missed?** Specifically:
+   - A SwiftUI internals nuance about `_FlexFrameLayout` + `_PaddingLayout` interaction that would short-circuit the cycle differently than removing `.scrollPosition`.
+   - A WWDC24/25 API or recent macOS 15.x update that changes the calculus.
+   - A non-obvious code path (e.g., `MarkdownUI`'s internal `Table` rendering via `TableBounds.init`, which appeared in the prior freeze) that's a co-contributor we should investigate before assuming the row chrome is the only flex-frame source.
+
+5. **Is the GeometryReader hit at `TerminalContainerView.swift:215` definitely noise, or worth investigating?** Claude said "downstream of the transcript layout cycle dirtying ancestors" — verify or refute. If it could be a partial contributor, what's the test?
+
+## Reference docs
+
+- `docs/superpowers/specs/research-2026-05-06-swiftui-long-list-perf.md` — collected prior art (~30 sources, IceCubes pattern, MarkdownUI maintenance-mode story, etc.).
+- `docs/superpowers/specs/2026-05-06-transcript-list-migration-design.md` — the structural-fallback migration design.
+- `docs/superpowers/specs/2026-05-11-transcript-render-node-design.md` — the PR #134 implementation spec.
+- `docs/superpowers/specs/2026-05-11-transcript-hang-research-{brief,discussion}.md` — the prior research pair for the `estimatedCount` signature (now resolved).
+
+## Constraints
+
+- Read-only investigation. No code changes.
+- Reference files by `path:line` when relevant.
+- Use grep/awk on `freeze.2.log` rather than reading the whole 18MB.
+- Working directory: `/Users/chang/tbd/worktrees/tbd/20260511-patient-tarantula/`.
+- Issue tracker: <https://github.com/cheapsteak/tbd/issues/129> (still open).
+
+## Coordination
+
+If you want to leave findings: append to `docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-discussion.md` (sibling file). Template inside.

--- a/docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-discussion.md
+++ b/docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-discussion.md
@@ -1,0 +1,162 @@
+# Discussion: post-PR-#134 flex-frame hang — peer-review findings
+
+**Companion to:** [`2026-05-11-transcript-flex-frame-research-brief.md`](2026-05-11-transcript-flex-frame-research-brief.md) (read first).
+
+This file is the coordination channel between the original investigator (Claude) and reviewer LLMs/humans being asked to critique the existing analysis and propose alternatives. Each reviewer appends a section at the bottom; the investigator updates **Status** at the top after reading.
+
+> Distinct from the prior research pair ([`2026-05-11-transcript-hang-research-brief.md`](2026-05-11-transcript-hang-research-brief.md) + [`-discussion.md`](2026-05-11-transcript-hang-research-discussion.md)), which produced PR #134 and resolved the `_ViewList_Group.estimatedCount` signature. **This one is about what's left after that fix.**
+
+---
+
+## Status
+
+**Current state:** Codex + Gemini findings reviewed. Refined experiment plan below; key Claude blind spot identified.
+
+**Convergent finding both reviewers flagged (Claude missed it):** `.animation(.easeInOut(duration: 0.2), value: atBottom)` at `LiveTranscriptPaneView.swift:137` wraps the entire ScrollView. The 1pt `Color.clear` sentinel added in PR #134 toggles `atBottom` via `.onAppear`/`.onDisappear` *during lazy realization* — which means `atBottom` mutations happen *inside* the layout pass that's actively running, and the `.animation` modifier wraps that mutation in a `withAnimation` transaction on the container being sized. Both Codex and Gemini independently call this out as a likely contributor to the layout cycle.
+
+**Where Codex and Gemini diverge:**
+- **Codex**: pushes a **2×2 anchor test matrix** (baseline / drop `scrollPosition` / role-scope `defaultScrollAnchor(.bottom, for: .initialOffset)` / drop both). Separates three mechanisms: active-identity tracking, anchor size-change handling, explicit imperative scrolls. Wants Instruments + signpost overlap data *before* any code change.
+- **Gemini**: leads with the **animation-removal test** as the cheapest isolation, then drops both `.scrollPosition` *and* `.defaultScrollAnchor` (IceCubes pattern exactly).
+
+**Codex also surfaced:** `.scrollPosition(id:)` is documented to be used **alongside `.scrollTargetLayout()`** for active-identity tracking. We removed `.scrollTargetLayout()` pre-#134. So our current `.scrollPosition(id:)` is in an unsupported / degraded configuration regardless of the perf-anchor question.
+
+**Both reviewers agree:**
+- GeometryReader at `TerminalContainerView.swift:215` is noise (Codex: "mostly yes"; Gemini: "agree").
+- `TranscriptRow` wrapper ~25% amplification estimate plausible (Gemini: "highly plausible"; Codex: "plausible but unproven, tiny falsifying test exists").
+
+**Refined experiment order (cheapest → largest):**
+1. **Pre-change Instruments capture** (Codex): SwiftUI track + Time Profiler with existing `TranscriptSignposts` regions. Check whether the stall overlaps `transcript.scrollTo`, `transcript.items.body`, or neither. If neither → layout-after-body-evaluation, `.equatable()` won't help.
+2. **Drop `.animation(..., value: atBottom)`** (Gemini): cheapest single-line test. If hang signature changes, animation-transaction-wrapping is at least a co-contributor.
+3. **Codex's 2×2 scroll-anchor matrix.**
+4. **If still hanging after 2 + 3**: narrow `.frame(maxWidth: .infinity)` removal in shared wrappers only (`ActivityRowChrome:60`, `ChatBubbleView:35`) — not all 21 leaf callsites (Codex).
+5. **Last resort**: `List` migration per existing design doc.
+
+**Open hypotheses now answered:**
+- ~~Does `.scrollPosition(id:)` force continuous content-height accounting?~~ → Apple documents `ScrollPosition` as maintaining visible identity across reorder/size-change/initial layout. Combined with `.defaultScrollAnchor(.bottom)`'s un-role-scoped form *also* handling content-size-change maintenance, both share blame.
+- ~~Is GeometryReader at TerminalContainerView noise?~~ → Yes (both reviewers).
+- ~~Is the `TranscriptRow` wrapper a primary contributor?~~ → Falsifiable test exists (replace with `.overlay(alignment: .bottomLeading)` per Codex; tiny).
+
+**New open hypothesis:**
+- Does `.animation(..., value: atBottom)` × 1pt sentinel toggle during realization create animated layout transactions that aggravate the StackLayout↔FlexFrame cycle?
+
+**Updates from investigator (most recent first):**
+- 2026-05-12 — Codex + Gemini reviews synthesized. Refined plan: animation-removal as step 2 (was not on Claude's list), then 2×2 anchor matrix.
+- 2026-05-11 — research findings submitted by Codex and Gemini.
+- 2026-05-11 — research brief written; Claude general-purpose agent analysis embedded in §"Claude's analysis"; awaiting reviewer.
+
+---
+
+## How to leave findings
+
+1. Read the brief in full.
+2. Append a new section at the bottom of this file using the template below.
+3. Cite sources with URLs. If you're reasoning from SwiftUI internals (binary symbols, ABI, Apple docs), say which.
+4. Keep your section under ~1000 words. Multiple shorter sections fine.
+5. If you want the investigator to verify something locally before you commit more research time, put it in "Suggested next-step probe."
+
+### Reviewer template
+
+```markdown
+## Reviewer: [your name / model]
+**Date:** YYYY-MM-DD
+
+### Verdict on Claude's leading hypothesis (Fix A: drop `.scrollPosition(id:)`)
+Agree / Disagree / Partially agree. One paragraph of reasoning.
+
+### Counter-proposal or refinement
+If you'd lead with a different fix, what is it and why? If you'd run a different diagnostic test first, what is it?
+
+### Specific answers to the brief's 5 questions
+1. Is Fix A the leading candidate, or should something else be first?
+2. Is there a cheaper or more diagnostic test than Fix A?
+3. Is the `TranscriptRow` wrapper's ~25% amplification estimate plausible?
+4. Anything Claude missed?
+5. Is the `TerminalContainerView.swift:215` GeometryReader definitely noise?
+
+### Suggested next-step probe for the investigator
+(Optional. The first thing you'd want verified locally before committing more research time.)
+
+### Confidence
+Low / medium / high — and one sentence on what would move you.
+
+### Sources cited
+(Aggregate URL list.)
+```
+
+---
+
+## Reviewer findings
+
+(Append below this line.)
+
+## Reviewer: Codex
+**Date:** 2026-05-11
+
+### Verdict on Claude's leading hypothesis (Fix A: drop `.scrollPosition(id:)`)
+Partially agree. Dropping `.scrollPosition(id:)` is a good first falsification test, but I would not describe the proven mechanism as "continuous content-height accounting" from `.scrollPosition` alone. Apple documents two relevant behaviors: `scrollPosition(id:)` updates the binding while scrolling and uses the anchor to choose the active identity; `ScrollPosition` also tries to keep an identified view visible across reorder, size changes, and initial layout mismatches. That supports Claude's suspicion. But the current code also keeps `.defaultScrollAnchor(.bottom)` at [LiveTranscriptPaneView.swift](/Users/chang/tbd/worktrees/tbd/20260511-patient-tarantula/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift:132), and Apple documents that the non-role-scoped form controls both initial visibility and content-size-change handling. So if Fix A only removes line 133, any remaining `StackLayout ↔ _FlexFrameLayout` cycle may still be driven by bottom-anchor size-change maintenance.
+
+One more mismatch: Apple says `scrollPosition(id:)` is used along with `scrollTargetLayout()` to know active view identity. The brief says `.scrollTargetLayout()` was removed, and current [TranscriptItemsView.swift](/Users/chang/tbd/worktrees/tbd/20260511-patient-tarantula/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift:83) has no target-layout modifier. That makes the current `scrollPosition(id:)` even more suspect, but for "unsupported/degraded target discovery" reasons, not only exact y-position accounting.
+
+### Counter-proposal or refinement
+Run a 2x2 anchor test, not a single Fix A test:
+
+1. Baseline.
+2. Remove `.scrollPosition(id:)` only.
+3. Keep no `.scrollPosition`, but change `.defaultScrollAnchor(.bottom)` to role-scoped initial offset only: `.defaultScrollAnchor(.bottom, for: .initialOffset)`.
+4. Remove `.scrollPosition` and remove default bottom anchoring, then use explicit `proxy.scrollTo(lastRenderedNodeID, anchor: .bottom)` on appear/append.
+
+This separates three mechanisms: active identity tracking, default-anchor size-change handling, and explicit imperative scrolls. If variant 2 still hangs but variant 3 clears it, Claude blamed the wrong scroll primitive. If variant 2 clears it, Fix A is validated. If only variant 4 clears it, the issue is any declarative bottom-anchor maintenance on a variable-height `LazyVStack`.
+
+### Specific answers to the brief's 5 questions
+1. **Is Fix A first?** Yes, but as part of the 2x2 test above. Apple docs plus Fatbobman's ScrollView writeup both support performance risk for large data with `scrollPosition`, and the local code uses it without `scrollTargetLayout()`. I would remove `.scrollPosition(id:)` before touching 21 frame callsites.
+
+2. **Cheaper/more diagnostic test?** Yes: use existing `TranscriptSignposts` and one Instruments SwiftUI run before code changes. The spindump already shows 12/12 samples inside `LazySubviewPlacements.placeSubviews -> LazyHVStack.lengthAndSpacing -> StackLayout` and zero `TableBounds` / `StyledTextLayoutEngine` hits by `rg`, so Time Profiler plus the SwiftUI track should confirm whether the stall overlaps `transcript.scrollTo`, `transcript.items.body`, or neither. If neither, it is layout after body evaluation, and `.equatable()` will not help this signature.
+
+3. **Is the `TranscriptRow` wrapper 25% amplification plausible?** Plausible but unproven. The hottest path asks `StackLayout.explicitAlignment` before entering `_FlexFrameLayout`; [TranscriptRow.swift](/Users/chang/tbd/worktrees/tbd/20260511-patient-tarantula/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift:14)'s leading-aligned outer `VStack` is a direct candidate for that extra alignment query. The falsifying test is tiny: replace the outer row `VStack` with `content.overlay(alignment: .bottomLeading) { badge }` or a custom single-child wrapper for non-badge rows, then profile the same transcript. If recursion depth drops by one layer but total stall remains high, it is an amplifier. If the hang disappears, the wrapper estimate was too low.
+
+4. **Anything missed?** Two things. First, the 1pt bottom sentinel at [TranscriptItemsView.swift](/Users/chang/tbd/worktrees/tbd/20260511-patient-tarantula/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift:105) mutates `atBottom` during lazy realization, and `LiveTranscriptPaneView` animates on `atBottom` changes at line 137. That can create extra transactions while SwiftUI is placing lazy subviews. A diagnostic variant should hard-code `atBottom = true` or remove the `.animation(..., value: atBottom)` to see whether the sentinel is adding churn. Second, many expensive `.frame(maxWidth: .infinity)` nodes are inside already full-width chrome, especially [ActivityRowChrome.swift](/Users/chang/tbd/worktrees/tbd/20260511-patient-tarantula/Sources/TBDApp/Panes/Transcript/ActivityRowChrome.swift:60) and [ChatBubbleView.swift](/Users/chang/tbd/worktrees/tbd/20260511-patient-tarantula/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift:35). If scroll-anchor tests only partially help, the next narrow refactor should remove full-width frames from shared wrappers first, not all 21 leaf callsites.
+
+5. **Is `TerminalContainerView.swift:215` GeometryReader noise?** Mostly yes. In `freeze.2.log`, the GeometryReader branch appears in sample 9 as one sibling branch under `AG::Subgraph::update`; it is not nested inside the 12/12 `LazySubviewPlacements` branch. The code at [TerminalContainerView.swift](/Users/chang/tbd/worktrees/tbd/20260511-patient-tarantula/Sources/TBDApp/Terminal/TerminalContainerView.swift:215) publishes main-area size upward, so transcript layout changing ancestor geometry can dirty it. Still, the cheap test is to temporarily replace the background `GeometryReader` with a fixed cached size or throttle the preference write. If the GeometryReader sample vanishes but the 12/12 lazy-stack branch remains, it is confirmed noise.
+
+### Suggested next-step probe for the investigator
+Do the 2x2 scroll-anchor matrix first and use the same transcript/spindump grep for `_FlexFrameLayout`, `_PaddingLayout`, `StackLayout.UnmanagedImplementation`, `GeometryReader.Child`, `TableBounds`, and `StyledTextLayoutEngine`. Treat success as both fewer hang-watchdog events and a stack-shape change, not just a shorter single hang.
+
+### Confidence
+Medium-high that some declarative scroll-position/anchor maintenance is the trigger; medium that `.scrollPosition(id:)` alone is the trigger. The result that would move me most is variant 2 vs variant 3 in the matrix.
+
+### Sources cited
+- Apple `scrollPosition(id:anchor:)`: <https://developer.apple.com/documentation/swiftui/view/scrollposition%28id%3Aanchor%3A%29>
+- Apple `ScrollPosition`: <https://developer.apple.com/documentation/SwiftUI/ScrollPosition>
+- Apple `defaultScrollAnchor(_:)`: <https://developer.apple.com/documentation/swiftui/view/defaultscrollanchor%28_%3A%29>
+- Apple `defaultScrollAnchor(_:for:)` and `ScrollAnchorRole`: <https://developer.apple.com/documentation/swiftui/view/defaultscrollanchor%28_%3Afor%3A%29>, <https://developer.apple.com/documentation/swiftui/scrollanchorrole>
+- Apple `frame(minWidth:idealWidth:maxWidth:minHeight:idealHeight:maxHeight:alignment:)`: <https://developer.apple.com/documentation/swiftui/view/frame%28minwidth%3Aidealwidth%3Amaxwidth%3Aminheight%3Aidealheight%3Amaxheight%3Aalignment%3A%29>
+- Fatbobman, "Deep Dive into the New Features of ScrollView in SwiftUI": <https://fatbobman.com/en/posts/new-features-of-scrollview-in-swiftui5/>
+
+---
+
+## Reviewer: Gemini
+**Date:** 2026-05-11
+
+### Verdict on Claude's leading hypothesis (Fix A: drop `.scrollPosition(id:)`)
+Partially agree. Dropping `.scrollPosition(id:)` is a highly probable fix because without `.scrollTargetLayout()` providing explicit anchor boundaries, `.scrollPosition` forces SwiftUI to synthesize layout bounds continuously as variable-height children are realized. However, `.defaultScrollAnchor(.bottom)` has known issues with `LazyVStack` and variable heights (as documented in Apple Forums #741406 and #685461). Relying *only* on `defaultScrollAnchor` after dropping `scrollPosition` might still trigger a sizing cycle as the Stack attempts to resolve the anchor's physical offset against unfixed content sizes. 
+
+### Counter-proposal or refinement
+I propose a refined diagnostic approach before executing Fix A:
+1. **Instrument `atBottom` mutation:** The new 1pt `Color.clear` sentinel mutates `atBottom` via `.onAppear`. `LiveTranscriptPaneView` applies `.animation(.easeInOut(duration: 0.2), value: atBottom)` to the entire `ScrollView`. If `atBottom` toggles during initial layout or scrolling (e.g., the sentinel flickers in/out of the realization window), the `withAnimation` transaction wraps the *entire lazy layout pass*. SwiftUI layout is exceptionally sensitive to animated state changes during `sizeThatFits`. We must verify this isn't the root instigator of the flex-frame cycle.
+2. **Execute Fix A, but drop `.defaultScrollAnchor` too:** Fall back entirely to `ScrollViewReader.proxy.scrollTo(lastID, anchor: .bottom)` in `.onAppear`. This is the proven IceCubes pattern and removes all declarative scroll bounds accounting from the Stack layout pass.
+
+### Specific answers to the brief's 5 questions
+1. **Is Fix A the leading candidate?** Yes, but it should be modified to drop `.defaultScrollAnchor` as well to isolate the LazyVStack from all declarative scroll management. Use `proxy.scrollTo` exclusively for initial bottom-anchoring.
+2. **Cheaper or more diagnostic test?** Yes. Temporarily remove `.animation(.easeInOut(duration: 0.2), value: atBottom)` from `LiveTranscriptPaneView`. If the `_FlexFrameLayout` cycle duration drops significantly or disappears, the `atBottom` sentinel is triggering animated re-layouts during scroll realization.
+3. **Is the `TranscriptRow` wrapper's ~25% amplification estimate plausible?** Highly plausible. The `VStack` adds an explicit `StackLayout.placeChildren1` frame per row. Because `.frame(maxWidth: .infinity)` exists inside it, SwiftUI must measure the VStack's leading alignment, ask the inner FlexFrame to fit, which asks *its* inner padding/content to fit. Removing the VStack wrapper is an excellent secondary target if Fix A only partially works. 
+4. **Anything Claude missed?** Claude missed the impact of the `.animation(..., value: atBottom)` applied to the `ScrollView` that wraps the `LazyVStack`. The sentinel's `.onAppear` firing during a layout pass creates a state mutation that triggers an animated transaction on the container actively being sized.
+5. **Is the `TerminalContainerView.swift:215` GeometryReader definitely noise?** Agree it is noise. The single `GeometryReader` sample sits under `AG::Subgraph::update`, not inside the `LazySubviewPlacements` branch dominating the CPU time.
+
+### Suggested next-step probe for the investigator
+Remove the `.animation(.easeInOut, value: atBottom)` modifier on the `ScrollView` in `LiveTranscriptPaneView`. If the hang persists, proceed with dropping `.scrollPosition` and `.defaultScrollAnchor` in favor of `proxy.scrollTo`.
+
+### Confidence
+High confidence that declarative scroll bounds (`.scrollPosition` / `.defaultScrollAnchor`) interacting with `maxWidth: .infinity` children is the root cause. Medium confidence that the `atBottom` animation is an aggravating factor.
+
+### Sources cited
+- Apple Forums thread/741406 (defaultScrollAnchor issues): <https://developer.apple.com/forums/thread/741406>

--- a/docs/superpowers/specs/2026-05-12-transcript-scroll-bounds-design.md
+++ b/docs/superpowers/specs/2026-05-12-transcript-scroll-bounds-design.md
@@ -1,0 +1,223 @@
+# Transcript pane: drop declarative scroll-bounds + animation-wrapping
+
+**Date:** 2026-05-12
+**Status:** Approved for implementation.
+**Goal:** Eliminate the second `StackLayout ↔ _FlexFrameLayout ↔ _PaddingLayout` recursion signature characterized in the 2026-05-11 16:37 freeze, by removing the declarative scroll-bounds maintenance machinery (`.scrollPosition(id:)` + non-role-scoped `.defaultScrollAnchor(.bottom)`) and the ScrollView-wide `.animation(..., value: atBottom)` that wraps layout passes in animated transactions.
+
+## Why
+
+PR #134 successfully eliminated the `_ViewList_Group.estimatedCount` recursion (the prior dominant signature). A different signature now dominates the 16:37 hang: `LazyHVStack.lengthAndSpacing → StackLayout.placeChildren1 ↔ _FlexFrameLayout.sizeThatFits ↔ _PaddingLayout.sizeThatFits` ~4 deep × 12/12 samples. Reviewer convergence (Codex + Gemini, see [`2026-05-11-transcript-flex-frame-research-discussion.md`](2026-05-11-transcript-flex-frame-research-discussion.md)) points at three contributors in the same theme — **declarative scroll-bounds machinery + animated transactions wrapping the layout pass** — that we should address as one batch since the bug is not reliably reproducible locally and longitudinal observation is the validator.
+
+Specific contributors this spec targets:
+
+1. **`.animation(.easeInOut(duration: 0.2), value: atBottom)`** at `LiveTranscriptPaneView.swift:137` wraps the entire `ScrollView`. The 1pt sentinel added in PR #134 toggles `atBottom` *during lazy realization*, so `atBottom` mutations land inside the layout pass that's actively running. The `.animation` modifier wraps that mutation in a `withAnimation` transaction on the container being sized. Flagged by both Codex and Gemini.
+
+2. **`.scrollPosition(id: $visibleID, anchor: .bottom)`** at `LiveTranscriptPaneView.swift:133` requires SwiftUI to maintain the identified row's visible position across reorder / size-change / initial-layout mismatches. Apple documents `.scrollPosition(id:)` as designed to be used alongside `.scrollTargetLayout()` — which we removed long ago — so we're already in a documented-degraded configuration.
+
+3. **Non-role-scoped `.defaultScrollAnchor(.bottom)`** at `LiveTranscriptPaneView.swift:132` handles both initial position *and* content-size-change maintenance. Role-scoping to `.initialOffset` (macOS 15+ API) keeps the no-flash first paint while opting out of ongoing size-change accounting.
+
+## Out of scope (deliberately deferred)
+
+- **Drop the `TranscriptRow` outer `VStack` wrapper** (replace with `.overlay(alignment: .bottomLeading)` for the badge). Different theme; visual-regression risk on badge layering. Next batch if this one doesn't move the needle.
+- **Remove `.frame(maxWidth: .infinity)` from `ActivityRowChrome:60` and `ChatBubbleView:35`** (shared wrappers only, per Codex). Different theme; visual-regression risk on right-aligned user bubbles. Next batch.
+- **Remove all 21 `.frame(maxWidth: .infinity)` callsites.** Too risky without measurement.
+- **`List` migration** — structural fallback, deserves its own PR per [`2026-05-06-transcript-list-migration-design.md`](2026-05-06-transcript-list-migration-design.md).
+- **`@Observable` migration of `AppState`** — separate concern.
+- **`.equatable()` on `TranscriptRow`** — Codex notes this skips `body` re-eval but not `sizeThatFits`; doesn't address the cycle.
+
+## Scope
+
+Four coordinated changes, **landed as one commit**. All target the same mechanism (declarative scroll-bounds + animated-transaction wrapping) and share the same UX trade-off; bundling them keeps the PR thematically tight and avoids attribution ambiguity if a longitudinal observation comes back positive.
+
+### Change A — scope `.animation(..., value: atBottom)` to just the jump-button overlay
+
+**Files:** `Sources/TBDApp/Panes/LiveTranscriptPaneView.swift` (line ~137), `Sources/TBDApp/Panes/HistoryPaneView.swift` (parallel location).
+
+Current shape:
+
+```swift
+ScrollView { ... }
+    .defaultScrollAnchor(.bottom)
+    .scrollPosition(id: $visibleID, anchor: .bottom)
+    .overlay(alignment: .bottomTrailing) {
+        jumpToBottomButton(proxy: proxy)
+    }
+    .animation(.easeInOut(duration: 0.2), value: atBottom)   // ← wraps everything
+```
+
+Target shape:
+
+```swift
+ScrollView { ... }
+    // .defaultScrollAnchor(.bottom, for: .initialOffset)  — change C
+    // scrollPosition removed                              — change B
+    .overlay(alignment: .bottomTrailing) {
+        jumpToBottomButton(proxy: proxy)
+            .animation(.easeInOut(duration: 0.2), value: atBottom)  // ← scoped to overlay only
+    }
+```
+
+Rationale: the animation should affect *only* the jump-button's appear/disappear transition. Wrapping the entire ScrollView in a `value: atBottom`-keyed animation means every `atBottom` toggle (which fires from the lazy sentinel mid-realization) wraps the layout pass in a `withAnimation` transaction. Bad pattern. Scoping to the button preserves the visual intent.
+
+### Change B — drop `.scrollPosition(id: $visibleID, anchor: .bottom)`
+
+**Files:** same as A.
+
+Delete:
+- The `.scrollPosition(id: $visibleID, anchor: .bottom)` modifier line.
+- `@State private var visibleID: String? = nil` declaration.
+- The `.onAppear { if let id = visibleID { proxy.scrollTo(id, anchor: .bottom) } }` restore block — `visibleID` is now nil, this is a no-op anyway, and `defaultScrollAnchor(.bottom, for: .initialOffset)` handles initial position.
+- The `.onChange(of: messages.last?.id)` writer that assigns `visibleID = targetID` — replaced by direct `proxy.scrollTo` (change D).
+
+Keep:
+- The `transcript.scrollTo` signposter regions; they wrap the new `proxy.scrollTo` calls instead.
+
+### Change C — role-scope `.defaultScrollAnchor`
+
+**Files:** same.
+
+```swift
+// Before:
+.defaultScrollAnchor(.bottom)
+
+// After:
+.defaultScrollAnchor(.bottom, for: .initialOffset)
+```
+
+Available on macOS 15+ (we target macOS 14+; this is fine for actively-running macOS 15 sessions). Role-scoping to `.initialOffset` says "use this as the initial scroll position only; don't continuously maintain it against content-size changes." Preserves the flash-free first paint that Phase-1 of the List migration would have lost.
+
+### Change D — rewire autoscroll-on-new-message to use `proxy.scrollTo`
+
+**Files:** same.
+
+Current `.onChange` block (after PR #134 fixup `558a8d8`):
+
+```swift
+.onChange(of: messages.last?.id) { oldID, newID in
+    guard let _ = oldID, let _ = newID, atBottom else { return }
+    guard let targetID = lastRenderedNodeID(for: messages) else { return }
+    withAnimation(.easeOut(duration: 0.15)) {
+        visibleID = targetID
+    }
+}
+```
+
+New shape:
+
+```swift
+.onChange(of: messages.last?.id) { oldID, newID in
+    guard let _ = oldID, let _ = newID, atBottom else { return }
+    guard let targetID = lastRenderedNodeID(for: messages) else { return }
+    let scrollInterval = TranscriptSignposts.signposter.beginInterval("transcript.scrollTo")
+    withAnimation(.easeOut(duration: 0.15)) {
+        proxy.scrollTo(targetID, anchor: .bottom)
+    }
+    TranscriptSignposts.signposter.endInterval("transcript.scrollTo", scrollInterval)
+}
+```
+
+`ScrollViewProxy.scrollTo(_:anchor:)` is the IceCubes pattern (research doc has citations). `withAnimation` is what gives it the easing — `proxy.scrollTo` doesn't natively animate.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `Sources/TBDApp/Panes/LiveTranscriptPaneView.swift` | A + B + C + D. Drop `visibleID` state, `.scrollPosition`, ScrollView-wide `.animation`, restore-on-appear; rewire `.onChange`. |
+| `Sources/TBDApp/Panes/HistoryPaneView.swift` | Same changes applied in parallel. HistoryPaneView is read-only so no `.onChange` rewire needed (no streaming) — just the modifier set + jump button. Verify the equivalent structure exists and apply. |
+| `Sources/TBDShared/...` | None. |
+| `Sources/TBDApp/Panes/Transcript/...` | None. The flex-frame mechanism survives; this PR doesn't touch row chrome. |
+
+## UX trade-off (explicit; accepted)
+
+- **Lose scroll-position-preservation across pane close/reopen.** Every re-entry to the live or history transcript pane will land at the bottom regardless of where the user was scrolled when they left. The `.scrollPosition(id:)` binding was the only mechanism preserving this; without it, `defaultScrollAnchor(.bottom, for: .initialOffset)` always wins on entry.
+- **Jump-to-bottom button appearance/disappearance only animates on transition** — same as today, just scoped to the overlay subtree instead of riding on the ScrollView's keyed animation. No visible difference.
+- **Autoscroll on new-message arrival** continues to animate smoothly via `withAnimation(.easeOut(duration: 0.15)) { proxy.scrollTo(...) }`.
+
+This trade-off was already on the Phase-2 deferral list of the List migration design and is acceptable as a foundation here too.
+
+## Success criteria
+
+The bug is not reliably reproducible locally; longitudinal observation is the validator.
+
+**Required:**
+- `swift build` clean.
+- `swift test` clean (no UI tests cover this, but ensure nothing else regresses).
+- Manual sanity in a fresh restart:
+  - Live transcript pane lands at the bottom on first paint (no flash, no top-of-list briefly visible).
+  - Sending a new message smoothly autoscrolls to the new content.
+  - Scrolling up: jump-to-bottom button appears (with easing). Tapping it scrolls smoothly to the bottom.
+  - Closing and reopening the pane: lands at bottom (intended trade-off; no preservation).
+  - History pane: equivalent behavior.
+
+**Longitudinal (over the next ~24 hours of normal use):**
+- `log show --last 24h --predicate 'subsystem == "com.tbd.app" AND category == "hang-watchdog"' --info --style compact` — should show zero `hang detected stallMs=>1000` lines.
+- If a freeze does occur, the stack signature should no longer match the `StackLayout.placeChildren1 ↔ _FlexFrameLayout.sizeThatFits` 12/12 dominance characterized in the 16:37 freeze. (Different signature still alive → next batch tackles row chrome.)
+
+## Implementation phasing
+
+**One commit.** The four changes share code paths and a single UX trade-off; splitting them up makes review harder without enabling per-step measurement (which we can't do anyway due to the no-repro constraint).
+
+Conventional commit message:
+
+```
+perf(transcript): drop declarative scroll-bounds + animation wrapping (#129)
+
+Removes three contributors to the StackLayout ↔ _FlexFrameLayout
+recursion characterized in the 2026-05-11 16:37 freeze, all in the
+same theme of "declarative scroll-bounds maintenance + animated
+transactions wrapping the layout pass":
+
+1. Scope the .animation(.easeInOut, value: atBottom) modifier to the
+   jump-button overlay only. Was wrapping the entire ScrollView, so
+   every atBottom toggle (fired by the lazy sentinel mid-realization)
+   wrapped the layout pass in a withAnimation transaction.
+2. Drop .scrollPosition(id: $visibleID, anchor: .bottom). Apple docs
+   require pairing with .scrollTargetLayout() (which we don't use),
+   and .scrollPosition is documented to maintain visible identity
+   across content-size changes — forcing continuous bottom-anchor
+   accounting on the LazyVStack. Drop the corresponding visibleID
+   state and onAppear restore.
+3. Role-scope .defaultScrollAnchor(.bottom) to .defaultScrollAnchor(
+   .bottom, for: .initialOffset). The unrole-scoped form continues to
+   maintain bottom alignment against content-size changes; the
+   .initialOffset role makes it a one-shot initial-position hint.
+4. Rewire .onChange autoscroll on new messages to use
+   proxy.scrollTo(lastRenderedNodeID, anchor: .bottom) instead of
+   writing visibleID (which is now removed).
+
+Trade-off: scroll-position-preservation across pane close/reopen is
+lost. Re-entry always lands at bottom. This was already on the
+List-migration Phase-2 deferral list; acceptable here too.
+
+Reviewer convergence (Codex + Gemini) recorded in
+docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-discussion.md.
+Bug is not reliably reproducible locally; validation is longitudinal
+HangWatchdog observation.
+```
+
+## Verification plan
+
+1. `swift build` from worktree cwd — must succeed cleanly. No new warnings.
+2. `swift test` — must remain at 681 passing.
+3. **Do not run `scripts/restart.sh` in the subagent** — that's the user's verification step. Subagent reports back without restarting.
+4. After user's restart + manual sanity check, push branch and open PR (or merge directly if user prefers, given no reliable repro and the PR-#134 pattern).
+5. Watch HangWatchdog telemetry over the next ~24h.
+
+## Risks
+
+- **macOS 15.x version skew on `.defaultScrollAnchor(_:for:)`.** Verify availability annotation. If we target macOS 14+, this needs an `if #available(macOS 15.0, *)` guard. (Project actually runs on macOS 15+ in practice; CLAUDE.md mentions Sequoia. But check `Package.swift` `.platforms` declaration.)
+- **First-paint position behavior change.** `.defaultScrollAnchor(.bottom, for: .initialOffset)` *should* preserve the flash-free first paint, but if SwiftUI's role-scoped variant behaves differently than the unrole-scoped form here, we may see a brief top-of-list flash on first appear. Worth a manual sanity check.
+- **`proxy.scrollTo` race with `withAnimation` on macOS 15.** Documented pattern, but verify the autoscroll feels right; if not, drop the `withAnimation` wrapper (loses easing, instant snap — minor degradation).
+- **HistoryPaneView parity.** The history pane has a different structure (no streaming, no `.onChange(of: messages.last?.id)`). Just remove the modifiers + state; don't add rewires that don't apply.
+
+## References
+
+- Discussion: [`2026-05-11-transcript-flex-frame-research-discussion.md`](2026-05-11-transcript-flex-frame-research-discussion.md) — Codex + Gemini findings.
+- Research brief: [`2026-05-11-transcript-flex-frame-research-brief.md`](2026-05-11-transcript-flex-frame-research-brief.md).
+- Issue: [#129](https://github.com/cheapsteak/tbd/issues/129).
+- Prior PR (still on main): [#134](https://github.com/cheapsteak/tbd/pull/134) — eliminated the `_ViewList_Group.estimatedCount` signature.
+- Apple docs cited:
+  - [`scrollPosition(id:anchor:)`](https://developer.apple.com/documentation/swiftui/view/scrollposition%28id%3Aanchor%3A%29)
+  - [`defaultScrollAnchor(_:for:)`](https://developer.apple.com/documentation/swiftui/view/defaultscrollanchor%28_%3Afor%3A%29) + [`ScrollAnchorRole`](https://developer.apple.com/documentation/swiftui/scrollanchorrole)
+  - [Apple Forums #770682](https://developer.apple.com/forums/thread/770682) — Apple DTS reply on `.scrollPosition` not working on `List`.
+- Reference implementation: [IceCubesApp `TimelineListView.swift`](https://github.com/Dimillian/IceCubesApp/blob/main/Packages/Timeline/Sources/Timeline/View/TimelineListView.swift) — `ScrollViewReader.proxy.scrollTo` pattern, no `.scrollPosition`, no `.defaultScrollAnchor`.


### PR DESCRIPTION
## Summary

- After PR #134 killed the `_ViewList_Group.estimatedCount` recursion, a different signature has been driving the recurring transcript-pane hangs: `StackLayout ↔ _FlexFrameLayout ↔ _PaddingLayout` cycle ~4 deep × 12/12 samples (last captured 2026-05-11 16:37, 1.18s freeze).
- Three declarative scroll-bounds mechanisms together force SwiftUI to maintain the LazyVStack's bottom anchor against every content-size change — re-measuring every row from `visibleID` to end on every transaction. Codex + Gemini independently converged on this family (see [`docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-discussion.md`](docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-discussion.md)).
- This PR removes the family as one batch: (A) scope `.animation(..., value: atBottom)` to the jump-button overlay only — was wrapping the whole ScrollView in a `withAnimation` transaction every time the 1pt sentinel toggled `atBottom` mid-realization; (B) drop `.scrollPosition(id: $visibleID, anchor: .bottom)` + the corresponding `visibleID` state and `.onAppear` restore (Apple docs require pairing it with `.scrollTargetLayout()` which we don't use); (C) role-scope `.defaultScrollAnchor(.bottom)` → `.defaultScrollAnchor(.bottom, for: .initialOffset)` so the anchor is a one-shot initial-position hint, not ongoing maintenance; (D) rewire `.onChange` autoscroll on new messages to call `proxy.scrollTo(lastRenderedNodeID, anchor: .bottom)` directly.
- Trade-off: lose scroll-position-preservation across pane close/reopen — every re-entry to live/history transcript lands at the bottom now. Already on the List-migration Phase-2 deferral list; acceptable here too.

Refs #129 — leave open after merge; bug is not reliably reproducible locally, so validation is longitudinal HangWatchdog observation over the next ~24h.

## Test plan

- [ ] `swift build` clean (verified locally)
- [ ] `scripts/restart.sh` smoke (verified — exactly one TBDDaemon + one TBDApp from the worktree path, no crashes, no `hang detected` in 2m post-restart)
- [ ] Manual UI sanity on the live transcript pane:
  - [ ] First paint lands at bottom, **no top-of-list flash**
  - [ ] Sending a new message: smooth autoscroll to new content with easing
  - [ ] Scroll up → jump-button appears (easing) → tap → scrolls smoothly to bottom
  - [ ] Close + reopen pane → lands at bottom (intended trade-off, not a regression)
- [ ] HistoryPaneView: equivalent behavior on a session detail view
- [ ] Longitudinal: `log show --last 24h --predicate 'subsystem == "com.tbd.app" AND category == "hang-watchdog"' --info --style compact` should show no `hang detected stallMs=>1000` lines from the `StackLayout/_FlexFrameLayout` family. If hangs recur with the same signature, the next batch tackles row chrome (drop the `TranscriptRow` outer VStack + selectively remove `.frame(maxWidth: .infinity)` from `ActivityRowChrome` and `ChatBubbleView`).

## Refs

- Tracking issue (keep open): #129
- Prior fix that closed the `estimatedCount` signature: #134 (merged)
- Reviewer findings: [`docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-discussion.md`](docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-discussion.md)
- Implementation spec: [`docs/superpowers/specs/2026-05-12-transcript-scroll-bounds-design.md`](docs/superpowers/specs/2026-05-12-transcript-scroll-bounds-design.md)
- Reference: IceCubesApp `TimelineListView.swift` (uses `ScrollViewReader.proxy.scrollTo` exclusively, no `.scrollPosition`, no `.defaultScrollAnchor`)

---

_Do not auto-close #129 on merge — experimental fix in a recurring bug class; will close manually after longitudinal observation confirms the hang has not recurred._

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=CE610865-D6AE-44A6-90A7-9EF513C65143)