### PR TITLE
fix: serialize codex stop hooks

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -57,11 +57,14 @@ enum CodexHookOverlay {
     static let sessionStartCommand =
         #"tbd session-event 2>/dev/null || true"#
 
-    static let stopCommand =
-        #"MSG=$(jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
+    static let responseCompleteCommand =
+        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
 
     static let stopRenameCheckCommand =
         #"tbd hooks stop-rename-check 2>/dev/null || true"#
+
+    static let stopCommand =
+        #"PAYLOAD=$(cat); RENAME_RESULT=$(printf '%s' "$PAYLOAD" | \#(stopRenameCheckCommand)); if [ -n "$RENAME_RESULT" ]; then printf '%s\n' "$RENAME_RESULT"; else \#(responseCompleteCommand); fi"#
 
     static func hookPath(in pluginRoot: URL) -> URL {
         pluginRoot.appendingPathComponent(relativePath, isDirectory: false)
@@ -81,13 +84,6 @@ enum CodexHookOverlay {
                 "Stop": [
                     [
                         "hooks": [
-                            ["type": "command", "command": stopRenameCheckCommand]
-                        ]
-                    ],
-                    [
-                        "hooks": [
-                            // Run response_complete only after any rename prompt
-                            // has finished blocking and Codex is ready again.
                             ["type": "command", "command": stopCommand]
                         ]
                     ]

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -18,36 +18,32 @@ import TBDShared
         #expect(sessionCommand?.contains("tbd session-event") == true)
 
         let stop = hooks?["Stop"] as? [[String: Any]]
-        #expect(stop?.count == 2)
-        let stopCommands: [String] = (stop ?? []).flatMap { entry -> [String] in
-            let inner = entry["hooks"] as? [[String: Any]] ?? []
-            return inner.compactMap { $0["command"] as? String }
-        }
-        #expect(stopCommands.contains {
-            $0.contains("tbd notify --type response_complete")
-                && $0.contains("last_assistant_message")
-                && !$0.contains("stop-rename-check")
-        })
-        #expect(stopCommands.contains {
-            $0.contains("stop-rename-check")
-                && !$0.contains("tbd notify --type response_complete")
-        })
+        #expect(stop?.count == 1)
+        let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
+        #expect(stopHooks?.count == 1)
+        let stopCommand = stopHooks?.first?["command"] as? String
+        #expect(stopCommand?.contains("tbd hooks stop-rename-check") == true)
+        #expect(stopCommand?.contains("tbd notify --type response_complete") == true)
+        #expect(stopCommand?.contains("last_assistant_message") == true)
     }
 
-    @Test func stopHooksRunRenameCheckBeforeResponseComplete() throws {
+    @Test func stopHookRunsRenameCheckBeforeResponseComplete() throws {
         let data = try CodexHookOverlay.generateBody()
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let hooks = parsed?["hooks"] as? [String: Any]
         let stop = hooks?["Stop"] as? [[String: Any]]
+        let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
+        let stopCommand = stopHooks?.first?["command"] as? String
 
-        let stopCommands: [String] = (stop ?? []).flatMap { entry -> [String] in
-            let inner = entry["hooks"] as? [[String: Any]] ?? []
-            return inner.compactMap { $0["command"] as? String }
+        let renameIndex = stopCommand?.range(of: "tbd hooks stop-rename-check")?.lowerBound
+        let notifyIndex = stopCommand?.range(of: "tbd notify --type response_complete")?.lowerBound
+
+        #expect(renameIndex != nil)
+        #expect(notifyIndex != nil)
+        if let renameIndex, let notifyIndex {
+            #expect(renameIndex < notifyIndex)
         }
-
-        #expect(stopCommands.count == 2)
-        #expect(stopCommands.first?.contains("stop-rename-check") == true)
-        #expect(stopCommands.last?.contains("tbd notify --type response_complete") == true)
+        #expect(stopCommand?.contains("if [ -n \"$RENAME_RESULT\" ]") == true)
     }
 
     @Test func roundtripsAsValidJSON() throws {


### PR DESCRIPTION
## Summary
I had split these apart to fix the issue of the second hook not calling, but I was wrong about these firing in sequence, they are concurrent. Lets put them back as 1!
- collapse the Codex `Stop` overlay back to a single command that reads the hook payload once
- run `tbd hooks stop-rename-check` before `response_complete`, and only send the notification when the rename check does not block
- update the Codex hook overlay tests to assert the single-hook serial execution shape

## Test Plan
- `swift test`
