### PR TITLE
Fix: stop drag-reorder crash from stale SwiftUI indices

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -259,6 +259,11 @@ extension AppState {
             .filter { ($0.status == .active || $0.status == .creating) && $0.parentWorktreeID == nil }
             .sorted { $0.sortOrder < $1.sortOrder }
         logger.debug("reorderTopLevel BEFORE: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public) source=\(Array(source), privacy: .public) destination=\(destination, privacy: .public)")
+        // guard: source/destination can outlive the snapshot they were captured against
+        if topLevel.isEmpty || source.contains(where: { $0 >= topLevel.count }) || destination > topLevel.count {
+            logger.warning("reorderTopLevel skipped: stale indices (topLevel.count=\(topLevel.count, privacy: .public) source=\(Array(source), privacy: .public) destination=\(destination, privacy: .public))")
+            return
+        }
         // Apply the swap to derive the new top-level order.
         topLevel.move(fromOffsets: source, toOffset: destination)
         logger.debug("reorderTopLevel AFTER: \(topLevel.map(\.displayName).joined(separator: " | "), privacy: .public)")


### PR DESCRIPTION
## Summary

Defensive bounds-check in `reorderTopLevelWorktrees` to prevent an `EXC_BREAKPOINT` crash on drag-to-reorder in the sidebar.

## Crash

SwiftUI's NSOutlineView delivers `.onMove(source:destination:)` indices captured against a view-state snapshot. The closure isn't guaranteed to run synchronously with that snapshot — by the time it fires, a daemon push (e.g. a worktree archive/create) can shrink the filtered `topLevel` array. `Array.move(fromOffsets:toOffset:)` then traps on the stale subscript and the app dies.

## Root cause

The function re-derives `topLevel` from the current `worktrees[repoID]` on entry, but blindly forwards the original `source`/`destination` to `Array.move`. There was no reconciliation between the just-captured indices and the now-current array length.

## Fix

Guard immediately before `Array.move`: bail (and log `.warning` via `os.Logger`) when

- `topLevel.isEmpty`, or
- any `source` index is `>= topLevel.count`, or
- `destination > topLevel.count` (note: `.onMove` legitimately uses `destination == count` for "append at end", so `>` not `>=`).

When the guard fires, the optimistic local mutation is skipped and no RPC is sent. SwiftUI re-renders from the published `worktrees[repoID]` on the next tick, so the visual order self-corrects against authoritative state. Diagnostic log line records the stale-index condition for triage.

## Test gap

`CLAUDE.md` calls for a test per branch of a gating conditional. The TBDApp test target uses swift-testing (`import Testing` / `@Test` / `#expect`), which is unavailable in this environment (no Xcode, no swift-testing module). Test was not added in this PR — happy to follow up if there's a preferred XCTest-shaped harness, or once swift-testing is available.

## Test plan

- [ ] Manual: trigger an archive/create burst while dragging a worktree row; verify no crash and that drop either applies or is silently ignored (no stale visual state).
- [ ] Verify normal drag-reorder still works for in-range indices.
- [ ] Check `log stream --level debug --predicate 'subsystem BEGINSWITH "com.tbd" AND category == "appstate"'` shows the `.warning` line when the guard fires.