### PR TITLE
fix: autofocus terminal after worktree switch

### DIFF
--- a/Sources/TBDApp/AppState+TerminalFocus.swift
+++ b/Sources/TBDApp/AppState+TerminalFocus.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+@MainActor
+final class TerminalFocusTarget {
+    weak var view: TBDTerminalView?
+
+    init(_ view: TBDTerminalView) {
+        self.view = view
+    }
+}
+
+extension AppState {
+    func registerTerminalView(_ view: TBDTerminalView, for terminalID: UUID) {
+        terminalFocusTargets[terminalID] = TerminalFocusTarget(view)
+    }
+
+    func unregisterTerminalView(_ view: TBDTerminalView, for terminalID: UUID) {
+        guard terminalFocusTargets[terminalID]?.view === view else { return }
+        terminalFocusTargets.removeValue(forKey: terminalID)
+    }
+
+    func terminalIDForAutofocus(worktreeID: UUID) -> UUID? {
+        guard !historyActiveWorktrees.contains(worktreeID),
+              let worktreeTabs = tabs[worktreeID],
+              !worktreeTabs.isEmpty
+        else {
+            return nil
+        }
+
+        let rawIndex = activeTabIndices[worktreeID] ?? 0
+        let activeIndex = min(max(rawIndex, 0), worktreeTabs.count - 1)
+        let activeTab = worktreeTabs[activeIndex]
+        let activeLayout = layouts[activeTab.id] ?? .pane(activeTab.content)
+
+        return activeLayout.allTerminalIDs().first
+    }
+
+    func focusTerminalAfterSelectionChange(worktreeID: UUID) {
+        guard let terminalID = terminalIDForAutofocus(worktreeID: worktreeID) else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let terminalView = self.terminalFocusTargets[terminalID]?.view,
+                  terminalView.window != nil
+            else {
+                return
+            }
+
+            terminalView.window?.makeFirstResponder(terminalView)
+        }
+    }
+}

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -208,6 +208,9 @@ final class AppState: ObservableObject {
     /// Closures registered by live TerminalPanelView instances to capture a screenshot.
     /// Keyed by terminal UUID. Populated in makeNSView, cleared on view disappear.
     var snapshotProviders: [UUID: () -> NSImage?] = [:]
+    /// Weak terminal views keyed by terminal UUID, used to restore AppKit first
+    /// responder after worktree navigation.
+    var terminalFocusTargets: [UUID: TerminalFocusTarget] = [:]
     /// Visual screenshots taken at suspend-click time, shown while daemon works.
     /// Keyed by terminal UUID. Cleared when suspend completes.
     @Published var suspendingSnapshots: [UUID: NSImage] = [:]

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -181,6 +181,7 @@ struct ContentView: View {
             // Keep-alive: track most-recently-visited worktree for view-tree preservation.
             if newSelection.count == 1, let id = newSelection.first {
                 appState.touchVisitedWorktree(id)
+                appState.focusTerminalAfterSelectionChange(worktreeID: id)
             }
         }
         .alert(
@@ -199,6 +200,7 @@ struct ContentView: View {
             // selection so the ZStack renders the right SingleWorktreeView on first frame.
             if appState.selectedWorktreeIDs.count == 1, let id = appState.selectedWorktreeIDs.first {
                 appState.touchVisitedWorktree(id)
+                appState.focusTerminalAfterSelectionChange(worktreeID: id)
             }
         }
     }

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -175,6 +175,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         context.coordinator.tmuxBridge = tmuxBridge
         context.coordinator.tmuxServer = tmuxServer
         context.coordinator.panelID = terminalID
+        context.coordinator.appState = appState
         context.coordinator.onDeadWindow = onDeadWindow
         context.coordinator.shouldSuppressEvents = shouldSuppressEvents
 
@@ -216,6 +217,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         appState.snapshotProviders[captureID] = { [weak tv] in
             tv?.captureScreenshot()
         }
+        appState.registerTerminalView(tv, for: terminalID)
 
         return tv
     }
@@ -225,6 +227,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ nsView: TBDTerminalView, coordinator: Coordinator) {
+        coordinator.appState?.unregisterTerminalView(nsView, for: coordinator.panelID)
         coordinator.cleanup()
     }
 
@@ -236,6 +239,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
 
     final class Coordinator: NSObject, TerminalViewDelegate, LocalProcessDelegate, @unchecked Sendable {
         weak var terminalView: TerminalView?
+        weak var appState: AppState?
         var tmuxBridge: TmuxBridge?
         var tmuxServer: String = ""
         var panelID: UUID = UUID()

--- a/Tests/TBDAppTests/TerminalAutofocusTests.swift
+++ b/Tests/TBDAppTests/TerminalAutofocusTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+
+@MainActor
+@Suite("Terminal autofocus")
+struct TerminalAutofocusTests {
+    @Test func activeTerminalInSelectedWorktreeIsFocusTarget() {
+        let state = AppState()
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        let tabID = UUID()
+
+        state.tabs[worktreeID] = [
+            Tab(id: tabID, content: .terminal(terminalID: terminalID), label: nil),
+        ]
+        state.activeTabIndices[worktreeID] = 0
+
+        #expect(state.terminalIDForAutofocus(worktreeID: worktreeID) == terminalID)
+    }
+
+    @Test func activeTabLayoutChoosesFirstVisibleTerminal() {
+        let state = AppState()
+        let worktreeID = UUID()
+        let firstTerminalID = UUID()
+        let secondTerminalID = UUID()
+        let tabID = UUID()
+
+        state.tabs[worktreeID] = [
+            Tab(id: tabID, content: .note(noteID: UUID()), label: nil),
+        ]
+        state.layouts[tabID] = .split(
+            direction: .horizontal,
+            children: [
+                .pane(.codeViewer(id: UUID(), path: "/tmp/file.swift")),
+                .pane(.terminal(terminalID: firstTerminalID)),
+                .pane(.terminal(terminalID: secondTerminalID)),
+            ],
+            ratios: [0.3, 0.35, 0.35]
+        )
+
+        #expect(state.terminalIDForAutofocus(worktreeID: worktreeID) == firstTerminalID)
+    }
+
+    @Test func historyViewDoesNotStealFocus() {
+        let state = AppState()
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        let tabID = UUID()
+
+        state.tabs[worktreeID] = [
+            Tab(id: tabID, content: .terminal(terminalID: terminalID), label: nil),
+        ]
+        state.historyActiveWorktrees.insert(worktreeID)
+
+        #expect(state.terminalIDForAutofocus(worktreeID: worktreeID) == nil)
+    }
+
+    @Test func nonTerminalActiveTabDoesNotAutofocusTerminal() {
+        let state = AppState()
+        let worktreeID = UUID()
+        let tabID = UUID()
+
+        state.tabs[worktreeID] = [
+            Tab(id: tabID, content: .note(noteID: UUID()), label: nil),
+        ]
+
+        #expect(state.terminalIDForAutofocus(worktreeID: worktreeID) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- restore terminal focus when switching to or restoring a single selected worktree
- track live terminal views so the active layout's first terminal can become first responder again
- add autofocus coverage for terminal tabs, split layouts, history mode, and non-terminal tabs

## Test Plan
- [x] swift test