### PR TITLE
Fix: Stop Codex tab from silently morphing into a shell on tab-switch

### DIFF
--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -292,7 +292,7 @@ private struct TabBarItem: View {
     }
 
     private var isCodexTerminal: Bool {
-        terminal?.label == "Codex"
+        terminal?.kind == .codex || terminal?.label == "Codex"
     }
 
     private var isSuspended: Bool {

--- a/Sources/TBDDaemon/Conductor/ConductorManager.swift
+++ b/Sources/TBDDaemon/Conductor/ConductorManager.swift
@@ -176,7 +176,8 @@ public final class ConductorManager: Sendable {
             worktreeID: worktreeID,
             tmuxWindowID: window.windowID,
             tmuxPaneID: window.paneID,
-            label: "conductor:\(name)"
+            label: "conductor:\(name)",
+            kind: .shell
         )
 
         try await db.conductors.updateTerminalID(conductorID: conductor.id, terminalID: terminal.id)

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -381,6 +381,16 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        migrator.registerMigration("v22_terminal_kind") { db in
+            try db.alter(table: "terminal") { t in
+                t.add(column: "kind", .text)
+            }
+            // Backfill from existing label heuristics
+            try db.execute(sql: "UPDATE terminal SET kind = 'codex' WHERE label = 'Codex'")
+            try db.execute(sql: "UPDATE terminal SET kind = 'claude' WHERE kind IS NULL AND claudeSessionID IS NOT NULL")
+            try db.execute(sql: "UPDATE terminal SET kind = 'shell' WHERE kind IS NULL")
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -18,6 +18,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var suspendedSnapshot: String?
     var profile_id: String?
     var transcriptPath: String?
+    var kind: String?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -32,6 +33,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.suspendedSnapshot = terminal.suspendedSnapshot
         self.profile_id = terminal.profileID?.uuidString
         self.transcriptPath = terminal.transcriptPath
+        self.kind = terminal.kind?.rawValue
     }
 
     func toModel() -> Terminal {
@@ -47,7 +49,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             suspendedAt: suspendedAt,
             suspendedSnapshot: suspendedSnapshot,
             profileID: profile_id.flatMap(UUID.init(uuidString:)),
-            transcriptPath: transcriptPath
+            transcriptPath: transcriptPath,
+            kind: kind.flatMap(TerminalKind.init(rawValue:))
         )
     }
 }
