### PR TITLE
Feat: Let agents reparent worktrees from the CLI

### DIFF
--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -367,7 +367,10 @@ struct WorktreeReparent: AsyncParsableCommand {
             newParentID = nil
         }
 
-        // Fetch the moving worktree so we know which repo we're operating in.
+        if let newParentID, newParentID == worktreeID {
+            throw CLIError.invalidArgument("A worktree cannot be its own parent.")
+        }
+
         let allWorktrees: [Worktree] = try client.call(
             method: RPCMethod.worktreeList,
             params: WorktreeListParams(),
@@ -377,18 +380,13 @@ struct WorktreeReparent: AsyncParsableCommand {
             throw CLIError.invalidArgument("Worktree not found: \(nameOrID)")
         }
 
-        let siblings: [Worktree] = try client.call(
-            method: RPCMethod.worktreeList,
-            params: WorktreeListParams(repoID: moving.repoID),
-            resultType: [Worktree].self
-        )
-
         let newSortOrder: Int
         if let idx = index {
             newSortOrder = idx
         } else {
-            newSortOrder = siblings.filter { wt in
-                wt.id != worktreeID
+            newSortOrder = allWorktrees.filter { wt in
+                wt.repoID == moving.repoID
+                    && wt.id != worktreeID
                     && wt.parentWorktreeID == newParentID
                     && (wt.status == .active || wt.status == .creating)
             }.count

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -12,6 +12,7 @@ struct WorktreeCommand: ParsableCommand {
             WorktreeArchive.self,
             WorktreeRevive.self,
             WorktreeRename.self,
+            WorktreeReparent.self,
         ]
     )
 }
@@ -320,6 +321,122 @@ struct WorktreeRename: AsyncParsableCommand {
         )
 
         print("Worktree renamed to: \(newName)")
+    }
+}
+
+// MARK: - worktree reparent
+
+struct WorktreeReparent: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "reparent",
+        abstract: "Move a worktree under a new parent (or promote to top-level)"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var nameOrID: String
+
+    @Option(name: .long, help: "New parent worktree (name or ID). Mutually exclusive with --root.")
+    var parent: String?
+
+    @Flag(name: .long, help: "Promote the worktree to top-level (no parent). Mutually exclusive with --parent.")
+    var root = false
+
+    @Option(name: .long, help: "Sort order within the new sibling group (default: append to end).")
+    var index: Int?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func validate() throws {
+        if parent == nil && !root {
+            throw ValidationError("Specify either --parent <name-or-id> or --root.")
+        }
+        if parent != nil && root {
+            throw ValidationError("--parent and --root are mutually exclusive.")
+        }
+    }
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeNameOrID(nameOrID, client: client)
+
+        let newParentID: UUID?
+        if let parent = parent {
+            newParentID = try resolveWorktreeNameOrID(parent, client: client)
+        } else {
+            newParentID = nil
+        }
+
+        // Fetch the moving worktree so we know which repo we're operating in.
+        let allWorktrees: [Worktree] = try client.call(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(),
+            resultType: [Worktree].self
+        )
+        guard let moving = allWorktrees.first(where: { $0.id == worktreeID }) else {
+            throw CLIError.invalidArgument("Worktree not found: \(nameOrID)")
+        }
+
+        let siblings: [Worktree] = try client.call(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(repoID: moving.repoID),
+            resultType: [Worktree].self
+        )
+
+        let newSortOrder: Int
+        if let idx = index {
+            newSortOrder = idx
+        } else {
+            newSortOrder = siblings.filter { wt in
+                wt.id != worktreeID
+                    && wt.parentWorktreeID == newParentID
+                    && (wt.status == .active || wt.status == .creating)
+            }.count
+        }
+
+        try client.callVoid(
+            method: RPCMethod.worktreeMove,
+            params: WorktreeMoveParams(
+                worktreeID: worktreeID,
+                newParentID: newParentID,
+                newSortOrder: newSortOrder
+            )
+        )
+
+        if json {
+            // Custom Encodable so `newParentID` serializes as explicit `null`
+            // (rather than being omitted) when the worktree is promoted to root.
+            struct ReparentJSON: Encodable {
+                let worktreeID: String
+                let newParentID: String?
+                let newSortOrder: Int
+
+                enum CodingKeys: String, CodingKey {
+                    case worktreeID, newParentID, newSortOrder
+                }
+
+                func encode(to encoder: Encoder) throws {
+                    var c = encoder.container(keyedBy: CodingKeys.self)
+                    try c.encode(worktreeID, forKey: .worktreeID)
+                    try c.encode(newSortOrder, forKey: .newSortOrder)
+                    if let newParentID {
+                        try c.encode(newParentID, forKey: .newParentID)
+                    } else {
+                        try c.encodeNil(forKey: .newParentID)
+                    }
+                }
+            }
+            printJSON(ReparentJSON(
+                worktreeID: worktreeID.uuidString,
+                newParentID: newParentID?.uuidString,
+                newSortOrder: newSortOrder
+            ))
+        } else if let pid = newParentID {
+            let parentName = allWorktrees.first(where: { $0.id == pid })?.displayName ?? pid.uuidString
+            print("Reparented \(moving.displayName) under \(parentName)")
+        } else {
+            print("Reparented \(moving.displayName) to top level")
+        }
     }
 }
 

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -68,6 +68,17 @@ want to spawn workers under yourself.
 
 Use `--position=root` to force the new worktree to be top-level.
 
