### PR TITLE
Feat: Render Claude fullscreen by default to kill tmux screen-tearing

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -556,6 +556,7 @@ final class AppState: ObservableObject {
                     } else {
                         let didConnect = await self.daemonClient.connect()
                         self.isConnected = didConnect
+                        if didConnect { self.pushClaudeSpawnPreferences() }
                     }
                     if !self.isConnected { return }
                 }
@@ -590,6 +591,7 @@ final class AppState: ObservableObject {
                     suspendEnabled: suspendEnabled
                 )
             }
+            pushClaudeSpawnPreferences()
         } else {
             logger.warning("Could not connect to daemon — is tbdd running?")
         }
@@ -934,6 +936,38 @@ final class AppState: ObservableObject {
     /// the developer's live app preferences.
     static func autoSuspendClaudeEnabled(defaults: UserDefaults = .standard) -> Bool {
         defaults.object(forKey: autoSuspendClaudeKey) as? Bool ?? true
+    }
+
+    /// UserDefaults key for a Claude spawn-env setting, by registry ID.
+    nonisolated static func claudeEnvKey(_ settingID: String) -> String {
+        "claudeEnvSetting.\(settingID)"
+    }
+
+    /// Build the overrides map from UserDefaults: a setting is included only
+    /// when the user has changed it from its registry default. Settings left
+    /// at default are omitted so the daemon falls back to registry defaults.
+    nonisolated static func claudeEnvOverrides(defaults: UserDefaults = .standard) -> [String: ClaudeEnvValue] {
+        var overrides: [String: ClaudeEnvValue] = [:]
+        for setting in ClaudeEnvRegistry.all {
+            let key = claudeEnvKey(setting.id)
+            switch setting.kind {
+            case .toggle(let def, _):
+                if let stored = defaults.object(forKey: key) as? Bool, stored != def {
+                    overrides[setting.id] = .bool(stored)
+                }
+            }
+        }
+        return overrides
+    }
+
+    /// Push the current Claude spawn-env setting overrides to the daemon.
+    /// Safe to call repeatedly — the daemon persists the latest value.
+    func pushClaudeSpawnPreferences() {
+        let overrides = Self.claudeEnvOverrides(defaults: userDefaults)
+        Task { [daemonClient] in
+            try? await daemonClient.setClaudeSpawnPreferences(
+                ClaudeSpawnPreferences(settingOverrides: overrides))
+        }
     }
 
     /// Convert the current `mainAreaSize` (pixels) into tmux cell dimensions

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -586,6 +586,14 @@ actor DaemonClient {
         )
     }
 
