### PR TITLE
[testing-only] ci: force TBDShared rebuild to dodge SPM #7715

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,29 @@ jobs:
           restore-keys: |
             spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-deps-${{ hashFiles('Package.resolved') }}-
 
+      # Workaround for SwiftPM bug swiftlang/swift-package-manager#7715: a
+      # cache-restored `.build/` can have a stale `TBDShared` object archive
+      # alongside a fresh `.swiftmodule`. Downstream files compile against the
+      # new module but the linker can't find the new symbols, producing
+      # "Undefined symbols ... TBDShared.<NewType>.init" link-time flakes.
+      # Wiping just the TBDShared artifacts forces SPM to re-emit them while
+      # keeping the rest of `.build/` warm. Always exits 0: first-run cold
+      # cache won't have these paths and that's expected.
+      - name: Force-rebuild TBDShared (workaround SPM #7715)
+        run: |
+          echo "=== Before wipe ==="
+          ls -la .build/*/debug/TBDShared.build 2>/dev/null || true
+          ls -la .build/*/debug/Modules/TBDShared.swiftmodule 2>/dev/null || true
+          ls -la .build/*/debug/libTBDShared*.a 2>/dev/null || true
+          rm -rf .build/*/debug/TBDShared.build 2>/dev/null || true
+          rm -rf .build/*/debug/Modules/TBDShared.swiftmodule 2>/dev/null || true
+          rm -rf .build/*/debug/libTBDShared*.a 2>/dev/null || true
+          echo "=== After wipe ==="
+          ls -la .build/*/debug/TBDShared.build 2>/dev/null || true
+          ls -la .build/*/debug/Modules/TBDShared.swiftmodule 2>/dev/null || true
+          ls -la .build/*/debug/libTBDShared*.a 2>/dev/null || true
+          exit 0
+
       - name: SwiftLint (strict)
         run: swift package plugin --allow-writing-to-package-directory swiftlint --strict
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A macOS native app for managing git worktrees and terminals, designed for multi-agent Claude Code workflows.
 
+<!-- ci-test: validating SPM #7715 workaround -->
+
+
 TBD gives you a unified interface to spin up isolated worktrees, run Claude Code sessions in embedded terminals, and orchestrate parallel development across branches — all from a single SwiftUI app.
 
 ## Architecture


### PR DESCRIPTION
## Summary

**Testing-only branch — please do not merge until reviewed.**

Validates a proposed CI workflow fix for an occasional link-time flake:

```
Undefined symbols ... TBDShared.<NewType>.init
```

The flake is caused by [swiftlang/swift-package-manager#7715](https://github.com/swiftlang/swift-package-manager/issues/7715): a cache-restored `.build/` can have a stale `TBDShared` object archive (`libTBDShared*.a` / `TBDShared.build/`) alongside a fresh `.swiftmodule`. Downstream files compile against the new module but the linker can't find the new symbols.

## Fix

New workflow step inserted between the `Cache SwiftPM build artifacts and dependencies` step and `SwiftLint (strict)`:

- Logs `ls -la` of the relevant TBDShared artifacts before wiping (for diagnostic visibility).
- `rm -rf` on `.build/*/debug/TBDShared.build`, `.build/*/debug/Modules/TBDShared.swiftmodule`, `.build/*/debug/libTBDShared*.a`.
- Logs `ls -la` again after.
- Always exits 0 — cold-cache first runs won't have these files and that's fine.

Cache key, restore-keys, and `git-restore-mtime` step are all untouched.

## What this PR is for

Pushing a trivial README comment to trigger CI on a feature branch so we can:

1. Confirm the new step runs cleanly (no syntax errors, sensible output).
2. Compare wall-clock against a recent `main` run to ensure the wipe doesn't blow up incremental rebuild times.

## Test plan

- [ ] CI run completes successfully
- [ ] "Force-rebuild TBDShared (workaround SPM #7715)" step shows expected before/after `ls` output
- [ ] Total runtime is comparable to recent `main` baseline