### PR TITLE
Fix Codex session metadata handling

### DIFF
--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -188,7 +188,7 @@ struct PanePlaceholder: View {
             }
             .buttonStyle(.borderless)
 
-            if terminal(for: terminalID)?.claudeSessionID != nil {
+            if terminal(for: terminalID)?.isClaudeResumable == true {
                 Button(action: { openTranscript(terminalID: terminalID) }) {
                     HStack(spacing: 2) {
                         Image(systemName: "text.bubble")
@@ -500,4 +500,3 @@ struct EditableNoteTitle: View {
         }
     }
 }
-

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -28,10 +28,10 @@ struct SidebarContextMenu: View {
 
                 let terminals = appState.terminals[worktree.id] ?? []
                 let hasUnsuspendedClaude = terminals.contains {
-                    $0.claudeSessionID != nil && $0.suspendedAt == nil
+                    $0.isClaudeResumable && $0.suspendedAt == nil
                 }
                 let hasSuspendedClaude = terminals.contains {
-                    $0.claudeSessionID != nil && $0.suspendedAt != nil
+                    $0.isClaudeResumable && $0.suspendedAt != nil
                 }
                 let hasActiveChildren = !appState.children(of: worktree.id).isEmpty
 
@@ -39,7 +39,7 @@ struct SidebarContextMenu: View {
                     Button("Suspend Claude") {
                         let wtID = worktree.id
                         let claudeTerminalIDs = terminals
-                            .filter { $0.claudeSessionID != nil && $0.suspendedAt == nil }
+                            .filter { $0.isClaudeResumable && $0.suspendedAt == nil }
                             .map { $0.id }
                         // Capture screenshot synchronously before any state change
                         for id in claudeTerminalIDs {

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -368,11 +368,11 @@ private struct TabBarItem: View {
     }
 
     private var isClaudeTerminal: Bool {
-        terminal?.claudeSessionID != nil
+        terminal?.isClaudeResumable == true
     }
 
     private var isCodexTerminal: Bool {
-        terminal?.kind == .codex || terminal?.label == "Codex"
+        terminal?.isCodexTerminal == true
     }
 
     private var isSuspended: Bool {
@@ -752,4 +752,3 @@ private struct HistoryTabButton: View {
         .help("Session History")
     }
 }
-

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -84,7 +84,7 @@ public actor SuspendResumeCoordinator {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
         }
-        guard let sessionID = terminal.claudeSessionID else {
+        guard terminal.isClaudeResumable, let sessionID = terminal.claudeSessionID else {
             return .notClaudeTerminal
         }
         guard terminal.suspendedAt == nil else {
@@ -189,7 +189,7 @@ public actor SuspendResumeCoordinator {
         guard terminal.suspendedAt != nil else {
             return .notSuspended
         }
-        guard terminal.claudeSessionID != nil else {
+        guard terminal.isClaudeResumable else {
             return .noSessionID
         }
         guard await worktreeServer(for: terminal.worktreeID) != nil else {
@@ -228,7 +228,7 @@ public actor SuspendResumeCoordinator {
         Task {
             guard let terminals = try? await db.terminals.list(worktreeID: worktreeID) else { return }
             for terminal in terminals {
-                guard terminal.claudeSessionID != nil,
+                guard terminal.isClaudeResumable,
                       terminal.pinnedAt == nil,
                       terminal.suspendedAt == nil else { continue }
 
@@ -319,6 +319,7 @@ public actor SuspendResumeCoordinator {
         Task {
             guard let terminals = try? await db.terminals.list(worktreeID: worktreeID) else { return }
             for terminal in terminals where terminal.suspendedAt != nil {
+                guard terminal.isClaudeResumable else { continue }
                 inFlight[terminal.id]?.cancel()
                 let task = Task<Void, Never> { await resumeTerminal(terminal) }
                 inFlight[terminal.id] = task
@@ -482,7 +483,7 @@ public actor SuspendResumeCoordinator {
         // This handles the case where the daemon restarts while Claude is sitting idle —
         // without this, the in-memory flag would be empty and suspend would never trigger.
         for terminal in allTerminals {
-            guard terminal.claudeSessionID != nil,
+            guard terminal.isClaudeResumable,
                   terminal.suspendedAt == nil else { continue }
             guard let server = await worktreeServer(for: terminal.worktreeID) else { continue }
             if await detector.isIdle(server: server, paneID: terminal.tmuxPaneID) {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -46,7 +46,8 @@ extension WorktreeLifecycle {
         let terminals = try await db.terminals.list(worktreeID: worktreeID)
         let claudeSessionIDs = terminals
             .sorted(by: { $0.createdAt < $1.createdAt })
-            .compactMap { $0.claudeSessionID }
+            .filter(\.isClaudeResumable)
+            .compactMap(\.claudeSessionID)
 
         // Sync the branch in DB with what git reports for the worktree path,
         // so a rename done inside the worktree (e.g. `git branch -m`) is

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -163,7 +163,7 @@ extension WorktreeLifecycle {
                 if serverAlive {
                     let alive = await tmux.windowExists(server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
                     if !alive {
-                        if let sessionID = terminal.claudeSessionID {
+                        if terminal.isClaudeResumable, let sessionID = terminal.claudeSessionID {
                             // Window is gone but a resumable session exists.
                             // Suspend the terminal instead of deleting it — the
                             // suspend/resume machinery rebuilds a window from the
@@ -276,7 +276,22 @@ extension WorktreeLifecycle {
         // rollovers without depending on cwd-based heuristics.
         env["TBD_TERMINAL_ID"] = terminal.id.uuidString
 
-        if let sessionID = terminal.claudeSessionID {
+        if terminal.isCodexTerminal {
+            // Codex's SessionStart hook records session metadata into the
+            // shared Claude fields, so terminal kind must win over the
+            // presence of a captured session ID during reboot recovery.
+            let codexHome = try CodexHomeManager().ensureProfilePlugin()
+            env["CODEX_HOME"] = codexHome.path
+            spawn = ClaudeSpawnCommandBuilder.build(
+                resumeID: nil,
+                freshSessionID: nil,
+                appendSystemPrompt: nil,
+                initialPrompt: nil,
+                profileSecret: nil,
+                cmd: CodexSpawnCommandBuilder.command,
+                shellFallback: defaultShell
+            )
+        } else if terminal.isClaudeResumable, let sessionID = terminal.claudeSessionID {
             // Claude terminal — resume existing session with persisted profile
             var resolvedProfile: ResolvedModelProfile? = nil
             if let profileID = terminal.profileID, let resolver = modelProfileResolver {
@@ -299,24 +314,6 @@ extension WorktreeLifecycle {
                 settingsOverlayPath: ClaudeHookOverlay.overlayPath,
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides
-            )
-        } else if terminal.kind == .codex || terminal.label == "Codex" {
-            // Codex terminal — detected by kind (primary signal) or legacy label fallback.
-            // kind is the primary discriminator; label is checked for backward compatibility.
-            let codexHome = try CodexHomeManager().ensureProfilePlugin()
-            // Explicitly export the global Codex home. This is intentional —
-            // the design's allowed "set the global path" option — not leftover
-            // per-repo isolation: it pins deterministic behavior and lets the
-            // TBD_TEST_CODEX_HOME test-isolation override flow through.
-            env["CODEX_HOME"] = codexHome.path
-            spawn = ClaudeSpawnCommandBuilder.build(
-                resumeID: nil,
-                freshSessionID: nil,
-                appendSystemPrompt: nil,
-                initialPrompt: nil,
-                profileSecret: nil,
-                cmd: CodexSpawnCommandBuilder.command,
-                shellFallback: defaultShell
             )
         } else {
             // Shell or custom-cmd terminal. Plain shell terminals have label nil or "shell";

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -37,9 +37,7 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree not found")
         }
 
-        let claudeTerminals = terminals.filter {
-            $0.claudeSessionID != nil && $0.suspendedAt == nil
-        }
+        let claudeTerminals = terminals.filter { $0.isClaudeResumable && $0.suspendedAt == nil }
 
         // Fire in background — RPC returns immediately so the app can show
         // the suspending overlay while the daemon does its work.
@@ -58,9 +56,7 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree not found")
         }
 
-        let suspendedTerminals = terminals.filter {
-            $0.claudeSessionID != nil && $0.suspendedAt != nil
-        }
+        let suspendedTerminals = terminals.filter { $0.isClaudeResumable && $0.suspendedAt != nil }
 
         // Sequential — the coordinator is an actor so calls serialize anyway
         for terminal in suspendedTerminals {

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -226,6 +226,20 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
+public extension Terminal {
+    var isCodexTerminal: Bool {
+        kind == .codex || label == "Codex"
+    }
+
+    /// True only for Claude terminals whose session can be resumed through
+    /// Claude-specific lifecycle flows like suspend/resume and dead-window
+    /// preservation.
+    var isClaudeResumable: Bool {
+        guard claudeSessionID != nil, !isCodexTerminal else { return false }
+        return kind == .claude || kind == nil
+    }
+}
+
 public enum CredentialKind: String, Codable, Sendable {
     case oauth
     case apiKey

--- a/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
@@ -106,6 +106,35 @@ struct SuspendResumeCoordinatorTests {
         #expect(result == .notSuspended)
     }
 
+    @Test func autoResumeSkipsSuspendedCodexTerminalWithSessionMetadata() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-repo-codex", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt-codex",
+            branch: "main", path: "/tmp/test-repo-codex",
+            tmuxServer: "tbd-codex"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@0",
+            tmuxPaneID: "%0",
+            label: "Codex",
+            claudeSessionID: "session-abc",
+            kind: .codex
+        )
+        try await db.terminals.setSuspended(
+            id: terminal.id, sessionID: "session-abc", snapshot: "fake snapshot"
+        )
+        let tmux = TmuxManager(dryRun: true)
+        let coordinator = SuspendResumeCoordinator(db: db, tmux: tmux)
+
+        await coordinator.selectionChanged(to: [wt.id], suspendEnabled: true)
+        try await Task.sleep(for: .milliseconds(250))
+
+        let after = try await db.terminals.get(id: terminal.id)
+        #expect(after?.suspendedAt != nil)
+    }
+
     @Test func resumeInjectsTokenWhenResolverProvided() async throws {
         // Build DB with a token row + suspended terminal referencing it.
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -230,6 +230,53 @@ func testRecreateAfterRebootShellBranchSetsWorktreeID() async throws {
             "shell-branch recreation must export TBD_WORKTREE_ID; got bodies: \(bodies)")
 }
 
+@Test("recreateAfterReboot — codex kind wins over captured session ID")
+func testRecreateAfterRebootCodexKindWinsOverCapturedSessionID() async throws {
+    installCodexTestHomeOverride()
+    defer { unsetenv("TBD_TEST_CODEX_HOME") }
+
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in
+        recorded.append(args)
+    })
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: tmux,
+        hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-codex-session", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-codex-session",
+        branch: "tbd/wt-codex-session",
+        path: "/tmp/fake-repo-codex-session/wt-codex-session",
+        tmuxServer: "tbd-c0dexsid"
+    )
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@stale-codex-session",
+        tmuxPaneID: "%stale-codex-session",
+        label: "Codex",
+        claudeSessionID: "codex-session-id-captured-by-hook",
+        kind: .codex
+    )
+
+    try await lifecycle.recreateAfterReboot(terminal: terminal, worktree: wt)
+
+    let bodies = newWindowBodies(recorded.snapshot())
+    #expect(bodies.contains {
+        $0.contains("unset CODEX_CI CODEX_THREAD_ID;") && $0.contains("codex ")
+    }, "codex terminal with a captured session ID must still launch codex; got bodies: \(bodies)")
+    #expect(!bodies.contains {
+        $0.contains("claude") && $0.contains("--resume codex-session-id-captured-by-hook")
+    }, "codex terminal must not be misclassified as a Claude resume; got bodies: \(bodies)")
+}
+
 // MARK: - Fix 2b: handleTerminalRecreateWindow sets TBD_WORKTREE_ID
 
 @Test("handleTerminalRecreateWindow sets TBD_WORKTREE_ID on the recreated pane")

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -350,6 +350,44 @@ import Testing
             "Should not save empty session list")
 }
 
+@Test func testArchiveIgnoresCodexSessionMetadata() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+    _ = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@codex-1",
+        tmuxPaneID: "%codex-1",
+        label: "Codex",
+        claudeSessionID: "codex-session-id",
+        kind: .codex
+    )
+    _ = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@claude-1",
+        tmuxPaneID: "%claude-1",
+        label: "Claude Code",
+        claudeSessionID: "claude-session-id",
+        kind: .claude
+    )
+
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    let archived = try await db.worktrees.get(id: wt.id)
+    #expect(archived?.archivedClaudeSessions == ["claude-session-id"])
+}
+
 @Test func testReviveWithSkipClaudePreservesSessions() async throws {
     let (tempDir, repoDir) = try await createTestRepo()
     defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -824,6 +862,45 @@ import Testing
     try? await realTmux.killServer(server: serverName)
 
     #expect(after == nil, "shell terminal with no session must still be deleted")
+}
+
+@Test func testReconcileDeadWindowCodexTerminalWithSessionMetadataDeleted() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let realTmux = TmuxManager()
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(), tmux: realTmux, hooks: HookResolver()
+    )
+
+    let repo = try await db.repos.create(
+        path: repoDir.path, displayName: "test", defaultBranch: "main"
+    )
+    let serverName = TmuxManager.serverName(forRepoPath: repo.path)
+    _ = try await realTmux.ensureServer(server: serverName, session: "main", cwd: repoDir.path)
+
+    let wt = try await db.worktrees.create(
+        repoID: repo.id, name: "wt", branch: "main",
+        path: repoDir.path, tmuxServer: serverName
+    )
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@stale-codex", tmuxPaneID: "%stale-codex",
+        label: "Codex", claudeSessionID: UUID().uuidString, kind: .codex
+    )
+
+    do {
+        try await lifecycle.reconcile(repoID: repo.id)
+    } catch {
+        try? await realTmux.killServer(server: serverName)
+        throw error
+    }
+
+    let after = try await db.terminals.get(id: terminal.id)
+    try? await realTmux.killServer(server: serverName)
+
+    #expect(after == nil, "stale codex terminal must be deleted, not suspended via Claude semantics")
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## Summary
- gate Claude-only suspend, resume, reconcile, and UI behaviors on a Claude-resumable predicate instead of any captured session metadata
- let Codex terminals keep storing session metadata without surfacing Claude transcript or lifecycle behavior
- filter archived Claude session capture and add regressions for reboot recovery, dead-window reconcile, auto-resume, and archive persistence

## Test Plan
- [x] `swift test`