+    /// Push the user's Claude spawn-env setting overrides to the daemon.
+    func setClaudeSpawnPreferences(_ preferences: ClaudeSpawnPreferences) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.claudeSetSpawnPreferences,
+            params: preferences
+        )
+    }
+
     /// Manually suspend a single Claude terminal.
     func terminalSuspend(terminalID: UUID) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -5,6 +5,7 @@ import TBDShared
 
 struct TerminalSettingsView: View {
     @EnvironmentObject var appearance: AppearanceSettings
+    @EnvironmentObject var appState: AppState
     @AppStorage(AppState.terminalAutoResizeKey) private var enableTerminalAutoResize: Bool = false
 
     var body: some View {
@@ -74,6 +75,20 @@ struct TerminalSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            Section {
+                ForEach(ClaudeEnvRegistry.all, id: \.id) { setting in
+                    ClaudeEnvSettingRow(setting: setting) {
+                        appState.pushClaudeSpawnPreferences()
+                    }
+                }
+            } header: {
+                Text("Claude Environment")
+            } footer: {
+                Text("Applies to newly spawned Claude sessions.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
         .padding()
@@ -83,6 +98,34 @@ struct TerminalSettingsView: View {
         // Use the resolved font's display name so a poisoned/missing font name
         // shows the actual fallback in the Settings label, not the invalid stored value.
         appearance.font.displayName ?? appearance.fontName
+    }
+}
+
+/// One row in the registry-driven Claude Environment settings section.
+/// Renders the control matching the setting's `Kind`. v1 handles `.toggle`;
+/// adding `.integer` / `.choice` is a new `switch` arm here.
+private struct ClaudeEnvSettingRow: View {
+    let setting: ClaudeEnvSetting
+    let onChange: () -> Void
+    @AppStorage private var boolValue: Bool
+
+    init(setting: ClaudeEnvSetting, onChange: @escaping () -> Void) {
+        self.setting = setting
+        self.onChange = onChange
+        let def: Bool
+        switch setting.kind {
+        case .toggle(let d, _): def = d
+        }
+        _boolValue = AppStorage(wrappedValue: def, AppState.claudeEnvKey(setting.id))
+    }
+
+    var body: some View {
+        switch setting.kind {
+        case .toggle:
+            Toggle(setting.title, isOn: $boolValue)
+                .help(setting.help)
+                .onChange(of: boolValue) { _, _ in onChange() }
+        }
     }
 }
 

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -228,7 +228,7 @@ class TBDTerminalView: TerminalView {
                     self.didDrag = true
                 }
             case .leftMouseUp:
-                self.handleClickPassthrough(at: locationInSelf)
+                self.handleClickPassthrough(at: locationInSelf, modifiers: event.modifierFlags)
             default:
                 break
             }
@@ -289,7 +289,18 @@ class TBDTerminalView: TerminalView {
         }
     }
 
-    private func handleClickPassthrough(at point: CGPoint) {
+    /// Plain (unmodified) clicks are forwarded into the pane; clicks carrying
+    /// a modifier belong to TBD's own file/link handling and must not also be
+    /// forwarded — otherwise a Cmd+click both opens a file and clicks Claude.
+    static func clickPassthroughBlocked(by modifiers: NSEvent.ModifierFlags) -> Bool {
+        !modifiers
+            .intersection(.deviceIndependentFlagsMask)
+            .intersection([.command, .shift, .control, .option])
+            .isEmpty
+    }
+
+    private func handleClickPassthrough(at point: CGPoint, modifiers: NSEvent.ModifierFlags) {
+        guard !Self.clickPassthroughBlocked(by: modifiers) else { return }
         // If this was a click (not a drag) and tmux has mouse mode enabled,
         // forward the click to tmux so it can handle pane switching.
         //

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -292,7 +292,7 @@ class TBDTerminalView: TerminalView {
     /// Plain (unmodified) clicks are forwarded into the pane; clicks carrying
     /// a modifier belong to TBD's own file/link handling and must not also be
     /// forwarded — otherwise a Cmd+click both opens a file and clicks Claude.
-    static func clickPassthroughBlocked(by modifiers: NSEvent.ModifierFlags) -> Bool {
+    nonisolated static func clickPassthroughBlocked(by modifiers: NSEvent.ModifierFlags) -> Bool {
         !modifiers
             .intersection(.deviceIndependentFlagsMask)
             .intersection([.command, .shift, .control, .option])

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -295,8 +295,7 @@ class TBDTerminalView: TerminalView {
     nonisolated static func clickPassthroughBlocked(by modifiers: NSEvent.ModifierFlags) -> Bool {
         !modifiers
             .intersection(.deviceIndependentFlagsMask)
-            .intersection([.command, .shift, .control, .option])
-            .isEmpty
+            .isDisjoint(with: [.command, .shift, .control, .option])
     }
 
     private func handleClickPassthrough(at point: CGPoint, modifiers: NSEvent.ModifierFlags) {

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -54,6 +54,7 @@ enum ClaudeSpawnCommandBuilder {
         shellFallback: String,
         settingsOverlayPath: String? = nil,
         pluginDirPath: String? = nil,
+        envSettingOverrides: [String: ClaudeEnvValue] = [:],
         fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
     ) -> Result {
         // Optional --settings flag merged into the claude invocation.
@@ -121,6 +122,15 @@ enum ClaudeSpawnCommandBuilder {
             // a dir, so if profileConfigDir is non-nil, inject it.
             if let configDir = profileConfigDir {
                 env["CLAUDE_CONFIG_DIR"] = configDir
+            }
+        }
+        // Registry-driven Claude spawn-env settings. This block only runs in
+        // the Claude branches — the `cmd` / `shellFallback` branches return
+        // earlier, before `env` exists — so non-Claude spawns are unaffected.
+        for setting in ClaudeEnvRegistry.all {
+            let value = envSettingOverrides[setting.id] ?? setting.defaultValue
+            if let envValue = setting.emit(value) {
+                env[setting.envVar] = envValue
             }
         }
         return Result(command: base, sensitiveEnv: env)

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let configLogger = Logger(subsystem: "com.tbd.daemon", category: "config")
 
 struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     static let databaseTableName = "config"
@@ -35,12 +38,19 @@ public struct ConfigStore: Sendable {
 
     /// Decode the `claude_env_settings` JSON column into an overrides map.
     /// Any malformed/absent value decodes to an empty map so a corrupt row
-    /// degrades to registry defaults rather than crashing a spawn.
+    /// degrades to registry defaults rather than crashing a spawn. A genuinely
+    /// corrupt row (JSON present but undecodable) is logged so it's observable
+    /// via `log stream` instead of silently resetting the user's settings.
     static func decodeOverrides(_ json: String?) -> [String: ClaudeEnvValue] {
-        guard let json, let data = json.data(using: .utf8),
-              let map = try? JSONDecoder().decode([String: ClaudeEnvValue].self, from: data)
-        else { return [:] }
-        return map
+        guard let json, let data = json.data(using: .utf8) else { return [:] }
+        do {
+            return try JSONDecoder().decode([String: ClaudeEnvValue].self, from: data)
+        } catch {
+            configLogger.error(
+                "Corrupt claude_env_settings row, falling back to defaults: \(String(describing: error), privacy: .public)"
+            )
+            return [:]
+        }
     }
 
     public func setDefaultProfileID(_ id: UUID?) async throws {

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -51,4 +51,16 @@ public struct ConfigStore: Sendable {
             )
         }
     }
+
+    /// Persist the Claude spawn-env setting overrides map. An empty map
+    /// clears all overrides; spawns then use every setting's registry default.
+    public func setEnvSettingOverrides(_ overrides: [String: ClaudeEnvValue]) async throws {
+        let json = String(data: try JSONEncoder().encode(overrides), encoding: .utf8)
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET claude_env_settings = ? WHERE id = ?",
+                arguments: [json, Self.singletonID]
+            )
+        }
+    }
 }

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -7,10 +7,14 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
 
     var id: String
     var default_profile_id: String?
+    /// JSON-encoded `[String: ClaudeEnvValue]` overrides map. Nil/absent
+    /// means no overrides — every setting falls back to its registry default.
+    var claude_env_settings: String?
 
     func toModel() -> Config {
         Config(
-            defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:))
+            defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
+            envSettingOverrides: ConfigStore.decodeOverrides(claude_env_settings)
         )
     }
 }
@@ -27,6 +31,16 @@ public struct ConfigStore: Sendable {
         try await writer.read { db in
             try ConfigRecord.fetchOne(db, key: Self.singletonID)?.toModel() ?? Config()
         }
+    }
+
+    /// Decode the `claude_env_settings` JSON column into an overrides map.
+    /// Any malformed/absent value decodes to an empty map so a corrupt row
+    /// degrades to registry defaults rather than crashing a spawn.
+    static func decodeOverrides(_ json: String?) -> [String: ClaudeEnvValue] {
+        guard let json, let data = json.data(using: .utf8),
+              let map = try? JSONDecoder().decode([String: ClaudeEnvValue].self, from: data)
+        else { return [:] }
+        return map
     }
 
     public func setDefaultProfileID(_ id: UUID?) async throws {

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -501,6 +501,10 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "model_profiles", column: "aws_profile", type: .text)
         }
 
+        migrator.registerMigration("v26_claude_env_settings") { db in
+            try db.addColumnIfMissing(table: "config", column: "claude_env_settings", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -377,6 +377,7 @@ public actor SuspendResumeCoordinator {
             }
         }
 
+        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
         let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: sessionID,
             freshSessionID: nil,
@@ -392,7 +393,8 @@ public actor SuspendResumeCoordinator {
             cmd: nil,
             shellFallback: defaultShell,
             settingsOverlayPath: ClaudeHookOverlay.overlayPath,
-            pluginDirPath: PluginDirWriter.pluginDirPath
+            pluginDirPath: PluginDirWriter.pluginDirPath,
+            envSettingOverrides: claudeEnvOverrides
         )
         // Inject TBD_WORKTREE_ID + TBD_TERMINAL_ID into the resumed pane so
         // notifications and the SessionStart hook bridge attribute to the

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -227,6 +227,7 @@ extension WorktreeLifecycle {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
         let worktreePath = worktreePath ?? worktree.path
+        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
         // Resolve a usable size: prefer caller's value, otherwise fall back to
         // TmuxManager's defaults. tmux's own 80x24 default would let Claude
         // render into hard-wrapped scrollback that can never be reflowed when
@@ -292,7 +293,8 @@ extension WorktreeLifecycle {
                 cmd: nil,
                 shellFallback: defaultShell,
                 settingsOverlayPath: ClaudeHookOverlay.overlayPath,
-                pluginDirPath: PluginDirWriter.pluginDirPath
+                pluginDirPath: PluginDirWriter.pluginDirPath,
+                envSettingOverrides: claudeEnvOverrides
             )
             claudeCommand = spawn.command
             claudeSensitiveEnv = spawn.sensitiveEnv
@@ -376,7 +378,8 @@ extension WorktreeLifecycle {
                     cmd: nil,
                     shellFallback: defaultShell,
                     settingsOverlayPath: ClaudeHookOverlay.overlayPath,
-                    pluginDirPath: PluginDirWriter.pluginDirPath
+                    pluginDirPath: PluginDirWriter.pluginDirPath,
+                    envSettingOverrides: claudeEnvOverrides
                 )
                 let perTermEnv: [String: String] = [
                     "TBD_WORKTREE_ID": worktreeID.uuidString,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -252,6 +252,7 @@ extension WorktreeLifecycle {
             server: worktree.tmuxServer, session: "main", cwd: worktree.path
         )
 
+        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
         let spawn: ClaudeSpawnCommandBuilder.Result
         var env: [String: String] = [:]
         // Always announce the worktree to recreated panes. Without this, the
@@ -285,7 +286,8 @@ extension WorktreeLifecycle {
                 cmd: nil,
                 shellFallback: defaultShell,
                 settingsOverlayPath: ClaudeHookOverlay.overlayPath,
-                pluginDirPath: PluginDirWriter.pluginDirPath
+                pluginDirPath: PluginDirWriter.pluginDirPath,
+                envSettingOverrides: claudeEnvOverrides
             )
         } else if terminal.kind == .codex || terminal.label == "Codex" {
             // Codex terminal — detected by kind (primary signal) or legacy label fallback.

--- a/Sources/TBDDaemon/Server/RPCRouter+ClaudePreferencesHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ClaudePreferencesHandlers.swift
@@ -1,0 +1,10 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+    func handleSetClaudeSpawnPreferences(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ClaudeSpawnPreferences.self, from: data)
+        try await db.config.setEnvSettingOverrides(params.settingOverrides ?? [:])
+        return .ok()
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+ClaudePreferencesHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ClaudePreferencesHandlers.swift
@@ -2,6 +2,9 @@ import Foundation
 import TBDShared
 
 extension RPCRouter {
+    // Intentionally does NOT broadcast a state delta: overrides are read from
+    // the DB at the next Claude spawn, and the spec treats the app's own
+    // setting as the display source of truth, so no live multi-client refresh.
     func handleSetClaudeSpawnPreferences(_ data: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ClaudeSpawnPreferences.self, from: data)
         try await db.config.setEnvSettingOverrides(params.settingOverrides ?? [:])

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -195,6 +195,7 @@ extension RPCRouter {
             label = nil
         }
 
+        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
         let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: params.resumeSessionID,
             freshSessionID: freshSessionID,
@@ -210,7 +211,8 @@ extension RPCRouter {
             cmd: params.cmd,
             shellFallback: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
             settingsOverlayPath: isClaudeType ? ClaudeHookOverlay.overlayPath : nil,
-            pluginDirPath: isClaudeType ? PluginDirWriter.pluginDirPath : nil
+            pluginDirPath: isClaudeType ? PluginDirWriter.pluginDirPath : nil,
+            envSettingOverrides: claudeEnvOverrides
         )
 
         let window = try await tmux.createWindow(
@@ -565,6 +567,7 @@ extension RPCRouter {
         )
         let plan = Self.planTerminalSwap(oldSessionID: sessionID, isBlank: blank)
 
+        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
         let spawn: ClaudeSpawnCommandBuilder.Result
         let storedSessionID: String
         let scheduleRecapture: Bool
@@ -586,7 +589,8 @@ extension RPCRouter {
                 cmd: nil,
                 shellFallback: "",
                 settingsOverlayPath: ClaudeHookOverlay.overlayPath,
-                pluginDirPath: PluginDirWriter.pluginDirPath
+                pluginDirPath: PluginDirWriter.pluginDirPath,
+                envSettingOverrides: claudeEnvOverrides
             )
             storedSessionID = resumeID
             scheduleRecapture = true
@@ -610,7 +614,8 @@ extension RPCRouter {
                 cmd: nil,
                 shellFallback: "",
                 settingsOverlayPath: ClaudeHookOverlay.overlayPath,
-                pluginDirPath: PluginDirWriter.pluginDirPath
+                pluginDirPath: PluginDirWriter.pluginDirPath,
+                envSettingOverrides: claudeEnvOverrides
             )
             storedSessionID = newSessionID
             scheduleRecapture = false

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -140,6 +140,8 @@ public final class RPCRouter: Sendable {
                 return try await handlePRRefresh(request.paramsData)
             case RPCMethod.worktreeSelectionChanged:
                 return try await handleWorktreeSelectionChanged(request.paramsData)
+            case RPCMethod.claudeSetSpawnPreferences:
+                return try await handleSetClaudeSpawnPreferences(request.paramsData)
             case RPCMethod.terminalSuspend:
                 return try await handleTerminalSuspend(request.paramsData)
             case RPCMethod.terminalResume:

--- a/Sources/TBDShared/ClaudeEnvRegistry.swift
+++ b/Sources/TBDShared/ClaudeEnvRegistry.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// A spawn-time environment value the user can configure. The on-disk JSON
+/// format is frozen — all three cases exist from day one so adding settings
+/// of any type never requires a storage migration.
+public enum ClaudeEnvValue: Codable, Equatable, Sendable {
+    case bool(Bool)
+    case int(Int)
+    case string(String)
+
+    private enum CodingKeys: String, CodingKey { case kind, value }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .bool(let b):
+            try c.encode("bool", forKey: .kind); try c.encode(b, forKey: .value)
+        case .int(let i):
+            try c.encode("int", forKey: .kind); try c.encode(i, forKey: .value)
+        case .string(let s):
+            try c.encode("string", forKey: .kind); try c.encode(s, forKey: .value)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch try c.decode(String.self, forKey: .kind) {
+        case "bool": self = .bool(try c.decode(Bool.self, forKey: .value))
+        case "int": self = .int(try c.decode(Int.self, forKey: .value))
+        case "string": self = .string(try c.decode(String.self, forKey: .value))
+        case let other:
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind, in: c, debugDescription: "unknown ClaudeEnvValue kind '\(other)'")
+        }
+    }
+}
+
+/// One configurable Claude spawn-time environment setting.
+public struct ClaudeEnvSetting: Sendable {
+    /// The value type, default, and env-emission rule for a setting.
+    /// v1 ships only `.toggle`; `.integer` / `.choice` are added — as new
+    /// cases plus a settings-UI switch arm — when the first such setting
+    /// is introduced.
+    public enum Kind: Sendable {
+        /// `emit` maps the boolean to the env value, or nil to omit the
+        /// variable. A normal flag emits when on; an inverted `DISABLE_*`
+        /// flag emits when off.
+        case toggle(default: Bool, emit: @Sendable (Bool) -> String?)
+    }
+
+    /// Stable semantic key — used in persistence and RPC, never the env-var name.
+    public let id: String
+    /// The environment variable this setting controls.
+    public let envVar: String
+    public let title: String
+    public let help: String
+    public let kind: Kind
+
+    public init(id: String, envVar: String, title: String, help: String, kind: Kind) {
+        self.id = id
+        self.envVar = envVar
+        self.title = title
+        self.help = help
+        self.kind = kind
+    }
+
+    /// The setting's default value as a `ClaudeEnvValue`.
+    public var defaultValue: ClaudeEnvValue {
+        switch kind {
+        case .toggle(let def, _): return .bool(def)
+        }
+    }
+
+    /// Resolve a stored value to the env-var value to set, or nil to omit.
+    /// A value whose type doesn't match the kind falls back to the default.
+    public func emit(_ value: ClaudeEnvValue) -> String? {
+        switch kind {
+        case .toggle(let def, let emit):
+            if case .bool(let b) = value { return emit(b) }
+            return emit(def)
+        }
+    }
+}
+
+/// The single source of truth for which Claude spawn-time env settings exist.
+/// Adding a setting is one entry here — no migration, no RPC change, and (for
+/// `.toggle`) no UI code.
+public enum ClaudeEnvRegistry {
+    public static let all: [ClaudeEnvSetting] = [
+        ClaudeEnvSetting(
+            id: "fullscreenRendering",
+            envVar: "CLAUDE_CODE_NO_FLICKER",
+            title: "Fullscreen rendering for Claude sessions",
+            help: "Flicker-free renderer for Claude Code. Research-preview "
+                + "feature — run /tui in a session to override per-session.",
+            kind: .toggle(default: true, emit: { $0 ? "1" : nil })
+        ),
+    ]
+
+    public static func setting(id: String) -> ClaudeEnvSetting? {
+        all.first { $0.id == id }
+    }
+}

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -346,14 +346,20 @@ public struct ModelProfileWithUsage: Codable, Sendable, Equatable {
 
 public struct Config: Codable, Sendable, Equatable {
     public var defaultProfileID: UUID?
+    /// Claude spawn-env setting overrides, keyed by `ClaudeEnvSetting.id`.
+    public var envSettingOverrides: [String: ClaudeEnvValue]
 
-    public init(defaultProfileID: UUID? = nil) {
+    public init(defaultProfileID: UUID? = nil,
+                envSettingOverrides: [String: ClaudeEnvValue] = [:]) {
         self.defaultProfileID = defaultProfileID
+        self.envSettingOverrides = envSettingOverrides
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         defaultProfileID = try c.decodeIfPresent(UUID.self, forKey: .defaultProfileID)
+        envSettingOverrides = try c.decodeIfPresent(
+            [String: ClaudeEnvValue].self, forKey: .envSettingOverrides) ?? [:]
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -102,6 +102,7 @@ public enum RPCMethod {
     public static let prRefresh = "pr.refresh"
     public static let cleanup = "cleanup"
     public static let worktreeSelectionChanged = "worktree.selectionChanged"
+    public static let claudeSetSpawnPreferences = "claude.setSpawnPreferences"
     public static let terminalSuspend = "terminal.suspend"
     public static let terminalResume = "terminal.resume"
     public static let worktreeSuspend = "worktree.suspend"
@@ -620,6 +621,17 @@ public struct NotifyParams: Codable, Sendable {
 public struct ResolvePathParams: Codable, Sendable {
     public let path: String
     public init(path: String) { self.path = path }
+}
+
+/// Params for `claude.setSpawnPreferences`. Carries the user's Claude
+/// spawn-env setting overrides, keyed by `ClaudeEnvSetting.id` (semantic
+/// key — never an env-var name). Optional/defaulted for backward
+/// compatibility with clients that omit it.
+public struct ClaudeSpawnPreferences: Codable, Sendable, Equatable {
+    public let settingOverrides: [String: ClaudeEnvValue]?
+    public init(settingOverrides: [String: ClaudeEnvValue]? = nil) {
+        self.settingOverrides = settingOverrides
+    }
 }
 
 public struct WorktreeSelectionChangedParams: Codable, Sendable {

--- a/Tests/TBDAppTests/ClaudeEnvOverridesTests.swift
+++ b/Tests/TBDAppTests/ClaudeEnvOverridesTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Foundation
+@testable import TBDApp
+import TBDShared
+
+@Suite("AppState.claudeEnvOverrides")
+struct ClaudeEnvOverridesTests {
+    private func freshDefaults() -> UserDefaults {
+        let suite = "ClaudeEnvOverridesTests-\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    @Test("untouched settings produce no overrides")
+    func emptyByDefault() {
+        let d = freshDefaults()
+        #expect(AppState.claudeEnvOverrides(defaults: d).isEmpty)
+    }
+
+    @Test("a value equal to the registry default produces no override")
+    func defaultValueNotAnOverride() {
+        let d = freshDefaults()
+        d.set(true, forKey: AppState.claudeEnvKey("fullscreenRendering"))
+        #expect(AppState.claudeEnvOverrides(defaults: d).isEmpty)
+    }
+
+    @Test("a value differing from the default is an override")
+    func changedValueIsOverride() {
+        let d = freshDefaults()
+        d.set(false, forKey: AppState.claudeEnvKey("fullscreenRendering"))
+        #expect(AppState.claudeEnvOverrides(defaults: d)["fullscreenRendering"] == .bool(false))
+    }
+}

--- a/Tests/TBDAppTests/ClickPassthroughTests.swift
+++ b/Tests/TBDAppTests/ClickPassthroughTests.swift
@@ -1,0 +1,26 @@
+import Testing
+import AppKit
+@testable import TBDApp
+
+@Suite("Click passthrough modifier guard")
+struct ClickPassthroughTests {
+    @Test("plain click is not blocked")
+    func plainClickAllowed() {
+        #expect(TBDTerminalView.clickPassthroughBlocked(by: []) == false)
+    }
+
+    @Test("command-click is blocked")
+    func commandBlocks() {
+        #expect(TBDTerminalView.clickPassthroughBlocked(by: .command) == true)
+    }
+
+    @Test("shift-click is blocked")
+    func shiftBlocks() {
+        #expect(TBDTerminalView.clickPassthroughBlocked(by: .shift) == true)
+    }
+
+    @Test("non-intercession flags (capsLock) do not block")
+    func capsLockAllowed() {
+        #expect(TBDTerminalView.clickPassthroughBlocked(by: .capsLock) == false)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeEnvSettingsMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeEnvSettingsMigrationTests.swift
@@ -1,0 +1,23 @@
+import Testing
+import GRDB
+@testable import TBDDaemonLib
+
+@Suite("v26 claude_env_settings migration")
+struct ClaudeEnvSettingsMigrationTests {
+    @Test("config table has claude_env_settings column")
+    func columnExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { conn in
+            let cols = try Row.fetchAll(conn, sql: "PRAGMA table_info(config)")
+                .map { $0["name"] as String }
+            #expect(cols.contains("claude_env_settings"))
+        }
+    }
+
+    @Test("config defaults to empty env overrides")
+    func defaultsEmpty() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.envSettingOverrides.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import TBDDaemonLib
+import TBDShared
 
 @Suite("ClaudeSpawnCommandBuilder")
 struct ClaudeSpawnCommandBuilderTests {
@@ -21,7 +22,8 @@ struct ClaudeSpawnCommandBuilderTests {
             shellFallback: "/bin/zsh"
         )
         #expect(r.command == "claude --resume abc-123 --dangerously-skip-permissions")
-        #expect(r.sensitiveEnv.isEmpty)
+        // Registry injects CLAUDE_CODE_NO_FLICKER=1 by default for all Claude spawns.
+        #expect(r.sensitiveEnv == ["CLAUDE_CODE_NO_FLICKER": "1"])
     }
 
     @Test("fresh session id only")
@@ -36,7 +38,8 @@ struct ClaudeSpawnCommandBuilderTests {
             shellFallback: "/bin/zsh"
         )
         #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions")
-        #expect(r.sensitiveEnv.isEmpty)
+        // Registry injects CLAUDE_CODE_NO_FLICKER=1 by default for all Claude spawns.
+        #expect(r.sensitiveEnv == ["CLAUDE_CODE_NO_FLICKER": "1"])
     }
 
     @Test("fresh + appendSystemPrompt")
@@ -148,7 +151,8 @@ struct ClaudeSpawnCommandBuilderTests {
             shellFallback: ""
         )
         #expect(!r.command.contains(fakeOauth))
-        #expect(r.sensitiveEnv == ["ANTHROPIC_API_KEY": fakeOauth])
+        // Registry injects CLAUDE_CODE_NO_FLICKER=1 by default for all Claude spawns.
+        #expect(r.sensitiveEnv == ["ANTHROPIC_API_KEY": fakeOauth, "CLAUDE_CODE_NO_FLICKER": "1"])
     }
 
     @Test("cmd path ignores token (non-claude shell)")
@@ -540,8 +544,8 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv["ANTHROPIC_BASE_URL"] == nil)
         #expect(r.sensitiveEnv["CLAUDE_CONFIG_DIR"] == nil)
         #expect(r.sensitiveEnv["ANTHROPIC_CONFIG_DIR"] == nil)
-        // Exactly these 4 keys
-        #expect(r.sensitiveEnv.keys.sorted() == ["ANTHROPIC_MODEL", "AWS_PROFILE", "AWS_REGION", "CLAUDE_CODE_USE_BEDROCK"])
+        // Exactly these 5 keys (registry adds CLAUDE_CODE_NO_FLICKER=1 for all Claude spawns)
+        #expect(r.sensitiveEnv.keys.sorted() == ["ANTHROPIC_MODEL", "AWS_PROFILE", "AWS_REGION", "CLAUDE_CODE_NO_FLICKER", "CLAUDE_CODE_USE_BEDROCK"])
     }
 
     @Test("bedrock: AWS_PROFILE omitted when nil")
@@ -609,5 +613,48 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv["CLAUDE_CODE_OAUTH_TOKEN"] == nil)
         #expect(r.sensitiveEnv["AWS_REGION"] == nil)
         #expect(r.sensitiveEnv["CLAUDE_CODE_USE_BEDROCK"] == nil)
+    }
+}
+
+@Suite("ClaudeSpawnCommandBuilder env settings")
+struct ClaudeSpawnCommandBuilderEnvTests {
+    @Test("fresh Claude spawn with no overrides emits CLAUDE_CODE_NO_FLICKER=1")
+    func defaultOnFresh() {
+        let result = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil, freshSessionID: "S1", appendSystemPrompt: nil,
+            initialPrompt: nil, profileSecret: nil,
+            cmd: nil, shellFallback: "/bin/zsh",
+            envSettingOverrides: [:])
+        #expect(result.sensitiveEnv["CLAUDE_CODE_NO_FLICKER"] == "1")
+    }
+
+    @Test("explicit false override omits CLAUDE_CODE_NO_FLICKER")
+    func falseOverrideOmits() {
+        let result = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil, freshSessionID: "S1", appendSystemPrompt: nil,
+            initialPrompt: nil, profileSecret: nil,
+            cmd: nil, shellFallback: "/bin/zsh",
+            envSettingOverrides: ["fullscreenRendering": .bool(false)])
+        #expect(result.sensitiveEnv["CLAUDE_CODE_NO_FLICKER"] == nil)
+    }
+
+    @Test("resume Claude spawn also emits the env var")
+    func defaultOnResume() {
+        let result = ClaudeSpawnCommandBuilder.build(
+            resumeID: "R1", freshSessionID: nil, appendSystemPrompt: nil,
+            initialPrompt: nil, profileSecret: nil,
+            cmd: nil, shellFallback: "/bin/zsh",
+            envSettingOverrides: [:])
+        #expect(result.sensitiveEnv["CLAUDE_CODE_NO_FLICKER"] == "1")
+    }
+
+    @Test("non-Claude (cmd) spawn never emits the env var")
+    func cmdSpawnNoEnv() {
+        let result = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil, freshSessionID: nil, appendSystemPrompt: nil,
+            initialPrompt: nil, profileSecret: nil,
+            cmd: "codex", shellFallback: "/bin/zsh",
+            envSettingOverrides: [:])
+        #expect(result.sensitiveEnv["CLAUDE_CODE_NO_FLICKER"] == nil)
     }
 }

--- a/Tests/TBDDaemonTests/ClaudeSpawnPreferencesHandlerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnPreferencesHandlerTests.swift
@@ -1,0 +1,21 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("claude.setSpawnPreferences data path")
+struct ClaudeSpawnPreferencesHandlerTests {
+    @Test("decoding params then persisting yields the override")
+    func decodeAndPersist() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let prefs = ClaudeSpawnPreferences(
+            settingOverrides: ["fullscreenRendering": .bool(false)])
+        let data = try JSONEncoder().encode(prefs)
+
+        let decoded = try JSONDecoder().decode(ClaudeSpawnPreferences.self, from: data)
+        try await db.config.setEnvSettingOverrides(decoded.settingOverrides ?? [:])
+
+        let cfg = try await db.config.get()
+        #expect(cfg.envSettingOverrides["fullscreenRendering"] == .bool(false))
+    }
+}

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -27,4 +27,25 @@ struct ConfigStoreTests {
         let cfg = try await db.config.get()
         #expect(cfg.defaultProfileID == nil)
     }
+
+    @Test func envOverridesDefaultEmpty() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.envSettingOverrides.isEmpty)
+    }
+
+    @Test func setAndGetEnvOverrides() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setEnvSettingOverrides(["fullscreenRendering": .bool(false)])
+        let cfg = try await db.config.get()
+        #expect(cfg.envSettingOverrides["fullscreenRendering"] == .bool(false))
+    }
+
+    @Test func overwriteEnvOverrides() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setEnvSettingOverrides(["fullscreenRendering": .bool(false)])
+        try await db.config.setEnvSettingOverrides([:])
+        let cfg = try await db.config.get()
+        #expect(cfg.envSettingOverrides.isEmpty)
+    }
 }

