### PR TITLE
fix: make tab padding clickable

### DIFF
--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -435,6 +435,9 @@ private struct TabBarItem: View {
                             .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))
                     }
                 }
+                .padding(.leading, 8)
+                .frame(minHeight: 28, alignment: .leading)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
 
@@ -458,7 +461,6 @@ private struct TabBarItem: View {
             .opacity(showClose ? 1 : 0)
             .animation(.easeInOut(duration: 0.12), value: showClose)
         }
-        .padding(.leading, 8)
         .frame(minHeight: 28)
         .background(
             isSelected

--- a/Tests/TBDAppTests/TabBarHitAreaTests.swift
+++ b/Tests/TBDAppTests/TabBarHitAreaTests.swift
@@ -12,36 +12,43 @@ struct TabBarHitAreaTests {
         let worktreeID = UUID()
         let terminalID = UUID()
         let tab = Tab(id: terminalID, content: .terminal(terminalID: terminalID), label: "A")
-        let appState = AppState(
-            userDefaults: UserDefaults(suiteName: "TabBarHitAreaTests-\(UUID().uuidString)")!
-        )
-        appState.terminals[worktreeID] = [
-            Terminal(
-                id: terminalID,
-                worktreeID: worktreeID,
-                tmuxWindowID: "1",
-                tmuxPaneID: "%1"
-            )
-        ]
+        let suiteName = "TabBarHitAreaTests-\(UUID().uuidString)"
 
-        let host = NSHostingView(
-            rootView: TabBar(
-                tabs: [tab],
-                worktreeID: worktreeID,
-                activeTabIndex: .constant(0),
-                onCloseTab: { _ in }
-            )
-            .environmentObject(appState)
-            .frame(width: 220, height: 30)
-        )
-        host.frame = NSRect(x: 0, y: 0, width: 220, height: 30)
-        host.layoutSubtreeIfNeeded()
+        do {
+            let defaults = UserDefaults(suiteName: suiteName)!
+            defaults.set(true, forKey: "probe")
+            defer { defaults.removePersistentDomain(forName: suiteName) }
+            let appState = AppState(userDefaults: defaults)
+            appState.terminals[worktreeID] = [
+                Terminal(
+                    id: terminalID,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: "1",
+                    tmuxPaneID: "%1"
+                )
+            ]
 
-        let proxyWidths = keyViewProxyFrames(in: host).map(\.width)
-        // A label-only target was 28pt in the broken layout. The HStack fix
-        // moves the leading padding/min-height onto the select button, which
-        // should push the button's AppKit hit region beyond that label-only size.
-        #expect((proxyWidths.max() ?? 0) > 30)
+            let host = NSHostingView(
+                rootView: TabBar(
+                    tabs: [tab],
+                    worktreeID: worktreeID,
+                    activeTabIndex: .constant(0),
+                    onCloseTab: { _ in }
+                )
+                .environmentObject(appState)
+                .frame(width: 220, height: 30)
+            )
+            host.frame = NSRect(x: 0, y: 0, width: 220, height: 30)
+            host.layoutSubtreeIfNeeded()
+
+            let proxyWidths = keyViewProxyFrames(in: host).map(\.width)
+            // A label-only target was 28pt in the broken layout. The HStack fix
+            // moves the leading padding/min-height onto the select button, which
+            // should push the button's AppKit hit region beyond that label-only size.
+            #expect((proxyWidths.max() ?? 0) > 30)
+        }
+
+        #expect(UserDefaults.standard.persistentDomain(forName: suiteName) == nil)
     }
 
     private func keyViewProxyFrames(in view: NSView) -> [CGRect] {

--- a/Tests/TBDAppTests/TabBarHitAreaTests.swift
+++ b/Tests/TBDAppTests/TabBarHitAreaTests.swift
@@ -1,0 +1,51 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import TBDApp
+import TBDShared
+
+@Suite("Tab bar hit area")
+@MainActor
+struct TabBarHitAreaTests {
+    @Test("selection target includes tab padding, not just the label")
+    func selectionTargetIncludesTabPadding() {
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        let tab = Tab(id: terminalID, content: .terminal(terminalID: terminalID), label: "A")
+        let appState = AppState(
+            userDefaults: UserDefaults(suiteName: "TabBarHitAreaTests-\(UUID().uuidString)")!
+        )
+        appState.terminals[worktreeID] = [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "1",
+                tmuxPaneID: "%1"
+            )
+        ]
+
+        let host = NSHostingView(
+            rootView: TabBar(
+                tabs: [tab],
+                worktreeID: worktreeID,
+                activeTabIndex: .constant(0),
+                onCloseTab: { _ in }
+            )
+            .environmentObject(appState)
+            .frame(width: 220, height: 30)
+        )
+        host.frame = NSRect(x: 0, y: 0, width: 220, height: 30)
+        host.layoutSubtreeIfNeeded()
+
+        let proxyWidths = keyViewProxyFrames(in: host).map(\.width)
+        // A label-only target was 28pt in the broken layout. The HStack fix
+        // moves the leading padding/min-height onto the select button, which
+        // should push the button's AppKit hit region beyond that label-only size.
+        #expect((proxyWidths.max() ?? 0) > 30)
+    }
+
+    private func keyViewProxyFrames(in view: NSView) -> [CGRect] {
+        let current = String(describing: type(of: view)) == "KeyViewProxy" ? [view.frame] : []
+        return current + view.subviews.flatMap(keyViewProxyFrames(in:))
+    }
+}

--- a/Tests/TBDAppTests/TabBarHitAreaTests.swift
+++ b/Tests/TBDAppTests/TabBarHitAreaTests.swift
@@ -28,8 +28,8 @@ struct TabBarHitAreaTests {
                 )
             ]
 
