### PR TITLE
fix: keep non-tbd branches in PR sync

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -142,8 +142,7 @@ public actor PRStatusManager {
                   let state = node["state"] as? String,
                   let mergeStateStatus = node["mergeStateStatus"] as? String,
                   let headRefName = node["headRefName"] as? String,
-                  let createdAt = node["createdAt"] as? String,
-                  headRefName.hasPrefix("tbd/") else { return nil }
+                  let createdAt = node["createdAt"] as? String else { return nil }
             let reviewDecision = node["reviewDecision"] as? String ?? ""
             return PRNode(number: number, url: url, state: state,
                           mergeStateStatus: mergeStateStatus,

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -52,7 +52,7 @@ struct PRStatusManagerTests {
 
     // MARK: - JSON parsing
 
-    @Test("parseGraphQLResponse extracts matching branches")
+    @Test("parseGraphQLResponse keeps all branch names")
     func parsesResponse() throws {
         let json = """
         {
@@ -95,12 +95,12 @@ struct PRStatusManagerTests {
         """.data(using: .utf8)!
 
         let nodes = try PRStatusManager.parsePRNodes(from: json)
-        // Only tbd/ branches
-        #expect(nodes.count == 2)
+        #expect(nodes.count == 3)
         #expect(nodes[0].headRefName == "tbd/cool-feature")
         #expect(nodes[0].state == "OPEN")
         #expect(nodes[0].mergeStateStatus == "CLEAN")
         #expect(nodes[1].headRefName == "tbd/old-feature")
+        #expect(nodes[2].headRefName == "feature/not-tbd")
     }
 
     @Test("parseGraphQLResponse ignores null nodes in partial results")
@@ -148,9 +148,10 @@ struct PRStatusManagerTests {
         """.data(using: .utf8)!
 
         let nodes = try PRStatusManager.parsePRNodes(from: json)
-        #expect(nodes.count == 2)
+        #expect(nodes.count == 3)
         #expect(nodes[0].headRefName == "tbd/cool-feature")
         #expect(nodes[1].headRefName == "tbd/old-feature")
+        #expect(nodes[2].headRefName == "feature/not-tbd")
     }
 
     @Test("graphQLOutputData keeps non-empty stdout")


### PR DESCRIPTION
## Summary
- stop filtering GraphQL PR nodes to `tbd/*` branch names
- keep batch PR sync matching available for non-`tbd/*` branches
- update parser tests to cover mixed branch-name responses

## Verification
- `swift test --filter PRStatusManagerTests`
