### PR TITLE
Reliability: Stop renumbered migrations from bricking the daemon on startup (2 incidents in 2 weeks)

### DIFF
--- a/Sources/TBDDaemon/Database/CLAUDE.md
+++ b/Sources/TBDDaemon/Database/CLAUDE.md
@@ -1,0 +1,39 @@
+# Database / Migrations
+
+## Use the idempotent helpers in new migrations
+
+New migrations that add columns, tables, or indexes MUST go through
+`MigrationHelpers.swift`:
+
+- `addColumnIfMissing(table:column:type:defaults:)`
+- `createTableIfNotExists(_:body:)`
+- `addIndexIfMissing(_:on:columns:unique:where:)`
+
+Do not call `t.add(column:)`, `db.create(table:)`, or raw `CREATE INDEX`
+directly in a new migration. Reason: parallel branches that renumber the same
+additive migration have bricked the daemon twice (May 6 and May 13 2026). When
+the schema already has the column but the renamed migration ID is unapplied,
+GRDB re-runs the body and SQLite throws `duplicate column name`. The helpers
+turn that scenario into a logged no-op.
+
+## Migration ID convention
+
+Continue `v<N>_descriptive_suffix` (e.g. `v23_repo_archived_at`). The numeric
+prefix preserves ordering; the suffix makes parallel branch collisions
+debuggable.
+
+## Don't edit existing migration bodies
+
+v1 through v22 are frozen. They have run on user machines; mutating them now
+would either be a no-op (because GRDB skips them) or cause a fresh
+divergence between dev and prod schemas. The helpers are for FUTURE
+migrations only.
+
+## Pre-migration snapshot
+
+`init(path:)` automatically copies `~/tbd/state.db` to
+`~/tbd/state.db.pre-migration.<UTC-timestamp>` (e.g.
+`state.db.pre-migration.20260513T143055Z`) whenever there is pending
+migration work AND the DB file already existed. Failures are logged at error
+level but do not block the migration — best effort only. Safe to delete the
+snapshot after confirming the upgrade was clean.

--- a/Sources/TBDDaemon/Database/CLAUDE.md
+++ b/Sources/TBDDaemon/Database/CLAUDE.md
@@ -24,10 +24,12 @@ debuggable.
 
 ## Don't edit existing migration bodies
 
-v1 through v22 are frozen. They have run on user machines; mutating them now
+v1 through v23 are frozen. They have run on user machines; mutating them now
 would either be a no-op (because GRDB skips them) or cause a fresh
 divergence between dev and prod schemas. The helpers are for FUTURE
-migrations only.
+migrations only. (v23 landed on `main` in #143 before this PR opened, so it
+is grandfathered into the frozen range even though its body uses raw
+`t.add(column:)`.)
 
 ## Pre-migration snapshot
 

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
 
 /// Central database class that manages the SQLite connection and exposes store accessors.