@@ -73,7 +76,8 @@ public struct TerminalStore: Sendable {
         tmuxPaneID: String,
         label: String? = nil,
         claudeSessionID: String? = nil,
-        profileID: UUID? = nil
+        profileID: UUID? = nil,
+        kind: TerminalKind? = nil
     ) async throws -> Terminal {
         let terminal = Terminal(
             id: id,
@@ -82,7 +86,8 @@ public struct TerminalStore: Sendable {
             tmuxPaneID: tmuxPaneID,
             label: label,
             claudeSessionID: claudeSessionID,
-            profileID: profileID
+            profileID: profileID,
+            kind: kind
         )
         let record = TerminalRecord(from: terminal)
         try await writer.write { db in

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -213,6 +213,7 @@ public struct TerminalStore: Sendable {
             record.suspendedAt = nil
             record.suspendedSnapshot = nil
             record.label = "shell"
+            record.kind = TerminalKind.shell.rawValue
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -302,7 +302,8 @@ extension WorktreeLifecycle {
             tmuxPaneID: window1.paneID,
             label: skipClaude ? "shell" : "Claude Code",
             claudeSessionID: claudeSessionID,
-            profileID: pinnedProfileID
+            profileID: pinnedProfileID,
+            kind: skipClaude ? .shell : .claude
         )
 
         // Create terminal 2: setup hook
@@ -324,7 +325,8 @@ extension WorktreeLifecycle {
             worktreeID: worktreeID,
             tmuxWindowID: window2.windowID,
             tmuxPaneID: window2.paneID,
-            label: "setup"
+            label: "setup",
+            kind: .shell
         )
 
         // Restore additional archived Claude sessions (beyond the first which was used above)
@@ -367,7 +369,8 @@ extension WorktreeLifecycle {
                     tmuxPaneID: window.paneID,
                     label: "Claude Code",
                     claudeSessionID: sessionID,
-                    profileID: resolvedProfile?.profileID
+                    profileID: resolvedProfile?.profileID,
+                    kind: .claude
                 )
             }
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -270,9 +270,9 @@ extension WorktreeLifecycle {
                 settingsOverlayPath: ClaudeHookOverlay.overlayPath,
                 pluginDirPath: PluginDirWriter.pluginDirPath
             )
-        } else if terminal.label == "Codex" {
-            // Codex terminal — detected by label "Codex" (set during terminal creation).
-            // No structured type field exists; label matching is the only discriminator available.
+        } else if terminal.kind == .codex || terminal.label == "Codex" {
+            // Codex terminal — detected by kind (primary signal) or legacy label fallback.
+            // kind is the primary discriminator; label is checked for backward compatibility.
             let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
             env["CODEX_HOME"] = codexHome.path
             spawn = ClaudeSpawnCommandBuilder.build(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -133,7 +133,8 @@ extension RPCRouter {
                 tmuxPaneID: window.paneID,
                 label: "Codex",
                 claudeSessionID: nil,
-                profileID: nil
+                profileID: nil,
+                kind: .codex
             )
 
             subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
@@ -221,6 +222,7 @@ extension RPCRouter {
             rows: resolvedRows
         )
 
+        let terminalKind: TerminalKind? = isClaudeType ? .claude : .shell
         let terminal = try await db.terminals.create(
             id: plannedTerminalID,
             worktreeID: params.worktreeID,
@@ -228,7 +230,8 @@ extension RPCRouter {
             tmuxPaneID: window.paneID,
             label: label,
             claudeSessionID: claudeSessionID,
-            profileID: resolvedProfile?.profileID
+            profileID: resolvedProfile?.profileID,
+            kind: terminalKind
         )
 
         subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
@@ -305,40 +308,74 @@ extension RPCRouter {
             rows: resolvedRows
         )
 
-        // Create a new tmux window with a default shell.
-        // Defensively set TBD_WORKTREE_ID even though the recreated pane runs a
-        // plain shell — the user may run `tbd` CLI commands or launch `claude`
-        // themselves from that shell, and those tools resolve the worktree from
-        // the env. Without this set, the pane would inherit whatever TBD_WORKTREE_ID
-        // got baked into the tmux server's global env, leaking another worktree's
-        // identity into this one.
-        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
-        let env: [String: String] = ["TBD_WORKTREE_ID": worktree.id.uuidString]
-        let window = try await tmux.createWindow(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path,
-            shellCommand: shell,
-            env: env,
-            cols: resolvedCols,
-            rows: resolvedRows
-        )
+        // Branch on terminal kind: codex stays codex; shell/claude become shell
+        if terminal.kind == .codex || terminal.label == "Codex" {
+            // Recreate as codex — preserve identity
+            let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
+            var codexEnv: [String: String] = [:]
+            codexEnv["TBD_WORKTREE_ID"] = worktree.id.uuidString
+            codexEnv["TBD_TERMINAL_ID"] = terminal.id.uuidString
+            codexEnv["CODEX_HOME"] = codexHome.path
 
-        // Update the terminal record with new window/pane IDs and clear stale
-        // Claude metadata — the recreated window runs a plain shell, not Claude.
-        try await db.terminals.updateTmuxIDs(
-            id: params.terminalID,
-            windowID: window.windowID,
-            paneID: window.paneID
-        )
-        try await db.terminals.clearRecreated(id: params.terminalID)
+            let window = try await tmux.createWindow(
+                server: worktree.tmuxServer,
+                session: "main",
+                cwd: worktree.path,
+                shellCommand: "codex --full-auto",
+                env: codexEnv,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
 
-        // Return updated terminal
-        guard let updated = try await db.terminals.get(id: params.terminalID) else {
-            return RPCResponse(error: "Terminal not found after update")
+            // Update tmux IDs but DO NOT call clearRecreated — that nukes the label and kind
+            try await db.terminals.updateTmuxIDs(
+                id: params.terminalID,
+                windowID: window.windowID,
+                paneID: window.paneID
+            )
+
+            // Return updated terminal
+            guard let updated = try await db.terminals.get(id: params.terminalID) else {
+                return RPCResponse(error: "Terminal not found after update")
+            }
+
+            return try RPCResponse(result: updated)
+        } else {
+            // Recreate as shell (claude or shell terminal becomes a plain shell)
+            // Defensively set TBD_WORKTREE_ID even though the recreated pane runs a
+            // plain shell — the user may run `tbd` CLI commands or launch `claude`
+            // themselves from that shell, and those tools resolve the worktree from
+            // the env. Without this set, the pane would inherit whatever TBD_WORKTREE_ID
+            // got baked into the tmux server's global env, leaking another worktree's
+            // identity into this one.
+            let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+            let env: [String: String] = ["TBD_WORKTREE_ID": worktree.id.uuidString]
+            let window = try await tmux.createWindow(
+                server: worktree.tmuxServer,
+                session: "main",
+                cwd: worktree.path,
+                shellCommand: shell,
+                env: env,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+
+            // Update the terminal record with new window/pane IDs and clear stale
+            // Claude metadata — the recreated window runs a plain shell, not Claude.
+            try await db.terminals.updateTmuxIDs(
+                id: params.terminalID,
+                windowID: window.windowID,
+                paneID: window.paneID
+            )
+            try await db.terminals.clearRecreated(id: params.terminalID)
+
+            // Return updated terminal
+            guard let updated = try await db.terminals.get(id: params.terminalID) else {
+                return RPCResponse(error: "Terminal not found after update")
+            }
+
+            return try RPCResponse(result: updated)
         }
-
-        return try RPCResponse(result: updated)
     }
 
     func handleTerminalOutput(_ paramsData: Data) async throws -> RPCResponse {
@@ -596,7 +633,8 @@ extension RPCRouter {
             tmuxPaneID: window.paneID,
             label: "claude",
             claudeSessionID: storedSessionID,
-            profileID: resolved?.profileID
+            profileID: resolved?.profileID,
+            kind: .claude
         )
 
         subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -144,6 +144,12 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
+public enum TerminalKind: String, Codable, Sendable {
+    case shell
+    case claude
+    case codex
+}
+
 public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var worktreeID: UUID
@@ -162,13 +168,15 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// `/compact` rollovers (where Claude may pick a different
     /// `~/.claude/projects/` subdirectory than cwd would suggest).
     public var transcriptPath: String?
+    public var kind: TerminalKind?
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
                 pinnedAt: Date? = nil, claudeSessionID: String? = nil,
                 suspendedAt: Date? = nil, suspendedSnapshot: String? = nil,
                 profileID: UUID? = nil,
-                transcriptPath: String? = nil) {
+                transcriptPath: String? = nil,
+                kind: TerminalKind? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -181,6 +189,12 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.suspendedSnapshot = suspendedSnapshot
         self.profileID = profileID
         self.transcriptPath = transcriptPath
+        self.kind = kind
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
+        case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
     }
 
     public init(from decoder: Decoder) throws {
@@ -197,6 +211,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         suspendedSnapshot = try c.decodeIfPresent(String.self, forKey: .suspendedSnapshot)
         profileID = try c.decodeIfPresent(UUID.self, forKey: .profileID)
         transcriptPath = try c.decodeIfPresent(String.self, forKey: .transcriptPath)
+        kind = try c.decodeIfPresent(TerminalKind.self, forKey: .kind)
     }
 }
 

--- a/Tests/TBDDaemonTests/MigrationV22Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV22Tests.swift
@@ -1,0 +1,101 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct MigrationV22Tests {
+
+    @Test func v22ColumnExistsAndDefaultsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v22-repo", displayName: "V22", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v22-repo/wt", tmuxServer: "tbd-v22"
+        )
+
+        // Create a terminal without specifying kind — should round-trip as nil
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "1",
+            tmuxPaneID: "1.0",
+            label: "test"
+        )
+
+        // Verify kind defaults to nil when not specified
+        let fetched = try await db.terminals.get(id: terminal.id)
+        #expect(fetched?.kind == nil)
+    }
+
+    @Test func codexKindRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v22b-repo", displayName: "V22b", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v22b-repo/wt", tmuxServer: "tbd-v22b"
+        )
+
+        // Create a codex terminal with explicit kind
+        let codexTerminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "2",
+            tmuxPaneID: "2.0",
+            label: "Codex",
+            kind: .codex
+        )
+
+        let fetched = try await db.terminals.get(id: codexTerminal.id)
+        #expect(fetched?.kind == .codex)
+    }
+
+    @Test func claudeKindRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v22c-repo", displayName: "V22c", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v22c-repo/wt", tmuxServer: "tbd-v22c"
+        )
+
+        // Create a claude terminal with explicit kind
+        let claudeTerminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "3",
+            tmuxPaneID: "3.0",
+            label: "Claude Code",
+            claudeSessionID: "session-123",
+            kind: .claude
+        )
+
+        let fetched = try await db.terminals.get(id: claudeTerminal.id)
+        #expect(fetched?.kind == .claude)
+    }
+
+    @Test func shellKindRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v22d-repo", displayName: "V22d", defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/v22d-repo/wt", tmuxServer: "tbd-v22d"
+        )
+
+        // Create a shell terminal with explicit kind
+        let shellTerminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "4",
+            tmuxPaneID: "4.0",
+            label: "setup",
+            kind: .shell
+        )
+
+        let fetched = try await db.terminals.get(id: shellTerminal.id)
+        #expect(fetched?.kind == .shell)
+    }
+}


