### PR TITLE
Fix: Migrate alt-profile sessions and customizations even when cwd-hash dirs collide

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -135,7 +135,8 @@ public struct ClaudeProfileConfigDirManager: Sendable {
 
                         // projects/ is expected to contain only cwd-hash subdirectories.
                         // Skip stray non-directory entries (e.g. a .DS_Store Finder leaves
-                        // behind) so they aren't silently deleted by removeItem in pass 2.
+                        // behind) for the collision scan — they get swept explicitly before
+                        // the final removeItem below.
                         var isCwdHashDir: ObjCBool = false
                         guard fm.fileExists(atPath: cwdHashPath.path, isDirectory: &isCwdHashDir),
                               isCwdHashDir.boolValue else { continue }
@@ -167,8 +168,8 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                         let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
                         let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
 
-                        // Same directory-only guard as pass 1 — skip stray files so
-                        // removeItem can't silently destroy them.
+                        // Same directory-only guard as pass 1 — stray files are handled
+                        // explicitly in the sweep below.
                         var isCwdHashDir: ObjCBool = false
                         guard fm.fileExists(atPath: cwdHashPath.path, isDirectory: &isCwdHashDir),
                               isCwdHashDir.boolValue else { continue }
@@ -186,6 +187,16 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                             // Host doesn't have this cwd-hash dir. Move the whole directory.
                             try fm.moveItem(at: cwdHashPath, to: hostCwdHashPath)
                         }
