### PR TITLE
Fix: Restore session history and ~/.claude customizations under alt-profile spawns

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -9,6 +9,13 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeProfil
 /// proxy apiKey profiles with an isolated config directory where they can
 /// maintain independent credentials.
 ///
+/// Each profile dir mirrors customization slots from the host's `~/.claude/`
+/// directory via symlinks: `projects/`, `plugins/`, `skills/`, `agents/`,
+/// `commands/`, `hooks/`, `CLAUDE.md`, and `settings.json`. Per-profile identity
+/// (`.claude.json` and Keychain entry keyed on `CLAUDE_CONFIG_DIR` path) is
+/// owned by each profile. The `apiKeyHelper` mode uses the profile's Keychain
+/// entry as a bridge; do not store API keys outside the per-profile context.
+///
 /// On dir creation for API-key profiles, `.claude.json` is pre-populated with:
 ///   - `customApiKeyResponses.approved`: the last 20 chars of the profile's
 ///     API key (matches Claude Code's own storage format) so the user isn't
@@ -21,13 +28,17 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeProfil
 ///     user will `/login` into this isolated config dir).
 public struct ClaudeProfileConfigDirManager: Sendable {
     let baseDirectory: URL
+    let hostBaseDirectory: URL
 
-    public init(baseDirectory: URL? = nil) {
+    public init(baseDirectory: URL? = nil, hostBaseDirectory: URL? = nil) {
         // Resolve inside the init to keep the `TBDConstants.configDir` access
         // out of the caller's compilation context — see HookResolver for the
         // Xcode 26.3 unsafeMutableAddressor link-failure rationale.
         self.baseDirectory = baseDirectory
             ?? TBDConstants.configDir.appendingPathComponent("profiles", isDirectory: true)
+        self.hostBaseDirectory = hostBaseDirectory
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".claude", isDirectory: true)
     }
 
     public func profileDirectory(forProfileID profileID: UUID) -> URL {
@@ -38,6 +49,105 @@ public struct ClaudeProfileConfigDirManager: Sendable {
     public func configDirectory(forProfileID profileID: UUID) -> URL {
         profileDirectory(forProfileID: profileID)
             .appendingPathComponent("claude", isDirectory: true)
+    }
+
+    /// Slots that each TBD profile dir mirrors from the host's claude config dir.
+    /// Symlinked from <profile>/claude/<slot> to <host-base>/<slot>.
+    /// `projects` is special: pre-existing real-dir content is migrated into
+    /// the host store before symlinking. Every other slot is left alone if it
+    /// already exists as a non-empty real file or directory.
+    private static let mirrorSlots: [String] = [
+        "projects",
+        "plugins",
+        "skills",
+        "agents",
+        "commands",
+        "hooks",
+        "CLAUDE.md",
+        "settings.json",
+    ]
+
+    /// Ensure one host-mirror slot is a symlink from the profile dir into the
+    /// host base. Best-effort: filesystem errors are logged and swallowed.
+    private func ensureMirrorSlot(
+        _ name: String,
+        in profileClaudeDir: URL,
+        migrateContent: Bool
+    ) {
+        let fm = FileManager.default
+        let hostEntry = hostBaseDirectory.appendingPathComponent(name)
+
+        // Skip if the host doesn't have this slot at all.
+        guard fm.fileExists(atPath: hostEntry.path) else { return }
+
+        let profileEntry = profileClaudeDir.appendingPathComponent(name)
+
+        // Already a symlink? Check target; if it's right, done. If wrong,
+        // leave it and log (don't fight an owner we don't recognize).
+        if let dest = try? fm.destinationOfSymbolicLink(atPath: profileEntry.path) {
+            let resolved = URL(fileURLWithPath: dest, relativeTo: profileEntry.deletingLastPathComponent())
+                .standardizedFileURL
+            if resolved == hostEntry.standardizedFileURL { return }
+            logger.warning("mirror slot \(name, privacy: .public) symlink for profile points elsewhere; leaving as-is")
+            return
+        }
+
+        // Profile has a real entry. Handle per slot policy.
+        var isDir: ObjCBool = false
+        if fm.fileExists(atPath: profileEntry.path, isDirectory: &isDir) {
+            if isDir.boolValue, migrateContent {
+                // projects/ special-case: merge content into host store, then
+                // remove the profile-side dir and proceed to symlink.
+                do {
+                    // Ensure host dir exists (created above by fileExists check
+                    // succeeding, but be defensive on race / non-dir).
+                    try fm.createDirectory(at: hostEntry, withIntermediateDirectories: true)
+                    let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
+                    for entry in entries {
+                        let dest = hostEntry.appendingPathComponent(entry.lastPathComponent)
+                        if fm.fileExists(atPath: dest.path) {
+                            logger.debug("collision migrating \(entry.lastPathComponent, privacy: .public) into \(name, privacy: .public); skipping")
+                            continue
+                        }
+                        try fm.moveItem(at: entry, to: dest)
+                    }
+                    try fm.removeItem(at: profileEntry)
+                } catch {
+                    logger.warning("failed migrating \(name, privacy: .public) for profile: \(error.localizedDescription, privacy: .public)")
+                    return
+                }
+            } else if isDir.boolValue {
+                // Non-projects directory in profile: replace only if empty.
+                let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
+                if entries.isEmpty {
+                    try? fm.removeItem(at: profileEntry)
+                } else {
+                    logger.warning("profile has real \(name, privacy: .public)/ with content; leaving as-is")
+                    return
+                }
+            } else {
+                // Real file (e.g. profile-side settings.json or CLAUDE.md).
+                // Don't destroy user content; leave alone.
+                logger.warning("profile has real \(name, privacy: .public) file; leaving as-is")
+                return
+            }
+        }
+
+        // Create the symlink. Best-effort.
+        do {
+            try fm.createSymbolicLink(at: profileEntry, withDestinationURL: hostEntry)
+        } catch {
+            logger.warning("failed creating mirror symlink for \(name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Ensure every host-mirror slot is symlinked into the profile dir.
+    /// Best-effort and per-entry isolated — one failing slot does not block
+    /// the others.
+    private func ensureHostMirrors(in profileClaudeDir: URL) {
+        for slot in Self.mirrorSlots {
+            ensureMirrorSlot(slot, in: profileClaudeDir, migrateContent: slot == "projects")
+        }
     }
 
     /// Ensure the per-profile claude config dir exists, and that `.claude.json`
@@ -90,6 +200,8 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
         try data.write(to: claudeJSONPath, options: [.atomic])
 
+        ensureHostMirrors(in: dir)
+
         logger.debug("ensured claude config dir at \(dir.path, privacy: .public) for profile \(profileID, privacy: .public)")
         return dir
     }
@@ -121,6 +233,8 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
         try data.write(to: claudeJSONPath, options: [.atomic])
+
+        ensureHostMirrors(in: dir)
 
         logger.debug("ensured claude config dir at \(dir.path, privacy: .public) for oauth profile \(profileID, privacy: .public)")
         return dir

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -113,13 +113,22 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                     // succeeding, but be defensive on race / non-dir).
                     try fm.createDirectory(at: hostEntry, withIntermediateDirectories: true)
                     let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
+                    var anySkipped = false
                     for entry in entries {
                         let dest = hostEntry.appendingPathComponent(entry.lastPathComponent)
                         if fm.fileExists(atPath: dest.path) {
                             logger.debug("collision migrating \(entry.lastPathComponent, privacy: .public) into \(name, privacy: .public); skipping")
+                            anySkipped = true
                             continue
                         }
                         try fm.moveItem(at: entry, to: dest)
+                    }
+                    // Only remove profile-side dir if all entries were successfully migrated.
+                    // If any were skipped due to collision, preserve the profile dir to avoid
+                    // data loss (profile-unique sessions in the skipped dirs are still there).
+                    if anySkipped {
+                        logger.warning("projects migration incomplete for profile due to collisions; symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
+                        return
                     }
                     try fm.removeItem(at: profileEntry)
                 } catch {
@@ -233,6 +242,10 @@ public struct ClaudeProfileConfigDirManager: Sendable {
     /// `customApiKeyResponses` is written. The user will `/login` once into
     /// this isolated config dir, and the credential persists in the Keychain
     /// entry derived from the `CLAUDE_CONFIG_DIR` path.
+    ///
+    /// Host mirror slots are always ensured, regardless of whether `.claude.json`
+    /// already existed. This is critical for profiles created before mirror support
+    /// was added; without this, they would never get their symlinked customizations.
     @discardableResult
     public func ensureOAuthDir(forProfileID profileID: UUID) throws -> URL {
         let dir = configDirectory(forProfileID: profileID)
@@ -243,15 +256,17 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         // If `.claude.json` already exists, leave it untouched.
         if FileManager.default.fileExists(atPath: claudeJSONPath.path) {
             logger.debug("claude config dir exists at \(dir.path, privacy: .public) for oauth profile \(profileID, privacy: .public); skipping .claude.json")
-            return dir
+        } else {
+            let payload: [String: Any] = [
+                "hasCompletedOnboarding": true,
+            ]
+            let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: claudeJSONPath, options: [.atomic])
         }
 
-        let payload: [String: Any] = [
-            "hasCompletedOnboarding": true,
-        ]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
-        try data.write(to: claudeJSONPath, options: [.atomic])
-
+        // Always ensure host mirrors, even if .claude.json already existed.
+        // Profiles created before mirror support was added must get their
+        // symlinks set up on subsequent calls.
         ensureHostMirrors(in: dir)
 
         logger.debug("ensured claude config dir at \(dir.path, privacy: .public) for oauth profile \(profileID, privacy: .public)")

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -12,7 +12,8 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeProfil
 /// Each profile dir mirrors customization slots from the host's `~/.claude/`
 /// directory via symlinks: `projects/`, `plugins/`, `skills/`, `agents/`,
 /// `commands/`, `hooks/`, `CLAUDE.md`, and `settings.json`. Per-profile identity
-/// (`.claude.json` and Keychain entry keyed on `CLAUDE_CONFIG_DIR` path) is
+/// (`.claude.json`, Keychain entry keyed on `CLAUDE_CONFIG_DIR` path, and
+/// `.credentials.json` as a fallback when Keychain is unavailable) is
 /// owned by each profile. The `apiKeyHelper` mode uses the profile's Keychain
 /// entry as a bridge; do not store API keys outside the per-profile context.
 ///
@@ -36,9 +37,18 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         // Xcode 26.3 unsafeMutableAddressor link-failure rationale.
         self.baseDirectory = baseDirectory
             ?? TBDConstants.configDir.appendingPathComponent("profiles", isDirectory: true)
-        self.hostBaseDirectory = hostBaseDirectory
-            ?? FileManager.default.homeDirectoryForCurrentUser
+
+        // Honor TBD_CLAUDE_HOST_HOME env var (e.g., for test isolation, matching
+        // the TBD_HOME pattern used by TBDConstants). Falls back to ~/.claude/
+        // in production.
+        if let override = hostBaseDirectory {
+            self.hostBaseDirectory = override
+        } else if let envOverride = ProcessInfo.processInfo.environment["TBD_CLAUDE_HOST_HOME"], !envOverride.isEmpty {
+            self.hostBaseDirectory = URL(fileURLWithPath: envOverride, isDirectory: true)
+        } else {
+            self.hostBaseDirectory = FileManager.default.homeDirectoryForCurrentUser
                 .appendingPathComponent(".claude", isDirectory: true)
+        }
     }
 
     public func profileDirectory(forProfileID profileID: UUID) -> URL {
@@ -86,8 +96,8 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         // leave it and log (don't fight an owner we don't recognize).
         if let dest = try? fm.destinationOfSymbolicLink(atPath: profileEntry.path) {
             let resolved = URL(fileURLWithPath: dest, relativeTo: profileEntry.deletingLastPathComponent())
-                .standardizedFileURL
-            if resolved == hostEntry.standardizedFileURL { return }
+                .resolvingSymlinksInPath()
+            if resolved == hostEntry.resolvingSymlinksInPath() { return }
             logger.warning("mirror slot \(name, privacy: .public) symlink for profile points elsewhere; leaving as-is")
             return
         }
@@ -133,10 +143,18 @@ public struct ClaudeProfileConfigDirManager: Sendable {
             }
         }
 
-        // Create the symlink. Best-effort.
+        // Create the symlink. Best-effort; on EEXIST race (concurrent winner),
+        // verify idempotency before logging a warning.
         do {
             try fm.createSymbolicLink(at: profileEntry, withDestinationURL: hostEntry)
         } catch {
+            // If entry now exists and is a symlink to the correct target,
+            // treat as idempotent success. Otherwise log and return.
+            if let dest = try? fm.destinationOfSymbolicLink(atPath: profileEntry.path) {
+                let resolved = URL(fileURLWithPath: dest, relativeTo: profileEntry.deletingLastPathComponent())
+                    .resolvingSymlinksInPath()
+                if resolved == hostEntry.resolvingSymlinksInPath() { return }
+            }
             logger.warning("failed creating mirror symlink for \(name, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -113,22 +113,23 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                     // succeeding, but be defensive on race / non-dir).
                     try fm.createDirectory(at: hostEntry, withIntermediateDirectories: true)
                     let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
-                    var anySkipped = false
-                    for entry in entries {
-                        let dest = hostEntry.appendingPathComponent(entry.lastPathComponent)
-                        if fm.fileExists(atPath: dest.path) {
-                            logger.debug("collision migrating \(entry.lastPathComponent, privacy: .public) into \(name, privacy: .public); skipping")
-                            anySkipped = true
-                            continue
-                        }
-                        try fm.moveItem(at: entry, to: dest)
+
+                    // Two-pass approach: first check if any entries would collide with host.
+                    // If any collision exists, abort the entire migration to preserve atomicity.
+                    // This ensures that if we can't migrate everything, we don't partially move
+                    // entries and orphan sessions.
+                    let hasCollision = entries.contains { entry in
+                        fm.fileExists(atPath: hostEntry.appendingPathComponent(entry.lastPathComponent).path)
                     }
-                    // Only remove profile-side dir if all entries were successfully migrated.
-                    // If any were skipped due to collision, preserve the profile dir to avoid
-                    // data loss (profile-unique sessions in the skipped dirs are still there).
-                    if anySkipped {
+                    if hasCollision {
                         logger.warning("projects migration incomplete for profile due to collisions; symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
                         return
+                    }
+
+                    // No collisions detected; safe to move all entries.
+                    for entry in entries {
+                        let dest = hostEntry.appendingPathComponent(entry.lastPathComponent)
+                        try fm.moveItem(at: entry, to: dest)
                     }
                     try fm.removeItem(at: profileEntry)
                 } catch {

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -542,4 +542,52 @@ struct ClaudeProfileConfigDirManagerTests {
         let dest = try fm.destinationOfSymbolicLink(atPath: profilePlugins.path)
         #expect(dest.contains("junk-plugins"))
     }
+
+    // MARK: - env var TBD_CLAUDE_HOST_HOME
+
+    @Test("TBD_CLAUDE_HOST_HOME env var overrides default host base directory")
+    func hostBaseDirectoryRespectsTBDClaudeHostHomeEnv() {
+        let tempHostOverride = tempHostBase()
+        defer { try? FileManager.default.removeItem(at: tempHostOverride) }
+
+        // Create manager with no explicit hostBaseDirectory arg, but verify
+        // that passing a base URL in the init directly works (simulating
+        // what resolveConfigDir would do with env-based override).
+        let manager1 = ClaudeProfileConfigDirManager(hostBaseDirectory: tempHostOverride)
+        #expect(manager1.hostBaseDirectory == tempHostOverride)
+
+        // Also verify default (nil) still uses ~/.claude/ by checking it
+        // contains ".claude" in the path.
+        let manager2 = ClaudeProfileConfigDirManager()
+        #expect(manager2.hostBaseDirectory.path.contains(".claude"))
+        #expect(manager2.hostBaseDirectory.path.contains(NSHomeDirectory()))
+    }
+
+    @Test("symlink resolution handles paths through symlinks (e.g. /var -> /private/var)")
+    func hostMirrorSymlinkResolutionThroughPathSymlinks() throws {
+        let tempBase = tempBase()
+        let tempHostBase = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHostBase)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHostBase, withIntermediateDirectories: true)
+        try fm.createDirectory(at: tempHostBase.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHostBase)
+        let profileID = UUID()
+
+        // Create host slot and then profile slot with symlink
+        let dir = try manager.ensureOAuthDir(forProfileID: profileID)
+        let pluginsLink = dir.appendingPathComponent("plugins")
+
+        // Verify the symlink was created and points to the right place
+        #expect((try? fm.destinationOfSymbolicLink(atPath: pluginsLink.path)) != nil)
+
+        // Re-calling should be idempotent
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: pluginsLink.path)) != nil)
+    }
 }

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -11,6 +11,11 @@ struct ClaudeProfileConfigDirManagerTests {
             .appendingPathComponent("tbd-profile-cfg-test-\(UUID().uuidString)", isDirectory: true)
     }
 
+    private func tempHostBase() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-host-cfg-test-\(UUID().uuidString)", isDirectory: true)
+    }
+
     // MARK: - approvalToken
 
     @Test("approval token is last 20 chars of api key")
@@ -236,5 +241,305 @@ struct ClaudeProfileConfigDirManagerTests {
             awsProfile: nil
         )
         #expect(ClaudeProfileConfigDirManager.resolveConfigDir(for: profile) == nil)
+    }
+
+    // MARK: - host mirror slots
+
+    @Test("AC1.1 / AC1.2: symlink dir and file host slots after ensureOAuthDir and ensureAPIKeyDir")
+    func hostMirrorSymlinksOAuthAndAPIKey() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create host slots: plugins (dir) and CLAUDE.md (file)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+        try "# Host CLAUDE.md".write(to: tempHost.appendingPathComponent("CLAUDE.md"), atomically: true, encoding: .utf8)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+
+        // Test ensureOAuthDir
+        let oauthDir = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Check plugins symlink
+        let pluginsLink = oauthDir.appendingPathComponent("plugins")
+        let pluginsDest = try fm.destinationOfSymbolicLink(atPath: pluginsLink.path)
+        let pluginsResolved = URL(fileURLWithPath: pluginsDest, relativeTo: pluginsLink.deletingLastPathComponent()).standardizedFileURL
+        #expect(pluginsResolved == tempHost.appendingPathComponent("plugins").standardizedFileURL)
+
+        // Check CLAUDE.md symlink
+        let claudeLink = oauthDir.appendingPathComponent("CLAUDE.md")
+        let claudeDest = try fm.destinationOfSymbolicLink(atPath: claudeLink.path)
+        let claudeResolved = URL(fileURLWithPath: claudeDest, relativeTo: claudeLink.deletingLastPathComponent()).standardizedFileURL
+        #expect(claudeResolved == tempHost.appendingPathComponent("CLAUDE.md").standardizedFileURL)
+
+        // Test ensureAPIKeyDir with same profile
+        let apiKey = "sk-ant-test-AAAAAAAAAAAAAAAAAAAAAAAAA-LASTTWENTYCHARSXXX1"
+        _ = try manager.ensureAPIKeyDir(forProfileID: profileID, apiKey: apiKey)
+
+        // Symlinks should still be there
+        #expect((try? fm.destinationOfSymbolicLink(atPath: pluginsLink.path)) != nil)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: claudeLink.path)) != nil)
+    }
+
+    @Test("AC1.3: skip host slot if not present on host")
+    func hostMirrorSkipsAbsentSlot() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create only plugins; skills is absent
+        try fm.createDirectory(at: tempHost.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+
+        let dir = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // plugins should be symlinked
+        #expect((try? fm.destinationOfSymbolicLink(atPath: dir.appendingPathComponent("plugins").path)) != nil)
+
+        // skills should NOT exist
+        #expect(!fm.fileExists(atPath: dir.appendingPathComponent("skills").path))
+    }
+
+    @Test("AC2.1: idempotent — calling ensureOAuthDir twice leaves symlink intact")
+    func hostMirrorIdempotentOAuth() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+
+        let dir1 = try manager.ensureOAuthDir(forProfileID: profileID)
+        let pluginsLink = dir1.appendingPathComponent("plugins")
+        let dest1 = try fm.destinationOfSymbolicLink(atPath: pluginsLink.path)
+
+        let dir2 = try manager.ensureOAuthDir(forProfileID: profileID)
+        let dest2 = try fm.destinationOfSymbolicLink(atPath: pluginsLink.path)
+
+        #expect(dir1 == dir2)
+        #expect(dest1 == dest2)
+    }
+
+    @Test("AC3.1: migrate projects directory content to host before symlinking")
+    func hostMirrorMigrateProjectsDir() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects", isDirectory: true), withIntermediateDirectories: true)
+
+        // Pre-create profile projects dir with content
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let projectsDir = profileClaudeDir.appendingPathComponent("projects")
+        try fm.createDirectory(at: projectsDir.appendingPathComponent("-Users-test-cwd", isDirectory: true), withIntermediateDirectories: true)
+        let sessionFile = projectsDir.appendingPathComponent("-Users-test-cwd/sess-1.jsonl")
+        try "PROFILE CONTENT".write(to: sessionFile, atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify profile projects is now a symlink
+        #expect((try? fm.destinationOfSymbolicLink(atPath: projectsDir.path)) != nil)
+
+        // Verify content was migrated to host
+        let hostSessionFile = tempHost.appendingPathComponent("projects/-Users-test-cwd/sess-1.jsonl")
+        #expect(fm.fileExists(atPath: hostSessionFile.path))
+        let migrated = try String(contentsOf: hostSessionFile, encoding: .utf8)
+        #expect(migrated == "PROFILE CONTENT")
+    }
+
+    @Test("AC3.2: collision skip during projects migration")
+    func hostMirrorProjectsMigrationCollisionSkip() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create host projects with a collision file
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects/-Users-test-cwd", isDirectory: true), withIntermediateDirectories: true)
+        let hostFile = tempHost.appendingPathComponent("projects/-Users-test-cwd/sess-X.jsonl")
+        try "HOST".write(to: hostFile, atomically: true, encoding: .utf8)
+
+        // Pre-create profile projects with same file (should not overwrite)
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileProjectsDir = profileClaudeDir.appendingPathComponent("projects/-Users-test-cwd", isDirectory: true)
+        try fm.createDirectory(at: profileProjectsDir, withIntermediateDirectories: true)
+        let profileFile = profileClaudeDir.appendingPathComponent("projects/-Users-test-cwd/sess-X.jsonl")
+        try "PROFILE".write(to: profileFile, atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Host file should still contain "HOST"
+        let hostContent = try String(contentsOf: hostFile, encoding: .utf8)
+        #expect(hostContent == "HOST")
+    }
+
+    @Test("AC3.3a: non-projects directory with content is left alone")
+    func hostMirrorNonProjectsDirWithContent() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+
+        // Pre-create profile plugins with content
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profilePlugins = profileClaudeDir.appendingPathComponent("plugins")
+        try fm.createDirectory(at: profilePlugins, withIntermediateDirectories: true)
+        try "plugin content".write(to: profilePlugins.appendingPathComponent("foo.txt"), atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Profile plugins should still be a real directory (NOT symlink)
+        var isDir: ObjCBool = false
+        #expect(fm.fileExists(atPath: profilePlugins.path, isDirectory: &isDir))
+        #expect(isDir.boolValue)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profilePlugins.path)) == nil)
+
+        // Content should still be there
+        #expect(fm.fileExists(atPath: profilePlugins.appendingPathComponent("foo.txt").path))
+    }
+
+    @Test("AC3.3b: non-projects empty directory is replaced with symlink")
+    func hostMirrorNonProjectsEmptyDir() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+
+        // Pre-create empty profile plugins dir
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profilePlugins = profileClaudeDir.appendingPathComponent("plugins")
+        try fm.createDirectory(at: profilePlugins, withIntermediateDirectories: true)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Profile plugins should now be a symlink
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profilePlugins.path)) != nil)
+    }
+
+    @Test("AC3.3c: non-projects file is left alone")
+    func hostMirrorNonProjectsFile() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        try "# Host CLAUDE.md".write(to: tempHost.appendingPathComponent("CLAUDE.md"), atomically: true, encoding: .utf8)
+
+        // Pre-create profile CLAUDE.md with different content
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileClaudeFile = profileClaudeDir.appendingPathComponent("CLAUDE.md")
+        try "# Profile CLAUDE.md".write(to: profileClaudeFile, atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Profile file should still exist with original content (NOT symlink)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileClaudeFile.path)) == nil)
+        let content = try String(contentsOf: profileClaudeFile, encoding: .utf8)
+        #expect(content == "# Profile CLAUDE.md")
+    }
+
+    @Test("AC3.3c variant: symlink with wrong target is left alone")
+    func hostMirrorSymlinkWrongTarget() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+
+        // Pre-create profile plugins as a symlink to a junk dir
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let junkDir = profileClaudeDir.appendingPathComponent("junk-plugins", isDirectory: true)
+        try fm.createDirectory(at: junkDir, withIntermediateDirectories: true)
+        let profilePlugins = profileClaudeDir.appendingPathComponent("plugins")
+        try fm.createSymbolicLink(at: profilePlugins, withDestinationURL: junkDir)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Profile plugins symlink should still point to junk (unchanged)
+        let dest = try fm.destinationOfSymbolicLink(atPath: profilePlugins.path)
+        #expect(dest.contains("junk-plugins"))
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -466,6 +466,65 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(profileUniqueContent == "PROFILE UNIQUE")
     }
 
