### PR TITLE
Fix Codex stop hook ordering

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -81,12 +81,14 @@ enum CodexHookOverlay {
                 "Stop": [
                     [
                         "hooks": [
-                            ["type": "command", "command": stopCommand]
+                            ["type": "command", "command": stopRenameCheckCommand]
                         ]
                     ],
                     [
                         "hooks": [
-                            ["type": "command", "command": stopRenameCheckCommand]
+                            // Run response_complete only after any rename prompt
+                            // has finished blocking and Codex is ready again.
+                            ["type": "command", "command": stopCommand]
                         ]
                     ]
                 ]

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -34,6 +34,22 @@ import TBDShared
         })
     }
 
+    @Test func stopHooksRunRenameCheckBeforeResponseComplete() throws {
+        let data = try CodexHookOverlay.generateBody()
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let hooks = parsed?["hooks"] as? [String: Any]
+        let stop = hooks?["Stop"] as? [[String: Any]]
+
+        let stopCommands: [String] = (stop ?? []).flatMap { entry -> [String] in
+            let inner = entry["hooks"] as? [[String: Any]] ?? []
+            return inner.compactMap { $0["command"] as? String }
+        }
+
+        #expect(stopCommands.count == 2)
+        #expect(stopCommands.first?.contains("stop-rename-check") == true)
+        #expect(stopCommands.last?.contains("tbd notify --type response_complete") == true)
+    }
+
     @Test func roundtripsAsValidJSON() throws {
         let data = try CodexHookOverlay.generateBody()
         _ = try JSONSerialization.jsonObject(with: data, options: [])


### PR DESCRIPTION
## Summary
- run the Codex `stop-rename-check` hook before the `response_complete` notification hook
- document the ordering dependency inline so the completion notification only fires after Codex is ready for input again
- add a regression test that asserts the `Stop` hook order in the generated Codex hook overlay

## Test Plan
- `swift test --filter CodexHookOverlayTests`
