### PR TITLE
Feat: Pick a Claude profile when starting a session from the + menu

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -80,13 +80,17 @@ extension AppState {
     }
 
     /// Create a Claude terminal in a worktree and add a new tab for it.
-    func createClaudeTerminal(worktreeID: UUID) async {
+    /// `profileID` pins the session to a specific model profile; when nil the
+    /// daemon resolves the profile normally (repo override → global default →
+    /// keychain login).
+    func createClaudeTerminal(worktreeID: UUID, profileID: UUID? = nil) async {
         do {
             let size = mainAreaTerminalSize()
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
                 cmd: nil,
                 type: .claude,
+                overrideProfileID: profileID,
                 cols: size.cols,
                 rows: size.rows
             )

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -261,23 +261,26 @@ enum AddTabMenu {
         shellItem.target = coordinator
         menu.addItem(shellItem)
 
+        let claudeIcon = claudeAsteriskImage()
         let claudeItem = NSMenuItem(
             title: "Claude", action: #selector(MenuCoordinator.addClaude), keyEquivalent: ""
         )
-        claudeItem.image = claudeAsteriskImage()
+        claudeItem.image = claudeIcon
         claudeItem.target = coordinator
         menu.addItem(claudeItem)
 
-        // One indented item per profile, titled with the profile's display
-        // name. The profile id rides along in `representedObject` for
-        // MenuCoordinator.addClaudeProfile.
+        // One item per profile, titled with the profile's display name. Each
+        // gets a transparent placeholder icon the same size as the Claude
+        // asterisk so its title lines up in the same title column as "Claude"
+        // — the empty icon slot is the visual nesting cue. The profile id
+        // rides along in `representedObject` for MenuCoordinator.addClaudeProfile.
         for entry in profiles {
             let item = NSMenuItem(
                 title: entry.profile.name,
                 action: #selector(MenuCoordinator.addClaudeProfile(_:)),
                 keyEquivalent: ""
             )
-            item.indentationLevel = 1
+            item.image = blankIcon(size: claudeIcon.size)
             item.representedObject = entry.profile.id
             item.target = coordinator
             menu.addItem(item)
@@ -314,6 +317,16 @@ enum AddTabMenu {
         label.draw(at: .zero)
         image.unlockFocus()
         image.isTemplate = true
+        return image
+    }
+
+    /// A fully-transparent image used as the icon for profile menu items, so
+    /// their titles align with the "Claude" item's title (the empty icon slot
+    /// is the visual nesting cue). Sized to match `claudeAsteriskImage()`.
+    private static func blankIcon(size: NSSize) -> NSImage {
+        let image = NSImage(size: size)
+        image.lockFocus()   // empty draw pass — produces a transparent representation
+        image.unlockFocus()
         return image
     }
 }

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -88,6 +88,7 @@ struct TabBar: View {
     @Binding var activeTabIndex: Int
     var onAddShell: () -> Void = {}
     var onAddClaude: () -> Void = {}
+    var onAddClaudeProfile: (UUID) -> Void = { _ in }
     var onAddCodex: () -> Void = {}
     var onAddNote: () -> Void = {}
     var onCloseTab: (Int) -> Void
@@ -128,8 +129,10 @@ struct TabBar: View {
                 .frame(width: 1, height: 18)
 
             AddTabButton(
+                profiles: appState.modelProfiles,
                 onAddShell: onAddShell,
                 onAddClaude: onAddClaude,
+                onAddClaudeProfile: onAddClaudeProfile,
                 onAddCodex: onAddCodex,
                 onAddNote: onAddNote
             )
@@ -160,8 +163,10 @@ struct TabBar: View {
 /// swallows hover events, making custom hover styling impossible. Using NSMenu
 /// directly sidesteps this entirely.
 private struct AddTabButton: View {
+    let profiles: [ModelProfileWithUsage]
     let onAddShell: () -> Void
     let onAddClaude: () -> Void
+    let onAddClaudeProfile: (UUID) -> Void
     let onAddCodex: () -> Void
     let onAddNote: () -> Void
     @State private var isHovering = false
@@ -183,64 +188,42 @@ private struct AddTabButton: View {
     }
 
     private func showMenu() {
-        let menu = NSMenu()
-
-        let shellItem = NSMenuItem(title: "Shell", action: nil, keyEquivalent: "")
-        shellItem.image = NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
-        menu.addItem(shellItem)
-
-        let claudeItem = NSMenuItem(title: "Claude", action: nil, keyEquivalent: "")
-        let claudeLabel = NSAttributedString(string: "✳", attributes: [.font: NSFont.systemFont(ofSize: 13)])
-        let claudeLabelSize = claudeLabel.size()
-        let claudeImage = NSImage(size: claudeLabelSize)
-        claudeImage.lockFocus()
-        claudeLabel.draw(at: .zero)
-        claudeImage.unlockFocus()
-        claudeImage.isTemplate = true
-        claudeItem.image = claudeImage
-        menu.addItem(claudeItem)
-
-        let codexItem = NSMenuItem(title: "Codex", action: nil, keyEquivalent: "")
-        codexItem.image = NSImage(systemSymbolName: "chevron.left.forwardslash.chevron.right", accessibilityDescription: nil)
-        menu.addItem(codexItem)
-
-        menu.addItem(.separator())
-
-        let noteItem = NSMenuItem(title: "Note", action: nil, keyEquivalent: "")
-        noteItem.image = NSImage(systemSymbolName: "note.text", accessibilityDescription: nil)
-        menu.addItem(noteItem)
-
-        // Use a coordinator to handle menu item actions via closures
         let coordinator = MenuCoordinator(
-            onShell: onAddShell, onClaude: onAddClaude, onCodex: onAddCodex, onNote: onAddNote
+            onShell: onAddShell,
+            onClaude: onAddClaude,
+            onClaudeProfile: onAddClaudeProfile,
+            onCodex: onAddCodex,
+            onNote: onAddNote
         )
-        shellItem.target = coordinator
-        shellItem.action = #selector(MenuCoordinator.addShell)
-        claudeItem.target = coordinator
-        claudeItem.action = #selector(MenuCoordinator.addClaude)
-        codexItem.target = coordinator
-        codexItem.action = #selector(MenuCoordinator.addCodex)
-        noteItem.target = coordinator
-        noteItem.action = #selector(MenuCoordinator.addNote)
+        let menu = AddTabMenu.build(profiles: profiles, coordinator: coordinator)
 
-        // Keep coordinator alive for the duration of the menu
+        // Keep coordinator alive for the duration of the menu.
         objc_setAssociatedObject(menu, "coordinator", coordinator, .OBJC_ASSOCIATION_RETAIN)
 
         let location = NSEvent.mouseLocation
         menu.popUp(positioning: nil, at: location, in: nil)
     }
-
 }
 
-private class MenuCoordinator: NSObject {
+/// Routes "+" menu clicks from AppKit's target/selector world into SwiftUI
+/// closures. Internal (not private) so AddTabMenu and the unit tests can use it.
+final class MenuCoordinator: NSObject {
     let onShell: () -> Void
     let onClaude: () -> Void
+    let onClaudeProfile: (UUID) -> Void
     let onCodex: () -> Void
     let onNote: () -> Void
 
-    init(onShell: @escaping () -> Void, onClaude: @escaping () -> Void, onCodex: @escaping () -> Void, onNote: @escaping () -> Void) {
+    init(
+        onShell: @escaping () -> Void,
+        onClaude: @escaping () -> Void,
+        onClaudeProfile: @escaping (UUID) -> Void,
+        onCodex: @escaping () -> Void,
+        onNote: @escaping () -> Void
+    ) {
         self.onShell = onShell
         self.onClaude = onClaude
+        self.onClaudeProfile = onClaudeProfile
         self.onCodex = onCodex
         self.onNote = onNote
     }
@@ -249,6 +232,90 @@ private class MenuCoordinator: NSObject {
     @objc func addClaude() { onClaude() }
     @objc func addCodex() { onCodex() }
     @objc func addNote() { onNote() }
+
+    /// Profile menu items carry their `ModelProfile.id` in `representedObject`.
+    /// A nil representedObject (should not happen for profile items) is a no-op.
+    @objc func addClaudeProfile(_ sender: NSMenuItem) {
+        guard let profileID = sender.representedObject as? UUID else { return }
+        onClaudeProfile(profileID)
+    }
+}
+
+// MARK: - AddTabMenu
+
+/// Pure builder for the "+" new-tab NSMenu. Extracted from AddTabButton so the
+/// menu structure (especially the nested Claude profile items) can be
+/// unit-tested without popping up UI.
+enum AddTabMenu {
+    /// Builds the new-tab menu. Profile items are inserted, indented, directly
+    /// below the "Claude" item — clicking one starts a Claude session pinned to
+    /// that profile. With an empty `profiles` list, no profile items appear and
+    /// the menu is identical to the pre-feature menu.
+    static func build(profiles: [ModelProfileWithUsage], coordinator: MenuCoordinator) -> NSMenu {
+        let menu = NSMenu()
+
+        let shellItem = NSMenuItem(
+            title: "Shell", action: #selector(MenuCoordinator.addShell), keyEquivalent: ""
+        )
+        shellItem.image = NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
+        shellItem.target = coordinator
+        menu.addItem(shellItem)
+
+        let claudeItem = NSMenuItem(
+            title: "Claude", action: #selector(MenuCoordinator.addClaude), keyEquivalent: ""
+        )
+        claudeItem.image = claudeAsteriskImage()
+        claudeItem.target = coordinator
+        menu.addItem(claudeItem)
+
+        // One indented item per profile, titled with the profile's display
+        // name. The profile id rides along in `representedObject` for
+        // MenuCoordinator.addClaudeProfile.
+        for entry in profiles {
+            let item = NSMenuItem(
+                title: entry.profile.name,
+                action: #selector(MenuCoordinator.addClaudeProfile(_:)),
+                keyEquivalent: ""
+            )
+            item.indentationLevel = 1
+            item.representedObject = entry.profile.id
+            item.target = coordinator
+            menu.addItem(item)
+        }
+
+        let codexItem = NSMenuItem(
+            title: "Codex", action: #selector(MenuCoordinator.addCodex), keyEquivalent: ""
+        )
+        codexItem.image = NSImage(
+            systemSymbolName: "chevron.left.forwardslash.chevron.right", accessibilityDescription: nil
+        )
+        codexItem.target = coordinator
+        menu.addItem(codexItem)
+
+        menu.addItem(.separator())
+
+        let noteItem = NSMenuItem(
+            title: "Note", action: #selector(MenuCoordinator.addNote), keyEquivalent: ""
+        )
+        noteItem.image = NSImage(systemSymbolName: "note.text", accessibilityDescription: nil)
+        noteItem.target = coordinator
+        menu.addItem(noteItem)
+
+        return menu
+    }
+
+    /// Renders the ✳ glyph as a template image for the Claude menu item.
+    private static func claudeAsteriskImage() -> NSImage {
+        let label = NSAttributedString(
+            string: "✳", attributes: [.font: NSFont.systemFont(ofSize: 13)]
+        )
+        let image = NSImage(size: label.size())
+        image.lockFocus()
+        label.draw(at: .zero)
+        image.unlockFocus()
+        image.isTemplate = true
+        return image
+    }
 }
 
 // MARK: - TabBarItem

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -157,6 +157,14 @@ struct SingleWorktreeView: View {
                                 selectLastTab()
                             }
                         },
+                        onAddClaudeProfile: { profileID in
+                            Task {
+                                await appState.createClaudeTerminal(
+                                    worktreeID: worktreeID, profileID: profileID
+                                )
+                                selectLastTab()
+                            }
+                        },
                         onAddCodex: {
                             Task {
                                 await appState.createCodexTerminal(worktreeID: worktreeID)

--- a/Tests/TBDAppTests/AddTabMenuTests.swift
+++ b/Tests/TBDAppTests/AddTabMenuTests.swift
@@ -33,7 +33,7 @@ private func claudeIndex(_ menu: NSMenu) -> Int {
 // MARK: - AddTabMenu.build
 
 @MainActor
-@Test func addTabMenu_withNoProfiles_hasNoIndentedItems() {
+@Test func addTabMenu_withNoProfiles_insertsNoProfileItems() {
     let menu = AddTabMenu.build(profiles: [], coordinator: makeCoordinator())
 
     let idx = claudeIndex(menu)
@@ -52,11 +52,13 @@ private func claudeIndex(_ menu: NSMenu) -> Int {
     let second = menu.items[idx + 2]
 
     #expect(first.title == "Work")
-    #expect(first.indentationLevel == 1)
+    #expect(first.indentationLevel == 0)
+    #expect(first.image != nil)
     #expect(first.representedObject as? UUID == work.profile.id)
 
     #expect(second.title == "Personal")
-    #expect(second.indentationLevel == 1)
+    #expect(second.indentationLevel == 0)
+    #expect(second.image != nil)
     #expect(second.representedObject as? UUID == personal.profile.id)
 
     #expect(menu.items[idx + 3].title == "Codex")

--- a/Tests/TBDAppTests/AddTabMenuTests.swift
+++ b/Tests/TBDAppTests/AddTabMenuTests.swift
@@ -1,0 +1,116 @@
+import AppKit
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// MARK: - Helpers
+
+private func makeProfile(name: String) -> ModelProfileWithUsage {
+    ModelProfileWithUsage(
+        profile: ModelProfile(id: UUID(), name: name, kind: .oauth),
+        usage: nil
+    )
+}
+
+private func makeCoordinator(
+    onClaudeProfile: @escaping (UUID) -> Void = { _ in }
+) -> MenuCoordinator {
+    MenuCoordinator(
+        onShell: {},
+        onClaude: {},
+        onClaudeProfile: onClaudeProfile,
+        onCodex: {},
+        onNote: {}
+    )
+}
+
+/// Index of the menu item titled "Claude".
+private func claudeIndex(_ menu: NSMenu) -> Int {
+    menu.items.firstIndex { $0.title == "Claude" }!
+}
+
+// MARK: - AddTabMenu.build
+
+@MainActor
+@Test func addTabMenu_withNoProfiles_hasNoIndentedItems() {
+    let menu = AddTabMenu.build(profiles: [], coordinator: makeCoordinator())
+
+    let idx = claudeIndex(menu)
+    #expect(menu.items[idx + 1].title == "Codex")
+    #expect(menu.items.allSatisfy { $0.indentationLevel == 0 })
+}
+
+@MainActor
+@Test func addTabMenu_withProfiles_insertsIndentedItemsAfterClaude() {
+    let work = makeProfile(name: "Work")
+    let personal = makeProfile(name: "Personal")
+    let menu = AddTabMenu.build(profiles: [work, personal], coordinator: makeCoordinator())
+
+    let idx = claudeIndex(menu)
+    let first = menu.items[idx + 1]
+    let second = menu.items[idx + 2]
+
+    #expect(first.title == "Work")
+    #expect(first.indentationLevel == 1)
+    #expect(first.representedObject as? UUID == work.profile.id)
+
+    #expect(second.title == "Personal")
+    #expect(second.indentationLevel == 1)
+    #expect(second.representedObject as? UUID == personal.profile.id)
+
+    #expect(menu.items[idx + 3].title == "Codex")
+}
+
+@MainActor
+@Test func addTabMenu_nonProfileItems_keepCorrectWiring() {
+    // Hold a strong reference: NSMenuItem.target is weak.
+    let coordinator = makeCoordinator()
+    let menu = AddTabMenu.build(profiles: [], coordinator: coordinator)
+
+    func item(_ title: String) -> NSMenuItem {
+        menu.items.first { $0.title == title }!
+    }
+
+    let shell = item("Shell")
+    #expect(shell.action == #selector(MenuCoordinator.addShell))
+    #expect(shell.target as? MenuCoordinator === coordinator)
+
+    #expect(item("Claude").action == #selector(MenuCoordinator.addClaude))
+    #expect(item("Codex").action == #selector(MenuCoordinator.addCodex))
+    #expect(item("Note").action == #selector(MenuCoordinator.addNote))
+}
+
+@MainActor
+@Test func addTabMenu_profileItems_useAddClaudeProfileSelector() {
+    let work = makeProfile(name: "Work")
+    let menu = AddTabMenu.build(profiles: [work], coordinator: makeCoordinator())
+
+    let item = menu.items[claudeIndex(menu) + 1]
+    #expect(item.action == #selector(MenuCoordinator.addClaudeProfile(_:)))
+}
+
+// MARK: - MenuCoordinator.addClaudeProfile
+
+@MainActor
+@Test func menuCoordinator_addClaudeProfile_forwardsRepresentedObjectUUID() {
+    var received: UUID?
+    let coordinator = makeCoordinator { received = $0 }
+
+    let profileID = UUID()
+    let item = NSMenuItem()
+    item.representedObject = profileID
+    coordinator.addClaudeProfile(item)
+
+    #expect(received == profileID)
+}
+
+@MainActor
+@Test func menuCoordinator_addClaudeProfile_withNilRepresentedObject_isNoOp() {
+    var called = false
+    let coordinator = makeCoordinator { _ in called = true }
+
+    coordinator.addClaudeProfile(NSMenuItem())
+
+    #expect(called == false)
+}

--- a/docs/superpowers/specs/2026-05-20-claude-profiles-in-new-menu-design.md
+++ b/docs/superpowers/specs/2026-05-20-claude-profiles-in-new-menu-design.md
@@ -1,0 +1,110 @@
+# Claude profiles in the "+" new-session menu
+
+**Date:** 2026-05-20
+**Status:** Approved design
+
+## Problem
+
+TBD supports multiple Claude model profiles (OAuth/API-key/Bedrock), but the "+"
+tab menu only offers a single "Claude" option. That option spawns a session
+whose profile is resolved by the existing precedence chain (per-repo override →
+global `defaultProfileID` → keychain login). There is no way to start a new
+Claude session pinned to a *specific* profile — the user must spawn a session
+and then use the "Swap profile" context menu, which forks the session.
+
+## Goal
+
+List the configured Claude profiles directly in the "+" menu, nested under the
+existing "Claude" item, so a user can start a session on a chosen profile in one
+click. The plain "Claude" item keeps its current behavior unchanged.
+
+## Behavior
+
+The "+" menu becomes:
+
+```
+  Shell
+  Claude               ← click = default (unchanged resolution chain)
+    Work (sonnet)       ← indented; click = spawn pinned to this profile
+    Personal (oauth)
+    Bedrock (us-east-1)
+  Codex
+  ──────────
+  Note
+```
+
+- The "Claude" item stays a direct, clickable `NSMenuItem` (no submenu). Clicking
+  it spawns a default Claude session exactly as today.
+- Below it, one indented item per configured profile, in the same order as
+  `appState.modelProfiles`. Clicking one spawns a Claude session pinned to that
+  profile via `overrideProfileID`.
+- Item labels reuse the existing `formatProfileSubmenuLabel()` formatter used by
+  the "Swap profile" context menu, for consistency. No "Claude ·" prefix —
+  indentation conveys that they are Claude sessions.
+- If no profiles are configured, only the plain "Claude" item shows; no
+  sub-items, no separator.
+- The "Codex" and "Note" items are unchanged.
+- The menu is rebuilt on every open (`showMenu()`), so the profile list is
+  always current; no refresh logic needed.
+
+## Scope
+
+This is a UI-only change. `overrideProfileID` already flows end-to-end
+(`TerminalCreateParams.overrideProfileID` → `handleTerminalCreate` → daemon
+resolves and pins it → `Terminal.profileID` is stored). No daemon, RPC-protocol,
+or database changes are required.
+
+## Components & data flow
+
+1. **`Sources/TBDApp/TabBar.swift` — `AddTabButton`**
+   - Gains an input for the profile list (`[ModelProfileWithUsage]`, sourced from
+     `appState.modelProfiles`) and a new callback `onAddClaudeProfile: (UUID) -> Void`.
+   - `showMenu()` inserts indented `NSMenuItem`s immediately after the "Claude"
+     item. Each carries its profile `UUID` in `representedObject` and uses
+     `indentationLevel = 1`.
+
+2. **`Sources/TBDApp/TabBar.swift` — `MenuCoordinator`**
+   - Gains one new `@objc` action, `addClaudeProfile(_ sender: NSMenuItem)`,
+     which reads `sender.representedObject as? UUID` and forwards it to the
+     `onAddClaudeProfile` closure. A single selector + `representedObject` is used
+     rather than one selector per profile.
+   - The coordinator must be retained for the menu's lifetime exactly as the
+     existing one is (it is currently held via the menu's `representedObject` /
+     associated reference — match whatever the current code does).
+
+3. **`Sources/TBDApp/TabBar.swift` — `TabBar.body`**
+   - Passes `appState.modelProfiles` into `AddTabButton`.
+   - Wires `onAddClaudeProfile` to `Task { await appState.createClaudeTerminal(worktreeID:, profileID:) }`.
+
+4. **`Sources/TBDApp/AppState+Terminals.swift` — `createClaudeTerminal()`**
+   - Gains an optional parameter `profileID: UUID? = nil`, forwarded as the
+     `overrideProfileID` argument of the `daemonClient.createTerminal(...)` call.
+   - Existing call sites pass nothing and are unaffected (still send `nil`).
+
+## Error handling
+
+No new failure modes. Spawning a profile-pinned session uses the identical RPC
+path as the existing "Claude" item; daemon-side resolution failures already fall
+back to keychain login with a logged warning.
+
+## Testing
+
+Per CLAUDE.md, the new conditional (profile-pinned vs. default spawn) gets a test
+for each branch.
+
+- **Menu construction:** Given N profiles, the items produced by `showMenu()`'s
+  building logic contain the plain "Claude" item plus N indented items whose
+  `representedObject` UUIDs match the input profiles in order. Given zero
+  profiles, only the plain "Claude" item is present (no sub-items, no extra
+  separator). If menu building is not currently unit-testable, extract the
+  item-list construction into a pure helper function and test that.
+- **`createClaudeTerminal(profileID:)`:** Calling with a profile UUID sends that
+  value as `overrideProfileID`; calling with no argument sends `nil`. Both
+  branches verified.
+
+## Out of scope
+
+- Codex profiles (Codex has no model-profile concept here).
+- Reordering or grouping profiles, or marking which profile the plain "Claude"
+  item resolves to.
+- Any change to the "Swap profile" context menu on existing tabs.


### PR DESCRIPTION
## Summary
- The "+" tab menu only offered a single "Claude" option, so starting a session on a non-default model profile meant spawning one and then forking it via the "Swap profile" context menu. This adds each configured Claude profile to the "+" menu, listed under the "Claude" item, so you can start a session pinned to a chosen profile in one click.
- The plain "Claude" item is unchanged — it still spawns a default session whose profile resolves the usual way (repo override → global default → keychain login). Profile items pass an explicit `overrideProfileID`; no daemon, RPC, or DB changes were needed since that parameter already flows end to end.
- Menu construction was extracted from `AddTabButton` into a pure, testable `AddTabMenu` builder. Profile items use a transparent placeholder icon so their titles align with the "Claude" item's title, with the empty icon slot as the nesting cue.

## Test plan
- [ ] `swift build` and `swift test` pass (994 tests; 6 new in `AddTabMenuTests`).
- [ ] With profiles configured, the "+" menu shows them indented under "Claude", then Codex / separator / Note.
- [ ] Clicking "Claude" starts a default session; clicking a profile starts one pinned to it (verify via the new tab's "Swap profile" context-menu header).
- [ ] With no profiles configured, only "Claude" shows — no sub-items.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B79FB2AE-D7FA-41D6-9B34-0FC7D5DA2F56)