### PR TITLE
Fix Cmd-W close tab behavior

### DIFF
--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -124,6 +124,49 @@ extension AppState {
         }
     }
 
+    // MARK: - Close
+
+    /// Close one tab and clean up resources owned by that tab. This is shared
+    /// by the tab bar close button and the Cmd-W menu shortcut.
+    func closeTab(worktreeID: UUID, index: Int) {
+        guard var arr = tabs[worktreeID],
+              arr.indices.contains(index) else { return }
+
+        let tab = arr[index]
+        let layout = layouts[tab.id] ?? .pane(tab.content)
+        let terminalIDsInTab = Set(layout.allTerminalIDs())
+
+        layouts.removeValue(forKey: tab.id)
+        arr.remove(at: index)
+        tabs[worktreeID] = arr
+        worktreeTabOrders[worktreeID] = arr.map(\.id)
+
+        for terminalID in terminalIDsInTab {
+            Task {
+                await deleteTerminal(terminalID: terminalID, worktreeID: worktreeID)
+            }
+        }
+
+        if case .note(let noteID) = tab.content {
+            Task {
+                await deleteNote(noteID: noteID, worktreeID: worktreeID)
+            }
+        }
+
+        let remaining = arr.count
+        activeTabIndices[worktreeID] = remaining > 0 ? min(index, remaining - 1) : 0
+
+        let snapshot = arr.map(\.id)
+        Task {
+            do {
+                try await daemonClient.setTabOrder(worktreeID: worktreeID, tabIDs: snapshot)
+            } catch {
+                logger.error("closeTab persist order failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+                handleConnectionError(error)
+            }
+        }
+    }
+
     // MARK: - Reorder
 
     /// Move `draggedID` to land next to `targetID`. `edge == .leading` inserts

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -136,6 +136,11 @@ extension AppState {
         let layout = layouts[tab.id] ?? .pane(tab.content)
         let terminalIDsInTab = Set(layout.allTerminalIDs())
 
+        if focusedTabCloseContext?.worktreeID == worktreeID,
+           focusedTabCloseContext?.tabID == tab.id {
+            focusedTabCloseContext = nil
+        }
+
         layouts.removeValue(forKey: tab.id)
         arr.remove(at: index)
         tabs[worktreeID] = arr
@@ -165,6 +170,29 @@ extension AppState {
                 handleConnectionError(error)
             }
         }
+    }
+
+    func closeTab(worktreeID: UUID, tabID: UUID) {
+        guard let arr = tabs[worktreeID],
+              let index = arr.firstIndex(where: { $0.id == tabID }) else {
+            if focusedTabCloseContext?.worktreeID == worktreeID,
+               focusedTabCloseContext?.tabID == tabID {
+                focusedTabCloseContext = nil
+            }
+            return
+        }
+        closeTab(worktreeID: worktreeID, index: index)
+    }
+
+    var canCloseFocusedTab: Bool {
+        guard let context = resolvedFocusedTabCloseContext(),
+              let arr = tabs[context.worktreeID] else { return false }
+        return arr.contains(where: { $0.id == context.tabID })
+    }
+
+    func closeFocusedTab() {
+        guard let context = resolvedFocusedTabCloseContext() else { return }
+        closeTab(worktreeID: context.worktreeID, tabID: context.tabID)
     }
 
     // MARK: - Reorder

--- a/Sources/TBDApp/AppState+TerminalFocus.swift
+++ b/Sources/TBDApp/AppState+TerminalFocus.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 @MainActor
@@ -14,9 +15,31 @@ extension AppState {
         terminalFocusTargets[terminalID] = TerminalFocusTarget(view)
     }
 
