### PR TITLE
Fix: Stop --position=sibling warning from lying when TBD_WORKTREE_ID is garbage

### DIFF
--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -111,7 +111,7 @@ struct WorktreeCreate: AsyncParsableCommand {
                 branch: branch,
                 displayName: name,
                 prompt: resolvedPrompt,
-                parentWorktreeID: parentingFields.parentWorktreeID,
+                parentWorktreeID: nil,
                 siblingOfWorktreeID: parentingFields.siblingOfWorktreeID,
                 callerWorktreeID: parentingFields.callerWorktreeID,
                 suppressAutoParent: parentingFields.suppressAutoParent

--- a/Sources/TBDCLI/Commands/WorktreePosition.swift
+++ b/Sources/TBDCLI/Commands/WorktreePosition.swift
@@ -32,7 +32,7 @@ public enum WorktreePosition: String, CaseIterable, ExpressibleByArgument {
     /// Translate `(position, TBD_WORKTREE_ID)` into the four parenting fields
     /// the daemon's `ParentResolver` consumes.
     ///
-    /// `child` and `sibling` are caller-relative; when the caller is unset
+    /// `child` and `sibling` are caller-relative; when the caller is unresolved
     /// they degrade gracefully:
     /// - `child` with no caller: passes nil for every field, so the daemon
     ///   creates a top-level worktree (same fallback as the old default).
@@ -78,7 +78,7 @@ public enum WorktreePosition: String, CaseIterable, ExpressibleByArgument {
     public func unmetIntentWarning(callerEnvID: UUID?) -> String? {
         switch self {
         case .sibling where callerEnvID == nil:
-            return "warning: --position=sibling has no caller (TBD_WORKTREE_ID unset); creating top-level worktree"
+            return "warning: --position=sibling has no caller (TBD_WORKTREE_ID not set or not a valid UUID); creating top-level worktree"
         case .child, .sibling, .root:
             return nil
         }

--- a/Sources/TBDCLI/Commands/WorktreePosition.swift
+++ b/Sources/TBDCLI/Commands/WorktreePosition.swift
@@ -23,7 +23,6 @@ public enum WorktreePosition: String, CaseIterable, ExpressibleByArgument {
 
     /// Resolved RPC fields for `WorktreeCreateParams`.
     public struct RPCFields: Equatable {
-        public let parentWorktreeID: UUID?
         public let siblingOfWorktreeID: UUID?
         public let callerWorktreeID: UUID?
         public let suppressAutoParent: Bool?
@@ -44,21 +43,18 @@ public enum WorktreePosition: String, CaseIterable, ExpressibleByArgument {
         switch self {
         case .child:
             return RPCFields(
-                parentWorktreeID: nil,
                 siblingOfWorktreeID: nil,
                 callerWorktreeID: callerEnvID,
                 suppressAutoParent: nil
             )
         case .sibling:
             return RPCFields(
-                parentWorktreeID: nil,
                 siblingOfWorktreeID: callerEnvID,
                 callerWorktreeID: nil,
                 suppressAutoParent: nil
             )
         case .root:
             return RPCFields(
-                parentWorktreeID: nil,
                 siblingOfWorktreeID: nil,
                 callerWorktreeID: nil,
                 suppressAutoParent: true

--- a/Tests/TBDCLITests/WorktreePositionTests.swift
+++ b/Tests/TBDCLITests/WorktreePositionTests.swift
@@ -12,7 +12,6 @@ struct WorktreePositionTests {
     @Test func childPassesCallerToDaemon() {
         let fields = WorktreePosition.child.rpcFields(callerEnvID: Self.callerID)
         #expect(fields.callerWorktreeID == Self.callerID)
-        #expect(fields.parentWorktreeID == nil)
         #expect(fields.siblingOfWorktreeID == nil)
         #expect(fields.suppressAutoParent == nil)
     }
@@ -22,7 +21,6 @@ struct WorktreePositionTests {
         // top-level create (same fallback as the old un-flagged default).
         let fields = WorktreePosition.child.rpcFields(callerEnvID: nil)
         #expect(fields.callerWorktreeID == nil)
-        #expect(fields.parentWorktreeID == nil)
         #expect(fields.siblingOfWorktreeID == nil)
         #expect(fields.suppressAutoParent == nil)
     }
@@ -33,7 +31,6 @@ struct WorktreePositionTests {
         let fields = WorktreePosition.sibling.rpcFields(callerEnvID: Self.callerID)
         #expect(fields.siblingOfWorktreeID == Self.callerID)
         #expect(fields.callerWorktreeID == nil)
-        #expect(fields.parentWorktreeID == nil)
         #expect(fields.suppressAutoParent == nil)
     }
 
@@ -43,7 +40,6 @@ struct WorktreePositionTests {
         let fields = WorktreePosition.sibling.rpcFields(callerEnvID: nil)
         #expect(fields.siblingOfWorktreeID == nil)
         #expect(fields.callerWorktreeID == nil)
-        #expect(fields.parentWorktreeID == nil)
         #expect(fields.suppressAutoParent == nil)
     }
 
@@ -54,7 +50,6 @@ struct WorktreePositionTests {
         #expect(fields.suppressAutoParent == true)
         #expect(fields.callerWorktreeID == nil)
         #expect(fields.siblingOfWorktreeID == nil)
-        #expect(fields.parentWorktreeID == nil)
     }
 
     @Test func rootIgnoresCaller() {

--- a/Tests/TBDCLITests/WorktreePositionTests.swift
+++ b/Tests/TBDCLITests/WorktreePositionTests.swift
@@ -100,6 +100,7 @@ struct WorktreePositionTests {
         // Keep the message greppable on substring, not exact wording.
         #expect(warning?.contains("sibling") == true)
         #expect(warning?.contains("TBD_WORKTREE_ID") == true)
+        #expect(warning?.contains("not a valid UUID") == true)
     }
 
     @Test func rootWithCallerHasNoWarning() {


### PR DESCRIPTION
## Summary

- The `--position=sibling` warning said `TBD_WORKTREE_ID unset`, but the same code path is also reached when the env var is set to a non-UUID string — the caller does `.flatMap { UUID(uuidString: $0) }`, which returns nil for both. Reword to `not set or not a valid UUID` so the message stops lying. The doc-comment on `rpcFields(callerEnvID:)` likewise changes from "unset" → "unresolved".
- Drop the unused `parentWorktreeID: UUID?` field from `WorktreePosition.RPCFields`. It was nil in all three switch arms — a passthrough slot for a hypothetical `--parent=<uuid>` flag we explicitly decided not to add. Per house style against designing for hypothetical futures, drop it. If we ever add the flag, we add the field back in the same commit.
- The daemon-side `WorktreeCreateParams.parentWorktreeID` stays (the SwiftUI app sidebar's "New worktree…" action uses it); only the CLI helper struct shrinks.

Follow-up to claude[bot]'s review on #152. Two tiny commits, ~12 lines of net deletion.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 783 tests pass across 80 suites
- [x] `swift package plugin --allow-writing-to-package-directory swiftlint --strict` — 0 violations in 164 files
- [x] Pinned the new wording with a `warning?.contains("not a valid UUID")` assertion in `siblingWithoutCallerWarns` so a future regression to "unset" gets caught
- [ ] Manual spot-check (post-merge): `TBD_WORKTREE_ID=garbage tbd worktree create --position=sibling …` → the new wording appears on stderr

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=A4BD844A-AF50-46CC-BD24-9012B8A5ACA4)