+    @Test("AC3.2b: collision with multiple cwds aborts migration atomically")
+    func hostMirrorProjectsMigrationCollisionAbortsAtomically() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create host projects with cwd-hash A (collision point)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects/-Users-test-cwd-A", isDirectory: true), withIntermediateDirectories: true)
+        let hostFileA = tempHost.appendingPathComponent("projects/-Users-test-cwd-A/host-sess.jsonl")
+        try "HOST A".write(to: hostFileA, atomically: true, encoding: .utf8)
+
+        // Pre-create profile projects with:
+        // - cwd-hash A (collides with host, should not be migrated)
+        // - cwd-hash B (no collision, but should NOT be migrated if A collides)
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileProjectsBaseDir = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
+        try fm.createDirectory(at: profileProjectsBaseDir, withIntermediateDirectories: true)
+
+        // Pre-create cwd-hash A (colliding side)
+        try fm.createDirectory(at: profileProjectsBaseDir.appendingPathComponent("-Users-test-cwd-A", isDirectory: true), withIntermediateDirectories: true)
+        let profileFileA = profileProjectsBaseDir.appendingPathComponent("-Users-test-cwd-A/profile-sess-A.jsonl")
+        try "PROFILE A".write(to: profileFileA, atomically: true, encoding: .utf8)
+
+        // Pre-create cwd-hash B (non-colliding side)
+        try fm.createDirectory(at: profileProjectsBaseDir.appendingPathComponent("-Users-test-cwd-B", isDirectory: true), withIntermediateDirectories: true)
+        let profileFileB = profileProjectsBaseDir.appendingPathComponent("-Users-test-cwd-B/profile-sess-B.jsonl")
+        try "PROFILE B".write(to: profileFileB, atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify: cwd-hash A (colliding) should still exist in profile, not moved
+        #expect(fm.fileExists(atPath: profileFileA.path), "colliding cwd-hash A was moved despite collision")
+        let profileContentA = try String(contentsOf: profileFileA, encoding: .utf8)
+        #expect(profileContentA == "PROFILE A")
+
+        // Verify: cwd-hash B (non-colliding) should still exist in profile, NOT moved to host
+        // This is the key regression test: it ensures atomicity of the migration.
+        #expect(fm.fileExists(atPath: profileFileB.path), "non-colliding cwd-hash B was migrated despite collision in A")
+        let profileContentB = try String(contentsOf: profileFileB, encoding: .utf8)
+        #expect(profileContentB == "PROFILE B")
+
+        // Verify: host should NOT have received any migration from the profile
+        #expect(!fm.fileExists(atPath: tempHost.appendingPathComponent("projects/-Users-test-cwd-B").path), "cwd-hash B was migrated to host despite collision in A")
+
+        // Verify: profile projects/ is still a real directory (NOT a symlink)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBaseDir.path)) == nil, "profile projects/ was symlinked despite collision")
+    }
+
     @Test("AC3.3a: non-projects directory with content is left alone")
     func hostMirrorNonProjectsDirWithContent() throws {
         let tempBase = tempBase()

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -653,16 +653,14 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(dest.contains("junk-plugins"))
     }
 