### PR DESCRIPTION
## Summary

- **What's broken:** Creating a Codex tab works — codex CLI renders, you can interact. Switch to another tab and back, and the tab is now a generic shell. No warning, no error.
- **Why it happens:** Codex panes run `codex --full-auto` as the only process (no shell wrapper). When the user briefly detaches, the codex pane dies. `TerminalPanelView`'s window-dead recovery auto-fires `recreateTerminalWindow`, which unconditionally respawns a `/bin/zsh` and stamps `label = "shell"` over the row — destroying the only thing identifying it as Codex.
- **What this PR does:** Adds a structural `kind: TerminalKind` enum (`.shell / .claude / .codex`) on `Terminal`, persisted via migration v22 with backfill from existing label heuristics. The recreate handler now branches on `kind`: codex respawns `codex --full-auto` with `CODEX_HOME` and keeps `kind`/`label` intact; claude/shell keep today's "becomes a shell" behavior unchanged. `WorktreeLifecycle+Reconcile` and the app's `isCodexTerminal` both check `kind` first, with the legacy `label == "Codex"` match as a fallback.

The daemon comment that read *"No structured type field exists; label matching is the only discriminator available"* is now obsolete and updated.

## Test plan

- [ ] Existing terminals (Claude / setup / shell) still spawn and run correctly after restart — migration backfills their `kind` from `label` + `claudeSessionID`.
- [ ] Create a new Codex tab → verify the codex prompt renders and you can interact.
- [ ] Switch tabs, switch back → tab still shows the chevron icon, still labeled "Codex", and the pane is still `codex --full-auto`.
- [ ] Click the "Recreate Window" button on a Codex tab → pane respawns as codex, identity preserved.
- [ ] Click "Recreate Window" on a Claude tab → still becomes a plain shell (existing escape-hatch behavior is unchanged).
- [ ] `MigrationV22Tests` covers kind round-tripping for all three variants on a fresh DB.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=0A9CE90C-9348-412D-9B89-89E095098E56)