### PR TITLE
perf: drop withAnimation around transcript scrollTo (#129)

### DIFF
--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -147,9 +147,7 @@ struct LiveTranscriptPaneView: View {
                 guard let _ = oldID, let _ = newID, atBottom else { return }
                 guard let targetID = lastRenderedNodeID(for: messages) else { return }
                 let scrollInterval = TranscriptSignposts.signposter.beginInterval("transcript.scrollTo")
-                withAnimation(.easeOut(duration: 0.15)) {
-                    proxy.scrollTo(targetID, anchor: .bottom)
-                }
+                proxy.scrollTo(targetID, anchor: .bottom)
                 TranscriptSignposts.signposter.endInterval("transcript.scrollTo", scrollInterval)
             }
             .onChange(of: messages.count) { _, newCount in
@@ -179,9 +177,7 @@ struct LiveTranscriptPaneView: View {
             Button {
                 guard let lastID = lastRenderedNodeID(for: messages) else { return }
                 let scrollInterval = TranscriptSignposts.signposter.beginInterval("transcript.scrollTo")
-                withAnimation(.easeOut(duration: 0.2)) {
-                    proxy.scrollTo(lastID, anchor: .bottom)
-                }
+                proxy.scrollTo(lastID, anchor: .bottom)
                 TranscriptSignposts.signposter.endInterval("transcript.scrollTo", scrollInterval)
             } label: {
                 Image(systemName: "arrow.down.circle.fill")


### PR DESCRIPTION
## Summary

Removes `withAnimation(...)` wrappers around `proxy.scrollTo(...)` at both call sites in `LiveTranscriptPaneView.swift`:

1. `.onChange(of: messages.last?.id)` autoscroll handler
2. Jump-to-bottom button

This is **option #4** from the post-PR-#137 brief at `docs/superpowers/specs/2026-05-12-transcript-flex-frame-post-pr137-brief.md` — never previously tested, and now the prime suspect after two fresh spindumps on the same git HEAD captured 48 minutes apart.

## Why

Each `withAnimation` opens a 150-200ms transaction that interpolates the scroll position, and during each interpolated frame the `LazyVStack` remeasures. A burst of message arrivals (subagent reply, tool output, multiple `TranscriptItem`s in one 1.5s poll) fires `.onChange` repeatedly, layering animations and producing the classic "state mutated during layout → re-layout → more state mutation" feedback loop.

`freeze2.log` (19.74s hang) shows exactly this signature:
- `LazyLayoutCacheItem.AllItemsPhaseMutation` in 3/25 samples — every lazy row dirtied mid-transaction
- `ValueActionDispatcher.updateValue` — a SwiftUI state action fired inside the layout transaction
- `DynamicLayoutViewChildGeometry.updateValue → AGGraphSetOutputValue` — geometry written back to the attribute graph mid-transaction
- Plus the steady-state `StackLayout ↔ _FlexFrameLayout ↔ ViewLayoutEngine.sizeThatFits` recursion under `LazySubviewPlacements.placeSubviews` already seen in `freeze.log` (1.06s).

The hang grew 20× as the session accumulated rows — consistent with O(rows × animations × frames) work per burst.

Signpost intervals around the call sites are intentionally **kept** so `HangWatchdog` can continue to attribute future stalls to `transcript.scrollTo` if the issue recurs in another form.

## Linked issue

Closes #129 (pending validation).

## Validation plan

This is a behavioral fix that can only be validated empirically. After merging / pulling locally:

1. Restart via `scripts/restart.sh` (per CLAUDE.md — do NOT use the main project's copy).
2. Drive several minutes of bursty transcript activity (subagent runs, parallel tool calls, long tool outputs).
3. If a stall is observed, capture a spindump: `sudo spindump TBDApp 10 -file /tmp/freeze3.log`.
4. Confirm the trace **no longer contains**:
   - `LazyLayoutCacheItem.AllItemsPhaseMutation`
   - `ValueActionDispatcher.updateValue` inside a layout transaction
   - `DynamicLayoutViewChildGeometry.updateValue → AGGraphSetOutputValue`
5. The residual `StackLayout/_FlexFrameLayout` recursion may still appear in steady state — that's a separate symptom (option #1/#2 in the brief) and not in scope here.

## Notes

- `swift build`: PASS (103s, only pre-existing warnings).
- SwiftLint: PASS via direct binary (`.build/artifacts/.../swiftlint lint --strict`, exit 0). The `swift package plugin swiftlint` invocation crashes in this environment loading `sourcekitdInProc.framework` from CommandLineTools — this is a known SPM plugin sandbox/DYLD issue unrelated to the change. CI (which has a full Xcode) will run cleanly.
- No other files touched (no `contentAreaHeight` cleanup, no comment churn).

[🧊 Diagnose Freeze 129](https://cheapsteak.github.io/tbd/open/?worktree=9C6CE4AE-88D4-429A-9C58-306FF01ACDEA)