### PR TITLE
feat: prompt Codex to rename worktrees

### DIFF
--- a/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
+++ b/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
@@ -2,9 +2,9 @@ import ArgumentParser
 import Foundation
 import TBDShared
 
-/// `tbd hooks stop-rename-check` — a Claude Code `Stop` hook that prompts
-/// the agent to rename its worktree/branch at end-of-turn, when context is
-/// highest and the work is freshly visible.
+/// `tbd hooks stop-rename-check` — a `Stop` hook that prompts the agent to
+/// rename its worktree/branch at end-of-turn, when context is highest and the
+/// work is freshly visible.
 ///
 /// Behavior (any error path = exit 0 silent so the agent is never wedged):
 /// 1. Read the Stop hook JSON payload from stdin.
@@ -13,8 +13,7 @@ import TBDShared
 ///    branch doesn't start with `tbd/`, or we've already fired > 2 times
 ///    this session.
 /// 4. Otherwise emit `{"decision":"block","reason":"<directive>"}` so
-///    Claude Code keeps the session alive and surfaces the directive
-///    to the agent.
+///    the agent stays in-turn and sees the directive.
 struct StopRenameCheckCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "stop-rename-check",
@@ -97,7 +96,7 @@ enum StopRenameCheckCore {
                 },
                 counterPath: { sessionID in
                     // Sanitize against forward slashes so the cap guarantee doesn't rely on
-                    // Claude Code's session-id format (UUIDs today, but an external contract).
+                    // the agent's session-id format (UUIDs today, but an external contract).
                     let safe = sessionID.replacingOccurrences(of: "/", with: "-")
                     return "/tmp/tbd-stop-rename-\(safe)"
                 }

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -53,6 +53,9 @@ enum CodexHookOverlay {
     static let stopCommand =
         #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
 
+    static let stopRenameCheckCommand =
+        #"tbd hooks stop-rename-check 2>/dev/null || true"#
+
     static func overlayPath(in codexHome: URL) -> URL {
         codexHome.appendingPathComponent(fileName, isDirectory: false)
     }
@@ -72,6 +75,11 @@ enum CodexHookOverlay {
                     [
                         "hooks": [
                             ["type": "command", "command": stopCommand]
+                        ]
+                    ],
+                    [
+                        "hooks": [
+                            ["type": "command", "command": stopRenameCheckCommand]
                         ]
                     ]
                 ]

--- a/Tests/TBDCLITests/StopRenameCheckCommandTests.swift
+++ b/Tests/TBDCLITests/StopRenameCheckCommandTests.swift
@@ -7,7 +7,7 @@ import TBDShared
 @Suite("StopRenameCheckCore")
 struct StopRenameCheckCommandTests {
 
-    /// Build a stdin JSON payload matching Claude Code's Stop hook shape.
+    /// Build a stdin JSON payload matching the common Stop hook shape.
     private static func payload(
         sessionID: String = "test-session",
         cwd: String = "/tmp/worktree",
@@ -19,6 +19,20 @@ struct StopRenameCheckCommandTests {
             "hook_event_name": "Stop",
             "stop_hook_active": stopHookActive,
             "last_assistant_message": "ok"
+        ]
+        return try! JSONSerialization.data(withJSONObject: dict)
+    }
+
+    /// Build a stdin JSON payload matching Codex's documented Stop hook fields.
+    private static func codexPayload(
+        sessionID: String = "codex-session",
+        cwd: String = "/tmp/worktree"
+    ) -> Data {
+        let dict: [String: Any] = [
+            "session_id": sessionID,
+            "cwd": cwd,
+            "hook_event_name": "Stop",
+            "last_assistant_message": "done"
         ]
         return try! JSONSerialization.data(withJSONObject: dict)
     }
@@ -139,6 +153,27 @@ struct StopRenameCheckCommandTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let out = StopRenameCheckCore.decide(
             stdinData: Self.payload(),
+            dependencies: Self.deps(
+                branch: "tbd/20260515-surprised-giraffe",
+                folder: "20260515-surprised-giraffe",
+                counterDirectory: dir
+            )
+        )
+        let raw = try #require(out)
+        let parsed = try JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any]
+        #expect(parsed?["decision"] as? String == "block")
+        let reason = try #require(parsed?["reason"] as? String)
+        #expect(reason.contains("tbd/20260515-surprised-giraffe"))
+        #expect(reason.contains("20260515-surprised-giraffe"))
+        #expect(reason.contains("git branch -m"))
+        #expect(reason.contains("tbd worktree rename"))
+    }
+
+    @Test func codexStopPayload_happyPath_emitsBlockWithBranchAndFolder() throws {
+        let dir = Self.tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let out = StopRenameCheckCore.decide(
+            stdinData: Self.codexPayload(),
             dependencies: Self.deps(
                 branch: "tbd/20260515-surprised-giraffe",
                 folder: "20260515-surprised-giraffe",

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -17,11 +17,16 @@ import Testing
         #expect(sessionCommand?.contains("tbd session-event") == true)
 
         let stop = hooks?["Stop"] as? [[String: Any]]
-        #expect(stop?.count == 1)
-        let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
-        let stopCommand = stopHooks?.first?["command"] as? String
-        #expect(stopCommand?.contains("tbd notify --type response_complete") == true)
-        #expect(stopCommand?.contains("last_assistant_message") == true)
+        #expect(stop?.count == 2)
+        let stopCommands: [String] = (stop ?? []).flatMap { entry -> [String] in
+            let inner = entry["hooks"] as? [[String: Any]] ?? []
+            return inner.compactMap { $0["command"] as? String }
+        }
+        #expect(stopCommands.contains {
+            $0.contains("tbd notify --type response_complete")
+                && $0.contains("last_assistant_message")
+        })
+        #expect(stopCommands.contains { $0.contains("stop-rename-check") })
     }
 
     @Test func roundtripsAsValidJSON() throws {


### PR DESCRIPTION
## Summary
- add `tbd hooks stop-rename-check` as a second Codex `Stop` hook
- make the rename-check hook documentation agent-agnostic instead of Claude-specific
- add coverage for a Codex-shaped Stop hook payload
- update Codex hook overlay tests to expect both Stop hooks

## Testing
- `swift test --filter CodexHookOverlayTests`
- `swift test --filter StopRenameCheckCommandTests`

## Notes
- Like the existing Codex notification hooks, the new Stop hook must be trusted in Codex `/hooks` before it runs.
- This branch is based on `origin/main` after #170 merged.