### PR TITLE
fix: clarify PR status semantics

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -309,33 +309,16 @@ private func overlayFrameIsWindowRoot(
 private struct PRButtonLabel: View {
     let prStatus: PRStatus
 
-    private var iconName: String {
-        switch prStatus.state {
-        case .open, .changesRequested, .mergeable: return "git-pull-request"
-        case .merged:                              return "git-merge"
-        case .closed:                              return "git-pull-request-closed"
-        }
-    }
-
-    private var iconColor: Color {
-        switch prStatus.state {
-        case .open:             return .secondary
-        case .changesRequested: return .red
-        case .mergeable:        return .green
-        case .merged:           return .purple
-        case .closed:           return .secondary
-        }
-    }
-
     var body: some View {
         HStack(spacing: 3) {
-            if let nsImage = loadIcon(iconName) {
+            if let presentation = PRStatusPresentation.make(for: prStatus),
+               let nsImage = loadIcon(presentation.iconName) {
                 Image(nsImage: nsImage)
                     .renderingMode(.template)
                     .resizable()
                     .scaledToFit()
                     .frame(width: 12, height: 12)
-                    .foregroundStyle(iconColor)
+                    .foregroundStyle(presentation.color)
             }
             Text("#\(prStatus.number)")
                 .font(.caption)

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import TBDShared
+
+struct PRStatusPresentation: Equatable {
+    enum ColorSemantic: Equatable {
+        case neutral
+        case checksFailed
+        case draft
+        case mergeable
+        case merged
+    }
+
+    let iconName: String
+    let colorSemantic: ColorSemantic
+
+    var color: Color {
+        switch colorSemantic {
+        case .neutral:          return .secondary
+        case .checksFailed:     return .red
+        case .draft:            return .secondary
+        case .mergeable:        return .green
+        case .merged:           return .purple
+        }
+    }
+
+    static func make(for prStatus: PRStatus?) -> PRStatusPresentation? {
+        guard let prStatus else { return nil }
+        switch prStatus.state {
+        case .open:
+            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .neutral)
+        case .changesRequested:
+            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .neutral)
+        case .checksFailed:
+            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .checksFailed)
+        case .draft:
+            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .draft)
+        case .mergeable:
+            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .mergeable)
+        case .merged:
+            return PRStatusPresentation(iconName: "git-merge", colorSemantic: .merged)
+        case .closed:
+            return PRStatusPresentation(iconName: "git-pull-request-closed", colorSemantic: .neutral)
+        }
+    }
+}

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -3,8 +3,8 @@ import TBDShared
 
 struct PRStatusPresentation: Equatable {
     enum ColorSemantic: Equatable {
-        case neutral
-        case checksFailed
+        case pending
+        case nonMergeable
         case draft
         case mergeable
         case merged
@@ -15,8 +15,8 @@ struct PRStatusPresentation: Equatable {
 
     var color: Color {
         switch colorSemantic {
-        case .neutral:          return .secondary
-        case .checksFailed:     return .red
+        case .pending:          return .yellow
+        case .nonMergeable:     return .red
         case .draft:            return .secondary
         case .mergeable:        return .green
         case .merged:           return .purple
@@ -26,12 +26,14 @@ struct PRStatusPresentation: Equatable {
     static func make(for prStatus: PRStatus?) -> PRStatusPresentation? {
         guard let prStatus else { return nil }
         switch prStatus.state {
-        case .open:
-            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .neutral)
+        case .pending:
+            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .pending)
+        case .blocked:
+            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .nonMergeable)
         case .changesRequested:
-            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .neutral)
+            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .nonMergeable)
         case .checksFailed:
-            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .checksFailed)
+            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .nonMergeable)
         case .draft:
             return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .draft)
         case .mergeable:
@@ -39,7 +41,7 @@ struct PRStatusPresentation: Equatable {
         case .merged:
             return PRStatusPresentation(iconName: "git-merge", colorSemantic: .merged)
         case .closed:
-            return PRStatusPresentation(iconName: "git-pull-request-closed", colorSemantic: .neutral)
+            return PRStatusPresentation(iconName: "git-pull-request-closed", colorSemantic: .nonMergeable)
         }
     }
 }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -1,16 +1,15 @@
 import SwiftUI
 import TBDShared
 
