### PR TITLE
Use profile-v2 for TBD Codex overlay

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -6,9 +6,10 @@ private let codexLogger = Logger(subsystem: "com.tbd.daemon", category: "codex-i
 
 /// Installs TBD's Codex integration into the user's global Codex home.
 ///
-/// TBD uses `codex --profile tbd` instead of an isolated per-repo
-/// `CODEX_HOME`, so user auth/config/plugins continue to merge with TBD's
-/// runtime integration while the TBD plugin remains profile-scoped.
+/// TBD uses the file-backed `codex --profile-v2 tbd` overlay instead of an
+/// isolated per-repo `CODEX_HOME`, so user auth/config/plugins continue to
+/// merge with TBD's runtime integration while the TBD plugin remains
+/// profile-scoped.
 struct CodexHomeManager: Sendable {
     let codexHome: URL
 
@@ -245,5 +246,5 @@ enum CodexProfileWriter {
 }
 
 enum CodexSpawnCommandBuilder {
-    static let command = "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox"
+    static let command = "unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox"
 }

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -246,4 +246,9 @@ import TBDShared
         #expect(FileManager.default.fileExists(
             atPath: CodexProfileWriter.profilePath(in: codexHome).path))
     }
+
+    @Test func codexSpawnCommandUsesFileBackedProfileOverlay() {
+        #expect(CodexSpawnCommandBuilder.command.contains("codex --profile-v2 tbd"))
+        #expect(!CodexSpawnCommandBuilder.command.contains("codex --profile tbd"))
+    }
 }

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -183,7 +183,7 @@ func testRecreateAfterRebootCodexBranchSetsWorktreeID() async throws {
     #expect(bodies.contains { $0.contains("export CODEX_HOME=") },
             "codex-branch must still export CODEX_HOME; got bodies: \(bodies)")
     #expect(bodies.contains {
-        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox")
+        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox")
     }, "codex-branch must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "codex-branch must not use removed --full-auto flag; got bodies: \(bodies)")
@@ -328,7 +328,7 @@ func testHandleTerminalRecreateWindowCodexLaunchCommand() async throws {
 
     let bodies = newWindowBodies(recorded.snapshot())
     #expect(bodies.contains {
-        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox")
+        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox")
     }, "recreated codex tab must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "recreated codex tab must not use removed --full-auto flag; got bodies: \(bodies)")
@@ -503,7 +503,7 @@ func testHandleTerminalCreateCodexLaunchCommand() async throws {
     #expect(bodies.contains { $0.contains("export CODEX_HOME=") },
             "created codex tab must export CODEX_HOME; got bodies: \(bodies)")
     #expect(bodies.contains {
-        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox")
+        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox")
     }, "created codex tab must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "created codex tab must not use removed --full-auto flag; got bodies: \(bodies)")


### PR DESCRIPTION
## Summary
- switch TBD's Codex launch command to `--profile-v2 tbd` so it loads `$CODEX_HOME/tbd.config.toml`
- update the integration comment to reflect the file-backed overlay behavior
- add regression coverage for the launch flag and keep the Codex terminal tests aligned with the runtime command

## Test Plan
- `swift test --filter 'CodexHookOverlayTests|testRecreateAfterRebootCodexBranchSetsWorktreeID|testHandleTerminalRecreateWindowCodexLaunchCommand|testHandleTerminalCreateCodexLaunchCommand'`
