### PR TITLE
Feat: One-script migration from Conductor to TBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ scripts/restart.sh --quick  # skip build
 swift test
 ```
 
+## Migrating from Conductor
+
+Adopt your existing [Conductor](https://conductor.build) worktrees into TBD in place — no files moved, branches untouched, Conductor keeps working alongside. By default, only active (`ready`) Conductor workspaces are adopted, and any repos they reference are auto-registered in TBD.
+
+```sh
+./scripts/import-conductor.sh --dry-run    # preview
+./scripts/import-conductor.sh              # run
+```
+
+Flags:
+- `--all` — also adopt archived Conductor workspaces.
+- `--repo <name>` — limit to one Conductor repo (e.g. `--repo longeye-app`).
+- `--dry-run` — print the plan, don't write anything.
+
+Idempotent — safe to re-run as you create new Conductor worktrees.
+
+Existing Claude session transcripts and `conductor.json` hooks are picked up automatically — nothing extra to migrate.
+
 ## License
 
 Private / All rights reserved.

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -249,7 +249,7 @@ struct WorktreeAdopt: AsyncParsableCommand {
     var json = false
 
     mutating func run() async throws {
-        let absolute = resolvePath(path)
+        let absolute = try canonicalizePath(path)
         guard FileManager.default.fileExists(atPath: absolute) else {
             throw CLIError.invalidArgument("Path does not exist: \(absolute)")
         }
@@ -285,6 +285,24 @@ struct WorktreeAdopt: AsyncParsableCommand {
             print("  Branch: \(worktree.branch)")
             print("  Path:   \(worktree.path)")
         }
+    }
+
+    /// Canonicalizes a user-supplied path: expands `~`, resolves to absolute,
+    /// AND follows symlinks via `realpath(3)`. The symlink-following step is
+    /// required because git's `worktree list --porcelain` always reports
+    /// `realpath()`-canonicalized paths, so a user passing `/tmp/foo` (which
+    /// macOS symlinks to `/private/tmp/foo`) wouldn't match the list entry
+    /// otherwise. Foundation's `URL.resolvingSymlinksInPath()` does NOT
+    /// follow `/var → /private/var` on macOS, so we use C's `realpath`.
+    private func canonicalizePath(_ input: String) throws -> String {
+        let absolute = resolvePath(input)
+        var buf = [Int8](repeating: 0, count: Int(PATH_MAX))
+        guard realpath(absolute, &buf) != nil else {
+            // realpath fails when any component along the path doesn't exist.
+            // Let the caller's fileExists check surface that as a clearer error.
+            return absolute
+        }
+        return buf.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
     }
 
     /// Resolves the main-repo root for a given worktree path by shelling out

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -9,6 +9,7 @@ struct WorktreeCommand: ParsableCommand {
         subcommands: [
             WorktreeCreate.self,
             WorktreeList.self,
+            WorktreeAdopt.self,
             WorktreeArchive.self,
             WorktreeRevive.self,
             WorktreeRename.self,
@@ -224,6 +225,100 @@ struct WorktreeList: AsyncParsableCommand {
                 print(line + tag)
             }
         }
+    }
+}
+
+// MARK: - worktree adopt
+
+struct WorktreeAdopt: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "adopt",
+        abstract: "Register an existing git worktree directory into TBD"
+    )
+
+    @Argument(help: "Absolute path to the existing git worktree directory")
+    var path: String
+
+    @Option(name: .long, help: "Repository path or ID (default: auto-detected from the worktree's git common-dir)")
+    var repo: String?
+
+    @Option(name: .long, help: "Display name shown in TBD UI (default: last path component)")
+    var name: String?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let absolute = resolvePath(path)
+        guard FileManager.default.fileExists(atPath: absolute) else {
+            throw CLIError.invalidArgument("Path does not exist: \(absolute)")
+        }
+
+        let client = SocketClient()
+        let repoID: UUID
+        if let repo = repo {
+            if let id = UUID(uuidString: repo) {
+                repoID = id
+            } else {
+                let resolver = PathResolver(client: client)
+                repoID = try resolver.resolveRepoID(path: repo)
+            }
+        } else {
+            // Auto-detect: run `git rev-parse --git-common-dir` from the worktree
+            // path, then walk to the repo root and resolve via PathResolver.
+            let repoRoot = try detectRepoRoot(forWorktreePath: absolute)
+            let resolver = PathResolver(client: client)
+            repoID = try resolver.resolveRepoID(path: repoRoot)
+        }
+
+        let worktree: Worktree = try client.call(
+            method: RPCMethod.worktreeAdopt,
+            params: WorktreeAdoptParams(repoID: repoID, path: absolute, displayName: name),
+            resultType: Worktree.self
+        )
+
+        if json {
+            printJSON(worktree)
+        } else {
+            print("Adopted worktree: \(worktree.displayName)")
+            print("  ID:     \(worktree.id)")
+            print("  Branch: \(worktree.branch)")
+            print("  Path:   \(worktree.path)")
+        }
+    }
+
+    /// Resolves the main-repo root for a given worktree path by shelling out
+    /// to `git rev-parse --git-common-dir` and walking up one level from the
+    /// resulting `.git` directory.
+    private func detectRepoRoot(forWorktreePath path: String) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", path, "rev-parse", "--git-common-dir"]
+        let out = Pipe()
+        let err = Pipe()
+        process.standardOutput = out
+        process.standardError = err
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let stderrData = err.fileHandleForReading.readDataToEndOfFile()
+            let msg = String(data: stderrData, encoding: .utf8) ?? "git rev-parse failed"
+            throw CLIError.invalidArgument("Not a git worktree (\(path)): \(msg.trimmingCharacters(in: .whitespacesAndNewlines))")
+        }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        let rawGitDir = (String(data: data, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // rawGitDir may be relative — resolve against the worktree path.
+        let gitDir: String
+        if rawGitDir.hasPrefix("/") {
+            gitDir = rawGitDir
+        } else {
+            gitDir = (path as NSString).appendingPathComponent(rawGitDir)
+        }
+        // gitDir typically ends in "/.git" — the repo root is its parent.
+        let resolved = URL(fileURLWithPath: gitDir).standardized.path
+        let repoRoot = (resolved as NSString).deletingLastPathComponent
+        return repoRoot
     }
 }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Adopt.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Adopt.swift
@@ -1,0 +1,80 @@
+import Foundation
+import os
+import TBDShared
+
+private let adoptLogger = Logger(subsystem: "com.tbd.daemon", category: "worktreeAdopt")
+
+extension WorktreeLifecycle {
+    // MARK: - Adopt
+
+    /// Adopt an existing git worktree directory into TBD.
+    ///
+    /// Unlike `createWorktree`, this does NOT call `git worktree add` and does
+    /// NOT spawn tmux terminals — the on-disk worktree is assumed to already
+    /// exist and be registered with git. We just insert a `worktrees` row
+    /// pointing at it. The user (or app) can spawn terminals later via the
+    /// regular terminal-create flow.
+    ///
+    /// Idempotent:
+    /// - If an active worktree row already exists for `path`, returns it unchanged.
+    /// - If an archived row exists for `path`, flips its status to `.active` and returns it.
+    /// - Otherwise inserts a fresh row.
+    public func adoptWorktree(
+        repoID: UUID,
+        path: String,
+        displayName: String? = nil
+    ) async throws -> Worktree {
+        guard let repo = try await db.repos.get(id: repoID) else {
+            throw WorktreeLifecycleError.repoNotFound(repoID)
+        }
+
+        // Verify git knows about this worktree path. If we adopted a path git
+        // doesn't track, TBD would archive it on the next reconcile sweep.
+        let gitWorktrees = try await git.worktreeList(repoPath: repo.path)
+        guard let gitWt = gitWorktrees.first(where: { $0.path == path }) else {
+            throw WorktreeAdoptError.notInGitWorktreeList(path: path)
+        }
+
+        let name = (path as NSString).lastPathComponent
+        let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
+
+        // Idempotency: check for an existing row at this exact path.
+        let existingActive = try await db.worktrees.list(repoID: repoID, status: .active)
+        if let match = existingActive.first(where: { $0.path == path }) {
+            adoptLogger.info("adoptWorktree: \(path, privacy: .public) already active as \(match.id, privacy: .public)")
+            return match
+        }
+        let existingArchived = try await db.worktrees.list(repoID: repoID, status: .archived)
+        if let match = existingArchived.first(where: { $0.path == path }) {
+            adoptLogger.info("adoptWorktree: reviving archived row \(match.id, privacy: .public) for \(path, privacy: .public)")
+            try await db.worktrees.updateStatus(id: match.id, status: .active)
+            guard let refreshed = try await db.worktrees.get(id: match.id) else {
+                throw WorktreeLifecycleError.worktreeNotFound(match.id)
+            }
+            return refreshed
+        }
+
+        let worktree = try await db.worktrees.create(
+            repoID: repoID,
+            name: name,
+            displayName: displayName ?? name,
+            branch: gitWt.branch,
+            path: path,
+            tmuxServer: tmuxServer,
+            status: .active
+        )
+        adoptLogger.info("adoptWorktree: inserted \(worktree.id, privacy: .public) for \(path, privacy: .public)")
+        return worktree
+    }
+}
+
+public enum WorktreeAdoptError: Error, CustomStringConvertible {
+    case notInGitWorktreeList(path: String)
+
+    public var description: String {
+        switch self {
+        case .notInGitWorktreeList(let path):
+            return "Path is not registered in `git worktree list` for the resolved repo: \(path). Run `git worktree repair` and retry."
+        }
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Adopt.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Adopt.swift
@@ -4,6 +4,23 @@ import TBDShared
 
 private let adoptLogger = Logger(subsystem: "com.tbd.daemon", category: "worktreeAdopt")
 
+/// The outcome of an `adoptWorktree` call. Conveys whether a new row was
+/// inserted, an archived row was revived, or an active row was returned
+/// unchanged — so the RPC handler can pick the right delta to broadcast
+/// (or skip the broadcast entirely on the idempotent path).
+public enum WorktreeAdoptOutcome: Sendable {
+    case inserted(Worktree)
+    case revived(Worktree)
+    case unchanged(Worktree)
+
+    public var worktree: Worktree {
+        switch self {
+        case .inserted(let w), .revived(let w), .unchanged(let w):
+            return w
+        }
+    }
+}
+
 extension WorktreeLifecycle {
     // MARK: - Adopt
 
@@ -16,14 +33,15 @@ extension WorktreeLifecycle {
     /// regular terminal-create flow.
     ///
     /// Idempotent:
-    /// - If an active worktree row already exists for `path`, returns it unchanged.
-    /// - If an archived row exists for `path`, flips its status to `.active` and returns it.
-    /// - Otherwise inserts a fresh row.
+    /// - If an active worktree row already exists for `path`, returns `.unchanged`.
+    /// - If an archived row exists for `path`, flips its status to `.active`,
+    ///   applies any `displayName` override, and returns `.revived`.
+    /// - Otherwise inserts a fresh row and returns `.inserted`.
     public func adoptWorktree(
         repoID: UUID,
         path: String,
         displayName: String? = nil
-    ) async throws -> Worktree {
+    ) async throws -> WorktreeAdoptOutcome {
         guard let repo = try await db.repos.get(id: repoID) else {
             throw WorktreeLifecycleError.repoNotFound(repoID)
         }
@@ -42,16 +60,22 @@ extension WorktreeLifecycle {
         let existingActive = try await db.worktrees.list(repoID: repoID, status: .active)
         if let match = existingActive.first(where: { $0.path == path }) {
             adoptLogger.info("adoptWorktree: \(path, privacy: .public) already active as \(match.id, privacy: .public)")
-            return match
+            return .unchanged(match)
         }
         let existingArchived = try await db.worktrees.list(repoID: repoID, status: .archived)
         if let match = existingArchived.first(where: { $0.path == path }) {
             adoptLogger.info("adoptWorktree: reviving archived row \(match.id, privacy: .public) for \(path, privacy: .public)")
             try await db.worktrees.updateStatus(id: match.id, status: .active)
+            // Honor caller's displayName override on revival — without this, a
+            // user calling `tbd worktree adopt <path> --name "New Label"` would
+            // silently keep the row's old archived name.
+            if let displayName, displayName != match.displayName {
+                try await db.worktrees.rename(id: match.id, displayName: displayName)
+            }
             guard let refreshed = try await db.worktrees.get(id: match.id) else {
                 throw WorktreeLifecycleError.worktreeNotFound(match.id)
             }
-            return refreshed
+            return .revived(refreshed)
         }
 
         let worktree = try await db.worktrees.create(
@@ -64,7 +88,7 @@ extension WorktreeLifecycle {
             status: .active
         )
         adoptLogger.info("adoptWorktree: inserted \(worktree.id, privacy: .public) for \(path, privacy: .public)")
-        return worktree
+        return .inserted(worktree)
     }
 }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -118,16 +118,31 @@ extension RPCRouter {
 
     func handleWorktreeAdopt(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeAdoptParams.self, from: paramsData)
-        let worktree = try await lifecycle.adoptWorktree(
+        let outcome = try await lifecycle.adoptWorktree(
             repoID: params.repoID,
             path: params.path,
             displayName: params.displayName
         )
+        let worktree = outcome.worktree
 
-        subscriptions.broadcast(delta: .worktreeCreated(WorktreeDelta(
-            worktreeID: worktree.id, repoID: worktree.repoID,
-            name: worktree.name, path: worktree.path
-        )))
+        // Pick the broadcast that matches what actually changed. Idempotent
+        // calls (already-active) emit nothing — clients already know about
+        // this row, and a spurious `.worktreeCreated` could cause duplicate
+        // sidebar entries depending on client-side dedup.
+        switch outcome {
+        case .inserted:
+            subscriptions.broadcast(delta: .worktreeCreated(WorktreeDelta(
+                worktreeID: worktree.id, repoID: worktree.repoID,
+                name: worktree.name, path: worktree.path
+            )))
+        case .revived:
+            subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
+                worktreeID: worktree.id, repoID: worktree.repoID,
+                name: worktree.name, path: worktree.path
+            )))
+        case .unchanged:
+            break
+        }
 
         return try RPCResponse(result: worktree)
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -116,6 +116,22 @@ extension RPCRouter {
         return try RPCResponse(result: worktree)
     }
 
+    func handleWorktreeAdopt(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeAdoptParams.self, from: paramsData)
+        let worktree = try await lifecycle.adoptWorktree(
+            repoID: params.repoID,
+            path: params.path,
+            displayName: params.displayName
+        )
+
+        subscriptions.broadcast(delta: .worktreeCreated(WorktreeDelta(
+            worktreeID: worktree.id, repoID: worktree.repoID,
+            name: worktree.name, path: worktree.path
+        )))
+
+        return try RPCResponse(result: worktree)
+    }
+
     func handleWorktreeRename(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeRenameParams.self, from: paramsData)
         try await db.worktrees.rename(id: params.worktreeID, displayName: params.displayName)

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -94,6 +94,8 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeArchive(request.paramsData)
             case RPCMethod.worktreeRevive:
                 return try await handleWorktreeRevive(request.paramsData)
+            case RPCMethod.worktreeAdopt:
+                return try await handleWorktreeAdopt(request.paramsData)
             case RPCMethod.worktreeRename:
                 return try await handleWorktreeRename(request.paramsData)
             case RPCMethod.worktreeReorder:

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -83,6 +83,7 @@ public enum RPCMethod {
     public static let worktreeList = "worktree.list"
     public static let worktreeArchive = "worktree.archive"
     public static let worktreeRevive = "worktree.revive"
+    public static let worktreeAdopt = "worktree.adopt"
     public static let worktreeRename = "worktree.rename"
     public static let worktreeReorder = "worktree.reorder"
     public static let worktreeMove = "worktree.move"
@@ -463,6 +464,17 @@ public struct WorktreeReviveParams: Codable, Sendable {
         self.cols = cols
         self.rows = rows
         self.preferredSessionID = preferredSessionID
+    }
+}
+
+public struct WorktreeAdoptParams: Codable, Sendable {
+    public let repoID: UUID
+    public let path: String
+    public let displayName: String?
+    public init(repoID: UUID, path: String, displayName: String? = nil) {
+        self.repoID = repoID
+        self.path = path
+        self.displayName = displayName
     }
 }
 

--- a/Tests/TBDDaemonTests/WorktreeAdoptTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeAdoptTests.swift
@@ -179,3 +179,44 @@ private func makeRepoWithExternalWorktree() async throws -> (tempDir: URL, repoD
     #expect(result.displayName == "Custom Label")
     #expect(result.name == "feature-x")
 }
+
+/// Detached-HEAD worktrees are accepted (no crash, no error), but TBD's
+/// `git worktree list --porcelain` parser only extracts the `branch ` line —
+/// detached worktrees emit `HEAD <sha>` + `detached` instead, so the branch
+/// column ends up empty. Documented as a known limitation in the design doc;
+/// real-world Conductor migrations don't hit this because Conductor always
+/// names branches `cw/<name>`. This test pins the behavior so future parser
+/// changes that surface the SHA will deliberately break it.
+@Test func testAdoptDetachedHeadStoresEmptyBranch() async throws {
+    let tempDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-adopt-test-\(UUID().uuidString)")
+    let repoDir = tempDir.appendingPathComponent("repo")
+    let extDir = tempDir.appendingPathComponent("external-worktrees/detached")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: extDir.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try await shell("git init -b main && git commit --allow-empty -m 'init'", at: repoDir)
+    try await shell("git worktree add --detach '\(extDir.path)' HEAD", at: repoDir)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    // Resolve via realpath so the path matches what git's worktree-list
+    // reports (/var/folders/... canonicalizes to /private/var/folders/...
+    // on macOS, and Foundation's URL APIs don't follow `/var` → `/private/var`).
+    var resolvedBuf = [Int8](repeating: 0, count: Int(PATH_MAX))
+    guard realpath(extDir.path, &resolvedBuf) != nil else {
+        throw NSError(domain: "test", code: 0, userInfo: [NSLocalizedDescriptionKey: "realpath failed for \(extDir.path)"])
+    }
+    let canonicalPath = String(cString: resolvedBuf)
+    let result = try await lifecycle.adoptWorktree(repoID: repo.id, path: canonicalPath)
+    #expect(result.status == .active)
+    #expect(result.name == "detached")
+    #expect(result.branch == "")
+}

--- a/Tests/TBDDaemonTests/WorktreeAdoptTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeAdoptTests.swift
@@ -73,7 +73,11 @@ private func makeRepoWithExternalWorktree() async throws -> (tempDir: URL, repoD
         path: repoDir.path, displayName: "test", defaultBranch: "main"
     )
 
-    let result = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    let outcome = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    guard case .inserted(let result) = outcome else {
+        Issue.record("expected .inserted, got \(outcome)")
+        return
+    }
 
     #expect(result.status == .active)
     #expect(result.path == worktreePath)
@@ -95,8 +99,16 @@ private func makeRepoWithExternalWorktree() async throws -> (tempDir: URL, repoD
         path: repoDir.path, displayName: "test", defaultBranch: "main"
     )
 
-    let first = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
-    let second = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    let firstOutcome = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    guard case .inserted(let first) = firstOutcome else {
+        Issue.record("expected .inserted, got \(firstOutcome)")
+        return
+    }
+    let secondOutcome = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    guard case .unchanged(let second) = secondOutcome else {
+        Issue.record("expected .unchanged, got \(secondOutcome)")
+        return
+    }
 
     #expect(first.id == second.id)
     let allActive = try await db.worktrees.list(repoID: repo.id, status: .active)
@@ -116,12 +128,56 @@ private func makeRepoWithExternalWorktree() async throws -> (tempDir: URL, repoD
         path: repoDir.path, displayName: "test", defaultBranch: "main"
     )
 
-    let first = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    let firstOutcome = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    guard case .inserted(let first) = firstOutcome else {
+        Issue.record("expected .inserted, got \(firstOutcome)")
+        return
+    }
     try await db.worktrees.updateStatus(id: first.id, status: .archived)
 
-    let revived = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    let revivedOutcome = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    guard case .revived(let revived) = revivedOutcome else {
+        Issue.record("expected .revived, got \(revivedOutcome)")
+        return
+    }
     #expect(revived.id == first.id)
     #expect(revived.status == .active)
+}
+
+/// Revival must honor a `displayName` override — without this, a user
+/// re-adopting an archived worktree with `--name "New Label"` would silently
+/// keep the old archived name.
+@Test func testAdoptRevivalAppliesDisplayNameOverride() async throws {
+    let (tempDir, repoDir, worktreePath, _) = try await makeRepoWithExternalWorktree()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    let firstOutcome = try await lifecycle.adoptWorktree(
+        repoID: repo.id, path: worktreePath, displayName: "Original"
+    )
+    guard case .inserted(let first) = firstOutcome else {
+        Issue.record("expected .inserted, got \(firstOutcome)")
+        return
+    }
+    try await db.worktrees.updateStatus(id: first.id, status: .archived)
+
+    let revivedOutcome = try await lifecycle.adoptWorktree(
+        repoID: repo.id, path: worktreePath, displayName: "Renamed"
+    )
+    guard case .revived(let revived) = revivedOutcome else {
+        Issue.record("expected .revived, got \(revivedOutcome)")
+        return
+    }
+    #expect(revived.id == first.id)
+    #expect(revived.displayName == "Renamed")
 }
 
 @Test func testAdoptRejectsPathNotInGitWorktreeList() async throws {
@@ -173,9 +229,10 @@ private func makeRepoWithExternalWorktree() async throws -> (tempDir: URL, repoD
         path: repoDir.path, displayName: "test", defaultBranch: "main"
     )
 
-    let result = try await lifecycle.adoptWorktree(
+    let outcome = try await lifecycle.adoptWorktree(
         repoID: repo.id, path: worktreePath, displayName: "Custom Label"
     )
+    let result = outcome.worktree
     #expect(result.displayName == "Custom Label")
     #expect(result.name == "feature-x")
 }
@@ -214,8 +271,9 @@ private func makeRepoWithExternalWorktree() async throws -> (tempDir: URL, repoD
     guard realpath(extDir.path, &resolvedBuf) != nil else {
         throw NSError(domain: "test", code: 0, userInfo: [NSLocalizedDescriptionKey: "realpath failed for \(extDir.path)"])
     }
-    let canonicalPath = String(cString: resolvedBuf)
-    let result = try await lifecycle.adoptWorktree(repoID: repo.id, path: canonicalPath)
+    let canonicalPath = resolvedBuf.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
+    let outcome = try await lifecycle.adoptWorktree(repoID: repo.id, path: canonicalPath)
+    let result = outcome.worktree
     #expect(result.status == .active)
     #expect(result.name == "detached")
     #expect(result.branch == "")

--- a/Tests/TBDDaemonTests/WorktreeAdoptTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeAdoptTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Helper to run shell commands in tests.
+private func shell(_ command: String, at dir: URL) async throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = ["-c", command]
+    process.currentDirectoryURL = dir
+    process.environment = [
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
+        "HOME": NSHomeDirectory(),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+    ]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        throw NSError(domain: "shell", code: Int(process.terminationStatus),
+                      userInfo: [NSLocalizedDescriptionKey: "Command failed: \(command)\n\(output)"])
+    }
+}
+
+/// Sets up a temp git repo with one worktree at an arbitrary (non-canonical) path.
+/// Returns the canonicalized path (via realpath) to match what git worktree list reports.
+private func makeRepoWithExternalWorktree() async throws -> (tempDir: URL, repoDir: URL, worktreePath: String, worktreeBranch: String) {
+    let tempDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-adopt-test-\(UUID().uuidString)")
+    let repoDir = tempDir.appendingPathComponent("repo")
+    let extDir = tempDir.appendingPathComponent("external-worktrees/feature-x")
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: extDir.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try await shell("git init -b main && git commit --allow-empty -m 'init'", at: repoDir)
+    try await shell("git worktree add -b feature-x '\(extDir.path)'", at: repoDir)
+
+    // Get the realpath-canonicalized path (git worktree list returns realpath)
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/realpath")
+    process.arguments = [extDir.path]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    try process.run()
+    process.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let canonicalPath = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? extDir.path
+
+    return (tempDir, repoDir, canonicalPath, "feature-x")
+}
+
+@Test func testAdoptInsertsRowForExistingWorktree() async throws {
+    let (tempDir, repoDir, worktreePath, branch) = try await makeRepoWithExternalWorktree()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    let result = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+
+    #expect(result.status == .active)
+    #expect(result.path == worktreePath)
+    #expect(result.branch == branch)
+    #expect(result.name == "feature-x")
+    #expect(result.repoID == repo.id)
+}
+
+@Test func testAdoptIsIdempotentForActiveRow() async throws {
+    let (tempDir, repoDir, worktreePath, _) = try await makeRepoWithExternalWorktree()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    let first = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    let second = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+
+    #expect(first.id == second.id)
+    let allActive = try await db.worktrees.list(repoID: repo.id, status: .active)
+    #expect(allActive.filter { $0.path == worktreePath }.count == 1)
+}
+
+@Test func testAdoptRevivesArchivedRow() async throws {
+    let (tempDir, repoDir, worktreePath, _) = try await makeRepoWithExternalWorktree()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    let first = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    try await db.worktrees.updateStatus(id: first.id, status: .archived)
+
+    let revived = try await lifecycle.adoptWorktree(repoID: repo.id, path: worktreePath)
+    #expect(revived.id == first.id)
+    #expect(revived.status == .active)
+}
+
+@Test func testAdoptRejectsPathNotInGitWorktreeList() async throws {
+    let tempDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-adopt-test-\(UUID().uuidString)")
+    let repoDir = tempDir.appendingPathComponent("repo")
+    let bogusPath = tempDir.appendingPathComponent("not-a-real-worktree").path
+    try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(atPath: bogusPath, withIntermediateDirectories: true)
+    try await shell("git init -b main && git commit --allow-empty -m 'init'", at: repoDir)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    await #expect(throws: WorktreeAdoptError.self) {
+        _ = try await lifecycle.adoptWorktree(repoID: repo.id, path: bogusPath)
+    }
+}
+
+@Test func testAdoptErrorsForUnknownRepo() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let bogusRepoID = UUID()
+    await #expect(throws: WorktreeLifecycleError.self) {
+        _ = try await lifecycle.adoptWorktree(repoID: bogusRepoID, path: "/tmp/anywhere")
+    }
+}
+
+@Test func testAdoptHonorsDisplayNameOverride() async throws {
+    let (tempDir, repoDir, worktreePath, _) = try await makeRepoWithExternalWorktree()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(),
+        tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+
+    let result = try await lifecycle.adoptWorktree(
+        repoID: repo.id, path: worktreePath, displayName: "Custom Label"
+    )
+    #expect(result.displayName == "Custom Label")
+    #expect(result.name == "feature-x")
+}

--- a/docs/superpowers/specs/2026-05-16-conductor-import-design.md
+++ b/docs/superpowers/specs/2026-05-16-conductor-import-design.md
@@ -282,6 +282,16 @@ These are decisions to make during implementation, not blockers for planning:
 - **`tbd repo list --json`** — does this exist today? If not, add it as a small flag during this work. Used by the script to detect already-registered repos by `root_path`.
 - **`tbd worktree list --json`** — same question, for idempotency reporting (optional polish; the script doesn't strictly need it since `adopt` handles the dedup).
 
+## Known issues
+
+**Archive is destructive for adopted worktrees.** TBD's archive flow runs `git worktree remove` in its background phase, which deletes the worktree directory unconditionally — there's no flag distinguishing TBD-created worktrees from adopted ones. For an adopted Conductor worktree, this means `tbd worktree archive <name>` deletes the underlying Conductor directory, breaking the dual-use design intent of this migration.
+
+Revive partially recovers: it re-runs `git worktree add` at the original path (preferring the original branch, falling back to the captured `archivedHeadSHA`), so committed work returns. But uncommitted changes, untracked files (`.envrc`, `.direnv`, `node_modules`, IDE state, build caches) are gone.
+
+**Workaround for now:** don't archive adopted Conductor worktrees in TBD unless you're OK with the directory being deleted. If you want to remove an adopted worktree from TBD's sidebar without touching the files, there's currently no clean way — the next-best option is to hide it via a future "adopted" flag (see Future work).
+
+Likely fix: add a boolean column `worktrees.adopted` (default false), set to true by `adoptWorktree`, and have `WorktreeLifecycle+Archive.swift`'s phase-2 background task skip the `git worktree remove` call when `adopted == true`. Same change should also short-circuit the revive flow's `git worktree add` since the directory is still there.
+
 ## Future work (out of scope)
 
 - A `tbd worktree relocate <name> <new-path>` command for users who later want to move an adopted worktree from `~/conductor/...` into TBD's canonical `~/tbd/worktrees/...` layout. Today they can do this manually with `mv` + `git worktree repair` + `tbd worktree archive` + `tbd worktree adopt`.

--- a/docs/superpowers/specs/2026-05-16-conductor-import-design.md
+++ b/docs/superpowers/specs/2026-05-16-conductor-import-design.md
@@ -62,7 +62,7 @@ tbd worktree adopt <path> [--repo <id-or-path>] [--name <name>]
 6. Idempotency:
    - If a TBD `worktrees` row already has this exact path and is active, exit 0 with `already adopted: <name>`.
    - If a row exists but is archived, revive it (reuse existing `WorktreeRevive` flow) rather than inserting a new row.
-7. Read the branch from git (`git -C <path> branch --show-current`); if detached HEAD, store the commit SHA.
+7. Read the branch from git's `worktree list --porcelain` output. For detached worktrees the branch column ends up empty (see Known Issues).
 8. Insert (or revive) the worktree row via a new daemon RPC method:
    - `repoID` = resolved repo
    - `name` = `--name` flag, else last path component of the resolved path
@@ -87,7 +87,7 @@ tbd worktree adopt <path> [--repo <id-or-path>] [--name <name>]
 - Adopting a non-git directory errors with a clear message.
 - Adopting a path whose git common-dir doesn't match any TBD repo errors with "register the repo first."
 - Adopting a path not in `git worktree list` errors with a `git worktree repair` hint.
-- Adopting a detached-HEAD worktree stores the commit SHA in the branch column.
+- Adopting a detached-HEAD worktree stores an empty string as the branch (current behavior; documented as a known limitation).
 
 ## Part 2: `scripts/import-conductor.sh`
 
@@ -221,7 +221,7 @@ Existing Claude session transcripts and `conductor.json` hooks are picked up aut
 | Path is a git worktree but not in `git worktree list` (corrupt git state) | `adopt` | error: "git worktree list does not include this path; run `git worktree repair`" |
 | Path already in TBD as active | `adopt` | exit 0, log `already adopted` |
 | Path already in TBD as archived | `adopt` | revive the row |
-| Detached HEAD | `adopt` | store commit SHA as branch |
+| Detached HEAD | `adopt` | store empty string as branch (see Known Issues — `parseWorktreeList` doesn't surface the SHA) |
 
 **Per Conductor repo (registration):**
 
@@ -283,6 +283,8 @@ These are decisions to make during implementation, not blockers for planning:
 - **`tbd worktree list --json`** — same question, for idempotency reporting (optional polish; the script doesn't strictly need it since `adopt` handles the dedup).
 
 ## Known issues
+
+**Detached-HEAD worktrees adopt with an empty branch column.** TBD's `GitManager.parseWorktreeList` only extracts `branch refs/heads/<name>` lines; detached worktrees emit `HEAD <sha>` + `detached` instead, which the parser drops. The adopt path stores `""` in the branch column. Matches existing TBD behavior for detached worktrees elsewhere. Not hit by real-world Conductor migrations (Conductor always names branches `cw/<name>`). Fix: extend `parseWorktreeList` to read the `HEAD <sha>` line when no `branch ` line follows, and return the SHA as branch. `testAdoptDetachedHeadStoresEmptyBranch` pins the current behavior — a future parser fix will deliberately break it.
 
 **Archive is destructive for adopted worktrees.** TBD's archive flow runs `git worktree remove` in its background phase, which deletes the worktree directory unconditionally — there's no flag distinguishing TBD-created worktrees from adopted ones. For an adopted Conductor worktree, this means `tbd worktree archive <name>` deletes the underlying Conductor directory, breaking the dual-use design intent of this migration.
 

--- a/docs/superpowers/specs/2026-05-16-conductor-import-design.md
+++ b/docs/superpowers/specs/2026-05-16-conductor-import-design.md
@@ -1,0 +1,279 @@
+# Conductor Import — Design
+
+**Date:** 2026-05-16
+**Status:** Approved (brainstorming complete, ready for planning)
+
+## Goal
+
+Let users migrate their existing [Conductor](https://conductor.build) worktrees into TBD with a single script. Migration is non-destructive and supports dual-use: Conductor keeps working alongside TBD, and the same worktree directory is now managed by both apps.
+
+## Non-goals
+
+- Migrating Conductor's session/chat history.
+- Migrating Conductor's setup/archive scripts or custom prompts.
+- Migrating linked or secondary Conductor workspaces (only the primary `workspace_path`).
+- Writing to Conductor's database. The migration never modifies Conductor state; users can manually archive in Conductor's UI if they want.
+- Moving files. Worktree directories stay where Conductor put them (`~/conductor/workspaces/<repo>/<name>/`).
+
+## Why this works without a filesystem move
+
+TBD's reconcile loop only filters by canonical/legacy path prefixes when **auto-discovering** unknown worktrees from `git worktree list`. Once a worktree row exists in TBD's database, reconcile leaves it alone regardless of where the path lives:
+
+- The "add unknown worktrees" branch (`WorktreeLifecycle+Reconcile.swift:140-152`) skips entries already in `dbPaths`.
+- The "archive missing worktrees" branch (line 109) only archives rows whose path is *missing from git's worktree list* — the adopted Conductor path is in git's list, so it stays.
+- Every other path-consuming site in the codebase (archive, revive, status refresh, file viewer, terminal cwd) reads `worktree.path` from the database row.
+
+So adoption reduces to "insert a `worktrees` row whose path field points outside the canonical prefix." No reconcile changes, no prefix filter relaxation.
+
+## Architecture
+
+Two artifacts:
+
+1. **`tbd worktree adopt`** — a new Swift CLI subcommand. General-purpose primitive for registering an existing git worktree directory into TBD's database. Independent of Conductor.
+2. **`scripts/import-conductor.sh`** — a bash script that reads Conductor's SQLite database, generates a migration plan, and drives `tbd repo add` + `tbd worktree adopt` to execute it.
+
+This split keeps Conductor-specific schema knowledge out of the Swift binary. `tbd worktree adopt` is independently useful for users who created worktrees via raw `git worktree add` or other tools.
+
+## Part 1: `tbd worktree adopt`
+
+### Invocation
+
+```
+tbd worktree adopt <path> [--repo <id-or-path>] [--name <name>]
+```
+
+### Behavior
+
+1. Resolve `<path>` to an absolute, symlink-canonicalized path.
+2. Verify it's a valid git worktree: `git -C <path> rev-parse --is-inside-work-tree`.
+3. Find the parent repo via `git -C <path> rev-parse --git-common-dir`, then walk to the repo root.
+4. Resolve the TBD repo record:
+   - If `--repo` is set, use it.
+   - Otherwise match by `root_path` against TBD's `repos` table.
+   - Error if no match — the caller (script or user) is responsible for adding the repo first.
+5. Verify the path appears in `git worktree list` for the resolved repo. If not, error with a hint to run `git worktree repair`.
+6. Idempotency:
+   - If a TBD `worktrees` row already has this exact path and is active, exit 0 with `already adopted: <name>`.
+   - If a row exists but is archived, revive it (reuse existing `WorktreeRevive` flow) rather than inserting a new row.
+7. Read the branch from git (`git -C <path> branch --show-current`); if detached HEAD, store the commit SHA.
+8. Insert (or revive) the worktree row via a new daemon RPC method:
+   - `repoID` = resolved repo
+   - `name` = `--name` flag, else last path component of the resolved path
+   - `branch` = from git
+   - `path` = canonicalized input path
+   - `tmuxServer` = `TmuxManager.serverName(forRepoPath: repo.path)`
+   - `status = .active`
+
+### Files touched
+
+- `Sources/TBDCLI/Commands/WorktreeCommands.swift` — add `WorktreeAdopt` subcommand to the `worktree` command group.
+- `Sources/TBDShared/` (RPC types) — add `WorktreeAdoptRequest` / `WorktreeAdoptResponse`.
+- `Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift` — add the new handler.
+- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Adopt.swift` — new file. Mirrors the structure of `+Create.swift` but skips the `git worktree add` step (the worktree already exists on disk).
+- `Tests/TBDDaemonTests/WorktreeAdoptTests.swift` — adoption tests.
+
+### Tests
+
+- Adopting a valid out-of-prefix git worktree succeeds and the row appears in the database with the correct path.
+- Adopting the same path twice is a no-op (second call exits 0, no duplicate row).
+- Adopting a previously-archived worktree revives it.
+- Adopting a non-git directory errors with a clear message.
+- Adopting a path whose git common-dir doesn't match any TBD repo errors with "register the repo first."
+- Adopting a path not in `git worktree list` errors with a `git worktree repair` hint.
+- Adopting a detached-HEAD worktree stores the commit SHA in the branch column.
+
+## Part 2: `scripts/import-conductor.sh`
+
+### Invocation
+
+```
+scripts/import-conductor.sh [--all] [--repo <name>] [--dry-run]
+```
+
+### Inputs
+
+- `~/Library/Application Support/com.conductor.app/conductor.db` (SQLite + WAL). Copied to `$(mktemp)` before reading to avoid contention with a running Conductor.
+- `tbd` CLI on `$PATH`.
+- `sqlite3` (ships with macOS).
+
+### Flow
+
+**1. Preconditions.** Check `tbd`, `sqlite3`, and the Conductor DB. Copy DB to tmp, install `trap rm` for cleanup.
+
+**2. Query Conductor.** Two queries:
+
+```sql
+SELECT id, name, root_path, default_branch FROM repos;
+
+SELECT w.id, w.repository_id, w.directory_name, w.branch, w.state, w.workspace_path
+FROM workspaces w
+WHERE w.state = 'ready'
+  AND w.workspace_path IS NOT NULL
+  AND (:repo_filter_id IS NULL OR w.repository_id = :repo_filter_id);
+```
+
+Under `--all`, the state filter becomes `w.state IN ('ready', 'archived')`.
+
+Use `-separator $'\x1f'` (ASCII unit separator) to safely handle paths with spaces.
+
+**3. Build the plan** (no writes).
+
+For each Conductor repo referenced by selected workspaces:
+- If the repo's `root_path` doesn't exist on disk → mark repo and all its workspaces as `skip: repo path missing`.
+- If TBD already has a repo with the same `root_path` (matched via `tbd repo list --json` — adding the `--json` flag is part of this work if not already present) → `reuse: <repo-name>`.
+- Otherwise → queue `tbd repo add <root_path> --name <name>`.
+
+For each workspace:
+- If `workspace_path` doesn't exist on disk → `skip: path missing`.
+- If `git -C <workspace_path> rev-parse --is-inside-work-tree` fails → `skip: not a git worktree`.
+- Otherwise → queue `tbd worktree adopt <workspace_path>`. (Idempotency lives inside `adopt`; the script doesn't pre-check.)
+
+**4. Print the plan.**
+
+```
+Conductor → TBD migration plan
+──────────────────────────────
+Repos:
+  + longeye-app    /Users/chang/projects/longeye-app    (default branch: main)
+  ~ standup-kit    /Users/chang/projects/standup-kit    (already in TBD, reusing)
+
+Workspaces:
+  + denver-v3      cw/denver-v3    →  longeye-app
+  + cambridge-v1   cw/cambridge-v1 →  longeye-app
+  + atlanta        main            →  standup-kit
+  - riyadh-v1      (skip: path /Users/chang/conductor/workspaces/longeye-docs/riyadh-v1 not found)
+
+Summary: 1 repo to add, 1 to reuse · 3 workspaces to adopt, 1 to skip
+```
+
+Under `--dry-run`, exit here.
+
+**5. Execute.** Stream per-item progress:
+
+```
+[1/4] adding repo longeye-app… ok
+[2/4] adopting denver-v3… ok
+[3/4] adopting cambridge-v1… ok
+[4/4] adopting atlanta… ok
+```
+
+Continue on error. If a step fails, print `FAILED: <reason>` and continue.
+
+**6. Summary line.**
+
+```
+Done: 1 repo added · 3 worktrees adopted · 1 skipped · 0 failed
+```
+
+### Exit codes
+
+- `0` — success, even if some items were skipped (skipping is expected behavior for missing paths).
+- `1` — at least one `tbd` invocation returned an error (distinct from a skip).
+- `2` — script-level usage error (bad flag, missing dependency, no Conductor DB).
+
+### Implementation notes
+
+- Pure bash. No Python.
+- `set -euo pipefail` at the top, locally relaxed inside the execute loop so continue-on-error works.
+- NUL/unit-separator-delimited sqlite output for safe path handling.
+- If `tbd repo list --json` doesn't yet exist, add it as part of this work (small flag, generally useful for scripting).
+
+## Part 3: README documentation
+
+New section in the project README, placed before "Critical Rules":
+
+````markdown
+## Migrating from Conductor
+
+Adopt your existing Conductor worktrees into TBD in place — no files moved, branches untouched, Conductor keeps working alongside. By default, only active (`ready`) Conductor workspaces are adopted, and any repos they reference are auto-registered in TBD.
+
+```sh
+./scripts/import-conductor.sh --dry-run    # preview
+./scripts/import-conductor.sh              # run
+```
+
+Flags:
+- `--all` — also adopt archived Conductor workspaces.
+- `--repo <name>` — limit to one Conductor repo (e.g. `--repo longeye-app`).
+- `--dry-run` — print the plan, don't write anything.
+
+Idempotent — safe to re-run as you create new Conductor worktrees.
+````
+
+## Edge cases & error handling
+
+**Per workspace (filesystem / git state):**
+
+| Case | Handled by | Behavior |
+|---|---|---|
+| `workspace_path` doesn't exist on disk | script | skip, log `path missing` |
+| Path exists but isn't a git worktree | script | skip, log `not a git worktree` |
+| Git common-dir doesn't match any TBD repo | `adopt` | error: "register the repo first with `tbd repo add <root>`"; script catches and continues |
+| Path is a git worktree but not in `git worktree list` (corrupt git state) | `adopt` | error: "git worktree list does not include this path; run `git worktree repair`" |
+| Path already in TBD as active | `adopt` | exit 0, log `already adopted` |
+| Path already in TBD as archived | `adopt` | revive the row |
+| Detached HEAD | `adopt` | store commit SHA as branch |
+
+**Per Conductor repo (registration):**
+
+| Case | Handled by | Behavior |
+|---|---|---|
+| `repos.root_path` doesn't exist on disk | script | skip the repo and its workspaces, log `repo path missing` |
+| TBD already has a repo at the same `root_path` | script | reuse existing repo |
+| Two Conductor repos with the same `root_path` | script | use the first, warn on duplicates |
+| `tbd repo add` fails | script | log error, skip workspaces for that repo, continue |
+
+**Conductor-side:**
+
+| Case | Behavior |
+|---|---|
+| Conductor is currently running | not blocked — dual-use is intentional |
+| Conductor DB locked (WAL contention) | preempted by copying DB to tmp before reading |
+| Conductor DB schema changed in a future version | `sqlite3` query fails loudly with the SQL error; user files an issue |
+| `workspace_path` is NULL in the DB | skip with `null path` reason |
+
+**Script-level:**
+
+| Case | Behavior |
+|---|---|
+| `sqlite3` not on `$PATH` | exit 2 with install hint |
+| `tbd` not on `$PATH` | exit 2 with hint |
+| Conductor DB missing entirely | exit 0 with "no Conductor data found, nothing to migrate" |
+| `--repo <name>` with no matching repo | exit 1 with "no Conductor repo matches '<name>'" |
+| Zero workspaces match the filter | print "no workspaces to migrate" and exit 0 |
+
+**Archived-worktree note.** Conductor's archived workspaces usually have their on-disk directory removed. Under `--all`, most archived rows will land in the "path missing" skip bucket — that's correct. The few whose directory still exists get adopted normally.
+
+## Conductor database reference
+
+For implementer convenience, the two tables the script reads:
+
+```sql
+-- repos
+id TEXT PRIMARY KEY,
+name TEXT,
+root_path TEXT,
+default_branch TEXT DEFAULT 'main',
+-- (plus many fields we don't read: setup_script, run_script, custom_prompt_*, etc.)
+
+-- workspaces
+id TEXT PRIMARY KEY,
+repository_id TEXT,
+directory_name TEXT,
+branch TEXT,
+state TEXT DEFAULT 'active',   -- observed values: 'ready', 'archived'
+workspace_path TEXT,            -- absolute path, e.g. /Users/chang/conductor/workspaces/longeye-app/denver-v3
+-- (plus many fields we don't read: setup_log_path, derived_status, linked_workspace_ids, etc.)
+```
+
+## Open implementation questions
+
+These are decisions to make during implementation, not blockers for planning:
+
+- **`tbd repo list --json`** — does this exist today? If not, add it as a small flag during this work. Used by the script to detect already-registered repos by `root_path`.
+- **`tbd worktree list --json`** — same question, for idempotency reporting (optional polish; the script doesn't strictly need it since `adopt` handles the dedup).
+
+## Future work (out of scope)
+
+- A `tbd worktree relocate <name> <new-path>` command for users who later want to move an adopted worktree from `~/conductor/...` into TBD's canonical `~/tbd/worktrees/...` layout. Today they can do this manually with `mv` + `git worktree repair` + `tbd worktree archive` + `tbd worktree adopt`.
+- Importers for other worktree managers (Phantom, Worktrees.nvim) — the `tbd worktree adopt` primitive supports them already; only the source-DB-reading layer would be new.

--- a/docs/superpowers/specs/2026-05-16-conductor-import-design.md
+++ b/docs/superpowers/specs/2026-05-16-conductor-import-design.md
@@ -7,11 +7,18 @@
 
 Let users migrate their existing [Conductor](https://conductor.build) worktrees into TBD with a single script. Migration is non-destructive and supports dual-use: Conductor keeps working alongside TBD, and the same worktree directory is now managed by both apps.
 
+## What's inherited for free
+
+In-place adoption gives us two big wins with zero migration code:
+
+- **Claude session transcripts.** TBD discovers Claude Code transcripts at `~/.claude/projects/<encoded-cwd>/` keyed by the worktree's directory path (`Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift`). Because the worktree directory doesn't move, the encoded cwd is unchanged, and TBD picks up whatever transcripts already exist for that path.
+- **Setup / archive / run hooks.** TBD's `HookResolver.resolve()` reads `conductor.json` from the repo root as a deprecation-warned fallback (`Sources/TBDDaemon/Hooks/HookResolver.swift:63-69`). Conductor users typically have a `conductor.json` checked into the repo describing their setup/archive/run scripts; adopted worktrees execute those identically to how Conductor did. The user gets a `consider migrating to .worktree-hooks/` warning, but everything works.
+
 ## Non-goals
 
-- Migrating Conductor's session/chat history.
-- Migrating Conductor's setup/archive scripts or custom prompts.
+- Migrating Conductor's own `session_messages` table (its custom chat UI rendering). TBD has no equivalent feature — it lives off Claude Code's transcript files, which are already in the right place.
 - Migrating linked or secondary Conductor workspaces (only the primary `workspace_path`).
+- Migrating Conductor-DB-only metadata like `custom_prompt_*`, `agent_personality`, `model`, `permission_mode` per workspace. TBD doesn't have direct equivalents for most of these.
 - Writing to Conductor's database. The migration never modifies Conductor state; users can manually archive in Conductor's UI if they want.
 - Moving files. Worktree directories stay where Conductor put them (`~/conductor/workspaces/<repo>/<name>/`).
 
@@ -198,6 +205,8 @@ Flags:
 - `--dry-run` — print the plan, don't write anything.
 
 Idempotent — safe to re-run as you create new Conductor worktrees.
+
+Existing Claude session transcripts and `conductor.json` hooks are picked up automatically — nothing extra to migrate.
 ````
 
 ## Edge cases & error handling

--- a/scripts/import-conductor.sh
+++ b/scripts/import-conductor.sh
@@ -35,7 +35,13 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --all) INCLUDE_ARCHIVED=1; shift ;;
         --dry-run) DRY_RUN=1; shift ;;
-        --repo) REPO_FILTER="${2:-}"; shift 2 ;;
+        --repo)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --repo requires a Conductor repo name." >&2
+                usage >&2
+                exit 2
+            fi
+            REPO_FILTER="$2"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown flag: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -52,6 +58,14 @@ if ! command -v "$TBD_BIN" >/dev/null 2>&1; then
 fi
 if ! command -v sqlite3 >/dev/null 2>&1; then
     echo "Error: sqlite3 not found on PATH (ships with macOS — odd)." >&2
