### PR TITLE
DX: Stop macOS keychain prompts from blocking SPM resolve

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install swiftlint
+        run: brew install swiftlint
+
+      - name: SwiftLint (strict)
+        run: swiftlint --strict
+
   test:
     runs-on: macos-15
     steps:
@@ -53,8 +65,7 @@ jobs:
           # restored. restore-keys falls back to a cache with the same dep
           # set (same Package.resolved hash) — without this scoping, restore
           # could pull a cache from before a dep was added, leaving stale
-          # `.build/checkouts/` that breaks SPM resolution of binary targets
-          # (e.g. SwiftLintBinary).
+          # `.build/checkouts/` that breaks SPM resolution of binary targets.
           key: spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-deps-${{ hashFiles('Package.resolved') }}-src-${{ hashFiles('Package.swift', 'Sources/**/*.swift', 'Tests/**/*.swift') }}
           restore-keys: |
             spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-deps-${{ hashFiles('Package.resolved') }}-
@@ -78,9 +89,6 @@ jobs:
           echo "=== TBDShared artifacts after wipe ==="
           ls -la .build/*/debug/TBDShared.build 2>/dev/null || echo "(absent)"
           ls -la .build/*/debug/Modules/TBDShared.swiftmodule 2>/dev/null || echo "(absent)"
-
-      - name: SwiftLint (strict)
-        run: swift package plugin --allow-writing-to-package-directory swiftlint --strict
 
       # `-j 2` caps parallel swift-frontend processes. The macos-15 runner
       # has limited RAM (~7-14 GB) and Swift 6.2.4 frontends each consume

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Applies to `TBDShared`, `TBDDaemonLib`, `TBDDaemon`, and `TBDApp`. **`TBDCLI` is
 
 Use `os.Logger` (`import os`) with one of the established subsystems (`com.tbd.app`, `com.tbd.daemon`) and a feature-shaped category. `.debug` is the right level for traces you'd previously have used `print()` for — they're silent by default and activated with `log stream --level debug`. Always pass an explicit `privacy:` argument on dynamic interpolations (default `.public` for this dev tool, `.private`/`.sensitive` for secrets). Full rationale and category taxonomy: [`docs/diagnostics-strategy.md`](docs/diagnostics-strategy.md).
 
-This rule is enforced mechanically by SwiftLint (custom rule `no_print_in_sources`) in CI (`swift package plugin swiftlint --strict`) and in the pre-push git hook. Run `swift package plugin --allow-writing-to-package-directory swiftlint --strict` locally to lint manually. See `.swiftlint.yml`.
+This rule is enforced mechanically by SwiftLint (custom rule `no_print_in_sources`) in the dedicated `lint` CI job and the pre-push git hook, both invoking a Homebrew-installed `swiftlint --strict` directly. To lint manually: `swiftlint --strict`. Prerequisite: `brew install swiftlint`. See `.swiftlint.yml`.
 
 ## Quick Reference
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "54e8d1aacfe50bff048354e01819161f554066fe1dfca9c8d088e22b86c67500",
+  "originHash" : "6b4ef2d7b9f338239f06147a86fb81a991fbd5c88195513612158d4b48138aad",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -89,15 +89,6 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
-      }
-    },
-    {
-      "identity" : "swiftlintplugins",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
-      "state" : {
-        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
-        "version" : "0.63.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@ let package = Package(
         .package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
         .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),
-        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.63.2"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Three components communicate over a Unix socket using a JSON RPC protocol:
 - macOS 15+
 - Swift 6.0+ / Xcode 16+
 - [tmux](https://github.com/tmux/tmux) installed (`brew install tmux`)
+- [SwiftLint](https://github.com/realm/SwiftLint) installed (`brew install swiftlint`) — required for the pre-push git hook
 
 ## Build & Run
 

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -5,6 +5,11 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+if ! command -v swiftlint &>/dev/null; then
+  echo "[pre-push] swiftlint not found. Install it with: brew install swiftlint" >&2
+  exit 1
+fi
+
 # Determine merge base; fall back to HEAD~1 if origin/main isn't fetched.
 base="$(git merge-base origin/main HEAD 2>/dev/null || echo HEAD~1)"
 
@@ -21,4 +26,4 @@ if [ ${#files[@]} -eq 0 ]; then
 fi
 
 echo "[pre-push] Linting ${#files[@]} changed Swift file(s) with SwiftLint --strict..."
-swift package plugin --allow-writing-to-package-directory swiftlint --strict -- "${files[@]}"
+swiftlint --strict "${files[@]}"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -12,3 +12,9 @@ for hook in "$hooks_src"/*; do
   chmod +x "$hook"
   echo "Installed: $name"
 done
+
+if ! command -v swiftlint &>/dev/null; then
+  echo ""
+  echo "Warning: swiftlint not found on PATH. The pre-push hook requires it."
+  echo "Install with: brew install swiftlint"
+fi


### PR DESCRIPTION
## Summary
- `swift package resolve` (and any clean `swift build`) triggered a macOS keychain prompt because `SimplyDanny/SwiftLintPlugins` pulls `SwiftLintBinary.artifactbundle.zip` via SPM's URLSession-based artifact downloader, which consults the keychain for every `github.com` URL — even for public release assets
- Contributors with multiple `github.com` keychain entries (gh-cli + Xcode + browser sync) hit `errSecUserCanceled (-128)` and resolve fails outright with `error: fatalError`
- Removed the SPM dep entirely. SwiftLint now installs via `brew install swiftlint` and runs in a dedicated `Lint` CI job (parallel with `test`, gives the gate an explicit name for branch protection) and directly from the pre-push hook

## Follow-up after merge
- Add `Lint` as a required status check in branch protection alongside `test`
- Existing contributors need a one-time `brew install swiftlint` (the pre-push hook exits with a hint if it's missing)

## Test plan
- [ ] `Lint` CI job appears as a new check on this PR and passes
- [ ] `test` job still passes (no SwiftLint step inside it now)
- [ ] Local: `swiftlint --strict` passes against a fresh `brew install swiftlint`
- [ ] On a fresh clone with multiple `github.com` keychain entries: `swift package resolve` succeeds without any keychain prompt

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=C6FC526A-C894-4C56-BC37-73B09392132D)