### PR TITLE
Fix: Auto-close the Cmd+K jump menu when you click outside it

### DIFF
--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -15,6 +15,7 @@ final class JumpMenuController {
     private weak var appState: AppState?
     private var panel: FloatingPanel?
     private var viewModel: JumpMenuViewModel?
+    private var resignKeyObserver: NSObjectProtocol?
 
     private init() {}
 
@@ -81,10 +82,36 @@ final class JumpMenuController {
         panel.makeKey()
         self.panel = panel
 
+        // Auto-close when the panel loses key status (user clicked outside).
+        // Defensive: remove any prior token so reopening can't stack observers
+        // even if close() didn't run. resignKey fires only on losing focus,
+        // never on gaining it, so registering here (post-makeKey) is safe.
+        if let resignKeyObserver {
+            NotificationCenter.default.removeObserver(resignKeyObserver)
+        }
+        resignKeyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                logger.debug("Jump menu lost key focus — auto-closing")
+                self.close()
+            }
+        }
+
         logger.debug("Jump menu opened with \(snapshots.count, privacy: .public) worktrees, \(appState.unreadByWorktree.count, privacy: .public) unread, \(appState.recentWorktreeIDs.count, privacy: .public) recents")
     }
 
     private func close() {
+        // Remove the observer before dismissing so dismiss()'s own key-loss
+        // doesn't re-enter close(). A nil token makes a second close() a no-op
+        // for the observer path, so submit/Escape -> close() can't double-fire.
+        if let resignKeyObserver {
+            NotificationCenter.default.removeObserver(resignKeyObserver)
+            self.resignKeyObserver = nil
+        }
         panel?.dismiss()
         panel = nil
         viewModel = nil


### PR DESCRIPTION
## Summary
- The Cmd+K worktree quick-switcher stayed overlaid when you clicked outside it — you had to press Escape or submit a row to dismiss it.
- The `JumpMenuPanel` becomes the key window so its search field receives input, but nothing dismissed it when it *lost* key status. This adds an `NSWindow.didResignKeyNotification` observer scoped to the panel that calls `close()` on focus loss.
- The observer is torn down in `close()` before `dismiss()` so submit/Escape paths don't double-fire, and any stale token is cleared on reopen so observers can't stack.

## Test plan
- [ ] Press Cmd+K to open the jump menu, then click anywhere outside the panel — it closes.
- [ ] Open the jump menu and press Escape — it still closes, no double-close.
- [ ] Open the jump menu and submit a row — it jumps and closes cleanly.
- [ ] Open and close the menu several times in a row — no leaked/stacked observers (search field still focuses on each open).

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=0ACABCFA-B092-4393-9AAF-22FEC204AC03)