### PR TITLE
Reliability: Stop concurrent worktree creates from stalling 2-4min

### DIFF
--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -139,7 +139,9 @@ struct WorktreeCreate: AsyncParsableCommand {
     }
 
     private func waitForActive(pending: Worktree, client: SocketClient) throws -> Worktree {
-        let deadline = Date().addingTimeInterval(60)
+        let start = Date()
+        let deadline = start.addingTimeInterval(180)
+        var nextHeartbeat: TimeInterval = 2
         while Date() < deadline {
             let worktrees: [Worktree] = try client.call(
                 method: RPCMethod.worktreeList,
@@ -152,6 +154,14 @@ struct WorktreeCreate: AsyncParsableCommand {
                 }
             } else {
                 throw CLIError.invalidArgument("Worktree creation failed (see daemon logs)")
+            }
+            let elapsed = Date().timeIntervalSince(start)
+            if elapsed >= nextHeartbeat {
+                let secs = Int(elapsed)
+                // Emit a fresh line each tick — Claude Code's Bash tool captures
+                // stderr line-by-line, so \r overwrites would be invisible to it.
+                FileHandle.standardError.write(Data("waiting for worktree to become active… \(secs)s\n".utf8))
+                nextHeartbeat += 2
             }
             Thread.sleep(forTimeInterval: 0.2)
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -23,7 +23,8 @@ extension RPCRouter {
             suppressAutoParent: params.suppressAutoParent ?? false
         )
 
-        // Phase 2: Fire-and-forget — git operations + tmux setup in background
+        // Phase 2: Fire-and-forget — git operations + tmux setup in background.
+        // Serialize per-repo so concurrent creates don't contend on .git/index.lock.
         let lifecycle = self.lifecycle
         let subs = self.subscriptions
         let initialPrompt = params.prompt
@@ -31,10 +32,9 @@ extension RPCRouter {
         let userSpecifiedBranch = params.branch != nil
         let cols = params.cols
         let rows = params.rows
-        Task.detached {
+        await repoSerializer.submit(repoID: pending.repoID) {
             do {
                 try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows)
-                // Broadcast the completed worktree
                 subs.broadcast(delta: .worktreeCreated(WorktreeDelta(
                     worktreeID: pending.id, repoID: pending.repoID,
                     name: pending.name, path: pending.path

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -19,6 +19,7 @@ public final class RPCRouter: Sendable {
     public let modelProfileResolver: ModelProfileResolver
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     public let pendingQuestions: PendingQuestionStore
+    public let repoSerializer: RepoSerializer
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -33,7 +34,8 @@ public final class RPCRouter: Sendable {
         prManager: PRStatusManager = PRStatusManager(),
         usageFetcher: ClaudeUsageFetcher = LiveClaudeUsageFetcher(),
         modelProfileResolver: ModelProfileResolver? = nil,
-        pendingQuestions: PendingQuestionStore = PendingQuestionStore()
+        pendingQuestions: PendingQuestionStore = PendingQuestionStore(),
+        repoSerializer: RepoSerializer = RepoSerializer()
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -53,6 +55,7 @@ public final class RPCRouter: Sendable {
         )
         self.usageFetcher = usageFetcher
         self.pendingQuestions = pendingQuestions
+        self.repoSerializer = repoSerializer
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.

--- a/Sources/TBDDaemon/Server/RepoSerializer.swift
+++ b/Sources/TBDDaemon/Server/RepoSerializer.swift
@@ -19,14 +19,27 @@ public actor RepoSerializer {
             await work()
         }
         lanes[repoID] = task
+        // Prune the lane once this task finishes — but only if no later submit
+        // has replaced it. Without this, `lanes` would accumulate one entry per
+        // unique repoID ever seen by the daemon.
+        Task { [weak self] in
+            await task.value
+            await self?.removeIfTail(repoID: repoID, task: task)
+        }
         return task
+    }
+
+    private func removeIfTail(repoID: UUID, task: Task<Void, Never>) {
+        if lanes[repoID] == task {
+            lanes[repoID] = nil
+        }
     }
 
     /// Test-only inspection: number of repos currently tracked.
     var trackedRepoCount: Int { lanes.count }
 
     /// Test-only: await completion of the current tail for a given repo.
-    public func waitForRepo(_ repoID: UUID) async {
+    func waitForRepo(_ repoID: UUID) async {
         await lanes[repoID]?.value
     }
 }

--- a/Sources/TBDDaemon/Server/RepoSerializer.swift
+++ b/Sources/TBDDaemon/Server/RepoSerializer.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Serializes per-repo background work so concurrent `git fetch` / `git worktree add`
+/// invocations don't queue on git's `.git/index.lock`. Different repos still run
+/// in parallel; each repo gets a chained `Task` lane that awaits its predecessor
+/// before invoking the next body.
+public actor RepoSerializer {
+    private var lanes: [UUID: Task<Void, Never>] = [:]
+
+    public init() {}
+
+    /// Schedule `work` to run after any in-flight work for `repoID` completes.
+    /// Returns immediately with the chained task; callers normally don't await it.
+    @discardableResult
+    public func submit(repoID: UUID, work: @Sendable @escaping () async -> Void) -> Task<Void, Never> {
+        let predecessor = lanes[repoID]
+        let task = Task { [predecessor] in
+            await predecessor?.value
+            await work()
+        }
+        lanes[repoID] = task
+        return task
+    }
+
+    /// Test-only inspection: number of repos currently tracked.
+    var trackedRepoCount: Int { lanes.count }
+
+    /// Test-only: await completion of the current tail for a given repo.
+    public func waitForRepo(_ repoID: UUID) async {
+        await lanes[repoID]?.value
+    }
+}

--- a/Tests/TBDDaemonTests/RepoSerializerTests.swift
+++ b/Tests/TBDDaemonTests/RepoSerializerTests.swift
@@ -1,0 +1,139 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+
+@Suite("RepoSerializer")
+struct RepoSerializerTests {
+
+    /// Records start/end timestamps for each tagged piece of work so tests can
+    /// assert ordering and overlap properties.
+    actor TimelineRecorder {
+        struct Span { let tag: String; let start: Date; let end: Date }
+        private(set) var spans: [Span] = []
+
+        func record(tag: String, work: () async -> Void) async {
+            let start = Date()
+            await work()
+            let end = Date()
+            spans.append(Span(tag: tag, start: start, end: end))
+        }
+
+        func allSpans() -> [Span] { spans }
+    }
+
+    @Test("same repoID serializes consecutively, never overlapping")
+    func sameRepoSerializes() async throws {
+        let serializer = RepoSerializer()
+        let recorder = TimelineRecorder()
+        let repoID = UUID()
+        let sleep: UInt64 = 150_000_000 // 150ms
+
+        // Submit two pieces of work back-to-back for the same repo. They must
+        // run in submission order with zero overlap.
+        let t1 = await serializer.submit(repoID: repoID) {
+            await recorder.record(tag: "A") {
+                try? await Task.sleep(nanoseconds: sleep)
+            }
+        }
+        let t2 = await serializer.submit(repoID: repoID) {
+            await recorder.record(tag: "B") {
+                try? await Task.sleep(nanoseconds: sleep)
+            }
+        }
+        await t1.value
+        await t2.value
+
+        let spans = await recorder.allSpans()
+        #expect(spans.count == 2)
+        #expect(spans[0].tag == "A")
+        #expect(spans[1].tag == "B")
+        // B must start strictly after A ends.
+        #expect(spans[1].start >= spans[0].end)
+    }
+
+    @Test("different repoIDs run in parallel")
+    func differentReposOverlap() async throws {
+        let serializer = RepoSerializer()
+        let recorder = TimelineRecorder()
+        let repoA = UUID()
+        let repoB = UUID()
+        let sleep: UInt64 = 200_000_000 // 200ms
+
+        let t1 = await serializer.submit(repoID: repoA) {
+            await recorder.record(tag: "A") {
+                try? await Task.sleep(nanoseconds: sleep)
+            }
+        }
+        let t2 = await serializer.submit(repoID: repoB) {
+            await recorder.record(tag: "B") {
+                try? await Task.sleep(nanoseconds: sleep)
+            }
+        }
+        await t1.value
+        await t2.value
+
+        let spans = await recorder.allSpans()
+        #expect(spans.count == 2)
+        let aSpan = try #require(spans.first { $0.tag == "A" })
+        let bSpan = try #require(spans.first { $0.tag == "B" })
+        // Overlap proof: each one started before the other finished.
+        #expect(aSpan.start < bSpan.end)
+        #expect(bSpan.start < aSpan.end)
+    }
+
+    @Test("submit returns immediately even if predecessor is long-running")
+    func submitReturnsBeforeWorkFinishes() async throws {
+        let serializer = RepoSerializer()
+        let repoID = UUID()
+        let firstStarted = AsyncSignal()
+        let firstMayFinish = AsyncSignal()
+        let sentinel = SendableBox(false)
+
+        let slow = await serializer.submit(repoID: repoID) {
+            await firstStarted.signal()
+            await firstMayFinish.wait()
+        }
+        await firstStarted.wait()
+
+        // The second submit must not block on the in-flight first.
+        let t0 = Date()
+        let queued = await serializer.submit(repoID: repoID) {
+            sentinel.set(true)
+        }
+        #expect(Date().timeIntervalSince(t0) < 0.05)
+        #expect(sentinel.get() == false)
+
+        await firstMayFinish.signal()
+        await slow.value
+        await queued.value
+        #expect(sentinel.get() == true)
+    }
+}
+
+// MARK: - Local test utilities
+
+/// One-shot async semaphore (set-once, multi-await).
+private actor AsyncSignal {
+    private var fired = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        guard !fired else { return }
+        fired = true
+        for w in waiters { w.resume() }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        if fired { return }
+        await withCheckedContinuation { cont in waiters.append(cont) }
+    }
+}
+
+private final class SendableBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: T
+    init(_ value: T) { self.value = value }
+    func get() -> T { lock.lock(); defer { lock.unlock() }; return value }
+    func set(_ v: T) { lock.lock(); value = v; lock.unlock() }
+}

--- a/Tests/TBDDaemonTests/RepoSerializerTests.swift
+++ b/Tests/TBDDaemonTests/RepoSerializerTests.swift
@@ -81,6 +81,28 @@ struct RepoSerializerTests {
         #expect(bSpan.start < aSpan.end)
     }
 
+    @Test("lane entries are pruned after work completes")
+    func lanesArePrunedAfterCompletion() async throws {
+        let serializer = RepoSerializer()
+        let repoA = UUID()
+        let repoB = UUID()
+
+        let t1 = await serializer.submit(repoID: repoA) { }
+        let t2 = await serializer.submit(repoID: repoB) { }
+        await t1.value
+        await t2.value
+
+        // Cleanup tasks chain off the work tasks; give the actor a couple of
+        // hops to drain them before asserting.
+        for _ in 0..<10 {
+            let count = await serializer.trackedRepoCount
+            if count == 0 { break }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let finalCount = await serializer.trackedRepoCount
+        #expect(finalCount == 0)
+    }
+
     @Test("submit returns immediately even if predecessor is long-running")
     func submitReturnsBeforeWorkFinishes() async throws {
         let serializer = RepoSerializer()


### PR DESCRIPTION
## Summary

Orchestrator agents that fan out multiple `tbd worktree create` calls against the same repo were taking 2–4 minutes per call wall-clock — long enough to exceed Claude Code's 120s Bash timeout. The agent then loses direct stdout and has to poll output files to verify the create succeeded.

**Root cause:** the daemon's Phase-2 worktree work (`git fetch` + `git worktree add`) ran as `Task.detached` with no coordination, so concurrent same-repo creates contended on `.git/index.lock` and serialized at the git level anyway — just messily, and without bound.

**What this PR does:**
- Adds a `RepoSerializer` actor that chains Phase-2 work per `repoID`. Different repos still run in parallel; same-repo creates queue cleanly.
- Phase 1 (DB row insert) still returns immediately, so the CLI sees no added latency on the RPC round-trip.
- Bumps the CLI's `waitForActive` deadline 60s → 180s and adds a 2s stderr heartbeat (`waiting for worktree to become active… 12s`) so a watching agent (or human) sees liveness instead of silent polling.

## Test plan

- [x] `swift build` clean
- [x] New `RepoSerializerTests` (3 tests) pass: same-repo serial ordering, cross-repo overlap, non-blocking submit
- [x] `RPCRouterWorktreeTests | WorktreeLifecycleTests | WorktreeAdoptTests` — 31/31 pass, no regressions
- [ ] Manual verification: spawn 3+ worktrees back-to-back in same repo from an orchestrator agent; confirm each `tbd worktree create` completes inside the 120s Bash window and stderr heartbeat is visible

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=27AB895B-80EE-47AE-AF32-772C3E531C94)