### PR TITLE
fix: pass initial prompts to fresh Codex tabs

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -254,4 +254,11 @@ enum CodexProfileWriter {
 
 enum CodexSpawnCommandBuilder {
     static let command = "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox"
+
+    static func build(initialPrompt: String?) -> String {
+        guard let initialPrompt, !initialPrompt.isEmpty else {
+            return command
+        }
+        return "\(command) \(SystemPromptBuilder.shellEscape(initialPrompt))"
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -124,7 +124,7 @@ extension RPCRouter {
                 server: worktree.tmuxServer,
                 session: "main",
                 cwd: worktree.path,
-                shellCommand: CodexSpawnCommandBuilder.command,
+                shellCommand: CodexSpawnCommandBuilder.build(initialPrompt: params.prompt),
                 env: codexEnv,
                 cols: resolvedCols,
                 rows: resolvedRows

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -568,7 +568,7 @@ public struct TerminalCreateParams: Codable, Sendable {
     public let type: TerminalCreateType?
     /// Session ID to resume from (for forking a Claude session).
     public let resumeSessionID: String?
-    /// Initial prompt to send to the Claude session (only used with type: .claude).
+    /// Initial prompt for a fresh Claude or Codex session.
     public let prompt: String?
     /// Pin a specific profile ID for this terminal, bypassing resolve(repoID:).
     public let overrideProfileID: UUID?

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -508,3 +508,52 @@ func testHandleTerminalCreateCodexLaunchCommand() async throws {
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "created codex tab must not use removed --full-auto flag; got bodies: \(bodies)")
 }
+
+@Test("handleTerminalCreate passes initial prompt to fresh Codex sessions")
+func testHandleTerminalCreateCodexInitialPrompt() async throws {
+    installCodexTestHomeOverride()
+    defer { unsetenv("TBD_TEST_CODEX_HOME") }
+
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: tmux,
+            hooks: HookResolver()
+        ),
+        tmux: tmux
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-create-codex-prompt", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-create-codex-prompt",
+        branch: "tbd/wt-create-codex-prompt",
+        path: "/tmp/fake-repo-create-codex-prompt/wt-create-codex-prompt",
+        tmuxServer: "tbd-c0de9876"
+    )
+
+    let request = try RPCRequest(
+        method: RPCMethod.terminalCreate,
+        params: TerminalCreateParams(
+            worktreeID: wt.id,
+            type: .codex,
+            prompt: "don't ship regressions"
+        )
+    )
+    let response = await router.handle(request)
+    #expect(response.success, "expected success; error: \(response.error ?? "nil")")
+
+    let bodies = newWindowBodies(recorded.snapshot())
+    #expect(bodies.contains {
+        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox 'don'\\''t ship regressions'")
+    }, "fresh codex tab must append the initial prompt as a shell-escaped positional argument; got bodies: \(bodies)")
+}


### PR DESCRIPTION
## Summary
- pass `TerminalCreateParams.prompt` through fresh Codex terminal creation
- keep Codex recreate behavior unchanged so prompt replay still matches Claude semantics
- add a regression test for shell-escaped Codex initial prompts and update the shared RPC comment

## Test Plan
- swift test --filter testHandleTerminalCreateCodexInitialPrompt
- swift test --filter testHandleTerminalCreateCodexLaunchCommand
- swift test --filter testHandleTerminalRecreateWindowCodexLaunchCommand
- swift test --filter RPCRouterTests