### PR TITLE
Compound: Resync the tbd-project skill so changelog scouts stop re-proposing shipped features

### DIFF
--- a/.claude/skills/tbd-project/SKILL.md
+++ b/.claude/skills/tbd-project/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: tbd-project
-description: TBD project knowledge — architecture, components, and conventions. Use when working on the TBD codebase, adding features, fixing bugs, or understanding how the system works. Triggers on questions about the daemon, CLI, SwiftUI app, tmux integration, worktree lifecycle, or RPC protocol.
+description: TBD project knowledge — architecture, components, and conventions. Use when working on the TBD codebase, adding features, fixing bugs, or understanding how the system works. Triggers on questions about the daemon, CLI, SwiftUI app, tmux integration, worktree lifecycle, session instrumentation, or RPC protocol.
 ---
+
+<!-- skill-synced-through: 7c9ba0f (2026-05-21) -->
+<!-- Next maintainer: run `git log 7c9ba0f..HEAD -- Sources/` to find drift since this sync. -->
 
 # TBD Project Guide
 
@@ -28,9 +31,13 @@ For a map of key files and what they do: consult `references/file-map.md`
 
 ## Key Conventions
 
+### Config directory is `~/tbd`, not `~/.tbd`
+
+Every daemon-managed path lives under `~/tbd/` (no dot): `~/tbd/state.db`, `~/tbd/sock`, `~/tbd/tbdd.pid`, `~/tbd/port`, `~/tbd/repos/`, `~/tbd/runtime/`, `~/tbd/worktrees/`. `TBDConstants.configDir` honors `TBD_HOME` (and `TBD_SOCKET_PATH` for the socket alone) so tests never collide with the live daemon — see CLAUDE.md.
+
 ### SPM Package Structure
 
-Four targets in one package — `TBDShared` (library), `TBDDaemonLib` (library), `TBDDaemon` (executable, just main.swift), `TBDCLI` (executable), `TBDApp` (executable). Tests import `TBDDaemonLib`, not `TBDDaemon`.
+Five targets in one package — `TBDShared` (library), `TBDDaemonLib` (library), `TBDDaemon` (executable, just main.swift), `TBDCLI` (executable), `TBDApp` (executable). Tests import `TBDDaemonLib`, not `TBDDaemon`.
 
 The `TBDDaemon` and `TBDDaemonLib` targets share `Sources/TBDDaemon/` — `TBDDaemonLib` excludes `main.swift`, `TBDDaemon` only includes `main.swift` and excludes all subdirectories.
 
@@ -46,38 +53,55 @@ Uses **grouped sessions** — NOT control mode. Each terminal panel creates a gr
 
 All git commands use `Process.arguments` arrays — never shell string interpolation (prevents command injection). GitManager methods are async, using `terminationHandler` with `CheckedContinuation`.
 
-### Hooks
+### Worktree Hooks
 
-Resolution order (first match wins, no chaining): app per-repo config → conductor.json → .dmux-hooks → global default. This avoids double-execution when dmux hooks call conductor scripts internally.
+Lifecycle hooks (`setup`, `archive`, `preMerge`, `postMerge`) resolve in priority order (first match wins): app per-repo config → `.worktree-hooks/` → `conductor.json` (deprecated) → `.dmux-hooks/` (deprecated) → global default (`~/tbd/hooks/default/`). `.worktree-hooks/` is the supported in-repo location; the conductor/dmux entries only survive for backward compatibility and log a migration hint. See `docs/worktree-hooks.md`.
+
+> Do not confuse these with **Claude session hooks** — see "Session Instrumentation" below.
 
 ### Testing
 
-Tests use Swift Testing framework (`import Testing`, `@Test`, `#expect`), not XCTest. Import `TBDDaemonLib` for daemon tests. Database tests use in-memory `DatabaseQueue`.
+Tests use Swift Testing framework (`import Testing`, `@Test`, `#expect`), not XCTest. Import `TBDDaemonLib` for daemon tests. Database tests use in-memory `DatabaseQueue`. Tests must isolate from `~/tbd` and `UserDefaults` (see CLAUDE.md).
 
 ### Adding New RPC Methods
 
 1. Add method constant to `RPCMethod` in `Sources/TBDShared/RPCProtocol.swift`
 2. Add param/result structs in the same file
-3. Add handler in `Sources/TBDDaemon/Server/RPCRouter.swift`
+3. Add handler in the appropriate `Sources/TBDDaemon/Server/RPCRouter+*Handlers.swift` extension
 4. Add client method in `Sources/TBDApp/DaemonClient.swift`
-5. Add CLI command in `Sources/TBDCLI/Commands/`
-6. Broadcast state delta if mutation
+5. Add CLI command in `Sources/TBDCLI/Commands/` (if user-facing)
+6. Broadcast a `StateDelta` if the method mutates state
 
-### Worktree Names
+### Worktree Names & Location
 
-Auto-generated as `YYYYMMDD-adjective-animal` from curated word lists (sourced from unique-names-generator). Branch: `tbd/<name>`. Path: `<repo>/.tbd/worktrees/<name>/`.
+Auto-generated as `YYYYMMDD-adjective-animal` from curated word lists (sourced from unique-names-generator). Branch: `tbd/<name>`. New worktrees are created under `~/tbd/worktrees/<repo-slot>/<name>/`. Worktrees created before the canonical-location switch still live at `<repo>/.tbd/worktrees/<name>/` and are read from both prefixes for backward compatibility.
+
+## Session Instrumentation
+
+TBD instruments every `claude` (and `codex`) session it spawns so the app can observe and drive them. Three mechanisms, all set up at daemon startup (`Daemon.start()`):
+
+- **TBD plugin** — `PluginDirWriter` writes a Claude Code plugin to `~/Library/Application Support/TBD/plugin/` (`.claude-plugin/plugin.json` + `skills/tbd/SKILL.md`). The bundled skill body is `TBDSkillContent.body` (single source of truth, also dropped to a failsafe path by `SkillFileWriter`). `ClaudeSpawnCommandBuilder` appends `--plugin-dir <path>` to every spawned `claude`, so the `tbd` skill is available *only* in TBD-spawned sessions, never globally.
+
+- **Settings overlay** — `ClaudeHookOverlay` writes `~/tbd/runtime/claude-overlay.json` and the spawn builder appends `--settings <path>`. Claude merges array settings (the `hooks` dict) with the user's `~/.claude/settings.json` rather than replacing it, so TBD ships hooks without touching user config. The overlay registers: `SessionStart` (`tbd session-event` → relays new session id + transcript path to the daemon, fixing the post-`/clear`/`/compact` transcript freeze), `Stop` (two entries — `tbd notify` for response-complete notifications, and `tbd hooks stop-rename-check` to prompt renaming a still-default worktree), and `PreToolUse`/`PostToolUse` matched on `AskUserQuestion` (bridge the question into the transcript pane before the JSONL flush).
+
+- **Codex sessions** — `CodexHomeManager` gives Codex a per-repo isolated `CODEX_HOME` with its own hooks + bundled `tbd` skill, so Codex is instrumented equivalently without polluting `~/.codex/`.
+
+The overlay and plugin are regenerated on every daemon startup; both writes are idempotent and non-fatal on failure (the session just loses instrumentation, it still runs).
 
 ## Common Tasks
 
 ### Restart for testing
 ```bash
-scripts/restart.sh          # rebuild + restart (~2s)
-scripts/restart.sh --app    # app only
+scripts/restart.sh          # rebuild + restart (~2s) — always use the worktree-relative path
+scripts/restart.sh --app    # app only (NOT for daemon/shared changes)
 scripts/restart.sh --quick  # skip build
 ```
 
 ### Debug terminal rendering
 Check `/tmp/tbd-bridge.log` for tmux bridge diagnostics.
+
+### Diagnostics
+Use `os.Logger` with the `com.tbd.app` / `com.tbd.daemon` subsystems — no `print()` in `Sources/` (SwiftLint-enforced; `TBDCLI` excepted). Stream a feature area: `log stream --level debug --predicate 'subsystem BEGINSWITH "com.tbd"'`. Full guide: `docs/diagnostics-strategy.md`.
 
 ### Debug SwiftUI layout / positioning
 Add colored borders at each layer of the modifier chain to visualize what occupies what space:

--- a/.claude/skills/tbd-project/references/architecture.md
+++ b/.claude/skills/tbd-project/references/architecture.md
@@ -153,16 +153,16 @@ JSON-RPC style over Unix socket (newline-delimited) and HTTP POST `/rpc`. Method
 
 - **Repo**: `repo.add`, `repo.remove`, `repo.list`, `repo.rename`, `repo.relocate`, `repo.updateInstructions`, hidden/expanded toggles
 - **Worktree**: `worktree.create`, `.list`, `.archive`, `.revive`, `.adopt`, `.rename`, `.reorder`, `.move` (reparent), `.selectionChanged`, `.suspend`, `.resume`
-- **Terminal**: `terminal.create` (`type`/`prompt`), `.list`, `.send` (`submit`), `.delete`, `.setPin`, `.output`, `.conversation`, `.transcript`, `.suspend`, `.resume`, `.recreateWindow`
-- **Tab**: set label, set order, list, set active tab
-- **Session**: `session.list`, `session.messages` — list/parse Claude JSONL transcripts; plus the `session-event` bridge that records SessionStart hook data
-- **AskUserQuestion**: pre/post bridge handlers backed by `PendingQuestionStore`
-- **Model profile**: CRUD + global default + usage
+- **Terminal**: `terminal.create` (`type`/`prompt`), `.list`, `.send` (`submit`), `.delete`, `.setPin`, `.output`, `.conversation`, `.transcript`, `.transcriptItemFullBody`, `.suspend`, `.resume`, `.recreateWindow`, `.swapProfile`
+- **Tab**: `tab.setLabel`, `tab.setOrder`, `tab.list`, `worktree.setActiveTab`
+- **Session**: `session.list`, `session.messages` — list/parse Claude JSONL transcripts; plus `terminal.sessionEvent` (SessionStart hook bridge)
+- **AskUserQuestion**: `terminal.askUserQuestionPending` / `terminal.askUserQuestionCleared`, backed by `PendingQuestionStore`
+- **Model profile**: `modelProfile.list`/`.add`/`.delete`/`.rename`/`.updateEndpoint`/`.updateBedrock`/`.setGlobalDefault`/`.setRepoOverride`/`.fetchUsage`/`.healthCheck`
 - **Notification**: `notify`, `notifications.list`, `notifications.markRead`
 - **PR**: `pr.list`, `pr.refresh`
 - **Note**: `note.create`/`.get`/`.update`/`.delete`/`.list`
-- **Legacy hooks**: scan + remove legacy globally-installed `tbd` hook entries
-- **Meta**: `daemon.status`, `resolve.path`, `cleanup`, `state.subscribe`
+- **Legacy hooks**: `daemon.legacyHooksStatus`, `daemon.removeLegacyGlobalHooks`
+- **Meta**: `daemon.status`, `resolve.path`, `cleanup`, `state.subscribe`, `app.setForegroundState`, `app.setMainAreaSize`
 
 ## CLI Commands
 

--- a/.claude/skills/tbd-project/references/architecture.md
+++ b/.claude/skills/tbd-project/references/architecture.md
@@ -2,77 +2,92 @@
 
 ## System Overview
 
-Three components, one SPM package:
+Three components, one SPM package. All daemon-managed paths live under `~/tbd/` (no dot — `TBDConstants.configDir`, overridable via `TBD_HOME`).
 
 ### tbdd (Daemon)
 Long-running headless process. Owns all state and logic.
-- **SQLite** at `~/.tbd/state.db` — worktree ledger, repo list, per-repo config (WAL mode, GRDB)
-- **Unix socket** at `~/.tbd/sock` — primary RPC interface
-- **HTTP** on localhost (port in `~/.tbd/port`) — for debugging/curl
+- **SQLite** at `~/tbd/state.db` — worktree ledger, repo list, terminals, notes, tabs, model profiles (WAL mode, GRDB)
+- **Unix socket** at `~/tbd/sock` — primary RPC interface
+- **HTTP** on localhost (port in `~/tbd/port`) — for debugging/curl
 - **Tmux manager** — one tmux server per repo (`tbd-<djb2-hash-of-repo-path>`), creates/destroys windows
 - **Git manager** — fetch, worktree add/remove/list, conflict check, headSHA, merge-base ancestry
-- **Hook executor** — resolves and runs hooks per priority chain
-- **Worktree lifecycle** — orchestrates create/archive/revive/reconcile + conflict detection
+- **Hook resolver** — resolves and runs worktree lifecycle hooks per priority chain
+- **Worktree lifecycle** — orchestrates create/archive/revive/adopt/reconcile + conflict detection, parent/lineage resolution
 - **PR status manager** — polls GitHub for PR state (open/merged/closed, mergeable) per worktree
 - **SSH agent resolver** — finds live SSH agent socket, maintains `~/.ssh/tbd-agent.sock` symlink
 - **Suspend/resume coordinator** — auto-suspends idle Claude sessions on worktree deselection, supports manual suspend/resume
-- **Conductor manager** — meta-agent sessions scoped across repos
-- **State broadcaster** — pushes deltas to subscribed clients (worktree CRUD, notifications, conflict changes, terminal pins, reorder)
-- **Background git fetch** — periodic fetch (every 60s) for all repos
-- **PID file** at `~/.tbd/tbdd.pid`
+- **Model profile resolver** — picks the credential profile (oauth/apiKey/proxy/bedrock) for a spawned Claude session
+- **Claude usage poller** — polls Claude OAuth usage every 30 min, broadcasts to clients
+- **Session instrumentation writers** — `PluginDirWriter`, `ClaudeHookOverlay`, `SkillFileWriter`, `CodexHomeManager` (see "Session Instrumentation")
+- **State broadcaster** — pushes `StateDelta` events to subscribed clients
+- **Background tasks** — git fetch (60s), git status/conflict refresh (10s), SSH refresh (60s)
+- **PID file** at `~/tbd/tbdd.pid`
 
 ### TBDApp (SwiftUI)
 Connects to daemon on launch (starts it if not running). Stateless except for UI layout.
-- **Sidebar** — collapsible repo sections, worktree rows with PR status icons/badges/inline rename, context menus, drag-to-reorder
-- **Tab system** — generic Tab model wrapping PaneContent (.terminal/.webview/.codeViewer/.note), per-worktree tab list
-- **Pane types** — terminal (TBDTerminalView), webview (WKWebView), code viewer (Highlightr syntax highlighting), note (freeform text editor)
-- **Terminal rendering** — grouped tmux sessions + direct PTY attachment (NOT control mode)
+- **Sidebar** — collapsible repo sections, nested worktree rows (lineage by spawner), PR status icons/badges, inline rename, drag-to-reorder, repo hide/remove, sidebar extends under the titlebar
+- **Tab system** — generic Tab model wrapping `PaneContent` (`.terminal`/`.webview`/`.codeViewer`/`.note`/`.liveTranscript`/`.history`); tabs are renameable, reorderable, and DB-persisted
+- **Pane types** — terminal, webview (WKWebView), code viewer (Highlightr), note (text editor), live transcript (Claude conversation as chat), history (past sessions)
+- **Transcript pane** — renders a Claude session's JSONL as a chat UI with per-tool cards (Read/Write/Edit/Bash/Grep/Glob/Agent/AskUserQuestion/...), context-usage badge, subagent expansion; retargets automatically when the session id rolls over
+- **Terminal rendering** — grouped tmux sessions + direct PTY attachment (NOT control mode); customizable font, colors, cursor
 - **Pinned terminal dock** — vertical dock showing pinned terminals from worktrees not currently visible
-- **Conductor overlay** — Guake-style dropdown triggered by Opt+. hotkey
-- **State polling** — refreshes repos/worktrees/terminals/notifications every 2s via batched RPCs; state.subscribe stream for push deltas
-- **Layout persistence** — per-tab `LayoutNode` tree (using .pane(PaneContent)) in UserDefaults
-- **Optimistic UI** — worktree creation inserts placeholder immediately, replaced when RPC returns; pendingWorktreeIDs prevents polling from clobbering placeholders
-- **AppState split** — base (properties/polling/connection) + Repos + Worktrees + Terminals + Notifications + Notes extensions
+- **Jump menu** — Cmd-K palette that jumps to the worktree that just pinged
+- **Navigation history** — browser-style back/forward across recently selected worktrees
+- **State sync** — batched polling + `state.subscribe` stream for push deltas
+- **AppState split** — base + Repos / Worktrees / Terminals / Tabs / Notes / Notifications / Navigation / History / ModelProfiles extensions
 - **macOS native notifications** via UNUserNotificationCenter, configurable sounds
