### PR TITLE
Feat: Order Cmd+K jump menu search results by recency

### DIFF
--- a/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift
@@ -122,6 +122,12 @@ final class JumpMenuViewModel: ObservableObject {
 
     private func matchRows(query: String) -> [JumpMenuRow] {
         let needle = query.lowercased()
+        // Recency rank: position in the LRU list (0 = most recent). Worktrees
+        // absent from the list (never visited this session, or past the
+        // 32-item cap) rank `Int.max` and sink to the bottom of their tier.
+        let recencyRank: [UUID: Int] = Dictionary(
+            uniqueKeysWithValues: recentIDs.enumerated().map { ($0.element, $0.offset) }
+        )
         return allWorktrees
             .filter { snap in
                 snap.displayName.lowercased().contains(needle)
@@ -136,23 +142,39 @@ final class JumpMenuViewModel: ObservableObject {
                     section: .match
                 )
             }
-            // Order: rows with an unread severity first (severity desc), then
-            // rows without. Within each group, sort by displayName asc, with
-            // a UUID lexicographic tiebreak for determinism. Dict iteration
-            // order of `allWorktrees` is otherwise arbitrary.
+            // Order: unread rows first (severity desc), then recency
+            // (most-recently-used first) across both tiers, then an
+            // emoji-stripped alphabetical fallback, then a UUID tiebreak
+            // for determinism (dict iteration order is otherwise arbitrary).
             .sorted { lhs, rhs in
-                let lhsSev = lhs.severity?.severity ?? -1
-                let rhsSev = rhs.severity?.severity ?? -1
                 let lhsHas = lhs.severity != nil
                 let rhsHas = rhs.severity != nil
                 if lhsHas != rhsHas { return lhsHas && !rhsHas }
+                let lhsSev = lhs.severity?.severity ?? -1
+                let rhsSev = rhs.severity?.severity ?? -1
                 if lhsSev != rhsSev { return lhsSev > rhsSev }
-                if lhs.displayName != rhs.displayName {
-                    return lhs.displayName < rhs.displayName
-                }
+                let lhsRank = recencyRank[lhs.id] ?? Int.max
+                let rhsRank = recencyRank[rhs.id] ?? Int.max
+                if lhsRank != rhsRank { return lhsRank < rhsRank }
+                let lhsKey = Self.alphabeticalSortKey(lhs.displayName)
+                let rhsKey = Self.alphabeticalSortKey(rhs.displayName)
+                if lhsKey != rhsKey { return lhsKey < rhsKey }
                 return lhs.id.uuidString < rhs.id.uuidString
             }
             .prefix(Self.rowCap)
             .map { $0 }
+    }
+
+    /// Sort key for the alphabetical fallback. Display names are formatted
+    /// `<emoji> <Title Case>`, so leading non-alphanumeric characters (the
+    /// emoji and the space after it) are dropped to order by words rather
+    /// than emoji codepoints. A `Character` is a grapheme cluster, so a
+    /// multi-scalar emoji (flags, ZWJ sequences) is dropped as one unit. A
+    /// name that is entirely emoji yields an empty key; the UUID tiebreak
+    /// keeps such rows deterministically ordered.
+    private static func alphabeticalSortKey(_ displayName: String) -> String {
+        displayName
+            .drop { !$0.isLetter && !$0.isNumber }
+            .lowercased()
     }
 }

--- a/Tests/TBDAppTests/JumpMenuViewModelTests.swift
+++ b/Tests/TBDAppTests/JumpMenuViewModelTests.swift
@@ -161,6 +161,103 @@ struct JumpMenuViewModelTests {
         #expect(vm.selectedRow == nil)
     }
 
