### PR TITLE
Fix: Show merge-conflict marker on PRs that would fail to merge

### DIFF
--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -10,7 +10,9 @@ enum WorktreeRowConflictFallback {
         hasNotification: Bool
     ) -> Bool {
         guard let prStatus, hasConflicts, !hasNotification else { return false }
-        return prStatus.state != .merged
+        // Closed and merged PRs have no pending merge action, so a conflict warning is noise.
+        // The PR-icon slot is mutually exclusive with the conflict glyph; suppress here to keep .closed/.merged visible.
+        return prStatus.state != .merged && prStatus.state != .closed
     }
 }
 

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -2,14 +2,14 @@ import SwiftUI
 import TBDShared
 
 enum WorktreeRowConflictFallback {
-    static let iconName = "hand.raised.slash.fill"
+    static let iconName = "git-merge-conflict"
 
     static func shouldShow(
         prStatus: PRStatus?,
         hasConflicts: Bool,
         hasNotification: Bool
     ) -> Bool {
-        prStatus == nil && hasConflicts && !hasNotification
+        prStatus != nil && hasConflicts && !hasNotification
     }
 }
 
@@ -87,9 +87,12 @@ struct WorktreeRowView: View {
             Circle()
                 .fill(color)
                 .frame(width: 8, height: 8)
-        } else if showsConflictFallback {
-            Image(systemName: WorktreeRowConflictFallback.iconName)
-                .font(.system(size: 10, weight: .semibold))
+        } else if showsConflictFallback, let nsImage = loadIcon(WorktreeRowConflictFallback.iconName) {
+            Image(nsImage: nsImage)
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 12, height: 12)
                 .foregroundStyle(.red)
         }
         if let presentation = prPresentation, let nsImage = loadIcon(presentation.iconName) {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -9,7 +9,8 @@ enum WorktreeRowConflictFallback {
         hasConflicts: Bool,
         hasNotification: Bool
     ) -> Bool {
-        prStatus != nil && hasConflicts && !hasNotification
+        guard let prStatus, hasConflicts, !hasNotification else { return false }
+        return prStatus.state != .merged
     }
 }
 
@@ -95,7 +96,9 @@ struct WorktreeRowView: View {
                 .frame(width: 12, height: 12)
                 .foregroundStyle(.red)
         }
