### PR TITLE
Compound: Stop --sibling from making orchestrators spawn peers instead of children

### DIFF
--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -42,14 +42,18 @@ struct WorktreeCreate: AsyncParsableCommand {
     @Option(name: .long, help: "Read initial prompt from a file (use - for stdin)")
     var promptFile: String?
 
-    @Option(name: .customLong("parent"), help: "Nest the new worktree under this parent (worktree ID or display name).")
-    var parent: String?
-
-    @Flag(name: .customLong("sibling"), help: "Spawn as a sibling of the caller (same parent as TBD_WORKTREE_ID).")
-    var asSibling: Bool = false
-
-    @Flag(name: .customLong("no-parent"), help: "Force the new worktree to be top-level (ignore TBD_WORKTREE_ID).")
-    var noParent: Bool = false
+    @Option(
+        name: .customLong("position"),
+        help: ArgumentHelp(
+            "Position of the new worktree in the tree, relative to the caller (TBD_WORKTREE_ID).",
+            discussion: """
+                child   (default) New worktree is a child of the caller.
+                sibling          New worktree is a peer of the caller (same parent).
+                root             New worktree has no parent (top-level).
+                """
+        )
+    )
+    var position: WorktreePosition = .child
 
     @Flag(name: .long, help: "Return immediately without waiting for the worktree to become active")
     var noWait = false
@@ -92,39 +96,9 @@ struct WorktreeCreate: AsyncParsableCommand {
 
         let resolvedPrompt = try resolvePrompt(inline: prompt, file: promptFile)
 
-        // Mutually exclusive parenting flags
-        let flagsSet = (parent != nil ? 1 : 0) + (asSibling ? 1 : 0) + (noParent ? 1 : 0)
-        if flagsSet > 1 {
-            throw ValidationError("Pass at most one of --parent, --sibling, --no-parent.")
-        }
-
-        // Resolve --parent (UUID or display name / folder name)
-        var explicitParentID: UUID?
-        if let p = parent {
-            if let uuid = UUID(uuidString: p) {
-                explicitParentID = uuid
-            } else {
-                let worktrees: [Worktree] = try client.call(
-                    method: RPCMethod.worktreeList,
-                    params: WorktreeListParams(),
-                    resultType: [Worktree].self
-                )
-                let matches = worktrees.filter { $0.displayName == p || $0.name == p }
-                if matches.isEmpty {
-                    throw ValidationError("No worktree matches --parent '\(p)'.")
-                }
-                if matches.count > 1 {
-                    throw ValidationError("Multiple worktrees match --parent '\(p)' — pass the UUID instead.")
-                }
-                explicitParentID = matches[0].id
-            }
-        }
-
         let callerEnvID = ProcessInfo.processInfo.environment["TBD_WORKTREE_ID"]
             .flatMap { UUID(uuidString: $0) }
-        let siblingOfID: UUID? = asSibling ? callerEnvID : nil
-        let passCaller = explicitParentID == nil && !asSibling && !noParent
-        let callerWorktreeID: UUID? = passCaller ? callerEnvID : nil
+        let parentingFields = position.rpcFields(callerEnvID: callerEnvID)
 
         let pending: Worktree = try client.call(
             method: RPCMethod.worktreeCreate,
@@ -134,10 +108,10 @@ struct WorktreeCreate: AsyncParsableCommand {
                 branch: branch,
                 displayName: name,
                 prompt: resolvedPrompt,
-                parentWorktreeID: explicitParentID,
-                siblingOfWorktreeID: siblingOfID,
-                callerWorktreeID: callerWorktreeID,
-                suppressAutoParent: noParent ? true : nil
+                parentWorktreeID: parentingFields.parentWorktreeID,
+                siblingOfWorktreeID: parentingFields.siblingOfWorktreeID,
+                callerWorktreeID: parentingFields.callerWorktreeID,
+                suppressAutoParent: parentingFields.suppressAutoParent
             ),
             resultType: Worktree.self
         )

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -98,6 +98,9 @@ struct WorktreeCreate: AsyncParsableCommand {
 
         let callerEnvID = ProcessInfo.processInfo.environment["TBD_WORKTREE_ID"]
             .flatMap { UUID(uuidString: $0) }
+        if let warning = position.unmetIntentWarning(callerEnvID: callerEnvID) {
+            FileHandle.standardError.write(Data("\(warning)\n".utf8))
+        }
         let parentingFields = position.rpcFields(callerEnvID: callerEnvID)
 
         let pending: Worktree = try client.call(

--- a/Sources/TBDCLI/Commands/WorktreePosition.swift
+++ b/Sources/TBDCLI/Commands/WorktreePosition.swift
@@ -1,0 +1,68 @@
+import ArgumentParser
+import Foundation
+
+/// CLI-level position enum for `tbd worktree create --position`.
+///
+/// Names the new worktree's location in the worktree tree *relative to the
+/// caller* (the worktree identified by `TBD_WORKTREE_ID`):
+///
+/// - `child` (default): the new worktree is a child of the caller. This is
+///   the orchestrator-spawns-workers fan-out case.
+/// - `sibling`: the new worktree is a peer of the caller (same parent).
+/// - `root`: the new worktree has no parent (top-level).
+///
+/// This enum is purely a CLI input concept. It maps to the four
+/// `WorktreeCreateParams` parenting fields the daemon already understands.
+public enum WorktreePosition: String, CaseIterable, ExpressibleByArgument {
+    case child
+    case sibling
+    case root
+
+    /// Default value used by ArgumentParser's pretty-printed help.
+    public static var defaultValueDescription: String { "child" }
+
+    /// Resolved RPC fields for `WorktreeCreateParams`.
+    public struct RPCFields: Equatable {
+        public let parentWorktreeID: UUID?
+        public let siblingOfWorktreeID: UUID?
+        public let callerWorktreeID: UUID?
+        public let suppressAutoParent: Bool?
+    }
+
+    /// Translate `(position, TBD_WORKTREE_ID)` into the four parenting fields
+    /// the daemon's `ParentResolver` consumes.
+    ///
+    /// `child` and `sibling` are caller-relative; when the caller is unset
+    /// they degrade gracefully:
+    /// - `child` with no caller: passes nil for every field, so the daemon
+    ///   creates a top-level worktree (same fallback as the old default).
+    /// - `sibling` with no caller: there is no reference point to spawn a
+    ///   peer of, so the new worktree is also created top-level (same
+    ///   behavior as the old `--sibling` flag, whose `siblingOf` field was
+    ///   nil and which resolved to nil in `ParentResolver`).
+    public func rpcFields(callerEnvID: UUID?) -> RPCFields {
+        switch self {
+        case .child:
+            return RPCFields(
+                parentWorktreeID: nil,
+                siblingOfWorktreeID: nil,
+                callerWorktreeID: callerEnvID,
+                suppressAutoParent: nil
+            )
+        case .sibling:
+            return RPCFields(
+                parentWorktreeID: nil,
+                siblingOfWorktreeID: callerEnvID,
+                callerWorktreeID: nil,
+                suppressAutoParent: nil
+            )
+        case .root:
+            return RPCFields(
+                parentWorktreeID: nil,
+                siblingOfWorktreeID: nil,
+                callerWorktreeID: nil,
+                suppressAutoParent: true
+            )
+        }
+    }
+}

--- a/Sources/TBDCLI/Commands/WorktreePosition.swift
+++ b/Sources/TBDCLI/Commands/WorktreePosition.swift
@@ -65,4 +65,22 @@ public enum WorktreePosition: String, CaseIterable, ExpressibleByArgument {
             )
         }
     }
+
+    /// Returns a stderr warning string when the requested position cannot be
+    /// fulfilled because the caller environment is missing, otherwise nil.
+    ///
+    /// Only `.sibling` warns: a sibling has no reference point without a
+    /// caller and silently degrades to a top-level worktree, which is exactly
+    /// the silent-misbehavior pattern this flag exists to prevent.
+    ///
+    /// `.child` and `.root` both treat "no caller" as their documented
+    /// graceful fallback (top-level), so neither warns.
+    public func unmetIntentWarning(callerEnvID: UUID?) -> String? {
+        switch self {
+        case .sibling where callerEnvID == nil:
+            return "warning: --position=sibling has no caller (TBD_WORKTREE_ID unset); creating top-level worktree"
+        case .child, .sibling, .root:
+            return nil
+        }
+    }
 }

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -50,6 +50,24 @@ briefing here
 EOF
 ```
 
+### Spawn worker worktrees from an orchestrator (most common fan-out)
+
+The default `--position=child` nests the new worktree under the caller. This
+is what you want when an orchestrator is fanning out a batch of workers —
+they'll all be siblings of each other and children of the orchestrator.
+
+```bash
+tbd worktree create --branch tbd/<task> --name "<task>" --prompt-file - <<'EOF'
+briefing here
+EOF
+```
+
+Use `--position=sibling` when you (the caller) are *already* a worker under
+some parent and you want to spawn a peer alongside yourself — not when you
+want to spawn workers under yourself.
+
+Use `--position=root` to force the new worktree to be top-level.
+
 ### Send input to an existing terminal / read its output
 
 ```bash

--- a/Tests/TBDCLITests/WorktreePositionTests.swift
+++ b/Tests/TBDCLITests/WorktreePositionTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+
+@testable import TBDCLI
+
+@Suite("WorktreePosition → WorktreeCreateParams field mapping")
+struct WorktreePositionTests {
+    private static let callerID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+
+    // MARK: - --position=child (default)
+
+    @Test func childPassesCallerToDaemon() {
+        let fields = WorktreePosition.child.rpcFields(callerEnvID: Self.callerID)
+        #expect(fields.callerWorktreeID == Self.callerID)
+        #expect(fields.parentWorktreeID == nil)
+        #expect(fields.siblingOfWorktreeID == nil)
+        #expect(fields.suppressAutoParent == nil)
+    }
+
+    @Test func childWithNoCallerProducesAllNilFields() {
+        // Without TBD_WORKTREE_ID, child has no anchor and degrades to a
+        // top-level create (same fallback as the old un-flagged default).
+        let fields = WorktreePosition.child.rpcFields(callerEnvID: nil)
+        #expect(fields.callerWorktreeID == nil)
+        #expect(fields.parentWorktreeID == nil)
+        #expect(fields.siblingOfWorktreeID == nil)
+        #expect(fields.suppressAutoParent == nil)
+    }
+
+    // MARK: - --position=sibling
+
+    @Test func siblingPassesCallerInSiblingSlot() {
+        let fields = WorktreePosition.sibling.rpcFields(callerEnvID: Self.callerID)
+        #expect(fields.siblingOfWorktreeID == Self.callerID)
+        #expect(fields.callerWorktreeID == nil)
+        #expect(fields.parentWorktreeID == nil)
+        #expect(fields.suppressAutoParent == nil)
+    }
+
+    @Test func siblingWithNoCallerProducesAllNilFields() {
+        // Without TBD_WORKTREE_ID, there is no peer to anchor on; falls back
+        // to top-level (same as the old --sibling flag behavior).
+        let fields = WorktreePosition.sibling.rpcFields(callerEnvID: nil)
+        #expect(fields.siblingOfWorktreeID == nil)
+        #expect(fields.callerWorktreeID == nil)
+        #expect(fields.parentWorktreeID == nil)
+        #expect(fields.suppressAutoParent == nil)
+    }
+
+    // MARK: - --position=root
+
+    @Test func rootSetsSuppressAutoParent() {
+        let fields = WorktreePosition.root.rpcFields(callerEnvID: Self.callerID)
+        #expect(fields.suppressAutoParent == true)
+        #expect(fields.callerWorktreeID == nil)
+        #expect(fields.siblingOfWorktreeID == nil)
+        #expect(fields.parentWorktreeID == nil)
+    }
+
+    @Test func rootIgnoresCaller() {
+        // Should be identical whether or not TBD_WORKTREE_ID is set.
+        let withCaller = WorktreePosition.root.rpcFields(callerEnvID: Self.callerID)
+        let withoutCaller = WorktreePosition.root.rpcFields(callerEnvID: nil)
+        #expect(withCaller == withoutCaller)
+    }
+
+    // MARK: - Argument parsing
+
+    @Test func parsesValidValues() {
+        #expect(WorktreePosition(argument: "child") == .child)
+        #expect(WorktreePosition(argument: "sibling") == .sibling)
+        #expect(WorktreePosition(argument: "root") == .root)
+    }
+
+    @Test func rejectsUnknownValue() {
+        #expect(WorktreePosition(argument: "parent") == nil)
+        #expect(WorktreePosition(argument: "") == nil)
+    }
+}

--- a/Tests/TBDCLITests/WorktreePositionTests.swift
+++ b/Tests/TBDCLITests/WorktreePositionTests.swift
@@ -76,4 +76,38 @@ struct WorktreePositionTests {
         #expect(WorktreePosition(argument: "parent") == nil)
         #expect(WorktreePosition(argument: "") == nil)
     }
+
+    // MARK: - unmetIntentWarning
+
+    @Test func childWithCallerHasNoWarning() {
+        #expect(WorktreePosition.child.unmetIntentWarning(callerEnvID: Self.callerID) == nil)
+    }
+
+    @Test func childWithoutCallerHasNoWarning() {
+        // Degrading to top-level is the documented graceful fallback for child.
+        #expect(WorktreePosition.child.unmetIntentWarning(callerEnvID: nil) == nil)
+    }
+
+    @Test func siblingWithCallerHasNoWarning() {
+        #expect(WorktreePosition.sibling.unmetIntentWarning(callerEnvID: Self.callerID) == nil)
+    }
+
+    @Test func siblingWithoutCallerWarns() {
+        // The whole point of the warning: sibling intent silently degrades to
+        // a top-level worktree when there's no caller to anchor on.
+        let warning = WorktreePosition.sibling.unmetIntentWarning(callerEnvID: nil)
+        #expect(warning != nil)
+        // Keep the message greppable on substring, not exact wording.
+        #expect(warning?.contains("sibling") == true)
+        #expect(warning?.contains("TBD_WORKTREE_ID") == true)
+    }
+
+    @Test func rootWithCallerHasNoWarning() {
+        #expect(WorktreePosition.root.unmetIntentWarning(callerEnvID: Self.callerID) == nil)
+    }
+
+    @Test func rootWithoutCallerHasNoWarning() {
+        // Top-level is exactly what root requested; nothing to warn about.
+        #expect(WorktreePosition.root.unmetIntentWarning(callerEnvID: nil) == nil)
+    }
 }