+                    }
+
+                    // Sweep any stray non-directory entries left behind by the
+                    // pass 1/2 guards (e.g. a .DS_Store). removeItem(at:) on the
+                    // parent would delete them recursively without a log trail
+                    // — do it explicitly here so the destruction is observable.
+                    let leftover = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
+                    for stray in leftover {
+                        logger.debug("removing stray entry \(stray.lastPathComponent, privacy: .public) from profile projects/ during migration")
+                        try? fm.removeItem(at: stray)
                     }
                     try fm.removeItem(at: profileEntry)
                 } catch {

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -131,6 +131,13 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                         let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
                         let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
 
+                        // projects/ is expected to contain only cwd-hash subdirectories.
+                        // Skip stray non-directory entries (e.g. a .DS_Store Finder leaves
+                        // behind) so they aren't silently deleted by removeItem in pass 2.
+                        var isCwdHashDir: ObjCBool = false
+                        guard fm.fileExists(atPath: cwdHashPath.path, isDirectory: &isCwdHashDir),
+                              isCwdHashDir.boolValue else { continue }
+
                         // If host doesn't have this cwd-hash dir, no collision possible.
                         guard fm.fileExists(atPath: hostCwdHashPath.path) else { continue }
 
@@ -157,6 +164,12 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                     for entry in entries {
                         let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
                         let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
+
+                        // Same directory-only guard as pass 1 — skip stray files so
+                        // removeItem can't silently destroy them.
+                        var isCwdHashDir: ObjCBool = false
+                        guard fm.fileExists(atPath: cwdHashPath.path, isDirectory: &isCwdHashDir),
+                              isCwdHashDir.boolValue else { continue }
 
                         if fm.fileExists(atPath: hostCwdHashPath.path) {
                             // Host has this cwd-hash dir. Migrate files individually.

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -63,9 +63,11 @@ public struct ClaudeProfileConfigDirManager: Sendable {
 
     /// Slots that each TBD profile dir mirrors from the host's claude config dir.
     /// Symlinked from <profile>/claude/<slot> to <host-base>/<slot>.
-    /// `projects` is special: pre-existing real-dir content is migrated into
-    /// the host store before symlinking. Every other slot is left alone if it
-    /// already exists as a non-empty real file or directory.
+    /// `projects` migrates pre-existing real-dir content into the host store
+    /// before symlinking (file-level collision check; atomic abort). Every other
+    /// slot with pre-existing real content is moved to `<slot>.profile-local`
+    /// as a sidecar before the symlink is created — see `ensureMirrorSlot` for
+    /// the full per-slot policy.
     private static let mirrorSlots: [String] = [
         "projects",
         "plugins",

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -83,7 +83,10 @@ public struct ClaudeProfileConfigDirManager: Sendable {
     /// For `projects/` (migrateContent=true), performs file-level collision detection
     /// by recursing one directory deep into cwd-hash directories. Cwd-hash directories
     /// with disjoint session files are merged into the host store; only actual file
-    /// collisions abort the migration.
+    /// collisions abort the migration. Atomic with respect to name collisions: pass 1
+    /// confirms no file-level conflicts before pass 2 moves anything. Not atomic with
+    /// respect to I/O failures during pass 2 — those leave partial state that the next
+    /// call cleans up.
     ///
     /// For other slots (migrateContent=false) with real content, the content is moved
     /// to a `<slot>.profile-local` sidecar, allowing the symlink to be created and the
@@ -123,7 +126,7 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                     // Pass 1: Collision scan at file level. For each top-level cwd-hash entry,
                     // check if it exists on host and if so, scan for file collisions inside.
                     var hasCollision = false
-                    var collidingFileName: String?
+                    var collidingFilePath: String?
                     for entry in entries {
                         let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
                         let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
@@ -137,7 +140,7 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                             let hostFilePath = hostCwdHashPath.appendingPathComponent(profileFile.lastPathComponent)
                             if fm.fileExists(atPath: hostFilePath.path) {
                                 hasCollision = true
-                                collidingFileName = profileFile.lastPathComponent
+                                collidingFilePath = "\(entry.lastPathComponent)/\(profileFile.lastPathComponent)"
                                 break
                             }
                         }
@@ -145,7 +148,7 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                     }
 
                     if hasCollision {
-                        let collisionDesc = collidingFileName.map { " (\($0))" } ?? ""
+                        let collisionDesc = collidingFilePath.map { " (\($0))" } ?? ""
                         logger.warning("projects migration incomplete for profile due to file collision\(collisionDesc); symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
                         return
                     }
@@ -182,6 +185,8 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                 } else {
                     // Non-empty directory: rename to sidecar if it doesn't already exist.
                     let sidecarURL = profileEntry.appendingPathExtension("profile-local")
+                    // Note: fileExists(atPath:) returns false for dangling symlinks. We never
+                    // create dangling symlinks, so this is unlikely, but edge case documented.
                     if !fm.fileExists(atPath: sidecarURL.path) {
                         do {
                             try fm.moveItem(at: profileEntry, to: sidecarURL)

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -79,6 +79,15 @@ public struct ClaudeProfileConfigDirManager: Sendable {
 
     /// Ensure one host-mirror slot is a symlink from the profile dir into the
     /// host base. Best-effort: filesystem errors are logged and swallowed.
+    ///
+    /// For `projects/` (migrateContent=true), performs file-level collision detection
+    /// by recursing one directory deep into cwd-hash directories. Cwd-hash directories
+    /// with disjoint session files are merged into the host store; only actual file
+    /// collisions abort the migration.
+    ///
+    /// For other slots (migrateContent=false) with real content, the content is moved
+    /// to a `<slot>.profile-local` sidecar, allowing the symlink to be created and the
+    /// profile to access host customizations.
     private func ensureMirrorSlot(
         _ name: String,
         in profileClaudeDir: URL,
@@ -106,30 +115,59 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         var isDir: ObjCBool = false
         if fm.fileExists(atPath: profileEntry.path, isDirectory: &isDir) {
             if isDir.boolValue, migrateContent {
-                // projects/ special-case: merge content into host store, then
-                // remove the profile-side dir and proceed to symlink.
+                // projects/ special-case: file-level collision detection with one-level recursion.
                 do {
-                    // Ensure host dir exists (created above by fileExists check
-                    // succeeding, but be defensive on race / non-dir).
                     try fm.createDirectory(at: hostEntry, withIntermediateDirectories: true)
                     let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
 
-                    // Two-pass approach: first check if any entries would collide with host.
-                    // If any collision exists, abort the entire migration to preserve atomicity.
-                    // This ensures that if we can't migrate everything, we don't partially move
-                    // entries and orphan sessions.
-                    let hasCollision = entries.contains { entry in
-                        fm.fileExists(atPath: hostEntry.appendingPathComponent(entry.lastPathComponent).path)
+                    // Pass 1: Collision scan at file level. For each top-level cwd-hash entry,
+                    // check if it exists on host and if so, scan for file collisions inside.
+                    var hasCollision = false
+                    var collidingFileName: String?
+                    for entry in entries {
+                        let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
+                        let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
+
+                        // If host doesn't have this cwd-hash dir, no collision possible.
+                        guard fm.fileExists(atPath: hostCwdHashPath.path) else { continue }
+
+                        // Host has this cwd-hash dir. Check for file-level collisions inside.
+                        let profileFiles = (try? fm.contentsOfDirectory(at: cwdHashPath, includingPropertiesForKeys: nil)) ?? []
+                        for profileFile in profileFiles {
+                            let hostFilePath = hostCwdHashPath.appendingPathComponent(profileFile.lastPathComponent)
+                            if fm.fileExists(atPath: hostFilePath.path) {
+                                hasCollision = true
+                                collidingFileName = profileFile.lastPathComponent
+                                break
+                            }
+                        }
+                        if hasCollision { break }
                     }
+
                     if hasCollision {
-                        logger.warning("projects migration incomplete for profile due to collisions; symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
+                        let collisionDesc = collidingFileName.map { " (\($0))" } ?? ""
+                        logger.warning("projects migration incomplete for profile due to file collision\(collisionDesc); symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
                         return
                     }
 
-                    // No collisions detected; safe to move all entries.
+                    // Pass 2: No collisions detected; safe to migrate all entries.
                     for entry in entries {
-                        let dest = hostEntry.appendingPathComponent(entry.lastPathComponent)
-                        try fm.moveItem(at: entry, to: dest)
+                        let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
+                        let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
+
+                        if fm.fileExists(atPath: hostCwdHashPath.path) {
+                            // Host has this cwd-hash dir. Migrate files individually.
+                            let profileFiles = (try? fm.contentsOfDirectory(at: cwdHashPath, includingPropertiesForKeys: nil)) ?? []
+                            for profileFile in profileFiles {
+                                let srcPath = cwdHashPath.appendingPathComponent(profileFile.lastPathComponent)
+                                let destPath = hostCwdHashPath.appendingPathComponent(profileFile.lastPathComponent)
+                                try fm.moveItem(at: srcPath, to: destPath)
+                            }
+                            try fm.removeItem(at: cwdHashPath)
+                        } else {
+                            // Host doesn't have this cwd-hash dir. Move the whole directory.
+                            try fm.moveItem(at: cwdHashPath, to: hostCwdHashPath)
+                        }
                     }
                     try fm.removeItem(at: profileEntry)
                 } catch {
@@ -137,19 +175,40 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                     return
                 }
             } else if isDir.boolValue {
-                // Non-projects directory in profile: replace only if empty.
+                // Non-projects directory in profile: move to sidecar if non-empty, otherwise remove.
                 let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
                 if entries.isEmpty {
                     try? fm.removeItem(at: profileEntry)
                 } else {
-                    logger.warning("profile has real \(name, privacy: .public)/ with content; leaving as-is")
-                    return
+                    // Non-empty directory: rename to sidecar if it doesn't already exist.
+                    let sidecarURL = profileEntry.appendingPathExtension("profile-local")
+                    if !fm.fileExists(atPath: sidecarURL.path) {
+                        do {
+                            try fm.moveItem(at: profileEntry, to: sidecarURL)
+                            logger.warning("profile has real \(name, privacy: .public)/ with content; moved to \(sidecarURL.lastPathComponent, privacy: .public)")
+                        } catch {
+                            logger.warning("failed moving \(name, privacy: .public)/ to sidecar: \(error.localizedDescription, privacy: .public)")
+                            return
+                        }
+                    } else {
+                        logger.debug("profile has real \(name, privacy: .public)/ with content and sidecar already exists; skipping rename")
+                    }
                 }
             } else {
                 // Real file (e.g. profile-side settings.json or CLAUDE.md).
-                // Don't destroy user content; leave alone.
-                logger.warning("profile has real \(name, privacy: .public) file; leaving as-is")
-                return
+                // Move to sidecar if it doesn't already exist.
+                let sidecarURL = profileEntry.appendingPathExtension("profile-local")
+                if !fm.fileExists(atPath: sidecarURL.path) {
+                    do {
+                        try fm.moveItem(at: profileEntry, to: sidecarURL)
+                        logger.warning("profile has real \(name, privacy: .public) file; moved to \(sidecarURL.lastPathComponent, privacy: .public)")
+                    } catch {
+                        logger.warning("failed moving \(name, privacy: .public) file to sidecar: \(error.localizedDescription, privacy: .public)")
+                        return
+                    }
+                } else {
+                    logger.debug("profile has real \(name, privacy: .public) file and sidecar already exists; skipping rename")
+                }
             }
         }
 

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -466,8 +466,8 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect(profileUniqueContent == "PROFILE UNIQUE")
     }
 
-    @Test("AC3.2b: collision with multiple cwds aborts migration atomically")
-    func hostMirrorProjectsMigrationCollisionAbortsAtomically() throws {
+    @Test("AC1.1: overlapping cwd-hash dirs with disjoint files merge successfully")
+    func hostMirrorProjectsMigrationMergesDisjointFiles() throws {
         let tempBase = tempBase()
         let tempHost = tempHostBase()
         defer {
@@ -478,14 +478,98 @@ struct ClaudeProfileConfigDirManagerTests {
         let fm = FileManager.default
         try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
 
-        // Pre-create host projects with cwd-hash A (collision point)
-        try fm.createDirectory(at: tempHost.appendingPathComponent("projects/-Users-test-cwd-A", isDirectory: true), withIntermediateDirectories: true)
-        let hostFileA = tempHost.appendingPathComponent("projects/-Users-test-cwd-A/host-sess.jsonl")
-        try "HOST A".write(to: hostFileA, atomically: true, encoding: .utf8)
+        // Pre-create host projects with cwd-hash A, one session file
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects/-cwd-A", isDirectory: true), withIntermediateDirectories: true)
+        let hostFileA = tempHost.appendingPathComponent("projects/-cwd-A/sess-host.jsonl")
+        try "HOST".write(to: hostFileA, atomically: true, encoding: .utf8)
+
+        // Pre-create profile projects with same cwd-hash A but different session file
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileProjectsBaseDir = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
+        try fm.createDirectory(at: profileProjectsBaseDir.appendingPathComponent("-cwd-A", isDirectory: true), withIntermediateDirectories: true)
+        let profileFileA = profileProjectsBaseDir.appendingPathComponent("-cwd-A/sess-profile.jsonl")
+        try "PROFILE".write(to: profileFileA, atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify: host file still has original content (untouched)
+        let hostContent = try String(contentsOf: hostFileA, encoding: .utf8)
+        #expect(hostContent == "HOST")
+
+        // Verify: profile file was migrated to host
+        let migratedFile = tempHost.appendingPathComponent("projects/-cwd-A/sess-profile.jsonl")
+        #expect(fm.fileExists(atPath: migratedFile.path))
+        let migratedContent = try String(contentsOf: migratedFile, encoding: .utf8)
+        #expect(migratedContent == "PROFILE")
+
+        // Verify: profile projects/ is now a symlink to host
+        let profileProjectsLink = profileClaudeDir.appendingPathComponent("projects")
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsLink.path)) != nil)
+    }
+
+    @Test("AC1.2: cwd-hash dir only in profile is moved to host intact")
+    func hostMirrorProjectsMigrationMovesProfileOnlyDir() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects", isDirectory: true), withIntermediateDirectories: true)
+
+        // Pre-create profile projects with a cwd-hash dir that doesn't exist on host
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileProjectsBaseDir = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
+        try fm.createDirectory(at: profileProjectsBaseDir.appendingPathComponent("-cwd-only-profile", isDirectory: true), withIntermediateDirectories: true)
+        let profileFile = profileProjectsBaseDir.appendingPathComponent("-cwd-only-profile/sess-X.jsonl")
+        try "PROFILE ONLY".write(to: profileFile, atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify: profile-only dir was moved to host intact
+        let hostFile = tempHost.appendingPathComponent("projects/-cwd-only-profile/sess-X.jsonl")
+        #expect(fm.fileExists(atPath: hostFile.path))
+        let content = try String(contentsOf: hostFile, encoding: .utf8)
+        #expect(content == "PROFILE ONLY")
+
+        // Verify: profile projects/ is now a symlink
+        let profileProjectsLink = profileClaudeDir.appendingPathComponent("projects")
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsLink.path)) != nil)
+    }
+
+    @Test("AC1.3: actual file-level collision aborts migration atomically")
+    func hostMirrorProjectsMigrationFileCollisionAbortsAtomically() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create host projects with cwd-hash A with a specific session file (collision point)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects/-cwd-A", isDirectory: true), withIntermediateDirectories: true)
+        let hostFileCollide = tempHost.appendingPathComponent("projects/-cwd-A/sess-collide.jsonl")
+        try "HOST".write(to: hostFileCollide, atomically: true, encoding: .utf8)
 
         // Pre-create profile projects with:
-        // - cwd-hash A (collides with host, should not be migrated)
-        // - cwd-hash B (no collision, but should NOT be migrated if A collides)
+        // - cwd-hash A with same session file (file-level collision)
+        // - cwd-hash B with unique content (should NOT be migrated due to atomic abort)
         let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
         let profileID = UUID()
         let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
@@ -494,39 +578,42 @@ struct ClaudeProfileConfigDirManagerTests {
         let profileProjectsBaseDir = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
         try fm.createDirectory(at: profileProjectsBaseDir, withIntermediateDirectories: true)
 
-        // Pre-create cwd-hash A (colliding side)
-        try fm.createDirectory(at: profileProjectsBaseDir.appendingPathComponent("-Users-test-cwd-A", isDirectory: true), withIntermediateDirectories: true)
-        let profileFileA = profileProjectsBaseDir.appendingPathComponent("-Users-test-cwd-A/profile-sess-A.jsonl")
-        try "PROFILE A".write(to: profileFileA, atomically: true, encoding: .utf8)
+        // cwd-hash A with collision file
+        try fm.createDirectory(at: profileProjectsBaseDir.appendingPathComponent("-cwd-A", isDirectory: true), withIntermediateDirectories: true)
+        let profileFileCollide = profileProjectsBaseDir.appendingPathComponent("-cwd-A/sess-collide.jsonl")
+        try "PROFILE".write(to: profileFileCollide, atomically: true, encoding: .utf8)
 
-        // Pre-create cwd-hash B (non-colliding side)
-        try fm.createDirectory(at: profileProjectsBaseDir.appendingPathComponent("-Users-test-cwd-B", isDirectory: true), withIntermediateDirectories: true)
-        let profileFileB = profileProjectsBaseDir.appendingPathComponent("-Users-test-cwd-B/profile-sess-B.jsonl")
-        try "PROFILE B".write(to: profileFileB, atomically: true, encoding: .utf8)
+        // cwd-hash B with clean content (but should not be migrated due to atomic abort)
+        try fm.createDirectory(at: profileProjectsBaseDir.appendingPathComponent("-cwd-B", isDirectory: true), withIntermediateDirectories: true)
+        let profileFileClean = profileProjectsBaseDir.appendingPathComponent("-cwd-B/sess-clean.jsonl")
+        try "PROFILE B".write(to: profileFileClean, atomically: true, encoding: .utf8)
 
         // Call ensureOAuthDir
         _ = try manager.ensureOAuthDir(forProfileID: profileID)
 
-        // Verify: cwd-hash A (colliding) should still exist in profile, not moved
-        #expect(fm.fileExists(atPath: profileFileA.path), "colliding cwd-hash A was moved despite collision")
-        let profileContentA = try String(contentsOf: profileFileA, encoding: .utf8)
-        #expect(profileContentA == "PROFILE A")
+        // Verify: host file still has original content (collision not overwritten)
+        let hostContent = try String(contentsOf: hostFileCollide, encoding: .utf8)
+        #expect(hostContent == "HOST")
 
-        // Verify: cwd-hash B (non-colliding) should still exist in profile, NOT moved to host
-        // This is the key regression test: it ensures atomicity of the migration.
-        #expect(fm.fileExists(atPath: profileFileB.path), "non-colliding cwd-hash B was migrated despite collision in A")
-        let profileContentB = try String(contentsOf: profileFileB, encoding: .utf8)
-        #expect(profileContentB == "PROFILE B")
+        // Verify: profile collision file was NOT migrated (atomic abort)
+        #expect(fm.fileExists(atPath: profileFileCollide.path))
+        let profileContent = try String(contentsOf: profileFileCollide, encoding: .utf8)
+        #expect(profileContent == "PROFILE")
 
-        // Verify: host should NOT have received any migration from the profile
-        #expect(!fm.fileExists(atPath: tempHost.appendingPathComponent("projects/-Users-test-cwd-B").path), "cwd-hash B was migrated to host despite collision in A")
+        // Verify: profile clean file was NOT migrated (atomic abort)
+        #expect(fm.fileExists(atPath: profileFileClean.path))
+        let profileCleanContent = try String(contentsOf: profileFileClean, encoding: .utf8)
+        #expect(profileCleanContent == "PROFILE B")
+
+        // Verify: host cwd-hash B was NOT created (atomic abort)
+        #expect(!fm.fileExists(atPath: tempHost.appendingPathComponent("projects/-cwd-B").path))
 
         // Verify: profile projects/ is still a real directory (NOT a symlink)
-        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBaseDir.path)) == nil, "profile projects/ was symlinked despite collision")
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBaseDir.path)) == nil)
     }
 
-    @Test("AC3.3a: non-projects directory with content is left alone")
-    func hostMirrorNonProjectsDirWithContent() throws {
+    @Test("AC2.1: non-projects directory with content gets sidecar + symlink")
+    func hostMirrorNonProjectsDirWithContentGetsSidecar() throws {
         let tempBase = tempBase()
         let tempHost = tempHostBase()
         defer {
@@ -546,19 +633,19 @@ struct ClaudeProfileConfigDirManagerTests {
 
         let profilePlugins = profileClaudeDir.appendingPathComponent("plugins")
         try fm.createDirectory(at: profilePlugins, withIntermediateDirectories: true)
-        try "plugin content".write(to: profilePlugins.appendingPathComponent("foo.txt"), atomically: true, encoding: .utf8)
+        try "plugin content".write(to: profilePlugins.appendingPathComponent("profile-only.txt"), atomically: true, encoding: .utf8)
 
         // Call ensureOAuthDir
         _ = try manager.ensureOAuthDir(forProfileID: profileID)
 
-        // Profile plugins should still be a real directory (NOT symlink)
-        var isDir: ObjCBool = false
-        #expect(fm.fileExists(atPath: profilePlugins.path, isDirectory: &isDir))
-        #expect(isDir.boolValue)
-        #expect((try? fm.destinationOfSymbolicLink(atPath: profilePlugins.path)) == nil)
+        // Profile plugins should now be a symlink to host
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profilePlugins.path)) != nil)
 
-        // Content should still be there
-        #expect(fm.fileExists(atPath: profilePlugins.appendingPathComponent("foo.txt").path))
+        // Sidecar should exist with original content
+        let sidecar = profileClaudeDir.appendingPathComponent("plugins.profile-local")
+        #expect(fm.fileExists(atPath: sidecar.path))
+        let sidecarContent = try String(contentsOf: sidecar.appendingPathComponent("profile-only.txt"), encoding: .utf8)
+        #expect(sidecarContent == "plugin content")
     }
 
     @Test("AC3.3b: non-projects empty directory is replaced with symlink")
@@ -590,8 +677,8 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect((try? fm.destinationOfSymbolicLink(atPath: profilePlugins.path)) != nil)
     }
 
-    @Test("AC3.3c: non-projects file is left alone")
-    func hostMirrorNonProjectsFile() throws {
+    @Test("AC2.1 file variant: non-projects file gets sidecar + symlink")
+    func hostMirrorNonProjectsFileGetsSidecar() throws {
         let tempBase = tempBase()
         let tempHost = tempHostBase()
         defer {
@@ -615,10 +702,87 @@ struct ClaudeProfileConfigDirManagerTests {
         // Call ensureOAuthDir
         _ = try manager.ensureOAuthDir(forProfileID: profileID)
 
-        // Profile file should still exist with original content (NOT symlink)
-        #expect((try? fm.destinationOfSymbolicLink(atPath: profileClaudeFile.path)) == nil)
-        let content = try String(contentsOf: profileClaudeFile, encoding: .utf8)
-        #expect(content == "# Profile CLAUDE.md")
+        // Profile CLAUDE.md should now be a symlink to host
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileClaudeFile.path)) != nil)
+
+        // Sidecar should exist with original profile content
+        let sidecar = profileClaudeDir.appendingPathComponent("CLAUDE.md.profile-local")
+        #expect(fm.fileExists(atPath: sidecar.path))
+        let sidecarContent = try String(contentsOf: sidecar, encoding: .utf8)
+        #expect(sidecarContent == "# Profile CLAUDE.md")
+    }
+
+    @Test("AC2.2: pre-existing sidecar is not overwritten")
+    func hostMirrorSidecarNotOverwritten() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        try "# Host CLAUDE.md".write(to: tempHost.appendingPathComponent("CLAUDE.md"), atomically: true, encoding: .utf8)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileClaudeFile = profileClaudeDir.appendingPathComponent("CLAUDE.md")
+        let sidecar = profileClaudeDir.appendingPathComponent("CLAUDE.md.profile-local")
+
+        // Run 1: Create the file and sidecar
+        try "# Profile CLAUDE.md Run 1".write(to: profileClaudeFile, atomically: true, encoding: .utf8)
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify sidecar was created with Run 1 content
+        #expect(fm.fileExists(atPath: sidecar.path))
+        var sidecarContent = try String(contentsOf: sidecar, encoding: .utf8)
+        #expect(sidecarContent == "# Profile CLAUDE.md Run 1")
+
+        // Run 2: Simulate Claude writing new content to the profile-side file
+        // (this could happen if someone edits CLAUDE.md after the first mirror, before the second)
+        try "# Profile CLAUDE.md Run 2".write(to: profileClaudeFile, atomically: true, encoding: .utf8)
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify: sidecar still has Run 1 content (not overwritten)
+        sidecarContent = try String(contentsOf: sidecar, encoding: .utf8)
+        #expect(sidecarContent == "# Profile CLAUDE.md Run 1")
+    }
+
+    @Test("AC2.3: empty real directory becomes symlink without sidecar")
+    func hostMirrorEmptyDirNoSidecar() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("skills", isDirectory: true), withIntermediateDirectories: true)
+
+        // Pre-create empty profile skills dir
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileSkills = profileClaudeDir.appendingPathComponent("skills")
+        try fm.createDirectory(at: profileSkills, withIntermediateDirectories: true)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Profile skills should now be a symlink
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileSkills.path)) != nil)
+
+        // No sidecar should exist
+        let sidecar = profileClaudeDir.appendingPathComponent("skills.profile-local")
+        #expect(!fm.fileExists(atPath: sidecar.path))
     }
 
     @Test("AC3.3c variant: symlink with wrong target is left alone")

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -744,12 +744,27 @@ struct ClaudeProfileConfigDirManagerTests {
 
         // Run 2: Simulate Claude writing new content to the profile-side file
         // (this could happen if someone edits CLAUDE.md after the first mirror, before the second)
+        // Note: String.write(to:atomically:true) uses rename(2) under the hood, which replaces
+        // the symlink with a real file rather than writing through it. So at the start of the
+        // second ensureOAuthDir, profileClaudeFile is a real file with "Run 2" content.
+        // This documents that the "skip if sidecar exists" code path is genuinely exercised.
         try "# Profile CLAUDE.md Run 2".write(to: profileClaudeFile, atomically: true, encoding: .utf8)
         _ = try manager.ensureOAuthDir(forProfileID: profileID)
 
-        // Verify: sidecar still has Run 1 content (not overwritten)
+        // Verify full post-Run-2 state:
+        // 1. Sidecar still has Run 1 content (not overwritten)
         sidecarContent = try String(contentsOf: sidecar, encoding: .utf8)
         #expect(sidecarContent == "# Profile CLAUDE.md Run 1")
+
+        // 2. Profile-side CLAUDE.md is a real file (not a symlink) containing "Run 2"
+        let isSidecarSymlink = (try? fm.destinationOfSymbolicLink(atPath: profileClaudeFile.path)) != nil
+        #expect(!isSidecarSymlink, "profile-side CLAUDE.md should be a real file, not a symlink after atomic write")
+        let profileContent = try String(contentsOf: profileClaudeFile, encoding: .utf8)
+        #expect(profileContent == "# Profile CLAUDE.md Run 2")
+
+        // 3. Host CLAUDE.md is unchanged
+        let hostContent = try String(contentsOf: tempHost.appendingPathComponent("CLAUDE.md"), encoding: .utf8)
+        #expect(hostContent == "# Host CLAUDE.md")
     }
 
     @Test("AC2.3: empty real directory becomes symlink without sidecar")

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -245,7 +245,7 @@ struct ClaudeProfileConfigDirManagerTests {
 
     // MARK: - host mirror slots
 
-    @Test("AC1.1 / AC1.2: symlink dir and file host slots after ensureOAuthDir and ensureAPIKeyDir")
+    @Test("shared-claude-projects.AC1.1/AC1.2: symlink dir and file host slots after ensureOAuthDir and ensureAPIKeyDir")
     func hostMirrorSymlinksOAuthAndAPIKey() throws {
         let tempBase = tempBase()
         let tempHost = tempHostBase()
@@ -288,7 +288,7 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect((try? fm.destinationOfSymbolicLink(atPath: claudeLink.path)) != nil)
     }
 
-    @Test("AC1.3: skip host slot if not present on host")
+    @Test("shared-claude-projects.AC1.3: skip host slot if not present on host")
     func hostMirrorSkipsAbsentSlot() throws {
         let tempBase = tempBase()
         let tempHost = tempHostBase()

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -424,7 +424,7 @@ struct ModelProfileRPCTests {
         #expect(!FileManager.default.fileExists(atPath: profileDir.path))
     }
 
-    @Test("delete preserves host mirror targets across multiple slots")
+    @Test("delete preserves host mirror targets across multiple slots and removes sidecars")
     func deletePreservesHostMirrors() async throws {
         let tempBaseDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let tempHostDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -440,6 +440,7 @@ struct ModelProfileRPCTests {
         // Pre-create host slots
         try fm.createDirectory(at: tempHostDir.appendingPathComponent("projects", isDirectory: true), withIntermediateDirectories: true)
         try fm.createDirectory(at: tempHostDir.appendingPathComponent("plugins", isDirectory: true), withIntermediateDirectories: true)
+        try "# Host CLAUDE.md".write(to: tempHostDir.appendingPathComponent("CLAUDE.md"), atomically: true, encoding: .utf8)
 
         let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBaseDir, hostBaseDirectory: tempHostDir)
         let (router, db, _) = makeRouter(configDirManager: manager)
@@ -447,6 +448,7 @@ struct ModelProfileRPCTests {
 
         // Create an OAuth profile and ensure its config dir with mirror symlinks
         let oauthProfile = try await db.modelProfiles.create(name: "OAuth", kind: .oauth)
+        let profileClaudeDir = manager.configDirectory(forProfileID: oauthProfile.id)
         _ = try manager.ensureOAuthDir(forProfileID: oauthProfile.id)
 
         // Write sentinel files in host slots
@@ -457,13 +459,25 @@ struct ModelProfileRPCTests {
         let pluginsSentinel = tempHostDir.appendingPathComponent("plugins/sentinel.txt")
         try "PLUGINS_SENTINEL".write(to: pluginsSentinel, atomically: true, encoding: .utf8)
 
+        // Create a sidecar by seeding profile-side CLAUDE.md, then calling ensure again
+        let profileClaudeFile = profileClaudeDir.appendingPathComponent("CLAUDE.md")
+        try "# Profile CLAUDE.md".write(to: profileClaudeFile, atomically: true, encoding: .utf8)
+        _ = try manager.ensureOAuthDir(forProfileID: oauthProfile.id)
+
         let profileDir = manager.profileDirectory(forProfileID: oauthProfile.id)
 
         // Verify symlinks were created
-        let profileProjects = manager.configDirectory(forProfileID: oauthProfile.id).appendingPathComponent("projects")
-        let profilePlugins = manager.configDirectory(forProfileID: oauthProfile.id).appendingPathComponent("plugins")
+        let profileProjects = profileClaudeDir.appendingPathComponent("projects")
+        let profilePlugins = profileClaudeDir.appendingPathComponent("plugins")
         #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjects.path)) != nil)
         #expect((try? fm.destinationOfSymbolicLink(atPath: profilePlugins.path)) != nil)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileClaudeFile.path)) != nil)
+
+        // Verify sidecar was created
+        let sidecar = profileClaudeDir.appendingPathComponent("CLAUDE.md.profile-local")
+        #expect(fm.fileExists(atPath: sidecar.path))
+        let sidecarContent = try String(contentsOf: sidecar, encoding: .utf8)
+        #expect(sidecarContent == "# Profile CLAUDE.md")
 
         // Delete the profile via RPC
         let resp = await router.handle(try RPCRequest(method: RPCMethod.modelProfileDelete,
@@ -482,6 +496,9 @@ struct ModelProfileRPCTests {
 
         let pluginsContent = try String(contentsOf: pluginsSentinel, encoding: .utf8)
         #expect(pluginsContent == "PLUGINS_SENTINEL")
+
+        // Verify sidecar is also gone (deleted with the profile dir)
+        #expect(!fm.fileExists(atPath: sidecar.path))
     }
 
     // MARK: - rename

--- a/docs/implementation-plans/2026-05-20-file-level-collisions/phase_01.md
+++ b/docs/implementation-plans/2026-05-20-file-level-collisions/phase_01.md
@@ -1,0 +1,302 @@
+# File-level collision detection — Implementation Plan
+
+**Goal:** Change `ClaudeProfileConfigDirManager.ensureMirrorSlot` so the
+`projects/` migration detects collisions at the individual session-file level
+(not the cwd-hash directory level), and non-`projects/` slots with
+pre-existing real content are migrated via a `<slot>.profile-local` sidecar
+plus symlink.
+
+**Architecture:** Internal change to `ClaudeProfileConfigDirManager`. Two
+behavior changes in `ensureMirrorSlot`'s "profile has a real entry" path:
+- For `migrateContent` (i.e. `projects/`): two-pass with one level of
+  recursion. Pass 1 checks each profile cwd-hash dir against the host —
+  whole-dir-new = no collision, dir-exists-on-host = check files inside for
+  name collisions. If any file collides, abort. Pass 2 moves either whole
+  cwd-hash dirs or individual files into the host store.
+- For non-`migrateContent` real entries: rename to
+  `<slot>.profile-local` (if no such sidecar already exists) and proceed to
+  create the symlink. Replaces today's "leave alone, no symlink" path.
+
+No DB change, no call-site change.
+
+**Tech stack:** Swift 6, SwiftPM, Swift Testing (`@Test`/`#expect`).
+
+**Scope:** 1 phase, 3 tasks. Source design:
+`docs/specs/2026-05-20-file-level-collisions-design.md`.
+
+**Codebase verified:** 2026-05-20 — `ensureMirrorSlot` lives at
+`Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`; the current
+two-pass dir-level collision detection is around lines 115–137.
+
+---
+
+## Acceptance Criteria Coverage
+
+Copied literally from the design doc.
+
+### file-level-collisions.AC1: `projects/` migration recurses to file level
+- **AC1.1 Success:** When `<profile>/projects/<cwd>/` overlaps a host
+  `projects/<cwd>/` directory but the individual `.jsonl` files inside have
+  disjoint UUIDs, migration succeeds: every profile-side file ends up in the
+  corresponding host directory, the profile-side `projects/` is removed,
+  and `<profile>/projects` is a symlink to `<host>/projects/`.
+- **AC1.2 Success:** When a top-level cwd-hash directory exists only in the
+  profile, the whole directory is moved intact to host.
+- **AC1.3 Success:** When any individual `.jsonl` file exists with the same
+  name in both stores, the migration aborts atomically: no files moved,
+  profile-side `projects/` preserved, no symlink.
+
+### file-level-collisions.AC2: non-`projects/` slots get sidecar-and-symlink
+- **AC2.1 Success:** Real non-empty file or directory in the profile gets
+  renamed to `<slot>.profile-local`, then `<profile>/<slot>` becomes a
+  symlink to `<host>/<slot>`.
+- **AC2.2 Success:** Re-running does not overwrite an existing
+  `<slot>.profile-local` — left untouched.
+- **AC2.3 Success:** Empty real directory and missing entry paths keep
+  current behavior — symlink created without sidecar.
+
+### file-level-collisions.AC3: profile deletion preserves host state
+- **AC3.1 Success:** Deleting a profile that contains both symlinks and a
+  `<slot>.profile-local` sidecar removes the profile dir (sidecar included)
+  but leaves all of `<host>/` untouched.
+
+---
+
+# Phase 1 — File-level collisions + sidecar fallback
+
+Files:
+- Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
+- Modify: `Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift`
+- Modify: `Tests/TBDDaemonTests/ModelProfileRPCTests.swift` (extend the
+  existing `deletePreservesHostMirrors` test to also seed a sidecar)
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: `projects/` migration with file-level recursion + sidecar fallback for other slots
+
+**Verifies:** all of AC1, all of AC2
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
+
+**Implementation:**
+
+Locate the `ensureMirrorSlot` function and replace the "Profile has a real
+entry" branch. There are two cases to handle:
+
+**Case A — `migrateContent` is true (i.e. `projects/`)**:
+
+Replace the current "two-pass at directory level" logic with a "two-pass at
+file level, recursing one directory deep" logic. Concretely:
+
+1. List the top-level entries of `profileEntry` (these are cwd-hash dirs,
+   e.g. `-Users-chang-myrepo`).
+2. **Collision scan** (pass 1, mutation-free):
+   - For each top-level entry `E`:
+     - If `host/<slot>/<E>` does not exist on disk, no collision possible for
+       this entry. Skip.
+     - Else, the dir exists on host. List the files inside the profile's
+       `<E>/`. For each file `F`, if `host/<slot>/<E>/<F>` exists, mark
+       `hasCollision = true` and break out of all loops.
+3. If `hasCollision` is true: log a warning naming the slot and the colliding
+   file (one is enough), return without creating the symlink. Profile-side
+   directory remains intact.
+4. **Migration** (pass 2, all moves):
+   - For each top-level entry `E`:
+     - If `host/<slot>/<E>` does not exist: `moveItem(E → host/<slot>/<E>)`
+       (whole directory).
+     - Else: list `E`'s files; for each `F`, `moveItem(E/F → host/<slot>/<E>/F)`;
+       then `removeItem(E)` (now empty).
+   - `removeItem(profileEntry)` (now empty).
+5. Fall through to `createSymbolicLink(profileEntry → hostEntry)`.
+
+Preserve the existing logger.debug for skipped-collisions only when it
+provides useful diagnostic — actually drop the per-collision debug noise from
+the current code; one warning at abort time is enough.
+
+**Case B — `migrateContent` is false (every other dir slot, plus file
+slots)**:
+
+Replace the current "log warning, leave alone, no symlink" early-return with
+a sidecar-and-symlink path:
+
+1. Compute the sidecar URL: `profileEntry.appendingPathExtension("profile-local")`
+   resolves to `<profile>/<slot>.profile-local`. Note: for `CLAUDE.md` this
+   produces `CLAUDE.md.profile-local` — that's fine, the literal dot is
+   acceptable in a sidecar name.
+2. If `<slot>.profile-local` already exists, do NOT overwrite. Log a debug
+   message, skip the rename, and proceed to step 4 — we still want to
+   attempt the symlink (the previous run may have failed midway).
+3. Otherwise: `moveItem(profileEntry → sidecarURL)`. Log a warning naming the
+   slot and the sidecar path.
+4. Fall through to `createSymbolicLink(profileEntry → hostEntry)`.
+
+The empty-real-directory branch (current behavior — `removeItem` then
+fall-through to symlink) should be preserved unchanged. The sidecar path is
+only for non-empty real entries (files always, and dirs with `entries` count
+> 0).
+
+**Doc comment update:**
+
+Update `ensureMirrorSlot`'s doc comment so it accurately describes:
+- file-level collision detection for `projects/`,
+- sidecar-and-symlink for other real entries,
+- still-best-effort, still logs and continues across slots.
+
+Also update the type-level doc comment if it mentions either policy.
+
+**Testing:** see Task 2.
+
+**Verification:**
+Run: `swift build`
+Expected: builds without errors.
+
+**Commit:** `feat: file-level collisions + sidecar for non-projects slots`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Tests for the new behavior
+
+**Verifies:** all of AC1, all of AC2
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift`
+
+**Testing:**
+
+All tests run against an injected temp `hostBaseDirectory` and `baseDirectory`
+— never `~/.claude/`. Use the existing `tempBase()` / `tempHostBase()`
+helpers.
+
+Replace or augment the existing collision tests with the file-level versions.
+The existing `hostMirrorProjectsMigrationCollisionAbortsAtomically` test
+currently asserts atomic abort on dir-level collision — its scenario (same
+cwd-hash dir on both sides, different individual files) will now SUCCEED
+under the new logic. Either rewrite that test to match the new behavior, or
+rename it and add a new test for the actual file-level abort.
+
+Concrete cases to cover:
+
+- **AC1.1 — overlapping cwd-hash dirs, disjoint files merge:**
+  Seed `<host>/projects/-cwd-A/sess-host.jsonl` ("HOST") and
+  `<profile>/claude/projects/-cwd-A/sess-profile.jsonl` ("PROFILE"). Call
+  `ensureOAuthDir`. Assert:
+  - `<host>/projects/-cwd-A/sess-host.jsonl` content "HOST" (untouched).
+  - `<host>/projects/-cwd-A/sess-profile.jsonl` content "PROFILE" (moved in).
+  - `<profile>/claude/projects/-cwd-A/` no longer exists at the profile path
+    OR is a symlink (the migration removes the original real dir).
+  - `<profile>/claude/projects` is a symlink.
+- **AC1.2 — cwd-hash dir only in profile, moved whole:**
+  Seed `<profile>/claude/projects/-cwd-only-profile/sess-X.jsonl`
+  with no corresponding host directory. Call `ensureOAuthDir`. Assert
+  `<host>/projects/-cwd-only-profile/sess-X.jsonl` now exists with original
+  content and `<profile>/claude/projects` is a symlink.
+- **AC1.3 — same session UUID in both, abort atomically:**
+  Seed `<host>/projects/-cwd-A/sess-collide.jsonl` content "HOST"
+  AND `<profile>/claude/projects/-cwd-A/sess-collide.jsonl` content
+  "PROFILE" (deliberate file-name collision). Also seed a non-colliding
+  `<profile>/claude/projects/-cwd-B/sess-clean.jsonl`. Call
+  `ensureOAuthDir`. Assert:
+  - `<host>/projects/-cwd-A/sess-collide.jsonl` content still "HOST".
+  - `<profile>/claude/projects/-cwd-A/sess-collide.jsonl` content still
+    "PROFILE" (un-moved).
+  - `<profile>/claude/projects/-cwd-B/sess-clean.jsonl` still exists at the
+    profile path (NOT moved — atomic abort).
+  - `<host>/projects/-cwd-B/` does NOT exist.
+  - `<profile>/claude/projects` is a real directory, NOT a symlink.
+
+- **AC2.1 — non-`projects` real dir gets sidecar + symlink:**
+  Seed `<host>/plugins/somefile.txt` AND
+  `<profile>/claude/plugins/profile-only.txt`. Call `ensureOAuthDir`.
+  Assert:
+  - `<profile>/claude/plugins.profile-local/profile-only.txt` exists with
+    original content.
+  - `<profile>/claude/plugins` is a symlink to `<host>/plugins/`.
+- **AC2.1 (file variant) — non-`projects` real file gets sidecar + symlink:**
+  Seed `<host>/CLAUDE.md` AND `<profile>/claude/CLAUDE.md` with content
+  "PROFILE-OWNED". Call `ensureOAuthDir`. Assert:
+  - `<profile>/claude/CLAUDE.md.profile-local` contains "PROFILE-OWNED".
+  - `<profile>/claude/CLAUDE.md` is a symlink to `<host>/CLAUDE.md`.
+- **AC2.2 — pre-existing sidecar not overwritten:**
+  Seed `<profile>/claude/CLAUDE.md` with "RUN-1", call `ensureOAuthDir`
+  (creates sidecar with "RUN-1"). Then write a new
+  `<profile>/claude/CLAUDE.md` with "RUN-2" (simulating claude writing
+  something later, before the next mirror call). Call `ensureOAuthDir`
+  again. Assert the existing `.profile-local` sidecar still reads "RUN-1"
+  (not "RUN-2"). The new "RUN-2" file is left alone in place (the rename
+  is skipped because the sidecar already exists), so no second symlink
+  attempt — but the existing first-pass symlink should still resolve to
+  host. Phrase the assertions according to whichever clean behavior the
+  implementation produces — the key point is: don't overwrite the sidecar.
+- **AC2.3 — empty real directory still becomes a symlink (no sidecar):**
+  Seed `<host>/skills/whatever` AND an empty `<profile>/claude/skills/`
+  directory. Call `ensureOAuthDir`. Assert no
+  `skills.profile-local` exists, and `<profile>/claude/skills` is a
+  symlink to `<host>/skills/`.
+
+Update or remove the old `hostMirrorProjectsMigrationCollisionAbortsAtomically`
+test that encoded dir-level abort as the "right" behavior — under the new
+logic that exact scenario succeeds, so the test will fail unless rewritten.
+
+**Verification:**
+Run: `swift test --filter ClaudeProfileConfigDirManager`
+Expected: all tests pass; new AC1.x / AC2.x tests cover the new behavior;
+prior tests that assumed dir-level abort are either updated to assert the
+new merge behavior or removed.
+
+**Commit:** `test: cover file-level collisions and sidecar policy`
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Sidecar survives profile deletion (no host leakage)
+
+**Verifies:** file-level-collisions.AC3.1
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/ModelProfileRPCTests.swift`
+
+**Testing:**
+
+Find the existing `deletePreservesHostMirrors` test (or whichever name it
+goes by — read the file to confirm). It already seeds sentinels in
+`<host>/projects/` and `<host>/plugins/` and verifies they survive profile
+deletion. Extend it (or add a sibling test) to also seed a
+`<profile>/<id>/claude/CLAUDE.md.profile-local` sidecar before deletion, and
+assert:
+- The profile directory is gone after delete.
+- Both `<host>/` sentinels still exist (existing assertions).
+- The sidecar is also gone (it lived under the profile dir).
+
+This locks in that `removeItem(at: profileDir)` removes the sidecar with the
+profile but doesn't traverse into the host store via the symlinks — a
+property that follows directly from macOS `FileManager`'s
+non-symlink-following recursive delete, but worth pinning down explicitly
+for the sidecar case.
+
+**Verification:**
+Run: `swift test --filter ModelProfile`
+Expected: all tests pass.
+
+**Commit:** `test: profile delete cleans up sidecar with the profile dir`
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->
+
+---
+
+## Final verification
+
+- `swift build` — clean.
+- `swift test` — full suite passes (currently 980 tests; will gain ~6).
+- `swift package plugin --allow-writing-to-package-directory swiftlint --strict`
+  — no violations.
+- Manual sanity check:
+  - Restart TBD via `scripts/restart.sh`.
+  - Pick a known affected profile (e.g. the "22222" example), spawn into it
+    (or attempt the swap-profile that previously failed). Confirm the
+    `projects/` symlink got created and the swap-resume now finds the
+    session.
+  - Confirm the affected profile's `<profile>/claude/plugins` and
+    `settings.json` are now symlinks, with the originals at
+    `plugins.profile-local` / `settings.json.profile-local`.

--- a/docs/specs/2026-05-20-file-level-collisions-design.md
+++ b/docs/specs/2026-05-20-file-level-collisions-design.md
@@ -1,0 +1,191 @@
+# File-level collision detection in alt-profile mirror migration
+
+**Date:** 2026-05-20
+**Status:** Design (follow-up to `2026-05-20-shared-claude-projects-design.md`)
+
+## Problem
+
+PR #178 made every TBD alt-profile dir mirror customization slots from
+`~/.claude/` via symlinks. The `projects/` slot has special migration logic
+because pre-existing profiles built up real content there during the PR #177
+window. The migration is **atomic on collision**: if any top-level entry in the
+profile's `projects/` already exists in the host's `projects/`, the whole
+migration is aborted and the profile-side `projects/` is preserved as a real
+directory — no symlink is created.
+
+That policy was correct for atomicity but **too coarse**. Encountered in the
+wild this morning:
+
+- A profile with five cwd-hash directories in its `projects/`, every one of
+  which also exists in `~/.claude/projects/` (same working directories, used
+  from both host and profile over time).
+- The session UUIDs *inside* those cwd-hash dirs were entirely disjoint
+  between host and profile — zero file-level conflicts.
+- But the dir-level collision check fired five times → atomic abort → no
+  symlink → profile's `projects/` stays a real dir → `claude --resume <id>`
+  spawned under that profile can't see sessions in `~/.claude/projects/` →
+  the swap-profile feature exits to a shell.
+
+This is the dominant case for any actively-used pre-existing profile, not an
+edge case. The fix is to detect collisions at the *file* level — where they
+actually mean "data conflict" — not at the directory level.
+
+A related issue: **non-`projects/` slots with real content** (`plugins/`,
+`settings.json`, etc.) are left alone with no symlink under the current
+policy. Two profiles in the wild are affected. The user loses access to
+host-installed plugins and host settings when spawning under those profiles.
+Less urgent than the `projects/` failure but worth addressing in the same
+pass.
+
+## Goal
+
+After this change:
+
+1. The `projects/` migration succeeds whenever no *individual session file* in
+   the profile would clobber an existing host file. Cwd-hash directory-name
+   overlaps are no longer a barrier.
+2. Non-`projects/` slots that have accumulated real content during the PR
+   #177 era are also migrated: profile's content is set aside under a
+   `<slot>.profile-local` sibling and the symlink to host is created. No
+   user data is destroyed, customization losses are recoverable, and the
+   alt-profile session sees host plugins / settings / etc. from the next
+   spawn onward.
+
+## Out of scope
+
+- Three-way merging of `plugins/installed_plugins.json` or `settings.json`
+  JSON content. Profile-local versions are preserved on disk under a sibling
+  name; users who care can re-apply by hand. Auto-merge of arbitrary JSON is
+  brittle and not worth the engineering for two profiles.
+- Anything else from the prior follow-ups' "Out of scope" list.
+
+## Approach
+
+### `projects/` — recurse one level deep
+
+The shape Claude Code writes is exactly:
+```
+projects/<cwd-hash>/<session-uuid>.jsonl
+```
+Two levels of directory below the slot root. The migration recurses one level
+deep:
+
+```
+For each top-level entry E in profile/projects/:
+  hostE = host/projects/<E>
+  if hostE does not exist:
+    Nothing collides → safe to migrate E whole.
+  else:
+    For each file F in profile/projects/<E>/:
+      if host/projects/<E>/<F> exists → mark file-level collision.
+
+If any file-level collision exists:
+  Abort. Profile/projects/ left as a real directory (current behavior).
+Else:
+  For each top-level entry E:
+    if host/projects/<E> does not exist:
+      moveItem(profile/projects/<E>, host/projects/<E>)        // whole dir
+    else:
+      For each F in profile/projects/<E>/:
+        moveItem(profile/projects/<E>/<F>, host/projects/<E>/<F>)  // per-file
+      removeItem(profile/projects/<E>)                          // now empty
+  removeItem(profile/projects/)
+  createSymbolicLink(profile/projects → host/projects/)
+```
+
+Same all-or-nothing atomicity guarantee as before, just with sharper
+granularity. Session UUIDs are UUIDs, so file-level collisions are
+astronomically improbable in practice — but if one ever happens, the abort
+preserves both sides.
+
+### Non-`projects/` slots — sidecar-and-symlink
+
+For every other mirror slot (`plugins/`, `skills/`, `agents/`, `commands/`,
+`hooks/`, `CLAUDE.md`, `settings.json`), if the profile entry exists as a
+real file or non-empty real directory **and** the host has that slot:
+
+```
+profile/<slot>  →  rename to  profile/<slot>.profile-local
+createSymbolicLink(profile/<slot> → host/<slot>)
+```
+
+Profile-side content is preserved verbatim under a recoverable sibling name.
+The symlink is created so the alt-profile sees host customizations from now
+on. Log a warning so the user knows the sidecar exists.
+
+If `profile/<slot>.profile-local` already exists (a prior migration ran),
+skip the rename — leave the existing sidecar untouched and proceed to
+attempting the symlink (which will no-op if the symlink already points right).
+
+Empty real directories and missing entries follow current behavior unchanged.
+
+### Why a sidecar instead of three-way merge
+
+Two profiles in the wild are affected. The sidecar approach is mechanical,
+zero-loss, reversible by `mv <slot>.profile-local <slot>`, and doesn't
+require us to understand the schema of every file claude writes. Engineering
+a JSON-aware merger for `installed_plugins.json` etc. would be substantially
+more code for two known users.
+
+## Acceptance criteria
+
+### file-level-collisions.AC1: `projects/` migration recurses to file level
+
+- **AC1.1 Success:** When `<profile>/projects/<cwd>/` overlaps a host
+  `projects/<cwd>/` directory but the individual `.jsonl` files inside have
+  disjoint UUIDs, migration succeeds: every profile-side file ends up in the
+  corresponding host directory, the profile-side `projects/` is removed, and
+  `<profile>/projects` is a symlink to `<host>/projects/`.
+- **AC1.2 Success:** When a top-level cwd-hash directory exists only in the
+  profile (no host directory of the same name), the whole directory is
+  moved intact to host (`moveItem` of the directory, not per-file).
+- **AC1.3 Success:** When any individual `.jsonl` file exists with the same
+  name in both `<profile>/projects/<cwd>/<id>.jsonl` and
+  `<host>/projects/<cwd>/<id>.jsonl`, the migration aborts atomically: no
+  files are moved, profile-side `projects/` is preserved intact, no symlink
+  is created.
+
+### file-level-collisions.AC2: non-`projects/` slots get sidecar-and-symlink
+
+- **AC2.1 Success:** For a non-`projects/` slot present on the host where the
+  profile has a real non-empty file or directory, after
+  `ensureOAuthDir` / `ensureAPIKeyDir` runs: the original profile-side
+  content lives at `<profile>/<slot>.profile-local`, and `<profile>/<slot>`
+  is a symlink to `<host>/<slot>`.
+- **AC2.2 Success:** Re-running `ensureOAuthDir` / `ensureAPIKeyDir` does not
+  overwrite an existing `<slot>.profile-local` sidecar — it's left untouched.
+- **AC2.3 Success:** When the host has the slot but the profile entry is
+  missing (or an empty directory), the symlink is created as before — no
+  sidecar produced.
+
+### file-level-collisions.AC3: profile deletion still preserves host state
+
+- **AC3.1 Success:** Deleting a profile whose dir contains both the symlinks
+  and a `<slot>.profile-local` sidecar removes the profile dir (including the
+  sidecar) but leaves every file under `<host>/` untouched. The sidecar is
+  unique to the profile and goes away with it; host state is unaffected.
+
+## Risks / known limitations
+
+1. **Profile-side plugin settings are not auto-merged into host.** Users
+   who had `enabledPlugins` or other profile-specific plugin state in
+   `<profile>/plugins/installed_plugins.json` need to manually merge it into
+   `~/.claude/plugins/installed_plugins.json` if they want those plugins
+   under that profile. The sidecar at `<profile>/plugins.profile-local`
+   preserves the originals.
+2. **Same for `settings.json`.** If the user had profile-specific settings,
+   they're at `<profile>/settings.json.profile-local`; the alt-profile now
+   uses host's `~/.claude/settings.json`.
+3. **Astronomical UUID collisions still abort.** If the same session UUID
+   appears in both stores, the abort preserves both — current dir-level
+   atomicity for the rare file-collision case. Not a regression.
+
+## Compatibility / migration
+
+- No DB change.
+- No call-site change (still internal to `ClaudeProfileConfigDirManager`).
+- On the next daemon restart, every reconciled profile's `ensure*Dir`
+  call runs the new logic. Profiles that successfully migrated under PR #178
+  already have symlinks — they pass through the idempotent check and are
+  left alone. The two affected profiles get their migration completed on
+  this restart.


### PR DESCRIPTION
## Summary

PR #178's `projects/` migration aborts atomically when any top-level entry (cwd-hash directory) of `<profile>/projects/` also exists in `<host>/projects/`. In the wild, the dominant case is "same working directory used from both host and profile over time" — the cwd-hash dir names collide but the actual session UUIDs inside are disjoint. The atomic abort fires defensively, leaves the profile's `projects/` as a real directory, and breaks swap-profile (which expects `claude --resume <id>` to find the session under the new profile's config dir).

Same shape affects non-`projects/` slots that accumulated real content during the PR #177 era: `plugins/`, `settings.json`, etc. are left alone, no symlink, so alt-profile spawns miss host customizations.

## What this does

**Recurse one level deep on `projects/` collision detection.** Pass 1 walks each profile-side cwd-hash directory; if the host has the same dir, check the *files* inside for name collisions. Only abort if an individual session JSONL would clobber an existing host file. Pass 2 moves either whole cwd-hash dirs (host doesn't have one yet) or merges file-by-file (host already has the dir).

**Sidecar-and-symlink for non-`projects/` slots with real content.** Move the existing profile-side entry to `<slot>.profile-local` (preserving everything), then create the symlink to host. The alt-profile sees host plugins/skills/settings from the next spawn; the profile-local content is recoverable by hand if the user customized it specifically.

Both behaviors preserve the same atomicity guarantee against actual data conflicts. Profile deletion still doesn't follow the symlinks — host state is untouched.

## What this does not do

- Three-way merge of `plugins/installed_plugins.json` or `settings.json` content. Two profiles in the wild are affected — engineering an auto-merger for arbitrary JSON formats is heavier than the situation warrants. Sidecar preserves the originals.
- Address claude's atomic-write replacing symlinks (`String.write(atomically:)` uses `rename(2)`, which converts a symlink slot into a real file on each write). The branch documents the behavior explicitly in the AC2.2 test — separate follow-up if/when it becomes a problem in practice.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 984 tests pass (6 new tests + 1 rewritten for the new behavior)
- [x] `swiftlint --strict` — 0 violations
- [ ] On next TBD restart with this branch deployed, profiles that previously had real `projects/` / `plugins/` / `settings.json` get migrated cleanly: `projects/` becomes a symlink (with sessions merged into `~/.claude/projects/`), `plugins.profile-local` and `settings.json.profile-local` sidecars hold the originals, and the slot itself is a symlink to host.
- [ ] Manual swap-profile from the host conversation (no profile) to a previously-affected alt-profile now lands in claude resumed with full history instead of exiting to a shell.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7FA064AB-109F-4F2D-A959-541E334BBFC8)