@@ -21,8 +22,15 @@ public final class TBDDatabase: Sendable {
     public let meta: TBDMetaStore
     public let tabs: TabStore
 
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
+
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
     public init(path: String) throws {
+        // Capture existence BEFORE DatabasePool opens the file — opening
+        // creates an empty DB on the first launch, so we'd otherwise lose the
+        // ability to distinguish "first launch" from "upgrade".
+        let fileExisted = FileManager.default.fileExists(atPath: path)
+
         var config = Configuration()
         #if DEBUG
         config.prepareDatabase { db in
@@ -42,7 +50,17 @@ public final class TBDDatabase: Sendable {
         self.config = ConfigStore(writer: pool)
         self.meta = TBDMetaStore(writer: pool)
         self.tabs = TabStore(writer: pool)
-        try Self.migrate(writer: pool)
+
+        let migrator = Self.buildMigrator()
+        if fileExisted {
+            let hasPending = try pool.read { db in
+                try !migrator.hasCompletedMigrations(db)
+            }
+            if hasPending {
+                Self.takePreMigrationSnapshot(pool: pool, path: path)
+            }
+        }
+        try migrator.migrate(pool)
     }
 
     /// Create an in-memory database for testing using DatabaseQueue.
@@ -61,10 +79,32 @@ public final class TBDDatabase: Sendable {
         self.config = ConfigStore(writer: queue)
         self.meta = TBDMetaStore(writer: queue)
         self.tabs = TabStore(writer: queue)
-        try Self.migrate(writer: queue)
+        try Self.buildMigrator().migrate(queue)
     }
 
-    private static func migrate(writer: any DatabaseWriter) throws {
+    /// Best-effort pre-migration snapshot. Failures are logged, not thrown —
+    /// the migration must still be allowed to proceed even if e.g. the disk
+    /// is full or the parent directory isn't writable.
+    private static func takePreMigrationSnapshot(pool: DatabasePool, path: String) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let stamp = formatter.string(from: Date())
+        let snapshotPath = "\(path).pre-migration.\(stamp)"
+        do {
+            try pool.write { db in
+                try db.execute(sql: "VACUUM INTO ?", arguments: [snapshotPath])
+            }
+            logger.info("Pre-migration snapshot written to \(snapshotPath, privacy: .public)")
+        } catch {
+            logger.error(
+                "Pre-migration snapshot failed at \(snapshotPath, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+        }
+    }
+
+    private static func buildMigrator() -> DatabaseMigrator {
         var migrator = DatabaseMigrator()
 
         migrator.registerMigration("v1") { db in
@@ -398,6 +438,6 @@ public final class TBDDatabase: Sendable {
             }
         }
 
-        try migrator.migrate(writer)
+        return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -85,7 +85,7 @@ public final class TBDDatabase: Sendable {
     /// Best-effort pre-migration snapshot. Failures are logged, not thrown —
     /// the migration must still be allowed to proceed even if e.g. the disk
     /// is full or the parent directory isn't writable.
-    private static func takePreMigrationSnapshot(pool: DatabasePool, path: String) {
+    internal static func takePreMigrationSnapshot(pool: DatabasePool, path: String) {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
         formatter.timeZone = TimeZone(identifier: "UTC")
@@ -93,7 +93,12 @@ public final class TBDDatabase: Sendable {
         let stamp = formatter.string(from: Date())
         let snapshotPath = "\(path).pre-migration.\(stamp)"
         do {
-            try pool.write { db in
+            // VACUUM INTO requires autocommit mode — it cannot run inside a
+            // transaction. `pool.write` wraps the closure in a deferred
+            // transaction, which silently turns the snapshot into a no-op
+            // (catch-and-log path below was hiding the failure). Use
+            // writeWithoutTransaction so SQLite stays in autocommit.
+            try pool.writeWithoutTransaction { db in
                 try db.execute(sql: "VACUUM INTO ?", arguments: [snapshotPath])
             }
             logger.info("Pre-migration snapshot written to \(snapshotPath, privacy: .public)")

--- a/Sources/TBDDaemon/Database/MigrationHelpers.swift
+++ b/Sources/TBDDaemon/Database/MigrationHelpers.swift
@@ -1,0 +1,102 @@
+import Foundation
+import GRDB
+import os
+
+/// Idempotent schema-change helpers for `DatabaseMigrator` bodies.
+///
+/// Parallel branches sometimes register an additive migration (e.g. `ADD COLUMN`)
+/// under different IDs. GRDB tracks applied migrations by string ID, so when the
+/// schema already has the column but the *new* ID has not been recorded, GRDB
+/// re-runs the body and SQLite throws `duplicate column name`. These helpers
+/// make the body a no-op in that case, turning the second crash-causing
+/// scenario into a clean skip.
+extension GRDB.Database {
+
+    /// Add `column` to `table` if it isn't already present.
+    ///
+    /// Column-name comparison is case-insensitive — SQLite identifiers are
+    /// case-insensitive, so a column declared as `FOO` must be detected by a
+    /// lookup of `"foo"`.
+    func addColumnIfMissing(
+        table: String,
+        column: String,
+        type: GRDB.Database.ColumnType,
+        defaults: (any DatabaseValueConvertible)? = nil
+    ) throws {
+        let existing = try Row.fetchAll(self, sql: "PRAGMA table_info(\(table))")
+            .compactMap { ($0["name"] as String?)?.lowercased() }
+        if existing.contains(column.lowercased()) {
+            Self.migrationsLogger.debug(
+                "addColumnIfMissing: skip \(table, privacy: .public).\(column, privacy: .public) (already present)"
+            )
+            return
+        }
+        try alter(table: table) { t in
+            let def = t.add(column: column, type)
+            if let defaults {
+                _ = def.defaults(to: defaults)
+            }
+        }
+        Self.migrationsLogger.debug(
+            "addColumnIfMissing: added \(table, privacy: .public).\(column, privacy: .public)"
+        )
+    }
+
+    /// Create `table` if it doesn't already exist. Wraps GRDB's
+    /// `create(table:options:body:)` with `.ifNotExists`.
+    func createTableIfNotExists(
+        _ table: String,
+        body: (TableDefinition) throws -> Void
+    ) throws {
+        // GRDB short-circuits if the table is already there, but we still log
+        // when we skipped vs created so the migration trail is clear.
+        let preexisting = try tableExists(table)
+        try create(table: table, options: [.ifNotExists], body: body)
+        if preexisting {
+            Self.migrationsLogger.debug(
+                "createTableIfNotExists: skip \(table, privacy: .public) (already present)"
+            )
+        } else {
+            Self.migrationsLogger.debug(
+                "createTableIfNotExists: created \(table, privacy: .public)"
+            )
+        }
+    }
+
+    /// Create an index if it doesn't already exist. Supports partial indexes
+    /// via the optional `where` clause.
+    func addIndexIfMissing(
+        _ indexName: String,
+        on table: String,
+        columns: [String],
+        unique: Bool = false,
+        where whereClause: String? = nil
+    ) throws {
+        let uniqueKW = unique ? "UNIQUE " : ""
+        let cols = columns.joined(separator: ", ")
+        var sql = "CREATE \(uniqueKW)INDEX IF NOT EXISTS \(indexName) ON \(table)(\(cols))"
+        if let whereClause, !whereClause.isEmpty {
+            sql += " WHERE \(whereClause)"
+        }
+        let existed = try Bool.fetchOne(
+            self,
+            sql: "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+            arguments: [indexName]
+        ) ?? false
+        try execute(sql: sql)
+        if existed {
+            Self.migrationsLogger.debug(
+                "addIndexIfMissing: skip \(indexName, privacy: .public) on \(table, privacy: .public) (already present)"
+            )
+        } else {
+            Self.migrationsLogger.debug(
+                "addIndexIfMissing: created \(indexName, privacy: .public) on \(table, privacy: .public)"
+            )
+        }
+    }
+
+    fileprivate static let migrationsLogger = Logger(
+        subsystem: "com.tbd.daemon",
+        category: "migrations"
+    )
+}

--- a/Tests/TBDDaemonTests/MigrationHelpersTests.swift
+++ b/Tests/TBDDaemonTests/MigrationHelpersTests.swift
@@ -1,0 +1,180 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+
+@Suite struct MigrationHelpersTests {
+
+    // MARK: addColumnIfMissing
+
+    @Test func addColumnIfMissingAddsWhenAbsent() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: "CREATE TABLE t (id TEXT PRIMARY KEY)")
+            try db.addColumnIfMissing(table: "t", column: "name", type: .text)
+            let cols = try Row.fetchAll(db, sql: "PRAGMA table_info(t)")
+                .compactMap { $0["name"] as String? }
+            #expect(cols.contains("name"))
+        }
+    }
+
+    @Test func addColumnIfMissingIsNoOpWhenPresent() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: "CREATE TABLE t (id TEXT PRIMARY KEY, name TEXT)")
+            // Should not throw "duplicate column name"
+            try db.addColumnIfMissing(table: "t", column: "name", type: .text)
+            let cols = try Row.fetchAll(db, sql: "PRAGMA table_info(t)")
+                .compactMap { $0["name"] as String? }
+            #expect(cols.filter { $0 == "name" }.count == 1)
+        }
+    }
+
+    @Test func addColumnIfMissingIsCaseInsensitive() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            // Column declared in uppercase
+            try db.execute(sql: "CREATE TABLE t (id TEXT PRIMARY KEY, FOO TEXT)")
+            // Helper called with lowercase — should detect existing and skip
+            try db.addColumnIfMissing(table: "t", column: "foo", type: .text)
+            let cols = try Row.fetchAll(db, sql: "PRAGMA table_info(t)")
+                .compactMap { $0["name"] as String? }
+            // Only the original FOO column should be present
+            #expect(cols.filter { $0.lowercased() == "foo" }.count == 1)
+        }
+    }
+
+    @Test func addColumnIfMissingAppliesDefault() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: "CREATE TABLE t (id TEXT PRIMARY KEY)")
+            try db.execute(sql: "INSERT INTO t (id) VALUES ('a')")
+            try db.addColumnIfMissing(
+                table: "t",
+                column: "flag",
+                type: .boolean,
+                defaults: false
+            )
+            // Existing row should observe the default
+            let value = try Bool.fetchOne(db, sql: "SELECT flag FROM t WHERE id = 'a'")
+            #expect(value == false)
+            // Newly inserted row without specifying flag should also pick up default
+            try db.execute(sql: "INSERT INTO t (id) VALUES ('b')")
+            let value2 = try Bool.fetchOne(db, sql: "SELECT flag FROM t WHERE id = 'b'")
+            #expect(value2 == false)
+        }
+    }
+
+    // MARK: createTableIfNotExists
+
+    @Test func createTableIfNotExistsCreatesWhenAbsent() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.createTableIfNotExists("widget") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("name", .text).notNull()
+            }
+            #expect(try db.tableExists("widget"))
+        }
+    }
+
+    @Test func createTableIfNotExistsIsNoOpWhenPresent() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: "CREATE TABLE widget (id TEXT PRIMARY KEY, name TEXT)")
+            // Different body should not throw; existing table wins.
+            try db.createTableIfNotExists("widget") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("other", .text)
+            }
+            // Verify table still has the original shape (no 'other' column).
+            let cols = try Row.fetchAll(db, sql: "PRAGMA table_info(widget)")
+                .compactMap { $0["name"] as String? }
+            #expect(cols.contains("name"))
+            #expect(!cols.contains("other"))
+        }
+    }
+
+    // MARK: addIndexIfMissing
+
+    @Test func addIndexIfMissingCreatesWhenAbsent() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: "CREATE TABLE t (id TEXT PRIMARY KEY, slot TEXT)")
+            try db.addIndexIfMissing(
+                "idx_t_slot",
+                on: "t",
+                columns: ["slot"],
+                unique: true,
+                where: "slot IS NOT NULL"
+            )
+            let found = try Bool.fetchOne(
+                db,
+                sql: "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?",
+                arguments: ["idx_t_slot"]
+            )
+            #expect(found == true)
+        }
+    }
+
+    @Test func addIndexIfMissingIsNoOpWhenPresent() throws {
+        let queue = try DatabaseQueue()
+        try queue.write { db in
+            try db.execute(sql: "CREATE TABLE t (id TEXT PRIMARY KEY, slot TEXT)")
+            try db.execute(sql: "CREATE INDEX idx_t_slot ON t(slot)")
+            // Should be a no-op without raising "index already exists".
+            try db.addIndexIfMissing("idx_t_slot", on: "t", columns: ["slot"])
+            let count = try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?",
+                arguments: ["idx_t_slot"]
+            )
+            #expect(count == 1)
+        }
+    }
+
+    // MARK: Regression — branch renumbering collision
+
+    /// Reproduces the May 13 2026 outage: an additive migration is registered
+    /// once under `v_old_id` (using raw `t.add(column:)`), then re-registered
+    /// in a parallel branch under `v_new_id`. Without the helper, GRDB sees
+    /// the new ID as unapplied and re-runs the body — SQLite throws
+    /// `duplicate column name`. With the helper, the body becomes a logged
+    /// no-op.
+    @Test func renumberCollisionIsNoOpWithHelper() throws {
+        let queue = try DatabaseQueue()
+
+        // Pre-create the schema base shared by both migrators.
+        try queue.write { db in
+            try db.execute(sql: "CREATE TABLE worktree (id TEXT PRIMARY KEY)")
+        }
+
+        // Migrator A — original ID, raw add(column:)
+        var migratorA = DatabaseMigrator()
+        migratorA.registerMigration("v_old_id") { db in
+            try db.alter(table: "worktree") { t in
+                t.add(column: "archivedHeadSHA", .text)
+            }
+        }
+        try migratorA.migrate(queue)
+
+        // Migrator B — renumbered ID, same additive change via helper.
+        var migratorB = DatabaseMigrator()
+        migratorB.registerMigration("v_new_id") { db in
+            try db.addColumnIfMissing(
+                table: "worktree",
+                column: "archivedHeadSHA",
+                type: .text
+            )
+        }
+        // Should NOT throw "duplicate column name".
+        try migratorB.migrate(queue)
+
+        // Column should still exist exactly once.
+        try queue.read { db in
+            let cols = try Row.fetchAll(db, sql: "PRAGMA table_info(worktree)")
+                .compactMap { $0["name"] as String? }
+            #expect(cols.filter { $0.lowercased() == "archivedheadsha" }.count == 1)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/PreMigrationSnapshotTests.swift
+++ b/Tests/TBDDaemonTests/PreMigrationSnapshotTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+
+@Suite("Pre-migration snapshot")
+struct PreMigrationSnapshotTests {
+
+    @Test func snapshotWritesAFileWithTheSourceContents() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let dbPath = "\(tempDir)/state.db"
+        let pool = try DatabasePool(path: dbPath)
+        try pool.write { db in
+            try db.execute(sql: "CREATE TABLE marker (id INTEGER PRIMARY KEY, note TEXT)")
+            try db.execute(sql: "INSERT INTO marker (note) VALUES ('hello')")
+        }
+
+        let before = snapshotFiles(in: tempDir)
+        TBDDatabase.takePreMigrationSnapshot(pool: pool, path: dbPath)
+        let after = snapshotFiles(in: tempDir)
+
+        let newSnapshots = after.subtracting(before)
+        #expect(newSnapshots.count == 1, "Expected exactly one new snapshot file")
+
+        let snapshotPath = "\(tempDir)/\(newSnapshots.first!)"
+        let attrs = try FileManager.default.attributesOfItem(atPath: snapshotPath)
+        let size = (attrs[.size] as? NSNumber)?.intValue ?? 0
+        #expect(size > 0, "Snapshot file should not be empty")
+
+        // Open the snapshot and confirm the row round-trips — this is the proof
+        // that VACUUM INTO actually ran (not just `touch`ed a file).
+        let snapshotQueue = try DatabaseQueue(path: snapshotPath)
+        let note: String? = try snapshotQueue.read { db in
+            try String.fetchOne(db, sql: "SELECT note FROM marker WHERE id = 1")
+        }
+        #expect(note == "hello")
+    }
+
+    @Test func snapshotFilenameUsesUtcTimestampFormat() throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let dbPath = "\(tempDir)/state.db"
+        let pool = try DatabasePool(path: dbPath)
+        try pool.write { db in
+            try db.execute(sql: "CREATE TABLE t (id INTEGER PRIMARY KEY)")
+        }
+
+        TBDDatabase.takePreMigrationSnapshot(pool: pool, path: dbPath)
+        let snapshots = snapshotFiles(in: tempDir)
+        #expect(snapshots.count == 1)
+
+        let name = snapshots.first ?? ""
+        // Format: state.db.pre-migration.YYYYMMDD'T'HHMMSS'Z'
+        let pattern = #"^state\.db\.pre-migration\.\d{8}T\d{6}Z$"#
+        let match = name.range(of: pattern, options: .regularExpression) != nil
+        #expect(match, "Snapshot filename '\(name)' did not match expected timestamp format")
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> String {
+        let dir = NSTemporaryDirectory().appending("tbd-snapshot-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func snapshotFiles(in dir: String) -> Set<String> {
+        let entries = (try? FileManager.default.contentsOfDirectory(atPath: dir)) ?? []
+        return Set(entries.filter { $0.contains(".pre-migration.") })
+    }
+}


### PR DESCRIPTION
## Summary

- **What kept breaking.** Twice in the last two weeks (May 6 and May 13) the daemon crashed on startup with `SQLite error 1: duplicate column name`. Both times the schema change was already applied — only GRDB's bookkeeping was stale because two branches each registered the same additive migration under different string IDs (e.g. `v15_archived_head_sha` vs `v16_archived_head_sha`, `v22_worktree_parent` vs `v23_worktree_parent`). Each incident required manually running `INSERT INTO grdb_migrations (identifier) VALUES (...)` to unstick the daemon.
- **What this PR adds.** Three idempotent helpers on `GRDB.Database` (`addColumnIfMissing`, `createTableIfNotExists`, `addIndexIfMissing`) so future migration bodies become logged no-ops instead of fatal aborts when re-applied under a different ID. Plus a best-effort `VACUUM INTO` snapshot of `state.db` before any migration with pending work — a one-command rollback if a future migration goes sideways.
- **How we enforce it going forward.** A path-scoped `Sources/TBDDaemon/Database/CLAUDE.md` instructs future migrations to use the helpers and explains the snapshot. Existing migrations v1–v22 are intentionally left alone to preserve their applied-state semantics.

Out of scope (deferred after discussion): retrofitting v1–v22 (risk of altering applied-state), replacing the daemon's `Fatal` path with a degraded-mode RPC (separate change), and `dropColumnIfPresent` (no current need).

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter MigrationHelpers` — 9/9 pass (includes the May-13 reproducer: raw \`t.add(column:)\` under one ID, then \`addColumnIfMissing\` under a different ID against the same DB)
- [x] `swift test --filter Migration` — 35/35 pass (existing migration tests still green)
- [x] `swift test --filter Database` — 27/27 pass
- [x] \`scripts/restart.sh\` produces exactly one TBDDaemon + one TBDApp from this worktree
- [x] Clean startup, no snapshot written (no pending migrations) — correct steady-state behavior

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=340E2F8F-1A1E-4CF8-84BA-33437B39F724)