### PR TITLE
Add primary-agent preference for worktrees

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -22,6 +22,9 @@ extension AppState {
             if result.defaultID != defaultProfileID {
                 defaultProfileID = result.defaultID
             }
+            if result.primaryAgentPreference != primaryAgentPreference {
+                primaryAgentPreference = result.primaryAgentPreference
+            }
         } catch {
             logger.error("Failed to list model profiles: \(error, privacy: .public)")
             handleConnectionError(error)
@@ -126,6 +129,17 @@ extension AppState {
         } catch {
             logger.error("Failed to set default model profile: \(error, privacy: .public)")
             showAlert("Failed to set default profile: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set the default primary agent used for new worktrees.
+    func setPrimaryAgentPreference(_ preference: PrimaryAgentPreference) async {
+        do {
+            try await daemonClient.setPrimaryAgentPreference(preference)
+            primaryAgentPreference = preference
+        } catch {
+            logger.error("Failed to set primary agent preference: \(error, privacy: .public)")
+            showAlert("Failed to set primary agent: \(error.localizedDescription)", isError: true)
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -227,6 +227,7 @@ final class AppState: ObservableObject {
     @Published var prStatuses: [UUID: PRStatus] = [:]
     @Published var modelProfiles: [ModelProfileWithUsage] = []
     @Published var defaultProfileID: UUID? = nil
+    @Published var primaryAgentPreference: PrimaryAgentPreference = .defaultValue
     /// Terminals where the user has dismissed the proxy-unreachable banner.
     /// Cleared on app relaunch (in-memory only — banners are advisory).
     @Published var dismissedProxyWarnings: Set<UUID> = []

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -860,7 +860,7 @@ actor DaemonClient {
     func setPrimaryAgentPreference(_ preference: PrimaryAgentPreference) async throws {
         try await callVoidAsync(
             method: RPCMethod.modelProfileSetPrimaryAgentPreference,
-            params: ModelProfileSetPrimaryAgentPreferenceParams(preference: preference)
+            params: ModelProfileSetAgentPreferenceParams(preference: preference)
         )
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -856,6 +856,14 @@ actor DaemonClient {
         )
     }
 
+    /// Set the default primary agent used for newly-created worktrees.
+    func setPrimaryAgentPreference(_ preference: PrimaryAgentPreference) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.modelProfileSetPrimaryAgentPreference,
+            params: ModelProfileSetPrimaryAgentPreferenceParams(preference: preference)
+        )
+    }
+
     /// Set or clear a per-repo model profile override.
     func setRepoProfileOverride(repoID: UUID, profileID: UUID?) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -31,6 +31,7 @@ struct SettingsView: View {
 // MARK: - General Tab
 
 struct GeneralSettingsTab: View {
+    @EnvironmentObject var appState: AppState
     @AppStorage("enableNotifications") private var enableNotifications: Bool = true
     @AppStorage("skipPermissions") private var skipPermissions: Bool = true
     @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = false
@@ -82,6 +83,15 @@ struct GeneralSettingsTab: View {
                 }
             }
 
+            Section("Agents") {
+                Picker("Default primary agent", selection: primaryAgentPreferenceBinding) {
+                    Text("Claude Code").tag(PrimaryAgentPreference.claude)
+                    Text("Codex").tag(PrimaryAgentPreference.codex)
+                }
+                .pickerStyle(.segmented)
+                .help("Used when TBD needs to choose the primary agent for a worktree and there is no prior agent state to restore.")
+            }
+
             Section("Claude") {
                 Toggle("Launch claude with --dangerously-skip-permissions", isOn: $skipPermissions)
                     .help("Skip the interactive permission prompt when launching claude in new worktrees")
@@ -94,6 +104,15 @@ struct GeneralSettingsTab: View {
         }
         .formStyle(.grouped)
         .padding()
+    }
+
+    private var primaryAgentPreferenceBinding: Binding<PrimaryAgentPreference> {
+        Binding(
+            get: { appState.primaryAgentPreference },
+            set: { newValue in
+                Task { await appState.setPrimaryAgentPreference(newValue) }
+            }
+        )
     }
 
     private func pickCustomSound() {

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -28,10 +28,10 @@ struct TerminalCreate: AsyncParsableCommand {
     @Option(name: .long, help: "Command to run in the terminal")
     var cmd: String?
 
-    @Option(name: .long, help: "Terminal type (shell or claude)")
+    @Option(name: .long, help: "Terminal type (shell, claude, or codex)")
     var type: TerminalCreateType?
 
-    @Option(name: .long, help: "Initial prompt to send to the Claude session (requires --type claude)")
+    @Option(name: .long, help: "Initial prompt to send to the spawned agent session (requires --type claude or --type codex)")
     var prompt: String?
 
     @Option(name: .long, help: "Read initial prompt from a file (use - for stdin)")

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -38,7 +38,7 @@ struct WorktreeCreate: AsyncParsableCommand {
     @Option(name: .long, help: "Repository path or ID")
     var repo: String?
 
-    @Option(name: .long, help: "Initial prompt for the auto-created Claude session")
+    @Option(name: .long, help: "Initial prompt for the auto-created primary agent session")
     var prompt: String?
 
     @Option(name: .long, help: "Read initial prompt from a file (use - for stdin)")

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -10,6 +10,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
 
     var id: String
     var default_profile_id: String?
+    var primary_agent_preference: String?
     /// JSON-encoded `[String: ClaudeEnvValue]` overrides map. Nil/absent
     /// means no overrides — every setting falls back to its registry default.
     var claude_env_settings: String?
@@ -17,6 +18,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     func toModel() -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
+            primaryAgentPreference: primary_agent_preference
+                .flatMap(PrimaryAgentPreference.init(rawValue:)) ?? .defaultValue,
             envSettingOverrides: ConfigStore.decodeOverrides(claude_env_settings)
         )
     }
@@ -58,6 +61,15 @@ public struct ConfigStore: Sendable {
             try db.execute(
                 sql: "UPDATE config SET default_profile_id = ? WHERE id = ?",
                 arguments: [id?.uuidString, Self.singletonID]
+            )
+        }
+    }
+
+    public func setPrimaryAgentPreference(_ preference: PrimaryAgentPreference) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET primary_agent_preference = ? WHERE id = ?",
+                arguments: [preference.rawValue, Self.singletonID]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -505,6 +505,10 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "config", column: "claude_env_settings", type: .text)
         }
 
+        migrator.registerMigration("v27_primary_agent_preference") { db in
+            try db.addColumnIfMissing(table: "config", column: "primary_agent_preference", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -351,8 +351,9 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Revive an archived worktree (set status back to active, clear archivedAt).
-    /// When `clearSessions` is true (default), also clears archivedClaudeSessions.
-    /// Pass false to preserve sessions when Claude wasn't restored (e.g. skipClaude).
+    /// When `clearSessions` is true (default), also clears archived Claude
+    /// sessions. Pass false to preserve them when the primary agent wasn't
+    /// restored (e.g. skipClaude).
     public func revive(id: UUID, clearSessions: Bool = true) async throws {
         try await writer.write { db in
             guard var record = try WorktreeRecord.fetchOne(db, key: id.uuidString) else {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -44,9 +44,8 @@ extension WorktreeLifecycle {
 
         // Collect Claude session IDs before archiving so they survive terminal deletion
         let terminals = try await db.terminals.list(worktreeID: worktreeID)
-        let claudeSessionIDs = terminals
-            .sorted(by: { $0.createdAt < $1.createdAt })
-            .compactMap { $0.claudeSessionID }
+        let sortedTerminals = terminals.sorted(by: { $0.createdAt < $1.createdAt })
+        let claudeSessionIDs = sortedTerminals.compactMap { $0.claudeSessionID }
 
         // Sync the branch in DB with what git reports for the worktree path,
         // so a rename done inside the worktree (e.g. `git branch -m`) is
@@ -153,7 +152,7 @@ extension WorktreeLifecycle {
     ///
     /// - Parameters:
     ///   - worktreeID: The archived worktree to revive.
-    ///   - skipClaude: If true, skip launching claude in the first terminal window.
+    ///   - skipClaude: If true, skip launching the primary agent in the first terminal window.
     /// - Returns: The revived worktree.
     public func reviveWorktree(worktreeID: UUID, skipClaude: Bool = false, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) async throws -> Worktree {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -201,6 +201,20 @@ extension WorktreeLifecycle {
         )
     }
 
+    private func resolvePrimaryTerminalKind(
+        skipClaude: Bool,
+        archivedClaudeSessions: [String]?,
+        configuredPreference: PrimaryAgentPreference
+    ) -> TerminalKind {
+        if skipClaude {
+            return .shell
+        }
+        if let archivedClaudeSessions, !archivedClaudeSessions.isEmpty {
+            return .claude
+        }
+        return configuredPreference.terminalKind
+    }
+
     /// Wraps a command so the user's shell takes over when it exits,
     /// preventing tmux from destroying the window and jumping to another.
     /// If the command is already the user's shell, returns it unchanged.
@@ -214,7 +228,7 @@ extension WorktreeLifecycle {
     /// Shared by `finishCreate` and `reviveWorktree`.
     ///
     /// When `archivedClaudeSessions` is provided (revive path), the first session ID
-    /// is reused for the main Claude terminal to restore the conversation, and any
+    /// is reused for the primary Claude terminal to restore the conversation, and any
     /// additional sessions get their own terminal windows.
     func setupTerminals(
         worktree: Worktree, repo: Repo,
@@ -227,7 +241,14 @@ extension WorktreeLifecycle {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
         let worktreePath = worktreePath ?? worktree.path
-        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
+        let config = try await db.config.get()
+        let claudeEnvOverrides = config.envSettingOverrides
+        let primaryTerminalKind = resolvePrimaryTerminalKind(
+            skipClaude: skipClaude,
+            archivedClaudeSessions: archivedClaudeSessions,
+            configuredPreference: config.primaryAgentPreference
+        )
+        let archivedSessions = archivedClaudeSessions ?? []
         // Resolve a usable size: prefer caller's value, otherwise fall back to
         // TmuxManager's defaults. tmux's own 80x24 default would let Claude
         // render into hard-wrapped scrollback that can never be reflowed when
@@ -245,8 +266,11 @@ extension WorktreeLifecycle {
 
         // Resolve model profile (repo override → global default → none).
         // Failures here must NOT break worktree creation — fall back to keychain login.
+        let needsResolvedClaudeProfile = !skipClaude && (
+            primaryTerminalKind == .claude || !archivedSessions.isEmpty
+        )
         var resolvedProfile: ResolvedModelProfile? = nil
-        if !skipClaude, let resolver = modelProfileResolver {
+        if needsResolvedClaudeProfile, let resolver = modelProfileResolver {
             do {
                 resolvedProfile = try await resolver.resolve(repoID: repo.id)
             } catch {
@@ -255,21 +279,41 @@ extension WorktreeLifecycle {
             }
         }
 
-        // Create terminal 1: claude (or shell if skipClaude)
+        // Create terminal 1: primary agent (or shell if skipped).
         let plannedTerminalID1 = UUID()
-        let claudeCommand: String
-        let claudeSensitiveEnv: [String: String]
-        let claudeSessionID: String?
-        let pinnedProfileID: UUID?
-        if skipClaude {
-            claudeCommand = defaultShell
-            claudeSensitiveEnv = [:]
-            claudeSessionID = nil
-            pinnedProfileID = nil
-        } else {
-            let archivedSession = archivedClaudeSessions?.first
+        let primaryCommand: String
+        let primaryEnv: [String: String]
+        let primarySensitiveEnv: [String: String]
+        let primarySessionID: String?
+        let primaryProfileID: UUID?
+        let primaryLabel: String
+        switch primaryTerminalKind {
+        case .shell:
+            primaryCommand = defaultShell
+            primaryEnv = [
+                "TBD_WORKTREE_ID": worktreeID.uuidString,
+                "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
+            ]
+            primarySensitiveEnv = [:]
+            primarySessionID = nil
+            primaryProfileID = nil
+            primaryLabel = "shell"
+        case .codex:
+            let codexHome = try CodexHomeManager().ensureProfilePlugin()
+            primaryCommand = CodexSpawnCommandBuilder.build(initialPrompt: initialPrompt)
+            primaryEnv = [
+                "TBD_WORKTREE_ID": worktreeID.uuidString,
+                "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
+                "CODEX_HOME": codexHome.path,
+            ]
+            primarySensitiveEnv = [:]
+            primarySessionID = nil
+            primaryProfileID = nil
+            primaryLabel = "Codex"
+        case .claude:
+            let archivedSession = archivedSessions.first
             let sessionUUID = archivedSession ?? UUID().uuidString
-            claudeSessionID = sessionUUID
+            primarySessionID = sessionUUID
             let isResume = archivedSession != nil
             // `--resume` is what actually restores the prior conversation;
             // `--session-id` is for starting a NEW session with a pre-chosen
@@ -296,23 +340,22 @@ extension WorktreeLifecycle {
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides
             )
-            claudeCommand = spawn.command
-            claudeSensitiveEnv = spawn.sensitiveEnv
-            pinnedProfileID = resolvedProfile?.profileID
+            primaryCommand = spawn.command
+            primaryEnv = [
+                "TBD_WORKTREE_ID": worktreeID.uuidString,
+                "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
+            ]
+            primarySensitiveEnv = spawn.sensitiveEnv
+            primaryProfileID = resolvedProfile?.profileID
+            primaryLabel = "Claude Code"
         }
-        // Inject TBD_TERMINAL_ID + TBD_WORKTREE_ID so the SessionStart hook
-        // bridge can route session events to the right terminal.
-        let claudeEnv: [String: String] = [
-            "TBD_WORKTREE_ID": worktreeID.uuidString,
-            "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
-        ]
         let window1 = try await tmux.createWindow(
             server: tmuxServer,
             session: "main",
             cwd: worktreePath,
-            shellCommand: claudeCommand,
-            env: claudeEnv,
-            sensitiveEnv: claudeSensitiveEnv,
+            shellCommand: primaryCommand,
+            env: primaryEnv,
+            sensitiveEnv: primarySensitiveEnv,
             cols: resolvedCols,
             rows: resolvedRows
         )
@@ -321,10 +364,10 @@ extension WorktreeLifecycle {
             worktreeID: worktreeID,
             tmuxWindowID: window1.windowID,
             tmuxPaneID: window1.paneID,
-            label: skipClaude ? "shell" : "Claude Code",
-            claudeSessionID: claudeSessionID,
-            profileID: pinnedProfileID,
-            kind: skipClaude ? .shell : .claude
+            label: primaryLabel,
+            claudeSessionID: primarySessionID,
+            profileID: primaryProfileID,
+            kind: primaryTerminalKind
         )
 
         // Create terminal 2: setup hook
@@ -359,9 +402,19 @@ extension WorktreeLifecycle {
             kind: .shell
         )
 
-        // Restore additional archived Claude sessions (beyond the first which was used above)
-        if !skipClaude, let sessions = archivedClaudeSessions, sessions.count > 1 {
-            for sessionID in sessions.dropFirst() {
+        // Restore any archived Claude sessions that were not consumed by the
+        // primary terminal.
+        let additionalArchivedClaudeSessions: [String]
+        switch primaryTerminalKind {
+        case .claude:
+            additionalArchivedClaudeSessions = Array(archivedSessions.dropFirst())
+        case .codex:
+            additionalArchivedClaudeSessions = archivedSessions
+        case .shell:
+            additionalArchivedClaudeSessions = []
+        }
+        if !skipClaude {
+            for sessionID in additionalArchivedClaudeSessions {
                 let plannedID = UUID()
                 let spawn = ClaudeSpawnCommandBuilder.build(
                     resumeID: sessionID,

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -15,7 +15,11 @@ extension RPCRouter {
             ModelProfileWithUsage(profile: profile, usage: usageByID[profile.id])
         }
         let config = try await db.config.get()
-        return try RPCResponse(result: ModelProfileListResult(profiles: result, defaultID: config.defaultProfileID))
+        return try RPCResponse(result: ModelProfileListResult(
+            profiles: result,
+            defaultID: config.defaultProfileID,
+            primaryAgentPreference: config.primaryAgentPreference
+        ))
     }
 
     // MARK: - Add
@@ -253,6 +257,13 @@ extension RPCRouter {
     func handleModelProfileSetGlobalDefault(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ModelProfileSetGlobalDefaultParams.self, from: paramsData)
         try await db.config.setDefaultProfileID(params.id)
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
+    func handleModelProfileSetPrimaryAgentPreference(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ModelProfileSetPrimaryAgentPreferenceParams.self, from: paramsData)
+        try await db.config.setPrimaryAgentPreference(params.preference)
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -262,7 +262,7 @@ extension RPCRouter {
     }
 
     func handleModelProfileSetPrimaryAgentPreference(_ paramsData: Data) async throws -> RPCResponse {
-        let params = try decoder.decode(ModelProfileSetPrimaryAgentPreferenceParams.self, from: paramsData)
+        let params = try decoder.decode(ModelProfileSetAgentPreferenceParams.self, from: paramsData)
         try await db.config.setPrimaryAgentPreference(params.preference)
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -188,6 +188,8 @@ public final class RPCRouter: Sendable {
                 return try await handleModelProfileUpdateBedrock(request.paramsData)
             case RPCMethod.modelProfileSetGlobalDefault:
                 return try await handleModelProfileSetGlobalDefault(request.paramsData)
+            case RPCMethod.modelProfileSetPrimaryAgentPreference:
+                return try await handleModelProfileSetPrimaryAgentPreference(request.paramsData)
             case RPCMethod.modelProfileSetRepoOverride:
                 return try await handleModelProfileSetRepoOverride(request.paramsData)
             case RPCMethod.modelProfileFetchUsage:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -76,6 +76,26 @@ public enum WorktreeStatus: String, Codable, Sendable {
     case active, archived, main, creating, failed
 }
 
+public enum TerminalKind: String, Codable, Sendable {
+    case shell
+    case claude
+    case codex
+}
+
+public enum PrimaryAgentPreference: String, Codable, Sendable, Equatable, CaseIterable {
+    case claude
+    case codex
+
+    public static let defaultValue: Self = .claude
+
+    public var terminalKind: TerminalKind {
+        switch self {
+        case .claude: return .claude
+        case .codex: return .codex
+        }
+    }
+}
+
 public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var repoID: UUID
@@ -153,12 +173,6 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         liveClaudeSessionCount = try c.decodeIfPresent(Int.self, forKey: .liveClaudeSessionCount)
         parentWorktreeID = try c.decodeIfPresent(UUID.self, forKey: .parentWorktreeID)
     }
-}
-
-public enum TerminalKind: String, Codable, Sendable {
-    case shell
-    case claude
-    case codex
 }
 
 public struct Terminal: Codable, Sendable, Identifiable, Equatable {
@@ -346,18 +360,25 @@ public struct ModelProfileWithUsage: Codable, Sendable, Equatable {
 
 public struct Config: Codable, Sendable, Equatable {
     public var defaultProfileID: UUID?
+    public var primaryAgentPreference: PrimaryAgentPreference
     /// Claude spawn-env setting overrides, keyed by `ClaudeEnvSetting.id`.
     public var envSettingOverrides: [String: ClaudeEnvValue]
 
     public init(defaultProfileID: UUID? = nil,
+                primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
                 envSettingOverrides: [String: ClaudeEnvValue] = [:]) {
         self.defaultProfileID = defaultProfileID
+        self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         defaultProfileID = try c.decodeIfPresent(UUID.self, forKey: .defaultProfileID)
+        primaryAgentPreference = try c.decodeIfPresent(
+            PrimaryAgentPreference.self,
+            forKey: .primaryAgentPreference
+        ) ?? .defaultValue
         envSettingOverrides = try c.decodeIfPresent(
             [String: ClaudeEnvValue].self, forKey: .envSettingOverrides) ?? [:]
     }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -301,7 +301,7 @@ public struct ModelProfileSetGlobalDefaultParams: Codable, Sendable {
     public init(id: UUID?) { self.id = id }
 }
 
-public struct ModelProfileSetPrimaryAgentPreferenceParams: Codable, Sendable {
+public struct ModelProfileSetAgentPreferenceParams: Codable, Sendable {
     public let preference: PrimaryAgentPreference
     public init(preference: PrimaryAgentPreference) { self.preference = preference }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -125,6 +125,7 @@ public enum RPCMethod {
     public static let modelProfileUpdateEndpoint = "modelProfile.updateEndpoint"
     public static let modelProfileUpdateBedrock = "modelProfile.updateBedrock"
     public static let modelProfileSetGlobalDefault = "modelProfile.setGlobalDefault"
+    public static let modelProfileSetPrimaryAgentPreference = "modelProfile.setPrimaryAgentPreference"
     public static let modelProfileSetRepoOverride = "modelProfile.setRepoOverride"
     public static let modelProfileFetchUsage = "modelProfile.fetchUsage"
     public static let modelProfileHealthCheck = "modelProfile.healthCheck"
@@ -300,6 +301,11 @@ public struct ModelProfileSetGlobalDefaultParams: Codable, Sendable {
     public init(id: UUID?) { self.id = id }
 }
 
+public struct ModelProfileSetPrimaryAgentPreferenceParams: Codable, Sendable {
+    public let preference: PrimaryAgentPreference
+    public init(preference: PrimaryAgentPreference) { self.preference = preference }
+}
+
 public struct ModelProfileSetRepoOverrideParams: Codable, Sendable {
     public let repoID: UUID
     public let profileID: UUID?
@@ -316,15 +322,25 @@ public struct ModelProfileFetchUsageParams: Codable, Sendable {
 public struct ModelProfileListResult: Codable, Sendable {
     public let profiles: [ModelProfileWithUsage]
     public let defaultID: UUID?
-    public init(profiles: [ModelProfileWithUsage], defaultID: UUID? = nil) {
+    public let primaryAgentPreference: PrimaryAgentPreference
+    public init(
+        profiles: [ModelProfileWithUsage],
+        defaultID: UUID? = nil,
+        primaryAgentPreference: PrimaryAgentPreference = .defaultValue
+    ) {
         self.profiles = profiles
         self.defaultID = defaultID
+        self.primaryAgentPreference = primaryAgentPreference
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         profiles = try c.decode([ModelProfileWithUsage].self, forKey: .profiles)
         defaultID = try c.decodeIfPresent(UUID.self, forKey: .defaultID)
+        primaryAgentPreference = try c.decodeIfPresent(
+            PrimaryAgentPreference.self,
+            forKey: .primaryAgentPreference
+        ) ?? .defaultValue
     }
 }
 

--- a/Tests/TBDAppTests/ModelProfileAppStateTests.swift
+++ b/Tests/TBDAppTests/ModelProfileAppStateTests.swift
@@ -13,6 +13,7 @@ import TBDShared
     let state = AppState()
     #expect(state.modelProfiles.isEmpty)
     #expect(state.defaultProfileID == nil)
+    #expect(state.primaryAgentPreference == .claude)
 }
 
 @MainActor

--- a/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("CodexSpawnCommandBuilder")
+struct CodexSpawnCommandBuilderTests {
+    @Test("base command remains unchanged when no prompt is supplied")
+    func baseCommand() {
+        #expect(
+            CodexSpawnCommandBuilder.build(initialPrompt: nil)
+                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox"
+        )
+    }
+
+    @Test("initial prompt is appended as a shell-escaped trailing argument")
+    func appendsInitialPrompt() {
+        #expect(
+            CodexSpawnCommandBuilder.build(initialPrompt: "fix the failing test")
+                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox 'fix the failing test'"
+        )
+    }
+}

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -9,6 +9,7 @@ struct ConfigStoreTests {
         let db = try TBDDatabase(inMemory: true)
         let cfg = try await db.config.get()
         #expect(cfg.defaultProfileID == nil)
+        #expect(cfg.primaryAgentPreference == .claude)
     }
 
     @Test func setAndGetDefaultClaudeTokenID() async throws {
@@ -47,5 +48,12 @@ struct ConfigStoreTests {
         try await db.config.setEnvSettingOverrides([:])
         let cfg = try await db.config.get()
         #expect(cfg.envSettingOverrides.isEmpty)
+    }
+
+    @Test func setAndGetPrimaryAgentPreference() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPrimaryAgentPreference(.codex)
+        let cfg = try await db.config.get()
+        #expect(cfg.primaryAgentPreference == .codex)
     }
 }

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -549,7 +549,7 @@ struct ModelProfileRPCTests {
         #expect(setResp.success)
         #expect(try await db.config.get().primaryAgentPreference == .codex)
 
-        let listResp = await router.handle(try RPCRequest(method: RPCMethod.modelProfileList))
+        let listResp = await router.handle(RPCRequest(method: RPCMethod.modelProfileList))
         let result = try listResp.decodeResult(ModelProfileListResult.self)
         #expect(result.primaryAgentPreference == .codex)
     }

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -544,7 +544,7 @@ struct ModelProfileRPCTests {
         let (router, db, _) = makeRouter()
         let setResp = await router.handle(try RPCRequest(
             method: RPCMethod.modelProfileSetPrimaryAgentPreference,
-            params: ModelProfileSetPrimaryAgentPreferenceParams(preference: .codex)
+            params: ModelProfileSetAgentPreferenceParams(preference: .codex)
         ))
         #expect(setResp.success)
         #expect(try await db.config.get().primaryAgentPreference == .codex)

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -539,6 +539,21 @@ struct ModelProfileRPCTests {
         #expect(try await db.config.get().defaultProfileID == nil)
     }
 
+    @Test("setPrimaryAgentPreference round-trip and list reports value")
+    func setPrimaryAgentPreference() async throws {
+        let (router, db, _) = makeRouter()
+        let setResp = await router.handle(try RPCRequest(
+            method: RPCMethod.modelProfileSetPrimaryAgentPreference,
+            params: ModelProfileSetPrimaryAgentPreferenceParams(preference: .codex)
+        ))
+        #expect(setResp.success)
+        #expect(try await db.config.get().primaryAgentPreference == .codex)
+
+        let listResp = await router.handle(try RPCRequest(method: RPCMethod.modelProfileList))
+        let result = try listResp.decodeResult(ModelProfileListResult.self)
+        #expect(result.primaryAgentPreference == .codex)
+    }
+
     @Test("setRepoOverride round-trip")
     func setRepoOverride() async throws {
         let (router, db, _) = makeRouter()

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -29,6 +29,68 @@ import Testing
     #expect(terminals.count == 2)
 }
 
+@Test func testCreateWorktreeUsesCodexPrimaryAgentPreference() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    try await db.config.setPrimaryAgentPreference(.codex)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let result = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+
+    let terminals = try await db.terminals.list(worktreeID: result.id)
+    #expect(terminals.count == 2)
+    #expect(terminals.contains { $0.kind == .codex && $0.label == "Codex" })
+    #expect(!terminals.contains { $0.kind == .claude || $0.label == "Claude Code" })
+}
+
+@Test func testCreateWorktreeWithCodexPreferenceDoesNotResolveClaudeProfile() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    try await db.config.setPrimaryAgentPreference(.codex)
+
+    let profile = try await db.modelProfiles.create(name: "Test", kind: .apiKey)
+    try await db.config.setDefaultProfileID(profile.id)
+
+    let keychainLookups = LockedInt()
+    let resolver = ModelProfileResolver(
+        profiles: db.modelProfiles,
+        repos: db.repos,
+        config: db.config,
+        keychain: { id in
+            keychainLookups.increment()
+            if id == profile.id.uuidString {
+                return "sk-ant-api03-FAKETOKEN_value"
+            }
+            return nil
+        }
+    )
+
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver(),
+        modelProfileResolver: resolver
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let result = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+
+    let terminals = try await db.terminals.list(worktreeID: result.id)
+    #expect(terminals.contains { $0.kind == .codex && $0.profileID == nil })
+    #expect(keychainLookups.value == 0)
+}
+
 @Test func testCreateWorktreeRepoNotFound() async throws {
     let db = try TBDDatabase(inMemory: true)
     let lifecycle = WorktreeLifecycle(
@@ -348,6 +410,53 @@ import Testing
     let archived = try await db.worktrees.get(id: wt.id)
     #expect(archived?.archivedClaudeSessions == nil,
             "Should not save empty session list")
+}
+
+@Test func testReviveWithArchivedClaudeSessionsPrefersClaudeOverCurrentSetting() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+    try await db.config.setPrimaryAgentPreference(.codex)
+
+    let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: false)
+    let terminals = try await db.terminals.list(worktreeID: revived.id)
+    #expect(terminals.contains { $0.kind == .claude && $0.label == "Claude Code" })
+}
+
+@Test func testReviveWithoutPriorPrimaryAgentFallsBackToConfiguredPreference() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+    try await db.config.setPrimaryAgentPreference(.codex)
+
+    let archived = try await db.worktrees.get(id: wt.id)
+    #expect(archived?.archivedClaudeSessions == nil)
+
+    let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: false)
+    let terminals = try await db.terminals.list(worktreeID: revived.id)
+    #expect(terminals.contains { $0.kind == .codex && $0.label == "Codex" })
 }
 
 @Test func testReviveWithSkipClaudePreservesSessions() async throws {
@@ -841,5 +950,20 @@ private final class LifecycleRecordedCommands: @unchecked Sendable {
     func snapshot() -> [[String]] {
         lock.lock(); defer { lock.unlock() }
         return commands
+    }
+}
+
+private final class LockedInt: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+
+    func increment() {
+        lock.lock(); defer { lock.unlock() }
+        storage += 1
+    }
+
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return storage
     }
 }

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -6,6 +6,10 @@ import Testing
     #expect(TBDConstants.version == "0.1.0")
 }
 
+@Test func testPrimaryAgentPreferenceDefault() {
+    #expect(PrimaryAgentPreference.defaultValue == .claude)
+}
+
 // MARK: - Model Codable Round-Trips
 
 @Test func testRepoRoundTrip() throws {
@@ -105,6 +109,17 @@ import Testing
     #expect(decoded.name == "old-worktree")
     #expect(decoded.hasConflicts == false)
     #expect(decoded.archivedAt == nil)
+}
+
+@Test func modelProfileListResultDecodesWithoutPrimaryAgentPreference() throws {
+    let json = """
+    {
+      "profiles": [],
+      "defaultID": null
+    }
+    """.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(ModelProfileListResult.self, from: json)
+    #expect(decoded.primaryAgentPreference == .claude)
 }
 
 // MARK: - NotificationType Severity Ordering


### PR DESCRIPTION
## Summary
- add a persisted Settings preference to choose the default primary agent for new worktrees (`Claude Code` or `Codex`)
- use that preference when TBD needs to choose a primary agent, while still reviving archived Claude session state as Claude-first
- pass initial prompts through Codex worktree and terminal spawn paths, and cover the new behavior with focused tests
<img width="483" height="122" alt="image" src="https://github.com/user-attachments/assets/23c41569-4265-47b1-8fc2-3074b1100cda" />


## Test Plan
- `swift test --filter 'ConfigStoreTests|ModelProfileRPCTests|ModelProfileAppStateTests|ModelsTests|WorktreeLifecycleTests|CodexSpawnCommandBuilderTests'`
