### PR TITLE
Fix GraphQL partial results in PR status sync

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -133,11 +133,11 @@ public actor PRStatusManager {
               let dataObj = root["data"] as? [String: Any],
               let viewer = dataObj["viewer"] as? [String: Any],
               let prs = viewer["pullRequests"] as? [String: Any],
-              let nodes = prs["nodes"] as? [[String: Any]] else {
+              let nodes = prs["nodes"] as? [Any] else {
             throw PRStatusError.invalidJSON
         }
 
-        return nodes.compactMap { node -> PRNode? in
+        return nodes.compactMap { $0 as? [String: Any] }.compactMap { node -> PRNode? in
             guard let number = node["number"] as? Int,
                   let url = node["url"] as? String,
                   let state = node["state"] as? String,
@@ -170,11 +170,45 @@ public actor PRStatusManager {
         }
         """
         let args = ["api", "graphql", "-f", "query=\(query)"]
-        guard let output = await runGH(args: args, repoPath: repoPath) else { return nil }
-        return output.data(using: .utf8)
+        guard let result = await runGHResult(args: args, repoPath: repoPath),
+              let data = Self.graphQLOutputData(stdout: result.stdout, exitStatus: result.exitStatus) else {
+            return nil
+        }
+
+        if result.exitStatus != 0 {
+            let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            if errSuffix.isEmpty {
+                logger.debug("gh graphql exited \(result.exitStatus) with partial stdout")
+            } else {
+                logger.debug("gh graphql exited \(result.exitStatus) with partial stdout: \(errSuffix)")
+            }
+        }
+
+        return data
     }
 
     private func runGH(args: [String], repoPath: String) async -> String? {
+        guard let result = await runGHResult(args: args, repoPath: repoPath) else {
+            return nil
+        }
+
+        guard result.exitStatus == 0 else {
+            let errStr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.debug("gh exited \(result.exitStatus): \(errStr)")
+            return nil
+        }
+
+        return result.stdout
+    }
+
+    static func graphQLOutputData(stdout: String, exitStatus: Int32) -> Data? {
+        let trimmed = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard exitStatus == 0 || !trimmed.isEmpty else { return nil }
+        guard !trimmed.isEmpty else { return nil }
+        return stdout.data(using: .utf8)
+    }
+
+    private func runGHResult(args: [String], repoPath: String) async -> GHCommandResult? {
         guard let ghPath = findGH() else {
             logger.debug("gh CLI not found in PATH")
             return nil
@@ -192,15 +226,13 @@ public actor PRStatusManager {
             process.standardError = stderr
 
             process.terminationHandler = { p in
-                if p.terminationStatus != 0 {
-                    let errData = stderr.fileHandleForReading.readDataToEndOfFile()
-                    let errStr = String(data: errData, encoding: .utf8) ?? ""
-                    logger.debug("gh exited \(p.terminationStatus): \(errStr)")
-                    continuation.resume(returning: nil)
-                    return
-                }
-                let data = stdout.fileHandleForReading.readDataToEndOfFile()
-                continuation.resume(returning: String(data: data, encoding: .utf8))
+                let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+                let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+                continuation.resume(returning: GHCommandResult(
+                    stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+                    stderr: String(data: stderrData, encoding: .utf8) ?? "",
+                    exitStatus: p.terminationStatus
+                ))
             }
 
             do {
@@ -226,6 +258,12 @@ public actor PRStatusManager {
         }
         return nil
     }
+}
+
+private struct GHCommandResult {
+    let stdout: String
+    let stderr: String
+    let exitStatus: Int32
 }
 
 // MARK: - Supporting types

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -171,16 +171,16 @@ public actor PRStatusManager {
         """
         let args = ["api", "graphql", "-f", "query=\(query)"]
         guard let result = await runGHResult(args: args, repoPath: repoPath),
-              let data = Self.graphQLOutputData(stdout: result.stdout, exitStatus: result.exitStatus) else {
+              let data = Self.graphQLOutputData(stdout: result.stdout) else {
             return nil
         }
 
         if result.exitStatus != 0 {
             let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             if errSuffix.isEmpty {
-                logger.debug("gh graphql exited \(result.exitStatus) with partial stdout")
+                logger.debug("gh graphql exited \(result.exitStatus, privacy: .public) with partial stdout")
             } else {
-                logger.debug("gh graphql exited \(result.exitStatus) with partial stdout: \(errSuffix)")
+                logger.debug("gh graphql exited \(result.exitStatus, privacy: .public) with partial stdout: \(errSuffix, privacy: .public)")
             }
         }
 
@@ -194,16 +194,15 @@ public actor PRStatusManager {
 
         guard result.exitStatus == 0 else {
             let errStr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            logger.debug("gh exited \(result.exitStatus): \(errStr)")
+            logger.debug("gh exited \(result.exitStatus, privacy: .public): \(errStr, privacy: .public)")
             return nil
         }
 
         return result.stdout
     }
 
-    static func graphQLOutputData(stdout: String, exitStatus: Int32) -> Data? {
+    static func graphQLOutputData(stdout: String) -> Data? {
         let trimmed = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard exitStatus == 0 || !trimmed.isEmpty else { return nil }
         guard !trimmed.isEmpty else { return nil }
         return stdout.data(using: .utf8)
     }

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -153,20 +153,20 @@ struct PRStatusManagerTests {
         #expect(nodes[1].headRefName == "tbd/old-feature")
     }
 
-    @Test("graphQLOutputData keeps stdout from partial GraphQL failures")
-    func graphQLOutputDataUsesStdoutOnNonZeroExit() {
+    @Test("graphQLOutputData keeps non-empty stdout")
+    func graphQLOutputDataUsesNonEmptyStdout() {
         let stdout = """
         {"data":{"viewer":{"pullRequests":{"nodes":[]}}}}
         """
 
-        let data = PRStatusManager.graphQLOutputData(stdout: stdout, exitStatus: 1)
+        let data = PRStatusManager.graphQLOutputData(stdout: stdout)
 
         #expect(data == stdout.data(using: .utf8))
     }
 
-    @Test("graphQLOutputData returns nil when GraphQL failure has no stdout")
-    func graphQLOutputDataRejectsEmptyStdoutOnNonZeroExit() {
-        let data = PRStatusManager.graphQLOutputData(stdout: " \n", exitStatus: 1)
+    @Test("graphQLOutputData returns nil when stdout is empty")
+    func graphQLOutputDataRejectsEmptyStdout() {
+        let data = PRStatusManager.graphQLOutputData(stdout: " \n")
 
         #expect(data == nil)
     }

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -103,6 +103,74 @@ struct PRStatusManagerTests {
         #expect(nodes[1].headRefName == "tbd/old-feature")
     }
 
+    @Test("parseGraphQLResponse ignores null nodes in partial results")
+    func parsesResponseWithNullNodes() throws {
+        let json = """
+        {
+          "data": {
+            "viewer": {
+              "pullRequests": {
+                "nodes": [
+                  null,
+                  {
+                    "number": 42,
+                    "url": "https://github.com/owner/repo/pull/42",
+                    "state": "OPEN",
+                    "mergeStateStatus": "CLEAN",
+                    "reviewDecision": null,
+                    "headRefName": "tbd/cool-feature",
+                    "createdAt": "2026-03-24T10:00:00Z"
+                  },
+                  null,
+                  {
+                    "number": 7,
+                    "url": "https://github.com/owner/repo/pull/7",
+                    "state": "MERGED",
+                    "mergeStateStatus": "UNKNOWN",
+                    "reviewDecision": null,
+                    "headRefName": "tbd/old-feature",
+                    "createdAt": "2026-03-20T10:00:00Z"
+                  },
+                  {
+                    "number": 99,
+                    "url": "https://github.com/owner/repo/pull/99",
+                    "state": "OPEN",
+                    "mergeStateStatus": "CLEAN",
+                    "reviewDecision": null,
+                    "headRefName": "feature/not-tbd",
+                    "createdAt": "2026-03-24T12:00:00Z"
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let nodes = try PRStatusManager.parsePRNodes(from: json)
+        #expect(nodes.count == 2)
+        #expect(nodes[0].headRefName == "tbd/cool-feature")
+        #expect(nodes[1].headRefName == "tbd/old-feature")
+    }
+
+    @Test("graphQLOutputData keeps stdout from partial GraphQL failures")
+    func graphQLOutputDataUsesStdoutOnNonZeroExit() {
+        let stdout = """
+        {"data":{"viewer":{"pullRequests":{"nodes":[]}}}}
+        """
+
+        let data = PRStatusManager.graphQLOutputData(stdout: stdout, exitStatus: 1)
+
+        #expect(data == stdout.data(using: .utf8))
+    }
+
+    @Test("graphQLOutputData returns nil when GraphQL failure has no stdout")
+    func graphQLOutputDataRejectsEmptyStdoutOnNonZeroExit() {
+        let data = PRStatusManager.graphQLOutputData(stdout: " \n", exitStatus: 1)
+
+        #expect(data == nil)
+    }
+
     @Test("allStatuses reflects cache after manual seed")
     func cacheRoundTrip() async {
         let manager = PRStatusManager()


### PR DESCRIPTION
## Summary
- tolerate partial GraphQL results by ignoring null or non-object PR nodes during batch parsing
- keep usable stdout from `gh api graphql` even when the command exits non-zero, while leaving other `gh` calls unchanged
- add focused tests for GraphQL partial-result parsing and non-zero-exit stdout handling

## Test Plan
- [x] `swift test --filter PRStatusManagerTests`

## Notes
- assumes partial GraphQL failures still emit valid JSON for accessible viewer PRs on stdout, with inaccessible entries surfacing as null nodes and/or GraphQL errors