+### Reparent a worktree
+
+Move an existing worktree under a different orchestrator, or promote a child
+to top-level. `--index` is optional and defaults to the end of the destination
+sibling group.
+
+```bash
+tbd worktree reparent <worktree> --parent <name-or-id> [--index N]
+tbd worktree reparent <worktree> --root [--index N]
+```
+
 ### Send input to an existing terminal / read its output
 
 ```bash

--- a/Tests/TBDCLITests/WorktreeReparentTests.swift
+++ b/Tests/TBDCLITests/WorktreeReparentTests.swift
@@ -1,0 +1,39 @@
+import ArgumentParser
+import Foundation
+import Testing
+
+@testable import TBDCLI
+
+@Suite("WorktreeReparent argument parsing")
+struct WorktreeReparentTests {
+    @Test func requiresParentOrRoot() {
+        // `.parse` invokes validate() internally; missing --parent / --root
+        // surfaces as a CommandError wrapping our ValidationError.
+        #expect(throws: (any Error).self) {
+            _ = try WorktreeReparent.parse(["my-worktree"])
+        }
+    }
+
+    @Test func rejectsBothParentAndRoot() {
+        #expect(throws: (any Error).self) {
+            _ = try WorktreeReparent.parse(["my-worktree", "--parent", "orchestrator", "--root"])
+        }
+    }
+
+    @Test func acceptsParentAlone() throws {
+        let cmd = try WorktreeReparent.parse(["my-worktree", "--parent", "orchestrator"])
+        #expect(cmd.parent == "orchestrator")
+        #expect(cmd.root == false)
+    }
+
+    @Test func acceptsRootAlone() throws {
+        let cmd = try WorktreeReparent.parse(["my-worktree", "--root"])
+        #expect(cmd.root == true)
+        #expect(cmd.parent == nil)
+    }
+
+    @Test func parsesOptionalIndex() throws {
+        let cmd = try WorktreeReparent.parse(["my-worktree", "--root", "--index", "2"])
+        #expect(cmd.index == 2)
+    }
+}


### PR DESCRIPTION
## Summary
- New `tbd worktree reparent <worktree> --parent <name-or-id> | --root [--index N] [--json]` subcommand wraps the existing `worktree.move` RPC. Until now, restructuring the worktree tree required drag-and-drop in the app — agents driving the CLI couldn't do it.
- `--parent` / `--root` are mutually exclusive (validated); `--index` defaults to "append to end of new sibling group" (counts active+creating siblings in the destination group, excluding self).
- Skill text in `TBDSkillContent.swift` now documents the workflow so agents loaded via `--plugin-dir` discover it.

## Test plan
- [x] `swift build` clean
- [x] `swift test` — 788 tests pass, including new `WorktreeReparentTests` covering `--parent`/`--root` exclusivity and `--index` parsing
- [x] `swift run TBDCLI worktree reparent --help` renders the new command
- [x] `swift run TBDCLI worktree reparent foo` errors cleanly with "Specify either --parent <name-or-id> or --root."
- [ ] After `scripts/restart.sh`, reparent a child worktree to `--root` and confirm the app reflects the move
- [ ] Reparent under a different parent worktree and confirm the new position lands at the end of that sibling group

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9D7C9912-459C-47E9-B314-F45746523886)