+    func registerTerminalCloseContext(_ context: TabCloseContext?, for terminalID: UUID) {
+        if let context {
+            terminalTabCloseContexts[terminalID] = context
+        } else {
+            terminalTabCloseContexts.removeValue(forKey: terminalID)
+        }
+    }
+
     func unregisterTerminalView(_ view: TBDTerminalView, for terminalID: UUID) {
         guard terminalFocusTargets[terminalID]?.view === view else { return }
         terminalFocusTargets.removeValue(forKey: terminalID)
+        terminalTabCloseContexts.removeValue(forKey: terminalID)
+    }
+
+    func resolvedFocusedTabCloseContext() -> TabCloseContext? {
+        if terminalFocusTargets.isEmpty {
+            return focusedTabCloseContext
+        }
+        guard let terminalView = NSApp.keyWindow?.firstResponder as? TBDTerminalView else {
+            return nil
+        }
+        guard let terminalID = terminalFocusTargets.first(where: { $0.value.view === terminalView })?.key else {
+            return nil
+        }
+        return terminalTabCloseContexts[terminalID]
     }
 
     func terminalIDForAutofocus(worktreeID: UUID) -> UUID? {
@@ -47,6 +70,7 @@ extension AppState {
             }
 
             terminalView.window?.makeFirstResponder(terminalView)
+            self.focusedTabCloseContext = self.terminalTabCloseContexts[terminalID]
         }
     }
 }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -427,9 +427,13 @@ extension AppState {
         }
     }
 
-    /// Placeholder: close terminal tab.
+    /// Close the active tab in the selected worktree.
     func closeTerminalTab() {
-        // TODO: implement terminal tab close
+        guard let worktreeID = selectedWorktreeIDs.first else { return }
+        guard let arr = tabs[worktreeID], !arr.isEmpty else { return }
+        let activeIndex = activeTabIndices[worktreeID] ?? 0
+        let index = min(max(activeIndex, 0), arr.count - 1)
+        closeTab(worktreeID: worktreeID, index: index)
     }
 
     /// Placeholder: split terminal horizontally.

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -427,13 +427,10 @@ extension AppState {
         }
     }
 
-    /// Close the active tab in the selected worktree.
+    /// Backward-compatible wrapper for callers that still ask to close the
+    /// current terminal tab. The close target now comes only from focus.
     func closeTerminalTab() {
-        guard let worktreeID = selectedWorktreeIDs.first else { return }
-        guard let arr = tabs[worktreeID], !arr.isEmpty else { return }
-        let activeIndex = activeTabIndices[worktreeID] ?? 0
-        let index = min(max(activeIndex, 0), arr.count - 1)
-        closeTab(worktreeID: worktreeID, index: index)
+        closeFocusedTab()
     }
 
     /// Placeholder: split terminal horizontally.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -20,6 +20,11 @@ enum ReviveState: Equatable {
     }
 }
 
