### PR TITLE
Feat: Stop baking conductor and dmux into the worktree hook lookup

### DIFF
--- a/Sources/TBDDaemon/Hooks/HookResolver.swift
+++ b/Sources/TBDDaemon/Hooks/HookResolver.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let hooksLogger = Logger(subsystem: "com.tbd.daemon", category: "hooks")
 
 public enum HookEvent: String, Sendable {
     case setup
@@ -51,11 +54,17 @@ public struct HookResolver: Sendable {
 
         // 3. conductor.json (deprecated)
         if let path = resolveConductor(event: event, repoPath: repoPath) {
+            hooksLogger.warning(
+                "conductor.json hook resolved for \(event.rawValue, privacy: .public); consider migrating to .worktree-hooks/"
+            )
             return path
         }
 
         // 4. .dmux-hooks (deprecated)
         if let path = resolveDmux(event: event, repoPath: repoPath) {
+            hooksLogger.warning(
+                ".dmux-hooks/ hook resolved for \(event.rawValue, privacy: .public); consider migrating to .worktree-hooks/"
+            )
             return path
         }
 

--- a/Sources/TBDDaemon/Hooks/HookResolver.swift
+++ b/Sources/TBDDaemon/Hooks/HookResolver.swift
@@ -37,24 +37,29 @@ public struct HookResolver: Sendable {
     }
 
     /// Resolves which hook script to run. First match wins, no chaining.
-    /// Priority: appHookPath > conductor.json > .dmux-hooks > global default
+    /// Priority: appHookPath > .worktree-hooks > conductor.json > .dmux-hooks > global default
     public func resolve(event: HookEvent, repoPath: String, appHookPath: String?) -> String? {
         // 1. App per-repo config
         if let path = appHookPath, FileManager.default.fileExists(atPath: path) {
             return path
         }
 
-        // 2. conductor.json
+        // 2. .worktree-hooks (canonical in-repo location)
+        if let path = resolveWorktreeHooks(event: event, repoPath: repoPath) {
+            return path
+        }
+
+        // 3. conductor.json (deprecated)
         if let path = resolveConductor(event: event, repoPath: repoPath) {
             return path
         }
 
-        // 3. .dmux-hooks
+        // 4. .dmux-hooks (deprecated)
         if let path = resolveDmux(event: event, repoPath: repoPath) {
             return path
         }
 
-        // 4. Global default
+        // 5. Global default
         let globalPath = (globalHooksDir as NSString).appendingPathComponent(event.rawValue)
         if FileManager.default.isExecutableFile(atPath: globalPath) {
             return globalPath
@@ -128,6 +133,12 @@ public struct HookResolver: Sendable {
     }
 
     // MARK: - Private
+
+    private func resolveWorktreeHooks(event: HookEvent, repoPath: String) -> String? {
+        let hookPath = (repoPath as NSString)
+            .appendingPathComponent(".worktree-hooks/\(event.rawValue)")
+        return FileManager.default.isExecutableFile(atPath: hookPath) ? hookPath : nil
+    }
 
     private func resolveConductor(event: HookEvent, repoPath: String) -> String? {
         let conductorPath = (repoPath as NSString).appendingPathComponent("conductor.json")

--- a/Tests/TBDDaemonTests/HookResolverTests.swift
+++ b/Tests/TBDDaemonTests/HookResolverTests.swift
@@ -220,3 +220,91 @@ private func makeTempDir() throws -> URL {
     #expect(hook != nil)
     #expect(hook!.contains(".worktree-hooks/setup"))
 }
+
+@Test func worktreeHooksArchive() throws {
+    let tempDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let resolver = HookResolver(globalHooksDir: tempDir.appendingPathComponent("global-hooks").path)
+
+    let hooksDir = tempDir.appendingPathComponent(".worktree-hooks")
+    try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+    let hookPath = hooksDir.appendingPathComponent("archive").path
+    try "#!/bin/bash\necho generic-archive".write(toFile: hookPath, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hookPath)
+
+    let hook = resolver.resolve(event: .archive, repoPath: tempDir.path, appHookPath: nil)
+    #expect(hook != nil)
+    #expect(hook!.contains(".worktree-hooks/archive"))
+}
+
+@Test func worktreeHooksBeatsConductor() throws {
+    let tempDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let resolver = HookResolver(globalHooksDir: tempDir.appendingPathComponent("global-hooks").path)
+
+    let conductorJSON = """
+    {"scripts":{"setup":"scripts/setup.sh"}}
+    """
+    try conductorJSON.write(
+        toFile: tempDir.appendingPathComponent("conductor.json").path,
+        atomically: true, encoding: .utf8
+    )
+    let scriptsDir = tempDir.appendingPathComponent("scripts")
+    try FileManager.default.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
+    try "#!/bin/bash\necho conductor".write(
+        toFile: scriptsDir.appendingPathComponent("setup.sh").path,
+        atomically: true, encoding: .utf8
+    )
+
+    let hooksDir = tempDir.appendingPathComponent(".worktree-hooks")
+    try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+    let genericPath = hooksDir.appendingPathComponent("setup").path
+    try "#!/bin/bash\necho generic".write(toFile: genericPath, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: genericPath)
+
+    let hook = resolver.resolve(event: .setup, repoPath: tempDir.path, appHookPath: nil)
+    #expect(hook == genericPath)
+}
+
+@Test func worktreeHooksBeatsDmux() throws {
+    let tempDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let resolver = HookResolver(globalHooksDir: tempDir.appendingPathComponent("global-hooks").path)
+
+    let dmuxDir = tempDir.appendingPathComponent(".dmux-hooks")
+    try FileManager.default.createDirectory(at: dmuxDir, withIntermediateDirectories: true)
+    let dmuxPath = dmuxDir.appendingPathComponent("worktree_created").path
+    try "#!/bin/bash\necho dmux".write(toFile: dmuxPath, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: dmuxPath)
+
+    let hooksDir = tempDir.appendingPathComponent(".worktree-hooks")
+    try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+    let genericPath = hooksDir.appendingPathComponent("setup").path
+    try "#!/bin/bash\necho generic".write(toFile: genericPath, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: genericPath)
+
+    let hook = resolver.resolve(event: .setup, repoPath: tempDir.path, appHookPath: nil)
+    #expect(hook == genericPath)
+}
+
+@Test func appConfigBeatsWorktreeHooks() throws {
+    let tempDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let resolver = HookResolver(globalHooksDir: tempDir.appendingPathComponent("global-hooks").path)
+
+    let hooksDir = tempDir.appendingPathComponent(".worktree-hooks")
+    try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+    let genericPath = hooksDir.appendingPathComponent("setup").path
+    try "#!/bin/bash\necho generic".write(toFile: genericPath, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: genericPath)
+
+    let appHookPath = tempDir.appendingPathComponent("app-hook.sh").path
+    try "#!/bin/bash\necho app".write(toFile: appHookPath, atomically: true, encoding: .utf8)
+
+    let hook = resolver.resolve(event: .setup, repoPath: tempDir.path, appHookPath: appHookPath)
+    #expect(hook == appHookPath)
+}

--- a/Tests/TBDDaemonTests/HookResolverTests.swift
+++ b/Tests/TBDDaemonTests/HookResolverTests.swift
@@ -203,3 +203,20 @@ private func makeTempDir() throws -> URL {
     #expect(success)
     #expect(output.contains("test_value"))
 }
+
+@Test func worktreeHooksSetup() throws {
+    let tempDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let resolver = HookResolver(globalHooksDir: tempDir.appendingPathComponent("global-hooks").path)
+
+    let hooksDir = tempDir.appendingPathComponent(".worktree-hooks")
+    try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+    let hookPath = hooksDir.appendingPathComponent("setup").path
+    try "#!/bin/bash\necho generic-setup".write(toFile: hookPath, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hookPath)
+
+    let hook = resolver.resolve(event: .setup, repoPath: tempDir.path, appHookPath: nil)
+    #expect(hook != nil)
+    #expect(hook!.contains(".worktree-hooks/setup"))
+}

--- a/docs/superpowers/specs/2026-05-15-generic-worktree-hooks-design.md
+++ b/docs/superpowers/specs/2026-05-15-generic-worktree-hooks-design.md
@@ -1,0 +1,75 @@
+# Generic `.worktree-hooks/` Convention
+
+**Date:** 2026-05-15
+**Status:** Approved, ready for implementation plan
+
+## Goal
+
+Introduce a generic, product-name-free in-repo hooks directory — `.worktree-hooks/` — as the canonical way for repos to declare worktree lifecycle hooks. Demote the existing `conductor.json` and `.dmux-hooks/` integrations to backward-compatibility fallbacks that emit a deprecation warning when used.
+
+## Motivation
+
+`HookResolver` currently bakes in two specific product names: Conductor (`conductor.json`) and dmux (`.dmux-hooks/`). Both products are vestigial in this codebase — Conductor was retired in commit `6cb865b` and the dmux skill notes it is no longer in use. A repo that uses neither product has no in-repo way to declare hooks; the only options are the app's per-repo GUI config (stored under `~/tbd/`) or a global default. Adding a tool-agnostic location closes that gap and gives a clean migration target for the legacy paths.
+
+## Convention
+
+- **Location:** `<repo>/.worktree-hooks/<event>` — one executable file per event, checked into the repo.
+- **Event filenames:** match `HookEvent.rawValue`. Initially `setup` and `archive`. (`preMerge` and `postMerge` exist in the enum but are not fired by the lifecycle today; they remain out of scope here.)
+- **Permissions:** must be executable (`chmod +x`), same requirement as `.dmux-hooks/` files.
+- **Env contract:** unchanged. Hooks receive the same `TBD_EVENT`, `TBD_WORKTREE_ID`, `TBD_WORKTREE_NAME`, `TBD_WORKTREE_PATH`, `TBD_REPO_PATH`, and `TBD_BRANCH` environment variables that existing conductor/dmux hooks receive.
+- **Timeout:** unchanged. 60 seconds, same as today.
+- **Working directory:** unchanged. Hook runs with `cwd` set to the worktree path.
+
+## Resolution Priority
+
+First match wins, no chaining (same model as today). The new order:
+
+1. App per-repo config — `~/tbd/repos/<uuid>/hooks/<event>`
+2. **`.worktree-hooks/<event>`** ← new canonical in-repo path
+3. `conductor.json` `scripts.<event>` ← legacy fallback, logs deprecation warning
+4. `.dmux-hooks/<event>` ← legacy fallback, logs deprecation warning
+5. Global default — `~/tbd/hooks/default/<event>`
+
+Steps 3 and 4 retain their existing resolution logic. The change is positional (now after the new generic location) and adds a one-line `os.Logger` warning when they are used.
+
+## Code Changes
+
+### `Sources/TBDDaemon/Hooks/HookResolver.swift`
+
+- Add a private `resolveWorktreeHooks(event:repoPath:)` method, mirroring `resolveDmux`, that returns `<repoPath>/.worktree-hooks/<event.rawValue>` if that path exists and is executable.
+- In `resolve(event:repoPath:appHookPath:)`, insert the new lookup as step 2, between the existing app-config check and the conductor check.
+- When `resolveConductor` returns a non-nil path, log a `.warning` via `Logger(subsystem: "com.tbd.daemon", category: "hooks")` with a message like `"conductor.json hook resolved for <event>; consider migrating to .worktree-hooks/"`.
+- When `resolveDmux` returns a non-nil path, log an analogous warning referencing `.dmux-hooks/`.
+
+The `HookEvent` enum's `conductorKey` and `dmuxHookName` properties stay as-is — they're still needed for the legacy lookups.
+
+### `Tests/TBDDaemonTests/HookResolverTests.swift`
+
+Add the following tests:
+
+- `worktreeHooksSetup` — only `.worktree-hooks/setup` exists; resolver returns that path.
+- `worktreeHooksArchive` — only `.worktree-hooks/archive` exists; resolver returns that path.
+- `worktreeHooksBeatsConductor` — both `.worktree-hooks/setup` and a matching `conductor.json` entry exist; resolver returns the `.worktree-hooks/` path.
+- `worktreeHooksBeatsDmux` — both `.worktree-hooks/setup` and `.dmux-hooks/worktree_created` exist; resolver returns the `.worktree-hooks/` path.
+- `appConfigBeatsWorktreeHooks` — confirms the existing top-of-priority behavior still holds.
+
+Existing tests for conductor, dmux, app-config, global-default, and no-hooks-returns-nil continue to pass unchanged.
+
+## Documentation
+
+Add a new `docs/worktree-hooks.md` covering:
+
+- The `.worktree-hooks/<event>` convention (one executable per event).
+- The full resolution priority chain.
+- The env-var contract passed to hooks.
+- The deprecation status of `conductor.json` and `.dmux-hooks/` — keep working today, will be removed in a future release.
+- A minimal example: `.worktree-hooks/setup` shell script that runs `npm install` or similar.
+
+If the main `README.md` or `CLAUDE.md` mentions hooks today, add a single-line pointer to the new doc; otherwise, leave them alone.
+
+## Out of Scope
+
+- Wiring `preMerge` and `postMerge` events into the lifecycle. They remain defined in the enum but unfired.
+- Renaming the `TBD_*` env vars to tool-agnostic names. The contract belongs to TBD; the location is what's being made generic.
+- An automated migration command. The deprecation warning at resolution time is the migration prompt.
+- Removing `conductor.json` and `.dmux-hooks/` support. That happens in a later change once the warning has been in place long enough.

--- a/docs/worktree-hooks.md
+++ b/docs/worktree-hooks.md
@@ -1,0 +1,62 @@
+# Worktree Hooks
+
+TBD can run scripts at key points in a worktree's lifecycle: when it's created (`setup`) and just before it's archived (`archive`). The canonical place to declare them is the `.worktree-hooks/` directory at the root of your repo.
+
+## Convention
+
+Each hook is an executable file inside `.worktree-hooks/`, named after the event:
+
+```
+my-repo/
+  .worktree-hooks/
+    setup       # runs in the new worktree right after it's created
+    archive     # runs in the worktree just before `git worktree remove`
+```
+
+Files must be executable (`chmod +x .worktree-hooks/setup`). They can be in any language — TBD just executes them.
+
+## Environment
+
+Hooks run with `cwd` set to the worktree path and receive these environment variables:
+
+| Variable | Value |
+| --- | --- |
+| `TBD_EVENT` | `setup` or `archive` |
+| `TBD_WORKTREE_ID` | UUID of the worktree |
+| `TBD_WORKTREE_NAME` | Display name |
+| `TBD_WORKTREE_PATH` | Absolute path to the worktree checkout |
+| `TBD_REPO_PATH` | Absolute path to the source repo |
+| `TBD_BRANCH` | Branch name |
+
+Hooks have a 60-second timeout. A non-zero exit status is logged but does not block the lifecycle action.
+
+## Example
+
+```bash
+#!/bin/bash
+# .worktree-hooks/setup
+set -euo pipefail
+
+npm install
+cp ../main-checkout/.env .env 2>/dev/null || true
+```
+
+## Resolution Priority
+
+When TBD looks up a hook for an event, it returns the first match from this chain:
+
+1. **App per-repo config** — `~/tbd/repos/<uuid>/hooks/<event>`, set via TBD's Settings UI.
+2. **`.worktree-hooks/<event>`** — the canonical in-repo location described above.
+3. **`conductor.json`** `scripts.<event>` — *deprecated*, kept for backward compatibility. TBD logs a warning when this path is used.
+4. **`.dmux-hooks/<event-name>`** — *deprecated*, kept for backward compatibility. TBD logs a warning when this path is used.
+5. **Global default** — `~/tbd/hooks/default/<event>`.
+
+First match wins; there is no chaining. To migrate from `conductor.json` or `.dmux-hooks/`, move your scripts into `.worktree-hooks/<event>`, ensure they are executable, and remove the old files.
+
+## Deprecation
+
+`conductor.json` and `.dmux-hooks/` continue to work today but will be removed in a future release. Each time TBD resolves a hook from one of these locations, it logs a warning to the `com.tbd.daemon` / `hooks` log category — stream it with:
+
+```
+log stream --level debug --predicate 'subsystem == "com.tbd.daemon" AND category == "hooks"'
+```


### PR DESCRIPTION
## Summary

- `HookResolver` baked two specific products into its in-repo lookups — `conductor.json` (now retired in this repo, see 6cb865b) and `.dmux-hooks/` (no longer used). A repo that used neither had no in-repo way to declare hooks.
- This PR adds a tool-agnostic `.worktree-hooks/<event>` directory as the canonical in-repo location, slotted between the app per-repo config and the legacy paths.
- Legacy `conductor.json` and `.dmux-hooks/` continue to resolve as fallbacks but log a one-line `os.Logger` warning on `com.tbd.daemon` / `hooks` pointing users at the new convention. Removal happens in a later change.

New resolution order: `app per-repo → .worktree-hooks → conductor.json (warns) → .dmux-hooks (warns) → global default`. First match wins; the env contract passed to hooks is unchanged.

User-facing docs: [`docs/worktree-hooks.md`](./docs/worktree-hooks.md). Approved spec: [`docs/superpowers/specs/2026-05-15-generic-worktree-hooks-design.md`](./docs/superpowers/specs/2026-05-15-generic-worktree-hooks-design.md).

## Test plan

- [x] `swift test --filter HookResolverTests` — 15/15 pass (5 new tests covering setup, archive, beats-conductor, beats-dmux, app-beats-generic; existing conductor/dmux/app/global/no-hooks/execute tests untouched)
- [x] `swift test` — full suite 788/788 pass
- [x] `swift package plugin --allow-writing-to-package-directory swiftlint --strict` — 0 violations across 164 files
- [ ] Manual: drop a `.worktree-hooks/setup` executable into a repo, create a new worktree, confirm it runs
- [ ] Manual: with `conductor.json` present, stream `log stream --predicate 'subsystem == "com.tbd.daemon" AND category == "hooks"'` and confirm the deprecation warning fires once per resolution

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B96220FB-B650-4AB7-B372-02DBB52541CF)