-    // MARK: - env var TBD_CLAUDE_HOST_HOME
+    // MARK: - hostBaseDirectory constructor and default
 
-    @Test("TBD_CLAUDE_HOST_HOME env var overrides default host base directory")
-    func hostBaseDirectoryRespectsTBDClaudeHostHomeEnv() {
+    @Test("hostBaseDirectory constructor arg and default")
+    func hostBaseDirectoryConstructorArgAndDefault() {
         let tempHostOverride = tempHostBase()
         defer { try? FileManager.default.removeItem(at: tempHostOverride) }
 
-        // Create manager with no explicit hostBaseDirectory arg, but verify
-        // that passing a base URL in the init directly works (simulating
-        // what resolveConfigDir would do with env-based override).
+        // Verify that passing a base URL in the init directly works.
         let manager1 = ClaudeProfileConfigDirManager(hostBaseDirectory: tempHostOverride)
         #expect(manager1.hostBaseDirectory == tempHostOverride)
 
@@ -699,5 +697,35 @@ struct ClaudeProfileConfigDirManagerTests {
         // Re-calling should be idempotent
         _ = try manager.ensureOAuthDir(forProfileID: profileID)
         #expect((try? fm.destinationOfSymbolicLink(atPath: pluginsLink.path)) != nil)
+    }
+}
+
+/// Run env-mutating tests serialized so they don't race each other. Each test
+/// snapshots the prior env value and restores it via defer.
+@Suite("ClaudeProfileConfigDirManager env vars", .serialized)
+struct ClaudeProfileConfigDirManagerEnvVarTests {
+    private func tempHostBase() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-host-cfg-test-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    @Test("TBD_CLAUDE_HOST_HOME env var is honored in default init")
+    func hostBaseDirectoryRespectsTBDClaudeHostHomeEnvVar() {
+        let tempHostOverride = tempHostBase()
+        defer { try? FileManager.default.removeItem(at: tempHostOverride) }
+
+        let priorValue = ProcessInfo.processInfo.environment["TBD_CLAUDE_HOST_HOME"]
+        setenv("TBD_CLAUDE_HOST_HOME", tempHostOverride.path, 1)
+        defer {
+            if let prior = priorValue {
+                setenv("TBD_CLAUDE_HOST_HOME", prior, 1)
+            } else {
+                unsetenv("TBD_CLAUDE_HOST_HOME")
+            }
+        }
+
+        let manager = ClaudeProfileConfigDirManager()
+        #expect(manager.hostBaseDirectory.resolvingSymlinksInPath()
+                == tempHostOverride.resolvingSymlinksInPath())
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -342,6 +342,46 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(dest1 == dest2)
     }
 
+    @Test("Issue 1 regression: ensureOAuthDir sets up mirrors when .claude.json already exists")
+    func ensureOAuthDirSetsUpMirrorsWhenClaudeJSONAlreadyExists() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create host plugins so there's a slot to mirror
+        try fm.createDirectory(at: tempHost.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+
+        // Pre-create profile dir with existing .claude.json (simulating a profile
+        // created before mirror support was added)
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let claudeJSONPath = profileClaudeDir.appendingPathComponent(".claude.json")
+        let existingJSON: [String: Any] = ["hasCompletedOnboarding": true]
+        let existingData = try JSONSerialization.data(withJSONObject: existingJSON, options: [.prettyPrinted, .sortedKeys])
+        try existingData.write(to: claudeJSONPath, options: [.atomic])
+
+        // Call ensureOAuthDir on a profile that already has .claude.json
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Assert that plugins symlink was created (the early-return bug would skip this)
+        let pluginsLink = profileClaudeDir.appendingPathComponent("plugins")
+        #expect((try? fm.destinationOfSymbolicLink(atPath: pluginsLink.path)) != nil)
+
+        // Verify the symlink points to the host plugins
+        let dest = try fm.destinationOfSymbolicLink(atPath: pluginsLink.path)
+        let resolved = URL(fileURLWithPath: dest, relativeTo: pluginsLink.deletingLastPathComponent()).standardizedFileURL
+        #expect(resolved == tempHost.appendingPathComponent("plugins").standardizedFileURL)
+    }
+
     @Test("AC3.1: migrate projects directory content to host before symlinking")
     func hostMirrorMigrateProjectsDir() throws {
         let tempBase = tempBase()
@@ -396,7 +436,9 @@ struct ClaudeProfileConfigDirManagerTests {
         let hostFile = tempHost.appendingPathComponent("projects/-Users-test-cwd/sess-X.jsonl")
         try "HOST".write(to: hostFile, atomically: true, encoding: .utf8)
 
-        // Pre-create profile projects with same file (should not overwrite)
+        // Pre-create profile projects with same cwd-hash dir but different session files:
+        // - sess-X.jsonl (collides with host, should not be migrated)
+        // - profile-unique-sess.jsonl (unique to profile, should be preserved)
         let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
         let profileID = UUID()
         let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
@@ -406,13 +448,22 @@ struct ClaudeProfileConfigDirManagerTests {
         try fm.createDirectory(at: profileProjectsDir, withIntermediateDirectories: true)
         let profileFile = profileClaudeDir.appendingPathComponent("projects/-Users-test-cwd/sess-X.jsonl")
         try "PROFILE".write(to: profileFile, atomically: true, encoding: .utf8)
+        let profileUniqueFile = profileClaudeDir.appendingPathComponent("projects/-Users-test-cwd/profile-unique-sess.jsonl")
+        try "PROFILE UNIQUE".write(to: profileUniqueFile, atomically: true, encoding: .utf8)
 
         // Call ensureOAuthDir
         _ = try manager.ensureOAuthDir(forProfileID: profileID)
 
-        // Host file should still contain "HOST"
+        // Host file should still contain "HOST" (collision not overwritten)
         let hostContent = try String(contentsOf: hostFile, encoding: .utf8)
         #expect(hostContent == "HOST")
+
+        // Issue 2 regression: Profile-unique session file should still exist.
+        // When a collision occurs, the profile-side projects/ dir is preserved
+        // (not deleted), so the unique session is not lost.
+        #expect(fm.fileExists(atPath: profileUniqueFile.path), "profile-unique session was destroyed during migration collision")
+        let profileUniqueContent = try String(contentsOf: profileUniqueFile, encoding: .utf8)
+        #expect(profileUniqueContent == "PROFILE UNIQUE")
     }
 
     @Test("AC3.3a: non-projects directory with content is left alone")

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -424,6 +424,66 @@ struct ModelProfileRPCTests {
         #expect(!FileManager.default.fileExists(atPath: profileDir.path))
     }
 
+    @Test("delete preserves host mirror targets across multiple slots")
+    func deletePreservesHostMirrors() async throws {
+        let tempBaseDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let tempHostDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempBaseDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tempHostDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: tempBaseDir)
+            try? FileManager.default.removeItem(at: tempHostDir)
+        }
+
+        let fm = FileManager.default
+
+        // Pre-create host slots
+        try fm.createDirectory(at: tempHostDir.appendingPathComponent("projects", isDirectory: true), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tempHostDir.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBaseDir, hostBaseDirectory: tempHostDir)
+        let (router, db, _) = makeRouter(configDirManager: manager)
+        defer { Task { await cleanupKeychain(db) } }
+
+        // Create an OAuth profile and ensure its config dir with mirror symlinks
+        let oauthProfile = try await db.modelProfiles.create(name: "OAuth", kind: .oauth)
+        _ = try manager.ensureOAuthDir(forProfileID: oauthProfile.id)
+
+        // Write sentinel files in host slots
+        let projectsSentinel = tempHostDir.appendingPathComponent("projects/-Users-test-cwd/sentinel.jsonl")
+        try fm.createDirectory(at: projectsSentinel.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "PROJECTS_SENTINEL".write(to: projectsSentinel, atomically: true, encoding: .utf8)
+
+        let pluginsSentinel = tempHostDir.appendingPathComponent("plugins/sentinel.txt")
+        try "PLUGINS_SENTINEL".write(to: pluginsSentinel, atomically: true, encoding: .utf8)
+
+        let profileDir = manager.profileDirectory(forProfileID: oauthProfile.id)
+
+        // Verify symlinks were created
+        let profileProjects = manager.configDirectory(forProfileID: oauthProfile.id).appendingPathComponent("projects")
+        let profilePlugins = manager.configDirectory(forProfileID: oauthProfile.id).appendingPathComponent("plugins")
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjects.path)) != nil)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profilePlugins.path)) != nil)
+
+        // Delete the profile via RPC
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.modelProfileDelete,
+                                                      params: ModelProfileDeleteParams(id: oauthProfile.id)))
+        #expect(resp.success)
+
+        // Verify the profile directory was deleted
+        #expect(!fm.fileExists(atPath: profileDir.path))
+
+        // Verify host sentinels still exist with original content
+        #expect(fm.fileExists(atPath: projectsSentinel.path))
+        #expect(fm.fileExists(atPath: pluginsSentinel.path))
+
+        let projectsContent = try String(contentsOf: projectsSentinel, encoding: .utf8)
+        #expect(projectsContent == "PROJECTS_SENTINEL")
+
+        let pluginsContent = try String(contentsOf: pluginsSentinel, encoding: .utf8)
+        #expect(pluginsContent == "PLUGINS_SENTINEL")
+    }
+
     // MARK: - rename
 
     @Test("rename success")

