### PR TITLE
Add TBD skill support for Codex sessions

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -2,7 +2,8 @@ import Foundation
 import os
 import TBDShared
 
-private let logger = Logger(subsystem: "com.tbd.daemon", category: "codex-hooks")
+private let hooksLogger = Logger(subsystem: "com.tbd.daemon", category: "codex-hooks")
+private let skillLogger = Logger(subsystem: "com.tbd.daemon", category: "codex-skill")
 
 /// Manages per-repo isolated `CODEX_HOME` directories under
 /// `~/.tbd/agents/codex/<repoID>/`. This keeps TBD-launched codex sessions
@@ -30,11 +31,16 @@ struct CodexHomeManager: Sendable {
         return home
     }
 
+    /// Ensure TBD's Codex integration files exist in the isolated CODEX_HOME.
+    ///
+    /// The method name is retained because existing call sites use it as the
+    /// launch-time setup point, but it now writes both hooks and the TBD skill.
     @discardableResult
     func ensureHomeWithHooks(forRepoID repoID: UUID) throws -> URL {
         let home = try ensureHome(forRepoID: repoID)
-        // Hook setup is best-effort: log failures, but do not block Codex launch.
+        // Integration setup is best-effort: log failures, but do not block Codex launch.
         CodexHookOverlay.writeOverlay(in: home)
+        CodexSkillWriter.writeSkill(in: home)
         return home
     }
 }