### PR DESCRIPTION
## Summary

A sibling Claude session running `tbd worktree create --sibling` four times got bitten by the flag's ambiguity: it parsed "sibling" as "sibling of the workers I'm spawning" and got peers of *itself* instead. The default behavior (nest under caller) also had no name, so an agent skimming `--help` couldn't grep for it and had to infer it by elimination.

- Replace `--parent` / `--sibling` / `--no-parent` with a single `--position=child|sibling|root` enum (default `child`).
- Every value now names the *new worktree's* tree position relative to the caller — no reference-point ambiguity, no nameless default.
- Updated the bundled `tbd` skill with a worked example for the orchestrator-fan-out case.

Arbitrary-UUID parent attachment is no longer reachable via a dedicated CLI flag — the daemon RPC still supports it (used by the SwiftUI sidebar), and the env-spoof `TBD_WORKTREE_ID=<uuid> tbd worktree create --position=child ...` keeps it reachable from scripts. Adding a `--parent=<uuid>` flag later is ~30 lines if it turns out to matter.

## Test plan
- [ ] `swift test` passes (new `WorktreePositionTests` covers each position + caller-unset fallbacks)
- [ ] `tbd worktree create --help` shows the three positions with the reference point spelled out
- [ ] From inside a worktree: default (`--position=child` implicit) nests under caller
- [ ] From inside a worktree: `--position=sibling` becomes peer of caller
- [ ] `--position=root` creates top-level regardless of caller

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=412473E9-880C-464F-8CF1-BC79C5E7F439)