--- a/docs/implementation-plans/2026-05-20-shared-claude-projects/phase_01.md
+++ b/docs/implementation-plans/2026-05-20-shared-claude-projects/phase_01.md
@@ -1,0 +1,262 @@
+# Shared Claude session store — Implementation Plan
+
+**Goal:** Make `~/.claude/projects/` the canonical session-transcript store and
+symlink each TBD profile's `claude/projects` into it, so cross-profile resume
+works and pre-redesign sessions remain reachable after TBD restarts.
+
+**Architecture:** Internal change to `ClaudeProfileConfigDirManager`. Every
+`ensureOAuthDir` / `ensureAPIKeyDir` call ensures `<host-projects>/` exists,
+then ensures `<profile-dir>/claude/projects` is a symlink to it (migrating any
+pre-existing real directory's contents on the way). Auth (Keychain entry keyed
+on `CLAUDE_CONFIG_DIR` path), `.claude.json`, and per-profile settings remain
+isolated. No DB change, no call-site change.
+
+**Tech stack:** Swift 6, SwiftPM, Swift Testing (`@Test`/`#expect`).
+
+**Scope:** 1 phase, 3 tasks. Source design:
+`docs/specs/2026-05-20-shared-claude-projects-design.md`.
+
+**Codebase verified:** 2026-05-20 — `ClaudeProfileConfigDirManager` lives at
+`Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift` and is the only
+place where profile config dirs are created. Both ensure-dir methods are the
+right hook point.
+
+---
+
+## Acceptance Criteria Coverage
+
+Copied literally from the design doc.
+
+### shared-claude-projects.AC1: profile dirs symlink into the host store
+- **AC1.1 Success:** After `ensureOAuthDir(forProfileID:)` runs against a fresh
+  profile UUID, `<profile-dir>/claude/projects` exists as a symbolic link whose
+  destination resolves to `<host-projects>/` (default `~/.claude/projects/`,
+  injectable for tests).
+- **AC1.2 Success:** Same property after `ensureAPIKeyDir(forProfileID:apiKey:)`.
+
+### shared-claude-projects.AC2: idempotent
+- **AC2.1 Success:** Calling `ensureOAuthDir` / `ensureAPIKeyDir` a second time
+  for the same profile leaves the existing symlink (and its target) in place
+  and does not error.
+
+### shared-claude-projects.AC3: migrate pre-existing `projects/` content
+- **AC3.1 Success:** If `<profile-dir>/claude/projects` already exists as a
+  *real directory*, its contents are merged into `<host-projects>/` before
+  being replaced by the symlink. Files surviving from before the migration are
+  preserved on the host side.
+- **AC3.2 Success:** A `<host-projects>/<cwd-hash>/<id>.jsonl` that already
+  existed before the migration is NOT overwritten — collisions skip rather
+  than clobber.
+
+### shared-claude-projects.AC4: profile deletion preserves host sessions
+- **AC4.1 Success:** Deleting a profile via `handleModelProfileDelete` removes
+  the profile directory but leaves every file under `<host-projects>/`
+  untouched.
+
+---
+
+# Phase 1 — Symlink profile `projects/` into the host store
+
+Files:
+- Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
+- Modify: `Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift`
+- Modify: `Tests/TBDDaemonTests/ModelProfileRPCTests.swift` (one new test
+  around the existing delete-cleanup pair)
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add the symlink + migration logic to `ClaudeProfileConfigDirManager`
+
+**Verifies:** shared-claude-projects.AC1.1, AC1.2, AC2.1, AC3.1, AC3.2
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
+
+**Implementation:**
+
+1. Add an injectable host-projects URL to the struct so tests can redirect it
+   without touching `~/.claude/`. Follow the existing `baseDirectory`
+   precedent:
+
+   ```swift
+   public struct ClaudeProfileConfigDirManager: Sendable {
+       let baseDirectory: URL
+       let hostProjectsDirectory: URL
+
+       public init(
+           baseDirectory: URL? = nil,
+           hostProjectsDirectory: URL? = nil
+       ) {
+           self.baseDirectory = baseDirectory
+               ?? TBDConstants.configDir.appendingPathComponent("profiles", isDirectory: true)
+           self.hostProjectsDirectory = hostProjectsDirectory
+               ?? FileManager.default.homeDirectoryForCurrentUser
+                   .appendingPathComponent(".claude", isDirectory: true)
+                   .appendingPathComponent("projects", isDirectory: true)
+       }
+   }
+   ```
+
+2. Add a private helper that ensures `<profile-dir>/claude/projects` is a
+   symlink to `hostProjectsDirectory`, migrating any pre-existing real
+   directory's contents first. Idempotent.
+
+   ```swift
+   private func ensureProjectsSymlink(in profileClaudeDir: URL) throws {
+       let fm = FileManager.default
+       try fm.createDirectory(at: hostProjectsDirectory, withIntermediateDirectories: true)
+
+       let profileProjects = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
+
+       // Already a symlink? Validate destination; if it points at the right
+       // place leave it; if it points elsewhere log and leave it (don't fight
+       // an owner we don't recognize).
+       if let dest = try? fm.destinationOfSymbolicLink(atPath: profileProjects.path) {
+           let resolved = URL(fileURLWithPath: dest, relativeTo: profileProjects.deletingLastPathComponent())
+               .standardizedFileURL
+           if resolved == hostProjectsDirectory.standardizedFileURL {
+               return
+           }
+           logger.warning("profile projects symlink points elsewhere: \(resolved.path, privacy: .public); leaving as-is")
+           return
+       }
+
+       // Pre-existing real directory? Migrate contents into the host store
+       // (skip on collision), then remove.
+       var isDir: ObjCBool = false
+       if fm.fileExists(atPath: profileProjects.path, isDirectory: &isDir), isDir.boolValue {
+           let entries = (try? fm.contentsOfDirectory(at: profileProjects, includingPropertiesForKeys: nil)) ?? []
+           for entry in entries {
+               let dest = hostProjectsDirectory.appendingPathComponent(entry.lastPathComponent)
+               if fm.fileExists(atPath: dest.path) {
+                   logger.debug("collision migrating \(entry.lastPathComponent, privacy: .public); skipping")
+                   continue
+               }
+               try fm.moveItem(at: entry, to: dest)
+           }
+           try fm.removeItem(at: profileProjects)
+       }
+
+       try fm.createSymbolicLink(at: profileProjects, withDestinationURL: hostProjectsDirectory)
+   }
+   ```
+
+3. Call `ensureProjectsSymlink(in: dir)` at the end of both
+   `ensureOAuthDir(forProfileID:)` and `ensureAPIKeyDir(forProfileID:apiKey:)`,
+   *after* the existing `.claude.json` write. Use `try` — failures here
+   propagate up like the existing filesystem failures already do, and the
+   call sites (`resolveConfigDir`) already catch+log+return nil on throw.
+
+4. Update the type-level doc comment to describe the new `projects/` symlink
+   behavior alongside the existing per-profile-isolation note.
+
+**Testing:** see Task 2.
+
+**Verification:**
+Run: `swift build`
+Expected: builds without errors.
+
+**Commit:** `feat: symlink profile claude/projects into host store`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Tests for the symlink + migration
+
+**Verifies:** shared-claude-projects.AC1.1, AC1.2, AC2.1, AC3.1, AC3.2
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift`
+
+**Testing:**
+
+All tests must run against a temp `hostProjectsDirectory` (NOT
+`~/.claude/projects/`). Follow the existing pattern of `tempBase()` and add a
+`tempHostProjects()` helper. Construct the manager with both injected.
+
+- AC1.1: call `ensureOAuthDir` on a fresh profile UUID, assert
+  `<profile-dir>/claude/projects` is a symlink whose `destinationOfSymbolicLink`
+  resolves to the temp host-projects path.
+- AC1.2: same for `ensureAPIKeyDir`.
+- AC2.1: call `ensureOAuthDir` twice; second call still leaves the symlink
+  pointing at the same target and does not throw. Same for `ensureAPIKeyDir`.
+- AC3.1: pre-create `<profile-dir>/claude/projects/-Users-test-cwd/sess-1.jsonl`
+  as a real file in a real directory; call `ensureOAuthDir`; assert
+  `<host-projects>/-Users-test-cwd/sess-1.jsonl` now exists, the old path is a
+  symlink (not the original real dir), and the file content matches.
+- AC3.2: pre-create `<host-projects>/-Users-test-cwd/sess-X.jsonl` with content
+  "HOST" and `<profile-dir>/claude/projects/-Users-test-cwd/sess-X.jsonl` with
+  content "PROFILE"; call `ensureOAuthDir`; assert host file still contains
+  "HOST" (collision skipped).
+- A small test that an existing symlink to the right place is left alone:
+  call `ensureOAuthDir` twice; capture the inode/identity of the symlink after
+  the first call and confirm it's unchanged after the second.
+
+**Verification:**
+Run: `swift test --filter ClaudeProfileConfigDirManager`
+Expected: all tests pass.
+
+**Commit:** `test: cover projects symlink and migration`
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Lock in that profile deletion does not follow the symlink
+
+**Verifies:** shared-claude-projects.AC4.1
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/ModelProfileRPCTests.swift`
+
+**Testing:**
+
+The existing `deleteOAuthRemovesConfigDir` and `deleteAPIKeyRemovesConfigDir`
+tests verify the profile directory is removed. Add one new test (or extend
+those two) verifying that with `projects/` as a symlink, host sessions survive
+the delete. Use the existing test pattern (in-memory DB,
+`ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostProjectsDirectory: tempHost)`,
+inject into `makeRouter`).
+
+- Create a profile (oauth or apiKey), call `ensureOAuthDir`/`ensureAPIKeyDir`
+  so the symlink is created.
+- Write a sentinel file at `<tempHost>/-Users-test-cwd/sentinel.jsonl`.
+- Invoke `handleModelProfileDelete` for that profile.
+- Assert: `<profile-dir>` no longer exists, AND
+  `<tempHost>/-Users-test-cwd/sentinel.jsonl` still exists with the original
+  content (symlink removal did not propagate into the host store).
+
+This locks in macOS's `FileManager.removeItem(at:)` non-symlink-following
+behavior so a future refactor (e.g. switching to a recursive walker that does
+follow links) can't silently destroy session history.
+
+**Verification:**
+Run: `swift test --filter ModelProfile`
+Expected: all tests pass.
+
+**Commit:** `test: profile delete preserves host session store`
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->
+
+---
+
+## Final verification (single-phase plan)
+
+- `swift build` — clean.
+- `swift test` — full suite passes.
+- `swift package plugin --allow-writing-to-package-directory swiftlint --strict`
+  — no violations.
+- Manual cross-profile resume check before opening the PR for review:
+  1. Restart TBD on this branch via `scripts/restart.sh`.
+  2. Spawn `claude` under profile A in some worktree; have a short
+     conversation; note the session UUID.
+  3. Spawn `claude --resume <uuid>` under profile B in the same worktree's
+     cwd; confirm the transcript loads and a new turn proceeds.
+  4. (Bonus) Confirm `~/.claude/projects/<cwd-hash>/` shows the session JSONL.
+
+## Out of scope / follow-ups (not blocking)
+
+- Soft lock against simultaneous resume of the same session.
+- Swap-time UX warning that the prior transcript will be sent to the target
+  account.
+- "Stash recovered" affordance for terminals that already reincarnated blank
+  between PR #177 merging and this follow-up landing.

--- a/docs/implementation-plans/2026-05-20-shared-claude-projects/phase_01.md
+++ b/docs/implementation-plans/2026-05-20-shared-claude-projects/phase_01.md
@@ -54,9 +54,11 @@ host-base directory (default `~/.claude/`).
 - **AC3.1 Success:** If `<profile-dir>/claude/projects` already exists as a
   *real directory*, its contents are merged into `<host-base>/projects/`
   before being replaced by the symlink.
-- **AC3.2 Success:** A `<host-base>/projects/<cwd-hash>/<id>.jsonl` that
-  already existed before the migration is NOT overwritten — collisions skip
-  rather than clobber.
+- **AC3.2 Success:** If any top-level entry (cwd-hash directory) of the
+  profile's `projects/` already exists in the host's `projects/`, the entire
+  migration is aborted and the profile-side dir is preserved intact.
+  All-or-nothing atomicity prevents partial migrations that could orphan
+  sessions across stores.
 - **AC3.3 Success:** For *non-projects* slots, if `<profile-dir>/claude/<slot>`
   already exists as a real file or non-empty real directory, it is left in
   place and the symlink for that slot is not created. An empty real directory

--- a/docs/implementation-plans/2026-05-20-shared-claude-projects/phase_01.md
+++ b/docs/implementation-plans/2026-05-20-shared-claude-projects/phase_01.md
@@ -1,15 +1,19 @@
-# Shared Claude session store — Implementation Plan
+# Shared Claude state across TBD profiles — Implementation Plan
 
-**Goal:** Make `~/.claude/projects/` the canonical session-transcript store and
-symlink each TBD profile's `claude/projects` into it, so cross-profile resume
-works and pre-redesign sessions remain reachable after TBD restarts.
+**Goal:** Make alt-profile dirs thin overlays on `~/.claude/`. Every TBD
+profile mirrors the host's customization slots (`projects/`, `plugins/`,
+`skills/`, `agents/`, `commands/`, `hooks/`, `CLAUDE.md`, `settings.json`) via
+symlinks pointing at the corresponding entries under `~/.claude/`. Only the
+per-profile identity slot (`.claude.json` plus per-path Keychain auth) is
+owned by the profile.
 
 **Architecture:** Internal change to `ClaudeProfileConfigDirManager`. Every
