### PR TITLE
Split Codex stop hooks to preserve stdin

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -57,7 +57,10 @@ enum CodexHookOverlay {
         #"tbd session-event 2>/dev/null || true"#
 
     static let stopCommand =
-        #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; tbd hooks stop-rename-check 2>/dev/null || true"#
+        #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
+
+    static let stopRenameCheckCommand =
+        #"tbd hooks stop-rename-check 2>/dev/null || true"#
 
     static func hookPath(in pluginRoot: URL) -> URL {
         pluginRoot.appendingPathComponent(relativePath, isDirectory: false)
@@ -78,6 +81,11 @@ enum CodexHookOverlay {
                     [
                         "hooks": [
                             ["type": "command", "command": stopCommand]
+                        ]
+                    ],
+                    [
+                        "hooks": [
+                            ["type": "command", "command": stopRenameCheckCommand]
                         ]
                     ]
                 ]

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -18,7 +18,7 @@ import TBDShared
         #expect(sessionCommand?.contains("tbd session-event") == true)
 
         let stop = hooks?["Stop"] as? [[String: Any]]
-        #expect(stop?.count == 1)
+        #expect(stop?.count == 2)
         let stopCommands: [String] = (stop ?? []).flatMap { entry -> [String] in
             let inner = entry["hooks"] as? [[String: Any]] ?? []
             return inner.compactMap { $0["command"] as? String }
@@ -26,8 +26,12 @@ import TBDShared
         #expect(stopCommands.contains {
             $0.contains("tbd notify --type response_complete")
                 && $0.contains("last_assistant_message")
+                && !$0.contains("stop-rename-check")
         })
-        #expect(stopCommands.contains { $0.contains("stop-rename-check") })
+        #expect(stopCommands.contains {
+            $0.contains("stop-rename-check")
+                && !$0.contains("tbd notify --type response_complete")
+        })
     }
 
     @Test func roundtripsAsValidJSON() throws {


### PR DESCRIPTION
## Summary
- split the Codex `Stop` hook into separate `tbd notify` and `tbd hooks stop-rename-check` entries
- preserve stdin for `stop-rename-check` so Codex can still read the Stop payload and block for worktree rename prompts
- tighten `CodexHookOverlayTests` so the hook shape must stay split and cannot regress to a combined command

## Test Plan
- `swift test`