-enum WorktreeRowIndicator: Equatable {
-    case conflict
+enum WorktreeRowConflictFallback {
+    static let iconName = "hand.raised.slash.fill"
 
-    static func make(
+    static func shouldShow(
         prStatus: PRStatus?,
         hasConflicts: Bool,
         hasNotification: Bool
-    ) -> WorktreeRowIndicator? {
-        guard prStatus == nil, hasConflicts, !hasNotification else { return nil }
-        return .conflict
+    ) -> Bool {
+        prStatus == nil && hasConflicts && !hasNotification
     }
 }
 
@@ -29,6 +28,10 @@ struct WorktreeRowView: View {
 
     private var notification: NotificationType? {
         appState.unreadByWorktree[worktree.id]?.type
+    }
+
+    private var prStatus: PRStatus? {
+        appState.prStatuses[worktree.id]
     }
 
     private var hasBoldNotification: Bool {
@@ -52,22 +55,17 @@ struct WorktreeRowView: View {
         }
     }
 
-    private var fallbackIndicator: WorktreeRowIndicator? {
-        WorktreeRowIndicator.make(
-            prStatus: appState.prStatuses[worktree.id],
+    private var showsConflictFallback: Bool {
+        WorktreeRowConflictFallback.shouldShow(
+            prStatus: prStatus,
             hasConflicts: worktree.hasConflicts,
             hasNotification: notification != nil
         )
     }
 
-    private var worktreeIcon: String? {
+    private var prPresentation: PRStatusPresentation? {
         guard !isMain else { return nil }
-        return PRStatusPresentation.make(for: appState.prStatuses[worktree.id])?.iconName
-    }
-
-    private var worktreeIconColor: Color {
-        guard !isMain else { return .secondary }
-        return PRStatusPresentation.make(for: appState.prStatuses[worktree.id])?.color ?? .secondary
+        return PRStatusPresentation.make(for: prStatus)
     }
 
     private var hasSuspendedTerminal: Bool {
@@ -89,18 +87,18 @@ struct WorktreeRowView: View {
             Circle()
                 .fill(color)
                 .frame(width: 8, height: 8)
-        } else if fallbackIndicator == .conflict {
-            Image(systemName: "xmark")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(.yellow)
+        } else if showsConflictFallback {
+            Image(systemName: WorktreeRowConflictFallback.iconName)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.red)
         }
-        if let icon = worktreeIcon, let nsImage = loadIcon(icon) {
+        if let presentation = prPresentation, let nsImage = loadIcon(presentation.iconName) {
             Image(nsImage: nsImage)
                 .renderingMode(.template)
                 .resizable()
                 .scaledToFit()
                 .frame(width: 12, height: 12)
-                .foregroundStyle(worktreeIconColor)
+                .foregroundStyle(presentation.color)
         }
     }
 

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -1,6 +1,19 @@
 import SwiftUI
 import TBDShared
 
+enum WorktreeRowIndicator: Equatable {
+    case conflict
+
+    static func make(
+        prStatus: PRStatus?,
+        hasConflicts: Bool,
+        hasNotification: Bool
+    ) -> WorktreeRowIndicator? {
+        guard prStatus == nil, hasConflicts, !hasNotification else { return nil }
+        return .conflict
+    }
+}
+
 struct WorktreeRowView: View {
     let worktree: Worktree
     var isMain: Bool = false
@@ -39,40 +52,22 @@ struct WorktreeRowView: View {
         }
     }
 
+    private var fallbackIndicator: WorktreeRowIndicator? {
+        WorktreeRowIndicator.make(
+            prStatus: appState.prStatuses[worktree.id],
+            hasConflicts: worktree.hasConflicts,
+            hasNotification: notification != nil
+        )
+    }
+
     private var worktreeIcon: String? {
         guard !isMain else { return nil }
-        let prState = appState.prStatuses[worktree.id]?.state
-        // PR state takes priority over local conflict detection —
-        // a merged PR means the branch is done regardless of local git status.
-        if let prState {
-            switch prState {
-            case .open, .changesRequested, .mergeable: return "git-pull-request"
-            case .merged:                              return "git-merge"
-            case .closed:                              return "git-pull-request-closed"
-            }
-        }
-        if worktree.hasConflicts {
-            return "git-merge-conflict"
-        }
-        return nil
+        return PRStatusPresentation.make(for: appState.prStatuses[worktree.id])?.iconName
     }
 
     private var worktreeIconColor: Color {
         guard !isMain else { return .secondary }
-        let prState = appState.prStatuses[worktree.id]?.state
-        if let prState {
-            switch prState {
-            case .open:             return .secondary
-            case .changesRequested: return .red
-            case .mergeable:        return .green
-            case .merged:           return .purple
-            case .closed:           return .secondary
-            }
-        }
-        if worktree.hasConflicts {
-            return .orange
-        }
-        return .secondary
+        return PRStatusPresentation.make(for: appState.prStatuses[worktree.id])?.color ?? .secondary
     }
 
     private var hasSuspendedTerminal: Bool {
@@ -94,6 +89,10 @@ struct WorktreeRowView: View {
             Circle()
                 .fill(color)
                 .frame(width: 8, height: 8)
+        } else if fallbackIndicator == .conflict {
+            Image(systemName: "xmark")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.yellow)
         }
         if let icon = worktreeIcon, let nsImage = loadIcon(icon) {
             Image(nsImage: nsImage)

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -63,7 +63,13 @@ public actor PRStatusManager {
                 cache[wt.id] = PRStatus(
                     number: node.number,
                     url: node.url,
-                    state: Self.mapState(ghState: node.state, mergeStateStatus: node.mergeStateStatus, reviewDecision: node.reviewDecision)
+                    state: Self.mapState(
+                        ghState: node.state,
+                        mergeStateStatus: node.mergeStateStatus,
+                        reviewDecision: node.reviewDecision,
+                        isDraft: node.isDraft,
+                        statusCheckRollupState: node.statusCheckRollupState
+                    )
                 )
             }
         }
@@ -77,7 +83,7 @@ public actor PRStatusManager {
         )
         for candidate in candidates {
             let args = ["pr", "view", candidate,
-                        "--json", "number,url,state,mergeStateStatus,reviewDecision"]
+                        "--json", "number,url,state,mergeStateStatus,reviewDecision,isDraft,statusCheckRollup"]
             guard let output = await runGH(args: args, repoPath: repoPath),
                   let data = output.data(using: .utf8),
                   let obj = try? JSONDecoder().decode(GHPRViewResult.self, from: data) else {
@@ -89,7 +95,9 @@ public actor PRStatusManager {
                 url: obj.url,
                 state: Self.mapState(ghState: obj.state,
                                      mergeStateStatus: obj.mergeStateStatus,
-                                     reviewDecision: obj.reviewDecision ?? "")
+                                     reviewDecision: obj.reviewDecision ?? "",
+                                     isDraft: obj.isDraft,
+                                     statusCheckRollupState: obj.statusCheckRollup?.state)
             )
             cache[worktreeID] = status
             return status
@@ -106,14 +114,27 @@ public actor PRStatusManager {
 
     // MARK: - State mapping (internal but static for testability)
 
-    public static func mapState(ghState: String, mergeStateStatus: String, reviewDecision: String = "") -> PRMergeableState {
+    public static func mapState(
+        ghState: String,
+        mergeStateStatus: String,
+        reviewDecision: String = "",
+        isDraft: Bool = false,
+        statusCheckRollupState: String? = nil
+    ) -> PRMergeableState {
         switch ghState {
         case "MERGED": return .merged
         case "CLOSED": return .closed
         default:
+            if isDraft { return .draft }
+            if Self.isFailingStatusCheckRollup(statusCheckRollupState) { return .checksFailed }
             if reviewDecision == "CHANGES_REQUESTED" { return .changesRequested }
             return mergeStateStatus == "CLEAN" ? .mergeable : .open
         }
+    }
+
+    private static func isFailingStatusCheckRollup(_ state: String?) -> Bool {
+        guard let state else { return false }
+        return ["ERROR", "FAILURE"].contains(state)
     }
 
     /// Priority for choosing between multiple PRs on the same branch.
@@ -144,6 +165,8 @@ public actor PRStatusManager {
         public let reviewDecision: String   // "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", or ""
         public let headRefName: String
         public let createdAt: String        // ISO 8601, e.g. "2026-03-24T15:58:27Z"
+        public let isDraft: Bool
+        public let statusCheckRollupState: String?
     }
 
     public static func parsePRNodes(from data: Data) throws -> [PRNode] {
@@ -163,11 +186,16 @@ public actor PRStatusManager {
                   let headRefName = node["headRefName"] as? String,
                   let createdAt = node["createdAt"] as? String else { return nil }
             let reviewDecision = node["reviewDecision"] as? String ?? ""
+            let isDraft = node["isDraft"] as? Bool ?? false
+            let statusCheckRollup = node["statusCheckRollup"] as? [String: Any]
+            let statusCheckRollupState = statusCheckRollup?["state"] as? String
             return PRNode(number: number, url: url, state: state,
                           mergeStateStatus: mergeStateStatus,
                           reviewDecision: reviewDecision,
                           headRefName: headRefName,
-                          createdAt: createdAt)
+                          createdAt: createdAt,
+                          isDraft: isDraft,
+                          statusCheckRollupState: statusCheckRollupState)
         }
     }
 
@@ -180,7 +208,8 @@ public actor PRStatusManager {
             pullRequests(first: 100, states: [OPEN, MERGED, CLOSED],
                          orderBy: {field: CREATED_AT, direction: DESC}) {
               nodes {
-                number url state mergeStateStatus reviewDecision headRefName createdAt
+                number url state mergeStateStatus reviewDecision headRefName createdAt isDraft
+                statusCheckRollup { state }
               }
             }
           }
@@ -290,6 +319,12 @@ private struct GHPRViewResult: Codable {
     let state: String
     let mergeStateStatus: String
     let reviewDecision: String?
+    let isDraft: Bool
+    let statusCheckRollup: GHStatusCheckRollup?
+}
+
+private struct GHStatusCheckRollup: Codable {
+    let state: String?
 }
 
 public enum PRStatusError: Error {

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -125,16 +125,33 @@ public actor PRStatusManager {
         case "MERGED": return .merged
         case "CLOSED": return .closed
         default:
-            if isDraft { return .draft }
-            if Self.isFailingStatusCheckRollup(statusCheckRollupState) { return .checksFailed }
+            if isDraft || mergeStateStatus == "DRAFT" { return .draft }
             if reviewDecision == "CHANGES_REQUESTED" { return .changesRequested }
-            return mergeStateStatus == "CLEAN" ? .mergeable : .open
+            if Self.isFailingStatusCheckRollup(statusCheckRollupState) { return .checksFailed }
+
+            switch mergeStateStatus {
+            case "CLEAN", "HAS_HOOKS":
+                return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .mergeable
+            case "BLOCKED", "DIRTY", "BEHIND":
+                return .blocked
+            case "UNSTABLE":
+                return .checksFailed
+            case "UNKNOWN":
+                return .pending
+            default:
+                return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .blocked
+            }
         }
     }
 
     private static func isFailingStatusCheckRollup(_ state: String?) -> Bool {
         guard let state else { return false }
         return ["ERROR", "FAILURE"].contains(state)
+    }
+
+    private static func isPendingStatusCheckRollup(_ state: String?) -> Bool {
+        guard let state else { return false }
+        return ["EXPECTED", "PENDING"].contains(state)
     }
 
     /// Priority for choosing between multiple PRs on the same branch.

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -434,6 +434,8 @@ public struct UnreadSummary: Codable, Sendable, Equatable {
 public enum PRMergeableState: String, Codable, Sendable {
     case open               // PR exists, no review decision yet
     case changesRequested   // reviewer requested changes
+    case draft              // PR exists, but is marked draft
+    case checksFailed       // PR has failing CI/status checks
     case mergeable          // GitHub considers it clean (checks + reviews satisfied)
     case merged             // PR was merged
     case closed             // PR was closed without merging

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -432,7 +432,8 @@ public struct UnreadSummary: Codable, Sendable, Equatable {
 }
 
 public enum PRMergeableState: String, Codable, Sendable {
-    case open               // PR exists, no review decision yet
+    case pending            // PR exists, but mergeability/checks are still computing
+    case blocked            // PR is known to be not currently mergeable
     case changesRequested   // reviewer requested changes
     case draft              // PR exists, but is marked draft
     case checksFailed       // PR has failing CI/status checks

--- a/Tests/TBDAppTests/PRStatusPresentationTests.swift
+++ b/Tests/TBDAppTests/PRStatusPresentationTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import TBDApp
+@testable import TBDShared
+
+@Suite("PR status presentation")
+struct PRStatusPresentationTests {
+    @Test("conflict-only worktrees do not get a PR icon")
+    func conflictOnlyWorktreeHasNoPRPresentation() {
+        let presentation = PRStatusPresentation.make(for: nil)
+
+        #expect(presentation == nil)
+    }
+
+    @Test("merged PRs use purple merge icon")
+    func mergedPresentation() {
+        let presentation = PRStatusPresentation.make(for: PRStatus(number: 1, url: "https://example.com/1", state: .merged))
+
+        #expect(presentation?.iconName == "git-merge")
+        #expect(presentation?.colorSemantic == .merged)
+    }
+
+    @Test("mergeable PRs use green pull request icon")
+    func mergeablePresentation() {
+        let presentation = PRStatusPresentation.make(for: PRStatus(number: 2, url: "https://example.com/2", state: .mergeable))
+
+        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.colorSemantic == .mergeable)
+    }
+
+    @Test("draft PRs use grey pull request icon")
+    func draftPresentation() {
+        let presentation = PRStatusPresentation.make(for: PRStatus(number: 3, url: "https://example.com/3", state: .draft))
+
+        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.colorSemantic == .draft)
+    }
+
+    @Test("PRs with failing checks use red pull request icon")
+    func checksFailedPresentation() {
+        let presentation = PRStatusPresentation.make(for: PRStatus(number: 4, url: "https://example.com/4", state: .checksFailed))
+
+        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.colorSemantic == .checksFailed)
+    }
+
+    @Test("changes-requested PRs stay neutral so red means CI errors")
+    func changesRequestedPresentation() {
+        let presentation = PRStatusPresentation.make(for: PRStatus(number: 5, url: "https://example.com/5", state: .changesRequested))
+
+        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.colorSemantic == .neutral)
+    }
+}

--- a/Tests/TBDAppTests/PRStatusPresentationTests.swift
+++ b/Tests/TBDAppTests/PRStatusPresentationTests.swift
@@ -40,14 +40,38 @@ struct PRStatusPresentationTests {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 4, url: "https://example.com/4", state: .checksFailed))
 
         #expect(presentation?.iconName == "git-pull-request")
-        #expect(presentation?.colorSemantic == .checksFailed)
+        #expect(presentation?.colorSemantic == .nonMergeable)
     }
 
-    @Test("changes-requested PRs stay neutral so red means CI errors")
+    @Test("changes-requested PRs are known non-mergeable")
     func changesRequestedPresentation() {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 5, url: "https://example.com/5", state: .changesRequested))
 
         #expect(presentation?.iconName == "git-pull-request")
-        #expect(presentation?.colorSemantic == .neutral)
+        #expect(presentation?.colorSemantic == .nonMergeable)
+    }
+
+    @Test("pending PRs use yellow pull request icon")
+    func pendingPresentation() {
+        let presentation = PRStatusPresentation.make(for: PRStatus(number: 6, url: "https://example.com/6", state: .pending))
+
+        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.colorSemantic == .pending)
+    }
+
+    @Test("blocked PRs use red pull request icon")
+    func blockedPresentation() {
+        let presentation = PRStatusPresentation.make(for: PRStatus(number: 7, url: "https://example.com/7", state: .blocked))
+
+        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.colorSemantic == .nonMergeable)
+    }
+
+    @Test("closed PRs use red closed icon")
+    func closedPresentation() {
+        let presentation = PRStatusPresentation.make(for: PRStatus(number: 8, url: "https://example.com/8", state: .closed))
+
+        #expect(presentation?.iconName == "git-pull-request-closed")
+        #expect(presentation?.colorSemantic == .nonMergeable)
     }
 }

