### PR TITLE
Fix: Unbreak `swift test` — leaked AppState subscription Tasks saturate the cooperative thread pool

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -301,11 +301,25 @@ final class AppState: ObservableObject {
         }
         startMemoryPressureMonitor()
         registerFocusObservers()
-        Task {
-            await connectAndLoadInitialState()
-            startPolling()
+        // Under `swift test`, the per-test `AppState()` instances would each
+        // spawn a subscription Task that blocks indefinitely in `recv()` on
+        // the daemon socket. With enough tests the Swift cooperative thread
+        // pool saturates and the test runner deadlocks. Production is
+        // unbundled (no .xctest in args), so this guard is a no-op there.
+        if !Self.isRunningUnderTests {
+            Task {
+                await connectAndLoadInitialState()
+                startPolling()
+            }
         }
     }
+
+    /// True when this process is a SwiftPM / XCTest test harness. Detected by
+    /// looking for a `.xctest` bundle path in the process arguments, which
+    /// both XCTest and Swift Testing (via `swiftpm-testing-helper`) pass.
+    private static let isRunningUnderTests: Bool = {
+        ProcessInfo.processInfo.arguments.contains { $0.contains(".xctest") }
+    }()
 
     // Note: AppState is singleton-lifetime in this app, so we deliberately
     // omit a deinit that removes the focus observers — Swift 6 concurrency

--- a/Tests/TBDAppTests/AppStateTestModeGuardTests.swift
+++ b/Tests/TBDAppTests/AppStateTestModeGuardTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Regression guard for the pre-existing bug where `AppState.init()`
+/// unconditionally spawned a daemon-subscription Task. Each per-test
+/// `AppState()` would leak a Task blocked in a synchronous `recv()`,
+/// saturating the Swift cooperative thread pool and deadlocking
+/// `swift test` once enough `AppState`s had been constructed.
+///
+/// The fix gates the auto-connect on whether the process is a test
+/// harness (presence of a `.xctest` argument). This test verifies the
+/// gate fires here: constructing many `AppState`s must not block, and
+/// `isConnected` must stay false because no connect Task ran.
+@MainActor
+@Suite("AppState test-mode guard")
+struct AppStateTestModeGuardTests {
+    @Test("init does not auto-connect when running under swift test")
+    func initSkipsAutoConnectInTests() async {
+        // If the guard regressed, each construction would spawn a Task
+        // blocked in recv() and this loop would eventually deadlock the
+        // cooperative thread pool. 32 is well above the typical pool
+        // size on Apple Silicon, so saturation would show up here.
+        var instances: [AppState] = []
+        for _ in 0..<32 {
+            instances.append(AppState())
+        }
+
+        // Give any (unwanted) connect Task a chance to run; with the
+        // guard in place there's nothing to wait for.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        for appState in instances {
+            #expect(appState.isConnected == false)
+            #expect(appState.isInitialStateLoaded == false)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`swift test` deadlocks mid-suite on `main` and has done for a while — anyone running the full unfiltered suite eventually hits it.

**What's broken.** `AppState.init()` unconditionally spawns a Task that calls `connectAndLoadInitialState()` → `startSubscription()`, which opens a Unix socket to the daemon and enters `while !Task.isCancelled { recv(fd, ...) }`. `recv()` is a synchronous syscall; it ignores Task cancellation and the test bodies never tear `AppState` down. So each per-test `AppState()` leaks a Task pinned to a cooperative-pool thread.

**Why it hangs.** All four test targets link into one xctest binary, and `AppState` gets constructed ~25 times across `DeepLinkHandlerTests`, `TabReorderTests`, `RepoExpandedAppStateTests`, etc. Once enough leaked Tasks have parked in `recv()`, the Swift Concurrency cooperative thread pool saturates and the runner can't schedule any further tests. A `sample(1)` of the hung `swiftpm-testing-helper` showed 12 threads stuck in `__recvfrom` under `DaemonClient.subscribe(onDelta:)` at `AppState.swift:387`.

**The fix.** Gate the connect/poll Task on a `.xctest`-in-args check so production behaviour is unchanged but tests don't open the socket. Discovered while reviewing the Conductor rip-out (#147) — bug is unrelated to that change and pre-dates it, so this lands standalone.

## Test plan
- [x] `swift build` clean on origin/main + this fix
- [x] `swift test` — 774 tests in 79 suites pass in ~3s (previously hung indefinitely after ~80 visible test completions)
- [x] New `AppStateTestModeGuardTests.initSkipsAutoConnectInTests` regression test: constructs 32 `AppState`s and asserts none auto-connect, so a future regression to the gate would surface here instead of as a mystery deadlock
- [ ] After merge, sanity-check that the production app still connects to the daemon on launch (the gate keys off `.xctest` in process args, which production never has)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=BADD5377-0038-4769-AD59-F80D090DA469)