--- a/Tests/TBDSharedTests/ClaudeEnvRegistryTests.swift
+++ b/Tests/TBDSharedTests/ClaudeEnvRegistryTests.swift
@@ -41,4 +41,12 @@ struct ClaudeEnvRegistryTests {
         let setting = try #require(ClaudeEnvRegistry.setting(id: "fullscreenRendering"))
         #expect(setting.emit(.string("garbage")) == "1")
     }
+
+    @Test("decoding an unknown kind throws")
+    func decodeUnknownKindThrows() {
+        let data = Data(#"{"kind":"date","value":1}"#.utf8)
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(ClaudeEnvValue.self, from: data)
+        }
+    }
 }

--- a/Tests/TBDSharedTests/ClaudeEnvRegistryTests.swift
+++ b/Tests/TBDSharedTests/ClaudeEnvRegistryTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite("ClaudeEnvRegistry")
+struct ClaudeEnvRegistryTests {
+    @Test("ClaudeEnvValue round-trips all three cases")
+    func valueCodableRoundTrip() throws {
+        let values: [ClaudeEnvValue] = [.bool(true), .int(7), .string("x")]
+        for v in values {
+            let data = try JSONEncoder().encode(v)
+            let back = try JSONDecoder().decode(ClaudeEnvValue.self, from: data)
+            #expect(back == v)
+        }
+    }
+
+    @Test("overrides map round-trips")
+    func mapCodableRoundTrip() throws {
+        let map: [String: ClaudeEnvValue] = ["fullscreenRendering": .bool(false)]
+        let data = try JSONEncoder().encode(map)
+        let back = try JSONDecoder().decode([String: ClaudeEnvValue].self, from: data)
+        #expect(back == map)
+    }
+
+    @Test("registry contains fullscreenRendering, default on")
+    func registryHasFullscreen() throws {
+        let setting = try #require(ClaudeEnvRegistry.setting(id: "fullscreenRendering"))
+        #expect(setting.envVar == "CLAUDE_CODE_NO_FLICKER")
+        #expect(setting.defaultValue == .bool(true))
+    }
+
+    @Test("fullscreen emits CLAUDE_CODE_NO_FLICKER=1 when on, nothing when off")
+    func fullscreenEmit() throws {
+        let setting = try #require(ClaudeEnvRegistry.setting(id: "fullscreenRendering"))
+        #expect(setting.emit(.bool(true)) == "1")
+        #expect(setting.emit(.bool(false)) == nil)
+    }
+
+    @Test("type-mismatched value falls back to the kind default")
+    func emitTypeMismatchFallsBack() throws {
+        let setting = try #require(ClaudeEnvRegistry.setting(id: "fullscreenRendering"))
+        #expect(setting.emit(.string("garbage")) == "1")
+    }
+}

