### PR TITLE
Feat: Bring back copy/paste in transcript rows now that the freeze fix has landed

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -39,7 +39,15 @@ struct TranscriptItemsView: View {
     /// need the signal.
     var atBottom: Binding<Bool>? = nil
 
-    // `transcriptTextSelection` forced `false` as a #129 falsification test — revert this PR to restore the hover-latch.
+    /// Tracks the most recently hovered row. The latched row is the only
+    /// one that materializes `.textSelection(.enabled)` (via
+    /// `transcriptSelectableText` + `EnvironmentValues.transcriptTextSelection`)
+    /// — every other visible row renders plain `Text` to avoid the per-row
+    /// `NSTextField` tax that caused ~17 s layout hangs (see
+    /// `TranscriptSelectableText.swift`). The latch is intentional: we do NOT
+    /// clear on hover-exit so that drag-select still works when the cursor
+    /// briefly leaves the row geometry.
+    @State private var hoveredItemID: String? = nil
 
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
@@ -73,7 +81,10 @@ struct TranscriptItemsView: View {
         LazyVStack(alignment: .leading, spacing: 4) {
             ForEach(nodes) { node in
                 TranscriptRow(node: node, terminalID: terminalID)
-                    .environment(\.transcriptTextSelection, false)
+                    .environment(\.transcriptTextSelection, hoveredItemID == node.id)
+                    .onHover { hovering in
+                        if hovering { hoveredItemID = node.id }
+                    }
             }
             // 1pt sentinel that drives `atBottom`. Replaced the prior
             // `.onScrollGeometryChange(for: AtBottomGeometry.self)` reader that

--- a/Sources/TBDApp/Panes/Transcript/TranscriptSelectableText.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptSelectableText.swift
@@ -10,12 +10,9 @@ import SwiftUI
 /// env propagation. Layout passes go super-linear and the main thread stalls
 /// (confirmed via spindumps showing ~17 s hangs).
 ///
-/// `TranscriptItemsView` normally flips this env to `true` only on the most-
-/// recently hovered row (latched, not live-hovered), so non-hovered rows render
-/// plain `Text` and skip the `NSTextField` materialization entirely. (Currently
-/// forced `false` for every row while the #129 hover-trigger falsification test
-/// in PR #140 is live — `ChatBubbleView` overrides to `true` in its subtree, so
-/// user/assistant text stays selectable.)
+/// `TranscriptItemsView` flips this env to `true` only on the most-recently
+/// hovered row (latched, not live-hovered), so non-hovered rows render plain
+/// `Text` and skip the `NSTextField` materialization entirely.
 private struct TranscriptTextSelectionKey: EnvironmentKey {
     static let defaultValue: Bool = false
 }


### PR DESCRIPTION
## Summary
- PR #140 forced `transcriptTextSelection` to `false` on every transcript row as a falsification test for the #129 layout-hang hypothesis (per-row `.onHover` mutating an env value broadcast across rows triggering `_FlexFrameLayout` recursion).
- The structural fix landed in #193 (click-to-open overlay rework), so the test is no longer needed. Restoring the original hover-latch lets the most-recently hovered row materialize `.textSelection(.enabled)` while every other row stays a plain `Text` — preserving the per-row `NSTextField` budget that prevented the 17 s hangs.
- User-visible: hovering a tool-call card (Bash, Edit, Write, etc.) again makes its text selectable, so drag-select and copy work.

## Test plan
- [ ] Open a session with several tool-call cards in the live transcript pane.
- [ ] Hover a card → drag-select some of its text → ⌘C copies it.
- [ ] Move pointer briefly off the row mid-drag → selection still works (hover-latch is enter-only, not cleared on exit).
- [ ] Scroll through a >100-item transcript and confirm no main-thread hangs.
- [ ] ChatBubbleView user/assistant text remains selectable (its subtree still hardcodes the env to `true`).

[📋 Restore Transcript Copy](https://cheapsteak.github.io/tbd/open/?worktree=E8779FF9-510C-4FCB-AF4F-8ADAC47F51AA)