### PR TITLE
Feat: One-script migration from Claude Code Desktop to TBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ Adopt your existing Claude Code Desktop worktrees into TBD in place. Pass any pa
 ./scripts/import-claude-code-desktop.sh --repo ~/projects/acme-app
 ```
 
-`--repo` is repeatable; `--dry-run` prints the plan without writing.
-
 ## License
 
 Private / All rights reserved.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Existing Claude session transcripts and `conductor.json` hooks are picked up aut
 
 ## Migrating from Claude Code Desktop
 
-Adopt your existing Claude Code Desktop worktrees into TBD in place. Pass any path inside the repo (the main checkout or any worktree); the script resolves to the main repo root and adopts every worktree under `.claude/worktrees/`. Repos not yet in TBD are auto-registered.
+Adopt your existing Claude Code Desktop worktrees into TBD in place. Pass any path inside the repo (the main checkout or any worktree); the script resolves to the main repo root and adopts every worktree under `.claude/worktrees/`. Repos not yet in TBD are auto-registered. Directories named `agent-*` (scratch worktrees from one-shot agent runs) are skipped by default — pass `--include-agents` to adopt them too.
 
 ```sh
 ./scripts/import-claude-code-desktop.sh --repo ~/projects/acme-app --dry-run

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Existing Claude session transcripts and `conductor.json` hooks are picked up aut
 
 ## Migrating from Claude Code Desktop
 
-Adopt your existing Claude Code Desktop worktrees into TBD in place — no files moved, branches untouched. Pass any path inside the repo (the main checkout or any worktree); the script resolves to the main repo root and adopts every worktree under `.claude/worktrees/`. Repos not yet in TBD are auto-registered.
+Adopt your existing Claude Code Desktop worktrees into TBD in place. Pass any path inside the repo (the main checkout or any worktree); the script resolves to the main repo root and adopts every worktree under `.claude/worktrees/`. Repos not yet in TBD are auto-registered.
 
 ```sh
 ./scripts/import-claude-code-desktop.sh --repo ~/projects/acme-app --dry-run
@@ -79,10 +79,6 @@ Adopt your existing Claude Code Desktop worktrees into TBD in place — no files
 Flags:
 - `--repo <path>` — required, repeatable. Any path inside the repo.
 - `--dry-run` — print the plan, don't write anything.
-
-Idempotent — safe to re-run as you create new Claude Code Desktop worktrees.
-
-Existing Claude session transcripts and `.worktree-hooks/` configs are picked up automatically — nothing extra to migrate.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ Idempotent — safe to re-run as you create new Conductor worktrees.
 
 Existing Claude session transcripts and `conductor.json` hooks are picked up automatically — nothing extra to migrate.
 
+## Migrating from Claude Code Desktop
+
+Adopt your existing Claude Code Desktop worktrees into TBD in place — no files moved, branches untouched. Pass any path inside the repo (the main checkout or any worktree); the script resolves to the main repo root and adopts every worktree under `.claude/worktrees/`. Repos not yet in TBD are auto-registered.
+
+```sh
+./scripts/import-claude-code-desktop.sh --repo ~/projects/acme-app --dry-run
+./scripts/import-claude-code-desktop.sh --repo ~/projects/acme-app
+```
+
+Flags:
+- `--repo <path>` — required, repeatable. Any path inside the repo.
+- `--dry-run` — print the plan, don't write anything.
+
+Idempotent — safe to re-run as you create new Claude Code Desktop worktrees.
+
+Existing Claude session transcripts and `.worktree-hooks/` configs are picked up automatically — nothing extra to migrate.
+
 ## License
 
 Private / All rights reserved.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,7 @@ Adopt your existing Claude Code Desktop worktrees into TBD in place. Pass any pa
 ./scripts/import-claude-code-desktop.sh --repo ~/projects/acme-app
 ```
 
-Flags:
-- `--repo <path>` — required, repeatable. Any path inside the repo.
-- `--dry-run` — print the plan, don't write anything.
+`--repo` is repeatable; `--dry-run` prints the plan without writing.
 
 ## License
 

