### PR TITLE
Isolate tests from the live daemon (~/tbd) and developer UserDefaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,14 @@ There should be exactly one `TBDDaemon` and one `TBDApp`, both from the worktree
 ### NEVER delete ~/tbd/state.db
 The database stores worktree display names, custom config, and notification history. Deleting it orphans tmux servers (repo UUID changes → tmux server name changes → old sessions become unreachable). If you encounter DB issues, diagnose and fix the schema/code — don't wipe the DB.
 
+### Tests must not touch ~/tbd
+`TBDConstants.configDir` and `socketPath` honor two env vars so tests, CI, and concurrent `swift test` runs across worktrees never collide with the live daemon or the developer's real config:
+
+- `TBD_HOME` redirects the base config directory (`~/tbd` by default). Every derived path (`socketPath`, `databasePath`, `pidFilePath`, `portFilePath`, `reposDir`) follows.
+- `TBD_SOCKET_PATH` overrides only the socket — an escape hatch for darwin's ~104-char `sun_path` limit when `TBD_HOME` is a deep tmp path.
+
+Tests that need filesystem isolation should `setenv("TBD_HOME", "/some/tmp/dir", 1)` (and optionally `TBD_SOCKET_PATH`) before any `TBDConstants.<path>` access. Tests that mutate `UserDefaults` should construct `AppState(userDefaults: UserDefaults(suiteName:))` and tear the suite down with `removePersistentDomain(forName:)` — `UserDefaults.standard` on this unbundled executable is the developer's real `TBDApp.plist`.
+
 ### Database migrations must update the shared model
 When adding a DB column in `Sources/TBDDaemon/Database/Database.swift`:
 1. Add the column with a `.defaults(to:)` value in the migration

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -142,7 +142,7 @@ final class AppState: ObservableObject {
     }
 
     @Published var dockRatio: CGFloat = 0.3 {
-        didSet { UserDefaults.standard.set(Double(dockRatio), forKey: Self.dockRatioKey) }
+        didSet { userDefaults.set(Double(dockRatio), forKey: Self.dockRatioKey) }
     }
     /// Pixel size of the main terminal area (the SingleWorktreeView slot
     /// inside DockSplitView, excluding the pinned dock and file panel).
