### PR TITLE
CI: Force TBDShared rebuild to dodge intermittent link-time flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,26 @@ jobs:
           restore-keys: |
             spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-deps-${{ hashFiles('Package.resolved') }}-
 
+      # Workaround for swiftlang/swift-package-manager#7715: a cache-restored
+      # `.build/` can hold a stale `TBDShared` object archive next to a fresh
+      # `.swiftmodule`. Downstream files compile happily against the new module
+      # interface but the linker fails to resolve the new symbol, producing
+      # "Undefined symbols ... TBDShared.<NewType>" link-time flakes that
+      # disappear on retry. The bug fires specifically when a PR adds a new
+      # public symbol to TBDShared. Wiping just the TBDShared build artifacts
+      # forces SPM to re-emit them while keeping the rest of `.build/` warm.
+      # Costs ~1-2min per run (TBDShared rebuild + downstream cascade relink)
+      # in exchange for never seeing the link-time flake again.
+      - name: Force-rebuild TBDShared (workaround SPM #7715)
+        run: |
+          echo "=== TBDShared artifacts before wipe ==="
+          ls -la .build/*/debug/TBDShared.build 2>/dev/null || echo "(absent)"
+          ls -la .build/*/debug/Modules/TBDShared.swiftmodule 2>/dev/null || echo "(absent)"
+          rm -rf .build/*/debug/TBDShared.build .build/*/debug/Modules/TBDShared.swiftmodule 2>/dev/null || true
+          echo "=== TBDShared artifacts after wipe ==="
+          ls -la .build/*/debug/TBDShared.build 2>/dev/null || echo "(absent)"
+          ls -la .build/*/debug/Modules/TBDShared.swiftmodule 2>/dev/null || echo "(absent)"
+
       - name: SwiftLint (strict)
         run: swift package plugin --allow-writing-to-package-directory swiftlint --strict
 


### PR DESCRIPTION
## Summary

Wipes TBDShared build artifacts after the cache restore step so SPM always re-emits them. Works around [swiftlang/swift-package-manager#7715](https://github.com/swiftlang/swift-package-manager/issues/7715), which surfaces in our CI as `Undefined symbols ... TBDShared.<NewType>` link-time failures.

## The bug

When a PR adds a new public symbol to `TBDShared`, the cache restore can produce a `.build/` where:
- `TBDShared.swiftmodule` is fresh (consistent with current sources) → downstream `.o` files compile happily, referencing the new symbol via the module interface.
- `TBDShared.build/*.o` is stale (from a prior cache) → the linker can't actually find the symbol.

llbuild's incremental rebuild check is mtime-equality-only (SPM emits `file-system: device-agnostic` in the manifest), and `chetan/git-restore-mtime-action` sets source mtimes to git-commit times, so llbuild concludes "TBDShared doesn't need rebuilding" even though the cached object archive predates the new symbol.

## Observed instances

Three in the last week, each citing a different newly-added TBDShared symbol:

| Run | PR | Missing symbol |
|---|---|---|
| [25825542022](https://github.com/cheapsteak/tbd/actions/runs/25825542022) | Worktree nesting | `TBDShared.TerminalKind.init(rawValue:)` |
| [25994749414](https://github.com/cheapsteak/tbd/actions/runs/25994749414) | add-bedrock-profile | `TBDShared.WorktreeAdoptParams.init(...)` |
| [25998557053](https://github.com/cheapsteak/tbd/actions/runs/25998557053) | unread-jump-menu | `TBDShared.UnreadSummary.init(type:mostRecentAt:)` |

Each auto-retry passed against the same SHA — confirming flake, not a code bug.

## Approach trade-offs considered

- ❌ **Drop `.build/` from cache entirely** — fixes the bug, costs ~4-5min per PR run.
- ❌ **Tighten the cache key** — still saves a poisoned `.build/` from any run that fired the bug silently; next exact-match restore re-poisons.
- ❌ **`swift package clean`** — turns 2min runs into ~15min.
- ✅ **Targeted wipe of just TBDShared** — bug only manifests on TBDShared (only foundation module everyone imports). Costs ~1-2min for the TBDShared rebuild + downstream cascade.

## Validation

Tested on two throwaway PRs (#165, #166):

| Scenario | Run | Result |
|---|---|---|
| Wipe only, clean repo | [25999045753](https://github.com/cheapsteak/tbd/actions/runs/25999045753) | ✅ 3m27s |
| Wipe + trigger pattern, cold cache | [25999103959](https://github.com/cheapsteak/tbd/actions/runs/25999103959) | ✅ 5m6s |
| Wipe + trigger pattern, primed cache + TBDShared edit | [25999233260](https://github.com/cheapsteak/tbd/actions/runs/25999233260) | ✅ 4m22s |

The trigger-pattern PR deliberately added a new public TBDShared type + downstream consumer — historically the exact failure shape — and stayed green across both a cold cache and a cache primed by the prior run. Pre-wipe `ls` logs in every run showed full TBDShared.build/ (60 files including 1.4MB EmojiData.swift.o and 1.1MB Models.swift.o) plus a 900+KB swiftmodule; post-wipe logs showed both absent.

Follow-up: close #165 and #166 once this lands.

## Test plan

- [x] CI green on this PR
- [x] Wipe step logs show real artifacts removed (validated via #165/#166)
- [ ] Monitor for 4 weeks — three confirmed organic flakes in 4 days means absence over 4 weeks is statistically meaningful

[🔍 Investigate CI Link Flake](https://cheapsteak.github.io/tbd/open/?worktree=A393A6DA-5DFA-498B-AD62-9FF45D84E48E)