### PR TITLE
Compound: Prompt agent to rename worktree on Stop instead of session start

### DIFF
--- a/Sources/TBDCLI/Commands/HooksCommand.swift
+++ b/Sources/TBDCLI/Commands/HooksCommand.swift
@@ -8,7 +8,7 @@ struct HooksCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "hooks",
         abstract: "Inspect and manage TBD's Claude Code hook integration",
-        subcommands: [HooksStatusCommand.self],
+        subcommands: [HooksStatusCommand.self, StopRenameCheckCommand.self],
         defaultSubcommand: HooksStatusCommand.self
     )
 }

--- a/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
+++ b/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
@@ -1,0 +1,250 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+/// `tbd hooks stop-rename-check` — a Claude Code `Stop` hook that prompts
+/// the agent to rename its worktree/branch at end-of-turn, when context is
+/// highest and the work is freshly visible.
+///
+/// Behavior (any error path = exit 0 silent so the agent is never wedged):
+/// 1. Read the Stop hook JSON payload from stdin.
+/// 2. Resolve the worktree for `cwd` via the daemon.
+/// 3. Skip if status is .main, displayName != name (already customized),
+///    branch doesn't start with `tbd/`, or we've already fired > 2 times
+///    this session.
+/// 4. Otherwise emit `{"decision":"block","reason":"<directive>"}` so
+///    Claude Code keeps the session alive and surfaces the directive
+///    to the agent.
+struct StopRenameCheckCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "stop-rename-check",
+        abstract: "Stop-hook directive prompting the agent to rename its worktree/branch"
+    )
+
+    mutating func run() async throws {
+        let stdin = FileHandle.standardInput.readDataToEndOfFile()
+        let output = StopRenameCheckCore.decide(
+            stdinData: stdin,
+            dependencies: .production()
+        )
+        if let output {
+            print(output)
+        }
+    }
+}
+
+// MARK: - Pure core (testable)
+
+/// Pure decision logic for `stop-rename-check`. Factored out so unit tests
+/// can exercise every branch without spinning up the daemon or git.
+///
+/// Returns the JSON string to print on stdout, or nil for the silent exit.
+enum StopRenameCheckCore {
+
+    /// Injectable side-effects so unit tests can stand in for the daemon,
+    /// git, and the filesystem counter.
+    struct Dependencies {
+        /// Look up the worktree for the cwd. Return nil for "skip silently"
+        /// (daemon down, cwd not inside a worktree).
+        var fetchWorktree: (_ cwd: String) -> WorktreeSummary?
+
+        /// Resolve the current git branch. Return nil for "skip silently".
+        var fetchBranch: (_ cwd: String) -> String?
+
+        /// Resolve the worktree's top-level folder basename. Used in the
+        /// directive text. Return nil for "skip silently".
+        var fetchFolder: (_ cwd: String) -> String?
+
+        /// Path of the per-session counter file. Production wires this to
+        /// `/tmp/tbd-stop-rename-<session_id>`.
+        var counterPath: (_ sessionID: String) -> String
+
+        /// Production wiring — talks to the daemon, shells out to git.
+        static func production() -> Dependencies {
+            Dependencies(
+                fetchWorktree: { cwd in
+                    let client = SocketClient()
+                    guard client.isDaemonRunning else { return nil }
+                    do {
+                        let resolver = PathResolver(client: client)
+                        let resolved = try resolver.resolve(path: cwd)
+                        guard let worktreeID = resolved.worktreeID else { return nil }
+                        let worktrees: [Worktree] = try client.call(
+                            method: RPCMethod.worktreeList,
+                            params: WorktreeListParams(),
+                            resultType: [Worktree].self
+                        )
+                        guard let wt = worktrees.first(where: { $0.id == worktreeID }) else {
+                            return nil
+                        }
+                        return WorktreeSummary(
+                            name: wt.name,
+                            displayName: wt.displayName,
+                            status: wt.status
+                        )
+                    } catch {
+                        return nil
+                    }
+                },
+                fetchBranch: { cwd in
+                    runGit(["-C", cwd, "branch", "--show-current"])
+                },
+                fetchFolder: { cwd in
+                    guard let topLevel = runGit(["-C", cwd, "rev-parse", "--show-toplevel"]) else {
+                        return nil
+                    }
+                    return (topLevel as NSString).lastPathComponent
+                },
+                counterPath: { sessionID in
+                    "/tmp/tbd-stop-rename-\(sessionID)"
+                }
+            )
+        }
+    }
+
+    /// Minimal subset of `Worktree` fields the decision logic needs.
+    struct WorktreeSummary {
+        var name: String
+        var displayName: String
+        var status: WorktreeStatus
+    }
+
+    /// Maximum number of times we'll fire the directive in one session
+    /// before giving up so we never trap the agent in a stop loop.
+    static let maxFireCount = 2
+
+    /// Run the decision. Returns the JSON `{"decision":"block",...}` string
+    /// to print, or nil for the silent exit.
+    static func decide(stdinData: Data, dependencies: Dependencies) -> String? {
+        // 1. Parse stdin. Malformed → silent exit.
+        guard
+            let payload = try? JSONSerialization.jsonObject(with: stdinData) as? [String: Any]
+        else {
+            return nil
+        }
+
+        let sessionID = (payload["session_id"] as? String) ?? ""
+        let cwd = (payload["cwd"] as? String) ?? ""
+        // `stop_hook_active` is read for completeness; we use the on-disk
+        // counter rather than relying on the flag because the flag also
+        // fires when other hooks block.
+        _ = (payload["stop_hook_active"] as? Bool) ?? false
+
+        guard !sessionID.isEmpty, !cwd.isEmpty else {
+            return nil
+        }
+
+        // 2. Resolve worktree.
+        guard let worktree = dependencies.fetchWorktree(cwd) else {
+            return nil
+        }
+
+        // 3a. Main worktree → skip.
+        if worktree.status == .main {
+            return nil
+        }
+
+        // 3b. Already customized → skip.
+        if worktree.displayName != worktree.name {
+            return nil
+        }
+
+        // 3c. Branch must be tbd/<...> for us to suggest renaming it.
+        guard let branch = dependencies.fetchBranch(cwd), branch.hasPrefix("tbd/") else {
+            return nil
+        }
+
+        // 3d. Counter check. Bump first; if the new value exceeds the cap,
+        // give up so we don't trap the agent in a stop loop.
+        let counterPath = dependencies.counterPath(sessionID)
+        let newCount = bumpCounter(at: counterPath)
+        if newCount > maxFireCount {
+            return nil
+        }
+
+        // 4. Folder for the `tbd worktree rename` example.
+        guard let folder = dependencies.fetchFolder(cwd) else {
+            return nil
+        }
+
+        // 5. Build the directive and encode it as a Stop-hook block response.
+        let reason = buildDirective(branch: branch, folder: folder)
+        return encodeBlock(reason: reason)
+    }
+
+    /// Read the counter file (treat absence as 0), increment, and persist
+    /// the new value. Returns the new value. Best-effort — IO failures fall
+    /// back to returning the post-bump value we tracked in memory.
+    static func bumpCounter(at path: String) -> Int {
+        let current: Int
+        if let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+           let text = String(data: data, encoding: .utf8),
+           let parsed = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            current = parsed
+        } else {
+            current = 0
+        }
+        let next = current + 1
+        try? String(next).write(toFile: path, atomically: true, encoding: .utf8)
+        return next
+    }
+
+    /// Build the directive shown to the agent. Mirrors the spec verbatim
+    /// except for branch/folder substitution.
+    static func buildDirective(branch: String, folder: String) -> String {
+        """
+        Before stopping: this worktree is still named \(branch). Now that the work is done, rename it to reflect what was accomplished:
+
+          git branch -m <kebab-case-name>
+          tbd worktree rename \(folder) "<emoji> <Title Case>"
+
+        Format:
+          Branch: kebab-case, under 30 chars, specific.
+          Display: a relevant emoji + the branch name in Title Case.
+
+        Examples:
+          fix-login-timeout  →  ⏱ Fix Login Timeout
+          add-export-csv     →  📊 Add Export CSV
+
+        Then you may stop.
+        """
+    }
+
+    /// Serialize `{"decision":"block","reason":"..."}` using JSONEncoder so
+    /// quoting/escaping is correct.
+    static func encodeBlock(reason: String) -> String? {
+        struct StopBlock: Encodable {
+            let decision: String
+            let reason: String
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(StopBlock(decision: "block", reason: reason)) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+}
+
+/// Run `git <args>` and return trimmed stdout, or nil if it fails or has
+/// no output. Best-effort — used by hook code where any failure should
+/// fall through to the silent exit path.
+private func runGit(_ args: [String]) -> String? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["git"] + args
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = Pipe()
+    do {
+        try process.run()
+    } catch {
+        return nil
+    }
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else { return nil }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let text = String(data: data, encoding: .utf8) else { return nil }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}

