### PR TITLE
DX: Sample main-thread stack on every detected hang -- fills the gap when macOS doesn't spindump

### DIFF
--- a/Sources/TBDApp/Diagnostics/HangStackWriter.swift
+++ b/Sources/TBDApp/Diagnostics/HangStackWriter.swift
@@ -38,8 +38,8 @@ final class HangStackWriter: @unchecked Sendable {
     /// Begin a new hang file with the initial sample.
     /// Returns the URL written, or nil on failure.
     func recordHangStart(stallMs: UInt64, snapshot: HangWatchdogSnapshot, frames: [MainThreadSampler.Frame]) -> URL? {
-        // Close any previous hang file.
-        recordHangRecovery(totalStallMs: 0)
+        // Close any previous hang file with a superseded marker.
+        recordHangSuperseded()
 
         // Create the hang-stacks directory if needed.
         do {
@@ -147,6 +147,41 @@ final class HangStackWriter: @unchecked Sendable {
                 try fileHandle.close()
             } catch {
                 Self.logger.error("Failed to close hang file: \(error.localizedDescription, privacy: .public)")
+            }
+
+            currentFileHandle = nil
+            currentHangFileURL = nil
+        }
+    }
+
+    /// Close the current hang file with a superseded marker. Used when a new hang is detected
+    /// while a previous hang file is still open. Idempotent.
+    private func recordHangSuperseded() {
+        lock.withLock {
+            guard let fileHandle = currentFileHandle,
+                  currentHangFileURL != nil else {
+                return
+            }
+
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withYear, .withMonth, .withDay, .withTime, .withColonSeparatorInTime]
+            let timestamp = formatter.string(from: Date())
+
+            let content = "\n=== Hang file superseded by new hang at \(timestamp) ===\n"
+
+            if let data = content.data(using: .utf8) {
+                do {
+                    try fileHandle.seekToEnd()
+                    try fileHandle.write(contentsOf: data)
+                } catch {
+                    Self.logger.error("Failed to write superseded marker: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+
+            do {
+                try fileHandle.close()
+            } catch {
+                Self.logger.error("Failed to close superseded hang file: \(error.localizedDescription, privacy: .public)")
             }
 
             currentFileHandle = nil

--- a/Sources/TBDApp/Diagnostics/HangStackWriter.swift
+++ b/Sources/TBDApp/Diagnostics/HangStackWriter.swift
@@ -1,0 +1,156 @@
+import Foundation
+import os
+
+/// Persists stack samples from hang events to disk in `~/Library/Logs/TBD/hang-stacks/`.
+/// One file per hang event. Supports appending resamples during sustained hangs.
+final class HangStackWriter: @unchecked Sendable {
+    static let shared = HangStackWriter()
+
+    private static let logger = Logger(subsystem: "com.tbd.app", category: "hang-stack-writer")
+
+    /// Directory where hang stack files are written.
+    private let baseDir: URL
+
+    /// URL of the currently open hang file, if any.
+    private var currentHangFileURL: URL?
+
+    /// Handle to the current hang file for appending.
+    private var currentFileHandle: FileHandle?
+
+    /// Lock protecting the file handle and URL.
+    private let lock = OSAllocatedUnfairLock<()>(initialState: ())
+
+    init(baseDir: URL? = nil) {
+        if let baseDir = baseDir {
+            self.baseDir = baseDir
+        } else {
+            // Default: ~/Library/Logs/TBD/hang-stacks/
+            let libraryURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
+                ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library")
+            self.baseDir = libraryURL.appendingPathComponent("Logs/TBD/hang-stacks")
+        }
+    }
+
+    deinit {
+        try? currentFileHandle?.close()
+    }
+
+    /// Begin a new hang file with the initial sample.
+    /// Returns the URL written, or nil on failure.
+    func recordHangStart(stallMs: UInt64, snapshot: HangWatchdogSnapshot, frames: [MainThreadSampler.Frame]) -> URL? {
+        // Close any previous hang file.
+        recordHangRecovery(totalStallMs: 0)
+
+        // Create the hang-stacks directory if needed.
+        do {
+            try FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+        } catch {
+            Self.logger.error("Failed to create hang-stacks directory: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+
+        // Generate filename: hang-<yyyy-MM-dd-HHmmss>-<pid>.txt
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withYear, .withMonth, .withDay, .withTime, .withColonSeparatorInTime, .withTimeZone]
+        let timestamp = formatter.string(from: Date())
+        // Extract just the date and time portion without timezone.
+        let dateTimeOnly = timestamp.split(separator: "T").joined(separator: "-")
+            .replacingOccurrences(of: ":", with: "")
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let filename = "hang-\(dateTimeOnly)-\(pid).txt"
+
+        let fileURL = baseDir.appendingPathComponent(filename)
+
+        // Write the header.
+        var content = ""
+        content += "=== TBD Hang Stack Sample ===\n"
+        content += "Timestamp: \(Date())\n"
+        content += "PID: \(pid)\n"
+        content += "Stall duration: \(stallMs) ms\n"
+        content += "\nApp Context:\n"
+        content += "  Focused terminal: \(snapshot.focusedTerminalIDShort ?? "-")\n"
+        content += "  Pane: \(snapshot.paneLabel ?? "-")\n"
+        content += "  Item count: \(snapshot.transcriptItemCount ?? -1)\n"
+        content += "\nMain Thread Stack:\n"
+        content += MainThreadSampler.format(frames)
+        content += "\n\n"
+
+        do {
+            if let data = content.data(using: .utf8) {
+                try data.write(to: fileURL, options: [.atomic])
+            }
+
+            return lock.withLock { () in
+                do {
+                    currentHangFileURL = fileURL
+                    currentFileHandle = try FileHandle(forWritingTo: fileURL)
+                    Self.logger.info("Recorded hang start to \(fileURL.lastPathComponent, privacy: .public)")
+                    return fileURL
+                } catch {
+                    Self.logger.error("Failed to open hang file for writing: \(error.localizedDescription, privacy: .public)")
+                    return nil
+                }
+            }
+        } catch {
+            Self.logger.error("Failed to write hang stack: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    /// Append a resample to the current open hang file. No-op if no current file.
+    func recordResample(elapsedMs: UInt64, frames: [MainThreadSampler.Frame]) {
+        lock.withLock {
+            guard let fileHandle = currentFileHandle else {
+                return
+            }
+
+            var content = ""
+            content += "\n--- Resample at +\(elapsedMs) ms ---\n"
+            content += MainThreadSampler.format(frames)
+            content += "\n"
+
+            if let data = content.data(using: .utf8) {
+                do {
+                    try fileHandle.seekToEnd()
+                    try fileHandle.write(contentsOf: data)
+                } catch {
+                    Self.logger.error("Failed to append resample: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+        }
+    }
+
+    /// Close the current hang file with a recovery line. Idempotent.
+    func recordHangRecovery(totalStallMs: UInt64) {
+        lock.withLock {
+            guard let fileHandle = currentFileHandle,
+                  currentHangFileURL != nil else {
+                return
+            }
+
+            var content = ""
+            if totalStallMs > 0 {
+                content += "\n=== Hang recovered ===\n"
+                content += "Total stall duration: \(totalStallMs) ms\n"
+            }
+
+            if let data = content.data(using: .utf8) {
+                do {
+                    try fileHandle.seekToEnd()
+                    try fileHandle.write(contentsOf: data)
+                } catch {
+                    Self.logger.error("Failed to write recovery marker: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+
+            do {
+                try fileHandle.close()
+            } catch {
+                Self.logger.error("Failed to close hang file: \(error.localizedDescription, privacy: .public)")
+            }
+
+            currentFileHandle = nil
+            currentHangFileURL = nil
+        }
+    }
+}

--- a/Sources/TBDApp/Diagnostics/HangStackWriter.swift
+++ b/Sources/TBDApp/Diagnostics/HangStackWriter.swift
@@ -164,7 +164,7 @@ final class HangStackWriter: @unchecked Sendable {
             }
 
             let formatter = ISO8601DateFormatter()
-            formatter.formatOptions = [.withYear, .withMonth, .withDay, .withTime, .withColonSeparatorInTime]
+            formatter.formatOptions = [.withYear, .withMonth, .withDay, .withTime, .withColonSeparatorInTime, .withTimeZone]
             let timestamp = formatter.string(from: Date())
 
             let content = "\n=== Hang file superseded by new hang at \(timestamp) ===\n"

--- a/Sources/TBDApp/Diagnostics/HangWatchdog.swift
+++ b/Sources/TBDApp/Diagnostics/HangWatchdog.swift
@@ -111,6 +111,10 @@ final class HangWatchdog: @unchecked Sendable {
     /// stall duration on recovery.
     private var hangStartedAtMach: UInt64 = 0
 
+    /// Mach timestamp of the last resample during a sustained hang.
+    /// Used to throttle resampling to every ~5 seconds.
+    private var lastResampleAtMach: UInt64 = 0
+
     private let thresholdMs: UInt64
     private var timer: DispatchSourceTimer?
     private let queue = DispatchQueue(label: "com.tbd.app.hang-watchdog", qos: .utility)
@@ -162,6 +166,7 @@ final class HangWatchdog: @unchecked Sendable {
             // match the .toHealthy edge in evaluate()).
             wasHung = false
             hangStartedAtMach = 0
+            lastResampleAtMach = 0
         }
     }
 
@@ -203,20 +208,43 @@ final class HangWatchdog: @unchecked Sendable {
 
         switch action {
         case .noop:
-            break
+            // During a sustained hang, resample every ~5 seconds.
+            if wasHung {
+                let resampleIntervalNs: UInt64 = 5_000_000_000  // 5 seconds
+                let timeSinceLastResampleNs = Self.machDeltaToNanos(now: now, then: lastResampleAtMach)
+                if timeSinceLastResampleNs >= resampleIntervalNs {
+                    lastResampleAtMach = now
+                    let frames = MainThreadSampler.sample()
+                    let elapsedNs = Self.machDeltaToNanos(now: now, then: hangStartedAtMach)
+                    let elapsedMs = elapsedNs / 1_000_000
+                    HangStackWriter.shared.recordResample(elapsedMs: elapsedMs, frames: frames)
+                }
+            }
         case .log(.toHung):
             wasHung = true
             hangStartedAtMach = lastTick
+            lastResampleAtMach = lastTick
             let stallMs = stallNs / 1_000_000
             let snap = snapshotLock.withLock { $0 }
-            Self.logger.warning(
-                "hang detected stallMs=\(stallMs, privacy: .public) terminalID=\(snap.focusedTerminalIDShort ?? "-", privacy: .public) itemCount=\(snap.transcriptItemCount ?? -1, privacy: .public) pane=\(snap.paneLabel ?? "-", privacy: .public)"
-            )
+
+            // Sample the main thread stack and write to disk.
+            let frames = MainThreadSampler.sample()
+            if let fileURL = HangStackWriter.shared.recordHangStart(stallMs: stallMs, snapshot: snap, frames: frames) {
+                Self.logger.warning(
+                    "hang detected stallMs=\(stallMs, privacy: .public) terminalID=\(snap.focusedTerminalIDShort ?? "-", privacy: .public) itemCount=\(snap.transcriptItemCount ?? -1, privacy: .public) pane=\(snap.paneLabel ?? "-", privacy: .public) stackFile=\(fileURL.lastPathComponent, privacy: .public)"
+                )
+            } else {
+                Self.logger.warning(
+                    "hang detected stallMs=\(stallMs, privacy: .public) terminalID=\(snap.focusedTerminalIDShort ?? "-", privacy: .public) itemCount=\(snap.transcriptItemCount ?? -1, privacy: .public) pane=\(snap.paneLabel ?? "-", privacy: .public)"
+                )
+            }
         case .log(.toHealthy):
             let totalStallNs = Self.machDeltaToNanos(now: now, then: hangStartedAtMach)
             let totalStallMs = totalStallNs / 1_000_000
             wasHung = false
             hangStartedAtMach = 0
+            lastResampleAtMach = 0
+            HangStackWriter.shared.recordHangRecovery(totalStallMs: totalStallMs)
             Self.logger.info("hang recovered after stallMs=\(totalStallMs, privacy: .public)")
         }
 

--- a/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
+++ b/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
@@ -88,14 +88,11 @@ enum MainThreadSampler {
         let pc = UInt(state.__pc)          // actual stuck instruction
         let lr = UInt(state.__lr)          // return address in caller
 
-        // Seed with both PCs; walkFramePointers will start with lr and the natural
-        // frame chain walk may naturally deduplicate the pc-lr pair on the first step.
+        // Start with the stuck instruction (pc). The frame pointer chain walk starting
+        // from lr will prepend it as the first frame, so no manual append needed.
         var pcs: [UInt] = []
         if pc != 0 {
             pcs.append(pc)
-        }
-        if lr != 0 && lr != pc {
-            pcs.append(lr)
         }
 
         // Continue with the frame pointer chain walk starting from lr.

--- a/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
+++ b/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
@@ -84,7 +84,7 @@ enum MainThreadSampler {
         let initialPC = UInt(state.__lr)
 
         // Walk the frame pointer chain and collect frames.
-        let pcs = walkFramePointers(initialFP: initialFP, initialPC: initialPC)
+        let pcs = walkLiveStack(initialFP: initialFP, initialPC: initialPC)
         return pcs.map { symbolize($0) }
         #else
         // Non-arm64 architectures: return empty (TBD only runs on arm64).
@@ -153,13 +153,19 @@ enum MainThreadSampler {
         }
     }
 
-    /// Walk the frame pointer chain starting from the given FP and PC.
-    /// On ARM64, each frame is [FP, LR] at [FP+0, FP+8].
+    /// Pure frame-pointer walk logic, testable with synthetic memory.
+    /// Walks the frame pointer chain starting from initialFP and initialPC,
+    /// collecting instruction pointers. The readWord closure provides memory reads.
+    /// On ARM64, each frame is [FP, LR] at [fp+0, fp+8].
     /// Returns a list of instruction pointers (one per frame).
-    private static func walkFramePointers(initialFP: UInt, initialPC: UInt) -> [UInt] {
+    static func walkFramePointers(
+        initialFP: UInt,
+        initialPC: UInt,
+        maxFrames: Int = 200,
+        readWord: (UInt) -> UInt?
+    ) -> [UInt] {
         var pcs: [UInt] = []
         var fp = initialFP
-        let maxFrames = 200
 
         // First PC is the initial LR.
         if initialPC != 0 {
@@ -178,9 +184,9 @@ enum MainThreadSampler {
             }
 
             // Read [FP, LR] from the frame pointer chain.
-            // FP at [FP+0], LR at [FP+8] on ARM64.
-            guard let nextFP = readUInt64(from: fp),
-                  let lr = readUInt64(from: fp + 8) else {
+            // FP at [fp+0], LR at [fp+8] on ARM64.
+            guard let nextFP = readWord(fp),
+                  let lr = readWord(fp + 8) else {
                 break
             }
 
@@ -193,6 +199,14 @@ enum MainThreadSampler {
         }
 
         return pcs
+    }
+
+    /// Production frame-pointer walk using direct memory reads.
+    /// Wraps walkFramePointers with a closure that reads from the live process memory.
+    private static func walkLiveStack(initialFP: UInt, initialPC: UInt) -> [UInt] {
+        walkFramePointers(initialFP: initialFP, initialPC: initialPC, maxFrames: 200) { address in
+            readUInt64(from: address)
+        }
     }
 
     /// Read a 64-bit unsigned integer from the given address.

--- a/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
+++ b/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
@@ -37,6 +37,7 @@ enum MainThreadSampler {
 
     /// Captured port for the main thread. Stored as a `nonisolated` static to avoid
     /// needing @MainActor everywhere (the lock handles synchronization).
+    /// The send right is intentionally held for process lifetime; not deallocated.
     nonisolated(unsafe) private static var mainThreadPort: OSAllocatedUnfairLock<mach_port_t> =
         OSAllocatedUnfairLock(initialState: 0)
 
@@ -62,17 +63,14 @@ enum MainThreadSampler {
         }
 
         // Get the thread's register state.
-        // Allocate the state structure separately to ensure proper alignment.
-        var stateCount = UInt32(ARM_THREAD_STATE64_COUNT)
-        var state = [natural_t](repeating: 0, count: Int(stateCount))
+        // Use the typed arm_thread_state64_t struct directly for correct size and field access.
+        var state = arm_thread_state64_t()
+        var count = mach_msg_type_number_t(MemoryLayout<arm_thread_state64_t>.size / MemoryLayout<natural_t>.size)
 
-        let krStatus = state.withUnsafeMutableBufferPointer { buffer in
-            thread_get_state(
-                port,
-                ARM_THREAD_STATE64,
-                buffer.baseAddress!,
-                &stateCount
-            )
+        let krStatus = withUnsafeMutablePointer(to: &state) { ptr -> kern_return_t in
+            ptr.withMemoryRebound(to: natural_t.self, capacity: Int(count)) { buf in
+                thread_get_state(port, ARM_THREAD_STATE64, buf, &count)
+            }
         }
 
         guard krStatus == KERN_SUCCESS else {
@@ -80,18 +78,10 @@ enum MainThreadSampler {
             return []
         }
 
-        // Extract FP and LR from the thread state.
-        // In arm_thread_state64_t, __fp is at offset 0 and __lr is at offset 8.
-        // We've read the state as natural_t array; convert back carefully.
-        guard state.count >= 2 else {
-            return []
-        }
-
-        // Reconstruct FP and LR from the state array.
-        // FP is x29, LR is x30 in the ARM64 ABI.
-        // In the state array, they're at fixed offsets.
-        let initialFP = UInt(state[29])  // x29 is frame pointer
-        let initialPC = UInt(state[30])  // x30 is link register
+        // Extract FP and LR from the thread state struct.
+        // The arm_thread_state64_t struct has __fp (x29) and __lr (x30) fields.
+        let initialFP = UInt(state.__fp)
+        let initialPC = UInt(state.__lr)
 
         // Walk the frame pointer chain and collect frames.
         let pcs = walkFramePointers(initialFP: initialFP, initialPC: initialPC)
@@ -123,13 +113,45 @@ enum MainThreadSampler {
                 offsetPart = ""
             }
 
-            return String(format: "%2d  0x%016x  %s%s", index, frame.address, symbolPart, offsetPart)
+            return String(format: "%2d  0x%016x  %@%@", index, frame.address, symbolPart as NSString, offsetPart as NSString)
         }
 
         return lines.joined(separator: "\n")
     }
 
     // MARK: - Private helpers
+
+    // Cache the swift_demangle function to avoid repeated dlopen/dlsym on every symbol.
+    private typealias SwiftDemangleFunc = @convention(c) (
+        UnsafePointer<CChar>?, Int,
+        UnsafeMutablePointer<CChar>?, UnsafeMutablePointer<Int>?,
+        UInt32
+    ) -> UnsafeMutablePointer<CChar>?
+
+    nonisolated(unsafe) private static var demangleFn: SwiftDemangleFunc?
+    private static let demangleLock = OSAllocatedUnfairLock<()>(initialState: ())
+
+    /// Load swift_demangle function (lazily, on first call).
+    private static func getDemangleFn() -> SwiftDemangleFunc? {
+        demangleLock.withLock {
+            // Return cached value if already loaded.
+            if demangleFn != nil {
+                return demangleFn
+            }
+
+            guard let h = dlopen("/usr/lib/swift/libswiftDemangle.dylib", RTLD_LAZY) else {
+                return nil
+            }
+            guard let sym = dlsym(h, "swift_demangle") else {
+                return nil
+            }
+            // Cast the symbol address to the function type.
+            // Note: We intentionally do NOT dlclose(h) — keep the handle open for process lifetime.
+            let fn = unsafeBitCast(sym, to: SwiftDemangleFunc.self)
+            demangleFn = fn
+            return fn
+        }
+    }
 
     /// Walk the frame pointer chain starting from the given FP and PC.
     /// On ARM64, each frame is [FP, LR] at [FP+0, FP+8].
@@ -216,43 +238,19 @@ enum MainThreadSampler {
     /// Demangle a Swift symbol name. Returns the original name if demangling fails
     /// or if libswiftDemangle is unavailable.
     private static func demangle(_ symbol: String) -> String? {
-        // Try to dlopen libswiftDemangle and call swift_demangle.
-        guard let handle = dlopen("/usr/lib/swift/libswiftDemangle.dylib", RTLD_LAZY) else {
-            return nil
+        guard let fn = getDemangleFn() else { return nil }
+
+        // Call swift_demangle with the C string pointer valid only inside the closure.
+        // The demangled result is allocated by the C function and must be freed.
+        return symbol.withCString { cStr -> String? in
+            guard let result = fn(cStr, symbol.utf8.count, nil, nil, 0) else { return nil }
+            defer { free(result) }
+            return String(cString: result)
         }
-        defer { dlclose(handle) }
-
-        // Look up swift_demangle function.
-        // Signature: char *swift_demangle(const char *mangledName, size_t mangledNameLength,
-        //                                   char *outputBuffer, size_t *outputBufferSize,
-        //                                   uint32_t options);
-        typealias SwiftDemangleFunc = @convention(c) (
-            UnsafePointer<CChar>,         // mangled name
-            Int,                          // length
-            UnsafeMutablePointer<CChar>?, // output buffer
-            UnsafeMutablePointer<Int>?,   // output buffer size
-            UInt32                        // options
-        ) -> UnsafeMutablePointer<CChar>?
-
-        guard let symAddr = dlsym(handle, "swift_demangle") else {
-            return nil
-        }
-
-        let demangleFn = unsafeBitCast(symAddr, to: SwiftDemangleFunc.self)
-
-        // Call swift_demangle with no output buffer (it allocates).
-        let mangledCStr = symbol.withCString { $0 }
-        guard let demangled = demangleFn(mangledCStr, symbol.count, nil, nil, 0) else {
-            return nil
-        }
-
-        defer { free(demangled) }
-        return String(cString: demangled)
     }
 }
 
 #if arch(arm64)
-// ARM64 thread state type and count.
+// ARM64 thread state type.
 private let ARM_THREAD_STATE64: thread_state_flavor_t = 6
-private let ARM_THREAD_STATE64_COUNT: UInt32 = 34
 #endif

--- a/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
+++ b/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
@@ -171,9 +171,9 @@ enum MainThreadSampler {
         while pcs.count < maxFrames && fp != 0 && (fp & 0x7) == 0 {
             // Sanity checks:
             // 1. FP must be strictly increasing (prevent loops)
-            // 2. FP must be reasonable distance from previous (prevent huge jumps)
+            // 2. FP must be reasonable distance from previous (prevent huge jumps, skip on first iteration)
             // 3. FP should not be in extreme ranges (kernel space)
-            guard fp > prevFP && (fp - prevFP) < 65536 && fp < (1 << 50) else {
+            guard fp > prevFP && (prevFP == 0 || (fp - prevFP) < 65536) && fp < (1 << 50) else {
                 break
             }
 

--- a/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
+++ b/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
@@ -43,9 +43,10 @@ enum MainThreadSampler {
 
     // MARK: - Public API
 
-    /// Capture the main thread port. Must be called exactly once on the main thread,
+    /// Capture the main thread port. Must be called on the main thread,
     /// ideally during application startup (from `applicationWillFinishLaunching`).
-    /// Safe to call multiple times — only the first call does anything.
+    /// Safe to call multiple times — subsequent calls are idempotent because
+    /// `mach_thread_self()` returns the same value.
     @MainActor
     static func captureMainThread() {
         let port = mach_thread_self()
@@ -54,7 +55,9 @@ enum MainThreadSampler {
     }
 
     /// Sample the main thread's call stack. Safe to call from any thread.
-    /// Returns an empty array if the main thread port was never captured or on non-arm64 architectures.
+    /// Captures state.__pc (actual stuck instruction) as the first frame, followed by
+    /// the frame pointer chain. Returns an empty array if the main thread port was never
+    /// captured or on non-arm64 architectures.
     static func sample() -> [Frame] {
         #if arch(arm64)
         let port = mainThreadPort.withLock { $0 }
@@ -78,13 +81,27 @@ enum MainThreadSampler {
             return []
         }
 
-        // Extract FP and LR from the thread state struct.
-        // The arm_thread_state64_t struct has __fp (x29) and __lr (x30) fields.
+        // Extract registers from the thread state struct.
+        // The arm_thread_state64_t struct has __pc (program counter), __lr (link register),
+        // and __fp (frame pointer, x29) fields.
         let initialFP = UInt(state.__fp)
-        let initialPC = UInt(state.__lr)
+        let pc = UInt(state.__pc)          // actual stuck instruction
+        let lr = UInt(state.__lr)          // return address in caller
 
-        // Walk the frame pointer chain and collect frames.
-        let pcs = walkLiveStack(initialFP: initialFP, initialPC: initialPC)
+        // Seed with both PCs; walkFramePointers will start with lr and the natural
+        // frame chain walk may naturally deduplicate the pc-lr pair on the first step.
+        var pcs: [UInt] = []
+        if pc != 0 {
+            pcs.append(pc)
+        }
+        if lr != 0 && lr != pc {
+            pcs.append(lr)
+        }
+
+        // Continue with the frame pointer chain walk starting from lr.
+        let chainPCs = walkLiveStack(initialFP: initialFP, initialPC: lr)
+        pcs.append(contentsOf: chainPCs)
+
         return pcs.map { symbolize($0) }
         #else
         // Non-arm64 architectures: return empty (TBD only runs on arm64).

--- a/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
+++ b/Sources/TBDApp/Diagnostics/MainThreadSampler.swift
@@ -1,0 +1,258 @@
+import Foundation
+import Darwin
+import os
+
+// MARK: - Frame type
+
+extension MainThreadSampler {
+    /// A single stack frame with symbol information.
+    struct Frame: Equatable {
+        /// Address of the instruction pointer.
+        let address: UInt
+
+        /// Resolved symbol name (may be mangled Swift or C symbol). nil if unresolved.
+        let symbol: String?
+
+        /// Last path component of the module name (e.g., "TBDApp"). nil if unresolved.
+        let module: String?
+
+        /// Offset from the symbol base address. nil if unresolved.
+        let offset: UInt?
+    }
+}
+
+// MARK: - MainThreadSampler
+
+/// Captures the main thread's port at startup and provides sampling of its call stack
+/// from any thread. Used by HangWatchdog to collect stacks when a hang is detected.
+///
+/// Architecture:
+/// 1. `captureMainThread()` is called once on the main thread at app startup.
+///    It captures `mach_thread_self()` and stores it in a lock.
+/// 2. `sample()` can be called from any thread and returns a formatted list of frames
+///    from the main thread's stack. Returns empty if no port was captured.
+/// 3. `format()` converts frames to a human-readable multi-line string.
+enum MainThreadSampler {
+    private static let logger = Logger(subsystem: "com.tbd.app", category: "hang-sampler")
+
+    /// Captured port for the main thread. Stored as a `nonisolated` static to avoid
+    /// needing @MainActor everywhere (the lock handles synchronization).
+    nonisolated(unsafe) private static var mainThreadPort: OSAllocatedUnfairLock<mach_port_t> =
+        OSAllocatedUnfairLock(initialState: 0)
+
+    // MARK: - Public API
+
+    /// Capture the main thread port. Must be called exactly once on the main thread,
+    /// ideally during application startup (from `applicationWillFinishLaunching`).
+    /// Safe to call multiple times — only the first call does anything.
+    @MainActor
+    static func captureMainThread() {
+        let port = mach_thread_self()
+        mainThreadPort.withLock { $0 = port }
+        logger.debug("Captured main thread port")
+    }
+
+    /// Sample the main thread's call stack. Safe to call from any thread.
+    /// Returns an empty array if the main thread port was never captured or on non-arm64 architectures.
+    static func sample() -> [Frame] {
+        #if arch(arm64)
+        let port = mainThreadPort.withLock { $0 }
+        guard port != 0 else {
+            return []
+        }
+
+        // Get the thread's register state.
+        // Allocate the state structure separately to ensure proper alignment.
+        var stateCount = UInt32(ARM_THREAD_STATE64_COUNT)
+        var state = [natural_t](repeating: 0, count: Int(stateCount))
+
+        let krStatus = state.withUnsafeMutableBufferPointer { buffer in
+            thread_get_state(
+                port,
+                ARM_THREAD_STATE64,
+                buffer.baseAddress!,
+                &stateCount
+            )
+        }
+
+        guard krStatus == KERN_SUCCESS else {
+            logger.debug("Failed to get thread state: kern_return=\(krStatus, privacy: .public)")
+            return []
+        }
+
+        // Extract FP and LR from the thread state.
+        // In arm_thread_state64_t, __fp is at offset 0 and __lr is at offset 8.
+        // We've read the state as natural_t array; convert back carefully.
+        guard state.count >= 2 else {
+            return []
+        }
+
+        // Reconstruct FP and LR from the state array.
+        // FP is x29, LR is x30 in the ARM64 ABI.
+        // In the state array, they're at fixed offsets.
+        let initialFP = UInt(state[29])  // x29 is frame pointer
+        let initialPC = UInt(state[30])  // x30 is link register
+
+        // Walk the frame pointer chain and collect frames.
+        let pcs = walkFramePointers(initialFP: initialFP, initialPC: initialPC)
+        return pcs.map { symbolize($0) }
+        #else
+        // Non-arm64 architectures: return empty (TBD only runs on arm64).
+        return []
+        #endif
+    }
+
+    /// Format a list of frames as a human-readable multi-line string suitable for logging.
+    static func format(_ frames: [Frame]) -> String {
+        let lines = frames.enumerated().map { index, frame in
+            let symbolPart: String
+            if let symbol = frame.symbol, let module = frame.module {
+                let demangled = demangle(symbol) ?? symbol
+                symbolPart = "\(module)`\(demangled)"
+            } else if let symbol = frame.symbol {
+                let demangled = demangle(symbol) ?? symbol
+                symbolPart = demangled
+            } else {
+                symbolPart = String(format: "0x%x", frame.address)
+            }
+
+            let offsetPart: String
+            if let offset = frame.offset {
+                offsetPart = " + \(offset)"
+            } else {
+                offsetPart = ""
+            }
+
+            return String(format: "%2d  0x%016x  %s%s", index, frame.address, symbolPart, offsetPart)
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Private helpers
+
+    /// Walk the frame pointer chain starting from the given FP and PC.
+    /// On ARM64, each frame is [FP, LR] at [FP+0, FP+8].
+    /// Returns a list of instruction pointers (one per frame).
+    private static func walkFramePointers(initialFP: UInt, initialPC: UInt) -> [UInt] {
+        var pcs: [UInt] = []
+        var fp = initialFP
+        let maxFrames = 200
+
+        // First PC is the initial LR.
+        if initialPC != 0 {
+            pcs.append(initialPC)
+        }
+
+        // Walk the chain with strict sanity checks to prevent reading invalid memory.
+        var prevFP: UInt = 0
+        while pcs.count < maxFrames && fp != 0 && (fp & 0x7) == 0 {
+            // Sanity checks:
+            // 1. FP must be strictly increasing (prevent loops)
+            // 2. FP must be reasonable distance from previous (prevent huge jumps)
+            // 3. FP should not be in extreme ranges (kernel space)
+            guard fp > prevFP && (fp - prevFP) < 65536 && fp < (1 << 50) else {
+                break
+            }
+
+            // Read [FP, LR] from the frame pointer chain.
+            // FP at [FP+0], LR at [FP+8] on ARM64.
+            guard let nextFP = readUInt64(from: fp),
+                  let lr = readUInt64(from: fp + 8) else {
+                break
+            }
+
+            if lr != 0 {
+                pcs.append(lr)
+            }
+
+            prevFP = fp
+            fp = nextFP
+        }
+
+        return pcs
+    }
+
+    /// Read a 64-bit unsigned integer from the given address.
+    /// Returns nil to indicate read failure. Note: this may still crash on
+    /// invalid addresses without proper signal handlers, which is a limitation
+    /// of in-process sampling on macOS without ptrace.
+    private static func readUInt64(from address: UInt) -> UInt? {
+        guard address != 0 else { return nil }
+
+        let ptr = UnsafeRawPointer(bitPattern: address)
+        guard let ptr = ptr else { return nil }
+
+        // Attempt to read. This may crash if the address is unmapped.
+        // A full solution would use signal handlers or ptrace, but for now
+        // we rely on the sanity checks in walkFramePointers to prevent bad reads.
+        let value = ptr.assumingMemoryBound(to: UInt64.self).pointee
+        return UInt(value)
+    }
+
+    /// Symbolize a single address using dladdr and optionally demangle.
+    private static func symbolize(_ address: UInt) -> Frame {
+        var info = Dl_info()
+        let found = dladdr(UnsafeMutableRawPointer(bitPattern: address), &info)
+
+        guard found != 0, let dli_sname = info.dli_sname else {
+            return Frame(address: address, symbol: nil, module: nil, offset: nil)
+        }
+
+        let symbol = String(cString: dli_sname)
+        let module: String? = info.dli_fname.flatMap { fname in
+            let fpath = String(cString: fname)
+            return URL(fileURLWithPath: fpath).lastPathComponent
+        }
+
+        let offset: UInt? = info.dli_saddr.flatMap { baseAddr in
+            let base = UInt(bitPattern: baseAddr)
+            return address > base ? address - base : nil
+        }
+
+        return Frame(address: address, symbol: symbol, module: module, offset: offset)
+    }
+
+    /// Demangle a Swift symbol name. Returns the original name if demangling fails
+    /// or if libswiftDemangle is unavailable.
+    private static func demangle(_ symbol: String) -> String? {
+        // Try to dlopen libswiftDemangle and call swift_demangle.
+        guard let handle = dlopen("/usr/lib/swift/libswiftDemangle.dylib", RTLD_LAZY) else {
+            return nil
+        }
+        defer { dlclose(handle) }
+
+        // Look up swift_demangle function.
+        // Signature: char *swift_demangle(const char *mangledName, size_t mangledNameLength,
+        //                                   char *outputBuffer, size_t *outputBufferSize,
+        //                                   uint32_t options);
+        typealias SwiftDemangleFunc = @convention(c) (
+            UnsafePointer<CChar>,         // mangled name
+            Int,                          // length
+            UnsafeMutablePointer<CChar>?, // output buffer
+            UnsafeMutablePointer<Int>?,   // output buffer size
+            UInt32                        // options
+        ) -> UnsafeMutablePointer<CChar>?
+
+        guard let symAddr = dlsym(handle, "swift_demangle") else {
+            return nil
+        }
+
+        let demangleFn = unsafeBitCast(symAddr, to: SwiftDemangleFunc.self)
+
+        // Call swift_demangle with no output buffer (it allocates).
+        let mangledCStr = symbol.withCString { $0 }
+        guard let demangled = demangleFn(mangledCStr, symbol.count, nil, nil, 0) else {
+            return nil
+        }
+
+        defer { free(demangled) }
+        return String(cString: demangled)
+    }
+}
+
+#if arch(arm64)
+// ARM64 thread state type and count.
+private let ARM_THREAD_STATE64: thread_state_flavor_t = 6
+private let ARM_THREAD_STATE64_COUNT: UInt32 = 34
+#endif

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -197,6 +197,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             lifecycleLogger.info("Crash forensics writing to \(dir.path, privacy: .public)")
         }
+
+        // Capture the main thread port for hang stack sampling.
+        // Must be done on the main thread before any background activity.
+        MainThreadSampler.captureMainThread()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Tests/TBDAppTests/MainThreadSamplerTests.swift
+++ b/Tests/TBDAppTests/MainThreadSamplerTests.swift
@@ -14,7 +14,11 @@ struct MainThreadSamplerTests {
 
         // Sample should not crash and should return non-empty frames with symbols.
         let frames = MainThreadSampler.sample()
-        #expect(frames.count >= 2, "Sample should return multiple frames from frame pointer walk (loop executed)")
+        // `>= 1` is intentional. Runtime stack depth in the test harness varies between
+        // dev and CI; the deterministic walker tests below are what catch regressions
+        // in the FP-chain walk logic. This test is the integration check that
+        // sample() returns non-crashing output with at least the initial PC.
+        #expect(frames.count >= 1, "Sample should return at least the initial frame")
 
         // At least one frame should have a symbol (not all unresolved).
         let hasSymbol = frames.contains { $0.symbol != nil }
@@ -29,9 +33,13 @@ struct MainThreadSamplerTests {
         let frames2 = MainThreadSampler.sample()
         let frames3 = MainThreadSampler.sample()
 
-        #expect(frames1.count >= 2, "First sample should return multiple frames from frame pointer walk")
-        #expect(frames2.count >= 2, "Second sample should return multiple frames from frame pointer walk")
-        #expect(frames3.count >= 2, "Third sample should return multiple frames from frame pointer walk")
+        // `>= 1` is intentional. Runtime stack depth in the test harness varies between
+        // dev and CI; the deterministic walker tests below are what catch regressions
+        // in the FP-chain walk logic. This test is the integration check that
+        // sample() returns non-crashing output with at least the initial PC.
+        #expect(frames1.count >= 1, "First sample should return at least the initial frame")
+        #expect(frames2.count >= 1, "Second sample should return at least the initial frame")
+        #expect(frames3.count >= 1, "Third sample should return at least the initial frame")
 
         // All samples should contain resolved symbols.
         let allHaveSymbols = [frames1, frames2, frames3].allSatisfy { frames in
@@ -39,6 +47,111 @@ struct MainThreadSamplerTests {
         }
         #expect(allHaveSymbols, "All samples should contain at least one resolved symbol")
     }
+
+    // MARK: - Deterministic walker tests (synthetic in-memory stacks)
+
+    @Test func walkerCapturesExpectedDepthFromSyntheticStack() {
+        // Build a synthetic frame-pointer chain:
+        // Frame 0 at addr 0x1000 → saved FP = 0x2000, saved LR = 0xAAA
+        // Frame 1 at addr 0x2000 → saved FP = 0x3000, saved LR = 0xBBB
+        // Frame 2 at addr 0x3000 → saved FP = 0,      saved LR = 0xCCC  (sentinel ends walk)
+        let memory: [UInt: UInt] = [
+            0x1000: 0x2000, 0x1008: 0xAAA,
+            0x2000: 0x3000, 0x2008: 0xBBB,
+            0x3000: 0x0000, 0x3008: 0xCCC,
+        ]
+        let pcs = MainThreadSampler.walkFramePointers(
+            initialFP: 0x1000,
+            initialPC: 0xFFF,   // initial PC always appears as frame[0]
+            maxFrames: 10,
+            readWord: { memory[$0] }
+        )
+        // Expect 4 frames: initialPC, plus saved LR of frames 0, 1, 2
+        #expect(pcs == [0xFFF, 0xAAA, 0xBBB, 0xCCC])
+    }
+
+    @Test func walkerEntersLoopOnFirstIterationWithLargeFP() {
+        // Real ARM64 FPs are ~6 GB. The fp - prevFP guard must not fire on the first iteration.
+        // This test verifies the specific bug that was previously reported:
+        // the loop body never executes if the first FP is large enough to fail (fp - prevFP) < 65536
+        // when prevFP starts at 0 — except the guard is `prevFP == 0 || (fp - prevFP) < 65536`,
+        // so the first iteration must enter because prevFP == 0.
+        let highFP: UInt = 0x16FFFE000   // ~6 GB
+        let memory: [UInt: UInt] = [
+            highFP: 0, highFP + 8: 0xDEAD,
+        ]
+        let pcs = MainThreadSampler.walkFramePointers(
+            initialFP: highFP,
+            initialPC: 0xBEEF,
+            maxFrames: 10,
+            readWord: { memory[$0] }
+        )
+        // Should capture initialPC and the saved LR from the first frame.
+        #expect(pcs == [0xBEEF, 0xDEAD])
+    }
+
+    @Test func walkerStopsAtMaxFrames() {
+        // Build a chain longer than maxFrames to verify the limit is enforced.
+        var memory: [UInt: UInt] = [:]
+        var fp: UInt = 0x1000
+        memory[0x1000] = 0x2000
+        memory[0x1008] = 0xAAA
+        for i in 1..<10 {
+            let nextFP = 0x1000 + UInt(i + 1) * 0x1000
+            memory[fp + 0x1000] = nextFP
+            memory[fp + 0x1008] = 0x0100 + UInt(i)
+            fp = nextFP
+        }
+        // Terminate the chain
+        memory[fp] = 0
+
+        let pcs = MainThreadSampler.walkFramePointers(
+            initialFP: 0x1000,
+            initialPC: 0xFFF,
+            maxFrames: 3,   // Limit to 3 frames
+            readWord: { memory[$0] }
+        )
+        // Should have exactly 3 frames: initialPC + 2 from the chain
+        #expect(pcs.count == 3)
+        #expect(pcs[0] == 0xFFF)
+    }
+
+    @Test func walkerStopsOnUnalignedFP() {
+        // FP must be 8-byte aligned. Test that unaligned FP terminates the walk.
+        let memory: [UInt: UInt] = [
+            0x1001: 0x2000, 0x1009: 0xAAA,   // Unaligned addresses
+        ]
+        let pcs = MainThreadSampler.walkFramePointers(
+            initialFP: 0x1001,   // Unaligned FP
+            initialPC: 0xFFF,
+            maxFrames: 10,
+            readWord: { memory[$0] }
+        )
+        // Loop should never enter because (fp & 0x7) != 0
+        #expect(pcs == [0xFFF])
+    }
+
+    @Test func walkerStopsOnDecreasingFP() {
+        // Frame pointers must be strictly increasing. Test that a decreasing FP stops the walk.
+        // Build a chain: Frame 0 at 0x2000 → FP=0x1000 (decreasing), LR=0xAAA
+        // The loop enters on the first iteration with fp=0x2000, reads frame 0,
+        // appends its LR (0xAAA), then on the next iteration detects fp < prevFP and stops.
+        let memory: [UInt: UInt] = [
+            0x2000: 0x1000,   // Next FP is less than current FP
+            0x2008: 0xAAA,
+        ]
+        let pcs = MainThreadSampler.walkFramePointers(
+            initialFP: 0x2000,
+            initialPC: 0xFFF,
+            maxFrames: 10,
+            readWord: { memory[$0] }
+        )
+        // Loop enters with fp=0x2000, reads frame 0, appends 0xAAA. Then on the next
+        // iteration, fp becomes 0x1000 which is < prevFP (0x2000), so we break.
+        #expect(pcs == [0xFFF, 0xAAA])
+    }
+
+    // MARK: - Symbol and formatting tests
 
     @Test func formatFramesYieldsMultilineString() {
         // Test that format() produces a readable multi-line output.

--- a/Tests/TBDAppTests/MainThreadSamplerTests.swift
+++ b/Tests/TBDAppTests/MainThreadSamplerTests.swift
@@ -14,7 +14,7 @@ struct MainThreadSamplerTests {
 
         // Sample should not crash and should return non-empty frames with symbols.
         let frames = MainThreadSampler.sample()
-        #expect(frames.count > 0, "Sample should return at least one frame")
+        #expect(frames.count >= 2, "Sample should return multiple frames from frame pointer walk (loop executed)")
 
         // At least one frame should have a symbol (not all unresolved).
         let hasSymbol = frames.contains { $0.symbol != nil }
@@ -29,9 +29,9 @@ struct MainThreadSamplerTests {
         let frames2 = MainThreadSampler.sample()
         let frames3 = MainThreadSampler.sample()
 
-        #expect(frames1.count > 0, "First sample should return frames")
-        #expect(frames2.count > 0, "Second sample should return frames")
-        #expect(frames3.count > 0, "Third sample should return frames")
+        #expect(frames1.count >= 2, "First sample should return multiple frames from frame pointer walk")
+        #expect(frames2.count >= 2, "Second sample should return multiple frames from frame pointer walk")
+        #expect(frames3.count >= 2, "Third sample should return multiple frames from frame pointer walk")
 
         // All samples should contain resolved symbols.
         let allHaveSymbols = [frames1, frames2, frames3].allSatisfy { frames in

--- a/Tests/TBDAppTests/MainThreadSamplerTests.swift
+++ b/Tests/TBDAppTests/MainThreadSamplerTests.swift
@@ -12,24 +12,37 @@ struct MainThreadSamplerTests {
         // Capture the main thread.
         MainThreadSampler.captureMainThread()
 
-        // Sample should not crash.
+        // Sample should not crash and should return non-empty frames with symbols.
         let frames = MainThreadSampler.sample()
-        #expect(frames.count >= 0)
+        #expect(frames.count > 0, "Sample should return at least one frame")
+
+        // At least one frame should have a symbol (not all unresolved).
+        let hasSymbol = frames.contains { $0.symbol != nil }
+        #expect(hasSymbol, "At least one frame should have a resolved symbol")
     }
 
     @Test @MainActor func sampleCanBeCalledMultipleTimes() {
-        // Calling sample multiple times should not crash.
+        // Calling sample multiple times should not crash and return consistent results.
         MainThreadSampler.captureMainThread()
 
         let frames1 = MainThreadSampler.sample()
         let frames2 = MainThreadSampler.sample()
+        let frames3 = MainThreadSampler.sample()
 
-        #expect(frames1.count >= 0)
-        #expect(frames2.count >= 0)
+        #expect(frames1.count > 0, "First sample should return frames")
+        #expect(frames2.count > 0, "Second sample should return frames")
+        #expect(frames3.count > 0, "Third sample should return frames")
+
+        // All samples should contain resolved symbols.
+        let allHaveSymbols = [frames1, frames2, frames3].allSatisfy { frames in
+            frames.contains { $0.symbol != nil }
+        }
+        #expect(allHaveSymbols, "All samples should contain at least one resolved symbol")
     }
 
     @Test func formatFramesYieldsMultilineString() {
         // Test that format() produces a readable multi-line output.
+        // The demangling infrastructure is tested indirectly by the sample() tests.
         let frames = [
             MainThreadSampler.Frame(
                 address: 0x100001234,
@@ -39,18 +52,24 @@ struct MainThreadSamplerTests {
             ),
             MainThreadSampler.Frame(
                 address: 0x100005678,
-                symbol: "foo",
+                symbol: "_ZN4test3fooEv",  // C++ mangled symbol (unlikely to demangle)
                 module: "TBDApp",
                 offset: 100
+            ),
+            MainThreadSampler.Frame(
+                address: 0x100009abc,
+                symbol: nil,  // Unresolved symbol
+                module: nil,
+                offset: nil
             ),
         ]
 
         let formatted = MainThreadSampler.format(frames)
-        #expect(formatted.contains("main"))
-        #expect(formatted.contains("foo"))
-        #expect(formatted.contains("\n"))  // Multi-line
-        // Should not contain mangled names or hex only
-        #expect(!formatted.contains("_ZN"))
+        #expect(formatted.contains("main"), "Unmangled symbol should appear as-is")
+        #expect(formatted.contains("\n"), "Output should be multi-line")
+        #expect(formatted.contains("1234"), "First address digits should appear in hex")
+        #expect(formatted.contains("5678"), "Second address digits should appear in hex")
+        #expect(formatted.contains("9abc"), "Unresolved address digits should appear in hex")
     }
 
     @Test func frameStructEquality() {

--- a/Tests/TBDAppTests/MainThreadSamplerTests.swift
+++ b/Tests/TBDAppTests/MainThreadSamplerTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+import Darwin
+
+@testable import TBDApp
+
+@Suite("MainThreadSampler")
+struct MainThreadSamplerTests {
+    // MARK: - Tests
+
+    @Test @MainActor func captureAndSampleDoesNotCrash() {
+        // Capture the main thread.
+        MainThreadSampler.captureMainThread()
+
+        // Sample should not crash.
+        let frames = MainThreadSampler.sample()
+        #expect(frames.count >= 0)
+    }
+
+    @Test @MainActor func sampleCanBeCalledMultipleTimes() {
+        // Calling sample multiple times should not crash.
+        MainThreadSampler.captureMainThread()
+
+        let frames1 = MainThreadSampler.sample()
+        let frames2 = MainThreadSampler.sample()
+
+        #expect(frames1.count >= 0)
+        #expect(frames2.count >= 0)
+    }
+
+    @Test func formatFramesYieldsMultilineString() {
+        // Test that format() produces a readable multi-line output.
+        let frames = [
+            MainThreadSampler.Frame(
+                address: 0x100001234,
+                symbol: "main",
+                module: "TBDApp",
+                offset: 10
+            ),
+            MainThreadSampler.Frame(
+                address: 0x100005678,
+                symbol: "foo",
+                module: "TBDApp",
+                offset: 100
+            ),
+        ]
+
+        let formatted = MainThreadSampler.format(frames)
+        #expect(formatted.contains("main"))
+        #expect(formatted.contains("foo"))
+        #expect(formatted.contains("\n"))  // Multi-line
+        // Should not contain mangled names or hex only
+        #expect(!formatted.contains("_ZN"))
+    }
+
+    @Test func frameStructEquality() {
+        let f1 = MainThreadSampler.Frame(
+            address: 0x100001234,
+            symbol: "foo",
+            module: "TBDApp",
+            offset: 10
+        )
+        let f2 = MainThreadSampler.Frame(
+            address: 0x100001234,
+            symbol: "foo",
+            module: "TBDApp",
+            offset: 10
+        )
+        let f3 = MainThreadSampler.Frame(
+            address: 0x100001235,
+            symbol: "foo",
+            module: "TBDApp",
+            offset: 10
+        )
+
+        #expect(f1 == f2)
+        #expect(f1 != f3)
+    }
+}


### PR DESCRIPTION
## Summary

Today's transcript-pane freeze (umbrella issue #129) produced exactly one log line — `hang detected stallMs=1031 pane=liveTranscript itemCount=1019` — and required force-quit. macOS never wrote a `.hang` spindump for it (the OS only samples severe or sustained-enough hangs; the recent fixes in #120/#130/#134 successfully knocked durations below that threshold), so we had **no stack** to point at the SwiftUI call that was wedged.

This PR adds in-process stack sampling so every hang the watchdog detects gets a stack file we can read, regardless of whether macOS feels like sampling it.

- **`MainThreadSampler`** captures the main thread's `mach_port_t` at launch, then walks its frame-pointer chain from the watchdog's background `.utility` queue using `thread_get_state` + `dladdr` + Swift demangling. No `thread_suspend` needed — a hung thread's registers are stationary by definition.
- **`HangStackWriter`** persists samples to `~/Library/Logs/TBD/hang-stacks/hang-<timestamp>-<pid>.txt`, with re-samples every ~5 s if the hang persists and a recovery footer when main drains.
- **Watchdog wire-in** triggers on the existing `.toHung` edge, so the existing threshold (1 s) and snapshot context (terminal ID, item count, pane label) keep applying.

The file path lands in the existing watchdog log line, so `log show --predicate 'subsystem == "com.tbd.app" AND category == "hang-watchdog"'` points straight at the stack file. Requires `scripts/restart.sh` to start collecting.

Refs #129.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter MainThreadSampler` — 3 visible passes; the 4th gets killed by an unrelated pre-existing SIGSEGV in another test target (reproduced on `origin/main` without this branch's changes, so not introduced here)
- [ ] After merge + `scripts/restart.sh`, induce a transcript hang (open a terminal with a long transcript, expand a bash card) and confirm a `hang-*.txt` file appears in `~/Library/Logs/TBD/hang-stacks/` with a readable SwiftUI stack

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=E91A54EC-5F63-40A7-8498-74AEF037FC6C)