### PR TITLE
fix: make PR status sync upstream-aware

### DIFF
--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -67,6 +67,25 @@ public struct GitManager: Sendable {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Returns the upstream head branch name configured for the current worktree branch.
+    public func upstreamBranchName(worktreePath: String, branch: String) async -> String? {
+        guard let mergeRef = try? await run(
+            arguments: ["config", "--get", "branch.\(branch).merge"],
+            at: worktreePath
+        ) else {
+            return nil
+        }
+
+        let trimmed = mergeRef.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefix = "refs/heads/"
+        if trimmed.hasPrefix(prefix) {
+            let branchName = String(trimmed.dropFirst(prefix.count))
+            return branchName.isEmpty ? nil : branchName
+        }
+
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// Fetches from origin for the given branch.
     public func fetch(repoPath: String, branch: String) async throws {
         _ = try await run(arguments: ["fetch", "origin", branch], at: repoPath)

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -70,25 +70,33 @@ public actor PRStatusManager {
     }
 
     /// Refresh a single worktree using `gh pr view`. Used for on-select refresh.
-    public func refresh(worktreeID: UUID, branch: String, repoPath: String) async -> PRStatus? {
-        let args = ["pr", "view", branch,
-                    "--json", "number,url,state,mergeStateStatus,reviewDecision"]
-        guard let output = await runGH(args: args, repoPath: repoPath),
-              let data = output.data(using: .utf8),
-              let obj = try? JSONDecoder().decode(GHPRViewResult.self, from: data) else {
-            // gh exited non-zero or parse failed — leave cache unchanged
-            return cache[worktreeID]
+    public func refresh(worktreeID: UUID, branch: String, upstreamBranch: String?, repoPath: String) async -> PRStatus? {
+        let candidates = Self.branchCandidates(
+            localBranch: branch,
+            upstreamBranch: upstreamBranch
+        )
+        for candidate in candidates {
+            let args = ["pr", "view", candidate,
+                        "--json", "number,url,state,mergeStateStatus,reviewDecision"]
+            guard let output = await runGH(args: args, repoPath: repoPath),
+                  let data = output.data(using: .utf8),
+                  let obj = try? JSONDecoder().decode(GHPRViewResult.self, from: data) else {
+                continue
+            }
+
+            let status = PRStatus(
+                number: obj.number,
+                url: obj.url,
+                state: Self.mapState(ghState: obj.state,
+                                     mergeStateStatus: obj.mergeStateStatus,
+                                     reviewDecision: obj.reviewDecision ?? "")
+            )
+            cache[worktreeID] = status
+            return status
         }
 
-        let status = PRStatus(
-            number: obj.number,
-            url: obj.url,
-            state: Self.mapState(ghState: obj.state,
-                                 mergeStateStatus: obj.mergeStateStatus,
-                                 reviewDecision: obj.reviewDecision ?? "")
-        )
-        cache[worktreeID] = status
-        return status
+        // gh exited non-zero or parse failed for every candidate — leave cache unchanged.
+        return cache[worktreeID]
     }
 
     /// For tests only: seed a cache entry directly.

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -19,11 +19,11 @@ public actor PRStatusManager {
     public func invalidate(worktreeID: UUID) { cache.removeValue(forKey: worktreeID) }
 
     /// Fetch all viewer PRs in one GraphQL call and update cache for all known worktrees.
-    /// worktrees: list of (id, branch, repoPath) for active non-main worktrees.
-    public func fetchAll(worktrees: [(id: UUID, branch: String, repoPath: String)]) async {
+    /// worktrees: list of (id, branch, upstreamBranch, worktreePath) for active non-main worktrees.
+    public func fetchAll(worktrees: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String)]) async {
         guard !worktrees.isEmpty else { return }
         // All worktrees share one repo; any path works as gh's working directory for auth.
-        let repoPath = worktrees[0].repoPath
+        let repoPath = worktrees[0].worktreePath
 
         guard let jsonData = await runGHGraphQL(repoPath: repoPath) else { return }
 
@@ -55,7 +55,11 @@ public actor PRStatusManager {
         // limited to 100 PRs across all repos, so older PRs may not appear.
         // Those entries may have been populated by a targeted `refresh` call.
         for wt in worktrees {
-            if let node = byBranch[wt.branch] {
+            let candidates = Self.branchCandidates(
+                localBranch: wt.branch,
+                upstreamBranch: wt.upstreamBranch
+            )
+            if let node = candidates.compactMap({ byBranch[$0] }).first {
                 cache[wt.id] = PRStatus(
                     number: node.number,
                     url: node.url,
@@ -113,6 +117,13 @@ public actor PRStatusManager {
         case "CLOSED": return 1
         default: return 0
         }
+    }
+
+    static func branchCandidates(localBranch: String, upstreamBranch: String?) -> [String] {
+        guard let upstreamBranch, upstreamBranch != localBranch else {
+            return [localBranch]
+        }
+        return [localBranch, upstreamBranch]
     }
 
     // MARK: - JSON parsing (internal but static for testability)

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -233,7 +233,20 @@ public final class RPCRouter: Sendable {
         // Fetch fresh PR data for all active worktrees before returning the cache.
         // This is called every ~30s by the app, so one GraphQL call per poll is acceptable.
         let worktrees = try await db.worktrees.list(status: .active)
-        let infos = worktrees.map { (id: $0.id, branch: $0.branch, repoPath: $0.path) }
+        var infos: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String)] = []
+        infos.reserveCapacity(worktrees.count)
+        for wt in worktrees {
+            let upstreamBranch = await git.upstreamBranchName(
+                worktreePath: wt.path,
+                branch: wt.branch
+            )
+            infos.append((
+                id: wt.id,
+                branch: wt.branch,
+                upstreamBranch: upstreamBranch,
+                worktreePath: wt.path
+            ))
+        }
         await prManager.fetchAll(worktrees: infos)
         let statuses = await prManager.allStatuses()
         return try RPCResponse(result: PRListResult(statuses: statuses))
@@ -242,16 +255,15 @@ public final class RPCRouter: Sendable {
     private func handlePRRefresh(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(PRRefreshParams.self, from: paramsData)
 
-        // Look up worktree and repo to get branch and repoPath
-        guard let wt = try await db.worktrees.get(id: params.worktreeID),
-              let repo = try await db.repos.get(id: wt.repoID) else {
+        // Run targeted refresh in the worktree so gh can see worktree-local branch config.
+        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
             return try RPCResponse(result: PRRefreshResult(status: nil))
         }
 
         let status = await prManager.refresh(
             worktreeID: wt.id,
             branch: wt.branch,
-            repoPath: repo.path
+            repoPath: wt.path
         )
         return try RPCResponse(result: PRRefreshResult(status: status))
     }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -255,14 +255,19 @@ public final class RPCRouter: Sendable {
     private func handlePRRefresh(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(PRRefreshParams.self, from: paramsData)
 
-        // Run targeted refresh in the worktree so gh can see worktree-local branch config.
+        // Run targeted refresh in the worktree and try the tracked upstream branch when needed.
         guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
             return try RPCResponse(result: PRRefreshResult(status: nil))
         }
+        let upstreamBranch = await git.upstreamBranchName(
+            worktreePath: wt.path,
+            branch: wt.branch
+        )
 
         let status = await prManager.refresh(
             worktreeID: wt.id,
             branch: wt.branch,
+            upstreamBranch: upstreamBranch,
             repoPath: wt.path
         )
         return try RPCResponse(result: PRRefreshResult(status: status))

--- a/Tests/TBDDaemonTests/GitManagerTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTests.swift
@@ -67,6 +67,17 @@ struct GitManagerTests {
         cleanup()
     }
 
+    @Test func upstreamBranchNameReturnsConfiguredMergeBranch() async throws {
+        try await GitManagerTests.shell("git checkout -b local-feature", at: repoDir)
+        try await GitManagerTests.shell("git config branch.local-feature.remote origin", at: repoDir)
+        try await GitManagerTests.shell("git config branch.local-feature.merge refs/heads/tbd/upstream-feature", at: repoDir)
+
+        let upstream = await git.upstreamBranchName(worktreePath: repoDir.path, branch: "local-feature")
+
+        #expect(upstream == "tbd/upstream-feature")
+        cleanup()
+    }
+
     /// Regression test for a race in `GitManager.run()` where the readability handler
     /// did `availableData` and `accumulator.append` in two non-atomic steps,
     /// allowing `terminationHandler` to snapshot between them and drop the chunk.

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -172,6 +172,23 @@ struct PRStatusManagerTests {
         #expect(data == nil)
     }
 
+    @Test("branchCandidates keeps only the local branch when no upstream is configured")
+    func branchCandidatesWithoutUpstream() {
+        let candidates = PRStatusManager.branchCandidates(localBranch: "feature/local", upstreamBranch: nil)
+
+        #expect(candidates == ["feature/local"])
+    }
+
+    @Test("branchCandidates includes a distinct upstream branch for PR matching")
+    func branchCandidatesWithDistinctUpstream() {
+        let candidates = PRStatusManager.branchCandidates(
+            localBranch: "feature/local",
+            upstreamBranch: "tbd/upstream-feature"
+        )
+
+        #expect(candidates == ["feature/local", "tbd/upstream-feature"])
+    }
+
     @Test("allStatuses reflects cache after manual seed")
     func cacheRoundTrip() async {
         let manager = PRStatusManager()


### PR DESCRIPTION
## Summary
- run targeted PR refresh from the worktree path so `gh pr view` can see worktree-local upstream config
- match batch PR status sync against either the local branch name or the tracked upstream head branch when they differ
- add focused tests for upstream branch resolution and branch-candidate matching

## Test Plan
- `swift test --filter GitManagerTests`
- `swift test --filter PRStatusManagerTests`
