### PR TITLE
Test: Disable transcript hover-driven env broadcast to validate hang trigger (#129)

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -39,17 +39,17 @@ struct TranscriptItemsView: View {
     /// need the signal.
     var atBottom: Binding<Bool>? = nil
 
-    /// Tracks the most recently hovered row. The latched row is the only
-    /// one that materializes `.textSelection(.enabled)` (via
-    /// `transcriptSelectableText` + `EnvironmentValues.transcriptTextSelection`)
-    /// — every other visible row renders plain `Text` to avoid the per-row
-    /// `NSTextField` tax that caused ~17 s layout hangs (see
-    /// `TranscriptSelectableText.swift`). The latch is intentional: we do NOT
-    /// clear on hover-exit so that drag-select still works when the cursor
-    /// briefly leaves the row geometry. Typed as `String?` because
-    /// `TranscriptRenderNode.id` is a `String` (matching
-    /// `TranscriptItem.ID`'s underlying type).
-    @State private var hoveredItemID: String? = nil
+    // Hover-driven `hoveredItemID` state removed as a falsification test for
+    // issue #129 (post-PR-#137 hangs). `freeze.2.log` sample 1 entered via
+    // `EventBindingManager.enqueueHoverUpdateIfNeeded → HoverEventDispatcher
+    // → HostingScrollView.PlatformGroupContainer.hitTest` before the layout
+    // storm; the hypothesis under test is that per-row `.onHover` mutating
+    // an environment value broadcast across every row is a trigger for the
+    // `StackLayout ↔ _FlexFrameLayout` recursion. While this is in place,
+    // `transcriptTextSelection` is forced `false`, so `.textSelection
+    // (.enabled)` does not materialize on tool-call cards. `ChatBubbleView`
+    // overrides the env to `true` inside its own subtree, so user/assistant
+    // bubble text remains selectable.
 
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
@@ -83,13 +83,7 @@ struct TranscriptItemsView: View {
         LazyVStack(alignment: .leading, spacing: 4) {
             ForEach(nodes) { node in
                 TranscriptRow(node: node, terminalID: terminalID)
-                    .environment(\.transcriptTextSelection, hoveredItemID == node.id)
-                    .onHover { hovering in
-                        // Latch on enter; intentionally do NOT clear on
-                        // exit so drag-select keeps working when the
-                        // cursor briefly leaves the row.
-                        if hovering { hoveredItemID = node.id }
-                    }
+                    .environment(\.transcriptTextSelection, false)
             }
             // 1pt sentinel that drives `atBottom`. Replaced the prior
             // `.onScrollGeometryChange(for: AtBottomGeometry.self)` reader that

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -39,17 +39,7 @@ struct TranscriptItemsView: View {
     /// need the signal.
     var atBottom: Binding<Bool>? = nil
 
-    // Hover-driven `hoveredItemID` state removed as a falsification test for
-    // issue #129 (post-PR-#137 hangs). `freeze.2.log` sample 1 entered via
-    // `EventBindingManager.enqueueHoverUpdateIfNeeded → HoverEventDispatcher
-    // → HostingScrollView.PlatformGroupContainer.hitTest` before the layout
-    // storm; the hypothesis under test is that per-row `.onHover` mutating
-    // an environment value broadcast across every row is a trigger for the
-    // `StackLayout ↔ _FlexFrameLayout` recursion. While this is in place,
-    // `transcriptTextSelection` is forced `false`, so `.textSelection
-    // (.enabled)` does not materialize on tool-call cards. `ChatBubbleView`
-    // overrides the env to `true` inside its own subtree, so user/assistant
-    // bubble text remains selectable.
+    // `transcriptTextSelection` forced `false` as a #129 falsification test — revert this PR to restore the hover-latch.
 
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 

--- a/Sources/TBDApp/Panes/Transcript/TranscriptSelectableText.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptSelectableText.swift
@@ -10,9 +10,12 @@ import SwiftUI
 /// env propagation. Layout passes go super-linear and the main thread stalls
 /// (confirmed via spindumps showing ~17 s hangs).
 ///
-/// `TranscriptItemsView` flips this env to `true` only on the most-recently
-/// hovered row (latched, not live-hovered), so non-hovered rows render plain
-/// `Text` and skip the `NSTextField` materialization entirely.
+/// `TranscriptItemsView` normally flips this env to `true` only on the most-
+/// recently hovered row (latched, not live-hovered), so non-hovered rows render
+/// plain `Text` and skip the `NSTextField` materialization entirely. (Currently
+/// forced `false` for every row while the #129 hover-trigger falsification test
+/// in PR #140 is live — `ChatBubbleView` overrides to `true` in its subtree, so
+/// user/assistant text stays selectable.)
 private struct TranscriptTextSelectionKey: EnvironmentKey {
     static let defaultValue: Bool = false
 }

--- a/docs/superpowers/specs/2026-05-12-transcript-flex-frame-post-pr137-brief.md
+++ b/docs/superpowers/specs/2026-05-12-transcript-flex-frame-post-pr137-brief.md
@@ -1,0 +1,340 @@
+# Research brief: SwiftUI transcript pane hang, post-PR-#137 — flex-frame cycle still dominant
+
+**Date:** 2026-05-12
+**Author:** Claude (investigating issue cheapsteak/tbd#129, reopened 2026-05-12)
+**Audience:** Codex (or other reviewer LLM/human) being asked to **investigate why the StackLayout ↔ _FlexFrameLayout cycle survived the PR #137 fix** and recommend next concrete steps.
+
+This is the third research-brief in the #129 series. The first two led to landed fixes (PR #134, PR #137). Both were grounded in the prior brief's hypothesis. The current freeze is the first longitudinal data point after the latest fix, and **it shows the bug class is still alive**. The previous brief proposed `.scrollPosition(id:)` removal as the falsification test for the leading hypothesis; PR #137 executed that test. The test came back negative — the cycle is largely unchanged.
+
+This brief asks: **given that the prior hypothesis was falsified, what should be tried next?**
+
+## TL;DR
+
+- **PR #137 (`261681b`, merged 2026-05-12 08:46)** removed all three contributors the prior brief identified: `.animation(.easeInOut, value: atBottom)` wrapping the `ScrollView`, `.scrollPosition(id: $visibleID, anchor: .bottom)`, and un-role-scoped `.defaultScrollAnchor(.bottom)`. Plus dead `visibleID` state cleanup.
+- **A new freeze was captured ~7 hours later** (2026-05-12 15:41:00 -0400, TBDApp PID 36142, 1.14s hang, 1.098s main-thread CPU, 12 samples × 100ms). The `StackLayout ↔ _FlexFrameLayout ↔ ScrollViewLayoutComputer.Engine.sizeThatFits` recursion is still dominant.
+- **Implication**: the prior brief's leading hypothesis ("`.scrollPosition(id:)` forces continuous content-height accounting, which drives the per-row layout fix-point search") was not the dominant cause. Removing it did not break the cycle.
+- **What we want from you**: investigate what *is* driving the cycle, given that the most-suspected modifier is now gone. Propose a new ranked candidate list with a falsification test for the top option.
+
+## Bug class history (extended from prior briefs)
+
+`TranscriptItemsView` (`Sources/TBDApp/Panes/Transcript/`) renders a SwiftUI chat-style transcript inside `ScrollView { LazyVStack { ForEach } }` on macOS 26.1. Heterogeneous rows: user prompts, MarkdownUI chat bubbles, ~9 kinds of tool-call cards. Long sessions (50–1000+ items). Recurring 1s–17s main-thread hangs for weeks. Each fix closes one stack signature; a new one appears. Prior fixes (do not re-propose):
+
+| When | What | Outcome |
+|---|---|---|
+| 2026-05-09 | Gated `.textSelection(.enabled)` on hover (PR #120, `a41f716`). | Closed 17s `StyledTextLayoutEngine` storm. |
+| 2026-05-11 morning | Capped `BashCard`/`WriteCard` inner-ScrollView heights at 600pt (PR #130, `937c1c4`). Centralized in `TranscriptCardLayout.{expandedMaxHeight, collapsedMaxHeight}`. | Closed `.frame(maxHeight: .infinity)` recursion. |
+| 2026-05-11 afternoon | PR #134 (`2a57ac7`): pre-flattened `[TranscriptRenderNode]` outside `body`, dropped `.onScrollGeometryChange(... contentSize.height ...)`, collapsed `SubagentDisclosure` to single non-interactive row, added `OSSignposter` (`TranscriptSignposts`). | Closed `_ViewList_Group.estimatedCount` recursion (≥40 deep → 0 frames). |
+| **2026-05-12 morning** | **PR #137 (`261681b`)**: dropped `.scrollPosition(id: $visibleID, anchor: .bottom)`, scoped `.animation(.easeInOut, value: atBottom)` to the jump-button overlay only, role-scoped `.defaultScrollAnchor(.bottom, for: .initialOffset)`, rewired autoscroll to `proxy.scrollTo(lastRenderedNodeID, anchor: .bottom)`. Trade-off accepted: scroll-position-preservation on pane re-entry. | **Targeted the StackLayout ↔ _FlexFrameLayout cycle. Validation: longitudinal HangWatchdog.** |
+
+Full research-doc prior art at `docs/superpowers/specs/research-2026-05-06-swiftui-long-list-perf.md`. The `List` migration design (`docs/superpowers/specs/2026-05-06-transcript-list-migration-design.md`) remains the structural fallback.
+
+## New hang capture (post-PR-#137)
+
+Captured **2026-05-12 15:41:00 -0400**, ~7 hours after PR #137 merged.
+Spindump: **`/Users/chang/tbd/worktrees/tbd/20260512-juicy-swordfish/freeze.1.log`** (234,755 lines).
+TBDApp PID 36142, time-since-fork 20,849s (~5.8h uptime), footprint 390 MB, 10 threads.
+Duration **1.14s, 12 samples × 100ms**, **1.098s main-thread CPU** (≈100% on-CPU — actively spinning, not blocked).
+
+All 12 samples share the same prefix (lines 198–230):
+```
+NSApplication.run
+  → CFRunLoop observer
+  → NSHostingView.beginTransaction
+  → Update.ensure
+  → ViewGraphRootValueUpdater.updateGraph
+  → GraphHost.flushTransactions
+```
+
+Sample-by-sample breakdown of the inner work (line numbers in `freeze.1.log`):
+
+| Sample | Inner work | Lines |
+|---|---|---|
+| 1 | `GraphHost.runTransaction` → `LazyLayoutCacheItem.AllItemsPhaseMutation.apply` → `LazyLayoutViewCache.updateItemPhase` → `AG::Graph::propagate_dirty` | 231–236 |
+| 2 | `GraphHost.runTransaction` → `AG::Subgraph::update` → `AG::Graph::UpdateStack::push` | 237–239 |
+| 3 | Same as sample 1 | 240–245 |
+| 4 | `AG::Graph::UpdateStack::update` (running) | 246–248 |
+| 5 | `AG::Graph::UpdateStack::update` (running) | 249 |
+| **6** | **`StackLayout` ↔ `_FlexFrameLayout` ↔ `ScrollViewLayoutComputer.Engine.sizeThatFits` cycle, ~25 frames deep, then `LazyVStackLayout` ↔ `LazyHStackLayout` → `LazyStack.measureEstimates` → `_LazyLayout_Subviews.apply` → `ForEachList.applyNodes` → `<deduplicated_symbol>` (libswiftCore)** | 250–317 |
+| 7 | `DynamicBody.updateValue` → `swift_retain` | 318–320 |
+| 8 | `AG::Graph::UpdateStack::update` (running) | 321 |
+| **9** | **Same recursive cycle as sample 6, fully expanded for ~70 frames, bottoming out in `LazyStack.measureEstimates` → `ForEachList.applyNodes` → `_PaddingLayout.sizeThatFits` × N → `StackLayout.UnmanagedImplementation.sizeChildrenGenerallyWithConcreteMajorProposal`** | 322–433 |
+| **10** | **Same recursive cycle, bottoming out in `PlatformViewLayoutEngine.sizeThatFits` → `ViewLeafView.sizeThatFits` → `Update.syncMain` → `AppKitPlatformViewHost.intrinsicLayoutTraits` → `-[NSView measureMin:max:ideal:stretchingPriority:]` → `-[NSISEngine withBehaviors:performModifications:]` → `NSISLinExpEnumerateVarsAndCoefficientsUntil` → `NSBitSetCount`** | 434–533 |
+| **11** | **`LazySubviewPlacements.updateValue` → `LazySubviewPlacements.placeSubviews` → `LazyStack.place` → `_ViewList_Node.estimatedCount` → `<deduplicated_symbol>`** — residual `estimatedCount` path that PR #134 mostly killed | 534–544 |
+| 12 | `AG::Subgraph::update` (running) | 545 |
+
+### Frame counts vs prior captures
+
+| Frame | 2026-05-11 12:18 (pre-PR-#134) | 2026-05-11 16:37 (post-PR-#134, pre-PR-#137) | **2026-05-12 15:41 (post-PR-#137)** |
+|---|---|---|---|
+| `_ViewList_Group.estimatedCount` / `ForEachList.estimatedCount` | ≥40 deep, ~67% CPU | 0 | **1 sample × 1 frame (sample 11)** |
+| `_ViewList_Node.estimatedCount` | n/a (folded above) | 0 | **1 sample × 1 frame (sample 11)** |
+| `StackLayout.placeChildren1` | secondary | 7 | **dominant (samples 6, 9, 10) — ~30 frames per sample** |
+| `_FlexFrameLayout.sizeThatFits` | 12/12 (masked) | 12/12 (dominant) | **3/12 samples directly, but cycle-defining when present** |
+| `_PaddingLayout.sizeThatFits` | 12/12 (masked) | 12/12 | **3/12 samples directly** |
+| `ScrollViewLayoutComputer.Engine.sizeThatFits` | not noted | 7 | **3/12 samples (samples 6, 9, 10)** |
+| `AppKitPlatformViewHost.intrinsicLayoutTraits` → `NSView measureMin` → `NSISEngine` | not noted | not noted | **1/12 sample (sample 10) — new, deeper into AppKit bridge** |
+| `LazyLayoutCacheItem.AllItemsPhaseMutation.apply` → `propagate_dirty` | not noted | not noted | **2/12 samples (samples 1, 3) — new** |
+
+### Verbatim deepest cycle (sample 9, lines 369–432 of `freeze.1.log`, condensed)
+
+```
+ScrollViewLayoutComputer.Engine.sizeThatFits           ← ScrollView inner content sizing
+  → ViewSizeCache.get
+    → static ScrollViewUtilities.sizeThatFits
+      → LayoutComputer.sizeThatFits
+        → LazyLayoutComputer.Engine.sizeThatFits        ← outer LazyVStack
+          → LazyVStackLayout.sizeThatFits
+            → LazyStack.sizeThatFits
+              → LazyStack.measureEstimates
+                → _LazyLayout_Subviews.apply
+                  → _ViewList_Node.applyNodes
+                    → _ViewList_Group.applyNodes
+                      → ForEachList.applyNodes
+                        → ForEachState.forEachItem
+                          → ModifiedViewList.applyNodes  ← .onHover + .environment
+                            → SubgraphList.applyNodes
+                              → BaseViewList.applyNodes
+                                → LazyStack.measureEstimates  ← inner LazyHVStack
+                                  → LazyHVStack.lengthAndSpacing
+                                    → StackLayout.placeChildren1
+                                      → StackLayout.sizeChildrenIdeally / sizeChildrenGenerallyWithConcreteMajorProposal
+                                        → _FlexFrameLayout.sizeThatFits        ← .frame(maxWidth: .infinity)
+                                          → ViewLayoutEngine.sizeThatFits
+                                            → StackLayout.placeChildren1       ← cycle continues
+                                              → _PaddingLayout.sizeThatFits    ← .padding(...)
+                                                → _PaddingLayout.sizeThatFits  ← stacked padding
+                                                  → StackLayout.placeChildren1 ← cycle 3-deep
+                                                    → ...
+```
+
+The pre-/post-#137 cycle shape is **structurally identical**. PR #137 removed three contributors that the prior brief identified as cycle drivers; the cycle is still there.
+
+### One notable new wrinkle (sample 10, lines 506–533)
+
+For the first time, a sample bottoms out **all the way through the SwiftUI → AppKit bridge**:
+
+```
+PlatformViewLayoutEngine.sizeThatFits
+  → ViewLeafView.sizeThatFits
+    → Update.syncMain  ← synchronously hopping to main thread (we are on main thread)
+      → ViewLeafView.layoutTraits
+        → AppKitPlatformViewHost.coreLayoutTraits
+          → AppKitPlatformViewHost.intrinsicLayoutTraits
+            → -[NSView(NSConstraintBasedLayoutInternal) measureMin:max:ideal:stretchingPriority:]
+              → -[NSISEngine withBehaviors:performModifications:]
+                → -[NSView addConstraints:]
+                  → -[NSView _withAutomaticEngineOptimizationDisabled:]
+                    → -[NSISEngine withBehaviors:performModifications:]
+                      → -[NSView _tryToAddConstraint:...]
+                        → -[NSLayoutConstraint _addToEngine:...]
+                          → -[NSISEngine tryToAddConstraintWithMarker:expression:...]
+                            → -[NSISEngine _tryToAddConstraintWithMarkerEngineVar:row:...]
+                              → -[NSISEngine tryAddingDirectly:]
+                                → -[NSISEngine chooseHeadForRow:chosenCol:outNewToEngine:]
+                                  → NSISLinExpEnumerateVarsAndCoefficientsUntil
+                                    → NSBitSetCount   ← actively running
+```
+
+A SwiftUI leaf view is being bridged into an `NSView` and measured via the Auto Layout (NSISEngine) solver. Candidates for that bridge in the transcript pane:
+
+- **MarkdownUI** — `swift-markdown-ui` renders selectable text via an `NSTextView`-backed bridge for the `.textSelection(.enabled)` branch.
+- **AttributedString / SwiftUI `Text` with rich attributes** — uses `NSAttributedString` and `TextKit`, can re-enter NSView measurement.
+- **An `NSHostingView` we instantiate ourselves** — we use this for worktree keep-alive at the terminal level (`KeepAliveHost`, `TerminalContainerView`) but I'm not aware of one inside transcript rows. Worth verifying.
+
+This is the first capture where the cycle drives all the way into the AppKit measurement path. May be a new contributor exposed by PR #137 (the removal of `.scrollPosition(id:)` may have unblocked more layout passes per frame, increasing the chance of hitting this branch in a sample).
+
+## Current code state (post-PR-#137)
+
+### `LiveTranscriptPaneView.swift:62–87` (transcriptWithAutoscroll)
+
+```swift
+@ViewBuilder
+private var transcriptWithAutoscroll: some View {
+    ScrollViewReader { proxy in
+        ScrollView {
+            TranscriptItemsView(items: messages, terminalID: terminalID, atBottom: $atBottom)
+        }
+        .defaultScrollAnchor(.bottom, for: .initialOffset)          // role-scoped (was un-scoped pre-#137)
+        .overlay(alignment: .bottomTrailing) {
+            jumpToBottomButton(proxy: proxy)
+                .animation(.easeInOut(duration: 0.2), value: atBottom)  // scoped to overlay (was wrapping ScrollView pre-#137)
+        }
+        // .scrollPosition(id: $visibleID, anchor: .bottom)         // ← removed in PR #137
+        .onAppear { ... HangWatchdog context ... }
+        .onChange(of: messages.last?.id) { oldID, newID in
+            guard let _ = oldID, let _ = newID, atBottom else { return }
+            guard let targetID = lastRenderedNodeID(for: messages) else { return }
+            let scrollInterval = TranscriptSignposts.signposter.beginInterval("transcript.scrollTo")
+            withAnimation(.easeOut(duration: 0.15)) {
+                proxy.scrollTo(targetID, anchor: .bottom)            // rewired in PR #137
+            }
+            TranscriptSignposts.signposter.endInterval("transcript.scrollTo", scrollInterval)
+        }
+        .onChange(of: messages.count) { ... HangWatchdog context ... }
+        .onDisappear { ... HangWatchdog clear ... }
+    }
+}
+```
+
+### `TranscriptItemsView.swift:64–113`
+
+```swift
+var body: some View {
+    let intervalState = TranscriptSignposts.signposter.beginInterval("transcript.items.body")
+    defer { TranscriptSignposts.signposter.endInterval("transcript.items.body", intervalState) }
+    return bodyView
+}
+
+@ViewBuilder
+private var bodyView: some View {
+    let nodes = transcriptRenderNodes(from: items)
+    let _ = { /* debug log when >100 nodes */ }()
+    LazyVStack(alignment: .leading, spacing: 4) {
+        ForEach(nodes) { node in
+            TranscriptRow(node: node, terminalID: terminalID)
+                .environment(\.transcriptTextSelection, hoveredItemID == node.id)
+                .onHover { hovering in
+                    if hovering { hoveredItemID = node.id }  // latch on enter, no clear on exit
+                }
+        }
+        Color.clear                                          // 1pt at-bottom sentinel
+            .frame(height: 1)
+            .onAppear { atBottom?.wrappedValue = true }
+            .onDisappear { atBottom?.wrappedValue = false }
+    }
+    .padding(.vertical, 8)
+}
+```
+
+### `TranscriptRow.swift` (unchanged from PR #134)
+
+```swift
+struct TranscriptRow: View {
+    let node: TranscriptRenderNode
+    let terminalID: UUID?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {     // wrapper added in PR #134
+            content
+            if let usage = node.badgeUsage {
+                ContextUsageBadge(total: usage.contextTotal)
+                    .padding(.leading, 12).padding(.top, 2)
+            }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        switch node.kind {
+        case .chatBubble(let item):       ChatBubbleView(item: item)
+        case .systemReminder(...):        SystemReminderRow(...)
+        case .skillBody(...):             SkillBodyRow(...)
+        case .toolCall(...):              toolCard(...)
+        case .subagentSummary(...):       SubagentSummaryRow(...)
+        }
+    }
+    // ... toolCard switch over 9 tool names ...
+}
+```
+
+### `.frame(maxWidth: .infinity)` cardinality (unchanged)
+
+Still **21 callsites** across 12 files in `Sources/TBDApp/Panes/Transcript/`:
+`ActivityRowChrome.swift`, `AgentCard.swift`, `AskUserQuestionCard.swift`, `BashCard.swift`, `ChatBubbleView.swift`, `EditCard.swift`, `GenericToolCard.swift`, `GlobCard.swift`, `GrepCard.swift`, `ReadCard.swift`, `SkillBodyRow.swift`, `WriteCard.swift`.
+
+`.frame(maxHeight: .infinity)` has been replaced with finite caps (`TranscriptCardLayout.expandedMaxHeight = 600`, `collapsedMaxHeight = 120`) — see `BashCard.swift:73,109`, `WriteCard.swift:66`. The horizontal axis is the open question.
+
+## What the previous brief proposed and what shipped
+
+| Fix from 2026-05-11 brief | Confidence ranked | Shipped in PR #137? |
+|---|---|---|
+| **A**: Drop `.scrollPosition(id:)`, keep `.defaultScrollAnchor` | High | **Yes (+ also role-scoped `.defaultScrollAnchor` and removed animation wrapping)** |
+| B: `.fixedSize(horizontal: false, vertical: true)` on `TranscriptRow` outer VStack | Medium | No |
+| C: Hoist `.frame(maxWidth: .infinity)` from per-row to LazyVStack level + remove from 21 callsites | Med-high | No (riskier — visual regressions, esp. `ChatBubbleView` right-alignment) |
+| D: `TranscriptRow: Equatable + .equatable()` | Med | No |
+| E: `List` migration (structural fix) | High that it works | No |
+| F: Always-render `ContextUsageBadge` with opacity instead of conditional | Low-Med | No |
+
+The PR #137 commit message confirms the team picked Fix A but also folded in the animation-wrapping removal and `.defaultScrollAnchor` role-scoping, so it's slightly more aggressive than just Fix A. The cycle survived all three changes.
+
+## What we want from you (Codex)
+
+### 1. Re-evaluate the leading hypothesis
+
+The prior brief said `.scrollPosition(id:)` was "forcing continuous content-height accounting, which drives the per-row layout fix-point search". That's now falsified — its removal didn't break the cycle. Two possibilities:
+
+- **(a)** The hypothesis was wrong: `.scrollPosition(id:)` doesn't actually force continuous accounting; the cycle was always driven by something else.
+- **(b)** The hypothesis was right *for that modifier* but the cycle has multiple drivers, and `.scrollPosition(id:)` was a small one; removing it didn't move the needle.
+
+Which is it, and what's the evidence? (Specifically: is there a SwiftUI internals reference, a WWDC talk, or an Apple DTS thread that documents what *does* force continuous content-height accounting on `LazyVStack` inside a `ScrollView`?)
+
+### 2. Propose a new ranked candidate list
+
+Given the cycle is still 30+ frames deep across 3/12 samples, what are the next candidate fixes to investigate? **Constraints:**
+
+- No `.scrollPosition(id:)`-equivalent re-introduction (we accepted that trade-off in PR #137).
+- Prefer single-line / single-file experiments before structural refactors.
+- For each candidate: state the hypothesis, the verification signal (frame count change in spindump grep), the falsification signal, and the trade-off.
+- Include `List` migration as the last-resort structural option, but only after cheaper options are exhausted or determined infeasible.
+
+Specific candidates to evaluate (consider, then accept/reject/refine):
+
+- **C** (hoist `.frame(maxWidth: .infinity)` from per-row to LazyVStack). The 21 callsites mean the per-row flex frame is the structural anchor of every cycle bottom. Hoisting *might* break alignment guarantees in `ChatBubbleView` (which uses `maxWidth: .infinity, alignment: .trailing` for user-bubbles). What's the actual impact?
+- **B** (`.fixedSize(horizontal: false, vertical: true)` on `TranscriptRow`). The prior brief rated this medium because "the cycle is width-shaped, not height-shaped". Reconsider: does the cycle now look height-shaped given samples 9 and 10 walk through `_FlexFrameLayout.sizeThatFits` for height, not width? Could `.fixedSize(horizontal: false, vertical: true)` short-circuit the flex-frame's contribution to the recursion?
+- **G** (new candidate): **kill the inner LazyHVStack invocation.** Sample 9 shows `LazyStack.measureEstimates → ForEachList.applyNodes → … → LazyStack.measureEstimates` — there's a *second* LazyStack instance inside the outer one. Is `TranscriptRow`'s `VStack` lowering to a `LazyHVStack` under the hood, or is this the outer LazyVStack re-entering itself? The 4960199 commit added the row wrapper — could a plain `Group` instead of `VStack` avoid the inner stack-layout entirely?
+- **H** (new candidate): **investigate the sample-10 AppKit bridge.** Which view is being measured via `NSView measureMin → NSISEngine`? MarkdownUI selectable text? Something else? Is there a config we can pass to disable the AppKit-side measurement?
+
+### 3. Diagnose sample 10's AppKit bridge
+
+Sample 10 (lines 506–533 of `freeze.1.log`) is the first capture showing the cycle walks all the way into `-[NSISEngine chooseHeadForRow:chosenCol:outNewToEngine:]`. **Identify which transcript view is the source.** Hypotheses:
+
+- `swift-markdown-ui` `MarkdownTextView` (NSTextView-backed, used in `ChatBubbleView`)
+- A `Text` with attributed content + selection
+- An accidental `NSHostingView` we don't know about
+
+If it's MarkdownUI: is the upcoming `Textual` migration (the maintainer's successor library) likely to remove this bridge? Worth coupling Phase 2 of the fix?
+
+### 4. Sanity-check the residual `estimatedCount` path
+
+Sample 11 (line 543) shows `_ViewList_Node.estimatedCount + 136` — exactly the path PR #134 was designed to eliminate. PR #134 reduced it from "≥40 deep, ~67% CPU" to "0 occurrences" in the 2026-05-11 16:37 capture. It's now back to 1/12 samples × 1 frame in the 2026-05-12 15:41 capture.
+
+- Is this a regression introduced by PR #137 (animation removal exposing a code path that was previously masked)?
+- Or is it the always-residual `estimatedCount` path that PR #134's design doc said couldn't be fully eliminated without `List`?
+- Reference: `docs/superpowers/specs/2026-05-11-transcript-render-node-design.md`, the PR #134 impl spec.
+
+### 5. Recommend the next falsification test
+
+Given the new evidence, what's the **single-line or smallest-possible change** that would best discriminate between the remaining hypotheses?
+
+## Reference docs (prior work)
+
+- `docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-brief.md` — the **prior brief** that produced PR #137. Its Fix A was implemented; its central hypothesis is now falsified by this freeze.
+- `docs/superpowers/specs/2026-05-11-transcript-flex-frame-research-discussion.md` — the Codex/Gemini reviewer convergence on the prior brief.
+- `docs/superpowers/specs/2026-05-11-transcript-hang-research-brief.md` — the earlier brief about `_ViewList_Group.estimatedCount` recursion. PR #134 closed that signature.
+- `docs/superpowers/specs/2026-05-11-transcript-hang-research-discussion.md` — its reviewer convergence.
+- `docs/superpowers/specs/2026-05-11-transcript-render-node-design.md` — the PR #134 impl spec (introduces `TranscriptRenderNode`, `TranscriptRow`).
+- `docs/superpowers/specs/2026-05-12-transcript-scroll-bounds-design.md` — the PR #137 impl spec.
+- `docs/superpowers/specs/2026-05-06-transcript-list-migration-design.md` — the structural-fallback `List`-migration design (IceCubesApp pattern).
+- `docs/superpowers/specs/research-2026-05-06-swiftui-long-list-perf.md` — collected prior art (~30 sources, IceCubes/cmux #2327, MarkdownUI maintenance trajectory).
+
+## Reference commits
+
+- `261681b` — PR #137 — "perf(transcript): drop declarative scroll-bounds + animation wrapping (#129)" — merged 2026-05-12 08:46.
+- `2a57ac7` — PR #134 — "Perf: flatten transcript ForEach body to kill estimatedCount recursion (#129)" — merged 2026-05-11.
+- `937c1c4` — PR #130 — "Fix: Stop expanded transcript cards from freezing the UI" — merged 2026-05-11.
+- `a41f716` — PR #120 — "Fix: 17s transcript hang from per-row text-selection storm" — merged 2026-05-09.
+
+## Constraints
+
+- **Read-only investigation. No code changes.**
+- Reference files by `path:line` when relevant.
+- Use `grep`/`awk` on `freeze.1.log` rather than reading the whole 235k-line file. The main thread is at lines 198–545 (see Sample-by-sample table above for which inner-work is where).
+- Working directory: `/Users/chang/tbd/worktrees/tbd/20260512-juicy-swordfish/`.
+- Issue tracker: <https://github.com/cheapsteak/tbd/issues/129> (reopened 2026-05-12).
+- The main session's previous reasoning is in this brief — feel free to disagree with any of it. Cite evidence.
+
+## Coordination
+
+**Write your findings into the sibling blank file:**
+`docs/superpowers/specs/2026-05-12-transcript-flex-frame-post-pr137-findings.md`
+
+That file contains a suggested template. The main session will read your findings before deciding whether to open a follow-up implementation PR or kick off the `List` migration.

--- a/docs/superpowers/specs/2026-05-12-transcript-flex-frame-post-pr137-findings.md
+++ b/docs/superpowers/specs/2026-05-12-transcript-flex-frame-post-pr137-findings.md
@@ -1,0 +1,127 @@
+# Findings: SwiftUI transcript pane hang, post-PR-#137
+
+**Companion to:** [`2026-05-12-transcript-flex-frame-post-pr137-brief.md`](2026-05-12-transcript-flex-frame-post-pr137-brief.md)
+**Issue:** [cheapsteak/tbd#129](https://github.com/cheapsteak/tbd/issues/129) (reopened 2026-05-12)
+**Spindumps:** `freeze.1.log`, `freeze.2.log`
+
+## TL;DR
+
+`freeze.2.log` confirms the same broad bug class as `freeze.1.log`: a short main-thread hang in SwiftUI/AttributeGraph layout, not daemon I/O and not the titlebar/sidebar chrome branch. The dominant signal remains SwiftUI transaction flushing through lazy scroll content, `GeometryReader`, `ForEach`, `LazyVStack`, `_FlexFrameLayout`, and AppKit bridge measurement. The next smallest falsification test should remove or gate the transcript row hover environment mutation, because `freeze.2.log` starts with SwiftUI hover hit-testing before entering the same AttributeGraph/layout storm.
+
+## 1. Re-evaluation of the prior hypothesis
+
+The `.scrollPosition(id:)` hypothesis was right-but-minor, not dominant. PR #137 removed `.scrollPosition(id:)`, unscoped scroll animation, and unscoped `.defaultScrollAnchor`; `freeze.1.log` still showed the same `StackLayout` / `_FlexFrameLayout` / `ScrollViewLayoutComputer` shape.
+
+`freeze.2.log` adds one new clue: sample 1 enters through hover dispatch and SwiftUI hit-testing:
+
+```text
+EventBindingManager.enqueueHoverUpdateIfNeeded
+NSHostingView.didRequestHoverUpdate
+HoverEventDispatcher.receiveEvents
+ViewResponder.hitTest
+HostingScrollView.PlatformGroupContainer.hitTest
+```
+
+Then samples 2-12 move into the familiar transaction path:
+
+```text
+NSRunLoop.flushObservers
+NSHostingView.beginTransaction
+GraphHost.flushTransactions
+AG::Subgraph::update
+```
+
+That makes hover-driven invalidation the best new candidate trigger. In current code, `TranscriptItemsView` mutates `hoveredItemID` and writes `.environment(\.transcriptTextSelection, hoveredItemID == node.id)` across every row. That is a plausible high-blast-radius invalidation: one hover change can change the environment value seen by all `ForEach` rows.
+
+## 2. New ranked candidate list
+
+| # | Fix | Hypothesis | Verification signal | Falsification signal | Trade-off | Effort | Confidence |
+|---|---|---|---|---|---|---|---|
+| 1 | Temporarily remove row `.onHover` and force `.transcriptTextSelection` false | Hover changes invalidate every transcript row and kick the lazy stack into a layout fix-point search | Next hang lacks `EventBindingManager.enqueueHoverUpdateIfNeeded`, `HoverEventDispatcher`, and row-wide environment churn | Same stack appears without hover frames | Loses hover-enabled text selection during test | Low | Medium-high |
+| 2 | Replace row-wide environment with local per-row prop/state | The expensive part is not hover itself, but broadcasting hover state through environment to all rows | Hangs drop while hover UI behavior remains | No reduction | Slight row API churn | Medium | Medium |
+| 3 | Remove `GeometryReader` / `PreferenceKey` feedback for `contentAreaHeight` in `ContentView` | A layout measurement writes SwiftUI state during layout and feeds overlay sizing, amplifying graph updates | Hangs no longer include `GeometryReaderLayout.placeSubviews` and repeated root geometry/flex-frame passes | `GeometryReaderLayout` remains common in new captures | Conductor overlay needs alternate sizing | Low-medium | Medium |
+| 4 | Disable animated `proxy.scrollTo` | Even scoped scroll animation can force repeated content placement in lazy scroll containers | Hangs no longer show `LazyLayoutCacheItem.AllItemsPhaseMutation` / item phase updates near scroll events | Same cycle appears when idle/hovering | Autoscroll becomes abrupt | Low | Medium-low |
+| 5 | Migrate transcript rendering from `ScrollView { LazyVStack }` to `List`/AppKit table | The structural issue is SwiftUI lazy stack measurement of heterogeneous rich rows on macOS 26 | Eliminates lazy-stack/flex-frame signatures | Migration reproduces equivalent hangs or breaks transcript UX | Larger behavior/design change | High | Medium |
+| 6 | Keep chasing individual `.frame(maxWidth: .infinity)` and padding sites | The cycle is caused by one row/card layout modifier | Removing one card class eliminates hangs | Hangs persist across many row types | Many narrow tests | Medium-high | Low-medium |
+
+## 3. Sample-10 AppKit bridge diagnosis
+
+`freeze.1.log` sample 10 bottoms out in:
+
+```text
+PlatformViewLayoutEngine.sizeThatFits
+ViewLeafView.sizeThatFits
+AppKitPlatformViewHost.intrinsicLayoutTraits
+NSView measureMin:max:ideal:stretchingPriority:
+NSISEngine
+```
+
+I cannot identify the exact leaf from the stack alone, but ranked candidates are:
+
+1. Markdown/rich text rows in the transcript cards, especially selectable text paths.
+2. `TranscriptSelectableText` / AppKit-backed text measurement.
+3. Embedded AppKit views from terminal/file/transcript panes if the active view is not only transcript.
+
+`freeze.2.log` strengthens the "SwiftUI platform view / scroll view" diagnosis but does not name the app leaf. It shows hit-testing through `HostingScrollView.PlatformGroupContainer`, then later layout through `ScrollViewLayoutComputer.Engine.sizeThatFits`, `LazyLayoutComputer.Engine.sizeThatFits`, and `LazyVStackLayout`.
+
+Implication: the next test should reduce broad invalidation before chasing a single bridge leaf. If hover/environment churn is removed and the AppKit bridge still dominates, instrument row identity/type around visible transcript nodes next.
+
+## 4. Residual `estimatedCount` path
+
+`freeze.1.log` has one residual `_ViewList_Node.estimatedCount` sample. That looks like known residual work, not the dominant regression PR #134 fixed. The dominant post-PR-#137 behavior is flex-frame/lazy-stack/layout transaction work, plus `LazyLayoutCacheItem.AllItemsPhaseMutation`.
+
+`freeze.2.log` does not shift the ranking back toward `estimatedCount`. It instead adds hover hit-testing as a likely trigger and repeats lazy layout/flex-frame paths.
+
+## 5. Recommended next falsification test
+
+Smallest possible change:
+
+```swift
+TranscriptRow(node: node, terminalID: terminalID)
+    .environment(\.transcriptTextSelection, false)
+//  .onHover { ... }   // temporarily disabled
+```
+
+Where: `Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift`, inside the `ForEach(nodes)` row body.
+
+Why this test: `freeze.2.log` sample 1 starts in SwiftUI hover event dispatch/hit-testing, and the current hover handler mutates state that changes an environment value across every transcript row. This is the cheapest way to test whether hover invalidation is the trigger for the subsequent AttributeGraph/layout storm.
+
+Pass criteria from the next hang capture:
+
+- No `EventBindingManager.enqueueHoverUpdateIfNeeded` / `HoverEventDispatcher` lead-in.
+- Fewer or no `GraphHost.flushTransactions -> AG::Subgraph::update` samples during mouse movement over transcript rows.
+- No repeated `LazyVStackLayout` / `ScrollViewLayoutComputer.Engine.sizeThatFits` / `_FlexFrameLayout` cycle under hover.
+
+Fail criteria:
+
+- Same 1s+ main-thread hang recurs with the same lazy layout/flex-frame stack while hover is disabled.
+- Hang appears during autoscroll/new-message arrival instead of pointer movement.
+
+## 6. Notes from `freeze.2.log`
+
+`freeze.2.log` was captured on 2026-05-13 at 09:12:58 -0400. Target process:
+
+```text
+Command: TBDApp
+PID: 69996
+Event: hang
+Duration: 1.13s
+Steps: 12
+CPU Time: 1.104s on main thread
+```
+
+It also includes other TBDApp processes in the system snapshot. Those are not the hang target. Some non-TBD system noise is present: Notes hit the dispatch thread hard limit, and Notes/Mail deadlocks were reported. The target TBDApp stack is still an on-CPU main-thread SwiftUI layout hang, so those external issues do not change the app-level diagnosis.
+
+This log does not include the sidebar/titlebar branch changes. It also does not implicate `NSWindow`, `NSSplitViewItem`, titlebar separator, or `AppDelegate` chrome work.
+
+## 7. Open questions
+
+- Was the pointer moving over the transcript at the time of `freeze.2.log`? If yes, the hover test should be first.
+- Was a new transcript item arriving at the same time? If yes, compare against disabling animated `proxy.scrollTo`.
+- Do hangs reproduce with the file panel closed? If not, `FileViewerPanel`'s `LazyVStack` and `GeometryReader` paths need to enter the candidate list.
+
+## 8. References consulted
+
+- Local spindumps: `freeze.1.log`, `freeze.2.log`.
+- Local code: `TranscriptItemsView.swift`, `LiveTranscriptPaneView.swift`, `ContentView.swift`, `AppState.swift`.
+- Prior design notes in this directory, especially the post-PR-#137 brief and earlier transcript lazy-list performance research.


### PR DESCRIPTION
## Summary

- Falsification test for issue #129 — removes the per-row `.onHover` mutation in `TranscriptItemsView` and forces `transcriptTextSelection=false` so the layout-cycle hypothesis around hover-driven environment broadcast can be tested longitudinally with HangWatchdog.
- `freeze.2.log` sample 1 (captured today) shows the hang entering via `EventBindingManager.enqueueHoverUpdateIfNeeded → HoverEventDispatcher → HostingScrollView.PlatformGroupContainer.hitTest` before the same `NSHostingView.beginTransaction → GraphHost.flushTransactions → LazyVStack/StackLayout/_FlexFrameLayout` cycle that survived PR #137. The per-row environment write `(\.transcriptTextSelection, hoveredItemID == node.id)` is the suspected broadcast trigger.
- Also adds the post-PR-#137 research brief and Codex's findings doc that motivated this experiment.

**Trade-off accepted while this is in main:** `.textSelection(.enabled)` no longer materializes on tool-call cards (BashCard / EditCard / WriteCard / ReadCard / GrepCard / GlobCard / GenericToolCard / AgentCard / AskUserQuestionCard). `ChatBubbleView.swift:289,379` still hardcodes the environment to `true` inside its own subtree, so **user/assistant bubble text remains selectable**. One-commit revert if the experiment fails.

## What we'll measure

If a subsequent spindump captures another hang:

- **Pass** (hover is a trigger): no `EventBindingManager.enqueueHoverUpdateIfNeeded` / `HoverEventDispatcher` lead-in, and no `LazyVStack/_FlexFrameLayout` cycle firing during pointer movement over the transcript.
- **Fail** (hover isn't a primary trigger): same 1s+ main-thread hang recurs with the same lazy-layout / flex-frame stack with hover disabled. We'd then move to Codex's test #2 (row-local `@Environment` read) or escalate one of the other non-`List` workarounds from `docs/superpowers/specs/2026-05-12-transcript-flex-frame-post-pr137-brief.md`.

## References

- Brief: `docs/superpowers/specs/2026-05-12-transcript-flex-frame-post-pr137-brief.md`
- Findings: `docs/superpowers/specs/2026-05-12-transcript-flex-frame-post-pr137-findings.md`
- Prior PRs in the #129 series: #134 (`estimatedCount` flattening), #137 (scroll-bounds + animation wrapping removal)
- Issue: #129 (reopened 2026-05-12)

## Test plan

- [ ] `swift build` clean (verified locally — 76s, no errors)
- [ ] After merge, run `scripts/restart.sh` and use the app for a session
- [ ] Verify user/assistant chat bubble text is still selectable
- [ ] Verify tool-card text is **not** selectable (intentional regression for the test window)
- [ ] Collect HangWatchdog telemetry and/or a fresh spindump if a hang occurs
- [ ] Report pass/fail on #129; if Fail, revert (`git revert 3b135bc`) and try the next candidate

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=6A484786-1A21-4A1E-85CB-027D5ECDAE3E)