### PR TITLE
Feat: Nest worktrees by their spawner so the sidebar shows lineage

### DIFF
--- a/Sources/TBDApp/AppState+Repos.swift
+++ b/Sources/TBDApp/AppState+Repos.swift
@@ -5,6 +5,13 @@ import os
 private let logger = Logger(subsystem: "com.tbd.app", category: "AppState+Repos")
 
 extension AppState {
+    // MARK: - Repo Lookups
+
+    /// Display name of a repo by ID, if known.
+    func repoName(for repoID: UUID) -> String? {
+        repos.first(where: { $0.id == repoID })?.displayName
+    }
+
     // MARK: - Repo Actions
 
     /// Add a repository by path.

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -267,6 +267,50 @@ extension AppState {
         }
     }
 
+    // MARK: - Reorder top-level
+
+    /// Reorder ONLY the top-level worktrees of a repo (parentWorktreeID == nil),
+    /// triggered by SwiftUI `.onMove` whose indices index the top-level ForEach.
+    /// Nested children stay attached to their parents — only top-level sortOrders change.
+    /// Updates locally first (optimistic), then persists via RPC; rolls back on error.
+    func reorderTopLevelWorktrees(repoID: UUID, fromOffsets source: IndexSet, toOffset destination: Int) {
+        let previous = worktrees[repoID]
+        var rows = (worktrees[repoID] ?? [])
+        // Snapshot the top-level order BEFORE the move (matches the ForEach).
+        var topLevel = rows
+            .filter { ($0.status == .active || $0.status == .creating) && $0.parentWorktreeID == nil }
+            .sorted { $0.sortOrder < $1.sortOrder }
+        logger.notice("reorderTopLevel BEFORE: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public) source=\(Array(source), privacy: .public) destination=\(destination, privacy: .public)")
+        // Items the user is moving (typically one).
+        let movedIDs = source.map { topLevel[$0].id }
+        // Apply the swap to derive the new top-level order.
+        topLevel.move(fromOffsets: source, toOffset: destination)
+        logger.notice("reorderTopLevel AFTER: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public)")
+
+        // Optimistic local update: reassign sortOrders for the new top-level order.
+        for (i, wt) in topLevel.enumerated() {
+            if let idx = rows.firstIndex(where: { $0.id == wt.id }) {
+                rows[idx].sortOrder = i
+            }
+        }
+        worktrees[repoID] = rows
+
+        // Persist via the bulk reorder RPC. Daemon renumbers all listed worktrees
+        // to contiguous sortOrders matching the new top-level order, avoiding
+        // gappy/non-contiguous values from prior individual moves.
+        let orderedIDs = topLevel.map(\.id)
+        _ = movedIDs  // suppress unused warning; kept for log readability earlier
+        Task {
+            do {
+                logger.notice("RPC worktree.reorder ids=\(orderedIDs.map { $0.uuidString.prefix(8) }.joined(separator: ","), privacy: .public)")
+                try await daemonClient.reorderWorktrees(repoID: repoID, worktreeIDs: orderedIDs)
+            } catch {
+                logger.error("reorderTopLevelWorktrees RPC failed: \(error.localizedDescription, privacy: .public)")
+                await MainActor.run { self.worktrees[repoID] = previous }
+            }
+        }
+    }
+
     // MARK: - Move (nested worktrees)
 
     /// Move a worktree to a new parent (or top-level) and sortOrder.

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -259,8 +259,6 @@ extension AppState {
             .filter { ($0.status == .active || $0.status == .creating) && $0.parentWorktreeID == nil }
             .sorted { $0.sortOrder < $1.sortOrder }
         logger.debug("reorderTopLevel BEFORE: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public) source=\(Array(source), privacy: .public) destination=\(destination, privacy: .public)")
-        // Items the user is moving (typically one).
-        let movedIDs = source.map { topLevel[$0].id }
         // Apply the swap to derive the new top-level order.
         topLevel.move(fromOffsets: source, toOffset: destination)
         logger.debug("reorderTopLevel AFTER: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public)")
@@ -277,7 +275,6 @@ extension AppState {
         // to contiguous sortOrders matching the new top-level order, avoiding
         // gappy/non-contiguous values from prior individual moves.
         let orderedIDs = topLevel.map(\.id)
-        _ = movedIDs  // suppress unused warning; kept for log readability earlier
         Task {
             do {
                 logger.debug("RPC worktree.reorder ids=\(orderedIDs.map { $0.uuidString.prefix(8) }.joined(separator: ","), privacy: .public)")

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -341,10 +341,41 @@ extension AppState {
 
     // MARK: - Keyboard Shortcut Actions
 
-    /// All worktrees in sidebar order (sorted by repo, then by sortOrder).
+    /// All worktrees in **visual sidebar order**: each repo's main row (if any),
+    /// then a depth-first walk of top-level worktrees followed by their
+    /// descendants. Matches what the user sees in the sidebar so cmd+N keyboard
+    /// shortcuts (via `selectWorktreeByIndex`) land on the right row.
+    ///
+    /// `sortOrder` is scoped per sibling group (top-level OR children-of-X), so
+    /// a flat repo-wide sort by `sortOrder` would collapse two namespaces
+    /// together and put nested children with `sortOrder: 0` ahead of top-level
+    /// rows with `sortOrder: 1+`.
     var allWorktreesOrdered: [Worktree] {
-        repos.flatMap { repo in
-            (worktrees[repo.id] ?? []).sorted { $0.sortOrder < $1.sortOrder }
+        var result: [Worktree] = []
+        for repo in repos {
+            let inRepo = worktrees[repo.id] ?? []
+            // Main row first (if present in this repo).
+            if let main = inRepo.first(where: { $0.status == .main }) {
+                result.append(main)
+            }
+            // Top-level active/creating worktrees in this repo, sorted by sortOrder.
+            let topLevel = inRepo
+                .filter { ($0.status == .active || $0.status == .creating) && $0.parentWorktreeID == nil }
+                .sorted { $0.sortOrder < $1.sortOrder }
+            for wt in topLevel {
+                appendSubtree(wt, into: &result)
+            }
+        }
+        return result
+    }
+
+    /// Depth-first append: the worktree itself, then its children (across all
+    /// repos, since a child can have a different `repoID` from its parent),
+    /// recursively. Used by `allWorktreesOrdered` to match sidebar order.
+    private func appendSubtree(_ wt: Worktree, into result: inout [Worktree]) {
+        result.append(wt)
+        for child in children(of: wt.id) {
+            appendSubtree(child, into: &result)
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -11,7 +11,9 @@ extension AppState {
     /// Create a new worktree in a repo.
     /// Shows an optimistic placeholder immediately, then replaces it with the
     /// real worktree once the daemon responds.
-    func createWorktree(repoID: UUID) {
+    /// When `parentWorktreeID` is non-nil, the new worktree is created as a
+    /// nested child of that worktree (must be in the same repo).
+    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil) {
         // Optimistic placeholder so the row appears instantly
         let placeholderName = NameGenerator.generate()
         let placeholder = Worktree(
@@ -21,7 +23,8 @@ extension AppState {
             branch: "tbd/\(placeholderName)",
             path: "",
             status: .creating,
-            tmuxServer: ""
+            tmuxServer: "",
+            parentWorktreeID: parentWorktreeID
         )
         pendingWorktreeIDs.insert(placeholder.id)
         worktrees[repoID, default: []].append(placeholder)
@@ -32,7 +35,10 @@ extension AppState {
             defer { pendingWorktreeIDs.remove(placeholder.id) }
             do {
                 let size = mainAreaTerminalSize()
-                let wt = try await daemonClient.createWorktree(repoID: repoID, cols: size.cols, rows: size.rows)
+                let wt = try await daemonClient.createWorktree(
+                    repoID: repoID, cols: size.cols, rows: size.rows,
+                    parentWorktreeID: parentWorktreeID
+                )
                 // Replace the placeholder with the real worktree
                 if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == placeholder.id }) {
                     worktrees[repoID]?[idx] = wt

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -360,7 +360,7 @@ extension AppState {
                 .filter { ($0.status == .active || $0.status == .creating) && $0.parentWorktreeID == nil }
                 .sorted { $0.sortOrder < $1.sortOrder }
             for wt in topLevel {
-                appendSubtree(wt, into: &result)
+                appendSubtree(wt, depth: 0, into: &result)
             }
         }
         return result
@@ -369,10 +369,15 @@ extension AppState {
     /// Depth-first append: the worktree itself, then its children (across all
     /// repos, since a child can have a different `repoID` from its parent),
     /// recursively. Used by `allWorktreesOrdered` to match sidebar order.
-    private func appendSubtree(_ wt: Worktree, into result: inout [Worktree]) {
+    /// Caps recursion at 50 to mirror `WorktreeSubtreeView.kMaxSubtreeDepth`
+    /// in case a cyclic parent chain ever makes it into the in-memory state
+    /// (DB-side cycle guards make this unlikely, but the keyboard-nav path
+    /// shouldn't blow the stack while the renderer gracefully degrades).
+    private func appendSubtree(_ wt: Worktree, depth: Int, into result: inout [Worktree]) {
         result.append(wt)
+        guard depth < 50 else { return }
         for child in children(of: wt.id) {
-            appendSubtree(child, into: &result)
+            appendSubtree(child, depth: depth + 1, into: &result)
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -267,6 +267,56 @@ extension AppState {
         }
     }
 
+    // MARK: - Move (nested worktrees)
+
+    /// Move a worktree to a new parent (or top-level) and sortOrder.
+    /// Optimistic local update; rolls back on RPC error.
+    func moveWorktree(id: UUID, newParentID: UUID?, newSortOrder: Int) {
+        let snapshot = worktrees
+        if let repoID = repoIDForWorktree(id), var rows = worktrees[repoID] {
+            if let idx = rows.firstIndex(where: { $0.id == id }) {
+                rows[idx].parentWorktreeID = newParentID
+                rows[idx].sortOrder = newSortOrder
+                worktrees[repoID] = rows
+            }
+        }
+        Task {
+            do {
+                try await daemonClient.moveWorktree(
+                    worktreeID: id, newParentID: newParentID, newSortOrder: newSortOrder
+                )
+            } catch {
+                logger.error("moveWorktree failed: \(error.localizedDescription)")
+                await MainActor.run { self.worktrees = snapshot }
+            }
+        }
+    }
+
+    /// All worktrees whose parentWorktreeID == parentID, across all repos, in sortOrder.
+    /// Only active or creating worktrees are returned.
+    func children(of parentID: UUID) -> [Worktree] {
+        worktrees.values
+            .flatMap { $0 }
+            .filter { $0.parentWorktreeID == parentID && ($0.status == .active || $0.status == .creating) }
+            .sorted { $0.sortOrder < $1.sortOrder }
+    }
+
+    /// Find a worktree by id across all repos.
+    func findWorktree(id: UUID) -> Worktree? {
+        for (_, rows) in worktrees {
+            if let wt = rows.first(where: { $0.id == id }) { return wt }
+        }
+        return nil
+    }
+
+    /// Repo ID of the repo containing the given worktree, if any.
+    private func repoIDForWorktree(_ id: UUID) -> UUID? {
+        for (rid, rows) in worktrees where rows.contains(where: { $0.id == id }) {
+            return rid
+        }
+        return nil
+    }
+
     // MARK: - Keyboard Shortcut Actions
 
     /// All worktrees in sidebar order (sorted by repo, then by sortOrder).

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -286,12 +286,12 @@ extension AppState {
         var topLevel = rows
             .filter { ($0.status == .active || $0.status == .creating) && $0.parentWorktreeID == nil }
             .sorted { $0.sortOrder < $1.sortOrder }
-        logger.notice("reorderTopLevel BEFORE: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public) source=\(Array(source), privacy: .public) destination=\(destination, privacy: .public)")
+        logger.debug("reorderTopLevel BEFORE: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public) source=\(Array(source), privacy: .public) destination=\(destination, privacy: .public)")
         // Items the user is moving (typically one).
         let movedIDs = source.map { topLevel[$0].id }
         // Apply the swap to derive the new top-level order.
         topLevel.move(fromOffsets: source, toOffset: destination)
-        logger.notice("reorderTopLevel AFTER: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public)")
+        logger.debug("reorderTopLevel AFTER: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public)")
 
         // Optimistic local update: reassign sortOrders for the new top-level order.
         for (i, wt) in topLevel.enumerated() {
@@ -308,7 +308,7 @@ extension AppState {
         _ = movedIDs  // suppress unused warning; kept for log readability earlier
         Task {
             do {
-                logger.notice("RPC worktree.reorder ids=\(orderedIDs.map { $0.uuidString.prefix(8) }.joined(separator: ","), privacy: .public)")
+                logger.debug("RPC worktree.reorder ids=\(orderedIDs.map { $0.uuidString.prefix(8) }.joined(separator: ","), privacy: .public)")
                 try await daemonClient.reorderWorktrees(repoID: repoID, worktreeIDs: orderedIDs)
             } catch {
                 logger.error("reorderTopLevelWorktrees RPC failed: \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -245,34 +245,6 @@ extension AppState {
         }
     }
 
-    // MARK: - Reorder
-
-    /// Reorder worktrees within a repo. Updates locally first (optimistic), then persists via RPC.
-    /// Rolls back local state if the RPC call fails.
-    func reorderWorktrees(repoID: UUID, fromOffsets source: IndexSet, toOffset destination: Int) {
-        let previousWorktrees = worktrees[repoID]
-        guard var repoWorktrees = worktrees[repoID]?.filter({ $0.status == .active || $0.status == .creating }) else { return }
-        repoWorktrees.move(fromOffsets: source, toOffset: destination)
-        for i in repoWorktrees.indices {
-            repoWorktrees[i].sortOrder = i
-        }
-
-        // Rebuild the full array: keep main/other statuses in place, replace active/creating with reordered
-        let others = (worktrees[repoID] ?? []).filter { $0.status != .active && $0.status != .creating }
-        worktrees[repoID] = others + repoWorktrees
-
-        // Persist via RPC
-        let worktreeIDs = repoWorktrees.map(\.id)
-        Task {
-            do {
-                try await daemonClient.reorderWorktrees(repoID: repoID, worktreeIDs: worktreeIDs)
-            } catch {
-                logger.error("Failed to reorder worktrees: \(error)")
-                worktrees[repoID] = previousWorktrees
-            }
-        }
-    }
-
     // MARK: - Reorder top-level
 
     /// Reorder ONLY the top-level worktrees of a repo (parentWorktreeID == nil),

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -425,8 +425,27 @@ final class AppState: ObservableObject {
             Task { [weak self] in await self?.loadModelProfiles() }
         case .terminalSessionUpdated(let d):
             applyTerminalSessionDelta(d)
+        case .worktreeMoved(let d):
+            applyWorktreeMovedDelta(d)
         default:
             break
+        }
+    }
+
+    /// Apply a worktree move (new parent + sortOrder) directly to the in-memory
+    /// model so the sidebar reflects the change without waiting for the next
+    /// `worktree.list` poll. Searches all repos for the worktree — moves
+    /// across repos aren't supported by the daemon today, so we mutate in
+    /// place once we find it.
+    private func applyWorktreeMovedDelta(_ delta: WorktreeMovedDelta) {
+        for (repoID, rows) in worktrees {
+            if let idx = rows.firstIndex(where: { $0.id == delta.worktreeID }) {
+                var updated = rows
+                updated[idx].parentWorktreeID = delta.newParentID
+                updated[idx].sortOrder = delta.newSortOrder
+                worktrees[repoID] = updated
+                break
+            }
         }
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -402,10 +402,10 @@ actor DaemonClient {
     }
 
     /// Create a new worktree in a repo.
-    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil) async throws -> Worktree {
+    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil) async throws -> Worktree {
         return try await callAsync(
             method: RPCMethod.worktreeCreate,
-            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows),
+            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID),
             resultType: Worktree.self
         )
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -451,6 +451,19 @@ actor DaemonClient {
         )
     }
 
+    /// Move a worktree to a new parent (or top-level) and sortOrder.
+    func moveWorktree(worktreeID: UUID, newParentID: UUID?, newSortOrder: Int) async throws {
+        _ = try await callAsync(
+            method: RPCMethod.worktreeMove,
+            params: WorktreeMoveParams(
+                worktreeID: worktreeID,
+                newParentID: newParentID,
+                newSortOrder: newSortOrder
+            ),
+            resultType: WorktreeMoveResult.self
+        )
+    }
+
     /// Set or clear the pin on a terminal.
     func setTerminalPin(id: UUID, pinned: Bool) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -453,14 +453,13 @@ actor DaemonClient {
 
     /// Move a worktree to a new parent (or top-level) and sortOrder.
     func moveWorktree(worktreeID: UUID, newParentID: UUID?, newSortOrder: Int) async throws {
-        _ = try await callAsync(
+        try await callVoidAsync(
             method: RPCMethod.worktreeMove,
             params: WorktreeMoveParams(
                 worktreeID: worktreeID,
                 newParentID: newParentID,
                 newSortOrder: newSortOrder
-            ),
-            resultType: WorktreeMoveResult.self
+            )
         )
     }
 

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -55,9 +55,9 @@ struct RepoSectionView: View {
             .first { $0.status == .main }
     }
 
-    var worktrees: [Worktree] {
+    var topLevelWorktrees: [Worktree] {
         (appState.worktrees[repo.id] ?? [])
-            .filter { $0.status == .active || $0.status == .creating }
+            .filter { ($0.status == .active || $0.status == .creating) && $0.parentWorktreeID == nil }
             .sorted { $0.sortOrder < $1.sortOrder }
     }
 
@@ -201,20 +201,12 @@ struct RepoSectionView: View {
                     .listRowBackground(Color.clear)
                     .tag(main.id)
             }
-            ForEach(worktrees) { worktree in
-                WorktreeRowView(worktree: worktree)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color.white.opacity(0.0001))
+            ForEach(topLevelWorktrees) { wt in
+                WorktreeSubtreeView(worktree: wt, depth: 0, sectionRepoID: repo.id)
                     .opacity(isChevronHovered ? 0.7 : 1.0)
                     .onHover { onSectionHoverChange($0) }
-                    .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
-                    .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
-                    .tag(worktree.id)
             }
-            .onMove { source, destination in
-                appState.reorderWorktrees(repoID: repo.id, fromOffsets: source, toOffset: destination)
-            }
+            // Drag-and-drop is reimplemented in a later task.
         }
     }
 

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -206,7 +206,13 @@ struct RepoSectionView: View {
                     .opacity(isChevronHovered ? 0.7 : 1.0)
                     .onHover { onSectionHoverChange($0) }
             }
-            // Drag-and-drop is reimplemented in a later task.
+            .onMove { source, destination in
+                appState.reorderTopLevelWorktrees(
+                    repoID: repo.id,
+                    fromOffsets: source,
+                    toOffset: destination
+                )
+            }
         }
     }
 

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 import TBDShared
 
-private struct HoverPressButtonStyle: ButtonStyle {
+struct HoverPressButtonStyle: ButtonStyle {
     @State private var isHovering = false
 
     func makeBody(configuration: Configuration) -> some View {

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -33,6 +33,7 @@ struct SidebarContextMenu: View {
                 let hasSuspendedClaude = terminals.contains {
                     $0.claudeSessionID != nil && $0.suspendedAt != nil
                 }
+                let hasActiveChildren = !appState.children(of: worktree.id).isEmpty
 
                 if hasUnsuspendedClaude {
                     Button("Suspend Claude") {
@@ -86,6 +87,8 @@ struct SidebarContextMenu: View {
                         await appState.archiveWorktree(id: wtID)
                     }
                 }
+                .disabled(hasActiveChildren)
+                .help(hasActiveChildren ? "Archive nested worktrees first" : "")
 
                 Divider()
 

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -81,6 +81,12 @@ struct SidebarContextMenu: View {
                     }
                 }
 
+                Button("Create Nested Worktree") {
+                    let parentID = worktree.id
+                    let repoID = worktree.repoID
+                    appState.createWorktree(repoID: repoID, parentWorktreeID: parentID)
+                }
+
                 Button("Archive", role: .destructive) {
                     let wtID = worktree.id
                     Task {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -147,7 +147,7 @@ struct WorktreeRowView: View {
                     .lineLimit(1)
             }
         }
-        .padding(.leading, CGFloat(indentLevel) * 12)
+        .padding(.leading, CGFloat(indentLevel) * 16)
         .contentShape(Rectangle())
         .onTapGesture {
             if NSEvent.modifierFlags.contains(.command) {
@@ -168,6 +168,23 @@ struct WorktreeRowView: View {
             RoundedRectangle(cornerRadius: 4)
                 .fill(appState.selectedWorktreeIDs.contains(worktree.id) ? Color.accentColor.opacity(0.2) : Color.clear)
         )
+        // Hierarchy guide lines: one 1pt vertical at each ancestor depth.
+        // Each line sits at `depth * 16 + 8` from the row's leading edge so
+        // segments butt up against neighboring nested rows into a continuous
+        // thread down the parent's gutter.
+        .overlay(alignment: .leading) {
+            if indentLevel > 0 {
+                ZStack(alignment: .leading) {
+                    ForEach(0..<indentLevel, id: \.self) { depth in
+                        Rectangle()
+                            .fill(Color.secondary.opacity(0.25))
+                            .frame(width: 1)
+                            .offset(x: CGFloat(depth) * 16 + 8)
+                    }
+                }
+                .allowsHitTesting(false)
+            }
+        }
         .contextMenu {
             SidebarContextMenu(worktree: worktree, onRename: startRename)
         }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -8,6 +8,7 @@ struct WorktreeRowView: View {
     var sectionRepoID: UUID? = nil
     @EnvironmentObject var appState: AppState
     @State private var isEditing = false
+    @State private var isRowHovered: Bool = false
 
     private var isPending: Bool {
         worktree.status == .creating
@@ -185,6 +186,23 @@ struct WorktreeRowView: View {
                 .allowsHitTesting(false)
             }
         }
+        .overlay(alignment: .trailing) {
+            if isRowHovered && !isMain {
+                Button(action: {
+                    let parentID = worktree.id
+                    let repoID = worktree.repoID
+                    appState.createWorktree(repoID: repoID, parentWorktreeID: parentID)
+                }) {
+                    Image(systemName: "plus")
+                        .font(.caption)
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(HoverPressButtonStyle())
+                .help("New nested worktree")
+                .padding(.trailing, 4)
+            }
+        }
+        .onHover { isRowHovered = $0 }
         .contextMenu {
             SidebarContextMenu(worktree: worktree, onRename: startRename)
         }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -108,7 +108,6 @@ struct WorktreeRowView: View {
     var body: some View {
         HStack(spacing: 6) {
             rowIcons()
-                .allowsHitTesting(false)
             RenameableLabel(
                 text: worktree.displayName,
                 isEditing: $isEditing,
@@ -138,7 +137,6 @@ struct WorktreeRowView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                .allowsHitTesting(false)
             }
             if let sectionRepoID, sectionRepoID != worktree.repoID,
                let homeRepo = appState.repoName(for: worktree.repoID) {
@@ -149,20 +147,7 @@ struct WorktreeRowView: View {
             }
         }
         .padding(.leading, CGFloat(indentLevel) * 16)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            if NSEvent.modifierFlags.contains(.command) {
-                if appState.selectedWorktreeIDs.contains(worktree.id) {
-                    appState.selectedWorktreeIDs.remove(worktree.id)
-                } else {
-                    appState.selectedWorktreeIDs.insert(worktree.id)
-                }
-            } else if !isMain && appState.selectedWorktreeIDs == [worktree.id] && !isEditing {
-                startRename()
-            } else {
-                appState.selectedWorktreeIDs = [worktree.id]
-            }
-        }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: 28)
         .help(isEditing ? "" : worktree.displayName)
         .background(

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -4,6 +4,8 @@ import TBDShared
 struct WorktreeRowView: View {
     let worktree: Worktree
     var isMain: Bool = false
+    var indentLevel: Int = 0
+    var sectionRepoID: UUID? = nil
     @EnvironmentObject var appState: AppState
     @State private var isEditing = false
 
@@ -137,7 +139,15 @@ struct WorktreeRowView: View {
                 }
                 .allowsHitTesting(false)
             }
+            if let sectionRepoID, sectionRepoID != worktree.repoID,
+               let homeRepo = appState.repoName(for: worktree.repoID) {
+                Text("(\(homeRepo))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
         }
+        .padding(.leading, CGFloat(indentLevel) * 12)
         .contentShape(Rectangle())
         .onTapGesture {
             if NSEvent.modifierFlags.contains(.command) {

--- a/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
@@ -6,8 +6,8 @@ private let subtreeLogger = Logger(subsystem: "com.tbd.app", category: "sidebar-
 
 /// Hard recursion cap to defend against a cyclic `parentWorktreeID` chain in
 /// the DB (e.g. introduced by a manual `sqlite3` edit that slipped past
-/// `WorktreeStore.nullOrphanedParents()`'s cycle pass). Without this guard,
-/// `WorktreeSubtreeView` would stack-overflow on any cyclic graph.
+/// `WorktreeStore.breakCyclicParents()` at daemon startup). Without this
+/// guard, `WorktreeSubtreeView` would stack-overflow on any cyclic graph.
 private let kMaxSubtreeDepth = 50
 
 /// Renders a worktree row plus its descendants, recursively.

--- a/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
@@ -1,5 +1,14 @@
+import os
 import SwiftUI
 import TBDShared
+
+private let subtreeLogger = Logger(subsystem: "com.tbd.app", category: "sidebar-subtree")
+
+/// Hard recursion cap to defend against a cyclic `parentWorktreeID` chain in
+/// the DB (e.g. introduced by a manual `sqlite3` edit that slipped past
+/// `WorktreeStore.nullOrphanedParents()`'s cycle pass). Without this guard,
+/// `WorktreeSubtreeView` would stack-overflow on any cyclic graph.
+private let kMaxSubtreeDepth = 50
 
 /// Renders a worktree row plus its descendants, recursively.
 ///
@@ -25,12 +34,22 @@ struct WorktreeSubtreeView: View {
         .listRowBackground(Color.clear)
         .tag(worktree.id)
 
-        ForEach(appState.children(of: worktree.id)) { child in
-            WorktreeSubtreeView(
-                worktree: child,
-                depth: depth + 1,
-                sectionRepoID: sectionRepoID
-            )
+        if depth < kMaxSubtreeDepth {
+            ForEach(appState.children(of: worktree.id)) { child in
+                WorktreeSubtreeView(
+                    worktree: child,
+                    depth: depth + 1,
+                    sectionRepoID: sectionRepoID
+                )
+            }
+        } else {
+            // Cap hit. Almost certainly a cyclic parent chain in the DB.
+            // Log once per cap-hit row so a future incident is debuggable.
+            Color.clear
+                .frame(height: 0)
+                .onAppear {
+                    subtreeLogger.error("WorktreeSubtreeView depth cap (\(kMaxSubtreeDepth, privacy: .public)) hit at worktree \(worktree.id, privacy: .public); suspect cyclic parentWorktreeID chain")
+                }
         }
     }
 }

--- a/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeSubtreeView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import TBDShared
+
+/// Renders a worktree row plus its descendants, recursively.
+///
+/// Children render directly under their parent within the parent's repo section,
+/// indented further. A child whose `repoID` differs from the section's repo gets
+/// a muted `(repo-name)` suffix in the row label (handled in `WorktreeRowView`).
+struct WorktreeSubtreeView: View {
+    let worktree: Worktree
+    let depth: Int
+    let sectionRepoID: UUID
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        WorktreeRowView(
+            worktree: worktree,
+            indentLevel: depth,
+            sectionRepoID: sectionRepoID
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white.opacity(0.0001))
+        .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
+        .tag(worktree.id)
+
+        ForEach(appState.children(of: worktree.id)) { child in
+            WorktreeSubtreeView(
+                worktree: child,
+                depth: depth + 1,
+                sectionRepoID: sectionRepoID
+            )
+        }
+    }
+}

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -42,6 +42,15 @@ struct WorktreeCreate: AsyncParsableCommand {
     @Option(name: .long, help: "Read initial prompt from a file (use - for stdin)")
     var promptFile: String?
 
+    @Option(name: .customLong("parent"), help: "Nest the new worktree under this parent (worktree ID or display name).")
+    var parent: String?
+
+    @Flag(name: .customLong("sibling"), help: "Spawn as a sibling of the caller (same parent as TBD_WORKTREE_ID).")
+    var asSibling: Bool = false
+
+    @Flag(name: .customLong("no-parent"), help: "Force the new worktree to be top-level (ignore TBD_WORKTREE_ID).")
+    var noParent: Bool = false
+
     @Flag(name: .long, help: "Return immediately without waiting for the worktree to become active")
     var noWait = false
 
@@ -83,9 +92,53 @@ struct WorktreeCreate: AsyncParsableCommand {
 
         let resolvedPrompt = try resolvePrompt(inline: prompt, file: promptFile)
 
+        // Mutually exclusive parenting flags
+        let flagsSet = (parent != nil ? 1 : 0) + (asSibling ? 1 : 0) + (noParent ? 1 : 0)
+        if flagsSet > 1 {
+            throw ValidationError("Pass at most one of --parent, --sibling, --no-parent.")
+        }
+
+        // Resolve --parent (UUID or display name / folder name)
+        var explicitParentID: UUID?
+        if let p = parent {
+            if let uuid = UUID(uuidString: p) {
+                explicitParentID = uuid
+            } else {
+                let worktrees: [Worktree] = try client.call(
+                    method: RPCMethod.worktreeList,
+                    params: WorktreeListParams(),
+                    resultType: [Worktree].self
+                )
+                let matches = worktrees.filter { $0.displayName == p || $0.name == p }
+                if matches.isEmpty {
+                    throw ValidationError("No worktree matches --parent '\(p)'.")
+                }
+                if matches.count > 1 {
+                    throw ValidationError("Multiple worktrees match --parent '\(p)' — pass the UUID instead.")
+                }
+                explicitParentID = matches[0].id
+            }
+        }
+
+        let callerEnvID = ProcessInfo.processInfo.environment["TBD_WORKTREE_ID"]
+            .flatMap { UUID(uuidString: $0) }
+        let siblingOfID: UUID? = asSibling ? callerEnvID : nil
+        let passCaller = explicitParentID == nil && !asSibling && !noParent
+        let callerWorktreeID: UUID? = passCaller ? callerEnvID : nil
+
         let pending: Worktree = try client.call(
             method: RPCMethod.worktreeCreate,
-            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: name, prompt: resolvedPrompt),
+            params: WorktreeCreateParams(
+                repoID: repoID,
+                folder: folder,
+                branch: branch,
+                displayName: name,
+                prompt: resolvedPrompt,
+                parentWorktreeID: explicitParentID,
+                siblingOfWorktreeID: siblingOfID,
+                callerWorktreeID: callerWorktreeID,
+                suppressAutoParent: noParent ? true : nil
+            ),
             resultType: Worktree.self
         )
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -172,6 +172,14 @@ public final class Daemon: Sendable {
 
         // 11. Reconcile worktrees for all known repos
         await rpcRouter.suspendResumeCoordinator.reconcileOnStartup()
+        // Break any cyclic parent pointers in the worktree tree (manual sqlite
+        // edits, future regressions). Once at startup only — the cycle guard
+        // in WorktreeStore.move prevents new cycles via normal operations.
+        do {
+            try await database.worktrees.breakCyclicParents()
+        } catch {
+            print("[Daemon] Warning: breakCyclicParents failed at startup: \(error)")
+        }
         do {
             let repos = try await database.repos.list()
             for repo in repos {

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -2,6 +2,8 @@ import Foundation
 import TBDShared
 import os
 
+private let daemonLogger = Logger(subsystem: "com.tbd.daemon", category: "startup")
+
 /// Top-level daemon orchestrator.
 ///
 /// Coordinates all subsystems: database, managers, servers, and subscriptions.
@@ -178,7 +180,7 @@ public final class Daemon: Sendable {
         do {
             try await database.worktrees.breakCyclicParents()
         } catch {
-            print("[Daemon] Warning: breakCyclicParents failed at startup: \(error)")
+            daemonLogger.warning("breakCyclicParents failed at startup: \(error.localizedDescription, privacy: .public)")
         }
         do {
             let repos = try await database.repos.list()

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -391,6 +391,13 @@ public final class TBDDatabase: Sendable {
             try db.execute(sql: "UPDATE terminal SET kind = 'shell' WHERE kind IS NULL")
         }
 
+        migrator.registerMigration("v23_worktree_parent") { db in
+            try db.alter(table: "worktree") { t in
+                t.add(column: "parentWorktreeID", .text)
+                    .references("worktree", onDelete: .setNull)
+            }
+        }
+
         try migrator.migrate(writer)
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -440,9 +440,12 @@ public struct WorktreeStore: Sendable {
                     arguments: [p, newSortOrder, worktreeID.uuidString]
                 )
             } else {
-                // Top-level siblings = same repo, parent null. Exclude main from sibling group (it has its own status).
+                // Top-level siblings = same repo, parent null, NOT main. The UI
+                // renders main via a status-filtered path (so an updated sortOrder
+                // on a main row is invisible), but excluding it here keeps the
+                // sibling group consistent with how the UI orders top-level rows.
                 try db.execute(
-                    sql: "UPDATE worktree SET sortOrder = sortOrder + 1 WHERE repoID = ? AND parentWorktreeID IS NULL AND sortOrder >= ? AND id != ?",
+                    sql: "UPDATE worktree SET sortOrder = sortOrder + 1 WHERE repoID = ? AND parentWorktreeID IS NULL AND status != 'main' AND sortOrder >= ? AND id != ?",
                     arguments: [movingRecord.repoID, newSortOrder, worktreeID.uuidString]
                 )
             }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -91,6 +91,14 @@ public enum WorktreeMoveError: Error, CustomStringConvertible {
     }
 }
 
+public enum WorktreeArchiveError: Error, CustomStringConvertible {
+    case hasActiveChildren
+
+    public var description: String {
+        "Archive nested worktrees first."
+    }
+}
+
 /// Provides CRUD operations for worktrees.
 public struct WorktreeStore: Sendable {
     let writer: any DatabaseWriter
@@ -241,6 +249,28 @@ public struct WorktreeStore: Sendable {
                 record.archivedHeadSHA = sha
             }
             try record.update(db)
+        }
+    }
+
+    /// Throws `WorktreeArchiveError.hasActiveChildren` if the worktree has any
+    /// direct children with status `.active` or `.creating`. Used as a precheck
+    /// by the archive RPC handler so app and CLI surface the same error.
+    public func assertArchivable(id: UUID) async throws {
+        try await writer.read { db in
+            let activeRaw = WorktreeStatus.active.rawValue
+            let creatingRaw = WorktreeStatus.creating.rawValue
+            let count = try Int.fetchOne(
+                db,
+                sql: """
+                SELECT COUNT(*) FROM worktree
+                WHERE parentWorktreeID = ?
+                  AND status IN (?, ?)
+                """,
+                arguments: [id.uuidString, activeRaw, creatingRaw]
+            ) ?? 0
+            if count > 0 {
+                throw WorktreeArchiveError.hasActiveChildren
+            }
         }
     }
 

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -172,6 +172,19 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// Null out any `parentWorktreeID` that doesn't reference an existing row.
+    /// Called on daemon startup to handle out-of-band parent removal.
+    public func nullOrphanedParents() async throws {
+        try await writer.write { db in
+            try db.execute(sql: """
+                UPDATE worktree
+                SET parentWorktreeID = NULL
+                WHERE parentWorktreeID IS NOT NULL
+                  AND parentWorktreeID NOT IN (SELECT id FROM worktree)
+            """)
+        }
+    }
+
     /// Create a synthetic "main" worktree entry pointing at the repo root.
     public func createMain(
         repoID: UUID,

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -317,8 +317,17 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Throws `WorktreeArchiveError.hasActiveChildren` if the worktree has any
-    /// direct children with status `.active` or `.creating`. Used as a precheck
+    /// **direct** children with status `.active` or `.creating`. Used as a precheck
     /// by the archive RPC handler so app and CLI surface the same error.
+    ///
+    /// Note: only depth-1 children are checked here. A tree shape like
+    /// `A → B(archived) → C(active)` would let `A` be archived because its
+    /// only direct child `B` is already archived; `C` then briefly points at
+    /// an archived ancestor. That window is closed by `nullOrphanedParents`
+    /// on the next reconcile (which now treats archived parents the same as
+    /// missing ones), so `C` self-promotes to top-level rather than going
+    /// invisible. Deepening the check to "any active descendant" would block
+    /// legitimate archive cascades, so the current depth-1 scope is intentional.
     public func assertArchivable(id: UUID) async throws {
         try await writer.read { db in
             let activeRaw = WorktreeStatus.active.rawValue
@@ -463,6 +472,12 @@ public struct WorktreeStore: Sendable {
                 }
                 if parent.status == WorktreeStatus.main.rawValue {
                     throw WorktreeMoveError.parentIsMain
+                }
+                if parent.status == WorktreeStatus.archived.rawValue {
+                    // Symmetric to ParentResolver's create-time check: moving a
+                    // worktree under an archived parent would produce an
+                    // invisible row until reconcile clears the pointer.
+                    throw WorktreeMoveError.parentIsArchived
                 }
                 // Cycle check: walk up from parent; if we ever hit `worktreeID`, cycle.
                 // The `visited` set defends against a pre-existing cycle in the DB

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -78,6 +78,7 @@ public enum WorktreeMoveError: Error, CustomStringConvertible {
     case cycle
     case parentNotFound
     case parentIsMain
+    case parentIsArchived
     case worktreeNotFound
 
     public var description: String {
@@ -86,6 +87,7 @@ public enum WorktreeMoveError: Error, CustomStringConvertible {
         case .cycle: return "This move would create a cycle in the worktree tree."
         case .parentNotFound: return "Parent worktree not found."
         case .parentIsMain: return "Cannot nest under the main worktree."
+        case .parentIsArchived: return "Cannot nest under an archived worktree."
         case .worktreeNotFound: return "Worktree not found."
         }
     }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -414,9 +414,17 @@ public struct WorktreeStore: Sendable {
                     throw WorktreeMoveError.parentIsMain
                 }
                 // Cycle check: walk up from parent; if we ever hit `worktreeID`, cycle.
+                // The `visited` set defends against a pre-existing cycle in the DB
+                // (manual edit or future regression) by treating any revisit as a
+                // cycle too — otherwise the loop would spin forever inside the
+                // write transaction and block the database.
                 var cursor: String? = parent.parentWorktreeID
+                var visited: Set<String> = [pid.uuidString]
                 while let curID = cursor {
                     if curID == worktreeID.uuidString {
+                        throw WorktreeMoveError.cycle
+                    }
+                    if !visited.insert(curID).inserted {
                         throw WorktreeMoveError.cycle
                     }
                     cursor = try WorktreeRecord.fetchOne(db, key: curID)?.parentWorktreeID

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -172,16 +172,52 @@ public struct WorktreeStore: Sendable {
         }
     }
 
-    /// Null out any `parentWorktreeID` that doesn't reference an existing row.
-    /// Called on daemon startup to handle out-of-band parent removal.
+    /// Null out parent pointers that would corrupt the worktree tree:
+    /// 1. Parents that reference a missing row (orphans).
+    /// 2. Parents that participate in a cycle (e.g. A.parent = B and B.parent = A
+    ///    after a manual `sqlite3` edit). `WorktreeStore.move()`'s cycle guard
+    ///    prevents new cycles from forming through normal operations, but we
+    ///    still need to defuse any that exist at startup — otherwise
+    ///    `WorktreeSubtreeView`'s recursive render would stack-overflow.
+    /// Called on daemon startup.
     public func nullOrphanedParents() async throws {
         try await writer.write { db in
+            // Pass 1: orphans (parent pointer references a missing row).
             try db.execute(sql: """
                 UPDATE worktree
                 SET parentWorktreeID = NULL
                 WHERE parentWorktreeID IS NOT NULL
                   AND parentWorktreeID NOT IN (SELECT id FROM worktree)
             """)
+
+            // Pass 2: cycles. For each row with a non-null parent, walk upward
+            // with a visited set. If we revisit a node, the chain is cyclic;
+            // null the original row's parent to break the cycle. We null only
+            // the row we started from (not every member of the cycle) so the
+            // damage is minimal and predictable.
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT id, parentWorktreeID FROM worktree
+                WHERE parentWorktreeID IS NOT NULL
+            """)
+            for row in rows {
+                guard let rowID = row["id"] as String? else { continue }
+                var cursor: String? = row["parentWorktreeID"] as String?
+                var visited: Set<String> = [rowID]
+                while let curID = cursor {
+                    if !visited.insert(curID).inserted {
+                        try db.execute(
+                            sql: "UPDATE worktree SET parentWorktreeID = NULL WHERE id = ?",
+                            arguments: [rowID]
+                        )
+                        break
+                    }
+                    cursor = try Row.fetchOne(
+                        db,
+                        sql: "SELECT parentWorktreeID FROM worktree WHERE id = ?",
+                        arguments: [curID]
+                    )?["parentWorktreeID"] as String?
+                }
+            }
         }
     }
 

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -22,6 +22,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var archivedHeadSHA: String?
     var tabOrder: String  // JSON array of UUID strings, e.g. "[]" or "[\"...\",\"...\"]"
     var activeTabID: String?
+    var parentWorktreeID: String?
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -43,6 +44,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         }
         self.tabOrder = "[]"  // overwritten by GRDB when fetched; only "new worktree" path uses this initializer
         self.activeTabID = nil  // new worktrees start with no stored selection
+        self.parentWorktreeID = wt.parentWorktreeID?.uuidString
     }
 
     func toModel() -> Worktree {
@@ -65,7 +67,8 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             tmuxServer: tmuxServer,
             archivedClaudeSessions: sessions,
             sortOrder: sortOrder,
-            archivedHeadSHA: archivedHeadSHA
+            archivedHeadSHA: archivedHeadSHA,
+            parentWorktreeID: parentWorktreeID.flatMap { UUID(uuidString: $0) }
         )
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -447,7 +447,10 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Reorder worktrees within a repo. The worktreeIDs array defines the new order.
-    /// Worktrees not in the array are pushed to sortOrder values after the provided list.
+    /// Only affects worktrees in the provided list (typically top-level). Any other
+    /// top-level worktrees not in the list are pushed to sortOrder values after the
+    /// reordered ones. Nested children (parentWorktreeID IS NOT NULL) are left alone
+    /// — their sortOrder is scoped to their parent group.
     public func reorder(repoID: UUID, worktreeIDs: [UUID]) async throws {
         try await writer.write { db in
             for (index, wtID) in worktreeIDs.enumerated() {
@@ -456,14 +459,18 @@ public struct WorktreeStore: Sendable {
                     arguments: [index, wtID.uuidString, repoID.uuidString]
                 )
             }
-            // Push any worktrees not in the provided list to after the reordered ones
+            // Push any TOP-LEVEL worktrees not in the provided list to after the
+            // reordered ones. Children are scoped per parent and untouched.
             let idStrings = worktreeIDs.map(\.uuidString)
             let placeholders = idStrings.map { _ in "?" }.joined(separator: ",")
             let args: [any DatabaseValueConvertible] = [worktreeIDs.count, repoID.uuidString] + idStrings
             try db.execute(
                 sql: """
                     UPDATE worktree SET sortOrder = ? + rowid
-                    WHERE repoID = ? AND status IN ('active', 'creating') AND id NOT IN (\(placeholders))
+                    WHERE repoID = ?
+                      AND status IN ('active', 'creating')
+                      AND parentWorktreeID IS NULL
+                      AND id NOT IN (\(placeholders))
                     """,
                 arguments: StatementArguments(args)
             )

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -100,7 +100,10 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Create a new worktree. The displayName defaults to the name.
-    /// Automatically assigns sortOrder = max(sortOrder) + 1 for the repo.
+    /// Automatically assigns sortOrder = max(sortOrder) + 1 scoped to the
+    /// new worktree's sibling group (same parentWorktreeID), so nested
+    /// children get their own contiguous ordering separate from top-level
+    /// worktrees in the same repo.
     public func create(
         repoID: UUID,
         name: String,
@@ -108,14 +111,24 @@ public struct WorktreeStore: Sendable {
         branch: String,
         path: String,
         tmuxServer: String,
-        status: WorktreeStatus = .active
+        status: WorktreeStatus = .active,
+        parentWorktreeID: UUID? = nil
     ) async throws -> Worktree {
         try await writer.write { db in
-            let maxOrder = try Int.fetchOne(
-                db,
-                sql: "SELECT MAX(sortOrder) FROM worktree WHERE repoID = ?",
-                arguments: [repoID.uuidString]
-            ) ?? 0
+            let maxOrder: Int
+            if let pid = parentWorktreeID {
+                maxOrder = try Int.fetchOne(
+                    db,
+                    sql: "SELECT MAX(sortOrder) FROM worktree WHERE parentWorktreeID = ?",
+                    arguments: [pid.uuidString]
+                ) ?? 0
+            } else {
+                maxOrder = try Int.fetchOne(
+                    db,
+                    sql: "SELECT MAX(sortOrder) FROM worktree WHERE repoID = ? AND parentWorktreeID IS NULL",
+                    arguments: [repoID.uuidString]
+                ) ?? 0
+            }
             let wt = Worktree(
                 repoID: repoID,
                 name: name,
@@ -124,7 +137,8 @@ public struct WorktreeStore: Sendable {
                 path: path,
                 status: status,
                 tmuxServer: tmuxServer,
-                sortOrder: maxOrder + 1
+                sortOrder: maxOrder + 1,
+                parentWorktreeID: parentWorktreeID
             )
             let record = WorktreeRecord(from: wt)
             try record.insert(db)

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -73,6 +73,12 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     }
 }
 
+/// Errors raised when validating a worktree's parent relationship. Named
+/// `WorktreeMoveError` for historical reasons (introduced with `move()`) but
+/// also raised by `ParentResolver` during worktree *creation* — the parent
+/// validation rules (`parentNotFound`, `parentIsMain`, `parentIsArchived`)
+/// apply identically at both call sites. The `selfReference` and `cycle`
+/// cases are move-only by construction (a brand-new row has no descendants).
 public enum WorktreeMoveError: Error, CustomStringConvertible {
     case selfReference
     case cycle

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -172,29 +172,31 @@ public struct WorktreeStore: Sendable {
         }
     }
 
-    /// Null out parent pointers that would corrupt the worktree tree:
-    /// 1. Parents that reference a missing row (orphans).
-    /// 2. Parents that participate in a cycle (e.g. A.parent = B and B.parent = A
-    ///    after a manual `sqlite3` edit). `WorktreeStore.move()`'s cycle guard
-    ///    prevents new cycles from forming through normal operations, but we
-    ///    still need to defuse any that exist at startup — otherwise
-    ///    `WorktreeSubtreeView`'s recursive render would stack-overflow.
-    /// Called on daemon startup.
+    /// NULL out any `parentWorktreeID` that references a row no longer in the
+    /// table (e.g. the parent was deleted out-of-band by a manual sqlite edit
+    /// or a future regression). Safe to call on every reconcile — a single
+    /// `UPDATE … NOT IN (SELECT id FROM worktree)`.
     public func nullOrphanedParents() async throws {
         try await writer.write { db in
-            // Pass 1: orphans (parent pointer references a missing row).
             try db.execute(sql: """
                 UPDATE worktree
                 SET parentWorktreeID = NULL
                 WHERE parentWorktreeID IS NOT NULL
                   AND parentWorktreeID NOT IN (SELECT id FROM worktree)
             """)
+        }
+    }
 
-            // Pass 2: cycles. For each row with a non-null parent, walk upward
-            // with a visited set. If we revisit a node, the chain is cyclic;
-            // null the original row's parent to break the cycle. We null only
-            // the row we started from (not every member of the cycle) so the
-            // damage is minimal and predictable.
+    /// Walk every row with a non-null `parentWorktreeID` and break any cycles
+    /// found (A.parent=B, B.parent=A) by NULLing the parent on the row we
+    /// started from. `WorktreeStore.move()`'s cycle guard prevents new cycles
+    /// through normal operations, so this only catches DB damage from manual
+    /// sqlite edits or regressions — call it at daemon startup, NOT on every
+    /// reconcile. (Reconcile fires from cleanup RPCs and periodic git sweeps;
+    /// running this O(N) walk every time is wasted work for the common case
+    /// of a healthy DB.)
+    public func breakCyclicParents() async throws {
+        try await writer.write { db in
             let rows = try Row.fetchAll(db, sql: """
                 SELECT id, parentWorktreeID FROM worktree
                 WHERE parentWorktreeID IS NOT NULL

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -73,6 +73,24 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     }
 }
 
+public enum WorktreeMoveError: Error, CustomStringConvertible {
+    case selfReference
+    case cycle
+    case parentNotFound
+    case parentIsMain
+    case worktreeNotFound
+
+    public var description: String {
+        switch self {
+        case .selfReference: return "A worktree cannot be its own parent."
+        case .cycle: return "This move would create a cycle in the worktree tree."
+        case .parentNotFound: return "Parent worktree not found."
+        case .parentIsMain: return "Cannot nest under the main worktree."
+        case .worktreeNotFound: return "Worktree not found."
+        }
+    }
+}
+
 /// Provides CRUD operations for worktrees.
 public struct WorktreeStore: Sendable {
     let writer: any DatabaseWriter
@@ -314,6 +332,60 @@ public struct WorktreeStore: Sendable {
                 .filter(Column("path") == path)
                 .fetchOne(db)?
                 .toModel()
+        }
+    }
+
+    /// Move a worktree to a new parent (or top-level) and a new sort-order
+    /// position within its destination sibling group.
+    /// Validates: not-self, parent exists, parent is not `main`, no cycle.
+    /// Renumbers siblings in the destination group so the moved row lands at
+    /// the requested sortOrder.
+    public func move(worktreeID: UUID, newParentID: UUID?, newSortOrder: Int) async throws {
+        try await writer.write { db in
+            guard let movingRecord = try WorktreeRecord.fetchOne(db, key: worktreeID.uuidString) else {
+                throw WorktreeMoveError.worktreeNotFound
+            }
+
+            if let pid = newParentID {
+                if pid == worktreeID {
+                    throw WorktreeMoveError.selfReference
+                }
+                guard let parent = try WorktreeRecord.fetchOne(db, key: pid.uuidString) else {
+                    throw WorktreeMoveError.parentNotFound
+                }
+                if parent.status == WorktreeStatus.main.rawValue {
+                    throw WorktreeMoveError.parentIsMain
+                }
+                // Cycle check: walk up from parent; if we ever hit `worktreeID`, cycle.
+                var cursor: String? = parent.parentWorktreeID
+                while let curID = cursor {
+                    if curID == worktreeID.uuidString {
+                        throw WorktreeMoveError.cycle
+                    }
+                    cursor = try WorktreeRecord.fetchOne(db, key: curID)?.parentWorktreeID
+                }
+            }
+
+            // Renumber destination siblings: shift sortOrder of siblings >= newSortOrder by +1,
+            // then set moving to newSortOrder.
+            let parentArg = newParentID?.uuidString
+            if let p = parentArg {
+                try db.execute(
+                    sql: "UPDATE worktree SET sortOrder = sortOrder + 1 WHERE parentWorktreeID = ? AND sortOrder >= ? AND id != ?",
+                    arguments: [p, newSortOrder, worktreeID.uuidString]
+                )
+            } else {
+                // Top-level siblings = same repo, parent null. Exclude main from sibling group (it has its own status).
+                try db.execute(
+                    sql: "UPDATE worktree SET sortOrder = sortOrder + 1 WHERE repoID = ? AND parentWorktreeID IS NULL AND sortOrder >= ? AND id != ?",
+                    arguments: [movingRecord.repoID, newSortOrder, worktreeID.uuidString]
+                )
+            }
+
+            try db.execute(
+                sql: "UPDATE worktree SET parentWorktreeID = ?, sortOrder = ? WHERE id = ?",
+                arguments: [parentArg, newSortOrder, worktreeID.uuidString]
+            )
         }
     }
 

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -172,17 +172,28 @@ public struct WorktreeStore: Sendable {
         }
     }
 
-    /// NULL out any `parentWorktreeID` that references a row no longer in the
-    /// table (e.g. the parent was deleted out-of-band by a manual sqlite edit
-    /// or a future regression). Safe to call on every reconcile — a single
-    /// `UPDATE … NOT IN (SELECT id FROM worktree)`.
+    /// NULL out `parentWorktreeID` for rows whose parent is either missing or
+    /// archived. Both cases would leave the child unreachable in the sidebar:
+    /// 1. **Missing parent** — deleted out-of-band (manual sqlite edit / future
+    ///    regression).
+    /// 2. **Archived parent** — `assertArchivable` allows archiving a parent
+    ///    once all its children are archived; if the user later revives the
+    ///    child but not the parent, the child's `parentWorktreeID` still points
+    ///    at an archived row. The sidebar's `topLevelWorktrees` filter excludes
+    ///    children-of-anything, and `WorktreeSubtreeView` never visits an
+    ///    archived parent's subtree — so the revived child becomes invisible.
+    ///    Promoting it to top-level here matches the "if parent disappears,
+    ///    null the pointer" pattern.
+    /// Safe to call on every reconcile — single UPDATE with a NOT IN subquery.
     public func nullOrphanedParents() async throws {
         try await writer.write { db in
             try db.execute(sql: """
                 UPDATE worktree
                 SET parentWorktreeID = NULL
                 WHERE parentWorktreeID IS NOT NULL
-                  AND parentWorktreeID NOT IN (SELECT id FROM worktree)
+                  AND parentWorktreeID NOT IN (
+                    SELECT id FROM worktree WHERE status NOT IN ('archived')
+                  )
             """)
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/ParentResolver.swift
+++ b/Sources/TBDDaemon/Lifecycle/ParentResolver.swift
@@ -1,0 +1,43 @@
+import Foundation
+import TBDShared
+
+/// Resolves a worktree's parent at create time, following the order:
+/// 1. `suppressAutoParent` → nil (flat)
+/// 2. explicit parent (validated: exists, not `main`) — throws on invalid
+/// 3. `siblingOf` X → X.parentWorktreeID (nil if X is top-level or missing)
+/// 4. `caller` (validated: exists, not `main`; nil fallback if missing or main)
+/// 5. nil
+public enum ParentResolver {
+    public static func resolve(
+        db: TBDDatabase,
+        explicitParent: UUID?,
+        siblingOf: UUID?,
+        caller: UUID?,
+        suppressAutoParent: Bool
+    ) async throws -> UUID? {
+        if suppressAutoParent { return nil }
+
+        if let pid = explicitParent {
+            guard let p = try await db.worktrees.get(id: pid) else {
+                throw WorktreeMoveError.parentNotFound
+            }
+            if p.status == .main { throw WorktreeMoveError.parentIsMain }
+            return pid
+        }
+
+        if let sid = siblingOf {
+            guard let s = try await db.worktrees.get(id: sid) else {
+                return nil
+            }
+            return s.parentWorktreeID
+        }
+
+        if let cid = caller {
+            guard let c = try await db.worktrees.get(id: cid) else { return nil }
+            if c.status == .main { return nil }
+            return cid
+        }
+
+        return nil
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/ParentResolver.swift
+++ b/Sources/TBDDaemon/Lifecycle/ParentResolver.swift
@@ -3,10 +3,21 @@ import TBDShared
 
 /// Resolves a worktree's parent at create time, following the order:
 /// 1. `suppressAutoParent` → nil (flat)
-/// 2. explicit parent (validated: exists, not `main`) — throws on invalid
-/// 3. `siblingOf` X → X.parentWorktreeID (nil if X is top-level or missing)
-/// 4. `caller` (validated: exists, not `main`; nil fallback if missing or main)
+/// 2. explicit parent (validated: exists, not `main`, not `archived`) — throws
+///    on invalid
+/// 3. `siblingOf` X → X.parentWorktreeID — silent fallback to nil when X is
+///    missing or X itself is archived (the resolved grandparent might still be
+///    valid, but treating archived siblings as "not a valid spawn point" is
+///    safer than producing an invisible child)
+/// 4. `caller` (validated: exists, not `main`, not `archived`) — silent
+///    fallback to nil otherwise
 /// 5. nil
+///
+/// Archived parents are rejected because the sidebar's `topLevelWorktrees`
+/// filter excludes children (regardless of the child's own status), and
+/// `WorktreeSubtreeView` never descends into an archived parent's subtree —
+/// so a newly-created child of an archived row would be invisible until a
+/// reconcile pass nulls its parent pointer.
 public enum ParentResolver {
     public static func resolve(
         db: TBDDatabase,
@@ -22,6 +33,7 @@ public enum ParentResolver {
                 throw WorktreeMoveError.parentNotFound
             }
             if p.status == .main { throw WorktreeMoveError.parentIsMain }
+            if p.status == .archived { throw WorktreeMoveError.parentIsArchived }
             return pid
         }
 
@@ -29,12 +41,14 @@ public enum ParentResolver {
             guard let s = try await db.worktrees.get(id: sid) else {
                 return nil
             }
+            if s.status == .archived { return nil }
             return s.parentWorktreeID
         }
 
         if let cid = caller {
             guard let c = try await db.worktrees.get(id: cid) else { return nil }
             if c.status == .main { return nil }
+            if c.status == .archived { return nil }
             return cid
         }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -22,13 +22,20 @@ extension WorktreeLifecycle {
     ///   - force: If true, skip running the archive hook.
     /// Phase 1 (fast): Validates, updates DB status, kills tmux windows.
     /// Returns the worktree and repo for phase 2.
-    public func beginArchiveWorktree(worktreeID: UUID) async throws -> (Worktree, Repo) {
+    public func beginArchiveWorktree(worktreeID: UUID, force: Bool = false) async throws -> (Worktree, Repo) {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
 
         if worktree.status == .main {
             throw WorktreeLifecycleError.invalidOperation("Cannot archive the main branch worktree")
+        }
+
+        // Refuse to archive a worktree whose direct children are still active
+        // or being created. `force` bypasses the check for cascade flows like
+        // repo deletion. Performed before any tmux/disk work.
+        if !force {
+            try await db.worktrees.assertArchivable(id: worktreeID)
         }
 
         guard let repo = try await db.repos.get(id: worktree.repoID) else {
@@ -136,7 +143,7 @@ extension WorktreeLifecycle {
 
     /// Legacy all-in-one archive (used by CLI).
     public func archiveWorktree(worktreeID: UUID, force: Bool = false) async throws {
-        let (worktree, repo) = try await beginArchiveWorktree(worktreeID: worktreeID)
+        let (worktree, repo) = try await beginArchiveWorktree(worktreeID: worktreeID, force: force)
         await completeArchiveWorktree(worktree: worktree, repo: repo, force: force)
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -11,8 +11,8 @@ extension WorktreeLifecycle {
     ///
     /// This is the legacy all-in-one method. Prefer `beginCreateWorktree` +
     /// `completeCreateWorktree` for non-blocking creation.
-    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil) async throws -> Worktree {
-        let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude)
+    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false) async throws -> Worktree {
+        let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude, parentWorktreeID: parentWorktreeID, siblingOfWorktreeID: siblingOfWorktreeID, callerWorktreeID: callerWorktreeID, suppressAutoParent: suppressAutoParent)
         try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows)
         guard let completed = try await db.worktrees.get(id: pending.id) else {
             throw WorktreeLifecycleError.worktreeNotFound(pending.id)
@@ -25,11 +25,20 @@ extension WorktreeLifecycle {
     /// Phase 1: Synchronous-fast. Generates a name, inserts a DB row with
     /// `status = .creating`, and returns the worktree immediately.
     /// NO git operations happen here.
-    public func beginCreateWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false) async throws -> Worktree {
+    public func beginCreateWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false) async throws -> Worktree {
         // 1. Fetch repo
         guard let repo = try await db.repos.get(id: repoID) else {
             throw WorktreeLifecycleError.repoNotFound(repoID)
         }
+
+        // 1a. Resolve parent worktree (caller/sibling/explicit → parent id, or nil)
+        let resolvedParent = try await ParentResolver.resolve(
+            db: db,
+            explicitParent: parentWorktreeID,
+            siblingOf: siblingOfWorktreeID,
+            caller: callerWorktreeID,
+            suppressAutoParent: suppressAutoParent
+        )
 
         // 2. Generate name and construct path
         let name = folder ?? NameGenerator.generate()
@@ -60,7 +69,8 @@ extension WorktreeLifecycle {
             branch: branch,
             path: worktreePath,
             tmuxServer: tmuxServer,
-            status: .creating
+            status: .creating,
+            parentWorktreeID: resolvedParent
         )
 
         return worktree

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -67,9 +67,11 @@ extension WorktreeLifecycle {
     /// - Worktrees in db but missing from git: marked as archived
     /// - Worktrees in git but missing from db: added with default names
     public func reconcile(repoID: UUID) async throws {
-        // Null out parent pointers that reference rows no longer in the table
-        // (e.g. parent deleted out-of-band). Archived parents are left alone so
-        // they can still be revived. Cheap single UPDATE — safe to run per repo.
+        // Null out parent pointers whose target is missing OR archived. Either
+        // case would leave the child unreachable in the sidebar — missing rows
+        // can't render, and archived parents are filtered out of the subtree
+        // walk. Promoting to top-level is the only sensible recovery. Cheap
+        // single UPDATE — safe to run per repo.
         try await db.worktrees.nullOrphanedParents()
 
         guard let repo = try await db.repos.get(id: repoID) else {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -67,6 +67,11 @@ extension WorktreeLifecycle {
     /// - Worktrees in db but missing from git: marked as archived
     /// - Worktrees in git but missing from db: added with default names
     public func reconcile(repoID: UUID) async throws {
+        // Null out parent pointers that reference rows no longer in the table
+        // (e.g. parent deleted out-of-band). Archived parents are left alone so
+        // they can still be revived. Cheap single UPDATE — safe to run per repo.
+        try await db.worktrees.nullOrphanedParents()
+
         guard let repo = try await db.repos.get(id: repoID) else {
             throw WorktreeLifecycleError.repoNotFound(repoID)
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "worktreeHandlers")
 
 extension RPCRouter {
 
@@ -42,7 +45,7 @@ extension RPCRouter {
                 subs.broadcast(delta: .worktreeArchived(WorktreeIDDelta(
                     worktreeID: pending.id
                 )))
-                print("[RPCRouter] Background worktree creation failed for \(pending.id): \(error)")
+                logger.error("background worktreeCreate failed for \(pending.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -9,7 +9,16 @@ extension RPCRouter {
         let params = try decoder.decode(WorktreeCreateParams.self, from: paramsData)
 
         // Phase 1: Fast — insert DB row with status = .creating, return immediately
-        let pending = try await lifecycle.beginCreateWorktree(repoID: params.repoID, folder: params.folder, branch: params.branch, displayName: params.displayName)
+        let pending = try await lifecycle.beginCreateWorktree(
+            repoID: params.repoID,
+            folder: params.folder,
+            branch: params.branch,
+            displayName: params.displayName,
+            parentWorktreeID: params.parentWorktreeID,
+            siblingOfWorktreeID: params.siblingOfWorktreeID,
+            callerWorktreeID: params.callerWorktreeID,
+            suppressAutoParent: params.suppressAutoParent ?? false
+        )
 
         // Phase 2: Fire-and-forget — git operations + tmux setup in background
         let lifecycle = self.lifecycle
@@ -124,5 +133,22 @@ extension RPCRouter {
         )))
 
         return .ok()
+    }
+
+    func handleWorktreeMove(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeMoveParams.self, from: paramsData)
+        try await db.worktrees.move(
+            worktreeID: params.worktreeID,
+            newParentID: params.newParentID,
+            newSortOrder: params.newSortOrder
+        )
+
+        subscriptions.broadcast(delta: .worktreeMoved(WorktreeMovedDelta(
+            worktreeID: params.worktreeID,
+            newParentID: params.newParentID,
+            newSortOrder: params.newSortOrder
+        )))
+
+        return try RPCResponse(result: WorktreeMoveResult())
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -152,6 +152,6 @@ extension RPCRouter {
             newSortOrder: params.newSortOrder
         )))
 
-        return try RPCResponse(result: WorktreeMoveResult())
+        return .ok()
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -103,6 +103,8 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeRename(request.paramsData)
             case RPCMethod.worktreeReorder:
                 return try await handleWorktreeReorder(request.paramsData)
+            case RPCMethod.worktreeMove:
+                return try await handleWorktreeMove(request.paramsData)
             case RPCMethod.terminalCreate:
                 return try await handleTerminalCreate(request.paramsData)
             case RPCMethod.terminalList:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -99,6 +99,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// not enriched (active worktrees, or archived worktrees whose Claude
     /// project dir could not be resolved).
     public var liveClaudeSessionCount: Int?
+    public var parentWorktreeID: UUID?
 
     public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
@@ -106,7 +107,8 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 createdAt: Date = Date(), archivedAt: Date? = nil, tmuxServer: String,
                 archivedClaudeSessions: [String]? = nil, sortOrder: Int = 0,
                 archivedHeadSHA: String? = nil,
-                liveClaudeSessionCount: Int? = nil) {
+                liveClaudeSessionCount: Int? = nil,
+                parentWorktreeID: UUID? = nil) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -122,6 +124,14 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.sortOrder = sortOrder
         self.archivedHeadSHA = archivedHeadSHA
         self.liveClaudeSessionCount = liveClaudeSessionCount
+        self.parentWorktreeID = parentWorktreeID
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, repoID, name, displayName, branch, path, status
+        case hasConflicts, createdAt, archivedAt, tmuxServer
+        case archivedClaudeSessions, sortOrder, archivedHeadSHA
+        case liveClaudeSessionCount, parentWorktreeID
     }
 
     public init(from decoder: Decoder) throws {
@@ -141,6 +151,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         sortOrder = try c.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
         archivedHeadSHA = try c.decodeIfPresent(String.self, forKey: .archivedHeadSHA)
         liveClaudeSessionCount = try c.decodeIfPresent(Int.self, forKey: .liveClaudeSessionCount)
+        parentWorktreeID = try c.decodeIfPresent(UUID.self, forKey: .parentWorktreeID)
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -502,10 +502,6 @@ public struct WorktreeMoveParams: Codable, Sendable {
     }
 }
 
-public struct WorktreeMoveResult: Codable, Sendable {
-    public init() {}
-}
-
 public enum TerminalCreateType: String, Codable, Sendable {
     case shell
     case claude

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -427,10 +427,10 @@ public struct WorktreeCreateParams: Codable, Sendable {
     public let cols: Int?
     public let rows: Int?
     // Nested-worktree support. All optional, defaulted for backward compat.
-    public var parentWorktreeID: UUID?     // --parent
-    public var siblingOfWorktreeID: UUID?  // --sibling (caller worktree id)
-    public var callerWorktreeID: UUID?     // TBD_WORKTREE_ID env
-    public var suppressAutoParent: Bool?   // --no-parent
+    public let parentWorktreeID: UUID?     // --parent
+    public let siblingOfWorktreeID: UUID?  // --sibling (caller worktree id)
+    public let callerWorktreeID: UUID?     // TBD_WORKTREE_ID env
+    public let suppressAutoParent: Bool?   // --no-parent
     public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -85,6 +85,7 @@ public enum RPCMethod {
     public static let worktreeRevive = "worktree.revive"
     public static let worktreeRename = "worktree.rename"
     public static let worktreeReorder = "worktree.reorder"
+    public static let worktreeMove = "worktree.move"
     public static let terminalCreate = "terminal.create"
     public static let terminalList = "terminal.list"
     public static let terminalSend = "terminal.send"
@@ -425,9 +426,18 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// default and produce hard-wrapped scrollback that can never be reflowed.
     public let cols: Int?
     public let rows: Int?
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil) {
+    // Nested-worktree support. All optional, defaulted for backward compat.
+    public var parentWorktreeID: UUID?     // --parent
+    public var siblingOfWorktreeID: UUID?  // --sibling (caller worktree id)
+    public var callerWorktreeID: UUID?     // TBD_WORKTREE_ID env
+    public var suppressAutoParent: Bool?   // --no-parent
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows
+        self.parentWorktreeID = parentWorktreeID
+        self.siblingOfWorktreeID = siblingOfWorktreeID
+        self.callerWorktreeID = callerWorktreeID
+        self.suppressAutoParent = suppressAutoParent
     }
 }
 
@@ -478,6 +488,22 @@ public struct WorktreeReorderParams: Codable, Sendable {
     public init(repoID: UUID, worktreeIDs: [UUID]) {
         self.repoID = repoID; self.worktreeIDs = worktreeIDs
     }
+}
+
+public struct WorktreeMoveParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let newParentID: UUID?
+    public let newSortOrder: Int
+
+    public init(worktreeID: UUID, newParentID: UUID?, newSortOrder: Int) {
+        self.worktreeID = worktreeID
+        self.newParentID = newParentID
+        self.newSortOrder = newSortOrder
+    }
+}
+
+public struct WorktreeMoveResult: Codable, Sendable {
+    public init() {}
 }
 
 public enum TerminalCreateType: String, Codable, Sendable {

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -22,6 +22,7 @@ public enum StateDelta: Codable, Sendable {
     case modelProfileUsageUpdated(ModelProfileUsage)
     case modelProfilesChanged
     case terminalSessionUpdated(TerminalSessionDelta)
+    case worktreeMoved(WorktreeMovedDelta)
 }
 
 /// Delta payload for Claude session ID/transcript path rollover, fired when
@@ -154,5 +155,17 @@ public struct TerminalPinDelta: Codable, Sendable {
     public let pinnedAt: Date?
     public init(terminalID: UUID, pinnedAt: Date?) {
         self.terminalID = terminalID; self.pinnedAt = pinnedAt
+    }
+}
+
+public struct WorktreeMovedDelta: Codable, Sendable {
+    public let worktreeID: UUID
+    public let newParentID: UUID?
+    public let newSortOrder: Int
+
+    public init(worktreeID: UUID, newParentID: UUID?, newSortOrder: Int) {
+        self.worktreeID = worktreeID
+        self.newParentID = newParentID
+        self.newSortOrder = newSortOrder
     }
 }

--- a/Tests/TBDDaemonTests/MigrationV23Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV23Tests.swift
@@ -1,0 +1,47 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct MigrationV23Tests {
+
+    @Test func parentColumnExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let columns = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(worktree)")
+            let names = columns.compactMap { $0["name"] as String? }
+            #expect(names.contains("parentWorktreeID"))
+        }
+    }
+
+    @Test func parentColumnDefaultsToNull() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v23-repo-\(UUID().uuidString)",
+            displayName: "V23",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "w",
+            branch: "b",
+            path: "/tmp/v23-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-v23"
+        )
+        #expect(wt.parentWorktreeID == nil)
+
+        try await db.writerForTests.read { dbConn in
+            let row = try Row.fetchOne(
+                dbConn,
+                sql: "SELECT parentWorktreeID FROM worktree WHERE id = ?",
+                arguments: [wt.id.uuidString]
+            )
+            #expect(row?["parentWorktreeID"] as String? == nil)
+        }
+
+        // Round-trip via the store API.
+        let fetched = try await db.worktrees.get(id: wt.id)
+        #expect(fetched?.parentWorktreeID == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeArchiveGuardTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveGuardTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct WorktreeArchiveGuardTests {
+
+    @Test func archivingParentWithActiveChildrenFails() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main"
+        )
+        let parent = try await db.worktrees.create(
+            repoID: repo.id, name: "p", branch: "tbd/p",
+            path: "/tmp/p-\(UUID())", tmuxServer: "srv"
+        )
+        _ = try await db.worktrees.create(
+            repoID: repo.id, name: "c", branch: "tbd/c",
+            path: "/tmp/c-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: parent.id
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await db.worktrees.assertArchivable(id: parent.id)
+        }
+    }
+
+    @Test func archivingLeafSucceedsAndCrossRepoChildBlocks() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let r1 = try await db.repos.create(path: "/tmp/r1-\(UUID())", displayName: "R1", defaultBranch: "main")
+        let r2 = try await db.repos.create(path: "/tmp/r2-\(UUID())", displayName: "R2", defaultBranch: "main")
+        let parent = try await db.worktrees.create(
+            repoID: r1.id, name: "p", branch: "tbd/p",
+            path: "/tmp/p-\(UUID())", tmuxServer: "srv"
+        )
+        let child = try await db.worktrees.create(
+            repoID: r2.id, name: "c", branch: "tbd/c",
+            path: "/tmp/c-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: parent.id
+        )
+
+        // Cross-repo child still blocks archive of parent
+        await #expect(throws: (any Error).self) {
+            try await db.worktrees.assertArchivable(id: parent.id)
+        }
+
+        // Leaf child is archivable
+        try await db.worktrees.assertArchivable(id: child.id)
+    }
+
+    @Test func archivingParentWithOnlyArchivedChildrenSucceeds() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main"
+        )
+        let parent = try await db.worktrees.create(
+            repoID: repo.id, name: "p", branch: "tbd/p",
+            path: "/tmp/p-\(UUID())", tmuxServer: "srv"
+        )
+        let child = try await db.worktrees.create(
+            repoID: repo.id, name: "c", branch: "tbd/c",
+            path: "/tmp/c-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: parent.id
+        )
+        try await db.worktrees.updateStatus(id: child.id, status: .archived)
+
+        // Should succeed — only active/creating children block
+        try await db.worktrees.assertArchivable(id: parent.id)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeMoveTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeMoveTests.swift
@@ -1,0 +1,100 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct WorktreeMoveTests {
+
+    func makeDB() throws -> TBDDatabase {
+        try TBDDatabase(inMemory: true)
+    }
+
+    func makeRepo(_ db: TBDDatabase, name: String = "r") async throws -> Repo {
+        try await db.repos.create(
+            path: "/tmp/repo-\(UUID())",
+            displayName: name,
+            defaultBranch: "main"
+        )
+    }
+
+    func makeWT(_ db: TBDDatabase, repo: Repo, name: String) async throws -> Worktree {
+        try await db.worktrees.create(
+            repoID: repo.id, name: name, branch: "tbd/\(name)",
+            path: "/tmp/\(name)-\(UUID())", tmuxServer: "srv"
+        )
+    }
+
+    @Test func moveToTopLevelChangesSortOrder() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+        _ = try await makeWT(db, repo: repo, name: "a")
+        _ = try await makeWT(db, repo: repo, name: "b")
+        let c = try await makeWT(db, repo: repo, name: "c")
+
+        try await db.worktrees.move(worktreeID: c.id, newParentID: nil, newSortOrder: 0)
+
+        let all = try await db.worktrees.list(repoID: repo.id)
+            .filter { $0.parentWorktreeID == nil && $0.status != .main }
+            .sorted { $0.sortOrder < $1.sortOrder }
+        // c should now be at the front
+        #expect(all.first?.name == "c")
+    }
+
+    @Test func nestUnderAnotherWorktreeSetsParent() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+        let a = try await makeWT(db, repo: repo, name: "a")
+        let b = try await makeWT(db, repo: repo, name: "b")
+
+        try await db.worktrees.move(worktreeID: b.id, newParentID: a.id, newSortOrder: 0)
+
+        let updated = try await db.worktrees.get(id: b.id)
+        #expect(updated?.parentWorktreeID == a.id)
+    }
+
+    @Test func cycleIsRejected() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+        let a = try await makeWT(db, repo: repo, name: "a")
+        let b = try await makeWT(db, repo: repo, name: "b")
+        try await db.worktrees.move(worktreeID: b.id, newParentID: a.id, newSortOrder: 0)
+
+        await #expect(throws: (any Error).self) {
+            try await db.worktrees.move(worktreeID: a.id, newParentID: b.id, newSortOrder: 0)
+        }
+    }
+
+    @Test func nestingUnderSelfIsRejected() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+        let a = try await makeWT(db, repo: repo, name: "a")
+
+        await #expect(throws: (any Error).self) {
+            try await db.worktrees.move(worktreeID: a.id, newParentID: a.id, newSortOrder: 0)
+        }
+    }
+
+    @Test func crossRepoNestSucceeds() async throws {
+        let db = try makeDB()
+        let r1 = try await makeRepo(db, name: "r1")
+        let r2 = try await makeRepo(db, name: "r2")
+        let a = try await makeWT(db, repo: r1, name: "a")
+        let b = try await makeWT(db, repo: r2, name: "b")
+
+        try await db.worktrees.move(worktreeID: b.id, newParentID: a.id, newSortOrder: 0)
+        let updated = try await db.worktrees.get(id: b.id)
+        #expect(updated?.parentWorktreeID == a.id)
+        #expect(updated?.repoID == r2.id) // repoID unchanged
+    }
+
+    @Test func multiLevelNestingAllowed() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+        let a = try await makeWT(db, repo: repo, name: "a")
+        let b = try await makeWT(db, repo: repo, name: "b")
+        let c = try await makeWT(db, repo: repo, name: "c")
+        try await db.worktrees.move(worktreeID: b.id, newParentID: a.id, newSortOrder: 0)
+        try await db.worktrees.move(worktreeID: c.id, newParentID: b.id, newSortOrder: 0)
+        #expect(try await db.worktrees.get(id: c.id)?.parentWorktreeID == b.id)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeMoveTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeMoveTests.swift
@@ -143,3 +143,40 @@ import TBDShared
         #expect(c2.sortOrder > c1.sortOrder)
     }
 }
+
+@Suite struct WorktreeReconcileOrphanTests {
+
+    @Test func parentPointingAtMissingWorktreeIsNulled() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let p = try await db.worktrees.create(repoID: repo.id, name: "p", branch: "tbd/p", path: "/tmp/p-\(UUID())", tmuxServer: "srv")
+        let c = try await db.worktrees.create(
+            repoID: repo.id, name: "c", branch: "tbd/c",
+            path: "/tmp/c-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: p.id
+        )
+
+        try await db.worktrees.delete(id: p.id)
+        try await db.worktrees.nullOrphanedParents()
+
+        let updated = try await db.worktrees.get(id: c.id)
+        #expect(updated?.parentWorktreeID == nil)
+    }
+
+    @Test func parentPointingAtArchivedWorktreeIsLeftAlone() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let p = try await db.worktrees.create(repoID: repo.id, name: "p", branch: "tbd/p", path: "/tmp/p-\(UUID())", tmuxServer: "srv")
+        let c = try await db.worktrees.create(
+            repoID: repo.id, name: "c", branch: "tbd/c",
+            path: "/tmp/c-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: p.id
+        )
+        try await db.worktrees.updateStatus(id: p.id, status: .archived)
+
+        try await db.worktrees.nullOrphanedParents()
+
+        let updated = try await db.worktrees.get(id: c.id)
+        #expect(updated?.parentWorktreeID == p.id)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeMoveTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeMoveTests.swift
@@ -163,7 +163,13 @@ import TBDShared
         #expect(updated?.parentWorktreeID == nil)
     }
 
-    @Test func parentPointingAtArchivedWorktreeIsLeftAlone() async throws {
+    @Test func parentPointingAtArchivedWorktreeIsNulled() async throws {
+        // Scenario: A→B→C, archive C (leaf), archive B (allowed — no active
+        // children block it), revive C. C's parentWorktreeID still points at
+        // archived B. Without this fix C is active but invisible in the
+        // sidebar (topLevelWorktrees excludes children, WorktreeSubtreeView
+        // never visits an archived parent's subtree). Reconcile promotes C
+        // to top-level by nulling the pointer.
         let db = try TBDDatabase(inMemory: true)
         let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
         let p = try await db.worktrees.create(repoID: repo.id, name: "p", branch: "tbd/p", path: "/tmp/p-\(UUID())", tmuxServer: "srv")
@@ -177,7 +183,7 @@ import TBDShared
         try await db.worktrees.nullOrphanedParents()
 
         let updated = try await db.worktrees.get(id: c.id)
-        #expect(updated?.parentWorktreeID == p.id)
+        #expect(updated?.parentWorktreeID == nil)
     }
 
     @Test func cycleParentPointerIsBrokenByReconcile() async throws {

--- a/Tests/TBDDaemonTests/WorktreeMoveTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeMoveTests.swift
@@ -97,6 +97,21 @@ import TBDShared
         try await db.worktrees.move(worktreeID: c.id, newParentID: b.id, newSortOrder: 0)
         #expect(try await db.worktrees.get(id: c.id)?.parentWorktreeID == b.id)
     }
+
+    @Test func movingUnderArchivedParentIsRejected() async throws {
+        // Symmetric to ParentResolver's create-time check. Drag-to-nest (#142)
+        // calls worktree.move; dropping onto an archived row would produce an
+        // invisible child until reconcile clears the pointer.
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+        let a = try await makeWT(db, repo: repo, name: "a")
+        let b = try await makeWT(db, repo: repo, name: "b")
+        try await db.worktrees.updateStatus(id: a.id, status: .archived)
+
+        await #expect(throws: WorktreeMoveError.parentIsArchived) {
+            try await db.worktrees.move(worktreeID: b.id, newParentID: a.id, newSortOrder: 0)
+        }
+    }
 }
 
 @Suite struct WorktreeCreateWithParentTests {

--- a/Tests/TBDDaemonTests/WorktreeMoveTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeMoveTests.swift
@@ -179,4 +179,35 @@ import TBDShared
         let updated = try await db.worktrees.get(id: c.id)
         #expect(updated?.parentWorktreeID == p.id)
     }
+
+    @Test func cycleParentPointerIsBrokenByReconcile() async throws {
+        // The public API can't create a cycle (WorktreeStore.move's cycle guard
+        // refuses), so simulate a manually-introduced one by writing the
+        // forbidden state directly through the writer.
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let a = try await db.worktrees.create(repoID: repo.id, name: "a", branch: "tbd/a", path: "/tmp/a-\(UUID())", tmuxServer: "srv")
+        let b = try await db.worktrees.create(
+            repoID: repo.id, name: "b", branch: "tbd/b",
+            path: "/tmp/b-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: a.id
+        )
+        // Inject: a.parent = b (giving us a <-> b cycle).
+        try await db.worktrees.writer.write { dbConn in
+            try dbConn.execute(
+                sql: "UPDATE worktree SET parentWorktreeID = ? WHERE id = ?",
+                arguments: [b.id.uuidString, a.id.uuidString]
+            )
+        }
+
+        try await db.worktrees.nullOrphanedParents()
+
+        // The walk starting from `a` revisits `a` and nulls its parent — that's
+        // enough to break the cycle. `b` retains its parent pointing at `a`,
+        // which is now a clean depth-1 chain.
+        let updatedA = try await db.worktrees.get(id: a.id)
+        let updatedB = try await db.worktrees.get(id: b.id)
+        #expect(updatedA?.parentWorktreeID == nil)
+        #expect(updatedB?.parentWorktreeID == a.id)
+    }
 }

--- a/Tests/TBDDaemonTests/WorktreeMoveTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeMoveTests.swift
@@ -200,7 +200,7 @@ import TBDShared
             )
         }
 
-        try await db.worktrees.nullOrphanedParents()
+        try await db.worktrees.breakCyclicParents()
 
         // The walk starting from `a` revisits `a` and nulls its parent — that's
         // enough to break the cycle. `b` retains its parent pointing at `a`,

--- a/Tests/TBDDaemonTests/WorktreeMoveTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeMoveTests.swift
@@ -98,3 +98,48 @@ import TBDShared
         #expect(try await db.worktrees.get(id: c.id)?.parentWorktreeID == b.id)
     }
 }
+
+@Suite struct WorktreeCreateWithParentTests {
+
+    func makeDB() throws -> TBDDatabase { try TBDDatabase(inMemory: true) }
+
+    @Test func createWithParentSetsField() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main"
+        )
+        let parent = try await db.worktrees.create(
+            repoID: repo.id, name: "p", branch: "tbd/p",
+            path: "/tmp/p-\(UUID())", tmuxServer: "srv"
+        )
+        let child = try await db.worktrees.create(
+            repoID: repo.id, name: "c", branch: "tbd/c",
+            path: "/tmp/c-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: parent.id
+        )
+        #expect(child.parentWorktreeID == parent.id)
+    }
+
+    @Test func sortOrderScopedToParentGroup() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main"
+        )
+        let parent = try await db.worktrees.create(
+            repoID: repo.id, name: "p", branch: "tbd/p",
+            path: "/tmp/p-\(UUID())", tmuxServer: "srv"
+        )
+        let c1 = try await db.worktrees.create(
+            repoID: repo.id, name: "c1", branch: "tbd/c1",
+            path: "/tmp/c1-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: parent.id
+        )
+        let c2 = try await db.worktrees.create(
+            repoID: repo.id, name: "c2", branch: "tbd/c2",
+            path: "/tmp/c2-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: parent.id
+        )
+        #expect(c1.sortOrder != c2.sortOrder)
+        #expect(c2.sortOrder > c1.sortOrder)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeParentResolutionTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeParentResolutionTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct WorktreeParentResolutionTests {
+
+    @Test func suppressAutoParentBeatsEverything() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let caller = try await db.worktrees.create(
+            repoID: repo.id, name: "caller", branch: "tbd/caller",
+            path: "/tmp/caller-\(UUID())", tmuxServer: "srv"
+        )
+
+        let resolved = try await ParentResolver.resolve(
+            db: db,
+            explicitParent: caller.id,
+            siblingOf: nil,
+            caller: caller.id,
+            suppressAutoParent: true
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test func explicitParentBeatsSiblingAndCaller() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let p = try await db.worktrees.create(repoID: repo.id, name: "p", branch: "tbd/p", path: "/tmp/p-\(UUID())", tmuxServer: "srv")
+        let other = try await db.worktrees.create(repoID: repo.id, name: "o", branch: "tbd/o", path: "/tmp/o-\(UUID())", tmuxServer: "srv")
+
+        let resolved = try await ParentResolver.resolve(
+            db: db,
+            explicitParent: p.id,
+            siblingOf: other.id,
+            caller: other.id,
+            suppressAutoParent: false
+        )
+        #expect(resolved == p.id)
+    }
+
+    @Test func siblingResolvesToCallerParent() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let p = try await db.worktrees.create(repoID: repo.id, name: "p", branch: "tbd/p", path: "/tmp/p-\(UUID())", tmuxServer: "srv")
+        let child = try await db.worktrees.create(
+            repoID: repo.id, name: "c", branch: "tbd/c",
+            path: "/tmp/c-\(UUID())", tmuxServer: "srv",
+            parentWorktreeID: p.id
+        )
+
+        let resolved = try await ParentResolver.resolve(
+            db: db, explicitParent: nil, siblingOf: child.id, caller: nil, suppressAutoParent: false
+        )
+        #expect(resolved == p.id)
+    }
+
+    @Test func siblingOfTopLevelResolvesToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let top = try await db.worktrees.create(repoID: repo.id, name: "top", branch: "tbd/top", path: "/tmp/top-\(UUID())", tmuxServer: "srv")
+
+        let resolved = try await ParentResolver.resolve(
+            db: db, explicitParent: nil, siblingOf: top.id, caller: nil, suppressAutoParent: false
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test func callerBecomesParentByDefault() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let caller = try await db.worktrees.create(repoID: repo.id, name: "caller", branch: "tbd/caller", path: "/tmp/caller-\(UUID())", tmuxServer: "srv")
+
+        let resolved = try await ParentResolver.resolve(
+            db: db, explicitParent: nil, siblingOf: nil, caller: caller.id, suppressAutoParent: false
+        )
+        #expect(resolved == caller.id)
+    }
+
+    @Test func mainCallerFallsBackToFlat() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let main = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main",
+            path: "/tmp/main-\(UUID())", tmuxServer: "srv"
+        )
+
+        let resolved = try await ParentResolver.resolve(
+            db: db, explicitParent: nil, siblingOf: nil, caller: main.id, suppressAutoParent: false
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test func missingCallerFallsBackToFlat() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let resolved = try await ParentResolver.resolve(
+            db: db, explicitParent: nil, siblingOf: nil, caller: UUID(), suppressAutoParent: false
+        )
+        #expect(resolved == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeParentResolutionTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeParentResolutionTests.swift
@@ -98,4 +98,54 @@ import TBDShared
         )
         #expect(resolved == nil)
     }
+
+    @Test func explicitArchivedParentIsRejected() async throws {
+        // Spawning a child under an archived parent would produce an invisible
+        // row in the sidebar (topLevelWorktrees filters out children;
+        // WorktreeSubtreeView skips archived parents). Reject before creation.
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let p = try await db.worktrees.create(repoID: repo.id, name: "p", branch: "tbd/p", path: "/tmp/p-\(UUID())", tmuxServer: "srv")
+        try await db.worktrees.updateStatus(id: p.id, status: .archived)
+
+        await #expect(throws: WorktreeMoveError.parentIsArchived) {
+            _ = try await ParentResolver.resolve(
+                db: db,
+                explicitParent: p.id,
+                siblingOf: nil,
+                caller: nil,
+                suppressAutoParent: false
+            )
+        }
+    }
+
+    @Test func archivedCallerFallsBackToFlat() async throws {
+        // CLI invoked from a terminal whose TBD_WORKTREE_ID points at a
+        // worktree that's since been archived. Auto-parent silently falls
+        // back to top-level instead of producing an invisible child.
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let caller = try await db.worktrees.create(repoID: repo.id, name: "caller", branch: "tbd/caller", path: "/tmp/caller-\(UUID())", tmuxServer: "srv")
+        try await db.worktrees.updateStatus(id: caller.id, status: .archived)
+
+        let resolved = try await ParentResolver.resolve(
+            db: db, explicitParent: nil, siblingOf: nil, caller: caller.id, suppressAutoParent: false
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test func archivedSiblingFallsBackToFlat() async throws {
+        // --sibling pointing at an archived worktree: silently fall back to
+        // top-level instead of inheriting the archived row's (possibly also
+        // archived) parent chain.
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID())", displayName: "R", defaultBranch: "main")
+        let s = try await db.worktrees.create(repoID: repo.id, name: "s", branch: "tbd/s", path: "/tmp/s-\(UUID())", tmuxServer: "srv")
+        try await db.worktrees.updateStatus(id: s.id, status: .archived)
+
+        let resolved = try await ParentResolver.resolve(
+            db: db, explicitParent: nil, siblingOf: s.id, caller: nil, suppressAutoParent: false
+        )
+        #expect(resolved == nil)
+    }
 }

--- a/Tests/TBDSharedTests/WorktreeParentCodableTests.swift
+++ b/Tests/TBDSharedTests/WorktreeParentCodableTests.swift
@@ -1,0 +1,40 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct WorktreeParentCodableTests {
+
+    @Test func roundTripWithParent() throws {
+        let parentID = UUID()
+        let wt = Worktree(
+            repoID: UUID(),
+            name: "child",
+            displayName: "child",
+            branch: "tbd/child",
+            path: "/tmp/child",
+            tmuxServer: "srv",
+            parentWorktreeID: parentID
+        )
+        let data = try JSONEncoder().encode(wt)
+        let decoded = try JSONDecoder().decode(Worktree.self, from: data)
+        #expect(decoded.parentWorktreeID == parentID)
+    }
+
+    @Test func decodesLegacyJSONWithoutParentField() throws {
+        let legacy = """
+        {
+            "id": "\(UUID().uuidString)",
+            "repoID": "\(UUID().uuidString)",
+            "name": "legacy",
+            "displayName": "legacy",
+            "branch": "tbd/legacy",
+            "path": "/tmp/legacy",
+            "status": "active",
+            "createdAt": 0,
+            "tmuxServer": "srv"
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(Worktree.self, from: legacy)
+        #expect(decoded.parentWorktreeID == nil)
+    }
+}

--- a/docs/superpowers/specs/2026-05-12-nested-worktrees-design.md
+++ b/docs/superpowers/specs/2026-05-12-nested-worktrees-design.md
@@ -1,22 +1,30 @@
 # Nested Worktrees Design
 
-Add one level of parent/child nesting to TBD's per-repo worktree list, so that worktrees spawned from inside another worktree's session appear indented under their spawner instead of dumped at the end of the flat list. Nesting is also user-controllable via drag-and-drop.
+Add parent/child nesting to TBD's worktree sidebar so that worktrees spawned from inside another worktree's session appear indented under their spawner instead of dumped at the end of the flat list. Nesting is multi-level, can cross repo boundaries, and is also user-controllable via drag-and-drop.
 
 ## Goals
 
-- A worktree can have at most one parent worktree (depth-1 cap).
-- New worktrees created by `tbd worktree create` from inside a TBD-managed terminal automatically attach to a sensible parent (the group head of where the CLI was invoked).
-- Users can manually reorder and re-parent worktrees by drag-and-drop in the sidebar, including promoting a child back to flat.
-- Parents and their children move as a unit when dragged.
-- Archiving a parent that still has active children is blocked, not cascaded.
+- A worktree can have one parent worktree; arbitrary nesting depth is allowed.
+- Parent and child can live in different repos. A child of a worktree in repo A renders under that parent inside repo A's sidebar section, regardless of which repo the child itself lives in.
+- New worktrees created by `tbd worktree create` from inside a TBD-managed terminal automatically attach to their caller. Flags allow opting out, becoming a sibling, or setting an explicit parent.
+- Users can manually reorder and re-parent worktrees by drag-and-drop in the sidebar, including promoting any child back to flat in its own repo.
+- Parents and their entire subtrees move as a unit when dragged.
+- Archiving a worktree that still has active children is blocked, not cascaded.
 
 ## Non-goals
 
-- Multi-level nesting. The cap is one level for now; deeper hierarchies are out of scope.
-- Cross-repo lineage. Parent and child must live in the same repo.
-- Nesting under the `main` worktree. Main remains a special row that cannot be a parent.
-- Drag-and-drop in the CLI or in `worktree list` JSON output.
-- Changing how `sortOrder` is stored on disk beyond what depth-1 nesting requires.
+- Per-parent collapse/expand of children. Children render whenever their containing repo section is expanded.
+- A "lineage" filter or alternate view that flattens repos.
+- Repo-changing drags. A worktree's home repo is determined by its on-disk location and `repoID`; drag-and-drop changes `parentWorktreeID` and `sortOrder` only.
+- Drag-and-drop in the CLI or in `tbd worktree list` JSON output.
+
+## Concepts
+
+- **Home repo** of a worktree: the repo it physically lives in (`worktree.repoID`). Determined at create time, never changed by drag-and-drop.
+- **Section repo** of a row: the repo whose sidebar section is currently rendering this worktree. Equal to the home repo of the worktree's top-level ancestor. May differ from the worktree's own home repo for cross-repo children.
+- **Top-level worktree**: `parentWorktreeID == nil`. Lives in its own home repo's section.
+- **Nested worktree**: any worktree with a non-nil parent. Rendered indented under its parent, recursively, regardless of repo crossings.
+- **Subtree**: a worktree plus all its descendants.
 
 ## Data model
 
@@ -30,217 +38,250 @@ public var parentWorktreeID: UUID?
 
 Decoded with `decodeIfPresent` so older JSON / older DB rows still load.
 
-Invariant (enforced everywhere it can be written): if `parentWorktreeID != nil`, the referenced worktree exists in the same repo, has `parentWorktreeID == nil`, and is not the `main` worktree.
+Invariants (enforced at every write site):
+
+- If non-nil, the referenced worktree exists.
+- The referenced worktree is not `main` (main cannot be a parent — it is a repo-root pin, not a task).
+- The reference does not create a cycle (the referenced worktree is not a descendant of the current worktree).
+
+There is **no** same-repo constraint and **no** depth cap.
 
 ### `sortOrder` semantics
 
-`sortOrder` becomes scoped *within siblings*:
+`sortOrder` is scoped within siblings:
 
-- Top-level worktrees (parent nil) are ordered by `sortOrder` relative to each other.
-- Children of a given parent are ordered by `sortOrder` relative to each other.
-- Sort orders across levels are independent. No global ordering is implied.
+- Top-level worktrees in a given repo are ordered relative to each other.
+- Children of a given parent are ordered relative to each other, regardless of any child's home repo.
 
-The existing column is reused; no schema change beyond the new parent column.
+Existing column is reused; no schema change beyond the new parent column.
 
 ### Migration
 
-Add migration `v10` (or next available) in `Sources/TBDDaemon/Database/Database.swift`:
+Add the next sequential migration (e.g. `v10`) in `Sources/TBDDaemon/Database/Database.swift`:
 
 - `ALTER TABLE worktrees ADD COLUMN parent_worktree_id TEXT NULL`.
-- No backfill — all existing rows become top-level (parent nil), which preserves current behavior.
+- No backfill — all existing rows become top-level. Behavior preserved for everyone.
 
-Update the GRDB record type in `Sources/TBDDaemon/Database/` to include the new column, and update the Codable model in `TBDShared/Models.swift` in the same commit (per CLAUDE.md rule on DB-column changes).
+Update the GRDB record type in `Sources/TBDDaemon/Database/WorktreeStore.swift` and the Codable model in `TBDShared/Models.swift` in the same commit (per CLAUDE.md rule on DB-column changes).
 
 ## CLI: auto-parent on create
 
-`Sources/TBDCLI/Commands/WorktreeCommands.swift::WorktreeCreate` adds two flags and one auto-detect step:
+`Sources/TBDCLI/Commands/WorktreeCommands.swift::WorktreeCreate` adds three mutually-exclusive flags governing parent attachment:
 
-- `--no-parent` (boolean) — force top-level, ignore env.
-- `--parent <id-or-name>` — explicit parent override. Resolved server-side; rejected if it points to a different repo, to `main`, or to a worktree that already has a parent.
+- `--no-parent` — force top-level, ignore env.
+- `--sibling` — new worktree becomes a sibling of the caller (its parent equals the caller's own `parentWorktreeID`, which may be nil).
+- `--parent <id-or-name>` — explicit parent override. Resolved server-side; rejected if the resolved worktree is `main` or if the parent assignment would create a cycle.
 
-Auto-detect, when neither flag is set and `TBD_WORKTREE_ID` is present in env:
+When none of the flags are passed and `TBD_WORKTREE_ID` is present in env, the CLI forwards that value as `callerWorktreeID`. The daemon then:
 
-1. Resolve the env value to a worktree (via daemon — same lookup path as `tbd link`).
-2. If the resolved worktree is in the same repo as the new worktree *and* is not `main`:
-   - If its own `parentWorktreeID == nil`, use it as the new parent.
-   - Otherwise, use *its* `parentWorktreeID` as the new parent ("group-head rule").
-3. Otherwise (cross-repo, missing, archived, or `main`), do not auto-parent.
+1. Resolves `callerWorktreeID` to a worktree. If the resolved worktree is missing or is `main`, falls back to top-level.
+2. Otherwise, uses the resolved worktree as the new worktree's parent. (Multi-level: nest directly under the caller, regardless of caller's own depth.)
 
-The CLI just forwards `parentWorktreeID` in `WorktreeCreateParams`; the auto-detect logic can live either in the CLI or in the daemon. Putting it in the daemon (server-side resolution from `TBD_WORKTREE_ID` passed as a param) keeps validation and group-head lookup in one place and avoids duplicating the rule across clients. **Decision:** the daemon does the resolution. The CLI passes an optional `callerWorktreeID` taken from env; the `--parent` and `--no-parent` flags override that.
+This rule fires across repos: a CLI in repo A creating a worktree in repo B auto-nests the new B-worktree under the A-worktree.
 
 ### RPC change
 
-`WorktreeCreateParams` (TBDShared/RPCProtocol.swift) gains:
+`WorktreeCreateParams` (TBDShared/RPCProtocol.swift) gains three optional fields:
 
 ```swift
-public var parentWorktreeID: UUID?      // explicit, from --parent
-public var callerWorktreeID: UUID?      // from TBD_WORKTREE_ID, used for auto-parent
+public var parentWorktreeID: UUID?      // from --parent
+public var siblingOfWorktreeID: UUID?   // from --sibling (the caller); daemon resolves to caller.parentWorktreeID
+public var callerWorktreeID: UUID?      // from TBD_WORKTREE_ID (when no flag set)
 public var suppressAutoParent: Bool     // from --no-parent
 ```
 
 Resolution order in `worktree.create`:
 
-1. If `suppressAutoParent`, ignore both `parentWorktreeID` and `callerWorktreeID`. New worktree is flat.
-2. Else if `parentWorktreeID` is set, validate (same repo, not main, target's parent is nil) and use it. Reject with an error on violation.
-3. Else if `callerWorktreeID` is set and refers to a valid same-repo non-main worktree, apply the group-head rule.
-4. Else: flat.
+1. If `suppressAutoParent` → flat (parent nil).
+2. Else if `parentWorktreeID` set → validate (not main, no cycle) → use as parent.
+3. Else if `siblingOfWorktreeID` set → resolve to that worktree's `parentWorktreeID` (which may be nil) → use as parent.
+4. Else if `callerWorktreeID` set and resolves to a non-main worktree → use as parent.
+5. Else → flat.
 
-The new worktree is appended to its sibling group (highest existing `sortOrder + 1` within its parent scope).
+The new worktree is appended to its destination sibling group (highest existing `sortOrder + 1` within that group).
 
 ## App: sidebar rendering
 
-`Sources/TBDApp/Sidebar/RepoSectionView.swift`:
+`Sources/TBDApp/Sidebar/RepoSectionView.swift` switches from a flat per-repo list to a recursive render rooted at top-level worktrees.
 
-Inside `body` under `if repo.expanded`, replace the single `ForEach(worktrees)` block with a two-pass render:
+### Layout
+
+For each repo section that's expanded:
+
+1. Render the `main` worktree row (existing styling, never indented, never a parent).
+2. Collect this repo's **top-level worktrees**: all worktrees with `repoID == repo.id` and `parentWorktreeID == nil`. Sort by `sortOrder`.
+3. For each top-level worktree, render it and recursively render its children. A child's children are looked up across all repos (a parent can have children whose `repoID` differs).
+
+A recursive view `WorktreeSubtreeView(worktree, depth, sectionRepoID)` handles one node:
+
+- Renders `WorktreeRowView(worktree, indentLevel: depth)`.
+- Looks up `appState.children(of: worktree.id)` (a precomputed `[parentID: [Worktree]]` map across all repos, sorted by `sortOrder`).
+- For each child, recurses with `depth + 1`.
+
+`WorktreeRowView` accepts an `indentLevel: Int` parameter and applies `.padding(.leading, CGFloat(indentLevel) * 12)` (in addition to its existing 12pt leading for the repo section).
+
+### Cross-repo indicator
+
+When `worktree.repoID != sectionRepoID`, the row appends a muted suffix `(<sectionRepoName-of-its-home-repo>)` in `.caption` font and `.secondary` foregroundStyle after the worktree's display name. This is the only visual difference between same-repo and cross-repo nested rows.
+
+(There is no double-render. A cross-repo child appears exactly once, under its parent.)
+
+### Always expanded
+
+There is no per-parent chevron. Whenever the repo section is expanded, the entire subtree under each top-level worktree renders. Indent depth grows without bound; cramping at depth 4+ is accepted for v1 and revisited if it becomes a problem in practice.
+
+### Archive UI
+
+In `Sources/TBDApp/Sidebar/SidebarContextMenu.swift`, the Archive menu item on a worktree row checks for any direct active children (across all repos):
 
 ```swift
-let active = (appState.worktrees[repo.id] ?? [])
-    .filter { $0.status == .active || $0.status == .creating }
-let topLevel = active.filter { $0.parentWorktreeID == nil }
-                     .sorted { $0.sortOrder < $1.sortOrder }
-let childrenByParent = Dictionary(grouping: active.filter { $0.parentWorktreeID != nil },
-                                  by: { $0.parentWorktreeID! })
+let hasActiveChildren = appState.allWorktrees.contains {
+    $0.parentWorktreeID == worktree.id
+        && ($0.status == .active || $0.status == .creating)
+}
 ```
 
-For each top-level worktree, render its row, then `childrenByParent[id]` sorted by `sortOrder`, each with an additional 12pt of leading inset (so children sit at total leading ~24pt vs. ~12pt for flat).
+If `hasActiveChildren`, the Archive item is `.disabled(true)` with `.help("Archive nested worktrees first")` so hover reveals the reason.
 
-The `main` worktree continues to render separately at the top of the section with its existing `isMain: true` styling. It cannot be a parent, so no special handling is needed beyond the validation rules above.
-
-There is no per-parent chevron — children are always visible whenever the repo section is expanded. (Depth-1 + typical group sizes of 1–4 make collapse unnecessary; the existing repo-level chevron already provides bulk hide/show.)
-
-### Archive UI on parents
-
-In `SidebarContextMenu.swift` (or wherever the worktree row's Archive menu item is built), check whether the worktree has any active children:
-
-```swift
-let hasActiveChildren = (appState.worktrees[repo.id] ?? [])
-    .contains { $0.parentWorktreeID == worktree.id && ($0.status == .active || $0.status == .creating) }
-```
-
-If `hasActiveChildren`, render the Archive menu item with `.disabled(true)` and `.help("Archive nested worktrees first")` so hovering shows the reason.
-
-On the CLI side, `tbd worktree archive` returns an error from the daemon with the same message — discoverable, no surprise cascade.
+The CLI's `tbd worktree archive` returns the same error from the daemon — no tooltip surface, but the message is identical.
 
 ## Drag and drop
 
-The existing `.onMove { source, destination in appState.reorderWorktrees(...) }` on the worktree `ForEach` is replaced because `.onMove` exposes only source/destination offsets, not local drop coordinates or a way to disambiguate "between rows" from "on a row."
+The existing `.onMove` on the worktree `ForEach` is removed because it can only express same-level offset reorders. Drag-and-drop is rebuilt on `.draggable` + `.dropDestination` so the handler can read drop coordinates and pick reorder vs. nest.
 
-### Mechanic
+### Drag payload
 
-Each worktree row gets:
+Each row sources a drag of a `WorktreeDragPayload(id: UUID)` via a `Transferable` conformance.
 
-- `.draggable { WorktreeDragPayload(id: worktree.id) }` — provides the drag source. Use a custom `Transferable` carrying the UUID.
-- An overlay or `.dropDestination(for: WorktreeDragPayload.self)` that receives drops and reads `DropInfo.location.y` against the row's bounds to pick a band.
+### Drop bands
 
-The dragged ghost uses the system default (a snapshot of the row that tracks the cursor unchanged — no indent animation on the ghost).
+Per row, the handler reads `DropInfo.location.y` and converts it to a fraction of the row's height. The band layout depends on the *target* row's situation:
 
-### Drop bands per row
-
-Computed as fractions of the row's height:
-
-| Drop target | Y band | Action |
+| Target row | Y band | Action |
 |---|---|---|
-| Flat childless row | top 25% | reorder above target at flat depth |
-| Flat childless row | middle 50% | nest under target (becomes its first child) |
-| Flat childless row | bottom 25% | reorder below target at flat depth |
-| Flat parent row | top 25% | reorder above target at flat depth |
-| Flat parent row | middle 50% | append to target's group as last child |
-| Flat parent row | bottom 25% | insert as **first** child of target (the parent's bottom edge is visually adjacent to its first child's top, so this band falls inside the group rather than "below the whole subtree at flat depth") |
-| Child row | top 50% | reorder above target within group |
-| Child row | bottom 50% | reorder below target within group |
+| Top-level row, no children | top 25% | reorder above target at top-level (in its repo's section) |
+| Top-level row, no children | middle 50% | nest under target (becomes its first child) |
+| Top-level row, no children | bottom 25% | reorder below target at top-level |
+| Top-level row, has children | top 25% | reorder above target at top-level |
+| Top-level row, has children | middle 50% | append to target's child group |
+| Top-level row, has children | bottom 25% | insert as target's **first** child (the parent's bottom edge is visually adjacent to its first child) |
+| Nested row, no children | top 25% | reorder above target within target's parent group |
+| Nested row, no children | middle 50% | nest under target (becomes its first child) |
+| Nested row, no children | bottom 25% | reorder below target within target's parent group |
+| Nested row, has children | top 25% | reorder above target within target's parent group |
+| Nested row, has children | middle 50% | append to target's child group |
+| Nested row, has children | bottom 25% | insert as target's **first** child |
 
-To insert a new flat worktree below an expanded parent's whole subtree, drop on the *top band of the next flat row* (or the empty space at the bottom of the repo section).
-
-Child rows have no middle band; rule 2a ("drop on a child = join group") is satisfied implicitly by the top/bottom bands at indented depth.
+To insert below an entire subtree at its top-level depth, drop on the *top band of the next top-level row* or on the empty area at the bottom of the repo section.
 
 ### Drop validation (rejects)
 
-A drop is rejected (no-op, no feedback shown as a valid target) when:
+A drop is rejected (treated as no valid drop target; no feedback shown) when:
 
-- The dragged worktree has active children *and* the action would put it at any non-flat position. Parents with children can only land flat. (Rule 3a.)
-- The drop target is a descendant of the dragged worktree (prevents cycles — trivially true at depth-1 but still guarded).
-- The drop target is in a different repo.
-- The drop target is the `main` worktree and the action would be "nest under main."
+- The dragged worktree is the target.
+- The dragged worktree is an ancestor of the target (would create a cycle).
+- The target is the `main` worktree of any repo and the action would nest under it.
+
+There is no rule against "parents being nested" — multi-level allows arbitrary subtree moves as long as no cycle results.
+
+### Cross-section drops
+
+Dragging a worktree from one repo's section to another repo's section is meaningful and permitted:
+
+- Drop on a row in any repo's section → re-parents under that row (the dragged worktree's subtree now renders inside that row's section, even if the dragged worktree's home repo is different).
+- Drop on the empty area at the bottom of a repo section → un-parents (`parentWorktreeID = nil`) **only if** the dragged worktree's home repo matches that section. Otherwise the drop is rejected. (Reason: un-parented worktrees render in their home repo's section, so dropping in a foreign repo's empty area would not put the row where the user gestured. Forcing the user to target their home repo's empty area keeps drop-position and outcome aligned.)
+- The dragged worktree's `repoID` never changes via drag-and-drop.
 
 ### Group drag
 
-When a parent worktree is dragged, its children come along. Implementation: the daemon-side `worktree.move` handler updates the `sortOrder` of the parent and shifts the parent's children to the new location in a single transaction. Children's `parentWorktreeID` stays the same; only `sortOrder` of surrounding flat-level worktrees changes.
+When a node is dragged, its entire subtree comes with it. The dragged ghost shows only the dragged node (SwiftUI default); the subtree snaps into place after drop. Custom multi-row ghost rendering is out of scope for v1.
 
-In SwiftUI, the dragged ghost only shows the parent row (system default). That's acceptable visually — the group "snaps" into place after the drop. Custom multi-row ghost rendering is out of scope for v1.
+The daemon handles subtree moves transactionally: only the dragged node's `parentWorktreeID` and `sortOrder` change. Descendants keep their `parentWorktreeID` pointing at their existing parent within the subtree, and their `sortOrder` is unchanged. The visual relocation happens because the rendering walks parent pointers; no descendant rows need to be rewritten in the DB.
 
-### Visual feedback during drag
+### Visual feedback
 
-While a drop target is valid:
-
-- **Nest action (middle band on a flat row)**: target row gets a full-row tint (e.g., `Color.accentColor.opacity(0.15)`).
-- **Reorder action (any other valid band)**: an insertion line appears between rows at the depth where the item will land — flat depth for flat-level drops, indented depth for child-level drops. Line is rendered as a thin colored rectangle (e.g., 2pt tall, `Color.accentColor`) overlaying the row gap.
-
-While a drop target is invalid: no visual; the row passes the drag through.
+- **Valid nest target** (middle band of any row): target row gets a full-row tint (`Color.accentColor.opacity(0.15)`).
+- **Valid reorder target** (top/bottom band of any row): a thin (2pt) accent-colored insertion line is drawn at the appropriate y-offset, indented to match the destination depth.
+- **Invalid target**: no visual; the drag passes through.
 
 ## RPC
 
-Two changes to TBDShared/RPCProtocol.swift:
+Two changes in `Sources/TBDShared/RPCProtocol.swift`:
 
 ### `WorktreeCreateParams`
 
-Adds `parentWorktreeID`, `callerWorktreeID`, `suppressAutoParent` as described above. All optional/defaulted so older clients still work.
+Adds `parentWorktreeID`, `siblingOfWorktreeID`, `callerWorktreeID`, `suppressAutoParent` as described above. All optional/defaulted so older clients still work.
 
 ### Replace `worktree.reorder` with `worktree.move`
-
-Today's `worktree.reorder` only supports same-level offset shuffling. Replace it (or add alongside and deprecate) with:
 
 ```swift
 public static let worktreeMove = "worktree.move"
 
 public struct WorktreeMoveParams: Codable, Sendable {
     public let worktreeID: UUID
-    public let newParentID: UUID?    // nil = top-level
-    public let newSortOrder: Int     // position within the new sibling group
+    public let newParentID: UUID?    // nil = top-level (within worktreeID's home repo)
+    public let newSortOrder: Int     // position within destination sibling group
 }
 ```
 
-The handler validates depth cap, same-repo, not-main, not-descendant; updates `parentWorktreeID` and `sortOrder` for the moved worktree; renumbers surrounding siblings in the destination group to make room; and if a parent moves between flat positions, shifts its children's adjacent flat siblings together.
+The handler validates not-self, not-ancestor, not-nesting-under-main; updates the moved worktree's `parentWorktreeID` and `sortOrder`; renumbers surrounding siblings in the destination group to make room.
+
+Existing `worktree.reorder` is removed (or kept as an alias emitting the same delta) so subscribed clients update consistently.
 
 ### State delta
 
-Add `worktreeMoved` to `StateDelta.swift` carrying the worktree id, new parent id, and new sort order. Existing `worktreeReordered` is removed (or kept as an alias emitting the new delta) so subscribed clients update consistently.
+Add `worktreeMoved` to `Sources/TBDShared/StateDelta.swift` carrying the worktree id, new parent id, and new sort order. Replaces `worktreeReordered`.
 
 ## Daemon-side validation
 
-In `WorktreeStore` / `WorktreeLifecycle`:
+`Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift`:
 
-- `create`: applies the parent-resolution order above. On validation failure, returns an RPC error.
-- `move`: enforces depth cap, cycle prevention, same-repo, not-main, dragged-parent-only-lands-flat. Returns RPC error on violation.
-- `archive`: if the target has any active or creating children, returns an RPC error: "Archive nested worktrees first."
+- Applies the resolution order above.
+- Validates the chosen parent (not main, not creating a cycle — trivially true at create time since the new worktree has no descendants, but the check is the same code path as `move`).
+- Returns an RPC error on violation; the partially-created DB row is rolled back.
 
-These rules also serve as the safety net for the app — if the UI ever offered an action by mistake, the daemon refuses.
+`Sources/TBDDaemon/Database/WorktreeStore.swift::move`:
+
+- Enforces not-self, not-ancestor (walks `parentWorktreeID` upward from `newParentID`), not-main.
+- Renumbers `sortOrder` within the destination group.
+- Emits `worktreeMoved` after commit.
+
+`Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift`:
+
+- Before archiving, checks for any active or creating direct children. Returns an RPC error "Archive nested worktrees first" on violation.
+
+### Reconcile
+
+`Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift` should, at daemon startup, null out any `parentWorktreeID` that points to a missing or archived parent. This handles the rare case where the parent's row was removed out-of-band; the orphan becomes top-level in its own home repo.
 
 ## Files touched
 
 - `Sources/TBDShared/Models.swift` — add `parentWorktreeID` to `Worktree`.
 - `Sources/TBDShared/RPCProtocol.swift` — extend `WorktreeCreateParams`; add `worktreeMove` + `WorktreeMoveParams`.
-- `Sources/TBDShared/StateDelta.swift` — add `worktreeMoved` payload.
-- `Sources/TBDDaemon/Database/Database.swift` — v10 migration adding `parent_worktree_id`.
-- `Sources/TBDDaemon/Database/WorktreeStore.swift` — record type update; new `move` method; archive guard.
-- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift` — parent resolution (auto + explicit) and validation.
+- `Sources/TBDShared/StateDelta.swift` — add `worktreeMoved` payload, remove/alias `worktreeReordered`.
+- `Sources/TBDDaemon/Database/Database.swift` — migration adding `parent_worktree_id`.
+- `Sources/TBDDaemon/Database/WorktreeStore.swift` — record type update; new `move` method with cycle check; archive guard.
+- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift` — parent resolution.
 - `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift` — refuse archive when active children exist.
+- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift` — null out parent references to missing/archived worktrees on startup.
 - `Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift` — wire `worktree.move`; extend create handler.
-- `Sources/TBDCLI/Commands/WorktreeCommands.swift` — `--parent`, `--no-parent`; pass `TBD_WORKTREE_ID` as `callerWorktreeID`.
+- `Sources/TBDCLI/Commands/WorktreeCommands.swift` — `--parent`, `--sibling`, `--no-parent`; pass `TBD_WORKTREE_ID` as `callerWorktreeID`.
 - `Sources/TBDApp/DaemonClient.swift` — call `worktree.move`; extend create call.
-- `Sources/TBDApp/AppState+Worktrees.swift` — replace `reorderWorktrees` with a move method that takes a new parent.
-- `Sources/TBDApp/Sidebar/RepoSectionView.swift` — two-pass render (top-level + grouped children).
-- `Sources/TBDApp/Sidebar/WorktreeRowView.swift` — accept an `indentLevel` (or `isChild`) parameter; expose drop-target bands.
+- `Sources/TBDApp/AppState+Worktrees.swift` — replace `reorderWorktrees` with `moveWorktree(id:, newParentID:, newSortOrder:)`; expose `children(of:)` lookup map.
+- `Sources/TBDApp/Sidebar/RepoSectionView.swift` — recursive subtree render.
+- `Sources/TBDApp/Sidebar/WorktreeRowView.swift` — accept `indentLevel` and `sectionRepoID`; render `(repo-name)` suffix when home repo differs; expose drop bands.
 - `Sources/TBDApp/Sidebar/SidebarContextMenu.swift` — disable Archive on parents-with-children with tooltip.
 
 ## Tests
 
-- DB: round-trip a worktree with and without `parentWorktreeID`; migration leaves existing rows with NULL parent.
-- Daemon create: covers each branch of the parent-resolution order, including `--no-parent` overriding env, `--parent` overriding env, cross-repo `callerWorktreeID` ignored, group-head rule when caller is a child.
-- Daemon move: depth-cap violation rejected; cycle rejected; cross-repo rejected; main-as-parent rejected; dragged-parent-with-children-going-non-flat rejected; valid moves update `sortOrder` and `parentWorktreeID` and emit `worktreeMoved`.
-- Daemon archive: refuses when active children exist; succeeds when children are all archived; succeeds for leaf and top-level-without-children.
-- CLI: `--parent`, `--no-parent`, env-driven auto-parent, group-head fallback when caller has a parent.
-- App snapshot or unit test of sidebar ordering: top-level + nested rendering, correct indent, parent and children move together when sort orders change.
+- DB round-trip with and without `parentWorktreeID`; migration leaves existing rows with NULL parent.
+- Daemon create: each branch of the resolution order, including `--no-parent` overriding env, `--sibling` resolving to caller's parent (nil and non-nil cases), `--parent` overriding env, missing/archived `callerWorktreeID` falls back to flat, main as `callerWorktreeID` falls back to flat, cross-repo caller succeeds.
+- Daemon move: not-self, not-ancestor (multi-level cycle check), not-main; cross-repo move succeeds; sort-order renumber works at top-level and within a parent group; subtree moves don't touch descendants' DB rows.
+- Daemon archive: refuses when active children exist (same-repo and cross-repo children); succeeds when children are all archived; succeeds for leaf nodes.
+- Reconcile: parent pointer to a missing worktree gets nulled.
+- CLI: `--parent`, `--sibling`, `--no-parent`, env-driven auto-parent, group-head behavior gone (direct caller used instead).
+- App snapshot / unit test of sidebar ordering: top-level + nested rendering, correct indent levels at depth 1 and 2, cross-repo `(repo-name)` suffix appears only when section repo differs.
 
 ## Open questions
 
-None — all design questions resolved through brainstorming. Edge cases (cross-repo CLI, child caller, parent with children, main worktree) are explicitly handled by the rules above.
+None — design questions resolved. Visual cramping at very deep nesting and the eventual need for per-parent collapse are noted as future work but not blockers for v1.

--- a/docs/superpowers/specs/2026-05-12-nested-worktrees-design.md
+++ b/docs/superpowers/specs/2026-05-12-nested-worktrees-design.md
@@ -1,0 +1,246 @@
+# Nested Worktrees Design
+
+Add one level of parent/child nesting to TBD's per-repo worktree list, so that worktrees spawned from inside another worktree's session appear indented under their spawner instead of dumped at the end of the flat list. Nesting is also user-controllable via drag-and-drop.
+
+## Goals
+
+- A worktree can have at most one parent worktree (depth-1 cap).
+- New worktrees created by `tbd worktree create` from inside a TBD-managed terminal automatically attach to a sensible parent (the group head of where the CLI was invoked).
+- Users can manually reorder and re-parent worktrees by drag-and-drop in the sidebar, including promoting a child back to flat.
+- Parents and their children move as a unit when dragged.
+- Archiving a parent that still has active children is blocked, not cascaded.
+
+## Non-goals
+
+- Multi-level nesting. The cap is one level for now; deeper hierarchies are out of scope.
+- Cross-repo lineage. Parent and child must live in the same repo.
+- Nesting under the `main` worktree. Main remains a special row that cannot be a parent.
+- Drag-and-drop in the CLI or in `worktree list` JSON output.
+- Changing how `sortOrder` is stored on disk beyond what depth-1 nesting requires.
+
+## Data model
+
+### `Worktree` (TBDShared/Models.swift)
+
+Add one nullable field:
+
+```swift
+public var parentWorktreeID: UUID?
+```
+
+Decoded with `decodeIfPresent` so older JSON / older DB rows still load.
+
+Invariant (enforced everywhere it can be written): if `parentWorktreeID != nil`, the referenced worktree exists in the same repo, has `parentWorktreeID == nil`, and is not the `main` worktree.
+
+### `sortOrder` semantics
+
+`sortOrder` becomes scoped *within siblings*:
+
+- Top-level worktrees (parent nil) are ordered by `sortOrder` relative to each other.
+- Children of a given parent are ordered by `sortOrder` relative to each other.
+- Sort orders across levels are independent. No global ordering is implied.
+
+The existing column is reused; no schema change beyond the new parent column.
+
+### Migration
+
+Add migration `v10` (or next available) in `Sources/TBDDaemon/Database/Database.swift`:
+
+- `ALTER TABLE worktrees ADD COLUMN parent_worktree_id TEXT NULL`.
+- No backfill — all existing rows become top-level (parent nil), which preserves current behavior.
+
+Update the GRDB record type in `Sources/TBDDaemon/Database/` to include the new column, and update the Codable model in `TBDShared/Models.swift` in the same commit (per CLAUDE.md rule on DB-column changes).
+
+## CLI: auto-parent on create
+
+`Sources/TBDCLI/Commands/WorktreeCommands.swift::WorktreeCreate` adds two flags and one auto-detect step:
+
+- `--no-parent` (boolean) — force top-level, ignore env.
+- `--parent <id-or-name>` — explicit parent override. Resolved server-side; rejected if it points to a different repo, to `main`, or to a worktree that already has a parent.
+
+Auto-detect, when neither flag is set and `TBD_WORKTREE_ID` is present in env:
+
+1. Resolve the env value to a worktree (via daemon — same lookup path as `tbd link`).
+2. If the resolved worktree is in the same repo as the new worktree *and* is not `main`:
+   - If its own `parentWorktreeID == nil`, use it as the new parent.
+   - Otherwise, use *its* `parentWorktreeID` as the new parent ("group-head rule").
+3. Otherwise (cross-repo, missing, archived, or `main`), do not auto-parent.
+
+The CLI just forwards `parentWorktreeID` in `WorktreeCreateParams`; the auto-detect logic can live either in the CLI or in the daemon. Putting it in the daemon (server-side resolution from `TBD_WORKTREE_ID` passed as a param) keeps validation and group-head lookup in one place and avoids duplicating the rule across clients. **Decision:** the daemon does the resolution. The CLI passes an optional `callerWorktreeID` taken from env; the `--parent` and `--no-parent` flags override that.
+
+### RPC change
+
+`WorktreeCreateParams` (TBDShared/RPCProtocol.swift) gains:
+
+```swift
+public var parentWorktreeID: UUID?      // explicit, from --parent
+public var callerWorktreeID: UUID?      // from TBD_WORKTREE_ID, used for auto-parent
+public var suppressAutoParent: Bool     // from --no-parent
+```
+
+Resolution order in `worktree.create`:
+
+1. If `suppressAutoParent`, ignore both `parentWorktreeID` and `callerWorktreeID`. New worktree is flat.
+2. Else if `parentWorktreeID` is set, validate (same repo, not main, target's parent is nil) and use it. Reject with an error on violation.
+3. Else if `callerWorktreeID` is set and refers to a valid same-repo non-main worktree, apply the group-head rule.
+4. Else: flat.
+
+The new worktree is appended to its sibling group (highest existing `sortOrder + 1` within its parent scope).
+
+## App: sidebar rendering
+
+`Sources/TBDApp/Sidebar/RepoSectionView.swift`:
+
+Inside `body` under `if repo.expanded`, replace the single `ForEach(worktrees)` block with a two-pass render:
+
+```swift
+let active = (appState.worktrees[repo.id] ?? [])
+    .filter { $0.status == .active || $0.status == .creating }
+let topLevel = active.filter { $0.parentWorktreeID == nil }
+                     .sorted { $0.sortOrder < $1.sortOrder }
+let childrenByParent = Dictionary(grouping: active.filter { $0.parentWorktreeID != nil },
+                                  by: { $0.parentWorktreeID! })
+```
+
+For each top-level worktree, render its row, then `childrenByParent[id]` sorted by `sortOrder`, each with an additional 12pt of leading inset (so children sit at total leading ~24pt vs. ~12pt for flat).
+
+The `main` worktree continues to render separately at the top of the section with its existing `isMain: true` styling. It cannot be a parent, so no special handling is needed beyond the validation rules above.
+
+There is no per-parent chevron — children are always visible whenever the repo section is expanded. (Depth-1 + typical group sizes of 1–4 make collapse unnecessary; the existing repo-level chevron already provides bulk hide/show.)
+
+### Archive UI on parents
+
+In `SidebarContextMenu.swift` (or wherever the worktree row's Archive menu item is built), check whether the worktree has any active children:
+
+```swift
+let hasActiveChildren = (appState.worktrees[repo.id] ?? [])
+    .contains { $0.parentWorktreeID == worktree.id && ($0.status == .active || $0.status == .creating) }
+```
+
+If `hasActiveChildren`, render the Archive menu item with `.disabled(true)` and `.help("Archive nested worktrees first")` so hovering shows the reason.
+
+On the CLI side, `tbd worktree archive` returns an error from the daemon with the same message — discoverable, no surprise cascade.
+
+## Drag and drop
+
+The existing `.onMove { source, destination in appState.reorderWorktrees(...) }` on the worktree `ForEach` is replaced because `.onMove` exposes only source/destination offsets, not local drop coordinates or a way to disambiguate "between rows" from "on a row."
+
+### Mechanic
+
+Each worktree row gets:
+
+- `.draggable { WorktreeDragPayload(id: worktree.id) }` — provides the drag source. Use a custom `Transferable` carrying the UUID.
+- An overlay or `.dropDestination(for: WorktreeDragPayload.self)` that receives drops and reads `DropInfo.location.y` against the row's bounds to pick a band.
+
+The dragged ghost uses the system default (a snapshot of the row that tracks the cursor unchanged — no indent animation on the ghost).
+
+### Drop bands per row
+
+Computed as fractions of the row's height:
+
+| Drop target | Y band | Action |
+|---|---|---|
+| Flat childless row | top 25% | reorder above target at flat depth |
+| Flat childless row | middle 50% | nest under target (becomes its first child) |
+| Flat childless row | bottom 25% | reorder below target at flat depth |
+| Flat parent row | top 25% | reorder above target at flat depth |
+| Flat parent row | middle 50% | append to target's group as last child |
+| Flat parent row | bottom 25% | insert as **first** child of target (the parent's bottom edge is visually adjacent to its first child's top, so this band falls inside the group rather than "below the whole subtree at flat depth") |
+| Child row | top 50% | reorder above target within group |
+| Child row | bottom 50% | reorder below target within group |
+
+To insert a new flat worktree below an expanded parent's whole subtree, drop on the *top band of the next flat row* (or the empty space at the bottom of the repo section).
+
+Child rows have no middle band; rule 2a ("drop on a child = join group") is satisfied implicitly by the top/bottom bands at indented depth.
+
+### Drop validation (rejects)
+
+A drop is rejected (no-op, no feedback shown as a valid target) when:
+
+- The dragged worktree has active children *and* the action would put it at any non-flat position. Parents with children can only land flat. (Rule 3a.)
+- The drop target is a descendant of the dragged worktree (prevents cycles — trivially true at depth-1 but still guarded).
+- The drop target is in a different repo.
+- The drop target is the `main` worktree and the action would be "nest under main."
+
+### Group drag
+
+When a parent worktree is dragged, its children come along. Implementation: the daemon-side `worktree.move` handler updates the `sortOrder` of the parent and shifts the parent's children to the new location in a single transaction. Children's `parentWorktreeID` stays the same; only `sortOrder` of surrounding flat-level worktrees changes.
+
+In SwiftUI, the dragged ghost only shows the parent row (system default). That's acceptable visually — the group "snaps" into place after the drop. Custom multi-row ghost rendering is out of scope for v1.
+
+### Visual feedback during drag
+
+While a drop target is valid:
+
+- **Nest action (middle band on a flat row)**: target row gets a full-row tint (e.g., `Color.accentColor.opacity(0.15)`).
+- **Reorder action (any other valid band)**: an insertion line appears between rows at the depth where the item will land — flat depth for flat-level drops, indented depth for child-level drops. Line is rendered as a thin colored rectangle (e.g., 2pt tall, `Color.accentColor`) overlaying the row gap.
+
+While a drop target is invalid: no visual; the row passes the drag through.
+
+## RPC
+
+Two changes to TBDShared/RPCProtocol.swift:
+
+### `WorktreeCreateParams`
+
+Adds `parentWorktreeID`, `callerWorktreeID`, `suppressAutoParent` as described above. All optional/defaulted so older clients still work.
+
+### Replace `worktree.reorder` with `worktree.move`
+
+Today's `worktree.reorder` only supports same-level offset shuffling. Replace it (or add alongside and deprecate) with:
+
+```swift
+public static let worktreeMove = "worktree.move"
+
+public struct WorktreeMoveParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let newParentID: UUID?    // nil = top-level
+    public let newSortOrder: Int     // position within the new sibling group
+}
+```
+
+The handler validates depth cap, same-repo, not-main, not-descendant; updates `parentWorktreeID` and `sortOrder` for the moved worktree; renumbers surrounding siblings in the destination group to make room; and if a parent moves between flat positions, shifts its children's adjacent flat siblings together.
+
+### State delta
+
+Add `worktreeMoved` to `StateDelta.swift` carrying the worktree id, new parent id, and new sort order. Existing `worktreeReordered` is removed (or kept as an alias emitting the new delta) so subscribed clients update consistently.
+
+## Daemon-side validation
+
+In `WorktreeStore` / `WorktreeLifecycle`:
+
+- `create`: applies the parent-resolution order above. On validation failure, returns an RPC error.
+- `move`: enforces depth cap, cycle prevention, same-repo, not-main, dragged-parent-only-lands-flat. Returns RPC error on violation.
+- `archive`: if the target has any active or creating children, returns an RPC error: "Archive nested worktrees first."
+
+These rules also serve as the safety net for the app — if the UI ever offered an action by mistake, the daemon refuses.
+
+## Files touched
+
+- `Sources/TBDShared/Models.swift` — add `parentWorktreeID` to `Worktree`.
+- `Sources/TBDShared/RPCProtocol.swift` — extend `WorktreeCreateParams`; add `worktreeMove` + `WorktreeMoveParams`.
+- `Sources/TBDShared/StateDelta.swift` — add `worktreeMoved` payload.
+- `Sources/TBDDaemon/Database/Database.swift` — v10 migration adding `parent_worktree_id`.
+- `Sources/TBDDaemon/Database/WorktreeStore.swift` — record type update; new `move` method; archive guard.
+- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift` — parent resolution (auto + explicit) and validation.
+- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift` — refuse archive when active children exist.
+- `Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift` — wire `worktree.move`; extend create handler.
+- `Sources/TBDCLI/Commands/WorktreeCommands.swift` — `--parent`, `--no-parent`; pass `TBD_WORKTREE_ID` as `callerWorktreeID`.
+- `Sources/TBDApp/DaemonClient.swift` — call `worktree.move`; extend create call.
+- `Sources/TBDApp/AppState+Worktrees.swift` — replace `reorderWorktrees` with a move method that takes a new parent.
+- `Sources/TBDApp/Sidebar/RepoSectionView.swift` — two-pass render (top-level + grouped children).
+- `Sources/TBDApp/Sidebar/WorktreeRowView.swift` — accept an `indentLevel` (or `isChild`) parameter; expose drop-target bands.
+- `Sources/TBDApp/Sidebar/SidebarContextMenu.swift` — disable Archive on parents-with-children with tooltip.
+
+## Tests
+
+- DB: round-trip a worktree with and without `parentWorktreeID`; migration leaves existing rows with NULL parent.
+- Daemon create: covers each branch of the parent-resolution order, including `--no-parent` overriding env, `--parent` overriding env, cross-repo `callerWorktreeID` ignored, group-head rule when caller is a child.
+- Daemon move: depth-cap violation rejected; cycle rejected; cross-repo rejected; main-as-parent rejected; dragged-parent-with-children-going-non-flat rejected; valid moves update `sortOrder` and `parentWorktreeID` and emit `worktreeMoved`.
+- Daemon archive: refuses when active children exist; succeeds when children are all archived; succeeds for leaf and top-level-without-children.
+- CLI: `--parent`, `--no-parent`, env-driven auto-parent, group-head fallback when caller has a parent.
+- App snapshot or unit test of sidebar ordering: top-level + nested rendering, correct indent, parent and children move together when sort orders change.
+
+## Open questions
+
+None — all design questions resolved through brainstorming. Edge cases (cross-repo CLI, child caller, parent with children, main worktree) are explicitly handled by the rules above.


### PR DESCRIPTION
## Summary

- **CLI auto-parent**: `tbd worktree create` from inside a TBD-managed terminal now nests the new worktree under its caller (using `TBD_WORKTREE_ID`). Multi-level supported. Cross-repo lineage works (child can live in a different repo from its parent, rendered under the parent with a muted `(repo-name)` suffix).
- **Manual nested-create**: each non-main worktree row gets a context-menu "Create Nested Worktree" item and a hover-revealed `+` button on the right.
- **CLI flags**: `--parent <id-or-name>`, `--sibling`, `--no-parent` on `tbd worktree create` to override the default auto-parent behavior.
- **Sidebar render**: recursive — children appear indented under their parent (16pt per level) with thin vertical guide lines at each ancestor depth. Top-level reorder via List's native `.onMove`.
- **Archive guard**: a worktree with active children can't be archived. The Archive menu item is disabled with the tooltip "Archive nested worktrees first"; the CLI surfaces the same error.
- **Data model**: new `parentWorktreeID` column on `worktree` (migration v23) + new `worktree.move` RPC + `worktreeMoved` state delta. `Worktree.sortOrder` is now scoped per sibling group (top-level OR children-of-parent), not per repo.

## Caveats

- **Drag-to-nest deferred to #142.** SwiftUI's `.onMove` (which we use for top-level reorder) and `.draggable` (which we'd need for nest) are mutually exclusive on the same List row — `.onMove` consumes the drag gesture before `.draggable` can engage. We tried 8 distinct API combinations across two debugging sessions before retreating. Issue captures the full failure log + a viable path forward for a future implementer (drop `.onMove`, do reorder + nest both via `.draggable` + drop targets).
- **Lost click-to-rename.** The custom `.onTapGesture` we had on each row was preempting `NSTableView`'s row-drag tracker (FB7367473 family), so `.onMove` only initiated from the empty right-hand gutter. Removing the gesture lets selection + drag flow through `List(selection:)` natively. Rename is still available via the context menu "Rename..." and the inline editor that auto-appears on worktree create.

## Test plan

- [ ] From a TBD-managed terminal: `tbd worktree create` → new row appears indented under the current worktree.
- [ ] `tbd worktree create --no-parent` → flat. `--sibling` → same level as caller. `--parent <name>` → explicit parent.
- [ ] Right-click a worktree row → "Create Nested Worktree" creates a child.
- [ ] Hover a row → `+` button on the right creates a child.
- [ ] Drag a top-level row to reorder → reorders and persists across restart.
- [ ] Right-click a parent with active children → Archive item disabled, tooltip explains why.
- [ ] Restart the daemon while nested → layout survives (`worktree.parentWorktreeID` persisted in v23).
- [ ] Stop daemon, set a bad `parentWorktreeID` in `~/tbd/state.db`, restart → orphan parent pointer is nulled on reconcile, child reverts to top-level.
- [ ] Selection: single-click selects, cmd-click toggles multi-select, context-menu "Rename..." works.

Spec: `docs/superpowers/specs/2026-05-12-nested-worktrees-design.md`
Follow-up: #142 (drag-to-nest)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=4DE489CE-1ACE-4D88-9C14-1BE36B4716CC)
