### PR TITLE
Refactor: Make tmux style detection testable, lock in regex regressions

### DIFF
--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -41,7 +41,7 @@ final class AppearanceSettings: ObservableObject {
 
     /// True if the user's tmux config sets a cell-painting style option that
     /// would override the chosen color scheme's foreground/background. Best-
-    /// effort detection at init — see `detectTmuxStyleOverrides()`.
+    /// effort detection at init — see `TmuxConfigStyleDetector`.
     @Published private(set) var hasTmuxStyleOverrides: Bool
 
     init(defaults: UserDefaults = .standard) {
@@ -79,50 +79,10 @@ final class AppearanceSettings: ObservableObject {
         self.hasTmuxStyleOverrides = false
         Task { @MainActor [weak self] in
             let detected = await Task.detached {
-                AppearanceSettings.detectTmuxStyleOverrides()
+                TmuxConfigStyleDetector.detectFromUserConfig()
             }.value
             self?.hasTmuxStyleOverrides = detected
         }
-    }
-
-    /// Greps the user's tmux config files for any of the cell-painting style
-    /// options that would override TBD's color scheme. Best-effort: misses
-    /// configs loaded via `source-file` or `if-shell`, but catches the common
-    /// case of a directly-set `window-style` etc.
-    ///
-    /// `nonisolated` because it reads files and has no actor-isolated state —
-    /// safe to call from a detached task.
-    nonisolated private static func detectTmuxStyleOverrides() -> Bool {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let candidatePaths = ["\(home)/.tmux.conf", "\(home)/.config/tmux/tmux.conf"]
-        // Match lines that set one of the cell-painting options. Skip the
-        // `-u` (unset) form — `set -gu window-style` is exactly the fix our
-        // own tooltip recommends, so it would be wrong to flag it.
-        let pattern = #"^\s*(set|setw)\b(\s+-[a-zA-Z]+)*\s+(window-style|window-active-style|pane-style|default-style)\b"#
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines]) else {
-            return false
-        }
-        for path in candidatePaths {
-            guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { continue }
-            let nsContents = contents as NSString
-            let range = NSRange(location: 0, length: nsContents.length)
-            var detected = false
-            regex.enumerateMatches(in: contents, options: [], range: range) { result, _, stop in
-                guard let result else { return }
-                // `result.range(at: 2)` is the captured flag group, e.g. " -g" or " -gu".
-                // It may be absent (NSRange(NSNotFound)) when the line has no flags
-                // at all (e.g. bare `set window-style ...`) — that's still an
-                // override; only the `-u` unset directive should be skipped.
-                if let flagsRange = Range(result.range(at: 2), in: contents),
-                   contents[flagsRange].contains("u") {
-                    return
-                }
-                detected = true
-                stop.pointee = true
-            }
-            if detected { return true }
-        }
-        return false
     }
 
     /// Resolves `fontName` + `fontSize` to an `NSFont`. Falls back to system

