### PR TITLE
DX: Per-row transcript signposts to identify which row hangs the main thread

### DIFF
--- a/Sources/TBDApp/Diagnostics/HangWatchdog.swift
+++ b/Sources/TBDApp/Diagnostics/HangWatchdog.swift
@@ -227,6 +227,17 @@ final class HangWatchdog: @unchecked Sendable {
             let stallMs = stallNs / 1_000_000
             let snap = snapshotLock.withLock { $0 }
 
+            // Drop a one-shot event signpost on the shared transcript-perf
+            // timeline so a captured Instruments trace shows the hang marker
+            // aligned with the surrounding `transcript.row.body` /
+            // `transcript.markdown.build` intervals. The structured log line
+            // below remains the primary diagnostic; this is purely a marker
+            // for visual correlation in the os_signpost lane.
+            TranscriptSignposts.signposter.emitEvent(
+                "hang.detected",
+                "stallMs=\(stallMs, privacy: .public) terminalID=\(snap.focusedTerminalIDShort ?? "-", privacy: .public) itemCount=\(snap.transcriptItemCount ?? -1, privacy: .public) pane=\(snap.paneLabel ?? "-", privacy: .public)"
+            )
+
             // Sample the main thread stack and write to disk.
             let frames = MainThreadSampler.sample()
             if let fileURL = HangStackWriter.shared.recordHangStart(stallMs: stallMs, snapshot: snap, frames: frames) {

--- a/Sources/TBDApp/Diagnostics/TranscriptSignposts.swift
+++ b/Sources/TBDApp/Diagnostics/TranscriptSignposts.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 import os
 
 /// Shared OSSignposter for `category: "perf-transcript"`. Use `signposter.beginInterval(_:)`
@@ -6,11 +7,65 @@ import os
 /// in Xcode Instruments' "os_signpost" lane and (with the SwiftUI template) alongside
 /// view-body / layout events.
 ///
-/// Region names used today (see docs/superpowers/specs/2026-05-11-transcript-render-node-design.md):
+/// Region names used today (see docs/superpowers/specs/2026-05-11-transcript-render-node-design.md
+/// and docs/diagnostics-strategy.md for capture recipes):
 /// - "transcript.swap"             — LiveTranscriptPaneView.pollOnce mainActor block
-/// - "transcript.items.body"       — TranscriptItemsView.body (whole pass, pre-refactor)
+/// - "transcript.items.body"       — TranscriptItemsView.body (whole pass)
+/// - "transcript.row.body"         — TranscriptRow.body per row (issue #129 signposts)
+/// - "transcript.markdown.build"   — ChatBubbleView.bubbleBody (split + Markdown view tree)
 /// - "transcript.markdown.segment" — MarkdownSegments.split
 /// - "transcript.scrollTo"         — proxy.scrollTo call sites
+///
+/// `event` names:
+/// - "hang.detected" — emitted from HangWatchdog when a hang transitions to `.toHung`,
+///                     so an Instruments trace shows the marker on the same timeline as
+///                     the row intervals.
 enum TranscriptSignposts {
     nonisolated static let signposter = OSSignposter(subsystem: "com.tbd.app", category: "perf-transcript")
+
+    /// Short, signpost-friendly classification for a transcript render node.
+    /// Kept stable and `.public`-safe — no message content, only structural tags.
+    nonisolated static func kindLabel(for node: TranscriptRenderNode) -> String {
+        switch node.kind {
+        case .chatBubble(let item):
+            switch item {
+            case .userPrompt: return "userPrompt"
+            case .assistantText: return "assistantText"
+            default: return "chat"
+            }
+        case .systemReminder: return "systemReminder"
+        case .skillBody: return "skillBody"
+        case .toolCall(_, let name, _, _, _, _): return "tool:\(name)"
+        case .subagentSummary: return "subagentSummary"
+        }
+    }
+
+    /// Conservative "how big is this row's payload" measurement, in characters.
+    /// Used as signpost metadata so the longest `row.body` interval in a hang
+    /// trace can be cross-referenced against payload size. Returns 0 when the
+    /// node has no obvious text payload (e.g. a subagent summary).
+    nonisolated static func contentLength(for node: TranscriptRenderNode) -> Int {
+        switch node.kind {
+        case .chatBubble(let item):
+            switch item {
+            case .userPrompt(_, let t, _),
+                 .assistantText(_, let t, _, _),
+                 .thinking(_, let t, _):
+                return t.count
+            case .systemReminder(_, _, let t, _):
+                return t.count
+            case .toolCall(_, _, let inputJSON, _, let result, _, _, _):
+                return inputJSON.count + (result?.text.count ?? 0)
+            case .slashCommand(_, let name, let args, _):
+                return name.count + (args?.count ?? 0)
+            }
+        case .systemReminder(_, _, let text, _),
+             .skillBody(_, let text, _):
+            return text.count
+        case .toolCall(_, _, let inputJSON, _, let result, _):
+            return inputJSON.count + (result?.text.count ?? 0)
+        case .subagentSummary:
+            return 0
+        }
+    }
 }

--- a/Sources/TBDApp/Diagnostics/TranscriptSignposts.swift
+++ b/Sources/TBDApp/Diagnostics/TranscriptSignposts.swift
@@ -31,7 +31,10 @@ enum TranscriptSignposts {
             switch item {
             case .userPrompt: return "userPrompt"
             case .assistantText: return "assistantText"
-            default: return "chat"
+            case .thinking: return "thinking"
+            case .systemReminder: return "chatSystemReminder"
+            case .slashCommand: return "slashCommand"
+            case .toolCall(_, let name, _, _, _, _, _, _): return "chatTool:\(name)"
             }
         case .systemReminder: return "systemReminder"
         case .skillBody: return "skillBody"

--- a/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
+++ b/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
@@ -56,10 +56,20 @@ struct ChatBubbleView: View {
         .padding(.horizontal, 4)
     }
 
-    @ViewBuilder
     private var bubbleBody: some View {
+        // Wrap the whole bubble-body construction (split + Markdown view tree
+        // assembly) so a transcript-perf trace can distinguish "row body slow
+        // because markdown" from "row body slow because outer layout". The
+        // narrower "transcript.markdown.segment" interval inside split() is
+        // still emitted — both will appear in the trace. See issue #129.
+        let state = TranscriptSignposts.signposter.beginInterval(
+            "transcript.markdown.build",
+            id: TranscriptSignposts.signposter.makeSignpostID(),
+            "len=\(text.count, privacy: .public) role=\(isUser ? "user" : "assistant", privacy: .public)"
+        )
+        defer { TranscriptSignposts.signposter.endInterval("transcript.markdown.build", state) }
         let segments = MarkdownSegments.split(text)
-        VStack(alignment: .leading, spacing: 6) {
+        return VStack(alignment: .leading, spacing: 6) {
             ForEach(segments) { seg in
                 switch seg {
                 case .prose(let p):

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
@@ -11,6 +11,23 @@ struct TranscriptRow: View {
     let terminalID: UUID?
 
     var body: some View {
+        // Per-row signpost so a hang trace identifies which row was being
+        // evaluated when the main thread stalled. Metadata (kind, length, id)
+        // is passed on the begin call — see docs/diagnostics-strategy.md
+        // ("Capturing a transcript-perf trace") and issue #129.
+        let kind = TranscriptSignposts.kindLabel(for: node)
+        let len = TranscriptSignposts.contentLength(for: node)
+        let state = TranscriptSignposts.signposter.beginInterval(
+            "transcript.row.body",
+            id: TranscriptSignposts.signposter.makeSignpostID(),
+            "id=\(node.id, privacy: .public) kind=\(kind, privacy: .public) len=\(len, privacy: .public)"
+        )
+        defer { TranscriptSignposts.signposter.endInterval("transcript.row.body", state) }
+        return rowBody
+    }
+
+    @ViewBuilder
+    private var rowBody: some View {
         VStack(alignment: .leading, spacing: 2) {
             content
             if let usage = node.badgeUsage {

--- a/Tests/TBDAppTests/TranscriptSignpostsTests.swift
+++ b/Tests/TBDAppTests/TranscriptSignpostsTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDApp
+
+/// Coverage for the `TranscriptSignposts` metadata helpers. These pure helpers
+/// build the strings/lengths that get attached to per-row signpost intervals
+/// (issue #129), so a regression here would silently make hang traces less
+/// useful. CLAUDE.md branching-conditional rule: one test per `kind` arm.
+@Suite("TranscriptSignposts")
+struct TranscriptSignpostsTests {
+    private func node(_ kind: TranscriptRenderNode.Kind, id: String = "n1") -> TranscriptRenderNode {
+        TranscriptRenderNode(id: id, kind: kind, badgeUsage: nil)
+    }
+
+    // MARK: - kindLabel
+
+    @Test func kindLabel_userPrompt() {
+        let n = node(.chatBubble(.userPrompt(id: "u1", text: "hi", timestamp: nil)))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "userPrompt")
+    }
+
+    @Test func kindLabel_assistantText() {
+        let n = node(.chatBubble(.assistantText(id: "a1", text: "hello", timestamp: nil, usage: nil)))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "assistantText")
+    }
+
+    @Test func kindLabel_systemReminder() {
+        let n = node(.systemReminder(id: "s1", kind: .skillBody, text: "x", timestamp: nil))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "systemReminder")
+    }
+
+    @Test func kindLabel_skillBody() {
+        let n = node(.skillBody(id: "k1", text: "body", timestamp: nil))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "skillBody")
+    }
+
+    @Test func kindLabel_toolCall_includesName() {
+        let n = node(.toolCall(id: "t1", name: "Bash", inputJSON: "{}", inputTruncatedTo: nil, result: nil, timestamp: nil))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "tool:Bash")
+    }
+
+    @Test func kindLabel_subagentSummary() {
+        let n = node(.subagentSummary(parentItemID: "t1", count: 3, agentType: nil))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "subagentSummary")
+    }
+
+    // MARK: - contentLength
+
+    @Test func contentLength_chatBubble_userPrompt() {
+        let n = node(.chatBubble(.userPrompt(id: "u1", text: "hello", timestamp: nil)))
+        #expect(TranscriptSignposts.contentLength(for: n) == 5)
+    }
+
+    @Test func contentLength_chatBubble_assistantText() {
+        let n = node(.chatBubble(.assistantText(id: "a1", text: "1234567", timestamp: nil, usage: nil)))
+        #expect(TranscriptSignposts.contentLength(for: n) == 7)
+    }
+
+    @Test func contentLength_toolCallNode_sumsInputAndResult() {
+        let result = ToolResult(text: "RESULT", truncatedTo: nil, isError: false)
+        let n = node(.toolCall(id: "t1", name: "Bash", inputJSON: "{\"x\":1}", inputTruncatedTo: nil, result: result, timestamp: nil))
+        // inputJSON "{\"x\":1}" is 7 chars + "RESULT" is 6 → 13
+        #expect(TranscriptSignposts.contentLength(for: n) == 13)
+    }
+
+    @Test func contentLength_toolCallNode_nilResult() {
+        let n = node(.toolCall(id: "t1", name: "Bash", inputJSON: "abc", inputTruncatedTo: nil, result: nil, timestamp: nil))
+        #expect(TranscriptSignposts.contentLength(for: n) == 3)
+    }
+
+    @Test func contentLength_skillBody_textLength() {
+        let n = node(.skillBody(id: "k1", text: "abcdef", timestamp: nil))
+        #expect(TranscriptSignposts.contentLength(for: n) == 6)
+    }
+
+    @Test func contentLength_subagentSummary_isZero() {
+        let n = node(.subagentSummary(parentItemID: "t1", count: 1, agentType: nil))
+        #expect(TranscriptSignposts.contentLength(for: n) == 0)
+    }
+
+    // MARK: - Signposter does not crash
+
+    /// Smoke test: the shared signposter accepts our begin/end pattern with
+    /// privacy-qualified metadata and the new `hang.detected` event without
+    /// crashing. Doesn't (and can't easily) verify what Instruments sees —
+    /// that's a manual-capture verification step documented in
+    /// `docs/diagnostics-strategy.md`.
+    @Test func signposter_emitEventAndIntervalDoNotCrash() {
+        let id = TranscriptSignposts.signposter.makeSignpostID()
+        let state = TranscriptSignposts.signposter.beginInterval(
+            "transcript.row.body",
+            id: id,
+            "id=test kind=tool:Bash len=42"
+        )
+        TranscriptSignposts.signposter.endInterval("transcript.row.body", state)
+        TranscriptSignposts.signposter.emitEvent(
+            "hang.detected",
+            "stallMs=1200 terminalID=abcd itemCount=10 pane=transcript"
+        )
+    }
+}

--- a/Tests/TBDAppTests/TranscriptSignpostsTests.swift
+++ b/Tests/TBDAppTests/TranscriptSignpostsTests.swift
@@ -31,6 +31,31 @@ struct TranscriptSignpostsTests {
         #expect(TranscriptSignposts.kindLabel(for: n) == "systemReminder")
     }
 
+    @Test func kindLabel_chatBubble_thinking() {
+        let n = node(.chatBubble(.thinking(id: "th1", text: "musing", timestamp: nil)))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "thinking")
+    }
+
+    @Test func kindLabel_chatBubble_systemReminder() {
+        // Distinct from the node-level `.systemReminder` arm above — this is a
+        // `TranscriptItem.systemReminder` wrapped in a chatBubble render node.
+        let n = node(.chatBubble(.systemReminder(id: "s2", kind: .skillBody, text: "x", timestamp: nil)))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "chatSystemReminder")
+    }
+
+    @Test func kindLabel_chatBubble_slashCommand() {
+        let n = node(.chatBubble(.slashCommand(id: "sl1", name: "compact", args: nil, timestamp: nil)))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "slashCommand")
+    }
+
+    @Test func kindLabel_chatBubble_toolCall_includesName() {
+        let n = node(.chatBubble(.toolCall(
+            id: "t1", name: "Bash", inputJSON: "{}", inputTruncatedTo: nil,
+            result: nil, subagent: nil, timestamp: nil, usage: nil
+        )))
+        #expect(TranscriptSignposts.kindLabel(for: n) == "chatTool:Bash")
+    }
+
     @Test func kindLabel_skillBody() {
         let n = node(.skillBody(id: "k1", text: "body", timestamp: nil))
         #expect(TranscriptSignposts.kindLabel(for: n) == "skillBody")

--- a/docs/diagnostics-strategy.md
+++ b/docs/diagnostics-strategy.md
@@ -212,6 +212,30 @@ balances on early return and throw, which manual pairs do not. Dangling
 intervals make Instruments choke. Put payload data on the begin call, not the
 end call.
 
+### Capturing a transcript-perf trace (issue #129)
+
+When the transcript pane hangs (or feels janky) and you want to know *which
+row* the main thread was measuring:
+
+1. Build + launch via `scripts/restart.sh` (signposts are always on — no flag).
+2. Open Instruments → **SwiftUI** template → attach to `TBDApp`.
+3. In the os_signpost lane, filter by subsystem `com.tbd.app` and category
+   `perf-transcript`. The intervals you'll see:
+   - `transcript.row.body` — one per `TranscriptRow.body` evaluation, tagged
+     with `id=`, `kind=` (e.g. `tool:Bash`, `assistantText`), and `len=`.
+   - `transcript.markdown.build` — chat-bubble Markdown view-tree assembly.
+   - `transcript.markdown.segment` — the prose/code split inside `bubbleBody`.
+   - `transcript.items.body`, `transcript.swap`, `transcript.scrollTo`
+     (existing wider-grain intervals).
+4. Reproduce the hang. Look for the `hang.detected` **event** marker on the
+   same lane and the *longest* `transcript.row.body` interval near it — its
+   metadata identifies the offending row's kind, id, and payload size.
+5. Cross-reference with `HangWatchdog`'s structured log:
+   `log show --last 5m --predicate 'subsystem == "com.tbd.app" AND category == "hang-watchdog"'`.
+
+Signposts are zero-cost when no tracer is attached, so this instrumentation
+ships in every build with no behavior or performance impact.
+
 ## Migration path
 
 This is intentionally a slow, no-big-bang migration. The proposal is the

--- a/docs/diagnostics-strategy.md
+++ b/docs/diagnostics-strategy.md
@@ -210,7 +210,10 @@ Prefer the closure form `signposter.withIntervalSignpost("worktree.create") {
 ... }` (macOS 12+) over manual `beginInterval` / `endInterval` — it auto-
 balances on early return and throw, which manual pairs do not. Dangling
 intervals make Instruments choke. Put payload data on the begin call, not the
-end call.
+end call. `defer { signposter.endInterval(...) }` is an equivalent alternative
+when the call site is a non-throwing computed property (e.g. SwiftUI `body`),
+and is preferred when the closure form would force restructuring the view
+builder.
 
 ### Capturing a transcript-perf trace (issue #129)
 


### PR DESCRIPTION
## Summary

The 2026-05-17 transcript-pane hang (`freeze.log` at repo root, 19.21s, stack recurses through `LazyVStack.place` → `_FlexFrameLayout.sizeThatFits`) told us *that* a row hung but not *which* row. This PR adds zero-cost `OSSignposter` intervals around each `TranscriptRow.body` evaluation so the next freeze captures actionable evidence.

- **`transcript.row.body`** — one interval per `TranscriptRow.body`, tagged with `id=`, `kind=` (e.g. `tool:Bash`, `assistantText`, `subagentSummary`), and `len=` (payload size in chars). Look for the longest interval near the hang marker.
- **`transcript.markdown.build`** — wraps the `MarkdownSegments.split` + MarkdownUI view-tree assembly inside `ChatBubbleView.bubbleBody`, so "row slow because markdown" is distinguishable from "row slow because outer layout".
- **`hang.detected` event** — `HangWatchdog` now emits a one-shot signpost event on the same `perf-transcript` lane when it fires, so the hang marker visually aligns with the row intervals in Instruments.

Diagnostic-only change: signposts are zero-cost when no tracer is attached, so there is no behavior change and no perf change in non-traced runs. The existing `HangWatchdog` structured log line remains the primary text-based diagnostic.

Capture recipe (Instruments → SwiftUI template → subsystem `com.tbd.app` / category `perf-transcript`) added to [`docs/diagnostics-strategy.md`](./docs/diagnostics-strategy.md) under "Capturing a transcript-perf trace".

Refs #129.

## Test plan

- [x] `swift build` clean.
- [x] `scripts/restart.sh` (worktree copy) — app launches, transcript pane renders without crashing.
- [x] `Tests/TBDAppTests/TranscriptSignpostsTests.swift` covers `kindLabel` / `contentLength` per render-node kind plus a smoke test that the new `beginInterval` / `endInterval` / `emitEvent` calls don't crash. (CI will run them — local `swift test` can't load the `Testing` module without Xcode in this sandbox.)
- [ ] Next time the transcript pane hangs, capture an Instruments trace per the docs section and confirm the longest `transcript.row.body` interval near the `hang.detected` event identifies the offending row.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=30E6C3DB-4375-4A49-8656-615F6C6D50E0)