+    @Test func match_recentOutranksNonRecentByName() {
+        // A recently-used match must rank above a non-recent one even when
+        // it sorts later alphabetically.
+        let recent = UUID(); let nonRecent = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [
+                snap(recent, name: "zzz-standup"),
+                snap(nonRecent, name: "aaa-standup"),
+            ],
+            unread: [:],
+            recentIDs: [recent]   // only `recent` was visited
+        )
+        vm.query = "standup"
+        let rows = vm.rows
+        #expect(rows.count == 2)
+        #expect(rows[0].id == recent)      // recency beats alphabetical
+        #expect(rows[1].id == nonRecent)
+    }
+
+    @Test func match_unreadOutranksMoreRecentRead() {
+        // An unread worktree stays on top even when a read worktree was
+        // used more recently.
+        let read = UUID(); let unreadWT = UUID()
+        let now = Date()
+        let vm = JumpMenuViewModel(
+            worktrees: [
+                snap(read, name: "standup-read"),
+                snap(unreadWT, name: "standup-unread"),
+            ],
+            unread: [unreadWT: UnreadSummary(type: .error, mostRecentAt: now)],
+            recentIDs: [read]   // `read` is the most recently used
+        )
+        vm.query = "standup"
+        let rows = vm.rows
+        #expect(rows.count == 2)
+        #expect(rows[0].id == unreadWT)   // unread tier wins over recency
+        #expect(rows[1].id == read)
+    }
+
+    @Test func match_recencyOrdersWithinUnreadTier() {
+        // Two equal-severity unread matches order by recency.
+        let older = UUID(); let newer = UUID()
+        let now = Date()
+        let vm = JumpMenuViewModel(
+            worktrees: [
+                snap(older, name: "standup-a"),
+                snap(newer, name: "standup-b"),
+            ],
+            unread: [
+                older: UnreadSummary(type: .error, mostRecentAt: now),
+                newer: UnreadSummary(type: .error, mostRecentAt: now),
+            ],
+            recentIDs: [newer, older]   // `newer` is more recent
+        )
+        vm.query = "standup"
+        let rows = vm.rows
+        #expect(rows.count == 2)
+        #expect(rows[0].id == newer)   // equal severity -> recency decides
+        #expect(rows[1].id == older)
+    }
+
+    @Test func match_emojiPrefixSortsByWords() {
+        // Non-recent matches fall back to alphabetical; a leading emoji
+        // must not drive the order.
+        let apple = UUID(); let zebra = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [
+                snap(zebra, name: "🔧 zebra standup"),
+                snap(apple, name: "🦓 apple standup"),
+            ],
+            unread: [:],
+            recentIDs: []   // neither recent -> alphabetical fallback
+        )
+        vm.query = "standup"
+        let rows = vm.rows
+        #expect(rows.count == 2)
+        #expect(rows[0].id == apple)   // "apple..." < "zebra..." despite emoji
+        #expect(rows[1].id == zebra)
+    }
+
+    @Test func match_nonRecentFallbackAlphabetical() {
+        // With no recency data, matches order alphabetically by words.
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let vm = JumpMenuViewModel(
+            worktrees: [
+                snap(c, name: "charlie-standup"),
+                snap(a, name: "alpha-standup"),
+                snap(b, name: "bravo-standup"),
+            ],
+            unread: [:],
+            recentIDs: []
+        )
+        vm.query = "standup"
+        let rows = vm.rows
+        #expect(rows.map(\.id) == [a, b, c])
+    }
+
     @Test func deletionsAreFiltered() {
         let stale = UUID()    // not present in `worktrees`
         let live = UUID()

--- a/docs/superpowers/specs/2026-05-22-jump-menu-recency-ordering-design.md
+++ b/docs/superpowers/specs/2026-05-22-jump-menu-recency-ordering-design.md
@@ -1,7 +1,7 @@
 # Jump Menu — Recency-Dominant Search Result Ordering
 
 **Date:** 2026-05-22
-**Status:** Approved, ready for implementation
+**Status:** Implemented (PR #191)
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-05-22-jump-menu-recency-ordering-design.md
+++ b/docs/superpowers/specs/2026-05-22-jump-menu-recency-ordering-design.md
@@ -1,0 +1,89 @@
+# Jump Menu — Recency-Dominant Search Result Ordering
+
+**Date:** 2026-05-22
+**Status:** Approved, ready for implementation
+
+## Problem
+
+When a query is typed into the Cmd+K jump menu, results are ordered
+alphabetically by display name (after an unread-severity tier). The sort
+ignores how recently a worktree was used and ignores match quality. Typing
+`standup` surfaces `fix standup tmp file` above `standup2` purely because
+`f < s`, even when `standup2` was visited far more recently.
+
+Two latent issues compound it:
+
+- The alphabetical key leads with the display name's emoji prefix
+  (`<emoji> <Title Case>`), so ordering is partly driven by emoji Unicode
+  values rather than words.
+- Recency data already flows into the view model (`recentIDs`) but is unused
+  on the typed-query path.
+
+## Goal
+
+Make typed-query results **recency-dominant**: among matches, the
+most-recently-used worktree ranks highest. Match position is explicitly not a
+factor. Unread worktrees still float to the top.
+
+## Scope
+
+In scope: the sort comparator in `JumpMenuViewModel.matchRows()`.
+
+Out of scope: the filter predicate (unchanged — case-insensitive substring on
+display name or repo name), the empty-query `defaultRows()` path, fuzzy
+matching, match-position scoring, and persisting real visit timestamps.
+
+## Design
+
+All changes are confined to `JumpMenuViewModel.matchRows()` in
+`Sources/TBDApp/JumpMenu/JumpMenuViewModel.swift`.
+
+### Recency lookup
+
+At the top of `matchRows`, build `recencyRank: [UUID: Int]` from
+`recentIDs.enumerated()` — index 0 is the most recent. Worktrees absent from
+`recentIDs` (never visited this session, or beyond the 32-item LRU cap) are
+treated as rank `Int.max`.
+
+### Comparator
+
+Sort each matched row by, in priority order:
+
+1. **Unread tier** — rows with an unread severity sort before rows without.
+   (Unchanged.)
+2. **Severity** — higher severity first. Relevant only within the unread tier;
+   non-unread rows have `nil` severity and compare equal here. (Unchanged.)
+3. **Recency** — lower `recencyRank` first. New key. Applies to *both* tiers,
+   so unread rows of equal severity are also recency-ordered.
+4. **Alphabetical fallback** — for rows with equal recency (notably the
+   `Int.max` non-recent group), compare display names with a leading emoji
+   stripped (see helper below).
+5. **UUID tiebreak** — lexicographic, for deterministic output. (Unchanged.)
+
+### Emoji-strip helper
+
+A small pure helper produces the alphabetical fallback key: drop leading
+characters that are neither letters nor digits, trim whitespace, lowercase.
+Because a Swift `Character` is a grapheme cluster, a multi-scalar emoji (flags,
+ZWJ sequences) is a single `Character` and is dropped cleanly. A name that is
+entirely emoji yields an empty key; it sorts to the top of the fallback group
+and the UUID tiebreak keeps it deterministic.
+
+## Testing
+
+Add cases to `Tests/TBDAppTests/JumpMenuViewModelTests.swift`:
+
+- A recently-used match outranks a non-recent match regardless of display name.
+- An unread worktree still outranks a more-recently-used read worktree.
+- Within the unread tier, equal-severity rows are recency-ordered.
+- Emoji-prefixed display names sort by words, not emoji, in the fallback group.
+- Non-recent matches (rank `Int.max`) still produce a stable alphabetical
+  order.
+
+## Accepted limitations
+
+- `recentWorktreeIDs` is an in-memory LRU: it resets on app restart and caps at
+  32 entries. A worktree searched for by name is almost always one touched
+  recently in the same session, so this is acceptable. Persisting real
+  timestamps was considered (would need a DB migration) and rejected as not
+  worth the cost.


### PR DESCRIPTION
## Summary
- Typing a query into the Cmd+K jump menu ordered matches alphabetically by display name. Searching `standup` surfaced `fix standup tmp file` above `standup2` purely because `f < s` — the sort ignored which worktree you actually used most recently.
- Recency data already flowed into the view model (`recentIDs`, the LRU list) but was unused on the typed-query path. This PR makes typed-query results recency-dominant: among matches, the most-recently-used worktree ranks highest. Unread worktrees still float to the top by severity.
- Two fold-ins: recency now also orders within the unread tier (after severity), and the alphabetical fallback strips a leading emoji so it sorts on words rather than emoji codepoints (display names are formatted `<emoji> <Title Case>`).

New sort priority in `matchRows()`: unread tier → severity → recency → emoji-stripped alphabetical → UUID tiebreak. Filtering and the empty-query path are unchanged. No DB migration; the LRU resets on app restart and caps at 32, which is acceptable for name-search.

## Test plan
- [ ] `swift test --filter JumpMenuViewModelTests` — 17/17 pass (5 new cases + 12 existing).
- [ ] In the app: visit `standup2`, open Cmd+K, type `standup` — `standup2` ranks first.
- [ ] An unread worktree still outranks a more-recently-used read worktree.
- [ ] Worktrees not visited this session fall back to alphabetical-by-words; a leading emoji no longer skews the order.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=0ACABCFA-B092-4393-9AAF-22FEC204AC03)