### PR TITLE
Fix: Stop splitting Codex auth and config between TBD and the user's normal shell

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -160,7 +160,7 @@ enum CodexProfileWriter {
         let current = (try? String(contentsOf: path, encoding: .utf8)) ?? ""
         let updated = ensurePluginEnabled(in: current)
 
-        guard updated != current || !FileManager.default.fileExists(atPath: path.path) else {
+        guard updated != current else {
             return
         }
 
@@ -173,7 +173,17 @@ enum CodexProfileWriter {
 
     static func ensurePluginEnabled(in toml: String) -> String {
         let header = #"[plugins."\#(CodexPlugin.pluginKey)"]"#
+
+        // Splitting a `\n`-terminated string with `omittingEmptySubsequences:
+        // false` yields a trailing empty element. Drop it so the join below
+        // does not append an extra blank line on every call — otherwise the
+        // file grows and `ensureProfile`'s `updated != current` guard never
+        // short-circuits.
         var lines = toml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let hadTrailingNewline = toml.hasSuffix("\n")
+        if hadTrailingNewline, lines.last == "" {
+            lines.removeLast()
+        }
 
         guard let headerIndex = lines.firstIndex(where: { $0.trimmingCharacters(in: .whitespaces) == header }) else {
             var updated = toml
@@ -189,18 +199,29 @@ enum CodexProfileWriter {
 
         let nextSectionIndex = lines[(headerIndex + 1)...]
             .firstIndex { line in
+                // A section header is a line that trims to `[...]` and is not
+                // a key/value assignment — reject lines containing `=` so a
+                // multi-line array value or `[[table]]` element inside the
+                // section is not misread as the next section boundary.
                 let trimmed = line.trimmingCharacters(in: .whitespaces)
-                return trimmed.hasPrefix("[") && trimmed.hasSuffix("]")
+                return trimmed.hasPrefix("[") && trimmed.hasSuffix("]") && !trimmed.contains("=")
             } ?? lines.endIndex
 
         if let enabledIndex = lines[(headerIndex + 1)..<nextSectionIndex]
-            .firstIndex(where: { $0.trimmingCharacters(in: .whitespaces).hasPrefix("enabled") }) {
+            .firstIndex(where: { line in
+                // Match the exact `enabled` key, not prefixes like
+                // `enabled_features` which would otherwise be clobbered.
+                let key = line.trimmingCharacters(in: .whitespaces)
+                    .prefix { $0 != "=" }
+                    .trimmingCharacters(in: .whitespaces)
+                return key == "enabled"
+            }) {
             lines[enabledIndex] = "enabled = true"
         } else {
             lines.insert("enabled = true", at: headerIndex + 1)
         }
 
-        return lines.joined(separator: "\n") + (toml.hasSuffix("\n") ? "\n" : "")
+        return lines.joined(separator: "\n") + (hadTrailingNewline ? "\n" : "")
     }
 }
 

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -91,7 +91,9 @@ enum CodexHookOverlay {
     }
 }
 
-enum CodexSkillWriter {
+/// On-disk layout of the TBD skill inside the Codex plugin cache. This is a
+/// pure path helper — the actual write happens in `CodexPluginWriter.writeSkill`.
+enum CodexSkillLayout {
     static let relativePath = "skills/tbd/SKILL.md"
 
     static func skillPath(in pluginRoot: URL) -> URL {
@@ -139,7 +141,7 @@ enum CodexPluginWriter {
     }
 
     private static func writeSkill(in root: URL) throws {
-        let path = CodexSkillWriter.skillPath(in: root)
+        let path = CodexSkillLayout.skillPath(in: root)
         try FileManager.default.createDirectory(
             at: path.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -174,19 +176,36 @@ enum CodexProfileWriter {
     static func ensurePluginEnabled(in toml: String) -> String {
         let header = #"[plugins."\#(CodexPlugin.pluginKey)"]"#
 
+        // Normalize line endings to `\n` before splitting. A CRLF-terminated
+        // `tbd.config.toml` would otherwise leave a trailing `\r` on every
+        // line: `CharacterSet.whitespaces` does NOT include `\r`, so the
+        // header matcher, the exact-`enabled` key matcher, and the
+        // section-boundary detector below would all silently fail — appending
+        // a duplicate `[plugins."tbd@tbd"]` table and orphaning the user's
+        // original section. TBD owns this profile section, so we deliberately
+        // normalize the whole file to LF on rewrite; a file that was CRLF
+        // becomes LF. That is intentional and acceptable (and keeps the
+        // writer's output well-formed so `ensureProfile`'s `updated != current`
+        // idempotency guard still short-circuits on the second run).
+        let normalized = toml
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+
         // Splitting a `\n`-terminated string with `omittingEmptySubsequences:
         // false` yields a trailing empty element. Drop it so the join below
         // does not append an extra blank line on every call — otherwise the
         // file grows and `ensureProfile`'s `updated != current` guard never
         // short-circuits.
-        var lines = toml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        let hadTrailingNewline = toml.hasSuffix("\n")
+        var lines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let hadTrailingNewline = normalized.hasSuffix("\n")
         if hadTrailingNewline, lines.last == "" {
             lines.removeLast()
         }
 
         guard let headerIndex = lines.firstIndex(where: { $0.trimmingCharacters(in: .whitespaces) == header }) else {
-            var updated = toml
+            // Build from `normalized`, not the raw `toml`, so TBD's appended
+            // section is LF-terminated even if the source file was CRLF.
+            var updated = normalized
             if !updated.isEmpty, !updated.hasSuffix("\n") {
                 updated += "\n"
             }

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -2,68 +2,65 @@ import Foundation
 import os
 import TBDShared
 
-private let hooksLogger = Logger(subsystem: "com.tbd.daemon", category: "codex-hooks")
-private let skillLogger = Logger(subsystem: "com.tbd.daemon", category: "codex-skill")
+private let codexLogger = Logger(subsystem: "com.tbd.daemon", category: "codex-integration")
 
-/// Manages per-repo isolated `CODEX_HOME` directories under
-/// `~/.tbd/agents/codex/<repoID>/`. This keeps TBD-launched codex sessions
-/// from touching the user's real `~/.codex/` — so config, hooks, and
-/// sessions stay scoped per repo and TBD never pollutes global codex state.
+/// Installs TBD's Codex integration into the user's global Codex home.
+///
+/// TBD uses `codex --profile tbd` instead of an isolated per-repo
+/// `CODEX_HOME`, so user auth/config/plugins continue to merge with TBD's
+/// runtime integration while the TBD plugin remains profile-scoped.
 struct CodexHomeManager: Sendable {
-    let baseDirectory: URL
+    let codexHome: URL
 
-    init(baseDirectory: URL? = nil) {
-        // See HookResolver — keep cross-module `TBDConstants.configDir` access
-        // inside this module to avoid Xcode 26.3 unsafeMutableAddressor link
-        // failures in test targets that call this initializer with defaults.
-        self.baseDirectory = baseDirectory
-            ?? TBDConstants.configDir.appendingPathComponent("agents/codex", isDirectory: true)
-    }
-
-    func homeDirectory(forRepoID repoID: UUID) -> URL {
-        baseDirectory.appendingPathComponent(repoID.uuidString.lowercased(), isDirectory: true)
+    init(codexHome: URL? = nil) {
+        self.codexHome = codexHome
+            ?? Self.testCodexHomeOverride()
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".codex", isDirectory: true)
     }
 
     @discardableResult
-    func ensureHome(forRepoID repoID: UUID) throws -> URL {
-        let home = homeDirectory(forRepoID: repoID)
-        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
-        return home
+    func ensureProfilePlugin() throws -> URL {
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try CodexPluginWriter.writePlugin(in: codexHome)
+        try CodexProfileWriter.ensureProfile(in: codexHome)
+        codexLogger.info("Ensured Codex TBD profile plugin in \(codexHome.path, privacy: .public)")
+        return codexHome
     }
 
-    /// Ensure TBD's Codex integration files exist in the isolated CODEX_HOME.
-    ///
-    /// The method name is retained because existing call sites use it as the
-    /// launch-time setup point, but it now writes both hooks and the TBD skill.
-    @discardableResult
-    func ensureHomeWithHooks(forRepoID repoID: UUID) throws -> URL {
-        let home = try ensureHome(forRepoID: repoID)
-        // Integration setup is best-effort: log failures, but do not block Codex launch.
-        CodexHookOverlay.writeOverlay(in: home)
-        CodexSkillWriter.writeSkill(in: home)
-        return home
+    private static func testCodexHomeOverride() -> URL? {
+        guard let rawValue = getenv("TBD_TEST_CODEX_HOME"),
+              let path = String(validatingCString: rawValue),
+              !path.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: path, isDirectory: true)
     }
 }
 
-/// Generates TBD-owned Codex hook configuration inside the isolated CODEX_HOME.
-///
-/// Codex reads hooks from `$CODEX_HOME/hooks.json`; unlike Claude's
-/// `--settings` overlay, the CODEX_HOME itself is already TBD-owned per repo,
-/// so writing the file there avoids touching the user's global `~/.codex`.
+enum CodexPlugin {
+    static let profileName = "tbd"
+    static let marketplaceName = "tbd"
+    static let pluginName = "tbd"
+    static let pluginVersion = "local"
+    static let pluginKey = "\(pluginName)@\(marketplaceName)"
+
+    static let relativeRoot =
+        "plugins/cache/\(marketplaceName)/\(pluginName)/\(pluginVersion)"
+}
+
+/// Generates TBD-owned Codex hook configuration for the TBD plugin.
 enum CodexHookOverlay {
-    static let fileName = "hooks.json"
+    static let relativePath = "hooks/hooks.json"
 
     static let sessionStartCommand =
         #"tbd session-event 2>/dev/null || true"#
 
     static let stopCommand =
-        #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
+        #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; tbd hooks stop-rename-check 2>/dev/null || true"#
 
-    static let stopRenameCheckCommand =
-        #"tbd hooks stop-rename-check 2>/dev/null || true"#
-
-    static func overlayPath(in codexHome: URL) -> URL {
-        codexHome.appendingPathComponent(fileName, isDirectory: false)
+    static func hookPath(in pluginRoot: URL) -> URL {
+        pluginRoot.appendingPathComponent(relativePath, isDirectory: false)
     }
 
     static func generateBody() throws -> Data {
@@ -82,11 +79,6 @@ enum CodexHookOverlay {
                         "hooks": [
                             ["type": "command", "command": stopCommand]
                         ]
-                    ],
-                    [
-                        "hooks": [
-                            ["type": "command", "command": stopRenameCheckCommand]
-                        ]
                     ]
                 ]
             ]
@@ -97,59 +89,121 @@ enum CodexHookOverlay {
             options: [.prettyPrinted, .sortedKeys]
         )
     }
-
-    @discardableResult
-    static func writeOverlay(in codexHome: URL) -> Bool {
-        do {
-            try FileManager.default.createDirectory(
-                at: codexHome,
-                withIntermediateDirectories: true
-            )
-            let data = try generateBody()
-            let path = overlayPath(in: codexHome)
-            try data.write(to: path, options: .atomic)
-            hooksLogger.info("Wrote Codex hooks at \(path.path, privacy: .public)")
-            return true
-        } catch {
-            hooksLogger.error("Failed to write Codex hooks: \(error.localizedDescription, privacy: .public)")
-            return false
-        }
-    }
 }
 
-/// Writes the TBD skill into the isolated CODEX_HOME for TBD-spawned Codex
-/// sessions. Codex loads local skills from `$CODEX_HOME/skills/<name>/SKILL.md`,
-/// so this mirrors the Claude plugin skill without relying on Codex plugin
-/// hook support.
 enum CodexSkillWriter {
     static let relativePath = "skills/tbd/SKILL.md"
 
-    static func skillPath(in codexHome: URL) -> URL {
-        codexHome.appendingPathComponent(relativePath, isDirectory: false)
+    static func skillPath(in pluginRoot: URL) -> URL {
+        pluginRoot.appendingPathComponent(relativePath, isDirectory: false)
+    }
+}
+
+enum CodexPluginWriter {
+    static func pluginRoot(in codexHome: URL) -> URL {
+        codexHome.appendingPathComponent(CodexPlugin.relativeRoot, isDirectory: true)
     }
 
-    @discardableResult
-    static func writeSkill(in codexHome: URL) -> Bool {
-        do {
-            let path = skillPath(in: codexHome)
-            try FileManager.default.createDirectory(
-                at: path.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try TBDSkillContent.body.write(
-                to: path,
-                atomically: true,
-                encoding: .utf8
-            )
-            skillLogger.info("Wrote Codex skill at \(path.path, privacy: .public)")
-            return true
-        } catch {
-            skillLogger.error("Failed to write Codex skill: \(error.localizedDescription, privacy: .public)")
-            return false
+    static func writePlugin(in codexHome: URL) throws {
+        let root = pluginRoot(in: codexHome)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try writeManifest(in: root)
+        try writeHooks(in: root)
+        try writeSkill(in: root)
+    }
+
+    private static func writeManifest(in root: URL) throws {
+        let manifest: [String: Any] = [
+            "name": CodexPlugin.pluginName,
+            "version": CodexPlugin.pluginVersion,
+            "description": "TBD integration for Codex",
+            "skills": "./skills",
+            "hooks": "./hooks/hooks.json"
+        ]
+        let manifestDir = root.appendingPathComponent(".codex-plugin", isDirectory: true)
+        try FileManager.default.createDirectory(at: manifestDir, withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(
+            withJSONObject: manifest,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: manifestDir.appendingPathComponent("plugin.json"), options: .atomic)
+    }
+
+    private static func writeHooks(in root: URL) throws {
+        let path = CodexHookOverlay.hookPath(in: root)
+        try FileManager.default.createDirectory(
+            at: path.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try CodexHookOverlay.generateBody().write(to: path, options: .atomic)
+    }
+
+    private static func writeSkill(in root: URL) throws {
+        let path = CodexSkillWriter.skillPath(in: root)
+        try FileManager.default.createDirectory(
+            at: path.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try TBDSkillContent.body.write(to: path, atomically: true, encoding: .utf8)
+    }
+}
+
+enum CodexProfileWriter {
+    static let profileFileName = "\(CodexPlugin.profileName).config.toml"
+
+    static func profilePath(in codexHome: URL) -> URL {
+        codexHome.appendingPathComponent(profileFileName, isDirectory: false)
+    }
+
+    static func ensureProfile(in codexHome: URL) throws {
+        let path = profilePath(in: codexHome)
+        let current = (try? String(contentsOf: path, encoding: .utf8)) ?? ""
+        let updated = ensurePluginEnabled(in: current)
+
+        guard updated != current || !FileManager.default.fileExists(atPath: path.path) else {
+            return
         }
+
+        try FileManager.default.createDirectory(
+            at: path.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try updated.write(to: path, atomically: true, encoding: .utf8)
+    }
+
+    static func ensurePluginEnabled(in toml: String) -> String {
+        let header = #"[plugins."\#(CodexPlugin.pluginKey)"]"#
+        var lines = toml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+        guard let headerIndex = lines.firstIndex(where: { $0.trimmingCharacters(in: .whitespaces) == header }) else {
+            var updated = toml
+            if !updated.isEmpty, !updated.hasSuffix("\n") {
+                updated += "\n"
+            }
+            if !updated.isEmpty {
+                updated += "\n"
+            }
+            updated += "\(header)\nenabled = true\n"
+            return updated
+        }
+
+        let nextSectionIndex = lines[(headerIndex + 1)...]
+            .firstIndex { line in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                return trimmed.hasPrefix("[") && trimmed.hasSuffix("]")
+            } ?? lines.endIndex
+
+        if let enabledIndex = lines[(headerIndex + 1)..<nextSectionIndex]
+            .firstIndex(where: { $0.trimmingCharacters(in: .whitespaces).hasPrefix("enabled") }) {
+            lines[enabledIndex] = "enabled = true"
+        } else {
+            lines.insert("enabled = true", at: headerIndex + 1)
+        }
+
+        return lines.joined(separator: "\n") + (toml.hasSuffix("\n") ? "\n" : "")
     }
 }
 
 enum CodexSpawnCommandBuilder {
-    static let command = "unset CODEX_CI CODEX_THREAD_ID; codex --dangerously-bypass-approvals-and-sandbox"
+    static let command = "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox"
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -304,6 +304,10 @@ extension WorktreeLifecycle {
             // Codex terminal — detected by kind (primary signal) or legacy label fallback.
             // kind is the primary discriminator; label is checked for backward compatibility.
             let codexHome = try CodexHomeManager().ensureProfilePlugin()
+            // Explicitly export the global Codex home. This is intentional —
+            // the design's allowed "set the global path" option — not leftover
+            // per-repo isolation: it pins deterministic behavior and lets the
+            // TBD_TEST_CODEX_HOME test-isolation override flow through.
             env["CODEX_HOME"] = codexHome.path
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -303,7 +303,7 @@ extension WorktreeLifecycle {
         } else if terminal.kind == .codex || terminal.label == "Codex" {
             // Codex terminal — detected by kind (primary signal) or legacy label fallback.
             // kind is the primary discriminator; label is checked for backward compatibility.
-            let codexHome = try CodexHomeManager().ensureHomeWithHooks(forRepoID: worktree.repoID)
+            let codexHome = try CodexHomeManager().ensureProfilePlugin()
             env["CODEX_HOME"] = codexHome.path
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -100,9 +100,9 @@ extension RPCRouter {
         env["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
         env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
 
-        // Codex branch: minimal launch with isolated CODEX_HOME. No session
-        // tracking, no system prompt injection, no token resolution. Session
-        // resume / state detection are tracked as follow-up issues.
+        // Codex branch: minimal launch with TBD's profile plugin installed in
+        // the user's global Codex home. No system prompt injection or token
+        // resolution; Codex should keep using the user's normal auth/config.
         //
         // Build env independently — do NOT inherit the Claude-shaped
         // TBD_PROMPT_CONTEXT / TBD_PROMPT_RENAME / TBD_PROMPT_INSTRUCTIONS
@@ -110,7 +110,7 @@ extension RPCRouter {
         // a Claude-centric host and would be misleading noise inside a
         // Codex pane.
         if params.type == .codex {
-            let codexHome = try CodexHomeManager().ensureHomeWithHooks(forRepoID: worktree.repoID)
+            let codexHome = try CodexHomeManager().ensureProfilePlugin()
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
             codexEnv["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
@@ -315,7 +315,7 @@ extension RPCRouter {
         // Branch on terminal kind: codex stays codex; shell/claude become shell
         if terminal.kind == .codex || terminal.label == "Codex" {
             // Recreate as codex — preserve identity
-            let codexHome = try CodexHomeManager().ensureHomeWithHooks(forRepoID: worktree.repoID)
+            let codexHome = try CodexHomeManager().ensureProfilePlugin()
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = worktree.id.uuidString
             codexEnv["TBD_TERMINAL_ID"] = terminal.id.uuidString

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -114,6 +114,10 @@ extension RPCRouter {
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
             codexEnv["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
+            // Explicitly export the global Codex home. This is intentional —
+            // the design's allowed "set the global path" option — not leftover
+            // per-repo isolation: it pins deterministic behavior and lets the
+            // TBD_TEST_CODEX_HOME test-isolation override flow through.
             codexEnv["CODEX_HOME"] = codexHome.path
 
             let window = try await tmux.createWindow(
@@ -319,6 +323,10 @@ extension RPCRouter {
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = worktree.id.uuidString
             codexEnv["TBD_TERMINAL_ID"] = terminal.id.uuidString
+            // Explicitly export the global Codex home. This is intentional —
+            // the design's allowed "set the global path" option — not leftover
+            // per-repo isolation: it pins deterministic behavior and lets the
+            // TBD_TEST_CODEX_HOME test-isolation override flow through.
             codexEnv["CODEX_HOME"] = codexHome.path
 
             let window = try await tmux.createWindow(

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -8,8 +8,8 @@ import Foundation
 /// - `PluginDirWriter` → `~/Library/Application Support/TBD/plugin/skills/tbd/SKILL.md`
 ///   (loaded into TBD-spawned Claude sessions via `--plugin-dir`, where the
 ///   skill registers as `tbd:tbd`)
-/// - `CodexSkillWriter` → `$CODEX_HOME/skills/tbd/SKILL.md`
-///   (loaded into TBD-spawned Codex sessions through the isolated CODEX_HOME)
+/// - `CodexPluginWriter` → `$CODEX_HOME/plugins/cache/tbd/tbd/local/skills/tbd/SKILL.md`
+///   (loaded into TBD-spawned Codex sessions through the `tbd` profile plugin)
 public enum TBDSkillContent {
 
     public static let body: String = """

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -167,4 +167,83 @@ import TBDShared
         #expect(output.contains("enabled = true"))
         #expect(!output.contains("enabled = false"))
     }
+
+    /// A CRLF-terminated profile must not get a duplicate `[plugins."tbd@tbd"]`
+    /// table appended: the `\r` left on each split line must be stripped so the
+    /// header matcher recognizes the existing section and flips `enabled` in
+    /// place. The rewrite normalizes to LF (TBD owns the section).
+    @Test func ensurePluginEnabledHandlesCRLFWithoutDuplicatingSection() {
+        let input = "model = \"gpt-5.1\"\r\n\r\n[plugins.\"tbd@tbd\"]\r\nenabled = false\r\n"
+
+        let output = CodexProfileWriter.ensurePluginEnabled(in: input)
+
+        let headerCount = output.components(separatedBy: #"[plugins."tbd@tbd"]"#).count - 1
+        #expect(headerCount == 1, "exactly one [plugins.\"tbd@tbd\"] table expected, got \(headerCount)")
+        #expect(output.contains("enabled = true"))
+        #expect(!output.contains("enabled = false"))
+        #expect(!output.contains("\r"), "output must be normalized to LF line endings")
+
+        // Second run must be byte-identical (idempotent).
+        let second = CodexProfileWriter.ensurePluginEnabled(in: output)
+        #expect(second == output, "ensurePluginEnabled must be idempotent on a CRLF-sourced profile")
+    }
+
+    /// A CRLF section with a custom `enabled_features` key must survive the
+    /// rewrite (the `\r` must not defeat the exact-`enabled` key matcher and
+    /// clobber the prefixed key).
+    @Test func ensurePluginEnabledPreservesCustomKeysFromCRLFProfile() {
+        let input = "[plugins.\"tbd@tbd\"]\r\nenabled_features = [\"x\"]\r\nenabled = false\r\n"
+
+        let output = CodexProfileWriter.ensurePluginEnabled(in: input)
+
+        #expect(output.contains(#"enabled_features = ["x"]"#))
+        #expect(output.contains("enabled = true"))
+        #expect(!output.contains("enabled = false"))
+        let headerCount = output.components(separatedBy: #"[plugins."tbd@tbd"]"#).count - 1
+        #expect(headerCount == 1)
+    }
+
+    /// CRLF idempotency through the full `ensureProfile` file path: a CRLF
+    /// `tbd.config.toml` with `enabled = false` must be rewritten to a single
+    /// LF table with `enabled = true`, and a second `ensureProfile` run must
+    /// leave the file byte-identical.
+    @Test func ensureProfileHandlesCRLFFileIdempotently() throws {
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-crlf-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+
+        let path = CodexProfileWriter.profilePath(in: codexHome)
+        let crlf = "model = \"gpt-5.1\"\r\n\r\n[plugins.\"tbd@tbd\"]\r\nenabled = false\r\n"
+        try crlf.write(to: path, atomically: true, encoding: .utf8)
+
+        try CodexProfileWriter.ensureProfile(in: codexHome)
+        let firstContent = try String(contentsOf: path, encoding: .utf8)
+
+        let headerCount = firstContent.components(separatedBy: #"[plugins."tbd@tbd"]"#).count - 1
+        #expect(headerCount == 1, "exactly one [plugins.\"tbd@tbd\"] table after rewrite")
+        #expect(firstContent.contains("enabled = true"))
+        #expect(!firstContent.contains("enabled = false"))
+        #expect(!firstContent.contains("\r"), "rewritten profile must use LF endings")
+
+        try CodexProfileWriter.ensureProfile(in: codexHome)
+        let secondContent = try String(contentsOf: path, encoding: .utf8)
+        #expect(secondContent == firstContent, "second ensureProfile run must be byte-identical")
+    }
+
+    /// Happy-path: `ensureProfilePlugin` against a fresh writable Codex home
+    /// must succeed without throwing and produce a valid profile + plugin.
+    /// (The `throws` path is fatal-to-launch by design; making the home
+    /// unwritable is impractical in a unit test, so this asserts the
+    /// successful-setup contract instead — see code-review note.)
+    @Test func ensureProfilePluginSucceedsOnWritableHome() throws {
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-writable-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        let home = try CodexHomeManager(codexHome: codexHome).ensureProfilePlugin()
+        #expect(home == codexHome)
+        #expect(FileManager.default.fileExists(
+            atPath: CodexProfileWriter.profilePath(in: codexHome).path))
+    }
 }

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -105,4 +105,66 @@ import TBDShared
         #expect(output.contains("enabled = true"))
         #expect(!output.contains("enabled = false"))
     }
+
+    @Test func ensurePluginEnabledIsIdempotent() {
+        let inputs = [
+            "",
+            """
+            model = "gpt-5.1"
+
+            [plugins."tbd@tbd"]
+            enabled = false
+            custom = "keep"
+
+            [tools]
+            web_search = true
+            """,
+            """
+            model = "gpt-5.1"
+
+            [plugins."tbd@tbd"]
+            enabled = true
+
+            """
+        ]
+        for input in inputs {
+            let first = CodexProfileWriter.ensurePluginEnabled(in: input)
+            let second = CodexProfileWriter.ensurePluginEnabled(in: first)
+            #expect(first == second, "ensurePluginEnabled must be idempotent")
+        }
+    }
+
+    @Test func ensureProfileIsIdempotentAndDoesNotRewrite() throws {
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-profile-idem-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+
+        try CodexProfileWriter.ensureProfile(in: codexHome)
+        let path = CodexProfileWriter.profilePath(in: codexHome)
+        let firstContent = try String(contentsOf: path, encoding: .utf8)
+        let firstModified = try FileManager.default
+            .attributesOfItem(atPath: path.path)[.modificationDate] as? Date
+
+        try CodexProfileWriter.ensureProfile(in: codexHome)
+        let secondContent = try String(contentsOf: path, encoding: .utf8)
+        let secondModified = try FileManager.default
+            .attributesOfItem(atPath: path.path)[.modificationDate] as? Date
+
+        #expect(firstContent == secondContent, "profile content must be byte-identical after second run")
+        #expect(firstModified == secondModified, "second ensureProfile run must not rewrite the file")
+    }
+
+    @Test func ensurePluginEnabledPreservesEnabledPrefixedKeys() {
+        let input = """
+        [plugins."tbd@tbd"]
+        enabled_features = ["x"]
+        enabled = false
+        """
+
+        let output = CodexProfileWriter.ensurePluginEnabled(in: input)
+
+        #expect(output.contains(#"enabled_features = ["x"]"#))
+        #expect(output.contains("enabled = true"))
+        #expect(!output.contains("enabled = false"))
+    }
 }

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -18,7 +18,7 @@ import TBDShared
         #expect(sessionCommand?.contains("tbd session-event") == true)
 
         let stop = hooks?["Stop"] as? [[String: Any]]
-        #expect(stop?.count == 2)
+        #expect(stop?.count == 1)
         let stopCommands: [String] = (stop ?? []).flatMap { entry -> [String] in
             let inner = entry["hooks"] as? [[String: Any]] ?? []
             return inner.compactMap { $0["command"] as? String }
@@ -35,14 +35,15 @@ import TBDShared
         _ = try JSONSerialization.jsonObject(with: data, options: [])
     }
 
-    @Test func writeOverlayCreatesHooksJSONInCodexHome() throws {
+    @Test func writePluginCreatesHooksJSONInCodexPlugin() throws {
         let codexHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-hooks-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: codexHome) }
 
-        #expect(CodexHookOverlay.writeOverlay(in: codexHome))
+        try CodexPluginWriter.writePlugin(in: codexHome)
 
-        let path = codexHome.appendingPathComponent("hooks.json")
+        let path = CodexPluginWriter.pluginRoot(in: codexHome)
+            .appendingPathComponent("hooks/hooks.json")
         let data = try Data(contentsOf: path)
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let hooks = parsed?["hooks"] as? [String: Any]
@@ -50,29 +51,58 @@ import TBDShared
         #expect(hooks?["Stop"] != nil)
     }
 
-    @Test func writeSkillCreatesTBDSkillInCodexHome() throws {
+    @Test func writePluginCreatesTBDSkillInCodexPlugin() throws {
         let codexHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-skill-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: codexHome) }
 
-        #expect(CodexSkillWriter.writeSkill(in: codexHome))
+        try CodexPluginWriter.writePlugin(in: codexHome)
 
-        let path = codexHome.appendingPathComponent("skills/tbd/SKILL.md")
+        let path = CodexPluginWriter.pluginRoot(in: codexHome)
+            .appendingPathComponent("skills/tbd/SKILL.md")
         let written = try String(contentsOf: path, encoding: .utf8)
         #expect(written == TBDSkillContent.body)
     }
 
-    @Test func ensureHomeWithHooksCreatesHooksAndSkill() throws {
-        let base = FileManager.default.temporaryDirectory
+    @Test func ensureProfilePluginCreatesProfileAndPlugin() throws {
+        let codexHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-home-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: base) }
+        defer { try? FileManager.default.removeItem(at: codexHome) }
 
-        let repoID = UUID()
-        let home = try CodexHomeManager(baseDirectory: base)
-            .ensureHomeWithHooks(forRepoID: repoID)
+        let home = try CodexHomeManager(codexHome: codexHome).ensureProfilePlugin()
+        let pluginRoot = CodexPluginWriter.pluginRoot(in: codexHome)
 
-        #expect(home == base.appendingPathComponent(repoID.uuidString.lowercased(), isDirectory: true))
-        #expect(FileManager.default.fileExists(atPath: home.appendingPathComponent("hooks.json").path))
-        #expect(FileManager.default.fileExists(atPath: home.appendingPathComponent("skills/tbd/SKILL.md").path))
+        #expect(home == codexHome)
+        #expect(FileManager.default.fileExists(atPath: pluginRoot.appendingPathComponent(".codex-plugin/plugin.json").path))
+        #expect(FileManager.default.fileExists(atPath: pluginRoot.appendingPathComponent("hooks/hooks.json").path))
+        #expect(FileManager.default.fileExists(atPath: pluginRoot.appendingPathComponent("skills/tbd/SKILL.md").path))
+
+        let profile = try String(
+            contentsOf: codexHome.appendingPathComponent("tbd.config.toml"),
+            encoding: .utf8
+        )
+        #expect(profile.contains(#"[plugins."tbd@tbd"]"#))
+        #expect(profile.contains("enabled = true"))
+    }
+
+    @Test func ensurePluginEnabledPreservesProfileAndEnablesExistingSection() {
+        let input = """
+        model = "gpt-5.1"
+
+        [plugins."tbd@tbd"]
+        enabled = false
+        custom = "keep"
+
+        [tools]
+        web_search = true
+        """
+
+        let output = CodexProfileWriter.ensurePluginEnabled(in: input)
+
+        #expect(output.contains(#"model = "gpt-5.1""#))
+        #expect(output.contains(#"custom = "keep""#))
+        #expect(output.contains(#"[tools]"#))
+        #expect(output.contains("enabled = true"))
+        #expect(!output.contains("enabled = false"))
     }
 }

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -140,6 +140,7 @@ func testRecreateAfterRebootClaudeBranchSetsWorktreeID() async throws {
 @Test("recreateAfterReboot — codex branch sets TBD_WORKTREE_ID")
 func testRecreateAfterRebootCodexBranchSetsWorktreeID() async throws {
     installCodexTestHomeOverride()
+    defer { unsetenv("TBD_TEST_CODEX_HOME") }
 
     let db = try TBDDatabase(inMemory: true)
     let recorded = RecordedCommands()
@@ -282,6 +283,7 @@ func testHandleTerminalRecreateWindowSetsWorktreeID() async throws {
 @Test("handleTerminalRecreateWindow uses current Codex launch command")
 func testHandleTerminalRecreateWindowCodexLaunchCommand() async throws {
     installCodexTestHomeOverride()
+    defer { unsetenv("TBD_TEST_CODEX_HOME") }
 
     let db = try TBDDatabase(inMemory: true)
     let recorded = RecordedCommands()
@@ -457,6 +459,7 @@ func testHandleTerminalCreateRegressionWorktreeID() async throws {
 @Test("handleTerminalCreate uses current Codex launch command")
 func testHandleTerminalCreateCodexLaunchCommand() async throws {
     installCodexTestHomeOverride()
+    defer { unsetenv("TBD_TEST_CODEX_HOME") }
 
     let db = try TBDDatabase(inMemory: true)
     let recorded = RecordedCommands()

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -41,6 +41,18 @@ private func newWindowBodies(_ recorded: [[String]]) -> [String] {
     }
 }
 
+private let codexTestHomePath: String = {
+    let path = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-codex-home-tests-\(UUID().uuidString)", isDirectory: true)
+        .path
+    setenv("TBD_TEST_CODEX_HOME", path, 1)
+    return path
+}()
+
+private func installCodexTestHomeOverride() {
+    _ = codexTestHomePath
+}
+
 // MARK: - Fix 1: Daemon scrubInheritedTBDEnv
 
 @Test("Daemon.scrubInheritedTBDEnv clears inherited routing vars")
@@ -127,6 +139,8 @@ func testRecreateAfterRebootClaudeBranchSetsWorktreeID() async throws {
 
 @Test("recreateAfterReboot — codex branch sets TBD_WORKTREE_ID")
 func testRecreateAfterRebootCodexBranchSetsWorktreeID() async throws {
+    installCodexTestHomeOverride()
+
     let db = try TBDDatabase(inMemory: true)
     let recorded = RecordedCommands()
     let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
@@ -164,11 +178,12 @@ func testRecreateAfterRebootCodexBranchSetsWorktreeID() async throws {
     let expected = "export TBD_WORKTREE_ID='\(wt.id.uuidString)';"
     #expect(bodies.contains { $0.contains(expected) },
             "codex-branch recreation must export TBD_WORKTREE_ID; got bodies: \(bodies)")
-    // CODEX_HOME should still be exported alongside (regression guard).
+    // Global CODEX_HOME should still be exported alongside (regression guard).
     #expect(bodies.contains { $0.contains("export CODEX_HOME=") },
             "codex-branch must still export CODEX_HOME; got bodies: \(bodies)")
-    #expect(bodies.contains { $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --dangerously-bypass-approvals-and-sandbox") },
-            "codex-branch must launch current interactive codex without inherited session env; got bodies: \(bodies)")
+    #expect(bodies.contains {
+        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox")
+    }, "codex-branch must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "codex-branch must not use removed --full-auto flag; got bodies: \(bodies)")
 }
@@ -266,6 +281,8 @@ func testHandleTerminalRecreateWindowSetsWorktreeID() async throws {
 
 @Test("handleTerminalRecreateWindow uses current Codex launch command")
 func testHandleTerminalRecreateWindowCodexLaunchCommand() async throws {
+    installCodexTestHomeOverride()
+
     let db = try TBDDatabase(inMemory: true)
     let recorded = RecordedCommands()
     let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
@@ -308,8 +325,9 @@ func testHandleTerminalRecreateWindowCodexLaunchCommand() async throws {
     #expect(response.success, "expected success; error: \(response.error ?? "nil")")
 
     let bodies = newWindowBodies(recorded.snapshot())
-    #expect(bodies.contains { $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --dangerously-bypass-approvals-and-sandbox") },
-            "recreated codex tab must launch current interactive codex without inherited session env; got bodies: \(bodies)")
+    #expect(bodies.contains {
+        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox")
+    }, "recreated codex tab must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "recreated codex tab must not use removed --full-auto flag; got bodies: \(bodies)")
 }
@@ -438,6 +456,8 @@ func testHandleTerminalCreateRegressionWorktreeID() async throws {
 
 @Test("handleTerminalCreate uses current Codex launch command")
 func testHandleTerminalCreateCodexLaunchCommand() async throws {
+    installCodexTestHomeOverride()
+
     let db = try TBDDatabase(inMemory: true)
     let recorded = RecordedCommands()
     let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
@@ -479,8 +499,9 @@ func testHandleTerminalCreateCodexLaunchCommand() async throws {
     let bodies = newWindowBodies(recorded.snapshot())
     #expect(bodies.contains { $0.contains("export CODEX_HOME=") },
             "created codex tab must export CODEX_HOME; got bodies: \(bodies)")
-    #expect(bodies.contains { $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --dangerously-bypass-approvals-and-sandbox") },
-            "created codex tab must launch current interactive codex without inherited session env; got bodies: \(bodies)")
+    #expect(bodies.contains {
+        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox")
+    }, "created codex tab must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "created codex tab must not use removed --full-auto flag; got bodies: \(bodies)")
 }

--- a/docs/specs/2026-05-22-codex-global-home-profile-plugin-design.md
+++ b/docs/specs/2026-05-22-codex-global-home-profile-plugin-design.md
@@ -94,8 +94,8 @@ unmanaged hooks runnable, including all plugin hooks. It is not scoped to one
 plugin.
 
 Codex hook state supports per-hook `trusted_hash` entries. Plugin hook keys
-include plugin/source identity, so TBD can trust only the hooks from the TBD
-plugin by writing trust entries into the `tbd` profile.
+include plugin/source identity, so Codex can persist trust for the TBD plugin
+without trusting unrelated user hooks or other plugins.
 
 ## Design
 
@@ -154,7 +154,7 @@ Create a real Codex plugin with a manifest:
 
 The manifest name must be `tbd` so it can be activated as `tbd@tbd`.
 
-Install or link it into Codex's plugin cache path:
+Install it into Codex's plugin cache path:
 
 ```text
 ~/.codex/plugins/cache/tbd/tbd/local/
@@ -203,11 +203,11 @@ So the trust flow is:
    `tbd.config.toml` (because the `--profile tbd` session's
    `user_config_path` override points there).
 
-This is **one-and-done and machine-global**: plugin hook keys carry no `cwd`,
+This is **machine-global after trust**: plugin hook keys carry no `cwd`,
 session, tab, or worktree dimension, so a single trust applies to every
-TBD-launched Codex session on the machine, forever after. It scopes trust to
-the TBD plugin — other user hooks and other plugin hooks remain subject to
-normal Codex trust behavior.
+TBD-launched Codex session on the machine while the hook identity and command
+hash are unchanged. It scopes trust to the TBD plugin — other user hooks and
+other plugin hooks remain subject to normal Codex trust behavior.
 
 The one re-prompt trigger: if TBD changes a plugin hook's command string, its
 `current_hash` changes, the stored `trusted_hash` no longer matches, and Codex
@@ -362,7 +362,7 @@ hook command string, which is under TBD's control.
 ### Profile file ownership
 
 Users may edit `~/.codex/tbd.config.toml`. TBD should preserve unknown fields
-and only own the plugin enablement and hook-state entries it manages.
+and only own the TBD plugin enablement. Codex owns hook-state entries.
 
 ### Plugin cache mutation
 

--- a/docs/specs/2026-05-22-codex-global-home-profile-plugin-design.md
+++ b/docs/specs/2026-05-22-codex-global-home-profile-plugin-design.md
@@ -1,0 +1,403 @@
+# Codex global home with TBD profile plugin
+
+**Date:** 2026-05-22
+**Status:** Design
+**Upstream checked:** `openai/codex` `932f72c225889102257493f57460251016cbfdc2`
+
+## Problem
+
+TBD currently launches Codex with an isolated per-repo `CODEX_HOME` under
+`~/tbd/agents/codex/<repoID>/`. That keeps TBD's `hooks.json` and `skills/tbd`
+out of the user's normal `~/.codex`, but it also splits Codex user state:
+
+- a user who signed in with normal Codex may appear unsigned-in inside TBD;
+- token refreshes or login changes outside TBD can leave TBD stale;
+- user-level Codex config, plugins, skills, and model preferences do not
+  naturally apply inside TBD-launched Codex;
+- TBD has to mimic parts of Codex home management instead of letting Codex use
+  its own global home.
+
+The desired behavior is the opposite: TBD-launched Codex should use the user's
+normal Codex environment, while TBD-specific hooks/skills should only be active
+inside TBD sessions.
+
+## Goals
+
+- Use the user's real `~/.codex` as `CODEX_HOME` for TBD-launched Codex.
+- Preserve normal Codex behavior outside TBD.
+- Activate TBD-specific Codex integration only for TBD launches.
+- Avoid `--dangerously-bypass-hook-trust`, because it trusts all enabled
+  unmanaged hooks in the session.
+- Keep TBD's hook trust scoped to TBD's own plugin hooks.
+- Leave room for users to keep their normal Codex config, plugins, auth, and
+  profile choices.
+
+## Non-goals
+
+- Reimplement Codex plugin loading.
+- Write TBD-specific hooks into the user's base `~/.codex/config.toml`.
+- Trust all user/plugin hooks globally.
+- Continue maintaining per-repo isolated Codex homes as the primary launch mode.
+
+## Upstream Codex facts
+
+These facts were checked against upstream `openai/codex` commit
+`932f72c225889102257493f57460251016cbfdc2`.
+
+### `CODEX_HOME`
+
+Codex resolves its home from `CODEX_HOME`, defaulting to `~/.codex`
+(`codex-rs/utils/home-dir/src/lib.rs`). File auth is stored at
+`$CODEX_HOME/auth.json` (`codex-rs/login/src/auth/storage.rs`). Keyring auth is
+also keyed by the canonical Codex home path, so changing `CODEX_HOME` changes
+the keyring identity.
+
+This is why isolated TBD homes cause separate auth state.
+
+### Profiles
+
+Codex supports `--profile/-p`, which layers
+`$CODEX_HOME/<name>.config.toml` on top of the base user config. For TBD,
+`codex --profile tbd` means:
+
+- base user layer: `~/.codex/config.toml`
+- TBD overlay layer: `~/.codex/tbd.config.toml`
+
+This gives us exactly the desired merge behavior: normal Codex settings apply,
+and TBD-only config lives in the `tbd` profile.
+
+### Plugin hooks
+
+Codex plugins can provide hooks:
+
+- plugin manifests accept a `hooks` field;
+- hooks may be inline or in files such as `hooks/hooks.json`;
+- session hook construction loads enabled plugin hook sources.
+
+So TBD can be represented as a Codex plugin rather than writing global
+`hooks.json` into the Codex home.
+
+### Plugin activation
+
+Plugin activation is not a pure runtime override. Codex loads configured
+plugins from the merged **user config layers** via `effective_user_config()`.
+Runtime `-c key=value` overrides are session layers, not user layers, so
+`codex -c 'plugins."tbd@tbd".enabled=true'` should not be treated as a
+reliable plugin activation mechanism.
+
+The profile overlay file is therefore the right activation point.
+
+### Hook trust
+
+`--dangerously-bypass-hook-trust` is session-wide. It marks all enabled
+unmanaged hooks runnable, including all plugin hooks. It is not scoped to one
+plugin.
+
+Codex hook state supports per-hook `trusted_hash` entries. Plugin hook keys
+include plugin/source identity, so TBD can trust only the hooks from the TBD
+plugin by writing trust entries into the `tbd` profile.
+
+## Design
+
+### Launch shape
+
+TBD should launch Codex with the user's normal Codex home:
+
+```sh
+CODEX_HOME="$HOME/.codex" codex --profile tbd ...
+```
+
+The rest of TBD's launch env stays:
+
+- `TBD_WORKTREE_ID`
+- `TBD_TERMINAL_ID`
+
+Remove the per-repo `CODEX_HOME` export from Codex terminal creation and
+recreation once the profile/plugin path is in place.
+
+### TBD Codex profile
+
+TBD owns a profile overlay:
+
+```text
+~/.codex/tbd.config.toml
+```
+
+The minimal profile enables the TBD plugin:
+
+```toml
+[plugins."tbd@tbd"]
+enabled = true
+```
+
+It may also contain hook state entries for the TBD plugin hooks:
+
+```toml
+[hooks.state."<hook-key>"]
+trusted_hash = "sha256:..."
+```
+
+TBD may choose to make `~/.codex/tbd.config.toml` a symlink to a file under
+`~/tbd/agents/codex/tbd.config.toml`, but Codex must see it as the profile
+file inside `CODEX_HOME` so it is loaded as a user profile layer.
+
+### TBD Codex plugin
+
+Create a real Codex plugin with a manifest:
+
+```text
+<tbd-owned-source>/codex-plugin/
+  .codex-plugin/plugin.json
+  skills/tbd/SKILL.md
+  hooks/hooks.json
+```
+
+The manifest name must be `tbd` so it can be activated as `tbd@tbd`.
+
+Install or link it into Codex's plugin cache path:
+
+```text
+~/.codex/plugins/cache/tbd/tbd/local/
+```
+
+Codex's plugin store resolves active plugins from
+`$CODEX_HOME/plugins/cache/<marketplace>/<plugin>/<version>/`; `local` is a
+valid default version for local plugins.
+
+The plugin contains:
+
+- the TBD skill content currently written to `$CODEX_HOME/skills/tbd/SKILL.md`;
+- TBD lifecycle hooks currently written to `$CODEX_HOME/hooks.json`;
+- any future TBD-specific Codex MCP/app connector integration.
+
+### Hook trust flow
+
+Do not launch with `--dangerously-bypass-hook-trust`.
+
+TBD does **not** write hook trust entries itself. The trust state is persisted
+by Codex into the `tbd` profile when the user trusts TBD's hooks once, through
+Codex's own hook-review UI.
+
+Why TBD cannot write trust into the profile programmatically:
+
+- `config/batchWrite` (the RPC Codex's TUI uses to persist `[hooks.state]`)
+  writes to whatever `LoaderOverrides.user_config_path` resolves to at
+  app-server startup. An explicit `file_path` argument is rejected unless it
+  equals that already-allowed path (`ConfigLayerReadonly` otherwise).
+- The in-process TUI sets that override to `<profile>.config.toml` when launched
+  with `--profile`, so trust written *inside* a `codex --profile tbd` session
+  lands in `tbd.config.toml`.
+- The standalone `codex app-server` binary exposes no `--profile` flag and the
+  app-server protocol carries no per-connection profile selection, so a
+  side-channel app-server TBD might spawn to pre-trust hooks would write to base
+  `~/.codex/config.toml` — which violates the non-goal of keeping TBD state out
+  of base config.
+
+So the trust flow is:
+
+1. Ensure the TBD plugin is installed in the Codex plugin cache.
+2. Ensure `~/.codex/tbd.config.toml` enables `tbd@tbd`.
+3. On the first TBD-launched Codex session, Codex surfaces TBD's plugin hooks as
+   untrusted. The user trusts them once via Codex's hook-review UI.
+4. Codex persists `trusted_hash` entries under `[hooks.state]` in
+   `tbd.config.toml` (because the `--profile tbd` session's
+   `user_config_path` override points there).
+
+This is **one-and-done and machine-global**: plugin hook keys carry no `cwd`,
+session, tab, or worktree dimension, so a single trust applies to every
+TBD-launched Codex session on the machine, forever after. It scopes trust to
+the TBD plugin — other user hooks and other plugin hooks remain subject to
+normal Codex trust behavior.
+
+The one re-prompt trigger: if TBD changes a plugin hook's command string, its
+`current_hash` changes, the stored `trusted_hash` no longer matches, and Codex
+flips the hook to `Modified` — prompting the user to re-trust once. TBD should
+therefore treat the Codex hook command strings as a stable interface, change
+them rarely, and document the expected one-time re-trust in any release that
+must change them.
+
+### Trust UX
+
+On the first TBD-launched Codex session, Codex's startup hook-review prompt
+offers three choices:
+
+```text
+1. Review hooks
+2. Trust all and continue
+3. Continue without trusting (hooks won't run)
+```
+
+`Trust all` is broader than TBD: it trusts every untrusted unmanaged hook in
+the session, not only TBD's. Two facts make this acceptable:
+
+- Under `--profile tbd`, the untrusted-hook set is the merge of base
+  `config.toml` and the `tbd` profile. For a user with no custom hooks of
+  their own — the common case — the only untrusted hooks present are TBD's, so
+  `Trust all` trusts only TBD. The over-trust risk materializes solely when the
+  user already has their own untrusted hooks in base config.
+- `Review hooks` opens the hooks browser, which supports **per-hook** trust:
+  drilling into an event and pressing `t` trusts only that one handler
+  (`trust_selected_hook`), versus `t` on the events page which trusts all
+  (`trust_all_hooks`). A user with custom hooks can therefore trust exactly
+  TBD's handlers and nothing else.
+
+Guidance TBD should surface to users (e.g. in onboarding docs or a first-run
+note):
+
+- No custom Codex hooks → `Trust all and continue` is correct; it trusts only
+  TBD.
+- Has custom Codex hooks → `Review hooks`, then per-hook `t` on TBD's handlers.
+
+TBD should also keep its own hook count minimal so the review surface is small
+(see Phase 1). Making TBD's hooks `managed` would skip the prompt entirely
+(`HookTrustStatus::Managed` needs no trust), but managed hooks come only from
+system/MDM-level managed config, which requires admin-level global writes —
+exactly the invasive mutation this design avoids. Rejected.
+
+### User config merging
+
+This design intentionally lets TBD sessions inherit the user's Codex setup:
+
+- auth and token refreshes;
+- base config;
+- model defaults;
+- user plugins;
+- user skills;
+- MCP configuration;
+- normal Codex history/state behavior.
+
+The only TBD-specific additions are in the `tbd` profile and the `tbd@tbd`
+plugin. A normal `codex` launch that does not pass `--profile tbd` will not see
+the TBD plugin activation or TBD hook trust entries.
+
+## Implementation plan
+
+### Phase 1 — plugin/profile writer
+
+Replace `CodexHomeManager`'s isolated-home setup with a new manager that:
+
+- resolves the global Codex home, normally `~/.codex`;
+- creates the Codex home if needed;
+- writes or updates the TBD plugin source/cache;
+- writes or updates `tbd.config.toml`;
+- preserves existing user config files.
+
+While porting the hook definitions into the plugin, **minimize the hook
+count** to keep the trust-review surface small (see Trust UX). The current
+overlay ships three handlers: one `SessionStart` and two `Stop`. Merge the two
+`Stop` handlers (`tbd notify ...` and `tbd hooks stop-rename-check`) into a
+single `Stop` command so the plugin presents two hooks instead of three. The
+merged command should run both steps and preserve their existing
+best-effort/non-blocking behavior (`... 2>/dev/null || true`).
+
+Candidate type names:
+
+- `CodexIntegrationManager`
+- `CodexProfileManager`
+- `CodexPluginWriter`
+
+### Phase 2 — verify hook trust UX
+
+TBD writes no hook trust entries. This phase verifies the interactive trust
+flow instead:
+
+- Confirm a first-run `codex --profile tbd` session surfaces the TBD plugin
+  hooks as untrusted in Codex's hook-review UI.
+- Confirm trusting them once persists `[hooks.state]` entries into
+  `tbd.config.toml` (not base `config.toml`).
+- Confirm subsequent TBD-launched Codex sessions — other tabs, other
+  worktrees — load the hooks without re-prompting.
+- Confirm that changing a plugin hook command string flips the hook to
+  `Modified` and triggers exactly one re-trust prompt.
+
+If TBD ever needs the `[hooks.state]` entries written into `tbd.config.toml`
+without an interactive prompt, that is a separate, currently-unsupported path
+— it would require either replicating Codex's hook hashing in Swift (fragile;
+the upstream key format is marked unstable) or an upstream change letting
+`codex app-server` select a profile. Out of scope here.
+
+### Phase 3 — launch with global home and profile
+
+Change Codex launch command from:
+
+```sh
+unset CODEX_CI CODEX_THREAD_ID; codex --dangerously-bypass-approvals-and-sandbox
+```
+
+to:
+
+```sh
+unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox
+```
+
+Keep `--dangerously-bypass-approvals-and-sandbox` if TBD still wants that
+execution mode, but do not add `--dangerously-bypass-hook-trust`.
+
+Stop exporting isolated `CODEX_HOME` for Codex tabs. Either do not set
+`CODEX_HOME`, letting Codex default to `~/.codex`, or explicitly set it to the
+global path if TBD needs deterministic behavior.
+
+### Phase 4 — migration and cleanup
+
+For existing isolated homes:
+
+- do not delete them automatically;
+- stop writing `hooks.json` and `skills/tbd/SKILL.md` there;
+- optionally surface a cleanup command later.
+
+If an existing TBD Codex session has useful history in the isolated home, it
+will not automatically appear in global Codex history. That is acceptable for
+the first migration unless users report needing history migration.
+
+## Risks
+
+### Trust key stability
+
+This risk is now largely sidestepped: TBD does not compute hook keys or hashes
+(see Hook trust flow), so an upstream key-format change cannot break a TBD
+trust writer — there is none. Codex owns trust persistence end to end. The
+residual exposure is only the `Modified` re-prompt when TBD itself changes a
+hook command string, which is under TBD's control.
+
+### Profile file ownership
+
+Users may edit `~/.codex/tbd.config.toml`. TBD should preserve unknown fields
+and only own the plugin enablement and hook-state entries it manages.
+
+### Plugin cache mutation
+
+Installing into `~/.codex/plugins/cache` mutates the user's Codex home. This is
+acceptable because the plugin is inactive unless the `tbd` profile enables it,
+but the writer should be careful and only touch the `tbd/tbd` plugin path.
+
+### Existing global hooks
+
+When running with `--profile tbd`, normal user hooks from base config still
+exist. This is intentional user-config merging. TBD must not bypass hook trust
+globally, so untrusted user hooks remain blocked until the user trusts them.
+
+## Open questions
+
+- ~~Does Codex expose a stable endpoint to list hooks with keys and hashes?~~
+  Resolved: `hooks/list` returns live keys/hashes, and `config/batchWrite`
+  persists trust — but only into the file selected by the writing process's
+  `user_config_path` override, which the standalone `codex app-server` cannot
+  set. The design therefore uses interactive trust instead of programmatic
+  writes (see Hook trust flow, Phase 2).
+- Should `~/.codex/tbd.config.toml` be a real file or a symlink into `~/tbd`?
+  A real file is simpler and more native to Codex; a symlink centralizes TBD
+  cleanup.
+- Should TBD support a setting to disable Codex profile/plugin integration and
+  fall back to plain global Codex?
+
+## Success criteria
+
+- A user signed into Codex outside TBD is signed in inside TBD without another
+  login.
+- Updating Codex auth outside TBD is immediately reflected in TBD sessions.
+- Normal `codex` does not load TBD's plugin hooks.
+- `codex --profile tbd` loads the TBD plugin and its skill.
+- After a one-time interactive trust, TBD plugin hooks run in every TBD-launched
+  Codex session — across tabs and worktrees — without re-prompting and without
+  `--dangerously-bypass-hook-trust`.
+- Other untrusted hooks remain untrusted in TBD sessions.


### PR DESCRIPTION
## Summary

- TBD used to launch Codex with a per-repo isolated `CODEX_HOME` under `~/tbd/agents/codex/<repoID>/`, which split auth, config, plugins, and skills between TBD and the user's normal `codex`. Users had to re-login inside TBD, token refreshes outside TBD didn't propagate, and user-level config/plugins didn't apply.
- Now TBD launches `codex --profile tbd` against the user's real `~/.codex`. TBD-specific behavior ships as a real Codex plugin (`tbd@tbd`) installed at `~/.codex/plugins/cache/tbd/tbd/local/` and activated by a `tbd.config.toml` profile overlay. The plugin owns TBD's `SessionStart` + `Stop` hooks and the `tbd` skill; everything else (auth, MCP servers, model defaults, user plugins) inherits from the user's normal Codex setup. Plain `codex` outside TBD is unchanged.
- Hook trust is **interactive one-time** via Codex's own hook-review UI — no `--dangerously-bypass-hook-trust`. Plugin hook keys carry no cwd/tab/worktree dimension, so trusting once persists in `tbd.config.toml` and applies to every TBD-launched Codex session on the machine forever after (until TBD itself changes a hook command string).

Full design + upstream verification against `openai/codex` 932f72c2: `docs/specs/2026-05-22-codex-global-home-profile-plugin-design.md`.

## Test plan

- [ ] First Codex tab in TBD prompts Codex's hook-review UI for the TBD plugin's 2 hooks; trust them once.
- [ ] Subsequent Codex tabs — same worktree, other worktrees, after restart — launch silently with no re-prompt.
- [ ] Plain `codex` outside TBD does NOT load the TBD plugin or skill (no `--profile tbd`).
- [ ] Sign into Codex outside TBD → the next TBD Codex tab is signed in (no separate login).
- [ ] Editing `~/.codex/tbd.config.toml` by hand (e.g. adding a custom key under `[plugins."tbd@tbd"]`) — TBD preserves it on next launch (verified by tests `ensurePluginEnabledPreservesEnabledPrefixedKeys`, `ensurePluginEnabledPreservesCustomKeysFromCRLFProfile`).
- [ ] `swift build`, `swift test --filter CodexHookOverlayTests` (13/13), `swift test --filter TBDWorktreeIDLeakTests` (9/9), SwiftLint strict — all green.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=CCDB86A9-46E1-4B72-94B7-4A17872D4BCB)