### PR TITLE
feat: add Codex hook notifications

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "codex-hooks")
 
 /// Manages per-repo isolated `CODEX_HOME` directories under
 /// `~/.tbd/agents/codex/<repoID>/`. This keeps TBD-launched codex sessions
@@ -25,6 +28,78 @@ struct CodexHomeManager: Sendable {
         let home = homeDirectory(forRepoID: repoID)
         try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
         return home
+    }
+
+    @discardableResult
+    func ensureHomeWithHooks(forRepoID repoID: UUID) throws -> URL {
+        let home = try ensureHome(forRepoID: repoID)
+        // Hook setup is best-effort: log failures, but do not block Codex launch.
+        CodexHookOverlay.writeOverlay(in: home)
+        return home
+    }
+}
+
+/// Generates TBD-owned Codex hook configuration inside the isolated CODEX_HOME.
+///
+/// Codex reads hooks from `$CODEX_HOME/hooks.json`; unlike Claude's
+/// `--settings` overlay, the CODEX_HOME itself is already TBD-owned per repo,
+/// so writing the file there avoids touching the user's global `~/.codex`.
+enum CodexHookOverlay {
+    static let fileName = "hooks.json"
+
+    static let sessionStartCommand =
+        #"tbd session-event 2>/dev/null || true"#
+
+    static let stopCommand =
+        #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
+
+    static func overlayPath(in codexHome: URL) -> URL {
+        codexHome.appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    static func generateBody() throws -> Data {
+        let body: [String: Any] = [
+            "hooks": [
+                "SessionStart": [
+                    [
+                        "matcher": "startup|resume|clear",
+                        "hooks": [
+                            ["type": "command", "command": sessionStartCommand]
+                        ]
+                    ]
+                ],
+                "Stop": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": stopCommand]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+
+        return try JSONSerialization.data(
+            withJSONObject: body,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+    }
+
+    @discardableResult
+    static func writeOverlay(in codexHome: URL) -> Bool {
+        do {
+            try FileManager.default.createDirectory(
+                at: codexHome,
+                withIntermediateDirectories: true
+            )
+            let data = try generateBody()
+            let path = overlayPath(in: codexHome)
+            try data.write(to: path, options: .atomic)
+            logger.info("Wrote Codex hooks at \(path.path, privacy: .public)")
+            return true
+        } catch {
+            logger.error("Failed to write Codex hooks: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
     }
 }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -290,7 +290,7 @@ extension WorktreeLifecycle {
         } else if terminal.kind == .codex || terminal.label == "Codex" {
             // Codex terminal — detected by kind (primary signal) or legacy label fallback.
             // kind is the primary discriminator; label is checked for backward compatibility.
-            let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
+            let codexHome = try CodexHomeManager().ensureHomeWithHooks(forRepoID: worktree.repoID)
             env["CODEX_HOME"] = codexHome.path
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -102,7 +102,7 @@ extension RPCRouter {
 
         // Codex branch: minimal launch with isolated CODEX_HOME. No session
         // tracking, no system prompt injection, no token resolution. Session
-        // resume / state detection / hooks are tracked as follow-up issues.
+        // resume / state detection are tracked as follow-up issues.
         //
         // Build env independently — do NOT inherit the Claude-shaped
         // TBD_PROMPT_CONTEXT / TBD_PROMPT_RENAME / TBD_PROMPT_INSTRUCTIONS
@@ -110,7 +110,7 @@ extension RPCRouter {
         // a Claude-centric host and would be misleading noise inside a
         // Codex pane.
         if params.type == .codex {
-            let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
+            let codexHome = try CodexHomeManager().ensureHomeWithHooks(forRepoID: worktree.repoID)
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
             codexEnv["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
@@ -313,7 +313,7 @@ extension RPCRouter {
         // Branch on terminal kind: codex stays codex; shell/claude become shell
         if terminal.kind == .codex || terminal.label == "Codex" {
             // Recreate as codex — preserve identity
-            let codexHome = try CodexHomeManager().ensureHome(forRepoID: worktree.repoID)
+            let codexHome = try CodexHomeManager().ensureHomeWithHooks(forRepoID: worktree.repoID)
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = worktree.id.uuidString
             codexEnv["TBD_TERMINAL_ID"] = terminal.id.uuidString

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct CodexHookOverlayTests {
+
+    @Test func generateBodyHasExpectedShape() throws {
+        let data = try CodexHookOverlay.generateBody()
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let hooks = parsed?["hooks"] as? [String: Any]
+        #expect(hooks != nil)
+
+        let sessionStart = hooks?["SessionStart"] as? [[String: Any]]
+        #expect(sessionStart?.first?["matcher"] as? String == "startup|resume|clear")
+        let sessionHooks = sessionStart?.first?["hooks"] as? [[String: Any]]
+        let sessionCommand = sessionHooks?.first?["command"] as? String
+        #expect(sessionCommand?.contains("tbd session-event") == true)
+
+        let stop = hooks?["Stop"] as? [[String: Any]]
+        #expect(stop?.count == 1)
+        let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
+        let stopCommand = stopHooks?.first?["command"] as? String
+        #expect(stopCommand?.contains("tbd notify --type response_complete") == true)
+        #expect(stopCommand?.contains("last_assistant_message") == true)
+    }
+
+    @Test func roundtripsAsValidJSON() throws {
+        let data = try CodexHookOverlay.generateBody()
+        _ = try JSONSerialization.jsonObject(with: data, options: [])
+    }
+
+    @Test func writeOverlayCreatesHooksJSONInCodexHome() throws {
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-hooks-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        #expect(CodexHookOverlay.writeOverlay(in: codexHome))
+
+        let path = codexHome.appendingPathComponent("hooks.json")
+        let data = try Data(contentsOf: path)
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let hooks = parsed?["hooks"] as? [String: Any]
+        #expect(hooks?["SessionStart"] != nil)
+        #expect(hooks?["Stop"] != nil)
+    }
+}


### PR DESCRIPTION
## Summary
- write TBD-owned Codex `hooks.json` inside the isolated per-repo `CODEX_HOME`
- hook Codex `SessionStart` into `tbd session-event` and `Stop` into `tbd notify --type response_complete`
- ensure new, recreated, and reconciled Codex panes get the hook overlay
- add Codex hook overlay tests

## Testing
- `swift test --filter CodexHookOverlayTests`
- `swift test --filter TBDWorktreeIDLeakTests`
- local smoke: created a Codex pane in this worktree, trusted the generated hooks in `/hooks`, sent `Reply with exactly: TBD_CODEX_HOOK_SMOKE_OK`, and verified TBD recorded an unread `response_complete` notification with that message

## Notes
- Codex requires first-run hook review in `/hooks`; generated hooks are detected immediately but do not run until trusted.