@@ -94,10 +100,43 @@ enum CodexHookOverlay {
             let data = try generateBody()
             let path = overlayPath(in: codexHome)
             try data.write(to: path, options: .atomic)
-            logger.info("Wrote Codex hooks at \(path.path, privacy: .public)")
+            hooksLogger.info("Wrote Codex hooks at \(path.path, privacy: .public)")
             return true
         } catch {
-            logger.error("Failed to write Codex hooks: \(error.localizedDescription, privacy: .public)")
+            hooksLogger.error("Failed to write Codex hooks: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+}
+
+/// Writes the TBD skill into the isolated CODEX_HOME for TBD-spawned Codex
+/// sessions. Codex loads local skills from `$CODEX_HOME/skills/<name>/SKILL.md`,
+/// so this mirrors the Claude plugin skill without relying on Codex plugin
+/// hook support.
+enum CodexSkillWriter {
+    static let relativePath = "skills/tbd/SKILL.md"
+
+    static func skillPath(in codexHome: URL) -> URL {
+        codexHome.appendingPathComponent(relativePath, isDirectory: false)
+    }
+
+    @discardableResult
+    static func writeSkill(in codexHome: URL) -> Bool {
+        do {
+            let path = skillPath(in: codexHome)
+            try FileManager.default.createDirectory(
+                at: path.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try TBDSkillContent.body.write(
+                to: path,
+                atomically: true,
+                encoding: .utf8
+            )
+            skillLogger.info("Wrote Codex skill at \(path.path, privacy: .public)")
+            return true
+        } catch {
+            skillLogger.error("Failed to write Codex skill: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -8,17 +8,19 @@ import Foundation
 /// - `PluginDirWriter` → `~/Library/Application Support/TBD/plugin/skills/tbd/SKILL.md`
 ///   (loaded into TBD-spawned Claude sessions via `--plugin-dir`, where the
 ///   skill registers as `tbd:tbd`)
+/// - `CodexSkillWriter` → `$CODEX_HOME/skills/tbd/SKILL.md`
+///   (loaded into TBD-spawned Codex sessions through the isolated CODEX_HOME)
 public enum TBDSkillContent {
 
     public static let body: String = """
 ---
 name: tbd
-description: Drive TBD (a macOS worktree + terminal manager). Use when the user asks to create a worktree, spawn a Claude or shell session in another tab, send input to a terminal, read terminal output, link to a worktree, or send a UI notification — or whenever running inside a TBD-managed terminal (TBD_WORKTREE_ID env var is set).
+description: Drive TBD (a macOS worktree + terminal manager). Use when the user asks to create a worktree, spawn a Claude, Codex, or shell session in another tab, send input to a terminal, read terminal output, link to a worktree, or send a UI notification — or whenever running inside a TBD-managed terminal (TBD_WORKTREE_ID env var is set).
 ---
 
 # TBD
 
-TBD is a macOS app that manages git worktrees and terminal tabs (Claude Code or shell). Sessions running inside a TBD-managed terminal have `TBD_WORKTREE_ID` set in env.
+TBD is a macOS app that manages git worktrees and terminal tabs (Claude Code, Codex, or shell). Sessions running inside a TBD-managed terminal have `TBD_WORKTREE_ID` set in env.
 
 ## When to use this skill
 
@@ -31,12 +33,21 @@ Always run `tbd <subcommand> --help` for current flags — flag detail is not du
 
 ## Common workflows
 
-### Spawn a new Claude tab in the current worktree
+### Spawn a new agent tab in the current worktree
 
 New sessions you spawn start with NO conversation history. Brief them like a colleague who just walked into the room.
 
 ```bash
 tbd terminal create "$TBD_WORKTREE_ID" --type claude --prompt-file - <<'EOF'
+Goal, what you've ruled out, file paths/lines, enough surrounding context
+that the new session can make judgment calls rather than follow narrow steps.
+EOF
+```
+
+Use `--type codex` to spawn Codex instead of Claude:
+
+```bash
+tbd terminal create "$TBD_WORKTREE_ID" --type codex --prompt-file - <<'EOF'
 Goal, what you've ruled out, file paths/lines, enough surrounding context
 that the new session can make judgment calls rather than follow narrow steps.
 EOF
@@ -111,7 +122,7 @@ Use `--prompt-file -` with a heredoc to avoid shell escaping issues.
 ## Env vars set in TBD-managed terminals
 
 - `TBD_WORKTREE_ID` — current worktree UUID.
-- `TBD_PROMPT_CONTEXT` — short context hint confirming you're inside a TBD-managed session. The full `tbd` skill is loaded by your harness (Claude Code spawns it via `--plugin-dir`); other harnesses may fall back to reading `~/Library/Application Support/TBD/skill/SKILL.md`.
+- `TBD_PROMPT_CONTEXT` — short context hint confirming you're inside a TBD-managed session. The full `tbd` skill is loaded by your harness when supported; other harnesses may fall back to reading `~/Library/Application Support/TBD/skill/SKILL.md`.
 - `TBD_PROMPT_INSTRUCTIONS` — per-repo custom instructions (if configured).
 
 ## Outside a TBD terminal

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import TBDShared
 @testable import TBDDaemonLib
 
 @Suite struct CodexHookOverlayTests {
@@ -42,5 +43,31 @@ import Testing
         let hooks = parsed?["hooks"] as? [String: Any]
         #expect(hooks?["SessionStart"] != nil)
         #expect(hooks?["Stop"] != nil)
+    }
+
+    @Test func writeSkillCreatesTBDSkillInCodexHome() throws {
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-skill-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        #expect(CodexSkillWriter.writeSkill(in: codexHome))
+
+        let path = codexHome.appendingPathComponent("skills/tbd/SKILL.md")
+        let written = try String(contentsOf: path, encoding: .utf8)
+        #expect(written == TBDSkillContent.body)
+    }
+
+    @Test func ensureHomeWithHooksCreatesHooksAndSkill() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-home-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        let repoID = UUID()
+        let home = try CodexHomeManager(baseDirectory: base)
+            .ensureHomeWithHooks(forRepoID: repoID)
+
+        #expect(home == base.appendingPathComponent(repoID.uuidString.lowercased(), isDirectory: true))
+        #expect(FileManager.default.fileExists(atPath: home.appendingPathComponent("hooks.json").path))
+        #expect(FileManager.default.fileExists(atPath: home.appendingPathComponent("skills/tbd/SKILL.md").path))
     }
 }

--- a/Tests/TBDSharedTests/TBDSkillContentTests.swift
+++ b/Tests/TBDSharedTests/TBDSkillContentTests.swift
@@ -20,6 +20,7 @@ import Foundation
     let body = TBDSkillContent.body
     #expect(body.contains("## Common workflows"))
     #expect(body.contains("tbd terminal create"))
+    #expect(body.contains("--type codex"))
     #expect(body.contains("tbd worktree create"))
     #expect(body.contains("tbd notify"))
     #expect(body.contains("tbd link"))
@@ -32,4 +33,3 @@ import Foundation
     // Versioning-drift mitigation: instruct the model to use --help for current flags.
     #expect(body.contains("--help"))
 }
-


### PR DESCRIPTION
## Summary
- write the shared TBD skill into each isolated Codex home at `skills/tbd/SKILL.md`
- update the shared skill content to mention Codex and include `--type codex` examples
- add tests for Codex skill placement and combined Codex home setup

## Tests
- `swift test --filter CodexHookOverlayTests`
- `swift test --filter TBDSkillContentTests`
- `swift test`