### PR TITLE
Add webview find interface

### DIFF
--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -3,12 +3,15 @@ import AppKit
 
 enum TextFinderCommand {
     static let action = #selector(NSResponder.performTextFinderAction(_:))
-    static let tag = NSTextFinder.Action.showFindInterface.rawValue
+    
+    static func tag(for action: NSTextFinder.Action) -> Int {
+        action.rawValue
+    }
 
     @MainActor
-    static func perform() {
+    static func perform(_ finderAction: NSTextFinder.Action = .showFindInterface) {
         let sender = NSMenuItem()
-        sender.tag = tag
+        sender.tag = tag(for: finderAction)
 
         if let host = webviewHost(from: NSApp.keyWindow?.firstResponder) {
             host.performTextFinderAction(sender)
@@ -74,6 +77,16 @@ struct TBDCommands: Commands {
                 TextFinderCommand.perform()
             }
             .keyboardShortcut("f", modifiers: .command)
+
+            Button("Find Next") {
+                TextFinderCommand.perform(.nextMatch)
+            }
+            .keyboardShortcut("g", modifiers: .command)
+
+            Button("Find Previous") {
+                TextFinderCommand.perform(.previousMatch)
+            }
+            .keyboardShortcut("g", modifiers: [.command, .shift])
         }
 
         // Worktree commands

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -3,7 +3,7 @@ import AppKit
 
 enum TextFinderCommand {
     static let action = #selector(NSResponder.performTextFinderAction(_:))
-    
+
     static func tag(for action: NSTextFinder.Action) -> Int {
         action.rawValue
     }

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -1,4 +1,53 @@
 import SwiftUI
+import AppKit
+
+enum TextFinderCommand {
+    static let action = #selector(NSResponder.performTextFinderAction(_:))
+    static let tag = NSTextFinder.Action.showFindInterface.rawValue
+
+    @MainActor
+    static func perform() {
+        let sender = NSMenuItem()
+        sender.tag = tag
+
+        if let host = webviewHost(from: NSApp.keyWindow?.firstResponder) {
+            host.performTextFinderAction(sender)
+            return
+        }
+
+        NSApp.sendAction(action, to: nil, from: sender)
+    }
+
+    @MainActor
+    static func webviewHost(from responder: NSResponder?) -> WebviewPaneHostView? {
+        var current = responder
+        var visited = Set<ObjectIdentifier>()
+
+        while let responder = current {
+            let id = ObjectIdentifier(responder)
+            guard !visited.contains(id) else { return nil }
+            visited.insert(id)
+
+            if let host = responder as? WebviewPaneHostView {
+                return host
+            }
+
+            if let view = responder as? NSView {
+                var superview = view.superview
+                while let candidate = superview {
+                    if let host = candidate as? WebviewPaneHostView {
+                        return host
+                    }
+                    superview = candidate.superview
+                }
+            }
+
+            current = responder.nextResponder
+        }
+
+        return nil
+    }
+}
 
 /// Menu commands providing keyboard shortcuts for the app.
 struct TBDCommands: Commands {
@@ -16,6 +65,15 @@ struct TBDCommands: Commands {
                     await appState.migrateClaudeHooks()
                 }
             }
+        }
+
+        CommandGroup(after: .pasteboard) {
+            Divider()
+
+            Button("Find…") {
+                TextFinderCommand.perform()
+            }
+            .keyboardShortcut("f", modifiers: .command)
         }
 
         // Worktree commands

--- a/Sources/TBDApp/Panes/WebviewPaneView.swift
+++ b/Sources/TBDApp/Panes/WebviewPaneView.swift
@@ -214,6 +214,12 @@ final class WebviewFindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         onQueryChanged?(searchField.stringValue)
     }
 
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        guard commandSelector == #selector(NSResponder.cancelOperation(_:)) else { return false }
+        onClose?()
+        return true
+    }
+
     func submit(backwards: Bool) {
         onSubmit?(backwards)
     }

--- a/Sources/TBDApp/Panes/WebviewPaneView.swift
+++ b/Sources/TBDApp/Panes/WebviewPaneView.swift
@@ -1,23 +1,256 @@
 import SwiftUI
 import WebKit
 
+@MainActor
+protocol WebviewFindClient: AnyObject {
+    func find(_ string: String, backwards: Bool, completionHandler: @escaping (Bool) -> Void)
+}
+
+extension WKWebView: WebviewFindClient {
+    func find(_ string: String, backwards: Bool, completionHandler: @escaping (Bool) -> Void) {
+        let config = WKFindConfiguration()
+        config.backwards = backwards
+        config.wraps = true
+        find(string, configuration: config) { result in
+            completionHandler(result.matchFound)
+        }
+    }
+}
+
 struct WebviewPaneView: NSViewRepresentable {
     let url: URL
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
-    func makeNSView(context: Context) -> WKWebView {
-        let config = WKWebViewConfiguration()
-        config.websiteDataStore = .default()
-        let webView = WKWebView(frame: .zero, configuration: config)
-        webView.navigationDelegate = context.coordinator
-        webView.load(URLRequest(url: url))
-        return webView
+    func makeNSView(context: Context) -> WebviewPaneHostView {
+        let host = WebviewPaneHostView(url: url)
+        host.webView.navigationDelegate = context.coordinator
+        return host
     }
 
-    func updateNSView(_ webView: WKWebView, context: Context) {
+    func updateNSView(_ host: WebviewPaneHostView, context: Context) {
         // Don't reload on SwiftUI updates — only initial load matters
     }
 
     class Coordinator: NSObject, WKNavigationDelegate {}
+}
+
+final class WebviewPaneHostView: NSView, NSUserInterfaceValidations {
+    let webView: WKWebView
+    let findBar = WebviewFindBarView()
+
+    private let findClient: WebviewFindClient
+
+    init(url: URL, findClient: WebviewFindClient? = nil) {
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .default()
+
+        webView = WKWebView(frame: .zero, configuration: config)
+        self.findClient = findClient ?? webView
+
+        super.init(frame: .zero)
+
+        addSubview(webView)
+        addSubview(findBar)
+        findBar.isHidden = true
+        findBar.onQueryChanged = { [weak self] query in
+            self?.search(query, backwards: false)
+        }
+        findBar.onSubmit = { [weak self] backwards in
+            self?.search(self?.findBar.searchField.stringValue ?? "", backwards: backwards)
+        }
+        findBar.onClose = { [weak self] in
+            self?.hideFindBar()
+        }
+        webView.load(URLRequest(url: url))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func performTextFinderAction(_ sender: Any?) {
+        let action = textFinderAction(from: sender)
+        switch action {
+        case .showFindInterface:
+            showFindBar()
+        case .nextMatch:
+            search(findBar.searchField.stringValue, backwards: false)
+        case .previousMatch:
+            search(findBar.searchField.stringValue, backwards: true)
+        case .hideFindInterface:
+            hideFindBar()
+        default:
+            showFindBar()
+        }
+    }
+
+    func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
+        true
+    }
+
+    func showFindBar() {
+        findBar.isHidden = false
+        needsLayout = true
+        window?.makeFirstResponder(findBar.searchField)
+        findBar.searchField.selectText(nil)
+    }
+
+    func hideFindBar() {
+        findBar.isHidden = true
+        needsLayout = true
+        window?.makeFirstResponder(webView)
+    }
+
+    override func layout() {
+        super.layout()
+
+        webView.frame = bounds
+
+        let margin: CGFloat = 10
+        let barSize = findBar.fittingSize
+        findBar.frame = CGRect(
+            x: max(margin, bounds.maxX - barSize.width - margin),
+            y: max(margin, bounds.maxY - barSize.height - margin),
+            width: barSize.width,
+            height: barSize.height
+        )
+    }
+
+    private func textFinderAction(from sender: Any?) -> NSTextFinder.Action {
+        let tag = (sender as? NSValidatedUserInterfaceItem)?.tag ?? NSTextFinder.Action.showFindInterface.rawValue
+        return NSTextFinder.Action(rawValue: tag) ?? .showFindInterface
+    }
+
+    private func search(_ query: String, backwards: Bool) {
+        guard !query.isEmpty else { return }
+        findClient.find(query, backwards: backwards) { [weak self] matchFound in
+            self?.findBar.setMatchFound(matchFound)
+        }
+    }
+}
+
+final class WebviewFindBarView: NSVisualEffectView, NSSearchFieldDelegate {
+    let searchField = WebviewFindSearchField()
+
+    var onQueryChanged: ((String) -> Void)?
+    var onSubmit: ((Bool) -> Void)?
+    var onClose: (() -> Void)?
+
+    private let previousButton = NSButton()
+    private let nextButton = NSButton()
+    private let closeButton = NSButton()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        material = .popover
+        blendingMode = .withinWindow
+        state = .active
+        wantsLayer = true
+        layer?.cornerRadius = 8
+
+        searchField.placeholderString = "Find"
+        searchField.delegate = self
+        searchField.target = self
+        searchField.action = #selector(searchFieldSubmitted)
+        searchField.onSubmit = { [weak self] backwards in
+            self?.submit(backwards: backwards)
+        }
+        searchField.onEscape = { [weak self] in
+            self?.onClose?()
+        }
+
+        configureButton(previousButton, symbolName: "chevron.up", action: #selector(previous))
+        configureButton(nextButton, symbolName: "chevron.down", action: #selector(next))
+        configureButton(closeButton, symbolName: "xmark", action: #selector(close))
+
+        [searchField, previousButton, nextButton, closeButton].forEach(addSubview)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var fittingSize: NSSize {
+        NSSize(width: 330, height: 38)
+    }
+
+    override func layout() {
+        super.layout()
+
+        let height: CGFloat = 28
+        let buttonSize = NSSize(width: 28, height: height)
+        let padding: CGFloat = 6
+        let y = (bounds.height - height) / 2
+        let closeX = bounds.maxX - padding - buttonSize.width
+        let nextX = closeX - buttonSize.width
+        let previousX = nextX - buttonSize.width
+
+        closeButton.frame = CGRect(origin: CGPoint(x: closeX, y: y), size: buttonSize)
+        nextButton.frame = CGRect(origin: CGPoint(x: nextX, y: y), size: buttonSize)
+        previousButton.frame = CGRect(origin: CGPoint(x: previousX, y: y), size: buttonSize)
+        searchField.frame = CGRect(
+            x: padding,
+            y: y,
+            width: max(80, previousX - padding - 6),
+            height: height
+        )
+    }
+
+    func controlTextDidChange(_ notification: Notification) {
+        onQueryChanged?(searchField.stringValue)
+    }
+
+    func submit(backwards: Bool) {
+        onSubmit?(backwards)
+    }
+
+    func setMatchFound(_ matchFound: Bool) {
+        searchField.textColor = matchFound ? .labelColor : .systemRed
+    }
+
+    private func configureButton(_ button: NSButton, symbolName: String, action: Selector) {
+        button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+        button.bezelStyle = .texturedRounded
+        button.isBordered = false
+        button.target = self
+        button.action = action
+    }
+
+    @objc private func previous() {
+        submit(backwards: true)
+    }
+
+    @objc private func next() {
+        submit(backwards: false)
+    }
+
+    @objc private func close() {
+        onClose?()
+    }
+
+    @objc private func searchFieldSubmitted() {
+        submit(backwards: false)
+    }
+}
+
+final class WebviewFindSearchField: NSSearchField {
+    var onSubmit: ((Bool) -> Void)?
+    var onEscape: (() -> Void)?
+
+    override func keyDown(with event: NSEvent) {
+        switch event.charactersIgnoringModifiers {
+        case "\r", "\n":
+            onSubmit?(event.modifierFlags.contains(.shift))
+        case "\u{1b}":
+            onEscape?()
+        default:
+            super.keyDown(with: event)
+        }
+    }
 }

--- a/Sources/TBDApp/Panes/WebviewPaneView.swift
+++ b/Sources/TBDApp/Panes/WebviewPaneView.swift
@@ -142,7 +142,7 @@ final class WebviewPaneHostView: NSView, NSUserInterfaceValidations {
 }
 
 final class WebviewFindBarView: NSVisualEffectView, NSSearchFieldDelegate {
-    let searchField = WebviewFindSearchField()
+    let searchField = NSSearchField()
 
     var onQueryChanged: ((String) -> Void)?
     var onSubmit: ((Bool) -> Void)?
@@ -160,17 +160,12 @@ final class WebviewFindBarView: NSVisualEffectView, NSSearchFieldDelegate {
         state = .active
         wantsLayer = true
         layer?.cornerRadius = 8
+        layer?.masksToBounds = true
 
         searchField.placeholderString = "Find"
         searchField.delegate = self
         searchField.target = self
         searchField.action = #selector(searchFieldSubmitted)
-        searchField.onSubmit = { [weak self] backwards in
-            self?.submit(backwards: backwards)
-        }
-        searchField.onEscape = { [weak self] in
-            self?.onClose?()
-        }
 
         configureButton(previousButton, symbolName: "chevron.up", action: #selector(previous))
         configureButton(nextButton, symbolName: "chevron.down", action: #selector(next))
@@ -250,21 +245,5 @@ final class WebviewFindBarView: NSVisualEffectView, NSSearchFieldDelegate {
 
     @objc private func searchFieldSubmitted() {
         submit(backwards: false)
-    }
-}
-
-final class WebviewFindSearchField: NSSearchField {
-    var onSubmit: ((Bool) -> Void)?
-    var onEscape: (() -> Void)?
-
-    override func keyDown(with event: NSEvent) {
-        switch event.charactersIgnoringModifiers {
-        case "\r", "\n":
-            onSubmit?(event.modifierFlags.contains(.shift))
-        case "\u{1b}":
-            onEscape?()
-        default:
-            super.keyDown(with: event)
-        }
     }
 }

--- a/Sources/TBDApp/Panes/WebviewPaneView.swift
+++ b/Sources/TBDApp/Panes/WebviewPaneView.swift
@@ -39,6 +39,13 @@ final class WebviewPaneHostView: NSView, NSUserInterfaceValidations {
     let webView: WKWebView
     let findBar = WebviewFindBarView()
 
+    private static let supportedTextFinderActions: Set<NSTextFinder.Action> = [
+        .showFindInterface,
+        .hideFindInterface,
+        .nextMatch,
+        .previousMatch,
+    ]
+
     private let findClient: WebviewFindClient
 
     init(url: URL, findClient: WebviewFindClient? = nil) {
@@ -73,7 +80,7 @@ final class WebviewPaneHostView: NSView, NSUserInterfaceValidations {
     override var acceptsFirstResponder: Bool { true }
 
     override func performTextFinderAction(_ sender: Any?) {
-        let action = textFinderAction(from: sender)
+        guard let action = textFinderAction(from: sender) else { return }
         switch action {
         case .showFindInterface:
             showFindBar()
@@ -84,12 +91,13 @@ final class WebviewPaneHostView: NSView, NSUserInterfaceValidations {
         case .hideFindInterface:
             hideFindBar()
         default:
-            showFindBar()
+            return
         }
     }
 
     func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
-        true
+        guard let action = textFinderAction(from: item) else { return false }
+        return Self.supportedTextFinderActions.contains(action)
     }
 
     func showFindBar() {
@@ -120,9 +128,9 @@ final class WebviewPaneHostView: NSView, NSUserInterfaceValidations {
         )
     }
 
-    private func textFinderAction(from sender: Any?) -> NSTextFinder.Action {
+    private func textFinderAction(from sender: Any?) -> NSTextFinder.Action? {
         let tag = (sender as? NSValidatedUserInterfaceItem)?.tag ?? NSTextFinder.Action.showFindInterface.rawValue
-        return NSTextFinder.Action(rawValue: tag) ?? .showFindInterface
+        return NSTextFinder.Action(rawValue: tag)
     }
 
     private func search(_ query: String, backwards: Bool) {

--- a/Tests/TBDAppTests/TextFinderCommandTests.swift
+++ b/Tests/TBDAppTests/TextFinderCommandTests.swift
@@ -2,10 +2,17 @@ import AppKit
 import Testing
 @testable import TBDApp
 
+@MainActor
 struct TextFinderCommandTests {
     @Test("Find command uses AppKit text finder action")
     func findCommandUsesAppKitTextFinderAction() {
         #expect(TextFinderCommand.action == #selector(NSResponder.performTextFinderAction(_:)))
-        #expect(TextFinderCommand.tag == NSTextFinder.Action.showFindInterface.rawValue)
+        #expect(TextFinderCommand.tag(for: .showFindInterface) == NSTextFinder.Action.showFindInterface.rawValue)
+    }
+
+    @Test("Find next and previous commands use AppKit text finder tags")
+    func findNextAndPreviousCommandsUseAppKitTextFinderTags() {
+        #expect(TextFinderCommand.tag(for: .nextMatch) == NSTextFinder.Action.nextMatch.rawValue)
+        #expect(TextFinderCommand.tag(for: .previousMatch) == NSTextFinder.Action.previousMatch.rawValue)
     }
 }

--- a/Tests/TBDAppTests/TextFinderCommandTests.swift
+++ b/Tests/TBDAppTests/TextFinderCommandTests.swift
@@ -1,0 +1,11 @@
+import AppKit
+import Testing
+@testable import TBDApp
+
+struct TextFinderCommandTests {
+    @Test("Find command uses AppKit text finder action")
+    func findCommandUsesAppKitTextFinderAction() {
+        #expect(TextFinderCommand.action == #selector(NSResponder.performTextFinderAction(_:)))
+        #expect(TextFinderCommand.tag == NSTextFinder.Action.showFindInterface.rawValue)
+    }
+}

--- a/Tests/TBDAppTests/WebviewPaneFindTests.swift
+++ b/Tests/TBDAppTests/WebviewPaneFindTests.swift
@@ -64,11 +64,41 @@ struct WebviewPaneFindTests {
 
         #expect(client.requests == [FindRequest(query: "needle", backwards: false)])
     }
+
+    @Test("unsupported text finder actions do not open the find bar")
+    func unsupportedTextFinderActionsDoNotOpenTheFindBar() {
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!)
+
+        host.performTextFinderAction(TestValidatedItem(tag: NSTextFinder.Action.replaceAll.rawValue))
+
+        #expect(host.findBar.isHidden)
+    }
+
+    @Test("validation only enables supported text finder actions")
+    func validationOnlyEnablesSupportedTextFinderActions() {
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!)
+
+        #expect(host.validateUserInterfaceItem(TestValidatedItem(tag: NSTextFinder.Action.showFindInterface.rawValue)))
+        #expect(host.validateUserInterfaceItem(TestValidatedItem(tag: NSTextFinder.Action.nextMatch.rawValue)))
+        #expect(host.validateUserInterfaceItem(TestValidatedItem(tag: NSTextFinder.Action.previousMatch.rawValue)))
+        #expect(host.validateUserInterfaceItem(TestValidatedItem(tag: NSTextFinder.Action.hideFindInterface.rawValue)))
+        #expect(!host.validateUserInterfaceItem(TestValidatedItem(tag: NSTextFinder.Action.replaceAll.rawValue)))
+    }
 }
 
 private struct FindRequest: Equatable {
     let query: String
     let backwards: Bool
+}
+
+private final class TestValidatedItem: NSObject, NSValidatedUserInterfaceItem {
+    let action: Selector?
+    let tag: Int
+
+    init(tag: Int, action: Selector? = #selector(NSResponder.performTextFinderAction(_:))) {
+        self.tag = tag
+        self.action = action
+    }
 }
 
 @MainActor

--- a/Tests/TBDAppTests/WebviewPaneFindTests.swift
+++ b/Tests/TBDAppTests/WebviewPaneFindTests.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Testing
+import WebKit
+@testable import TBDApp
+
+@MainActor
+struct WebviewPaneFindTests {
+    @Test("webview host starts with hidden Chrome-style find bar")
+    func webviewHostStartsWithHiddenFindBar() {
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!)
+
+        #expect(host.findBar.isHidden)
+    }
+
+    @Test("text finder command locates enclosing webview host from focused descendant")
+    func textFinderCommandLocatesEnclosingWebviewHost() {
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!)
+        let focusedDescendant = NSView(frame: .zero)
+
+        host.webView.addSubview(focusedDescendant)
+
+        #expect(TextFinderCommand.webviewHost(from: focusedDescendant) === host)
+    }
+
+    @Test("typing in find bar searches immediately")
+    func typingInFindBarSearchesImmediately() {
+        let client = RecordingFindClient()
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!, findClient: client)
+
+        host.showFindBar()
+        host.findBar.searchField.stringValue = "needle"
+        host.findBar.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification))
+
+        #expect(client.requests == [FindRequest(query: "needle", backwards: false)])
+    }
+
+    @Test("enter advances and shift enter goes backward")
+    func enterAdvancesAndShiftEnterGoesBackward() {
+        let client = RecordingFindClient()
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!, findClient: client)
+
+        host.showFindBar()
+        host.findBar.searchField.stringValue = "needle"
+        host.findBar.submit(backwards: false)
+        host.findBar.submit(backwards: true)
+
+        #expect(client.requests == [
+            FindRequest(query: "needle", backwards: false),
+            FindRequest(query: "needle", backwards: true),
+        ])
+    }
+
+    @Test("search field return action advances to next result")
+    func searchFieldReturnActionAdvancesToNextResult() {
+        let client = RecordingFindClient()
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!, findClient: client)
+
+        host.showFindBar()
+        host.findBar.searchField.stringValue = "needle"
+        host.findBar.searchField.sendAction(
+            host.findBar.searchField.action,
+            to: host.findBar.searchField.target
+        )
+
+        #expect(client.requests == [FindRequest(query: "needle", backwards: false)])
+    }
+}
+
+private struct FindRequest: Equatable {
+    let query: String
+    let backwards: Bool
+}
+
+@MainActor
+private final class RecordingFindClient: WebviewFindClient {
+    var requests: [FindRequest] = []
+
+    func find(_ string: String, backwards: Bool, completionHandler: @escaping (Bool) -> Void) {
+        requests.append(FindRequest(query: string, backwards: backwards))
+        completionHandler(true)
+    }
+}

--- a/Tests/TBDAppTests/WebviewPaneFindTests.swift
+++ b/Tests/TBDAppTests/WebviewPaneFindTests.swift
@@ -12,6 +12,13 @@ struct WebviewPaneFindTests {
         #expect(host.findBar.isHidden)
     }
 
+    @Test("find bar uses a plain search field")
+    func findBarUsesAPlainSearchField() {
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!)
+
+        #expect(type(of: host.findBar.searchField) == NSSearchField.self)
+    }
+
     @Test("text finder command locates enclosing webview host from focused descendant")
     func textFinderCommandLocatesEnclosingWebviewHost() {
         let host = WebviewPaneHostView(url: URL(string: "https://example.com")!)

--- a/Tests/TBDAppTests/WebviewPaneFindTests.swift
+++ b/Tests/TBDAppTests/WebviewPaneFindTests.swift
@@ -84,6 +84,22 @@ struct WebviewPaneFindTests {
         #expect(host.validateUserInterfaceItem(TestValidatedItem(tag: NSTextFinder.Action.hideFindInterface.rawValue)))
         #expect(!host.validateUserInterfaceItem(TestValidatedItem(tag: NSTextFinder.Action.replaceAll.rawValue)))
     }
+
+    @Test("escape command closes the find bar through the text editing delegate")
+    func escapeCommandClosesTheFindBarThroughTheTextEditingDelegate() {
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!)
+        let delegate: NSControlTextEditingDelegate = host.findBar
+
+        host.showFindBar()
+        let handled = delegate.control?(
+            host.findBar.searchField,
+            textView: NSTextView(),
+            doCommandBy: #selector(NSResponder.cancelOperation(_:))
+        )
+
+        #expect(handled == true)
+        #expect(host.findBar.isHidden)
+    }
 }
 
 private struct FindRequest: Equatable {


### PR DESCRIPTION
## Summary
- add a Chrome-style find bar wrapper around the webview pane and route text-finder actions through it
- wire keyboard shortcuts for find, next match, and previous match to the active webview pane
- cover the new behavior with focused TBDApp tests for command routing and incremental find behavior

## Test Plan
- swift test
