### PR TITLE
fix(reconcile): defer bootstrap window kill in reboot recovery

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Restore source mtimes from git commit times
         uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2
 
+      - name: Install tmux
+        # macos-15 runners don't ship tmux. The reconcile reboot-recovery
+        # regression test (WorktreeLifecycleTests.testRecreateAfterRebootBootstrapKillOrdering)
+        # drives TmuxManager against a real tmux server on a unique socket.
+        run: brew install tmux
+
       - name: Capture Swift toolchain version
         run: echo "SWIFT_VERSION=$(xcrun swift --version | head -1)" >> $GITHUB_ENV
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -307,14 +307,28 @@ extension WorktreeLifecycle {
             )
         }
 
-        let window = try await tmux.createWindow(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path,
-            shellCommand: spawn.command,
-            env: env,
-            sensitiveEnv: spawn.sensitiveEnv
-        )
+        let window: (windowID: String, paneID: String)
+        do {
+            window = try await tmux.createWindow(
+                server: worktree.tmuxServer,
+                session: "main",
+                cwd: worktree.path,
+                shellCommand: spawn.command,
+                env: env,
+                sensitiveEnv: spawn.sensitiveEnv
+            )
+        } catch {
+            // If we just bootstrapped the server and createWindow failed, the
+            // server is alive with only the placeholder window. On the next
+            // reconcile, `serverAlive=true` + `windowExists("@stale")=false`
+            // would route this terminal to the dead-window-delete path and
+            // lose the record. Kill the server so the next reconcile takes
+            // the serverExists=false branch and retries recovery here.
+            if bootstrapWindowID != nil {
+                try? await tmux.killServer(server: worktree.tmuxServer)
+            }
+            throw error
+        }
         // Now that a real window exists, it's safe to kill the bootstrap.
         // The session retains the freshly-created window, so it stays alive
         // and the server keeps running. Best-effort: a failure here just

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -233,9 +233,17 @@ extension WorktreeLifecycle {
     /// this path directly. The reconcile dispatcher only enters this branch when
     /// `serverExists → false`, which `TmuxManager(dryRun: true)` cannot simulate.
     internal func recreateAfterReboot(terminal: Terminal, worktree: Worktree) async throws {
-        if let bootstrapWindowID = try await tmux.ensureServer(server: worktree.tmuxServer, session: "main", cwd: worktree.path) {
-            try? await tmux.killWindow(server: worktree.tmuxServer, windowID: bootstrapWindowID)
-        }
+        // tmux invariant: killing the ONLY window in a session destroys the
+        // session, and a server with no sessions exits. `ensureServer` here
+        // bootstraps a brand-new server via `new-session -d -s main`, leaving
+        // exactly one window. If we kill that bootstrap window now, the
+        // session collapses, the server exits, and the `createWindow` call
+        // below fails with `no server running on …`. Defer the kill until
+        // after the real window exists so the session always has at least
+        // one window during the transition.
+        let bootstrapWindowID = try await tmux.ensureServer(
+            server: worktree.tmuxServer, session: "main", cwd: worktree.path
+        )
 
         let spawn: ClaudeSpawnCommandBuilder.Result
         var env: [String: String] = [:]
@@ -307,6 +315,14 @@ extension WorktreeLifecycle {
             env: env,
             sensitiveEnv: spawn.sensitiveEnv
         )
+        // Now that a real window exists, it's safe to kill the bootstrap.
+        // The session retains the freshly-created window, so it stays alive
+        // and the server keeps running. Best-effort: a failure here just
+        // leaves an empty placeholder window behind, which the orphan-window
+        // cleanup pass in reconcile() will remove next time.
+        if let bootstrapWindowID {
+            try? await tmux.killWindow(server: worktree.tmuxServer, windowID: bootstrapWindowID)
+        }
         try await db.terminals.updateTmuxIDs(id: terminal.id, windowID: window.windowID, paneID: window.paneID)
     }
 }

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -750,11 +750,7 @@ private func createTestRepoResolvingSymlinks() async throws -> (tempDir: URL, re
     // Use the same temp-repo machinery as other lifecycle tests so the worktree
     // path actually exists on disk (tmux refuses to set cwd to a missing dir).
     let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
-    defer {
-        // Always tear down the tmux server, even on test failure.
-        Task { try? await realTmux.killServer(server: socketName) }
-        try? FileManager.default.removeItem(at: tempDir)
-    }
+    defer { try? FileManager.default.removeItem(at: tempDir) }
 
     let db = try TBDDatabase(inMemory: true)
     let lifecycle = WorktreeLifecycle(
@@ -786,7 +782,13 @@ private func createTestRepoResolvingSymlinks() async throws -> (tempDir: URL, re
 
     // Drive the recovery path. Must not throw — with the buggy ordering this
     // throws `TmuxError.commandFailed` with output "no server running on …".
-    try await lifecycle.recreateAfterReboot(terminal: terminal, worktree: wt)
+    do {
+        try await lifecycle.recreateAfterReboot(terminal: terminal, worktree: wt)
+    } catch {
+        // Make sure we tear down even when the assertion below fails.
+        try? await realTmux.killServer(server: socketName)
+        throw error
+    }
 
     // The terminal's IDs must have been updated to point at the freshly
     // created tmux window/pane.
@@ -807,6 +809,10 @@ private func createTestRepoResolvingSymlinks() async throws -> (tempDir: URL, re
     let windows = try await realTmux.listWindows(server: socketName, session: "main")
     #expect(windows.count == 1,
             "session should contain exactly the freshly-created window after bootstrap kill; got \(windows)")
+
+    // Explicit cleanup: ensure the test server is gone before we leave.
+    // (defer can't `await`, so we tear down inline.)
+    try? await realTmux.killServer(server: socketName)
 }
 
 // MARK: - Helpers

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -726,6 +726,89 @@ private func createTestRepoResolvingSymlinks() async throws -> (tempDir: URL, re
     // mock IDs when the server is gone.
 }
 
+/// Regression test for the bug where `recreateAfterReboot` killed the bootstrap
+/// window before any real window existed in the session. tmux's rule: killing
+/// the only window destroys the session, and a server with no sessions exits.
+/// The buggy code would therefore lose the server between `ensureServer` and
+/// `createWindow`, causing the latter to fail with "no server running on …".
+///
+/// Drives the path with a REAL `TmuxManager` (not dry-run) against a unique
+/// socket name so we can observe actual tmux behavior. The test:
+///   1. Verifies the socket does not exist before the call.
+///   2. Calls `recreateAfterReboot` and asserts it does not throw.
+///   3. Asserts the terminal's window/pane IDs were updated in the DB.
+///   4. Tears down by killing the test tmux server.
+@Test func testRecreateAfterRebootBootstrapKillOrdering() async throws {
+    let socketName = "tbd-test-\(UUID().uuidString.prefix(8))"
+    let realTmux = TmuxManager()
+    // Make sure no stray server is alive on this socket (it shouldn't be, but
+    // be defensive — and verify it isn't before we call into the recovery path).
+    try? await realTmux.killServer(server: socketName)
+    let aliveBefore = await realTmux.serverExists(server: socketName)
+    #expect(!aliveBefore, "Test precondition: socket \(socketName) must not have a live server")
+
+    // Use the same temp-repo machinery as other lifecycle tests so the worktree
+    // path actually exists on disk (tmux refuses to set cwd to a missing dir).
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer {
+        // Always tear down the tmux server, even on test failure.
+        Task { try? await realTmux.killServer(server: socketName) }
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: realTmux,
+        hooks: HookResolver()
+    )
+
+    // Insert a worktree + terminal record pointing at the test socket. We do
+    // NOT go through `createWorktree` — that would spawn windows. Instead we
+    // simulate a freshly-rebooted state where DB rows exist but the tmux
+    // server is gone.
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt",
+        branch: "main",
+        path: repoDir.path,
+        tmuxServer: socketName
+    )
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@stale-1",
+        tmuxPaneID: "%stale-1"
+    )
+
+    // Drive the recovery path. Must not throw — with the buggy ordering this
+    // throws `TmuxError.commandFailed` with output "no server running on …".
+    try await lifecycle.recreateAfterReboot(terminal: terminal, worktree: wt)
+
+    // The terminal's IDs must have been updated to point at the freshly
+    // created tmux window/pane.
+    let updated = try await db.terminals.get(id: terminal.id)
+    #expect(updated != nil)
+    #expect(updated?.tmuxWindowID != "@stale-1",
+            "tmuxWindowID must be replaced with a freshly-allocated tmux window ID")
+    #expect(updated?.tmuxPaneID != "%stale-1",
+            "tmuxPaneID must be replaced with a freshly-allocated tmux pane ID")
+    // Real tmux window IDs look like "@<digits>" and pane IDs like "%<digits>".
+    #expect(updated?.tmuxWindowID.hasPrefix("@") == true)
+    #expect(updated?.tmuxPaneID.hasPrefix("%") == true)
+
+    // Server should still be alive — and after the bootstrap kill, the session
+    // should contain exactly one window (the one we just created).
+    let aliveAfter = await realTmux.serverExists(server: socketName)
+    #expect(aliveAfter, "tmux server must still be running after recreateAfterReboot")
+    let windows = try await realTmux.listWindows(server: socketName, session: "main")
+    #expect(windows.count == 1,
+            "session should contain exactly the freshly-created window after bootstrap kill; got \(windows)")
+}
+
 // MARK: - Helpers
 
 /// Thread-safe collector for TmuxManager dryRun recorded args.