+    exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    # Used below to parse `tbd repo list --json`. Without python3 we silently
+    # treat every Conductor repo as not-yet-registered, which is functionally
+    # safe (`tbd repo add` for an already-registered repo is a no-op) but
+    # makes the plan-preview lie about which repos will be reused.
+    echo "Error: python3 not found on PATH (ships with macOS Xcode Command Line Tools)." >&2
     exit 2
 fi
 
@@ -244,6 +258,10 @@ echo
 total_steps=$((n_repo_add + n_ws_adopt))
 step=0
 n_failed=0
+# Actual-success counts (the summary needs to reflect what really happened,
+# not what was planned — failures must lower the "added" / "adopted" counts).
+n_repo_actually_added=0
+n_ws_actually_adopted=0
 
 # Phase A: add repos.
 for ((i=0; i<${#COND_REPO_IDS[@]}; i++)); do
@@ -252,6 +270,7 @@ for ((i=0; i<${#COND_REPO_IDS[@]}; i++)); do
     printf "[%d/%d] adding repo %s… " "$step" "$total_steps" "${COND_REPO_NAMES[$i]}"
     if "$TBD_BIN" repo add "${COND_REPO_PATHS[$i]}" >/dev/null 2>&1; then
         echo "ok"
+        n_repo_actually_added=$((n_repo_actually_added+1))
     else
         echo "FAILED"
         COND_REPO_ACTIONS[$i]="skip:repo add failed"
@@ -280,6 +299,7 @@ for ((i=0; i<${#WS_NAMES[@]}; i++)); do
     # Pass the repo's root_path to --repo; the adopt subcommand resolves it via PathResolver.
     if "$TBD_BIN" worktree adopt "${WS_PATHS[$i]}" --repo "${WS_REPO_PATHS[$i]}" >/dev/null 2>&1; then
         echo "ok"
+        n_ws_actually_adopted=$((n_ws_actually_adopted+1))
     else
         echo "FAILED"
         n_failed=$((n_failed+1))
@@ -288,7 +308,7 @@ done
 
 # ---- Summary ----
 echo
-echo "Done: $n_repo_add repo(s) added · $n_ws_adopt worktree(s) adopted · $((n_repo_skip + n_ws_skip)) skipped · $n_failed failed"
+echo "Done: $n_repo_actually_added repo(s) added · $n_ws_actually_adopted worktree(s) adopted · $((n_repo_skip + n_ws_skip)) skipped · $n_failed failed"
 if [[ $n_failed -gt 0 ]]; then
     exit 1
 fi

--- a/scripts/import-conductor.sh
+++ b/scripts/import-conductor.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# Migrate Conductor worktrees into TBD by reading Conductor's SQLite DB and
+# calling `tbd repo add` + `tbd worktree adopt` for each one.
+#
+# Adopts in place — no files are moved, Conductor keeps working alongside.
+# Idempotent: re-running picks up only new workspaces.
+
+set -euo pipefail
+
+CONDUCTOR_DB="$HOME/Library/Application Support/com.conductor.app/conductor.db"
+TBD_BIN="${TBD_BIN:-tbd}"
+
+# ---- Args ----
+INCLUDE_ARCHIVED=0
+DRY_RUN=0
+REPO_FILTER=""
+
+usage() {
+    cat <<EOF
+Usage: $0 [--all] [--repo <name>] [--dry-run]
+
+Adopts active Conductor worktrees into TBD in place. Reads
+~/Library/Application Support/com.conductor.app/conductor.db
+(read-only — copied to a temp file before reading).
+
+Options:
+  --all          Also adopt archived Conductor workspaces.
+  --repo <name>  Limit to one Conductor repo (matched by Conductor repo name).
+  --dry-run      Print the plan; don't run any tbd commands.
+  -h, --help     Show this message.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --all) INCLUDE_ARCHIVED=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --repo) REPO_FILTER="${2:-}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown flag: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+# ---- Preconditions ----
+if [[ ! -f "$CONDUCTOR_DB" ]]; then
+    echo "No Conductor data found at $CONDUCTOR_DB — nothing to migrate." >&2
+    exit 0
+fi
+if ! command -v "$TBD_BIN" >/dev/null 2>&1; then
+    echo "Error: tbd CLI not found on PATH (set TBD_BIN to override)." >&2
+    exit 2
+fi
+if ! command -v sqlite3 >/dev/null 2>&1; then
+    echo "Error: sqlite3 not found on PATH (ships with macOS — odd)." >&2
+    exit 2
+fi
+
+# Copy DB to tmp to avoid WAL contention with a running Conductor.
+TMP_DB="$(mktemp -t conductor-import.XXXXXX.db)"
+trap 'rm -f "$TMP_DB" "${TMP_DB}-wal" "${TMP_DB}-shm"' EXIT
+cp "$CONDUCTOR_DB" "$TMP_DB"
+[[ -f "${CONDUCTOR_DB}-wal" ]] && cp "${CONDUCTOR_DB}-wal" "${TMP_DB}-wal"
+[[ -f "${CONDUCTOR_DB}-shm" ]] && cp "${CONDUCTOR_DB}-shm" "${TMP_DB}-shm"
+
+# ---- State filter ----
+if [[ $INCLUDE_ARCHIVED -eq 1 ]]; then
+    STATE_CLAUSE="w.state IN ('ready','archived')"
+else
+    STATE_CLAUSE="w.state = 'ready'"
+fi
+
+# ASCII unit separator for safe path delimiting.
+US=$'\x1f'
+
+# ---- Query Conductor: repos ----
+REPOS_RAW="$(sqlite3 -separator "$US" "$TMP_DB" \
+    "SELECT id, name, IFNULL(root_path,''), IFNULL(default_branch,'main') FROM repos;")"
+
+# ---- Query Conductor: workspaces matching filter ----
+WORKSPACE_SQL="SELECT w.id, w.repository_id, IFNULL(w.directory_name,''), IFNULL(w.branch,''), w.state, IFNULL(w.workspace_path,'')
+FROM workspaces w
+WHERE $STATE_CLAUSE
+  AND w.workspace_path IS NOT NULL
+  AND w.workspace_path <> '';"
+
+WORKSPACES_RAW="$(sqlite3 -separator "$US" "$TMP_DB" "$WORKSPACE_SQL")"
+
+if [[ -z "$WORKSPACES_RAW" ]]; then
+    echo "No Conductor workspaces match the filter — nothing to migrate."
+    exit 0
+fi
+
+# ---- Resolve TBD's currently-registered repos (by root_path) ----
+TBD_REPOS_JSON="$("$TBD_BIN" repo list --json 2>/dev/null || echo '[]')"
+
+TBD_REPO_PATHS=()
+while IFS= read -r tpath; do
+    [[ -z "$tpath" ]] && continue
+    TBD_REPO_PATHS+=("$tpath")
+done < <(printf '%s' "$TBD_REPOS_JSON" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+for r in data:
+    print(r.get("path",""))
+' 2>/dev/null || true)
+
+tbd_has_repo_path() {
+    local needle="$1"
+    local p
+    for p in "${TBD_REPO_PATHS[@]+"${TBD_REPO_PATHS[@]}"}"; do
+        [[ "$p" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+# ---- Build the plan ----
+
+# Parallel arrays for Conductor repos and their planned action.
+COND_REPO_IDS=()
+COND_REPO_NAMES=()
+COND_REPO_PATHS=()
+COND_REPO_ACTIONS=()   # "add", "reuse", or "skip:<reason>"
+
+while IFS="$US" read -r cid cname croot cdef; do
+    [[ -z "$cid" ]] && continue
+    if [[ -n "$REPO_FILTER" && "$cname" != "$REPO_FILTER" ]]; then
+        continue
+    fi
+    COND_REPO_IDS+=("$cid")
+    COND_REPO_NAMES+=("$cname")
+    COND_REPO_PATHS+=("$croot")
+
+    if [[ -z "$croot" || ! -d "$croot" ]]; then
+        COND_REPO_ACTIONS+=("skip:repo path missing")
+    elif tbd_has_repo_path "$croot"; then
+        COND_REPO_ACTIONS+=("reuse")
+    else
+        COND_REPO_ACTIONS+=("add")
+    fi
+done <<< "$REPOS_RAW"
+
+# Parallel arrays for workspaces.
+WS_NAMES=()
+WS_BRANCHES=()
+WS_PATHS=()
+WS_REPO_NAMES=()
+WS_REPO_PATHS=()
+WS_ACTIONS=()
+
+lookup_conductor_repo_index() {
+    local needle="$1"
+    local i
+    for ((i=0; i<${#COND_REPO_IDS[@]}; i++)); do
+        if [[ "${COND_REPO_IDS[$i]}" == "$needle" ]]; then
+            echo "$i"
+            return 0
+        fi
+    done
+    return 1
+}
+
+while IFS="$US" read -r wid wrepo wdir wbranch wstate wpath; do
+    [[ -z "$wid" ]] && continue
+    repo_idx="$(lookup_conductor_repo_index "$wrepo" || true)"
+    if [[ -z "$repo_idx" ]]; then
+        continue
+    fi
+    repo_action="${COND_REPO_ACTIONS[$repo_idx]}"
+    repo_name="${COND_REPO_NAMES[$repo_idx]}"
+    repo_path="${COND_REPO_PATHS[$repo_idx]}"
+    WS_NAMES+=("$wdir")
+    WS_BRANCHES+=("$wbranch")
+    WS_PATHS+=("$wpath")
+    WS_REPO_NAMES+=("$repo_name")
+    WS_REPO_PATHS+=("$repo_path")
+
+    if [[ "$repo_action" == skip:* ]]; then
+        WS_ACTIONS+=("skip:parent repo skipped")
+    elif [[ ! -d "$wpath" ]]; then
+        WS_ACTIONS+=("skip:path missing")
+    elif ! git -C "$wpath" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        WS_ACTIONS+=("skip:not a git worktree")
+    else
+        WS_ACTIONS+=("adopt")
+    fi
+done <<< "$WORKSPACES_RAW"
+
+# ---- Print the plan ----
+echo "Conductor → TBD migration plan"
+echo "──────────────────────────────"
+echo
+echo "Repos:"
+if [[ ${#COND_REPO_IDS[@]} -eq 0 ]]; then
+    echo "  (none referenced by selected workspaces)"
+else
+    for ((i=0; i<${#COND_REPO_IDS[@]}; i++)); do
+        case "${COND_REPO_ACTIONS[$i]}" in
+            add)   echo "  + ${COND_REPO_NAMES[$i]}    ${COND_REPO_PATHS[$i]}    (will add)" ;;
+            reuse) echo "  ~ ${COND_REPO_NAMES[$i]}    ${COND_REPO_PATHS[$i]}    (already in TBD, reusing)" ;;
+            skip:*) echo "  - ${COND_REPO_NAMES[$i]}    ${COND_REPO_PATHS[$i]}    (${COND_REPO_ACTIONS[$i]#skip:})" ;;
+        esac
+    done
+fi
+echo
+echo "Workspaces:"
+if [[ ${#WS_NAMES[@]} -eq 0 ]]; then
+    echo "  (none)"
+else
+    for ((i=0; i<${#WS_NAMES[@]}; i++)); do
+        case "${WS_ACTIONS[$i]}" in
+            adopt)  echo "  + ${WS_NAMES[$i]}    ${WS_BRANCHES[$i]} →  ${WS_REPO_NAMES[$i]}" ;;
+            skip:*) echo "  - ${WS_NAMES[$i]}    (${WS_ACTIONS[$i]#skip:})" ;;
+        esac
+    done
+fi
+echo
+
+# Tally
+n_repo_add=0; n_repo_reuse=0; n_repo_skip=0
+for a in "${COND_REPO_ACTIONS[@]+"${COND_REPO_ACTIONS[@]}"}"; do
+    case "$a" in
+        add) n_repo_add=$((n_repo_add+1)) ;;
+        reuse) n_repo_reuse=$((n_repo_reuse+1)) ;;
+        skip:*) n_repo_skip=$((n_repo_skip+1)) ;;
+    esac
+done
+n_ws_adopt=0; n_ws_skip=0
+for a in "${WS_ACTIONS[@]+"${WS_ACTIONS[@]}"}"; do
+    case "$a" in
+        adopt) n_ws_adopt=$((n_ws_adopt+1)) ;;
+        skip:*) n_ws_skip=$((n_ws_skip+1)) ;;
+    esac
+done
+echo "Summary: $n_repo_add repo(s) to add, $n_repo_reuse to reuse, $n_repo_skip skipped · $n_ws_adopt workspace(s) to adopt, $n_ws_skip skipped"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo
+    echo "Dry-run — exiting before writes."
+    exit 0
+fi
+
+# ---- Execute ----
+echo
+total_steps=$((n_repo_add + n_ws_adopt))
+step=0
+n_failed=0
+
+# Phase A: add repos.
+for ((i=0; i<${#COND_REPO_IDS[@]}; i++)); do
+    [[ "${COND_REPO_ACTIONS[$i]}" == "add" ]] || continue
+    step=$((step+1))
+    printf "[%d/%d] adding repo %s… " "$step" "$total_steps" "${COND_REPO_NAMES[$i]}"
+    if "$TBD_BIN" repo add "${COND_REPO_PATHS[$i]}" >/dev/null 2>&1; then
+        echo "ok"
+    else
+        echo "FAILED"
+        COND_REPO_ACTIONS[$i]="skip:repo add failed"
+        n_failed=$((n_failed+1))
+    fi
+done
+
+# Phase B: adopt workspaces.
+for ((i=0; i<${#WS_NAMES[@]}; i++)); do
+    [[ "${WS_ACTIONS[$i]}" == "adopt" ]] || continue
+    parent_idx=""
+    for ((j=0; j<${#COND_REPO_NAMES[@]}; j++)); do
+        if [[ "${COND_REPO_NAMES[$j]}" == "${WS_REPO_NAMES[$i]}" ]]; then
+            parent_idx="$j"
+            break
+        fi
+    done
+    if [[ -n "$parent_idx" && "${COND_REPO_ACTIONS[$parent_idx]}" == skip:* ]]; then
+        echo "       skipping ${WS_NAMES[$i]} (parent repo unavailable)"
+        n_failed=$((n_failed+1))
+        continue
+    fi
+    step=$((step+1))
+    printf "[%d/%d] adopting %s… " "$step" "$total_steps" "${WS_NAMES[$i]}"
+    # Pass the repo's root_path to --repo; the adopt subcommand resolves it via PathResolver.
+    if "$TBD_BIN" worktree adopt "${WS_PATHS[$i]}" --repo "${WS_REPO_PATHS[$i]}" >/dev/null 2>&1; then
+        echo "ok"
+    else
+        echo "FAILED"
+        n_failed=$((n_failed+1))
+    fi
+done
+
+# ---- Summary ----
+echo
+echo "Done: $n_repo_add repo(s) added · $n_ws_adopt worktree(s) adopted · $((n_repo_skip + n_ws_skip)) skipped · $n_failed failed"
+if [[ $n_failed -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/import-conductor.sh
+++ b/scripts/import-conductor.sh
@@ -270,7 +270,8 @@ for ((i=0; i<${#WS_NAMES[@]}; i++)); do
         fi
     done
     if [[ -n "$parent_idx" && "${COND_REPO_ACTIONS[$parent_idx]}" == skip:* ]]; then
-        echo "       skipping ${WS_NAMES[$i]} (parent repo unavailable)"
+        step=$((step+1))
+        echo "[$step/$total_steps] skipping ${WS_NAMES[$i]} (parent repo unavailable)"
         n_failed=$((n_failed+1))
         continue
     fi


### PR DESCRIPTION
## Summary

- New `tbd worktree adopt <path>` CLI primitive that registers an existing git worktree directory into TBD's database. No `git worktree add`, no tmux spawning — just a row insert with idempotent revive-if-archived semantics. Useful beyond Conductor (raw `git worktree add`, other tools).
- `scripts/import-conductor.sh` reads Conductor's SQLite DB at `~/Library/Application Support/com.conductor.app/conductor.db`, auto-registers any missing repos in TBD (deduplicating by `root_path`), and adopts each `ready` workspace in place. Files stay at `~/conductor/workspaces/<repo>/<name>` — Conductor keeps working alongside (dual-use is the design intent).
- Inherited for free via in-place adoption: Claude session transcripts (TBD reads `~/.claude/projects/<encoded-cwd>/`) and `conductor.json` hooks (TBD's `HookResolver` already reads them with a deprecation warning).
- Flags: `--all` (include archived Conductor workspaces), `--repo <name>` (limit to one), `--dry-run`.
- 7 unit tests for the lifecycle method; verified end-to-end against a real Conductor DB (3 workspaces adopted, idempotent re-run, 818+1 → 819 tests pass, SwiftLint clean).

Design doc: `docs/superpowers/specs/2026-05-16-conductor-import-design.md` (includes a "What's inherited for free" section explaining why we don't migrate `session_messages` or hook configs — TBD already finds them).

## Known issues (documented in design doc)

- **Archive is destructive for adopted worktrees.** `tbd worktree archive` runs `git worktree remove` in its background phase, which deletes the underlying Conductor directory. Revive recovers committed files but loses uncommitted changes, `.envrc`/`.direnv`/`node_modules`/IDE state. Workaround: don't archive adopted Conductor worktrees. Future fix: add a `worktrees.adopted` column so archive can skip the destructive step.
- **Detached-HEAD worktrees adopt with an empty branch column.** `GitManager.parseWorktreeList` doesn't surface the `HEAD <sha>` line for detached worktrees. Not hit by Conductor (always branches as `cw/<name>`). Pinned by `testAdoptDetachedHeadStoresEmptyBranch` so a future parser fix deliberately breaks it.

## Test plan

- [ ] `./scripts/import-conductor.sh --dry-run` prints a plan listing your `ready` Conductor workspaces marked `+ adopt`, with parent repos marked `~ reuse` (if already registered) or `+ add` (if not)
- [ ] `./scripts/import-conductor.sh --dry-run --repo <name>` filters to one Conductor repo
- [ ] `./scripts/import-conductor.sh --dry-run --all` includes archived workspaces (most will skip as "path missing" since Conductor cleans up archived dirs)
- [ ] `./scripts/import-conductor.sh` runs end-to-end, prints `[N/M] adopting … ok` lines, summary with `0 failed`
- [ ] Re-running is idempotent (no duplicate rows; second run still shows `+ adopt` in the plan but the `adopt` RPC returns the existing row)
- [ ] Adopted worktrees appear in the TBD sidebar with correct branch and name, indistinguishable from native worktrees
- [ ] Right-click → "Show in Finder" on an adopted worktree opens the actual `~/conductor/workspaces/...` directory
- [ ] For a worktree with prior Claude history (e.g. `atlanta`), the session count surfaces automatically
- [ ] `swift test` (819 tests pass) and `swift package plugin --allow-writing-to-package-directory swiftlint --strict` (0 violations) both clean

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=1702371D-C8EC-4EB8-B600-0A75F1C9C327)