-- **Programmatic app icon** — generated at launch with purple gradient, branch lines, "TBD" text, optional worktree ribbon
+- **CLI installer coordinator** — offers to symlink `tbd` into `~/.local/bin` on launch
+- **Programmatic app icon** — generated at launch (purple gradient, branch lines, "TBD" text)
 
 ### tbd (CLI)
 Stateless. Connects to daemon socket, sends RPC, prints result, exits.
 - POSIX socket client (not NIO — simpler for one-shot connections)
 - Auto-resolves repo/worktree from `$PWD` via `resolve.path` RPC
-- All commands support `--json` for machine-readable output
+- Subcommands: `repo`, `worktree`, `terminal`, `notify`, `session-event`, `ask-user-question`, `daemon`, `hooks`, `setup-hooks` (deprecated), `cleanup`, `link`
+- `session-event` and `ask-user-question` are internal — invoked by the Claude settings-overlay hooks, not by humans
+
+## Session Instrumentation
+
+TBD instruments the agent sessions it spawns. At `Daemon.start()`:
+
+- **`PluginDirWriter`** writes a Claude Code plugin to `~/Library/Application Support/TBD/plugin/` containing `.claude-plugin/plugin.json` and `skills/tbd/SKILL.md`. The skill body is `TBDSkillContent.body`.
+- **`ClaudeHookOverlay`** writes `~/tbd/runtime/claude-overlay.json` registering `SessionStart`, `Stop` (×2), and `AskUserQuestion` Pre/PostToolUse hooks.
+- **`SkillFileWriter`** drops the same skill body to a failsafe path so a session can `Read` it even with no harness skill registered.
+- **`ClaudeSpawnCommandBuilder`** (pure function) builds the `claude` command, appending `--plugin-dir` and `--settings` (each only if the file exists). It also returns `sensitiveEnv` carrying auth/routing vars (`ANTHROPIC_API_KEY`, `CLAUDE_CONFIG_DIR`, `ANTHROPIC_BASE_URL`, `CLAUDE_CODE_USE_BEDROCK`, ...) — passed via tmux `-e KEY=VALUE` so secrets never appear in `ps` argv.
+- **`CodexHomeManager`** does the equivalent for Codex sessions via a per-repo isolated `CODEX_HOME`.
+
+The `SessionStart` hook calls `tbd session-event`, which RPCs the daemon with the new session id + transcript path; the daemon updates the terminal record and broadcasts `terminalSessionUpdated` so the transcript pane retargets after `/clear` or `/compact`.
 
 ## Data Model (SQLite)
 
-Six tables: `repo`, `worktree`, `terminal`, `notification`, `note`, `conductor`. See `Sources/TBDShared/Models.swift` and `Sources/TBDShared/ConductorModels.swift` for struct definitions and `Sources/TBDDaemon/Database/` + `Sources/TBDDaemon/Conductor/` for GRDB record types.
+Tables: `repo`, `worktree`, `terminal`, `notification`, `note`, `tab`, `model_profile`, `model_profile_usage`, plus a `tbd_meta` key/value store. See `Sources/TBDShared/Models.swift` for struct definitions and `Sources/TBDDaemon/Database/` for GRDB stores.
 
 ### Migrations
-- **v1** — initial schema: repo, worktree, terminal, notification tables
-- **v2** — adds `gitStatus` column to worktree (defaults to "current")
-- **v3** — adds `hasConflicts` bool column to worktree (defaults to false), replacing the gitStatus enum
-- **v4-v8** — adds pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, archivedClaudeSessions columns
-- **v9** — adds `conductor` table + synthetic "Conductors" pseudo-repo (well-known UUID)
-- **v10+** — adds note table, sortOrder on worktree, renamePrompt/customInstructions on repo
+GRDB `DatabaseMigrator`, numbered sequentially. Never modify an existing migration — always add a new one. Current range: `v1`–`v25`. Notables:
+- **v1–v13** — initial schema + incremental columns (gitStatus → hasConflicts, pinnedAt, claudeSessionID, suspend snapshots, notes, sortOrder, per-repo instructions, etc.)
+- **v14_worktree_location** — supports the canonical `~/tbd/worktrees/` location
+- **v15_model_profiles** / **v25_model_profiles_bedrock** — model profile table + bedrock fields
+- **v16_archived_head_sha**, **v17_terminal_transcript_path**
+- **v18_repo_hidden** — repo hide flag
+- **v19_tabs_and_order** — `tab` table + tab ordering
+- **v20_worktree_active_tab**, **v21_repo_expanded**, **v22_terminal_kind**
+- **v23_worktree_parent** — worktree lineage (parent pointer)
+- **v24_drop_conductor** — removes the retired Conductor feature's table + rows
 
 ### Key model types
-- `WorktreeStatus`: `.active`, `.archived`, `.main`, `.creating`, `.conductor`
-- `Repo`: `renamePrompt` + `customInstructions` optional fields for per-repo prompt customization
-- `Worktree`: `hasConflicts` bool (merge-tree vs main), `sortOrder` int for drag-to-reorder, `archivedClaudeSessions`
-- `Terminal`: `pinnedAt`, `claudeSessionID`, `suspendedAt`, `suspendedSnapshot` for pinning + suspend/resume
+- `WorktreeStatus`: `.active`, `.archived`, `.main`, `.creating`
+- `RepoStatus`: `.ok`, `.missing` (stale path)
+- `Repo`: `renamePrompt` + `customInstructions` (per-repo prompt customization), `hidden`, `expanded`
+- `Worktree`: `hasConflicts`, `sortOrder`, `parentID` (lineage), `activeTabID`, `tabOrder`, `archivedHeadSHA`
+- `Terminal`: `kind` (`TerminalKind`), `pinnedAt`, `claudeSessionID`, `transcriptPath`, `suspendedAt`/`suspendedSnapshot`, `modelProfileID`
+- `TerminalKind` / `TerminalCreateType`: `shell`, `claude`, `codex`
+- `CredentialKind`: `oauth`, `apiKey`, `proxy`, `bedrock`
+- `ModelProfile`: named credential container — kind + routing fields (baseURL/model for proxy, awsRegion/awsProfile for bedrock)
 - `Note`: freeform editor content tied to a worktree
-- `Conductor`: meta-agent session with scoped repos, permissions (`.observe`/`.observeAndInteract`), heartbeat config
-- `ConductorPermission`: enum — `.observe` (read-only) or `.observeAndInteract` (can send to terminals)
-- `PRStatus`: PR number + URL + `PRMergeableState` (open/changesRequested/mergeable/merged/closed)
-- `PaneContent`: `.terminal(terminalID:)`, `.webview(url:)`, `.codeViewer(filePath:)`, `.note(noteID:)`
-- `Tab`: wraps PaneContent with UUID + optional label
-- `LayoutNode`: recursive tree — `.pane(PaneContent)` or `.split(axis, ratio, first, second)`
-
-### Key RPC param structs
-- `TerminalCreateParams`: `worktreeID`, optional `cmd`, optional `type: TerminalCreateType` (`.shell`/`.claude`), optional `resumeSessionID`, optional `prompt` (initial prompt sent to new Claude session)
-- `TerminalSendParams`: `terminalID`, `text`, optional `submit: Bool` (when true, sends Enter keypress after text to submit it)
-- `TerminalCreateType`: enum `shell`/`claude`, conforms to `ExpressibleByArgument` in CLI for `--type` flag parsing
-- `RepoUpdateInstructionsParams`: `repoID` + optional `renamePrompt` and `customInstructions`
-- `WorktreeReorderParams`: `repoID` + ordered `worktreeIDs` array
+- `TabState`: persisted tab metadata (label, order)
+- `SessionSummary` / session message types: parsed Claude JSONL transcript items
+- `PRStatus`: PR number + URL + `PRMergeableState`
+- `PaneContent` / `Tab` / `LayoutNode`: app-side pane tree (Codable, in `Sources/TBDApp/Terminal/`)
 
 ## Tmux Architecture
 
