### PR TITLE
Fix Codex tab labels

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -115,7 +115,7 @@ extension AppState {
                 rows: size.rows
             )
             terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: terminal.label)
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
             tabs[worktreeID, default: []].append(tab)
         } catch {
             logger.error("Failed to create Codex terminal: \(error)")

--- a/Sources/TBDApp/AutoTabLabelResolver.swift
+++ b/Sources/TBDApp/AutoTabLabelResolver.swift
@@ -1,0 +1,42 @@
+import Foundation
+import TBDShared
+
+enum AutoTabLabelResolver {
+    static func terminalLabel(
+        terminal: Terminal?,
+        fallbackIndex: Int,
+        modelProfiles: [ModelProfileWithUsage],
+        worktreeTabs: [Tab],
+        worktreeTerminals: [Terminal]
+    ) -> String {
+        if let terminal,
+           terminal.isClaudeResumable,
+           let profileID = terminal.profileID,
+           let entry = modelProfiles.first(where: { $0.profile.id == profileID }) {
+            let sameProfileTerminalIDs = Set(
+                worktreeTerminals
+                    .filter { $0.profileID == profileID }
+                    .map(\.id)
+            )
+            let sameProfileTabs = worktreeTabs.filter { tab in
+                guard case .terminal(let terminalID) = tab.content else { return false }
+                return sameProfileTerminalIDs.contains(terminalID)
+            }
+            let position = (sameProfileTabs.firstIndex { tab in
+                guard case .terminal(let terminalID) = tab.content else { return false }
+                return terminalID == terminal.id
+            } ?? 0) + 1
+            return "\(entry.profile.tabDisplayName) \(position)"
+        }
+
+        if terminal?.isClaudeResumable == true {
+            return "Claude"
+        }
+
+        if terminal?.isCodexTerminal == true {
+            return "Codex"
+        }
+
+        return "Terminal \(fallbackIndex + 1)"
+    }
+}

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -686,31 +686,13 @@ private struct TabBarItem: View {
         }
         switch tab.content {
         case .terminal:
-            if isClaudeTerminal, let terminal, let profileID = terminal.profileID,
-               let entry = appState.modelProfiles.first(where: { $0.profile.id == profileID }) {
-                let name = entry.profile.tabDisplayName
-                let worktreeID = terminal.worktreeID
-                let allTabs = appState.tabs[worktreeID] ?? []
-                let allTerminals = appState.terminals[worktreeID] ?? []
-                let sameTokenTerminalIDs = Set(
-                    allTerminals
-                        .filter { $0.profileID == profileID }
-                        .map { $0.id }
-                )
-                let sameTokenTabs = allTabs.filter { tab in
-                    if case .terminal(let tID) = tab.content {
-                        return sameTokenTerminalIDs.contains(tID)
-                    }
-                    return false
-                }
-                let myTerminalID = terminal.id
-                let position = (sameTokenTabs.firstIndex { tab in
-                    if case .terminal(let tID) = tab.content { return tID == myTerminalID }
-                    return false
-                } ?? 0) + 1
-                return "\(name) \(position)"
-            }
-            return isClaudeTerminal ? "Claude" : "Terminal \(index + 1)"
+            return AutoTabLabelResolver.terminalLabel(
+                terminal: terminal,
+                fallbackIndex: index,
+                modelProfiles: appState.modelProfiles,
+                worktreeTabs: appState.tabs[worktreeID] ?? [],
+                worktreeTerminals: appState.terminals[worktreeID] ?? []
+            )
         case .webview(_, let url):
             return url.host ?? "Web"
         case .codeViewer(_, let path):

--- a/Tests/TBDAppTests/AutoTabLabelResolverTests.swift
+++ b/Tests/TBDAppTests/AutoTabLabelResolverTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+import TBDShared
+
+@Suite("AutoTabLabelResolver")
+struct AutoTabLabelResolverTests {
+    @Test func codexTerminalUsesCodexLabel() {
+        let terminal = Terminal(
+            worktreeID: UUID(),
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: nil,
+            kind: .codex
+        )
+
+        let label = AutoTabLabelResolver.terminalLabel(
+            terminal: terminal,
+            fallbackIndex: 1,
+            modelProfiles: [],
+            worktreeTabs: [],
+            worktreeTerminals: []
+        )
+
+        #expect(label == "Codex")
+    }
+
+    @Test func shellTerminalUsesGenericNumberedLabel() {
+        let terminal = Terminal(
+            worktreeID: UUID(),
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: nil,
+            kind: .shell
+        )
+
+        let label = AutoTabLabelResolver.terminalLabel(
+            terminal: terminal,
+            fallbackIndex: 2,
+            modelProfiles: [],
+            worktreeTabs: [],
+            worktreeTerminals: []
+        )
+
+        #expect(label == "Terminal 3")
+    }
+
+    @Test func claudeProfileUsesProfileNameAndPosition() {
+        let worktreeID = UUID()
+        let profileID = UUID()
+        let firstID = UUID()
+        let secondID = UUID()
+
+        let profile = ModelProfile(id: profileID, name: "Bedrock", kind: .bedrock)
+        let terminals = [
+            Terminal(
+                id: firstID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                claudeSessionID: "s1",
+                profileID: profileID,
+                kind: .claude
+            ),
+            Terminal(
+                id: secondID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@2",
+                tmuxPaneID: "%2",
+                claudeSessionID: "s2",
+                profileID: profileID,
+                kind: .claude
+            )
+        ]
+        let tabs = [
+            Tab(id: firstID, content: .terminal(terminalID: firstID), label: nil),
+            Tab(id: secondID, content: .terminal(terminalID: secondID), label: nil)
+        ]
+
+        let label = AutoTabLabelResolver.terminalLabel(
+            terminal: terminals[1],
+            fallbackIndex: 7,
+            modelProfiles: [ModelProfileWithUsage(profile: profile)],
+            worktreeTabs: tabs,
+            worktreeTerminals: terminals
+        )
+
+        #expect(label == "Bedrock 2")
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared auto-label resolver so Codex terminals render as `Codex` instead of falling back to `Terminal N`
- keep terminal type labels derived at render time by removing the stored `terminal.label` override from Codex tab creation
- cover Codex, shell, and Claude profile label behavior with focused app tests

## Test Plan
- `swift test`
