### PR TITLE
Fix: Mark worktree unread when Claude is waiting on AskUserQuestion

### DIFF
--- a/Sources/TBDDaemon/Server/RPCRouter+AskUserQuestionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AskUserQuestionHandlers.swift
@@ -4,10 +4,27 @@ import TBDShared
 
 private let askUserQuestionLog = Logger(subsystem: "com.tbd.daemon", category: "askUserQuestion")
 
+/// Banner-friendly cap for the message we store on the notification. Long
+/// enough to convey the gist, short enough not to overflow macOS notification
+/// banners or the app's unread tooltip.
+private let askUserQuestionMessageMaxLength = 120
+
+/// Fallback banner text when the AskUserQuestion `tool_input` can't be parsed.
+/// We never want a failed parse to swallow the unread signal — the agent is
+/// still paused waiting for the user.
+private let askUserQuestionFallbackMessage = "Claude is waiting for your answer"
+
 extension RPCRouter {
     /// Stores the pending question payload for a terminal so the merger
     /// inside `handleTerminalTranscript` can synthesize a transcript item
     /// before the assistant `tool_use` line is flushed to the JSONL.
+    ///
+    /// Additionally marks the worktree as needing attention by creating an
+    /// `attentionNeeded` notification and broadcasting the matching delta.
+    /// Without this the Stop hook (end of turn) is the only path that flips
+    /// the worktree to unread, but Stop doesn't fire while a tool call is
+    /// pending — so an AskUserQuestion would otherwise leave the worktree
+    /// silently waiting.
     func handleTerminalAskUserQuestionPending(_ paramsData: Data) async throws -> RPCResponse {
         let p = try decoder.decode(TerminalAskUserQuestionPendingParams.self, from: paramsData)
         let pending = PendingAskUserQuestion(
@@ -17,18 +34,89 @@ extension RPCRouter {
         )
         await pendingQuestions.set(terminalID: p.terminalID, pending)
         askUserQuestionLog.debug("pending stored terminalID=\(p.terminalID.uuidString, privacy: .public) toolUseID=\(p.toolUseID, privacy: .public)")
+
+        // Resolve the worktree this terminal belongs to. If the terminal row
+        // is missing (race with terminal teardown, or a stale CLI relay) we
+        // intentionally skip the notification — the pendingQuestions update
+        // above is still useful for the transcript merger.
+        if let terminal = try? await db.terminals.get(id: p.terminalID) {
+            let message = Self.askUserQuestionMessage(fromInputJSON: p.inputJSON)
+            do {
+                let notification = try await db.notifications.create(
+                    worktreeID: terminal.worktreeID,
+                    type: .attentionNeeded,
+                    message: message
+                )
+                subscriptions.broadcast(delta: .notificationReceived(NotificationDelta(
+                    notificationID: notification.id,
+                    worktreeID: notification.worktreeID,
+                    type: notification.type,
+                    message: notification.message
+                )))
+                askUserQuestionLog.debug("attentionNeeded notification created worktreeID=\(terminal.worktreeID.uuidString, privacy: .public)")
+            } catch {
+                askUserQuestionLog.debug("failed to create attentionNeeded notification: \(String(describing: error), privacy: .public)")
+            }
+        } else {
+            askUserQuestionLog.debug("terminal missing — skipped notification terminalID=\(p.terminalID.uuidString, privacy: .public)")
+        }
+
         return .ok()
     }
 
-    /// Defensive cleanup path — no-op today. The merger performs lazy
-    /// cleanup when it observes the matching `tool_use_id` in the JSONL,
-    /// which avoids the flicker that eager PostToolUse cleanup would
+    /// Cleanup path fired by `PostToolUse:AskUserQuestion`. Belt-and-suspenders
+    /// markRead: today, answering an AskUserQuestion requires typing into the
+    /// terminal, which means focusing the pane, which already triggers
+    /// `notifications.markRead` via `ContentView.onChange(selectedWorktreeIDs)`
+    /// on the app side. Marking read again here is harmless and lets future
+    /// answer-without-focus flows (e.g. an in-app picker) clear the badge
+    /// without any extra plumbing.
+    ///
+    /// The merger still performs lazy pendingQuestions cleanup when it
+    /// observes the matching `tool_use_id` in the JSONL — we don't eagerly
+    /// clear here, which avoids the flicker that eager cleanup would
     /// introduce (Claude flushes the JSONL line slightly after PostToolUse
-    /// returns). Keeping the wire format reserved so a future change to
-    /// eager cleanup needn't ship a protocol break.
+    /// returns).
     func handleTerminalAskUserQuestionCleared(_ paramsData: Data) async throws -> RPCResponse {
         let p = try decoder.decode(TerminalAskUserQuestionClearedParams.self, from: paramsData)
-        askUserQuestionLog.debug("cleared received (no-op) terminalID=\(p.terminalID.uuidString, privacy: .public) toolUseID=\(p.toolUseID, privacy: .public)")
+        askUserQuestionLog.debug("cleared received terminalID=\(p.terminalID.uuidString, privacy: .public) toolUseID=\(p.toolUseID, privacy: .public)")
+
+        if let terminal = try? await db.terminals.get(id: p.terminalID) {
+            do {
+                try await db.notifications.markRead(worktreeID: terminal.worktreeID)
+            } catch {
+                askUserQuestionLog.debug("markRead failed: \(String(describing: error), privacy: .public)")
+            }
+        }
         return .ok()
+    }
+
+    /// Extracts a banner-friendly message from the raw AskUserQuestion
+    /// `tool_input` JSON. The shape is
+    /// `{"questions":[{"question":"...","header":"...","options":[...]}, ...]}`
+    /// with 1–4 questions; we pick the first question's `question` field and
+    /// truncate to `askUserQuestionMessageMaxLength`. Anything malformed falls
+    /// back to a generic "waiting for your answer" string — we never throw
+    /// out of this path because that would swallow the unread signal.
+    static func askUserQuestionMessage(fromInputJSON inputJSON: String) -> String {
+        guard
+            let data = inputJSON.data(using: .utf8),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let questions = root["questions"] as? [[String: Any]],
+            let first = questions.first,
+            let text = first["question"] as? String,
+            !text.isEmpty
+        else {
+            return askUserQuestionFallbackMessage
+        }
+        return truncate(text, to: askUserQuestionMessageMaxLength)
+    }
+
+    private static func truncate(_ s: String, to maxLength: Int) -> String {
+        guard s.count > maxLength else { return s }
+        // Reserve one character for the ellipsis so the visible length stays
+        // <= maxLength.
+        let endIndex = s.index(s.startIndex, offsetBy: maxLength - 1)
+        return String(s[s.startIndex..<endIndex]) + "…"
     }
 }

--- a/Tests/TBDDaemonTests/RPCRouterAskUserQuestionHandlerTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterAskUserQuestionHandlerTests.swift
@@ -1,0 +1,192 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Tests for the AskUserQuestion RPC handlers — verifies that PreToolUse
+// flips the worktree to unread (attentionNeeded notification) and that
+// PostToolUse marks notifications read as a belt-and-suspenders cleanup.
+extension RPCRouterTests {
+
+    // MARK: - Helpers
+
+    private func makeRepoAndWorktree() async throws -> (repoID: UUID, worktreeID: UUID) {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        return (repo.id, wt.id)
+    }
+
+    private func sendPending(
+        terminalID: UUID,
+        toolUseID: String = "toolu_test",
+        inputJSON: String
+    ) async -> RPCResponse {
+        let params = TerminalAskUserQuestionPendingParams(
+            terminalID: terminalID,
+            toolUseID: toolUseID,
+            inputJSON: inputJSON,
+            timestampMillis: Int64(Date().timeIntervalSince1970 * 1000)
+        )
+        let request = try! RPCRequest(method: RPCMethod.terminalAskUserQuestionPending, params: params)
+        return await router.handle(request)
+    }
+
+    private func sendCleared(
+        terminalID: UUID,
+        toolUseID: String = "toolu_test"
+    ) async -> RPCResponse {
+        let params = TerminalAskUserQuestionClearedParams(
+            terminalID: terminalID,
+            toolUseID: toolUseID
+        )
+        let request = try! RPCRequest(method: RPCMethod.terminalAskUserQuestionCleared, params: params)
+        return await router.handle(request)
+    }
+
+    // MARK: - Pending: happy path
+
+    @Test("askUserQuestion.pending creates attentionNeeded notification for owning worktree")
+    func askUserQuestionPendingCreatesNotification() async throws {
+        let (_, worktreeID) = try await makeRepoAndWorktree()
+        let terminal = try await db.terminals.create(
+            worktreeID: worktreeID,
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0"
+        )
+
+        let inputJSON = #"{"questions":[{"question":"Pick a fruit","header":"Fruit","options":[{"label":"apple","description":""}],"multiSelect":false}]}"#
+        let response = await sendPending(terminalID: terminal.id, inputJSON: inputJSON)
+        #expect(response.success)
+
+        // Notification row was inserted with the expected fields.
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(unread.count == 1)
+        let notif = try #require(unread.first)
+        #expect(notif.type == .attentionNeeded)
+        #expect(notif.worktreeID == worktreeID)
+        let message = try #require(notif.message)
+        #expect(message.contains("Pick a fruit"))
+
+        // pendingQuestions is still populated for the transcript merger.
+        let entries = await router.pendingQuestions.entries(forTerminal: terminal.id)
+        #expect(entries.count == 1)
+        #expect(entries.first?.toolUseID == "toolu_test")
+    }
+
+    // MARK: - Pending: terminal missing
+
+    @Test("askUserQuestion.pending without DB terminal still stores pending entry, no notification")
+    func askUserQuestionPendingWithMissingTerminal() async throws {
+        let phantomTerminalID = UUID()
+        let inputJSON = #"{"questions":[{"question":"Anything?","header":"Q","options":[],"multiSelect":false}]}"#
+        let response = await sendPending(terminalID: phantomTerminalID, inputJSON: inputJSON)
+        #expect(response.success)
+
+        // No worktree to attach to → no notifications anywhere in the DB.
+        let allRecords = try await db.notifications.unreadSummaryByWorktree()
+        #expect(allRecords.isEmpty)
+
+        // pendingQuestions still records the entry so any later transcript
+        // request for this terminal can use it (preserves prior behavior).
+        let entries = await router.pendingQuestions.entries(forTerminal: phantomTerminalID)
+        #expect(entries.count == 1)
+    }
+
+    // MARK: - Pending: message extraction
+
+    @Test("askUserQuestion.pending uses first question and truncates long text")
+    func askUserQuestionPendingMessageExtraction() async throws {
+        let (_, worktreeID) = try await makeRepoAndWorktree()
+        let terminal = try await db.terminals.create(
+            worktreeID: worktreeID,
+            tmuxWindowID: "@mock-1",
+            tmuxPaneID: "%mock-1"
+        )
+
+        // 200-char question to force truncation, plus a second question we
+        // must ignore.
+        let longText = String(repeating: "A", count: 200)
+        let inputJSON = """
+        {"questions":[{"question":"\(longText)","header":"long","options":[],"multiSelect":false},{"question":"second question text","header":"second","options":[],"multiSelect":false}]}
+        """
+
+        let response = await sendPending(terminalID: terminal.id, inputJSON: inputJSON)
+        #expect(response.success)
+
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        let message = try #require(unread.first?.message)
+        // First question wins.
+        #expect(message.hasPrefix("A"))
+        #expect(!message.contains("second question text"))
+        // Truncated to <= 120 chars including the ellipsis.
+        #expect(message.count <= 120)
+        #expect(message.hasSuffix("…"))
+    }
+
+    // MARK: - Pending: malformed JSON
+
+    @Test("askUserQuestion.pending with malformed inputJSON falls back to generic message")
+    func askUserQuestionPendingMalformedJSON() async throws {
+        let (_, worktreeID) = try await makeRepoAndWorktree()
+        let terminal = try await db.terminals.create(
+            worktreeID: worktreeID,
+            tmuxWindowID: "@mock-2",
+            tmuxPaneID: "%mock-2"
+        )
+
+        let response = await sendPending(terminalID: terminal.id, inputJSON: "not-json-at-all{")
+        #expect(response.success)
+
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(unread.count == 1)
+        let notif = try #require(unread.first)
+        #expect(notif.type == .attentionNeeded)
+        #expect(notif.message == "Claude is waiting for your answer")
+    }
+
+    // MARK: - Cleared: happy path
+
+    @Test("askUserQuestion.cleared marks worktree notifications read")
+    func askUserQuestionClearedMarksRead() async throws {
+        let (_, worktreeID) = try await makeRepoAndWorktree()
+        let terminal = try await db.terminals.create(
+            worktreeID: worktreeID,
+            tmuxWindowID: "@mock-3",
+            tmuxPaneID: "%mock-3"
+        )
+
+        // Seed an unread notification (as if a prior PreToolUse already
+        // marked attention needed).
+        _ = try await db.notifications.create(
+            worktreeID: worktreeID,
+            type: .attentionNeeded,
+            message: "Pick one"
+        )
+        let beforeUnread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(beforeUnread.count == 1)
+
+        let response = await sendCleared(terminalID: terminal.id)
+        #expect(response.success)
+
+        let afterUnread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(afterUnread.isEmpty)
+    }
+
+    // MARK: - Cleared: terminal missing
+
+    @Test("askUserQuestion.cleared returns ok when terminal is missing")
+    func askUserQuestionClearedWithMissingTerminal() async throws {
+        let response = await sendCleared(terminalID: UUID())
+        #expect(response.success)
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug**: when a Claude session calls `AskUserQuestion`, the worktree never goes bold/dot — the only path that flips unread state today is the `Stop` hook, which doesn't fire until the user answers. So an unfocused worktree could sit silently blocked on input.
- **Fix**: `handleTerminalAskUserQuestionPending` now resolves the terminal → worktree, creates a `.attentionNeeded` notification (severity 3 — outranks `responseComplete`/`taskComplete` so the badge correctly upgrades), and broadcasts `NotificationDelta` mirroring the existing `handleNotify` path. Message is parsed from the first question's text (defensive `JSONSerialization`, truncated to 120 chars, falls back to "Claude is waiting for your answer" on any parse failure).
- **Cleared handler**: now calls `db.notifications.markRead` as belt-and-suspenders for any future answer-without-focus flow. Today, answering requires focusing the pane → existing `markSelectedWorktreesAsRead` already handles it.
- No new RPC method, no protocol change, no migration. Subagent payloads stay suppressed at the CLI layer.

## Test plan

- [x] `swift build` (5.96s)
- [x] `swift test` 1051/1051 passing (3.1s), including 6 new tests in `RPCRouterAskUserQuestionHandlerTests` covering both branches of the new gating conditional, message-extraction truncation, and malformed-JSON fallback
- [x] SwiftLint `--strict` 0 violations
- [x] Manual: from a Claude session in an unfocused worktree, invoke `AskUserQuestion` → worktree row goes bold + unread dot appears; focusing the pane clears it

> Note: macOS banner suppression for this notification type is a pre-existing separate issue and not addressed here.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=E5696BEE-C8F4-4429-A641-FED023F0DFC5)