@@ -83,110 +98,78 @@ tmux server: tbd-<djb2-hash-of-repo-path>
 ├── Session "main" (daemon-managed, persists across app restarts)
 │   ├── Window @1: claude code
 │   ├── Window @2: setup hook / shell
-│   ├── Window @3: claude code
-│   └── Window @4: setup hook / shell
-├── Session "tbd-view-abc123" (grouped, created by app for viewing)
-│   └── Currently viewing @1
-└── Session "tbd-view-def456" (grouped)
-    └── Currently viewing @3
+│   └── ...
+└── Session "tbd-view-abc123" (grouped, created by app for viewing)
 ```
 
-- Daemon creates windows in `main` session
-- App creates grouped sessions per visible terminal panel
-- Each grouped session shares all windows but has independent current-window
-- Each has independent PTY size (no size conflicts)
-- `main` persists when app closes. Grouped sessions are ephemeral.
+- Daemon creates windows in `main`; app creates grouped sessions per visible terminal panel
+- Each grouped session shares all windows but has independent current-window and PTY size
+- `main` persists when app closes; grouped sessions are ephemeral
 - Server name uses djb2 hash of repo path (deterministic, survives DB recreations)
+- Secrets/routing env reach windows via tmux's `-e KEY=VALUE` (`createWindow(sensitiveEnv:)`), keeping them out of `ps`
 
 ### TmuxManager API highlights
-- `sendKeys(server:paneID:text:)` — sends literal text (tmux `-l` flag); used for typing into terminals
-- `sendKey(server:paneID:key:)` — sends a tmux key name like "Enter" or "Escape" (no `-l` flag); used to submit Claude prompts after `sendKeys`
-- `sendKeyCommand(server:paneID:key:)` — static command builder for `sendKey`, paired with `sendKeysCommand`
-- `sendCommand(server:paneID:command:)` — text followed by Enter in a single tmux invocation
-- `capturePaneOutput` / `capturePaneWithAnsi` — plain text or ANSI-escaped snapshot
-- `paneCurrentCommand` / `panePID` — used by ClaudeStateDetector
-- `windowExists` — reconcile check
+- `sendKeys` — literal text (tmux `-l`); `sendKey` — a key name like "Enter"; `sendCommand` — text + Enter
+- `capturePaneOutput` / `capturePaneWithAnsi` — plain or ANSI-escaped snapshot
+- `paneCurrentCommand` / `panePID` — used by `ClaudeStateDetector`
+- `windowExists` — reconcile check; `dryRun` mode for tests
 
 ## Worktree Lifecycle
 
-Split across 4 files: base struct, +Create, +Archive, +Reconcile.
+Split across files: base struct (`WorktreeLifecycle.swift`), `+Create`, `+Archive`, `+Reconcile`, `+Adopt`.
 
 ### Create (two-phase async)
-**Phase 1 (beginCreateWorktree):** Generate name → insert DB row with `status = .creating` → return immediately. App shows optimistic placeholder in UI before RPC even fires.
+**Phase 1 (beginCreateWorktree):** Resolve parent via `ParentResolver` → generate name → insert DB row with `status = .creating` → return immediately. App shows an optimistic placeholder before the RPC returns.
 
-**Phase 2 (completeCreateWorktree):** Best-effort fetch → create parent dir → git worktree add (tries origin/<default> then local <default>, retries with new name on collision) → ensure tmux server → create 2 windows (claude + setup hook) with `TBD_PROMPT_*` env vars → insert terminals → update status to `.active`. On failure, deletes the DB row.
+**Phase 2 (completeCreateWorktree):** Best-effort fetch → create base dir (`~/tbd/worktrees/<repo>/`) → git worktree add (retries with a new name on collision) → ensure tmux server → create windows with `TBD_*` env vars → insert terminals → status `.active`. On failure, deletes the DB row.
 
 ### Archive (two-phase async)
-**Phase 1 (beginArchiveWorktree):** Validate not `.main` or `.creating` → update status to `.archived` + set archivedAt → kill tmux windows → delete terminals from DB → return immediately. Broadcasts `worktreeArchived` delta.
+**Phase 1:** Validate not `.main`/`.creating` → status `.archived` + `archivedAt` → kill tmux windows → delete terminals → return. **Phase 2:** background — run archive hook → `git worktree remove`.
 
-**Phase 2 (completeArchiveWorktree):** Fire-and-forget background task — run archive hook (blocking, 60s timeout) → git worktree remove.
+### Revive / Adopt
+Revive recreates a worktree from an archived branch. Adopt (`worktree.adopt`) registers an existing on-disk git worktree into TBD (idempotent).
 
-### Revive
-Validate archived status → create parent dir → git worktree add (existing branch) → create tmux windows + terminals → update status to active.
-
-### Conflict Detection
-Concurrent per-repo scan of all active worktrees. Uses merge-tree conflict detection against main branch. Updates `hasConflicts` bool on worktree. Broadcasts `worktreeConflictsChanged` deltas.
-
-### Reconcile (on daemon startup)
-Compare `git worktree list` against DB. Missing on disk → mark archived + kill tmux windows. Unknown on disk (inside `.tbd/worktrees/`) → add with default name. Fixes stale tmux server names. Validates terminal records for all live worktrees (active + main) against tmux — deletes records pointing to dead windows. Cleans up orphaned tmux windows not tracked by any terminal record.
+### Conflict Detection & Reconcile
+Per-repo merge-tree conflict scan against the default branch updates `hasConflicts`. On startup, `reconcile` compares `git worktree list` against the DB, marks missing worktrees archived, adopts unknown ones, fixes stale tmux server names, and prunes dead terminal records. `breakCyclicParents` runs once at startup to repair any parent-pointer cycles.
 
 ## System Prompt Layers
 
-`SystemPromptBuilder` manages the prompt context injected into Claude sessions created by TBD.
+`SystemPromptBuilder` builds the prompt context injected into spawned Claude sessions.
+- `promptLayers(repo:worktree:)` returns env-var → value pairs: `TBD_PROMPT_CONTEXT` (always — describes the `tbd` CLI), `TBD_PROMPT_INSTRUCTIONS` (per-repo `customInstructions`, if set), `TBD_PROMPT_RENAME` (rename prompt, non-main un-renamed worktrees only).
+- These are set as window env vars so child processes can re-inject them.
+- `build(repo:worktree:isResume:)` joins the layers for the initial `--append-system-prompt`; returns `nil` for resumed sessions.
 
-- `promptLayers(repo:worktree:)` returns a `[String: String]` of env-var-name → value pairs:
-  - `TBD_PROMPT_CONTEXT` — built-in TBD context (always set) describing `tbd` CLI commands, env vars, and how to spawn new terminals/worktrees
-  - `TBD_PROMPT_INSTRUCTIONS` — per-repo `customInstructions` (only if configured)
-  - `TBD_PROMPT_RENAME` — rename-prompt text (only for non-main worktrees that haven't been renamed yet; the main worktree is skipped)
-- These layers are set as environment variables on every terminal (shell and Claude) via `TmuxManager.createWindow(env:)`, so spawned children can re-inject them via `claude --append-system-prompt "$TBD_PROMPT_CONTEXT"` etc.
-- `build(repo:worktree:isResume:)` joins the layers in order (rename, context, instructions) with `---` separators for the direct `--append-system-prompt` passed to the initial Claude invocation. Returns `nil` for resumed sessions.
-- `buildForConductor(repo:)` produces the equivalent prompt for a conductor session (context + optional instructions).
+## Model Profiles
+
+A model profile is a named credential container routing a spawned Claude session's auth. `CredentialKind`: `oauth` (isolated `CLAUDE_CONFIG_DIR`, user `/login`s), `apiKey` (`ANTHROPIC_API_KEY` from a 0600 token file under `~/tbd/`), `proxy` (api key + `ANTHROPIC_BASE_URL`/`ANTHROPIC_MODEL`), `bedrock` (`CLAUDE_CODE_USE_BEDROCK=1` + `AWS_REGION`/`AWS_PROFILE`, AWS credential chain). `ModelProfileResolver` chains per-terminal override → per-repo override → global default. The `+` menu can pick a profile explicitly; `ClaudeProfileConfigDirManager` isolates each profile's Claude config dir under `~/tbd/profiles/<id>/claude/`.
 
 ## SSH Agent Resolver
 
-Maintains a stable symlink at `~/.ssh/tbd-agent.sock` pointing to a live SSH agent socket.
-- Checks if current symlink target is connectable
-- If stale, discovers candidates from `/private/tmp/com.apple.launchd.*/Listeners`
-- Probes each with `ssh-add -l` (2s timeout)
-- Atomically updates symlink via temp + rename
-- Worktrees can use `SSH_AUTH_SOCK=~/.ssh/tbd-agent.sock` for reliable SSH access
-
-## Hook System
-
-Priority order (first match wins):
-1. App per-repo config (`~/.tbd/repos/<repo-id>/hooks/<event>`)
-2. `conductor.json` → `scripts.<event>`
-3. `.dmux-hooks/<dmux-event-name>`
-4. `~/.tbd/hooks/default/<event>`
-
-Events: `setup`, `archive`, `preMerge`, `postMerge`
-
-Environment variables: `TBD_REPO_PATH`, `TBD_WORKTREE_PATH`, `TBD_WORKTREE_NAME`, `TBD_BRANCH`, `TBD_EVENT`, `TBD_TARGET_BRANCH` (merge only), `TBD_WORKTREE_ID`
+Maintains a stable symlink at `~/.ssh/tbd-agent.sock` pointing to a live SSH agent socket. Probes candidates from `/private/tmp/com.apple.launchd.*/Listeners` with `ssh-add -l`, updates the symlink atomically. Worktrees use `SSH_AUTH_SOCK=~/.ssh/tbd-agent.sock`.
 
 ## RPC Protocol
 
-JSON-RPC style over Unix socket (newline-delimited) and HTTP POST `/rpc`.
+JSON-RPC style over Unix socket (newline-delimited) and HTTP POST `/rpc`. Method families (see `Sources/TBDDaemon/Server/RPCRouter+*Handlers.swift`):
 
-Methods:
-- **Repo**: `repo.add`, `repo.remove`, `repo.list`, `repo.updateInstructions`
-- **Worktree**: `worktree.create`, `worktree.list`, `worktree.archive`, `worktree.revive`, `worktree.rename`, `worktree.reorder`, `worktree.selectionChanged`, `worktree.suspend`, `worktree.resume`
-- **Terminal**: `terminal.create` (supports `type`/`prompt`), `terminal.list`, `terminal.send` (supports `submit`), `terminal.delete`, `terminal.setPin`, `terminal.output`, `terminal.conversation`, `terminal.suspend`, `terminal.resume`, `terminal.recreateWindow`
+- **Repo**: `repo.add`, `repo.remove`, `repo.list`, `repo.rename`, `repo.relocate`, `repo.updateInstructions`, hidden/expanded toggles
+- **Worktree**: `worktree.create`, `.list`, `.archive`, `.revive`, `.adopt`, `.rename`, `.reorder`, `.move` (reparent), `.selectionChanged`, `.suspend`, `.resume`
+- **Terminal**: `terminal.create` (`type`/`prompt`), `.list`, `.send` (`submit`), `.delete`, `.setPin`, `.output`, `.conversation`, `.transcript`, `.suspend`, `.resume`, `.recreateWindow`
+- **Tab**: set label, set order, list, set active tab
+- **Session**: `session.list`, `session.messages` — list/parse Claude JSONL transcripts; plus the `session-event` bridge that records SessionStart hook data
+- **AskUserQuestion**: pre/post bridge handlers backed by `PendingQuestionStore`
+- **Model profile**: CRUD + global default + usage
 - **Notification**: `notify`, `notifications.list`, `notifications.markRead`
 - **PR**: `pr.list`, `pr.refresh`
-- **Note**: `note.create`, `note.get`, `note.update`, `note.delete`, `note.list`
-- **Conductor**: `conductor.setup`, `conductor.start`, `conductor.stop`, `conductor.teardown`, `conductor.list`, `conductor.status`, `conductor.suggest`, `conductor.clearSuggestion`
+- **Note**: `note.create`/`.get`/`.update`/`.delete`/`.list`
+- **Legacy hooks**: scan + remove legacy globally-installed `tbd` hook entries
 - **Meta**: `daemon.status`, `resolve.path`, `cleanup`, `state.subscribe`
 
 ## CLI Commands
 
-Highlights of new flags (see `Sources/TBDCLI/Commands/` for full definitions):
-
-- `tbd terminal create <worktree> [--type claude|shell] [--cmd <command>] [--prompt <text>] [--json]`
-  - `--type` selects the terminal kind (default: shell). `TerminalCreateType` conforms to `ExpressibleByArgument` so the flag parses directly into the enum.
-  - `--prompt` sends an initial prompt to the Claude session (only meaningful with `--type claude`).
-  - All new terminals automatically receive `TBD_WORKTREE_ID`, `TBD_PROMPT_CONTEXT`, and (when applicable) `TBD_PROMPT_INSTRUCTIONS` / `TBD_PROMPT_RENAME` as env vars.
-- `tbd terminal send --terminal <id> --text <text> [--submit] [--json]`
-  - `--submit` presses Enter after the text (useful for submitting a Claude prompt in one call).
-- `tbd terminal conversation <terminal-id> [--messages N]` — read recent Claude conversation messages from a terminal.
-- `tbd worktree` — supports `create`, `list`, `archive`, `revive`, `rename`, and the daemon additionally exposes `worktree.reorder` / `worktree.suspend` / `worktree.resume` via the app.
-- `tbd repo` — the daemon exposes `repo.updateInstructions` for per-repo `renamePrompt` and `customInstructions` (edited from the app's Repo Instructions view).
+See `Sources/TBDCLI/Commands/`. Highlights:
+- `tbd worktree create [--position child|sibling|root] [--branch] [--prompt|--prompt-file] [--no-wait] [--json]`, plus `list`, `adopt`, `archive`, `revive`, `rename`, `reparent`
+- `tbd terminal create <worktree> [--type shell|claude|codex] [--cmd] [--prompt|--prompt-file] [--json]`, `send --terminal <id> --text <t> [--submit]`, `list`, `output`, `conversation`
+- `tbd hooks status` — show the Claude overlay + legacy hook state; `tbd hooks stop-rename-check` — internal Stop-hook
+- `tbd session-event`, `tbd ask-user-question pre|post` — internal hooks fired by the settings overlay
+- `tbd link` — print a `tbd://` deep link for the current worktree
+- `tbd notify`, `tbd daemon status`, `tbd cleanup`, `tbd setup-hooks` (deprecated)

