### PR TITLE
[testing-only] test(ci): exercise SPM #7715 trigger with wipe fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,30 @@ jobs:
           restore-keys: |
             spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-deps-${{ hashFiles('Package.resolved') }}-
 
+      # SwiftPM #7715 workaround: a cache-restored `.build/` can end up with a
+      # stale `TBDShared` object archive while accepting a fresh `.swiftmodule`,
+      # so downstream files compile but the linker can't find newly-added
+      # symbols (e.g. `Undefined symbols ... TBDShared.<NewType>.init`).
+      # Force a clean rebuild of TBDShared's compiled artifacts only; the rest
+      # of `.build/` (deps, other targets) stays cached.
+      - name: Force-rebuild TBDShared (workaround SPM #7715)
+        run: |
+          set +e
+          echo "::group::Before wipe"
+          ls -la .build/*/debug/TBDShared.build 2>&1 || true
+          ls -la .build/*/debug/Modules/TBDShared.swiftmodule 2>&1 || true
+          ls -la .build/*/debug/libTBDShared*.a 2>&1 || true
+          echo "::endgroup::"
+          rm -rf .build/*/debug/TBDShared.build
+          rm -rf .build/*/debug/Modules/TBDShared.swiftmodule
+          rm -rf .build/*/debug/libTBDShared*.a
+          echo "::group::After wipe"
+          ls -la .build/*/debug/TBDShared.build 2>&1 || true
+          ls -la .build/*/debug/Modules/TBDShared.swiftmodule 2>&1 || true
+          ls -la .build/*/debug/libTBDShared*.a 2>&1 || true
+          echo "::endgroup::"
+          exit 0
+
       - name: SwiftLint (strict)
         run: swift package plugin --allow-writing-to-package-directory swiftlint --strict
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1044,3 +1044,8 @@ extension RPCRouter {
         return try RPCResponse(result: TerminalTranscriptItemFullBodyResult(text: text))
     }
 }
+
+// swiftlint:disable:next identifier_name
+private func _ciFlakeTriggerProbeReference() -> TBDShared.CIFlakeTriggerProbe {
+    TBDShared.CIFlakeTriggerProbe(nonce: "ci-test", createdAt: Date())
+}

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -631,6 +631,7 @@ public struct TabState: Codable, Sendable, Equatable, Identifiable {
 }
 
 /// Test-only type added to exercise SPM #7715 trigger pattern.
+/// Second push: tweaked this doc comment so a primed cache must rebuild TBDShared.
 public struct CIFlakeTriggerProbe: Codable, Sendable, Equatable {
     public let nonce: String
     public let createdAt: Date

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -629,3 +629,14 @@ public struct TabState: Codable, Sendable, Equatable, Identifiable {
         self.createdAt = createdAt
     }
 }
+
+/// Test-only type added to exercise SPM #7715 trigger pattern.
+public struct CIFlakeTriggerProbe: Codable, Sendable, Equatable {
+    public let nonce: String
+    public let createdAt: Date
+
+    public init(nonce: String, createdAt: Date) {
+        self.nonce = nonce
+        self.createdAt = createdAt
+    }
+}


### PR DESCRIPTION
## Testing-only PR — DO NOT MERGE

This PR deliberately exercises the historical CI link-time flake trigger pattern (new public symbol in `TBDShared` + downstream consumer that references it) with the proposed `.build/` TBDShared wipe step applied. Goal: confirm CI stays green across two runs (cold cache + primed cache).

## Background

CI occasionally hit `Undefined symbols ... TBDShared.<NewType>.init` link-time failures caused by SwiftPM bug [swiftlang/swift-package-manager#7715](https://github.com/swiftlang/swift-package-manager/issues/7715): a cache-restored `.build/` can carry a stale `TBDShared` object archive while accepting a fresh `.swiftmodule`. Downstream files compile but the linker can't find the new symbol.

## What this PR contains

1. **New workflow step** in `.github/workflows/test.yml`: "Force-rebuild TBDShared (workaround SPM #7715)" — wipes `TBDShared.build`, `TBDShared.swiftmodule`, and `libTBDShared*.a` from the cache-restored `.build/` before SwiftLint/Test. Logs `ls -la` before and after.
2. **New public type** `CIFlakeTriggerProbe` added to `Sources/TBDShared/Models.swift` — the trigger surface.
3. **Downstream consumer** in `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift` — a private function that references `TBDShared.CIFlakeTriggerProbe`, forcing the linker to resolve the new symbol.

## Test plan

- [x] Local `swift build` passes (precondition: failure mode is CI-only)
- [ ] CI run #1 (cold cache scenario) passes
- [ ] CI run #2 (primed cache scenario, after a second push) passes

Please do not merge — this will be reverted/deleted after the test concludes.