### PR DESCRIPTION
## Summary
- `recreateAfterReboot` bootstrapped a fresh tmux server via `ensureServer`, then immediately killed the placeholder window. Because that placeholder was the only window in the only session, killing it destroyed the session — and a server with no sessions exits. The follow-up `createWindow` then failed with `no server running on /private/tmp/tmux-502/<socket>`, leaving **every** saved terminal unrecoverable after a machine reboot.
- Moved the kill to after `createWindow` so the session always has at least one window during the transition; added a comment explaining the tmux invariant.
- Added regression test in `WorktreeLifecycleTests.swift` that drives the recovery path against a real tmux server on a unique socket, then asserts the terminal record's window/pane IDs were updated, the server stays alive, and the bootstrap window has been cleaned up.

Caught in the wild after a macOS update — all 11 saved terminals across two repos failed reconcile with identical "no server running" errors. With this fix applied locally, recovery succeeded against the still-broken `tbd-20d47045` server (2/2 terminals recreated, including a `claude --resume` session).

## Test plan
- [x] `swift build` passes
- [x] Manually validated the tmux invariant (`new-session` → `kill-window` of the bootstrap → server exits) reproduces the original bug; with the fix's ordering (`new-session` → `new-window` → `kill-window`) the session/server stay alive
- [x] Drove recovery against real broken state (permissions.svc tmux server): 2/2 terminals recreated, `claude --resume <id>` reattached cleanly
- [ ] `swift test` — currently blocked on this machine by a pre-existing toolchain gap (Apple Swift 6.3.1 via CommandLineTools missing the `Testing` module); reproduced on `main` with this branch stashed, so it's not introduced here. Should run cleanly in CI / with Xcode toolchain.