--- a/.claude/skills/tbd-project/references/file-map.md
+++ b/.claude/skills/tbd-project/references/file-map.md
@@ -1,168 +1,106 @@
 # TBD File Map
 
-Key source files and what they do.
+Key source files and what they do. Not exhaustive — see the directory listing for the rest.
 
 ## Package
 - `Package.swift` — SPM manifest. Targets: TBDShared, TBDDaemonLib, TBDDaemon, TBDCLI, TBDApp
 
 ## Sources/TBDShared/
-- `Constants.swift` — paths (~/.tbd/), version string, socket path, conductor constants
-- `ConductorModels.swift` — Conductor struct, ConductorPermission enum, ConductorSuggestion
-- `Models.swift` — Repo (with renamePrompt, customInstructions), Worktree (with hasConflicts, sortOrder), Terminal (with pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot), Note, TBDNotification, NotificationType, WorktreeStatus (.active/.archived/.main/.creating/.conductor), PRMergeableState, PRStatus
-- `RPCProtocol.swift` — RPCRequest/Response, all param/result structs (incl. TerminalCreateType enum, TerminalCreateParams with `type`/`prompt`, TerminalSendParams with `submit`, TerminalConversationParams/Result, ConversationMessage), RPCMethod constants
-- `StateDelta.swift` — StateDelta enum (worktreeCreated/Archived/Revived/Renamed, notificationReceived, repoAdded/Removed, terminalCreated/Removed, worktreeConflictsChanged, terminalPinChanged, worktreeReordered) + delta payload structs
-- `RepoConstants.swift` — default rename prompt template for worktrees
-- `NameGenerator.swift` — YYYYMMDD-adjective-animal name generation
-- `Adjectives.swift` — ~1,179 curated adjectives (from unique-names-generator)
-- `Animals.swift` — ~353 curated animals
-- `EmojiData.swift` — emoji dataset for Slack-style autocomplete in worktree names
+- `Constants.swift` — paths under `~/tbd/` (configDir, socket, db, pid, port, repos), version; honors `TBD_HOME`/`TBD_SOCKET_PATH`
+- `Models.swift` — Repo, Worktree, Terminal, TerminalKind, Note, TBDNotification, ModelProfile, CredentialKind, Config, PRStatus, SessionSummary + transcript message types, TabState, WorktreeStatus, RepoStatus
+- `RPCProtocol.swift` — RPCRequest/Response, all param/result structs, `RPCMethod` constants, `TerminalCreateType`
+- `StateDelta.swift` — `StateDelta` enum + delta payload structs (worktree/repo/terminal/tab/modelProfile/session deltas)
+- `TBDSkillContent.swift` — canonical `tbd` skill body, single source of truth for the plugin + failsafe writers
+- `CLIInstaller.swift` — logic for symlinking `tbd` into `~/.local/bin`
+- `SettingsJSONWriter.swift` — safe atomic edits to Claude `settings.json` (legacy hook removal)
+- `DeepLinks.swift` — `tbd://` URL parsing/building
+- `NameGenerator.swift` / `Adjectives.swift` / `Animals.swift` — `YYYYMMDD-adjective-animal` names
+- `RepoConstants.swift` — default rename-prompt template
+- `EmojiData.swift` — emoji dataset for worktree-name autocomplete
 
 ## Sources/TBDDaemon/ (TBDDaemonLib target)
 