--- a/Sources/TBDApp/Terminal/TmuxConfigStyleDetector.swift
+++ b/Sources/TBDApp/Terminal/TmuxConfigStyleDetector.swift
@@ -10,6 +10,26 @@ import Foundation
 /// form, unusual flag ordering); centralizing the pattern here lets us cover
 /// each with a string-literal test in `TmuxConfigStyleDetectorTests`.
 enum TmuxConfigStyleDetector {
+    /// Anchored to line start. Between the command and the option name we
+    /// allow ONLY whitespace and flag tokens (`-xyz`) — not arbitrary
+    /// content. Otherwise an option name appearing inside a quoted value
+    /// (e.g. `set -g status-left 'window-style is great'`) would match.
+    ///
+    /// We scan the matched substring for any `-…u…` flag rather than trying
+    /// to capture the flag group with `*`, which only retains the last
+    /// iteration and silently misses unset markers in unusual orderings like
+    /// `set -u -g window-style`.
+    private static let stylePattern = try? NSRegularExpression(
+        pattern: #"(?m)^\s*(set|setw|set-option|set-window-option)(\s+-[a-zA-Z]+)*\s+(window-style|window-active-style|pane-style|default-style)\b"#
+    )
+
+    /// Matches an unset flag token (`-u`, `-gu`, `-ug`, etc) anywhere inside
+    /// the line. Compiled once at file-scope to avoid recompiling per outer
+    /// match in `declaresStyleOverride(in:)`.
+    private static let unsetFlagPattern = try? NSRegularExpression(
+        pattern: #"\s-[a-zA-Z]*u[a-zA-Z]*\b"#
+    )
+
     /// Pure function: returns true if the given tmux config text appears to set
     /// any of the cell-painting style options (window-style, window-active-style,
     /// pane-style, default-style). Best-effort regex — does not resolve
@@ -19,26 +39,16 @@ enum TmuxConfigStyleDetector {
     /// later in the file will still report true (acceptable false positive for
     /// an unusual case).
     static func declaresStyleOverride(in content: String) -> Bool {
-        // Anchored to line start. Between the command and the option name we
-        // allow ONLY whitespace and flag tokens (`-xyz`) — not arbitrary
-        // content. Otherwise an option name appearing inside a quoted value
-        // (e.g. `set -g status-left 'window-style is great'`) would match.
-        //
-        // We scan the matched substring for any `-…u…` flag below rather
-        // than trying to capture the flag group with `*`, which only retains
-        // the last iteration and silently misses unset markers in unusual
-        // orderings like `set -u -g window-style`.
-        let pattern = #"(?m)^\s*(set|setw|set-option|set-window-option)(\s+-[a-zA-Z]+)*\s+(window-style|window-active-style|pane-style|default-style)\b"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+        guard let stylePattern, let unsetFlagPattern else { return false }
         let nsContent = content as NSString
         var found = false
-        regex.enumerateMatches(in: content, range: NSRange(location: 0, length: nsContent.length)) { result, _, stop in
+        stylePattern.enumerateMatches(in: content, range: NSRange(location: 0, length: nsContent.length)) { result, _, stop in
             guard let result else { return }
-            let matchedLine = nsContent.substring(with: result.range)
+            let matchedRange = result.range
             // Skip unset directives. A flag token containing `u` (alone, like
             // `-u`, or grouped with other letters like `-gu` / `-ug`) means
             // unset — exactly what our own tooltip recommends as a fix.
-            if matchedLine.range(of: #"\s-[a-zA-Z]*u[a-zA-Z]*\b"#, options: .regularExpression) != nil {
+            if unsetFlagPattern.firstMatch(in: content, range: matchedRange) != nil {
                 return
             }
             found = true
@@ -52,7 +62,11 @@ enum TmuxConfigStyleDetector {
     /// falling back to `~/.config` per the XDG Base Directory spec.
     static func detectFromUserConfig() -> Bool {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
+        // The XDG Base Directory spec says an empty `$XDG_CONFIG_HOME` should
+        // be treated as unset, falling back to `~/.config`. `??` alone only
+        // handles the absent-key case.
         let xdg = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+            .flatMap { $0.isEmpty ? nil : $0 }
             ?? "\(home)/.config"
         let candidatePaths = [
             "\(home)/.tmux.conf",

--- a/Sources/TBDApp/Terminal/TmuxConfigStyleDetector.swift
+++ b/Sources/TBDApp/Terminal/TmuxConfigStyleDetector.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Detects whether the user's tmux configuration sets one of the cell-painting
+/// style options (`window-style`, `window-active-style`, `pane-style`,
+/// `default-style`) that would override TBD's chosen color scheme.
+///
+/// Split out from `AppearanceSettings` so the pure regex logic is unit-testable
+/// without touching the file system. The previous in-place implementation had
+/// three regression-prone bugs across review rounds (bare `set`, `-gu` unset
+/// form, unusual flag ordering); centralizing the pattern here lets us cover
+/// each with a string-literal test in `TmuxConfigStyleDetectorTests`.
+enum TmuxConfigStyleDetector {
+    /// Pure function: returns true if the given tmux config text appears to set
+    /// any of the cell-painting style options (window-style, window-active-style,
+    /// pane-style, default-style). Best-effort regex — does not resolve
+    /// `source-file`, `if-shell`, or `%if`/`%endif` conditionals, and does not
+    /// track last-write-wins across the file. We detect *presence* of override
+    /// directives, not *effective* state. An override followed by an unset
+    /// later in the file will still report true (acceptable false positive for
+    /// an unusual case).
+    static func declaresStyleOverride(in content: String) -> Bool {
+        // Anchored to line start. Between the command and the option name we
+        // allow ONLY whitespace and flag tokens (`-xyz`) — not arbitrary
+        // content. Otherwise an option name appearing inside a quoted value
+        // (e.g. `set -g status-left 'window-style is great'`) would match.
+        //
+        // We scan the matched substring for any `-…u…` flag below rather
+        // than trying to capture the flag group with `*`, which only retains
+        // the last iteration and silently misses unset markers in unusual
+        // orderings like `set -u -g window-style`.
+        let pattern = #"(?m)^\s*(set|setw|set-option|set-window-option)(\s+-[a-zA-Z]+)*\s+(window-style|window-active-style|pane-style|default-style)\b"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+        let nsContent = content as NSString
+        var found = false
+        regex.enumerateMatches(in: content, range: NSRange(location: 0, length: nsContent.length)) { result, _, stop in
+            guard let result else { return }
+            let matchedLine = nsContent.substring(with: result.range)
+            // Skip unset directives. A flag token containing `u` (alone, like
+            // `-u`, or grouped with other letters like `-gu` / `-ug`) means
+            // unset — exactly what our own tooltip recommends as a fix.
+            if matchedLine.range(of: #"\s-[a-zA-Z]*u[a-zA-Z]*\b"#, options: .regularExpression) != nil {
+                return
+            }
+            found = true
+            stop.pointee = true
+        }
+        return found
+    }
+
+    /// I/O wrapper: reads candidate tmux.conf paths and calls
+    /// `declaresStyleOverride(in:)` on each. Honors `$XDG_CONFIG_HOME` if set,
+    /// falling back to `~/.config` per the XDG Base Directory spec.
+    static func detectFromUserConfig() -> Bool {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let xdg = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+            ?? "\(home)/.config"
+        let candidatePaths = [
+            "\(home)/.tmux.conf",
+            "\(xdg)/tmux/tmux.conf",
+        ]
+        for path in candidatePaths {
+            guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { continue }
+            if declaresStyleOverride(in: contents) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Tests/TBDAppTests/TmuxConfigStyleDetectorTests.swift
+++ b/Tests/TBDAppTests/TmuxConfigStyleDetectorTests.swift
@@ -1,0 +1,98 @@
+import Testing
+@testable import TBDApp
+
+@Suite("TmuxConfigStyleDetector")
+struct TmuxConfigStyleDetectorTests {
+    @Test("empty input is not an override")
+    func empty() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "") == false)
+    }
+
+    @Test("baseline: set -g window-style is an override")
+    func setG() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set -g window-style 'fg=red'") == true)
+    }
+
+    @Test("regression: bare `set` with no flags is still an override")
+    func setBare() {
+        // The previous capture-based implementation treated `NSRange(NSNotFound)`
+        // (missing flag group) as "skip", silently missing this case.
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set window-style 'fg=red'") == true)
+    }
+
+    @Test("regression: -gu unset is the recommended fix, not an override")
+    func setGUUnset() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set -gu window-style") == false)
+    }
+
+    @Test("regression: -u not last in flag list is still an unset")
+    func setUnusualOrder() {
+        // `*` quantifier on a capture group only retains the LAST iteration,
+        // so naïvely capturing flag tokens makes `-u` invisible when `-g`
+        // follows. Scanning the whole matched range catches it.
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set -u -g window-style") == false)
+    }
+
+    @Test("setw -g window-active-style is an override")
+    func setwG() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "setw -g window-active-style 'fg=red'") == true)
+    }
+
+    @Test("pane-style is an override")
+    func paneStyle() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set -g pane-style 'bg=blue'") == true)
+    }
+
+    @Test("default-style is an override")
+    func defaultStyle() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set -g default-style 'fg=white'") == true)
+    }
+
+    @Test("set-option long form is an override")
+    func setOptionLong() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set-option -g window-style 'fg=red'") == true)
+    }
+
+    @Test("set-window-option long form is an override")
+    func setWindowOptionLong() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set-window-option -g window-active-style 'fg=red'") == true)
+    }
+
+    @Test("commented-out lines are not overrides")
+    func commented() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "# set -g window-style 'fg=red'") == false)
+    }
+
+    @Test("look-alike option name `status-style` is not an override")
+    func lookAlikeStatusStyle() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set -g status-style 'fg=red'") == false)
+    }
+
+    @Test("option name appearing as substring inside a quoted value is not an override")
+    func quotedSubstring() {
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: "set -g status-left 'window-style is great'") == false)
+    }
+
+    @Test("multi-line: first line negative, second line positive")
+    func multilineFirstNegativeSecondPositive() {
+        let config = """
+        set -g status-style 'fg=red'
+        set -g window-style 'fg=red'
+        """
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: config) == true)
+    }
+
+    @Test("multi-line: override followed by unset still reports presence")
+    func multilineOverrideThenUnset() {
+        // NOTE: This is a documented limitation. We detect *presence* of
+        // override directives, not *effective* state. A later `-gu` unset
+        // would in fact neutralize the earlier override at runtime, but
+        // tracking last-write-wins (and `source-file`/`if-shell`/`%if`
+        // conditionals) is out of scope for this best-effort regex.
+        let config = """
+        set -g window-style 'fg=red'
+        set -gu window-style
+        """
+        #expect(TmuxConfigStyleDetector.declaresStyleOverride(in: config) == true)
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts the tmux config-style detection from `AppearanceSettings` (private static method, hardcoded `\$HOME` paths, untestable) into a new `TmuxConfigStyleDetector` namespace at `Sources/TBDApp/Terminal/TmuxConfigStyleDetector.swift`.
- Splits the logic into a pure `declaresStyleOverride(in: String) -> Bool` (now unit-testable) plus a thin `detectFromUserConfig()` I/O wrapper that walks candidate paths.
- Adds a 15-case test corpus that locks in **all three regex regressions** caught during #163 review:
  - `set -gu window-style` → false (the unset form, which is exactly what our own tooltip tells users to run)
  - bare `set window-style ...` (no flags at all) → true
  - `set -u -g window-style` (unusual flag ordering, `-u` not last) → false (still an unset directive)
- Folds in `\$XDG_CONFIG_HOME/tmux/tmux.conf` lookup that was flagged but deferred during #163.

## Background

During #163 review, the original `detectTmuxStyleOverrides` had three subtle regex bugs across four review rounds. Each was a one-line patch on the same function. The pattern was clear: this function wanted real test coverage, not another one-line patch. The design was scoped during #163 (deferred to this PR) — see the design notes in that thread for the trade-offs considered (content vs path injection, file placement, scope creep guards).

## Non-goals

- **Not** parsing `source-file`, `if-shell`, `%if`/`%endif` directives. Best-effort regex only.
- **Not** tracking last-write-wins semantics. We detect *presence* of override directives, not effective state. An override followed by an unset later in the file still reports \`true\` — documented in the multi-line test case as an accepted false positive for an unusual case.
- **Not** handling line continuations.
- **Not** introducing a \`FileReader\` protocol or other DI scaffolding beyond the content/path split.

## Test plan
- [ ] \`swift test --filter TmuxConfigStyleDetectorTests\` — 15/15 pass
- [ ] \`swift test --filter AppearanceSettingsTests\` — 8/8 still pass (caller updated, behavior unchanged)
- [ ] \`swift test --filter ColorSchemesTests\` — 7/7 still pass (untouched)
- [ ] \`scripts/restart.sh\`, open Settings → Terminal: info ⓘ icon still appears on the Scheme picker (your \`~/.tmux.conf\` has \`window-style\` set, so detection should fire)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=4E8CF284-2A26-4BC6-852D-DAAF7E71D107)