### PR TITLE
Fix pending PR checks icon color

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -132,7 +132,9 @@ public actor PRStatusManager {
             switch mergeStateStatus {
             case "CLEAN", "HAS_HOOKS":
                 return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .mergeable
-            case "BLOCKED", "DIRTY", "BEHIND":
+            case "BLOCKED":
+                return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .blocked
+            case "DIRTY", "BEHIND":
                 return .blocked
             case "UNSTABLE":
                 return .checksFailed

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -58,6 +58,16 @@ struct PRStatusManagerTests {
         #expect(status == .pending)
     }
 
+    @Test("maps OPEN + BLOCKED + pending status checks to .pending")
+    func mapsPendingChecksOverBlocked() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            statusCheckRollupState: "PENDING"
+        )
+        #expect(status == .pending)
+    }
+
     @Test("maps HAS_HOOKS to .mergeable")
     func mapsHasHooks() {
         let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "HAS_HOOKS")


### PR DESCRIPTION
## Summary
- treat `OPEN` pull requests with `mergeStateStatus == BLOCKED` and pending required checks as `.pending` instead of `.blocked`
- preserve red states for real failures, merge conflicts, behind branches, and changes requested
- add a regression test covering the blocked-plus-pending status check case

## Test Plan
- `swift test --filter PRStatusManagerTests`
- `swift test --filter PRStatusPresentationTests`
