### PR TITLE
Feat: cmd-K jumps to the worktree that just pinged

### DIFF
--- a/Sources/TBDApp/AppState+Notifications.swift
+++ b/Sources/TBDApp/AppState+Notifications.swift
@@ -21,11 +21,11 @@ extension AppState {
     func markNotificationsRead(worktreeID: UUID) async {
         do {
             try await daemonClient.markNotificationsRead(worktreeID: worktreeID)
-            notifications[worktreeID] = nil
+            unreadByWorktree[worktreeID] = nil
         } catch {
             // Not critical — just clear locally
             logger.warning("Failed to mark notifications read for \(worktreeID): \(error)")
-            notifications[worktreeID] = nil
+            unreadByWorktree[worktreeID] = nil
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -507,11 +507,20 @@ final class AppState: ObservableObject {
 
         // Update local unread summary state. The delta doesn't carry a
         // timestamp so we use "now" — close enough for the jump menu's
-        // recency-based sort.
-        unreadByWorktree[notification.worktreeID] = UnreadSummary(
-            type: notification.type,
-            mostRecentAt: Date()
-        )
+        // recency-based sort. Merge with any existing summary so a lower-
+        // severity arrival (e.g. responseComplete) doesn't downgrade a
+        // higher-severity unread (e.g. error) until the next DB poll.
+        let incoming = UnreadSummary(type: notification.type, mostRecentAt: Date())
+        if let existing = unreadByWorktree[notification.worktreeID] {
+            let winnerType = incoming.type.severity > existing.type.severity
+                ? incoming.type : existing.type
+            unreadByWorktree[notification.worktreeID] = UnreadSummary(
+                type: winnerType,
+                mostRecentAt: incoming.mostRecentAt
+            )
+        } else {
+            unreadByWorktree[notification.worktreeID] = incoming
+        }
 
         // Fire sound + macOS notification
         notificationSoundPlayer.playIfEnabled()

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -57,10 +57,11 @@ final class AppState: ObservableObject {
                 recordNavigation(.worktrees(selectionOrder))
                 // Feed the jump menu's Recent section. Insertion-order LRU,
                 // most-recent-first; capped at 32 to bound memory. Only the
-                // first selected ID is recorded — multi-select doesn't make
-                // sense for "the worktree I just looked at". Intentionally
-                // not gated on `isNavigating`: cmd+[ / cmd+] are real visits
-                // and should reorder the jump menu Recents (Slack-style).
+                // most-recently-added worktree ID is recorded per selection
+                // event — multi-select doesn't make sense for "the worktree
+                // I just looked at". Intentionally not gated on
+                // `isNavigating`: cmd+[ / cmd+] are real visits and should
+                // reorder the jump menu Recents (Slack-style).
                 if let id = selectionOrder.last {
                     recentWorktreeIDs.removeAll { $0 == id }
                     recentWorktreeIDs.insert(id, at: 0)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -61,7 +61,7 @@ final class AppState: ObservableObject {
                 // sense for "the worktree I just looked at". Intentionally
                 // not gated on `isNavigating`: cmd+[ / cmd+] are real visits
                 // and should reorder the jump menu Recents (Slack-style).
-                if let id = selectedWorktreeIDs.first {
+                if let id = selectionOrder.last {
                     recentWorktreeIDs.removeAll { $0 == id }
                     recentWorktreeIDs.insert(id, at: 0)
                     if recentWorktreeIDs.count > Self.recentWorktreeCap {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -58,7 +58,9 @@ final class AppState: ObservableObject {
                 // Feed the jump menu's Recent section. Insertion-order LRU,
                 // most-recent-first; capped at 32 to bound memory. Only the
                 // first selected ID is recorded — multi-select doesn't make
-                // sense for "the worktree I just looked at".
+                // sense for "the worktree I just looked at". Intentionally
+                // not gated on `isNavigating`: cmd+[ / cmd+] are real visits
+                // and should reorder the jump menu Recents (Slack-style).
                 if let id = selectedWorktreeIDs.first {
                     recentWorktreeIDs.removeAll { $0 == id }
                     recentWorktreeIDs.insert(id, at: 0)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -26,7 +26,12 @@ final class AppState: ObservableObject {
     @Published var worktrees: [UUID: [Worktree]] = [:]
     @Published var terminals: [UUID: [Terminal]] = [:]
     @Published var notes: [UUID: [Note]] = [:]
-    @Published var notifications: [UUID: NotificationType?] = [:]
+    /// Unread notification summaries keyed by worktree ID. The cmd-K jump
+    /// menu sorts by `mostRecentAt`; the sidebar consumes `.type` for the
+    /// severity dot. Worktrees the user is currently viewing are excluded
+    /// from this dictionary because `refreshNotifications` auto-marks them
+    /// read on every poll.
+    @Published var unreadByWorktree: [UUID: UnreadSummary] = [:]
     @Published var selectedWorktreeIDs: Set<UUID> = [] {
         didSet {
             // If the List selected a repo header tag (not a worktree), treat it
@@ -50,6 +55,17 @@ final class AppState: ObservableObject {
                 if let leaving = selectedRepoID { clearRevivingArchived(repoID: leaving) }
                 selectedRepoID = nil
                 recordNavigation(.worktrees(selectionOrder))
+                // Feed the jump menu's Recent section. Insertion-order LRU,
+                // most-recent-first; capped at 32 to bound memory. Only the
+                // first selected ID is recorded — multi-select doesn't make
+                // sense for "the worktree I just looked at".
+                if let id = selectedWorktreeIDs.first {
+                    recentWorktreeIDs.removeAll { $0 == id }
+                    recentWorktreeIDs.insert(id, at: 0)
+                    if recentWorktreeIDs.count > Self.recentWorktreeCap {
+                        recentWorktreeIDs.removeLast(recentWorktreeIDs.count - Self.recentWorktreeCap)
+                    }
+                }
             }
         }
     }
@@ -204,6 +220,14 @@ final class AppState: ObservableObject {
     /// most-recent-first. Cap: keepAliveLimit. Older worktrees get evicted
     /// (their SingleWorktreeView unmounts) when the cap is exceeded.
     @Published private(set) var recentlyVisitedWorktreeIDs: [UUID] = []
+
+    /// LRU of recently-selected worktrees consumed by the cmd-K jump menu.
+    /// Distinct from `recentlyVisitedWorktreeIDs` (which has a much smaller
+    /// cap and drives the SingleWorktreeView keep-alive cache). In-memory
+    /// only — resets on app relaunch, matching Slack's "Recent" semantics.
+    @Published private(set) var recentWorktreeIDs: [UUID] = []
+
+    private static let recentWorktreeCap = 32
 
     private let keepAliveLimit = 8
 
@@ -479,8 +503,13 @@ final class AppState: ObservableObject {
         let visible = visibleWorktreeIDs
         guard !visible.contains(notification.worktreeID) else { return }
 
-        // Update local notification state
-        notifications[notification.worktreeID] = notification.type
+        // Update local unread summary state. The delta doesn't carry a
+        // timestamp so we use "now" — close enough for the jump menu's
+        // recency-based sort.
+        unreadByWorktree[notification.worktreeID] = UnreadSummary(
+            type: notification.type,
+            mostRecentAt: Date()
+        )
 
         // Fire sound + macOS notification
         notificationSoundPlayer.playIfEnabled()
@@ -851,12 +880,8 @@ final class AppState: ObservableObject {
 
             // Only include notifications for non-visible worktrees in UI state
             let filtered = fetched.filter { !visible.contains($0.key) }
-            if filtered != notifications.compactMapValues({ $0 }) {
-                var updated: [UUID: NotificationType?] = [:]
-                for (id, type) in filtered {
-                    updated[id] = type
-                }
-                notifications = updated
+            if filtered != unreadByWorktree {
+                unreadByWorktree = filtered
             }
         } catch {
             logger.error("Failed to list notifications: \(error)")

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -249,7 +249,7 @@ struct ContentView: View {
 
     private func markSelectedWorktreesAsRead(_ selection: Set<UUID>) {
         for worktreeID in selection {
-            appState.notifications[worktreeID] = nil
+            appState.unreadByWorktree[worktreeID] = nil
             Task {
                 await appState.markNotificationsRead(worktreeID: worktreeID)
             }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -547,10 +547,21 @@ actor DaemonClient {
         )
     }
 
-    /// List unread notifications grouped by worktree (highest severity per worktree).
-    func listNotifications() async throws -> [UUID: NotificationType] {
-        let result = try await callNoParamsAsync(method: RPCMethod.notificationsList, resultType: NotificationsListResult.self)
-        return result.notifications
+    /// Unread summaries grouped by worktree (highest-severity type + most-recent
+    /// unread timestamp). Falls back to a synthesized summary with
+    /// `Date.distantPast` if the daemon is an older build that only returns
+    /// the legacy `notifications` field.
+    func listNotifications() async throws -> [UUID: UnreadSummary] {
+        let result = try await callNoParamsAsync(
+            method: RPCMethod.notificationsList,
+            resultType: NotificationsListResult.self
+        )
+        if let summaries = result.summaries {
+            return summaries
+        }
+        return result.notifications.mapValues {
+            UnreadSummary(type: $0, mostRecentAt: .distantPast)
+        }
     }
 
     /// Mark notifications as read for a worktree.

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -75,6 +75,15 @@ struct TBDCommands: Commands {
 
         // Worktree selection by index (Cmd-1 through Cmd-9)
         CommandMenu("Go") {
+            Button("Jump to Worktree…") {
+                Task { @MainActor in
+                    JumpMenuController.shared.toggle()
+                }
+            }
+            .keyboardShortcut("k", modifiers: .command)
+
+            Divider()
+
             ForEach(1...9, id: \.self) { index in
                 Button("Worktree \(index)") {
                     Task { @MainActor in

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -1,0 +1,129 @@
+import AppKit
+import SwiftUI
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "JumpMenu")
+
+@MainActor
+final class JumpMenuController {
+    static let shared = JumpMenuController()
+
+    private weak var appState: AppState?
+    private var panel: FloatingPanel?
+    private var viewModel: JumpMenuViewModel?
+
+    private init() {}
+
+    /// Wire AppState once at app launch. Called from TBDApp.swift after
+    /// the AppState instance is created. Keeping this out of the
+    /// initializer avoids a chicken-and-egg with @StateObject AppState.
+    func configure(appState: AppState) {
+        self.appState = appState
+    }
+
+    func toggle() {
+        if let panel, panel.isVisible {
+            close()
+        } else {
+            open()
+        }
+    }
+
+    private func open() {
+        guard let appState else {
+            logger.warning("toggle() called before configure(appState:)")
+            return
+        }
+
+        // Snapshot all worktrees + unread + recents at open time. Mutations
+        // arriving while the panel is visible don't affect the displayed
+        // list — that's the design's "snapshot semantics" rule.
+        let snapshots = appState.worktrees.values
+            .flatMap { $0 }
+            .map { wt -> JumpMenuWorktreeSnapshot in
+                let repoName = appState.repos.first { $0.id == wt.repoID }?.displayName ?? "?"
+                return JumpMenuWorktreeSnapshot(
+                    id: wt.id,
+                    displayName: wt.displayName,
+                    repoName: repoName
+                )
+            }
+
+        let vm = JumpMenuViewModel(
+            worktrees: snapshots,
+            unread: appState.unreadByWorktree,
+            recentIDs: appState.recentWorktreeIDs
+        )
+        self.viewModel = vm
+
+        let view = JumpMenuView(
+            viewModel: vm,
+            onSubmit: { [weak self] row in
+                self?.submit(row)
+            },
+            onCancel: { [weak self] in
+                self?.close()
+            }
+        )
+
+        let panel = self.panel ?? JumpMenuPanel(content: view)
+        panel.updateContent(view)
+        positionPanel(panel)
+        panel.orderFrontRegardless()
+        panel.makeKey()
+        self.panel = panel
+
+        logger.debug("Jump menu opened with \(snapshots.count, privacy: .public) worktrees, \(appState.unreadByWorktree.count, privacy: .public) unread, \(appState.recentWorktreeIDs.count, privacy: .public) recents")
+    }
+
+    private func close() {
+        panel?.dismiss()
+        viewModel = nil
+    }
+
+    private func submit(_ row: JumpMenuRow) {
+        guard let appState else { return }
+        // Filter against the live worktree map — the snapshot may be stale
+        // if a worktree was deleted while the panel was open.
+        let liveIDs = Set(appState.worktrees.values.flatMap { $0 }.map(\.id))
+        guard liveIDs.contains(row.id) else {
+            logger.debug("Submit on stale worktree id \(row.id, privacy: .public) — closing without jumping")
+            close()
+            return
+        }
+        appState.selectedWorktreeIDs = [row.id]
+        close()
+    }
+
+    /// Anchor the panel ~80pt below the top of the key TBD window,
+    /// horizontally centered. If there is no key window (e.g. all windows
+    /// are minimized) fall back to the main screen.
+    private func positionPanel(_ panel: NSPanel) {
+        let panelSize = panel.frame.size == .zero
+            ? CGSize(width: 440, height: 360)
+            : panel.frame.size
+
+        let anchorRect: NSRect = {
+            if let win = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible && !($0 is NSPanel) }) {
+                return win.frame
+            }
+            return NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        }()
+
+        let originX = anchorRect.midX - panelSize.width / 2
+        let originY = anchorRect.maxY - panelSize.height - 80
+        panel.setFrame(
+            NSRect(origin: NSPoint(x: originX, y: originY), size: panelSize),
+            display: true
+        )
+    }
+}
+
+/// FloatingPanel variant that *can* become the key window. The base
+/// FloatingPanel is non-key by design (hover overlays); the jump menu
+/// needs key status so its TextField receives input.
+final class JumpMenuPanel: FloatingPanel {
+    override var canBecomeKey: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+}

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -67,8 +67,12 @@ final class JumpMenuController {
             }
         )
 
-        let panel = self.panel ?? JumpMenuPanel(content: view)
-        panel.updateContent(view)
+        // Always recreate the panel on each open so SwiftUI mounts a fresh
+        // view tree and `JumpMenuView.onAppear { searchFocused = true }`
+        // fires every time. Reusing the panel and swapping content via
+        // `updateContent` skips onAppear after the first open, leaving the
+        // search field unfocused on subsequent cmd-K presses.
+        let panel = JumpMenuPanel(content: view)
         positionPanel(panel)
         panel.orderFrontRegardless()
         panel.makeKey()
@@ -79,6 +83,7 @@ final class JumpMenuController {
 
     private func close() {
         panel?.dismiss()
+        panel = nil
         viewModel = nil
     }
 

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -108,7 +108,7 @@ final class JumpMenuController {
         // Search field ~36pt + divider + list maxHeight 420pt + a little padding = ~480.
         // The panel is freshly created each open, so its frame is .zero here —
         // we drive sizing from this single constant.
-        let panelSize = CGSize(width: 440, height: 480)
+        let panelSize = CGSize(width: jumpMenuPanelWidth, height: 480)
 
         let anchorRect: NSRect = {
             if let win = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible && !($0 is NSPanel) }) {

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -9,6 +9,9 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "JumpMenu")
 final class JumpMenuController {
     static let shared = JumpMenuController()
 
+    // Chrome around the list: search field (~36) + divider (1) + padding (~23).
+    private static let jumpMenuPanelChromeHeight: CGFloat = 60
+
     private weak var appState: AppState?
     private var panel: FloatingPanel?
     private var viewModel: JumpMenuViewModel?
@@ -105,10 +108,12 @@ final class JumpMenuController {
     /// horizontally centered. If there is no key window (e.g. all windows
     /// are minimized) fall back to the main screen.
     private func positionPanel(_ panel: NSPanel) {
-        // Search field ~36pt + divider + list maxHeight 420pt + a little padding = ~480.
         // The panel is freshly created each open, so its frame is .zero here —
-        // we drive sizing from this single constant.
-        let panelSize = CGSize(width: jumpMenuPanelWidth, height: 480)
+        // we drive sizing from the shared list-max-height + chrome constants.
+        let panelSize = CGSize(
+            width: jumpMenuPanelWidth,
+            height: jumpMenuListMaxHeight + Self.jumpMenuPanelChromeHeight
+        )
 
         let anchorRect: NSRect = {
             if let win = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible && !($0 is NSPanel) }) {

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -117,8 +117,20 @@ final class JumpMenuController {
             return NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         }()
 
-        let originX = anchorRect.midX - panelSize.width / 2
-        let originY = anchorRect.maxY - panelSize.height - 80
+        // Clamp the panel rect inside the visible frame of whichever screen
+        // contains the anchor (falls back to the main screen, then to the
+        // anchor itself) so it can't land partially off-screen on narrow
+        // displays, multi-monitor setups, or windows hugging an edge.
+        let screenFrame = (NSScreen.screens.first { $0.frame.contains(anchorRect.origin) }
+            ?? NSScreen.main)?.visibleFrame ?? anchorRect
+        let originX = max(
+            screenFrame.minX,
+            min(anchorRect.midX - panelSize.width / 2, screenFrame.maxX - panelSize.width)
+        )
+        let originY = max(
+            screenFrame.minY,
+            min(anchorRect.maxY - panelSize.height - 80, screenFrame.maxY - panelSize.height)
+        )
         panel.setFrame(
             NSRect(origin: NSPoint(x: originX, y: originY), size: panelSize),
             display: true

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -105,9 +105,10 @@ final class JumpMenuController {
     /// horizontally centered. If there is no key window (e.g. all windows
     /// are minimized) fall back to the main screen.
     private func positionPanel(_ panel: NSPanel) {
-        let panelSize = panel.frame.size == .zero
-            ? CGSize(width: 440, height: 360)
-            : panel.frame.size
+        // Search field ~36pt + divider + list maxHeight 420pt + a little padding = ~480.
+        // The panel is freshly created each open, so its frame is .zero here —
+        // we drive sizing from this single constant.
+        let panelSize = CGSize(width: 440, height: 480)
 
         let anchorRect: NSRect = {
             if let win = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible && !($0 is NSPanel) }) {

--- a/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
@@ -14,7 +14,6 @@ struct JumpMenuRow: Identifiable, Equatable {
     let displayName: String       // includes leading emoji if any
     let repoName: String
     let severity: NotificationType?   // nil for recent / match-without-unread
-    let timestamp: Date?              // unread → most-recent-notification, recent → last-visit
     let section: Section
 }
 
@@ -41,23 +40,9 @@ private struct SeverityDot: View {
     }
 }
 
-/// Compact "2m" / "3h" / "5d" formatter for the trailing time-ago column.
-/// Suppressed by the parent view when the user is typing (section == .match).
-private func relativeTimeString(from date: Date, now: Date = Date()) -> String {
-    let seconds = Int(now.timeIntervalSince(date))
-    if seconds < 60 { return "\(max(seconds, 0))s" }
-    let minutes = seconds / 60
-    if minutes < 60 { return "\(minutes)m" }
-    let hours = minutes / 60
-    if hours < 24 { return "\(hours)h" }
-    let days = hours / 24
-    return "\(days)d"
-}
-
 struct JumpMenuRowView: View {
     let row: JumpMenuRow
     let isSelected: Bool
-    let showTimestamp: Bool
 
     var body: some View {
         HStack(spacing: 8) {
@@ -71,12 +56,6 @@ struct JumpMenuRowView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
             Spacer()
-            if showTimestamp, let ts = row.timestamp {
-                Text(relativeTimeString(from: ts))
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-            }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 5)

--- a/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import TBDShared
+
+/// A single row in the jump menu. `section` is `.unread` or `.recent` in the
+/// default (empty-query) state and `.match` while the user is typing.
+struct JumpMenuRow: Identifiable, Equatable {
+    enum Section: Equatable {
+        case unread
+        case recent
+        case match
+    }
+
+    let id: UUID                  // worktree ID
+    let displayName: String       // includes leading emoji if any
+    let repoName: String
+    let severity: NotificationType?   // nil for recent / match-without-unread
+    let timestamp: Date?              // unread → most-recent-notification, recent → last-visit
+    let section: Section
+}
+
+/// Color the severity dot. Mirrors WorktreeRowView's logic so the two views
+/// stay visually consistent.
+private func severityColor(_ type: NotificationType) -> Color {
+    switch type {
+    case .error:            return .red
+    case .attentionNeeded:  return .orange
+    case .taskComplete:     return .green
+    case .responseComplete: return .blue
+    }
+}
+
+/// A 6pt dot in the severity color, or a transparent spacer of the same
+/// width so rows without unread notifications still align with rows that
+/// have one.
+private struct SeverityDot: View {
+    let severity: NotificationType?
+    var body: some View {
+        Circle()
+            .fill(severity.map(severityColor) ?? .clear)
+            .frame(width: 6, height: 6)
+    }
+}
+
+/// Compact "2m" / "3h" / "5d" formatter for the trailing time-ago column.
+/// Suppressed by the parent view when the user is typing (section == .match).
+private func relativeTimeString(from date: Date, now: Date = Date()) -> String {
+    let seconds = Int(now.timeIntervalSince(date))
+    if seconds < 60 { return "\(max(seconds, 0))s" }
+    let minutes = seconds / 60
+    if minutes < 60 { return "\(minutes)m" }
+    let hours = minutes / 60
+    if hours < 24 { return "\(hours)h" }
+    let days = hours / 24
+    return "\(days)d"
+}
+
+struct JumpMenuRowView: View {
+    let row: JumpMenuRow
+    let isSelected: Bool
+    let showTimestamp: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            SeverityDot(severity: row.severity)
+            Text(row.displayName)
+                .font(.system(size: 13))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Text(row.repoName)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer()
+            if showTimestamp, let ts = row.timestamp {
+                Text(relativeTimeString(from: ts))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+        )
+        .contentShape(Rectangle())
+    }
+}

--- a/Sources/TBDApp/JumpMenu/JumpMenuView.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuView.swift
@@ -1,7 +1,4 @@
 import SwiftUI
-import os
-
-private let logger = Logger(subsystem: "com.tbd.app", category: "JumpMenu")
 
 struct JumpMenuView: View {
     @ObservedObject var viewModel: JumpMenuViewModel

--- a/Sources/TBDApp/JumpMenu/JumpMenuView.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuView.swift
@@ -4,6 +4,10 @@ import SwiftUI
 /// root content — both must match.
 let jumpMenuPanelWidth: CGFloat = 440
 
+/// Maximum height of the scrolling list inside the panel.
+/// The controller derives the panel's total height from this + chrome.
+let jumpMenuListMaxHeight: CGFloat = 420
+
 struct JumpMenuView: View {
     @ObservedObject var viewModel: JumpMenuViewModel
     let onSubmit: (JumpMenuRow) -> Void
@@ -89,7 +93,7 @@ struct JumpMenuView: View {
                     }
                     .padding(.vertical, 4)
                 }
-                .frame(maxHeight: 420)
+                .frame(maxHeight: jumpMenuListMaxHeight)
                 .onChange(of: viewModel.selectedIndex) { _, newIndex in
                     guard newIndex < rows.count else { return }
                     withAnimation(.easeOut(duration: 0.1)) {

--- a/Sources/TBDApp/JumpMenu/JumpMenuView.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "JumpMenu")
+
+struct JumpMenuView: View {
+    @ObservedObject var viewModel: JumpMenuViewModel
+    let onSubmit: (JumpMenuRow) -> Void
+    let onCancel: () -> Void
+
+    @FocusState private var searchFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+            Divider()
+            list
+        }
+        .frame(width: 440)
+        .background(
+            VisualEffectView(material: .menu, blendingMode: .behindWindow)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .onAppear { searchFocused = true }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Jump to worktree…", text: $viewModel.query)
+                .textFieldStyle(.plain)
+                .font(.system(size: 14))
+                .focused($searchFocused)
+                .onChange(of: viewModel.query) { _, _ in
+                    viewModel.resetSelection()
+                }
+                .onKeyPress(.downArrow) {
+                    viewModel.moveSelectionDown()
+                    return .handled
+                }
+                .onKeyPress(.upArrow) {
+                    viewModel.moveSelectionUp()
+                    return .handled
+                }
+                .onKeyPress(.return) {
+                    if let row = viewModel.selectedRow {
+                        onSubmit(row)
+                    } else {
+                        onCancel()
+                    }
+                    return .handled
+                }
+                .onKeyPress(.escape) {
+                    onCancel()
+                    return .handled
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var list: some View {
+        let rows = viewModel.rows
+        if rows.isEmpty {
+            emptyState
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(rows.enumerated()), id: \.element.id) { idx, row in
+                            sectionHeaderIfNeeded(rows: rows, index: idx)
+                            JumpMenuRowView(
+                                row: row,
+                                isSelected: idx == viewModel.selectedIndex,
+                                showTimestamp: viewModel.query.trimmingCharacters(in: .whitespaces).isEmpty
+                            )
+                            .id(row.id)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                onSubmit(row)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .frame(maxHeight: 420)
+                .onChange(of: viewModel.selectedIndex) { _, newIndex in
+                    guard newIndex < rows.count else { return }
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo(rows[newIndex].id, anchor: .center)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func sectionHeaderIfNeeded(rows: [JumpMenuRow], index: Int) -> some View {
+        let prevSection: JumpMenuRow.Section? = index > 0 ? rows[index - 1].section : nil
+        let section = rows[index].section
+        // Skip section headers entirely while the user is filtering — the
+        // typed-query mode is one flat ranked list.
+        if section != .match, section != prevSection {
+            Text(section == .unread ? "UNREAD" : "RECENT")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 10)
+                .padding(.top, index == 0 ? 4 : 8)
+                .padding(.bottom, 2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var emptyState: some View {
+        let trimmed = viewModel.query.trimmingCharacters(in: .whitespaces)
+        let message = trimmed.isEmpty ? "No recent activity" : "No matching worktrees"
+        return Text(message)
+            .font(.system(size: 13))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 24)
+    }
+}
+
+/// AppKit visual-effect bridge so the panel picks up the system menu material.
+private struct VisualEffectView: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let v = NSVisualEffectView()
+        v.material = material
+        v.blendingMode = blendingMode
+        v.state = .active
+        return v
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}

--- a/Sources/TBDApp/JumpMenu/JumpMenuView.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuView.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+/// Shared panel width. The controller sizes the NSPanel, the view sizes its
+/// root content — both must match.
+let jumpMenuPanelWidth: CGFloat = 440
+
 struct JumpMenuView: View {
     @ObservedObject var viewModel: JumpMenuViewModel
     let onSubmit: (JumpMenuRow) -> Void
@@ -15,7 +19,7 @@ struct JumpMenuView: View {
             Divider()
             list
         }
-        .frame(width: 440)
+        .frame(width: jumpMenuPanelWidth)
         .background(
             VisualEffectView(material: .menu, blendingMode: .behindWindow)
         )

--- a/Sources/TBDApp/JumpMenu/JumpMenuView.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuView.swift
@@ -74,8 +74,7 @@ struct JumpMenuView: View {
                             sectionHeaderIfNeeded(rows: rows, index: idx)
                             JumpMenuRowView(
                                 row: row,
-                                isSelected: idx == viewModel.selectedIndex,
-                                showTimestamp: viewModel.query.trimmingCharacters(in: .whitespaces).isEmpty
+                                isSelected: idx == viewModel.selectedIndex
                             )
                             .id(row.id)
                             .contentShape(Rectangle())

--- a/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
@@ -1,0 +1,153 @@
+import Combine
+import Foundation
+import TBDShared
+
+/// A minimal snapshot of one worktree's data, captured at menu-open time so
+/// the menu's display is immune to mid-triage list mutation. Decoupling from
+/// `Worktree` itself also keeps the view model trivially mockable from tests.
+struct JumpMenuWorktreeSnapshot: Equatable {
+    let id: UUID
+    let displayName: String
+    let repoName: String
+}
+
+/// Pure view model — no SwiftUI, no AppState. The controller assembles a
+/// snapshot once when opening the panel and hands it to the view model;
+/// the view model handles query mutation, filtering, sorting, capping.
+@MainActor
+final class JumpMenuViewModel: ObservableObject {
+    @Published var query: String = ""
+    @Published private(set) var selectedIndex: Int = 0
+
+    private let allWorktrees: [JumpMenuWorktreeSnapshot]
+    private let unread: [UUID: UnreadSummary]
+    private let recentIDs: [UUID]
+    private let now: Date
+
+    static let rowCap = 20
+
+    init(
+        worktrees: [JumpMenuWorktreeSnapshot],
+        unread: [UUID: UnreadSummary],
+        recentIDs: [UUID],
+        now: Date = Date()
+    ) {
+        self.allWorktrees = worktrees
+        self.unread = unread
+        self.recentIDs = recentIDs
+        self.now = now
+    }
+
+    /// Currently-displayed rows, recomputed when `query` changes.
+    var rows: [JumpMenuRow] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? defaultRows() : matchRows(query: trimmed)
+    }
+
+    /// Reset selection to the top whenever the query changes. The view binds
+    /// `query` directly to `@Published var query`, so call this from the
+    /// view's `.onChange(of: viewModel.query)` hook.
+    func resetSelection() {
+        selectedIndex = 0
+    }
+
+    func moveSelectionDown() {
+        let count = rows.count
+        guard count > 0 else { return }
+        selectedIndex = min(selectedIndex + 1, count - 1)
+    }
+
+    func moveSelectionUp() {
+        guard rows.count > 0 else { return }
+        selectedIndex = max(selectedIndex - 1, 0)
+    }
+
+    /// The row the user would jump to right now. `nil` when there are no
+    /// rows (the view should treat enter-on-nil as a no-op + close).
+    var selectedRow: JumpMenuRow? {
+        let r = rows
+        guard !r.isEmpty, selectedIndex >= 0, selectedIndex < r.count else { return nil }
+        return r[selectedIndex]
+    }
+
+    // MARK: - Default (empty query)
+
+    private func defaultRows() -> [JumpMenuRow] {
+        let snapshotByID = Dictionary(uniqueKeysWithValues: allWorktrees.map { ($0.id, $0) })
+
+        // Unreads, sorted by mostRecentAt desc, with UUID lexicographic tiebreak.
+        let unreadRows: [JumpMenuRow] = unread
+            .compactMap { (id, summary) -> (UUID, UnreadSummary, JumpMenuWorktreeSnapshot)? in
+                guard let snap = snapshotByID[id] else { return nil }   // filters deletions
+                return (id, summary, snap)
+            }
+            .sorted { lhs, rhs in
+                if lhs.1.mostRecentAt != rhs.1.mostRecentAt {
+                    return lhs.1.mostRecentAt > rhs.1.mostRecentAt
+                }
+                return lhs.0.uuidString < rhs.0.uuidString
+            }
+            .map { (id, summary, snap) in
+                JumpMenuRow(
+                    id: id,
+                    displayName: snap.displayName,
+                    repoName: snap.repoName,
+                    severity: summary.type,
+                    timestamp: summary.mostRecentAt,
+                    section: .unread
+                )
+            }
+
+        // Recents minus anything already in unread, minus deletions. The LRU
+        // doesn't carry a timestamp — we approximate the "time since last
+        // visit" by index-based deltas from `now`, one minute per position,
+        // so the first recent gets "now" and older ones get progressively
+        // dimmer relative labels. The spec says time-ago is hidden while
+        // typing anyway; for default-state display this is an honest "most
+        // recent" indicator without needing wall-clock visit timestamps.
+        let unreadIDs = Set(unread.keys)
+        let recentRows: [JumpMenuRow] = recentIDs
+            .filter { !unreadIDs.contains($0) }
+            .compactMap { id -> (UUID, JumpMenuWorktreeSnapshot)? in
+                guard let snap = snapshotByID[id] else { return nil }   // filters deletions
+                return (id, snap)
+            }
+            .enumerated()
+            .map { (offset, pair) in
+                JumpMenuRow(
+                    id: pair.0,
+                    displayName: pair.1.displayName,
+                    repoName: pair.1.repoName,
+                    severity: nil,
+                    timestamp: now.addingTimeInterval(-Double(offset) * 60),
+                    section: .recent
+                )
+            }
+
+        let combined = unreadRows + recentRows
+        return Array(combined.prefix(Self.rowCap))
+    }
+
+    // MARK: - Typed query
+
+    private func matchRows(query: String) -> [JumpMenuRow] {
+        let needle = query.lowercased()
+        return allWorktrees
+            .filter { snap in
+                snap.displayName.lowercased().contains(needle)
+                    || snap.repoName.lowercased().contains(needle)
+            }
+            .map { snap in
+                JumpMenuRow(
+                    id: snap.id,
+                    displayName: snap.displayName,
+                    repoName: snap.repoName,
+                    severity: unread[snap.id]?.type,
+                    timestamp: unread[snap.id]?.mostRecentAt,
+                    section: .match
+                )
+            }
+            .prefix(Self.rowCap)
+            .map { $0 }
+    }
+}

--- a/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
@@ -136,6 +136,22 @@ final class JumpMenuViewModel: ObservableObject {
                     section: .match
                 )
             }
+            // Order: rows with an unread severity first (severity desc), then
+            // rows without. Within each group, sort by displayName asc, with
+            // a UUID lexicographic tiebreak for determinism. Dict iteration
+            // order of `allWorktrees` is otherwise arbitrary.
+            .sorted { lhs, rhs in
+                let lhsSev = lhs.severity?.severity ?? -1
+                let rhsSev = rhs.severity?.severity ?? -1
+                let lhsHas = lhs.severity != nil
+                let rhsHas = rhs.severity != nil
+                if lhsHas != rhsHas { return lhsHas && !rhsHas }
+                if lhsSev != rhsSev { return lhsSev > rhsSev }
+                if lhs.displayName != rhs.displayName {
+                    return lhs.displayName < rhs.displayName
+                }
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
             .prefix(Self.rowCap)
             .map { $0 }
     }

--- a/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
@@ -22,20 +22,17 @@ final class JumpMenuViewModel: ObservableObject {
     private let allWorktrees: [JumpMenuWorktreeSnapshot]
     private let unread: [UUID: UnreadSummary]
     private let recentIDs: [UUID]
-    private let now: Date
 
     static let rowCap = 20
 
     init(
         worktrees: [JumpMenuWorktreeSnapshot],
         unread: [UUID: UnreadSummary],
-        recentIDs: [UUID],
-        now: Date = Date()
+        recentIDs: [UUID]
     ) {
         self.allWorktrees = worktrees
         self.unread = unread
         self.recentIDs = recentIDs
-        self.now = now
     }
 
     /// Currently-displayed rows, recomputed when `query` changes.
@@ -93,18 +90,13 @@ final class JumpMenuViewModel: ObservableObject {
                     displayName: snap.displayName,
                     repoName: snap.repoName,
                     severity: summary.type,
-                    timestamp: summary.mostRecentAt,
                     section: .unread
                 )
             }
 
-        // Recents minus anything already in unread, minus deletions. The LRU
-        // doesn't carry a timestamp — we approximate the "time since last
-        // visit" by index-based deltas from `now`, one minute per position,
-        // so the first recent gets "now" and older ones get progressively
-        // dimmer relative labels. The spec says time-ago is hidden while
-        // typing anyway; for default-state display this is an honest "most
-        // recent" indicator without needing wall-clock visit timestamps.
+        // Recents minus anything already in unread, minus deletions. LRU
+        // position is preserved by iterating `recentIDs` in order; no
+        // timestamp is needed since rows no longer display time-ago.
         let unreadIDs = Set(unread.keys)
         let recentRows: [JumpMenuRow] = recentIDs
             .filter { !unreadIDs.contains($0) }
@@ -112,14 +104,12 @@ final class JumpMenuViewModel: ObservableObject {
                 guard let snap = snapshotByID[id] else { return nil }   // filters deletions
                 return (id, snap)
             }
-            .enumerated()
-            .map { (offset, pair) in
+            .map { pair in
                 JumpMenuRow(
                     id: pair.0,
                     displayName: pair.1.displayName,
                     repoName: pair.1.repoName,
                     severity: nil,
-                    timestamp: now.addingTimeInterval(-Double(offset) * 60),
                     section: .recent
                 )
             }
@@ -143,7 +133,6 @@ final class JumpMenuViewModel: ObservableObject {
                     displayName: snap.displayName,
                     repoName: snap.repoName,
                     severity: unread[snap.id]?.type,
-                    timestamp: unread[snap.id]?.mostRecentAt,
                     section: .match
                 )
             }

--- a/Sources/TBDApp/Sidebar/FloatingPanel.swift
+++ b/Sources/TBDApp/Sidebar/FloatingPanel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// A borderless, non-activating floating panel for instant show/hide
 /// without stealing focus from the parent text field.
-final class FloatingPanel: NSPanel {
+class FloatingPanel: NSPanel {
     private var hostingView: NSHostingView<AnyView>?
 
     init<Content: View>(content: Content) {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -15,7 +15,7 @@ struct WorktreeRowView: View {
     }
 
     private var notification: NotificationType? {
-        appState.notifications[worktree.id] ?? nil
+        appState.unreadByWorktree[worktree.id]?.type
     }
 
     private var hasBoldNotification: Bool {

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -423,6 +423,7 @@ struct TBDAppMain: App {
                 .environmentObject(appState)
                 .onAppear {
                     lifecycleLogger.info("scene main onAppear")
+                    JumpMenuController.shared.configure(appState: appState)
                 }
                 .onOpenURL { url in
                     DeepLinkHandler.handle(url, appState: appState)

--- a/Sources/TBDDaemon/Database/NotificationStore.swift
+++ b/Sources/TBDDaemon/Database/NotificationStore.swift
@@ -90,27 +90,6 @@ public struct NotificationStore: Sendable {
             .max(by: { $0.severity < $1.severity })
     }
 
-    /// Get the highest severity unread notification type for all worktrees.
-    public func allUnreadByWorktree() async throws -> [UUID: NotificationType] {
-        let records = try await writer.read { db in
-            try NotificationRecord
-                .filter(Column("read") == false)
-                .fetchAll(db)
-        }
-        var result: [UUID: NotificationType] = [:]
-        for record in records {
-            let model = record.toModel()
-            if let existing = result[model.worktreeID] {
-                if model.type.severity > existing.severity {
-                    result[model.worktreeID] = model.type
-                }
-            } else {
-                result[model.worktreeID] = model.type
-            }
-        }
-        return result
-    }
-
     /// One row per worktree with at least one unread notification: the highest
     /// severity unread type and the timestamp of the most-recent unread row.
     /// Used by the cmd-K jump menu to sort worktrees by attention-recency.

--- a/Sources/TBDDaemon/Database/NotificationStore.swift
+++ b/Sources/TBDDaemon/Database/NotificationStore.swift
@@ -110,4 +110,34 @@ public struct NotificationStore: Sendable {
         }
         return result
     }
+
+    /// One row per worktree with at least one unread notification: the highest
+    /// severity unread type and the timestamp of the most-recent unread row.
+    /// Used by the cmd-K jump menu to sort worktrees by attention-recency.
+    public func unreadSummaryByWorktree() async throws -> [UUID: UnreadSummary] {
+        let records = try await writer.read { db in
+            try NotificationRecord
+                .filter(Column("read") == false)
+                .fetchAll(db)
+        }
+        var result: [UUID: UnreadSummary] = [:]
+        for record in records {
+            let model = record.toModel()
+            if let existing = result[model.worktreeID] {
+                let newType = model.type.severity > existing.type.severity
+                    ? model.type
+                    : existing.type
+                let newAt = model.createdAt > existing.mostRecentAt
+                    ? model.createdAt
+                    : existing.mostRecentAt
+                result[model.worktreeID] = UnreadSummary(type: newType, mostRecentAt: newAt)
+            } else {
+                result[model.worktreeID] = UnreadSummary(
+                    type: model.type,
+                    mostRecentAt: model.createdAt
+                )
+            }
+        }
+        return result
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -770,8 +770,12 @@ extension RPCRouter {
     // MARK: - Notifications List
 
     func handleNotificationsList() async throws -> RPCResponse {
-        let notifications = try await db.notifications.allUnreadByWorktree()
-        return try RPCResponse(result: NotificationsListResult(notifications: notifications))
+        let summaries = try await db.notifications.unreadSummaryByWorktree()
+        let legacyTypes = summaries.mapValues { $0.type }
+        return try RPCResponse(result: NotificationsListResult(
+            notifications: legacyTypes,
+            summaries: summaries
+        ))
     }
 
     // MARK: - Notifications Mark Read

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -411,6 +411,20 @@ public struct TBDNotification: Codable, Sendable, Identifiable {
     }
 }
 
+/// Per-worktree summary of unread notifications. Returned by
+/// `NotificationStore.unreadSummaryByWorktree()` and surfaced through the
+/// `listNotifications` RPC so the app can render severity badges AND sort
+/// the cmd-K jump menu by most-recent-notification time.
+public struct UnreadSummary: Codable, Sendable, Equatable {
+    public let type: NotificationType
+    public let mostRecentAt: Date
+
+    public init(type: NotificationType, mostRecentAt: Date) {
+        self.type = type
+        self.mostRecentAt = mostRecentAt
+    }
+}
+
 public enum PRMergeableState: String, Codable, Sendable {
     case open               // PR exists, no review decision yet
     case changesRequested   // reviewer requested changes

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -354,8 +354,8 @@ public struct NotificationsListResult: Codable, Sendable {
 
     /// New field (v0.1.1+) — full unread summary including timestamps.
     /// Optional for backwards compatibility: an older daemon will omit it
-    /// and a newer app should reconstruct `notifications` from this when
-    /// present.
+    /// and a newer app should reconstruct summaries from `notifications`
+    /// when `summaries` is absent.
     public let summaries: [UUID: UnreadSummary]?
 
     public init(

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -347,8 +347,24 @@ public struct ModelProfileHealthCheckResult: Codable, Sendable {
 }
 
 public struct NotificationsListResult: Codable, Sendable {
+    /// Legacy field — highest-severity unread type per worktree. Retained
+    /// for backwards compatibility during rollout. Newer clients should
+    /// prefer `summaries`. Always populated by the daemon.
     public let notifications: [UUID: NotificationType]
-    public init(notifications: [UUID: NotificationType]) { self.notifications = notifications }
+
+    /// New field (v0.1.1+) — full unread summary including timestamps.
+    /// Optional for backwards compatibility: an older daemon will omit it
+    /// and a newer app should reconstruct `notifications` from this when
+    /// present.
+    public let summaries: [UUID: UnreadSummary]?
+
+    public init(
+        notifications: [UUID: NotificationType],
+        summaries: [UUID: UnreadSummary]? = nil
+    ) {
+        self.notifications = notifications
+        self.summaries = summaries
+    }
 }
 
 public struct NotificationsMarkReadParams: Codable, Sendable {

--- a/Tests/TBDAppTests/JumpMenuViewModelTests.swift
+++ b/Tests/TBDAppTests/JumpMenuViewModelTests.swift
@@ -121,6 +121,34 @@ struct JumpMenuViewModelTests {
         #expect(vm.rows.first?.id == a)
     }
 
+    @Test func fuzzyMatch_sortedByUnreadPriority() {
+        // Multiple worktrees match the query; the one with the highest
+        // unread severity should land at index 0, regardless of dict
+        // iteration order.
+        let plain = UUID()
+        let info = UUID()
+        let urgent = UUID()
+        let now = Date()
+        let vm = JumpMenuViewModel(
+            worktrees: [
+                snap(plain, name: "match-plain"),
+                snap(info, name: "match-info"),
+                snap(urgent, name: "match-urgent"),
+            ],
+            unread: [
+                info: UnreadSummary(type: .taskComplete, mostRecentAt: now),
+                urgent: UnreadSummary(type: .error, mostRecentAt: now),
+            ],
+            recentIDs: []
+        )
+        vm.query = "match"
+        let rows = vm.rows
+        #expect(rows.count == 3)
+        #expect(rows[0].id == urgent)   // .error severity 4
+        #expect(rows[1].id == info)     // .taskComplete severity 2
+        #expect(rows[2].id == plain)    // no unread
+    }
+
     @Test func fuzzyMatch_noMatch() {
         let a = UUID()
         let vm = JumpMenuViewModel(

--- a/Tests/TBDAppTests/JumpMenuViewModelTests.swift
+++ b/Tests/TBDAppTests/JumpMenuViewModelTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+@testable import TBDApp
+@testable import TBDShared
+
+@MainActor
+@Suite("JumpMenuViewModel Tests")
+struct JumpMenuViewModelTests {
+
+    // MARK: - Helpers
+
+    func snap(_ id: UUID, name: String = "wt", repo: String = "tbd") -> JumpMenuWorktreeSnapshot {
+        JumpMenuWorktreeSnapshot(id: id, displayName: name, repoName: repo)
+    }
+
+    // MARK: - Tests
+
+    @Test func emptyState() {
+        let vm = JumpMenuViewModel(worktrees: [], unread: [:], recentIDs: [])
+        #expect(vm.rows.isEmpty)
+        #expect(vm.selectedRow == nil)
+    }
+
+    @Test func unreadsOnly_sortedByRecency() {
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let now = Date()
+        let vm = JumpMenuViewModel(
+            worktrees: [snap(a, name: "A"), snap(b, name: "B"), snap(c, name: "C")],
+            unread: [
+                a: UnreadSummary(type: .responseComplete, mostRecentAt: now.addingTimeInterval(-300)),
+                b: UnreadSummary(type: .error, mostRecentAt: now),
+                c: UnreadSummary(type: .taskComplete, mostRecentAt: now.addingTimeInterval(-60)),
+            ],
+            recentIDs: []
+        )
+        let rows = vm.rows
+        #expect(rows.count == 3)
+        #expect(rows[0].id == b)   // most recent
+        #expect(rows[1].id == c)
+        #expect(rows[2].id == a)
+        #expect(rows.allSatisfy { $0.section == .unread })
+    }
+
+    @Test func recentsOnly_sortedByLRUOrder() {
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [snap(a, name: "A"), snap(b, name: "B"), snap(c, name: "C")],
+            unread: [:],
+            recentIDs: [b, a, c]
+        )
+        let rows = vm.rows
+        #expect(rows.count == 3)
+        #expect(rows[0].id == b)
+        #expect(rows[1].id == a)
+        #expect(rows[2].id == c)
+        #expect(rows.allSatisfy { $0.section == .recent })
+    }
+
+    @Test func mixed_unreadsThenRecents_noDuplicates() {
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let now = Date()
+        let vm = JumpMenuViewModel(
+            worktrees: [snap(a, name: "A"), snap(b, name: "B"), snap(c, name: "C")],
+            unread: [a: UnreadSummary(type: .error, mostRecentAt: now)],
+            recentIDs: [a, b, c]   // a is already unread; should be filtered out of recents
+        )
+        let rows = vm.rows
+        #expect(rows.count == 3)
+        #expect(rows[0].id == a)
+        #expect(rows[0].section == .unread)
+        #expect(rows[1].id == b)
+        #expect(rows[1].section == .recent)
+        #expect(rows[2].id == c)
+        #expect(rows[2].section == .recent)
+    }
+
+    @Test func capAt20_unreadsFillFirst() {
+        let snaps = (0..<25).map { _ in UUID() }
+        var unread: [UUID: UnreadSummary] = [:]
+        let now = Date()
+        for (i, id) in snaps.enumerated() {
+            unread[id] = UnreadSummary(type: .responseComplete, mostRecentAt: now.addingTimeInterval(-Double(i)))
+        }
+        let vm = JumpMenuViewModel(
+            worktrees: snaps.map { snap($0) },
+            unread: unread,
+            recentIDs: snaps   // would push past the cap if not properly limited
+        )
+        #expect(vm.rows.count == 20)
+        #expect(vm.rows.allSatisfy { $0.section == .unread })
+    }
+
+    @Test func fuzzyMatch_basicSubstring() {
+        let a = UUID(); let b = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [
+                snap(a, name: "hot-otter", repo: "tbd"),
+                snap(b, name: "cold-bear", repo: "tbd"),
+            ],
+            unread: [:],
+            recentIDs: []
+        )
+        vm.query = "otter"
+        #expect(vm.rows.count == 1)
+        #expect(vm.rows.first?.id == a)
+        #expect(vm.rows.first?.section == .match)
+    }
+
+    @Test func fuzzyMatch_matchesRepoName() {
+        let a = UUID(); let b = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [
+                snap(a, name: "alpha", repo: "longeye-app"),
+                snap(b, name: "beta", repo: "tbd"),
+            ],
+            unread: [:],
+            recentIDs: []
+        )
+        vm.query = "longeye"
+        #expect(vm.rows.count == 1)
+        #expect(vm.rows.first?.id == a)
+    }
+
+    @Test func fuzzyMatch_noMatch() {
+        let a = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [snap(a, name: "hot-otter")],
+            unread: [:],
+            recentIDs: []
+        )
+        vm.query = "zzz"
+        #expect(vm.rows.isEmpty)
+        #expect(vm.selectedRow == nil)
+    }
+
+    @Test func deletionsAreFiltered() {
+        let stale = UUID()    // not present in `worktrees`
+        let live = UUID()
+        let now = Date()
+        let vm = JumpMenuViewModel(
+            worktrees: [snap(live, name: "L")],
+            unread: [stale: UnreadSummary(type: .error, mostRecentAt: now)],
+            recentIDs: [stale, live]
+        )
+        let rows = vm.rows
+        #expect(rows.count == 1)
+        #expect(rows[0].id == live)
+    }
+
+    @Test func tiebreakerByUUIDLexicographic() {
+        // Two notifications at the exact same instant — sort must be deterministic.
+        let now = Date()
+        let a = UUID(uuidString: "00000000-0000-0000-0000-00000000000A")!
+        let b = UUID(uuidString: "00000000-0000-0000-0000-00000000000B")!
+        let vm = JumpMenuViewModel(
+            worktrees: [snap(a, name: "A"), snap(b, name: "B")],
+            unread: [
+                a: UnreadSummary(type: .error, mostRecentAt: now),
+                b: UnreadSummary(type: .error, mostRecentAt: now),
+            ],
+            recentIDs: []
+        )
+        let rows = vm.rows
+        #expect(rows.count == 2)
+        #expect(rows[0].id == a)   // "0...A" < "0...B"
+        #expect(rows[1].id == b)
+    }
+
+    @Test func selectionMovesAndClamps() {
+        let a = UUID(); let b = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [snap(a), snap(b)],
+            unread: [:],
+            recentIDs: [a, b]
+        )
+        #expect(vm.selectedRow?.id == a)
+        vm.moveSelectionDown()
+        #expect(vm.selectedRow?.id == b)
+        vm.moveSelectionDown()       // clamps at last
+        #expect(vm.selectedRow?.id == b)
+        vm.moveSelectionUp()
+        #expect(vm.selectedRow?.id == a)
+        vm.moveSelectionUp()         // clamps at first
+        #expect(vm.selectedRow?.id == a)
+    }
+}

--- a/Tests/TBDDaemonTests/NotificationUnreadSummaryTests.swift
+++ b/Tests/TBDDaemonTests/NotificationUnreadSummaryTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("Notification Unread Summary Tests")
+struct NotificationUnreadSummaryTests {
+
+    // Helper: create a real worktree row in the DB so notification FK passes.
+    private func makeWorktree(_ db: TBDDatabase, name: String) async throws -> Worktree {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-\(UUID().uuidString)",
+            displayName: "test",
+            defaultBranch: "main"
+        )
+        return try await db.worktrees.create(
+            repoID: repo.id,
+            name: name,
+            branch: "tbd/\(name)",
+            path: "/tmp/test/.tbd/worktrees/\(name)",
+            tmuxServer: "tbd-test"
+        )
+    }
+
+    @Test func emptyStoreReturnsEmpty() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        #expect(summary.isEmpty)
+    }
+
+    @Test func singleWorktreeSingleNotification() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await makeWorktree(db, name: "wt-single")
+        let n = try await db.notifications.create(worktreeID: wt.id, type: .responseComplete)
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        #expect(summary.count == 1)
+        #expect(summary[wt.id]?.type == .responseComplete)
+        // SQLite round-trip rounds to millisecond precision, so allow small delta.
+        let delta = abs((summary[wt.id]?.mostRecentAt.timeIntervalSince1970 ?? 0) - n.createdAt.timeIntervalSince1970)
+        #expect(delta < 0.001)
+    }
+
+    @Test func picksHighestSeverityAcrossNotifications() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await makeWorktree(db, name: "wt-severity")
+        _ = try await db.notifications.create(worktreeID: wt.id, type: .responseComplete)
+        _ = try await db.notifications.create(worktreeID: wt.id, type: .error)
+        _ = try await db.notifications.create(worktreeID: wt.id, type: .taskComplete)
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        #expect(summary[wt.id]?.type == .error)
+    }
+
+    @Test func picksMostRecentTimestamp() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await makeWorktree(db, name: "wt-recent")
+        let a = try await db.notifications.create(worktreeID: wt.id, type: .responseComplete)
+        try await Task.sleep(nanoseconds: 10_000_000)
+        let b = try await db.notifications.create(worktreeID: wt.id, type: .taskComplete)
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        // SQLite stores at millisecond precision; allow tolerance.
+        let expected = max(a.createdAt, b.createdAt).timeIntervalSince1970
+        let actual = summary[wt.id]?.mostRecentAt.timeIntervalSince1970 ?? 0
+        #expect(abs(actual - expected) < 0.001)
+    }
+
+    @Test func skipsReadNotifications() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await makeWorktree(db, name: "wt-read")
+        _ = try await db.notifications.create(worktreeID: wt.id, type: .error)
+        try await db.notifications.markRead(worktreeID: wt.id)
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        #expect(summary.isEmpty)
+    }
+
+    @Test func groupsByWorktree() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let a = try await makeWorktree(db, name: "wt-a")
+        let b = try await makeWorktree(db, name: "wt-b")
+        _ = try await db.notifications.create(worktreeID: a.id, type: .error)
+        _ = try await db.notifications.create(worktreeID: b.id, type: .responseComplete)
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        #expect(summary.count == 2)
+        #expect(summary[a.id]?.type == .error)
+        #expect(summary[b.id]?.type == .responseComplete)
+    }
+}

--- a/docs/superpowers/specs/2026-05-14-unread-jump-menu-design.md
+++ b/docs/superpowers/specs/2026-05-14-unread-jump-menu-design.md
@@ -1,0 +1,177 @@
+# Unread Jump Menu — Design
+
+A Slack-style cmd-K floating panel that surfaces worktrees with unread notifications, falls back to recently-visited worktrees, and acts as a fuzzy quick-switcher when the user types.
+
+## Summary
+
+cmd-K opens a borderless overlay anchored to the main TBD window. Default state lists unread worktrees (most-recent-notification first), then recents (LRU). The top item is pre-selected so cmd-K → enter jumps the user to whatever is asking for attention. Typing turns the panel into a fuzzy quick-switcher across all worktrees. The list is capped at 20 rows.
+
+## Motivation
+
+A user running 6–10 agents needs a one-keystroke-after-the-shortcut way to triage worktrees needing attention. Today they scan the sidebar for severity badges and click. With this feature, the happy path is cmd-K → enter → the most-recently-pinged worktree is focused. The shortcut becomes the user's triage inbox, with a recents fallback for the idle case and a quick-switcher when they want to navigate by name.
+
+## User Experience
+
+### Trigger and panel
+
+- **cmd-K** toggles the panel. Pressing it while open closes it.
+- The panel is a borderless floating overlay built on the existing `FloatingPanel` (NSPanel subclass, `.popUpMenu` level, non-activating, no shadow).
+- Width ~440pt, anchored above-center of the key TBD window. Height fits content up to a scroll-limited maximum.
+- A search field sits at the top with placeholder `Jump to worktree…` and is auto-focused on open.
+- A scrollable list sits below the search field. The list shows at most **20 rows** at any time.
+
+### Default state (empty query)
+
+Two sections, in order:
+
+- **Unread** — worktrees with unread notifications, sorted by most-recent notification timestamp, descending.
+- **Recent** — worktrees recently visited (LRU), most-recent first, excluding anything already in Unread.
+
+Section headers are visible when there's content in each section. Combined cap = 20 rows. Unreads fill first; if there are more than 20 unreads, Recents drop off entirely.
+
+### Typed query
+
+- Section headers disappear; the list flattens into a single ranked match list.
+- Match scope expands to **all worktrees**, not just unreads + recents.
+- Match rule: case-insensitive substring on worktree display name **and** repo name (either matches). Simple v1; fzf-style scoring deferred.
+- Max 20 results.
+
+### Empty states
+
+- Typing with no matches → "No matching worktrees".
+- Default state with zero unreads and zero recents (fresh install, first launch) → "No recent activity".
+
+### Row content
+
+A single dense line per row:
+
+```
+[severity dot] [emoji] Worktree Name        repo-name    2m
+```
+
+- **Severity dot** (left): red = error, orange = attentionNeeded, blue = taskComplete, green = responseComplete. Hidden when the worktree has no unread notification.
+- **Emoji + name**: the worktree's display name (with its leading emoji).
+- **Repo name** (inline after the worktree name, dim): the repo this worktree belongs to.
+- **Time-ago** (far right of the row, dim): for Unread rows, time since the most-recent notification; for Recent rows, time since last visit. Suppressed while typing (the filter takes the user out of recency-browsing mode).
+- **Selected row** uses the system accent color at low opacity for its background.
+
+## Keyboard Model
+
+| Key | Action |
+|---|---|
+| cmd-K | Toggle the panel |
+| Up / Down | Move selection within the visible list |
+| Enter | Jump to the selected worktree, close the panel |
+| Escape | Close the panel, no state change |
+| Type | Filter the list |
+| Backspace on empty query | No-op |
+
+Jumping is implemented by mutating `appState.selectedWorktreeIDs = [target]`. The existing `selectedWorktreeIDs.didSet` machinery handles navigation history and the auto-mark-read pass for visible worktrees, so unread clearing requires no additional code.
+
+## Data Model and RPC Changes
+
+The current `listNotifications` RPC returns `[UUID: NotificationType]` — severity only, no timestamps. The menu needs timestamps to sort by recency.
+
+### Daemon
+
+Extend `NotificationStore` (in `Sources/TBDDaemon/Database/NotificationStore.swift`) with a method that returns one row per worktree containing the highest-severity unread type **and** the most-recent unread `createdAt`:
+
+```swift
+struct UnreadSummary {
+    let type: NotificationType
+    let mostRecentAt: Date
+}
+
+func unreadSummaryByWorktree() throws -> [UUID: UnreadSummary]
+```
+
+The SQL is a single GROUP BY query over the notifications table, joining/aggregating to pick max severity and max `createdAt` per `worktreeID` among unread rows.
+
+### RPC
+
+Extend the existing `listNotifications` RPC payload (rather than adding a parallel RPC) to carry `mostRecentAt` alongside the severity type. One round-trip, no new endpoint surface.
+
+### App state
+
+Migrate the existing field:
+
+```swift
+// before
+@Published var notifications: [UUID: NotificationType?]
+
+// after
+@Published var unreadByWorktree: [UUID: UnreadSummary]
+```
+
+Update the only existing consumer — `WorktreeRowView`'s severity dot — to read `appState.unreadByWorktree[id]?.type` instead of the old field. One source of truth, no parallel shape.
+
+## Recents — In-Memory LRU
+
+### Why not derive from back/forward navigation
+
+The cmd+[ / cmd+] back/forward stack is path-history with forward-clear-on-new-nav semantics:
+
+```
+visit A, B, C, D    → back: [A, B, C]   current: D   forward: []
+press Back twice    → back: [A]          current: B   forward: [C, D]
+jump to E from B    → back: [A, B]       current: E   forward: []   ← D dropped
+```
+
+Reading the back stack as "recents" makes D invisible even though the user was just there, and the ordering doesn't reflect actual last-visit per worktree. Different data structure for different semantics.
+
+### Dedicated LRU
+
+Add a small tracker in `AppState`, fed from the same `selectedWorktreeIDs.didSet` hook that already records nav history:
+
+```swift
+@Published private(set) var recentWorktreeIDs: [UUID] = []  // LRU, most-recent first
+
+// inside selectedWorktreeIDs.didSet, after existing nav-history work:
+if let id = selectedWorktreeIDs.first {
+    recentWorktreeIDs.removeAll { $0 == id }
+    recentWorktreeIDs.insert(id, at: 0)
+    if recentWorktreeIDs.count > 32 { recentWorktreeIDs.removeLast() }
+}
+```
+
+In-memory only. The list resets when the app relaunches. Slack behaves the same way; persistence is a future iteration if it ever turns out to matter.
+
+The jump menu reads `recentWorktreeIDs`, filters out IDs already present in `unreadByWorktree` (no duplicates across sections) and IDs no longer in the worktree list (handles deletion), then takes the top N needed to fill the 20-row budget.
+
+## Architecture
+
+New module: `Sources/TBDApp/JumpMenu/`.
+
+- **`JumpMenuController.swift`** — owns a `FloatingPanel` instance and the lifecycle around it. Exposes a singleton (or AppState-held instance) so the keyboard shortcut can call `toggle()`. Computes panel positioning relative to the current key window. Handles open / close / focus restoration on close.
+- **`JumpMenuViewModel.swift`** — `@Observable` (or `ObservableObject` if the project's deployment target predates the new macro). Holds `query: String` and exposes a computed `rows: [JumpMenuRow]`. All ranking, capping, and fuzzy-match logic lives here so it can be unit-tested without the SwiftUI layer.
+- **`JumpMenuView.swift`** — SwiftUI view: search field at top, list of rows below. Keyboard handling via `.onKeyPress` (macOS 14+) or a small `NSEvent.addLocalMonitorForEvents` shim if the deployment target is lower.
+- **`JumpMenuRow.swift`** — small value type for a row's data plus its row view.
+
+Wiring point: `Sources/TBDApp/Helpers/KeyboardShortcuts.swift` gains one new entry, likely in the existing **Go** menu:
+
+```swift
+Button("Jump to Unread") { JumpMenuController.shared.toggle() }
+    .keyboardShortcut("k", modifiers: .command)
+```
+
+## Snapshot Semantics
+
+The menu computes its row list once when opened. Notifications arriving while the panel is visible do **not** mutate the displayed list. Closing and reopening refreshes. Rationale: predictable selection, no rows shifting underneath the user's keyboard cursor mid-triage.
+
+## Edge Cases and Open Risks
+
+1. **cmd-K conflict in terminal panes.** SwiftUI Commands shortcuts normally take precedence over view-level key handlers, but if TBD's terminal emulator routes key events through a custom NSResponder chain that runs before menu validation, cmd-K could be swallowed before the menu sees it. Mitigation: verify during implementation. If the Commands route doesn't reach the menu reliably from a focused terminal, hoist registration to a global `NSEvent.addLocalMonitorForEvents` shim at app level.
+2. **Tie-breaking on equal timestamps.** Two notifications recorded in the same millisecond — sort by worktree UUID lexicographically as the deterministic tiebreaker so the default-selected item is stable across opens.
+3. **Worktree deletion while menu is open.** Static snapshot semantics mean a stale UUID may be in the list. Pressing enter on a missing UUID should be a no-op + close, not a crash. Filter the snapshot against the live worktree map at render time.
+4. **Fuzzy match upgrade path.** v1 ships substring matching on name + repo. fzf-style scoring (initials, contiguous-run bonuses, etc.) is a drop-in inside `JumpMenuViewModel` later — the view doesn't need to know.
+5. **Daemon disconnect / stale data.** If the daemon is unreachable when the menu opens, the displayed snapshot is whatever was last pushed to `unreadByWorktree`. Acceptable for a triage tool — no special error UI required.
+
+## Out of Scope (v1)
+
+- Persisting `recentWorktreeIDs` across app relaunches.
+- "Mark all as read" or per-row mark-read actions from inside the menu.
+- Cmd-Shift-Enter or other modifier-chord secondary actions.
+- fzf-style fuzzy scoring.
+- Multi-window or per-window menus — one menu, anchored to the key window.
+- A configurable shortcut (cmd-K is hardcoded).
+- Live updates while the menu is open.


### PR DESCRIPTION
## Summary

- Adds a Slack-style cmd-K jump menu — a floating panel pinned above the main TBD window that lists worktrees with unread notifications (sorted by most-recent ping), falls back to recently-visited worktrees, and becomes a fuzzy quick-switcher when you start typing. Default selection is the top item, so cmd-K → enter triages whichever agent just pinged.
- One-keystroke triage replaces "scan the sidebar for severity dots, click the right row." Cap is 20 rows, fuzzy-match (substring on name + repo) covers all worktrees when you type.
- Foundational changes that the menu rides on: daemon's `listNotifications` RPC now returns per-worktree `(severity, mostRecentAt)` instead of severity alone; `AppState.notifications` migrated to `unreadByWorktree: [UUID: UnreadSummary]` (sidebar badge consumer updated); new in-memory `recentWorktreeIDs` LRU fed from `selectedWorktreeIDs.didSet` (back/forward navigation intentionally feeds it too — Slack-style).

Design + plan: `docs/superpowers/specs/2026-05-14-unread-jump-menu-design.md`.

## Test plan

- [ ] `swift build` — green
- [ ] `swift test` — full suite passes (adds `JumpMenuViewModelTests`, `NotificationUnreadSummaryTests`)
- [ ] cmd-K opens panel with search field focused; cmd-K again closes it
- [ ] Open → close → open: search field is still focused on the second open (regression guard for the panel-reuse focus bug)
- [ ] Default state: **Unread** section sorted most-recent first, **Recent** section below (no duplicates across sections), total ≤ 20 rows
- [ ] Severity dot colors: red=error, orange=attentionNeeded, green=taskComplete, blue=responseComplete
- [ ] Type to filter: section headers collapse into a flat ranked list across **all** worktrees (substring, case-insensitive, name + repo)
- [ ] Empty states: "No matching worktrees" while typing, "No recent activity" in default state with zero unreads/recents
- [ ] Up/Down arrows move selection; Enter jumps + closes; Escape closes without changing selection
- [ ] Snapshot semantics: open menu, trigger a notification elsewhere → visible list does NOT mutate; closing + reopening picks it up
- [ ] Recents LRU: visit A→B→C then re-visit A → Recents order is A, C, B
- [ ] cmd+[ / cmd+] back-forward navigation reorders Recents (intentional)
- [ ] Sidebar badge dot still works after the `notifications` → `unreadByWorktree` migration

[⌘ Unread Jump Menu](https://cheapsteak.github.io/tbd/open/?worktree=5D8F65DE-5BA6-4014-B213-05A8EFBEF756)
