### PR TITLE
Reliability: Stop losing Claude sessions when a tmux server restarts (~40 lost in one incident)

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -45,9 +45,46 @@ public final class Daemon: Sendable {
         unsetenv("CODEX_THREAD_ID")
     }
 
+    /// Raise the process's `RLIMIT_NOFILE` soft limit so every tmux server the
+    /// daemon spawns inherits a generous file-descriptor budget. Called at
+    /// startup before any tmux server is created.
+    ///
+    /// Rationale: macOS hands LaunchServices-spawned apps a 256-fd soft limit.
+    /// The daemon inherits it from the App, and tmux inherits it from the
+    /// daemon. A tmux server hosting dozens of pty panes can exhaust 256
+    /// descriptors and `exit(1)`, taking every session with it.
+    ///
+    /// Best-effort: a `getrlimit`/`setrlimit` failure is logged and ignored —
+    /// the daemon must still start. Returns the resulting limit (for tests).
+    @discardableResult
+    public static func raiseFileDescriptorLimit() -> rlimit {
+        var limit = rlimit()
+        guard getrlimit(RLIMIT_NOFILE, &limit) == 0 else {
+            daemonLogger.warning("getrlimit(RLIMIT_NOFILE) failed: \(String(cString: strerror(errno)), privacy: .public)")
+            return limit
+        }
+        let target = min(limit.rlim_max, rlim_t(8192))
+        if limit.rlim_cur < target {
+            let previous = limit.rlim_cur
+            limit.rlim_cur = target
+            if setrlimit(RLIMIT_NOFILE, &limit) == 0 {
+                daemonLogger.info("Raised RLIMIT_NOFILE soft limit \(previous, privacy: .public) → \(target, privacy: .public)")
+            } else {
+                daemonLogger.warning("setrlimit(RLIMIT_NOFILE) failed: \(String(cString: strerror(errno)), privacy: .public)")
+                limit.rlim_cur = previous
+            }
+        } else {
+            daemonLogger.info("RLIMIT_NOFILE soft limit already \(limit.rlim_cur, privacy: .public) (≥ \(target, privacy: .public))")
+        }
+        return limit
+    }
+
     /// Start the daemon: create config directory, clean up stale state,
     /// initialize database and all managers, start servers, reconcile worktrees.
     public func start() async throws {
+        // 0. Raise the file-descriptor limit before any tmux server is spawned.
+        Self.raiseFileDescriptorLimit()
+
         // 1. Create ~/tbd/ directory if needed
         let configDir = TBDConstants.configDir.path
         let fm = FileManager.default

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -163,7 +163,18 @@ extension WorktreeLifecycle {
                 if serverAlive {
                     let alive = await tmux.windowExists(server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
                     if !alive {
-                        try? await db.terminals.delete(id: terminal.id)
+                        if let sessionID = terminal.claudeSessionID {
+                            // Window is gone but a resumable session exists.
+                            // Suspend the terminal instead of deleting it — the
+                            // suspend/resume machinery rebuilds a window from the
+                            // session ID on demand. Deleting here would orphan the
+                            // transcript and the session would vanish from TBD.
+                            try? await db.terminals.setSuspended(id: terminal.id, sessionID: sessionID)
+                            logger.info("reconcile: suspended terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone, session \(sessionID, privacy: .public) preserved")
+                        } else {
+                            try? await db.terminals.delete(id: terminal.id)
+                            logger.info("reconcile: deleted terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone, no session to preserve")
+                        }
                         await pendingQuestions.clear(terminalID: terminal.id)
                     }
                 } else {

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -195,6 +195,7 @@ public struct TmuxManager: Sendable {
             // Session does not exist, create it — capture the initial window ID
             let args = Self.newServerCommand(server: server, session: session, cwd: cwd, cols: cols, rows: rows)
             let output = try await runTmux(args)
+            logger.info("ensureServer: created tmux server \(server, privacy: .public)")
             // Hide tmux chrome globally — TBD app provides its own UI
             try? await runTmux(["-L", server, "set", "-g", "status", "off"])
             try? await runTmux(["-L", server, "set", "-g", "pane-border-style", "fg=black"])
@@ -216,6 +217,7 @@ public struct TmuxManager: Sendable {
     /// Kills an entire tmux server and all its sessions.
     public func killServer(server: String) async throws {
         if dryRun { return }
+        logger.info("killServer: killing tmux server \(server, privacy: .public)")
         try await runTmux(["-L", server, "kill-server"])
     }
 

--- a/Tests/TBDDaemonTests/DaemonFileLimitTests.swift
+++ b/Tests/TBDDaemonTests/DaemonFileLimitTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// `raiseFileDescriptorLimit()` must lift the soft limit toward 8192 (capped
+/// by the hard limit) and never throw.
+@Test func testRaiseFileDescriptorLimitRaisesSoftLimit() {
+    let result = Daemon.raiseFileDescriptorLimit()
+
+    var current = rlimit()
+    #expect(getrlimit(RLIMIT_NOFILE, &current) == 0)
+
+    let target = min(current.rlim_max, rlim_t(8192))
+    #expect(current.rlim_cur >= target,
+            "soft limit must be at least min(hard, 8192) after the call")
+    #expect(result.rlim_cur == current.rlim_cur,
+            "returned limit must match the live process limit")
+}
+
+/// The soft limit must never exceed the hard limit (which a process cannot
+/// raise without privilege).
+@Test func testRaiseFileDescriptorLimitNeverExceedsHardLimit() {
+    let result = Daemon.raiseFileDescriptorLimit()
+    #expect(result.rlim_cur <= result.rlim_max)
+}

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -736,6 +736,96 @@ import Testing
     try? await realTmux.killServer(server: socketName)
 }
 
+/// Dead-window cleanup, real tmux server alive: a terminal that holds a
+/// `claudeSessionID` must be SUSPENDED (not deleted) so the session can be
+/// resumed. Regression test for the 2026-05-21 mass session-loss incident.
+@Test func testReconcileDeadWindowClaudeTerminalSuspended() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let realTmux = TmuxManager()
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(), tmux: realTmux, hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+    let serverName = TmuxManager.serverName(forRepoPath: repo.path)
+    // Start a REAL tmux server so reconcile sees serverAlive == true.
+    _ = try await realTmux.ensureServer(server: serverName, session: "main", cwd: repoDir.path)
+
+    // A worktree whose path == the repo path is reported by `git worktree
+    // list`, so reconcile will not archive it as missing.
+    let wt = try await db.worktrees.create(
+        repoID: repo.id, name: "wt", branch: "main",
+        path: repoDir.path, tmuxServer: serverName
+    )
+    // A claude terminal pointing at a window that does not exist on the server.
+    let sessionID = UUID().uuidString
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@stale-claude", tmuxPaneID: "%stale-claude",
+        label: "claude", claudeSessionID: sessionID, kind: .claude
+    )
+
+    do {
+        try await lifecycle.reconcile(repoID: repo.id)
+    } catch {
+        try? await realTmux.killServer(server: serverName)
+        throw error
+    }
+
+    let after = try await db.terminals.get(id: terminal.id)
+    try? await realTmux.killServer(server: serverName)
+
+    #expect(after != nil, "claude terminal must NOT be deleted on dead window")
+    #expect(after?.suspendedAt != nil, "claude terminal must be marked suspended")
+    #expect(after?.claudeSessionID == sessionID, "session ID must be preserved")
+}
+
+/// Dead-window cleanup, real tmux server alive: a terminal with NO
+/// `claudeSessionID` (plain shell) has nothing to recover and is still
+/// deleted — unchanged behavior.
+@Test func testReconcileDeadWindowShellTerminalDeleted() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let realTmux = TmuxManager()
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(), tmux: realTmux, hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+    let serverName = TmuxManager.serverName(forRepoPath: repo.path)
+    _ = try await realTmux.ensureServer(server: serverName, session: "main", cwd: repoDir.path)
+
+    let wt = try await db.worktrees.create(
+        repoID: repo.id, name: "wt", branch: "main",
+        path: repoDir.path, tmuxServer: serverName
+    )
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@stale-shell", tmuxPaneID: "%stale-shell"
+    )
+
+    do {
+        try await lifecycle.reconcile(repoID: repo.id)
+    } catch {
+        try? await realTmux.killServer(server: serverName)
+        throw error
+    }
+
+    let after = try await db.terminals.get(id: terminal.id)
+    try? await realTmux.killServer(server: serverName)
+
+    #expect(after == nil, "shell terminal with no session must still be deleted")
+}
+
 // MARK: - Helpers
 
 /// Thread-safe collector for TmuxManager dryRun recorded args.