--- a/Tests/TBDSharedTests/ClaudeSpawnPreferencesTests.swift
+++ b/Tests/TBDSharedTests/ClaudeSpawnPreferencesTests.swift
@@ -1,0 +1,27 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite("ClaudeSpawnPreferences")
+struct ClaudeSpawnPreferencesTests {
+    @Test("round-trips with overrides")
+    func roundTrip() throws {
+        let prefs = ClaudeSpawnPreferences(
+            settingOverrides: ["fullscreenRendering": .bool(false)])
+        let data = try JSONEncoder().encode(prefs)
+        let back = try JSONDecoder().decode(ClaudeSpawnPreferences.self, from: data)
+        #expect(back.settingOverrides?["fullscreenRendering"] == .bool(false))
+    }
+
+    @Test("decodes when settingOverrides field is absent")
+    func decodesMissingField() throws {
+        let data = Data("{}".utf8)
+        let back = try JSONDecoder().decode(ClaudeSpawnPreferences.self, from: data)
+        #expect(back.settingOverrides == nil)
+    }
+
+    @Test("method constant is stable")
+    func methodConstant() {
+        #expect(RPCMethod.claudeSetSpawnPreferences == "claude.setSpawnPreferences")
+    }
+}

--- a/docs/superpowers/specs/2026-05-21-claude-fullscreen-rendering-design.md
+++ b/docs/superpowers/specs/2026-05-21-claude-fullscreen-rendering-design.md
@@ -141,9 +141,11 @@ values are **persisted in the daemon database**.
   semantic setting ID, never by env-var name.
 - New RPC `setClaudeSpawnPreferences(ClaudeSpawnPreferences)`. The daemon
   writes the overrides map into the `config` table.
