### PR TITLE
Feat: Auto-dismiss notification banners when the worktree they were about becomes visible

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -372,8 +372,11 @@ final class AppState: ObservableObject {
             guard let self else { return }
             // Dismiss banners for any worktree that is already visible so
             // stale Notification Center entries are cleared when TBD comes
-            // to the foreground.
-            self.macNotificationManager.dismissDelivered(worktreeIDs: self.visibleWorktreeIDs)
+            // to the foreground. The observer runs on .main, but the closure
+            // is Sendable from Swift 6's view — hop via assumeIsolated.
+            MainActor.assumeIsolated {
+                self.macNotificationManager.dismissDelivered(worktreeIDs: self.visibleWorktreeIDs)
+            }
             Task { [weak self] in
                 guard let self else { return }
                 do {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -370,6 +370,10 @@ final class AppState: ObservableObject {
             queue: .main
         ) { [weak self] _ in
             guard let self else { return }
+            // Dismiss banners for any worktree that is already visible so
+            // stale Notification Center entries are cleared when TBD comes
+            // to the foreground.
+            self.macNotificationManager.dismissDelivered(worktreeIDs: self.visibleWorktreeIDs)
             Task { [weak self] in
                 guard let self else { return }
                 do {

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -282,6 +282,7 @@ struct ContentView: View {
                 await appState.markNotificationsRead(worktreeID: worktreeID)
             }
         }
+        appState.macNotificationManager.dismissDelivered(worktreeIDs: selection)
     }
 
 }

--- a/Sources/TBDApp/Services/MacNotificationManager.swift
+++ b/Sources/TBDApp/Services/MacNotificationManager.swift
@@ -91,6 +91,16 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         handler([.banner])
     }
 
+    /// Remove delivered banners for the given worktrees from Notification Center.
+    /// Safe to call on unbundled executables — guarded by `isAvailable`.
+    /// Empty sequences are a no-op.
+    func dismissDelivered(worktreeIDs: some Sequence<UUID>) {
+        guard isAvailable else { return }
+        let identifiers = worktreeIDs.map(\.uuidString)
+        guard !identifiers.isEmpty else { return }
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: identifiers)
+    }
+
     /// Parse a notification request identifier and navigate to the matching worktree.
     /// Factored out of the delegate method so it's testable without faking
     /// `UNNotificationResponse` (which has no public initializer).

--- a/Tests/TBDAppTests/MacNotificationManagerClickTests.swift
+++ b/Tests/TBDAppTests/MacNotificationManagerClickTests.swift
@@ -66,3 +66,29 @@ private func tearDown(_ suiteName: String) {
 
     #expect(manager.appState == nil)
 }
+
+// MARK: - dismissDelivered tests
+
+@MainActor
+@Test func dismissDelivered_emptySequence_doesNotCrash() async {
+    // Empty input must be a no-op — no assertion, just verify no crash or
+    // precondition failure.
+    let manager = MacNotificationManager()
+    manager.dismissDelivered(worktreeIDs: [] as [UUID])
+}
+
+@MainActor
+@Test func dismissDelivered_nonEmptyOnUnbundled_doesNotCrash() async {
+    // In the unbundled test process, isAvailable is false, so the call
+    // returns early without touching UNUserNotificationCenter.
+    let manager = MacNotificationManager()
+    let ids = [UUID(), UUID(), UUID()]
+    manager.dismissDelivered(worktreeIDs: ids)
+    // If we reach here without crashing, the guard is working correctly.
+}
+
+@MainActor
+@Test func dismissDelivered_singleID_doesNotCrash() async {
+    let manager = MacNotificationManager()
+    manager.dismissDelivered(worktreeIDs: [UUID()])
+}


### PR DESCRIPTION
## Summary

- macOS notification banners stayed in Notification Center even after the user switched to (or already had visible) the worktree the notification was about, leaving a stale pile of badges that no longer match what the user is looking at.
- `MacNotificationManager` already uses `worktreeID.uuidString` as the `UNNotificationRequest.identifier`, so dismissal is a one-call API: new `dismissDelivered(worktreeIDs:)` wraps `UNUserNotificationCenter.removeDeliveredNotifications(withIdentifiers:)`, guarded by the existing `isAvailable` bundle check and short-circuiting on empty input.
- Two hook points: (1) `ContentView.markSelectedWorktreesAsRead` — fires on sidebar selection change, alongside the existing in-app/DB mark-read. (2) `AppState.registerFocusObservers` — `didBecomeActiveNotification` now also dismisses banners for `visibleWorktreeIDs`, so backgrounded TBD coming forward clears stale banners for selected + pinned worktrees too. The `assumeIsolated` hop matches the observer's `queue: .main`.

## Test plan

- [ ] Background TBD, generate a notification for a non-visible worktree (e.g. trigger an AskUserQuestion in another worktree's terminal), confirm banner appears.
- [ ] Click into TBD on a different worktree, then select the worktree the banner was for — the banner should disappear from Notification Center.
- [ ] Background TBD with a worktree already selected, generate a banner for that worktree (e.g. by waiting through a Stop hook from outside), bring TBD forward — banner should clear without needing to re-select.
- [ ] Pinned-but-not-selected worktree: notification arrives → since pinned worktrees are in `visibleWorktreeIDs`, banner should be suppressed at post time (existing behavior) and any pre-existing delivered banner should clear when TBD comes forward.
- [ ] `swift test` — three new tests in `MacNotificationManagerClickTests` cover empty-input no-op and unbundled-process safe paths.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=080E13B5-8C28-4614-AC2E-71AAB5F9D834)