### PR TITLE
Fix: Stop wiping the Claude conversation when reviving an archived worktree

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -266,13 +266,20 @@ extension WorktreeLifecycle {
             claudeSessionID = nil
             pinnedProfileID = nil
         } else {
-            let sessionUUID = archivedClaudeSessions?.first ?? UUID().uuidString
+            let archivedSession = archivedClaudeSessions?.first
+            let sessionUUID = archivedSession ?? UUID().uuidString
             claudeSessionID = sessionUUID
-            let isResume = archivedClaudeSessions?.first != nil
-            let appendPrompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: isResume)
+            let isResume = archivedSession != nil
+            // `--resume` is what actually restores the prior conversation;
+            // `--session-id` is for starting a NEW session with a pre-chosen
+            // UUID (used on fresh create). Reviving with `--session-id` on an
+            // already-existing session file would lose the transcript.
+            let appendPrompt = isResume
+                ? nil
+                : SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false)
             let spawn = ClaudeSpawnCommandBuilder.build(
-                resumeID: nil,
-                freshSessionID: sessionUUID,
+                resumeID: isResume ? sessionUUID : nil,
+                freshSessionID: isResume ? nil : sessionUUID,
                 appendSystemPrompt: appendPrompt,
                 initialPrompt: isResume ? nil : initialPrompt,
                 profileSecret: resolvedProfile?.secret,
@@ -353,8 +360,8 @@ extension WorktreeLifecycle {
             for sessionID in sessions.dropFirst() {
                 let plannedID = UUID()
                 let spawn = ClaudeSpawnCommandBuilder.build(
-                    resumeID: nil,
-                    freshSessionID: sessionID,
+                    resumeID: sessionID,
+                    freshSessionID: nil,
                     appendSystemPrompt: nil,
                     initialPrompt: nil,
                     profileSecret: resolvedProfile?.secret,

--- a/Tests/TBDDaemonTests/ArchivedReviveBranchRenameTests.swift
+++ b/Tests/TBDDaemonTests/ArchivedReviveBranchRenameTests.swift
@@ -296,3 +296,93 @@ private func makeRepoRow(db: TBDDatabase, tempDir: URL, repoDir: URL) async thro
     #expect(after?.branch == beforeBranch)
     #expect(after?.archivedHeadSHA == beforeSHA)
 }
+
+// MARK: - Revive must --resume archived Claude sessions
+
+/// Captures the argv tmux would have been invoked with so we can assert the
+/// shell command body. Mirrors the recorder pattern in ModelProfileSpawnTests.
+private final class TmuxArgvRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [[String]] = []
+    var calls: [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return _calls
+    }
+    func record(_ args: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        _calls.append(args)
+    }
+    /// Last argv element of each call — the shell command body for new-window.
+    var shellBodies: [String] { calls.compactMap { $0.last } }
+}
+
+@Test func testReviveSpawnsClaudeWithResumeFlag() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let recorder = TmuxArgvRecorder()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // Create + archive with skipClaude so create-side doesn't spawn anything.
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    // Seed an archived Claude session ID so the revive path believes there's
+    // a conversation to resume.
+    let sessionID = "AAAAAAAA-1111-2222-3333-444444444444"
+    try await db.worktrees.setArchivedClaudeSessions(id: wt.id, sessions: [sessionID])
+
+    // Revive with skipClaude=false so setupTerminals actually spawns claude.
+    _ = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: false)
+
+    // Find the new-window invocation whose shell body launches claude.
+    let claudeBodies = recorder.shellBodies.filter { $0.contains("claude ") }
+    #expect(!claudeBodies.isEmpty, "expected at least one claude spawn during revive; recorded: \(recorder.shellBodies)")
+
+    let body = claudeBodies.first ?? ""
+    #expect(body.contains("--resume \(sessionID)"),
+            "revive should spawn claude with --resume <archivedSession>, got: \(body)")
+    #expect(!body.contains("--session-id \(sessionID)"),
+            "revive must NOT spawn claude with --session-id <archivedSession> (that's the bug — it starts a fresh session and loses the conversation), got: \(body)")
+}
+
+@Test func testReviveResumesEveryArchivedSession() async throws {
+    let (tempDir, repoDir) = try await makeRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let recorder = TmuxArgvRecorder()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()
+    )
+    let repo = try await makeRepoRow(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    let sessionA = "AAAAAAAA-1111-2222-3333-444444444444"
+    let sessionB = "BBBBBBBB-1111-2222-3333-444444444444"
+    let sessionC = "CCCCCCCC-1111-2222-3333-444444444444"
+    try await db.worktrees.setArchivedClaudeSessions(
+        id: wt.id, sessions: [sessionA, sessionB, sessionC]
+    )
+
+    _ = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: false)
+
+    let claudeBodies = recorder.shellBodies.filter { $0.contains("claude ") }
+    // One per archived session — first via primary terminal, rest via dropFirst loop.
+    #expect(claudeBodies.count == 3,
+            "expected 3 claude spawns (one per archived session), got \(claudeBodies.count): \(claudeBodies)")
+    for sid in [sessionA, sessionB, sessionC] {
+        #expect(claudeBodies.contains { $0.contains("--resume \(sid)") },
+                "missing --resume \(sid) in any claude spawn body; got: \(claudeBodies)")
+        #expect(!claudeBodies.contains { $0.contains("--session-id \(sid)") },
+                "should not spawn --session-id \(sid) on revive; got: \(claudeBodies)")
+    }
+}


### PR DESCRIPTION
## Summary

- **What's broken:** Reviving an archived worktree did not restore the previous Claude conversation. The Claude tab either silently started a fresh session (transcript lost) or — when Claude rejected the duplicate session ID — exited and left the tab looking like a plain shell.
- **Why it happens:** `setupTerminals` is shared between `finishCreate` and `reviveWorktree`. It always spawned `claude --session-id <UUID>`, which is the flag for starting a NEW session with a pre-chosen UUID. On the revive path the UUID already had a transcript file on disk, so the resume never happened. The post-reboot reconcile path (`WorktreeLifecycle+Reconcile.swift`) already gets this right with `--resume`; revive was the outlier.
- **The fix:** On revive, pass `resumeID: <archivedSessionID>` (and `freshSessionID: nil`) to `ClaudeSpawnCommandBuilder`. Same change for the additional-sessions loop that restores extra archived sessions. Two new tests record tmux argv via `dryRun` and assert every spawned claude command uses `--resume <id>` rather than `--session-id <id>`.

The existing revive test suite all passed `skipClaude: true`, so the Claude spawn path on revive was never exercised — that's how this slipped through. The new tests close that gap.

## Test plan

- [x] `swift test --filter "testReviveSpawnsClaudeWithResumeFlag|testReviveResumesEveryArchivedSession"` — both pass.
- [x] `swift test` — full suite, 814/814 pass.
- [x] `swift build` — clean.
- [ ] Manual: archive a worktree with an active Claude conversation, revive it from the archived view, confirm the transcript is restored and the Claude tab keeps its ✳ icon.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9CE24E6F-6FB2-4472-9ACE-4B49E13A69CB)