-- The daemon broadcasts the current overrides (via the existing state
-  delta mechanism) so the app's Settings UI reflects the daemon's
-  persisted truth.
+- No daemon→app broadcast. The app's Settings UI binds directly to its
+  own `@AppStorage` values — the app is the display source of truth. The
+  daemon `config` table is the *spawn-time* persistence, and the app keeps
+  it in sync by pushing (see below). Since no other writer of the
+  overrides exists, a broadcast would add nothing.
 - **App push timing.** The app pushes `setClaudeSpawnPreferences`
   (a) whenever the user changes a setting, and (b) whenever it
   establishes or re-establishes a daemon connection — both

--- a/docs/superpowers/specs/2026-05-21-claude-fullscreen-rendering-design.md
+++ b/docs/superpowers/specs/2026-05-21-claude-fullscreen-rendering-design.md
@@ -1,0 +1,304 @@
+# Claude Spawn Environment Settings — Design
+
+Date: 2026-05-21
+Status: draft — under brainstorming, not yet approved
+
+## Problem
+
+Claude Code's classic renderer streams full-frame repaints as plain text
+through the tmux relay into SwiftTerm. SwiftTerm paints partial frames,
+producing visible screen-tearing inside TBD terminal panes. Claude Code's
+**fullscreen rendering** (alternate-screen buffer, opt-in via
+`CLAUDE_CODE_NO_FLICKER=1`) renders only visible messages with diffed
+redraws, which eliminates the tearing. It also gives flat memory use and
+in-app scroll.
+
+The immediate need is to enable fullscreen rendering by default for Claude
+sessions, with a user-facing toggle. But fullscreen is one of dozens of
+behavior/UX environment variables Claude Code exposes. Rather than wiring a
+bespoke toggle, this design introduces a **registry-driven system** for
+managing Claude spawn-time environment settings, and ships fullscreen as
+its first entry.
+
+## Goals
+
+- A registry-driven system for Claude spawn-time env settings that
+  accommodates dozens of settings of mixed value types (boolean, integer,
+  choice) at O(1) cost per new setting — no migration, no RPC change, no
+  per-setting UI code.
+- Ship `fullscreenRendering` as the first registry entry, on by default.
+- The default value of every setting holds for **every** spawn path,
+  including daemon-restart reconcile and CLI-driven spawns with no app
+  running.
+- In-pane mouse behavior (wheel scroll, drag-select, link/file clicking)
+  continues to work with fullscreen Claude.
+
+## Non-goals
+
+- Per-profile, per-repo, or per-terminal configuration. Settings are
+  global.
+- Managing env vars already owned by TBD's profile system —
+  `ANTHROPIC_MODEL`, auth tokens, `CLAUDE_CONFIG_DIR`, the AWS/Bedrock
+  vars (see `ClaudeSpawnCommandBuilder`). The registry covers only
+  behavior/UX/limit env vars; profile-owned keys must never appear in it.
+- Migrating the existing `suspendEnabled` flag into this system.
+  `suspendEnabled` rides on the `worktreeSelectionChanged` RPC and is
+  consumed synchronously with that event — read at selection-change time,
+  never persisted, always fresh. This registry is for values read at
+  *spawn* time, decoupled from any event, which is why they must be
+  persisted. Different lifetimes; `suspendEnabled` stays on the selection
+  event.
+- Codex sessions (Claude only).
+- Reworking `ClaudeStateDetector` logic. Its interaction with the
+  alternate screen is **verified**, not assumed — see Testing.
+- `.integer` / `.choice` setting UI (see "v1 scope" — model only).
+
+## Design
+
+### 1. The registry
+
+A single declarative registry in `TBDShared`, compiled into both the app
+and the daemon, is the one source of truth for what settings exist:
+
+```swift
+enum ClaudeEnvValue: Codable, Equatable {   // persisted form
+    case bool(Bool)
+    case int(Int)
+    case string(String)
+}
+
+struct ClaudeEnvSetting {
+    let id: String          // stable semantic key, e.g. "fullscreenRendering"
+    let envVar: String      // "CLAUDE_CODE_NO_FLICKER"
+    let title: String       // UI label
+    let help: String        // UI help text
+    let kind: Kind
+
+    enum Kind {
+        case toggle(default: Bool,   emit: (Bool) -> String?)
+        case integer(default: Int,   range: ClosedRange<Int>, emit: (Int) -> String?)
+        case choice(default: String, options: [String],       emit: (String) -> String?)
+    }
+}
+
+enum ClaudeEnvRegistry {
+    static let all: [ClaudeEnvSetting] = [
+        ClaudeEnvSetting(
+            id: "fullscreenRendering",
+            envVar: "CLAUDE_CODE_NO_FLICKER",
+            title: "Fullscreen rendering for Claude sessions",
+            help: "Flicker-free renderer. Claude Code research-preview "
+                + "feature; use /tui in-session to override.",
+            kind: .toggle(default: true, emit: { $0 ? "1" : nil })
+        ),
+    ]
+}
+```
+
+Key properties of the `Kind` model:
+
+- Each kind bundles its **default**, its value type, and an **emit
+  function** `(value) -> String?` that returns the env value to set, or
+  `nil` to omit the variable entirely.
+- The emit function decouples the user-facing semantic from the env
+  emission. A normal flag emits when on (`{ $0 ? "1" : nil }`); an
+  inverted `DISABLE_*` flag emits when off (`{ $0 ? nil : "1" }`); a
+  scalar omits when it equals the Claude default.
+- The registry holds closures, so it is code, not data — it is never
+  serialized. Only setting *values* are persisted.
+
+### 2. Persistence — daemon `config` table, one JSON blob
+
+The daemon owns Claude spawning, is a separate process, and **respawns
+Claude during boot-time reconcile before any client can connect**. A
+memory-only cache would be empty for reconcile spawns and for CLI-driven
+spawns when the app is closed — breaking the default guarantee. So setting
+values are **persisted in the daemon database**.
+
+- A new numbered GRDB migration adds one column,
+  `claude_env_settings TEXT`, to the existing `config` singleton table
+  (`Database.swift:294`, the single-row `id = 'singleton'` table). It
+  holds a JSON-encoded `[String: ClaudeEnvValue]` — an **overrides map**:
+  setting ID → user-chosen value, containing only settings the user has
+  changed from their registry default. Per the project migration rule,
+  the same commit updates the GRDB `Config` record type and the
+  `TBDShared` Codable model; the field is optional so existing rows
+  decode.
+- Because the column stores only *overrides*, adding a new registry entry
+  needs **no migration** — the JSON shape is stable forever. This is the
+  one and only schema change for the entire system.
+- Effective value of a setting = `overrides[id] ?? registry default`. A
+  daemon with an empty/absent blob (fresh install, boot-time reconcile,
+  CLI-only usage) still uses every setting's registry default — so
+  fullscreen-on-by-default holds with zero client interaction.
+- `ConfigStore` (GRDB writer) serializes all access; no in-memory cache,
+  no bespoke locking.
+
+### 3. App ↔ daemon plumbing
+
+- RPC payload struct `ClaudeSpawnPreferences { settingOverrides: [String:
+  ClaudeEnvValue]? }` in `TBDShared` — one stable Codable field, keyed by
+  semantic setting ID, never by env-var name.
+- New RPC `setClaudeSpawnPreferences(ClaudeSpawnPreferences)`. The daemon
+  writes the overrides map into the `config` table.
+- The daemon broadcasts the current overrides (via the existing state
+  delta mechanism) so the app's Settings UI reflects the daemon's
+  persisted truth.
+- **App push timing.** The app pushes `setClaudeSpawnPreferences`
+  (a) whenever the user changes a setting, and (b) whenever it
+  establishes or re-establishes a daemon connection — both
+  `connectAndLoadInitialState()` *and* the poll-driven reconnect branch
+  in `startPolling()` (`AppState.swift:548-571`) — so a daemon restart
+  while the app runs re-syncs. The push is reconciliation only; the DB
+  column is the source of truth.
+
+The boundary stays semantic: the RPC and the persisted blob carry setting
+IDs and typed values. The env-var *name* is declared once, in the
+registry, in shared code both processes compile against. The app never
+hardcodes Claude's env-var vocabulary; it iterates `ClaudeEnvRegistry.all`.
+
+Version skew is graceful: an override for an unknown setting ID (app
+newer than daemon, or the reverse) is ignored; a registry entry with no
+override falls back to its default.
+
+### 4. Env var injection — single choke point
+
+`ClaudeSpawnCommandBuilder.build` gains one parameter,
+`envSettingOverrides: [String: ClaudeEnvValue]`. When the resolved command
+is a Claude command (the `resumeID` / `freshSessionID` branches), the
+builder computes spawn env vars by iterating `ClaudeEnvRegistry.all`. For
+each setting it switches on `kind` to read that kind's `default` and
+`emit`, resolves the effective value against the overrides map, and sets
+the env var when `emit` returns non-nil:
+
+```
+for setting in ClaudeEnvRegistry.all {
+    // switch on setting.kind → (default, emit) for that case
+    let value = overrides[setting.id] ?? <kind default>
+    if let envValue = <kind emit>(value) { env[setting.envVar] = envValue }
+}
+```
+
+The `cmd` / `shellFallback` branches return before `env` is populated, so
+Codex and plain-shell spawns are structurally unaffected.
+
+All `ClaudeSpawnCommandBuilder.build` call sites (9 total) pass the
+overrides map, read from `ConfigStore`:
+
+| File | Line | Claude spawn? |
+|---|---|---|
+| `WorktreeLifecycle+Create.swift` | 280 | yes — fresh/resume first terminal |
+| `WorktreeLifecycle+Create.swift` | 364 | yes — restore additional archived sessions |
+| `WorktreeLifecycle+Reconcile.swift` | 273 | yes — `recreateAfterReboot` |
+| `WorktreeLifecycle+Reconcile.swift` | 295 | conditional — codex/shell branch (no-op) |
+| `WorktreeLifecycle+Reconcile.swift` | 308 | conditional — codex/shell branch (no-op) |
+| `SuspendResumeCoordinator.swift` | 380 | yes — resume after suspend |
+| `RPCRouter+TerminalHandlers.swift` | 198 | yes — create terminal |
+| `RPCRouter+TerminalHandlers.swift` | 574 | yes — recreate window |
+| `RPCRouter+TerminalHandlers.swift` | 598 | yes — recreate window (alt branch) |
+
+Non-Claude call sites may pass an empty map or the real one; the builder's
+early return makes it a no-op. The implementation plan confirms each site.
+
+Changing a setting affects **newly spawned** sessions only.
+
+### 5. Settings UI
+
+A new section in `TerminalSettingsView` iterates `ClaudeEnvRegistry.all`
+and renders one control per setting, switching on `Kind`:
+
+- `.toggle` → `Toggle`, label/help from the registry.
+
+The control is bound to the daemon-broadcast overrides; changing it pushes
+`setClaudeSpawnPreferences`. Adding a `.toggle` setting to the registry
+makes its row appear automatically — no UI code.
+
+### 6. In-pane mouse handling (fullscreen)
+
+With fullscreen Claude, `terminal.mouseMode` flips on. TBD's mouse
+architecture mostly absorbs this:
+
+- **Wheel scroll** — `scrollMonitor` (`TerminalPanelView.swift:329`)
+  forwards wheel events to the pane as mouse button 4/5 when `mouseMode
+  != .off`. The code path is unchanged, but scrollback **ownership moves**:
+  classic Claude → SwiftTerm's local scrollback; fullscreen Claude → the
+  wheel is delivered into Claude, which scrolls its in-app message view.
+  Intended behavior, and a verification item.
+- **Plain click** — `handleClickPassthrough` (`TBDTerminalView.swift:292`)
+  forwards the click into Claude (click-to-expand tool output). Intended.
+- **Drag-select** — SwiftTerm handles it locally (`allowMouseReporting =
+  false`). Unchanged.
+
+**Known fix required:** `handleClickPassthrough` does not check modifier
+keys, so a Cmd+click on a file path would both open the file in TBD *and*
+send a click into Claude. Add a guard to skip the passthrough when a
+modifier key is held — modified clicks belong to TBD's file/link handling,
+plain clicks go to Claude.
+
+Residual flicker (tmux does not pass synchronized-output / DECSET 2026) is
+a known limitation, out of scope unless verification shows it severe.
+
+### 7. Live-session remediation
+
+A setting governs new spawns only. For a live session misbehaving under
+fullscreen, the remedies are Claude's own `/tui default` command, or TBD's
+recreate-window action (`handleTerminalRecreateWindow`,
+`RPCRouter+TerminalHandlers.swift:287`), which respawns the pane with the
+current `config` values. The fullscreen setting's help text names `/tui`.
+
+## v1 scope
+
+The design accommodates dozens of mixed-type settings; the v1 build is
+deliberately narrower:
+
+- The persisted format (`ClaudeEnvValue` with `.bool` / `.int` / `.string`)
+  is defined fully now, so the on-disk JSON never migrates.
+- v1 implements the `.toggle` kind end-to-end — registry, emit, daemon
+  injection, settings UI, tests — and ships exactly one entry:
+  `fullscreenRendering`.
+- `.integer` and `.choice` exist in the `Kind` type but their settings-UI
+  rendering is **not** implemented in v1, to avoid shipping unexercised UI
+  branches (the project requires a test per branch). They land — as a new
+  UI switch arm plus a registry entry — with the first real setting that
+  needs them. No redesign required.
+
+## Testing
+
+- Unit: `ClaudeEnvValue` Codable round-trip for all three cases; the
+  overrides map decodes with unknown keys ignored and missing keys
+  defaulted.
+- Unit: `ClaudeSpawnPreferences` Codable round-trip; decodes with a
+  missing `settingOverrides` field.
+- Unit: the new `config` migration applies cleanly; `claude_env_settings`
+  is absent/empty for a pre-existing singleton row and effective values
+  fall back to registry defaults.
+- Unit: `ConfigStore` round-trips the overrides map.
+- Unit: registry emit — `fullscreenRendering` default (no override)
+  yields `CLAUDE_CODE_NO_FLICKER=1`; an explicit `false` override yields
+  no env var.
+- Unit: `ClaudeSpawnCommandBuilder.build` includes/omits
+  `CLAUDE_CODE_NO_FLICKER` per the overrides map for Claude commands, and
+  never emits it for `cmd` / `shellFallback` branches.
+- Manual verification matrix (inside a TBD pane, fullscreen Claude):
+  wheel scroll reaches Claude's in-app scroll; plain click; Cmd+click on
+  file path; Cmd+click on OSC 8 link; PR-number link; drag-select + copy;
+  split layouts; **`ClaudeStateDetector` idle/busy detection and
+  auto-suspend still work** (status bar captured correctly from the
+  alternate screen); residual flicker severity.
+- Manual: daemon restart (`scripts/restart.sh`) — reconcile-respawned
+  Claude panes come back fullscreen when the setting is on, classic when
+  off.
+
+## Resolved decisions
+
+- **Value model:** typed (`bool` / `int` / `string`) from day one, not
+  boolean-only — Claude Code's env vars include integers
+  (`CLAUDE_CODE_SCROLL_SPEED`, `BASH_DEFAULT_TIMEOUT_MS`) and enums
+  (`CLAUDE_CODE_EFFORT_LEVEL`).
+- **Persistence:** the `config` singleton table, one JSON column for an
+  overrides map — not a column per setting. Required for the default
+  guarantee across daemon restarts and CLI-only usage, and keeps the
+  schema fixed as settings are added.
+- **Concurrency:** `ConfigStore` (GRDB writer) serializes access.
+- **Boundary:** the registry never includes profile-owned env vars
+  (`ANTHROPIC_MODEL`, auth, `CLAUDE_CONFIG_DIR`, AWS/Bedrock).