--- a/docs/superpowers/specs/2026-05-21-tmux-session-loss-prevention-design.md
+++ b/docs/superpowers/specs/2026-05-21-tmux-session-loss-prevention-design.md
@@ -1,0 +1,185 @@
+# Prevent Claude session loss on tmux server death
+
+## Problem
+
+When a TBD-managed tmux server dies and is recreated, reconcile permanently
+deletes the `terminal` rows whose windows lived on the previous server
+instance. For `claude`/`codex` terminals this destroys the only database link
+to the session — the transcript JSONL survives on disk in
+`~/.claude/projects/`, but TBD can no longer show or resume it.
+
+On 2026-05-21 this destroyed ~40 Claude session links in the longeye-app repo
+in a single incident. The user reported it as "lost a bunch of Claude
+sessions".
+
+## Root cause
+
+Two independent defects combine to turn a recoverable event (a tmux server
+restart) into permanent data loss.
+
+### Defect 1 — reconcile deletes recoverable terminals
+
+`Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift:160-178`. The
+dead-window cleanup pass:
+
+```swift
+if serverAlive {
+    let alive = await tmux.windowExists(server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
+    if !alive {
+        try? await db.terminals.delete(id: terminal.id)   // line 166
+        await pendingQuestions.clear(terminalID: terminal.id)
+    }
+} else {
+    try await recreateAfterReboot(terminal: terminal, worktree: wt)
+}
+```
+
+The reboot-recovery path (which re-spawns stranded windows instead of deleting
+them) is gated on `serverExists == false`. But a **freshly recreated server
+still "exists"** — it simply contains none of the old windows. So reconcile
+takes the `serverAlive == true` branch, finds every pre-restart terminal's
+window absent, and silently deletes the row. A single boolean cannot
+distinguish "same server, one window died" from "server was replaced, all
+windows stranded". Confirmed by `0` "Reboot recovery" log lines on the
+incident day.
+
+### Defect 2 — tmux server runs under a 256 file-descriptor limit
+
+`launchctl limit maxfiles` is **256**. TBD raises `RLIMIT_NOFILE` nowhere
+(no `setrlimit` call in `Sources/` or `scripts/`). The TBDApp is launched by
+LaunchServices (default 256-fd soft limit), spawns the daemon as a child
+(`DaemonClient.swift:144`), which inherits 256, and the daemon spawns tmux,
+which inherits 256.
+
+A tmux server hosting many panes (the longeye-app server had 65 — each pane is
+a pty master fd, plus a socket fd per attached client, plus per-operation
+spikes when spawning new panes) can exhaust 256 descriptors. tmux handles
+fd-allocation failure with `fatal()` → `exit(1)`. A clean `exit(1)` produces
+no crash report, which matches the evidence: no `DiagnosticReports` entry, no
+`jetsam` log, no machine reboot, and the failure was size-correlated (only the
+largest server died — other repos' servers, all single-digit pane counts,
+survived the same daemon restarts).
+
+This is a strong, evidence-consistent hypothesis rather than a defect caught
+in the act; the daemon kept no persisted logs at the time (see Diagnostics).
+
+## Design
+
+Three changes, in `Sources/TBDDaemon/`. Parts A and C are independent and can
+land in either order. Diagnostics should land with them so a recurrence is
+observable.
+
+### Part A — reconcile suspends recoverable terminals instead of deleting
+
+In the dead-window branch (`reconcile.swift:165-168`), replace the
+unconditional delete with a decision keyed solely on `claudeSessionID`:
+
+- Terminal **has a `claudeSessionID`**: mark it suspended via
+  `db.terminals.setSuspended(id:sessionID:snapshot:)` with `snapshot: nil`.
+  Do **not** delete.
+- Terminal **has no `claudeSessionID`** (plain `shell`, custom-cmd, or a
+  `codex` terminal that never recorded a session id): keep the existing
+  `db.terminals.delete(id:)` — there is nothing the resume path can act on.
+
+`claudeSessionID` is the right discriminator because `resumeTerminal` keys
+entirely off it (`guard let sessionID = terminal.claudeSessionID`). A
+terminal without one cannot be resumed even if kept, so suspending it would
+only produce a permanently un-resumable row. Suspending happens exactly when
+a session *can* be brought back.
+
+`pendingQuestions.clear(terminalID:)` runs in both cases, unchanged.
+
+Why this is sufficient and correct:
+
+- A suspended terminal is exactly the existing "session exists, no live
+  window, resume on demand" state. reconcile's dead-window pass already skips
+  `terminal.suspendedAt != nil`, so a suspended terminal is never re-examined
+  or deleted by a later pass.
+- `SuspendResumeCoordinator.resumeTerminal` rebuilds a window from just the
+  `claudeSessionID` (`claude --resume`). It does not depend on the stale
+  `tmuxWindowID`/`tmuxPaneID` — step 1 probes the old pane, finds no Claude
+  process, and proceeds to `createWindow`. So a terminal stranded by a server
+  restart resumes cleanly.
+- `selectionChanged → scheduleResume` auto-resumes a worktree's suspended
+  terminals when the user selects it. After the fix, a worktree whose server
+  died shows its Claude terminal as suspended and resumes it on selection — no
+  manual step, no data loss.
+
+This makes server death non-catastrophic regardless of *why* the server died,
+including causes not addressed by Part C.
+
+### Part C — daemon raises its file-descriptor limit at startup
+
+Add `Daemon.raiseFileDescriptorLimit()`, a static method mirroring the
+existing `Daemon.scrubInheritedTBDEnv()` pattern, called at the very start of
+`Daemon.start()` (before any tmux server can be spawned).
+
+Behavior:
+- Read the current limit with `getrlimit(RLIMIT_NOFILE, &limit)`.
+- Raise `rlim_cur` to `min(rlim_max, 8192)` — 8192 is comfortably above any
+  realistic pane count; `rlim_max` is the ceiling we cannot exceed without
+  privilege.
+- Apply with `setrlimit(RLIMIT_NOFILE, &limit)`.
+- Log the before/after values at `.info` (subsystem `com.tbd.daemon`,
+  category `startup`).
+- A `getrlimit`/`setrlimit` failure is non-fatal — log a `.warning` and
+  continue. The daemon must still start.
+
+The tmux server, spawned as a daemon child, inherits the raised limit. This
+removes the most likely trigger of server death.
+
+### Diagnostics
+
+So the next occurrence is diagnosable in seconds rather than reconstructed
+forensically:
+
+1. **Log tmux server lifecycle events.** Add `.info` log lines (subsystem
+   `com.tbd.daemon`, category `tmux`) at:
+   - `TmuxManager.killServer` — log the server name and caller context.
+   - `TmuxManager.ensureServer` when it actually creates a new server (not
+     when it finds an existing one) — log the server name.
+   - `reconcile.swift:166` path — log when a terminal is suspended-by-reconcile
+     vs deleted-by-reconcile, with terminal id, kind, and worktree id.
+2. **Persist daemon logs across restarts.** `scripts/restart.sh:92` truncates
+   `/tmp/tbdd.log` on every restart (`>`), and `os.Logger` output is not
+   persisted by default. Change the redirect to append (`>>`) and rotate, OR
+   document the one-time `sudo log config --subsystem com.tbd.daemon --mode
+   "level:debug,persist:debug"` in `docs/diagnostics-strategy.md` as the
+   supported way to retain daemon logs. Pick the append-and-rotate option —
+   it needs no privileged one-time setup and survives unattended.
+
+## Testing
+
+- **Part A — claude terminal, dead window, live server:** construct a
+  `claude`-kind terminal with a `claudeSessionID` and a stale window id; run
+  the dead-window reconcile pass against a live server that lacks that
+  window; assert the terminal still exists and `suspendedAt != nil`.
+- **Part A — shell terminal, dead window, live server:** same setup with a
+  `shell` terminal and no `claudeSessionID`; assert the terminal row is
+  deleted (unchanged behavior).
+- **Part A — live window untouched:** terminal whose window *does* exist on
+  the live server is neither suspended nor deleted.
+- **Part C:** unit-test `raiseFileDescriptorLimit()` raises `rlim_cur` toward
+  the target and never above `rlim_max`; a simulated `setrlimit` failure does
+  not throw.
+- Diagnostics log lines need no automated test; verify manually via
+  `log stream`.
+
+## Out of scope
+
+- **Recovery of already-lost sessions.** The 40 transcripts from the
+  2026-05-21 incident remain intact on disk; the user will resume them
+  manually. No recovery script.
+- **The 187 orphaned `tab` rows.** A separate, pre-existing vestigial-feature
+  artifact (`worktree.tabOrder` is empty everywhere; all labels are `"Hello"`).
+  Unrelated to session loss. Leave for a follow-up.
+- **The deleted `cda230f5` model profile.** 28 terminals still reference a
+  profile removed from `model_profiles`; they resume under keychain login
+  (logged warning, no data loss). Separate issue.
+- **`window-style` neutralization in TBD.** The user's `~/.tmux.conf`
+  gray-cell styling was resolved by editing the user's config directly
+  (lines removed). TBD will not auto-neutralize `window-style`.
+- **Reboot-detection refinement.** Teaching reconcile to recognize a recreated
+  server (e.g. tracking a server instance id) and route all its terminals
+  through recovery would be a cleaner model, but Part A already makes the
+  outcome correct. Deferred.

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -88,6 +88,10 @@ if [ "$app_only" = false ]; then
     # Clean stale files
     rm -f ~/tbd/sock ~/tbd/tbdd.pid ~/tbd/port
 
