### PR TITLE
Feat: Markdown + clickable file paths in Agent transcript overlay

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,6 +60,8 @@ custom_rules:
     excluded:
       # TranscriptOverlayView renders outside the LazyVStack — ScrollView is safe here (#129).
       - "Sources/TBDApp/Panes/Transcript/TranscriptOverlayView\\.swift"
+      # OverlayFileView is the body of a file frame in the overlay — sibling of LazyVStack, real ScrollView is safe.
+      - "Sources/TBDApp/Panes/Transcript/OverlayFileView\\.swift"
     regex: '\bScrollView\b'
     match_kinds:
       - identifier

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -60,12 +60,12 @@ struct ContentView: View {
                     })
                     .onPreferenceChange(ContentHeightKey.self) { contentAreaHeight = $0 }
                     .overlay {
-                        if let frame = overlayCoordinator.openOverlay,
-                           frame.terminalID.map({ !visibleTerminalIDs.contains($0) }) ?? true {
+                        if let frame = overlayCoordinator.current,
+                           overlayFrameIsWindowRoot(frame, visibleTerminalIDs: visibleTerminalIDs) {
                             TranscriptOverlayView(
                                 frame: frame,
-                                hasBack: overlayCoordinator.parentFrame != nil,
-                                onBack: { overlayCoordinator.popOverlay() },
+                                hasBack: overlayCoordinator.hasBack,
+                                onBack: { overlayCoordinator.pop() },
                                 onClose: { overlayCoordinator.close() }
                             )
                             .frame(maxWidth: 900, maxHeight: 700)
@@ -76,7 +76,7 @@ struct ContentView: View {
                         // Window-wide click-outside catcher. Renders transparently behind
                         // the entire detail area; only consumes taps when an overlay is
                         // currently open, so it doesn't interfere with normal interaction.
-                        if overlayCoordinator.openOverlay != nil {
+                        if overlayCoordinator.isOpen {
                             Color.black.opacity(0.001)
                                 .onTapGesture { overlayCoordinator.close() }
                                 .allowsHitTesting(true)
@@ -282,6 +282,23 @@ struct ContentView: View {
         }
     }
 
+}
+
+// MARK: - Overlay helpers
+
+/// Returns true when the overlay's current frame should render in the
+/// window-root fallback (i.e. NOT in a terminal-pane `.overlay`).
+/// Item frames are window-root when their terminal is not currently
+/// visible (closed, in History pane, single-pane mode, etc.).
+/// File frames and nil-terminal frames always use the window-root.
+private func overlayFrameIsWindowRoot(
+    _ frame: OverlayFrame,
+    visibleTerminalIDs: Set<UUID>
+) -> Bool {
+    if case .item(let f) = frame {
+        return f.terminalID.map { !visibleTerminalIDs.contains($0) } ?? true
+    }
+    return true
 }
 
 // MARK: - PRButtonLabel

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 import TBDShared
 
+// MARK: - Overlay helpers
+
+@MainActor
+private func isOverlayItemFor(terminalID: UUID, coordinator: TranscriptOverlayCoordinator) -> Bool {
+    if case .item(let f)? = coordinator.current, f.terminalID == terminalID { return true }
+    return false
+}
+
 // MARK: - PanePlaceholder
 
 /// Universal leaf wrapper that renders the appropriate pane content
@@ -286,7 +294,9 @@ struct PanePlaceholder: View {
                     initialSnapshot: terminal.suspendedSnapshot,
                     isSuspendedSnapshot: terminal.suspendedAt != nil,
                     shouldSuppressEvents: { [overlayCoordinator] in
-                        overlayCoordinator.openOverlay?.terminalID == terminalID
+                        if case .item(let f)? = overlayCoordinator.current,
+                           f.terminalID == terminalID { return true }
+                        return false
                     }
                 )
                 .id("\(terminal.id)-\(terminal.tmuxWindowID)-\(terminal.suspendedAt != nil)")
@@ -314,12 +324,12 @@ struct PanePlaceholder: View {
                     }
                 }
                 .overlay {
-                    if let frame = overlayCoordinator.openOverlay,
-                       let tid = frame.terminalID, tid == terminalID {
+                    if let frame = overlayCoordinator.current,
+                       isOverlayItemFor(terminalID: terminalID, coordinator: overlayCoordinator) {
                         TranscriptOverlayView(
                             frame: frame,
-                            hasBack: overlayCoordinator.parentFrame != nil,
-                            onBack: { overlayCoordinator.popOverlay() },
+                            hasBack: overlayCoordinator.hasBack,
+                            onBack: { overlayCoordinator.pop() },
                             onClose: { overlayCoordinator.close() }
                         )
                         .environment(\.openFilePreview, { path in
@@ -330,7 +340,7 @@ struct PanePlaceholder: View {
                     }
                 }
                 .onDisappear {
-                    if overlayCoordinator.openOverlay?.terminalID == terminalID {
+                    if isOverlayItemFor(terminalID: terminalID, coordinator: overlayCoordinator) {
                         overlayCoordinator.close()
                     }
                     appState.snapshotProviders.removeValue(forKey: terminalID)

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -4,8 +4,22 @@ import TBDShared
 // MARK: - Overlay helpers
 
 @MainActor
-private func isOverlayItemFor(terminalID: UUID, coordinator: TranscriptOverlayCoordinator) -> Bool {
+func isOverlayItemFor(terminalID: UUID, coordinator: TranscriptOverlayCoordinator) -> Bool {
     if case .item(let f)? = coordinator.current, f.terminalID == terminalID { return true }
+    return false
+}
+
+/// True when the overlay should suppress key/mouse events from reaching
+/// the given terminal's underlying NSView.
+///
+/// Two cases trigger suppression:
+/// - An item frame for THIS terminal (the overlay sits over this terminal).
+/// - Any file frame (file frames always render at the window root over
+///   every terminal, so they must suppress every terminal's events).
+@MainActor
+func shouldSuppressEvents(in coordinator: TranscriptOverlayCoordinator, forTerminalID terminalID: UUID) -> Bool {
+    if isOverlayItemFor(terminalID: terminalID, coordinator: coordinator) { return true }
+    if case .file? = coordinator.current { return true }
     return false
 }
 
@@ -294,9 +308,7 @@ struct PanePlaceholder: View {
                     initialSnapshot: terminal.suspendedSnapshot,
                     isSuspendedSnapshot: terminal.suspendedAt != nil,
                     shouldSuppressEvents: { [overlayCoordinator] in
-                        if case .item(let f)? = overlayCoordinator.current,
-                           f.terminalID == terminalID { return true }
-                        return false
+                        shouldSuppressEvents(in: overlayCoordinator, forTerminalID: terminalID)
                     }
                 )
                 .id("\(terminal.id)-\(terminal.tmuxWindowID)-\(terminal.suspendedAt != nil)")

--- a/Sources/TBDApp/Panes/Transcript/AgentCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/AgentCardBody.swift
@@ -1,3 +1,4 @@
+import MarkdownUI
 import SwiftUI
 import TBDShared
 
@@ -43,9 +44,7 @@ struct AgentCardBody: View {
             if let prompt = parsed?.prompt, !prompt.isEmpty {
                 Text("Prompt")
                     .font(.caption2).foregroundStyle(.tertiary).textCase(.uppercase)
-                Text(prompt)
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                promptMarkdown(prompt)
                     .transcriptSelectableText()
                     .padding(8)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -77,9 +76,7 @@ struct AgentCardBody: View {
                 Divider().padding(.vertical, 4)
                 Text("Result")
                     .font(.caption2).foregroundStyle(.tertiary).textCase(.uppercase)
-                Text(fullResultText ?? result.text)
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                resultMarkdown(fullResultText ?? result.text)
                     .transcriptSelectableText()
                     .padding(8)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -105,6 +102,35 @@ struct AgentCardBody: View {
         guard let terminalID else { return }
         if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(terminalID: terminalID, itemID: "\(id)#input") {
             await MainActor.run { fullInputJSON = r.text }
+        }
+    }
+
+    @ViewBuilder
+    private func promptMarkdown(_ text: String) -> some View {
+        Markdown(LocalFileLinker.linkify(text))
+            .markdownTheme(.chatBubble)
+            .environment(\.openURL, fileLinkOpenAction)
+    }
+
+    @ViewBuilder
+    private func resultMarkdown(_ text: String) -> some View {
+        Markdown(LocalFileLinker.linkify(text))
+            .markdownTheme(.chatBubble)
+            .environment(\.openURL, fileLinkOpenAction)
+    }
+
+    private var fileLinkOpenAction: OpenURLAction {
+        OpenURLAction { url in
+            if url.scheme == "tbd-file" {
+                let p = (url.path as NSString).removingPercentEncoding ?? url.path
+                overlayCoordinator.pushFile(path: p)
+                return .handled
+            }
+            if url.isFileURL {
+                overlayCoordinator.pushFile(path: url.path)
+                return .handled
+            }
+            return .systemAction
         }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/AgentCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/AgentCardBody.swift
@@ -69,7 +69,7 @@ struct AgentCardBody: View {
                 // these IDs — see #129.
                 TranscriptItemsView(items: subagent.items, terminalID: nil)
                     .environment(\.openTranscriptOverlay) { itemID in
-                        overlayCoordinator.pushAndOpen(itemID: itemID)
+                        overlayCoordinator.pushItem(itemID: itemID)
                     }
             }
 

--- a/Sources/TBDApp/Panes/Transcript/AgentCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/AgentCardBody.swift
@@ -109,27 +109,14 @@ struct AgentCardBody: View {
     private func promptMarkdown(_ text: String) -> some View {
         Markdown(LocalFileLinker.linkify(text))
             .markdownTheme(.chatBubble)
-            .environment(\.openURL, fileLinkOpenAction)
+            .environment(\.openURL, overlayFileLinkAction(overlayCoordinator))
     }
 
     @ViewBuilder
     private func resultMarkdown(_ text: String) -> some View {
         Markdown(LocalFileLinker.linkify(text))
             .markdownTheme(.chatBubble)
-            .environment(\.openURL, fileLinkOpenAction)
+            .environment(\.openURL, overlayFileLinkAction(overlayCoordinator))
     }
 
-    private var fileLinkOpenAction: OpenURLAction {
-        OpenURLAction { url in
-            if url.scheme == "tbd-file" {
-                overlayCoordinator.pushFile(path: url.path)
-                return .handled
-            }
-            if url.isFileURL {
-                overlayCoordinator.pushFile(path: url.path)
-                return .handled
-            }
-            return .systemAction
-        }
-    }
 }

--- a/Sources/TBDApp/Panes/Transcript/AgentCardBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/AgentCardBody.swift
@@ -122,8 +122,7 @@ struct AgentCardBody: View {
     private var fileLinkOpenAction: OpenURLAction {
         OpenURLAction { url in
             if url.scheme == "tbd-file" {
-                let p = (url.path as NSString).removingPercentEncoding ?? url.path
-                overlayCoordinator.pushFile(path: p)
+                overlayCoordinator.pushFile(path: url.path)
                 return .handled
             }
             if url.isFileURL {

--- a/Sources/TBDApp/Panes/Transcript/LocalFileLinker.swift
+++ b/Sources/TBDApp/Panes/Transcript/LocalFileLinker.swift
@@ -63,6 +63,12 @@ enum LocalFileLinker {
         while i < chars.count {
             // Fenced code block: ``` at start of line, consume through the
             // matching ``` on its own line (or end of input).
+            // NOTE: only 3-backtick fences are recognized here. 4+-backtick
+            // fences and tilde (~~~) fences fall through and any paths
+            // inside them would be linkified. Not a real-world issue for
+            // Claude output (which uses standard ``` fences) but worth
+            // knowing if you see a false-positive inside an alternative
+            // fence style.
             if isAtLineStart(chars, i), startsWith(chars, i, "```") {
                 flushEligible()
                 let start = i
@@ -281,8 +287,10 @@ enum LocalFileLinker {
         if i == 0 { return true }
         let prev = chars[i - 1]
         if prev.isWhitespace { return true }
-        // Allow when preceded by typical sentence punctuation.
-        return "(\"'<[,;".contains(prev) || prev == "\n"
+        // Allow when preceded by typical sentence punctuation. `=` covers
+        // `output_file=/tmp/foo` shell-style assignments emitted by some
+        // tool wrappers (no space after `=`).
+        return "(\"'<[,;=".contains(prev) || prev == "\n"
     }
 
     private static func isPathChar(_ c: Character) -> Bool {

--- a/Sources/TBDApp/Panes/Transcript/LocalFileLinker.swift
+++ b/Sources/TBDApp/Panes/Transcript/LocalFileLinker.swift
@@ -1,0 +1,296 @@
+// Sources/TBDApp/Panes/Transcript/LocalFileLinker.swift
+import Foundation
+
+/// Pure helper that scans a markdown string for bare absolute POSIX paths
+/// (e.g. `/Users/...`, `/private/tmp/...`) and rewrites them as markdown
+/// links pointing at a custom `tbd-file:` URL scheme. The overlay view
+/// installs an `OpenURLAction` that intercepts that scheme and pushes a
+/// file frame onto the overlay coordinator.
+///
+/// Inline code spans, fenced code blocks, and existing markdown links are
+/// left untouched. `fileExists` lets callers stub the filesystem for tests
+/// and avoids false-positive linkification of `/foo/bar`-shaped strings
+/// that don't refer to a real file.
+enum LocalFileLinker {
+    /// Linkifies bare absolute paths in `text`. The default `fileExists`
+    /// queries `FileManager.default`.
+    static func linkify(
+        _ text: String,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> String {
+        if text.isEmpty { return text }
+
+        var result = ""
+        result.reserveCapacity(text.count)
+
+        // Tokenize into runs that should be passed through verbatim (fenced
+        // blocks, inline code, existing links) and runs that are eligible
+        // for path linkification.
+        for segment in protectSegments(in: text) {
+            switch segment {
+            case .verbatim(let s):
+                result.append(s)
+            case .eligible(let s):
+                result.append(linkifyEligible(s, fileExists: fileExists))
+            }
+        }
+        return result
+    }
+
+    // MARK: - Segmentation
+
+    private enum Segment {
+        case verbatim(String)
+        case eligible(String)
+    }
+
+    /// Splits `text` so that fenced code blocks, inline code spans, and
+    /// existing markdown links are emitted as `.verbatim`; everything else
+    /// is `.eligible`. Linear scan, no regex backtracking.
+    private static func protectSegments(in text: String) -> [Segment] {
+        var segments: [Segment] = []
+        var eligibleBuffer = ""
+        let chars = Array(text)
+        var i = 0
+
+        func flushEligible() {
+            if !eligibleBuffer.isEmpty {
+                segments.append(.eligible(eligibleBuffer))
+                eligibleBuffer.removeAll(keepingCapacity: true)
+            }
+        }
+
+        while i < chars.count {
+            // Fenced code block: ``` at start of line, consume through the
+            // matching ``` on its own line (or end of input).
+            if isAtLineStart(chars, i), startsWith(chars, i, "```") {
+                flushEligible()
+                let start = i
+                i += 3
+                // Consume to end of opening fence line.
+                while i < chars.count && chars[i] != "\n" { i += 1 }
+                if i < chars.count { i += 1 } // newline
+                // Consume body until closing fence on its own line.
+                while i < chars.count {
+                    if isAtLineStart(chars, i), startsWith(chars, i, "```") {
+                        i += 3
+                        while i < chars.count && chars[i] != "\n" { i += 1 }
+                        if i < chars.count { i += 1 }
+                        break
+                    }
+                    i += 1
+                }
+                segments.append(.verbatim(String(chars[start..<i])))
+                continue
+            }
+
+            // Inline code: a backtick run; consume until matching run.
+            if chars[i] == "`" {
+                let runLen = backtickRun(chars, i)
+                let start = i
+                i += runLen
+                while i < chars.count {
+                    if chars[i] == "`" {
+                        let close = backtickRun(chars, i)
+                        if close == runLen {
+                            i += close
+                            break
+                        }
+                        i += close
+                        continue
+                    }
+                    i += 1
+                }
+                flushEligible()
+                segments.append(.verbatim(String(chars[start..<i])))
+                continue
+            }
+
+            // Existing markdown link `[text](url)` — consume the whole thing.
+            if chars[i] == "[" {
+                if let end = matchMarkdownLink(chars, i) {
+                    flushEligible()
+                    segments.append(.verbatim(String(chars[i..<end])))
+                    i = end
+                    continue
+                }
+            }
+
+            eligibleBuffer.append(chars[i])
+            i += 1
+        }
+        flushEligible()
+        return segments
+    }
+
+    private static func isAtLineStart(_ chars: [Character], _ i: Int) -> Bool {
+        i == 0 || chars[i - 1] == "\n"
+    }
+
+    private static func startsWith(_ chars: [Character], _ i: Int, _ s: String) -> Bool {
+        let sChars = Array(s)
+        if i + sChars.count > chars.count { return false }
+        for k in 0..<sChars.count where chars[i + k] != sChars[k] { return false }
+        return true
+    }
+
+    private static func backtickRun(_ chars: [Character], _ i: Int) -> Int {
+        var n = 0
+        while i + n < chars.count && chars[i + n] == "`" { n += 1 }
+        return n
+    }
+
+    /// Returns the index *after* `](url)` if `chars[i...]` starts with a
+    /// well-formed inline markdown link; nil otherwise.
+    private static func matchMarkdownLink(_ chars: [Character], _ i: Int) -> Int? {
+        guard i < chars.count, chars[i] == "[" else { return nil }
+        var j = i + 1
+        // Bracket body: forbid line breaks; allow nested brackets one deep.
+        var depth = 1
+        while j < chars.count {
+            let c = chars[j]
+            if c == "\n" { return nil }
+            if c == "[" { depth += 1 }
+            if c == "]" {
+                depth -= 1
+                if depth == 0 { j += 1; break }
+            }
+            j += 1
+        }
+        guard depth == 0, j < chars.count, chars[j] == "(" else { return nil }
+        j += 1
+        // URL body: stop at ')' or newline.
+        while j < chars.count, chars[j] != ")" {
+            if chars[j] == "\n" { return nil }
+            j += 1
+        }
+        guard j < chars.count, chars[j] == ")" else { return nil }
+        return j + 1
+    }
+
+    // MARK: - Path linkification within eligible text
+
+    /// Path token chars: alphanumerics, `_`, `-`, `.`, `+`, `/`. Stops at
+    /// whitespace, quotes, parens, brackets, angle brackets. Trailing
+    /// punctuation (`. , : ; )`) is stripped to keep it outside the link.
+    private static func linkifyEligible(
+        _ text: String,
+        fileExists: (String) -> Bool
+    ) -> String {
+        let chars = Array(text)
+        var out = ""
+        out.reserveCapacity(text.count)
+        var i = 0
+        while i < chars.count {
+            if chars[i] == "/", isPathStart(chars, i) {
+                // Collect strict path chars (no spaces).
+                var j = i + 1
+                while j < chars.count, isPathChar(chars[j]) { j += 1 }
+
+                // Try strict candidate first (trim trailing punctuation).
+                var strictEnd = j
+                while strictEnd > i + 1,
+                      isTrailingPunctuation(chars[strictEnd - 1]) {
+                    strictEnd -= 1
+                }
+                let strictCandidate = String(chars[i..<strictEnd])
+                if strictCandidate.count > 1, fileExists(strictCandidate) {
+                    let encoded = strictCandidate
+                        .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+                        ?? strictCandidate
+                    out.append("[\(strictCandidate)](tbd-file:\(encoded))")
+                    i = strictEnd
+                    continue
+                }
+
+                // Strict candidate not found; try extending through spaces to
+                // handle paths with embedded spaces (common on macOS). Extend
+                // up to the next hard boundary (newline, quote, angle bracket).
+                var extEnd = j
+                while extEnd < chars.count, !isHardBoundary(chars[extEnd]) {
+                    let c = chars[extEnd]
+                    if c.isWhitespace {
+                        // Peek ahead: if the next non-space chars look like a
+                        // continuing path component, consume the space and keep
+                        // going; otherwise stop.
+                        var peek = extEnd + 1
+                        while peek < chars.count && chars[peek] == " " { peek += 1 }
+                        if peek < chars.count && isPathChar(chars[peek]) {
+                            extEnd = peek
+                            while extEnd < chars.count && isPathChar(chars[extEnd]) { extEnd += 1 }
+                            continue
+                        } else {
+                            break
+                        }
+                    }
+                    extEnd += 1
+                }
+
+                // For the extended candidate, try progressively shorter
+                // substrings (by trimming trailing words) until fileExists.
+                if extEnd > j {
+                    var candidate: String? = nil
+                    var endTry = extEnd
+                    while endTry > j {
+                        var trimEnd = endTry
+                        while trimEnd > i + 1, isTrailingPunctuation(chars[trimEnd - 1]) {
+                            trimEnd -= 1
+                        }
+                        let s = String(chars[i..<trimEnd])
+                        if s.count > 1, fileExists(s) {
+                            candidate = s
+                            endTry = trimEnd
+                            break
+                        }
+                        // Back off to just before the last space.
+                        endTry -= 1
+                        while endTry > j && chars[endTry - 1] != " " { endTry -= 1 }
+                        if endTry <= j { break }
+                        endTry -= 1 // skip the space
+                    }
+                    if let found = candidate {
+                        let encoded = found
+                            .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+                            ?? found
+                        out.append("[\(found)](tbd-file:\(encoded))")
+                        i = endTry
+                        continue
+                    }
+                }
+
+                out.append(contentsOf: chars[i..<j])
+                i = j
+                continue
+            }
+            out.append(chars[i])
+            i += 1
+        }
+        return out
+    }
+
+    private static func isHardBoundary(_ c: Character) -> Bool {
+        c == "\n" || c == "\"" || c == "'" || c == "<" || c == ">" || c == "[" || c == "]"
+    }
+
+    /// `/` is a path start if it is at the beginning of the eligible run,
+    /// preceded by whitespace, or by a non-path "boundary" punctuation.
+    /// Rejects `//` and `://` (URL-shaped).
+    private static func isPathStart(_ chars: [Character], _ i: Int) -> Bool {
+        if i + 1 < chars.count, chars[i + 1] == "/" { return false } // "//..."
+        if i > 0, chars[i - 1] == ":" { return false }              // "scheme:/..."
+        if i == 0 { return true }
+        let prev = chars[i - 1]
+        if prev.isWhitespace { return true }
+        // Allow when preceded by typical sentence punctuation.
+        return "(\"'<[,;".contains(prev) || prev == "\n"
+    }
+
+    private static func isPathChar(_ c: Character) -> Bool {
+        if c.isLetter || c.isNumber { return true }
+        return "._-+/".contains(c)
+    }
+
+    private static func isTrailingPunctuation(_ c: Character) -> Bool {
+        ".,:;)".contains(c)
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/OverlayFileLinkAction.swift
+++ b/Sources/TBDApp/Panes/Transcript/OverlayFileLinkAction.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Shared `OpenURLAction` for markdown rendered inside the transcript
+/// overlay. Intercepts `tbd-file:` (linkifier output) and `file:` URLs
+/// by pushing a file frame onto the overlay coordinator; everything
+/// else falls through to the system handler.
+///
+/// Lives in one place so adding a new in-overlay scheme later
+/// (e.g. `tbd-item:` deep-links) only touches one site instead of
+/// every markdown-rendering view that wants the same behaviour.
+@MainActor
+func overlayFileLinkAction(_ coordinator: TranscriptOverlayCoordinator) -> OpenURLAction {
+    OpenURLAction { url in
+        if url.scheme == "tbd-file" {
+            coordinator.pushFile(path: url.path)
+            return .handled
+        }
+        if url.isFileURL {
+            coordinator.pushFile(path: url.path)
+            return .handled
+        }
+        return .systemAction
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/OverlayFileView.swift
+++ b/Sources/TBDApp/Panes/Transcript/OverlayFileView.swift
@@ -51,8 +51,7 @@ struct OverlayFileView: View {
                     .textSelection(.enabled)
                     .environment(\.openURL, OpenURLAction { url in
                         if url.scheme == "tbd-file" {
-                            let p = (url.path as NSString).removingPercentEncoding ?? url.path
-                            overlayCoordinator.pushFile(path: p)
+                            overlayCoordinator.pushFile(path: url.path)
                             return .handled
                         }
                         if url.isFileURL {

--- a/Sources/TBDApp/Panes/Transcript/OverlayFileView.swift
+++ b/Sources/TBDApp/Panes/Transcript/OverlayFileView.swift
@@ -1,0 +1,111 @@
+// Sources/TBDApp/Panes/Transcript/OverlayFileView.swift
+import SwiftUI
+import AppKit
+import MarkdownUI
+
+/// File frame body for the transcript overlay. Renders markdown files
+/// (.md / .markdown) with `MarkdownUI` and other text files as plain
+/// monospaced text. Files >1 MB or non-text show a placeholder with a
+/// "Reveal in Finder" affordance.
+///
+/// Installs an `OpenURLAction` so `tbd-file:` and `file:` links inside
+/// rendered markdown push further file frames; everything else falls
+/// through to the system handler (browser, mail, etc.).
+struct OverlayFileView: View {
+    let path: String
+
+    @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
+    @State private var content: String?
+    @State private var loadError: String?
+    @State private var tooLarge: UInt64?
+
+    private static let maxBytes: UInt64 = 1_048_576
+
+    private var isMarkdown: Bool {
+        let ext = (path as NSString).pathExtension.lowercased()
+        return ext == "md" || ext == "markdown"
+    }
+
+    var body: some View {
+        ScrollView(.vertical) {
+            inner
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+        }
+        .task(id: path) { await load() }
+    }
+
+    @ViewBuilder
+    private var inner: some View {
+        if let err = loadError {
+            placeholder(title: "Could not load file", detail: err)
+        } else if let size = tooLarge {
+            placeholder(
+                title: "File too large to preview",
+                detail: "\(size / 1024) KB · open in Finder to view"
+            )
+        } else if let content {
+            if isMarkdown {
+                Markdown(content, baseURL: URL(fileURLWithPath: path))
+                    .markdownTheme(.chatBubble)
+                    .textSelection(.enabled)
+                    .environment(\.openURL, OpenURLAction { url in
+                        if url.scheme == "tbd-file" {
+                            let p = (url.path as NSString).removingPercentEncoding ?? url.path
+                            overlayCoordinator.pushFile(path: p)
+                            return .handled
+                        }
+                        if url.isFileURL {
+                            overlayCoordinator.pushFile(path: url.path)
+                            return .handled
+                        }
+                        return .systemAction
+                    })
+            } else {
+                Text(content)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        } else {
+            ProgressView().frame(maxWidth: .infinity, minHeight: 100)
+        }
+    }
+
+    @ViewBuilder
+    private func placeholder(title: String, detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.headline)
+            Text(path).font(.caption).foregroundStyle(.secondary).textSelection(.enabled)
+            Text(detail).font(.caption).foregroundStyle(.tertiary)
+            Button("Reveal in Finder") {
+                NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private func load() async {
+        await MainActor.run {
+            content = nil
+            loadError = nil
+            tooLarge = nil
+        }
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: path) else {
+            await MainActor.run { loadError = "File not found: \(path)" }
+            return
+        }
+        if let attrs = try? fm.attributesOfItem(atPath: path),
+           let size = attrs[.size] as? UInt64, size > Self.maxBytes {
+            await MainActor.run { tooLarge = size }
+            return
+        }
+        do {
+            let text = try String(contentsOfFile: path, encoding: .utf8)
+            await MainActor.run { content = text }
+        } catch {
+            await MainActor.run { loadError = "Not readable as UTF-8" }
+        }
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/OverlayFileView.swift
+++ b/Sources/TBDApp/Panes/Transcript/OverlayFileView.swift
@@ -85,26 +85,25 @@ struct OverlayFileView: View {
     }
 
     private func load() async {
-        await MainActor.run {
-            content = nil
-            loadError = nil
-            tooLarge = nil
-        }
+        // OverlayFileView is @MainActor so `load()` already runs on the
+        // main actor — no MainActor.run hops needed.
+        content = nil
+        loadError = nil
+        tooLarge = nil
         let fm = FileManager.default
         guard fm.fileExists(atPath: path) else {
-            await MainActor.run { loadError = "File not found: \(path)" }
+            loadError = "File not found: \(path)"
             return
         }
         if let attrs = try? fm.attributesOfItem(atPath: path),
            let size = attrs[.size] as? UInt64, size > Self.maxBytes {
-            await MainActor.run { tooLarge = size }
+            tooLarge = size
             return
         }
         do {
-            let text = try String(contentsOfFile: path, encoding: .utf8)
-            await MainActor.run { content = text }
+            content = try String(contentsOfFile: path, encoding: .utf8)
         } catch {
-            await MainActor.run { loadError = "Not readable as UTF-8" }
+            loadError = "Not readable as UTF-8"
         }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/OverlayFileView.swift
+++ b/Sources/TBDApp/Panes/Transcript/OverlayFileView.swift
@@ -49,17 +49,7 @@ struct OverlayFileView: View {
                 Markdown(content, baseURL: URL(fileURLWithPath: path))
                     .markdownTheme(.chatBubble)
                     .textSelection(.enabled)
-                    .environment(\.openURL, OpenURLAction { url in
-                        if url.scheme == "tbd-file" {
-                            overlayCoordinator.pushFile(path: url.path)
-                            return .handled
-                        }
-                        if url.isFileURL {
-                            overlayCoordinator.pushFile(path: url.path)
-                            return .handled
-                        }
-                        return .systemAction
-                    })
+                    .environment(\.openURL, overlayFileLinkAction(overlayCoordinator))
             } else {
                 Text(content)
                     .font(.system(.body, design: .monospaced))

--- a/Sources/TBDApp/Panes/Transcript/TranscriptOverlayCoordinator.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptOverlayCoordinator.swift
@@ -2,16 +2,10 @@
 import Combine
 import Foundation
 
-/// One frame of the transcript overlay state machine. Identifies the
-/// transcript item to display and the terminal pane region the overlay
-/// should render over. `terminalID` is nil when opened from the History
-/// pane (no bound terminal — uses the window-root centered-modal fallback);
-/// in that case `historySessionID` carries the session whose transcript is
-/// being viewed so the overlay can resolve items via
-/// `AppState.sessionTranscripts[sessionID]` without depending on SwiftUI
-/// environment propagation (the fallback overlay is a sibling of the
-/// History view, not a descendant — see #129).
-struct TranscriptOverlayFrame: Equatable {
+/// Identifies a transcript item the overlay should render. `terminalID` is
+/// nil when opened from the History pane; in that case `historySessionID`
+/// carries the session whose transcript is being viewed.
+struct ItemFrame: Equatable {
     let terminalID: UUID?
     let itemID: String
     let historySessionID: String?
@@ -23,64 +17,71 @@ struct TranscriptOverlayFrame: Equatable {
     }
 }
 
-/// At most one overlay open per window. Holds an optional one-step back
-/// stack used by AgentCard's nested-transcript recursion: opening a row
-/// inside an AgentCard overlay pushes the current frame and replaces it;
-/// the back button pops.
+/// One frame of the overlay navigation stack: either a transcript item
+/// or a local file. The overlay view branches on this to choose between
+/// the existing tool-body renderer and the new `OverlayFileView`.
+enum OverlayFrame: Equatable {
+    case item(ItemFrame)
+    case file(path: String)
+}
+
+/// At most one overlay open per window. Maintains a navigation stack so
+/// the user can drill from an Agent tool call into a subagent item, and
+/// from either into a referenced local file (and from that file into
+/// further linked files).
+///
+/// Tapping the same item frame currently at the top toggles the overlay
+/// closed — preserves the existing "click same row to dismiss" behaviour.
+/// File frames always push (you cannot toggle-close a file frame by
+/// reopening the same link).
 @MainActor
 final class TranscriptOverlayCoordinator: ObservableObject {
-    @Published private(set) var openOverlay: TranscriptOverlayFrame?
-    @Published private(set) var parentFrame: TranscriptOverlayFrame?
+    @Published private(set) var stack: [OverlayFrame] = []
 
-    /// Open or swap. If the requested frame matches what's already open,
-    /// close instead (modal-ish toggle: same row click = dismiss).
-    /// Swap clears any parent back-stack — the user has navigated away
-    /// from the AgentCard context.
-    ///
-    /// `historySessionID` is set by the History pane so the overlay can
-    /// look the item up directly in `AppState.sessionTranscripts` instead
-    /// of relying on environment propagation (the fallback overlay lives
-    /// outside the History subtree). For terminal-bound opens it stays nil.
+    var current: OverlayFrame? { stack.last }
+    var hasBack: Bool { stack.count > 1 }
+    var isOpen: Bool { !stack.isEmpty }
+
+    /// Top-level open. Clears any prior stack. If the same item is already
+    /// at the top of the stack, toggles closed.
     func open(terminalID: UUID?, itemID: String, historySessionID: String? = nil) {
-        let next = TranscriptOverlayFrame(
+        let frame = ItemFrame(
             terminalID: terminalID,
             itemID: itemID,
             historySessionID: historySessionID
         )
-        if openOverlay == next {
-            openOverlay = nil
-            parentFrame = nil
+        if case .item(let top)? = current, top == frame {
+            stack.removeAll()
             return
         }
-        openOverlay = next
-        parentFrame = nil
+        stack = [.item(frame)]
     }
 
-    /// Push current frame to back-stack and open the new one over the
-    /// same terminal. No-op if nothing is currently open. Called by row
-    /// clicks INSIDE an AgentCard's overlay nested transcript.
-    func pushAndOpen(itemID: String) {
-        guard let current = openOverlay else { return }
-        parentFrame = current
-        openOverlay = TranscriptOverlayFrame(
-            terminalID: current.terminalID,
+    /// Push another transcript item, inheriting the current frame's
+    /// terminal/session context. No-op if nothing is open or if the
+    /// current top is not an item frame.
+    func pushItem(itemID: String) {
+        guard let top = current, case .item(let frame) = top else { return }
+        stack.append(.item(ItemFrame(
+            terminalID: frame.terminalID,
             itemID: itemID,
-            historySessionID: current.historySessionID
-        )
+            historySessionID: frame.historySessionID
+        )))
     }
 
-    /// Restore the back-stack frame. If no parent, close the overlay.
-    func popOverlay() {
-        if let parent = parentFrame {
-            openOverlay = parent
-            parentFrame = nil
-        } else {
-            close()
-        }
+    /// Push a local file frame. No-op if nothing is open.
+    func pushFile(path: String) {
+        guard isOpen else { return }
+        stack.append(.file(path: path))
+    }
+
+    /// Pop one frame. Closes the overlay when the stack empties.
+    func pop() {
+        guard !stack.isEmpty else { return }
+        stack.removeLast()
     }
 
     func close() {
-        openOverlay = nil
-        parentFrame = nil
+        stack.removeAll()
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
@@ -10,7 +10,7 @@ import TBDShared
 /// the transcript pane's LazyVStack — no `_FlexFrameLayout`/
 /// `ScrollViewLayoutComputer` measure-then-clamp trap. See issue #129.
 struct TranscriptOverlayView: View {
-    let frame: TranscriptOverlayFrame
+    let frame: OverlayFrame
     let hasBack: Bool
     let onBack: () -> Void
     let onClose: () -> Void
@@ -20,6 +20,15 @@ struct TranscriptOverlayView: View {
     private static let decoder = JSONDecoder()
 
     var body: some View {
+        switch frame {
+        case .item:
+            itemBody
+        case .file(let path):
+            fileBody(path: path)
+        }
+    }
+
+    @ViewBuilder private var itemBody: some View {
         let item = lookupItem()
         VStack(spacing: 0) {
             header(item: item)
@@ -33,6 +42,51 @@ struct TranscriptOverlayView: View {
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .shadow(color: .black.opacity(0.18), radius: 12, x: 0, y: 4)
+    }
+
+    @ViewBuilder private func fileBody(path: String) -> some View {
+        VStack(spacing: 0) {
+            fileHeader(path: path)
+            Divider()
+            OverlayFileView(path: path)
+        }
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .shadow(color: .black.opacity(0.18), radius: 12, x: 0, y: 4)
+    }
+
+    @ViewBuilder
+    private func fileHeader(path: String) -> some View {
+        HStack(spacing: 8) {
+            if hasBack {
+                Button(action: onBack) {
+                    Image(systemName: "chevron.left").font(.caption)
+                }
+                .buttonStyle(.plain).help("Back")
+            }
+            Image(systemName: fileIcon(path: path))
+                .font(.caption).foregroundStyle(.secondary)
+            Text((path as NSString).lastPathComponent)
+                .font(.subheadline).foregroundStyle(.secondary)
+                .lineLimit(1).truncationMode(.middle)
+            Spacer()
+            Button(action: onClose) {
+                Image(systemName: "xmark").font(.caption)
+            }
+            .buttonStyle(.plain).help("Close")
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    private func fileIcon(path: String) -> String {
+        let ext = (path as NSString).pathExtension.lowercased()
+        if ext == "md" || ext == "markdown" || ext == "txt" { return "doc.text" }
+        return "doc.plaintext"
+    }
+
+    private func currentItemFrame() -> ItemFrame? {
+        if case .item(let f) = frame { return f } else { return nil }
     }
 
     @ViewBuilder
@@ -155,6 +209,7 @@ struct TranscriptOverlayView: View {
 
     @ViewBuilder
     private func bodyContent(item: TranscriptItem?) -> some View {
+        let f = currentItemFrame()
         if let item {
             Group {
                 switch item {
@@ -164,21 +219,21 @@ struct TranscriptOverlayView: View {
                         inputJSON: inputJSON,
                         inputTruncatedTo: inputTruncatedTo,
                         result: toolResult,
-                        terminalID: frame.terminalID
+                        terminalID: f?.terminalID
                     )
                 case .toolCall(let toolID, let name, let inputJSON, let inputTruncatedTo, _, _, _, _) where name == "Write":
                     WriteCardBody(
                         id: toolID,
                         inputJSON: inputJSON,
                         inputTruncatedTo: inputTruncatedTo,
-                        terminalID: frame.terminalID
+                        terminalID: f?.terminalID
                     )
                 case .toolCall(let toolID, let name, let inputJSON, _, let toolResult, _, _, _) where name == "Read":
                     ReadCardBody(
                         id: toolID,
                         inputJSON: inputJSON,
                         result: toolResult,
-                        terminalID: frame.terminalID
+                        terminalID: f?.terminalID
                     )
                 case .toolCall(let toolID, let name, let inputJSON, let inputTruncatedTo, let toolResult, _, _, _) where name == "Edit" || name == "MultiEdit":
                     EditCardBody(
@@ -187,19 +242,19 @@ struct TranscriptOverlayView: View {
                         inputJSON: inputJSON,
                         inputTruncatedTo: inputTruncatedTo,
                         result: toolResult,
-                        terminalID: frame.terminalID
+                        terminalID: f?.terminalID
                     )
                 case .toolCall(let toolID, let name, _, _, let toolResult, _, _, _) where name == "Grep":
                     GrepCardBody(
                         id: toolID,
                         result: toolResult,
-                        terminalID: frame.terminalID
+                        terminalID: f?.terminalID
                     )
                 case .toolCall(let toolID, let name, _, _, let toolResult, _, _, _) where name == "Glob":
                     GlobCardBody(
                         id: toolID,
                         result: toolResult,
-                        terminalID: frame.terminalID
+                        terminalID: f?.terminalID
                     )
                 case .toolCall(let toolID, let name, let inputJSON, let inputTruncatedTo, let toolResult, let subagent, _, _) where name == "Task" || name == "Agent":
                     AgentCardBody(
@@ -208,7 +263,7 @@ struct TranscriptOverlayView: View {
                         inputTruncatedTo: inputTruncatedTo,
                         result: toolResult,
                         subagent: subagent,
-                        terminalID: frame.terminalID
+                        terminalID: f?.terminalID
                     )
                 case .toolCall(let toolID, _, let inputJSON, let inputTruncatedTo, let toolResult, _, _, _):
                     GenericToolCardBody(
@@ -216,7 +271,7 @@ struct TranscriptOverlayView: View {
                         inputJSON: inputJSON,
                         inputTruncatedTo: inputTruncatedTo,
                         result: toolResult,
-                        terminalID: frame.terminalID
+                        terminalID: f?.terminalID
                     )
                 case .systemReminder(_, let kind, let text, _) where kind == .skillBody:
                     SkillBodyRowBody(text: text)
@@ -231,7 +286,7 @@ struct TranscriptOverlayView: View {
                         .textSelection(.enabled)
                 }
             }
-            .id(frame.itemID)
+            .id(f?.itemID ?? "no-item")
         } else {
             Text("Item not found.")
                 .font(.caption)
@@ -248,15 +303,16 @@ struct TranscriptOverlayView: View {
     /// see issue #129):
     ///
     /// - Terminal-bound: `terminalID → Terminal.claudeSessionID → items`.
-    /// - History pane (no bound terminal): `frame.historySessionID → items`,
+    /// - History pane (no bound terminal): `f.historySessionID → items`,
     ///   set by `SessionTranscriptView` when it requests an overlay open.
     ///
     /// Returns nil if the terminal isn't found, has no active session,
     /// the session isn't in the transcript store, or the item has been
     /// removed.
     private func lookupItem() -> TranscriptItem? {
+        guard let f = currentItemFrame() else { return nil }
         let items: [TranscriptItem]
-        if let terminalID = frame.terminalID {
+        if let terminalID = f.terminalID {
             guard let terminal = appState.terminals.values
                     .flatMap({ $0 })
                     .first(where: { $0.id == terminalID }),
@@ -264,13 +320,13 @@ struct TranscriptOverlayView: View {
                   let stored = appState.sessionTranscripts[sessionID]
             else { return nil }
             items = stored
-        } else if let sessionID = frame.historySessionID,
+        } else if let sessionID = f.historySessionID,
                   let stored = appState.sessionTranscripts[sessionID] {
             items = stored
         } else {
             return nil
         }
-        return deepFind(frame.itemID, in: items)
+        return deepFind(f.itemID, in: items)
     }
 
     private func deepFind(_ targetID: String, in items: [TranscriptItem]) -> TranscriptItem? {

--- a/Tests/TBDAppTests/LocalFileLinkerTests.swift
+++ b/Tests/TBDAppTests/LocalFileLinkerTests.swift
@@ -47,6 +47,16 @@ struct LocalFileLinkerTests {
         #expect(link(input) == want)
     }
 
+    @Test func barePath_afterEquals_noSpace_isLinkified() {
+        // `output_file=/tmp/foo.md` is a common shell-style assignment some
+        // tool wrappers emit (no space after `=`). `=` must count as a path
+        // predecessor for this to linkify.
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "output_file=/tmp/foo.md"
+        let want  = "output_file=[/tmp/foo.md](tbd-file:/tmp/foo.md)"
+        #expect(link(input) == want)
+    }
+
     @Test func barePath_insideParens_isLinkified_parensOutside() {
         let link = linker(existing: ["/tmp/foo.md"])
         let input = "(see /tmp/foo.md)"

--- a/Tests/TBDAppTests/LocalFileLinkerTests.swift
+++ b/Tests/TBDAppTests/LocalFileLinkerTests.swift
@@ -1,0 +1,111 @@
+// Tests/TBDAppTests/LocalFileLinkerTests.swift
+import Testing
+import Foundation
+@testable import TBDApp
+
+struct LocalFileLinkerTests {
+    // Stub `fileExists` so tests don't depend on the real filesystem.
+    private func linker(existing: Set<String> = []) -> (String) -> String {
+        { text in LocalFileLinker.linkify(text, fileExists: { existing.contains($0) }) }
+    }
+
+    @Test func emptyString_returnsEmpty() {
+        let link = linker()
+        #expect(link("") == "")
+    }
+
+    @Test func noPaths_returnsUnchanged() {
+        let link = linker()
+        #expect(link("just some prose without paths") == "just some prose without paths")
+    }
+
+    @Test func barePath_atEndOfLine_isLinkified() {
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "see /tmp/foo.md"
+        let want  = "see [/tmp/foo.md](tbd-file:/tmp/foo.md)"
+        #expect(link(input) == want)
+    }
+
+    @Test func barePath_followedByTrailingComma_isLinkified_punctuationOutside() {
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "wrote /tmp/foo.md, then continued"
+        let want  = "wrote [/tmp/foo.md](tbd-file:/tmp/foo.md), then continued"
+        #expect(link(input) == want)
+    }
+
+    @Test func barePath_followedByPeriod_isLinkified_periodOutside() {
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "wrote /tmp/foo.md."
+        let want  = "wrote [/tmp/foo.md](tbd-file:/tmp/foo.md)."
+        #expect(link(input) == want)
+    }
+
+    @Test func barePath_followedByColon_isLinkified_colonOutside() {
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "output_file: /tmp/foo.md"
+        let want  = "output_file: [/tmp/foo.md](tbd-file:/tmp/foo.md)"
+        #expect(link(input) == want)
+    }
+
+    @Test func barePath_insideParens_isLinkified_parensOutside() {
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "(see /tmp/foo.md)"
+        let want  = "(see [/tmp/foo.md](tbd-file:/tmp/foo.md))"
+        #expect(link(input) == want)
+    }
+
+    @Test func nonexistentPath_isNotLinkified() {
+        let link = linker(existing: [])
+        let input = "missing /tmp/nope.md"
+        #expect(link(input) == input)
+    }
+
+    @Test func httpURL_isNotLinkified() {
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "see http://example.com/path and /tmp/foo.md"
+        let want  = "see http://example.com/path and [/tmp/foo.md](tbd-file:/tmp/foo.md)"
+        #expect(link(input) == want)
+    }
+
+    @Test func existingMarkdownLink_isLeftAlone() {
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "[design](/tmp/foo.md)"
+        #expect(link(input) == input)
+    }
+
+    @Test func fencedCodeBlock_isLeftAlone() {
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "```\nls /tmp/foo.md\n```"
+        #expect(link(input) == input)
+    }
+
+    @Test func inlineCode_isLeftAlone() {
+        let link = linker(existing: ["/tmp/foo.md"])
+        let input = "the path `/tmp/foo.md` is fine"
+        #expect(link(input) == input)
+    }
+
+    @Test func multiplePaths_allLinkified() {
+        let link = linker(existing: ["/tmp/a.md", "/tmp/b.md"])
+        let input = "/tmp/a.md and /tmp/b.md"
+        let want  = "[/tmp/a.md](tbd-file:/tmp/a.md) and [/tmp/b.md](tbd-file:/tmp/b.md)"
+        #expect(link(input) == want)
+    }
+
+    @Test func pathWithSpecialCharacters_isLinkified() {
+        let p = "/private/tmp/claude-501/-Users-chang-tbd-worktrees-longeye-app-20260522-vertical-manatee/aa0e7f1a-ddfa-49be-9804-bbde46833998/tasks/a9af77d70d2239272.output"
+        let link = linker(existing: [p])
+        let input = "output_file: \(p)"
+        let want  = "output_file: [\(p)](tbd-file:\(p))"
+        #expect(link(input) == want)
+    }
+
+    @Test func percentEncodingInURL_isReversible() {
+        // A real file with a space — escaping must round-trip via URL decoding
+        // at click time. We verify the link target form here.
+        let p = "/tmp/file with space.md"
+        let link = linker(existing: [p])
+        let out = link("look at \(p)")
+        #expect(out.contains("(tbd-file:/tmp/file%20with%20space.md)"))
+    }
+}

--- a/Tests/TBDAppTests/LocalFileLinkerTests.swift
+++ b/Tests/TBDAppTests/LocalFileLinkerTests.swift
@@ -110,6 +110,17 @@ struct LocalFileLinkerTests {
         #expect(link(input) == want)
     }
 
+    @Test func spaceExtendedCandidate_trimsBackToShortestExisting() {
+        // The linker's space-aware extension peeks past whitespace to find
+        // paths-with-spaces. If the full extended candidate doesn't exist
+        // but a shorter prefix does, it trims one word at a time until
+        // fileExists. Regression guard for the trim-back branch.
+        let link = linker(existing: ["/tmp/a/b"])
+        let input = "look at /tmp/a/b c/d"
+        let want  = "look at [/tmp/a/b](tbd-file:/tmp/a/b) c/d"
+        #expect(link(input) == want)
+    }
+
     @Test func percentEncodingInURL_isReversible() {
         // A real file with a space — escaping must round-trip via URL decoding
         // at click time. We verify the link target form here.

--- a/Tests/TBDAppTests/ShouldSuppressEventsTests.swift
+++ b/Tests/TBDAppTests/ShouldSuppressEventsTests.swift
@@ -1,0 +1,47 @@
+import Testing
+import Foundation
+@testable import TBDApp
+
+@MainActor
+struct ShouldSuppressEventsTests {
+    private let t1 = UUID()
+    private let t2 = UUID()
+
+    @Test func noOverlayOpen_returnsFalse() {
+        let c = TranscriptOverlayCoordinator()
+        #expect(!shouldSuppressEvents(in: c, forTerminalID: t1))
+    }
+
+    @Test func itemFrame_forThisTerminal_returnsTrue() {
+        let c = TranscriptOverlayCoordinator()
+        c.open(terminalID: t1, itemID: "a")
+        #expect(shouldSuppressEvents(in: c, forTerminalID: t1))
+    }
+
+    @Test func itemFrame_forDifferentTerminal_returnsFalse() {
+        let c = TranscriptOverlayCoordinator()
+        c.open(terminalID: t1, itemID: "a")
+        #expect(!shouldSuppressEvents(in: c, forTerminalID: t2))
+    }
+
+    @Test func fileFrame_returnsTrueForAnyTerminal() {
+        // File frames render at the window root and must suppress key
+        // forwarding from EVERY terminal underneath — regression guard
+        // for #199 review (Medium): file overlays previously let arrow
+        // keys / letters route to the tmux terminal beneath.
+        let c = TranscriptOverlayCoordinator()
+        c.open(terminalID: t1, itemID: "agent")
+        c.pushFile(path: "/tmp/foo.md")
+        #expect(shouldSuppressEvents(in: c, forTerminalID: t1))
+        #expect(shouldSuppressEvents(in: c, forTerminalID: t2))
+    }
+
+    @Test func fileFrame_withNoTerminalBoundItem_returnsTrue() {
+        // History-pane case: file frame on top of a history (terminalID == nil)
+        // item frame must still suppress every terminal's events.
+        let c = TranscriptOverlayCoordinator()
+        c.open(terminalID: nil, itemID: "agent", historySessionID: "sess-1")
+        c.pushFile(path: "/tmp/foo.md")
+        #expect(shouldSuppressEvents(in: c, forTerminalID: t1))
+    }
+}

--- a/Tests/TBDAppTests/TranscriptOverlayCoordinatorTests.swift
+++ b/Tests/TBDAppTests/TranscriptOverlayCoordinatorTests.swift
@@ -8,126 +8,164 @@ struct TranscriptOverlayCoordinatorTests {
     private let t1 = UUID()
     private let t2 = UUID()
 
-    @Test func open_fromNil_setsOpenOverlay() {
-        let c = TranscriptOverlayCoordinator()
-        #expect(c.openOverlay == nil)
-        c.open(terminalID: t1, itemID: "a")
-        #expect(c.openOverlay == TranscriptOverlayFrame(terminalID: t1, itemID: "a"))
-        #expect(c.parentFrame == nil)
+    private func itemFrame(_ tid: UUID?, _ id: String, _ session: String? = nil) -> OverlayFrame {
+        .item(ItemFrame(terminalID: tid, itemID: id, historySessionID: session))
     }
 
-    @Test func open_sameFrame_togglesClosed() {
+    @Test func open_fromEmpty_setsCurrent() {
+        let c = TranscriptOverlayCoordinator()
+        #expect(c.current == nil)
+        c.open(terminalID: t1, itemID: "a")
+        #expect(c.current == itemFrame(t1, "a"))
+        #expect(!c.hasBack)
+    }
+
+    @Test func open_sameItem_togglesClosed() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: t1, itemID: "a")
         c.open(terminalID: t1, itemID: "a")
-        #expect(c.openOverlay == nil)
-        #expect(c.parentFrame == nil)
+        #expect(c.current == nil)
+        #expect(!c.isOpen)
     }
 
-    @Test func open_differentItem_swapsContent_keepsOpen() {
+    @Test func open_differentItem_swapsStack() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: t1, itemID: "a")
         c.open(terminalID: t1, itemID: "b")
-        #expect(c.openOverlay == TranscriptOverlayFrame(terminalID: t1, itemID: "b"))
-        #expect(c.parentFrame == nil)
+        #expect(c.current == itemFrame(t1, "b"))
+        #expect(!c.hasBack) // open always resets the stack
     }
 
-    @Test func open_differentTerminal_swapsContent_keepsOpen() {
+    @Test func open_differentTerminal_swapsStack() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: t1, itemID: "a")
         c.open(terminalID: t2, itemID: "a")
-        #expect(c.openOverlay == TranscriptOverlayFrame(terminalID: t2, itemID: "a"))
-        #expect(c.parentFrame == nil)
+        #expect(c.current == itemFrame(t2, "a"))
     }
 
-    @Test func pushAndOpen_savesParent_replacesCurrent() {
+    @Test func pushItem_appendsWithSameTerminal() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: t1, itemID: "parent")
-        c.pushAndOpen(itemID: "child")
-        #expect(c.openOverlay == TranscriptOverlayFrame(terminalID: t1, itemID: "child"))
-        #expect(c.parentFrame == TranscriptOverlayFrame(terminalID: t1, itemID: "parent"))
+        c.pushItem(itemID: "child")
+        #expect(c.current == itemFrame(t1, "child"))
+        #expect(c.hasBack)
     }
 
-    @Test func pushAndOpen_withoutCurrent_isNoOp() {
+    @Test func pushItem_withoutCurrent_isNoOp() {
         let c = TranscriptOverlayCoordinator()
-        c.pushAndOpen(itemID: "child")
-        #expect(c.openOverlay == nil)
-        #expect(c.parentFrame == nil)
+        c.pushItem(itemID: "child")
+        #expect(c.current == nil)
     }
 
-    @Test func popOverlay_withParent_restoresParent() {
+    @Test func pop_oneLevel_restoresPrevious() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: t1, itemID: "parent")
-        c.pushAndOpen(itemID: "child")
-        c.popOverlay()
-        #expect(c.openOverlay == TranscriptOverlayFrame(terminalID: t1, itemID: "parent"))
-        #expect(c.parentFrame == nil)
+        c.pushItem(itemID: "child")
+        c.pop()
+        #expect(c.current == itemFrame(t1, "parent"))
+        #expect(!c.hasBack)
     }
 
-    @Test func popOverlay_withoutParent_closes() {
+    @Test func pop_lastFrame_closesOverlay() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: t1, itemID: "a")
-        c.popOverlay()
-        #expect(c.openOverlay == nil)
-        #expect(c.parentFrame == nil)
+        c.pop()
+        #expect(c.current == nil)
+        #expect(!c.isOpen)
     }
 
-    @Test func close_clearsAll() {
+    @Test func close_clearsStack() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: t1, itemID: "a")
-        c.pushAndOpen(itemID: "b")
+        c.pushItem(itemID: "b")
         c.close()
-        #expect(c.openOverlay == nil)
-        #expect(c.parentFrame == nil)
+        #expect(c.current == nil)
+        #expect(!c.isOpen)
     }
 
-    @Test func open_whileParentFrameSet_clearsBackStack() {
+    @Test func open_resetsExistingStack() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: t1, itemID: "parent")
-        c.pushAndOpen(itemID: "child")          // parentFrame is now set
-        c.open(terminalID: t1, itemID: "other") // swap — should clear parentFrame
-        #expect(c.openOverlay == TranscriptOverlayFrame(terminalID: t1, itemID: "other"))
-        #expect(c.parentFrame == nil)
+        c.pushItem(itemID: "child")
+        c.open(terminalID: t1, itemID: "other")
+        #expect(c.current == itemFrame(t1, "other"))
+        #expect(!c.hasBack)
     }
 
-    // The historySessionID branch — set when the History pane opens an
-    // overlay so the lookup can resolve via AppState.sessionTranscripts
-    // without depending on SwiftUI environment scope (#129 follow-up).
+    // History-pane branch
 
     @Test func open_withHistorySessionID_storesIt() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: nil, itemID: "a", historySessionID: "sess-1")
-        #expect(c.openOverlay == TranscriptOverlayFrame(terminalID: nil, itemID: "a", historySessionID: "sess-1"))
+        #expect(c.current == itemFrame(nil, "a", "sess-1"))
     }
 
-    @Test func open_terminalBound_defaultsHistorySessionIDToNil() {
-        let c = TranscriptOverlayCoordinator()
-        c.open(terminalID: t1, itemID: "a")
-        #expect(c.openOverlay?.historySessionID == nil)
-    }
-
-    @Test func pushAndOpen_propagatesHistorySessionID() {
+    @Test func pushItem_propagatesHistorySessionID() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: nil, itemID: "parent", historySessionID: "sess-1")
-        c.pushAndOpen(itemID: "child")
-        #expect(c.openOverlay == TranscriptOverlayFrame(terminalID: nil, itemID: "child", historySessionID: "sess-1"))
-        #expect(c.parentFrame == TranscriptOverlayFrame(terminalID: nil, itemID: "parent", historySessionID: "sess-1"))
+        c.pushItem(itemID: "child")
+        #expect(c.current == itemFrame(nil, "child", "sess-1"))
     }
 
-    @Test func open_sameHistoryFrame_togglesClosed() {
-        let c = TranscriptOverlayCoordinator()
-        c.open(terminalID: nil, itemID: "a", historySessionID: "sess-1")
-        c.open(terminalID: nil, itemID: "a", historySessionID: "sess-1")
-        #expect(c.openOverlay == nil)
-    }
-
-    @Test func open_sameItemDifferentHistorySession_swapsContent() {
-        // Same itemID across different sessions must NOT be treated as the
-        // same frame — Equatable now includes historySessionID, so this
-        // opens (swaps) rather than toggling closed.
+    @Test func open_sameItemDifferentHistorySession_swaps() {
         let c = TranscriptOverlayCoordinator()
         c.open(terminalID: nil, itemID: "a", historySessionID: "sess-1")
         c.open(terminalID: nil, itemID: "a", historySessionID: "sess-2")
-        #expect(c.openOverlay == TranscriptOverlayFrame(terminalID: nil, itemID: "a", historySessionID: "sess-2"))
+        #expect(c.current == itemFrame(nil, "a", "sess-2"))
+    }
+
+    // File frames
+
+    @Test func pushFile_appendsFileFrame() {
+        let c = TranscriptOverlayCoordinator()
+        c.open(terminalID: t1, itemID: "a")
+        c.pushFile(path: "/tmp/foo.md")
+        #expect(c.current == .file(path: "/tmp/foo.md"))
+        #expect(c.hasBack)
+    }
+
+    @Test func pushFile_withoutOpenOverlay_isNoOp() {
+        let c = TranscriptOverlayCoordinator()
+        c.pushFile(path: "/tmp/foo.md")
+        #expect(c.current == nil)
+    }
+
+    @Test func pop_fromFile_returnsToItem() {
+        let c = TranscriptOverlayCoordinator()
+        c.open(terminalID: t1, itemID: "agent")
+        c.pushFile(path: "/tmp/foo.md")
+        c.pop()
+        #expect(c.current == itemFrame(t1, "agent"))
+        #expect(!c.hasBack)
+    }
+
+    @Test func pushFile_thenPushFile_thenPopTwice_returnsToItem() {
+        let c = TranscriptOverlayCoordinator()
+        c.open(terminalID: t1, itemID: "agent")
+        c.pushFile(path: "/tmp/a.md")
+        c.pushFile(path: "/tmp/b.md")
+        #expect(c.current == .file(path: "/tmp/b.md"))
+        #expect(c.hasBack)
+        c.pop()
+        #expect(c.current == .file(path: "/tmp/a.md"))
+        #expect(c.hasBack)
+        c.pop()
+        #expect(c.current == itemFrame(t1, "agent"))
+        #expect(!c.hasBack)
+    }
+
+    @Test func mixedSequence_itemThenFileThenItem_popsCorrectly() {
+        // agent → subagent-item → file → back → back → back
+        let c = TranscriptOverlayCoordinator()
+        c.open(terminalID: t1, itemID: "agent")
+        c.pushItem(itemID: "subitem")
+        c.pushFile(path: "/tmp/foo.md")
+        #expect(c.hasBack)
+        c.pop()
+        #expect(c.current == itemFrame(t1, "subitem"))
+        c.pop()
+        #expect(c.current == itemFrame(t1, "agent"))
+        c.pop()
+        #expect(c.current == nil)
     }
 }

--- a/docs/superpowers/specs/2026-05-24-agent-overlay-markdown-and-file-links-design.md
+++ b/docs/superpowers/specs/2026-05-24-agent-overlay-markdown-and-file-links-design.md
@@ -1,0 +1,214 @@
+# Agent overlay: markdown rendering + local file links
+
+## Problem
+
+The transcript overlay's Agent body (`AgentCardBody`) currently renders the
+subagent **prompt** and the launch/completion **result** as plain
+monospaced text. Both are authored as markdown in practice:
+
+- The prompt is markdown the human (or upstream agent) wrote — headings,
+  lists, bold, code spans.
+- The result is either (a) the async-launch confirmation, which is plain
+  prose containing a bare absolute path to the output file, or (b) the
+  agent's final report, which is full markdown often containing bare
+  absolute paths to files the agent created or modified.
+
+Rendering as monospaced text wastes the structure and makes references
+to local files inert. The user wants the modal to render markdown and
+to navigate into referenced local files in place.
+
+## Scope
+
+Only the `AgentCardBody` overlay body. Other tool overlays (Read, Edit,
+Bash, Grep, Glob, Write, GenericToolCardBody) are out of scope —
+their specialised renderings (diff viewers, terminal output, file
+previews) don't need markdown or file linkification.
+
+Subagent activity (the nested `TranscriptItemsView`) is also out of
+scope — each subagent item already renders with its own row body
+(e.g., a nested assistant text already renders as markdown via
+`ChatBubbleView`).
+
+## Behaviour
+
+### Markdown rendering
+
+The two prose panels — `Prompt` and `Result` — render via
+`MarkdownUI.Markdown(...)` using the existing
+`MarkdownUI.Theme.chatBubble` theme already used by `ChatBubbleView`.
+`.transcriptSelectableText()` is preserved for text selection. The
+truncation footer ("3,189 more chars · Show full output") continues to
+work as today; when the user expands, the full payload is re-rendered
+as markdown.
+
+### Local file link detection
+
+Agent text contains references to local files in two forms:
+
+1. **Bare absolute paths** in plain prose (the common case, e.g.
+   `output_file: /private/tmp/claude-501/.../foo.output`, or
+   `wrote design to /Users/chang/projects/tbd/docs/foo.md`).
+2. **Explicit markdown links** the agent occasionally writes
+   (`[design doc](/Users/chang/.../foo.md)` or
+   `[file](file:///Users/...)`).
+
+A small functional-core helper, `LocalFileLinker`, post-processes the
+prose before handing it to `Markdown(...)`. It:
+
+- Scans for bare POSIX absolute paths. A path token begins with `/`,
+  continues across `[A-Za-z0-9._/+\-]` characters, and stops at
+  whitespace, quote characters, parens, brackets, angle brackets, or a
+  trailing `.`/`,`/`:`/`;`/`)` punctuation char. Tokens that already
+  appear inside a markdown link, fenced code block, or inline code
+  span are left alone.
+- For each candidate path, checks `FileManager.default.fileExists`. If
+  the file does not exist on the local disk, the path is left as plain
+  text (no false-positive linkification).
+- Replaces each existing-file match with a markdown link:
+  `[<original-text>](tbd-file:<percent-encoded-abs-path>)`.
+
+Inline markdown links the agent already wrote pass through unchanged.
+The renderer's link-handler (below) interprets `tbd-file:` and `file:`
+schemes as local files and everything else as external URLs.
+
+This helper is pure (input string → output string) and is unit-tested
+in isolation.
+
+### Click handling
+
+Each `Markdown(...)` is wrapped with
+`.environment(\.openURL, OpenURLAction { ... })` that dispatches by
+URL scheme:
+
+- `tbd-file:` → decode the path, push a `.file(path:)` frame onto the
+  overlay coordinator's stack.
+- `file://` → same path, treat as a local file.
+- Anything else → return `.systemAction` (system handles `https`,
+  `mailto`, etc. — opens browser or default handler as today).
+
+### File viewer body
+
+A new `OverlayFileView` renders when the top of the overlay stack is a
+`.file(path:)` frame:
+
+- If path extension is `.md` / `.markdown` and the file is under
+  ~1 MB: render with `Markdown(content, baseURL: URL(fileURLWithPath:
+  path))` and the existing `Theme.codeViewer` (already defined in
+  `CodeViewerPaneView.swift`; promote it to file-private-or-internal
+  in the overlay module, or duplicate — TBD in plan).
+- Else if the file is plain text and under ~1 MB: render as
+  monospaced selectable text.
+- Else: show a placeholder with the path, size, and a "Reveal in
+  Finder" button (`NSWorkspace.shared.activateFileViewerSelecting`).
+
+The viewer also installs its own `openURL` handler with the same
+`tbd-file:` / `file:` dispatch, so navigating from one markdown file
+to another local file works.
+
+The viewer's header shows the file name (basename) instead of the
+agent tool label. The icon switches to `doc.text` for `.md` /
+`.txt`, `doc.plaintext` otherwise.
+
+### Navigation stack
+
+The coordinator currently supports a single-step back stack
+(`parentFrame: TranscriptOverlayFrame?`) used by the agent →
+subagent-item push. This becomes a real `[OverlayFrame]` stack so that
+sequences like `agent → subagent-item → file → another-file → …` all
+back-navigate one step at a time.
+
+The frame type generalises from `TranscriptOverlayFrame` (struct) to:
+
+```swift
+enum OverlayFrame: Equatable {
+    case item(TranscriptItemRef)  // existing struct, renamed
+    case file(path: String)
+}
+```
+
+where `TranscriptItemRef` keeps the existing
+`(terminalID, itemID, historySessionID)` fields.
+
+Coordinator API:
+
+- `open(item: TranscriptItemRef)` — top-level open (clears stack).
+- `pushItem(itemID: String)` — push a sibling subagent item; preserves
+  the active terminal/session.
+- `pushFile(path: String)` — push a file frame.
+- `pop()` — pop one frame; close when the stack is empty.
+- `close()` — clear and close.
+- `current: OverlayFrame?` — what's visible.
+
+Tapping the same item that's at the top still toggles (the existing
+"click same row to dismiss" behaviour) — this stays scoped to item
+frames; file frames always push.
+
+The header `hasBack` becomes `stack.count > 1`. `onBack` calls `pop()`.
+
+### Failure modes
+
+- Path no longer exists when clicked (race after detection): file
+  viewer renders an error placeholder ("File not found: …"); back
+  button still works.
+- File read fails (permissions, encoding): error placeholder with the
+  underlying error message.
+- Path appears in text but file isn't there: not linkified (decision
+  in detector, not at click time).
+- Empty file: render an empty markdown view (the existing
+  `RenderedContentView` in `CodeViewerPaneView` handles this).
+
+## Architecture / file impact
+
+New files in `Sources/TBDApp/Panes/Transcript/`:
+
+- `LocalFileLinker.swift` — pure helper, `func linkify(_ text: String,
+  fileExists: (String) -> Bool = FileManager.default.fileExists) ->
+  String`.
+- `OverlayFileView.swift` — the file viewer body.
+
+Modified:
+
+- `TranscriptOverlayCoordinator.swift` — frame enum + stack API.
+- `TranscriptOverlayView.swift` — switch on the top frame; route to
+  either the existing tool-body switch or `OverlayFileView`.
+  Header label/icon dispatch on frame kind too.
+- `AgentCardBody.swift` — replace the two `Text(...)` prose panels
+  with `Markdown(...)` + `LocalFileLinker.linkify(...)` +
+  `OpenURLAction`. Wire the open-URL action to
+  `overlayCoordinator.pushFile(...)`.
+- Callers that used to construct `TranscriptOverlayFrame` directly
+  (TerminalPanelView, History pane, anywhere `coordinator.open(...)`
+  is invoked) — update to the new `open(item:)` API. Confine the
+  rename ripple to call-sites; semantics unchanged.
+
+New tests:
+
+- `LocalFileLinkerTests` — bare path at EOL / in parens / with trailing
+  comma / followed by sentence; markdown link passthrough; fenced code
+  block passthrough; inline code passthrough; nonexistent paths
+  skipped; path-like-but-not (`http://...`) skipped; nested paths
+  inside larger tokens; empty string; no paths.
+- `TranscriptOverlayCoordinatorTests` — extend existing tests with:
+  push-file then pop; push-item then push-file then pop twice;
+  push-file then close; back button toggles `hasBack` correctly across
+  mixed-frame sequences.
+- `OverlayFileViewTests` (if testable as a pure view of the
+  loaded-content state machine; otherwise skip — existing
+  `RenderedContentView` in `CodeViewerPaneView` isn't unit-tested
+  either).
+
+## Out of scope
+
+- Linkifying relative paths or `~/`-prefixed paths. Agents almost
+  always emit absolutes in their reports; relatives are too ambiguous
+  to resolve without a working-directory context that the overlay
+  doesn't carry.
+- Linkifying paths inside subagent items (those render through other
+  card bodies — would be a separate change).
+- Honouring `file:line:col` suffixes (e.g., `foo.swift:42`) by jumping
+  to a specific line in the viewer. The viewer just renders the file
+  start; selection is via the user.
+- Showing a breadcrumb of the stack in the header. The back button is
+  enough for the depths we expect (rarely > 3).
+- Caching file contents across pop/re-push (re-read each time;
+  trivially cheap for the sub-MB files we render).


### PR DESCRIPTION
## Summary

- The Agent tool overlay now renders the **prompt** and **result** as markdown (via MarkdownUI, reusing the existing `chatBubble` theme) instead of monospaced plain text — headings, lists, bold, inline code all light up.
- Bare absolute POSIX paths in either panel (e.g. `output_file: /private/tmp/claude-501/…`) are detected, filtered against `FileManager.fileExists`, and rewritten as `tbd-file:` markdown links. Clicking one opens that file **inside the overlay** — `.md` rendered as markdown, other text as monospaced, large/binary files get a "Reveal in Finder" placeholder.
- Replaces the coordinator's single-step parent-frame back-pointer with a real `[OverlayFrame]` stack (`.item` or `.file` cases) so `agent → subagent-item → file → another-file` all back-navigate one step at a time.
- New: `LocalFileLinker` (pure helper, 15 tests covering punctuation, code fences, inline code, percent-encoding, nonexistent-path filtering), `OverlayFileView` (file frame body), and an extended `TranscriptOverlayCoordinator` (18 tests covering mixed item/file stack sequences).
- Scope is just the Agent overlay — Read/Edit/Bash specialised bodies are unchanged.

## Test plan

- [x] `swift test` — all 1092 tests pass (15 new `LocalFileLinkerTests`, 18 rewritten `TranscriptOverlayCoordinatorTests`).
- [x] `swiftlint --strict` — clean (added `OverlayFileView.swift` to the `no_scrollview_in_transcript_cards` exclusion list; it lives outside the LazyVStack so the `ScrollView` is safe).
- [x] Manual: opened the Agent overlay on a real subagent invocation, confirmed markdown formatting renders in both panels, clicked a bare path in the result, confirmed the modal swapped to the file's markdown rendering with a back chevron, popped back to the agent.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=C5DC73B9-C863-4D3B-AA63-F422DE27408A)