-### Conductor/
-- `ConductorStore.swift` — GRDB store for conductor table (CRUD, updateTerminalID, updateWorktreeID)
-- `ConductorManager.swift` — Conductor lifecycle: setup (directory + synthetic worktree + DB + CLAUDE.md), start (tmux window), stop, teardown. Name validation, interact conflict check, template generation.
-
-### Database/
-- `Database.swift` — TBDDatabase class, GRDB setup, WAL mode, migrations (v1 through v9+). Exposes stores: repos, worktrees, terminals, notifications, notes, conductors
-- `RepoStore.swift` — Repo CRUD
-- `WorktreeStore.swift` — Worktree CRUD (archive, revive, rename, findByPath, updateHasConflicts, updateTmuxServer, reorder)
-- `TerminalStore.swift` — Terminal CRUD (list supports optional worktreeID filter for batch fetching)
-- `NotificationStore.swift` — Notification CRUD, unread, highestSeverity
-- `NoteStore.swift` — Note CRUD (create, get, update, delete, list by worktreeID)
-
-### Git/
-- `GitManager.swift` — all git operations (fetch, worktree add/remove/list, conflict check, headSHA, isMergeBaseAncestor)
-
-### Hooks/
-- `HookResolver.swift` — hook priority chain resolution + async execution
-
-### SSH/
-- `SSHAgentResolver.swift` — finds live SSH agent socket, maintains ~/.ssh/tbd-agent.sock symlink
-
-### Tmux/
-- `TmuxManager.swift` — tmux server lifecycle, window CRUD, `sendKeys` (literal text with -l), `sendKey` (tmux key name like "Enter" without -l), `sendKeyCommand` (static command builder), `sendCommand` (text + Enter), `windowExists` check, `capturePaneOutput`, `capturePaneWithAnsi`, `paneCurrentCommand`, `panePID`, dryRun mode for tests
-- `ClaudeStateDetector.swift` — detects Claude CLI idle state from pane output (status bar + prompt indicators, excludes busy state), captures session ID from PID-based session files
-
-### Lifecycle/
-- `WorktreeLifecycle.swift` — base struct, error enum, init (coordinates db/git/tmux/hooks/subscriptions)
-- `WorktreeLifecycle+Create.swift` — two-phase async creation (beginCreate inserts DB row with .creating, completeCreate does git+tmux setup)
-- `WorktreeLifecycle+Archive.swift` — two-phase archive (beginArchive updates DB + kills tmux, completeArchive runs hook + git worktree remove in background) and revive (recreate worktree from archived branch)
-- `WorktreeLifecycle+Reconcile.swift` — reconcile DB against git worktree list on startup, git status refresh
-- `SystemPromptBuilder.swift` — builds `--append-system-prompt` for Claude sessions. `promptLayers()` returns env-var-name -> value pairs (TBD_PROMPT_CONTEXT, TBD_PROMPT_INSTRUCTIONS, TBD_PROMPT_RENAME) used both as terminal env vars and as input to the combined prompt. `build()` combines layers into `--append-system-prompt`. `buildForConductor()` for conductor sessions. Skips rename prompt for main worktree.
-- `SuspendResumeCoordinator.swift` — auto-suspend idle Claude sessions on worktree deselection, manual suspend/resume, snapshot capture via ClaudeStateDetector
-
-### PR/
-- `PRStatusManager.swift` — polls GitHub PR status for worktrees (open/merged/closed, mergeable state), caches results
-
-### Server/
-- `RPCRouter.swift` — maps RPC method names to handler functions (dispatch switch), owns all subsystem references
-- `RPCRouter+RepoHandlers.swift` — repo.add, repo.remove, repo.list, repo.updateInstructions handlers
-- `RPCRouter+WorktreeHandlers.swift` — worktree.create, worktree.list, worktree.archive, worktree.revive, worktree.rename, worktree.reorder handlers
-- `RPCRouter+TerminalHandlers.swift` — terminal.create, terminal.list, terminal.send, terminal.delete, terminal.setPin, terminal.output, terminal.conversation, terminal.recreateWindow, notify, notifications.list, notifications.markRead, cleanup, daemon.status, resolve.path, pr.list, pr.refresh handlers
-- `RPCRouter+ConductorHandlers.swift` — conductor.setup, conductor.start, conductor.stop, conductor.teardown, conductor.list, conductor.status, conductor.suggest, conductor.clearSuggestion handlers
-- `RPCRouter+SelectionHandlers.swift` — worktree.selectionChanged handler (triggers suspend/resume)
-- `RPCRouter+ManualSuspendHandlers.swift` — terminal.suspend, terminal.resume, worktree.suspend, worktree.resume handlers
-- `RPCRouter+SubscriptionHandler.swift` — state.subscribe registration/removal for streaming deltas
-- `RPCRouter+NoteHandlers.swift` — note.create, note.get, note.update, note.delete, note.list handlers
-- `SocketServer.swift` — Unix domain socket server (NIO)
-- `HTTPServer.swift` — HTTP server on localhost (NIO + NIOHTTP1)
-- `StateSubscription.swift` — StateDelta events + StateSubscriptionManager for streaming deltas to clients
-
-### Root files
-- `main.swift` — daemon entry point (signal handlers, start/stop)
-- `Daemon.swift` — top-level orchestrator (init all subsystems incl. PRStatusManager, startup/shutdown, background git fetch every 60s)
+### Root
+- `main.swift` — daemon entry point (signal handlers, SIGUSR1 self-relaunch)
+- `Daemon.swift` — top-level orchestrator: initializes subsystems, writes session-instrumentation files, starts servers, reconciles, runs background tasks
 - `PIDFile.swift` — PID file management + stale detection
 
