### PR TITLE
Feat: Customize terminal font, colors, cursor, and thin strokes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "98d5c07c3f7f007250c8a918b5602f2c33fe71b469babf32f3dfb2ba1c2fff13",
+  "originHash" : "54e8d1aacfe50bff048354e01819161f554066fe1dfca9c8d088e22b86c67500",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -105,8 +105,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftTerm",
       "state" : {
-        "revision" : "3c45fdcfcf4395c72d2a4ee23c0bce79017b5391",
-        "version" : "1.12.0"
+        "revision" : "dae32cc8f9bcda15713f4091bb2ea7e11f6dd57c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.65.0"),
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.0.0"),
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm", revision: "dae32cc8f9bcda15713f4091bb2ea7e11f6dd57c"),
         .package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
         .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,10 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.65.0"),
+        // Pinned to a main-branch revision because the `fontSmoothing` public
+        // property (PR #531) hasn't shipped in a tagged release yet. Switch back
+        // to `from: "1.14.0"` (or whichever) once SwiftTerm cuts a release that
+        // includes commit dae32cc.
         .package(url: "https://github.com/migueldeicaza/SwiftTerm", revision: "dae32cc8f9bcda15713f4091bb2ea7e11f6dd57c"),
         .package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
         .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -22,6 +22,14 @@ enum ReviveState: Equatable {
 
 @MainActor
 final class AppState: ObservableObject {
+    /// Reference to the global appearance settings, wired by `TBDAppMain`
+    /// after both StateObjects are constructed. Used by
+    /// `mainAreaTerminalSize()` to compute initial tmux pane dimensions
+    /// from the user's current font, before any `TBDTerminalView` exists.
+    /// Plain (non-weak) optional — `AppState` and `AppearanceSettings` share
+    /// the app's lifetime, so this reference cannot outlive its target.
+    var appearance: AppearanceSettings?
+
     @Published var repos: [Repo] = []
     @Published var worktrees: [UUID: [Worktree]] = [:]
     @Published var terminals: [UUID: [Terminal]] = [:]
@@ -939,7 +947,12 @@ final class AppState: ObservableObject {
     /// scrollback that #73 introduced these defaults to prevent.
     func mainAreaTerminalSize() -> (cols: Int?, rows: Int?) {
         guard terminalAutoResizeEnabled else { return (nil, nil) }
-        let cell = TBDTerminalView.cellDimensions(for: TBDTerminalView.defaultMonospaceFont)
+        // Use the user's current font so initial pane dimensions match what
+        // the freshly-spawned `TBDTerminalView` will render with. Falls back
+        // to the SwiftTerm default if `appearance` hasn't been wired yet
+        // (only possible during pre-`onAppear` startup ordering).
+        let font = appearance?.font ?? TBDTerminalView.defaultMonospaceFont
+        let cell = TBDTerminalView.cellDimensions(for: font)
         guard cell.width > 0, cell.height > 0 else { return (80, 24) }
         let cols = max(80, Int(mainAreaSize.width / cell.width))
         let rows = max(24, Int(mainAreaSize.height / cell.height))

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -16,6 +16,11 @@ struct SettingsView: View {
                     Label("Repositories", systemImage: "folder")
                 }
 
+            TerminalSettingsView()
+                .tabItem {
+                    Label("Terminal", systemImage: "terminal")
+                }
+
             ModelProfilesSettingsView()
                 .tabItem { Label("Model Profiles", systemImage: "key.fill") }
         }
@@ -32,7 +37,6 @@ struct GeneralSettingsTab: View {
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
-    @AppStorage(AppState.terminalAutoResizeKey) private var enableTerminalAutoResize: Bool = false
 
     private var systemSounds: [String] { NotificationSoundPlayer.systemSoundNames() }
     private let soundPlayer = NotificationSoundPlayer()
@@ -83,17 +87,6 @@ struct GeneralSettingsTab: View {
                     .help("Skip the interactive permission prompt when launching claude in new worktrees")
                 Toggle("Auto-suspend idle Claude when switching worktrees", isOn: $autoSuspend)
                     .help("Exit idle Claude instances when you switch away and resume them when you switch back, freeing memory")
-            }
-
-            Section {
-                Toggle("Auto-resize tmux windows to match the app pane (WIP)", isOn: $enableTerminalAutoResize)
-                    .help("When on, TBD broadcasts the live pane size to the daemon and resizes every tmux window on app resize. Currently unstable — can leave panes smaller than the visible area and clip the bottom rows.")
-            } header: {
-                Text("Experimental")
-            } footer: {
-                Text("Off by default — under active development. Known bugs around tmux \"window-size manual\" lock-in can clip the bottom rows of a pane. To bail out, turn it off and restart the app.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -32,13 +32,22 @@ struct TerminalSettingsView: View {
                 }
             }
 
-            Section("Color Scheme") {
-                Picker("Scheme", selection: $appearance.schemeID) {
-                    ForEach(ColorSchemes.bundled, id: \.id) { scheme in
-                        Text(scheme.displayName).tag(scheme.id)
+            Section {
+                HStack {
+                    Picker("Scheme", selection: $appearance.schemeID) {
+                        ForEach(ColorSchemes.bundled, id: \.id) { scheme in
+                            Text(scheme.displayName).tag(scheme.id)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    if appearance.hasTmuxStyleOverrides {
+                        Image(systemName: "info.circle")
+                            .foregroundStyle(.secondary)
+                            .help("Your ~/.tmux.conf sets window-style or a similar option that paints every cell with explicit colors. tmux's paint will override the scheme's foreground/background. To let this scheme drive the appearance, unset those options in your tmux config (e.g. `set -gu window-style`).")
                     }
                 }
-                .pickerStyle(.menu)
+            } header: {
+                Text("Color Scheme")
             }
 
             Section("Cursor") {

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -30,6 +30,8 @@ struct TerminalSettingsView: View {
                             .monospacedDigit()
                     }
                 }
+                Toggle("Thin strokes", isOn: $appearance.thinStrokes)
+                    .help("Disables font smoothing for thinner text on Retina displays. Matches iTerm's 'Thin Strokes' setting.")
             }
 
             Section {

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -11,7 +11,7 @@ struct TerminalSettingsView: View {
         Form {
             Section("Font") {
                 HStack {
-                    Text("\(displayFontName) \(Int(appearance.fontSize))")
+                    Text(displayFontName)
                         .foregroundStyle(.primary)
                     Spacer()
                     Button("Choose Font…") {
@@ -19,6 +19,15 @@ struct TerminalSettingsView: View {
                             appearance.fontName = newFont.fontName
                             appearance.fontSize = newFont.pointSize
                         }
+                    }
+                }
+                Stepper(value: $appearance.fontSize, in: 8...48, step: 1) {
+                    HStack {
+                        Text("Size")
+                        Spacer()
+                        Text("\(Int(appearance.fontSize)) pt")
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
                     }
                 }
             }

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -107,5 +107,6 @@ final class FontPickerCoordinator: NSObject {
         let current = sender.selectedFont ?? NSFont.systemFont(ofSize: 12)
         let newFont = sender.convert(current)
         completion?(newFont)
+        completion = nil
     }
 }

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -1,0 +1,90 @@
+import AppKit
+import SwiftTerm
+import SwiftUI
+import TBDShared
+
+struct TerminalSettingsView: View {
+    @EnvironmentObject var appearance: AppearanceSettings
+    @AppStorage(AppState.terminalAutoResizeKey) private var enableTerminalAutoResize: Bool = false
+
+    var body: some View {
+        Form {
+            Section("Font") {
+                HStack {
+                    Text("\(displayFontName) \(Int(appearance.fontSize))")
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Button("Choose Font…") {
+                        FontPickerCoordinator.shared.show(current: appearance.font) { newFont in
+                            appearance.fontName = newFont.fontName
+                            appearance.fontSize = newFont.pointSize
+                        }
+                    }
+                }
+            }
+
+            Section("Color Scheme") {
+                Picker("Scheme", selection: $appearance.schemeID) {
+                    ForEach(ColorSchemes.bundled, id: \.id) { scheme in
+                        Text(scheme.displayName).tag(scheme.id)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+
+            Section("Cursor") {
+                Picker("Style", selection: $appearance.cursorStyle) {
+                    Text("Block").tag(CursorStyle.steadyBlock)
+                    Text("Block (blinking)").tag(CursorStyle.blinkBlock)
+                    Text("Underline").tag(CursorStyle.steadyUnderline)
+                    Text("Underline (blinking)").tag(CursorStyle.blinkUnderline)
+                    Text("Bar").tag(CursorStyle.steadyBar)
+                    Text("Bar (blinking)").tag(CursorStyle.blinkBar)
+                }
+                .pickerStyle(.menu)
+            }
+
+            Section {
+                Toggle("Auto-resize tmux windows to match the app pane (WIP)", isOn: $enableTerminalAutoResize)
+                    .help("When on, TBD broadcasts the live pane size to the daemon and resizes every tmux window on app resize. Currently unstable — can leave panes smaller than the visible area and clip the bottom rows.")
+            } header: {
+                Text("Experimental")
+            } footer: {
+                Text("Off by default — under active development. Known bugs around tmux \"window-size manual\" lock-in can clip the bottom rows of a pane. To bail out, turn it off and restart the app.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+
+    private var displayFontName: String {
+        NSFont(name: appearance.fontName, size: appearance.fontSize)?.displayName
+            ?? appearance.fontName
+    }
+}
+
+/// Bridges NSFontPanel into AppKit. NSFontPanel is a singleton that delivers
+/// font choices via `changeFont(_:)` on the first responder; we route it
+/// through a coordinator so SwiftUI views can opt into the panel.
+@MainActor
+final class FontPickerCoordinator: NSObject {
+    static let shared = FontPickerCoordinator()
+    private var completion: ((NSFont) -> Void)?
+
+    func show(current: NSFont, completion: @escaping (NSFont) -> Void) {
+        self.completion = completion
+        NSFontManager.shared.setSelectedFont(current, isMultiple: false)
+        NSFontManager.shared.target = self
+        let panel = NSFontPanel.shared
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    @objc func changeFont(_ sender: NSFontManager?) {
+        guard let sender else { return }
+        let current = sender.selectedFont ?? NSFont.systemFont(ofSize: 12)
+        let newFont = sender.convert(current)
+        completion?(newFont)
+    }
+}

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -80,8 +80,9 @@ struct TerminalSettingsView: View {
     }
 
     private var displayFontName: String {
-        NSFont(name: appearance.fontName, size: appearance.fontSize)?.displayName
-            ?? appearance.fontName
+        // Use the resolved font's display name so a poisoned/missing font name
+        // shows the actual fallback in the Settings label, not the invalid stored value.
+        appearance.font.displayName ?? appearance.fontName
     }
 }
 

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -411,6 +411,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 struct TBDAppMain: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var appState = AppState()
+    @StateObject private var appearance = AppearanceSettings()
 
     init() {
         lifecycleLogger.info("TBDApp launching pid=\(getpid(), privacy: .public)")
@@ -421,6 +422,7 @@ struct TBDAppMain: App {
         Window("TBD", id: "main") {
             ContentView()
                 .environmentObject(appState)
+                .environmentObject(appearance)
                 .onAppear {
                     lifecycleLogger.info("scene main onAppear")
                     JumpMenuController.shared.configure(appState: appState)
@@ -440,6 +442,7 @@ struct TBDAppMain: App {
         Settings {
             SettingsView()
                 .environmentObject(appState)
+                .environmentObject(appearance)
         }
     }
 }

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -426,6 +426,13 @@ struct TBDAppMain: App {
                 .onAppear {
                     lifecycleLogger.info("scene main onAppear")
                     JumpMenuController.shared.configure(appState: appState)
+                    // Hand AppState a reference to the appearance settings so
+                    // `mainAreaTerminalSize()` can compute pre-spawn tmux pane
+                    // dimensions using the user's current font. Done in
+                    // `onAppear` rather than `init` because `@StateObject`
+                    // values aren't guaranteed to be initialized when the
+                    // App's `init` runs.
+                    appState.appearance = appearance
                 }
                 .onOpenURL { url in
                     DeepLinkHandler.handle(url, appState: appState)

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -42,7 +42,7 @@ final class AppearanceSettings: ObservableObject {
     /// True if the user's tmux config sets a cell-painting style option that
     /// would override the chosen color scheme's foreground/background. Best-
     /// effort detection at init — see `detectTmuxStyleOverrides()`.
-    @Published var hasTmuxStyleOverrides: Bool
+    @Published private(set) var hasTmuxStyleOverrides: Bool
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -95,16 +95,28 @@ final class AppearanceSettings: ObservableObject {
     nonisolated private static func detectTmuxStyleOverrides() -> Bool {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let candidatePaths = ["\(home)/.tmux.conf", "\(home)/.config/tmux/tmux.conf"]
+        // Match lines that set one of the cell-painting options. Skip the
+        // `-u` (unset) form — `set -gu window-style` is exactly the fix our
+        // own tooltip recommends, so it would be wrong to flag it.
         let pattern = #"^\s*(set|setw)\b(\s+-[a-zA-Z]+)*\s+(window-style|window-active-style|pane-style|default-style)\b"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines]) else {
             return false
         }
         for path in candidatePaths {
             guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { continue }
-            let range = NSRange(contents.startIndex..., in: contents)
-            if regex.firstMatch(in: contents, options: [], range: range) != nil {
-                return true
+            let nsContents = contents as NSString
+            let range = NSRange(location: 0, length: nsContents.length)
+            var detected = false
+            regex.enumerateMatches(in: contents, options: [], range: range) { result, _, stop in
+                guard let result, let flags = Range(result.range(at: 2), in: contents) else { return }
+                // `result.range(at: 2)` is the captured flag group, e.g. " -g" or " -gu".
+                // If any flag contains `u`, this is an unset directive — skip.
+                if !contents[flags].contains("u") {
+                    detected = true
+                    stop.pointee = true
+                }
             }
+            if detected { return true }
         }
         return false
     }

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -23,7 +23,7 @@ final class AppearanceSettings: ObservableObject {
 
     @MainActor
     enum Defaults {
-        static let fontName = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular).fontName
+        static let fontName = "Monaco"
         static let fontSize: CGFloat = 12.0
         static let schemeID = "tango"
         static let cursorStyle: CursorStyle = .blinkBlock

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -36,6 +36,11 @@ final class AppearanceSettings: ObservableObject {
     @Published var schemeID: String { didSet { defaults.set(schemeID, forKey: Keys.schemeID) } }
     @Published var cursorStyle: CursorStyle { didSet { defaults.set(cursorStyle.rawString, forKey: Keys.cursorStyle) } }
 
+    /// True if the user's tmux config sets a cell-painting style option that
+    /// would override the chosen color scheme's foreground/background. Best-
+    /// effort detection at init — see `detectTmuxStyleOverrides()`.
+    @Published var hasTmuxStyleOverrides: Bool
+
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
 
@@ -53,6 +58,29 @@ final class AppearanceSettings: ObservableObject {
         // Cursor — round-trip via rawString; fall back on unknown.
         let storedCursor = defaults.string(forKey: Keys.cursorStyle) ?? ""
         self.cursorStyle = CursorStyle.from(rawString: storedCursor) ?? Defaults.cursorStyle
+
+        self.hasTmuxStyleOverrides = Self.detectTmuxStyleOverrides()
+    }
+
+    /// Greps the user's tmux config files for any of the cell-painting style
+    /// options that would override TBD's color scheme. Best-effort: misses
+    /// configs loaded via `source-file` or `if-shell`, but catches the common
+    /// case of a directly-set `window-style` etc.
+    private static func detectTmuxStyleOverrides() -> Bool {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidatePaths = ["\(home)/.tmux.conf", "\(home)/.config/tmux/tmux.conf"]
+        let pattern = #"^\s*(set|setw)\b(\s+-[a-zA-Z]+)*\s+(window-style|window-active-style|pane-style|default-style)\b"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines]) else {
+            return false
+        }
+        for path in candidatePaths {
+            guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { continue }
+            let range = NSRange(contents.startIndex..., in: contents)
+            if regex.firstMatch(in: contents, options: [], range: range) != nil {
+                return true
+            }
+        }
+        return false
     }
 
     /// Resolves `fontName` + `fontSize` to an `NSFont`. Falls back to system

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -70,14 +70,26 @@ final class AppearanceSettings: ObservableObject {
             self.thinStrokes = Defaults.thinStrokes
         }
 
-        self.hasTmuxStyleOverrides = Self.detectTmuxStyleOverrides()
+        // Detection reads tmux config files from disk. Defer to a detached task
+        // so app launch isn't blocked by synchronous I/O; the property updates
+        // asynchronously on the main actor once detection finishes.
+        self.hasTmuxStyleOverrides = false
+        Task { @MainActor [weak self] in
+            let detected = await Task.detached {
+                AppearanceSettings.detectTmuxStyleOverrides()
+            }.value
+            self?.hasTmuxStyleOverrides = detected
+        }
     }
 
     /// Greps the user's tmux config files for any of the cell-painting style
     /// options that would override TBD's color scheme. Best-effort: misses
     /// configs loaded via `source-file` or `if-shell`, but catches the common
     /// case of a directly-set `window-style` etc.
-    private static func detectTmuxStyleOverrides() -> Bool {
+    ///
+    /// `nonisolated` because it reads files and has no actor-isolated state —
+    /// safe to call from a detached task.
+    nonisolated private static func detectTmuxStyleOverrides() -> Bool {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let candidatePaths = ["\(home)/.tmux.conf", "\(home)/.config/tmux/tmux.conf"]
         let pattern = #"^\s*(set|setw)\b(\s+-[a-zA-Z]+)*\s+(window-style|window-active-style|pane-style|default-style)\b"#

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -1,0 +1,94 @@
+import AppKit
+import Combine
+import Foundation
+import SwiftTerm
+
+/// Global user-customizable terminal appearance settings.
+///
+/// One instance lives at the app root and is injected as `@EnvironmentObject`.
+/// Live `TBDTerminalView` instances subscribe to `objectWillChange` to reapply
+/// font/colors/cursor whenever the user edits a value in the Terminal tab of
+/// Settings.
+///
+/// Persistence: each property writes to `UserDefaults` on `didSet`. `UserDefaults`
+/// is injectable for tests (see `Tests/TBDAppTests/AppearanceSettingsTests.swift`).
+@MainActor
+final class AppearanceSettings: ObservableObject {
+    enum Keys {
+        static let fontName = "terminal.font.name"
+        static let fontSize = "terminal.font.size"
+        static let schemeID = "terminal.scheme.id"
+        static let cursorStyle = "terminal.cursor.style"
+    }
+
+    @MainActor
+    enum Defaults {
+        static let fontName = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular).fontName
+        static let fontSize: CGFloat = 12.0
+        static let schemeID = "tango"
+        static let cursorStyle: CursorStyle = .blinkBlock
+    }
+
+    private let defaults: UserDefaults
+
+    @Published var fontName: String { didSet { defaults.set(fontName, forKey: Keys.fontName) } }
+    @Published var fontSize: CGFloat { didSet { defaults.set(Double(fontSize), forKey: Keys.fontSize) } }
+    @Published var schemeID: String { didSet { defaults.set(schemeID, forKey: Keys.schemeID) } }
+    @Published var cursorStyle: CursorStyle { didSet { defaults.set(cursorStyle.rawString, forKey: Keys.cursorStyle) } }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+
+        // Font name — accept any non-empty string; resolution happens in `font`.
+        let storedName = defaults.string(forKey: Keys.fontName)
+        self.fontName = (storedName?.isEmpty == false) ? storedName! : Defaults.fontName
+
+        // Font size — must be > 0 to be valid.
+        let storedSize = defaults.double(forKey: Keys.fontSize)
+        self.fontSize = storedSize > 0 ? CGFloat(storedSize) : Defaults.fontSize
+
+        // Scheme ID — accept any string (lookup itself falls back if unknown).
+        self.schemeID = defaults.string(forKey: Keys.schemeID) ?? Defaults.schemeID
+
+        // Cursor — round-trip via rawString; fall back on unknown.
+        let storedCursor = defaults.string(forKey: Keys.cursorStyle) ?? ""
+        self.cursorStyle = CursorStyle.from(rawString: storedCursor) ?? Defaults.cursorStyle
+    }
+
+    /// Resolves `fontName` + `fontSize` to an `NSFont`. Falls back to system
+    /// mono if the named font isn't installed.
+    var font: NSFont {
+        NSFont(name: fontName, size: fontSize)
+            ?? NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+    }
+}
+
+// MARK: - CursorStyle <-> String
+
+extension CursorStyle {
+    /// Stable string keys for UserDefaults round-tripping. Don't rename
+    /// without writing a migration — stored in user prefs.
+    var rawString: String {
+        switch self {
+        case .blinkBlock: return "blink-block"
+        case .steadyBlock: return "steady-block"
+        case .blinkUnderline: return "blink-underline"
+        case .steadyUnderline: return "steady-underline"
+        case .blinkBar: return "blink-bar"
+        case .steadyBar: return "steady-bar"
+        @unknown default: return "blink-block"
+        }
+    }
+
+    static func from(rawString: String) -> CursorStyle? {
+        switch rawString {
+        case "blink-block": return .blinkBlock
+        case "steady-block": return .steadyBlock
+        case "blink-underline": return .blinkUnderline
+        case "steady-underline": return .steadyUnderline
+        case "blink-bar": return .blinkBar
+        case "steady-bar": return .steadyBar
+        default: return nil
+        }
+    }
+}

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -19,6 +19,7 @@ final class AppearanceSettings: ObservableObject {
         static let fontSize = "terminal.font.size"
         static let schemeID = "terminal.scheme.id"
         static let cursorStyle = "terminal.cursor.style"
+        static let thinStrokes = "terminal.thin-strokes"
     }
 
     @MainActor
@@ -27,6 +28,7 @@ final class AppearanceSettings: ObservableObject {
         static let fontSize: CGFloat = 12.0
         static let schemeID = "tango"
         static let cursorStyle: CursorStyle = .blinkBlock
+        static let thinStrokes = true   // matches iTerm's typical Retina Dark Only behavior
     }
 
     private let defaults: UserDefaults
@@ -35,6 +37,7 @@ final class AppearanceSettings: ObservableObject {
     @Published var fontSize: CGFloat { didSet { defaults.set(Double(fontSize), forKey: Keys.fontSize) } }
     @Published var schemeID: String { didSet { defaults.set(schemeID, forKey: Keys.schemeID) } }
     @Published var cursorStyle: CursorStyle { didSet { defaults.set(cursorStyle.rawString, forKey: Keys.cursorStyle) } }
+    @Published var thinStrokes: Bool { didSet { defaults.set(thinStrokes, forKey: Keys.thinStrokes) } }
 
     /// True if the user's tmux config sets a cell-painting style option that
     /// would override the chosen color scheme's foreground/background. Best-
@@ -58,6 +61,14 @@ final class AppearanceSettings: ObservableObject {
         // Cursor — round-trip via rawString; fall back on unknown.
         let storedCursor = defaults.string(forKey: Keys.cursorStyle) ?? ""
         self.cursorStyle = CursorStyle.from(rawString: storedCursor) ?? Defaults.cursorStyle
+
+        // Thin strokes — UserDefaults.bool(forKey:) returns false for missing keys,
+        // so check existence explicitly to apply the default-on behavior.
+        if defaults.object(forKey: Keys.thinStrokes) != nil {
+            self.thinStrokes = defaults.bool(forKey: Keys.thinStrokes)
+        } else {
+            self.thinStrokes = Defaults.thinStrokes
+        }
 
         self.hasTmuxStyleOverrides = Self.detectTmuxStyleOverrides()
     }

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -55,8 +55,11 @@ final class AppearanceSettings: ObservableObject {
         let storedSize = defaults.double(forKey: Keys.fontSize)
         self.fontSize = storedSize > 0 ? CGFloat(storedSize) : Defaults.fontSize
 
-        // Scheme ID — accept any string (lookup itself falls back if unknown).
-        self.schemeID = defaults.string(forKey: Keys.schemeID) ?? Defaults.schemeID
+        // Scheme ID — normalize unknown ids to the default so the Settings Picker
+        // always has a matching tag selected (otherwise it renders empty).
+        let storedScheme = defaults.string(forKey: Keys.schemeID) ?? Defaults.schemeID
+        self.schemeID = ColorSchemes.bundled.contains(where: { $0.id == storedScheme })
+            ? storedScheme : Defaults.schemeID
 
         // Cursor — round-trip via rawString; fall back on unknown.
         let storedCursor = defaults.string(forKey: Keys.cursorStyle) ?? ""

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -26,7 +26,7 @@ final class AppearanceSettings: ObservableObject {
     enum Defaults {
         static let fontName = "Monaco"
         static let fontSize: CGFloat = 12.0
-        static let schemeID = "tango"
+        static let schemeID = ColorSchemes.defaultScheme.id
         static let cursorStyle: CursorStyle = .blinkBlock
         static let thinStrokes = true   // matches iTerm's typical Retina Dark Only behavior
     }

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -108,13 +108,17 @@ final class AppearanceSettings: ObservableObject {
             let range = NSRange(location: 0, length: nsContents.length)
             var detected = false
             regex.enumerateMatches(in: contents, options: [], range: range) { result, _, stop in
-                guard let result, let flags = Range(result.range(at: 2), in: contents) else { return }
+                guard let result else { return }
                 // `result.range(at: 2)` is the captured flag group, e.g. " -g" or " -gu".
-                // If any flag contains `u`, this is an unset directive — skip.
-                if !contents[flags].contains("u") {
-                    detected = true
-                    stop.pointee = true
+                // It may be absent (NSRange(NSNotFound)) when the line has no flags
+                // at all (e.g. bare `set window-style ...`) — that's still an
+                // override; only the `-u` unset directive should be skipped.
+                if let flagsRange = Range(result.range(at: 2), in: contents),
+                   contents[flagsRange].contains("u") {
+                    return
                 }
+                detected = true
+                stop.pointee = true
             }
             if detected { return true }
         }

--- a/Sources/TBDApp/Terminal/ColorSchemes.swift
+++ b/Sources/TBDApp/Terminal/ColorSchemes.swift
@@ -15,8 +15,14 @@ struct TerminalColorScheme {
 }
 
 enum ColorSchemes {
+    /// Single source of truth for the fallback scheme. Both `scheme(forID:)`
+    /// and `AppearanceSettings.Defaults.schemeID` route through this so a
+    /// poisoned id never lands the runtime renderer and the Settings Picker
+    /// on different schemes.
+    static let defaultScheme: TerminalColorScheme = tango
+
     static func scheme(forID id: String) -> TerminalColorScheme {
-        bundled.first { $0.id == id } ?? tbdDefault
+        bundled.first { $0.id == id } ?? defaultScheme
     }
 
     static let bundled: [TerminalColorScheme] = [

--- a/Sources/TBDApp/Terminal/ColorSchemes.swift
+++ b/Sources/TBDApp/Terminal/ColorSchemes.swift
@@ -1,6 +1,9 @@
 import Foundation
 import SwiftTerm
 
+// SwiftTerm.Color is a class but our usage is read-only post-construction.
+extension SwiftTerm.Color: @retroactive @unchecked Sendable {}
+
 struct TerminalColorScheme {
     let id: String
     let displayName: String
@@ -16,10 +19,7 @@ enum ColorSchemes {
         bundled.first { $0.id == id } ?? tbdDefault
     }
 
-    // `nonisolated(unsafe)` is required because `SwiftTerm.Color` is a
-    // non-final class (not `Sendable`), but these values are immutable
-    // after initialization and only read.
-    nonisolated(unsafe) static let bundled: [TerminalColorScheme] = [
+    static let bundled: [TerminalColorScheme] = [
         tbdDefault,
         tango,
     ]
@@ -27,7 +27,7 @@ enum ColorSchemes {
     // MARK: - tbd-default
     // Mirrors SwiftTerm's stock palette (xterm-compatible defaults). Provided
     // so existing users can revert to today's look.
-    nonisolated(unsafe) static let tbdDefault = TerminalColorScheme(
+    static let tbdDefault = TerminalColorScheme(
         id: "tbd-default",
         displayName: "TBD Default",
         ansi: [
@@ -54,28 +54,29 @@ enum ColorSchemes {
         selection: rgb(80, 80, 80)
     )
 
-    // MARK: - tango (dark variant of user's iTerm profile; Tango palette)
-    // RGB values transcribed from guake.json's dark-mode entries.
-    nonisolated(unsafe) static let tango = TerminalColorScheme(
+    // MARK: - tango
+    /// Dark variant of user's iTerm profile; Tango palette. RGB values
+    /// transcribed from guake.json's dark-mode entries.
+    static let tango = TerminalColorScheme(
         id: "tango",
         displayName: "Tango",
         ansi: [
-            rgb(0, 0, 0),
-            rgb(204, 0, 0),
-            rgb(78, 154, 6),
-            rgb(196, 160, 0),
-            rgb(52, 101, 164),
-            rgb(117, 80, 123),
-            rgb(6, 152, 154),
-            rgb(211, 215, 207),
-            rgb(85, 87, 83),
-            rgb(239, 41, 41),
-            rgb(138, 226, 52),
-            rgb(252, 233, 79),
-            rgb(114, 159, 207),
-            rgb(173, 127, 168),
-            rgb(52, 226, 226),
-            rgb(238, 238, 236),
+            rgb(0, 0, 0),           // 0 black
+            rgb(204, 0, 0),         // 1 red
+            rgb(78, 154, 6),        // 2 green
+            rgb(196, 160, 0),       // 3 yellow
+            rgb(52, 101, 164),      // 4 blue
+            rgb(117, 80, 123),      // 5 magenta
+            rgb(6, 152, 154),       // 6 cyan
+            rgb(211, 215, 207),     // 7 white
+            rgb(85, 87, 83),        // 8 bright black
+            rgb(239, 41, 41),       // 9 bright red
+            rgb(138, 226, 52),      // 10 bright green
+            rgb(252, 233, 79),      // 11 bright yellow
+            rgb(114, 159, 207),     // 12 bright blue
+            rgb(173, 127, 168),     // 13 bright magenta
+            rgb(52, 226, 226),      // 14 bright cyan
+            rgb(238, 238, 236),     // 15 bright white
         ],
         foreground: rgb(255, 255, 255),
         background: rgb(0, 0, 0),

--- a/Sources/TBDApp/Terminal/ColorSchemes.swift
+++ b/Sources/TBDApp/Terminal/ColorSchemes.swift
@@ -20,8 +20,9 @@ enum ColorSchemes {
     }
 
     static let bundled: [TerminalColorScheme] = [
-        tbdDefault,
-        tango,
+        tbdDefault, tango,
+        solarizedDark, tomorrowNight, dracula,
+        nord, oneDark, gruvboxDark,
     ]
 
     // MARK: - tbd-default
@@ -82,6 +83,180 @@ enum ColorSchemes {
         background: rgb(0, 0, 0),
         cursor: rgb(255, 255, 255),
         selection: rgb(181, 213, 255)
+    )
+
+    // MARK: - solarized-dark
+    /// Solarized Dark — Ethan Schoonover, https://ethanschoonover.com/solarized/
+    static let solarizedDark = TerminalColorScheme(
+        id: "solarized-dark",
+        displayName: "Solarized Dark",
+        ansi: [
+            rgb(7, 54, 66),         // 0 base02 (black)
+            rgb(220, 50, 47),       // 1 red
+            rgb(133, 153, 0),       // 2 green
+            rgb(181, 137, 0),       // 3 yellow
+            rgb(38, 139, 210),      // 4 blue
+            rgb(211, 54, 130),      // 5 magenta
+            rgb(42, 161, 152),      // 6 cyan
+            rgb(238, 232, 213),     // 7 base2 (white)
+            rgb(0, 43, 54),         // 8 base03 (bright black)
+            rgb(203, 75, 22),       // 9 orange (bright red)
+            rgb(88, 110, 117),      // 10 base01 (bright green)
+            rgb(101, 123, 131),     // 11 base00 (bright yellow)
+            rgb(131, 148, 150),     // 12 base0 (bright blue)
+            rgb(108, 113, 196),     // 13 violet (bright magenta)
+            rgb(147, 161, 161),     // 14 base1 (bright cyan)
+            rgb(253, 246, 227),     // 15 base3 (bright white)
+        ],
+        foreground: rgb(131, 148, 150),
+        background: rgb(0, 43, 54),
+        cursor: rgb(131, 148, 150),
+        selection: rgb(7, 54, 66)
+    )
+
+    // MARK: - tomorrow-night
+    /// Tomorrow Night — Chris Kempson, https://github.com/chriskempson/tomorrow-theme
+    static let tomorrowNight = TerminalColorScheme(
+        id: "tomorrow-night",
+        displayName: "Tomorrow Night",
+        ansi: [
+            rgb(29, 31, 33),        // 0 black
+            rgb(204, 102, 102),     // 1 red
+            rgb(181, 189, 104),     // 2 green
+            rgb(240, 198, 116),     // 3 yellow
+            rgb(129, 162, 190),     // 4 blue
+            rgb(178, 148, 187),     // 5 magenta
+            rgb(138, 190, 183),     // 6 cyan
+            rgb(197, 200, 198),     // 7 white
+            rgb(150, 152, 150),     // 8 bright black
+            rgb(204, 102, 102),     // 9 bright red
+            rgb(181, 189, 104),     // 10 bright green
+            rgb(240, 198, 116),     // 11 bright yellow
+            rgb(129, 162, 190),     // 12 bright blue
+            rgb(178, 148, 187),     // 13 bright magenta
+            rgb(138, 190, 183),     // 14 bright cyan
+            rgb(255, 255, 255),     // 15 bright white
+        ],
+        foreground: rgb(197, 200, 198),
+        background: rgb(29, 31, 33),
+        cursor: rgb(197, 200, 198),
+        selection: rgb(55, 59, 65)
+    )
+
+    // MARK: - dracula
+    /// Dracula — https://draculatheme.com/
+    static let dracula = TerminalColorScheme(
+        id: "dracula",
+        displayName: "Dracula",
+        ansi: [
+            rgb(33, 34, 44),        // 0 black
+            rgb(255, 85, 85),       // 1 red
+            rgb(80, 250, 123),      // 2 green
+            rgb(241, 250, 140),     // 3 yellow
+            rgb(189, 147, 249),     // 4 blue
+            rgb(255, 121, 198),     // 5 magenta
+            rgb(139, 233, 253),     // 6 cyan
+            rgb(248, 248, 242),     // 7 white
+            rgb(98, 114, 164),      // 8 bright black
+            rgb(255, 110, 103),     // 9 bright red
+            rgb(90, 247, 142),      // 10 bright green
+            rgb(244, 249, 157),     // 11 bright yellow
+            rgb(202, 169, 250),     // 12 bright blue
+            rgb(255, 146, 208),     // 13 bright magenta
+            rgb(154, 237, 254),     // 14 bright cyan
+            rgb(255, 255, 255),     // 15 bright white
+        ],
+        foreground: rgb(248, 248, 242),
+        background: rgb(40, 42, 54),
+        cursor: rgb(248, 248, 242),
+        selection: rgb(68, 71, 90)
+    )
+
+    // MARK: - nord
+    /// Nord — https://www.nordtheme.com/
+    static let nord = TerminalColorScheme(
+        id: "nord",
+        displayName: "Nord",
+        ansi: [
+            rgb(59, 66, 82),        // 0 black
+            rgb(191, 97, 106),      // 1 red
+            rgb(163, 190, 140),     // 2 green
+            rgb(235, 203, 139),     // 3 yellow
+            rgb(129, 161, 193),     // 4 blue
+            rgb(180, 142, 173),     // 5 magenta
+            rgb(136, 192, 208),     // 6 cyan
+            rgb(229, 233, 240),     // 7 white
+            rgb(76, 86, 106),       // 8 bright black
+            rgb(191, 97, 106),      // 9 bright red
+            rgb(163, 190, 140),     // 10 bright green
+            rgb(235, 203, 139),     // 11 bright yellow
+            rgb(129, 161, 193),     // 12 bright blue
+            rgb(180, 142, 173),     // 13 bright magenta
+            rgb(143, 188, 187),     // 14 bright cyan
+            rgb(236, 239, 244),     // 15 bright white
+        ],
+        foreground: rgb(216, 222, 233),
+        background: rgb(46, 52, 64),
+        cursor: rgb(216, 222, 233),
+        selection: rgb(67, 76, 94)
+    )
+
+    // MARK: - one-dark
+    /// One Dark — Atom / VS Code default dark.
+    static let oneDark = TerminalColorScheme(
+        id: "one-dark",
+        displayName: "One Dark",
+        ansi: [
+            rgb(40, 44, 52),        // 0 black
+            rgb(224, 108, 117),     // 1 red
+            rgb(152, 195, 121),     // 2 green
+            rgb(229, 192, 123),     // 3 yellow
+            rgb(97, 175, 239),      // 4 blue
+            rgb(198, 120, 221),     // 5 magenta
+            rgb(86, 182, 194),      // 6 cyan
+            rgb(171, 178, 191),     // 7 white
+            rgb(92, 99, 112),       // 8 bright black
+            rgb(224, 108, 117),     // 9 bright red
+            rgb(152, 195, 121),     // 10 bright green
+            rgb(229, 192, 123),     // 11 bright yellow
+            rgb(97, 175, 239),      // 12 bright blue
+            rgb(198, 120, 221),     // 13 bright magenta
+            rgb(86, 182, 194),      // 14 bright cyan
+            rgb(255, 255, 255),     // 15 bright white
+        ],
+        foreground: rgb(171, 178, 191),
+        background: rgb(40, 44, 52),
+        cursor: rgb(171, 178, 191),
+        selection: rgb(62, 68, 81)
+    )
+
+    // MARK: - gruvbox-dark
+    /// Gruvbox Dark — Pavel Pertsev, https://github.com/morhetz/gruvbox
+    static let gruvboxDark = TerminalColorScheme(
+        id: "gruvbox-dark",
+        displayName: "Gruvbox Dark",
+        ansi: [
+            rgb(40, 40, 40),        // 0 black
+            rgb(204, 36, 29),       // 1 red
+            rgb(152, 151, 26),      // 2 green
+            rgb(215, 153, 33),      // 3 yellow
+            rgb(69, 133, 136),      // 4 blue
+            rgb(177, 98, 134),      // 5 magenta
+            rgb(104, 157, 106),     // 6 cyan
+            rgb(168, 153, 132),     // 7 white
+            rgb(146, 131, 116),     // 8 bright black
+            rgb(251, 73, 52),       // 9 bright red
+            rgb(184, 187, 38),      // 10 bright green
+            rgb(250, 189, 47),      // 11 bright yellow
+            rgb(131, 165, 152),     // 12 bright blue
+            rgb(211, 134, 155),     // 13 bright magenta
+            rgb(142, 192, 124),     // 14 bright cyan
+            rgb(235, 219, 178),     // 15 bright white
+        ],
+        foreground: rgb(235, 219, 178),
+        background: rgb(40, 40, 40),
+        cursor: rgb(235, 219, 178),
+        selection: rgb(60, 56, 54)
     )
 
     /// 8-bit-per-channel → SwiftTerm.Color (16-bit per channel).

--- a/Sources/TBDApp/Terminal/ColorSchemes.swift
+++ b/Sources/TBDApp/Terminal/ColorSchemes.swift
@@ -1,0 +1,94 @@
+import Foundation
+import SwiftTerm
+
+struct TerminalColorScheme {
+    let id: String
+    let displayName: String
+    let ansi: [SwiftTerm.Color]      // 16 colors, indices 0..15
+    let foreground: SwiftTerm.Color
+    let background: SwiftTerm.Color
+    let cursor: SwiftTerm.Color
+    let selection: SwiftTerm.Color
+}
+
+enum ColorSchemes {
+    static func scheme(forID id: String) -> TerminalColorScheme {
+        bundled.first { $0.id == id } ?? tbdDefault
+    }
+
+    // `nonisolated(unsafe)` is required because `SwiftTerm.Color` is a
+    // non-final class (not `Sendable`), but these values are immutable
+    // after initialization and only read.
+    nonisolated(unsafe) static let bundled: [TerminalColorScheme] = [
+        tbdDefault,
+        tango,
+    ]
+
+    // MARK: - tbd-default
+    // Mirrors SwiftTerm's stock palette (xterm-compatible defaults). Provided
+    // so existing users can revert to today's look.
+    nonisolated(unsafe) static let tbdDefault = TerminalColorScheme(
+        id: "tbd-default",
+        displayName: "TBD Default",
+        ansi: [
+            rgb(0, 0, 0),           // 0 black
+            rgb(170, 0, 0),         // 1 red
+            rgb(0, 170, 0),         // 2 green
+            rgb(170, 85, 0),        // 3 yellow
+            rgb(0, 0, 170),         // 4 blue
+            rgb(170, 0, 170),       // 5 magenta
+            rgb(0, 170, 170),       // 6 cyan
+            rgb(170, 170, 170),     // 7 white
+            rgb(85, 85, 85),        // 8 bright black
+            rgb(255, 85, 85),       // 9 bright red
+            rgb(85, 255, 85),       // 10 bright green
+            rgb(255, 255, 85),      // 11 bright yellow
+            rgb(85, 85, 255),       // 12 bright blue
+            rgb(255, 85, 255),      // 13 bright magenta
+            rgb(85, 255, 255),      // 14 bright cyan
+            rgb(255, 255, 255),     // 15 bright white
+        ],
+        foreground: rgb(255, 255, 255),
+        background: rgb(0, 0, 0),
+        cursor: rgb(255, 255, 255),
+        selection: rgb(80, 80, 80)
+    )
+
+    // MARK: - tango (dark variant of user's iTerm profile; Tango palette)
+    // RGB values transcribed from guake.json's dark-mode entries.
+    nonisolated(unsafe) static let tango = TerminalColorScheme(
+        id: "tango",
+        displayName: "Tango",
+        ansi: [
+            rgb(0, 0, 0),
+            rgb(204, 0, 0),
+            rgb(78, 154, 6),
+            rgb(196, 160, 0),
+            rgb(52, 101, 164),
+            rgb(117, 80, 123),
+            rgb(6, 152, 154),
+            rgb(211, 215, 207),
+            rgb(85, 87, 83),
+            rgb(239, 41, 41),
+            rgb(138, 226, 52),
+            rgb(252, 233, 79),
+            rgb(114, 159, 207),
+            rgb(173, 127, 168),
+            rgb(52, 226, 226),
+            rgb(238, 238, 236),
+        ],
+        foreground: rgb(255, 255, 255),
+        background: rgb(0, 0, 0),
+        cursor: rgb(255, 255, 255),
+        selection: rgb(181, 213, 255)
+    )
+
+    /// 8-bit-per-channel → SwiftTerm.Color (16-bit per channel).
+    private static func rgb(_ r: Int, _ g: Int, _ b: Int) -> SwiftTerm.Color {
+        SwiftTerm.Color(
+            red: UInt16(r) * 257,
+            green: UInt16(g) * 257,
+            blue: UInt16(b) * 257
+        )
+    }
+}

--- a/Sources/TBDApp/Terminal/ColorSchemes.swift
+++ b/Sources/TBDApp/Terminal/ColorSchemes.swift
@@ -26,7 +26,9 @@ enum ColorSchemes {
     }
 
     static let bundled: [TerminalColorScheme] = [
-        tbdDefault, tango,
+        // tango sits first because it's the default on fresh install — users
+        // see it at the top of the Picker without having to scroll.
+        tango, tbdDefault,
         solarizedDark, tomorrowNight, dracula,
         nord, oneDark, gruvboxDark,
     ]

--- a/Sources/TBDApp/Terminal/ColorSchemes.swift
+++ b/Sources/TBDApp/Terminal/ColorSchemes.swift
@@ -268,7 +268,9 @@ enum ColorSchemes {
     )
 
     /// 8-bit-per-channel → SwiftTerm.Color (16-bit per channel).
-    private static func rgb(_ r: Int, _ g: Int, _ b: Int) -> SwiftTerm.Color {
+    /// `UInt8` parameters make the 0–255 constraint self-documenting and
+    /// prevent silent overflow if a future scheme uses an out-of-range literal.
+    private static func rgb(_ r: UInt8, _ g: UInt8, _ b: UInt8) -> SwiftTerm.Color {
         SwiftTerm.Color(
             red: UInt16(r) * 257,
             green: UInt16(g) * 257,

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -19,15 +19,14 @@ class TBDTerminalView: TerminalView {
     var remoteURL: String?
     var onNotification: ((String, String) -> Void)?
 
-    /// Global appearance settings (font, color scheme, cursor style).
-    /// Stored now so Task 5 can subscribe to `objectWillChange` and reapply
-    /// font/colors/cursor when the user edits Settings → Terminal.
+    /// Global appearance settings (font, color scheme, cursor style). The Combine
+    /// subscription set up in `init` reapplies these whenever the user edits
+    /// Settings → Terminal.
     ///
     /// Named `appearanceSettings` (not `appearance`) to avoid collision with
     /// `NSView.appearance: NSAppearance?` inherited from AppKit.
     let appearanceSettings: AppearanceSettings
-    /// Holds the `objectWillChange` subscription set up in Task 5.
-    /// Declared here so the property exists before the consumer is wired in.
+    /// Holds the Combine subscription that reapplies appearance when settings change.
     private var appearanceCancellable: AnyCancellable?
 
     /// Called once when the view has been laid out with non-zero bounds.

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -125,8 +125,10 @@ class TBDTerminalView: TerminalView {
     }
 
     private static func nsColor(from color: SwiftTerm.Color) -> NSColor {
+        // Bundled scheme values are sRGB hex codes; use sRGB so wide-gamut
+        // displays (Display P3) don't drift from the spec.
         NSColor(
-            deviceRed: CGFloat(color.red) / 65535.0,
+            srgbRed: CGFloat(color.red) / 65535.0,
             green: CGFloat(color.green) / 65535.0,
             blue: CGFloat(color.blue) / 65535.0,
             alpha: 1.0

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -41,9 +41,10 @@ class TBDTerminalView: TerminalView {
         // Apply current values once so first render uses user settings.
         applyAll()
 
-        // Reapply on any AppearanceSettings change. Debounce to main-async so
-        // multi-property mutations (e.g. NSFontPanel updating both name + size)
-        // collapse into one apply.
+        // Reapply on any AppearanceSettings change. `objectWillChange` fires
+        // *before* the property mutation lands on the published value, so we
+        // dispatch async to main — by the time the sink runs, the new value
+        // has been committed and `appearanceSettings.*` reads the right thing.
         self.appearanceCancellable = appearance.objectWillChange
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -98,7 +98,13 @@ class TBDTerminalView: TerminalView {
         // inline. `SwiftTerm.Color` channels are UInt16 on a 65535 scale.
         self.installColors(scheme.ansi)
         self.nativeForegroundColor = Self.nsColor(from: scheme.foreground)
-        self.nativeBackgroundColor = Self.nsColor(from: scheme.background)
+        let bg = Self.nsColor(from: scheme.background)
+        self.nativeBackgroundColor = bg
+        // SwiftTerm only paints layer.backgroundColor inside its private
+        // setupOptions(); the nativeBackgroundColor setter just updates the
+        // logical terminal.backgroundColor. Repaint the layer ourselves so live
+        // scheme changes (and the initial apply) actually show through.
+        self.layer?.backgroundColor = bg.cgColor
         self.caretColor = Self.nsColor(from: scheme.cursor)
         self.selectedTextBackgroundColor = Self.nsColor(from: scheme.selection)
     }

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftTerm
 
 private extension CharacterSet {
@@ -18,10 +19,32 @@ class TBDTerminalView: TerminalView {
     var remoteURL: String?
     var onNotification: ((String, String) -> Void)?
 
+    /// Global appearance settings (font, color scheme, cursor style).
+    /// Stored now so Task 5 can subscribe to `objectWillChange` and reapply
+    /// font/colors/cursor when the user edits Settings → Terminal.
+    ///
+    /// Named `appearanceSettings` (not `appearance`) to avoid collision with
+    /// `NSView.appearance: NSAppearance?` inherited from AppKit.
+    let appearanceSettings: AppearanceSettings
+    /// Holds the `objectWillChange` subscription set up in Task 5.
+    /// Declared here so the property exists before the consumer is wired in.
+    private var appearanceCancellable: AnyCancellable?
+
     /// Called once when the view has been laid out with non-zero bounds.
     /// Used to start the tmux client as soon as the terminal has real dimensions.
     var onReady: (() -> Void)?
     private var didFireReady = false
+
+    init(frame: CGRect, font: NSFont, appearance: AppearanceSettings) {
+        self.appearanceSettings = appearance
+        super.init(frame: frame, font: font)
+        // applyAll() and `appearanceCancellable` subscription are wired in Task 5.
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported — TBDTerminalView requires an AppearanceSettings")
+    }
 
     override func layout() {
         super.layout()

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -77,6 +77,8 @@ class TBDTerminalView: TerminalView {
     }
 
     private func applyFontSmoothing() {
+        // SwiftTerm's `fontSmoothing = false` is what produces iTerm's
+        // "Thin Strokes" rendering, so we invert the user-facing toggle.
         self.fontSmoothing = !appearanceSettings.thinStrokes
         self.needsDisplay = true
     }

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -76,8 +76,18 @@ class TBDTerminalView: TerminalView {
     }
 
     private func applyFont() {
+        // Setting `self.font` triggers SwiftTerm's `resetFont()`, which
+        // recomputes its internal `cellDimension`, calls `resize(cols:rows:)`,
+        // and that in turn invokes `sizeChanged(source:newCols:newRows:)` on
+        // our `TerminalViewDelegate`. The existing handler in
+        // `TerminalPanelView.Coordinator.sizeChanged(...)` writes the new
+        // dimensions to the PTY via `ioctl(TIOCSWINSZ)`, so tmux gets
+        // SIGWINCH and reflows the pane. No explicit forwarding needed here.
         self.font = appearanceSettings.font
-        // SwiftTerm reflows internally; pane resize handling is Task 6.
+        // Our own cell-dimension cache is keyed off `self.font`, so it must
+        // be invalidated whenever the font changes; otherwise click→grid
+        // mapping in `mouseUp` would keep using stale metrics.
+        cachedCellDimensions = nil
     }
 
     private func applyScheme() {

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -38,7 +38,18 @@ class TBDTerminalView: TerminalView {
     init(frame: CGRect, font: NSFont, appearance: AppearanceSettings) {
         self.appearanceSettings = appearance
         super.init(frame: frame, font: font)
-        // applyAll() and `appearanceCancellable` subscription are wired in Task 5.
+
+        // Apply current values once so first render uses user settings.
+        applyAll()
+
+        // Reapply on any AppearanceSettings change. Debounce to main-async so
+        // multi-property mutations (e.g. NSFontPanel updating both name + size)
+        // collapse into one apply.
+        self.appearanceCancellable = appearance.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.applyAll()
+            }
     }
 
     @available(*, unavailable)
@@ -54,6 +65,45 @@ class TBDTerminalView: TerminalView {
             onReady = nil
             DispatchQueue.main.async { callback?() }
         }
+    }
+
+    // MARK: - Appearance application
+
+    private func applyAll() {
+        applyFont()
+        applyScheme()
+        applyCursor()
+    }
+
+    private func applyFont() {
+        self.font = appearanceSettings.font
+        // SwiftTerm reflows internally; pane resize handling is Task 6.
+    }
+
+    private func applyScheme() {
+        let scheme = ColorSchemes.scheme(forID: appearanceSettings.schemeID)
+        // SwiftTerm's `installColors` takes `[SwiftTerm.Color]`; the per-view
+        // foreground/background/caret/selection setters take `NSColor`. We can't
+        // use SwiftTerm's internal `NSColor.make(color:)` bridge, so convert
+        // inline. `SwiftTerm.Color` channels are UInt16 on a 65535 scale.
+        self.installColors(scheme.ansi)
+        self.nativeForegroundColor = Self.nsColor(from: scheme.foreground)
+        self.nativeBackgroundColor = Self.nsColor(from: scheme.background)
+        self.caretColor = Self.nsColor(from: scheme.cursor)
+        self.selectedTextBackgroundColor = Self.nsColor(from: scheme.selection)
+    }
+
+    private static func nsColor(from color: SwiftTerm.Color) -> NSColor {
+        NSColor(
+            deviceRed: CGFloat(color.red) / 65535.0,
+            green: CGFloat(color.green) / 65535.0,
+            blue: CGFloat(color.blue) / 65535.0,
+            alpha: 1.0
+        )
+    }
+
+    private func applyCursor() {
+        self.terminal.setCursorStyle(appearanceSettings.cursorStyle)
     }
 
     // MARK: - Cell dimension calculation

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -73,6 +73,12 @@ class TBDTerminalView: TerminalView {
         applyFont()
         applyScheme()
         applyCursor()
+        applyFontSmoothing()
+    }
+
+    private func applyFontSmoothing() {
+        self.fontSmoothing = !appearanceSettings.thinStrokes
+        self.needsDisplay = true
     }
 
     private func applyFont() {

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -107,6 +107,13 @@ class TBDTerminalView: TerminalView {
         self.layer?.backgroundColor = bg.cgColor
         self.caretColor = Self.nsColor(from: scheme.cursor)
         self.selectedTextBackgroundColor = Self.nsColor(from: scheme.selection)
+
+        // Force SwiftTerm to repaint every cell. `installColors` updates the
+        // palette but does not invalidate cells already in the buffer; without
+        // this, default-bg cells continue showing the bg color they were drawn
+        // with at first paint (NSColor.textBackgroundColor = system gray).
+        self.getTerminal().updateFullScreen()
+        self.needsDisplay = true
     }
 
     private static func nsColor(from color: SwiftTerm.Color) -> NSColor {

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -147,7 +147,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
     func makeNSView(context: Context) -> TBDTerminalView {
         let tv = TBDTerminalView(
             frame: NSRect(x: 0, y: 0, width: 800, height: 600),
-            font: NSFont.monospacedSystemFont(ofSize: 13, weight: .regular),
+            font: appearance.font,
             appearance: appearance
         )
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -151,10 +151,6 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
             appearance: appearance
         )
 
-        // Dark terminal
-        tv.nativeBackgroundColor = NSColor.black
-        tv.nativeForegroundColor = NSColor(white: 0.85, alpha: 1.0)
-
         // Disable mouse reporting so click-drag selects text locally
         // instead of forwarding mouse events to tmux
         tv.allowMouseReporting = false

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -27,6 +27,7 @@ struct TerminalPanelView: View {
     var onFilePathClicked: ((String) -> Void)?
     var onTerminalNotification: ((String, String) -> Void)?
     @EnvironmentObject var appState: AppState
+    @EnvironmentObject var appearance: AppearanceSettings
     /// Called when the tmux window is dead and needs recreation. The callback
     /// should ask the daemon to recreate the window and trigger a state refresh.
     var onDeadWindow: (() -> Void)?
@@ -138,6 +139,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
     var onFilePathClicked: ((String) -> Void)?
     var onTerminalNotification: ((String, String) -> Void)?
     @EnvironmentObject var appState: AppState
+    @EnvironmentObject var appearance: AppearanceSettings
     var onDeadWindow: (() -> Void)?
     var initialSnapshot: String?
     var isSuspendedSnapshot: Bool = false
@@ -145,7 +147,8 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
     func makeNSView(context: Context) -> TBDTerminalView {
         let tv = TBDTerminalView(
             frame: NSRect(x: 0, y: 0, width: 800, height: 600),
-            font: NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+            font: NSFont.monospacedSystemFont(ofSize: 13, weight: .regular),
+            appearance: appearance
         )
 
         // Dark terminal

--- a/Tests/TBDAppTests/AppearanceSettingsTests.swift
+++ b/Tests/TBDAppTests/AppearanceSettingsTests.swift
@@ -23,6 +23,25 @@ struct AppearanceSettingsTests {
             #expect(settings.fontName == "Monaco")
             #expect(settings.fontSize == 12.0)
             #expect(settings.cursorStyle == .blinkBlock)
+            #expect(settings.thinStrokes == true)
+        }
+    }
+
+    @Test("fresh init has thinStrokes enabled by default")
+    func freshInitThinStrokes() {
+        withIsolatedDefaults { defaults in
+            let settings = AppearanceSettings(defaults: defaults)
+            #expect(settings.thinStrokes == true)
+        }
+    }
+
+    @Test("thinStrokes round-trips")
+    func roundTripThinStrokes() {
+        withIsolatedDefaults { defaults in
+            let settings = AppearanceSettings(defaults: defaults)
+            settings.thinStrokes = false
+            let reloaded = AppearanceSettings(defaults: defaults)
+            #expect(reloaded.thinStrokes == false)
         }
     }
 

--- a/Tests/TBDAppTests/AppearanceSettingsTests.swift
+++ b/Tests/TBDAppTests/AppearanceSettingsTests.swift
@@ -20,6 +20,7 @@ struct AppearanceSettingsTests {
         withIsolatedDefaults { defaults in
             let settings = AppearanceSettings(defaults: defaults)
             #expect(settings.schemeID == "tango")
+            #expect(settings.fontName == "Monaco")
             #expect(settings.fontSize == 12.0)
             #expect(settings.cursorStyle == .blinkBlock)
         }

--- a/Tests/TBDAppTests/AppearanceSettingsTests.swift
+++ b/Tests/TBDAppTests/AppearanceSettingsTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+import SwiftTerm
+@testable import TBDApp
+
+@MainActor
+@Suite("AppearanceSettings")
+struct AppearanceSettingsTests {
+    /// Run a body with an isolated UserDefaults suite so we never touch
+    /// the live `TBDApp.plist` (see Tests/TBDAppTests/AutoSuspendPreferenceTests.swift).
+    private func withIsolatedDefaults(_ body: (UserDefaults) -> Void) {
+        let suiteName = "TBDAppTests.Appearance.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(defaults)
+    }
+
+    @Test("fresh init has tango as the default scheme")
+    func freshInitDefaults() {
+        withIsolatedDefaults { defaults in
+            let settings = AppearanceSettings(defaults: defaults)
+            #expect(settings.schemeID == "tango")
+            #expect(settings.fontSize == 12.0)
+            #expect(settings.cursorStyle == .blinkBlock)
+        }
+    }
+
+    @Test("setting properties persists to UserDefaults")
+    func roundTripFont() {
+        withIsolatedDefaults { defaults in
+            let settings = AppearanceSettings(defaults: defaults)
+            settings.fontName = "Menlo"
+            settings.fontSize = 14
+            settings.schemeID = "dracula"
+            settings.cursorStyle = .steadyUnderline
+
+            let reloaded = AppearanceSettings(defaults: defaults)
+            #expect(reloaded.fontName == "Menlo")
+            #expect(reloaded.fontSize == 14)
+            #expect(reloaded.schemeID == "dracula")
+            #expect(reloaded.cursorStyle == .steadyUnderline)
+        }
+    }
+
+    @Test("invalid font size falls back to default")
+    func fallbackFontSize() {
+        withIsolatedDefaults { defaults in
+            defaults.set(0.0, forKey: "terminal.font.size")
+            let settings = AppearanceSettings(defaults: defaults)
+            #expect(settings.fontSize == 12.0)
+        }
+    }
+
+    @Test("unknown cursor style raw value falls back to blinkBlock")
+    func fallbackCursorStyle() {
+        withIsolatedDefaults { defaults in
+            defaults.set("not-a-real-style", forKey: "terminal.cursor.style")
+            let settings = AppearanceSettings(defaults: defaults)
+            #expect(settings.cursorStyle == .blinkBlock)
+        }
+    }
+
+    @Test("computed font falls back to system mono when fontName is bogus")
+    func fallbackFontResolution() {
+        withIsolatedDefaults { defaults in
+            let settings = AppearanceSettings(defaults: defaults)
+            settings.fontName = "NotARealFontNameXYZ"
+            settings.fontSize = 13
+            #expect(settings.font.pointSize == 13)
+            // Should resolve to system mono, not nil.
+            #expect(settings.font.fontName.lowercased().contains("mono") ||
+                    settings.font.fontName.lowercased().contains("sf"))
+        }
+    }
+}

--- a/Tests/TBDAppTests/AppearanceSettingsTests.swift
+++ b/Tests/TBDAppTests/AppearanceSettingsTests.swift
@@ -80,6 +80,15 @@ struct AppearanceSettingsTests {
         }
     }
 
+    @Test("unknown scheme id is normalized to the default at init")
+    func normalizeSchemeID() {
+        withIsolatedDefaults { defaults in
+            defaults.set("bogus-scheme", forKey: "terminal.scheme.id")
+            let settings = AppearanceSettings(defaults: defaults)
+            #expect(settings.schemeID == "tango")
+        }
+    }
+
     @Test("computed font falls back to system mono when fontName is bogus")
     func fallbackFontResolution() {
         withIsolatedDefaults { defaults in

--- a/Tests/TBDAppTests/ColorSchemesTests.swift
+++ b/Tests/TBDAppTests/ColorSchemesTests.swift
@@ -29,8 +29,8 @@ struct ColorSchemesTests {
         #expect(scheme.id == "tango")
     }
 
-    @Test("scheme(forID:) returns tbd-default when looked up by its id")
-    func lookupDefault() {
+    @Test("scheme(forID:) finds tbd-default by its own id (not the fallback path)")
+    func lookupTBDDefaultByID() {
         let scheme = ColorSchemes.scheme(forID: "tbd-default")
         #expect(scheme.id == "tbd-default")
     }

--- a/Tests/TBDAppTests/ColorSchemesTests.swift
+++ b/Tests/TBDAppTests/ColorSchemesTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("ColorSchemes")
+struct ColorSchemesTests {
+    @Test("bundled list is non-empty and contains tbd-default and tango")
+    func bundledContainsCore() {
+        let ids = ColorSchemes.bundled.map(\.id)
+        #expect(ids.contains("tbd-default"))
+        #expect(ids.contains("tango"))
+    }
+
+    @Test("every bundled scheme has exactly 16 ANSI colors")
+    func ansiCount() {
+        for scheme in ColorSchemes.bundled {
+            #expect(scheme.ansi.count == 16, "scheme \(scheme.id) has \(scheme.ansi.count) ANSI colors")
+        }
+    }
+
+    @Test("bundled IDs are unique")
+    func uniqueIDs() {
+        let ids = ColorSchemes.bundled.map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test("scheme(forID:) returns the requested scheme")
+    func lookupFound() {
+        let scheme = ColorSchemes.scheme(forID: "tango")
+        #expect(scheme.id == "tango")
+    }
+
+    @Test("scheme(forID:) falls back to tbd-default on unknown id")
+    func lookupFallback() {
+        let scheme = ColorSchemes.scheme(forID: "this-does-not-exist")
+        #expect(scheme.id == "tbd-default")
+    }
+}

--- a/Tests/TBDAppTests/ColorSchemesTests.swift
+++ b/Tests/TBDAppTests/ColorSchemesTests.swift
@@ -40,4 +40,14 @@ struct ColorSchemesTests {
         let scheme = ColorSchemes.scheme(forID: "this-does-not-exist")
         #expect(scheme.id == "tbd-default")
     }
+
+    @Test("bundled contains exactly 8 schemes with expected IDs")
+    func bundledCount() {
+        let ids = Set(ColorSchemes.bundled.map(\.id))
+        let expected: Set<String> = [
+            "tbd-default", "tango", "solarized-dark", "tomorrow-night",
+            "dracula", "nord", "one-dark", "gruvbox-dark",
+        ]
+        #expect(ids == expected)
+    }
 }

--- a/Tests/TBDAppTests/ColorSchemesTests.swift
+++ b/Tests/TBDAppTests/ColorSchemesTests.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Testing
 @testable import TBDApp
 
@@ -28,6 +27,12 @@ struct ColorSchemesTests {
     func lookupFound() {
         let scheme = ColorSchemes.scheme(forID: "tango")
         #expect(scheme.id == "tango")
+    }
+
+    @Test("scheme(forID:) returns tbd-default when looked up by its id")
+    func lookupDefault() {
+        let scheme = ColorSchemes.scheme(forID: "tbd-default")
+        #expect(scheme.id == "tbd-default")
     }
 
     @Test("scheme(forID:) falls back to tbd-default on unknown id")

--- a/Tests/TBDAppTests/ColorSchemesTests.swift
+++ b/Tests/TBDAppTests/ColorSchemesTests.swift
@@ -35,10 +35,10 @@ struct ColorSchemesTests {
         #expect(scheme.id == "tbd-default")
     }
 
-    @Test("scheme(forID:) falls back to tbd-default on unknown id")
+    @Test("scheme(forID:) falls back to defaultScheme on unknown id")
     func lookupFallback() {
         let scheme = ColorSchemes.scheme(forID: "this-does-not-exist")
-        #expect(scheme.id == "tbd-default")
+        #expect(scheme.id == ColorSchemes.defaultScheme.id)
     }
 
     @Test("bundled contains exactly 8 schemes with expected IDs")

--- a/docs/superpowers/specs/2026-05-16-terminal-appearance-design.md
+++ b/docs/superpowers/specs/2026-05-16-terminal-appearance-design.md
@@ -134,7 +134,7 @@ Cell dimensions change when the font changes; the tmux pane must resize to match
 | `tomorrow-night` | Tomorrow Night | Chris Kempson palette |
 | `dracula` | Dracula | High-contrast classic |
 | `nord` | Nord | Cool low-saturation |
-| `oneDark` | One Dark | Atom / VS Code default dark |
+| `one-dark` | One Dark | Atom / VS Code default dark |
 | `gruvbox-dark` | Gruvbox Dark | Warm retro |
 
 Specific RGB values for non-Tango schemes will be transcribed from each scheme's canonical published palette during implementation.

--- a/docs/superpowers/specs/2026-05-16-terminal-appearance-design.md
+++ b/docs/superpowers/specs/2026-05-16-terminal-appearance-design.md
@@ -1,0 +1,202 @@
+# Terminal Appearance Customization — v1 Design
+
+**Status:** Design approved, pending user spec review
+**Date:** 2026-05-16
+**Branch:** `customize-terminal-appearance`
+
+## Summary
+
+Expose four terminal-appearance settings, scoped globally via `@AppStorage`-style persistence, applied live to every open terminal pane:
+
+1. **Font family + size** (via the native macOS Font Panel)
+2. **Color scheme** (8 bundled, dropdown)
+3. **Cursor style** (block / underline / bar × steady / blink, single dropdown)
+4. **Caret color** (defined by the active color scheme — no separate setting)
+
+Settings live in a new **Terminal** tab in `SettingsView`. The existing "Auto-resize tmux windows" toggle relocates into this tab.
+
+## Motivation
+
+TBD currently exposes none of SwiftTerm's appearance knobs. Users running TBD all day cannot match the font, size, or color scheme they use elsewhere (iTerm, Ghostty, VS Code's integrated terminal). Anti-aliasing, ligatures, and per-tab profiles are out of scope for v1 (see "Deferred").
+
+## Architecture
+
+### New files
+
+- `Sources/TBDApp/Terminal/AppearanceSettings.swift` — `final class AppearanceSettings: ObservableObject`, singleton-style instance owned at app root, injected as `@EnvironmentObject`. Properties:
+  - `@Published var fontName: String` (default: `NSFont.monospacedSystemFont(...)`'s `fontName`)
+  - `@Published var fontSize: CGFloat` (default: `12.0`)
+  - `@Published var schemeID: String` (default: `"tango"`)
+  - `@Published var cursorStyle: SwiftTerm.CursorStyle` (default: `.blinkBlock`)
+  - Each property's `didSet` writes the new value to `UserDefaults` under keys `terminal.font.name`, `terminal.font.size`, `terminal.scheme.id`, `terminal.cursor.style`.
+  - `init()` reads from `UserDefaults` with fallback to defaults on missing/invalid values.
+  - Computed `var font: NSFont`: `NSFont(name: fontName, size: fontSize) ?? NSFont.monospacedSystemFont(ofSize: fontSize)`.
+
+- `Sources/TBDApp/Terminal/ColorSchemes.swift` — value-type definitions:
+  ```swift
+  struct TerminalColorScheme {
+      let id: String
+      let displayName: String
+      let ansi: [SwiftTerm.Color]      // 16 colors
+      let foreground: SwiftTerm.Color
+      let background: SwiftTerm.Color
+      let cursor: SwiftTerm.Color
+      let selection: SwiftTerm.Color
+  }
+
+  enum ColorSchemes {
+      static let bundled: [TerminalColorScheme] = [
+          tbdDefault, tango, solarizedDark, tomorrowNight,
+          dracula, nord, oneDark, gruvboxDark
+      ]
+      static func scheme(forID id: String) -> TerminalColorScheme {
+          bundled.first { $0.id == id } ?? tbdDefault
+      }
+      // Each scheme defined as a static let with hardcoded RGB values.
+  }
+  ```
+  All 8 schemes are compiled-in struct literals — no JSON, no plist, no I/O. The `tango` scheme is the dark variant of the user's iTerm profile (RGB values transcribed from `guake.json`'s `Ansi N Color (Dark)` / `Background Color (Dark)` / `Foreground Color (Dark)` / `Cursor Color (Dark)` entries).
+
+- `Sources/TBDApp/Settings/TerminalSettingsView.swift` — new tab body. Components:
+  - "Font" row: label showing current font + size (e.g. "SF Mono 12"), "Choose Font…" button that opens `NSFontPanel` via `NSFontManager.shared.orderFrontFontPanel(self)`. The view conforms to a `NSFontChanging` delegate; in `changeFont(_:)` it reads the chosen font and writes onto `AppearanceSettings`.
+  - "Color Scheme" row: `Picker` bound to `$settings.schemeID`, options enumerated from `ColorSchemes.bundled`. Each row shows the display name (no swatch preview in v1; can add later).
+  - "Cursor Style" row: `Picker` bound to `$settings.cursorStyle` with rows: "Block" / "Block (blinking)" / "Underline" / "Underline (blinking)" / "Bar" / "Bar (blinking)".
+  - "Experimental" section at the bottom containing the relocated `enableTerminalAutoResize` toggle.
+
+### Modified files
+
+- `Sources/TBDApp/Settings/SettingsView.swift` — add a 4th `tabItem` for "Terminal" with the `terminal` SF Symbol. Remove the `enableTerminalAutoResize` toggle and its Experimental section from `GeneralSettingsTab`.
+
+- `Sources/TBDApp/Terminal/TBDTerminalView.swift`:
+  - Accept `AppearanceSettings` in `init`.
+  - Store a `Set<AnyCancellable>` for Combine subscriptions.
+  - Subscribe to `settings.objectWillChange` in `init`; on receive, debounce via `DispatchQueue.main.async` and call `applyAll()`.
+  - Call `applyAll()` once at the end of `init`, before tmux attach.
+  - New private methods:
+    - `applyFont()` — sets `self.font = settings.font`. SwiftTerm internally rederives bold/italic and recomputes cell metrics.
+    - `applyScheme()` — `let scheme = ColorSchemes.scheme(forID: settings.schemeID)`; calls `installColors(scheme.ansi)`, sets `nativeForegroundColor`, `nativeBackgroundColor`, `caretColor = scheme.cursor`, `selectedTextBackgroundColor = scheme.selection`.
+    - `applyCursor()` — `terminal.setCursorStyle(settings.cursorStyle)`.
+  - After `applyFont()`, ensure pane resize fires (see "Tmux pane resize" below).
+
+- `Sources/TBDApp/Terminal/TerminalPanelView.swift`, `TerminalContainerView.swift` — pipe `AppearanceSettings` through to `TBDTerminalView` init via `@EnvironmentObject`.
+
+- `Sources/TBDApp/TBDApp.swift` (or the `@main` entry) — instantiate `let appearance = AppearanceSettings()` and apply `.environmentObject(appearance)` to the root view.
+
+- `Sources/TBDApp/AppState.swift` — currently calls `TBDTerminalView.cellDimensions(for:)` statically to compute rows/cols from `mainAreaSize`. These call sites need the **current** font from `AppearanceSettings`, not `TBDTerminalView.defaultMonospaceFont`. Either:
+  - Hold a weak reference to `AppearanceSettings` on `AppState`, or
+  - Pass `currentFont` as a parameter at the call sites.
+  Choose whichever pattern matches existing AppState dependency injection. Two or three call sites — verify via `grep "cellDimensions" Sources/`.
+
+## Data flow
+
+### Set path
+
+1. User opens Settings → Terminal tab.
+2. **Font:** clicks "Choose Font…" → `NSFontManager` panel opens. User picks. `changeFont(_:)` callback reads `convert(…)` result, writes `fontName` + `fontSize` onto `AppearanceSettings`.
+3. **Scheme / cursor:** `Picker` is bound to a `Binding<String>` / `Binding<CursorStyle>` derived from `AppearanceSettings` `@Published` properties. Selection mutates the property.
+4. `didSet` on each property persists to `UserDefaults`. `objectWillChange` fires.
+
+### Apply path
+
+1. Each live `TBDTerminalView` has a `settings.objectWillChange.sink { [weak self] _ in ... }` subscription.
+2. Sink callback dispatches `applyAll()` via `DispatchQueue.main.async` (debounces rapid multi-property publishes into one apply).
+3. `applyAll()` calls `applyFont()`, `applyScheme()`, `applyCursor()` in that order.
+4. `applyFont()` triggers SwiftTerm's internal cell-dim recompute → `sizeChanged(source:newCols:newRows:)` fires on the delegate → existing TBD code path forwards the new dims to the tmux pane.
+
+### Init path
+
+`TBDTerminalView.init` calls `applyAll()` once before tmux attach, so the first render uses the user's settings.
+
+### Failure modes
+
+- Missing/invalid font name → `NSFont(name:size:)` returns `nil` → fallback to `NSFont.monospacedSystemFont(ofSize:)`.
+- Unknown `schemeID` → `ColorSchemes.scheme(forID:)` returns `tbdDefault`. UserDefaults stays as-is (user can re-pick; no auto-correction).
+- Unknown cursor style raw value → init fallback to `.blinkBlock`.
+- No crashes, no migrations needed (v1 is additive: new keys, existing UserDefaults unaffected).
+
+## Tmux pane resize on font change
+
+Cell dimensions change when the font changes; the tmux pane must resize to match the new rows/cols-per-pixel-area.
+
+- **Existing infra:** `TBDTerminalView.cellDimensions(for:)` (Sources/TBDApp/Terminal/TBDTerminalView.swift:58-63) already computes from any `NSFont`. `AppState` has `mainAreaSize`. SwiftTerm fires `sizeChanged` on its delegate after internal reflow.
+- **Verification needed during implementation:** confirm `sizeChanged` actually fires when only `font` is set (not just on view bounds change). If it does, the existing delegate forwards the new dims to the daemon and we're done.
+- **If `sizeChanged` does not fire on font-only change:** after `applyFont()`, manually call the existing "send pane resize" path with `cellDimensions(for: settings.font)` against `self.bounds.size`.
+- **Auto-resize toggle does not gate this.** Even when `enableTerminalAutoResize` is off (default), font changes must always forward a one-shot pane resize — otherwise the visible region clips at the bottom.
+- **AppState pre-spawn rows/cols** (the static `cellDimensions(for:)` callers) must use `AppearanceSettings.font`, not `defaultMonospaceFont`, so newly spawned panes start at correct dims.
+
+## Bundled color schemes
+
+| ID | Display name | Notes |
+|---|---|---|
+| `tbd-default` | TBD Default | Current SwiftTerm defaults — included so existing-look is selectable |
+| `tango` | Tango | **Default on fresh install.** Dark variant of the user's iTerm profile (Tango palette: olive green, amber, dusty blue, brick red, muted purple, deep teal on black). |
+| `solarized-dark` | Solarized Dark | Ethan Schoonover palette |
+| `tomorrow-night` | Tomorrow Night | Chris Kempson palette |
+| `dracula` | Dracula | High-contrast classic |
+| `nord` | Nord | Cool low-saturation |
+| `oneDark` | One Dark | Atom / VS Code default dark |
+| `gruvbox-dark` | Gruvbox Dark | Warm retro |
+
+Specific RGB values for non-Tango schemes will be transcribed from each scheme's canonical published palette during implementation.
+
+## Default scheme on fresh install
+
+**Tango.** Existing TBD users will see a visual change on next launch (white text on black, with the Tango ANSI palette). Acceptable given the feature is new — users can switch back to "TBD Default" from the new Settings tab.
+
+No "Reset to Defaults" button in v1.
+
+## Testing
+
+### Automated (`swift test`)
+
+- `AppearanceSettings` round-trip: write each property, read back from a fresh instance against the same `UserDefaults`, verify match.
+- `AppearanceSettings` fallback: poison each UserDefaults key (bad font name, unknown scheme id, unknown cursor raw value), verify init returns the documented default.
+- `ColorSchemes.bundled` invariants: every scheme has exactly 16 ANSI colors; every `id` is unique; every scheme is reachable via `scheme(forID:)`.
+- `ColorSchemes.scheme(forID: "bogus")` returns `tbdDefault`.
+
+### Manual verification (golden path)
+
+- Settings → Terminal → change font to Menlo 14 → every open pane updates live; tmux content reflows; no bottom-clipping.
+- Cycle through all 8 schemes → colors update live; `ls --color`, `git status`, `vim`'s syntax all reflect new ANSI palette.
+- Cycle through all 6 cursor variants → caret shape and blink update live.
+- Quit + relaunch → settings persist.
+
+### Manual verification (edge cases)
+
+- `defaults write com.tbd.app terminal.scheme.id bogus` → relaunch shouldn't crash; falls back to `tbd-default`.
+- `defaults write com.tbd.app terminal.font.name NotARealFont` → relaunch shouldn't crash; falls back to system mono.
+- Font change with `top` or `vim` running in the pane → no garbled redraw, content reflows.
+- Delete `~/Library/Preferences/com.tbd.app.plist` (or run `defaults delete com.tbd.app`) → all four settings restore to factory.
+
+### Branch coverage
+
+This feature has no on/off flag — the Terminal tab is always present. If reviewer feedback adds one, add tests for both branches per [CLAUDE.md](/Users/chang/tbd/worktrees/tbd/20260514-previous-ostrich/CLAUDE.md) workflow rule.
+
+## Deferred (explicitly out of scope for v1)
+
+- **Anti-aliasing / "thin strokes" toggles.** SwiftTerm doesn't expose a public API for these and Retina defaults are good. Would require a SwiftTerm patch.
+- **Non-ASCII font slot.** SwiftTerm uses a single font; iTerm's dual-font feature would need upstream changes.
+- **Ligatures.** SwiftTerm draws glyph-by-glyph from `CTRun`s; no current ligature path.
+- **Line height / horizontal cell spacing.** No SwiftTerm public API.
+- **Bold-uses-bright-color toggle.** Uncertain SwiftTerm support; revisit if requested.
+- **Transparency / blur.** Wrong UX for TBD's tiled-many-panes shape.
+- **Per-worktree or per-tab appearance overrides.** Settings are global in v1. Per-worktree overrides can be layered later via `state.db` if needed.
+- **Custom color editing.** Bundled schemes only in v1; no swatch pickers.
+- **iTerm `.itermcolors` import.** Bundled schemes only.
+- **Color scheme preview swatches in the dropdown.** Names only in v1.
+- **"Reset to Defaults" button.** User can re-pick from the dropdowns.
+
+## Files touched (summary)
+
+**New:**
+- `Sources/TBDApp/Terminal/AppearanceSettings.swift`
+- `Sources/TBDApp/Terminal/ColorSchemes.swift`
+- `Sources/TBDApp/Settings/TerminalSettingsView.swift`
+
+**Modified:**
+- `Sources/TBDApp/Settings/SettingsView.swift`
+- `Sources/TBDApp/Terminal/TBDTerminalView.swift`
+- `Sources/TBDApp/Terminal/TerminalPanelView.swift`
+- `Sources/TBDApp/Terminal/TerminalContainerView.swift`
+- `Sources/TBDApp/AppState.swift` (cellDimensions call sites)
+- `Sources/TBDApp/TBDApp.swift` or `@main` entry (environment object injection)


### PR DESCRIPTION
## Summary
- New **Terminal** tab in Settings with live-applied controls: font family + size (NSFontPanel + inline stepper, Monaco 12 default), 8 bundled color schemes (Tango default — Tango palette on pure black), cursor style with blink variants, and a thin-strokes toggle that maps to SwiftTerm's new `fontSmoothing` property so text renders at iTerm-like weight on Retina displays.
- Every setting applies live to every open pane via a Combine subscription on `AppearanceSettings.objectWillChange`. Font changes also propagate cell-dim updates to the underlying tmux pane.
- Surfaces an info ⓘ tooltip next to the Scheme picker when the user's `~/.tmux.conf` defines `window-style`/`window-active-style`/`pane-style`/`default-style`, since those tmux options paint over the scheme's colors. We don't override the user's tmux config — we explain it.
- Bumps SwiftTerm from v1.12.0 to a main commit (`dae32cc8`) to pick up the public `fontSmoothing` property (PR #531) plus the v1.13.0 changes that came in between.

## Test plan
- [ ] Open Settings → Terminal: verify Font (with Choose Font… button + Size stepper), Color Scheme picker (8 entries), Cursor Style picker (6 entries), Thin Strokes toggle, and the relocated Auto-resize toggle in Experimental.
- [ ] Cycle each Color Scheme — every open terminal pane updates live; `ls --color` shows the new ANSI palette.
- [ ] Cycle each Cursor Style — caret shape/blink updates live.
- [ ] Change font (e.g. Menlo 14) via Choose Font… — every open pane updates live, no clipping at the bottom; tmux pane resizes to match.
- [ ] Toggle Thin Strokes — text visibly thins on Retina.
- [ ] Quit + relaunch — settings persist.
- [ ] Add `set -g window-style 'fg=colour247,bg=colour236'` to `~/.tmux.conf`, kill the TBD tmux server, relaunch — info ⓘ appears on the Scheme picker with the explanatory tooltip.
- [ ] Poison UserDefaults (`defaults write com.tbd.app terminal.scheme.id bogus`, `terminal.font.name NotARealFont`) — no crash, falls back to TBD Default + system mono.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=4E8CF284-2A26-4BC6-852D-DAAF7E71D107)