--- a/docs/superpowers/specs/2026-05-17-claude-code-desktop-import-design.md
+++ b/docs/superpowers/specs/2026-05-17-claude-code-desktop-import-design.md
@@ -35,11 +35,16 @@ One artifact: **`scripts/import-claude-code-desktop.sh`**, a bash script that re
 ## Invocation
 
 ```
-scripts/import-claude-code-desktop.sh --repo <path> [--repo <path>...] [--dry-run]
+scripts/import-claude-code-desktop.sh --repo <path> [--repo <path>...] [--include-agents] [--dry-run]
 ```
 
 - `--repo <path>` — required, repeatable. Accepts *any* path inside a repo: the main checkout, a Claude Code Desktop worktree, a TBD worktree, or any subdirectory. The script normalizes each to the main repo root before scanning.
+- `--include-agents` — also adopt directories named `agent-*` (skipped by default; see below).
 - `--dry-run` — print the plan, don't call any `tbd` write commands.
+
+### Skipping agent worktrees
+
+Claude Code Desktop creates two kinds of worktrees under `.claude/worktrees/`: user-managed ones (typically named `<adjective>-<surname>[-<hash>]` with a `cw/` branch) and scratch worktrees from individual agent runs (named `agent-<hash>` with arbitrary branch names). Users typically want only the first set in TBD. The importer skips directories matching `agent-*` by default; `--include-agents` opts back in.
 
 ## Flow
 
