### PR TITLE
fix: stop forcing repo-dot PR refresh

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -68,8 +68,7 @@ public actor PRStatusManager {
     /// Refresh a single worktree using `gh pr view`. Used for on-select refresh.
     public func refresh(worktreeID: UUID, branch: String, repoPath: String) async -> PRStatus? {
         let args = ["pr", "view", branch,
-                    "--json", "number,url,state,mergeStateStatus,reviewDecision",
-                    "-R", "."]
+                    "--json", "number,url,state,mergeStateStatus,reviewDecision"]
         guard let output = await runGH(args: args, repoPath: repoPath),
               let data = output.data(using: .utf8),
               let obj = try? JSONDecoder().decode(GHPRViewResult.self, from: data) else {


### PR DESCRIPTION
## Summary
- remove the invalid `-R .` override from targeted `gh pr view` refreshes
- rely on the process working directory for repo inference, which is already set to the target checkout

## Test Plan
- `swift test --filter PRStatusManagerTests`