+### Claude/
+- `ClaudeSpawnCommandBuilder.swift` — pure builder for the `claude` spawn command; appends `--plugin-dir`/`--settings`, returns auth/routing `sensitiveEnv`
+- `ClaudeProfileConfigDirManager.swift` — isolates a model profile's Claude config dir under `~/tbd/profiles/<id>/claude/`
+- `ClaudeSessionScanner.swift` — locates Claude JSONL session files for a worktree cwd
+- `TranscriptParser.swift` — parses Claude JSONL (incl. subagent transcripts) into transcript items
+- `UserMessageClassifier.swift` — distinguishes real user messages from system-injected lines
+- `ClaudeUsageFetcher.swift` / `ClaudeUsagePoller.swift` / `PollerClock.swift` — Claude OAuth usage polling
+
+### Codex/
+- `CodexHomeManager.swift` — per-repo isolated `CODEX_HOME` with TBD hooks + bundled skill
+
+### Hooks/
+- `ClaudeHookOverlay.swift` — generates `~/tbd/runtime/claude-overlay.json` (SessionStart/Stop/AskUserQuestion hooks)
+- `HookResolver.swift` — worktree lifecycle hook resolution (`.worktree-hooks/` etc.) + async execution
+- `LegacyHookScanner.swift` — detects legacy globally-installed `tbd` hook entries in user/repo settings.json
+
+### Lifecycle/
+- `WorktreeLifecycle.swift` (+`Create`/`Archive`/`Reconcile`/`Adopt`) — worktree create/archive/revive/adopt/reconcile orchestration
+- `ParentResolver.swift` — resolves a new worktree's parent (lineage)
+- `WorktreeLayout.swift` — canonical (`~/tbd/worktrees/`) + legacy path resolution, name sanitization
+- `SystemPromptBuilder.swift` — builds `TBD_PROMPT_*` layers + `--append-system-prompt`
+- `SuspendResumeCoordinator.swift` — auto/manual suspend-resume of idle Claude sessions
+- `PluginDirWriter.swift` — writes the TBD Claude Code plugin to Application Support
+- `SkillFileWriter.swift` — writes the failsafe copy of the skill body
+- `ArchivedWorktreeBackfill.swift` — repairs archived worktree rows with missing branches
+- `RepoHealthValidator.swift` — flips repos with stale paths to `.missing`
+
+### Database/
+- `Database.swift` — `TBDDatabase`, GRDB setup, WAL, migrations v1–v25
+- `MigrationHelpers.swift` — shared migration utilities
+- `RepoStore` / `WorktreeStore` / `TerminalStore` / `NotificationStore` / `NoteStore` / `TabStore` — GRDB CRUD stores
+- `ConfigStore.swift` / `TBDMetaStore.swift` — global config + key/value meta
+- `ModelProfileRecord.swift` / `ModelProfileUsageRecord.swift` — model profile GRDB records
+
+### ModelProfile/
+- `ModelProfileResolver.swift` — picks a profile per spawn (terminal → repo → global default)
+- `ModelProfileHealthProbe.swift` — validates a profile's credentials
+
+### Server/
+- `RPCRouter.swift` — method dispatch, owns subsystem references
+- `RPCRouter+*Handlers.swift` — Repo, Worktree, Terminal, Tab, Session, Note, ModelProfile, AskUserQuestion, ManualSuspend, Selection, Subscription, LegacyHook, Relocate handlers
+- `SocketServer.swift` / `HTTPServer.swift` — NIO Unix-socket + HTTP RPC servers
+- `StateSubscription.swift` — `StateDelta` broadcasting to subscribed clients
+- `RepoSerializer.swift` — repo serialization for RPC results
+
+### Git/ Tmux/ SSH/ Keychain/ AskUserQuestion/
+- `Git/GitManager.swift` — all git operations
+- `Tmux/TmuxManager.swift` — tmux server/window lifecycle, sendKeys/capture; `Tmux/ClaudeStateDetector.swift` — idle detection + session-id capture
+- `SSH/SSHAgentResolver.swift` — `~/.ssh/tbd-agent.sock` symlink maintenance
+- `Keychain/ModelProfileKeychain.swift` — stores apiKey profile secrets (0600 token files)
+- `AskUserQuestion/PendingQuestionStore.swift` — in-memory store bridging AskUserQuestion hook payloads
+- `PR/PRStatusManager.swift` — GitHub PR status polling
+
 ## Sources/TBDCLI/
-- `TBD.swift` — @main entry, registers all subcommands
-- `SocketClient.swift` — POSIX socket client for daemon RPC
-- `PathResolver.swift` — resolves $PWD to repo/worktree ID
-- `Utilities.swift` — printJSON, resolvePath helpers
-- `Commands/RepoCommands.swift` — tbd repo add/remove/list
-- `Commands/WorktreeCommands.swift` — tbd worktree create/list/archive/revive/rename
-- `Commands/TerminalCommands.swift` — tbd terminal create/list/send/output/conversation. Create supports `--type claude|shell`, `--cmd`, `--prompt`. Send supports `--submit` (presses Enter after text). TerminalCreateType conforms to ExpressibleByArgument for CLI flag parsing.
-- `Commands/ConductorCommands.swift` — tbd conductor setup/start/stop/teardown/list/status
-- `Commands/NotifyCommand.swift` — tbd notify (auto-resolves worktree from PWD)
-- `Commands/DaemonCommands.swift` — tbd daemon status
-- `Commands/SetupHooksCommand.swift` — tbd setup-hooks --global/--repo
-- `Commands/CleanupCommand.swift` — tbd cleanup
+- `TBD.swift` — `@main`, registers subcommands
+- `SocketClient.swift` / `PathResolver.swift` / `Utilities.swift` — POSIX RPC client, `$PWD`→repo/worktree resolution, helpers
+- `Commands/` — `RepoCommands`, `WorktreeCommands` (+`WorktreePosition`), `TerminalCommands`, `NotifyCommand`, `HooksCommand`, `SetupHooksCommand` (deprecated), `SessionEventCommand`, `AskUserQuestionEventCommand`, `StopRenameCheckCommand`, `LinkCommand`, `CleanupCommand`, `DaemonCommands`
 
 ## Sources/TBDApp/
-- `TBDApp.swift` — @main App, AppDelegate for dock visibility + programmatic icon
-- `AppIcon.swift` — programmatic icon generation (purple gradient, branch lines, "TBD" text, optional worktree ribbon)
-- `AppState.swift` — @MainActor ObservableObject, published state (repos, worktrees, terminals, tabs, layouts, prStatuses, activeTabIndices, pendingWorktreeIDs), daemon polling, connection management
-- `AppState+Repos.swift` — repo actions (add, remove, refresh)
-- `AppState+Worktrees.swift` — worktree actions (create with optimistic placeholder, archive, revive, rename, refresh)
-- `AppState+Terminals.swift` — terminal actions (create, createForSplit, delete, refresh, send)
-- `AppState+Notifications.swift` — notification refresh and alert helpers
-- `AppState+Notes.swift` — note actions (create, update, delete) + tab management for note panes
-- `ArchivedWorktreesView.swift` — list of archived worktrees with revive/delete actions
-- `DaemonClient.swift` — actor, POSIX socket RPC client for app
-- `ContentView.swift` — NavigationSplitView, toolbar (incl. PR link button), empty/disconnected states
-- `RepoDetailView.swift` — tabbed repo detail view (archived worktrees, instructions)
-- `RepoInstructionsView.swift` — per-repo custom instructions editor (rename prompt + custom instructions)
-- `TabBar.swift` — generic horizontal tab bar (supports terminal, webview, codeViewer, note tabs)
-- `FileViewer/FileViewerPanel.swift` — git status file viewer (staged/unstaged changes), clicks open code viewer tab
-- `Sidebar/SidebarView.swift` — repo list with filter, add repo button
-- `Sidebar/RepoSectionView.swift` — collapsible repo section with + button, shows active + creating worktrees
-- `Sidebar/WorktreeRowView.swift` — worktree item with badge, PR status icon, inline rename, selection handling
-- `Sidebar/SidebarContextMenu.swift` — right-click menu (rename, archive, etc.)
-- `Sidebar/EmojiPickerView.swift` — Slack-style emoji autocomplete popup for worktree names
-- `Sidebar/FloatingPanel.swift` — NSPanel wrapper for positioning popups near sidebar rows
-- `Sidebar/InlineTextField.swift` — inline text field for renaming worktrees in sidebar
-- `Panes/CodeViewerPaneView.swift` — syntax-highlighted code viewer (Highlightr) with file sidebar
-- `Panes/NotePaneView.swift` — freeform text editor pane for notes
-- `Panes/PanePlaceholder.swift` — empty state placeholder for panes
-- `Panes/WebviewPaneView.swift` — WKWebView pane with shared cookie store
-- `Conductor/ConductorHotkeyMonitor.swift` — local key event monitor for conductor toggle hotkey (Opt+.)
-- `Conductor/ConductorOverlayView.swift` — Guake-style conductor overlay for terminal panels
-- `Conductor/ConductorSuggestionBar.swift` — suggestion bar showing conductor navigation hints
-- `Terminal/TmuxBridge.swift` — grouped session management for terminal panels
-- `Terminal/TBDTerminalView.swift` — SwiftTerm subclass with natural text editing (Cmd+Arrow, Opt+Delete)
-- `Terminal/TerminalPanelView.swift` — NSViewRepresentable wrapping TBDTerminalView + LocalProcess
-- `Terminal/TerminalContainerView.swift` — tab bar + layout for single/multi worktree view
-- `Terminal/PaneContent.swift` — PaneContent enum (.terminal/.webview/.codeViewer/.note) + Tab model
-- `Terminal/SplitLayoutView.swift` — recursive split renderer with draggable dividers
-- `Terminal/LayoutNode.swift` — recursive layout tree using .pane(PaneContent), Codable with backward compat
-- `Terminal/PinnedTerminalDock.swift` — vertical dock showing pinned terminals from other worktrees with draggable dividers
-- `Services/MacNotificationManager.swift` — UNUserNotificationCenter wrapper for macOS native notifications
-- `Services/NotificationSoundPlayer.swift` — plays notification sounds (configurable via AppStorage)
-- `Settings/SettingsView.swift` — preferences (notifications, claude flags, per-repo)
-- `Helpers/StatusBarView.swift` — bottom status bar (version string)
-- `Helpers/KeyboardShortcuts.swift` — Cmd-N, Cmd-D, Cmd-1..9, etc.
-- `Helpers/ExpandingRow.swift` — auto-expanding row helper for sidebar
-- `Helpers/ExpandingTextField.swift` — text field that expands to fit content
+- `TBDApp.swift` — `@main` App + AppDelegate; `AppIcon.swift` — programmatic icon
+- `AppState.swift` + `AppState+*.swift` — observable state split (Repos/Worktrees/Terminals/Tabs/Notes/Notifications/Navigation/History/ModelProfiles)
+- `DaemonClient.swift` — actor, POSIX RPC client; `DeepLinkHandler.swift` — `tbd://` routing
+- `ContentView.swift` / `RepoDetailView.swift` / `RepoInstructionsView.swift` / `TabBar.swift` / `ArchivedWorktreesView.swift`
+- `CLIInstallerCoordinator.swift` / `LegacyHooksCoordinator.swift` — launch-time install + legacy-hook migration prompts
+- `Sidebar/` — repo sections, nested worktree rows/subtrees, context menu, emoji picker, inline rename
+- `Terminal/` — TmuxBridge, TBDTerminalView, panels, split layout, LayoutNode, PaneContent, pinned dock, appearance/color schemes, WorktreePager
+- `Panes/` — code viewer, note, webview, history, `LiveTranscriptPaneView`, `Transcript/` (per-tool cards, chat bubbles, context-usage badge, markdown)
+- `JumpMenu/` — Cmd-K worktree jump palette
+- `MenuBar/ModelProfileMenu.swift`, `Settings/` (general, terminal, repo hooks, model profiles, AWS/Bedrock pickers)
+- `Diagnostics/` — hang watchdog, main-thread sampler, transcript signposts
+- `Services/` — Mac notifications, notification sounds
+- `FileViewer/FileViewerPanel.swift` — git status file viewer
 