+struct TabCloseContext: Equatable {
+    let worktreeID: UUID
+    let tabID: UUID
+}
+
 @MainActor
 final class AppState: ObservableObject {
     /// Reference to the global appearance settings, wired by `TBDAppMain`
@@ -34,6 +39,7 @@ final class AppState: ObservableObject {
     @Published var worktrees: [UUID: [Worktree]] = [:]
     @Published var terminals: [UUID: [Terminal]] = [:]
     @Published var notes: [UUID: [Note]] = [:]
+    @Published var focusedTabCloseContext: TabCloseContext?
     /// Unread notification summaries keyed by worktree ID. The cmd-K jump
     /// menu sorts by `mostRecentAt`; the sidebar consumes `.type` for the
     /// severity dot. Worktrees the user is currently viewing are excluded
@@ -211,6 +217,9 @@ final class AppState: ObservableObject {
     /// Weak terminal views keyed by terminal UUID, used to restore AppKit first
     /// responder after worktree navigation.
     var terminalFocusTargets: [UUID: TerminalFocusTarget] = [:]
+    /// Tab-close ownership keyed by terminal UUID for views that belong to a
+    /// visible tab, used to resolve the currently focused closable tab.
+    var terminalTabCloseContexts: [UUID: TabCloseContext] = [:]
     /// Visual screenshots taken at suspend-click time, shown while daemon works.
     /// Keyed by terminal UUID. Cleared when suspend completes.
     @Published var suspendingSnapshots: [UUID: NSImage] = [:]

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -51,6 +51,7 @@ struct TBDCommands: Commands {
                     appState.closeFocusedTab()
                 }
             }
+            .keyboardShortcut("w", modifiers: .command)
             .disabled(!appState.canCloseFocusedTab)
 
             Divider()

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -18,18 +18,6 @@ struct TBDCommands: Commands {
             }
         }
 
-        // Replaces the default File > Close Window Cmd-W command. TBD is a
-        // tabbed workspace; Cmd-W should close the active tab instead.
-        CommandGroup(replacing: .saveItem) {
-            Button("Close Tab") {
-                Task { @MainActor in
-                    appState.closeTerminalTab()
-                }
-            }
-            .keyboardShortcut("w", modifiers: .command)
-            .disabled(appState.selectedWorktreeIDs.isEmpty)
-        }
-
         // Worktree commands
         CommandMenu("Worktree") {
             Button("New Worktree") {
@@ -60,10 +48,10 @@ struct TBDCommands: Commands {
 
             Button("Close Tab") {
                 Task { @MainActor in
-                    appState.closeTerminalTab()
+                    appState.closeFocusedTab()
                 }
             }
-            .disabled(appState.selectedWorktreeIDs.isEmpty)
+            .disabled(!appState.canCloseFocusedTab)
 
             Divider()
 

--- a/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
+++ b/Sources/TBDApp/Helpers/KeyboardShortcuts.swift
@@ -18,6 +18,18 @@ struct TBDCommands: Commands {
             }
         }
 
+        // Replaces the default File > Close Window Cmd-W command. TBD is a
+        // tabbed workspace; Cmd-W should close the active tab instead.
+        CommandGroup(replacing: .saveItem) {
+            Button("Close Tab") {
+                Task { @MainActor in
+                    appState.closeTerminalTab()
+                }
+            }
+            .keyboardShortcut("w", modifiers: .command)
+            .disabled(appState.selectedWorktreeIDs.isEmpty)
+        }
+
         // Worktree commands
         CommandMenu("Worktree") {
             Button("New Worktree") {
@@ -51,7 +63,6 @@ struct TBDCommands: Commands {
                     appState.closeTerminalTab()
                 }
             }
-            .keyboardShortcut("w", modifiers: .command)
             .disabled(appState.selectedWorktreeIDs.isEmpty)
 
             Divider()

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -30,6 +30,7 @@ func shouldSuppressEvents(in coordinator: TranscriptOverlayCoordinator, forTermi
 struct PanePlaceholder: View {
     let content: PaneContent
     let worktree: Worktree
+    let tabID: UUID?
     @Binding var layout: LayoutNode
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
@@ -294,6 +295,7 @@ struct PanePlaceholder: View {
                     tmuxServer: worktree.tmuxServer,
                     tmuxWindowID: terminal.tmuxWindowID,
                     tmuxBridge: appState.tmuxBridge,
+                    tabCloseContext: tabID.map { TabCloseContext(worktreeID: worktree.id, tabID: $0) },
                     worktreePath: worktree.path,
                     remoteURL: appState.repos.first(where: { $0.id == worktree.repoID })?.remoteURL,
                     onFilePathClicked: { path in
@@ -500,4 +502,3 @@ struct EditableNoteTitle: View {
         }
     }
 }
-

--- a/Sources/TBDApp/Terminal/SplitLayoutView.swift
+++ b/Sources/TBDApp/Terminal/SplitLayoutView.swift
@@ -6,6 +6,7 @@ import TBDShared
 struct SplitLayoutView: View {
     let node: LayoutNode
     let worktree: Worktree
+    let tabID: UUID?
     @Binding var layout: LayoutNode
 
     var body: some View {
@@ -14,6 +15,7 @@ struct SplitLayoutView: View {
             PanePlaceholder(
                 content: content,
                 worktree: worktree,
+                tabID: tabID,
                 layout: $layout
             )
         case .split(let direction, let children, let ratios):
@@ -22,6 +24,7 @@ struct SplitLayoutView: View {
                 children: children,
                 ratios: ratios,
                 worktree: worktree,
+                tabID: tabID,
                 layout: $layout
             )
         }
@@ -37,6 +40,7 @@ struct SplitContainer: View {
     let children: [LayoutNode]
     let ratios: [CGFloat]
     let worktree: Worktree
+    let tabID: UUID?
     @Binding var layout: LayoutNode
 
     /// Local mutable copy of ratios used during drag operations.
@@ -81,6 +85,7 @@ struct SplitContainer: View {
                     SplitLayoutView(
                         node: child,
                         worktree: worktree,
+                        tabID: tabID,
                         layout: $layout
                     )
                     .frame(width: activeRatios[index] * availableSpace)
@@ -103,6 +108,7 @@ struct SplitContainer: View {
                     SplitLayoutView(
                         node: child,
                         worktree: worktree,
+                        tabID: tabID,
                         layout: $layout
                     )
                     .frame(height: activeRatios[index] * availableSpace)

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -13,11 +13,15 @@ private extension CharacterSet {
 /// When enabled, macOS-native shortcuts (Cmd+Arrow, Cmd/Opt+Delete) are translated
 /// to the escape sequences that shells expect.
 class TBDTerminalView: TerminalView {
+    enum KeyEquivalentAction: Equatable {
+        case closeTab
+    }
     var naturalTextEditing: Bool = true
     var onFilePathClicked: ((String) -> Void)?
     var worktreePath: String = ""
     var remoteURL: String?
     var onNotification: ((String, String) -> Void)?
+    var onCloseTab: (() -> Void)?
 
     /// Global appearance settings (font, color scheme, cursor style). The Combine
     /// subscription set up in `init` reapplies these whenever the user edits
@@ -489,12 +493,29 @@ class TBDTerminalView: TerminalView {
         guard window?.firstResponder === self else {
             return super.performKeyEquivalent(with: event)
         }
+        if event.type == .keyDown, let action = Self.keyEquivalentAction(for: event) {
+            performKeyEquivalentAction(action)
+            return true
+        }
         if naturalTextEditing, event.type == .keyDown, handleNaturalTextEditing(event) {
             return true
         }
         return super.performKeyEquivalent(with: event)
     }
 
+    nonisolated static func keyEquivalentAction(for event: NSEvent) -> KeyEquivalentAction? {
+        let flags = event.modifierFlags.intersection([.command, .shift, .option, .control])
+        guard flags == .command else { return nil }
+        guard event.charactersIgnoringModifiers?.lowercased() == "w" else { return nil }
+        return .closeTab
+    }
+
+    func performKeyEquivalentAction(_ action: KeyEquivalentAction) {
+        switch action {
+        case .closeTab:
+            onCloseTab?()
+        }
+    }
     private func handleNaturalTextEditing(_ event: NSEvent) -> Bool {
         let flags = event.modifierFlags
         let hasCmd = flags.contains(.command)

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -259,6 +259,7 @@ struct SingleWorktreeView: View {
             SplitLayoutView(
                 node: layoutBinding.wrappedValue,
                 worktree: worktree,
+                tabID: tab.id,
                 layout: layoutBinding
             )
             .id(tab.id) // Force new view hierarchy when switching tabs
@@ -390,6 +391,13 @@ private struct MultiWorktreeCell: View {
         return appState.terminals[worktreeID]?.first { $0.id == firstID }
     }
 
+    private var activeTab: Tab? {
+        let tabs = appState.tabs[worktreeID] ?? []
+        guard !tabs.isEmpty else { return nil }
+        let activeIndex = appState.activeTabIndices[worktreeID] ?? 0
+        return tabs[min(activeIndex, tabs.count - 1)]
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Header with worktree name
@@ -448,6 +456,7 @@ private struct MultiWorktreeCell: View {
             PanePlaceholder(
                 content: .terminal(terminalID: terminal.id),
                 worktree: worktree,
+                tabID: activeTab?.id,
                 layout: layoutBinding
             )
         } else {

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -298,37 +298,7 @@ struct SingleWorktreeView: View {
     }
 
     private func closeTab(at index: Int) {
-        let tabs = worktreeTabs
-        guard index >= 0, index < tabs.count else { return }
-        let tab = tabs[index]
-
-        // Find all terminal IDs in this tab's layout (including splits)
-        let layout = appState.layouts[tab.id] ?? .pane(tab.content)
-        let terminalIDsInTab = Set(layout.allTerminalIDs())
-
-        // Remove layout
-        appState.layouts.removeValue(forKey: tab.id)
-
-        // Remove tab
-        appState.tabs[worktreeID]?.remove(at: index)
-
-        // Delete ALL terminals in this tab's layout from daemon (kills tmux windows + removes DB records + local state)
-        for terminalID in terminalIDsInTab {
-            Task {
-                await appState.deleteTerminal(terminalID: terminalID, worktreeID: worktreeID)
-            }
-        }
-
-        // Delete note if this is a note tab
-        if case .note(let noteID) = tab.content {
-            Task {
-                await appState.deleteNote(noteID: noteID, worktreeID: worktreeID)
-            }
-        }
-
-        // Adjust active tab index
-        let remaining = appState.tabs[worktreeID]?.count ?? 0
-        activeTabIndex = remaining > 0 ? min(activeTabIndex, remaining - 1) : 0
+        appState.closeTab(worktreeID: worktreeID, index: index)
     }
 }
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -138,7 +138,7 @@ struct TerminalPanelView: View {
 /// 1. TmuxBridge creates a grouped session pointing at the right window
 /// 2. SwiftTerm spawns `tmux attach -t <grouped-session>` in a native PTY
 /// 3. All input, output, and resize handled natively by the terminal driver
-private struct TerminalPanelRepresentable: NSViewRepresentable {
+struct TerminalPanelRepresentable: NSViewRepresentable {
     let terminalID: UUID
     let tmuxServer: String
     let tmuxWindowID: String
@@ -172,7 +172,6 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         tv.onFilePathClicked = onFilePathClicked
         tv.onNotification = onTerminalNotification
         tv.onCloseTab = {
-            guard tabCloseContext != nil else { return }
             appState.closeFocusedTab()
         }
 
@@ -183,7 +182,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         context.coordinator.tmuxServer = tmuxServer
         context.coordinator.panelID = terminalID
         context.coordinator.appState = appState
-        context.coordinator.tabCloseContext = tabCloseContext
+        context.coordinator.syncTabCloseContext(tabCloseContext, for: terminalID)
         context.coordinator.onDeadWindow = onDeadWindow
         context.coordinator.shouldSuppressEvents = shouldSuppressEvents
 
@@ -225,14 +224,13 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         appState.snapshotProviders[captureID] = { [weak tv] in
             tv?.captureScreenshot()
         }
-        appState.registerTerminalCloseContext(tabCloseContext, for: terminalID)
         appState.registerTerminalView(tv, for: terminalID)
 
         return tv
     }
 
     func updateNSView(_ nsView: TBDTerminalView, context: Context) {
-        // Resize is handled by sizeChanged delegate
+        context.coordinator.syncTabCloseContext(tabCloseContext, for: terminalID)
     }
 
     static func dismantleNSView(_ nsView: TBDTerminalView, coordinator: Coordinator) {
@@ -263,6 +261,13 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         private var clickMonitor: Any?
         private var recreationAttempts = 0
         private static let maxRecreationAttempts = 2
+
+        @MainActor
+        func syncTabCloseContext(_ context: TabCloseContext?, for terminalID: UUID) {
+            guard tabCloseContext != context else { return }
+            tabCloseContext = context
+            appState?.registerTerminalCloseContext(context, for: terminalID)
+        }
 
         @MainActor
         func startTmuxClient(

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -168,6 +168,9 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         tv.remoteURL = remoteURL
         tv.onFilePathClicked = onFilePathClicked
         tv.onNotification = onTerminalNotification
+        tv.onCloseTab = {
+            appState.closeTerminalTab()
+        }
 
         // Set delegate for terminal events
         tv.terminalDelegate = context.coordinator

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -22,6 +22,7 @@ struct TerminalPanelView: View {
     let tmuxServer: String
     let tmuxWindowID: String
     let tmuxBridge: TmuxBridge
+    var tabCloseContext: TabCloseContext? = nil
     var worktreePath: String = ""
     var remoteURL: String?
     var onFilePathClicked: ((String) -> Void)?
@@ -83,6 +84,7 @@ struct TerminalPanelView: View {
                 tmuxServer: tmuxServer,
                 tmuxWindowID: tmuxWindowID,
                 tmuxBridge: tmuxBridge,
+                tabCloseContext: tabCloseContext,
                 worktreePath: worktreePath,
                 remoteURL: remoteURL,
                 onFilePathClicked: onFilePathClicked,
@@ -141,6 +143,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
     let tmuxServer: String
     let tmuxWindowID: String
     let tmuxBridge: TmuxBridge
+    var tabCloseContext: TabCloseContext? = nil
     var worktreePath: String = ""
     var remoteURL: String?
     var onFilePathClicked: ((String) -> Void)?
@@ -169,7 +172,9 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         tv.onFilePathClicked = onFilePathClicked
         tv.onNotification = onTerminalNotification
         tv.onCloseTab = {
-            appState.closeTerminalTab()
+            guard let tabCloseContext else { return }
+            appState.focusedTabCloseContext = tabCloseContext
+            appState.closeFocusedTab()
         }
 
         // Set delegate for terminal events
@@ -179,6 +184,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         context.coordinator.tmuxServer = tmuxServer
         context.coordinator.panelID = terminalID
         context.coordinator.appState = appState
+        context.coordinator.tabCloseContext = tabCloseContext
         context.coordinator.onDeadWindow = onDeadWindow
         context.coordinator.shouldSuppressEvents = shouldSuppressEvents
 
@@ -220,6 +226,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         appState.snapshotProviders[captureID] = { [weak tv] in
             tv?.captureScreenshot()
         }
+        appState.registerTerminalCloseContext(tabCloseContext, for: terminalID)
         appState.registerTerminalView(tv, for: terminalID)
 
         return tv
@@ -246,6 +253,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         var tmuxBridge: TmuxBridge?
         var tmuxServer: String = ""
         var panelID: UUID = UUID()
+        var tabCloseContext: TabCloseContext?
         var onDeadWindow: (() -> Void)?
         /// Returns `true` when a SwiftUI overlay (e.g. transcript card) is open
         /// over this terminal and should receive scroll/click events instead of
@@ -326,6 +334,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
             // Focus on next run loop iteration (needs main actor for window access)
             DispatchQueue.main.async {
                 terminalView.window?.makeFirstResponder(terminalView)
+                self.appState?.focusedTabCloseContext = self.tabCloseContext
             }
 
             // Intercept scroll wheel events before they reach TerminalView.
@@ -402,7 +411,14 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
                     // receives key and click events.
                     if self.shouldSuppressEvents() { return }
                     let point = tv.convert(location, from: nil)
-                    guard tv.bounds.contains(point) else { return }
+                    if !tv.bounds.contains(point) {
+                        if self.appState?.focusedTabCloseContext == self.tabCloseContext,
+                           tv.window?.firstResponder === tv {
+                            self.appState?.focusedTabCloseContext = nil
+                        }
+                        return
+                    }
+                    self.appState?.focusedTabCloseContext = self.tabCloseContext
                     tv.window?.makeFirstResponder(tv)
                 }
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -172,8 +172,7 @@ private struct TerminalPanelRepresentable: NSViewRepresentable {
         tv.onFilePathClicked = onFilePathClicked
         tv.onNotification = onTerminalNotification
         tv.onCloseTab = {
-            guard let tabCloseContext else { return }
-            appState.focusedTabCloseContext = tabCloseContext
+            guard tabCloseContext != nil else { return }
             appState.closeFocusedTab()
         }
 

--- a/Tests/TBDAppTests/TabReorderTests.swift
+++ b/Tests/TBDAppTests/TabReorderTests.swift
@@ -143,3 +143,35 @@ import TBDShared
     state.setActiveTab(worktreeID: worktreeID, tabIndex: 99)
     #expect(state.activeTabIndices[worktreeID] == 99)
 }
+
+@MainActor
+@Test func closeTerminalTabRemovesActiveTabAndLayout() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let ids = [UUID(), UUID(), UUID()]
+    state.selectedWorktreeIDs = [worktreeID]
+    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    state.layouts[ids[1]] = .pane(.terminal(terminalID: ids[1]))
+    state.activeTabIndices[worktreeID] = 1
+
+    state.closeTerminalTab()
+
+    #expect(state.tabs[worktreeID]?.map(\.id) == [ids[0], ids[2]])
+    #expect(state.layouts[ids[1]] == nil)
+    #expect(state.activeTabIndices[worktreeID] == 1)
+}
+
+@MainActor
+@Test func closeTerminalTabClampsOutOfBoundsActiveIndex() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let ids = [UUID(), UUID()]
+    state.selectedWorktreeIDs = [worktreeID]
+    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    state.activeTabIndices[worktreeID] = 99
+
+    state.closeTerminalTab()
+
+    #expect(state.tabs[worktreeID]?.map(\.id) == [ids[0]])
+    #expect(state.activeTabIndices[worktreeID] == 0)
+}

--- a/Tests/TBDAppTests/TabReorderTests.swift
+++ b/Tests/TBDAppTests/TabReorderTests.swift
@@ -145,33 +145,52 @@ import TBDShared
 }
 
 @MainActor
-@Test func closeTerminalTabRemovesActiveTabAndLayout() {
+@Test func closeFocusedTabRemovesFocusedTabAndLayout() {
     let state = AppState()
     let worktreeID = UUID()
     let ids = [UUID(), UUID(), UUID()]
-    state.selectedWorktreeIDs = [worktreeID]
     state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
     state.layouts[ids[1]] = .pane(.terminal(terminalID: ids[1]))
-    state.activeTabIndices[worktreeID] = 1
+    state.focusedTabCloseContext = .init(worktreeID: worktreeID, tabID: ids[1])
 
-    state.closeTerminalTab()
+    state.closeFocusedTab()
 
     #expect(state.tabs[worktreeID]?.map(\.id) == [ids[0], ids[2]])
     #expect(state.layouts[ids[1]] == nil)
     #expect(state.activeTabIndices[worktreeID] == 1)
+    #expect(state.focusedTabCloseContext == nil)
 }
 
 @MainActor
-@Test func closeTerminalTabClampsOutOfBoundsActiveIndex() {
+@Test func closeFocusedTabUsesFocusedContextInsteadOfSelectedWorktree() {
+    let state = AppState()
+    let selectedWorktreeID = UUID()
+    let focusedWorktreeID = UUID()
+    let selectedTabID = UUID()
+    let focusedTabIDs = [UUID(), UUID()]
+    state.selectedWorktreeIDs = [selectedWorktreeID]
+    state.tabs[selectedWorktreeID] = [Tab(id: selectedTabID, content: .terminal(terminalID: selectedTabID), label: nil)]
+    state.tabs[focusedWorktreeID] = focusedTabIDs.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
+    state.focusedTabCloseContext = .init(worktreeID: focusedWorktreeID, tabID: focusedTabIDs[1])
+
+    state.closeFocusedTab()
+
+    #expect(state.tabs[selectedWorktreeID]?.map(\.id) == [selectedTabID])
+    #expect(state.tabs[focusedWorktreeID]?.map(\.id) == [focusedTabIDs[0]])
+}
+
+@MainActor
+@Test func canCloseFocusedTabRequiresLiveFocusedContext() {
     let state = AppState()
     let worktreeID = UUID()
-    let ids = [UUID(), UUID()]
-    state.selectedWorktreeIDs = [worktreeID]
-    state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
-    state.activeTabIndices[worktreeID] = 99
+    let tabID = UUID()
+    state.tabs[worktreeID] = [Tab(id: tabID, content: .terminal(terminalID: tabID), label: nil)]
 
-    state.closeTerminalTab()
+    #expect(state.canCloseFocusedTab == false)
 
-    #expect(state.tabs[worktreeID]?.map(\.id) == [ids[0]])
-    #expect(state.activeTabIndices[worktreeID] == 0)
+    state.focusedTabCloseContext = .init(worktreeID: worktreeID, tabID: tabID)
+    #expect(state.canCloseFocusedTab == true)
+
+    state.focusedTabCloseContext = .init(worktreeID: worktreeID, tabID: UUID())
+    #expect(state.canCloseFocusedTab == false)
 }

--- a/Tests/TBDAppTests/TerminalKeyEquivalentTests.swift
+++ b/Tests/TBDAppTests/TerminalKeyEquivalentTests.swift
@@ -1,0 +1,58 @@
+import AppKit
+import Testing
+@testable import TBDApp
+
+@Suite("Terminal key equivalents")
+struct TerminalKeyEquivalentTests {
+    @Test("plain command-w closes the active tab")
+    func commandWClosesActiveTab() {
+        let event = keyEvent(characters: "w", modifiers: .command)
+
+        #expect(TBDTerminalView.keyEquivalentAction(for: event) == .closeTab)
+    }
+
+    @Test("shift command-w is not claimed as close tab")
+    func shiftCommandWDoesNotCloseTab() {
+        let event = keyEvent(characters: "W", modifiers: [.command, .shift])
+
+        #expect(TBDTerminalView.keyEquivalentAction(for: event) == nil)
+    }
+
+    @MainActor
+    @Test("close tab action invokes external tab cleanup")
+    func closeTabActionInvokesExternalTabCleanup() {
+        let view = makeTerminalView()
+        var closeCount = 0
+        view.onCloseTab = { closeCount += 1 }
+
+        view.performKeyEquivalentAction(.closeTab)
+
+        #expect(closeCount == 1)
+    }
+
+    @MainActor
+    private func makeTerminalView() -> TBDTerminalView {
+        let view = TBDTerminalView(
+            frame: CGRect(x: 0, y: 0, width: 640, height: 480),
+            font: TBDTerminalView.defaultMonospaceFont,
+            appearance: AppearanceSettings(defaults: UserDefaults(suiteName: "TerminalKeyEquivalentTests.clearAction")!)
+        )
+        view.resize(cols: 10, rows: 5)
+        return view
+    }
+
+    private func keyEvent(characters: String, modifiers: NSEvent.ModifierFlags) -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters.lowercased(),
+            isARepeat: false,
+            keyCode: 40
+        )!
+    }
+}

--- a/Tests/TBDAppTests/TerminalPanelViewTests.swift
+++ b/Tests/TBDAppTests/TerminalPanelViewTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("Terminal panel close context")
+struct TerminalPanelViewTests {
+    @MainActor
+    @Test("syncTabCloseContext refreshes coordinator and app state registration")
+    func syncTabCloseContextRefreshesRegistration() {
+        let state = AppState()
+        let terminalID = UUID()
+        let first = TabCloseContext(worktreeID: UUID(), tabID: UUID())
+        let second = TabCloseContext(worktreeID: UUID(), tabID: UUID())
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+
+        coordinator.syncTabCloseContext(first, for: terminalID)
+        #expect(coordinator.tabCloseContext == first)
+        #expect(state.terminalTabCloseContexts[terminalID] == first)
+
+        coordinator.syncTabCloseContext(second, for: terminalID)
+        #expect(coordinator.tabCloseContext == second)
+        #expect(state.terminalTabCloseContexts[terminalID] == second)
+
+        let noContext: TabCloseContext? = nil
+        coordinator.syncTabCloseContext(noContext, for: terminalID)
+        #expect(coordinator.tabCloseContext == nil)
+        #expect(state.terminalTabCloseContexts[terminalID] == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- make plain `Cmd-W` close the active tab instead of falling through to window-close behavior
- scope tab closing to the focused terminal's owning tab so multi-worktree views do not close an arbitrary selected worktree tab
- remove the File menu override and keep `Close Tab` under the Terminal menu, enabled only when a focused closable tab exists

## Test Plan
- `swift test`