--- a/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
@@ -2,38 +2,43 @@ import Testing
 @testable import TBDApp
 @testable import TBDShared
 
-@Suite("Worktree row indicator")
-struct WorktreeRowIndicatorTests {
+@Suite("Worktree row conflict fallback")
+struct WorktreeRowConflictFallbackTests {
+    @Test("uses the hand-raised slash icon for conflict fallback")
+    func usesConflictFallbackIcon() {
+        #expect(WorktreeRowConflictFallback.iconName == "hand.raised.slash.fill")
+    }
+
     @Test("conflict fallback appears when there is no PR and no notification")
     func conflictFallbackWithoutPR() {
-        let indicator = WorktreeRowIndicator.make(
+        let showsFallback = WorktreeRowConflictFallback.shouldShow(
             prStatus: nil,
             hasConflicts: true,
             hasNotification: false
         )
 
-        #expect(indicator == .conflict)
+        #expect(showsFallback)
     }
 
     @Test("notification badge takes precedence over conflict fallback")
     func notificationWinsOverConflictFallback() {
-        let indicator = WorktreeRowIndicator.make(
+        let showsFallback = WorktreeRowConflictFallback.shouldShow(
             prStatus: nil,
             hasConflicts: true,
             hasNotification: true
         )
 
-        #expect(indicator == nil)
+        #expect(!showsFallback)
     }
 
     @Test("PR status suppresses conflict fallback")
     func prStatusSuppressesConflictFallback() {
-        let indicator = WorktreeRowIndicator.make(
+        let showsFallback = WorktreeRowConflictFallback.shouldShow(
             prStatus: PRStatus(number: 12, url: "https://example.com/12", state: .pending),
             hasConflicts: true,
             hasNotification: false
         )
 
-        #expect(indicator == nil)
+        #expect(!showsFallback)
     }
 }

--- a/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
@@ -29,7 +29,7 @@ struct WorktreeRowIndicatorTests {
     @Test("PR status suppresses conflict fallback")
     func prStatusSuppressesConflictFallback() {
         let indicator = WorktreeRowIndicator.make(
-            prStatus: PRStatus(number: 12, url: "https://example.com/12", state: .open),
+            prStatus: PRStatus(number: 12, url: "https://example.com/12", state: .pending),
             hasConflicts: true,
             hasNotification: false
         )

--- a/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import TBDApp
+@testable import TBDShared
+
+@Suite("Worktree row indicator")
+struct WorktreeRowIndicatorTests {
+    @Test("conflict fallback appears when there is no PR and no notification")
+    func conflictFallbackWithoutPR() {
+        let indicator = WorktreeRowIndicator.make(
+            prStatus: nil,
+            hasConflicts: true,
+            hasNotification: false
+        )
+
+        #expect(indicator == .conflict)
+    }
+
+    @Test("notification badge takes precedence over conflict fallback")
+    func notificationWinsOverConflictFallback() {
+        let indicator = WorktreeRowIndicator.make(
+            prStatus: nil,
+            hasConflicts: true,
+            hasNotification: true
+        )
+
+        #expect(indicator == nil)
+    }
+
+    @Test("PR status suppresses conflict fallback")
+    func prStatusSuppressesConflictFallback() {
+        let indicator = WorktreeRowIndicator.make(
+            prStatus: PRStatus(number: 12, url: "https://example.com/12", state: .open),
+            hasConflicts: true,
+            hasNotification: false
+        )
+
+        #expect(indicator == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -50,6 +50,33 @@ struct PRStatusManagerTests {
         #expect(status == .changesRequested)
     }
 
+    @Test("maps draft PRs to .draft")
+    func mapsDraft() {
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "CLEAN", isDraft: true)
+        #expect(status == .draft)
+    }
+
+    @Test("maps failing status checks to .checksFailed")
+    func mapsFailingChecks() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "CLEAN",
+            statusCheckRollupState: "FAILURE"
+        )
+        #expect(status == .checksFailed)
+    }
+
+    @Test("draft wins over failing status checks")
+    func mapsDraftOverFailingChecks() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "CLEAN",
+            isDraft: true,
+            statusCheckRollupState: "FAILURE"
+        )
+        #expect(status == .draft)
+    }
+
     // MARK: - JSON parsing
 
     @Test("parseGraphQLResponse keeps all branch names")
@@ -65,6 +92,8 @@ struct PRStatusManagerTests {
                     "url": "https://github.com/owner/repo/pull/42",
                     "state": "OPEN",
                     "mergeStateStatus": "CLEAN",
+                    "isDraft": true,
+                    "statusCheckRollup": { "state": "FAILURE" },
                     "reviewDecision": null,
                     "headRefName": "tbd/cool-feature",
                     "createdAt": "2026-03-24T10:00:00Z"
@@ -99,6 +128,8 @@ struct PRStatusManagerTests {
         #expect(nodes[0].headRefName == "tbd/cool-feature")
         #expect(nodes[0].state == "OPEN")
         #expect(nodes[0].mergeStateStatus == "CLEAN")
+        #expect(nodes[0].isDraft == true)
+        #expect(nodes[0].statusCheckRollupState == "FAILURE")
         #expect(nodes[1].headRefName == "tbd/old-feature")
         #expect(nodes[2].headRefName == "feature/not-tbd")
     }

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -14,16 +14,50 @@ struct PRStatusManagerTests {
         #expect(status == .mergeable)
     }
 
-    @Test("maps OPEN + BLOCKED to .open")
-    func mapsOpenBlocked() {
+    @Test("maps OPEN + BLOCKED to .blocked")
+    func mapsBlocked() {
         let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "BLOCKED")
-        #expect(status == .open)
+        #expect(status == .blocked)
     }
 
-    @Test("maps OPEN + DIRTY to .open")
-    func mapsOpenDirty() {
+    @Test("maps OPEN + DIRTY to .blocked")
+    func mapsDirty() {
         let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "DIRTY")
-        #expect(status == .open)
+        #expect(status == .blocked)
+    }
+
+    @Test("maps OPEN + BEHIND to .blocked")
+    func mapsBehind() {
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "BEHIND")
+        #expect(status == .blocked)
+    }
+
+    @Test("maps OPEN + UNKNOWN to .pending")
+    func mapsPendingUnknown() {
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "UNKNOWN")
+        #expect(status == .pending)
+    }
+
+    @Test("maps pending status checks to .pending")
+    func mapsPendingChecks() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "UNKNOWN",
+            statusCheckRollupState: "PENDING"
+        )
+        #expect(status == .pending)
+    }
+
+    @Test("maps HAS_HOOKS to .mergeable")
+    func mapsHasHooks() {
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "HAS_HOOKS")
+        #expect(status == .mergeable)
+    }
+
+    @Test("maps UNSTABLE to .checksFailed")
+    func mapsUnstable() {
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "UNSTABLE")
+        #expect(status == .checksFailed)
     }
 
     @Test("maps MERGED to .merged")