--- a/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
+++ b/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
@@ -96,7 +96,10 @@ enum StopRenameCheckCore {
                     return (topLevel as NSString).lastPathComponent
                 },
                 counterPath: { sessionID in
-                    "/tmp/tbd-stop-rename-\(sessionID)"
+                    // Sanitize against forward slashes so the cap guarantee doesn't rely on
+                    // Claude Code's session-id format (UUIDs today, but an external contract).
+                    let safe = sessionID.replacingOccurrences(of: "/", with: "-")
+                    return "/tmp/tbd-stop-rename-\(safe)"
                 }
             )
         }
@@ -125,10 +128,9 @@ enum StopRenameCheckCore {
 
         let sessionID = (payload["session_id"] as? String) ?? ""
         let cwd = (payload["cwd"] as? String) ?? ""
-        // `stop_hook_active` is read for completeness; we use the on-disk
-        // counter rather than relying on the flag because the flag also
-        // fires when other hooks block.
-        _ = (payload["stop_hook_active"] as? Bool) ?? false
+        // `stop_hook_active` is intentionally ignored: it also flips when *other*
+        // Stop hooks block, so it's not a reliable "this hook is re-entering"
+        // signal. We use the on-disk counter for loop protection instead.
 
         guard !sessionID.isEmpty, !cwd.isEmpty else {
             return nil

--- a/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
+++ b/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
@@ -156,7 +156,14 @@ enum StopRenameCheckCore {
             return nil
         }
 
-        // 3d. Counter check. Bump first; if the new value exceeds the cap,
+        // 3d. Folder for the `tbd worktree rename` example. Fetched before
+        // the counter bump so the "fire count = times directive was shown"
+        // invariant holds even if folder resolution silently fails.
+        guard let folder = dependencies.fetchFolder(cwd) else {
+            return nil
+        }
+
+        // 3e. Counter check. Bump first; if the new value exceeds the cap,
         // give up so we don't trap the agent in a stop loop.
         let counterPath = dependencies.counterPath(sessionID)
         let newCount = bumpCounter(at: counterPath)
@@ -164,12 +171,7 @@ enum StopRenameCheckCore {
             return nil
         }
 
-        // 4. Folder for the `tbd worktree rename` example.
-        guard let folder = dependencies.fetchFolder(cwd) else {
-            return nil
-        }
-
-        // 5. Build the directive and encode it as a Stop-hook block response.
+        // 4. Build the directive and encode it as a Stop-hook block response.
         let reason = buildDirective(branch: branch, folder: folder)
         return encodeBlock(reason: reason)
     }
@@ -213,18 +215,18 @@ enum StopRenameCheckCore {
     }
 
     /// Serialize `{"decision":"block","reason":"..."}` using JSONEncoder so
-    /// quoting/escaping is correct.
-    static func encodeBlock(reason: String) -> String? {
+    /// quoting/escaping is correct. Both failure paths are unreachable
+    /// (encoding two `String` fields can't fail and JSONEncoder always
+    /// produces valid UTF-8), so the return type is non-optional.
+    static func encodeBlock(reason: String) -> String {
         struct StopBlock: Encodable {
             let decision: String
             let reason: String
         }
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
-        guard let data = try? encoder.encode(StopBlock(decision: "block", reason: reason)) else {
-            return nil
-        }
-        return String(data: data, encoding: .utf8)
+        let data = try! encoder.encode(StopBlock(decision: "block", reason: reason))
+        return String(data: data, encoding: .utf8)!
     }
 }
 

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -44,6 +44,13 @@ public enum ClaudeHookOverlay {
     static let stopCommand =
         #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
 
+    /// Second Stop hook: prompt the agent to rename its worktree/branch at
+    /// end-of-turn while the work is fresh and context is highest. Reads
+    /// the Stop payload from stdin and may emit a `{"decision":"block",...}`
+    /// JSON response. Silent failure so we never wedge the agent.
+    static let stopRenameCheckCommand =
+        #"tbd hooks stop-rename-check 2>/dev/null || true"#
+
     /// Bridges the `PreToolUse:AskUserQuestion` hook into TBD. Captures the
     /// tool input and tool_use_id so the transcript pane can render the
     /// question before Claude flushes the assistant message to the JSONL.
@@ -72,6 +79,11 @@ public enum ClaudeHookOverlay {
                     [
                         "hooks": [
                             ["type": "command", "command": stopCommand]
+                        ]
+                    ],
+                    [
+                        "hooks": [
+                            ["type": "command", "command": stopRenameCheckCommand]
                         ]
                     ]
                 ],

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -12,12 +12,19 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-overl
 /// its own overlay file pinned at spawn time without touching the user's
 /// settings.json at all.
 ///
-/// The overlay registers two hooks:
+/// The overlay registers four event types:
 /// - `SessionStart` (matcher `*`): calls `tbd session-event`, which
 ///   relays the new session ID + transcript path to the daemon. This is
 ///   what fixes the post-`/clear`/`/compact` transcript freeze.
-/// - `Stop`: calls `tbd notify` for response-complete notifications,
-///   matching the legacy globally-installed hook.
+/// - `Stop` (two entries):
+///   - `tbd notify` for response-complete notifications, matching the
+///     legacy globally-installed hook.
+///   - `tbd hooks stop-rename-check`, which prompts the agent to rename
+///     a still-default worktree/branch at end-of-turn.
+/// - `PreToolUse:AskUserQuestion` / `PostToolUse:AskUserQuestion`:
+///   bridge tool input and `tool_use_id` so the transcript pane can
+///   render the question before Claude flushes the assistant message
+///   to the JSONL.
 ///
 /// The overlay is regenerated on every daemon startup so changes to the
 /// shape (new hooks, new commands) take effect on the next worktree open.

--- a/Tests/TBDCLITests/StopRenameCheckCommandTests.swift
+++ b/Tests/TBDCLITests/StopRenameCheckCommandTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDCLI
+
+@Suite("StopRenameCheckCore")
+struct StopRenameCheckCommandTests {
+
+    /// Build a stdin JSON payload matching Claude Code's Stop hook shape.
+    private static func payload(
+        sessionID: String = "test-session",
+        cwd: String = "/tmp/worktree",
+        stopHookActive: Bool = false
+    ) -> Data {
+        let dict: [String: Any] = [
+            "session_id": sessionID,
+            "cwd": cwd,
+            "hook_event_name": "Stop",
+            "stop_hook_active": stopHookActive,
+            "last_assistant_message": "ok"
+        ]
+        return try! JSONSerialization.data(withJSONObject: dict)
+    }
+
+    /// Build an injectable Dependencies value with sensible defaults. Tests
+    /// override only the bits they care about.
+    private static func deps(
+        worktree: StopRenameCheckCore.WorktreeSummary? = .init(
+            name: "20260515-surprised-giraffe",
+            displayName: "20260515-surprised-giraffe",
+            status: .active
+        ),
+        branch: String? = "tbd/20260515-surprised-giraffe",
+        folder: String? = "20260515-surprised-giraffe",
+        counterDirectory: URL
+    ) -> StopRenameCheckCore.Dependencies {
+        StopRenameCheckCore.Dependencies(
+            fetchWorktree: { _ in worktree },
+            fetchBranch: { _ in branch },
+            fetchFolder: { _ in folder },
+            counterPath: { sid in counterDirectory.appendingPathComponent("counter-\(sid)").path }
+        )
+    }
+
+    /// Create a unique temp directory the test owns for its counter file.
+    private static func tempDir() -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-stop-rename-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    // MARK: - Branches
+
+    @Test func invalidJSON_returnsNil() {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let out = StopRenameCheckCore.decide(
+            stdinData: Data("not json".utf8),
+            dependencies: Self.deps(counterDirectory: dir)
+        )
+        #expect(out == nil)
+    }
+
+    @Test func missingSessionID_returnsNil() {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let bad = try! JSONSerialization.data(withJSONObject: ["cwd": "/tmp/x"])
+        let out = StopRenameCheckCore.decide(
+            stdinData: bad,
+            dependencies: Self.deps(counterDirectory: dir)
+        )
+        #expect(out == nil)
+    }
+
+    @Test func daemonReturnsNoWorktree_returnsNil() {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let out = StopRenameCheckCore.decide(
+            stdinData: Self.payload(),
+            dependencies: Self.deps(worktree: nil, counterDirectory: dir)
+        )
+        #expect(out == nil)
+    }
+
+    @Test func mainWorktree_returnsNil() {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let out = StopRenameCheckCore.decide(
+            stdinData: Self.payload(),
+            dependencies: Self.deps(
+                worktree: .init(name: "main", displayName: "main", status: .main),
+                counterDirectory: dir
+            )
+        )
+        #expect(out == nil)
+    }
+
+    @Test func displayNameDiffersFromName_returnsNil() {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let out = StopRenameCheckCore.decide(
+            stdinData: Self.payload(),
+            dependencies: Self.deps(
+                worktree: .init(name: "raw-folder", displayName: "🦒 My Cool Feature", status: .active),
+                counterDirectory: dir
+            )
+        )
+        #expect(out == nil)
+    }
+
+    @Test func branchMissingTbdPrefix_returnsNil() {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let out = StopRenameCheckCore.decide(
+            stdinData: Self.payload(),
+            dependencies: Self.deps(branch: "main", counterDirectory: dir)
+        )
+        #expect(out == nil)
+    }
+
+    @Test func counterAtCap_returnsNil() throws {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // Pre-seed the counter at the cap so the next bump exceeds it.
+        let sessionID = "session-cap"
+        let counterPath = dir.appendingPathComponent("counter-\(sessionID)").path
+        try "\(StopRenameCheckCore.maxFireCount)".write(toFile: counterPath, atomically: true, encoding: .utf8)
+        let out = StopRenameCheckCore.decide(
+            stdinData: Self.payload(sessionID: sessionID),
+            dependencies: Self.deps(counterDirectory: dir)
+        )
+        #expect(out == nil)
+    }
+
+    @Test func happyPath_emitsBlockWithBranchAndFolder() throws {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let out = StopRenameCheckCore.decide(
+            stdinData: Self.payload(),
+            dependencies: Self.deps(
+                branch: "tbd/20260515-surprised-giraffe",
+                folder: "20260515-surprised-giraffe",
+                counterDirectory: dir
+            )
+        )
+        let raw = try #require(out)
+        let parsed = try JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any]
+        #expect(parsed?["decision"] as? String == "block")
+        let reason = try #require(parsed?["reason"] as? String)
+        #expect(reason.contains("tbd/20260515-surprised-giraffe"))
+        #expect(reason.contains("20260515-surprised-giraffe"))
+        #expect(reason.contains("git branch -m"))
+        #expect(reason.contains("tbd worktree rename"))
+    }
+
+    @Test func counterIncrementsAcrossInvocations() throws {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sessionID = "session-increments"
+
+        // First fire: counter becomes 1, block emitted.
+        let first = StopRenameCheckCore.decide(
+            stdinData: Self.payload(sessionID: sessionID),
+            dependencies: Self.deps(counterDirectory: dir)
+        )
+        #expect(first != nil)
+
+        // Second fire: counter becomes 2, still emits (cap is 2, not >2).
+        let second = StopRenameCheckCore.decide(
+            stdinData: Self.payload(sessionID: sessionID),
+            dependencies: Self.deps(counterDirectory: dir)
+        )
+        #expect(second != nil)
+
+        // Third fire: counter becomes 3, silent exit.
+        let third = StopRenameCheckCore.decide(
+            stdinData: Self.payload(sessionID: sessionID),
+            dependencies: Self.deps(counterDirectory: dir)
+        )
+        #expect(third == nil)
+    }
+
+    @Test func bumpCounter_absentFileTreatsAsZero() throws {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let path = dir.appendingPathComponent("absent").path
+        let next = StopRenameCheckCore.bumpCounter(at: path)
+        #expect(next == 1)
+        let read = try String(contentsOfFile: path, encoding: .utf8)
+        #expect(read.trimmingCharacters(in: .whitespacesAndNewlines) == "1")
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -17,11 +17,18 @@ import Testing
         let cmd0 = inner?.first?["command"] as? String
         #expect(cmd0?.contains("tbd session-event") == true)
 
-        // Stop entry registers `tbd notify`.
+        // Stop entry registers `tbd notify` as the first matcher and
+        // `tbd hooks stop-rename-check` as a sibling matcher.
         let stop = hooks?["Stop"] as? [[String: Any]]
+        #expect(stop?.count == 2)
         let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
         let stopCmd = stopHooks?.first?["command"] as? String
         #expect(stopCmd?.contains("tbd notify") == true)
+        let allStopCommands: [String] = (stop ?? []).flatMap { entry -> [String] in
+            let inner = entry["hooks"] as? [[String: Any]] ?? []
+            return inner.compactMap { $0["command"] as? String }
+        }
+        #expect(allStopCommands.contains(where: { $0.contains("stop-rename-check") }))
     }
 
     @Test func roundtripsAsValidJSON() throws {


### PR DESCRIPTION
## Summary

- Adds a `tbd hooks stop-rename-check` subcommand registered as a second `Stop` hook in the existing `ClaudeHookOverlay`. At end-of-turn — when the agent has just finished the work and has maximum context — the hook checks whether the worktree still has its default name (`tbd/<datestamp>-<words>` branch + matching display name). If so it emits `{"decision":"block","reason":"..."}` so Claude Code keeps the session alive and surfaces a directive telling the agent to rename based on what it actually accomplished.
- Previously the rename ask was injected at session *start* as part of `--append-system-prompt` (`RepoConstants.defaultRenamePrompt` + the per-repo override in `state.db`). Agents had to choose names from a one-line task description, lost the "do this first" race against louder skills like superpowers' ABSOLUTELY-MUST language, and quietly stopped without renaming. End-of-turn enforcement removes both problems.
- Per-session counter at `/tmp/tbd-stop-rename-<session_id>` caps re-fires at 2 so a stubborn agent isn't trapped in a Stop loop. Any error path (malformed stdin, daemon down, cwd outside a worktree, branch already renamed) exits silently — the hook never wedges the agent.
- Phase 1 of two: ships alongside the existing system-prompt directive so the redundant copy is harmless backup while we observe the hook in real use. Phase 2 (later PR) will trim the system prompt to short advisory text once Phase 1 is proven.

## Test plan

- [ ] `swift build` and `swift test` pass (793 tests across 81 suites, verified locally).
- [ ] After `scripts/restart.sh`, spawn a fresh Claude session in a new `tbd/`-prefixed worktree; ask it to do trivial work; verify it produces the directive at end-of-turn and renames before stopping.
- [ ] In a worktree whose display name has already been customized, verify the hook silently exits and the agent stops normally.
- [ ] Force the counter past 2 (`echo 3 > /tmp/tbd-stop-rename-<session>`); verify the hook silently exits so the agent isn't trapped.
- [ ] Confirm `tbd notify` (the existing Stop hook) still fires for end-of-turn notifications — both Stop entries should coexist.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=CAAFCB8A-2B7B-4706-AB82-192ED38EBC8B)