### PR TITLE
Fix: Recursively merge alt-profile projects/ so claude's memory subdirs don't block migration

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -194,7 +194,6 @@ public struct ClaudeProfileConfigDirManager: Sendable {
 
                     // Pass 1: Recursive collision scan. For each top-level cwd-hash entry,
                     // check if it exists on host and scan the full tree for collisions.
-                    var hasCollision = false
                     var collidingPath: URL?
                     for entry in entries {
                         let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
@@ -207,27 +206,21 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                               isCwdHashDir.boolValue else { continue }
 
                         if let collision = findCollisionRecursive(src: cwdHashPath, dst: hostCwdHashPath) {
-                            hasCollision = true
                             collidingPath = collision
                             break
                         }
                     }
 
-                    if hasCollision {
+                    if let collidingPath {
                         // Log the colliding entry as a path relative to the host slot root
                         // (e.g. "-cwd-A/sub/leaf.md") rather than the absolute host path —
                         // less noisy, and the host-slot context is already obvious from the
                         // slot name in the message.
-                        let collisionDesc: String
-                        if let path = collidingPath {
-                            let hostPrefix = hostEntry.path + "/"
-                            let rel = path.path.hasPrefix(hostPrefix)
-                                ? String(path.path.dropFirst(hostPrefix.count))
-                                : path.path
-                            collisionDesc = " (\(rel))"
-                        } else {
-                            collisionDesc = ""
-                        }
+                        let hostPrefix = hostEntry.path + "/"
+                        let rel = collidingPath.path.hasPrefix(hostPrefix)
+                            ? String(collidingPath.path.dropFirst(hostPrefix.count))
+                            : collidingPath.path
+                        let collisionDesc = " (\(rel))"
                         logger.warning("projects migration incomplete for profile due to file collision\(collisionDesc, privacy: .public); symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
                         return
                     }

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -209,8 +209,21 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                     }
 
                     if hasCollision {
-                        let collisionDesc = collidingPath.map { " (\($0.path))" } ?? ""
-                        logger.warning("projects migration incomplete for profile due to file collision\(collisionDesc); symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
+                        // Log the colliding entry as a path relative to the host slot root
+                        // (e.g. "-cwd-A/sub/leaf.md") rather than the absolute host path —
+                        // less noisy, and the host-slot context is already obvious from the
+                        // slot name in the message.
+                        let collisionDesc: String
+                        if let path = collidingPath {
+                            let hostPrefix = hostEntry.path + "/"
+                            let rel = path.path.hasPrefix(hostPrefix)
+                                ? String(path.path.dropFirst(hostPrefix.count))
+                                : path.path
+                            collisionDesc = " (\(rel))"
+                        } else {
+                            collisionDesc = ""
+                        }
+                        logger.warning("projects migration incomplete for profile due to file collision\(collisionDesc, privacy: .public); symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
                         return
                     }
 

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -79,16 +79,78 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         "settings.json",
     ]
 
+    /// Walk `src` against `dst`, returning the path of the first real collision
+    /// found, or nil if `src` can be merged into `dst` without overwriting any
+    /// existing file. Read-only.
+    ///
+    /// "Real collision" means: at some matching path, both sides exist AND
+    /// (either they have different types, or both are non-directory files).
+    /// Same-named directories on both sides recurse.
+    private func findCollisionRecursive(src: URL, dst: URL) -> URL? {
+        let fm = FileManager.default
+
+        var dstIsDir: ObjCBool = false
+        let dstExists = fm.fileExists(atPath: dst.path, isDirectory: &dstIsDir)
+        if !dstExists {
+            return nil  // dst absent → src can be moved whole-tree
+        }
+
+        var srcIsDir: ObjCBool = false
+        _ = fm.fileExists(atPath: src.path, isDirectory: &srcIsDir)
+
+        // Type mismatch (one file, one directory) → real collision.
+        if srcIsDir.boolValue != dstIsDir.boolValue {
+            return dst
+        }
+
+        // Both files at the same path → real collision (no overwrite).
+        if !srcIsDir.boolValue {
+            return dst
+        }
+
+        // Both directories — recurse into src's children.
+        let srcEntries = (try? fm.contentsOfDirectory(at: src, includingPropertiesForKeys: nil)) ?? []
+        for entry in srcEntries {
+            let dstEntry = dst.appendingPathComponent(entry.lastPathComponent)
+            if let collision = findCollisionRecursive(src: entry, dst: dstEntry) {
+                return collision
+            }
+        }
+        return nil
+    }
+
+    /// Move every file/subdirectory in `src` into the corresponding location
+    /// under `dst`. The caller must have already verified
+    /// `findCollisionRecursive(src:dst:)` returned nil — no overwrite checks are
+    /// performed here. After a successful merge, `src` is removed.
+    private func mergeRecursive(src: URL, dst: URL) throws {
+        let fm = FileManager.default
+
+        if !fm.fileExists(atPath: dst.path) {
+            try fm.moveItem(at: src, to: dst)  // whole-subtree move
+            return
+        }
+
+        // dst exists; pre-check guarantees it's a directory and src is too.
+        let srcEntries = (try? fm.contentsOfDirectory(at: src, includingPropertiesForKeys: nil)) ?? []
+        for entry in srcEntries {
+            let dstEntry = dst.appendingPathComponent(entry.lastPathComponent)
+            try mergeRecursive(src: entry, dst: dstEntry)
+        }
+        try fm.removeItem(at: src)  // now empty
+    }
+
     /// Ensure one host-mirror slot is a symlink from the profile dir into the
     /// host base. Best-effort: filesystem errors are logged and swallowed.
     ///
     /// For `projects/` (migrateContent=true), performs file-level collision detection
-    /// by recursing one directory deep into cwd-hash directories. Cwd-hash directories
-    /// with disjoint session files are merged into the host store; only actual file
-    /// collisions abort the migration. Atomic with respect to name collisions: pass 1
-    /// confirms no file-level conflicts before pass 2 moves anything. Not atomic with
-    /// respect to I/O failures during pass 2 — those leave partial state that the next
-    /// call cleans up.
+    /// by recursively walking the full tree structure. Same-named directories on both
+    /// sides recurse; type mismatches and same-named files are real collisions that
+    /// trigger atomic abort. Cwd-hash directories with disjoint trees are merged into
+    /// the host store. Atomic with respect to name collisions: pass 1 confirms no
+    /// file-level conflicts before pass 2 moves anything. Not atomic with respect to
+    /// I/O failures during pass 2 — those leave partial state that the next call
+    /// cleans up.
     ///
     /// For other slots (migrateContent=false) with real content, the content is moved
     /// to a `<slot>.profile-local` sidecar, allowing the symlink to be created and the
@@ -125,68 +187,44 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                     try fm.createDirectory(at: hostEntry, withIntermediateDirectories: true)
                     let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []
 
-                    // Pass 1: Collision scan at file level. For each top-level cwd-hash entry,
-                    // check if it exists on host and if so, scan for file collisions inside.
+                    // Pass 1: Recursive collision scan. For each top-level cwd-hash entry,
+                    // check if it exists on host and scan the full tree for collisions.
                     var hasCollision = false
-                    var collidingFilePath: String?
+                    var collidingPath: URL?
                     for entry in entries {
                         let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
                         let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
 
-                        // projects/ is expected to contain only cwd-hash subdirectories.
-                        // Skip stray non-directory entries (e.g. a .DS_Store Finder leaves
-                        // behind) for the collision scan — they get swept explicitly before
-                        // the final removeItem below.
+                        // Skip stray non-directory entries at the top level (e.g. .DS_Store).
+                        // These get swept explicitly before the final removeItem.
                         var isCwdHashDir: ObjCBool = false
                         guard fm.fileExists(atPath: cwdHashPath.path, isDirectory: &isCwdHashDir),
                               isCwdHashDir.boolValue else { continue }
 
-                        // If host doesn't have this cwd-hash dir, no collision possible.
-                        guard fm.fileExists(atPath: hostCwdHashPath.path) else { continue }
-
-                        // Host has this cwd-hash dir. Check for file-level collisions inside.
-                        let profileFiles = (try? fm.contentsOfDirectory(at: cwdHashPath, includingPropertiesForKeys: nil)) ?? []
-                        for profileFile in profileFiles {
-                            let hostFilePath = hostCwdHashPath.appendingPathComponent(profileFile.lastPathComponent)
-                            if fm.fileExists(atPath: hostFilePath.path) {
-                                hasCollision = true
-                                collidingFilePath = "\(entry.lastPathComponent)/\(profileFile.lastPathComponent)"
-                                break
-                            }
+                        if let collision = findCollisionRecursive(src: cwdHashPath, dst: hostCwdHashPath) {
+                            hasCollision = true
+                            collidingPath = collision
+                            break
                         }
-                        if hasCollision { break }
                     }
 
                     if hasCollision {
-                        let collisionDesc = collidingFilePath.map { " (\($0))" } ?? ""
+                        let collisionDesc = collidingPath.map { " (\($0.path))" } ?? ""
                         logger.warning("projects migration incomplete for profile due to file collision\(collisionDesc); symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
                         return
                     }
 
-                    // Pass 2: No collisions detected; safe to migrate all entries.
+                    // Pass 2: No collisions detected; safe to migrate all entries recursively.
                     for entry in entries {
                         let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
                         let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
 
-                        // Same directory-only guard as pass 1 — stray files are handled
-                        // explicitly in the sweep below.
+                        // Same directory-only guard as pass 1 — strays handled by the sweep below.
                         var isCwdHashDir: ObjCBool = false
                         guard fm.fileExists(atPath: cwdHashPath.path, isDirectory: &isCwdHashDir),
                               isCwdHashDir.boolValue else { continue }
 
-                        if fm.fileExists(atPath: hostCwdHashPath.path) {
-                            // Host has this cwd-hash dir. Migrate files individually.
-                            let profileFiles = (try? fm.contentsOfDirectory(at: cwdHashPath, includingPropertiesForKeys: nil)) ?? []
-                            for profileFile in profileFiles {
-                                let srcPath = cwdHashPath.appendingPathComponent(profileFile.lastPathComponent)
-                                let destPath = hostCwdHashPath.appendingPathComponent(profileFile.lastPathComponent)
-                                try fm.moveItem(at: srcPath, to: destPath)
-                            }
-                            try fm.removeItem(at: cwdHashPath)
-                        } else {
-                            // Host doesn't have this cwd-hash dir. Move the whole directory.
-                            try fm.moveItem(at: cwdHashPath, to: hostCwdHashPath)
-                        }
+                        try mergeRecursive(src: cwdHashPath, dst: hostCwdHashPath)
                     }
 
                     // Sweep any stray non-directory entries left behind by the

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -95,8 +95,11 @@ public struct ClaudeProfileConfigDirManager: Sendable {
             return nil  // dst absent → src can be moved whole-tree
         }
 
+        // If src has vanished between enumeration and this recursive call
+        // (rare race with another process), treat as no collision — there's
+        // nothing to merge so nothing to clash with.
         var srcIsDir: ObjCBool = false
-        _ = fm.fileExists(atPath: src.path, isDirectory: &srcIsDir)
+        guard fm.fileExists(atPath: src.path, isDirectory: &srcIsDir) else { return nil }
 
         // Type mismatch (one file, one directory) → real collision.
         if srcIsDir.boolValue != dstIsDir.boolValue {
@@ -132,7 +135,9 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         }
 
         // dst exists; pre-check guarantees it's a directory and src is too.
-        let srcEntries = (try? fm.contentsOfDirectory(at: src, includingPropertiesForKeys: nil)) ?? []
+        // Use `try` (not `try?`) so a listing failure surfaces to the caller
+        // instead of producing a misleading ENOTEMPTY from `removeItem` below.
+        let srcEntries = try fm.contentsOfDirectory(at: src, includingPropertiesForKeys: nil)
         for entry in srcEntries {
             let dstEntry = dst.appendingPathComponent(entry.lastPathComponent)
             try mergeRecursive(src: entry, dst: dstEntry)

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -877,6 +877,192 @@ struct ClaudeProfileConfigDirManagerTests {
         _ = try manager.ensureOAuthDir(forProfileID: profileID)
         #expect((try? fm.destinationOfSymbolicLink(atPath: pluginsLink.path)) != nil)
     }
+
+    // MARK: - recursive-projects-merge.AC1: same-name directories merge by recursing
+
+    @Test("AC1.1: nested dir-vs-dir with disjoint files merges successfully")
+    func hostMirrorProjectsMigrationNestedDirMerges() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create host projects with cwd-A/sub/ containing one file
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects/-cwd-A/sub", isDirectory: true), withIntermediateDirectories: true)
+        let hostLeaf = tempHost.appendingPathComponent("projects/-cwd-A/sub/host-leaf.md")
+        try "HOST".write(to: hostLeaf, atomically: true, encoding: .utf8)
+
+        // Pre-create profile projects with cwd-A/sub/ containing a different file
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileProjectsBase = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
+        try fm.createDirectory(at: profileProjectsBase.appendingPathComponent("-cwd-A/sub", isDirectory: true), withIntermediateDirectories: true)
+        let profileLeaf = profileProjectsBase.appendingPathComponent("-cwd-A/sub/profile-leaf.md")
+        try "PROFILE".write(to: profileLeaf, atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify: host file untouched
+        #expect(try String(contentsOf: hostLeaf, encoding: .utf8) == "HOST")
+
+        // Verify: profile file migrated into host tree
+        let migratedLeaf = tempHost.appendingPathComponent("projects/-cwd-A/sub/profile-leaf.md")
+        #expect(fm.fileExists(atPath: migratedLeaf.path))
+        #expect(try String(contentsOf: migratedLeaf, encoding: .utf8) == "PROFILE")
+
+        // Verify: profile projects/ is now a symlink
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBase.path)) != nil)
+    }
+
+    @Test("AC1.2: empty profile-side memory/ merges (the real bug)")
+    func hostMirrorProjectsMigrationEmptyProfileMemory() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create host projects with cwd-A/memory/ containing one file
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects/-cwd-A/memory", isDirectory: true), withIntermediateDirectories: true)
+        let hostMemNote = tempHost.appendingPathComponent("projects/-cwd-A/memory/note.md")
+        try "HOST NOTE".write(to: hostMemNote, atomically: true, encoding: .utf8)
+
+        // Pre-create profile projects with an empty cwd-A/memory/ directory
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileProjectsBase = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
+        try fm.createDirectory(at: profileProjectsBase.appendingPathComponent("-cwd-A/memory", isDirectory: true), withIntermediateDirectories: true)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify: host memory/note.md still has original content
+        #expect(try String(contentsOf: hostMemNote, encoding: .utf8) == "HOST NOTE")
+
+        // Verify: profile projects/ is now a symlink (recursive merge removed the empty memory dir)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBase.path)) != nil)
+    }
+
+    // MARK: - recursive-projects-merge.AC2: real collisions still abort atomically
+
+    @Test("AC2.1: nested file-vs-file collision aborts atomically")
+    func hostMirrorProjectsMigrationNestedFileCollisionAbortsAtomically() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create host projects with cwd-A/sub/leaf.md (collision point)
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects/-cwd-A/sub", isDirectory: true), withIntermediateDirectories: true)
+        let hostLeaf = tempHost.appendingPathComponent("projects/-cwd-A/sub/leaf.md")
+        try "HOST LEAF".write(to: hostLeaf, atomically: true, encoding: .utf8)
+
+        // Pre-create profile projects with cwd-A/sub/leaf.md (collision) and cwd-B/x.md (clean, non-colliding)
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileProjectsBase = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
+        try fm.createDirectory(at: profileProjectsBase, withIntermediateDirectories: true)
+
+        // cwd-A with collision file
+        try fm.createDirectory(at: profileProjectsBase.appendingPathComponent("-cwd-A/sub", isDirectory: true), withIntermediateDirectories: true)
+        let profileLeaf = profileProjectsBase.appendingPathComponent("-cwd-A/sub/leaf.md")
+        try "PROFILE LEAF".write(to: profileLeaf, atomically: true, encoding: .utf8)
+
+        // cwd-B with non-colliding file (to verify atomic abort)
+        try fm.createDirectory(at: profileProjectsBase.appendingPathComponent("-cwd-B", isDirectory: true), withIntermediateDirectories: true)
+        let profileX = profileProjectsBase.appendingPathComponent("-cwd-B/x.md")
+        try "PROFILE X".write(to: profileX, atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify: host leaf still has original content (collision not overwritten)
+        #expect(try String(contentsOf: hostLeaf, encoding: .utf8) == "HOST LEAF")
+
+        // Verify: profile collision file was NOT migrated (atomic abort)
+        #expect(fm.fileExists(atPath: profileLeaf.path))
+        #expect(try String(contentsOf: profileLeaf, encoding: .utf8) == "PROFILE LEAF")
+
+        // Verify: profile non-colliding file was NOT migrated (atomic abort)
+        #expect(fm.fileExists(atPath: profileX.path))
+        #expect(try String(contentsOf: profileX, encoding: .utf8) == "PROFILE X")
+
+        // Verify: host cwd-B was NOT created (atomic abort)
+        #expect(!fm.fileExists(atPath: tempHost.appendingPathComponent("projects/-cwd-B").path))
+
+        // Verify: profile projects/ is still a real directory (NOT a symlink)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBase.path)) == nil)
+    }
+
+    @Test("AC2.2: type-mismatch collision (directory vs file) aborts atomically")
+    func hostMirrorProjectsMigrationTypeCollisionAbortsAtomically() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        // Pre-create host projects with cwd-A/foo as a directory containing a file
+        try fm.createDirectory(at: tempHost.appendingPathComponent("projects/-cwd-A/foo", isDirectory: true), withIntermediateDirectories: true)
+        let hostFooFile = tempHost.appendingPathComponent("projects/-cwd-A/foo/content.txt")
+        try "HOST FOO CONTENT".write(to: hostFooFile, atomically: true, encoding: .utf8)
+
+        // Pre-create profile projects with cwd-A/foo as a file
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileClaudeDir = manager.configDirectory(forProfileID: profileID)
+        try fm.createDirectory(at: profileClaudeDir, withIntermediateDirectories: true)
+
+        let profileProjectsBase = profileClaudeDir.appendingPathComponent("projects", isDirectory: true)
+        try fm.createDirectory(at: profileProjectsBase.appendingPathComponent("-cwd-A", isDirectory: true), withIntermediateDirectories: true)
+        let profileFooFile = profileProjectsBase.appendingPathComponent("-cwd-A/foo")
+        try "PROFILE FOO FILE".write(to: profileFooFile, atomically: true, encoding: .utf8)
+
+        // Call ensureOAuthDir
+        _ = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Verify: host foo is still a directory with original content
+        #expect(fm.fileExists(atPath: hostFooFile.path))
+        #expect(try String(contentsOf: hostFooFile, encoding: .utf8) == "HOST FOO CONTENT")
+
+        // Verify: profile foo is still a file with original content
+        #expect(fm.fileExists(atPath: profileFooFile.path))
+        var profileIsDir: ObjCBool = false
+        fm.fileExists(atPath: profileFooFile.path, isDirectory: &profileIsDir)
+        #expect(!profileIsDir.boolValue, "profile foo should be a file, not a directory")
+        #expect(try String(contentsOf: profileFooFile, encoding: .utf8) == "PROFILE FOO FILE")
+
+        // Verify: profile projects/ is still a real directory (NOT a symlink)
+        #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBase.path)) == nil)
+    }
 }
 
 /// Run env-mutating tests serialized so they don't race each other. Each test

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -880,7 +880,7 @@ struct ClaudeProfileConfigDirManagerTests {
 
     // MARK: - recursive-projects-merge.AC1: same-name directories merge by recursing
 
-    @Test("AC1.1: nested dir-vs-dir with disjoint files merges successfully")
+    @Test("recursive-projects-merge.AC1.1: nested dir-vs-dir with disjoint files merges successfully")
     func hostMirrorProjectsMigrationNestedDirMerges() throws {
         let tempBase = tempBase()
         let tempHost = tempHostBase()
@@ -923,7 +923,7 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBase.path)) != nil)
     }
 