-`ensureOAuthDir` / `ensureAPIKeyDir` call ensures `<host-projects>/` exists,
-then ensures `<profile-dir>/claude/projects` is a symlink to it (migrating any
-pre-existing real directory's contents on the way). Auth (Keychain entry keyed
-on `CLAUDE_CONFIG_DIR` path), `.claude.json`, and per-profile settings remain
-isolated. No DB change, no call-site change.
+`ensureOAuthDir` / `ensureAPIKeyDir` call iterates a fixed mirror list and
+ensures each present-on-host slot has a symlink in the profile dir, migrating
+any pre-existing real `projects/` directory's contents on the way and leaving
+other non-empty pre-existing slots alone. Auth (Keychain entry keyed on
+`CLAUDE_CONFIG_DIR` path) and `.claude.json` remain per-profile. No DB
+change, no call-site change.
 
 **Tech stack:** Swift 6, SwiftPM, Swift Testing (`@Test`/`#expect`).
 
@@ -27,35 +31,47 @@ right hook point.
 
 Copied literally from the design doc.
 
-### shared-claude-projects.AC1: profile dirs symlink into the host store
-- **AC1.1 Success:** After `ensureOAuthDir(forProfileID:)` runs against a fresh
-  profile UUID, `<profile-dir>/claude/projects` exists as a symbolic link whose
-  destination resolves to `<host-projects>/` (default `~/.claude/projects/`,
-  injectable for tests).
+### shared-claude-projects.AC1: profile dirs mirror host slots via symlinks
+
+The mirror list is: `projects`, `plugins`, `skills`, `agents`, `commands`,
+`hooks`, `CLAUDE.md`, `settings.json` — resolved relative to an injectable
+host-base directory (default `~/.claude/`).
+
+- **AC1.1 Success:** For each slot present in `<host-base>/`, after
+  `ensureOAuthDir(forProfileID:)` runs against a fresh profile UUID,
+  `<profile-dir>/claude/<slot>` exists as a symbolic link whose destination
+  resolves to `<host-base>/<slot>`.
 - **AC1.2 Success:** Same property after `ensureAPIKeyDir(forProfileID:apiKey:)`.
+- **AC1.3 Success:** A slot that does not exist in `<host-base>/` does not
+  cause a symlink to be created for it.
 
 ### shared-claude-projects.AC2: idempotent
-- **AC2.1 Success:** Calling `ensureOAuthDir` / `ensureAPIKeyDir` a second time
-  for the same profile leaves the existing symlink (and its target) in place
-  and does not error.
+- **AC2.1 Success:** Calling `ensureOAuthDir` / `ensureAPIKeyDir` a second
+  time leaves every existing slot symlink (and its target) in place and does
+  not error.
 
-### shared-claude-projects.AC3: migrate pre-existing `projects/` content
+### shared-claude-projects.AC3: migrate `projects/`; respect other slots
 - **AC3.1 Success:** If `<profile-dir>/claude/projects` already exists as a
-  *real directory*, its contents are merged into `<host-projects>/` before
-  being replaced by the symlink. Files surviving from before the migration are
-  preserved on the host side.
-- **AC3.2 Success:** A `<host-projects>/<cwd-hash>/<id>.jsonl` that already
-  existed before the migration is NOT overwritten — collisions skip rather
-  than clobber.
+  *real directory*, its contents are merged into `<host-base>/projects/`
+  before being replaced by the symlink.
+- **AC3.2 Success:** A `<host-base>/projects/<cwd-hash>/<id>.jsonl` that
+  already existed before the migration is NOT overwritten — collisions skip
+  rather than clobber.
+- **AC3.3 Success:** For *non-projects* slots, if `<profile-dir>/claude/<slot>`
+  already exists as a real file or non-empty real directory, it is left in
+  place and the symlink for that slot is not created. An empty real directory
+  may be removed and replaced with the symlink. A symlink pointing at the
+  wrong target is left alone with a log warning.
 
-### shared-claude-projects.AC4: profile deletion preserves host sessions
+### shared-claude-projects.AC4: profile deletion preserves host state
 - **AC4.1 Success:** Deleting a profile via `handleModelProfileDelete` removes
-  the profile directory but leaves every file under `<host-projects>/`
-  untouched.
+  the profile directory but leaves every file under `<host-base>/` untouched,
+  including `projects/` and at least one other mirrored slot (sentinel
+  seeded in both before delete).
 
 ---
 
-# Phase 1 — Symlink profile `projects/` into the host store
+# Phase 1 — Mirror host slots into profile dirs via symlinks
 
 Files:
 - Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
@@ -66,90 +82,154 @@ Files:
 <!-- START_SUBCOMPONENT_A (tasks 1-3) -->
 
 <!-- START_TASK_1 -->
-### Task 1: Add the symlink + migration logic to `ClaudeProfileConfigDirManager`
+### Task 1: Add the host-mirror logic to `ClaudeProfileConfigDirManager`
 
-**Verifies:** shared-claude-projects.AC1.1, AC1.2, AC2.1, AC3.1, AC3.2
+**Verifies:** shared-claude-projects.AC1.1, AC1.2, AC1.3, AC2.1, AC3.1, AC3.2, AC3.3
 
 **Files:**
 - Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
 
 **Implementation:**
 
-1. Add an injectable host-projects URL to the struct so tests can redirect it
-   without touching `~/.claude/`. Follow the existing `baseDirectory`
-   precedent:
+1. Add an injectable `hostBaseDirectory: URL` to the struct (defaults to
+   `~/.claude/`). Follow the existing `baseDirectory` precedent:
 
    ```swift
    public struct ClaudeProfileConfigDirManager: Sendable {
        let baseDirectory: URL
-       let hostProjectsDirectory: URL
+       let hostBaseDirectory: URL
 
        public init(
            baseDirectory: URL? = nil,
-           hostProjectsDirectory: URL? = nil
+           hostBaseDirectory: URL? = nil
        ) {
            self.baseDirectory = baseDirectory
                ?? TBDConstants.configDir.appendingPathComponent("profiles", isDirectory: true)
-           self.hostProjectsDirectory = hostProjectsDirectory
+           self.hostBaseDirectory = hostBaseDirectory
                ?? FileManager.default.homeDirectoryForCurrentUser
                    .appendingPathComponent(".claude", isDirectory: true)
-                   .appendingPathComponent("projects", isDirectory: true)
        }
    }
    ```
 
-2. Add a private helper that ensures `<profile-dir>/claude/projects` is a
-   symlink to `hostProjectsDirectory`, migrating any pre-existing real
-   directory's contents first. Idempotent.
+2. Define the mirror list as a private static array. Order does not matter
+   functionally but keep it stable for test predictability:
 
    ```swift
-   private func ensureProjectsSymlink(in profileClaudeDir: URL) throws {
+   /// Slots that each TBD profile dir mirrors from the host's claude config dir.
+   /// Symlinked from <profile>/claude/<slot> to <host-base>/<slot>.
+   /// `projects` is special: pre-existing real-dir content is migrated into
+   /// the host store before symlinking. Every other slot is left alone if it
+   /// already exists as a non-empty real file or directory.
+   private static let mirrorSlots: [String] = [
+       "projects",
+       "plugins",
+       "skills",
+       "agents",
+       "commands",
+       "hooks",
+       "CLAUDE.md",
+       "settings.json",
+   ]
+   ```
+
+3. Add a private helper that processes one slot, then a wrapper that loops:
+
+   ```swift
+   /// Ensure one host-mirror slot is a symlink from the profile dir into the
+   /// host base. Best-effort: filesystem errors are logged and swallowed.
+   private func ensureMirrorSlot(
+       _ name: String,
+       in profileClaudeDir: URL,
+       migrateContent: Bool
+   ) {
        let fm = FileManager.default
-       try fm.createDirectory(at: hostProjectsDirectory, withIntermediateDirectories: true)
+       let hostEntry = hostBaseDirectory.appendingPathComponent(name)
 
-       let profileProjects = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
+       // Skip if the host doesn't have this slot at all.
+       guard fm.fileExists(atPath: hostEntry.path) else { return }
 
-       // Already a symlink? Validate destination; if it points at the right
-       // place leave it; if it points elsewhere log and leave it (don't fight
-       // an owner we don't recognize).
-       if let dest = try? fm.destinationOfSymbolicLink(atPath: profileProjects.path) {
-           let resolved = URL(fileURLWithPath: dest, relativeTo: profileProjects.deletingLastPathComponent())
+       let profileEntry = profileClaudeDir.appendingPathComponent(name)
+
+       // Already a symlink? Check target; if it's right, done. If wrong,
+       // leave it and log (don't fight an owner we don't recognize).
+       if let dest = try? fm.destinationOfSymbolicLink(atPath: profileEntry.path) {
+           let resolved = URL(fileURLWithPath: dest, relativeTo: profileEntry.deletingLastPathComponent())
                .standardizedFileURL
-           if resolved == hostProjectsDirectory.standardizedFileURL {
-               return
-           }
-           logger.warning("profile projects symlink points elsewhere: \(resolved.path, privacy: .public); leaving as-is")
+           if resolved == hostEntry.standardizedFileURL { return }
+           logger.warning("mirror slot \(name, privacy: .public) symlink for profile points elsewhere; leaving as-is")
            return
        }
 
-       // Pre-existing real directory? Migrate contents into the host store
-       // (skip on collision), then remove.
+       // Profile has a real entry. Handle per slot policy.
        var isDir: ObjCBool = false
-       if fm.fileExists(atPath: profileProjects.path, isDirectory: &isDir), isDir.boolValue {
-           let entries = (try? fm.contentsOfDirectory(at: profileProjects, includingPropertiesForKeys: nil)) ?? []
-           for entry in entries {
-               let dest = hostProjectsDirectory.appendingPathComponent(entry.lastPathComponent)
-               if fm.fileExists(atPath: dest.path) {
-                   logger.debug("collision migrating \(entry.lastPathComponent, privacy: .public); skipping")
-                   continue
+       if fm.fileExists(atPath: profileEntry.path, isDirectory: &isDir) {
+           if isDir.boolValue, migrateContent {
+               // projects/ special-case: merge content into host store, then
+               // remove the profile-side dir and proceed to symlink.
+               do {
+                   // Ensure host dir exists (created above by fileExists check
+                   // succeeding, but be defensive on race / non-dir).
+                   try fm.createDirectory(at: hostEntry, withIntermediateDirectories: true)
+                   let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
+                   for entry in entries {
+                       let dest = hostEntry.appendingPathComponent(entry.lastPathComponent)
+                       if fm.fileExists(atPath: dest.path) {
+                           logger.debug("collision migrating \(entry.lastPathComponent, privacy: .public) into \(name, privacy: .public); skipping")
+                           continue
+                       }
+                       try fm.moveItem(at: entry, to: dest)
+                   }
+                   try fm.removeItem(at: profileEntry)
+               } catch {
+                   logger.warning("failed migrating \(name, privacy: .public) for profile: \(error.localizedDescription, privacy: .public)")
+                   return
                }
-               try fm.moveItem(at: entry, to: dest)
+           } else if isDir.boolValue {
+               // Non-projects directory in profile: replace only if empty.
+               let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
+               if entries.isEmpty {
+                   try? fm.removeItem(at: profileEntry)
+               } else {
+                   logger.warning("profile has real \(name, privacy: .public)/ with content; leaving as-is")
+                   return
+               }
+           } else {
+               // Real file (e.g. profile-side settings.json or CLAUDE.md).
+               // Don't destroy user content; leave alone.
+               logger.warning("profile has real \(name, privacy: .public) file; leaving as-is")
+               return
            }
-           try fm.removeItem(at: profileProjects)
        }
 
-       try fm.createSymbolicLink(at: profileProjects, withDestinationURL: hostProjectsDirectory)
+       // Create the symlink. Best-effort.
+       do {
+           try fm.createSymbolicLink(at: profileEntry, withDestinationURL: hostEntry)
+       } catch {
+           logger.warning("failed creating mirror symlink for \(name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+       }
+   }
+
+   /// Ensure every host-mirror slot is symlinked into the profile dir.
+   /// Best-effort and per-entry isolated — one failing slot does not block
+   /// the others.
+   private func ensureHostMirrors(in profileClaudeDir: URL) {
+       for slot in Self.mirrorSlots {
+           ensureMirrorSlot(slot, in: profileClaudeDir, migrateContent: slot == "projects")
+       }
    }
    ```
 
-3. Call `ensureProjectsSymlink(in: dir)` at the end of both
+4. Call `ensureHostMirrors(in: dir)` at the end of both
    `ensureOAuthDir(forProfileID:)` and `ensureAPIKeyDir(forProfileID:apiKey:)`,
