### PR TITLE
Feat: Keep TBD's OAuth profiles on interactive subscription billing

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"EC0B788A-076E-4DB0-9848-162052468CD4","pid":14040,"procStart":"Tue May 19 20:25:01 2026","acquiredAt":1779230450633}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"EC0B788A-076E-4DB0-9848-162052468CD4","pid":14040,"procStart":"Tue May 19 20:25:01 2026","acquiredAt":1779230450633}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .tbd/
 icon-iterations/
 docs/superpowers/plans/
+.claude/scheduled_tasks.lock

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -405,12 +405,9 @@ struct AddModelProfileSheet: View {
 
                 switch preset {
                 case .claudeDirect:
-                    LabeledField("Token") {
-                        SecureField("", text: $token).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
-                    }
-                    (Text("Run ")
-                        + Text("claude setup-token").font(.system(.caption, design: .monospaced))
-                        + Text(" in a terminal and paste the resulting sk-ant-oat01-… token."))
+                    (Text("After creating this profile, open a session with it and run ")
+                        + Text("/login").font(.system(.caption, design: .monospaced))
+                        + Text(" once. TBD keeps each profile's login isolated in its own config directory."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -562,7 +559,7 @@ struct AddModelProfileSheet: View {
         if duplicate { return false }
         switch preset {
         case .claudeDirect:
-            return !token.isEmpty
+            return true
         case .proxy:
             return !token.isEmpty &&
                    !baseURL.trimmingCharacters(in: .whitespaces).isEmpty
@@ -626,7 +623,7 @@ struct AddModelProfileSheet: View {
             let priorAlert = await MainActor.run { appState.alertMessage }
             let warning = await appState.addModelProfile(
                 name: trimmedName,
-                token: tokenValue,
+                token: preset == .claudeDirect ? nil : tokenValue,
                 baseURL: preset == .proxy ? trimmedBase : nil,
                 model: preset == .proxy ? (trimmedModel.isEmpty ? nil : trimmedModel) : nil
             )

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -388,7 +388,7 @@ struct AddModelProfileSheet: View {
                 ForEach(AddPreset.allCases) { p in
                     Text(p.rawValue).tag(p).help({
                         switch p {
-                        case .claudeDirect: return "Claude (direct) — sk-ant-oat01- or sk-ant-api03- token"
+                        case .claudeDirect: return "Claude (direct) — authenticate once with /login"
                         case .proxy:        return "Anthropic-compatible proxy — local LLM router with its own token"
                         case .bedrock:      return "AWS Bedrock — uses the AWS SDK credential chain"
                         }

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -635,10 +635,11 @@ struct AddModelProfileSheet: View {
                     appState.alertMessage = priorAlert
                     return
                 }
-                // OAuth-add returned a non-nil verification warning (e.g. 429
-                // or network error from the Anthropic usage endpoint). Show it
-                // inline and keep the sheet open — the user must acknowledge
-                // before deciding whether to keep the unverified profile.
+                // For OAuth profiles with the claudeDirect preset, warning is always nil
+                // (the server doesn't store the token or perform usage checks).
+                // For backward-compat paths with a supplied OAuth token, the warning
+                // indicates the token was not stored. Show it inline and keep the sheet
+                // open so the user can acknowledge before deciding to keep the profile.
                 if let warning {
                     errorMessage = warning
                     return

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -19,10 +19,10 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeProfil
 /// For OAuth profiles, `.claude.json` is pre-populated with only:
 ///   - `hasCompletedOnboarding: true` (no `customApiKeyResponses`, since the
 ///     user will `/login` into this isolated config dir).
-struct ClaudeProfileConfigDirManager: Sendable {
+public struct ClaudeProfileConfigDirManager: Sendable {
     let baseDirectory: URL
 
-    init(baseDirectory: URL? = nil) {
+    public init(baseDirectory: URL? = nil) {
         // Resolve inside the init to keep the `TBDConstants.configDir` access
         // out of the caller's compilation context — see HookResolver for the
         // Xcode 26.3 unsafeMutableAddressor link-failure rationale.
@@ -30,12 +30,12 @@ struct ClaudeProfileConfigDirManager: Sendable {
             ?? TBDConstants.configDir.appendingPathComponent("profiles", isDirectory: true)
     }
 
-    func profileDirectory(forProfileID profileID: UUID) -> URL {
+    public func profileDirectory(forProfileID profileID: UUID) -> URL {
         baseDirectory
             .appendingPathComponent(profileID.uuidString.lowercased(), isDirectory: true)
     }
 
-    func configDirectory(forProfileID profileID: UUID) -> URL {
+    public func configDirectory(forProfileID profileID: UUID) -> URL {
         profileDirectory(forProfileID: profileID)
             .appendingPathComponent("claude", isDirectory: true)
     }
@@ -47,7 +47,7 @@ struct ClaudeProfileConfigDirManager: Sendable {
     /// include the approval for this key, the file is rewritten with the
     /// correct content. Existing approvals for other keys are preserved.
     @discardableResult
-    func ensureAPIKeyDir(forProfileID profileID: UUID, apiKey: String) throws -> URL {
+    public func ensureAPIKeyDir(forProfileID profileID: UUID, apiKey: String) throws -> URL {
         let dir = configDirectory(forProfileID: profileID)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
 
@@ -95,7 +95,7 @@ struct ClaudeProfileConfigDirManager: Sendable {
     /// this isolated config dir, and the credential persists in the Keychain
     /// entry derived from the `CLAUDE_CONFIG_DIR` path.
     @discardableResult
-    func ensureOAuthDir(forProfileID profileID: UUID) throws -> URL {
+    public func ensureOAuthDir(forProfileID profileID: UUID) throws -> URL {
         let dir = configDirectory(forProfileID: profileID)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
 
@@ -121,7 +121,7 @@ struct ClaudeProfileConfigDirManager: Sendable {
     /// (confirmed by inspecting `~/.claude.json#customApiKeyResponses.approved`).
     /// For keys shorter than 20 chars (unusual but possible in tests), use the
     /// full string — matches Claude Code's `.suffix(20)` behavior.
-    static func approvalToken(forAPIKey apiKey: String) -> String {
+    public static func approvalToken(forAPIKey apiKey: String) -> String {
         String(apiKey.suffix(20))
     }
 }

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -124,8 +124,9 @@ struct ClaudeProfileConfigDirManager: Sendable {
 
 extension ClaudeProfileConfigDirManager {
     /// Ensure the per-profile claude config dir for a resolved profile and
-    /// return its path. Returns nil only for bedrock profiles (which do not
-    /// need config-dir isolation) and nil profile.
+    /// return its path. Returns nil for bedrock profiles (which do not
+    /// need config-dir isolation), nil profile, and apiKey profiles with
+    /// a missing secret.
     ///
     /// For `.oauth` profiles, calls `ensureOAuthDir`.
     /// For `.apiKey` profiles, calls `ensureAPIKeyDir` (needs `profile.secret`;

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -4,21 +4,21 @@ import TBDShared
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeProfileConfigDir")
 
-/// Manages per-profile isolated `ANTHROPIC_CONFIG_DIR` directories under
-/// `~/tbd/profiles/<profile-id>/claude/`. Used only for proxy profiles
-/// (`baseURL` non-nil) so Claude Code's auth-conflict check doesn't see the
-/// user's claude.ai OAuth in `~/.claude/.credentials.json` while we're also
-/// passing `ANTHROPIC_API_KEY`.
+/// Manages per-profile isolated `CLAUDE_CONFIG_DIR` directories under
+/// `~/tbd/profiles/<profile-id>/claude/`. Serves oauth, direct apiKey, and
+/// proxy apiKey profiles with an isolated config directory where they can
+/// maintain independent credentials.
 ///
-/// On dir creation we pre-populate `.claude.json` with:
+/// On dir creation for API-key profiles, `.claude.json` is pre-populated with:
 ///   - `customApiKeyResponses.approved`: the last 20 chars of the profile's
 ///     API key (matches Claude Code's own storage format) so the user isn't
 ///     prompted to approve the key on first invocation.
 ///   - `hasCompletedOnboarding: true` so the spawn doesn't drop into the
 ///     onboarding flow inside an empty config dir.
 ///
-/// Direct-Claude profiles (baseURL == nil) do NOT use this — they keep
-/// reading `~/.claude` so the user's OAuth login flows through normally.
+/// For OAuth profiles, `.claude.json` is pre-populated with only:
+///   - `hasCompletedOnboarding: true` (no `customApiKeyResponses`, since the
+///     user will `/login` into this isolated config dir).
 struct ClaudeProfileConfigDirManager: Sendable {
     let baseDirectory: URL
 
@@ -43,7 +43,7 @@ struct ClaudeProfileConfigDirManager: Sendable {
     /// include the approval for this key, the file is rewritten with the
     /// correct content. Existing approvals for other keys are preserved.
     @discardableResult
-    func ensureDir(forProfileID profileID: UUID, apiKey: String) throws -> URL {
+    func ensureAPIKeyDir(forProfileID profileID: UUID, apiKey: String) throws -> URL {
         let dir = configDirectory(forProfileID: profileID)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
 
@@ -81,6 +81,38 @@ struct ClaudeProfileConfigDirManager: Sendable {
         return dir
     }
 
+    /// Ensure the per-profile claude config dir exists for an OAuth profile,
+    /// and write a minimal `.claude.json` with only `hasCompletedOnboarding: true`
+    /// if the file does not already exist. If the file already exists, leave it
+    /// untouched.
+    ///
+    /// OAuth profiles do not need a pre-approved API key, so no
+    /// `customApiKeyResponses` is written. The user will `/login` once into
+    /// this isolated config dir, and the credential persists in the Keychain
+    /// entry derived from the `CLAUDE_CONFIG_DIR` path.
+    @discardableResult
+    func ensureOAuthDir(forProfileID profileID: UUID) throws -> URL {
+        let dir = configDirectory(forProfileID: profileID)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let claudeJSONPath = dir.appendingPathComponent(".claude.json")
+
+        // If `.claude.json` already exists, leave it untouched.
+        if FileManager.default.fileExists(atPath: claudeJSONPath.path) {
+            logger.debug("claude config dir exists at \(dir.path, privacy: .public) for oauth profile \(profileID, privacy: .public); skipping .claude.json")
+            return dir
+        }
+
+        let payload: [String: Any] = [
+            "hasCompletedOnboarding": true,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: claudeJSONPath, options: [.atomic])
+
+        logger.debug("ensured claude config dir at \(dir.path, privacy: .public) for oauth profile \(profileID, privacy: .public)")
+        return dir
+    }
+
     /// Claude Code stores approved keys as the last 20 chars of the key
     /// (confirmed by inspecting `~/.claude.json#customApiKeyResponses.approved`).
     /// For keys shorter than 20 chars (unusual but possible in tests), use the
@@ -91,25 +123,47 @@ struct ClaudeProfileConfigDirManager: Sendable {
 }
 
 extension ClaudeProfileConfigDirManager {
-    /// Convenience: ensure the per-profile claude config dir for a resolved
-    /// profile and return its path — but ONLY for proxy profiles (baseURL
-    /// non-nil) using an API key. Returns nil for direct-Claude profiles or
-    /// OAuth-secret profiles, signalling the caller to NOT inject
-    /// `ANTHROPIC_CONFIG_DIR`. Filesystem errors are logged and swallowed —
-    /// failing to write the pre-approval shouldn't break terminal spawn.
+    /// Ensure the per-profile claude config dir for a resolved profile and
+    /// return its path. Returns nil only for bedrock profiles (which do not
+    /// need config-dir isolation) and nil profile.
+    ///
+    /// For `.oauth` profiles, calls `ensureOAuthDir`.
+    /// For `.apiKey` profiles, calls `ensureAPIKeyDir` (needs `profile.secret`;
+    /// if the secret is nil, logs a warning and returns nil).
+    /// For `.bedrock` profiles, returns nil.
+    ///
+    /// Filesystem errors are logged and swallowed — failing to write
+    /// the config dir shouldn't break terminal spawn.
     static func resolveConfigDir(for profile: ResolvedModelProfile?) -> String? {
-        guard let profile, profile.baseURL != nil, profile.kind == .apiKey else { return nil }
-        // Bedrock (and any future kind without a Keychain secret) doesn't need
-        // an isolated ANTHROPIC_CONFIG_DIR — we're not setting ANTHROPIC_API_KEY
-        // at all, so the "Auth conflict" warning this isolation defends against
-        // can't fire.
-        guard let apiKey = profile.secret else { return nil }
-        do {
-            let url = try ClaudeProfileConfigDirManager()
-                .ensureDir(forProfileID: profile.profileID, apiKey: apiKey)
-            return url.path
-        } catch {
-            logger.warning("failed to ensure claude config dir for profile \(profile.profileID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        guard let profile else { return nil }
+
+        let manager = ClaudeProfileConfigDirManager()
+
+        switch profile.kind {
+        case .oauth:
+            do {
+                let url = try manager.ensureOAuthDir(forProfileID: profile.profileID)
+                return url.path
+            } catch {
+                logger.warning("failed to ensure oauth config dir for profile \(profile.profileID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+
+        case .apiKey:
+            guard let apiKey = profile.secret else {
+                logger.warning("api-key profile \(profile.profileID, privacy: .public) has no secret; skipping config dir")
+                return nil
+            }
+            do {
+                let url = try manager.ensureAPIKeyDir(forProfileID: profile.profileID, apiKey: apiKey)
+                return url.path
+            } catch {
+                logger.warning("failed to ensure api-key config dir for profile \(profile.profileID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+
+        case .bedrock:
+            // Bedrock doesn't need config-dir isolation.
             return nil
         }
     }

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -46,6 +46,7 @@ public struct ClaudeProfileConfigDirManager: Sendable {
     /// If the dir already exists but `.claude.json` is missing or doesn't yet
     /// include the approval for this key, the file is rewritten with the
     /// correct content. Existing approvals for other keys are preserved.
+    /// All unknown top-level keys in the existing `.claude.json` are preserved.
     @discardableResult
     public func ensureAPIKeyDir(forProfileID profileID: UUID, apiKey: String) throws -> URL {
         let dir = configDirectory(forProfileID: profileID)
@@ -57,6 +58,7 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         var approved: [String] = []
         var rejected: [String] = []
         var hasOnboarding = true
+        var unknownKeys: [String: Any] = [:]
 
         if let existing = try? Data(contentsOf: claudeJSONPath),
            let parsed = try? JSONSerialization.jsonObject(with: existing) as? [String: Any] {
@@ -65,19 +67,26 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                 rejected = (responses["rejected"] as? [String]) ?? []
             }
             hasOnboarding = (parsed["hasCompletedOnboarding"] as? Bool) ?? true
+
+            // Preserve all unknown top-level keys from the existing file.
+            for (key, value) in parsed {
+                if key != "customApiKeyResponses" && key != "hasCompletedOnboarding" {
+                    unknownKeys[key] = value
+                }
+            }
         }
 
         if !approved.contains(approvalToken) {
             approved.append(approvalToken)
         }
 
-        let payload: [String: Any] = [
-            "customApiKeyResponses": [
-                "approved": approved,
-                "rejected": rejected,
-            ],
-            "hasCompletedOnboarding": hasOnboarding,
+        var payload: [String: Any] = unknownKeys
+        payload["customApiKeyResponses"] = [
+            "approved": approved,
+            "rejected": rejected,
         ]
+        payload["hasCompletedOnboarding"] = hasOnboarding
+
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
         try data.write(to: claudeJSONPath, options: [.atomic])
 

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -30,9 +30,13 @@ struct ClaudeProfileConfigDirManager: Sendable {
             ?? TBDConstants.configDir.appendingPathComponent("profiles", isDirectory: true)
     }
 
-    func configDirectory(forProfileID profileID: UUID) -> URL {
+    func profileDirectory(forProfileID profileID: UUID) -> URL {
         baseDirectory
             .appendingPathComponent(profileID.uuidString.lowercased(), isDirectory: true)
+    }
+
+    func configDirectory(forProfileID profileID: UUID) -> URL {
+        profileDirectory(forProfileID: profileID)
             .appendingPathComponent("claude", isDirectory: true)
     }
 

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -17,9 +17,9 @@ import TBDShared
 ///
 /// If we built a claude command (resume or fresh), `sensitiveEnv` carries the
 /// auth + routing env vars for the spawned session:
-/// - oauth: `CLAUDE_CODE_OAUTH_TOKEN=<secret>`
-/// - api key (direct or proxy): `ANTHROPIC_API_KEY=<secret>` (+ `ANTHROPIC_BASE_URL`,
-///   `ANTHROPIC_MODEL`, `ANTHROPIC_CONFIG_DIR` as applicable)
+/// - oauth: `CLAUDE_CONFIG_DIR=<profileDir>` (no auth token; user `/login`s into this dir)
+/// - api key (direct or proxy): `ANTHROPIC_API_KEY=<secret>` + `CLAUDE_CONFIG_DIR=<profileDir>`
+///   (+ `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL` for proxy)
 /// - bedrock: `CLAUDE_CODE_USE_BEDROCK=1` + `AWS_REGION` + optional `AWS_PROFILE`
 ///   + `ANTHROPIC_MODEL` (no token; AWS SDK credential chain handles auth)
 ///
@@ -101,27 +101,26 @@ enum ClaudeSpawnCommandBuilder {
             if let r = profileAwsRegion { env["AWS_REGION"] = r }
             if let p = profileAwsProfile { env["AWS_PROFILE"] = p }
             if let m = profileModel { env["ANTHROPIC_MODEL"] = m }
-            // Intentionally no ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN /
-            // ANTHROPIC_BASE_URL / ANTHROPIC_CONFIG_DIR for bedrock.
+            // Intentionally no ANTHROPIC_API_KEY / CLAUDE_CONFIG_DIR /
+            // ANTHROPIC_BASE_URL for bedrock.
         } else {
-            if let secret = profileSecret {
+            // Inject auth token only for apiKey profiles.
+            if let secret = profileSecret, profileKind == .apiKey {
                 // Secrets flow through tmux's `-e KEY=VALUE` (argv, no shell
                 // parsing), so we don't need shell-escape allowlists here.
                 // Storage-time validation rejects newlines / NULL bytes that would
                 // break tmux's single-line arg parsing.
-                let envVar = profileKind == .apiKey ? "ANTHROPIC_API_KEY" : "CLAUDE_CODE_OAUTH_TOKEN"
-                env[envVar] = secret
+                env["ANTHROPIC_API_KEY"] = secret
             }
+            // For oauth profiles, no auth token — they use the isolated
+            // CLAUDE_CONFIG_DIR to maintain an independent /login credential.
             if let baseURL = profileBaseURL { env["ANTHROPIC_BASE_URL"] = baseURL }
             if let model = profileModel { env["ANTHROPIC_MODEL"] = model }
-            // Only inject ANTHROPIC_CONFIG_DIR for proxy profiles. For direct
-            // (claude.ai) profiles, the spawned `claude` should keep reading
-            // `~/.claude` so the user's OAuth login works. For proxy profiles,
-            // isolating the config dir prevents Claude Code's >=2.1.x "Auth
-            // conflict: Both a token (claude.ai) and an API key (ANTHROPIC_API_KEY)
-            // are set" warning from firing.
-            if let configDir = profileConfigDir, profileBaseURL != nil {
-                env["ANTHROPIC_CONFIG_DIR"] = configDir
+            // Inject CLAUDE_CONFIG_DIR for all non-bedrock profiles that have
+            // a config dir. The caller (resolveConfigDir) decides which kinds get
+            // a dir, so if profileConfigDir is non-nil, inject it.
+            if let configDir = profileConfigDir {
+                env["CLAUDE_CONFIG_DIR"] = configDir
             }
         }
         return Result(command: base, sensitiveEnv: env)

--- a/Sources/TBDDaemon/Claude/ClaudeUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeUsagePoller.swift
@@ -4,10 +4,10 @@ import TBDShared
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "usagePoller")
 
-/// Background poller that keeps `claude_token_usage` rows fresh for OAuth tokens.
+/// Background poller that keeps `claude_token_usage` rows fresh for API key profiles.
 ///
 /// Rules (from spec "Usage fetching"):
-/// - OAuth only; api_key kind is skipped permanently.
+/// - API key profiles only (OAuth profiles are skipped — they don't store TBD-side secrets).
 /// - Default cadence: 30 min per token.
 /// - Startup stagger: first poll for each token at random(0..30s) from start().
 /// - HTTP 429 → next poll 60 min out; first success after that reverts to 30 min.
@@ -199,8 +199,8 @@ public actor ClaudeUsagePoller {
         }
     }
 
-    /// Re-read profiles from the store, add new oauth profiles (Claude direct
-    /// only — `baseURL == nil`) to the schedule, drop missing / api_key /
+    /// Re-read profiles from the store, add new API key profiles (Claude direct
+    /// only — `baseURL == nil`) to the schedule, drop missing / oauth /
     /// proxy-routed profiles.
     private func refreshSchedule() async {
         let allProfiles: [ModelProfile]
@@ -209,22 +209,23 @@ public actor ClaudeUsagePoller {
         } catch {
             return
         }
-        // Only poll OAuth profiles that target Claude direct (baseURL == nil).
+        // Only poll API key profiles that target Claude direct (baseURL == nil).
+        // OAuth profiles don't store TBD-side secrets, so they can't be polled.
         // Proxy-routed profiles can't use the Claude API usage endpoint —
         // cross-profile cost tracking is out of scope per the spec.
-        let oauthIDs = Set(
+        let apiKeyIDs = Set(
             allProfiles
-                .filter { $0.kind == .oauth && $0.baseURL == nil }
+                .filter { $0.kind == .apiKey && $0.baseURL == nil }
                 .map { $0.id.uuidString }
         )
 
         // Drop profiles no longer present, or no longer eligible.
-        for key in schedule.keys where !oauthIDs.contains(key) {
+        for key in schedule.keys where !apiKeyIDs.contains(key) {
             schedule.removeValue(forKey: key)
         }
         // Add new profiles with stagger.
         let now = clock.now()
-        for id in oauthIDs where schedule[id] == nil && !permanentlyExcluded.contains(id) {
+        for id in apiKeyIDs where schedule[id] == nil && !permanentlyExcluded.contains(id) {
             schedule[id] = Entry(
                 nextFireAt: now.addingTimeInterval(staggerProvider()),
                 backoffActive: false,
@@ -245,7 +246,7 @@ public actor ClaudeUsagePoller {
     // MARK: - Tick (single-token fetch)
 
     private func tick(profileID: String) async {
-        // 1. Confirm still exists, is oauth, and is Claude direct.
+        // 1. Confirm still exists, is apiKey, and is Claude direct.
         guard let uuid = UUID(uuidString: profileID) else {
             schedule.removeValue(forKey: profileID)
             return
@@ -256,7 +257,7 @@ public actor ClaudeUsagePoller {
         } catch {
             return
         }
-        guard let profile = row, profile.kind == .oauth, profile.baseURL == nil else {
+        guard let profile = row, profile.kind == .apiKey, profile.baseURL == nil else {
             schedule.removeValue(forKey: profileID)
             return
         }

--- a/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
+++ b/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
@@ -35,8 +35,9 @@ public struct ModelProfileResolver: Sendable {
 
     /// Load a profile by explicit ID, bypassing the precedence chain.
     /// Used by per-terminal pinning (resume) and mid-conversation swap.
-    /// Returns nil if the row is missing. For non-bedrock kinds, also returns
-    /// nil if the keychain secret is missing or empty.
+    /// Returns nil if the row is missing. For .apiKey profiles, also returns
+    /// nil if the keychain secret is missing or empty. OAuth and bedrock
+    /// profiles carry no TBD-stored secret and always succeed if the row exists.
     public func loadByID(_ id: UUID) async throws -> ResolvedModelProfile? {
         try await loadResolved(id: id)
     }
@@ -45,11 +46,11 @@ public struct ModelProfileResolver: Sendable {
         guard let row = try await profiles.get(id: id) else { return nil }
 
         let secret: String?
-        if row.kind == .bedrock {
-            secret = nil
-        } else {
+        if row.kind == .apiKey {
             guard let s = try keychain(id.uuidString), !s.isEmpty else { return nil }
             secret = s
+        } else {
+            secret = nil   // oauth + bedrock: no TBD-stored secret
         }
 
         try await profiles.touchLastUsed(id: row.id)

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -260,6 +260,9 @@ extension RPCRouter {
         }
 
         // Proxy and bedrock profiles can't be polled against the Claude API usage endpoint.
+        // NOTE: oauth profiles no longer hold a TBD-side token, so usage polling for
+        // them now fails with "Secret missing from keychain" — tracked as a follow-up;
+        // the redesign here is credentials-only and does not touch usage tracking.
         if profile.baseURL != nil || profile.kind == .bedrock {
             return RPCResponse(error: "Usage tracking is only available for Claude-direct profiles")
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -58,8 +58,20 @@ extension RPCRouter {
             return try RPCResponse(result: ModelProfileAddResult(profile: row, warning: nil))
         }
 
-        // ─── Claude-direct / proxy branch ────────────────────────────────────
+        // ─── Claude-direct / proxy branch ─────────────────────────────────────
         let trimmed = (params.token ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // If no token is provided, treat as OAuth (no token required for OAuth).
+        if trimmed.isEmpty {
+            let profileRow = try await db.modelProfiles.create(
+                name: name,
+                kind: .oauth,
+                baseURL: params.baseURL,
+                model: params.model
+            )
+            subscriptions.broadcast(delta: .modelProfilesChanged)
+            return try RPCResponse(result: ModelProfileAddResult(profile: profileRow, warning: nil))
+        }
 
         // Secrets pass through tmux's `-e KEY=VALUE` argv (no shell), so most
         // printables are safe. Reject only chars that would break a single-line
@@ -68,56 +80,27 @@ extension RPCRouter {
             return RPCResponse(error: "Token contains invalid characters (newlines or NULL bytes are not allowed)")
         }
 
-        // OAuth/api-key tokens get caught by the prefix check below, but proxy
-        // profiles (baseURL set) accept any non-empty string and would happily
-        // store an empty token, then inject `ANTHROPIC_API_KEY=` at spawn.
-        guard !trimmed.isEmpty else {
-            return RPCResponse(error: "Token cannot be empty")
-        }
-
-        // Infer credential kind. Claude-direct profiles must look like a Claude
-        // OAuth token or API key; proxy profiles (baseURL set) accept any
-        // string (the proxy decides what's valid).
+        // Infer credential kind. Claude-direct profiles must look like an API key;
+        // proxy profiles (baseURL set) accept any non-empty string (the proxy decides
+        // what's valid).
         let kind: CredentialKind
         if let _ = params.baseURL {
             // Proxy profile — credential is whatever the proxy expects. Treat
             // the secret as an API-key-shaped credential so it gets injected
             // via ANTHROPIC_API_KEY.
             kind = .apiKey
-        } else if trimmed.hasPrefix("sk-ant-oat01-") {
-            kind = .oauth
         } else if trimmed.hasPrefix("sk-ant-api03-") {
             kind = .apiKey
         } else {
-            return RPCResponse(error: "Token must start with sk-ant-oat01- or sk-ant-api03-")
+            return RPCResponse(error: "Token must start with sk-ant-api03-")
         }
 
         var warning: String? = nil
         var freshUsage: ClaudeUsageResult? = nil
         var freshStatus: String? = nil
 
-        // Only verify Claude-direct OAuth tokens against the Anthropic usage
-        // endpoint. Proxy profiles route to a user-managed endpoint that may
-        // not implement that API.
-        if kind == .oauth && params.baseURL == nil {
-            let status = await usageFetcher.fetchUsage(token: trimmed)
-            switch status {
-            case .ok(let usage):
-                freshUsage = usage
-                freshStatus = "ok"
-            case .http401:
-                return RPCResponse(error: "Token invalid")
-            case .http429:
-                warning = "Could not verify token with Anthropic; saved anyway"
-                freshStatus = "http_429"
-            case .networkError:
-                warning = "Could not verify token with Anthropic; saved anyway"
-                freshStatus = "network_error"
-            case .decodeError:
-                warning = "Could not verify token with Anthropic; saved anyway"
-                freshStatus = "decode_error"
-            }
-        }
+        // API key profiles do not verify against the Anthropic usage endpoint.
+        // (Only OAuth tokens would have, but OAuth profiles no longer have tokens.)
 
         // Create DB row first so we have the canonical UUID; the keychain entry
         // is keyed by that UUID. If the keychain write fails we roll back the row.

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -159,16 +159,18 @@ extension RPCRouter {
         // DB row deletion is the source of truth — don't fail the RPC if the
         // on-disk secret file delete fails (permission, missing, disk error).
         // Log so an orphan file isn't completely silent.
-        // Bedrock profiles never wrote a Keychain entry, so skip the delete.
-        if profile.kind != .bedrock {
+        // Only API-key profiles store a Keychain entry; OAuth and Bedrock profiles do not.
+        if profile.kind == .apiKey {
             do {
                 try ModelProfileKeychain.delete(id: params.id.uuidString)
             } catch {
                 logger.warning("Failed to delete secret file for \(params.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
+        }
 
-            // Remove the per-profile config directory. Non-bedrock profiles have an
-            // isolated config dir at ~/tbd/profiles/<uuid>/; bedrock profiles do not.
+        // Remove the per-profile config directory. Non-bedrock profiles have an
+        // isolated config dir at ~/tbd/profiles/<uuid>/; bedrock profiles do not.
+        if profile.kind != .bedrock {
             do {
                 let profileDir = self.configDirManager.profileDirectory(forProfileID: params.id)
                 try FileManager.default.removeItem(at: profileDir)

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -89,7 +89,7 @@ extension RPCRouter {
         // non-empty string (the proxy decides what's valid).
         let kind: CredentialKind
         let isOAuth: Bool
-        if let _ = params.baseURL {
+        if params.baseURL != nil {
             // Proxy profile — credential is whatever the proxy expects. Treat
             // the secret as an API-key-shaped credential so it gets injected
             // via ANTHROPIC_API_KEY.
@@ -116,6 +116,7 @@ extension RPCRouter {
         )
 
         // Only store keychain for API key profiles; OAuth profiles don't store secrets.
+        var warning: String? = nil
         if !isOAuth {
             do {
                 try ModelProfileKeychain.store(id: profileRow.id.uuidString, token: trimmed)
@@ -123,10 +124,14 @@ extension RPCRouter {
                 try? await db.modelProfiles.delete(id: profileRow.id)
                 return RPCResponse(error: "Failed to store secret in keychain")
             }
+        } else if !trimmed.isEmpty {
+            // OAuth profile was created with a token supplied, but OAuth profiles
+            // don't store secrets. Warn the user that the token was discarded.
+            warning = "OAuth profiles authenticate per-session via /login. The supplied token was not stored."
         }
 
         subscriptions.broadcast(delta: .modelProfilesChanged)
-        return try RPCResponse(result: ModelProfileAddResult(profile: profileRow, warning: nil))
+        return try RPCResponse(result: ModelProfileAddResult(profile: profileRow, warning: warning))
     }
 
     // MARK: - Delete

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -124,7 +124,7 @@ extension RPCRouter {
                 try? await db.modelProfiles.delete(id: profileRow.id)
                 return RPCResponse(error: "Failed to store secret in keychain")
             }
-        } else if !trimmed.isEmpty {
+        } else {
             // OAuth profile was created with a token supplied, but OAuth profiles
             // don't store secrets. Warn the user that the token was discarded.
             warning = "OAuth profiles authenticate per-session via /login. The supplied token was not stored."
@@ -170,8 +170,7 @@ extension RPCRouter {
             // Remove the per-profile config directory. Non-bedrock profiles have an
             // isolated config dir at ~/tbd/profiles/<uuid>/; bedrock profiles do not.
             do {
-                let manager = ClaudeProfileConfigDirManager()
-                let profileDir = manager.profileDirectory(forProfileID: params.id)
+                let profileDir = self.configDirManager.profileDirectory(forProfileID: params.id)
                 try FileManager.default.removeItem(at: profileDir)
             } catch {
                 logger.warning("Failed to delete config directory for \(params.id, privacy: .public): \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -62,11 +62,15 @@ extension RPCRouter {
         let trimmed = (params.token ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
 
         // If no token is provided, treat as OAuth (no token required for OAuth).
+        // OAuth profiles do not use baseURL (they are Claude-direct).
         if trimmed.isEmpty {
+            guard params.baseURL == nil else {
+                return RPCResponse(error: "Token cannot be empty")
+            }
             let profileRow = try await db.modelProfiles.create(
                 name: name,
                 kind: .oauth,
-                baseURL: params.baseURL,
+                baseURL: nil,
                 model: params.model
             )
             subscriptions.broadcast(delta: .modelProfilesChanged)
@@ -80,27 +84,27 @@ extension RPCRouter {
             return RPCResponse(error: "Token contains invalid characters (newlines or NULL bytes are not allowed)")
         }
 
-        // Infer credential kind. Claude-direct profiles must look like an API key;
-        // proxy profiles (baseURL set) accept any non-empty string (the proxy decides
-        // what's valid).
+        // Infer credential kind. Claude-direct profiles can be OAuth (sk-ant-oat01-)
+        // or API key (sk-ant-api03-); proxy profiles (baseURL set) accept any
+        // non-empty string (the proxy decides what's valid).
         let kind: CredentialKind
+        let isOAuth: Bool
         if let _ = params.baseURL {
             // Proxy profile — credential is whatever the proxy expects. Treat
             // the secret as an API-key-shaped credential so it gets injected
             // via ANTHROPIC_API_KEY.
             kind = .apiKey
+            isOAuth = false
+        } else if trimmed.hasPrefix("sk-ant-oat01-") {
+            // OAuth token (no longer stored in keychain per Phase 3)
+            kind = .oauth
+            isOAuth = true
         } else if trimmed.hasPrefix("sk-ant-api03-") {
             kind = .apiKey
+            isOAuth = false
         } else {
-            return RPCResponse(error: "Token must start with sk-ant-api03-")
+            return RPCResponse(error: "Token must start with sk-ant-oat01- or sk-ant-api03-")
         }
-
-        var warning: String? = nil
-        var freshUsage: ClaudeUsageResult? = nil
-        var freshStatus: String? = nil
-
-        // API key profiles do not verify against the Anthropic usage endpoint.
-        // (Only OAuth tokens would have, but OAuth profiles no longer have tokens.)
 
         // Create DB row first so we have the canonical UUID; the keychain entry
         // is keyed by that UUID. If the keychain write fails we roll back the row.
@@ -110,28 +114,19 @@ extension RPCRouter {
             baseURL: params.baseURL,
             model: params.model
         )
-        do {
-            try ModelProfileKeychain.store(id: profileRow.id.uuidString, token: trimmed)
-        } catch {
-            try? await db.modelProfiles.delete(id: profileRow.id)
-            return RPCResponse(error: "Failed to store secret in keychain")
-        }
 
-        if let usage = freshUsage {
-            let usageRow = ModelProfileUsage(
-                profileID: profileRow.id,
-                fiveHourPct: usage.fiveHourPct,
-                sevenDayPct: usage.sevenDayPct,
-                fiveHourResetsAt: usage.fiveHourResetsAt,
-                sevenDayResetsAt: usage.sevenDayResetsAt,
-                fetchedAt: Date(),
-                lastStatus: freshStatus
-            )
-            try await db.modelProfileUsage.upsert(usageRow)
+        // Only store keychain for API key profiles; OAuth profiles don't store secrets.
+        if !isOAuth {
+            do {
+                try ModelProfileKeychain.store(id: profileRow.id.uuidString, token: trimmed)
+            } catch {
+                try? await db.modelProfiles.delete(id: profileRow.id)
+                return RPCResponse(error: "Failed to store secret in keychain")
+            }
         }
 
         subscriptions.broadcast(delta: .modelProfilesChanged)
-        return try RPCResponse(result: ModelProfileAddResult(profile: profileRow, warning: warning))
+        return try RPCResponse(result: ModelProfileAddResult(profile: profileRow, warning: nil))
     }
 
     // MARK: - Delete

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -166,6 +166,16 @@ extension RPCRouter {
             } catch {
                 logger.warning("Failed to delete secret file for \(params.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
+
+            // Remove the per-profile config directory. Non-bedrock profiles have an
+            // isolated config dir at ~/tbd/profiles/<uuid>/; bedrock profiles do not.
+            do {
+                let manager = ClaudeProfileConfigDirManager()
+                let profileDir = manager.profileDirectory(forProfileID: params.id)
+                try FileManager.default.removeItem(at: profileDir)
+            } catch {
+                logger.warning("Failed to delete config directory for \(params.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
         }
 
         subscriptions.broadcast(delta: .modelProfilesChanged)
@@ -264,12 +274,11 @@ extension RPCRouter {
             return RPCResponse(error: "Profile not found")
         }
 
-        // Proxy and bedrock profiles can't be polled against the Claude API usage endpoint.
-        // NOTE: oauth profiles no longer hold a TBD-side token, so usage polling for
-        // them now fails with "Secret missing from keychain" — tracked as a follow-up;
-        // the redesign here is credentials-only and does not touch usage tracking.
-        if profile.baseURL != nil || profile.kind == .bedrock {
-            return RPCResponse(error: "Usage tracking is only available for Claude-direct profiles")
+        // Proxy, bedrock, and oauth profiles can't be polled against the Claude API usage endpoint.
+        // OAuth profiles authenticate per-session and don't store a TBD-side secret.
+        // Proxy and bedrock profiles are not supported by the Claude API usage endpoint.
+        if profile.baseURL != nil || profile.kind == .bedrock || profile.kind == .oauth {
+            return RPCResponse(error: "Usage tracking is not available for \(profile.kind == .oauth ? "OAuth" : profile.baseURL != nil ? "proxy" : "bedrock") profiles")
         }
 
         if let cached = try await db.modelProfileUsage.get(profileID: params.id),

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -20,6 +20,7 @@ public final class RPCRouter: Sendable {
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     public let pendingQuestions: PendingQuestionStore
     public let repoSerializer: RepoSerializer
+    public let configDirManager: ClaudeProfileConfigDirManager
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
@@ -35,7 +36,8 @@ public final class RPCRouter: Sendable {
         usageFetcher: ClaudeUsageFetcher = LiveClaudeUsageFetcher(),
         modelProfileResolver: ModelProfileResolver? = nil,
         pendingQuestions: PendingQuestionStore = PendingQuestionStore(),
-        repoSerializer: RepoSerializer = RepoSerializer()
+        repoSerializer: RepoSerializer = RepoSerializer(),
+        configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager()
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -56,6 +58,7 @@ public final class RPCRouter: Sendable {
         self.usageFetcher = usageFetcher
         self.pendingQuestions = pendingQuestions
         self.repoSerializer = repoSerializer
+        self.configDirManager = configDirManager
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -606,7 +606,7 @@ extension ModelProfile {
     }
 
     /// Secondary detail line. `nil` when there's nothing useful to show
-    /// beyond the kind badge (plain claude-direct OAuth / api-key).
+    /// beyond the kind badge (a plain direct api-key profile).
     public var detailCaption: String? {
         switch kind {
         case .oauth:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -609,7 +609,12 @@ extension ModelProfile {
     /// beyond the kind badge (plain claude-direct OAuth / api-key).
     public var detailCaption: String? {
         switch kind {
-        case .oauth, .apiKey:
+        case .oauth:
+            // OAuth profiles need a one-time /login to establish credentials
+            // in the isolated config dir. Show this hint even for simple OAuth.
+            if let baseURL { return "Run /login once · via \(baseURL)" }
+            return "Run /login once"
+        case .apiKey:
             guard let baseURL else { return nil }
             if let model, !model.isEmpty { return "via \(baseURL) · \(model)" }
             return "via \(baseURL)"

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -27,17 +27,17 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(ClaudeProfileConfigDirManager.approvalToken(forAPIKey: key) == "shortkey")
     }
 
-    // MARK: - ensureDir
+    // MARK: - ensureAPIKeyDir
 
-    @Test("ensureDir creates the directory tree and writes pre-populated .claude.json")
-    func ensureDirCreatesAndPopulates() throws {
+    @Test("ensureAPIKeyDir creates the directory tree and writes pre-populated .claude.json")
+    func ensureAPIKeyDirCreatesAndPopulates() throws {
         let base = tempBase()
         defer { try? FileManager.default.removeItem(at: base) }
         let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
         let profileID = UUID()
         let apiKey = "sk-ant-test-AAAAAAAAAAAAAAAAAAAAAAAAA-LASTTWENTYCHARSXXX1"
 
-        let dir = try manager.ensureDir(forProfileID: profileID, apiKey: apiKey)
+        let dir = try manager.ensureAPIKeyDir(forProfileID: profileID, apiKey: apiKey)
 
         #expect(FileManager.default.fileExists(atPath: dir.path))
         #expect(dir.path.hasSuffix("/claude"))
@@ -54,16 +54,16 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(json?["hasCompletedOnboarding"] as? Bool == true)
     }
 
-    @Test("ensureDir is idempotent — re-call with same key keeps single approval")
-    func ensureDirIdempotent() throws {
+    @Test("ensureAPIKeyDir is idempotent — re-call with same key keeps single approval")
+    func ensureAPIKeyDirIdempotent() throws {
         let base = tempBase()
         defer { try? FileManager.default.removeItem(at: base) }
         let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
         let profileID = UUID()
         let apiKey = "sk-ant-AAAAAAAAAAAAAAAAAAAAAAA-DUPLICATEKEYTEST123"
 
-        let dir1 = try manager.ensureDir(forProfileID: profileID, apiKey: apiKey)
-        let dir2 = try manager.ensureDir(forProfileID: profileID, apiKey: apiKey)
+        let dir1 = try manager.ensureAPIKeyDir(forProfileID: profileID, apiKey: apiKey)
+        let dir2 = try manager.ensureAPIKeyDir(forProfileID: profileID, apiKey: apiKey)
         #expect(dir1 == dir2)
 
         let data = try Data(contentsOf: dir2.appendingPathComponent(".claude.json"))
@@ -73,8 +73,8 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(approved?.first == String(apiKey.suffix(20)))
     }
 
-    @Test("ensureDir appends new approval if api key changed, preserving old ones")
-    func ensureDirAppendsApproval() throws {
+    @Test("ensureAPIKeyDir appends new approval if api key changed, preserving old ones")
+    func ensureAPIKeyDirAppendsApproval() throws {
         let base = tempBase()
         defer { try? FileManager.default.removeItem(at: base) }
         let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
@@ -82,8 +82,8 @@ struct ClaudeProfileConfigDirManagerTests {
         let oldKey = "sk-ant-OLDOLDOLDOLDOLDOLDOLDOLDOLD-OLDLASTTWENTYCHARS12"
         let newKey = "sk-ant-NEWNEWNEWNEWNEWNEWNEWNEW-NEWLASTTWENTYCHARS34"
 
-        _ = try manager.ensureDir(forProfileID: profileID, apiKey: oldKey)
-        let dir = try manager.ensureDir(forProfileID: profileID, apiKey: newKey)
+        _ = try manager.ensureAPIKeyDir(forProfileID: profileID, apiKey: oldKey)
+        let dir = try manager.ensureAPIKeyDir(forProfileID: profileID, apiKey: newKey)
 
         let data = try Data(contentsOf: dir.appendingPathComponent(".claude.json"))
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -92,41 +92,128 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(approved?.contains(String(newKey.suffix(20))) == true)
     }
 
-    // MARK: - resolveConfigDir (the proxy-vs-direct gate)
+    // MARK: - ensureOAuthDir
 
-    @Test("resolveConfigDir returns nil for direct-Claude profile (no baseURL)")
-    func resolveDirectClaudeReturnsNil() {
-        let profile = ResolvedModelProfile(
-            profileID: UUID(),
-            name: "Direct Claude",
-            kind: .oauth,
-            baseURL: nil,
-            model: nil,
-            secret: "oauth-token",
-            awsRegion: nil,
-            awsProfile: nil
-        )
-        #expect(ClaudeProfileConfigDirManager.resolveConfigDir(for: profile) == nil)
+    @Test("ensureOAuthDir creates the directory and writes .claude.json with hasCompletedOnboarding only")
+    func ensureOAuthDirCreatesAndPopulates() throws {
+        let base = tempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
+        let profileID = UUID()
+
+        let dir = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        #expect(FileManager.default.fileExists(atPath: dir.path))
+        #expect(dir.path.hasSuffix("/claude"))
+        #expect(dir.path.contains(profileID.uuidString.lowercased()))
+
+        let claudeJSON = dir.appendingPathComponent(".claude.json")
+        let data = try Data(contentsOf: claudeJSON)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["hasCompletedOnboarding"] as? Bool == true)
+        // OAuth dir should NOT have customApiKeyResponses
+        #expect((json?["customApiKeyResponses"] as? [String: Any]) == nil)
     }
+
+    @Test("ensureOAuthDir leaves existing .claude.json untouched")
+    func ensureOAuthDirLeavesExisting() throws {
+        let base = tempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
+        let profileID = UUID()
+
+        // First call creates the dir and .claude.json
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        let claudeJSON = manager.configDirectory(forProfileID: profileID).appendingPathComponent(".claude.json")
+        let originalData = try Data(contentsOf: claudeJSON)
+
+        // Second call should leave it untouched
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        let secondData = try Data(contentsOf: claudeJSON)
+        #expect(originalData == secondData)
+    }
+
+    // MARK: - resolveConfigDir
 
     @Test("resolveConfigDir returns nil for nil profile")
     func resolveNilProfileReturnsNil() {
         #expect(ClaudeProfileConfigDirManager.resolveConfigDir(for: nil) == nil)
     }
 
-    @Test("resolveConfigDir returns nil for OAuth-secret proxy profile (no API key to pre-approve)")
-    func resolveOAuthProxyReturnsNil() {
-        // Edge case: a proxy profile that's configured with an OAuth token
-        // instead of an API key. In that case there's no API key to
-        // pre-approve, AND Claude Code's auth-conflict check fires on
-        // ANTHROPIC_API_KEY only — so the isolation isn't needed.
+    @Test("resolveConfigDir returns a path for .oauth profile")
+    func resolveOAuthProfileReturnsPath() throws {
+        let base = tempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+        // Override the manager's default baseDir so the test doesn't touch ~/tbd
+        ClaudeProfileConfigDirManager(baseDirectory: base)
+
         let profile = ResolvedModelProfile(
             profileID: UUID(),
-            name: "OAuth Proxy",
+            name: "OAuth",
             kind: .oauth,
-            baseURL: "http://127.0.0.1:3456",
+            baseURL: nil,
             model: nil,
-            secret: "oauth-token",
+            secret: nil,  // OAuth profiles have no secret in the resolved form
+            awsRegion: nil,
+            awsProfile: nil
+        )
+
+        // For this test, we need to use the temp base via direct instantiation
+        // since resolveConfigDir is static and always uses the default.
+        // Instead, verify that a direct call to ensureOAuthDir works.
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
+        let dir = try manager.ensureOAuthDir(forProfileID: profile.profileID)
+        #expect(dir.path.contains(profile.profileID.uuidString.lowercased()))
+    }
+
+    @Test("resolveConfigDir returns a path for direct .apiKey profile (baseURL == nil)")
+    func resolveDirectAPIKeyReturnsPath() throws {
+        let base = tempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        let profile = ResolvedModelProfile(
+            profileID: UUID(),
+            name: "Direct API Key",
+            kind: .apiKey,
+            baseURL: nil,
+            model: nil,
+            secret: "sk-ant-api03-test-key-XXXXX",
+            awsRegion: nil,
+            awsProfile: nil
+        )
+
+        // Verify that a direct call to ensureAPIKeyDir works for direct profiles.
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
+        let dir = try manager.ensureAPIKeyDir(forProfileID: profile.profileID, apiKey: profile.secret!)
+        #expect(dir.path.contains(profile.profileID.uuidString.lowercased()))
+    }
+
+    @Test("resolveConfigDir returns nil for .bedrock profile")
+    func resolveBedrockeReturnsNil() {
+        let profile = ResolvedModelProfile(
+            profileID: UUID(),
+            name: "Bedrock",
+            kind: .bedrock,
+            baseURL: nil,
+            model: "anthropic.claude-sonnet-4-5",
+            secret: nil,
+            awsRegion: "us-west-2",
+            awsProfile: nil
+        )
+        #expect(ClaudeProfileConfigDirManager.resolveConfigDir(for: profile) == nil)
+    }
+
+    @Test("resolveConfigDir returns nil for .apiKey profile with no secret")
+    func resolveAPIKeyWithoutSecretReturnsNil() {
+        let profile = ResolvedModelProfile(
+            profileID: UUID(),
+            name: "API Key (no secret)",
+            kind: .apiKey,
+            baseURL: nil,
+            model: nil,
+            secret: nil,
             awsRegion: nil,
             awsProfile: nil
         )

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -154,30 +154,20 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(dir.path.contains(profileID.uuidString.lowercased()))
     }
 
-    @Test("resolveConfigDir returns a path for direct .apiKey profile (baseURL == nil)")
-    func resolveDirectAPIKeyReturnsPath() throws {
+    @Test("ensureAPIKeyDir produces a per-profile path")
+    func ensureAPIKeyDirReturnsPath() throws {
         let base = tempBase()
         defer { try? FileManager.default.removeItem(at: base) }
-
-        let profile = ResolvedModelProfile(
-            profileID: UUID(),
-            name: "Direct API Key",
-            kind: .apiKey,
-            baseURL: nil,
-            model: nil,
-            secret: "sk-ant-api03-test-key-XXXXX",
-            awsRegion: nil,
-            awsProfile: nil
-        )
-
-        // Verify that a direct call to ensureAPIKeyDir works for direct profiles.
+        // resolveConfigDir is static and uses the default ~/tbd base, so the
+        // api-key branch is exercised here via ensureAPIKeyDir against a temp base.
+        let profileID = UUID()
         let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
-        let dir = try manager.ensureAPIKeyDir(forProfileID: profile.profileID, apiKey: profile.secret!)
-        #expect(dir.path.contains(profile.profileID.uuidString.lowercased()))
+        let dir = try manager.ensureAPIKeyDir(forProfileID: profileID, apiKey: "sk-ant-api03-test-key-XXXXX")
+        #expect(dir.path.contains(profileID.uuidString.lowercased()))
     }
 
     @Test("resolveConfigDir returns nil for .bedrock profile")
-    func resolveBedrockeReturnsNil() {
+    func resolveBedrockReturnsNil() {
         let profile = ResolvedModelProfile(
             profileID: UUID(),
             name: "Bedrock",

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -92,6 +92,48 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(approved?.contains(String(newKey.suffix(20))) == true)
     }
 
+    @Test("ensureAPIKeyDir preserves unknown top-level keys from existing .claude.json")
+    func ensureAPIKeyDirPreservesUnknownKeys() throws {
+        let base = tempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
+        let profileID = UUID()
+        let apiKey = "sk-ant-test-AAAAAAAAAAAAAAAAAAAAAAAAA-LASTTWENTYCHARSXXX1"
+
+        // Manually write a .claude.json with an unknown top-level key
+        let dir = manager.configDirectory(forProfileID: profileID)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let initialPayload: [String: Any] = [
+            "customApiKeyResponses": [
+                "approved": [],
+                "rejected": [],
+            ],
+            "hasCompletedOnboarding": true,
+            "someClaudeCodeKey": "value",
+            "anotherCustomKey": 42,
+        ]
+        let initialData = try JSONSerialization.data(withJSONObject: initialPayload, options: [.prettyPrinted, .sortedKeys])
+        try initialData.write(to: dir.appendingPathComponent(".claude.json"), options: [.atomic])
+
+        // Call ensureAPIKeyDir and verify unknown keys survive
+        _ = try manager.ensureAPIKeyDir(forProfileID: profileID, apiKey: apiKey)
+
+        let claudeJSON = dir.appendingPathComponent(".claude.json")
+        let finalData = try Data(contentsOf: claudeJSON)
+        let finalJson = try JSONSerialization.jsonObject(with: finalData) as? [String: Any]
+
+        // Verify TBD keys are correct
+        let responses = finalJson?["customApiKeyResponses"] as? [String: Any]
+        let approved = responses?["approved"] as? [String]
+        #expect(approved?.contains(String(apiKey.suffix(20))) == true)
+        #expect(finalJson?["hasCompletedOnboarding"] as? Bool == true)
+
+        // Verify unknown keys are preserved
+        #expect(finalJson?["someClaudeCodeKey"] as? String == "value")
+        #expect(finalJson?["anotherCustomKey"] as? Int == 42)
+    }
+
     // MARK: - ensureOAuthDir
 
     @Test("ensureOAuthDir creates the directory and writes .claude.json with hasCompletedOnboarding only")

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -142,30 +142,16 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(ClaudeProfileConfigDirManager.resolveConfigDir(for: nil) == nil)
     }
 
-    @Test("resolveConfigDir returns a path for .oauth profile")
+    @Test("ensureOAuthDir produces a per-profile path")
     func resolveOAuthProfileReturnsPath() throws {
         let base = tempBase()
         defer { try? FileManager.default.removeItem(at: base) }
-        // Override the manager's default baseDir so the test doesn't touch ~/tbd
-        ClaudeProfileConfigDirManager(baseDirectory: base)
-
-        let profile = ResolvedModelProfile(
-            profileID: UUID(),
-            name: "OAuth",
-            kind: .oauth,
-            baseURL: nil,
-            model: nil,
-            secret: nil,  // OAuth profiles have no secret in the resolved form
-            awsRegion: nil,
-            awsProfile: nil
-        )
-
-        // For this test, we need to use the temp base via direct instantiation
-        // since resolveConfigDir is static and always uses the default.
-        // Instead, verify that a direct call to ensureOAuthDir works.
+        // resolveConfigDir is static and uses the default ~/tbd base, so the
+        // oauth branch is exercised here via ensureOAuthDir against a temp base.
+        let profileID = UUID()
         let manager = ClaudeProfileConfigDirManager(baseDirectory: base)
-        let dir = try manager.ensureOAuthDir(forProfileID: profile.profileID)
-        #expect(dir.path.contains(profile.profileID.uuidString.lowercased()))
+        let dir = try manager.ensureOAuthDir(forProfileID: profileID)
+        #expect(dir.path.contains(profileID.uuidString.lowercased()))
     }
 
     @Test("resolveConfigDir returns a path for direct .apiKey profile (baseURL == nil)")

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -589,7 +589,7 @@ struct ClaudeSpawnCommandBuilderTests {
     }
 
     @Test("oauth: ignores bedrock params and doesn't inject token without configDir")
-    func oauthIgnoresBedrocParams() {
+    func oauthIgnoresBedrockParams() {
         let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "sid",

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -99,37 +99,40 @@ struct ClaudeSpawnCommandBuilderTests {
 
     // MARK: - Token branches: secret returned via sensitiveEnv, NOT in command
 
-    @Test("resume + token: token in sensitiveEnv, not command")
-    func resumeWithToken() {
+    @Test("resume + oauth secret: token NOT injected (oauth profiles get config dir instead)")
+    func resumeWithOAuthSecret() {
         let r = ClaudeSpawnCommandBuilder.build(
             resumeID: "abc",
             freshSessionID: nil,
             appendSystemPrompt: nil,
             initialPrompt: nil,
             profileSecret: fakeOauth,
+            profileKind: .oauth,
             cmd: nil,
             shellFallback: ""
         )
         #expect(r.command == "claude --resume abc --dangerously-skip-permissions")
         #expect(!r.command.contains(fakeOauth))
         #expect(!r.command.contains("CLAUDE_CODE_OAUTH_TOKEN"))
-        #expect(r.sensitiveEnv == ["CLAUDE_CODE_OAUTH_TOKEN": fakeOauth])
+        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == nil)
     }
 
-    @Test("fresh + token: token in sensitiveEnv, not command")
-    func freshWithToken() {
+    @Test("fresh + api-key secret: uses ANTHROPIC_API_KEY in sensitiveEnv")
+    func freshWithAPIKeySecret() {
         let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "sid",
             appendSystemPrompt: nil,
             initialPrompt: nil,
             profileSecret: fakeOauth,
+            profileKind: .apiKey,
             cmd: nil,
             shellFallback: ""
         )
         #expect(r.command.hasPrefix("claude --session-id sid"))
         #expect(!r.command.contains(fakeOauth))
-        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == fakeOauth)
+        #expect(r.sensitiveEnv["ANTHROPIC_API_KEY"] == fakeOauth)
+        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == nil)
     }
 
     @Test("api key kind uses ANTHROPIC_API_KEY")
@@ -199,8 +202,8 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv["ANTHROPIC_MODEL"] == "gpt-5-codex")
     }
 
-    @Test("no base URL or model means env stays auth-only (today's behavior)")
-    func profileWithoutProxyOnlyInjectsAuth() {
+    @Test("oauth profile without configDir → no token, no config dir")
+    func oauthWithoutConfigDirInjectsNothing() {
         let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "abc",
@@ -210,18 +213,41 @@ struct ClaudeSpawnCommandBuilderTests {
             profileKind: .oauth,
             profileBaseURL: nil,
             profileModel: nil,
+            profileConfigDir: nil,
             cmd: nil,
             shellFallback: "/bin/zsh"
         )
-        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == "tok")
+        // OAuth profiles don't inject tokens; they rely on CLAUDE_CONFIG_DIR
+        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == nil)
+        #expect(r.sensitiveEnv["CLAUDE_CONFIG_DIR"] == nil)
         #expect(r.sensitiveEnv["ANTHROPIC_BASE_URL"] == nil)
         #expect(r.sensitiveEnv["ANTHROPIC_MODEL"] == nil)
     }
 
-    // MARK: - ANTHROPIC_CONFIG_DIR isolation for proxy profiles
+    // MARK: - CLAUDE_CONFIG_DIR for all non-bedrock profiles
 
-    @Test("proxy profile + profileConfigDir → ANTHROPIC_CONFIG_DIR injected")
-    func proxyProfileInjectsConfigDir() {
+    @Test("oauth profile + profileConfigDir → CLAUDE_CONFIG_DIR injected, no token")
+    func oauthProfileInjectsConfigDir() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "abc",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            profileKind: .oauth,
+            profileBaseURL: nil,
+            profileModel: nil,
+            profileConfigDir: "/Users/me/tbd/profiles/abc/claude",
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(r.sensitiveEnv["CLAUDE_CONFIG_DIR"] == "/Users/me/tbd/profiles/abc/claude")
+        #expect(r.sensitiveEnv["ANTHROPIC_API_KEY"] == nil)
+        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == nil)
+    }
+
+    @Test("api-key profile + profileConfigDir → CLAUDE_CONFIG_DIR + ANTHROPIC_API_KEY")
+    func apiKeyProfileInjectsConfigDirAndKey() {
         let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "abc",
@@ -235,38 +261,16 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: "/bin/zsh"
         )
-        #expect(r.sensitiveEnv["ANTHROPIC_CONFIG_DIR"] == "/Users/me/tbd/profiles/abc/claude")
-        #expect(r.sensitiveEnv["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:3456")
+        #expect(r.sensitiveEnv["CLAUDE_CONFIG_DIR"] == "/Users/me/tbd/profiles/abc/claude")
         #expect(r.sensitiveEnv["ANTHROPIC_API_KEY"] == "sk-proxy-key")
-    }
-
-    @Test("direct-Claude profile (no baseURL) → ANTHROPIC_CONFIG_DIR NOT injected")
-    func directClaudeProfileSkipsConfigDir() {
-        // Even if a configDir were somehow supplied, builder must skip it when
-        // baseURL is nil — otherwise we'd isolate the direct-Claude profile
-        // from the user's ~/.claude OAuth login.
-        let r = ClaudeSpawnCommandBuilder.build(
-            resumeID: nil,
-            freshSessionID: "abc",
-            appendSystemPrompt: nil,
-            initialPrompt: nil,
-            profileSecret: "oauth-tok",
-            profileKind: .oauth,
-            profileBaseURL: nil,
-            profileModel: nil,
-            profileConfigDir: "/should/not/be/used",
-            cmd: nil,
-            shellFallback: "/bin/zsh"
-        )
+        #expect(r.sensitiveEnv["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:3456")
         #expect(r.sensitiveEnv["ANTHROPIC_CONFIG_DIR"] == nil)
-        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == "oauth-tok")
     }
 
-    @Test("proxy profile but no profileConfigDir → ANTHROPIC_CONFIG_DIR NOT injected")
-    func proxyProfileWithoutConfigDirSkipsInjection() {
+    @Test("profile with no configDir → CLAUDE_CONFIG_DIR NOT injected")
+    func profileWithoutConfigDirSkipsInjection() {
         // Builder is pure — if the caller failed to resolve a config dir
-        // (e.g. mkdir errored), we still spawn rather than crash. The user
-        // will see the auth-conflict warning but the terminal works.
+        // (e.g. mkdir errored), we still spawn rather than crash.
         let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "abc",
@@ -280,7 +284,8 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: "/bin/zsh"
         )
-        #expect(r.sensitiveEnv["ANTHROPIC_CONFIG_DIR"] == nil)
+        #expect(r.sensitiveEnv["CLAUDE_CONFIG_DIR"] == nil)
+        #expect(r.sensitiveEnv["ANTHROPIC_API_KEY"] == "sk-proxy")
         #expect(r.sensitiveEnv["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:3456")
     }
 
@@ -533,6 +538,7 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv["ANTHROPIC_API_KEY"] == nil)
         #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == nil)
         #expect(r.sensitiveEnv["ANTHROPIC_BASE_URL"] == nil)
+        #expect(r.sensitiveEnv["CLAUDE_CONFIG_DIR"] == nil)
         #expect(r.sensitiveEnv["ANTHROPIC_CONFIG_DIR"] == nil)
         // Exactly these 4 keys
         #expect(r.sensitiveEnv.keys.sorted() == ["ANTHROPIC_MODEL", "AWS_PROFILE", "AWS_REGION", "CLAUDE_CODE_USE_BEDROCK"])
@@ -582,8 +588,8 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == nil)
     }
 
-    @Test("oauth: unaffected when bedrock params are passed")
-    func oauthUnaffectedByNewParams() {
+    @Test("oauth: ignores bedrock params and doesn't inject token without configDir")
+    func oauthIgnoresBedrocParams() {
         let r = ClaudeSpawnCommandBuilder.build(
             resumeID: nil,
             freshSessionID: "sid",
@@ -599,7 +605,8 @@ struct ClaudeSpawnCommandBuilderTests {
             cmd: nil,
             shellFallback: "/bin/zsh"
         )
-        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == fakeOauth)
+        // OAuth profiles don't inject tokens (they use config dir instead)
+        #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == nil)
         #expect(r.sensitiveEnv["AWS_REGION"] == nil)
         #expect(r.sensitiveEnv["CLAUDE_CODE_USE_BEDROCK"] == nil)
     }

--- a/Tests/TBDDaemonTests/ClaudeUsagePollerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeUsagePollerTests.swift
@@ -153,8 +153,8 @@ struct ClaudeUsagePollerTests {
 
     @Test func happyPathStaggerAndCadence() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let a = try await db.modelProfiles.create(name: "A", kind: .oauth)
-        let b = try await db.modelProfiles.create(name: "B", kind: .oauth)
+        let a = try await db.modelProfiles.create(name: "A", kind: .apiKey)
+        let b = try await db.modelProfiles.create(name: "B", kind: .apiKey)
         let clock = TestPollerClock()
         let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
         let poller = makePoller(db: db, fetcher: fetcher, clock: clock, stagger: 30)
@@ -184,7 +184,7 @@ struct ClaudeUsagePollerTests {
 
     @Test func dedupeWithinSixtySeconds() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let a = try await db.modelProfiles.create(name: "A", kind: .oauth)
+        let a = try await db.modelProfiles.create(name: "A", kind: .apiKey)
         let clock = TestPollerClock()
 
         // Pre-populate a fresh usage row (fetched 30s ago).
@@ -215,7 +215,7 @@ struct ClaudeUsagePollerTests {
 
     @Test func http429BackoffThenRecovery() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let a = try await db.modelProfiles.create(name: "A", kind: .oauth)
+        let a = try await db.modelProfiles.create(name: "A", kind: .apiKey)
         let clock = TestPollerClock()
         let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
         // First call: 429. Subsequent: ok.
@@ -250,7 +250,7 @@ struct ClaudeUsagePollerTests {
 
     @Test func http401PermanentExclusion() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let a = try await db.modelProfiles.create(name: "A", kind: .oauth)
+        let a = try await db.modelProfiles.create(name: "A", kind: .apiKey)
         let clock = TestPollerClock()
         let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
         fetcher.enqueue(token: a.id.uuidString, .http401)
@@ -270,10 +270,10 @@ struct ClaudeUsagePollerTests {
         await poller.stop()
     }
 
-    @Test func apiKeyTokensSkipped() async throws {
+    @Test func oauthProfilesNotPolled() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let oauthTok = try await db.modelProfiles.create(name: "Oauth", kind: .oauth)
-        let apiKey = try await db.modelProfiles.create(name: "Api", kind: .apiKey)
+        let oauthProfile = try await db.modelProfiles.create(name: "Oauth", kind: .oauth)
+        let apiKeyProfile = try await db.modelProfiles.create(name: "Api", kind: .apiKey)
         let clock = TestPollerClock()
         let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
         let poller = makePoller(db: db, fetcher: fetcher, clock: clock)
@@ -283,16 +283,18 @@ struct ClaudeUsagePollerTests {
         await clock.advance(by: 5 * 60)
         await pump()
 
-        #expect(fetcher.callCount(for: oauthTok.id.uuidString) == 1)
-        #expect(fetcher.callCount(for: apiKey.id.uuidString) == 0)
+        // OAuth profiles don't store TBD-side secrets, so they are not polled
+        #expect(fetcher.callCount(for: oauthProfile.id.uuidString) == 0)
+        // API key profiles store secrets and are polled
+        #expect(fetcher.callCount(for: apiKeyProfile.id.uuidString) == 1)
 
         await poller.stop()
     }
 
     @Test func focusPauseAndResume() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let a = try await db.modelProfiles.create(name: "A", kind: .oauth)
-        let b = try await db.modelProfiles.create(name: "B", kind: .oauth)
+        let a = try await db.modelProfiles.create(name: "A", kind: .apiKey)
+        let b = try await db.modelProfiles.create(name: "B", kind: .apiKey)
         let clock = TestPollerClock()
         let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
         let poller = makePoller(db: db, fetcher: fetcher, clock: clock)
@@ -328,8 +330,8 @@ struct ClaudeUsagePollerTests {
 
     @Test func pokeAllFiresEverythingEligible() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let a = try await db.modelProfiles.create(name: "A", kind: .oauth)
-        let b = try await db.modelProfiles.create(name: "B", kind: .oauth)
+        let a = try await db.modelProfiles.create(name: "A", kind: .apiKey)
+        let b = try await db.modelProfiles.create(name: "B", kind: .apiKey)
         let clock = TestPollerClock()
         let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
         // Use big stagger so first tick is far in the future.
@@ -353,7 +355,7 @@ struct ClaudeUsagePollerTests {
 
     @Test func broadcastCalledOnEachWrite() async throws {
         let db = try TBDDatabase(inMemory: true)
-        let a = try await db.modelProfiles.create(name: "A", kind: .oauth)
+        let a = try await db.modelProfiles.create(name: "A", kind: .apiKey)
         let clock = TestPollerClock()
         let fetcher = MockUsageFetcher(default: .ok(sampleUsageOK()))
         // First .ok, then .http429.
@@ -388,11 +390,11 @@ struct ClaudeUsagePollerTests {
     func proxyProfileSkipped() async throws {
         let db = try TBDDatabase(inMemory: true)
         // Claude direct profile — should be polled.
-        let direct = try await db.modelProfiles.create(name: "Direct", kind: .oauth)
+        let direct = try await db.modelProfiles.create(name: "Direct", kind: .apiKey)
         // Proxy-routed profile — must be skipped (baseURL != nil).
         _ = try await db.modelProfiles.create(
             name: "ProxyOAuth",
-            kind: .oauth,
+            kind: .apiKey,
             baseURL: "http://127.0.0.1:3456",
             model: "gpt-5-codex"
         )

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -94,8 +94,30 @@ struct ModelProfileRPCTests {
         #expect(kc == nil)
     }
 
-    @Test("add: oauth with token (backwards compat) ignores token, no keychain")
-    func addOauthWithTokenIgnored() async throws {
+    @Test("add: oauth without token succeeds, warning nil")
+    func addOauthWithoutTokenNoWarning() async throws {
+        let stub = StubClaudeUsageFetcher()
+        let (router, db, _) = makeRouter(stub: stub)
+
+        let req = try RPCRequest(method: RPCMethod.modelProfileAdd,
+                                 params: ModelProfileAddParams(name: "Personal", token: nil))
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ModelProfileAddResult.self)
+        #expect(result.warning == nil)
+        #expect(result.profile.kind == .oauth)
+
+        let listed = try await db.modelProfiles.list()
+        #expect(listed.count == 1)
+        // No keychain entry
+        let kc = try? ModelProfileKeychain.load(id: result.profile.id.uuidString)
+        #expect(kc == nil)
+        // Fetcher should never be called for OAuth
+        #expect(stub.callCount == 0)
+    }
+
+    @Test("add: oauth with token returns warning, ignores token, no keychain")
+    func addOauthWithTokenReturnsWarning() async throws {
         let stub = StubClaudeUsageFetcher()
         let (router, db, _) = makeRouter(stub: stub)
 
@@ -105,7 +127,9 @@ struct ModelProfileRPCTests {
         let resp = await router.handle(req)
         #expect(resp.success)
         let result = try resp.decodeResult(ModelProfileAddResult.self)
-        #expect(result.warning == nil)
+        #expect(result.warning != nil)
+        #expect(result.warning?.contains("OAuth") == true)
+        #expect(result.warning?.contains("not stored") == true)
         #expect(result.profile.kind == .oauth)
 
         let listed = try await db.modelProfiles.list()
@@ -113,9 +137,6 @@ struct ModelProfileRPCTests {
         // OAuth token provided but not stored per Phase 3
         let kc = try? ModelProfileKeychain.load(id: result.profile.id.uuidString)
         #expect(kc == nil)
-        // No usage fetch for OAuth profiles
-        let usage = try await db.modelProfileUsage.get(profileID: result.profile.id)
-        #expect(usage == nil)
         // Fetcher should never be called for OAuth
         #expect(stub.callCount == 0)
     }

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -37,7 +37,10 @@ struct ModelProfileRPCTests {
         prefix + UUID().uuidString
     }
 
-    private func makeRouter(stub: StubClaudeUsageFetcher = StubClaudeUsageFetcher())
+    private func makeRouter(
+        stub: StubClaudeUsageFetcher = StubClaudeUsageFetcher(),
+        configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager()
+    )
         -> (RPCRouter, TBDDatabase, StubClaudeUsageFetcher)
     {
         let db = try! TBDDatabase(inMemory: true)
@@ -50,7 +53,8 @@ struct ModelProfileRPCTests {
             ),
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
-            usageFetcher: stub
+            usageFetcher: stub,
+            configDirManager: configDirManager
         )
         return (router, db, stub)
     }
@@ -362,28 +366,26 @@ struct ModelProfileRPCTests {
         try FileManager.default.createDirectory(at: tempBaseDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempBaseDir) }
 
-        let (router, db, _) = makeRouter()
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBaseDir)
+        let (router, db, _) = makeRouter(configDirManager: manager)
 
         // Create an OAuth profile and ensure its config dir is created with temp base
         let oauthProfile = try await db.modelProfiles.create(name: "OAuth", kind: .oauth)
-        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBaseDir)
         let _ = try manager.ensureOAuthDir(forProfileID: oauthProfile.id)
         let profileDir = manager.profileDirectory(forProfileID: oauthProfile.id)
 
         // Verify dir exists before deletion
         #expect(FileManager.default.fileExists(atPath: profileDir.path))
 
-        // Inject the custom base directory into the RPC handler by verifying through a custom cleanup
-        // The actual deletion happens in the handler, so we verify via inspecting the filesystem
-        // after calling delete. We'll manually verify the fix works by checking that the deletion
-        // code path doesn't crash and the profile is removed from the database.
+        // Delete the profile via RPC; the handler uses the injected manager
         let resp = await router.handle(try RPCRequest(method: RPCMethod.modelProfileDelete,
                                                       params: ModelProfileDeleteParams(id: oauthProfile.id)))
         #expect(resp.success)
 
-        // The RPC handler removes the default location. For this test, we just verify the database
-        // deletion works correctly; the directory cleanup is tested via integration/system tests.
+        // Verify the profile is removed from the database
         #expect(try await db.modelProfiles.list().isEmpty)
+        // Verify the config directory was deleted
+        #expect(!FileManager.default.fileExists(atPath: profileDir.path))
     }
 
     @Test("delete apiKey: removes per-profile config directory")
@@ -392,7 +394,8 @@ struct ModelProfileRPCTests {
         try FileManager.default.createDirectory(at: tempBaseDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempBaseDir) }
 
-        let (router, db, _) = makeRouter()
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBaseDir)
+        let (router, db, _) = makeRouter(configDirManager: manager)
         defer { Task { await cleanupKeychain(db) } }
 
         // Create an API key profile and ensure its config dir is created with temp base
@@ -400,21 +403,21 @@ struct ModelProfileRPCTests {
         let token = freshToken(Self.apiPrefix)
         try ModelProfileKeychain.store(id: apiKeyProfile.id.uuidString, token: token)
 
-        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBaseDir)
         let _ = try manager.ensureAPIKeyDir(forProfileID: apiKeyProfile.id, apiKey: token)
         let profileDir = manager.profileDirectory(forProfileID: apiKeyProfile.id)
 
         // Verify dir exists before deletion
         #expect(FileManager.default.fileExists(atPath: profileDir.path))
 
-        // Delete the profile via RPC
+        // Delete the profile via RPC; the handler uses the injected manager
         let resp = await router.handle(try RPCRequest(method: RPCMethod.modelProfileDelete,
                                                       params: ModelProfileDeleteParams(id: apiKeyProfile.id)))
         #expect(resp.success)
 
-        // The RPC handler removes the default location. For this test, we just verify the database
-        // deletion works correctly; the directory cleanup is tested via integration/system tests.
+        // Verify the profile is removed from the database
         #expect(try await db.modelProfiles.list().isEmpty)
+        // Verify the config directory was deleted
+        #expect(!FileManager.default.fileExists(atPath: profileDir.path))
     }
 
     // MARK: - rename

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -74,11 +74,30 @@ struct ModelProfileRPCTests {
 
     // MARK: - add
 
-    @Test("add: oauth + .ok stores row, keychain, usage")
-    func addOauthOk() async throws {
-        let stub = StubClaudeUsageFetcher(responses: [.ok(sampleUsage())])
+    @Test("add: oauth without token succeeds, no keychain")
+    func addOauthNoToken() async throws {
+        let (router, db, _) = makeRouter()
+
+        let req = try RPCRequest(method: RPCMethod.modelProfileAdd,
+                                 params: ModelProfileAddParams(name: "Work", token: nil))
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ModelProfileAddResult.self)
+        #expect(result.warning == nil)
+        #expect(result.profile.kind == .oauth)
+        #expect(result.profile.name == "Work")
+
+        let listed = try await db.modelProfiles.list()
+        #expect(listed.count == 1)
+        // Verify no keychain entry was written
+        let kc = try? ModelProfileKeychain.load(id: result.profile.id.uuidString)
+        #expect(kc == nil)
+    }
+
+    @Test("add: oauth with token (backwards compat) ignores token, no keychain")
+    func addOauthWithTokenIgnored() async throws {
+        let stub = StubClaudeUsageFetcher()
         let (router, db, _) = makeRouter(stub: stub)
-        defer { Task { await cleanupKeychain(db) } }
 
         let tokenBytes = freshToken()
         let req = try RPCRequest(method: RPCMethod.modelProfileAdd,
@@ -91,41 +110,14 @@ struct ModelProfileRPCTests {
 
         let listed = try await db.modelProfiles.list()
         #expect(listed.count == 1)
-        let kc = try ModelProfileKeychain.load(id: result.profile.id.uuidString)
-        #expect(kc == tokenBytes)
+        // OAuth token provided but not stored per Phase 3
+        let kc = try? ModelProfileKeychain.load(id: result.profile.id.uuidString)
+        #expect(kc == nil)
+        // No usage fetch for OAuth profiles
         let usage = try await db.modelProfileUsage.get(profileID: result.profile.id)
-        #expect(usage != nil)
-        #expect(usage?.fiveHourPct == 0.42)
-        try? ModelProfileKeychain.delete(id: result.profile.id.uuidString)
-    }
-
-    @Test("add: oauth + .http401 rejects without persisting")
-    func addOauth401() async throws {
-        let stub = StubClaudeUsageFetcher(responses: [.http401])
-        let (router, db, _) = makeRouter(stub: stub)
-        let req = try RPCRequest(method: RPCMethod.modelProfileAdd,
-                                 params: ModelProfileAddParams(name: "Bad", token: freshToken()))
-        let resp = await router.handle(req)
-        #expect(!resp.success)
-        #expect(resp.error == "Token invalid")
-        #expect(try await db.modelProfiles.list().isEmpty)
-    }
-
-    @Test("add: oauth + .networkError saves with warning, no usage row")
-    func addOauthNetworkError() async throws {
-        let stub = StubClaudeUsageFetcher(responses: [.networkError("offline")])
-        let (router, db, _) = makeRouter(stub: stub)
-        defer { Task { await cleanupKeychain(db) } }
-
-        let req = try RPCRequest(method: RPCMethod.modelProfileAdd,
-                                 params: ModelProfileAddParams(name: "Maybe", token: freshToken()))
-        let resp = await router.handle(req)
-        #expect(resp.success)
-        let result = try resp.decodeResult(ModelProfileAddResult.self)
-        #expect(result.warning != nil)
-        #expect(try await db.modelProfiles.list().count == 1)
-        #expect(try await db.modelProfileUsage.get(profileID: result.profile.id) == nil)
-        try? ModelProfileKeychain.delete(id: result.profile.id.uuidString)
+        #expect(usage == nil)
+        // Fetcher should never be called for OAuth
+        #expect(stub.callCount == 0)
     }
 
     @Test("add: api_key prefix skips fetcher")
@@ -196,6 +188,43 @@ struct ModelProfileRPCTests {
             params: ModelProfileAddParams(
                 name: "WhitespaceProxy",
                 token: "   ",
+                baseURL: "http://127.0.0.1:3456",
+                model: nil
+            )
+        )
+        let resp = await router.handle(req)
+        #expect(!resp.success)
+        #expect(resp.error == "Token cannot be empty")
+        #expect(try await db.modelProfiles.list().isEmpty)
+    }
+
+    @Test("add: empty token with no baseURL treated as oauth (AC5.3 counterpart)")
+    func addEmptyTokenTreatedAsOAuth() async throws {
+        let (router, db, _) = makeRouter()
+        let req = try RPCRequest(
+            method: RPCMethod.modelProfileAdd,
+            params: ModelProfileAddParams(
+                name: "ImplicitOAuth",
+                token: nil,
+                baseURL: nil,
+                model: nil
+            )
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ModelProfileAddResult.self)
+        #expect(result.profile.kind == .oauth)
+        #expect(try await db.modelProfiles.list().count == 1)
+    }
+
+    @Test("add: empty token with baseURL rejected")
+    func addEmptyTokenWithBaseURLRejected() async throws {
+        let (router, db, _) = makeRouter()
+        let req = try RPCRequest(
+            method: RPCMethod.modelProfileAdd,
+            params: ModelProfileAddParams(
+                name: "ProxyNoToken",
+                token: nil,
                 baseURL: "http://127.0.0.1:3456",
                 model: nil
             )

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -303,8 +303,12 @@ struct ModelProfileRPCTests {
     @Test("delete clears global default + keychain + usage")
     func deleteClearsDefault() async throws {
         let (router, db, _) = makeRouter()
-        let tok = try await db.modelProfiles.create(name: "Solo", kind: .oauth)
-        try ModelProfileKeychain.store(id: tok.id.uuidString, token: "value")
+        defer { Task { await cleanupKeychain(db) } }
+
+        // Use an API-key profile (the only kind that stores keychain entries)
+        let tok = try await db.modelProfiles.create(name: "Solo", kind: .apiKey)
+        let token = freshToken(Self.apiPrefix)
+        try ModelProfileKeychain.store(id: tok.id.uuidString, token: token)
         try await db.modelProfileUsage.upsert(ModelProfileUsage(profileID: tok.id, fetchedAt: Date()))
         try await db.config.setDefaultProfileID(tok.id)
 

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -356,6 +356,67 @@ struct ModelProfileRPCTests {
         #expect(try await db.modelProfiles.list().isEmpty)
     }
 
+    @Test("delete oauth: removes per-profile config directory")
+    func deleteOAuthRemovesConfigDir() async throws {
+        let tempBaseDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempBaseDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempBaseDir) }
+
+        let (router, db, _) = makeRouter()
+
+        // Create an OAuth profile and ensure its config dir is created with temp base
+        let oauthProfile = try await db.modelProfiles.create(name: "OAuth", kind: .oauth)
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBaseDir)
+        let _ = try manager.ensureOAuthDir(forProfileID: oauthProfile.id)
+        let profileDir = manager.profileDirectory(forProfileID: oauthProfile.id)
+
+        // Verify dir exists before deletion
+        #expect(FileManager.default.fileExists(atPath: profileDir.path))
+
+        // Inject the custom base directory into the RPC handler by verifying through a custom cleanup
+        // The actual deletion happens in the handler, so we verify via inspecting the filesystem
+        // after calling delete. We'll manually verify the fix works by checking that the deletion
+        // code path doesn't crash and the profile is removed from the database.
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.modelProfileDelete,
+                                                      params: ModelProfileDeleteParams(id: oauthProfile.id)))
+        #expect(resp.success)
+
+        // The RPC handler removes the default location. For this test, we just verify the database
+        // deletion works correctly; the directory cleanup is tested via integration/system tests.
+        #expect(try await db.modelProfiles.list().isEmpty)
+    }
+
+    @Test("delete apiKey: removes per-profile config directory")
+    func deleteAPIKeyRemovesConfigDir() async throws {
+        let tempBaseDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempBaseDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempBaseDir) }
+
+        let (router, db, _) = makeRouter()
+        defer { Task { await cleanupKeychain(db) } }
+
+        // Create an API key profile and ensure its config dir is created with temp base
+        let apiKeyProfile = try await db.modelProfiles.create(name: "APIKey", kind: .apiKey)
+        let token = freshToken(Self.apiPrefix)
+        try ModelProfileKeychain.store(id: apiKeyProfile.id.uuidString, token: token)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBaseDir)
+        let _ = try manager.ensureAPIKeyDir(forProfileID: apiKeyProfile.id, apiKey: token)
+        let profileDir = manager.profileDirectory(forProfileID: apiKeyProfile.id)
+
+        // Verify dir exists before deletion
+        #expect(FileManager.default.fileExists(atPath: profileDir.path))
+
+        // Delete the profile via RPC
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.modelProfileDelete,
+                                                      params: ModelProfileDeleteParams(id: apiKeyProfile.id)))
+        #expect(resp.success)
+
+        // The RPC handler removes the default location. For this test, we just verify the database
+        // deletion works correctly; the directory cleanup is tested via integration/system tests.
+        #expect(try await db.modelProfiles.list().isEmpty)
+    }
+
     // MARK: - rename
 
     @Test("rename success")
@@ -414,7 +475,9 @@ struct ModelProfileRPCTests {
     func fetchUsageDedupes() async throws {
         let stub = StubClaudeUsageFetcher()
         let (router, db, _) = makeRouter(stub: stub)
-        let tok = try await db.modelProfiles.create(name: "A", kind: .oauth)
+        let tok = try await db.modelProfiles.create(name: "A", kind: .apiKey)
+        try ModelProfileKeychain.store(id: tok.id.uuidString, token: freshToken(Self.apiPrefix))
+        defer { try? ModelProfileKeychain.delete(id: tok.id.uuidString) }
         try await db.modelProfileUsage.upsert(ModelProfileUsage(
             profileID: tok.id, fiveHourPct: 0.7, sevenDayPct: 0.2, fetchedAt: Date()
         ))
@@ -438,8 +501,8 @@ struct ModelProfileRPCTests {
         let (router, db, _) = makeRouter(stub: stub)
         defer { Task { await cleanupKeychain(db) } }
 
-        let tok = try await db.modelProfiles.create(name: "A", kind: .oauth)
-        try ModelProfileKeychain.store(id: tok.id.uuidString, token: "secret")
+        let tok = try await db.modelProfiles.create(name: "A", kind: .apiKey)
+        try ModelProfileKeychain.store(id: tok.id.uuidString, token: freshToken(Self.apiPrefix))
         try await db.modelProfileUsage.upsert(ModelProfileUsage(
             profileID: tok.id, fiveHourPct: 0.1, sevenDayPct: 0.0,
             fetchedAt: Date().addingTimeInterval(-120)
@@ -462,8 +525,8 @@ struct ModelProfileRPCTests {
         let (router, db, _) = makeRouter(stub: stub)
         defer { Task { await cleanupKeychain(db) } }
 
-        let tok = try await db.modelProfiles.create(name: "A", kind: .oauth)
-        try ModelProfileKeychain.store(id: tok.id.uuidString, token: "secret")
+        let tok = try await db.modelProfiles.create(name: "A", kind: .apiKey)
+        try ModelProfileKeychain.store(id: tok.id.uuidString, token: freshToken(Self.apiPrefix))
         let resp = await router.handle(try RPCRequest(method: RPCMethod.modelProfileFetchUsage,
                                                       params: ModelProfileFetchUsageParams(id: tok.id)))
         #expect(!resp.success)
@@ -695,8 +758,7 @@ struct ModelProfileRPCTests {
             params: ModelProfileFetchUsageParams(id: row.id)
         ))
         #expect(!resp.success)
-        #expect(resp.error?.lowercased().contains("claude-direct") == true ||
-                resp.error?.lowercased().contains("only available") == true)
+        #expect(resp.error?.lowercased().contains("not available") == true)
         #expect(stub.callCount == 0)
     }
 }

--- a/Tests/TBDDaemonTests/ModelProfileResolverTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileResolverTests.swift
@@ -41,20 +41,20 @@ struct ModelProfileResolverTests {
 
     @Test func resolve_nilRepo_globalDefault_keychainPresent_returnsResolved() async throws {
         let (db, box, resolver) = try makeHarness()
-        let tok = try await db.modelProfiles.create(name: "Personal", kind: .oauth)
+        let tok = try await db.modelProfiles.create(name: "Personal", kind: .apiKey)
         try await db.config.setDefaultProfileID(tok.id)
         box.map[tok.id.uuidString] = "secret-A"
 
         let result = try await resolver.resolve(repoID: nil)
         #expect(result?.profileID == tok.id)
         #expect(result?.name == "Personal")
-        #expect(result?.kind == .oauth)
+        #expect(result?.kind == .apiKey)
         #expect(result?.secret == "secret-A")
     }
 
     @Test func resolve_nilRepo_globalDefault_keychainMissing_returnsNil() async throws {
         let (db, _, resolver) = try makeHarness()
-        let tok = try await db.modelProfiles.create(name: "Personal", kind: .oauth)
+        let tok = try await db.modelProfiles.create(name: "Personal", kind: .apiKey)
         try await db.config.setDefaultProfileID(tok.id)
 
         let result = try await resolver.resolve(repoID: nil)
@@ -63,7 +63,7 @@ struct ModelProfileResolverTests {
 
     @Test func resolve_repoOverride_keychainPresent_overrideWins() async throws {
         let (db, box, resolver) = try makeHarness()
-        let a = try await db.modelProfiles.create(name: "A", kind: .oauth)
+        let a = try await db.modelProfiles.create(name: "A", kind: .apiKey)
         let b = try await db.modelProfiles.create(name: "B", kind: .apiKey)
         try await db.config.setDefaultProfileID(b.id)
         let repo = try await makeRepo(db, override: a.id)
@@ -77,7 +77,7 @@ struct ModelProfileResolverTests {
 
     @Test func resolve_repoOverride_keychainMissing_fallsBackToGlobal() async throws {
         let (db, box, resolver) = try makeHarness()
-        let a = try await db.modelProfiles.create(name: "A", kind: .oauth)
+        let a = try await db.modelProfiles.create(name: "A", kind: .apiKey)
         let b = try await db.modelProfiles.create(name: "B", kind: .apiKey)
         try await db.config.setDefaultProfileID(b.id)
         let repo = try await makeRepo(db, override: a.id)
@@ -156,7 +156,7 @@ struct ModelProfileResolverTests {
 
     @Test func resolve_failure_doesNotBumpLastUsedAt() async throws {
         let (db, _, resolver) = try makeHarness()
-        let tok = try await db.modelProfiles.create(name: "T", kind: .oauth)
+        let tok = try await db.modelProfiles.create(name: "T", kind: .apiKey)
         try await db.config.setDefaultProfileID(tok.id)
         // no keychain entry
 
@@ -190,5 +190,42 @@ struct ModelProfileResolverTests {
         #expect(resolved?.awsRegion == "us-west-2")
         #expect(resolved?.awsProfile == "acme")
         #expect(resolved?.model == "anthropic.claude-sonnet-4-5")
+    }
+
+    @Test("AC4.1: oauth profile with missing keychain returns resolved with secret==nil via resolve")
+    func oauthProfile_keychainMissing_returnsResolvedViaResolve() async throws {
+        let (db, _, resolver) = try makeHarness()
+        let oauth = try await db.modelProfiles.create(name: "OAuth", kind: .oauth)
+        try await db.config.setDefaultProfileID(oauth.id)
+        // No keychain entry
+
+        let result = try await resolver.resolve(repoID: nil)
+        #expect(result != nil)
+        #expect(result?.profileID == oauth.id)
+        #expect(result?.kind == .oauth)
+        #expect(result?.secret == nil)
+    }
+
+    @Test("AC4.1: oauth profile with missing keychain returns resolved with secret==nil via loadByID")
+    func oauthProfile_keychainMissing_returnsResolvedViaLoadByID() async throws {
+        let (db, _, resolver) = try makeHarness()
+        let oauth = try await db.modelProfiles.create(name: "OAuth", kind: .oauth)
+        // No keychain entry
+
+        let result = try await resolver.loadByID(oauth.id)
+        #expect(result != nil)
+        #expect(result?.profileID == oauth.id)
+        #expect(result?.kind == .oauth)
+        #expect(result?.secret == nil)
+    }
+
+    @Test("AC4.2: apiKey profile with missing keychain returns nil")
+    func apiKeyProfile_keychainMissing_returnsNil() async throws {
+        let (db, _, resolver) = try makeHarness()
+        let apiKey = try await db.modelProfiles.create(name: "APIKey", kind: .apiKey)
+        // No keychain entry
+
+        let result = try await resolver.loadByID(apiKey.id)
+        #expect(result == nil)
     }
 }

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -86,12 +86,13 @@ struct ModelProfileSpawnTests {
         let term = try resp.decodeResult(Terminal.self)
         #expect(term.profileID == nil)
         #expect(!recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+        #expect(!recorder.joinedAll.contains("CLAUDE_CONFIG_DIR"))
     }
 
     // MARK: - Spawn: global default
 
-    @Test("spawn: global default → env prefix + profileID")
-    func spawnWithGlobalDefault() async throws {
+    @Test("spawn: global default oauth → CLAUDE_CONFIG_DIR + profileID, no token")
+    func spawnWithGlobalDefaultOAuth() async throws {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
@@ -107,10 +108,13 @@ struct ModelProfileSpawnTests {
         #expect(resp.success)
         let term = try resp.decodeResult(Terminal.self)
         #expect(term.profileID == tok.id)
-        // Token must be passed via tmux -e flag, never inlined in shell body.
-        #expect(recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secret)"))
-        #expect(!recorder.shellBodies.contains(secret),
-                "secret leaked into shell body")
+        // OAuth profiles inject CLAUDE_CONFIG_DIR, not a token.
+        // Secret is never leaked into the spawn call.
+        #expect(!recorder.joinedAll.contains(secret),
+                "secret leaked into tmux call")
+        #expect(!recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+        // The config dir is a path derived from the profile UUID, injected via tmux -e.
+        #expect(recorder.joinedAll.contains("CLAUDE_CONFIG_DIR="))
         #expect(!recorder.shellBodies.contains("CLAUDE_CODE_OAUTH_TOKEN"))
     }
 
@@ -136,10 +140,13 @@ struct ModelProfileSpawnTests {
         #expect(resp.success)
         let term = try resp.decodeResult(Terminal.self)
         #expect(term.profileID == b.id)
-        #expect(recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secretB)"))
+        // OAuth profiles inject CLAUDE_CONFIG_DIR, not a token.
         #expect(!recorder.joinedAll.contains(secretA))
+        #expect(!recorder.joinedAll.contains(secretB),
+                "secret leaked into tmux call")
         #expect(!recorder.shellBodies.contains(secretB),
                 "secret leaked into shell body")
+        #expect(recorder.joinedAll.contains("CLAUDE_CONFIG_DIR="))
     }
 
     // MARK: - Spawn: non-claude type ignores token
@@ -212,14 +219,16 @@ struct ModelProfileSpawnTests {
         let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
         #expect(!joined.contains("C-c"))
         #expect(!joined.contains("send-keys"))
-        // The new tab was spawned with B's secret via tmux -e (NOT inlined),
+        // The new tab was spawned with B's CLAUDE_CONFIG_DIR via tmux -e (NOT inlined),
         // and the shell body contains --session-id <newSessionID> (fresh path),
         // never --resume.
-        #expect(joined.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secretB)"))
+        #expect(joined.contains("CLAUDE_CONFIG_DIR="))
+        #expect(!joined.contains(secretB),
+                "secret leaked into tmux call")
         #expect(joined.contains("claude --session-id \(newTerm.claudeSessionID!)"))
         #expect(!joined.contains("claude --resume"))
         #expect(joined.contains("--dangerously-skip-permissions"))
-        // Negative: secret must NOT appear in any shell body of post-swap calls.
+        // Negative: secret must NOT appear in any shell body or tmux call.
         let postBodies = postSwap.compactMap { $0.last }.joined(separator: "\n")
         #expect(!postBodies.contains(secretB),
                 "secret leaked into shell body: \(postBodies)")
@@ -264,6 +273,7 @@ struct ModelProfileSpawnTests {
         #expect(joined.contains("claude --session-id"))
         #expect(!joined.contains("claude --resume"))
         #expect(!joined.contains("CLAUDE_CODE_OAUTH_TOKEN"))
+        #expect(!joined.contains("CLAUDE_CONFIG_DIR"))
         #expect(!joined.contains("C-c"))
     }
 

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -58,9 +58,8 @@ struct ModelProfileSpawnTests {
         return (repo, wt)
     }
 
-    private func seedToken(_ db: TBDDatabase, name: String, secret: String) async throws -> ModelProfile {
+    private func seedOAuthProfile(_ db: TBDDatabase, name: String) async throws -> ModelProfile {
         let row = try await db.modelProfiles.create(name: name, kind: .oauth)
-        try ModelProfileKeychain.store(id: row.id.uuidString, token: secret)
         return row
     }
 
@@ -96,8 +95,7 @@ struct ModelProfileSpawnTests {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
-        let secret = "sk-ant-oat01-fakeAAAA"
-        let tok = try await seedToken(db, name: "Default", secret: secret)
+        let tok = try await seedOAuthProfile(db, name: "Default")
         try await db.config.setDefaultProfileID(tok.id)
 
         let req = try RPCRequest(
@@ -109,9 +107,6 @@ struct ModelProfileSpawnTests {
         let term = try resp.decodeResult(Terminal.self)
         #expect(term.profileID == tok.id)
         // OAuth profiles inject CLAUDE_CONFIG_DIR, not a token.
-        // Secret is never leaked into the spawn call.
-        #expect(!recorder.joinedAll.contains(secret),
-                "secret leaked into tmux call")
         #expect(!recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN"))
         // The config dir is a path derived from the profile UUID, injected via tmux -e.
         #expect(recorder.joinedAll.contains("CLAUDE_CONFIG_DIR="))
@@ -125,10 +120,8 @@ struct ModelProfileSpawnTests {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
         let (repo, wt) = try await seedRepoAndWorktree(db)
-        let secretA = "sk-ant-oat01-AAAA"
-        let secretB = "sk-ant-oat01-BBBB"
-        let a = try await seedToken(db, name: "A", secret: secretA)
-        let b = try await seedToken(db, name: "B", secret: secretB)
+        let a = try await seedOAuthProfile(db, name: "A")
+        let b = try await seedOAuthProfile(db, name: "B")
         try await db.config.setDefaultProfileID(a.id)
         try await db.repos.setProfileOverride(id: repo.id, profileID: b.id)
 
@@ -141,11 +134,7 @@ struct ModelProfileSpawnTests {
         let term = try resp.decodeResult(Terminal.self)
         #expect(term.profileID == b.id)
         // OAuth profiles inject CLAUDE_CONFIG_DIR, not a token.
-        #expect(!recorder.joinedAll.contains(secretA))
-        #expect(!recorder.joinedAll.contains(secretB),
-                "secret leaked into tmux call")
-        #expect(!recorder.shellBodies.contains(secretB),
-                "secret leaked into shell body")
+        #expect(!recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN"))
         #expect(recorder.joinedAll.contains("CLAUDE_CONFIG_DIR="))
     }
 
@@ -156,8 +145,7 @@ struct ModelProfileSpawnTests {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
-        let secret = "sk-ant-oat01-AAAA"
-        let tok = try await seedToken(db, name: "A", secret: secret)
+        let tok = try await seedOAuthProfile(db, name: "A")
         try await db.config.setDefaultProfileID(tok.id)
 
         let req = try RPCRequest(
@@ -178,10 +166,8 @@ struct ModelProfileSpawnTests {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
-        let secretA = "sk-ant-oat01-AAAA"
-        let secretB = "sk-ant-oat01-BBBB"
-        let a = try await seedToken(db, name: "A", secret: secretA)
-        let b = try await seedToken(db, name: "B", secret: secretB)
+        let a = try await seedOAuthProfile(db, name: "A")
+        let b = try await seedOAuthProfile(db, name: "B")
         try await db.config.setDefaultProfileID(a.id)
 
         // Spawn original claude terminal with token A. The session is "blank" —
@@ -223,15 +209,11 @@ struct ModelProfileSpawnTests {
         // and the shell body contains --session-id <newSessionID> (fresh path),
         // never --resume.
         #expect(joined.contains("CLAUDE_CONFIG_DIR="))
-        #expect(!joined.contains(secretB),
-                "secret leaked into tmux call")
         #expect(joined.contains("claude --session-id \(newTerm.claudeSessionID!)"))
         #expect(!joined.contains("claude --resume"))
         #expect(joined.contains("--dangerously-skip-permissions"))
-        // Negative: secret must NOT appear in any shell body or tmux call.
+        // Negative: secrets and tokens must NOT appear in any shell body or tmux call.
         let postBodies = postSwap.compactMap { $0.last }.joined(separator: "\n")
-        #expect(!postBodies.contains(secretB),
-                "secret leaked into shell body: \(postBodies)")
         #expect(!postBodies.contains("CLAUDE_CODE_OAUTH_TOKEN"))
     }
 
@@ -242,8 +224,7 @@ struct ModelProfileSpawnTests {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
-        let secretA = "sk-ant-oat01-AAAA"
-        let a = try await seedToken(db, name: "A", secret: secretA)
+        let a = try await seedOAuthProfile(db, name: "A")
         try await db.config.setDefaultProfileID(a.id)
 
         let createResp = await router.handle(try RPCRequest(

--- a/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
@@ -115,7 +115,8 @@ struct SuspendResumeCoordinatorTests {
             branch: "main", path: "/tmp/test-repo",
             tmuxServer: "tbd-test"
         )
-        let token = try await db.modelProfiles.create(name: "test-token", kind: .oauth)
+        // api-key profile — oauth profiles no longer inject a token.
+        let token = try await db.modelProfiles.create(name: "test-token", kind: .apiKey)
         let terminal = try await db.terminals.create(
             worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
             label: "claude-1", claudeSessionID: "session-abc",
@@ -126,7 +127,7 @@ struct SuspendResumeCoordinatorTests {
         )
 
         // Stub keychain closure returns a known secret only for this token.
-        let secret = "sk-ant-oat01-FAKETOKEN_value"
+        let secret = "sk-ant-api03-FAKETOKEN_value"
         let resolver = ModelProfileResolver(
             profiles: db.modelProfiles,
             repos: db.repos,
@@ -153,13 +154,13 @@ struct SuspendResumeCoordinatorTests {
         let resumeCall = snap.first { $0.joined(separator: " ").contains("claude --resume") }
         #expect(resumeCall != nil, "expected a createWindow call containing claude --resume")
         // Token must be passed via tmux -e flag, NOT inlined in the shell command argv.
-        #expect(resumeCall?.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secret)") == true,
+        #expect(resumeCall?.contains("ANTHROPIC_API_KEY=\(secret)") == true,
                 "expected token in tmux -e flag; got: \(resumeCall ?? [])")
         // The shell command body (last arg, after -ic) must NOT contain the secret.
         let shellBody = resumeCall?.last ?? ""
         #expect(!shellBody.contains(secret),
                 "secret leaked into shell command body: \(shellBody)")
-        #expect(!shellBody.contains("CLAUDE_CODE_OAUTH_TOKEN"),
+        #expect(!shellBody.contains("ANTHROPIC_API_KEY"),
                 "env var name leaked into shell command body: \(shellBody)")
         #expect(shellBody.contains("claude --resume session-abc"))
     }

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -434,11 +434,12 @@ import Testing
 
     let db = try TBDDatabase(inMemory: true)
 
-    // Seed a token row and set it as the global default.
-    let token = try await db.modelProfiles.create(name: "Test", kind: .oauth)
+    // Seed an api-key profile row and set it as the global default.
+    // (oauth profiles no longer inject a token — they use CLAUDE_CONFIG_DIR.)
+    let token = try await db.modelProfiles.create(name: "Test", kind: .apiKey)
     try await db.config.setDefaultProfileID(token.id)
 
-    let secret = "sk-ant-oat01-FAKETOKEN_value"
+    let secret = "sk-ant-api03-FAKETOKEN_value"
     let resolver = ModelProfileResolver(
         profiles: db.modelProfiles,
         repos: db.repos,
@@ -472,12 +473,12 @@ import Testing
         return body.contains("claude --session-id")
     }
     #expect(claudeCall != nil, "expected a createWindow call spawning claude")
-    #expect(claudeCall?.contains("CLAUDE_CODE_OAUTH_TOKEN=\(secret)") == true,
+    #expect(claudeCall?.contains("ANTHROPIC_API_KEY=\(secret)") == true,
             "expected token in tmux -e flag; got: \(claudeCall ?? [])")
     let shellBody = claudeCall?.last ?? ""
     #expect(!shellBody.contains(secret),
             "secret leaked into shell command body: \(shellBody)")
-    #expect(!shellBody.contains("CLAUDE_CODE_OAUTH_TOKEN"),
+    #expect(!shellBody.contains("ANTHROPIC_API_KEY"),
             "env var name leaked into shell command body: \(shellBody)")
 
     // (b) Persisted terminal row has profileID set to the known token UUID.

--- a/Tests/TBDSharedTests/ModelProfileDisplayTests.swift
+++ b/Tests/TBDSharedTests/ModelProfileDisplayTests.swift
@@ -29,10 +29,16 @@ struct ModelProfileDisplayTests {
         #expect(p.kindLabel == "Bedrock")
     }
 
-    @Test("detailCaption: oauth → nil")
-    func detailOAuthNil() {
+    @Test("detailCaption: oauth → login hint")
+    func detailOAuthLoginHint() {
         let p = ModelProfile(name: "x", kind: .oauth)
-        #expect(p.detailCaption == nil)
+        #expect(p.detailCaption == "Run /login once")
+    }
+
+    @Test("detailCaption: oauth with baseURL → login hint + url")
+    func detailOAuthWithBaseURLLoginHint() {
+        let p = ModelProfile(name: "x", kind: .oauth, baseURL: "http://h:1")
+        #expect(p.detailCaption == "Run /login once · via http://h:1")
     }
 
     @Test("detailCaption: direct apiKey → nil")

--- a/docs/implementation-plans/2026-05-19-alt-profiles-config-dir/phase_01.md
+++ b/docs/implementation-plans/2026-05-19-alt-profiles-config-dir/phase_01.md
@@ -1,0 +1,202 @@
+# Alternate profiles → config-dir — Implementation Plan
+
+**Goal:** Make every alternate Claude profile spawn through one uniform
+mechanism — a per-profile `CLAUDE_CONFIG_DIR` — so OAuth profiles bill as
+ordinary interactive subscription sessions and the OAuth-shape vs. API-key-shape
+divergence is removed.
+
+**Architecture:** OAuth profiles stop storing a `setup-token` and stop injecting
+`CLAUDE_CODE_OAUTH_TOKEN`; instead they get an isolated `CLAUDE_CONFIG_DIR` the
+user `/login`s into once. API-key profiles keep injecting `ANTHROPIC_API_KEY`
+but now *all* of them (not just proxy ones) get an isolated `CLAUDE_CONFIG_DIR`.
+Bedrock is unchanged. The env var changes from the undocumented
+`ANTHROPIC_CONFIG_DIR` to the documented `CLAUDE_CONFIG_DIR`.
+
+**Tech Stack:** Swift 6, SwiftPM, GRDB, NIO, Swift Testing (`@Test`/`#expect`),
+SwiftUI.
+
+**Scope:** 4 phases. Source design:
+`docs/specs/2026-05-19-alternate-profiles-redesign-design.md`.
+
+**Codebase verified:** 2026-05-19.
+
+**No DB migration:** the config dir is derived from the profile UUID
+(`~/tbd/profiles/<id>/claude/`); no schema change. `CredentialKind` and
+`ModelProfile` are unchanged.
+
+**Out of scope:** `CLAUDE_CODE_DISABLE_1M_CONTEXT` knob (decision doc follow-up),
+Vertex profiles, programmatic "needs login" detection (Claude Code's own
+first-run flow handles login; TBD only shows a UI hint).
+
+---
+
+## Acceptance Criteria Coverage
+
+### alt-profiles-config-dir.AC1: OAuth profiles use an isolated config dir, no token
+- **AC1.1 Success:** A spawned oauth-profile claude session's `sensitiveEnv`
+  contains `CLAUDE_CONFIG_DIR` pointing at `<configDir>/profiles/<id>/claude`.
+- **AC1.2 Success:** A spawned oauth-profile claude session's `sensitiveEnv`
+  contains no `CLAUDE_CODE_OAUTH_TOKEN` key.
+
+### alt-profiles-config-dir.AC2: API-key profiles always get an isolated config dir
+- **AC2.1 Success:** A direct (non-proxy, `baseURL == nil`) api-key profile
+  spawn's `sensitiveEnv` contains `CLAUDE_CONFIG_DIR`.
+- **AC2.2 Success:** The injected env key is `CLAUDE_CONFIG_DIR`; the string
+  `ANTHROPIC_CONFIG_DIR` appears nowhere in `sensitiveEnv`.
+- **AC2.3 Success:** An api-key profile spawn still contains `ANTHROPIC_API_KEY`
+  with the resolved secret.
+
+### alt-profiles-config-dir.AC3: Bedrock unchanged
+- **AC3.1 Success:** A bedrock-profile spawn contains `CLAUDE_CODE_USE_BEDROCK=1`
+  and `AWS_REGION`, and no `CLAUDE_CONFIG_DIR` / `ANTHROPIC_CONFIG_DIR` /
+  `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`.
+
+---
+
+# Phase 1 — Config-dir manager + spawn command builder
+
+**Verifies:** alt-profiles-config-dir.AC1.1, AC1.2, AC2.1, AC2.2, AC2.3, AC3.1
+
+Generalize `ClaudeProfileConfigDirManager` so it produces a config dir for both
+oauth and api-key profiles, and rewire `ClaudeSpawnCommandBuilder` to inject
+`CLAUDE_CONFIG_DIR` (renamed from `ANTHROPIC_CONFIG_DIR`) for every non-bedrock
+profile while injecting an auth token only for api-key profiles.
+
+Files:
+- Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
+- Modify: `Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift`
+- Modify: `Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift`
+- Modify: `Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift`
+- Modify: `Tests/TBDDaemonTests/ModelProfileSpawnTests.swift`
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Generalize `ClaudeProfileConfigDirManager`
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
+
+**Implementation:**
+
+The manager today only serves proxy api-key profiles. Generalize it:
+
+1. Keep `configDirectory(forProfileID:)` as-is — it already returns
+   `<base>/profiles/<id>/claude`.
+2. Keep the existing `ensureDir(forProfileID:apiKey:)` (api-key pre-approval
+   path) but rename it to `ensureAPIKeyDir(forProfileID:apiKey:)` for clarity.
+3. Add `ensureOAuthDir(forProfileID:) throws -> URL`: creates the same
+   `<base>/profiles/<id>/claude` directory, and writes a minimal `.claude.json`
+   containing only `{"hasCompletedOnboarding": true}` if the file does not
+   already exist (so the spawned `claude` skips the theme/onboarding screens and
+   lands in a REPL where the user can run `/login`). Do NOT write
+   `customApiKeyResponses` for oauth. If `.claude.json` already exists, leave it
+   untouched.
+4. Rewrite `resolveConfigDir(for:)` so it returns a path for **both**
+   `.oauth` and `.apiKey` kinds, and `nil` only for `.bedrock` (and `nil`
+   profile). For `.apiKey` it calls `ensureAPIKeyDir` (needs `profile.secret`;
+   if the secret is nil, log a warning and return nil as today). For `.oauth`
+   it calls `ensureOAuthDir`. Filesystem errors are logged and swallowed
+   (return nil) exactly as the current implementation does.
+5. Update the type's doc comment to describe the generalized behavior.
+
+**Testing:** see Task 3.
+
+**Verification:**
+Run: `swift build`
+Expected: builds without errors.
+
+**Commit:** `refactor: generalize ClaudeProfileConfigDirManager to oauth + apiKey`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Rewire `ClaudeSpawnCommandBuilder` env injection
+
+**Verifies:** alt-profiles-config-dir.AC1.1, AC1.2, AC2.1, AC2.2, AC2.3, AC3.1
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift:98-127`
+
+**Implementation:**
+
+In the non-bedrock branch (currently lines 106-126):
+
+1. Inject an auth token **only for `.apiKey`**: keep
+   `env["ANTHROPIC_API_KEY"] = secret` when `profileKind == .apiKey` and a
+   `profileSecret` is present. Remove the `CLAUDE_CODE_OAUTH_TOKEN` branch
+   entirely — oauth profiles no longer carry a secret and no longer inject a
+   token. (`profileKind == .oauth` → no token env at all.)
+2. Keep `ANTHROPIC_BASE_URL` and `ANTHROPIC_MODEL` injection as-is (still apply
+   to proxy api-key profiles).
+3. Change the config-dir injection: when `profileConfigDir` is non-nil, set
+   `env["CLAUDE_CONFIG_DIR"] = configDir`. Remove the
+   `ANTHROPIC_CONFIG_DIR` key and remove the `profileBaseURL != nil` condition —
+   the caller (`resolveConfigDir`) now decides which kinds get a dir, so the
+   builder injects whatever it is handed.
+4. Update the type-level doc comment (lines 19-32) to describe the new behavior:
+   oauth → `CLAUDE_CONFIG_DIR` only; api-key → `ANTHROPIC_API_KEY` +
+   `CLAUDE_CONFIG_DIR` (+ `ANTHROPIC_BASE_URL`/`ANTHROPIC_MODEL` for proxy);
+   bedrock unchanged.
+
+Note `profileSecret` will be nil for oauth — the existing
+`if let secret = profileSecret` guard already handles that; just ensure the
+non-`.apiKey` path does not assign any token.
+
+**Testing:** see Task 3.
+
+**Verification:**
+Run: `swift build`
+Expected: builds without errors.
+
+**Commit:** `feat: inject CLAUDE_CONFIG_DIR for oauth + apiKey, drop oauth token`
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Tests for config-dir manager and spawn builder
+
+**Verifies:** alt-profiles-config-dir.AC1.1, AC1.2, AC2.1, AC2.2, AC2.3, AC3.1
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift`
+- Modify: `Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift`
+- Modify: `Tests/TBDDaemonTests/ModelProfileSpawnTests.swift`
+
+**Testing:**
+
+Follow the existing patterns in each file (temp base dirs for the config-dir
+manager; injectable `fileExists` and direct `Result` assertions for the spawn
+builder; `TmuxManager` dry-run argv capture for the spawn integration test).
+
+`ClaudeProfileConfigDirManagerTests`:
+- `ensureOAuthDir` creates the directory and writes `.claude.json` with
+  `hasCompletedOnboarding: true` and no `customApiKeyResponses`.
+- `ensureOAuthDir` leaves an existing `.claude.json` untouched.
+- `resolveConfigDir` returns a path for an `.oauth` profile.
+- `resolveConfigDir` returns a path for a direct (`baseURL == nil`) `.apiKey`
+  profile (changed behavior — previously nil).
+- `resolveConfigDir` returns nil for a `.bedrock` profile.
+- Existing `ensureAPIKeyDir` (renamed) tests still pass.
+
+`ClaudeSpawnCommandBuilderTests` — assert on `Result.sensitiveEnv`:
+- AC1.1/AC1.2: oauth profile with a `profileConfigDir` → `sensitiveEnv` has
+  `CLAUDE_CONFIG_DIR` and no `CLAUDE_CODE_OAUTH_TOKEN`.
+- AC2.1/AC2.2/AC2.3: api-key profile with a `profileConfigDir` → `sensitiveEnv`
+  has `ANTHROPIC_API_KEY`, has `CLAUDE_CONFIG_DIR`, and no `ANTHROPIC_CONFIG_DIR`.
+- AC3.1: bedrock profile → `CLAUDE_CODE_USE_BEDROCK` + `AWS_REGION` present, none
+  of `CLAUDE_CONFIG_DIR`/`ANTHROPIC_CONFIG_DIR`/`ANTHROPIC_API_KEY`/
+  `CLAUDE_CODE_OAUTH_TOKEN`.
+- Update any existing test that asserted `CLAUDE_CODE_OAUTH_TOKEN` or
+  `ANTHROPIC_CONFIG_DIR` to the new keys.
+
+`ModelProfileSpawnTests` — update full-path argv assertions to expect
+`CLAUDE_CONFIG_DIR` instead of `ANTHROPIC_CONFIG_DIR`, and to expect no
+`CLAUDE_CODE_OAUTH_TOKEN` for oauth spawns.
+
+**Verification:**
+Run: `swift test --filter ClaudeProfileConfigDirManager --filter ClaudeSpawnCommandBuilder --filter ModelProfileSpawn`
+Expected: all tests pass.
+
+**Commit:** `test: cover CLAUDE_CONFIG_DIR injection for oauth + apiKey`
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/implementation-plans/2026-05-19-alt-profiles-config-dir/phase_02.md
+++ b/docs/implementation-plans/2026-05-19-alt-profiles-config-dir/phase_02.md
@@ -1,0 +1,102 @@
+# Phase 2 — Resolver: oauth profiles no longer require a keychain secret
+
+**Verifies:** alt-profiles-config-dir.AC4
+
+`ModelProfileResolver.loadResolved` currently requires a non-empty keychain
+secret for every non-bedrock profile (`guard let s = try keychain(...)`). Under
+the redesign an oauth profile has no secret. Treat `.oauth` like `.bedrock`: no
+keychain lookup, `secret: nil`.
+
+## Acceptance Criteria Coverage
+
+### alt-profiles-config-dir.AC4: Resolver resolves a secret-less oauth profile
+- **AC4.1 Success:** `resolve(repoID:)` / `loadByID` for an `.oauth` profile
+  row returns a non-nil `ResolvedModelProfile` with `secret == nil`, even when
+  the keychain has no entry for that profile ID.
+- **AC4.2 Success:** An `.apiKey` profile with a missing/empty keychain secret
+  still resolves to `nil` (unchanged behavior).
+
+Files:
+- Modify: `Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift`
+- Modify: `Tests/TBDDaemonTests/ModelProfileResolverTests.swift`
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Skip the keychain requirement for oauth profiles
+
+**Verifies:** alt-profiles-config-dir.AC4.1, AC4.2
+
+**Files:**
+- Modify: `Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift:44-66`
+
+**Implementation:**
+
+In `loadResolved(id:)`, the secret-loading block currently is:
+
+```swift
+let secret: String?
+if row.kind == .bedrock {
+    secret = nil
+} else {
+    guard let s = try keychain(id.uuidString), !s.isEmpty else { return nil }
+    secret = s
+}
+```
+
+Change the condition so `.oauth` is also treated as secret-less. Only `.apiKey`
+loads (and requires) a keychain secret:
+
+```swift
+let secret: String?
+if row.kind == .apiKey {
+    guard let s = try keychain(id.uuidString), !s.isEmpty else { return nil }
+    secret = s
+} else {
+    secret = nil   // oauth + bedrock: no TBD-stored secret
+}
+```
+
+Update the doc comment on `loadByID` / `loadResolved` (lines 36-43) so it states
+that oauth and bedrock have no keychain secret and that only api-key returns nil
+on a missing secret.
+
+**Testing:** see Task 2.
+
+**Verification:**
+Run: `swift build`
+Expected: builds without errors.
+
+**Commit:** `fix: resolve oauth profiles without a keychain secret`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Resolver tests for the secret-less oauth path
+
+**Verifies:** alt-profiles-config-dir.AC4.1, AC4.2
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/ModelProfileResolverTests.swift`
+
+**Testing:**
+
+Follow the existing pattern in this file (in-memory DB + injected `keychain`
+closure).
+
+- AC4.1: create an `.oauth` profile row, set it as global default, inject a
+  `keychain` closure that returns `nil` for every ID; `resolve(repoID: nil)`
+  returns a non-nil `ResolvedModelProfile` with `kind == .oauth` and
+  `secret == nil`. Same assertion via `loadByID`.
+- AC4.2: create an `.apiKey` profile row, inject a `keychain` closure returning
+  `nil`; `loadByID` returns `nil` (unchanged).
+- Confirm an existing `.apiKey`-with-secret test and a `.bedrock` test still
+  pass.
+
+**Verification:**
+Run: `swift test --filter ModelProfileResolver`
+Expected: all tests pass.
+
+**Commit:** `test: resolver handles secret-less oauth profiles`
+<!-- END_TASK_2 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/implementation-plans/2026-05-19-alt-profiles-config-dir/phase_03.md
+++ b/docs/implementation-plans/2026-05-19-alt-profiles-config-dir/phase_03.md
@@ -1,0 +1,105 @@
+# Phase 3 — RPC: add an OAuth profile without a token
+
+**Verifies:** alt-profiles-config-dir.AC5
+
+`handleModelProfileAdd` currently validates an OAuth token
+(`sk-ant-oat01-` prefix) and writes it to the keychain. Under the redesign an
+OAuth profile carries no secret — it is just a name (and an implicit derived
+config dir). Adding one stores no keychain entry and needs no token.
+
+## Acceptance Criteria Coverage
+
+### alt-profiles-config-dir.AC5: Adding an OAuth profile takes only a name
+- **AC5.1 Success:** `handleModelProfileAdd` with `kind == .oauth` and no
+  `token` succeeds and returns a `ModelProfile` with `kind == .oauth`.
+- **AC5.2 Success:** After adding an `.oauth` profile, no keychain entry exists
+  for that profile ID (`ModelProfileKeychain.load` returns nil).
+- **AC5.3 Failure:** `handleModelProfileAdd` with `kind == .apiKey` and an empty
+  or missing `token` still fails with a validation error (unchanged).
+
+Files:
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift`
+- Modify: `Tests/TBDDaemonTests/ModelProfileRPCTests.swift` (or the existing
+  add-handler test file the codebase-investigator confirms)
+
+**Note on existing data:** pre-existing OAuth profiles have an orphaned
+`~/tbd/claude-tokens/<uuid>.token` file. We deliberately do **not** add a
+startup migration to delete them — the resolver (Phase 2) no longer reads them,
+they are mode-0600 and harmless, and a startup filesystem migration carries more
+risk than the wart it removes. `ModelProfileKeychain.delete` is still called on
+profile deletion, so they get cleaned up naturally over time.
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: OAuth add path skips token validation and keychain storage
+
+**Verifies:** alt-profiles-config-dir.AC5.1, AC5.2, AC5.3
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift`
+  (`handleModelProfileAdd`, around lines 23-95)
+
+**Implementation:**
+
+The codebase-investigator reported `handleModelProfileAdd` branches on `kind`
+and currently: validates the OAuth token prefix `sk-ant-oat01-` and the API-key
+prefix `sk-ant-api03-`, stores the token via `ModelProfileKeychain.store`, and
+(for bedrock) skips keychain storage.
+
+First read the current handler to confirm exact line numbers, then:
+
+1. For `kind == .oauth`: do **not** require a `token`, do **not** validate any
+   token prefix, and do **not** call `ModelProfileKeychain.store`. Treat it like
+   the bedrock branch (create the DB row, no keychain write). If a `token` is
+   present in the params, ignore it.
+2. For `kind == .apiKey`: keep the existing requirement that a non-empty
+   `token` is present and validate the `sk-ant-api03-` prefix; keep the
+   `ModelProfileKeychain.store` call. (If the codebase currently shares one
+   validation path for oauth+apiKey, split it so only apiKey validates.)
+3. For `kind == .bedrock`: unchanged.
+4. Keep the `.modelProfilesChanged` subscription delta broadcast for all kinds.
+
+Do not change `RPCProtocol.swift` — `ModelProfileAddParams.token` is already
+optional.
+
+**Testing:** see Task 2.
+
+**Verification:**
+Run: `swift build`
+Expected: builds without errors.
+
+**Commit:** `feat: add oauth profiles without a token or keychain entry`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: RPC tests for the token-less OAuth add
+
+**Verifies:** alt-profiles-config-dir.AC5.1, AC5.2, AC5.3
+
+**Files:**
+- Modify: the daemon test file covering `handleModelProfileAdd` (confirm path;
+  likely `Tests/TBDDaemonTests/ModelProfileRPCTests.swift`)
+
+**Testing:**
+
+Follow the existing add-handler test pattern (in-memory DB, router under test).
+
+- AC5.1: add a profile with `kind: .oauth`, `name: "Work"`, `token: nil` →
+  succeeds, returned profile has `kind == .oauth` and the given name; the row
+  is present via `ModelProfileStore.get`.
+- AC5.2: after the AC5.1 add, `ModelProfileKeychain.load(id:)` for that profile
+  ID returns `nil`.
+- AC5.3: add a profile with `kind: .apiKey` and `token: ""` (and separately
+  `token: nil`) → fails with a validation error; no row created.
+- Confirm an existing successful `.apiKey` add test and a `.bedrock` add test
+  still pass.
+
+**Verification:**
+Run: `swift test --filter ModelProfile`
+Expected: all tests pass.
+
+**Commit:** `test: cover token-less oauth profile add`
+<!-- END_TASK_2 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/implementation-plans/2026-05-19-alt-profiles-config-dir/phase_04.md
+++ b/docs/implementation-plans/2026-05-19-alt-profiles-config-dir/phase_04.md
@@ -1,0 +1,118 @@
+# Phase 4 — UI: OAuth add form drops the token field
+
+**Verifies:** alt-profiles-config-dir.AC6
+
+The "Claude Direct" (OAuth) add form currently shows a token `SecureField`.
+Under the redesign an OAuth profile is created with just a name; the user logs
+in once inside a spawned session. Update the form and the `AppState` call.
+
+## Acceptance Criteria Coverage
+
+### alt-profiles-config-dir.AC6: OAuth add UI needs only a name
+- **AC6.1 Success:** The "Claude Direct" add form shows a name field and no
+  token `SecureField`.
+- **AC6.2 Success:** The form shows explanatory text that the user must run
+  `/login` once in a session using this profile.
+- **AC6.3 Success:** `canSave` for the OAuth preset is true with just a
+  non-empty name (no token requirement).
+
+Files:
+- Modify: `Sources/TBDApp/Settings/ModelProfilesSettingsView.swift`
+- Modify: `Sources/TBDApp/AppState+ModelProfiles.swift`
+
+**Note:** `ModelProfileMenu`, `RepoDetailView`, and the proxy/bedrock add
+forms need no change — OAuth profiles still appear as ordinary profiles.
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Drop the token field from the OAuth add form
+
+**Verifies:** alt-profiles-config-dir.AC6.1, AC6.2, AC6.3
+
+**Files:**
+- Modify: `Sources/TBDApp/Settings/ModelProfilesSettingsView.swift`
+  (`AddModelProfileSheet`, the `claudeDirect` preset branch ~lines 405-415, and
+  the `canSave` computed property ~lines 558-573)
+- Modify: `Sources/TBDApp/AppState+ModelProfiles.swift`
+  (`addModelProfile`, ~lines 35-55)
+
+**Implementation:**
+
+First read `AddModelProfileSheet` to confirm exact line numbers.
+
+1. In the `claudeDirect` preset branch of the form body: remove the token
+   `SecureField`. Keep the name field. Add a short explanatory `Text` (use the
+   existing `LabeledField`/caption style) such as: "After creating this profile,
+   open a session with it and run `/login` once. TBD keeps each profile's login
+   isolated in its own config directory."
+2. In `canSave`: for the `claudeDirect` preset, require only a non-empty
+   trimmed name (drop any token check).
+3. In the save action for `claudeDirect`: call `appState.addModelProfile` with
+   `token: nil` (or omit it). Do not pass a token.
+4. In `AppState.addModelProfile`: `token` is already optional — confirm it
+   tolerates `nil`/empty for the oauth kind and forwards it unchanged to the
+   `modelProfileAdd` RPC params. No signature change expected; adjust only if a
+   non-optional assumption exists.
+5. Leave `EditEndpointSheet`, `EditBedrockSheet`, the `proxy` preset, and the
+   `bedrock` preset untouched.
+
+**Testing:** see Task 2. SwiftUI view bodies are not unit-tested in this
+project; verification is operational (build + manual UI check).
+
+**Verification:**
+Run: `swift build`
+Expected: builds without errors.
+
+**Commit:** `feat: oauth profile add form takes only a name`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Verify the OAuth add flow end to end
+
+**Verifies:** alt-profiles-config-dir.AC6.1, AC6.2, AC6.3
+
+**Files:**
+- Modify (only if a state-level assertion is feasible):
+  `Tests/TBDAppTests/ModelProfileAppStateTests.swift`
+
+**Testing & verification:**
+
+1. If `AppState.addModelProfile` has testable pure-state behavior for the oauth
+   path that does not require a daemon client, add a `@MainActor` test
+   following the existing `ModelProfileAppStateTests` pattern. If it cannot be
+   tested without a live daemon (the file's header comment says integration
+   coverage lives in daemon RPC tests — Phase 3 already covers the RPC), state
+   that explicitly and rely on Phase 3's coverage instead. Do not invent a
+   brittle test.
+2. Full restart and manual UI check (this project's `CLAUDE.md` requires
+   verifying UI changes in the running app):
+   - Run `scripts/restart.sh` from the worktree root.
+   - Verify exactly one `TBDDaemon` and one `TBDApp` from the worktree path:
+     `ps aux | grep -E "\.build/debug/TBD" | grep -v grep`.
+   - Open Settings → Model Profiles → Add → "Claude Direct": confirm there is
+     no token field, the explanatory text is present, and Save is enabled with
+     only a name entered.
+   - Create one, then open a session pinned to it and confirm `claude` starts
+     in an isolated config dir (it will prompt for `/login` on first use).
+
+**Verification:**
+Run: `swift build && swift test`
+Expected: builds; full test suite passes.
+
+**Commit:** `test: verify oauth add flow`
+<!-- END_TASK_2 -->
+
+<!-- END_SUBCOMPONENT_A -->
+
+---
+
+## Final verification (all phases)
+
+- `swift build` — clean.
+- `swift test` — full suite passes.
+- `swift package plugin --allow-writing-to-package-directory swiftlint --strict`
+  — no `no_print_in_sources` or other violations.
+- Manual: add an OAuth profile, spawn a session, `/login`, confirm the session
+  works and is isolated; add a second OAuth profile and confirm the two
+  sessions hold independent logins concurrently.

--- a/docs/specs/2026-05-19-alternate-profiles-redesign-design.md
+++ b/docs/specs/2026-05-19-alternate-profiles-redesign-design.md
@@ -1,0 +1,189 @@
+# Alternate Claude profiles — credential-delivery redesign
+
+**Date:** 2026-05-19
+**Status:** Decision doc (no implementation)
+
+## Problem
+
+TBD lets a user run Claude Code under alternate profiles. Today each profile
+injects credentials as environment variables at tmux spawn time
+(`Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift`):
+
+- **oauth** → `CLAUDE_CODE_OAUTH_TOKEN=<secret>` (a `setup-token`)
+- **apiKey** → `ANTHROPIC_API_KEY=<secret>` (+ optional `ANTHROPIC_BASE_URL`,
+  `ANTHROPIC_MODEL`, and — for proxy profiles only — `ANTHROPIC_CONFIG_DIR`)
+- **bedrock** → `CLAUDE_CODE_USE_BEDROCK=1` + AWS env vars
+
+Two problems motivate a redesign:
+
+1. **Billing divergence is about to sharpen.** Starting **2026-06-15**, Anthropic
+   bills `claude -p` / Agent SDK usage on subscription plans from a *separate*
+   monthly "Agent SDK credit" pool, distinct from interactive subscription
+   limits. Official docs place this warning inside the `claude setup-token`
+   section. Strong (but not officially confirmed) indication: a
+   `setup-token`-derived `CLAUDE_CODE_OAUTH_TOKEN` is classified as Agent-SDK
+   usage **even when used to drive an interactive REPL**. TBD's oauth profiles
+   inject exactly such a token — so after 2026-06-15 they would likely stop
+   behaving like "a normal terminal-based Claude Code subscription session" and
+   instead drain the Agent-SDK pool.
+
+2. **Profile types diverge in shape, which breeds bugs.** oauth/direct-apiKey
+   profiles share the host's `~/.claude`; proxy-apiKey profiles get an isolated
+   `ANTHROPIC_CONFIG_DIR`. Today's symptom: invoking a Sonnet subagent under an
+   apiKey profile fails with *"Usage credits required for 1M context"* while
+   Opus and Haiku subagents succeed. (Root cause is upstream Claude Code bug
+   #57249 — a subagent inherits the parent's `[1m]` context tier without the
+   matching per-model entitlement — but the divergent profile shapes make this
+   class of environment-dependent failure easy to hit and hard to reason about.)
+
+## Goal
+
+A single credential-delivery mechanism shared by every profile type, such that:
+
+- oauth profiles bill as ordinary **interactive** subscription sessions, before
+  and after 2026-06-15.
+- A user can keep **multiple** OAuth subscriptions side-by-side and switch
+  between them per-repo / per-session (existing capability — must not regress).
+- Profile types differ only in *which credential* is used, not in *how* the
+  session is shaped — so environment-divergence bug classes disappear.
+
+Scope is **credentials only**. Profiles do not gain model-selection or
+request-rewriting responsibilities.
+
+## Out of scope
+
+- Model selection or subagent-model control as a user-facing profile field.
+- An HTTP proxy / wire-level request rewriting layer.
+- Fixing upstream Claude Code bug #57249.
+- Vertex AI / GCP profiles.
+
+## Key research findings
+
+Sourced from official Claude Code docs, the `anthropics/claude-code` issue
+tracker, and corroborating community tooling. Items marked *(inferred)* are not
+in official documentation.
+
+1. **2026-06-15 billing split** — `claude -p` / Agent SDK usage on subscription
+   plans moves to a separate monthly credit pool. The warning lives in the
+   `setup-token` doc section. *(inferred)* `setup-token` tokens are classified
+   as Agent-SDK usage regardless of interactive vs. `-p` invocation.
+2. **`CLAUDE_CONFIG_DIR` isolates credentials on macOS** *(inferred, proven in
+   the wild)* — Claude Code SHA-256-hashes the `CLAUDE_CONFIG_DIR` path and
+   derives a unique macOS Keychain service name (`Claude Code-credentials-<hash>`).
+   Two `claude` processes with different `CLAUDE_CONFIG_DIR` values hold
+   independent logins without clobbering. Multiple community profile-switchers
+   (`claude-profile`, `claude-swap`, etc.) depend on this.
+3. **`ANTHROPIC_CONFIG_DIR` is not the documented Claude Code variable** —
+   `CLAUDE_CONFIG_DIR` is. TBD's current proxy-profile code uses the former and
+   relies on partial behavior.
+4. **No native multi-account feature** in Claude Code as of ~2.3.x; open feature
+   requests (#18435, #44687). `CLAUDE_CONFIG_DIR` is the only isolation lever.
+5. **Token refresh race** (#27933) — concurrent `claude` processes sharing one
+   credential store can race on OAuth refresh. Pre-exists in TBD today.
+6. **`.credentials.json` shape** — `{ claudeAiOauth: { accessToken, refreshToken,
+   expiresAt, scopes, subscriptionType } }`; access token ~24h, auto-refreshed
+   in place.
+
+## Options considered
+
+### Option A — Status quo + targeted hardening
+Keep env-var injection; tighten the oauth path (e.g. always isolate, or never).
+**Rejected:** does not address the 2026-06-15 billing reclassification — oauth
+profiles still inject a `setup-token` and still risk draining the Agent-SDK pool.
+
+### Option B — HTTP proxy intercepting the Anthropic API
+Local proxy attaches auth / rewrites requests.
+**Rejected:** large new moving part; overkill for "credentials only" scope; does
+not change how `claude` itself classifies the session for billing.
+
+### Option C — Swap a single shared credential store before each spawn
+Rewrite `~/.claude` / the shared Keychain entry per spawn.
+**Rejected:** concurrency-unsafe — parallel tmux panes on different profiles
+would clobber each other; refresh race (#27933) becomes routine.
+
+### Option D — One persistent `CLAUDE_CONFIG_DIR` per profile *(recommended)*
+Every profile is a persistent config directory. See below.
+
+## Recommended design — Option D
+
+**Every profile is a persistent `CLAUDE_CONFIG_DIR`.** That directory is the
+single delivery mechanism. Profile types differ only in what lives inside it and
+which (if any) env var rides alongside.
+
+| Profile | `CLAUDE_CONFIG_DIR` | Extra env | Credential origin | Billing |
+|---|---|---|---|---|
+| **Default** | `~/.claude` (host native, untouched) | none | host's existing `/login` | interactive subscription |
+| **Additional OAuth** | `~/tbd/profiles/<id>/` | none | user runs `/login` once in-pane; credential persists in that dir's hashed Keychain entry, auto-refreshes there | interactive subscription |
+| **API key** | `~/tbd/profiles/<id>/` | `ANTHROPIC_API_KEY` (+ `ANTHROPIC_BASE_URL` for proxy) | TBD-stored key | pay-as-you-go API |
+| **Bedrock** | `~/tbd/profiles/<id>/` | `CLAUDE_CODE_USE_BEDROCK=1` + AWS vars | AWS credential chain | AWS |
+
+### Why this satisfies the goal
+
+- **Multi-OAuth survives** — each OAuth profile is a real `/login` in its own
+  isolated config dir. Per-repo / per-session switching is just "which
+  `CLAUDE_CONFIG_DIR` is exported."
+- **Billing stays correct** — OAuth profiles never touch `setup-token` /
+  `CLAUDE_CODE_OAUTH_TOKEN`. Each is an ordinary interactive `/login` session
+  that happens to live in a non-default directory, so it is not reclassified
+  into the 2026-06-15 Agent-SDK pool.
+- **Unification** — every profile spawns `claude` identically; the only variable
+  is the config dir. The oauth-shape vs. apiKey-shape divergence is gone.
+
+### Changes vs. today
+
+1. oauth profiles stop storing a `setup-token` and stop injecting
+   `CLAUDE_CODE_OAUTH_TOKEN`. An oauth profile becomes "a config dir you log
+   into."
+2. Standardize on `CLAUDE_CONFIG_DIR` (the documented var the Keychain hashing
+   keys on); drop `ANTHROPIC_CONFIG_DIR`.
+3. Config-dir isolation applies to *all* non-default profiles, not just proxy
+   ones.
+4. First use of a new oauth profile is unauthenticated — TBD detects the empty
+   config dir and prompts the user to `/login` once.
+
+### Data model sketch
+
+- `ModelProfile` gains a config-dir association (a stored `configDirPath`, or
+  derive `~/tbd/profiles/<id>/` from the profile UUID). New field optional /
+  defaulted per the migration rules in `CLAUDE.md`.
+- `CredentialKind.oauth` keeps existing but changes meaning: **no Keychain
+  secret** — just a config dir the user logs into. apiKey / bedrock unchanged.
+- Migration is non-destructive: keep existing oauth profile rows, drop the now
+  unused stored `setup-token`, mark the profile "needs login." The default
+  profile maps to `~/.claude`.
+
+### The 1M-context subagent bug
+
+Unification makes every profile *behave* identically but cannot change what an
+account is entitled to: a Max-subscription oauth profile with extra-usage will
+not hit bug #57249; an apiKey profile without Sonnet-1M credits will. The bug
+stops being a TBD-architecture artifact but is not erased.
+
+**Optional mitigation:** TBD sets `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` for apiKey
+profiles by default — forces 200k context, so no subagent inherits a 1M tier and
+the entitlement error cannot fire. This touches model behavior (slightly past
+"credentials only"), so it is offered as a recommended-but-optional knob, not
+core to the redesign.
+
+## Risks
+
+1. **Keychain path-hashing is undocumented.** The multi-OAuth scheme rests on
+   Claude Code's SHA-256-of-`CLAUDE_CONFIG_DIR` Keychain keying. If Anthropic
+   changes it, isolation breaks. *Mitigation:* a startup health probe that
+   verifies two distinct config dirs yield two distinct Keychain entries.
+2. **OAuth-billing classification not officially confirmed.** Research strongly
+   indicates `/login` credentials = interactive billing, but no doc says so
+   explicitly. *Mitigation:* file one Anthropic support question to confirm
+   before relying on it past 2026-06-15.
+3. **Token-refresh race** (#27933) for two concurrent panes on the *same* oauth
+   profile sharing one Keychain entry. Pre-exists today; out of scope to fix.
+4. **First-run friction** — a new oauth profile's first session is
+   unauthenticated. *Mitigation:* TBD detects the empty config dir and prompts.
+
+## Open questions for follow-up
+
+- Confirm with Anthropic support whether a `/login` credential in a non-default
+  `CLAUDE_CONFIG_DIR`, driving an interactive REPL, bills as interactive
+  subscription usage after 2026-06-15.
+- Decide whether `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` for apiKey profiles ships
+  with the redesign or is deferred.


### PR DESCRIPTION
## Summary

- Redesigns how TBD delivers credentials to spawned `claude` sessions so every alternate profile uses one uniform mechanism — a per-profile isolated `CLAUDE_CONFIG_DIR` — instead of the old mix of `CLAUDE_CODE_OAUTH_TOKEN` injection (OAuth) and the undocumented `ANTHROPIC_CONFIG_DIR` (proxy API-key only).
- **Why:** Anthropic's 2026-06-15 billing change reclassifies `setup-token` / `CLAUDE_CODE_OAUTH_TOKEN` usage into a separate Agent-SDK credit pool. By dropping token injection, OAuth profiles become ordinary interactive `/login` sessions in an isolated config dir — they keep billing as a normal Claude Code subscription session, and multiple OAuth subscriptions still work side-by-side (macOS keys each config dir to its own Keychain entry).
- OAuth profiles now carry no TBD-stored secret and need a one-time in-session `/login`; the add form drops the token field and OAuth profile rows show a "Run /login once" hint. API-key profiles keep `ANTHROPIC_API_KEY` and now all get an isolated config dir. Bedrock is unchanged. No DB migration — the config dir is derived from the profile UUID.
- Full rationale in `docs/specs/2026-05-19-alternate-profiles-redesign-design.md`; 4-phase plan in `docs/implementation-plans/2026-05-19-alt-profiles-config-dir/`.

## Test plan

- [x] `swift build`, `swift test` (962 tests), `swiftlint --strict` — all green
- [x] Manual UI check: Settings → Model Profiles → Add → "Claude Direct" shows no token field
- [ ] Add an OAuth profile, open a session, run `/login`, confirm the session works and is isolated
- [ ] Add a second OAuth profile and confirm two sessions hold independent logins concurrently
- [ ] Confirm an API-key profile session still authenticates and an existing Bedrock profile is unaffected

## Known follow-ups (out of scope)

- Usage polling no longer works for OAuth profiles (it depended on a TBD-held token) — returns a keychain error; tracked for a separate change.
- The 2026-06-15 OAuth-billing classification is strongly indicated by Anthropic's docs but not explicitly confirmed — worth a support question before that date.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7FA064AB-109F-4F2D-A959-541E334BBFC8)