### PR DESCRIPTION
## Summary
- Claude Code's classic renderer streams full-frame repaints through the tmux relay, so SwiftTerm paints partial frames — visible screen-tearing in TBD panes. This spawns `claude` with `CLAUDE_CODE_NO_FLICKER=1` (the alternate-screen renderer) by default, which eliminates the tearing and gives in-pane scroll.
- Built as a **registry-driven system** rather than a one-off toggle: `ClaudeEnvRegistry` in `TBDShared` is the single source of truth for Claude spawn-time env settings. Adding a future setting is one registry entry — no migration (values persist as one JSON column on the `config` table), no RPC change (semantic-keyed `ClaudeSpawnPreferences`), and no UI code (`TerminalSettingsView` renders the registry). `ClaudeEnvValue` is typed (`bool`/`int`/`string`) so the on-disk format is frozen for future integer/choice settings.
- The default-on guarantee holds for **every** spawn path — including daemon-restart reconcile and CLI spawns with no app running — because the env var is injected at one choke point (`ClaudeSpawnCommandBuilder.build`) from a persisted, registry-defaulted value.
- Adds a `TerminalSettingsView` → "Claude Environment" toggle (on by default) to opt out.
- In-pane mouse fix: with the fullscreen renderer, `mouseMode` is on, so a Cmd+click on a file path would both open the file in TBD *and* click into Claude. `handleClickPassthrough` now skips the passthrough when a modifier key is held.

## Test plan
- [x] `swift build` clean, `swift test` — 1020 tests pass, SwiftLint `--strict` 0 violations
- [x] Manual: Claude pane renders fullscreen, no tearing; wheel scroll, plain click, Cmd+click on file path, drag-select, split layouts all verified in a live pane
- [x] Manual: Settings toggle defaults on; turning it off spawns classic-renderer Claude; reconcile-respawned panes honor the persisted setting after `scripts/restart.sh`

Design spec: `docs/superpowers/specs/2026-05-21-claude-fullscreen-rendering-design.md`

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=125718C6-EA34-4EF9-83CC-097E6FA1482A)