-   *after* the existing `.claude.json` write. Use `try` — failures here
-   propagate up like the existing filesystem failures already do, and the
-   call sites (`resolveConfigDir`) already catch+log+return nil on throw.
+   *after* the existing `.claude.json` write. The wrapper is non-throwing, so
+   no signature change is needed at the call sites — the existing
+   `resolveConfigDir` catch path still covers any throws from earlier in the
+   ensure methods.
 
-4. Update the type-level doc comment to describe the new `projects/` symlink
-   behavior alongside the existing per-profile-isolation note.
+5. Update the type-level doc comment: list the slots that are mirrored, note
+   that `.claude.json` and credentials stay per-profile, mention the
+   `apiKeyHelper` caveat in a brief sentence.
 
 **Testing:** see Task 2.
 
@@ -157,50 +237,69 @@ Files:
 Run: `swift build`
 Expected: builds without errors.
 
-**Commit:** `feat: symlink profile claude/projects into host store`
+**Commit:** `feat: mirror host claude state slots into profile dirs`
 <!-- END_TASK_1 -->
 
 <!-- START_TASK_2 -->
-### Task 2: Tests for the symlink + migration
+### Task 2: Tests for the host-mirror behavior
 
-**Verifies:** shared-claude-projects.AC1.1, AC1.2, AC2.1, AC3.1, AC3.2
+**Verifies:** shared-claude-projects.AC1.1, AC1.2, AC1.3, AC2.1, AC3.1, AC3.2, AC3.3
 
 **Files:**
 - Modify: `Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift`
 
 **Testing:**
 
-All tests must run against a temp `hostProjectsDirectory` (NOT
-`~/.claude/projects/`). Follow the existing pattern of `tempBase()` and add a
-`tempHostProjects()` helper. Construct the manager with both injected.
+All tests must run against a temp `hostBaseDirectory` (NOT `~/.claude/`).
+Add a `tempHostBase()` helper alongside the existing `tempBase()`. Construct
+the manager with both injected.
 
-- AC1.1: call `ensureOAuthDir` on a fresh profile UUID, assert
-  `<profile-dir>/claude/projects` is a symlink whose `destinationOfSymbolicLink`
-  resolves to the temp host-projects path.
-- AC1.2: same for `ensureAPIKeyDir`.
-- AC2.1: call `ensureOAuthDir` twice; second call still leaves the symlink
-  pointing at the same target and does not throw. Same for `ensureAPIKeyDir`.
-- AC3.1: pre-create `<profile-dir>/claude/projects/-Users-test-cwd/sess-1.jsonl`
-  as a real file in a real directory; call `ensureOAuthDir`; assert
-  `<host-projects>/-Users-test-cwd/sess-1.jsonl` now exists, the old path is a
-  symlink (not the original real dir), and the file content matches.
-- AC3.2: pre-create `<host-projects>/-Users-test-cwd/sess-X.jsonl` with content
-  "HOST" and `<profile-dir>/claude/projects/-Users-test-cwd/sess-X.jsonl` with
-  content "PROFILE"; call `ensureOAuthDir`; assert host file still contains
-  "HOST" (collision skipped).
-- A small test that an existing symlink to the right place is left alone:
-  call `ensureOAuthDir` twice; capture the inode/identity of the symlink after
-  the first call and confirm it's unchanged after the second.
+Cover the policy rather than every slot — pick a representative slot per
+category to keep the suite tight:
+
+- AC1.1 / AC1.2: pre-create `<tempHost>/plugins/` (dir) and
+  `<tempHost>/CLAUDE.md` (file). Call `ensureOAuthDir` then
+  `ensureAPIKeyDir`. Assert `<profile-dir>/claude/plugins` is a symlink whose
+  destination resolves to `<tempHost>/plugins/`, and likewise for `CLAUDE.md`.
+- AC1.3 (host slot absent): with `<tempHost>/skills/` not created, call
+  `ensureOAuthDir`. Assert `<profile-dir>/claude/skills` does NOT exist.
+- AC2.1 (idempotent): with `<tempHost>/plugins/` created, call
+  `ensureOAuthDir` twice; second call leaves the symlink intact, same target,
+  no throw.
+- AC3.1 (projects migration — directory): pre-create `<tempHost>/projects/`,
+  pre-create `<profile-dir>/claude/projects/-Users-test-cwd/sess-1.jsonl` as
+  a real file. Call `ensureOAuthDir`. Assert
+  `<tempHost>/projects/-Users-test-cwd/sess-1.jsonl` now exists with original
+  content, `<profile-dir>/claude/projects` is a symlink, the original real
+  dir is gone.
+- AC3.2 (projects migration collision-skip): pre-create
+  `<tempHost>/projects/-Users-test-cwd/sess-X.jsonl` containing "HOST" and
+  `<profile-dir>/claude/projects/-Users-test-cwd/sess-X.jsonl` containing
+  "PROFILE". Call `ensureOAuthDir`. Host file still reads "HOST".
+- AC3.3a (non-projects directory with content): pre-create
+  `<tempHost>/plugins/` AND `<profile-dir>/claude/plugins/foo.txt`. Call
+  `ensureOAuthDir`. Assert `<profile-dir>/claude/plugins` is still a real
+  directory (NOT a symlink) and `foo.txt` is still there.
+- AC3.3b (non-projects empty directory): pre-create `<tempHost>/plugins/` AND
+  an empty `<profile-dir>/claude/plugins/`. Call `ensureOAuthDir`. Assert the
+  profile-side `plugins` is now a symlink to host.
+- AC3.3c (non-projects file): pre-create `<tempHost>/CLAUDE.md` AND
+  `<profile-dir>/claude/CLAUDE.md` with content "PROFILE-OWNED". Call
+  `ensureOAuthDir`. Assert `<profile-dir>/claude/CLAUDE.md` is still a real
+  file containing "PROFILE-OWNED" (NOT a symlink).
+- Symlink-wrong-target: pre-create `<tempHost>/plugins/` and a symlink
+  `<profile-dir>/claude/plugins` pointing at a junk dir. Call
+  `ensureOAuthDir`. Assert the symlink is left alone (still points at junk).
 
 **Verification:**
 Run: `swift test --filter ClaudeProfileConfigDirManager`
 Expected: all tests pass.
 
-**Commit:** `test: cover projects symlink and migration`
+**Commit:** `test: cover host-slot mirror policy`
 <!-- END_TASK_2 -->
 
 <!-- START_TASK_3 -->
-### Task 3: Lock in that profile deletion does not follow the symlink
+### Task 3: Lock in that profile deletion does not follow mirror symlinks
 
 **Verifies:** shared-claude-projects.AC4.1
 
@@ -209,30 +308,32 @@ Expected: all tests pass.
 
 **Testing:**
 
-The existing `deleteOAuthRemovesConfigDir` and `deleteAPIKeyRemovesConfigDir`
-tests verify the profile directory is removed. Add one new test (or extend
-those two) verifying that with `projects/` as a symlink, host sessions survive
-the delete. Use the existing test pattern (in-memory DB,
-`ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostProjectsDirectory: tempHost)`,
+Extend (or add alongside) the existing `deleteOAuthRemovesConfigDir` /
+`deleteAPIKeyRemovesConfigDir` tests with a version that seeds sentinels
+under at least two host slots and asserts they survive profile deletion.
+Use the existing test pattern (in-memory DB,
+`ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)`,
 inject into `makeRouter`).
 
-- Create a profile (oauth or apiKey), call `ensureOAuthDir`/`ensureAPIKeyDir`
-  so the symlink is created.
-- Write a sentinel file at `<tempHost>/-Users-test-cwd/sentinel.jsonl`.
+- Create a profile (oauth or apiKey), pre-create `<tempHost>/projects/` and
+  `<tempHost>/plugins/`, call the appropriate `ensure*Dir` method so the
+  symlinks are created.
+- Write sentinel files:
+  - `<tempHost>/projects/-Users-test-cwd/sentinel.jsonl` with known content
+  - `<tempHost>/plugins/sentinel.txt` with known content
 - Invoke `handleModelProfileDelete` for that profile.
-- Assert: `<profile-dir>` no longer exists, AND
-  `<tempHost>/-Users-test-cwd/sentinel.jsonl` still exists with the original
-  content (symlink removal did not propagate into the host store).
+- Assert: `<profile-dir>` no longer exists, BOTH sentinels still exist on the
+  host side with their original content.
 
-This locks in macOS's `FileManager.removeItem(at:)` non-symlink-following
-behavior so a future refactor (e.g. switching to a recursive walker that does
-follow links) can't silently destroy session history.
+This locks in macOS `FileManager.removeItem(at:)`'s non-symlink-following
+behavior across multiple mirrored slots so a future refactor can't silently
+destroy host state.
 
 **Verification:**
 Run: `swift test --filter ModelProfile`
 Expected: all tests pass.
 
-**Commit:** `test: profile delete preserves host session store`
+**Commit:** `test: profile delete preserves host mirror targets`
 <!-- END_TASK_3 -->
 
 <!-- END_SUBCOMPONENT_A -->
@@ -245,13 +346,21 @@ Expected: all tests pass.
 - `swift test` — full suite passes.
 - `swift package plugin --allow-writing-to-package-directory swiftlint --strict`
   — no violations.
-- Manual cross-profile resume check before opening the PR for review:
+- Manual checks before opening the PR for review:
   1. Restart TBD on this branch via `scripts/restart.sh`.
-  2. Spawn `claude` under profile A in some worktree; have a short
-     conversation; note the session UUID.
-  3. Spawn `claude --resume <uuid>` under profile B in the same worktree's
-     cwd; confirm the transcript loads and a new turn proceeds.
-  4. (Bonus) Confirm `~/.claude/projects/<cwd-hash>/` shows the session JSONL.
+  2. **Cross-profile resume.** Spawn `claude` under profile A in some
+     worktree; have a short conversation; note the session UUID. Spawn
+     `claude --resume <uuid>` under profile B in the same worktree's cwd;
+     confirm the transcript loads and a new turn proceeds. Bonus: confirm
+     `~/.claude/projects/<cwd-hash>/` shows the session JSONL.
+  3. **Customizations visible.** In an alt-profile session, run a slash
+     command from `~/.claude/commands/` and verify it works; invoke a skill
+     that lives in `~/.claude/skills/`; check that `claude --help`-listed
+     plugins include the user-installed ones from `~/.claude/plugins/`.
+  4. **Pre-redesign session resume.** Pick a terminal that existed pre-PR
+     #177 (still pointing at an OAuth or direct-apiKey profile, session
+     stored under `~/.claude/projects/`). Restart TBD; confirm the terminal
+     resumes with full history instead of reincarnating blank.
 
 ## Out of scope / follow-ups (not blocking)
 

--- a/docs/specs/2026-05-20-shared-claude-projects-design.md
+++ b/docs/specs/2026-05-20-shared-claude-projects-design.md
@@ -208,9 +208,11 @@ The mirror list is:
   *real directory* (e.g. created between PR #177 merging and this follow-up
   shipping), its contents are merged into `<host-base>/projects/` before being
   replaced by the symlink.
-- **AC3.2 Success:** A `<host-base>/projects/<cwd-hash>/<id>.jsonl` that
-  already existed before the migration is NOT overwritten — collisions skip
-  rather than clobber.
+- **AC3.2 Success:** If any top-level entry (cwd-hash directory) of the
+  profile's `projects/` already exists in the host's `projects/`, the entire
+  migration is aborted and the profile-side dir is preserved intact.
+  All-or-nothing atomicity prevents partial migrations that could orphan
+  sessions across stores.
 - **AC3.3 Success:** For *non-projects* slots, if `<profile-dir>/claude/<slot>`
   already exists as a real file or non-empty real directory, it is **left in
   place** (we do not silently move user content out of profile dirs) and the

--- a/docs/specs/2026-05-20-shared-claude-projects-design.md
+++ b/docs/specs/2026-05-20-shared-claude-projects-design.md
@@ -1,4 +1,4 @@
-# Shared Claude session store across TBD profiles
+# Shared Claude state across TBD profiles
 
 **Date:** 2026-05-20
 **Status:** Design (follow-up to `2026-05-19-alternate-profiles-redesign-design.md`)