@@ -234,7 +268,7 @@ struct PRStatusManagerTests {
     func invalidate() async {
         let manager = PRStatusManager()
         let id = UUID()
-        let status = PRStatus(number: 2, url: "https://github.com/o/r/pull/2", state: .open)
+        let status = PRStatus(number: 2, url: "https://github.com/o/r/pull/2", state: .pending)
         await manager.seedForTesting(worktreeID: id, status: status)
         await manager.invalidate(worktreeID: id)
         let all = await manager.allStatuses()

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -48,6 +48,16 @@ struct PRStatusManagerTests {
         #expect(status == .pending)
     }
 
+    @Test("maps OPEN + CLEAN + pending status checks to .pending")
+    func mapsPendingChecksOverClean() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "CLEAN",
+            statusCheckRollupState: "PENDING"
+        )
+        #expect(status == .pending)
+    }
+
     @Test("maps HAS_HOOKS to .mergeable")
     func mapsHasHooks() {
         let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "HAS_HOOKS")
@@ -58,6 +68,22 @@ struct PRStatusManagerTests {
     func mapsUnstable() {
         let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "UNSTABLE")
         #expect(status == .checksFailed)
+    }
+
+    @Test("maps unknown future merge state to .blocked")
+    func mapsUnknownFutureMergeState() {
+        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "SOME_FUTURE_STATE")
+        #expect(status == .blocked)
+    }
+
+    @Test("maps unknown future merge state with pending checks to .pending")
+    func mapsPendingUnknownFutureMergeState() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "SOME_FUTURE_STATE",
+            statusCheckRollupState: "EXPECTED"
+        )
+        #expect(status == .pending)
     }
 
     @Test("maps MERGED to .merged")


### PR DESCRIPTION
## Summary
- add richer PR status semantics for GitHub sync, including draft and failing-check states while preserving upstream-branch PR lookup
- centralize PR icon/color presentation in the app and align the sidebar/toolbar with the new semantics
- show a yellow conflict fallback marker in the sidebar only when a worktree has conflicts, no PR, and no notification badge


Note: this changes the existing conflict fallback from a yellow pr icon, to a yellow X to consistently differentiate between PRs and no PRs
<img width="329" height="36" alt="image" src="https://github.com/user-attachments/assets/e7e163d3-d7f7-4ddc-847e-41f2cac8ab7d" />


## Test Plan
- [x] swift test --filter PRStatusManagerTests
- [x] swift test --filter PRStatusPresentationTests
- [x] swift test --filter WorktreeRowIndicatorTests
- [x] swift test
