### PR TITLE
Fix: Default auto-suspend OFF so it can't silently exit Claude sessions

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -957,17 +957,17 @@ final class AppState: ObservableObject {
     }
 
     /// UserDefaults key mirroring the `@AppStorage("autoSuspendClaude")`
-    /// toggle in ContentView/SettingsView. Read from non-View contexts (e.g.
-    /// the daemon-reconnect path) to avoid sending `suspendEnabled=true`
-    /// when the user has the toggle off.
+    /// toggle in the Settings → Experimental section. Read from non-View
+    /// contexts (e.g. the daemon-reconnect path) to avoid sending
+    /// `suspendEnabled=true` when the user has not opted in.
     static let autoSuspendClaudeKey = "autoSuspendClaude"
 
-    /// Whether auto-suspend is enabled. Defaults to true when the user has
-    /// never touched the toggle, matching the `@AppStorage` defaults.
-    /// Tests pass a private `UserDefaults(suiteName:)` so they never mutate
-    /// the developer's live app preferences.
+    /// Whether auto-suspend is enabled. Fails closed: defaults to false when
+    /// the user has never touched the toggle, matching the `@AppStorage`
+    /// defaults. Tests pass a private `UserDefaults(suiteName:)` so they
+    /// never mutate the developer's live app preferences.
     static func autoSuspendClaudeEnabled(defaults: UserDefaults = .standard) -> Bool {
-        defaults.object(forKey: autoSuspendClaudeKey) as? Bool ?? true
+        defaults.object(forKey: autoSuspendClaudeKey) as? Bool ?? false
     }
 
     /// UserDefaults key for a Claude spawn-env setting, by registry ID.

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -7,7 +7,7 @@ struct ContentView: View {
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
     @AppStorage("filePanel.isVisible") private var showFilePanel = true
     @AppStorage("filePanel.width") private var filePanelWidth: Double = 280
-    @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspendClaude: Bool = true
+    @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspendClaude: Bool = false
     @State private var contentAreaHeight: CGFloat = 600
 
     private var selectedWorktree: Worktree? {
@@ -107,17 +107,6 @@ struct ContentView: View {
                 }
 
                 ToolbarItemGroup(placement: .primaryAction) {
-                    Button {
-                        autoSuspendClaude.toggle()
-                    } label: {
-                        Image(systemName: autoSuspendClaude ? "pause.circle.fill" : "pause.circle")
-                            .foregroundStyle(autoSuspendClaude ? .primary : .secondary)
-                    }
-                    .accessibilityLabel(autoSuspendClaude ? "Auto-suspend on" : "Auto-suspend off")
-                    .help(autoSuspendClaude
-                        ? "Auto-suspend is on — idle Claude instances are suspended when switching worktrees"
-                        : "Auto-suspend is off — Claude instances stay running when switching worktrees")
-
                     Picker("Filter", selection: $appState.repoFilter) {
                         Text("All Repos").tag(UUID?.none)
                         Divider()

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -33,7 +33,7 @@ struct SettingsView: View {
 struct GeneralSettingsTab: View {
     @AppStorage("enableNotifications") private var enableNotifications: Bool = true
     @AppStorage("skipPermissions") private var skipPermissions: Bool = true
-    @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = true
+    @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = false
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
@@ -85,8 +85,11 @@ struct GeneralSettingsTab: View {
             Section("Claude") {
                 Toggle("Launch claude with --dangerously-skip-permissions", isOn: $skipPermissions)
                     .help("Skip the interactive permission prompt when launching claude in new worktrees")
+            }
+
+            Section("Experimental") {
                 Toggle("Auto-suspend idle Claude when switching worktrees", isOn: $autoSuspend)
-                    .help("Exit idle Claude instances when you switch away and resume them when you switch back, freeing memory")
+                    .help("Experimental: exit idle Claude instances when you switch away and resume them when you switch back, freeing memory. Off by default — may interrupt long-running work.")
             }
         }
         .formStyle(.grouped)

--- a/Tests/TBDAppTests/AutoSuspendPreferenceTests.swift
+++ b/Tests/TBDAppTests/AutoSuspendPreferenceTests.swift
@@ -52,10 +52,10 @@ struct AutoSuspendPreferenceTests {
         }
     }
 
-    @Test("defaults to true when the user has never touched the toggle")
-    func defaultsToTrueWhenUnset() {
+    @Test("defaults to false when the user has never touched the toggle — fail-closed")
+    func defaultsToFalseWhenUnset() {
         withIsolatedDefaults(seed: nil) { defaults in
-            #expect(AppState.autoSuspendClaudeEnabled(defaults: defaults) == true)
+            #expect(AppState.autoSuspendClaudeEnabled(defaults: defaults) == false)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Auto-suspend was silently turning itself on in fresh worktrees — both `@AppStorage` defaults and `AppState.autoSuspendClaudeEnabled(...)` defaulted to `true`, so any new worktree started killing idle Claudes the moment you switched away.
- Flip the helper to `?? false`, drop both `@AppStorage` defaults to `false`, and update the regression test that locked in the old behavior. Fails closed: the feature only runs if the user explicitly opts in.
- Remove the toolbar pause-circle button from `ContentView`, and move the Settings toggle out of "Claude" into a new "Experimental" section with help text noting it may interrupt long-running work.

## Test plan
- [ ] `swift test --filter AutoSuspendPreferenceTests` passes (3/3, including the flipped "defaults to false … fail-closed" case).
- [ ] `swift build` clean.
- [ ] Launch via `scripts/restart.sh` on a fresh `~/tbd` and confirm: no pause-circle in the toolbar; Settings → General shows a new "Experimental" section at the bottom with the toggle OFF; switching worktrees does NOT exit idle Claude sessions.
- [ ] Toggle it on in Settings → Experimental, switch worktrees, and confirm auto-suspend behavior still works for users who opt in.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=41478F23-F174-474A-A0BA-809CFCC94758)