@@ -56,7 +61,7 @@ scripts/import-claude-code-desktop.sh --repo <path> [--repo <path>...] [--dry-ru
 **4. Enumerate Claude Code Desktop worktrees.** For each root:
 - `git -C <root> worktree list --porcelain`, parse into (path, branch) tuples.
 - Filter to entries whose path starts with `<root>/.claude/worktrees/`.
-- Per-worktree skip checks: `[[ ! -d <path> ]]` → `skip: path missing`; not a git worktree → `skip: not a git worktree`.
+- Per-worktree skip checks: `[[ ! -d <path> ]]` → `skip: path missing`; basename matches `agent-*` and `--include-agents` not set → `skip: agent worktree`.
 - Otherwise → queue `adopt`.
 
 **5. Print the plan.**
@@ -110,6 +115,7 @@ Done: 1 repo added · 2 worktrees adopted · 1 skipped · 0 failed
 | Repo root not registered in TBD | script | queue `tbd repo add <root>` |
 | No `.claude/worktrees/` entries for a repo | script | log `no Claude Code Desktop worktrees in <repo>` |
 | Worktree path in git list but missing on disk | script | skip, log `path missing` |
+| Directory named `agent-*` (and `--include-agents` not set) | script | skip with `agent worktree (--include-agents to adopt)` |
 | Path already in TBD (active) | `adopt` | exit 0, log `already adopted` |
 | Path already in TBD (archived) | `adopt` | revive |
 | `tbd repo add` fails | script | log, skip child worktrees, continue |

--- a/docs/superpowers/specs/2026-05-17-claude-code-desktop-import-design.md
+++ b/docs/superpowers/specs/2026-05-17-claude-code-desktop-import-design.md
@@ -1,0 +1,154 @@
+# Claude Code Desktop Import — Design
+
+**Date:** 2026-05-17
+**Status:** Approved (brainstorming complete, ready for implementation)
+
+## Goal
+
+Let users migrate their existing [Claude Code Desktop](https://claude.com/claude-code) worktrees into TBD with a single script. Migration is non-destructive and dual-use: Claude Code Desktop keeps working alongside TBD, and the same worktree directory is managed by both apps.
+
+## What's inherited for free
+
+In-place adoption gives the same two wins as the Conductor migration ([2026-05-16-conductor-import-design.md](2026-05-16-conductor-import-design.md)) with zero migration code:
+
+- **Claude session transcripts.** TBD's `ClaudeSessionScanner` looks at `~/.claude/projects/<encoded-cwd>/` keyed by the worktree's directory path. The worktree doesn't move, so transcripts surface automatically.
+- **`.worktree-hooks/`.** TBD's `HookResolver` reads `.worktree-hooks/` from the worktree (with repo-level fallback). Whatever the user has set up keeps working.
+
+## Why this is simpler than the Conductor import
+
+Claude Code Desktop's worktrees are already registered in the parent repo's `git worktree list` (verified: in a real-world repo, 17 of 59 worktrees were Claude Code Desktop ones, identifiable by the `/.claude/worktrees/` path segment). No external SQLite DB, no WAL contention, no SQL. The data source is `git worktree list --porcelain` filtered by path prefix.
+
+## Non-goals
+
+- Walking the filesystem for repos. The user names the repo explicitly via `--repo <path>`.
+- Migrating any Claude Code Desktop UI state, agent slot config, or shell-snapshot data — TBD has no analogues.
+- Moving files. Worktrees stay at `<repo>/.claude/worktrees/<name>/`.
+
+## Why this works without a filesystem move
+
+Same property the Conductor design relied on: TBD's reconcile loop only filters by canonical/legacy path prefixes when **auto-discovering** unknown worktrees from `git worktree list`. Once a row exists in TBD's database, reconcile leaves it alone regardless of where the path lives. Adopting a `.claude/worktrees/...` path inserts a row that reconcile won't touch.
+
+## Architecture
+
+One artifact: **`scripts/import-claude-code-desktop.sh`**, a bash script that reads `git worktree list --porcelain` for each user-specified repo, generates a migration plan, and drives `tbd repo add` + `tbd worktree adopt` to execute it. No Swift changes — `tbd worktree adopt`, `tbd repo add`, and `tbd repo list --json` already exist (shipped in PR #161).
+
+## Invocation
+
+```
+scripts/import-claude-code-desktop.sh --repo <path> [--repo <path>...] [--dry-run]
+```
+
+- `--repo <path>` — required, repeatable. Accepts *any* path inside a repo: the main checkout, a Claude Code Desktop worktree, a TBD worktree, or any subdirectory. The script normalizes each to the main repo root before scanning.
+- `--dry-run` — print the plan, don't call any `tbd` write commands.
+
+## Flow
+
+**1. Preconditions.** `tbd` and `git` on `$PATH`; at least one `--repo` provided.
+
+**2. Resolve repo roots.** For each `--repo <path>`:
+- `realpath` the input.
+- `git -C <path> rev-parse --path-format=absolute --git-common-dir` → walk one level up → main repo root.
+- If the path isn't inside a git repo → `skip: not inside a git repo`.
+- De-dupe roots that two `--repo` args resolved to the same place.
+
+**3. Build the repo plan.** Call `tbd repo list --json` once; for each resolved root mark `reuse` (already registered) or `add`.
+
+**4. Enumerate Claude Code Desktop worktrees.** For each root:
+- `git -C <root> worktree list --porcelain`, parse into (path, branch) tuples.
+- Filter to entries whose path starts with `<root>/.claude/worktrees/`.
+- Per-worktree skip checks: `[[ ! -d <path> ]]` → `skip: path missing`; not a git worktree → `skip: not a git worktree`.
+- Otherwise → queue `adopt`.
+
+**5. Print the plan.**
+
+```
+Claude Code Desktop → TBD migration plan
+────────────────────────────────────────
+Repos:
+  + acme-app    /Users/me/projects/acme-app    (will add)
+  ~ acme-prod   /Users/me/projects/acme-prod   (already in TBD, reusing)
+
+Worktrees:
+  + focused-zhukovsky-f41df4    cw/focused-zhukovsky-f41df4    →  acme-app
+  + agent-a06139d7743d36520     cw/some-branch                 →  acme-app
+  - stale-dir                   (skip: path missing)
+
+Summary: 1 repo to add, 1 to reuse · 2 worktrees to adopt, 1 to skip
+```
+
+Under `--dry-run`, exit here.
+
+**6. Execute.** Two phases, mirroring `import-conductor.sh`:
+- Phase A: `tbd repo add <root>` for each `add`. On failure, mark child worktrees `skip: parent repo unavailable` and continue.
+- Phase B: `tbd worktree adopt <path>` for each `adopt`. Idempotency lives in `adopt`: existing-active is a no-op, archived is a revive.
+- Stream per-item progress: `[i/N] adopting <name>… ok / FAILED`.
+
+**7. Summary line.**
+
+```
+Done: 1 repo added · 2 worktrees adopted · 1 skipped · 0 failed
+```
+
+### Exit codes
+
+- `0` — success, even if some items were skipped.
+- `1` — at least one `tbd` invocation returned an error.
+- `2` — script-level usage error (no `--repo`, bad flag, missing dependency).
+
+### Implementation notes
+
+- Pure bash. No Python, no SQLite.
+- `set -euo pipefail` at the top, locally relaxed inside execute loops.
+- Porcelain parsing via the standard `worktree`/`HEAD`/`branch` triple. Detached worktrees emit `HEAD <sha>` + `detached` and drop the `branch` line — handled by the same parser; `adopt` stores empty string as the branch in that case (matches `GitManager.parseWorktreeList` behavior).
+
+## Edge cases & error handling
+
+| Case | Handled by | Behavior |
+|---|---|---|
+| `--repo <path>` not inside a git repo | script | skip, log `not inside a git repo` |
+| Two `--repo` args resolve to the same root | script | de-dupe with a note |
+| Repo root not registered in TBD | script | queue `tbd repo add <root>` |
+| No `.claude/worktrees/` entries for a repo | script | log `no Claude Code Desktop worktrees in <repo>` |
+| Worktree path in git list but missing on disk | script | skip, log `path missing` |
+| Path already in TBD (active) | `adopt` | exit 0, log `already adopted` |
+| Path already in TBD (archived) | `adopt` | revive |
+| `tbd repo add` fails | script | log, skip child worktrees, continue |
+| `tbd worktree adopt` fails | script | log, continue, count failures |
+| Detached HEAD | `adopt` | empty branch column (matches existing behavior) |
+
+## Testing
+
+No Swift code is added, so all tests are bash-script level:
+
+- **Plan generation** (against real `git worktree add` in a tempdir): worktrees under `.claude/worktrees/` are queued; worktrees elsewhere are filtered out; missing directories show as `skip: path missing`.
+- **Argument handling**: `--repo` is required; repeated `--repo` paths that resolve to the same root are de-duped; a `--repo` pointing inside a worktree resolves to the main repo root.
+- **Dry-run**: no `tbd` write commands are invoked.
+
+Fixtures use `acme-app` / `acme-prod` placeholders — never `longeye`.
+
+## README
+
+New sibling section after `## Migrating from Conductor`:
+
+````markdown
+## Migrating from Claude Code Desktop
+
+Adopt your existing Claude Code Desktop worktrees into TBD in place — no files moved, branches untouched. Pass any path inside the repo (main checkout or any worktree); the script resolves to the main repo root and adopts every worktree under `.claude/worktrees/`. Repos not yet in TBD are auto-registered.
+
+```sh
+./scripts/import-claude-code-desktop.sh --repo ~/projects/acme-app --dry-run
+./scripts/import-claude-code-desktop.sh --repo ~/projects/acme-app
+```
+
+Flags:
+- `--repo <path>` — required, repeatable. Any path inside the repo.
+- `--dry-run` — print the plan, don't write anything.
+
+Idempotent — safe to re-run as you create new Claude Code Desktop worktrees.
+
+Existing Claude session transcripts and `.worktree-hooks/` configs are picked up automatically — nothing extra to migrate.
+````
+
+## Future work (out of scope)
+
+- Importers for other worktree managers (Phantom, Worktrees.nvim) — the `tbd worktree adopt` primitive supports them already; only the source-specific scanning layer would be new.

--- a/scripts/import-claude-code-desktop.sh
+++ b/scripts/import-claude-code-desktop.sh
@@ -12,11 +12,12 @@ TBD_BIN="${TBD_BIN:-tbd}"
 
 # ---- Args ----
 DRY_RUN=0
+INCLUDE_AGENTS=0
 REPO_INPUTS=()
 
 usage() {
     cat <<EOF
-Usage: $0 --repo <path> [--repo <path>...] [--dry-run]
+Usage: $0 --repo <path> [--repo <path>...] [--include-agents] [--dry-run]
 
 Adopts Claude Code Desktop worktrees into TBD in place. For each --repo,
 resolves the main repo root via \`git rev-parse --git-common-dir\`, then
@@ -26,16 +27,22 @@ The path passed to --repo may be the repo's main checkout, any of its
 worktrees, or any subdirectory within them — all are normalized to the
 same main repo root.
 
+By default, directories whose name starts with \`agent-\` are skipped — those
+are scratch worktrees created by agent runs, not user-managed sessions. Pass
+\`--include-agents\` to include them.
+
 Options:
-  --repo <path>  Path inside the repo to import worktrees for. Repeatable.
-  --dry-run      Print the plan; don't run any tbd commands.
-  -h, --help     Show this message.
+  --repo <path>      Path inside the repo to import worktrees for. Repeatable.
+  --include-agents   Also adopt directories named \`agent-*\` (skipped by default).
+  --dry-run          Print the plan; don't run any tbd commands.
+  -h, --help         Show this message.
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run) DRY_RUN=1; shift ;;
+        --include-agents) INCLUDE_AGENTS=1; shift ;;
         --repo)
             if [[ $# -lt 2 ]]; then
                 echo "Error: --repo requires a path." >&2
@@ -184,17 +191,15 @@ for ((i=0; i<${#REPO_ROOTS[@]}; i++)); do
         if [[ -z "$line" ]]; then
             if [[ -n "$cur_path" && "$cur_path" == "$prefix"* ]]; then
                 wt_name="$(basename "$cur_path")"
+                WT_PATHS+=("$cur_path")
+                WT_BRANCHES+=("$cur_branch")
+                WT_NAMES+=("$wt_name")
+                WT_REPO_INDEXES+=("$i")
                 if [[ ! -d "$cur_path" ]]; then
-                    WT_PATHS+=("$cur_path")
-                    WT_BRANCHES+=("$cur_branch")
-                    WT_NAMES+=("$wt_name")
-                    WT_REPO_INDEXES+=("$i")
                     WT_ACTIONS+=("skip:path missing")
+                elif [[ "$wt_name" == agent-* && $INCLUDE_AGENTS -eq 0 ]]; then
+                    WT_ACTIONS+=("skip:agent worktree (--include-agents to adopt)")
                 else
-                    WT_PATHS+=("$cur_path")
-                    WT_BRANCHES+=("$cur_branch")
-                    WT_NAMES+=("$wt_name")
-                    WT_REPO_INDEXES+=("$i")
                     WT_ACTIONS+=("adopt")
                 fi
                 found_for_repo=$((found_for_repo+1))

--- a/scripts/import-claude-code-desktop.sh
+++ b/scripts/import-claude-code-desktop.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# Migrate Claude Code Desktop worktrees into TBD by reading the parent repo's
+# `git worktree list --porcelain` and calling `tbd repo add` + `tbd worktree adopt`
+# for each entry under `<repo>/.claude/worktrees/`.
+#
+# Adopts in place — no files are moved, Claude Code Desktop keeps working alongside.
+# Idempotent: re-running picks up only new worktrees.
+
+set -euo pipefail
+
+TBD_BIN="${TBD_BIN:-tbd}"
+
+# ---- Args ----
+DRY_RUN=0
+REPO_INPUTS=()
+
+usage() {
+    cat <<EOF
+Usage: $0 --repo <path> [--repo <path>...] [--dry-run]
+
+Adopts Claude Code Desktop worktrees into TBD in place. For each --repo,
+resolves the main repo root via \`git rev-parse --git-common-dir\`, then
+scans \`git worktree list\` for entries under <repo>/.claude/worktrees/.
+
+The path passed to --repo may be the repo's main checkout, any of its
+worktrees, or any subdirectory within them — all are normalized to the
+same main repo root.
+
+Options:
+  --repo <path>  Path inside the repo to import worktrees for. Repeatable.
+  --dry-run      Print the plan; don't run any tbd commands.
+  -h, --help     Show this message.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --repo)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --repo requires a path." >&2
+                usage >&2
+                exit 2
+            fi
+            REPO_INPUTS+=("$2"); shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown flag: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ ${#REPO_INPUTS[@]} -eq 0 ]]; then
+    echo "Error: at least one --repo <path> is required." >&2
+    usage >&2
+    exit 2
+fi
+
+# ---- Preconditions ----
+if ! command -v "$TBD_BIN" >/dev/null 2>&1; then
+    echo "Error: tbd CLI not found on PATH (set TBD_BIN to override)." >&2
+    exit 2
+fi
+if ! command -v git >/dev/null 2>&1; then
+    echo "Error: git not found on PATH." >&2
+    exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    # Used to parse `tbd repo list --json`. Without python3 we silently treat
+    # every repo as not-yet-registered, which is functionally safe (`tbd repo add`
+    # on an already-registered repo is a no-op) but makes the plan lie about
+    # which repos will be reused.
+    echo "Error: python3 not found on PATH (ships with macOS Xcode Command Line Tools)." >&2
+    exit 2
+fi
+
+# ---- Resolve repo roots ----
+
+# realpath that works on macOS (no coreutils dependency).
+canonicalize() {
+    local p="$1"
+    python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$p"
+}
+
+# Returns the main repo root for any path inside a repo, or "" if not in a repo.
+resolve_repo_root() {
+    local p="$1"
+    local git_common
+    if ! git_common="$(git -C "$p" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"; then
+        echo ""
+        return 0
+    fi
+    # git-common-dir is typically <root>/.git for the main checkout, or
+    # <root>/.git for a linked worktree (worktrees share the parent's git dir).
+    # Strip trailing /.git or /.git/ to get the repo root.
+    local parent
+    parent="$(dirname "$git_common")"
+    canonicalize "$parent"
+}
+
+# Parallel arrays of unique resolved roots, keyed by display name (basename).
+declare -a REPO_ROOTS=()
+declare -a REPO_NAMES=()
+declare -a REPO_ACTIONS=()  # "add" | "reuse" | "skip:<reason>"
+
+add_root_unique() {
+    local root="$1"
+    local existing
+    for existing in "${REPO_ROOTS[@]+"${REPO_ROOTS[@]}"}"; do
+        if [[ "$existing" == "$root" ]]; then
+            return 1
+        fi
+    done
+    REPO_ROOTS+=("$root")
+    REPO_NAMES+=("$(basename "$root")")
+    REPO_ACTIONS+=("")
+    return 0
+}
+
+declare -a INPUT_SKIPS=()
+for input in "${REPO_INPUTS[@]}"; do
+    if [[ ! -e "$input" ]]; then
+        INPUT_SKIPS+=("$input    (skip: path does not exist)")
+        continue
+    fi
+    root="$(resolve_repo_root "$input")"
+    if [[ -z "$root" ]]; then
+        INPUT_SKIPS+=("$input    (skip: not inside a git repo)")
+        continue
+    fi
+    if ! add_root_unique "$root"; then
+        INPUT_SKIPS+=("$input    (skip: duplicate of $root)")
+    fi
+done
+
+# ---- Resolve TBD's currently-registered repos (by path) ----
+TBD_REPOS_JSON="$("$TBD_BIN" repo list --json 2>/dev/null || echo '[]')"
+TBD_REPO_PATHS=()
+while IFS= read -r tpath; do
+    [[ -z "$tpath" ]] && continue
+    TBD_REPO_PATHS+=("$tpath")
+done < <(printf '%s' "$TBD_REPOS_JSON" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+for r in data:
+    print(r.get("path",""))
+' 2>/dev/null || true)
+
+tbd_has_repo_path() {
+    local needle="$1"
+    local p
+    for p in "${TBD_REPO_PATHS[@]+"${TBD_REPO_PATHS[@]}"}"; do
+        [[ "$p" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+for ((i=0; i<${#REPO_ROOTS[@]}; i++)); do
+    if tbd_has_repo_path "${REPO_ROOTS[$i]}"; then
+        REPO_ACTIONS[$i]="reuse"
+    else
+        REPO_ACTIONS[$i]="add"
+    fi
+done
+
+# ---- Enumerate worktrees under <root>/.claude/worktrees/ ----
+
+# Parallel arrays for worktrees.
+WT_PATHS=()
+WT_BRANCHES=()
+WT_NAMES=()
+WT_REPO_INDEXES=()
+WT_ACTIONS=()  # "adopt" | "skip:<reason>"
+
+for ((i=0; i<${#REPO_ROOTS[@]}; i++)); do
+    root="${REPO_ROOTS[$i]}"
+    prefix="$root/.claude/worktrees/"
+    found_for_repo=0
+
+    # Parse `git worktree list --porcelain`. Each entry is a block of lines
+    # starting with `worktree <path>`, then `HEAD <sha>`, then either
+    # `branch refs/heads/<name>` or `detached`. Blocks are separated by blank lines.
+    cur_path=""
+    cur_branch=""
+    while IFS= read -r line; do
+        if [[ -z "$line" ]]; then
+            if [[ -n "$cur_path" && "$cur_path" == "$prefix"* ]]; then
+                wt_name="$(basename "$cur_path")"
+                if [[ ! -d "$cur_path" ]]; then
+                    WT_PATHS+=("$cur_path")
+                    WT_BRANCHES+=("$cur_branch")
+                    WT_NAMES+=("$wt_name")
+                    WT_REPO_INDEXES+=("$i")
+                    WT_ACTIONS+=("skip:path missing")
+                else
+                    WT_PATHS+=("$cur_path")
+                    WT_BRANCHES+=("$cur_branch")
+                    WT_NAMES+=("$wt_name")
+                    WT_REPO_INDEXES+=("$i")
+                    WT_ACTIONS+=("adopt")
+                fi
+                found_for_repo=$((found_for_repo+1))
+            fi
+            cur_path=""
+            cur_branch=""
+            continue
+        fi
+        case "$line" in
+            worktree\ *) cur_path="${line#worktree }" ;;
+            branch\ refs/heads/*) cur_branch="${line#branch refs/heads/}" ;;
+        esac
+    done < <(git -C "$root" worktree list --porcelain; echo)
+    # Trailing blank line above ensures the final block flushes through the loop.
+
+    if [[ $found_for_repo -eq 0 ]]; then
+        INPUT_SKIPS+=("${REPO_NAMES[$i]}    (no Claude Code Desktop worktrees in $root)")
+    fi
+done
+
+# ---- Print the plan ----
+echo "Claude Code Desktop → TBD migration plan"
+echo "────────────────────────────────────────"
+echo
+echo "Repos:"
+if [[ ${#REPO_ROOTS[@]} -eq 0 ]]; then
+    echo "  (none)"
+else
+    for ((i=0; i<${#REPO_ROOTS[@]}; i++)); do
+        case "${REPO_ACTIONS[$i]}" in
+            add)   echo "  + ${REPO_NAMES[$i]}    ${REPO_ROOTS[$i]}    (will add)" ;;
+            reuse) echo "  ~ ${REPO_NAMES[$i]}    ${REPO_ROOTS[$i]}    (already in TBD, reusing)" ;;
+        esac
+    done
+fi
+
+if [[ ${#INPUT_SKIPS[@]} -gt 0 ]]; then
+    echo
+    echo "Notes:"
+    for note in "${INPUT_SKIPS[@]}"; do
+        echo "  - $note"
+    done
+fi
+
+echo
+echo "Worktrees:"
+if [[ ${#WT_PATHS[@]} -eq 0 ]]; then
+    echo "  (none)"
+else
+    for ((i=0; i<${#WT_PATHS[@]}; i++)); do
+        repo_idx="${WT_REPO_INDEXES[$i]}"
+        repo_name="${REPO_NAMES[$repo_idx]}"
+        branch_disp="${WT_BRANCHES[$i]:-(detached)}"
+        case "${WT_ACTIONS[$i]}" in
+            adopt)  echo "  + ${WT_NAMES[$i]}    ${branch_disp} →  ${repo_name}" ;;
+            skip:*) echo "  - ${WT_NAMES[$i]}    (${WT_ACTIONS[$i]#skip:})" ;;
+        esac
+    done
+fi
+echo
+
+# Tally
+n_repo_add=0; n_repo_reuse=0
+for a in "${REPO_ACTIONS[@]+"${REPO_ACTIONS[@]}"}"; do
+    case "$a" in
+        add) n_repo_add=$((n_repo_add+1)) ;;
+        reuse) n_repo_reuse=$((n_repo_reuse+1)) ;;
+    esac
+done
+n_wt_adopt=0; n_wt_skip=0
+for a in "${WT_ACTIONS[@]+"${WT_ACTIONS[@]}"}"; do
+    case "$a" in
+        adopt) n_wt_adopt=$((n_wt_adopt+1)) ;;
+        skip:*) n_wt_skip=$((n_wt_skip+1)) ;;
+    esac
+done
+echo "Summary: $n_repo_add repo(s) to add, $n_repo_reuse to reuse · $n_wt_adopt worktree(s) to adopt, $n_wt_skip skipped"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo
+    echo "Dry-run — exiting before writes."
+    exit 0
+fi
+
+if [[ $n_repo_add -eq 0 && $n_wt_adopt -eq 0 ]]; then
+    echo
+    echo "Nothing to do."
+    exit 0
+fi
+
+# ---- Execute ----
+echo
+total_steps=$((n_repo_add + n_wt_adopt))
+step=0
+n_failed=0
+n_repo_actually_added=0
+n_wt_actually_adopted=0
+
+# Phase A: add repos.
+for ((i=0; i<${#REPO_ROOTS[@]}; i++)); do
+    [[ "${REPO_ACTIONS[$i]}" == "add" ]] || continue
+    step=$((step+1))
+    printf "[%d/%d] adding repo %s… " "$step" "$total_steps" "${REPO_NAMES[$i]}"
+    if "$TBD_BIN" repo add "${REPO_ROOTS[$i]}" >/dev/null 2>&1; then
+        echo "ok"
+        n_repo_actually_added=$((n_repo_actually_added+1))
+    else
+        echo "FAILED"
+        REPO_ACTIONS[$i]="skip:repo add failed"
+        n_failed=$((n_failed+1))
+    fi
+done
+
+# Phase B: adopt worktrees.
+for ((i=0; i<${#WT_PATHS[@]}; i++)); do
+    [[ "${WT_ACTIONS[$i]}" == "adopt" ]] || continue
+    repo_idx="${WT_REPO_INDEXES[$i]}"
+    if [[ "${REPO_ACTIONS[$repo_idx]}" == skip:* ]]; then
+        step=$((step+1))
+        echo "[$step/$total_steps] skipping ${WT_NAMES[$i]} (parent repo unavailable)"
+        n_failed=$((n_failed+1))
+        continue
+    fi
+    step=$((step+1))
+    printf "[%d/%d] adopting %s… " "$step" "$total_steps" "${WT_NAMES[$i]}"
+    if "$TBD_BIN" worktree adopt "${WT_PATHS[$i]}" --repo "${REPO_ROOTS[$repo_idx]}" >/dev/null 2>&1; then
+        echo "ok"
+        n_wt_actually_adopted=$((n_wt_actually_adopted+1))
+    else
+        echo "FAILED"
+        n_failed=$((n_failed+1))
+    fi
+done
+
+# ---- Summary ----
+echo
+echo "Done: $n_repo_actually_added repo(s) added · $n_wt_actually_adopted worktree(s) adopted · $n_wt_skip skipped · $n_failed failed"
+if [[ $n_failed -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- New `scripts/import-claude-code-desktop.sh` adopts existing Claude Code Desktop worktrees (those under `<repo>/.claude/worktrees/`) in place — no files moved, branches untouched, dual-use with Claude Code Desktop preserved.
- Pass any path inside a repo via `--repo <path>` (repeatable). The script resolves to the main repo root via `git rev-parse --git-common-dir`, scans `git worktree list --porcelain`, filters to `.claude/worktrees/` entries, and drives `tbd repo add` + `tbd worktree adopt`.
- No Swift changes — reuses the `tbd worktree adopt`, `tbd repo add`, and `tbd repo list --json` primitives shipped in #161. Claude session transcripts and `.worktree-hooks/` configs are inherited for free because the worktree directory doesn't move.

Design: `docs/superpowers/specs/2026-05-17-claude-code-desktop-import-design.md`

## Test plan

- [x] `--dry-run` against a tempdir repo with two `.claude/worktrees/` entries + one unrelated worktree → only the two CC Desktop ones are queued
- [x] `--repo` pointing inside a worktree → resolves to the main repo root
- [x] Two `--repo` args resolving to the same root → de-duped with a note
- [x] `--repo` pointing at a nonexistent path → skipped with note
- [x] `--repo` pointing outside any git repo → skipped with note
- [x] Missing `--repo` → exit 2 with usage
- [x] `--dry-run` against a real repo (17 CC Desktop worktrees) → correct plan printed, no writes
- [ ] End-to-end adoption against a real TBD daemon (manual verification recommended)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=EB18F2AD-4D87-4FDE-A2EB-857C1E20DB24)