+    # Preserve the previous daemon's log for post-mortem diagnostics — the
+    # daemon does not persist os.Logger output, so this file is the only
+    # record of a crash that happened before a restart.
+    [ -f /tmp/tbdd.log ] && mv /tmp/tbdd.log /tmp/tbdd.log.1
     echo "Starting daemon..."
     "$BUILD_DIR/TBDDaemon" > /tmp/tbdd.log 2>&1 &
     # Wait for socket


### PR DESCRIPTION
## Summary

On 2026-05-21, ~40 Claude session links disappeared from TBD in the longeye-app repo in a single incident. This PR diagnoses the cause and fixes it.

**What was broken.** When a TBD-managed tmux server died and was recreated, every worktree's Claude session vanished from the UI — even though the transcript JSONL files were intact on disk.

**Why it happened — two compounding defects:**

1. **reconcile deleted recoverable terminals.** reconcile's reboot-recovery path (which re-spawns stranded windows) is gated on `serverExists == false`. A *freshly recreated* server still "exists" — it just holds none of the old windows. So reconcile took the server-alive branch, found every pre-restart terminal's window absent, and silently `delete`d the row — destroying the only DB link to the session transcript.

2. **The tmux server ran under a 256 file-descriptor limit.** macOS hands LaunchServices-spawned apps a 256-fd soft limit; the daemon inherits it from the App and tmux inherits it from the daemon. A server hosting dozens of pty panes exhausts 256 fds and `exit(1)`s — a clean exit that leaves no crash report. This matches all the evidence (size-correlated: only the largest server died; no crash report; no jetsam; no reboot).