@@ -258,8 +258,8 @@ final class AppState: ObservableObject {
 
     let daemonClient = DaemonClient()
     let tmuxBridge = TmuxBridge()
-    lazy var cliInstallerCoordinator = CLIInstallerCoordinator(daemonClient: daemonClient)
-    lazy var legacyHooksCoordinator = LegacyHooksCoordinator(daemonClient: daemonClient)
+    lazy var cliInstallerCoordinator = CLIInstallerCoordinator(daemonClient: daemonClient, userDefaults: userDefaults)
+    lazy var legacyHooksCoordinator = LegacyHooksCoordinator(daemonClient: daemonClient, userDefaults: userDefaults)
     private var pollTimer: Timer?
     private var pollCycle = 0
     private var subscriptionTask: Task<Void, Never>?
@@ -280,7 +280,7 @@ final class AppState: ObservableObject {
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
         restoreLayouts()
-        if let saved = UserDefaults.standard.object(forKey: Self.dockRatioKey) as? Double {
+        if let saved = userDefaults.object(forKey: Self.dockRatioKey) as? Double {
             dockRatio = max(0.1, min(0.6, CGFloat(saved)))
         }
         startMemoryPressureMonitor()
@@ -378,11 +378,11 @@ final class AppState: ObservableObject {
 
     private func persistLayouts() {
         guard let data = try? JSONEncoder().encode(layouts) else { return }
-        UserDefaults.standard.set(data, forKey: Self.layoutsKey)
+        userDefaults.set(data, forKey: Self.layoutsKey)
     }
 
     private func restoreLayouts() {
-        guard let data = UserDefaults.standard.data(forKey: Self.layoutsKey),
+        guard let data = userDefaults.data(forKey: Self.layoutsKey),
               let restored = try? JSONDecoder().decode([UUID: LayoutNode].self, from: data) else { return }
         layouts = restored
     }

--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -8,6 +8,7 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "cli-installer")
 @MainActor
 final class CLIInstallerCoordinator {
     private let daemonClient: DaemonClient
+    private let userDefaults: UserDefaults
     private let installer = CLIInstaller()
 
     /// Set after `checkOnLaunch` runs, so daemon reconnects within the same
@@ -20,12 +21,13 @@ final class CLIInstallerCoordinator {
     /// re-install via the menu re-arms the prompt for future deletions).
     private static let dismissedKey = "com.tbd.app.cliInstaller.notInstalledDismissed"
     private var notInstalledDismissed: Bool {
-        get { UserDefaults.standard.bool(forKey: Self.dismissedKey) }
-        set { UserDefaults.standard.set(newValue, forKey: Self.dismissedKey) }
+        get { userDefaults.bool(forKey: Self.dismissedKey) }
+        set { userDefaults.set(newValue, forKey: Self.dismissedKey) }
     }
 
-    init(daemonClient: DaemonClient) {
+    init(daemonClient: DaemonClient, userDefaults: UserDefaults = .standard) {
         self.daemonClient = daemonClient
+        self.userDefaults = userDefaults
     }
 
     /// Called once at end of `connectAndLoadInitialState`. Surfaces a one-click

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -45,8 +45,9 @@ actor DaemonClient {
     private let socketPath: String
     private(set) var connected: Bool = false
 
-    init(socketPath: String = TBDConstants.socketPath) {
-        self.socketPath = socketPath
+    init(socketPath: String? = nil) {
+        // See HookResolver — resolve here, not at the caller's site.
+        self.socketPath = socketPath ?? TBDConstants.socketPath
     }
 
     // MARK: - Connection

--- a/Sources/TBDApp/LegacyHooksCoordinator.swift
+++ b/Sources/TBDApp/LegacyHooksCoordinator.swift
@@ -22,17 +22,19 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "legacy-hooks")
 @MainActor
 final class LegacyHooksCoordinator {
     private let daemonClient: DaemonClient
+    private let userDefaults: UserDefaults
 
     private var hasCheckedThisSession = false
 
     private static let dismissedKey = "com.tbd.app.legacyHooks.dismissed"
     private var dismissed: Bool {
-        get { UserDefaults.standard.bool(forKey: Self.dismissedKey) }
-        set { UserDefaults.standard.set(newValue, forKey: Self.dismissedKey) }
+        get { userDefaults.bool(forKey: Self.dismissedKey) }
+        set { userDefaults.set(newValue, forKey: Self.dismissedKey) }
     }
 
-    init(daemonClient: DaemonClient) {
+    init(daemonClient: DaemonClient, userDefaults: UserDefaults = .standard) {
         self.daemonClient = daemonClient
+        self.userDefaults = userDefaults
     }
 
     /// One-time launch check. Skips on subsequent invocations within the

--- a/Sources/TBDCLI/SocketClient.swift
+++ b/Sources/TBDCLI/SocketClient.swift
@@ -35,8 +35,10 @@ enum SocketClientError: Error, CustomStringConvertible {
 struct SocketClient: Sendable {
     let socketPath: String
 
-    init(socketPath: String = TBDConstants.socketPath) {
-        self.socketPath = socketPath
+    init(socketPath: String? = nil) {
+        // See HookResolver in TBDDaemon — resolve here, not at the caller's
+        // site, to avoid cross-module addressor link failures.
+        self.socketPath = socketPath ?? TBDConstants.socketPath
     }
 
     /// Check if the daemon socket exists (quick check before connecting).

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -22,10 +22,12 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeProfil
 struct ClaudeProfileConfigDirManager: Sendable {
     let baseDirectory: URL
 
-    init(
-        baseDirectory: URL = TBDConstants.configDir.appendingPathComponent("profiles", isDirectory: true)
-    ) {
+    init(baseDirectory: URL? = nil) {
+        // Resolve inside the init to keep the `TBDConstants.configDir` access
+        // out of the caller's compilation context — see HookResolver for the
+        // Xcode 26.3 unsafeMutableAddressor link-failure rationale.
         self.baseDirectory = baseDirectory
+            ?? TBDConstants.configDir.appendingPathComponent("profiles", isDirectory: true)
     }
 
     func configDirectory(forProfileID profileID: UUID) -> URL {

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -8,10 +8,12 @@ import TBDShared
 struct CodexHomeManager: Sendable {
     let baseDirectory: URL
 
-    init(
-        baseDirectory: URL = TBDConstants.configDir.appendingPathComponent("agents/codex", isDirectory: true)
-    ) {
+    init(baseDirectory: URL? = nil) {
+        // See HookResolver — keep cross-module `TBDConstants.configDir` access
+        // inside this module to avoid Xcode 26.3 unsafeMutableAddressor link
+        // failures in test targets that call this initializer with defaults.
         self.baseDirectory = baseDirectory
+            ?? TBDConstants.configDir.appendingPathComponent("agents/codex", isDirectory: true)
     }
 
     func homeDirectory(forRepoID repoID: UUID) -> URL {

--- a/Sources/TBDDaemon/Hooks/HookResolver.swift
+++ b/Sources/TBDDaemon/Hooks/HookResolver.swift
@@ -29,11 +29,15 @@ public enum HookEvent: String, Sendable {
 public struct HookResolver: Sendable {
     public let globalHooksDir: String
 
-    public init(
-        globalHooksDir: String = TBDConstants.configDir
-            .appendingPathComponent("hooks/default").path
-    ) {
+    public init(globalHooksDir: String? = nil) {
+        // Resolve in this module's compilation context. Cross-module default
+        // expressions that reference `TBDConstants.configDir` get re-emitted
+        // at the caller's site, and under Swift 6 / Xcode 26.3 that re-emission
+        // generates a reference to the property's `unsafeMutableAddressor`
+        // symbol — which doesn't exist for a computed `static var`, breaking
+        // the link step in test targets. See PR #153 CI failure for context.
         self.globalHooksDir = globalHooksDir
+            ?? TBDConstants.configDir.appendingPathComponent("hooks/default").path
     }
 
     /// Resolves which hook script to run. First match wins, no chaining.

--- a/Sources/TBDDaemon/PIDFile.swift
+++ b/Sources/TBDDaemon/PIDFile.swift
@@ -4,8 +4,10 @@ import TBDShared
 public struct PIDFile: Sendable {
     let path: String
 
-    public init(path: String = TBDConstants.pidFilePath) {
-        self.path = path
+    public init(path: String? = nil) {
+        // See HookResolver — keep cross-module `TBDConstants` access inside
+        // this module to avoid Xcode 26.3 unsafeMutableAddressor link failures.
+        self.path = path ?? TBDConstants.pidFilePath
     }
 
     public func write() throws {

--- a/Sources/TBDDaemon/Server/HTTPServer.swift
+++ b/Sources/TBDDaemon/Server/HTTPServer.swift
@@ -21,9 +21,10 @@ public final class HTTPServer: Sendable {
     /// The port the server is bound to, available after start().
     public nonisolated(unsafe) var port: Int = 0
 
-    public init(router: RPCRouter, portFilePath: String = TBDConstants.portFilePath) {
+    public init(router: RPCRouter, portFilePath: String? = nil) {
         self.router = router
-        self.portFilePath = portFilePath
+        // See HookResolver — resolve here, not at the caller's site.
+        self.portFilePath = portFilePath ?? TBDConstants.portFilePath
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
     }
 

--- a/Sources/TBDDaemon/Server/SocketServer.swift
+++ b/Sources/TBDDaemon/Server/SocketServer.swift
@@ -23,9 +23,10 @@ public final class SocketServer: Sendable {
         _connectedClients.load(ordering: .relaxed)
     }
 
-    public init(router: RPCRouter, socketPath: String = TBDConstants.socketPath) {
+    public init(router: RPCRouter, socketPath: String? = nil) {
         self.router = router
-        self.socketPath = socketPath
+        // See HookResolver — resolve here, not at the caller's site.
+        self.socketPath = socketPath ?? TBDConstants.socketPath
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
     }
 

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -2,13 +2,32 @@ import Foundation
 
 public enum TBDConstants {
     public static let version = "0.1.0"
-    public static let configDir = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent("tbd")
-    public static let socketPath = configDir.appendingPathComponent("sock").path
-    public static let databasePath = configDir.appendingPathComponent("state.db").path
-    public static let pidFilePath = configDir.appendingPathComponent("tbdd.pid").path
-    public static let portFilePath = configDir.appendingPathComponent("port").path
-    public static let reposDir = configDir.appendingPathComponent("repos")
+
+    /// Base config directory. Resolves `TBD_HOME` env var on every access so a
+    /// process that sets the env after first read (e.g. a SwiftTesting suite
+    /// trait) gets the new value. Falls back to `~/tbd` when the env is unset
+    /// or empty, preserving production behavior.
+    public static var configDir: URL {
+        if let override = ProcessInfo.processInfo.environment["TBD_HOME"], !override.isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("tbd")
+    }
+
+    /// Unix socket path. Honors `TBD_SOCKET_PATH` independently of `TBD_HOME`
+    /// — darwin caps `sun_path` at ~104 bytes, so a deep `TBD_HOME` can
+    /// overflow even though `$configDir/sock` would fit a shallow override.
+    public static var socketPath: String {
+        if let override = ProcessInfo.processInfo.environment["TBD_SOCKET_PATH"], !override.isEmpty {
+            return override
+        }
+        return configDir.appendingPathComponent("sock").path
+    }
+    public static var databasePath: String { configDir.appendingPathComponent("state.db").path }
+    public static var pidFilePath: String { configDir.appendingPathComponent("tbdd.pid").path }
+    public static var portFilePath: String { configDir.appendingPathComponent("port").path }
+    public static var reposDir: URL { configDir.appendingPathComponent("repos") }
 
     public static func hookPath(repoID: UUID, eventName: String) -> String {
         reposDir

--- a/Tests/TBDAppTests/AppStateUserDefaultsIsolationTests.swift
+++ b/Tests/TBDAppTests/AppStateUserDefaultsIsolationTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Regression coverage for the UserDefaults-isolation invariant that PR #133
+/// established and this PR completes: when `AppState` is constructed with a
+/// non-`.standard` UserDefaults, NO path through the state's persistence code
+/// may touch `.standard`.
+///
+/// TBDApp ships as an unbundled SPM executable, so `.standard` is the running
+/// developer's real `TBDApp.plist`. A leak here clobbers their live UI
+/// preferences mid-test (dockRatio, layouts).
+@MainActor
+@Suite("AppState UserDefaults isolation")
+struct AppStateUserDefaultsIsolationTests {
+    private func withIsolatedDefaults(_ body: (UserDefaults) -> Void) {
+        let suiteName = "TBDAppTests.AppStateIsolation.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(defaults)
+    }
+
+    @Test("dockRatio writes go to the injected suite, not .standard")
+    func dockRatioWritesGoToInjectedSuite() {
+        withIsolatedDefaults { defaults in
+            let priorStandard = UserDefaults.standard.object(forKey: "com.tbd.app.dockRatio")
+            defer {
+                if let priorStandard {
+                    UserDefaults.standard.set(priorStandard, forKey: "com.tbd.app.dockRatio")
+                } else {
+                    UserDefaults.standard.removeObject(forKey: "com.tbd.app.dockRatio")
+                }
+            }
+
+            let state = AppState(userDefaults: defaults)
+            state.dockRatio = 0.42
+
+            #expect(defaults.object(forKey: "com.tbd.app.dockRatio") as? Double == 0.42)
+            // Critical invariant — must NOT mutate the developer's plist.
+            #expect(UserDefaults.standard.object(forKey: "com.tbd.app.dockRatio") as? Double != 0.42)
+        }
+    }
+
+    @Test("layout persistence reads + writes from the injected suite")
+    func layoutPersistenceUsesInjectedSuite() {
+        withIsolatedDefaults { defaults in
+            // Seed the injected suite, construct AppState — restoreLayouts
+            // must read from `defaults`, not from `.standard`.
+            let seededID = UUID()
+            let seeded: [UUID: LayoutNode] = [seededID: .pane(.terminal(terminalID: UUID()))]
+            let data = try? JSONEncoder().encode(seeded)
+            #expect(data != nil)
+            defaults.set(data, forKey: "com.tbd.app.layouts")
+
+            let state = AppState(userDefaults: defaults)
+            #expect(state.layouts.keys.contains(seededID))
+        }
+    }
+
+    @Test("init reads dockRatio from the injected suite")
+    func initReadsFromInjectedSuite() {
+        withIsolatedDefaults { defaults in
+            defaults.set(0.55, forKey: "com.tbd.app.dockRatio")
+
+            let state = AppState(userDefaults: defaults)
+            #expect(state.dockRatio == 0.55)
+        }
+    }
+}

--- a/Tests/TBDSharedTests/ConstantsTests.swift
+++ b/Tests/TBDSharedTests/ConstantsTests.swift
@@ -5,11 +5,86 @@ import Foundation
 @Test func hookPathSetup() {
     let repoID = UUID(uuidString: "12345678-1234-1234-1234-123456789abc")!
     let path = TBDConstants.hookPath(repoID: repoID, eventName: "setup")
-    #expect(path.hasSuffix("/tbd/repos/12345678-1234-1234-1234-123456789ABC/hooks/setup"))
+    #expect(path.hasSuffix("/repos/12345678-1234-1234-1234-123456789ABC/hooks/setup"))
 }
 
 @Test func hookPathArchive() {
     let repoID = UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!
     let path = TBDConstants.hookPath(repoID: repoID, eventName: "archive")
-    #expect(path.hasSuffix("/tbd/repos/AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA/hooks/archive"))
+    #expect(path.hasSuffix("/repos/AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA/hooks/archive"))
+}
+
+/// Run env-mutating tests serialized so they don't race each other. Each test
+/// snapshots the prior env value and restores it via defer.
+@Suite(.serialized)
+struct ConfigDirEnvOverrideTests {
+    private func withEnv(_ key: String, _ value: String?, _ body: () -> Void) {
+        let prior = ProcessInfo.processInfo.environment[key]
+        if let value {
+            setenv(key, value, 1)
+        } else {
+            unsetenv(key)
+        }
+        defer {
+            if let prior {
+                setenv(key, prior, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+        body()
+    }
+
+    @Test func configDirFallsBackToHomeTbdWhenEnvUnset() {
+        withEnv("TBD_HOME", nil) {
+            let path = TBDConstants.configDir.path
+            #expect(path.hasSuffix("/tbd"))
+            #expect(path.contains(FileManager.default.homeDirectoryForCurrentUser.path))
+        }
+    }
+
+    @Test func configDirHonorsTBDHome() {
+        withEnv("TBD_HOME", "/tmp/tbd-test-config") {
+            #expect(TBDConstants.configDir.path == "/tmp/tbd-test-config")
+        }
+    }
+
+    @Test func emptyTBDHomeIsTreatedAsUnset() {
+        withEnv("TBD_HOME", "") {
+            let path = TBDConstants.configDir.path
+            #expect(path.hasSuffix("/tbd"))
+        }
+    }
+
+    @Test func derivedPathsFollowTBDHome() {
+        withEnv("TBD_HOME", "/tmp/tbd-derived") {
+            withEnv("TBD_SOCKET_PATH", nil) {
+                #expect(TBDConstants.databasePath == "/tmp/tbd-derived/state.db")
+                #expect(TBDConstants.pidFilePath == "/tmp/tbd-derived/tbdd.pid")
+                #expect(TBDConstants.portFilePath == "/tmp/tbd-derived/port")
+                #expect(TBDConstants.reposDir.path == "/tmp/tbd-derived/repos")
+                #expect(TBDConstants.socketPath == "/tmp/tbd-derived/sock")
+            }
+        }
+    }
+
+    @Test func socketPathOverrideWinsOverTBDHome() {
+        withEnv("TBD_HOME", "/tmp/tbd-some-home") {
+            withEnv("TBD_SOCKET_PATH", "/tmp/short.sock") {
+                #expect(TBDConstants.socketPath == "/tmp/short.sock")
+                // Other paths still follow TBD_HOME — only socket is redirected.
+                #expect(TBDConstants.databasePath == "/tmp/tbd-some-home/state.db")
+            }
+        }
+    }
+
+    @Test func socketPathOverrideAloneWorks() {
+        withEnv("TBD_HOME", nil) {
+            withEnv("TBD_SOCKET_PATH", "/tmp/lone.sock") {
+                #expect(TBDConstants.socketPath == "/tmp/lone.sock")
+                // Other paths still resolve to ~/tbd.
+                #expect(TBDConstants.databasePath.hasSuffix("/tbd/state.db"))
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`TBDConstants` paths were hard-coded to `~/tbd` and `UserDefaults.standard` was reachable through `AppState`. Concurrent `swift test` runs across worktrees could collide on the live daemon socket / prod DB / developer's `TBDApp.plist`. PR #133 started the UserDefaults DI but only finished `autoSuspendClaude`; this PR finishes the rest and adds env overrides on `TBDConstants` so any future filesystem-touching test can opt in.

> **Note:** When this work was first scoped, the smoking gun was `ConductorManagerTests` writing into `~/tbd/conductors/` on every run. That test (and the entire Conductor feature) was retired on main in #147 while this PR was in flight, so the in-flight `IsolatedTBDHome` SwiftTesting trait was dropped at rebase time — it had no remaining consumer. The env-override layer is left in place for future filesystem-touching tests to wire up directly via `setenv`.

Production behavior is unchanged when env vars are unset and the default `.standard` is used.

## Commits

1. **`feat(shared): honor TBD_HOME and TBD_SOCKET_PATH env overrides`** — pure refactor of `TBDConstants` from `static let` → env-resolving `static var`. `TBD_HOME` redirects the base config dir (every derived path follows); `TBD_SOCKET_PATH` independently overrides the socket as an escape hatch for darwin's 104-char `sun_path` limit. New tests in `ConstantsTests.swift` cover both branches and the override precedence.
2. **`fix(app): finish routing AppState UserDefaults through the injected suite`** — closes the remaining `UserDefaults.standard` leaks in `AppState` (`dockRatio` reader/writer, `persistLayouts` / `restoreLayouts`) and adds a `userDefaults:` init param to `CLIInstallerCoordinator` + `LegacyHooksCoordinator` so their dismissal keys flow through the same suite. Regression tests assert the developer's `.standard` is never touched when a non-standard suite is injected.
3. **`docs: document TBD_HOME and TBD_SOCKET_PATH env overrides`** — adds a "Tests must not touch ~/tbd" section to `CLAUDE.md`.

## Design tradeoffs

- **Scope: test isolation only.** Production multi-instance daemons stay out of scope — LaunchServices, port allocation, and menu-bar coordination would explode the diff with no immediate payoff.
- **Two env vars, not one.** `TBD_SOCKET_PATH` is independently overridable so a deep `TBD_HOME` (sandboxed CI tmpdir) can still bind a short `/tmp/` socket without overflowing `sun_path`.
- **`@AppStorage` views are NOT refactored.** Today's tests don't render those views, so the `@AppStorage(...)` → `.standard` leak is latent. Refactoring all of them would require threading a UserDefaults through the SwiftUI environment — bigger blast radius, no concrete bug to motivate it.

## Out-of-scope follow-ups noticed (not in this PR)

- `registerFocusObservers()` + `startMemoryPressureMonitor()` still run unconditionally under tests. Benign today; the #149 reviewer flagged it.
- Existing tests (`GitStatusTests`, `WorktreeLifecycleTests`, `TBDWorktreeIDLeakTests`, `ArchivedReviveBranchRenameTests`) write `tbd-test-<UUID>` dirs into `$TMPDIR` without cleanup — 1800+ residue dirs accumulated locally. Pre-existing, not addressed here.
- The view-level `UserDefaults.standard` / `@AppStorage` call sites (`EmojiPickerView`, `OpenInEditorButton`, `ContentView`, `SettingsView`, etc.) remain unwrapped. Refactor when a test path needs them.

## Test plan

- [x] `swift build` — clean.
- [x] `swift test` — 792 tests in 82 suites, all passing.
- [x] `swift test --filter TBDSharedTests` — includes 6 new env-override tests.
- [x] `swift test --filter AppStateUserDefaultsIsolationTests` — 3 new tests confirming AppState never touches `.standard` when given an injected suite.

[isolate-test-paths](https://cheapsteak.github.io/tbd/open/?worktree=515CE532-6D1A-43F2-A595-9204E38CA7AF)