### PR TITLE
Fix: Break TabBar render loop that pegs the main thread and blacks out terminals

### DIFF
--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -512,7 +512,7 @@ private struct TabBarItem: View {
             // .onDrop below also clears to nil) from publishing needlessly.
             .onAppear {
                 let id = tab.id
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     if appState.draggingTabID != id { appState.draggingTabID = id }
                 }
             }
@@ -520,7 +520,7 @@ private struct TabBarItem: View {
             // Escape, drop on a non-target. Covers cancel paths that neither the
             // per-tab delegate nor the outer catch-all see.
             .onDisappear {
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     if appState.draggingTabID != nil { appState.draggingTabID = nil }
                 }
             }

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -505,11 +505,25 @@ private struct TabBarItem: View {
             .background(Color(nsColor: .controlBackgroundColor))
             .cornerRadius(4)
             .opacity(0.85)
-            .onAppear { appState.draggingTabID = tab.id }
+            // Defer the @Published write off SwiftUI's view-graph update pass.
+            // Writing it synchronously here re-invalidates the body that owns
+            // this preview, causing a runaway re-render loop. The equality
+            // guard also keeps a redundant same-value write (the catch-all
+            // .onDrop below also clears to nil) from publishing needlessly.
+            .onAppear {
+                let id = tab.id
+                DispatchQueue.main.async {
+                    if appState.draggingTabID != id { appState.draggingTabID = id }
+                }
+            }
             // Drag preview is dismissed on any drag end — drop, drop-outside-window,
             // Escape, drop on a non-target. Covers cancel paths that neither the
             // per-tab delegate nor the outer catch-all see.
-            .onDisappear { appState.draggingTabID = nil }
+            .onDisappear {
+                DispatchQueue.main.async {
+                    if appState.draggingTabID != nil { appState.draggingTabID = nil }
+                }
+            }
         }
         // Use onDrop+DropDelegate (instead of .dropDestination) so we get
         // info.location during hover via dropUpdated, which is required to


### PR DESCRIPTION
## Summary

Main-worktree terminals would stop rendering (black) while TBDApp burned ~55% CPU on the main thread — the bug accumulated under specific UI states and only cleared on app restart.

**What's broken:** A SwiftUI runaway re-render loop in `TabBar.swift`. The `sample` of the hung process showed all main-thread samples in `AppKitWindowController.updateRootView → GraphHost.preferenceValues → AG::Graph::update_attribute` (recursing, 11/12 samples) → `TabBarItem.body.getter` (`TabBar.swift:497`) → `View.draggable(_:preview:)` (`TabBar.swift:508`).

**Why it happens:** `TabBarItem.body` *reads* `appState.draggingTabID` at `TabBar.swift:486` for the source-tab dimming. The `.draggable` preview closure that same body owns *wrote* that `@Published` synchronously from its `.onAppear`/`.onDisappear`. Mutating observable state the enclosing body reads, during SwiftUI's view-graph update pass, re-invalidates that body — a self-sustaining invalidation loop.

**What this PR does:** Defers both `appState.draggingTabID` writes to a fresh runloop transaction via `DispatchQueue.main.async`, so the `@Published` mutation is never re-entrant with the update pass — killing the synchronous recursion. Adds value-equality guards so a redundant same-value clear (the catch-all `.onDrop` at `TabBar.swift:154` also resets to `nil`) doesn't publish needlessly. 16 lines, `TabBar.swift` only.

Distinct from #129 (TranscriptItemsView LazyVStack hang) — same Bug 2-class layout cycle, different view, no shared code.

## Test plan

- [ ] `swift build` clean — verified (67.7s)
- [ ] Restart, open several Claude tabs, sample idle main thread — verified parked in `mach_msg_trap`, no `TabBarItem.body.getter`/`View.draggable` in the call graph
- [ ] Drag-hover tabs and switch tabs rapidly; confirm CPU stays near idle when not actively dragging
- [ ] Confirm tab reorder via drag-and-drop and the source-tab dimming still work

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=E081CF73-7FDD-441E-84EC-9AF063EFF32E)