### PR TITLE
Feat: Click a TBD notification to jump to its worktree

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -326,6 +326,10 @@ final class AppState: ObservableObject {
         }
         startMemoryPressureMonitor()
         registerFocusObservers()
+        // Give the notification manager a back-reference so banner clicks
+        // can call navigateToWorktree. All stored properties are now
+        // initialized, so `self` is fully usable here.
+        macNotificationManager.configure(appState: self)
         // Under `swift test`, the per-test `AppState()` instances would each
         // spawn a subscription Task that blocks indefinitely in `recv()` on
         // the daemon socket. With enough tests the Swift cooperative thread

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -12,14 +12,38 @@ struct StatusBarView: View {
         return (worktree.path, worktree.repoID)
     }
 
+    /// Resolved once per process: the absolute path of the worktree that built
+    /// this running TBDApp. Primary source is a sidecar file written into the
+    /// bundle by `scripts/restart.sh`; falls back to parsing the exec path for
+    /// the legacy in-place `.build/debug/TBD.app` launch shape.
+    private static let sourceWorktreePath: String? = resolveSourceWorktreePath(
+        bundleURL: Bundle.main.bundleURL,
+        executablePath: Bundle.main.executablePath
+    )
+
+    /// Pure helper extracted so tests can exercise it without a real bundle.
+    /// Tries the sidecar file first, then the exec-path heuristic.
+    static func resolveSourceWorktreePath(
+        bundleURL: URL,
+        executablePath: String?,
+        sidecarReader: (URL) -> String? = { try? String(contentsOf: $0, encoding: .utf8) }
+    ) -> String? {
+        let sidecarURL = bundleURL.appendingPathComponent("Contents/SourceWorktreePath.txt")
+        if let raw = sidecarReader(sidecarURL) {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+        if let execPath = executablePath,
+           let buildRange = execPath.range(of: "/.build/", options: .backwards) {
+            return String(execPath[..<buildRange.lowerBound])
+        }
+        return nil
+    }
+
     private var footerLabel: (text: String, tooltip: String?) {
         let version = "v\(TBDConstants.version)"
-        guard let execPath = Bundle.main.executablePath,
-              let buildRange = execPath.range(of: "/.build/", options: .backwards) else {
-            return (version, nil)
-        }
-        let worktreePath = String(execPath[..<buildRange.lowerBound])
-        guard let worktree = appState.worktrees.values.flatMap({ $0 }).first(where: { $0.path == worktreePath }) else {
+        guard let sourcePath = Self.sourceWorktreePath,
+              let worktree = appState.worktrees.values.flatMap({ $0 }).first(where: { $0.path == sourcePath }) else {
             return (version, nil)
         }
         return (worktree.displayName, version)

--- a/Sources/TBDApp/Services/MacNotificationManager.swift
+++ b/Sources/TBDApp/Services/MacNotificationManager.swift
@@ -13,6 +13,14 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
     private var hasRequestedPermission = false
     private var hasLoggedUnavailable = false
 
+    /// Set by `AppState` after construction so banner clicks can drive navigation.
+    /// Weak to avoid a retain cycle — `AppState` owns this manager.
+    weak var appState: AppState?
+
+    func configure(appState: AppState) {
+        self.appState = appState
+    }
+
     /// UNUserNotificationCenter crashes unbundled executables (no CFBundleIdentifier).
     private var isAvailable: Bool {
         Bundle.main.bundleIdentifier != nil
@@ -81,5 +89,37 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         withCompletionHandler handler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         handler([.banner])
+    }
+
+    /// Parse a notification request identifier and navigate to the matching worktree.
+    /// Factored out of the delegate method so it's testable without faking
+    /// `UNNotificationResponse` (which has no public initializer).
+    func handleClick(identifier: String) {
+        guard let worktreeID = UUID(uuidString: identifier) else {
+            logger.error("Banner click identifier is not a UUID: \(identifier, privacy: .public)")
+            return
+        }
+        guard let appState else {
+            logger.error("Banner click ignored: appState not configured")
+            return
+        }
+        appState.navigateToWorktree(worktreeID)
+    }
+
+    /// Banner click → focus the worktree the notification was about.
+    /// `nonisolated` to satisfy the protocol's isolation requirement, matching
+    /// `willPresent` above. Hops back to the main actor to invoke `handleClick`.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let identifier = response.notification.request.identifier
+        // Call the completion handler synchronously to satisfy its
+        // non-Sendable isolation, then hop to the main actor for navigation.
+        completionHandler()
+        Task { @MainActor in
+            self.handleClick(identifier: identifier)
+        }
     }
 }

--- a/Tests/TBDAppTests/MacNotificationManagerClickTests.swift
+++ b/Tests/TBDAppTests/MacNotificationManagerClickTests.swift
@@ -1,0 +1,68 @@
+import Testing
+import Foundation
+import TBDShared
+@testable import TBDApp
+
+/// Per-suite UserDefaults so tests don't clobber the developer's real TBDApp.plist.
+/// See CLAUDE.md → "Tests must not touch ~/tbd".
+@MainActor
+private func makeIsolatedAppState() -> (AppState, String) {
+    let suiteName = "com.tbd.tests.notificationclick.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    let state = AppState(userDefaults: defaults)
+    return (state, suiteName)
+}
+
+@MainActor
+private func tearDown(_ suiteName: String) {
+    UserDefaults().removePersistentDomain(forName: suiteName)
+}
+
+@MainActor
+@Test func handleClick_validUUID_selectsWorktree() async {
+    let (appState, suite) = makeIsolatedAppState()
+    defer { tearDown(suite) }
+    appState.isInitialStateLoaded = true
+    let id = UUID()
+    let repoID = UUID()
+    appState.worktrees = [
+        repoID: [
+            Worktree(id: id, repoID: repoID, name: "x", displayName: "X",
+                     branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x"),
+        ],
+    ]
+
+    appState.macNotificationManager.handleClick(identifier: id.uuidString)
+
+    #expect(appState.selectedWorktreeIDs == [id])
+}
+
+@MainActor
+@Test func handleClick_malformedIdentifier_doesNotMutateSelection() async {
+    let (appState, suite) = makeIsolatedAppState()
+    defer { tearDown(suite) }
+    appState.isInitialStateLoaded = true
+    let id = UUID()
+    let repoID = UUID()
+    appState.worktrees = [
+        repoID: [
+            Worktree(id: id, repoID: repoID, name: "x", displayName: "X",
+                     branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x"),
+        ],
+    ]
+    appState.selectedWorktreeIDs = []
+
+    appState.macNotificationManager.handleClick(identifier: "not-a-uuid")
+
+    #expect(appState.selectedWorktreeIDs.isEmpty)
+}
+
+@MainActor
+@Test func handleClick_withoutConfiguredAppState_doesNotCrash() async {
+    // A bare manager with no configure() call — proves the guard works.
+    let manager = MacNotificationManager()
+
+    manager.handleClick(identifier: UUID().uuidString)
+
+    #expect(manager.appState == nil)
+}

--- a/Tests/TBDAppTests/StatusBarViewSourcePathTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewSourcePathTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import Foundation
+@testable import TBDApp
+
+@Test func resolveSourceWorktreePath_sidecarPresent_returnsTrimmedContents() {
+    let bundleURL = URL(fileURLWithPath: "/Applications/TBD.app")
+    let resolved = StatusBarView.resolveSourceWorktreePath(
+        bundleURL: bundleURL,
+        executablePath: "/Applications/TBD.app/Contents/MacOS/TBDApp",
+        sidecarReader: { url in
+            #expect(url.path == "/Applications/TBD.app/Contents/SourceWorktreePath.txt")
+            return "  /Users/me/tbd/worktrees/foo  \n"
+        }
+    )
+    #expect(resolved == "/Users/me/tbd/worktrees/foo")
+}
+
+@Test func resolveSourceWorktreePath_sidecarAbsent_fallsBackToExecPath() {
+    let bundleURL = URL(fileURLWithPath: "/some/worktree/.build/debug/TBD.app")
+    let resolved = StatusBarView.resolveSourceWorktreePath(
+        bundleURL: bundleURL,
+        executablePath: "/some/worktree/.build/debug/TBDApp",
+        sidecarReader: { _ in nil }
+    )
+    #expect(resolved == "/some/worktree")
+}
+
+@Test func resolveSourceWorktreePath_sidecarEmpty_fallsBackToExecPath() {
+    let bundleURL = URL(fileURLWithPath: "/some/worktree/.build/debug/TBD.app")
+    let resolved = StatusBarView.resolveSourceWorktreePath(
+        bundleURL: bundleURL,
+        executablePath: "/some/worktree/.build/debug/TBDApp",
+        sidecarReader: { _ in "   \n  " }
+    )
+    #expect(resolved == "/some/worktree")
+}
+
+@Test func resolveSourceWorktreePath_neitherAvailable_returnsNil() {
+    let bundleURL = URL(fileURLWithPath: "/Applications/TBD.app")
+    let resolved = StatusBarView.resolveSourceWorktreePath(
+        bundleURL: bundleURL,
+        executablePath: "/Applications/TBD.app/Contents/MacOS/TBDApp",
+        sidecarReader: { _ in nil }
+    )
+    #expect(resolved == nil)
+}
+
+@Test func resolveSourceWorktreePath_nilExecPathAndNoSidecar_returnsNil() {
+    let bundleURL = URL(fileURLWithPath: "/Applications/TBD.app")
+    let resolved = StatusBarView.resolveSourceWorktreePath(
+        bundleURL: bundleURL,
+        executablePath: nil,
+        sidecarReader: { _ in nil }
+    )
+    #expect(resolved == nil)
+}

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -71,6 +71,11 @@ if [ ! -f "$BUNDLE_PLIST" ] || [ "$SOURCE_PLIST" -nt "$BUNDLE_PLIST" ]; then
     cp "$SOURCE_PLIST" "$BUNDLE_PLIST"
 fi
 
+# Stash the source worktree path inside the bundle so the running app can
+# show it in the status bar — it can no longer infer this from its own
+# exec path now that it runs from /Applications instead of .build/.
+printf '%s' "$REPO_ROOT" > "$BUNDLE_DIR/Contents/SourceWorktreePath.txt"
+
 # Sign + install to /Applications to satisfy macOS UNUserNotificationCenter:
 #  - Re-signing with --force --deep makes the codesign identifier match
 #    CFBundleIdentifier (com.tbd.app); SPM's default ad-hoc signature uses


### PR DESCRIPTION
## Summary

- **Click-to-focus on macOS notification banners.** TBD's banners used to do nothing on click; now clicking one switches the sidebar selection to the worktree the notification was about and brings TBD to the front. Reuses the existing `tbd://open?worktree=<uuid>` deep-link path (`DeepLinkHandler` → `AppState.navigateToWorktree`), so all the existing side-effects cascade: mark notifications read, refresh PR/terminals, notify daemon of selection change, update visit history, handle cold-start buffering + archived-worktree fallback.
- **No new identifier plumbing.** The notification's `UNNotificationRequest.identifier` is already the `worktreeID.uuidString` — single source of truth — so the click handler parses it back to a UUID rather than duplicating into `userInfo`.
- **Status-bar regression fix from #195.** That PR moved the running TBDApp to `/Applications/TBD.app`, which broke `StatusBarView`'s exec-path heuristic for inferring the source worktree (it looked for `/.build/` in the path). `scripts/restart.sh` now stashes `$REPO_ROOT` inside the bundle as `Contents/SourceWorktreePath.txt` (sealed into the codesignature, carried into `/Applications` by `cp -cR`); `StatusBarView` reads from there first and falls back to the exec-path heuristic for any non-restart.sh launches.

## Test plan

- [x] `swift build` and `swift test` (1074 tests, all green).
- [x] `swiftlint --strict` clean across 194 files.
- [x] 3 new tests in `MacNotificationManagerClickTests` cover `handleClick`: valid UUID navigates, malformed identifier no-ops, missing appState no-ops.
- [x] 5 new tests in `StatusBarViewSourcePathTests` cover `resolveSourceWorktreePath`: sidecar present, sidecar absent + exec-path fallback, sidecar empty + fallback, neither available, nil exec path.
- [x] Manual: triggered an unfocused banner, clicked it → TBD came to front + selection switched to the source worktree. Status bar bottom-right now displays the source worktree's display name again.

## Notes

- `UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:)` has to be `nonisolated` under Swift 6 strict concurrency, so the delegate shim captures the identifier and hops to the `@MainActor` `handleClick` helper via `Task { @MainActor in ... }`. Helper is the testable seam — `UNNotificationResponse` has no public initializer.
- `MacNotificationManager` learns its `appState` via a `configure(appState:)` setter called at the end of `AppState.init`. Stored as `weak` to avoid the retain cycle.
- Same-identifier-replaces-banner behavior preserved (one banner per worktree at a time) — intentional, only the latest banner is what the user would want to click.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=E5696BEE-C8F4-4429-A641-FED023F0DFC5)