### PR TITLE
Fix: Truncate cross-repo badge so nested rows show the worktree name

### DIFF
--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -140,10 +140,12 @@ struct WorktreeRowView: View {
             }
             if let sectionRepoID, sectionRepoID != worktree.repoID,
                let homeRepo = appState.repoName(for: worktree.repoID) {
-                Text("(\(homeRepo))")
+                let short = homeRepo.count > 5 ? String(homeRepo.prefix(5)) + "…" : homeRepo
+                Text("(\(short))")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                    .help(homeRepo)
             }
         }
         .padding(.leading, CGFloat(indentLevel) * 16)


### PR DESCRIPTION
## Summary
- In nested cross-repo rows, the home-repo badge (e.g. `(📁 projects-files-service)`) was eating most of the row and clipping the worktree name itself.
- Truncate the badge text to the first 5 characters with an ellipsis; full repo name still appears in the row's help tooltip on hover.

## Test plan
- [ ] Open a worktree section that contains nested children belonging to a different repo (e.g. a Stream 1 orchestrator with Stream 2 nested rows from another repo).
- [ ] Verify the badge now renders as `(xxxxx…)` instead of crowding out the worktree name.
- [ ] Hover the badge — the full repo display name appears in the tooltip.
- [ ] Same-repo rows (no badge shown) are unaffected.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=E9BCA135-580C-4907-A754-27BA20CC912D)