### PR TITLE
Fix: Stop spawning setup tabs without TBD_WORKTREE_ID — hooks couldn't identify their worktree

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -306,21 +306,30 @@ extension WorktreeLifecycle {
         )
 
         // Create terminal 2: setup hook
+        let plannedTerminalID2 = UUID()
         let setupHookPath = hooks.resolve(
             event: .setup,
             repoPath: worktreePath,
             appHookPath: TBDConstants.hookPath(repoID: worktree.repoID, eventName: HookEvent.setup.rawValue)
         )
         let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
+        // Inject TBD_TERMINAL_ID + TBD_WORKTREE_ID so setup hooks and any
+        // tooling they run can identify their owning terminal.
+        let setupEnv: [String: String] = [
+            "TBD_WORKTREE_ID": worktreeID.uuidString,
+            "TBD_TERMINAL_ID": plannedTerminalID2.uuidString,
+        ]
         let window2 = try await tmux.createWindow(
             server: tmuxServer,
             session: "main",
             cwd: worktreePath,
             shellCommand: setupCommand,
+            env: setupEnv,
             cols: resolvedCols,
             rows: resolvedRows
         )
         _ = try await db.terminals.create(
+            id: plannedTerminalID2,
             worktreeID: worktreeID,
             tmuxWindowID: window2.windowID,
             tmuxPaneID: window2.paneID,

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -254,6 +254,83 @@ func testHandleTerminalRecreateWindowSetsWorktreeID() async throws {
             "handleTerminalRecreateWindow must export TBD_WORKTREE_ID; got bodies: \(bodies)")
 }
 
+// MARK: - Fix 3: setupTerminals injects TBD_TERMINAL_ID + TBD_WORKTREE_ID on the setup tab
+
+/// Regression test for the bug where the auto-created "setup" tab that gets
+/// born alongside the Claude tab during `createWorktree` was missing
+/// `TBD_WORKTREE_ID` and `TBD_TERMINAL_ID` env vars (the `env:` parameter was
+/// defaulting to `[:]`), so the setup hook couldn't identify its owning
+/// worktree/terminal.
+@Test("createWorktree — setup tab exports TBD_WORKTREE_ID and TBD_TERMINAL_ID")
+func testCreateWorktreeSetupTabExportsTBDIDs() async throws {
+    // Build a real git repo so completeCreateWorktree can run `git worktree add`.
+    let tempDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-test-\(UUID().uuidString)")
+    let repoDir = tempDir.appendingPathComponent("repo")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let initProcess = Process()
+    initProcess.executableURL = URL(fileURLWithPath: "/bin/bash")
+    initProcess.arguments = ["-c", "git init -b main && git commit --allow-empty -m init"]
+    initProcess.currentDirectoryURL = repoDir
+    initProcess.environment = [
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
+        "HOME": NSHomeDirectory(),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+    ]
+    let initPipe = Pipe()
+    initProcess.standardOutput = initPipe
+    initProcess.standardError = initPipe
+    try initProcess.run()
+    initProcess.waitUntilExit()
+    #expect(initProcess.terminationStatus == 0, "git init failed")
+
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: tmux,
+        hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+    let override = tempDir.appendingPathComponent(".tbd/worktrees").path
+    try await db.repos.updateWorktreeRoot(id: repo.id, path: override)
+    let resolvedRepo = try await db.repos.get(id: repo.id)!
+
+    // skipClaude: true puts a plain shell in window1 but window2 is still the
+    // setup tab — the very thing we're testing here.
+    let wt = try await lifecycle.createWorktree(repoID: resolvedRepo.id, skipClaude: true)
+
+    // Two terminals expected: shell + setup
+    let terminals = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminals.count == 2, "expected 2 terminals (shell + setup)")
+    guard let setup = terminals.first(where: { $0.label == "setup" }) else {
+        Issue.record("setup terminal not found; got: \(terminals.map { $0.label ?? "nil" })")
+        return
+    }
+
+    let bodies = newWindowBodies(recorded.snapshot())
+    let expectedWorktree = "export TBD_WORKTREE_ID='\(wt.id.uuidString)';"
+    let expectedTerminal = "export TBD_TERMINAL_ID='\(setup.id.uuidString)';"
+    #expect(
+        bodies.contains { $0.contains(expectedWorktree) && $0.contains(expectedTerminal) },
+        "setup tab must export both TBD_WORKTREE_ID and TBD_TERMINAL_ID matching its DB row; got bodies: \(bodies)"
+    )
+}
+
 // MARK: - Regression: handleTerminalCreate still sets TBD_WORKTREE_ID
 
 @Test("handleTerminalCreate (regression) still exports the correct TBD_WORKTREE_ID")


### PR DESCRIPTION
## Summary

- **What's broken:** When a new worktree is created, TBD auto-spawns two tabs — a Claude tab and a setup/shell tab. Only the Claude tab received `TBD_WORKTREE_ID` and `TBD_TERMINAL_ID` in its env. The setup tab spawned with `env: [:]`, so any hook script or tooling running in it couldn't identify its owning worktree or terminal. Repro: create a new worktree, switch to the second tab, run `echo "$TBD_WORKTREE_ID"` — empty. (A subsequent Cmd+T tab on the same worktree has it set, because that path goes through `RPCRouter+TerminalHandlers` which injects env correctly.)
- **Why it happens:** `WorktreeLifecycle+Create.swift` calls `tmux.createWindow` twice during initial setup. The Claude tab call (window1) passes `env: claudeEnv` with both IDs. The setup tab call (window2) omits the `env:` parameter, defaulting it to `[:]`. The `db.terminals.create` for the setup row also auto-generated its UUID, so even if env had been added later there was no way to keep env and DB in sync.
- **What this PR does:** Pre-mints `plannedTerminalID2`, builds a `setupEnv` dict mirroring the window1 pattern, passes it to `tmux.createWindow`, and passes the same UUID to `db.terminals.create` so the env and DB row agree. Adds a regression test in `TBDWorktreeIDLeakTests` that drives `createWorktree` end-to-end against a real temp git repo with a dryRun tmux recorder and asserts the setup-tab `new-window` body exports both vars matching the DB row.

Audited all other `tmux.createWindow` call sites in `Sources/`; two are borderline and left for follow-up: `ConductorManager.swift:168` (conductor spawn, intentional — conductors aren't tied to a single worktree) and `RPCRouter+TerminalHandlers.swift:317` (`handleTerminalRecreateWindow` injects `TBD_WORKTREE_ID` but not `TBD_TERMINAL_ID` — pane runs a plain shell so impact is low).

## Test plan

- [x] `swift build` succeeds
- [x] `swift test --filter testCreateWorktreeSetupTabExportsTBDIDs` passes (new regression test)
- [x] `swift test --filter TBDWorktreeIDLeak` 7/7 pass
- [x] `swift test --filter WorktreeLifecycle` 20/20 pass
- [ ] Manual: full restart (`scripts/restart.sh`), create a new worktree, switch to the setup/shell tab, confirm `echo "\$TBD_WORKTREE_ID \$TBD_TERMINAL_ID"` shows both UUIDs and `TBD_TERMINAL_ID` matches the row in `db.terminals` for that tab

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B634D5A9-C7C7-428E-85DA-56AED40E5E54)