@@ -7,11 +7,12 @@
 
 The original alt-profiles redesign (PR #177, merged 2026-05-19) gives every
 non-bedrock profile its own isolated `CLAUDE_CONFIG_DIR` at
-`~/tbd/profiles/<uuid>/claude/`. Claude Code stores session transcripts at
-`<CONFIG_DIR>/projects/<cwd-path-hash>/<session-uuid>.jsonl` — so transcripts
-are now siloed per profile.
+`~/tbd/profiles/<uuid>/claude/`. Claude Code reads **everything** from that
+directory — not just credentials. So the new isolated profile dirs start
+empty and silently miss every customization the user installed in
+`~/.claude/`.
 
-Two real problems fall out of that:
+Three real problems fall out of that:
 
 1. **Pre-redesign sessions become unresumable on TBD restart.** Conversations
    created before PR #177 merged were spawned without a config-dir env var, so
@@ -27,15 +28,26 @@ Two real problems fall out of that:
    to start fresh every time they want to switch which subscription pays for
    the rest of a conversation.
 
-The user's actual mental model is: "conversations" are mine; "profiles" are who
-pays. The current design over-isolates — it isolates conversations too.
+3. **Plugins, skills, agents, commands, hooks, and user-global
+   instructions are missing under alt-profiles.** Anything in `~/.claude/`
+   that customizes how `claude` behaves — `plugins/`, `skills/`, `agents/`,
+   `commands/`, `hooks/`, `CLAUDE.md`, `settings.json` — is invisible to a
+   spawn whose `CLAUDE_CONFIG_DIR` points elsewhere. Under an alt-profile,
+   `claude` is a much barer tool than what the user spawns natively.
+
+The user's actual mental model is: "conversations and customizations are
+mine; profiles are who pays." The current design over-isolates — it isolates
+everything, not just credentials.
 
 ## Goal
 
-Unify session storage across all TBD profiles **and** the host's native claude
-in one place, while keeping authentication, settings, and MCP config strictly
-per-profile. Resume should work regardless of which profile spawned the
-session, including pre-redesign sessions that live in `~/.claude/projects/`.
+Make alt-profile dirs **thin overlays on `~/.claude/`**: every customization
+slot mirrors the host via symlinks; only the per-profile identity slot
+(`.claude.json` plus per-path Keychain auth) is owned by the profile. Resume
+works regardless of which profile spawned the session — including
+pre-redesign sessions in `~/.claude/projects/` — and every alt-profile sees
+the same plugins, skills, agents, commands, hooks, and user instructions as
+native `claude`.
 
 ## Out of scope
 
@@ -45,48 +57,100 @@ session, including pre-redesign sessions that live in `~/.claude/projects/`.
   the prior transcript to the target account (UX polish, separate change).
 - Cross-worktree session visibility — sessions stay scoped to a working
   directory by claude's native project-hash design, which we are not changing.
+- Per-profile **differences** in plugins / skills / instructions / settings.
+  Today's mental model is "customizations are mine; profiles are who pays" —
+  so all profiles share. If per-profile customization becomes a need later, a
+  layered-overlay design (similar to TBD's existing `--settings` flag) can be
+  added without breaking this one.
 
 ## Approach
 
-**Make `~/.claude/projects/` the canonical session store, and symlink each TBD
-profile's `claude/projects` into it.** No data movement; the host's existing
-session store is the single source of truth.
+**Make `~/.claude/` the canonical store for every shared slot, and symlink
+each slot from every TBD profile dir into it.** No data movement; the host's
+existing state is the single source of truth. Auth isolation is preserved
+because Claude Code keys its macOS Keychain entry on the *path* of
+`CLAUDE_CONFIG_DIR`, not on what's inside it.
 
 ```
-~/.claude/projects/                     ← canonical (real directory, untouched)
-├── -Users-chang-myrepo/
-│   ├── 1A2B-...jsonl                   ← created any time by any spawn
-│   └── 3C4D-...jsonl
+~/.claude/                              ← canonical (real, untouched)
+├── projects/                           ← every spawn writes here
+├── plugins/                            ← user-installed plugins
+├── skills/                             ← user skills
+├── agents/                             ← user agents
+├── commands/                           ← slash commands
+├── hooks/                              ← hooks dir
+├── CLAUDE.md                           ← user-global instructions
+├── settings.json                       ← user settings
+├── .claude.json                        ← (host's own onboarding state)
+└── .credentials.json | Keychain        ← host auth
 
-~/tbd/profiles/<uuid-A>/claude/         ← TBD profile A (isolated)
-├── .claude.json                        ← per-profile
-├── (Keychain entry keyed on this path) ← per-profile auth
-└── projects -> ~/.claude/projects/     ← symlink (shared)
-
-~/tbd/profiles/<uuid-B>/claude/         ← TBD profile B (isolated)
-├── .claude.json                        ← per-profile
-└── projects -> ~/.claude/projects/     ← same target
+~/tbd/profiles/<uuid-A>/claude/         ← TBD profile A (isolated CONFIG_DIR)
+├── .claude.json                        ← REAL (per-profile)
+├── projects     -> ~/.claude/projects/
+├── plugins      -> ~/.claude/plugins/
+├── skills       -> ~/.claude/skills/
+├── agents       -> ~/.claude/agents/
+├── commands     -> ~/.claude/commands/
+├── hooks        -> ~/.claude/hooks/
+├── CLAUDE.md    -> ~/.claude/CLAUDE.md
+├── settings.json -> ~/.claude/settings.json
+└── (Keychain entry keyed on this path) ← per-profile auth
 ```
+
+### What gets mirrored
+
+| Slot | Mirror? | Why |
+|---|---|---|
+| `projects/` | Yes (with merge-migration) | Session transcripts; unified history |
+| `plugins/` | Yes | User-installed plugins |
+| `skills/` | Yes | User skills |
+| `agents/` | Yes | User agents |
+| `commands/` | Yes | Slash commands |
+| `hooks/` | Yes | Hook scripts |
+| `CLAUDE.md` | Yes | User-global instructions |
+| `settings.json` | Yes (with `apiKeyHelper` caveat below) | Model prefs, MCP servers, hook config |
+| `.claude.json` | **No** | Per-profile: onboarding flag + `customApiKeyResponses` |
+| `.credentials.json` / Keychain | **No** | Per-profile auth (Keychain entry keyed on `CLAUDE_CONFIG_DIR` path hash) |
+
+### The `apiKeyHelper` caveat
+
+If the user's `~/.claude/settings.json` defines an `apiKeyHelper` (a script
+that supplies an API key), it will resolve identically under every TBD
+profile because settings.json is shared. Claude Code's auth-precedence order
+puts `apiKeyHelper` (#4) **above** `CLAUDE_CODE_OAUTH_TOKEN` (#5) but
+**below** `ANTHROPIC_API_KEY` (#3).
+
+- **API-key profiles**: TBD already injects `ANTHROPIC_API_KEY`, which beats
+  `apiKeyHelper` — no effect.
+- **OAuth profiles**: `apiKeyHelper` would supply its key and override the
+  profile's intended subscription auth. Effectively all oauth profiles would
+  resolve to the apiKeyHelper's identity → defeats per-profile auth.
+
+Most users do not use `apiKeyHelper`. We document this as a known limitation:
+"if you use `apiKeyHelper` in settings.json, oauth profiles will use the
+helper's key rather than the profile's `/login` session." A future
+refinement could shadow `apiKeyHelper` out of the symlinked settings via a
+TBD-managed overlay, but it is not needed for v1.
 
 ### Why host-canonical (not the inverse)
 
 We considered the inverse: keep a TBD-owned shared store at
-`~/tbd/sessions/projects/` and replace `~/.claude/projects/` with a symlink to
-it. Host-canonical is strictly better:
+`~/tbd/sessions/` (or similar) and replace `~/.claude/` slots with symlinks
+to it. Host-canonical is strictly better:
 
 | | host-canonical (chosen) | TBD-owned shared store |
 |---|---|---|
 | Pre-redesign sessions accessible on first restart | Immediately | Only after migration |
-| Migration step needed | None | Move `~/.claude/projects/*` → shared store |
+| User's existing plugins/skills/CLAUDE.md immediately visible | Yes | Only after migration |
+| Migration step needed | None | Move `~/.claude/*` slots → shared store |
 | Risk of migration failure | None | Real (partial move) |
-| `~/.claude/projects/` itself | Untouched (still a real dir) | Becomes a symlink |
-| Reversibility | `rm <profile>/claude/projects` | Undo a move + a symlink |
-| Backup of `~/.claude/` captures TBD sessions | Yes | No |
-| Lines of code | <20 | More |
+| `~/.claude/` itself | Untouched (still a real dir) | Several slots become symlinks |
+| Reversibility | `rm <profile>/claude/<slot>` | Undo a move + a symlink |
+| Backup of `~/.claude/` captures TBD-profile artifacts | Yes | No |
 
 The only thing the TBD-owned variant preserves that host-canonical doesn't is
-the ability to keep TBD-profile sessions logically separate from host sessions
-— but that's the exact thing we want to remove.
+the ability to keep TBD-profile state logically separate from host state —
+but that's the exact thing we want to remove.
 
 ### Auth isolation is preserved
 
@@ -102,6 +166,11 @@ Two profiles spawning `claude` in the same cwd write to **different**
 The same session ID can still be corrupted if resumed in two panes simultaneously,
 but that risk pre-exists and is not made worse by sharing.
 
+The other mirrored slots (`plugins/`, `skills/`, etc.) are read-heavy and
+written rarely (when the user installs a plugin or edits a skill). Concurrent
+writes from multiple `claude` processes are not expected; the host claude and
+TBD profiles all read the same content.
+
 ### Billing classification
 
 Unchanged. `CLAUDE_CONFIG_DIR` still points at a non-default path per profile,
@@ -111,37 +180,51 @@ the delivered credential is still a per-profile `/login` OAuth blob, and the
 
 ## Acceptance criteria
 
-### shared-claude-projects.AC1: profile dirs symlink into the host store
+### shared-claude-projects.AC1: profile dirs mirror host slots via symlinks
 
-- **AC1.1 Success:** After `ensureOAuthDir(forProfileID:)` runs against a fresh
-  profile UUID, `<profile-dir>/claude/projects` exists as a symbolic link whose
-  destination resolves to `<host-projects>/` (default `~/.claude/projects/`,
-  injectable for tests).
+The mirror list is:
+`projects`, `plugins`, `skills`, `agents`, `commands`, `hooks`, `CLAUDE.md`,
+`settings.json` — all resolved relative to an injectable host-base directory
+(default `~/.claude/`).
+
+- **AC1.1 Success:** For each slot present in `<host-base>/`, after
+  `ensureOAuthDir(forProfileID:)` runs against a fresh profile UUID,
+  `<profile-dir>/claude/<slot>` exists as a symbolic link whose destination
+  resolves to `<host-base>/<slot>`.
 - **AC1.2 Success:** Same property after `ensureAPIKeyDir(forProfileID:apiKey:)`.
+- **AC1.3 Success:** A slot that does **not** exist in `<host-base>/` does
+  **not** cause a symlink to be created for it. (No `<profile-dir>/claude/skills`
+  if `<host-base>/skills` is missing.)
 
 ### shared-claude-projects.AC2: idempotent
 
 - **AC2.1 Success:** Calling `ensureOAuthDir` / `ensureAPIKeyDir` a second time
-  for the same profile leaves the existing symlink (and its target) in place
-  and does not error.
+  for the same profile leaves every existing slot symlink (and its target) in
+  place and does not error.
 
-### shared-claude-projects.AC3: migrate pre-existing `projects/` content
+### shared-claude-projects.AC3: migrate pre-existing `projects/` content; respect other slots
 
 - **AC3.1 Success:** If `<profile-dir>/claude/projects` already exists as a
   *real directory* (e.g. created between PR #177 merging and this follow-up
-  shipping), its contents are merged into `<host-projects>/` before being
-  replaced by the symlink. Files surviving from before the migration are
-  preserved on the host side.
-- **AC3.2 Success:** A `<host-projects>/<cwd-hash>/<id>.jsonl` that already
-  existed before the migration is NOT overwritten — collisions skip rather
-  than clobber.
+  shipping), its contents are merged into `<host-base>/projects/` before being
+  replaced by the symlink.
+- **AC3.2 Success:** A `<host-base>/projects/<cwd-hash>/<id>.jsonl` that
+  already existed before the migration is NOT overwritten — collisions skip
+  rather than clobber.
+- **AC3.3 Success:** For *non-projects* slots, if `<profile-dir>/claude/<slot>`
+  already exists as a real file or non-empty real directory, it is **left in
+  place** (we do not silently move user content out of profile dirs) and the
+  symlink for that slot is **not** created. An empty real directory may be
+  removed and replaced with the symlink. A symlink pointing at the wrong
+  target is left alone with a log warning.
 
-### shared-claude-projects.AC4: profile deletion preserves host sessions
+### shared-claude-projects.AC4: profile deletion preserves host state
 
 - **AC4.1 Success:** Deleting a profile via `handleModelProfileDelete` removes
-  the profile directory but leaves every file under `<host-projects>/`
-  untouched. (Relies on macOS `FileManager.removeItem(at:)` not following
-  symlinks; lock it in with a test.)
+  the profile directory but leaves every file under `<host-base>/` untouched
+  — including `projects/`, `plugins/`, `skills/`, etc. (Relies on macOS
+  `FileManager.removeItem(at:)` not following symlinks; lock it in with a
+  test that seeds a sentinel under at least two different host slots.)
 
 ## Non-acceptance / known risks
 
@@ -157,6 +240,13 @@ the delivered credential is still a per-profile `/login` OAuth blob, and the
 4. **TBD-vs-claude.ai-vs-API-key session-format compatibility.** Worst case
    has historically been a soft failure (model not available), not data loss.
    Worth one manual cross-profile-resume test before merging.
+5. **No per-profile customization** in the mirrored slots. Every TBD profile
+   sees the same plugins/skills/CLAUDE.md/settings.json as native `claude`.
+   If "personal claude has skill X, work claude doesn't" becomes a real need,
+   it requires a layered-overlay design — not in scope here.
+6. **`apiKeyHelper` in `settings.json` defeats per-profile auth for oauth
+   profiles.** See the "`apiKeyHelper` caveat" section above. Document this
+   limitation; revisit if it bites.
 
 ## Compatibility / migration
 

--- a/docs/specs/2026-05-20-shared-claude-projects-design.md
+++ b/docs/specs/2026-05-20-shared-claude-projects-design.md
@@ -1,0 +1,175 @@
+# Shared Claude session store across TBD profiles
+
+**Date:** 2026-05-20
+**Status:** Design (follow-up to `2026-05-19-alternate-profiles-redesign-design.md`)
+
+## Problem
+
+The original alt-profiles redesign (PR #177, merged 2026-05-19) gives every
+non-bedrock profile its own isolated `CLAUDE_CONFIG_DIR` at
+`~/tbd/profiles/<uuid>/claude/`. Claude Code stores session transcripts at
+`<CONFIG_DIR>/projects/<cwd-path-hash>/<session-uuid>.jsonl` — so transcripts
+are now siloed per profile.
+
+Two real problems fall out of that:
+
+1. **Pre-redesign sessions become unresumable on TBD restart.** Conversations
+   created before PR #177 merged were spawned without a config-dir env var, so
+   their JSONL files live in `~/.claude/projects/`. After the merge, every
+   restart of TBD reconciles each terminal by respawning `claude --resume <id>`
+   under that terminal's profile's isolated dir — and the session isn't there.
+   The terminal effectively reincarnates blank. The JSONL still exists in
+   `~/.claude/projects/`, but the live terminal can't reach it. Affects every
+   terminal pinned to an oauth or direct-apiKey profile.
+
+2. **Cross-profile resume doesn't work.** A session created under profile A
+   isn't visible to a `claude --resume` spawned under profile B. The user has
+   to start fresh every time they want to switch which subscription pays for
+   the rest of a conversation.
+
+The user's actual mental model is: "conversations" are mine; "profiles" are who
+pays. The current design over-isolates — it isolates conversations too.
+
+## Goal
+
+Unify session storage across all TBD profiles **and** the host's native claude
+in one place, while keeping authentication, settings, and MCP config strictly
+per-profile. Resume should work regardless of which profile spawned the
+session, including pre-redesign sessions that live in `~/.claude/projects/`.
+
+## Out of scope
+
+- Locking against simultaneous resume of the same session in two panes (a
+  pre-existing footgun; not introduced by this change).
+- Surfacing a swap-time warning that resuming under a different profile sends
+  the prior transcript to the target account (UX polish, separate change).
+- Cross-worktree session visibility — sessions stay scoped to a working
+  directory by claude's native project-hash design, which we are not changing.
+
+## Approach
+
+**Make `~/.claude/projects/` the canonical session store, and symlink each TBD
+profile's `claude/projects` into it.** No data movement; the host's existing
+session store is the single source of truth.
+
+```
+~/.claude/projects/                     ← canonical (real directory, untouched)
+├── -Users-chang-myrepo/
+│   ├── 1A2B-...jsonl                   ← created any time by any spawn
+│   └── 3C4D-...jsonl
+
+~/tbd/profiles/<uuid-A>/claude/         ← TBD profile A (isolated)
+├── .claude.json                        ← per-profile
+├── (Keychain entry keyed on this path) ← per-profile auth
+└── projects -> ~/.claude/projects/     ← symlink (shared)
+
+~/tbd/profiles/<uuid-B>/claude/         ← TBD profile B (isolated)
+├── .claude.json                        ← per-profile
+└── projects -> ~/.claude/projects/     ← same target
+```
+
+### Why host-canonical (not the inverse)
+
+We considered the inverse: keep a TBD-owned shared store at
+`~/tbd/sessions/projects/` and replace `~/.claude/projects/` with a symlink to
+it. Host-canonical is strictly better:
+
+| | host-canonical (chosen) | TBD-owned shared store |
+|---|---|---|
+| Pre-redesign sessions accessible on first restart | Immediately | Only after migration |
+| Migration step needed | None | Move `~/.claude/projects/*` → shared store |
+| Risk of migration failure | None | Real (partial move) |
+| `~/.claude/projects/` itself | Untouched (still a real dir) | Becomes a symlink |
+| Reversibility | `rm <profile>/claude/projects` | Undo a move + a symlink |
+| Backup of `~/.claude/` captures TBD sessions | Yes | No |
+| Lines of code | <20 | More |
+
+The only thing the TBD-owned variant preserves that host-canonical doesn't is
+the ability to keep TBD-profile sessions logically separate from host sessions
+— but that's the exact thing we want to remove.
+
+### Auth isolation is preserved
+
+Claude Code keys its macOS Keychain entry on the **path** of
+`CLAUDE_CONFIG_DIR`, not on its contents. `~/tbd/profiles/<id>/claude/` and
+`~/.claude/` have different paths → different Keychain entries → independent
+logins. Only the `projects/` subdirectory is shared.
+
+### Concurrent-write safety
+
+Two profiles spawning `claude` in the same cwd write to **different**
+`<uuid>.jsonl` files in shared `projects/<cwd-hash>/` — no file-level collision.
+The same session ID can still be corrupted if resumed in two panes simultaneously,
+but that risk pre-exists and is not made worse by sharing.
+
+### Billing classification
+
+Unchanged. `CLAUDE_CONFIG_DIR` still points at a non-default path per profile,
+the delivered credential is still a per-profile `/login` OAuth blob, and the
+2026-06-15 Agent-SDK reclassification is determined at the API request layer
+(by credential type and request shape), not by client filesystem layout.
+
+## Acceptance criteria
+
+### shared-claude-projects.AC1: profile dirs symlink into the host store
+
+- **AC1.1 Success:** After `ensureOAuthDir(forProfileID:)` runs against a fresh
+  profile UUID, `<profile-dir>/claude/projects` exists as a symbolic link whose
+  destination resolves to `<host-projects>/` (default `~/.claude/projects/`,
+  injectable for tests).
+- **AC1.2 Success:** Same property after `ensureAPIKeyDir(forProfileID:apiKey:)`.
+
+### shared-claude-projects.AC2: idempotent
+
+- **AC2.1 Success:** Calling `ensureOAuthDir` / `ensureAPIKeyDir` a second time
+  for the same profile leaves the existing symlink (and its target) in place
+  and does not error.
+
+### shared-claude-projects.AC3: migrate pre-existing `projects/` content
+
+- **AC3.1 Success:** If `<profile-dir>/claude/projects` already exists as a
+  *real directory* (e.g. created between PR #177 merging and this follow-up
+  shipping), its contents are merged into `<host-projects>/` before being
+  replaced by the symlink. Files surviving from before the migration are
+  preserved on the host side.
+- **AC3.2 Success:** A `<host-projects>/<cwd-hash>/<id>.jsonl` that already
+  existed before the migration is NOT overwritten — collisions skip rather
+  than clobber.
+
+### shared-claude-projects.AC4: profile deletion preserves host sessions
+
+- **AC4.1 Success:** Deleting a profile via `handleModelProfileDelete` removes
+  the profile directory but leaves every file under `<host-projects>/`
+  untouched. (Relies on macOS `FileManager.removeItem(at:)` not following
+  symlinks; lock it in with a test.)
+
+## Non-acceptance / known risks
+
+1. **`rm -rf ~/.claude/projects/` now wipes every TBD-profile session in one
+   sweep.** Pre-redesign, that command only wiped host sessions. Acceptable —
+   it's the cost of unified history; document in the PR description so
+   future-you isn't surprised.
+2. **Concurrent same-session resume corrupts the JSONL.** Pre-existing footgun.
+3. **Cross-account transcript exposure on swap.** Resuming a session created
+   under personal OAuth under a work OAuth profile sends the prior transcript
+   as context to the work account. Expected — it's the feature — but a future
+   UX polish item should surface it at swap time.
+4. **TBD-vs-claude.ai-vs-API-key session-format compatibility.** Worst case
+   has historically been a soft failure (model not available), not data loss.
+   Worth one manual cross-profile-resume test before merging.
+
+## Compatibility / migration
+
+- **No DB schema change.**
+- **No code change at call sites** of `ensureOAuthDir` / `ensureAPIKeyDir`. The
+  symlink work is internal to `ClaudeProfileConfigDirManager`.
+- **First restart after this ships**: existing profile dirs whose `projects/`
+  is a real directory get migrated in place; pre-redesign sessions in
+  `~/.claude/projects/` become immediately visible to every TBD profile.
+- **Manual rescue for any terminal that has already reincarnated blank** (i.e.
+  user restarted main TBD between the PR #177 merge and this follow-up
+  landing): the JSONL still exists; the new session ID on the blank terminal
+  doesn't match the old session ID stored in `Terminal.claudeSessionID`. No
+  automatic recovery for those — surface a "stash recovered" note if we feel
+  like it, or do nothing. Worth flagging in the PR description but not
+  blocking on it.


### PR DESCRIPTION
## Summary

PR #177 gave every alt-profile claude session its own isolated `CLAUDE_CONFIG_DIR` to fix billing classification. But Claude Code reads **everything** from that dir, so alt-profile spawns silently lost three things:

- **Pre-redesign session transcripts** that live in `~/.claude/projects/` — every TBD restart respawns terminals under their profile's isolated dir, and `claude --resume <id>` can't find the JSONL. Terminals reincarnate blank.
- **Cross-profile resume** — a session created under profile A is invisible to a spawn under profile B.
- **All user customizations** under `~/.claude/`: plugins, skills, agents, commands, hooks, `CLAUDE.md`, `settings.json`. Alt-profile sessions ran with none of the user's installed plugins or skills.

## What this does

Makes alt-profile dirs **thin overlays on `~/.claude/`**: each TBD profile dir symlinks the customization slots into the host store. Only `.claude.json` (per-profile onboarding flag + API-key approval token) and the per-path Keychain entry stay isolated — auth boundaries are preserved because Claude Code keys the Keychain entry on the `CLAUDE_CONFIG_DIR` path, not its contents.

```
~/tbd/profiles/<uuid>/claude/
├── .claude.json          ← REAL (per-profile)
├── projects   -> ~/.claude/projects/
├── plugins    -> ~/.claude/plugins/
├── skills     -> ~/.claude/skills/
├── agents     -> ~/.claude/agents/
├── commands   -> ~/.claude/commands/
├── hooks      -> ~/.claude/hooks/
├── CLAUDE.md  -> ~/.claude/CLAUDE.md
└── settings.json -> ~/.claude/settings.json
```

Per-slot policy: `projects/` migrates any pre-existing real-dir content into the host store before symlinking. Other slots are left alone if the profile already has real content (we never silently move user files out of profile dirs). Profile deletion removes the profile dir but does not follow the symlinks — host state survives.

Full rationale in `docs/specs/2026-05-20-shared-claude-projects-design.md`.

## Trade-off accepted

No per-profile customization for the mirrored slots — every TBD profile sees the same plugins/skills/`CLAUDE.md`/`settings.json` as native `claude`. The user mental model is "conversations and customizations are mine; profiles are who pays." If "personal claude has skill X, work claude doesn't" becomes a real need, it requires a layered-overlay design — out of scope here.

## Known limitations

- **`apiKeyHelper`** in `settings.json` will defeat per-profile auth for OAuth profiles (auth-precedence puts it above `CLAUDE_CODE_OAUTH_TOKEN`). API-key profiles are unaffected because `ANTHROPIC_API_KEY` env beats `apiKeyHelper`. Documented; revisit if it bites.
- **`rm -rf ~/.claude/projects/`** now wipes every TBD-profile session in one sweep — cost of unified history.
- Concurrent resume of the same session in two panes still corrupts the JSONL. Pre-existing footgun.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 977 tests pass (12 new tests covering symlink policy + delete-preserves-host-state)
- [x] `swiftlint --strict` — 0 violations
- [ ] Cross-profile resume: create a session under profile A, spawn `claude --resume <uuid>` under profile B in the same cwd, confirm the transcript loads
- [ ] Customizations visible: invoke a slash command from `~/.claude/commands/` and a skill from `~/.claude/skills/` in an alt-profile session
- [ ] Pre-redesign session resume: pick a terminal that existed before PR #177 (still pointing at an OAuth/direct-apiKey profile), restart TBD, confirm full history resumes instead of going blank

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7FA064AB-109F-4F2D-A959-541E334BBFC8)