### PR TITLE
Feat: Show session history when a worktree's last tab is closed

### DIFF
--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -28,6 +28,32 @@ enum HistoryLoadState {
     }
 }
 
+// MARK: - EmptyTabsContent
+
+/// What a worktree's main area shows when it has no open tabs.
+enum EmptyTabsContent: Equatable {
+    case history       // render HistoryPaneView
+    case placeholder   // render the "No terminals" empty state
+}
+
+extension HistoryLoadState {
+    /// Decide what to show in the empty-tabs state. Loading states and any
+    /// worktree with at least one past session show history; an empty load
+    /// result or a failure falls back to the placeholder. `.idle` shows
+    /// history so the placeholder never flashes before the first fetch
+    /// resolves.
+    var emptyTabsContent: EmptyTabsContent {
+        switch self {
+        case .idle, .loading, .loadingStale:
+            return .history
+        case .loaded(let sessions):
+            return sessions.isEmpty ? .placeholder : .history
+        case .failed:
+            return .placeholder
+        }
+    }
+}
+
 // MARK: - Equatable
 
 extension HistoryLoadState: Equatable {

--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -73,6 +73,13 @@ extension HistoryLoadState: Equatable {
 
 extension AppState {
 
+    /// Whether an empty-tabs worktree should populate its session history.
+    /// `.main` worktrees auto-create a terminal and never sit in the empty
+    /// state, so they skip the fetch; every other worktree fetches.
+    nonisolated static func shouldPopulateHistoryForEmptyTabs(worktree: Worktree) -> Bool {
+        worktree.status != .main
+    }
+
     /// Toggle the history pane for a worktree. Shows it (and triggers a fetch) or hides it.
     func toggleHistory(worktreeID: UUID) {
         if historyActiveWorktrees.contains(worktreeID) {

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -136,85 +136,84 @@ struct SingleWorktreeView: View {
     var body: some View {
         if let worktree {
             VStack(spacing: 0) {
-                // Tab bar
-                if !worktreeTabs.isEmpty {
-                    TabBar(
-                        tabs: worktreeTabs,
-                        worktreeID: worktreeID,
-                        activeTabIndex: Binding(
-                            get: { activeTabIndex },
-                            set: { activeTabIndex = $0 }
-                        ),
-                        onAddShell: {
-                            Task {
-                                await appState.createTerminal(worktreeID: worktreeID)
-                                selectLastTab()
-                            }
-                        },
-                        onAddClaude: {
-                            Task {
-                                await appState.createClaudeTerminal(worktreeID: worktreeID)
-                                selectLastTab()
-                            }
-                        },
-                        onAddClaudeProfile: { profileID in
-                            Task {
-                                await appState.createClaudeTerminal(
-                                    worktreeID: worktreeID, profileID: profileID
-                                )
-                                selectLastTab()
-                            }
-                        },
-                        onAddCodex: {
-                            Task {
-                                await appState.createCodexTerminal(worktreeID: worktreeID)
-                                selectLastTab()
-                            }
-                        },
-                        onAddNote: {
-                            Task {
-                                await appState.createNote(worktreeID: worktreeID)
-                                selectLastTab()
-                            }
-                        },
-                        onCloseTab: { index in
-                            closeTab(at: index)
-                        },
-                        terminalForTab: { tabID in
-                            guard let terminalID = terminalID(for: tabID) else { return nil }
-                            return appState.terminals[worktreeID]?.first { $0.id == terminalID }
-                        },
-                        onSuspendTab: { tabID in
-                            guard let terminalID = terminalID(for: tabID) else { return }
-                            Task {
-                                try? await appState.daemonClient.terminalSuspend(terminalID: terminalID)
-                                await appState.refreshTerminals(worktreeID: worktreeID)
-                            }
-                        },
-                        onResumeTab: { tabID in
-                            guard let terminalID = terminalID(for: tabID) else { return }
-                            Task {
-                                try? await appState.daemonClient.terminalResume(terminalID: terminalID)
-                                await appState.refreshTerminals(worktreeID: worktreeID)
-                            }
-                        },
-                        onForkTab: { tabID in
-                            guard let tID = terminalID(for: tabID) else { return }
-                            let terminal = appState.terminals[worktreeID]?.first { $0.id == tID }
-                            guard let sessionID = terminal?.claudeSessionID else { return }
-                            Task {
-                                await appState.forkClaudeTerminal(worktreeID: worktreeID, sessionID: sessionID, tokenID: terminal?.profileID)
-                                selectLastTab()
-                            }
-                        },
-                        isHistorySelected: appState.historyActiveWorktrees.contains(worktreeID),
-                        onHistoryTab: {
-                            appState.toggleHistory(worktreeID: worktreeID)
+                // Tab bar — always visible, even with no tabs, so the + menu
+                // and history button remain reachable from the empty state.
+                TabBar(
+                    tabs: worktreeTabs,
+                    worktreeID: worktreeID,
+                    activeTabIndex: Binding(
+                        get: { activeTabIndex },
+                        set: { activeTabIndex = $0 }
+                    ),
+                    onAddShell: {
+                        Task {
+                            await appState.createTerminal(worktreeID: worktreeID)
+                            selectLastTab()
                         }
-                    )
+                    },
+                    onAddClaude: {
+                        Task {
+                            await appState.createClaudeTerminal(worktreeID: worktreeID)
+                            selectLastTab()
+                        }
+                    },
+                    onAddClaudeProfile: { profileID in
+                        Task {
+                            await appState.createClaudeTerminal(
+                                worktreeID: worktreeID, profileID: profileID
+                            )
+                            selectLastTab()
+                        }
+                    },
+                    onAddCodex: {
+                        Task {
+                            await appState.createCodexTerminal(worktreeID: worktreeID)
+                            selectLastTab()
+                        }
+                    },
+                    onAddNote: {
+                        Task {
+                            await appState.createNote(worktreeID: worktreeID)
+                            selectLastTab()
+                        }
+                    },
+                    onCloseTab: { index in
+                        closeTab(at: index)
+                    },
+                    terminalForTab: { tabID in
+                        guard let terminalID = terminalID(for: tabID) else { return nil }
+                        return appState.terminals[worktreeID]?.first { $0.id == terminalID }
+                    },
+                    onSuspendTab: { tabID in
+                        guard let terminalID = terminalID(for: tabID) else { return }
+                        Task {
+                            try? await appState.daemonClient.terminalSuspend(terminalID: terminalID)
+                            await appState.refreshTerminals(worktreeID: worktreeID)
+                        }
+                    },
+                    onResumeTab: { tabID in
+                        guard let terminalID = terminalID(for: tabID) else { return }
+                        Task {
+                            try? await appState.daemonClient.terminalResume(terminalID: terminalID)
+                            await appState.refreshTerminals(worktreeID: worktreeID)
+                        }
+                    },
+                    onForkTab: { tabID in
+                        guard let tID = terminalID(for: tabID) else { return }
+                        let terminal = appState.terminals[worktreeID]?.first { $0.id == tID }
+                        guard let sessionID = terminal?.claudeSessionID else { return }
+                        Task {
+                            await appState.forkClaudeTerminal(worktreeID: worktreeID, sessionID: sessionID, tokenID: terminal?.profileID)
+                            selectLastTab()
+                        }
+                    },
+                    isHistorySelected: appState.historyActiveWorktrees.contains(worktreeID),
+                    onHistoryTab: {
+                        appState.toggleHistory(worktreeID: worktreeID)
+                    }
+                )
 
-                    Divider()
-                }
+                Divider()
 
                 // Split layout view for the active tab's layout. Publish its
                 // measured size to MainAreaSizeKey so the daemon-side tmux
@@ -232,6 +231,13 @@ struct SingleWorktreeView: View {
                 if worktree.status == .main && terminals.isEmpty {
                     await appState.createTerminal(worktreeID: worktreeID)
                 }
+            }
+            .task(id: worktreeTabs.isEmpty) {
+                // When a non-main worktree has no tabs, populate session
+                // history so the empty state can show it. `.main` worktrees
+                // auto-create a terminal above and never sit in this state.
+                guard worktreeTabs.isEmpty, worktree.status != .main else { return }
+                await appState.fetchSessions(worktreeID: worktreeID)
             }
         } else {
             Text("Worktree not found")
@@ -256,19 +262,24 @@ struct SingleWorktreeView: View {
             )
             .id(tab.id) // Force new view hierarchy when switching tabs
         } else {
-            VStack(spacing: 12) {
-                Image(systemName: "terminal")
-                    .font(.system(size: 40))
-                    .foregroundStyle(.tertiary)
-                Text("No terminals")
-                    .foregroundStyle(.secondary)
-                Button("Create Terminal") {
-                    Task {
-                        await appState.createTerminal(worktreeID: worktreeID)
+            switch (appState.historyLoadStates[worktreeID] ?? .idle).emptyTabsContent {
+            case .history:
+                HistoryPaneView(worktreeID: worktreeID)
+            case .placeholder:
+                VStack(spacing: 12) {
+                    Image(systemName: "terminal")
+                        .font(.system(size: 40))
+                        .foregroundStyle(.tertiary)
+                    Text("No terminals")
+                        .foregroundStyle(.secondary)
+                    Button("Create Terminal") {
+                        Task {
+                            await appState.createTerminal(worktreeID: worktreeID)
+                        }
                     }
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -236,7 +236,8 @@ struct SingleWorktreeView: View {
                 // When a non-main worktree has no tabs, populate session
                 // history so the empty state can show it. `.main` worktrees
                 // auto-create a terminal above and never sit in this state.
-                guard worktreeTabs.isEmpty, worktree.status != .main else { return }
+                guard worktreeTabs.isEmpty,
+                      AppState.shouldPopulateHistoryForEmptyTabs(worktree: worktree) else { return }
                 await appState.fetchSessions(worktreeID: worktreeID)
             }
         } else {

--- a/Tests/TBDAppTests/HistoryEmptyStateTests.swift
+++ b/Tests/TBDAppTests/HistoryEmptyStateTests.swift
@@ -53,4 +53,32 @@ struct HistoryEmptyStateTests {
     func failedShowsPlaceholder() {
         #expect(HistoryLoadState.failed("boom").emptyTabsContent == .placeholder)
     }
+
+    // MARK: - shouldPopulateHistoryForEmptyTabs
+
+    private func makeWorktree(status: WorktreeStatus) -> Worktree {
+        Worktree(
+            repoID: UUID(),
+            name: "test",
+            displayName: "Test",
+            branch: "main",
+            path: "/tmp/test",
+            status: status,
+            tmuxServer: "test-server"
+        )
+    }
+
+    @Test("main worktree does not populate history for empty tabs")
+    func mainWorktreeSkipsHistoryFetch() {
+        let worktree = makeWorktree(status: .main)
+        #expect(AppState.shouldPopulateHistoryForEmptyTabs(worktree: worktree) == false)
+    }
+
+    @Test("non-main worktree populates history for empty tabs")
+    func nonMainWorktreeFetchesHistory() {
+        for status in [WorktreeStatus.active, .archived, .creating, .failed] {
+            let worktree = makeWorktree(status: status)
+            #expect(AppState.shouldPopulateHistoryForEmptyTabs(worktree: worktree) == true)
+        }
+    }
 }

--- a/Tests/TBDAppTests/HistoryEmptyStateTests.swift
+++ b/Tests/TBDAppTests/HistoryEmptyStateTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// Tests for `HistoryLoadState.emptyTabsContent` — the decision that drives
+/// what a worktree's main area shows when it has no open tabs. Loading states
+/// and any worktree with at least one past session show history; an empty load
+/// result or a failed fetch falls back to the "No terminals" placeholder.
+@Suite("History empty-state decision")
+struct HistoryEmptyStateTests {
+
+    private func session(_ id: String) -> SessionSummary {
+        SessionSummary(
+            sessionId: id,
+            filePath: "/tmp/\(id).jsonl",
+            modifiedAt: Date(),
+            fileSize: 100,
+            lineCount: 10,
+            firstUserMessage: "Hello",
+            lastUserMessage: "Goodbye",
+            cwd: "/tmp",
+            gitBranch: "main"
+        )
+    }
+
+    @Test("idle shows history (avoids placeholder flash before first fetch)")
+    func idleShowsHistory() {
+        #expect(HistoryLoadState.idle.emptyTabsContent == .history)
+    }
+
+    @Test("loading shows history")
+    func loadingShowsHistory() {
+        #expect(HistoryLoadState.loading.emptyTabsContent == .history)
+    }
+
+    @Test("loadingStale shows history")
+    func loadingStaleShowsHistory() {
+        #expect(HistoryLoadState.loadingStale([session("a")]).emptyTabsContent == .history)
+    }
+
+    @Test("loaded with sessions shows history")
+    func loadedWithSessionsShowsHistory() {
+        #expect(HistoryLoadState.loaded([session("a")]).emptyTabsContent == .history)
+    }
+
+    @Test("loaded with no sessions shows placeholder")
+    func loadedEmptyShowsPlaceholder() {
+        #expect(HistoryLoadState.loaded([]).emptyTabsContent == .placeholder)
+    }
+
+    @Test("failed shows placeholder")
+    func failedShowsPlaceholder() {
+        #expect(HistoryLoadState.failed("boom").emptyTabsContent == .placeholder)
+    }
+}

--- a/docs/superpowers/specs/2026-05-21-history-empty-state-design.md
+++ b/docs/superpowers/specs/2026-05-21-history-empty-state-design.md
@@ -1,0 +1,94 @@
+# Session history as the empty state
+
+**Date:** 2026-05-21
+**Status:** Approved
+
+## Goal
+
+When a worktree has no open tabs, show its session history instead of the bare
+"No terminals" placeholder. Closing the last tab should land the user on a useful
+list of past Claude sessions they can resume, rather than a dead-end empty state.
+
+## Current behavior
+
+In `Sources/TBDApp/Terminal/TerminalContainerView.swift`:
+
+- The tab bar (`TabBar`) renders only when `!worktreeTabs.isEmpty` (line ~140).
+- `layoutContent(worktree:)` decides the main area:
+  - `historyActiveWorktrees.contains(worktreeID)` → `HistoryPaneView`
+  - else `activeTab` exists → `SplitLayoutView`
+  - else → a "No terminals" VStack (terminal icon + "Create Terminal" button)
+
+So when all tabs are closed, the user sees the "No terminals" placeholder and the
+tab bar — including its `+` menu and history button — disappears entirely.
+
+Session history is otherwise reached via the history button in the tab bar, which
+calls `AppState.toggleHistory(worktreeID:)`, adding the worktree to
+`historyActiveWorktrees` and triggering `fetchSessions`.
+
+## Design
+
+### 1. Tab bar always visible
+
+Remove the `if !worktreeTabs.isEmpty` guard so `TabBar` renders even with zero
+tabs. `TabBar` already handles an empty `tabs` array (the `ForEach` is empty; the
+`+` menu and history button still render). This preserves every terminal-creation
+path (shell / Claude / Claude-profile / Codex / note) from the empty state.
+
+### 2. Implicit history in the empty-tabs branch
+
+In `layoutContent(worktree:)`, the `else` branch (no `activeTab`) currently shows
+the "No terminals" VStack. New behavior, driven by `historyLoadStates[worktreeID]`:
+
+| Load state                                | Shown                                   |
+|--------------------------------------------|-----------------------------------------|
+| `.idle`, `.loading`, `.loadingStale`       | `HistoryPaneView`                       |
+| `.loaded` with ≥1 session                  | `HistoryPaneView`                       |
+| `.loaded([])` (no past sessions)           | existing "No terminals" empty state     |
+| `.failed`                                  | existing "No terminals" empty state     |
+
+This is *implicit* history: the worktree is **not** added to
+`historyActiveWorktrees`, so the history button's selected styling stays off and
+the explicit toggle continues to work independently. During loading,
+`HistoryPaneView` renders its own loading header, so there is no flash of the
+"No terminals" placeholder before sessions resolve.
+
+On `.failed`, falling back to "No terminals" is acceptable because the tab bar's
+`+` menu is visible right above it — the failure is non-blocking. The user can
+still explicitly toggle history to see the error.
+
+### 3. Fetching sessions when tabs go empty
+
+`fetchSessions` is currently only called by `toggleHistory`. It must also run
+when the empty-tabs state is entered, in two situations:
+
+- Selecting a worktree that already has no tabs.
+- Closing the last open tab of the currently selected worktree.
+
+Add a trigger in `TerminalContainerView` (e.g. `.task(id: worktreeTabs.isEmpty)`
+or `.onChange` of tab count) that, when tabs become empty on a non-`.main`
+worktree and `historyLoadStates[worktreeID]` is `.idle`, calls
+`appState.fetchSessions(worktreeID:)`.
+
+`.main` worktrees auto-create a terminal when empty (existing
+`.task(id: worktreeID)` logic), so they never sit in the empty state and need no
+session fetch.
+
+### 4. Unchanged
+
+- The explicit history toggle, `HistoryPaneView`, and Resume/Revive flows are
+  untouched. Resuming a session adds a tab → `activeTab` becomes non-nil → the
+  terminal shows.
+- The "No terminals" VStack stays as-is, now reachable only via the
+  `.loaded([])` and `.failed` cases.
+
+## Testing
+
+- Worktree with past sessions, all tabs closed → history pane shown, history
+  button not highlighted.
+- Worktree with no past sessions, all tabs closed → "No terminals" empty state.
+- Closing the last tab of a worktree with sessions → history pane appears.
+- Creating a terminal from the empty-state tab bar `+` menu → terminal shows,
+  history pane dismissed.
+- `.main` worktree with no tabs → auto-creates a terminal, no history pane.
+- Explicit history toggle still works while tabs are open.

--- a/docs/superpowers/specs/2026-05-21-history-empty-state-design.md
+++ b/docs/superpowers/specs/2026-05-21-history-empty-state-design.md
@@ -65,10 +65,12 @@ when the empty-tabs state is entered, in two situations:
 - Selecting a worktree that already has no tabs.
 - Closing the last open tab of the currently selected worktree.
 
-Add a trigger in `TerminalContainerView` (e.g. `.task(id: worktreeTabs.isEmpty)`
-or `.onChange` of tab count) that, when tabs become empty on a non-`.main`
-worktree and `historyLoadStates[worktreeID]` is `.idle`, calls
-`appState.fetchSessions(worktreeID:)`.
+Add a trigger in `TerminalContainerView` (`.task(id: worktreeTabs.isEmpty)`)
+that, whenever tabs become empty on a non-`.main` worktree, calls
+`appState.fetchSessions(worktreeID:)`. The fetch runs unconditionally on each
+empty-tabs transition (not gated on `.idle`) so the history list is refreshed
+after closing a tab — `fetchSessions` keeps any prior data visible via
+`.loadingStale` while it revalidates, so this never flashes the placeholder.
 
 `.main` worktrees auto-create a terminal when empty (existing
 `.task(id: worktreeID)` logic), so they never sit in the empty state and need no


### PR DESCRIPTION
## Summary
- Closing the last tab of a worktree used to leave a dead-end "No terminals" placeholder. It now shows that worktree's session history instead, so past Claude sessions are one click from being resumed.
- The tab bar (with its `+` menu and history button) now stays visible even with zero tabs, so every terminal-creation path remains reachable from the empty state.
- Worktrees with no past sessions (or a failed history fetch) still fall back to the original "No terminals" placeholder. `.main` worktrees auto-create a terminal and never hit this state.

## Implementation
- `HistoryLoadState.emptyTabsContent` — a pure decision mapping load state to `.history` vs `.placeholder` (loading states and any worktree with ≥1 session show history; empty/failed loads show the placeholder).
- `TerminalContainerView` consults that decision in its empty-tabs branch and fetches sessions whenever a non-`.main` worktree's tabs go empty.
- The `.main`/non-`.main` fetch gate is extracted into `AppState.shouldPopulateHistoryForEmptyTabs(worktree:)` with a test per branch.

## Test plan
- [x] `swift test --filter HistoryEmptyStateTests` — 8 tests pass (decision table + fetch-gate branches)
- [x] `swift build` and SwiftLint `--strict` clean; full TBDApp suite (218 tests) passes
- [x] Manually verified: closing all tabs on a worktree with past sessions shows the history pane; the `+` menu still creates terminals from the empty state

Design spec: `docs/superpowers/specs/2026-05-21-history-empty-state-design.md`

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=248E3A38-11EB-4D41-9FF9-1A1F11617C16)