### PR TITLE
Feat: Scroll sidebar to the worktree when its notification is clicked

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -133,6 +133,17 @@ extension AppState {
     func navigateToActiveWorktree(_ id: UUID) {
         highlightedArchivedWorktreeID = nil
         selectedWorktreeIDs = [id]
+        // Expand the containing repo so the row is part of the rendered list
+        // before we ask the sidebar to scroll to it. Update local state
+        // synchronously (List rerender + scroll), persist via RPC fire-and-forget.
+        if let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),
+           let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
+           !repos[repoIdx].expanded {
+            repos[repoIdx].expanded = true
+            let repoID = worktree.repoID
+            Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
+        }
+        pendingScrollToWorktreeID = id
         // Only foreground when the AppKit run loop is live — `NSApp` is nil
         // under unit tests, which would crash on the implicit unwrap.
         if NSApplication.shared.isRunning {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -132,6 +132,11 @@ final class AppState: ObservableObject {
     /// row, then clears the value after the flash animation completes.
     @Published var highlightedArchivedWorktreeID: UUID?
 
+    /// Set briefly when external navigation (notification click, deep link,
+    /// jump menu) lands on an active worktree. `SidebarView` observes this
+    /// to scroll the worktree row into view, then clears the value.
+    @Published var pendingScrollToWorktreeID: UUID?
+
     /// Test seam: when set, replaces the daemon roundtrip for archived
     /// lookups in `navigateToArchivedWorktree(_:)`. Production code leaves
     /// this nil; tests assign a closure returning a deterministic worktree

--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -17,10 +17,21 @@ struct SidebarView: View {
     }
 
     var body: some View {
-        List(selection: $appState.selectedWorktreeIDs) {
-            ForEach(filteredRepos) { repo in
-                RepoSectionView(repo: repo)
-                    .opacity(repo.hidden ? 0.55 : 1.0)
+        ScrollViewReader { proxy in
+            List(selection: $appState.selectedWorktreeIDs) {
+                ForEach(filteredRepos) { repo in
+                    RepoSectionView(repo: repo)
+                        .opacity(repo.hidden ? 0.55 : 1.0)
+                }
+            }
+            .onChange(of: appState.pendingScrollToWorktreeID) { _, target in
+                guard let target else { return }
+                // Defer to the next runloop tick so a freshly-expanded repo's
+                // rows are mounted in the List before we ask to scroll to them.
+                DispatchQueue.main.async {
+                    withAnimation { proxy.scrollTo(target, anchor: .center) }
+                    appState.pendingScrollToWorktreeID = nil
+                }
             }
         }
         .listStyle(.plain)

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -101,6 +101,38 @@ import TBDShared
 }
 
 @MainActor
+@Test func navigateToActive_setsPendingScrollTarget() async {
+    let appState = AppState()
+    let repoID = UUID()
+    let id = UUID()
+    appState.repos = [Repo(id: repoID, path: "/tmp/r", displayName: "R")]
+    appState.worktrees = [
+        repoID: [Worktree(id: id, repoID: repoID, name: "x", displayName: "X",
+                          branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x")]
+    ]
+
+    appState.navigateToActiveWorktree(id)
+
+    #expect(appState.pendingScrollToWorktreeID == id)
+}
+
+@MainActor
+@Test func navigateToActive_expandsContainingRepoIfCollapsed() async {
+    let appState = AppState()
+    let repoID = UUID()
+    let id = UUID()
+    appState.repos = [Repo(id: repoID, path: "/tmp/r", displayName: "R", expanded: false)]
+    appState.worktrees = [
+        repoID: [Worktree(id: id, repoID: repoID, name: "x", displayName: "X",
+                          branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x")]
+    ]
+
+    appState.navigateToActiveWorktree(id)
+
+    #expect(appState.repos.first(where: { $0.id == repoID })?.expanded == true)
+}
+
+@MainActor
 @Test func navigateToWorktree_beforeInitialLoad_buffersID() async {
     let appState = AppState()
     let id = UUID()


### PR DESCRIPTION
## Summary
- Clicking a worktree notification banner now scrolls the sidebar so the matching row is centered in view, instead of just selecting an invisible row off-screen.
- If the containing repo section is collapsed, it expands first so the row is actually mounted before scrolling.
- Same `navigateToActiveWorktree` path is shared by deep links and JumpMenu navigation, so they benefit too.

## Test plan
- [x] Unit tests: `pendingScrollToWorktreeID` is set and collapsed repo is auto-expanded.
- [ ] Manual: scroll the sidebar so a worktree row is off-screen, click a notification for it → row scrolls into view.
- [ ] Manual: collapse a repo section, click a notification for one of its worktrees → repo expands and the row scrolls in.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7F52662E-9945-4437-B79D-68633804F100)