-## Tests
-- `Tests/TBDSharedTests/ModelsTests.swift` — model encoding/decoding tests
-- `Tests/TBDSharedTests/EmojiDataTests.swift` — emoji data tests
-- `Tests/TBDDaemonTests/DatabaseTests.swift` — GRDB store tests
-- `Tests/TBDDaemonTests/GitManagerTests.swift` — git operation tests
-- `Tests/TBDDaemonTests/GitStatusTests.swift` — git status refresh tests
-- `Tests/TBDDaemonTests/HookResolverTests.swift` — hook resolution tests
-- `Tests/TBDDaemonTests/NameGeneratorTests.swift` — name generation tests
-- `Tests/TBDDaemonTests/PRStatusManagerTests.swift` — PR status manager tests
-- `Tests/TBDDaemonTests/RPCRouterTests.swift` — RPC routing tests
-- `Tests/TBDDaemonTests/SSHAgentResolverTests.swift` — SSH agent resolution tests
-- `Tests/TBDDaemonTests/TmuxManagerTests.swift` — tmux manager tests
-- `Tests/TBDDaemonTests/WorktreeLifecycleTests.swift` — lifecycle orchestration tests
-- `Tests/TBDDaemonTests/WorktreeStoreTests.swift` — worktree store tests
-- `Tests/TBDDaemonTests/ConductorStoreTests.swift` — conductor DB store tests
-- `Tests/TBDDaemonTests/ConductorManagerTests.swift` — conductor lifecycle tests
-- `Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift` — Claude idle detection + session ID parsing tests
-- `Tests/TBDDaemonTests/StateSubscriptionTests.swift` — state subscription broadcast tests
-- `Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift` — suspend/resume coordinator tests
-- `Tests/TBDDaemonTests/SystemPromptBuilderTests.swift` — system prompt builder tests
-- `Tests/TBDAppTests/LayoutNodeTests.swift` — layout node tree tests
-- `Tests/TBDAppTests/PaneContentTests.swift` — pane content encoding/decoding tests
-- `Tests/TBDAppTests/PlaceholderTests.swift` — placeholder
-- `Tests/TBDDaemonTests/PlaceholderTests.swift` — placeholder
+## Tests/
+Swift Testing framework. `TBDDaemonTests/` (database, git, lifecycle, tmux, hooks, RPC routing, model profiles, sessions, transcripts, suspend/resume, ...), `TBDSharedTests/` (models, emoji), `TBDAppTests/` (layout, pane content).
 
-## Scripts
-- `scripts/restart.sh` — rebuild + restart daemon + app (<1s when no code changes)
-
-## Docs
-- `docs/tmux-integration.md` — tmux learnings, grouped sessions vs control mode
-- `docs/superpowers/specs/` — design specs (TBD design, SSH agent, git status, PR status, multiformat panes, tmux input, worktree pinning, terminal enhancements, terminal pane pinning, recipe format, auto-suspend, manual suspend, conductor, conductor UI, idle notifications, per-repo instructions)
-- `docs/superpowers/plans/` — implementation plans (Phase 1 + Phase 2, SSH agent, git status, simplify god objects, PR status, multiformat panes, lucide icons, tmux input, terminal enhancements, terminal pane pinning, worktree pinning, recipe format, auto-suspend, manual suspend, conductor, conductor UI, idle notifications, per-repo instructions)
+## Scripts & Docs
+- `scripts/restart.sh` — rebuild + restart; `install-hooks.sh` — git hooks; `import-conductor.sh` / `import-claude-code-desktop.sh` — one-script migrations into TBD; `move-home-dir.sh`
+- `docs/` — `tmux-integration.md`, `diagnostics-strategy.md`, `worktree-hooks.md`, `worktree-location-design.md`, `transcript-context-usage.md`, plus `specs/` & `plans/`


### PR DESCRIPTION
## Summary
- The internal `tbd-project` skill — read by every agent working on TBD, including automated changelog-scout subagents — had not been meaningfully updated since `3e71decf` (2026-04-05). 61 commits of drift meant scouts kept re-proposing features TBD already has.
- Added a **Session Instrumentation** section documenting how TBD instruments the agent sessions it spawns: the TBD-owned Claude Code plugin (`PluginDirWriter`), the `--settings` overlay registering SessionStart/Stop/AskUserQuestion hooks (`ClaudeHookOverlay`), spawn-command wiring (`ClaudeSpawnCommandBuilder`), and per-repo Codex home isolation (`CodexHomeManager`).
- Corrected accumulated drift: config dir is `~/tbd` not `~/.tbd`; removed the retired Conductor feature; refreshed worktree hook resolution order, migrations (`v1`–`v25`), RPC method families, the CLI command map, and the whole `Sources/` file map; added model profiles, DB-persisted tabs, worktree lineage/nesting, transcript panes, and the session subsystem.
- Added a `skill-synced-through: 7c9ba0f` marker near the top of SKILL.md so the next maintainer can `git log 7c9ba0f..HEAD` to find new drift.

## Test plan
- [ ] Docs-only change — no code touched, nothing to build or test.
- [ ] Verified the RPC list against `RPCMethod` constants, migrations against `Database.swift`, `HookEvent` against `HookResolver.swift`, and the file map against the `Sources/` tree.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=717A6F41-F37C-4E9E-A034-848E09452C6D)