-            let host = NSHostingView(
-                rootView: TabBar(
+            let paddedWidth = keyViewProxyMaxWidth(
+                TabBar(
                     tabs: [tab],
                     worktreeID: worktreeID,
                     activeTabIndex: .constant(0),
@@ -38,20 +38,44 @@ struct TabBarHitAreaTests {
                 .environmentObject(appState)
                 .frame(width: 220, height: 30)
             )
-            host.frame = NSRect(x: 0, y: 0, width: 220, height: 30)
-            host.layoutSubtreeIfNeeded()
+            let labelOnlyWidth = keyViewProxyMaxWidth(
+                Button(action: {}) {
+                    HStack(spacing: 0) {
+                        Image(systemName: "terminal")
+                            .font(.system(size: 10))
+                            .frame(width: 14)
+                            .padding(.trailing, 3)
+                        Text(tab.label ?? "")
+                            .font(.system(size: 11))
+                            .lineLimit(1)
+                            .fixedSize()
+                    }
+                }
+                .buttonStyle(.plain)
+                .frame(width: 220, height: 30)
+            )
 
-            let proxyWidths = keyViewProxyFrames(in: host).map(\.width)
-            // A label-only target was 28pt in the broken layout. The HStack fix
-            // moves the leading padding/min-height onto the select button, which
-            // should push the button's AppKit hit region beyond that label-only size.
-            #expect((proxyWidths.max() ?? 0) > 30)
+            // The fix moves the leading padding and min-height onto the select
+            // button itself, so its AppKit hit region should be materially
+            // wider than the label-only baseline.
+            #expect(paddedWidth > labelOnlyWidth + 2)
         }
 
         #expect(UserDefaults.standard.persistentDomain(forName: suiteName) == nil)
     }
 
+    private func keyViewProxyMaxWidth<Content: View>(_ rootView: Content) -> CGFloat {
+        let host = NSHostingView(rootView: rootView)
+        host.frame = NSRect(x: 0, y: 0, width: 220, height: 30)
+        host.layoutSubtreeIfNeeded()
+        return keyViewProxyFrames(in: host).map(\.width).max() ?? 0
+    }
+
     private func keyViewProxyFrames(in view: NSView) -> [CGRect] {
+        // SwiftUI's AppKit button hit target is materialized as a private
+        // KeyViewProxy view. There's no public NSView API that exposes the
+        // same button hit-region frame directly, so this string match is a
+        // deliberate test seam rather than an accidental private dependency.
         let current = String(describing: type(of: view)) == "KeyViewProxy" ? [view.frame] : []
         return current + view.subviews.flatMap(keyViewProxyFrames(in:))
     }


### PR DESCRIPTION
## Summary
- move the tab body's leading padding and minimum height onto the select button so the padded tab area is clickable
- keep the simpler `HStack` tab layout instead of overlaying the close control with a `ZStack`
- add a regression test that asserts the tab hit target extends beyond the label-only width

## Test Plan
- [x] `swift test`
- [x] `swift test --filter TabBarHitAreaTests`
- [x] `swift test --filter AddTabMenuTests`
- [x] `swift test --filter TabReorderTests`