-    @Test("AC1.2: empty profile-side memory/ merges (the real bug)")
+    @Test("recursive-projects-merge.AC1.2: empty profile-side memory/ merges (the real bug)")
     func hostMirrorProjectsMigrationEmptyProfileMemory() throws {
         let tempBase = tempBase()
         let tempHost = tempHostBase()
@@ -961,7 +961,7 @@ struct ClaudeProfileConfigDirManagerTests {
 
     // MARK: - recursive-projects-merge.AC2: real collisions still abort atomically
 
-    @Test("AC2.1: nested file-vs-file collision aborts atomically")
+    @Test("recursive-projects-merge.AC2.1: nested file-vs-file collision aborts atomically")
     func hostMirrorProjectsMigrationNestedFileCollisionAbortsAtomically() throws {
         let tempBase = tempBase()
         let tempHost = tempHostBase()
@@ -1018,7 +1018,7 @@ struct ClaudeProfileConfigDirManagerTests {
         #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBase.path)) == nil)
     }
 
-    @Test("AC2.2: type-mismatch collision (directory vs file) aborts atomically")
+    @Test("recursive-projects-merge.AC2.2: type-mismatch collision (directory vs file) aborts atomically")
     func hostMirrorProjectsMigrationTypeCollisionAbortsAtomically() throws {
         let tempBase = tempBase()
         let tempHost = tempHostBase()

--- a/docs/implementation-plans/2026-05-20-recursive-projects-merge/phase_01.md
+++ b/docs/implementation-plans/2026-05-20-recursive-projects-merge/phase_01.md
@@ -1,0 +1,341 @@
+# Recursive `projects/` merge — Implementation Plan
+
+**Goal:** Replace PR #179's "one level deep" file-level collision scan in
+`ClaudeProfileConfigDirManager.ensureMirrorSlot` with a fully recursive
+collision scan + recursive merge. Same-name directories on both sides
+recurse; only actual file-vs-file or type-mismatch collisions trigger the
+atomic abort.
+
+**Architecture:** Internal change to `ClaudeProfileConfigDirManager`. Two
+private recursive helpers — `findCollisionRecursive(src:dst:)` (read-only)
+and `mergeRecursive(src:dst:)` (mutating, called only after pass 1 returned
+nil). Inside `ensureMirrorSlot`, the `migrateContent` branch's pass 1 and
+pass 2 inner per-cwd-hash loops are replaced with calls to these helpers.
+The top-level non-directory sweep stays. Non-`projects/` sidecar path is
+unchanged.
+
+No DB change, no call-site change.
+
+**Tech stack:** Swift 6, SwiftPM, Swift Testing.
+
+**Scope:** 1 phase, 3 tasks. Source design:
+`docs/specs/2026-05-20-recursive-projects-merge-design.md`.
+
+**Codebase verified:** 2026-05-20 — `ensureMirrorSlot` lives at
+`Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`; the existing
+pass 1 / pass 2 + sweep block (lines ~125–198) is the right replacement
+target.
+
+---
+
+## Acceptance Criteria Coverage
+
+Copied literally from the design doc.
+
+### recursive-projects-merge.AC1: same-name directories merge by recursing
+- **AC1.1 Success:** When `<profile>/projects/<cwd>/sub/` and
+  `<host>/projects/<cwd>/sub/` both exist as directories and contain no
+  same-named files between them, migration succeeds: every file inside the
+  profile's tree ends up at the corresponding host path, the profile-side
+  `projects/` is removed, and `<profile>/projects` is a symlink to host.
+- **AC1.2 Success:** When the profile's `memory/` is empty and host's
+  `memory/` has files, migration succeeds and the profile's empty
+  `memory/` is removed alongside the rest of the profile-side `projects/`.
+
+### recursive-projects-merge.AC2: real collisions still abort atomically
+- **AC2.1 Success:** A file at `<profile>/projects/<cwd>/sub/leaf.md` whose
+  name also exists at `<host>/projects/<cwd>/sub/leaf.md` triggers the
+  atomic abort: no moves happen anywhere in the tree; profile-side
+  `projects/` is preserved intact; no symlink created.
+- **AC2.2 Success:** Type-mismatch collision (host has `foo` as a directory,
+  profile has `foo` as a file) also aborts atomically.
+
+### recursive-projects-merge.AC3: existing AC1/2 from PR #179 still hold
+- **AC3.1 Success:** Top-level cwd-hash dir present only in the profile is
+  still moved whole-tree.
+- **AC3.2 Success:** Same-named session JSONLs in both stores still abort
+  atomically.
+- **AC3.3 Success:** Non-`projects/` slots still get the
+  `<slot>.profile-local` sidecar treatment unchanged.
+- **AC3.4 Success:** Stray non-directory entries at the top level of
+  `projects/` are still swept by the explicit cleanup before the parent
+  `removeItem`.
+
+---
+
+# Phase 1 — Recursive merge for `projects/`
+
+Files:
+- Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
+- Modify: `Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift`
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add the recursive helpers
+
+**Verifies:** none directly (helper plumbing for AC1/AC2)
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
+
+**Implementation:**
+
+Add two private helpers to the struct, near the existing `ensureMirrorSlot`:
+
+```swift
+/// Walk `src` against `dst`, returning the path of the first real collision
+/// found, or nil if `src` can be merged into `dst` without overwriting any
+/// existing file. Read-only.
+///
+/// "Real collision" means: at some matching path, both sides exist AND
+/// (either they have different types, or both are non-directory files).
+/// Same-named directories on both sides recurse.
+private func findCollisionRecursive(src: URL, dst: URL) -> URL? {
+    let fm = FileManager.default
+
+    var dstIsDir: ObjCBool = false
+    let dstExists = fm.fileExists(atPath: dst.path, isDirectory: &dstIsDir)
+    if !dstExists {
+        return nil  // dst absent → src can be moved whole-tree
+    }
+
+    var srcIsDir: ObjCBool = false
+    _ = fm.fileExists(atPath: src.path, isDirectory: &srcIsDir)
+
+    // Type mismatch (one file, one directory) → real collision.
+    if srcIsDir.boolValue != dstIsDir.boolValue {
+        return dst
+    }
+
+    // Both files at the same path → real collision (no overwrite).
+    if !srcIsDir.boolValue {
+        return dst
+    }
+
+    // Both directories — recurse into src's children.
+    let srcEntries = (try? fm.contentsOfDirectory(at: src, includingPropertiesForKeys: nil)) ?? []
+    for entry in srcEntries {
+        let dstEntry = dst.appendingPathComponent(entry.lastPathComponent)
+        if let collision = findCollisionRecursive(src: entry, dst: dstEntry) {
+            return collision
+        }
+    }
+    return nil
+}
+
+/// Move every file/subdirectory in `src` into the corresponding location
+/// under `dst`. The caller must have already verified
+/// `findCollisionRecursive(src:dst:)` returned nil — no overwrite checks are
+/// performed here. After a successful merge, `src` is removed.
+private func mergeRecursive(src: URL, dst: URL) throws {
+    let fm = FileManager.default
+
+    if !fm.fileExists(atPath: dst.path) {
+        try fm.moveItem(at: src, to: dst)  // whole-subtree move
+        return
+    }
+
+    // dst exists; pre-check guarantees it's a directory and src is too.
+    let srcEntries = (try? fm.contentsOfDirectory(at: src, includingPropertiesForKeys: nil)) ?? []
+    for entry in srcEntries {
+        let dstEntry = dst.appendingPathComponent(entry.lastPathComponent)
+        try mergeRecursive(src: entry, dst: dstEntry)
+    }
+    try fm.removeItem(at: src)  // now empty
+}
+```
+
+Place these immediately above `ensureMirrorSlot` (or wherever the
+file-organization is cleanest). Add doc comments — the snippets above already
+have them; refine the wording to match the file's existing tone.
+
+**Testing:** see Task 2 — these helpers are exercised indirectly through
+`ensureOAuthDir`.
+
+**Verification:**
+Run: `swift build`
+Expected: builds without errors.
+
+**Commit:** `feat: add recursive collision scan and merge helpers`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Wire recursive helpers into `ensureMirrorSlot`'s `projects/` branch
+
+**Verifies:** AC1.1, AC1.2, AC2.1, AC2.2, AC3.1, AC3.2, AC3.4
+
+**Files:**
+- Modify: `Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift`
+
+**Implementation:**
+
+In `ensureMirrorSlot`, inside the `migrateContent` (i.e. `projects/`) branch
+of "Profile has a real entry", replace the per-cwd-hash inner loops with
+calls to the new helpers.
+
+Pass 1 currently walks each top-level cwd-hash entry, checks if the host has
+the same dir, and (if so) scans for first-level filename collisions. Replace
+with:
+
+```swift
+var hasCollision = false
+var collidingPath: URL?
+for entry in entries {
+    let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
+    let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
+
+    // Skip stray non-directory entries at the top level (e.g. .DS_Store).
+    // These get swept explicitly before the final removeItem.
+    var isCwdHashDir: ObjCBool = false
+    guard fm.fileExists(atPath: cwdHashPath.path, isDirectory: &isCwdHashDir),
+          isCwdHashDir.boolValue else { continue }
+
+    if let collision = findCollisionRecursive(src: cwdHashPath, dst: hostCwdHashPath) {
+        hasCollision = true
+        collidingPath = collision
+        break
+    }
+}
+
+if hasCollision {
+    let collisionDesc = collidingPath.map { " (\($0.path))" } ?? ""
+    logger.warning("projects migration incomplete for profile due to file collision\(collisionDesc); symlink will not be created. profile-side \(name, privacy: .public)/ dir preserved.")
+    return
+}
+```
+
+Pass 2 currently walks each top-level cwd-hash entry and does either a
+whole-dir move or a file-by-file move. Replace with:
+
+```swift
+for entry in entries {
+    let cwdHashPath = profileEntry.appendingPathComponent(entry.lastPathComponent)
+    let hostCwdHashPath = hostEntry.appendingPathComponent(entry.lastPathComponent)
+
+    // Same directory-only guard as pass 1 — strays handled by the sweep below.
+    var isCwdHashDir: ObjCBool = false
+    guard fm.fileExists(atPath: cwdHashPath.path, isDirectory: &isCwdHashDir),
+          isCwdHashDir.boolValue else { continue }
+
+    try mergeRecursive(src: cwdHashPath, dst: hostCwdHashPath)
+}
+```
+
+Keep the stray-sweep block immediately after (the `leftover` loop logging
+each stray and `try? fm.removeItem(at: stray)`) unchanged. The final
+`try fm.removeItem(at: profileEntry)` also stays.
+
+Update the doc comment on `ensureMirrorSlot` (the existing block describing
+"atomic with respect to name collisions" etc.) to describe the recursive
+scan instead of the one-level scan. Be precise: "pass 1 walks the full
+tree…", "type mismatches and same-named files are conflicts; same-named
+directories recurse".
+
+**Testing:** see Task 3.
+
+**Verification:**
+Run: `swift build`
+Expected: builds without errors. Existing `ClaudeProfileConfigDirManager`
+test suite should also still pass — most prior AC cases (overlapping
+cwd-hash dirs with disjoint session UUIDs, cwd-only-in-profile, real
+file-vs-file collision) are preserved by the new helpers.
+
+**Commit:** `feat: recursive projects/ merge replaces one-level scan`
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Tests for the recursive behavior
+
+**Verifies:** AC1.1, AC1.2, AC2.1, AC2.2 (plus regression-protect AC3.*)
+
+**Files:**
+- Modify: `Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift`
+
+**Testing:**
+
+All tests use injected `baseDirectory:` and `hostBaseDirectory:` — never
+touch `~/.claude/` or `~/tbd/`. Follow the existing `tempBase()` /
+`tempHostBase()` helpers.
+
+Confirm with `git diff` that the PR #179 collision tests
+(`hostMirrorProjectsMigrationFileCollisionAbortsAtomically`,
+`hostMirrorProjectsMigrationMergesDisjointFiles`,
+`hostMirrorProjectsMigrationMovesProfileOnlyDir`) are still relevant after
+the helper swap — they should be, since their scenarios are well within
+what the recursive merge handles. Read the test file before writing to
+confirm exact existing test names.
+
+New tests:
+
+- **AC1.1 — nested dir-vs-dir with disjoint files merges:**
+  Seed:
+  - `<host>/projects/-cwd-A/sub/host-leaf.md` ("HOST")
+  - `<profile>/claude/projects/-cwd-A/sub/profile-leaf.md` ("PROFILE")
+  Call `ensureOAuthDir`. Assert:
+  - `<host>/projects/-cwd-A/sub/host-leaf.md` content "HOST" (untouched).
+  - `<host>/projects/-cwd-A/sub/profile-leaf.md` content "PROFILE" (moved
+    in).
+  - `<profile>/claude/projects` is a symlink to `<host>/projects/`.
+
+- **AC1.2 — empty profile-side `memory/` merges (the real bug):**
+  Seed `<host>/projects/-cwd-A/memory/note.md` ("HOST NOTE") and an empty
+  `<profile>/claude/projects/-cwd-A/memory/` directory (mkdir-only, no
+  files). Call `ensureOAuthDir`. Assert:
+  - `<host>/projects/-cwd-A/memory/note.md` still "HOST NOTE".
+  - The recursive merge removed the empty `<profile>/claude/projects/-cwd-A/memory/`
+    (or its parents) on the way to the symlink.
+  - `<profile>/claude/projects` is a symlink.
+
+- **AC2.1 — nested file-vs-file collision aborts atomically:**
+  Seed:
+  - `<host>/projects/-cwd-A/sub/leaf.md` ("HOST LEAF")
+  - `<profile>/claude/projects/-cwd-A/sub/leaf.md` ("PROFILE LEAF") —
+    same name, both files
+  Also seed a non-colliding `<profile>/claude/projects/-cwd-B/x.md` so
+  atomicity can be verified.
+  Call `ensureOAuthDir`. Assert:
+  - `<host>/projects/-cwd-A/sub/leaf.md` content still "HOST LEAF".
+  - `<profile>/claude/projects/-cwd-A/sub/leaf.md` content still
+    "PROFILE LEAF".
+  - `<profile>/claude/projects/-cwd-B/x.md` still exists at the profile
+    path (not moved — atomic abort).
+  - `<host>/projects/-cwd-B/` does not exist.
+  - `<profile>/claude/projects` is a real directory, NOT a symlink.
+
+- **AC2.2 — type-mismatch collision aborts atomically:**
+  Seed:
+  - `<host>/projects/-cwd-A/foo` as a *directory* containing some file
+  - `<profile>/claude/projects/-cwd-A/foo` as a *file* with content
+  Call `ensureOAuthDir`. Assert:
+  - Both sides retain their original type and content.
+  - `<profile>/claude/projects` is a real directory, NOT a symlink.
+
+After adding these, run the full filter and confirm prior tests still pass.
+
+**Verification:**
+Run: `swift test --filter ClaudeProfileConfigDirManager`
+Expected: all tests pass, including the new AC1.x / AC2.x and the
+preserved PR #179 cases.
+
+**Commit:** `test: cover recursive collision and merge`
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->
+
+---
+
+## Final verification
+
+- `swift build` — clean.
+- `swift test` — full suite passes (currently 984; will gain ~4).
+- `swift package plugin --allow-writing-to-package-directory swiftlint --strict`
+  — no violations.
+- Manual sanity check (the user is keeping profile 22222 in its broken state
+  on purpose as a regression-test fixture):
+  - Restart TBD via `scripts/restart.sh`.
+  - Attempt swap-profile from the current host conversation to profile
+    22222.
+  - Confirm `<profile>/claude/projects` becomes a symlink to
+    `~/.claude/projects/` and the swap-resume lands in claude with full
+    transcript loaded.

--- a/docs/specs/2026-05-20-recursive-projects-merge-design.md
+++ b/docs/specs/2026-05-20-recursive-projects-merge-design.md
@@ -1,0 +1,153 @@
+# Recursive merge for `projects/` migration
+
+**Date:** 2026-05-20
+**Status:** Design (follow-up to `2026-05-20-file-level-collisions-design.md`)
+
+## Problem
+
+PR #179 made `projects/` collision detection recurse **exactly one level** —
+walk each profile-side cwd-hash directory and check for individual entries
+inside that match host entries. That fixed the dominant case (same cwd worked
+from host and profile, disjoint session UUIDs).
+
+It's still too coarse in one realistic shape: Claude Code's auto-memory
+system creates a `memory/` subdirectory inside each cwd-hash directory,
+alongside the session JSONLs. Encountered live:
+
+- Host: `~/.claude/projects/-Users-chang-projects-longeye-app/` contains
+  many session JSONLs **plus** a `memory/` directory with ~22 markdown
+  notes.
+- Profile 22222: `<profile>/.../projects/-Users-chang-projects-longeye-app/`
+  contains a `memory/` directory too — but **empty**, never populated.
+
+PR #179's check at this level sees `memory` in both → marks it as a
+file-level collision → atomic abort. But these aren't conflicting files —
+they're both *directories*, one full and one empty, with no actual name
+collisions inside.
+
+This blocks swap-profile from any cwd whose profile-side cwd-hash dir
+contains an empty (or merely-disjoint) `memory/` subdirectory. The user
+deliberately kept profile 22222 in this state as a regression test for
+this fix.
+
+## Goal
+
+After this change, the `projects/` migration succeeds whenever **no actual
+file-vs-file (or type-mismatch) collision** exists anywhere in the tree —
+not just at one fixed depth. Same name on both sides where both are
+directories: recurse and merge. Same name where both are files, or types
+differ: abort atomically.
+
+## Out of scope
+
+- Changing the non-`projects/` sidecar policy (verified working in the wild
+  this cycle — `plugins → ~/.claude/plugins`, `settings.json` symlinked,
+  with `.profile-local` sidecars preserving overridden content).
+- Three-way content merge for files that share a name (still treated as a
+  hard conflict that aborts atomically).
+- Anything from prior follow-ups' "Out of scope".
+
+## Approach
+
+Replace PR #179's hand-rolled "one level deep" loops with two recursive
+helpers:
+
+**Pass 1 — collision scan (read-only):**
+```
+findCollisionRecursive(src, dst) -> URL?
+  if dst does not exist:
+    return nil                      // dst absent → src can be moved whole
+  if src and dst types differ (one is file, one is directory):
+    return dst                      // type mismatch is a real collision
+  if both are files:
+    return dst                      // same name + both files → real collision
+  // Both directories. Recurse for each entry in src.
+  for entry in src:
+    if let collision = findCollisionRecursive(entry, dst/entry.name):
+      return collision
+  return nil
+```
+
+**Pass 2 — recursive merge (mutating, only invoked if pass 1 returned nil
+for every cwd-hash dir):**
+```
+mergeRecursive(src, dst) throws
+  if dst does not exist:
+    moveItem(src → dst)             // whole-subtree move
+    return
+  // Pre-checked: dst exists and both are directories. Iterate src.
+  for entry in src:
+    mergeRecursive(entry, dst/entry.name)
+  removeItem(src)                   // src is now empty
+```
+
+These two functions get called from `ensureMirrorSlot`'s `projects/` branch
+in place of the existing per-cwd-hash loops. The "stray non-directory entry
+at the top level" sweep added last cycle is preserved unchanged.
+
+The atomicity guarantee tightens slightly — pass 1 walks the whole tree, not
+just one level. The wall-clock cost is bounded by the number of files in the
+profile's `projects/`, which is small (one user, one machine).
+
+## Why a recursive merge instead of "just recurse two levels"
+
+`memory/` is one example; future Claude Code versions could introduce other
+nested directories under `<cwd-hash>/`. A fixed depth keeps fragility around.
+Recursive merge matches the semantics we actually want — "move src into dst,
+without overwriting any existing file" — and stops being surprised when
+claude adds new subdirectory structures.
+
+## Acceptance criteria
+
+### recursive-projects-merge.AC1: same-name directories merge by recursing
+
+- **AC1.1 Success:** When `<profile>/projects/<cwd>/sub/` and
+  `<host>/projects/<cwd>/sub/` both exist as directories and contain no
+  same-named files between them, migration succeeds: every file inside the
+  profile's tree ends up at the corresponding host path, the profile-side
+  `projects/` is removed, and `<profile>/projects` is a symlink to host.
+- **AC1.2 Success:** When the profile's `memory/` is empty and host's
+  `memory/` has files, migration succeeds and the profile's empty
+  `memory/` (now also empty after recursive descent) is removed alongside
+  the rest of the profile-side `projects/`.
+
+### recursive-projects-merge.AC2: real collisions still abort atomically
+
+- **AC2.1 Success:** A file at `<profile>/projects/<cwd>/sub/leaf.md`
+  whose name also exists at `<host>/projects/<cwd>/sub/leaf.md` (regardless
+  of content) triggers the atomic abort. No moves happen anywhere in the
+  tree; profile-side `projects/` is preserved intact; no symlink created.
+- **AC2.2 Success:** Type-mismatch collision (e.g. host has `foo` as a
+  directory, profile has `foo` as a file at the same logical path) also
+  aborts atomically with no moves.
+
+### recursive-projects-merge.AC3: existing AC1/2 from PR #179 still hold
+
+- **AC3.1 Success:** Top-level cwd-hash dir present only in the profile is
+  still moved whole-tree (PR #179's AC1.2).
+- **AC3.2 Success:** Same-named session JSONLs in both stores still abort
+  atomically (PR #179's AC1.3).
+- **AC3.3 Success:** Non-`projects/` slots still get the
+  `<slot>.profile-local` sidecar treatment unchanged.
+- **AC3.4 Success:** Stray non-directory entries at the top level of
+  `projects/` are still swept by the explicit cleanup before the parent
+  `removeItem`.
+
+## Risks / known limitations
+
+1. **Pre-existing files in deep host subdirs are never overwritten.** This
+   is the design's central guarantee, but it means a profile that had
+   accumulated *content* (not just an empty subdir) in `memory/` whose
+   filenames also exist in host's `memory/` will still abort. Acceptable —
+   no data loss, just requires manual conflict resolution.
+2. **Recursive walk cost grows with file count under `projects/`.** O(N)
+   in profile-side file count. In practice N is small (~hundreds at most).
+
+## Compatibility / migration
+
+- No DB change, no call-site change.
+- Daemon restart re-runs `ensureOAuthDir` / `ensureAPIKeyDir` per profile;
+  the new recursive scan handles the dir-vs-dir case that PR #179 misread
+  as a collision.
+- Profiles that PR #179 successfully migrated have symlinks in place and
+  pass through the idempotent check unchanged.


### PR DESCRIPTION
## Summary

PR #179 made `projects/` collision detection one level deep, expecting `projects/<cwd-hash>/<session>.jsonl`. But Claude Code's auto-memory writes a `memory/` *subdirectory* inside each cwd-hash directory, alongside the session JSONLs. Reproduced live: profile-side `<cwd>/memory/` was empty, host-side `<cwd>/memory/` had ~22 markdown notes — same name at the first level, both are *directories*, with no actual file collisions inside. PR #179's one-level scan saw "memory in both" and atomic-aborted the whole migration → swap-profile still failed.

## What this does

Replace the hand-rolled per-cwd-hash loops with two recursive helpers:

- **`findCollisionRecursive(src:dst:)`** — read-only. Same-name directories on both sides → recurse into children. Same-name files → real collision (no overwrite). Type mismatch (file vs dir) → real collision. Returns the colliding path, or nil if `src` can be merged into `dst` safely.
- **`mergeRecursive(src:dst:)`** — mutating, called only after the pre-check returned nil. Whole-subtree `moveItem` when `dst` doesn't exist; per-child recursion when it does. Removes `src` once empty.

Pass 1 runs `findCollisionRecursive` over every cwd-hash dir; if any returns non-nil, atomic abort with the colliding path logged. Pass 2 runs `mergeRecursive` over each cwd-hash dir, then the existing stray-sweep + `removeItem(profileEntry)` finalizes.

Same atomicity guarantee as PR #179 — just with the right depth. Non-`projects/` sidecar policy unchanged.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 988 tests pass (4 new tests + 31 existing in `ClaudeProfileConfigDirManager`, including the real-world bug case)
- [x] `swiftlint --strict` — 0 violations
- [ ] Merge, restart TBD; the user has profile 22222 preserved in the broken state on disk as a fixture. Spawn / swap to it; confirm `<profile>/claude/projects` migrates to a symlink and `claude --resume` finds the session.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7FA064AB-109F-4F2D-A959-541E334BBFC8)