**What this PR does:**

- **reconcile suspends instead of deletes.** A terminal that holds a `claudeSessionID` is marked suspended rather than deleted. Suspended terminals are skipped by every later reconcile pass and resumed on demand by the existing suspend/resume machinery, which rebuilds a window from the session ID alone. Server death is no longer permanent data loss — regardless of *why* the server died. Plain shell terminals (no session) are still deleted.
- **The daemon raises `RLIMIT_NOFILE` to 8192 at startup**, before spawning any tmux server — removing the likely trigger.
- **Diagnostics:** tmux server create/kill are now logged, and `restart.sh` preserves the previous daemon log as `/tmp/tbdd.log.1` so a recurrence is observable rather than forensically reconstructed.

Design spec: `docs/superpowers/specs/2026-05-21-tmux-session-loss-prevention-design.md` (included).

## Test plan

- [x] `swift test` — full suite passes (998 tests), including 4 new tests
- [x] New: `testReconcileDeadWindowClaudeTerminalSuspended` — claude terminal with a dead window on a live server is suspended, not deleted
- [x] New: `testReconcileDeadWindowShellTerminalDeleted` — shell terminal with no session is still deleted
- [x] New: `testRaiseFileDescriptorLimitRaisesSoftLimit` / `…NeverExceedsHardLimit`
- [ ] After merge + `scripts/restart.sh`: `log show --last 5m --predicate 'subsystem == "com.tbd.daemon" AND category == "startup"' | grep RLIMIT` shows the soft limit raised from 256

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B634D5A9-C7C7-428E-85DA-56AED40E5E54)