-        if let presentation = prPresentation, let nsImage = loadIcon(presentation.iconName) {
+        if !showsConflictFallback,
+           let presentation = prPresentation,
+           let nsImage = loadIcon(presentation.iconName) {
             Image(nsImage: nsImage)
                 .renderingMode(.template)
                 .resizable()

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -47,7 +47,7 @@ extension WorktreeLifecycle {
     /// Returns nil if git commands fail (leaves status unchanged).
     private func checkHasConflicts(repoPath: String, defaultBranch: String, branch: String) async -> Bool? {
         guard let isAncestor = await git.isMergeBaseAncestor(
-            repoPath: repoPath, base: defaultBranch, branch: branch
+            repoPath: repoPath, base: "origin/\(defaultBranch)", branch: branch
         ) else {
             return nil  // git error — leave status unchanged
         }
@@ -55,7 +55,7 @@ extension WorktreeLifecycle {
 
         // Branches have diverged — check for conflicts
         let (hasConflicts, _) = await git.checkMergeConflicts(
-            repoPath: repoPath, branch: branch, targetBranch: defaultBranch
+            repoPath: repoPath, branch: branch, targetBranch: "origin/\(defaultBranch)"
         )
         return hasConflicts
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -49,7 +49,10 @@ extension WorktreeLifecycle {
         guard let isAncestor = await git.isMergeBaseAncestor(
             repoPath: repoPath, base: "origin/\(defaultBranch)", branch: branch
         ) else {
-            return nil  // git error — leave status unchanged
+            // git error or origin/<defaultBranch> doesn't exist yet —
+            // leave hasConflicts at its previous value. For purely local repos
+            // (no origin remote) this is a permanent no-op, which is acceptable.
+            return nil
         }
         if isAncestor { return false }
 

--- a/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
@@ -4,12 +4,12 @@ import Testing
 
 @Suite("Worktree row conflict fallback")
 struct WorktreeRowConflictFallbackTests {
-    @Test("uses the hand-raised slash icon for conflict fallback")
+    @Test("uses the git-merge-conflict icon for conflict fallback")
     func usesConflictFallbackIcon() {
-        #expect(WorktreeRowConflictFallback.iconName == "hand.raised.slash.fill")
+        #expect(WorktreeRowConflictFallback.iconName == "git-merge-conflict")
     }
 
-    @Test("conflict fallback appears when there is no PR and no notification")
+    @Test("conflict fallback does NOT appear when there is no PR")
     func conflictFallbackWithoutPR() {
         let showsFallback = WorktreeRowConflictFallback.shouldShow(
             prStatus: nil,
@@ -17,13 +17,13 @@ struct WorktreeRowConflictFallbackTests {
             hasNotification: false
         )
 
-        #expect(showsFallback)
+        #expect(!showsFallback)
     }
 
     @Test("notification badge takes precedence over conflict fallback")
     func notificationWinsOverConflictFallback() {
         let showsFallback = WorktreeRowConflictFallback.shouldShow(
-            prStatus: nil,
+            prStatus: PRStatus(number: 12, url: "https://example.com/12", state: .pending),
             hasConflicts: true,
             hasNotification: true
         )
@@ -31,7 +31,7 @@ struct WorktreeRowConflictFallbackTests {
         #expect(!showsFallback)
     }
 
-    @Test("PR status suppresses conflict fallback")
+    @Test("conflict fallback appears when a PR is present and the branch has conflicts")
     func prStatusSuppressesConflictFallback() {
         let showsFallback = WorktreeRowConflictFallback.shouldShow(
             prStatus: PRStatus(number: 12, url: "https://example.com/12", state: .pending),
@@ -39,6 +39,6 @@ struct WorktreeRowConflictFallbackTests {
             hasNotification: false
         )
 
-        #expect(!showsFallback)
+        #expect(showsFallback)
     }
 }

--- a/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
@@ -32,7 +32,7 @@ struct WorktreeRowConflictFallbackTests {
     }
 
     @Test("conflict fallback appears when a PR is present and the branch has conflicts")
-    func prStatusSuppressesConflictFallback() {
+    func conflictFallbackAppearsWithPR() {
         let showsFallback = WorktreeRowConflictFallback.shouldShow(
             prStatus: PRStatus(number: 12, url: "https://example.com/12", state: .pending),
             hasConflicts: true,

--- a/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
@@ -41,4 +41,14 @@ struct WorktreeRowConflictFallbackTests {
 
         #expect(showsFallback)
     }
+
+    @Test("merged PR icon wins over conflict fallback (squash-merge produces false-positive conflicts)")
+    func mergedPRSuppressesConflictFallback() {
+        let showsFallback = WorktreeRowConflictFallback.shouldShow(
+            prStatus: PRStatus(number: 12, url: "https://example.com/12", state: .merged),
+            hasConflicts: true,
+            hasNotification: false
+        )
+        #expect(!showsFallback)
+    }
 }

--- a/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowIndicatorTests.swift
@@ -51,4 +51,14 @@ struct WorktreeRowConflictFallbackTests {
         )
         #expect(!showsFallback)
     }
+
+    @Test("closed PR icon wins over conflict fallback (no pending merge action)")
+    func closedPRSuppressesConflictFallback() {
+        let showsFallback = WorktreeRowConflictFallback.shouldShow(
+            prStatus: PRStatus(number: 12, url: "https://example.com/12", state: .closed),
+            hasConflicts: true,
+            hasNotification: false
+        )
+        #expect(!showsFallback)
+    }
 }

--- a/Tests/TBDDaemonTests/GitStatusTests.swift
+++ b/Tests/TBDDaemonTests/GitStatusTests.swift
@@ -3,6 +3,18 @@ import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
 
+private func runShell(_ cmd: String, at dir: URL) async throws {
+    let p = Process()
+    p.executableURL = URL(fileURLWithPath: "/bin/zsh")
+    p.arguments = ["-c", cmd]
+    p.currentDirectoryURL = dir
+    try p.run()
+    p.waitUntilExit()
+    guard p.terminationStatus == 0 else {
+        throw NSError(domain: "shell", code: Int(p.terminationStatus))
+    }
+}
+
 @Suite("GitStatus Tests")
 struct GitStatusTests {
 
@@ -51,28 +63,16 @@ struct GitStatusTests {
         try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: repoDir) }
 
-        func shell(_ cmd: String, at dir: URL? = nil) async throws {
-            let p = Process()
-            p.executableURL = URL(fileURLWithPath: "/bin/zsh")
-            p.arguments = ["-c", cmd]
-            p.currentDirectoryURL = dir ?? repoDir
-            try p.run()
-            p.waitUntilExit()
-            guard p.terminationStatus == 0 else {
-                throw NSError(domain: "shell", code: Int(p.terminationStatus))
-            }
-        }
-
         // Init repo and make initial commit on main
-        try await shell("git init -b main")
-        try await shell("git config commit.gpgSign false")
-        try await shell("git config user.email 'test@test.com'")
-        try await shell("git config user.name 'Test'")
-        try await shell("touch README.md && git add . && git commit -m 'initial'")
+        try await runShell("git init -b main", at: repoDir)
+        try await runShell("git config commit.gpgSign false", at: repoDir)
+        try await runShell("git config user.email 'test@test.com'", at: repoDir)
+        try await runShell("git config user.name 'Test'", at: repoDir)
+        try await runShell("touch README.md && git add . && git commit -m 'initial'", at: repoDir)
 
         // Create feature branch with a commit
-        try await shell("git checkout -b feature")
-        try await shell("touch feature.txt && git add . && git commit -m 'feature commit'")
+        try await runShell("git checkout -b feature", at: repoDir)
+        try await runShell("touch feature.txt && git add . && git commit -m 'feature commit'", at: repoDir)
 
         // main IS an ancestor of feature
         let git = GitManager()
@@ -81,8 +81,8 @@ struct GitStatusTests {
         #expect(mainIsAncestor == true)
 
         // Now add a commit to main (diverge)
-        try await shell("git checkout main")
-        try await shell("touch main-extra.txt && git add . && git commit -m 'main diverges'")
+        try await runShell("git checkout main", at: repoDir)
+        try await runShell("touch main-extra.txt && git add . && git commit -m 'main diverges'", at: repoDir)
 
         // main is now NOT an ancestor of feature (main has diverged)
         let mainIsAncestorAfterDiverge = await git.isMergeBaseAncestor(repoPath: repoPath, base: "main", branch: "feature")
@@ -102,42 +102,30 @@ struct GitStatusTests {
             try? FileManager.default.removeItem(at: originDir)
         }
 
-        func shell(_ cmd: String, at dir: URL? = nil) async throws {
-            let p = Process()
-            p.executableURL = URL(fileURLWithPath: "/bin/zsh")
-            p.arguments = ["-c", cmd]
-            p.currentDirectoryURL = dir ?? repoDir
-            try p.run()
-            p.waitUntilExit()
-            guard p.terminationStatus == 0 else {
-                throw NSError(domain: "shell", code: Int(p.terminationStatus))
-            }
-        }
-
         // Init repo with a file
-        try await shell("git init -b main")
-        try await shell("git config commit.gpgSign false")
-        try await shell("git config user.email 'test@test.com'")
-        try await shell("git config user.name 'Test'")
-        try await shell("echo 'line1' > shared.txt && git add . && git commit -m 'initial'")
+        try await runShell("git init -b main", at: repoDir)
+        try await runShell("git config commit.gpgSign false", at: repoDir)
+        try await runShell("git config user.email 'test@test.com'", at: repoDir)
+        try await runShell("git config user.name 'Test'", at: repoDir)
+        try await runShell("echo 'line1' > shared.txt && git add . && git commit -m 'initial'", at: repoDir)
 
         // Set up bare origin remote and push the pre-conflict main
-        try await shell("git init --bare '\(originDir.path)'")
-        try await shell("git remote add origin '\(originDir.path)'")
-        try await shell("git push -u origin main")
+        try await runShell("git init --bare '\(originDir.path)'", at: repoDir)
+        try await runShell("git remote add origin '\(originDir.path)'", at: repoDir)
+        try await runShell("git push -u origin main", at: repoDir)
 
         // Create feature branch with conflicting change (NOT pushed to origin)
-        try await shell("git checkout -b tbd/feature-wt")
-        try await shell("echo 'feature-change' > shared.txt && git add . && git commit -m 'feature change'")
+        try await runShell("git checkout -b tbd/feature-wt", at: repoDir)
+        try await runShell("echo 'feature-change' > shared.txt && git add . && git commit -m 'feature change'", at: repoDir)
 
         // Back to main with conflicting change to same file, then push so
         // origin/main reflects the diverged state. The feature branch is NOT
         // pushed — origin/main is ahead of where feature branched off, with a
         // conflicting edit to shared.txt, which is what makes the conflict
         // detectable under the origin-based reconcile semantics.
-        try await shell("git checkout main")
-        try await shell("echo 'main-change' > shared.txt && git add . && git commit -m 'main change'")
-        try await shell("git push origin main")
+        try await runShell("git checkout main", at: repoDir)
+        try await runShell("echo 'main-change' > shared.txt && git add . && git commit -m 'main change'", at: repoDir)
+        try await runShell("git push origin main", at: repoDir)
 
         // Set up DB
         let db = try TBDDatabase(inMemory: true)
@@ -170,32 +158,20 @@ struct GitStatusTests {
             try? FileManager.default.removeItem(at: originDir)
         }
 
-        func shell(_ cmd: String, at dir: URL? = nil) async throws {
-            let p = Process()
-            p.executableURL = URL(fileURLWithPath: "/bin/zsh")
-            p.arguments = ["-c", cmd]
-            p.currentDirectoryURL = dir ?? repoDir
-            try p.run()
-            p.waitUntilExit()
-            guard p.terminationStatus == 0 else {
-                throw NSError(domain: "shell", code: Int(p.terminationStatus))
-            }
-        }
-
         // Init repo with a file
-        try await shell("git init -b main")
-        try await shell("git config commit.gpgSign false")
-        try await shell("git config user.email 'test@test.com'")
-        try await shell("git config user.name 'Test'")
-        try await shell("echo 'line1' > shared.txt && git add . && git commit -m 'initial'")
+        try await runShell("git init -b main", at: repoDir)
+        try await runShell("git config commit.gpgSign false", at: repoDir)
+        try await runShell("git config user.email 'test@test.com'", at: repoDir)
+        try await runShell("git config user.name 'Test'", at: repoDir)
+        try await runShell("echo 'line1' > shared.txt && git add . && git commit -m 'initial'", at: repoDir)
 
         // Set up bare origin remote and push main
-        try await shell("git init --bare '\(originDir.path)'")
-        try await shell("git remote add origin '\(originDir.path)'")
-        try await shell("git push -u origin main")
+        try await runShell("git init --bare '\(originDir.path)'", at: repoDir)
+        try await runShell("git remote add origin '\(originDir.path)'", at: repoDir)
+        try await runShell("git push -u origin main", at: repoDir)
 
         // Create feature branch pointing at the same commit as origin/main (no extra commits)
-        try await shell("git checkout -b tbd/feature-wt")
+        try await runShell("git checkout -b tbd/feature-wt", at: repoDir)
 
         // Set up DB
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/GitStatusTests.swift
+++ b/Tests/TBDDaemonTests/GitStatusTests.swift
@@ -92,9 +92,15 @@ struct GitStatusTests {
     // MARK: - refreshGitStatuses integration tests
 
     @Test func refreshGitStatusesDetectsConflicts() async throws {
-        let repoDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("tbd-test-\(UUID().uuidString)")
+        let tempBase = URL(fileURLWithPath: NSTemporaryDirectory())
+        let suffix = UUID().uuidString
+        let repoDir = tempBase.appendingPathComponent("tbd-test-\(suffix)")
+        let originDir = tempBase.appendingPathComponent("tbd-test-origin-\(suffix).git")
         try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: repoDir) }
+        defer {
+            try? FileManager.default.removeItem(at: repoDir)
+            try? FileManager.default.removeItem(at: originDir)
+        }
 
         func shell(_ cmd: String, at dir: URL? = nil) async throws {
             let p = Process()
@@ -115,13 +121,23 @@ struct GitStatusTests {
         try await shell("git config user.name 'Test'")
         try await shell("echo 'line1' > shared.txt && git add . && git commit -m 'initial'")
 
-        // Create feature branch with conflicting change
+        // Set up bare origin remote and push the pre-conflict main
+        try await shell("git init --bare '\(originDir.path)'")
+        try await shell("git remote add origin '\(originDir.path)'")
+        try await shell("git push -u origin main")
+
+        // Create feature branch with conflicting change (NOT pushed to origin)
         try await shell("git checkout -b tbd/feature-wt")
         try await shell("echo 'feature-change' > shared.txt && git add . && git commit -m 'feature change'")
 
-        // Back to main with conflicting change to same file
+        // Back to main with conflicting change to same file, then push so
+        // origin/main reflects the diverged state. The feature branch is NOT
+        // pushed — origin/main is ahead of where feature branched off, with a
+        // conflicting edit to shared.txt, which is what makes the conflict
+        // detectable under the origin-based reconcile semantics.
         try await shell("git checkout main")
         try await shell("echo 'main-change' > shared.txt && git add . && git commit -m 'main change'")
+        try await shell("git push origin main")
 
         // Set up DB
         let db = try TBDDatabase(inMemory: true)
@@ -141,5 +157,63 @@ struct GitStatusTests {
 
         let updated = try await db.worktrees.get(id: wt.id)
         #expect(updated?.hasConflicts == true)
+    }
+
+    @Test func refreshGitStatusesNoConflictsWhenBranchMatchesOrigin() async throws {
+        let tempBase = URL(fileURLWithPath: NSTemporaryDirectory())
+        let suffix = UUID().uuidString
+        let repoDir = tempBase.appendingPathComponent("tbd-test-\(suffix)")
+        let originDir = tempBase.appendingPathComponent("tbd-test-origin-\(suffix).git")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: repoDir)
+            try? FileManager.default.removeItem(at: originDir)
+        }
+
+        func shell(_ cmd: String, at dir: URL? = nil) async throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/bin/zsh")
+            p.arguments = ["-c", cmd]
+            p.currentDirectoryURL = dir ?? repoDir
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                throw NSError(domain: "shell", code: Int(p.terminationStatus))
+            }
+        }
+
+        // Init repo with a file
+        try await shell("git init -b main")
+        try await shell("git config commit.gpgSign false")
+        try await shell("git config user.email 'test@test.com'")
+        try await shell("git config user.name 'Test'")
+        try await shell("echo 'line1' > shared.txt && git add . && git commit -m 'initial'")
+
+        // Set up bare origin remote and push main
+        try await shell("git init --bare '\(originDir.path)'")
+        try await shell("git remote add origin '\(originDir.path)'")
+        try await shell("git push -u origin main")
+
+        // Create feature branch pointing at the same commit as origin/main (no extra commits)
+        try await shell("git checkout -b tbd/feature-wt")
+
+        // Set up DB
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: repoDir.path, displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "feature-wt", branch: "tbd/feature-wt",
+            path: repoDir.path + "/.tbd/worktrees/feature-wt", tmuxServer: "tbd-test"
+        )
+        #expect(wt.hasConflicts == false)
+
+        // Run refreshGitStatuses — branch is an ancestor of origin/main, no conflicts
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver(), subscriptions: StateSubscriptionManager()
+        )
+        await lifecycle.refreshGitStatuses(repoID: repo.id)
+
+        let updated = try await db.worktrees.get(id: wt.id)
+        #expect(updated?.hasConflicts == false)
     }
 }


### PR DESCRIPTION
## Summary
- Invert the sidebar's merge-conflict gate: the marker now appears when a PR exists AND the branch would conflict, instead of the opposite. Branches with conflicts but no PR no longer get the warning — there's no merge action pending.
- Detect conflicts against `origin/<defaultBranch>` instead of the local default branch. The daemon already fetches `origin/main` every 60s, so the comparison stays fresh independently of whether the user pulls. Previously a stale local `main` could mask conflicts that GitHub would actually reject.
- Restore the custom `git-merge-conflict` glyph (replacing `hand.raised.slash.fill` from #214), still rendered red, still using the same gating slot.

## Test plan
- [x] `swift test --filter WorktreeRowIndicatorTests` — gate semantics
- [x] `swift test --filter GitStatusTests` — reconcile against `origin/main` with a bare-origin fixture, plus a new no-conflict happy-path test
- [x] `swift test` full suite (one pre-existing unrelated failure in `TabBarHitAreaTests`)
- [ ] Visually: a worktree with an open PR whose branch would conflict shows the red merge-conflict glyph; the same conflict state on a branch with no PR shows nothing

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=70A5E099-B3E7-4D67-8640-D8F23AC2E476)