### PR TITLE
Feat: Export COLORFGBG so CLI tools auto-adapt to TBD's terminal scheme

### DIFF
--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -126,9 +126,11 @@ extension AppState {
     /// Resume a Claude session in a new terminal tab and switch focus to it.
     func resumeSession(worktreeID: UUID, sessionId: String) async {
         do {
+            let colorFgBg = appearance?.currentColorFgBg
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
-                resumeSessionID: sessionId
+                resumeSessionID: sessionId,
+                colorFgBg: colorFgBg
             )
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -11,7 +11,8 @@ extension AppState {
     func createTerminal(worktreeID: UUID, cmd: String? = nil) async {
         do {
             let size = mainAreaTerminalSize()
-            let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cmd: cmd, cols: size.cols, rows: size.rows)
+            let colorFgBg = appearance?.currentColorFgBg
+            let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cmd: cmd, cols: size.cols, rows: size.rows, colorFgBg: colorFgBg)
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
             tabs[worktreeID, default: []].append(tab)
@@ -27,7 +28,8 @@ extension AppState {
     func createTerminalForSplit(worktreeID: UUID) async -> Terminal? {
         do {
             let size = mainAreaTerminalSize()
-            let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cols: size.cols, rows: size.rows)
+            let colorFgBg = appearance?.currentColorFgBg
+            let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cols: size.cols, rows: size.rows, colorFgBg: colorFgBg)
             terminals[worktreeID, default: []].append(terminal)
             return terminal
         } catch {
@@ -86,13 +88,15 @@ extension AppState {
     func createClaudeTerminal(worktreeID: UUID, profileID: UUID? = nil) async {
         do {
             let size = mainAreaTerminalSize()
+            let colorFgBg = appearance?.currentColorFgBg
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
                 cmd: nil,
                 type: .claude,
                 overrideProfileID: profileID,
                 cols: size.cols,
-                rows: size.rows
+                rows: size.rows,
+                colorFgBg: colorFgBg
             )
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
@@ -107,12 +111,14 @@ extension AppState {
     func createCodexTerminal(worktreeID: UUID) async {
         do {
             let size = mainAreaTerminalSize()
+            let colorFgBg = appearance?.currentColorFgBg
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
                 cmd: nil,
                 type: .codex,
                 cols: size.cols,
-                rows: size.rows
+                rows: size.rows,
+                colorFgBg: colorFgBg
             )
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
@@ -127,12 +133,14 @@ extension AppState {
     func forkClaudeTerminal(worktreeID: UUID, sessionID: String, tokenID: UUID? = nil) async {
         do {
             let size = mainAreaTerminalSize()
+            let colorFgBg = appearance?.currentColorFgBg
             let terminal = try await daemonClient.createTerminal(
                 worktreeID: worktreeID,
                 resumeSessionID: sessionID,
                 overrideProfileID: tokenID,
                 cols: size.cols,
-                rows: size.rows
+                rows: size.rows,
+                colorFgBg: colorFgBg
             )
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -462,7 +462,12 @@ final class AppState: ObservableObject {
         // Subscribe to schemeID changes to push COLORFGBG updates to all running tmux servers.
         // When the user changes the color scheme, this notifies all shells so tools like vim,
         // less, fzf can auto-adjust to the new scheme.
+        // Debounce rapid changes (e.g., scrubbing through the scheme picker) to coalesce
+        // multiple RPCs into a single request. The 200ms window is long enough to capture
+        // rapid picker changes but short enough to feel responsive.
         appearanceSubscription = appearance.$schemeID
+            .removeDuplicates()
+            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
             .sink { [weak self] schemeID in
                 self?.broadcastAppearanceColorFgBg(appearance)
             }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import Foundation
 import SwiftUI
 import TBDShared
@@ -33,7 +34,15 @@ final class AppState: ObservableObject {
     /// from the user's current font, before any `TBDTerminalView` exists.
     /// Plain (non-weak) optional — `AppState` and `AppearanceSettings` share
     /// the app's lifetime, so this reference cannot outlive its target.
-    var appearance: AppearanceSettings?
+    var appearance: AppearanceSettings? {
+        didSet {
+            if let appearance {
+                setupAppearanceSubscriptions(appearance)
+            }
+        }
+    }
+    /// Subscription to appearance.$schemeID changes for pushing COLORFGBG updates to running tmux servers.
+    private var appearanceSubscription: AnyCancellable?
 
     @Published var repos: [Repo] = []
     @Published var worktrees: [UUID: [Worktree]] = [:]
@@ -441,6 +450,35 @@ final class AppState: ObservableObject {
         // Store must happen on MainActor
         Task { @MainActor in
             self.memoryPressureSource = source
+        }
+    }
+
+    // MARK: - Appearance Subscriptions
+
+    /// Subscribe to appearance setting changes and push updates to running tmux servers.
+    /// Called when `appearance` is set via didSet.
+    @MainActor
+    private func setupAppearanceSubscriptions(_ appearance: AppearanceSettings) {
+        // Subscribe to schemeID changes to push COLORFGBG updates to all running tmux servers.
+        // When the user changes the color scheme, this notifies all shells so tools like vim,
+        // less, fzf can auto-adjust to the new scheme.
+        appearanceSubscription = appearance.$schemeID
+            .sink { [weak self] schemeID in
+                self?.broadcastAppearanceColorFgBg(appearance)
+            }
+    }
+
+    /// Compute the new COLORFGBG value and push it to all running tmux servers.
+    @MainActor
+    private func broadcastAppearanceColorFgBg(_ appearance: AppearanceSettings) {
+        let newValue = appearance.currentColorFgBg
+        Task {
+            do {
+                try await daemonClient.updateAppearanceColorFgBg(value: newValue)
+            } catch {
+                logger.error("Failed to broadcast COLORFGBG update: \(error, privacy: .public)")
+                // Fire-and-forget: don't block on RPC failure
+            }
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -466,9 +466,15 @@ final class AppState: ObservableObject {
         // multiple RPCs into a single request. The 200ms window is long enough to capture
         // rapid picker changes but short enough to feel responsive.
         appearanceSubscription = appearance.$schemeID
+            // `@Published` delivers the current value at subscription time. Without
+            // `dropFirst()`, broadcastAppearanceColorFgBg runs on app launch before
+            // the daemon connection is even established — the RPC fails, the error
+            // gets logged and swallowed. Drop that subscriber-time emission so we
+            // only react to actual user-driven scheme changes.
+            .dropFirst()
             .removeDuplicates()
             .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
-            .sink { [weak self] schemeID in
+            .sink { [weak self] _ in
                 self?.broadcastAppearanceColorFgBg(appearance)
             }
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -473,10 +473,10 @@ actor DaemonClient {
     }
 
     /// Create a terminal in a worktree.
-    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, overrideProfileID: UUID? = nil, cols: Int? = nil, rows: Int? = nil) async throws -> Terminal {
+    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, overrideProfileID: UUID? = nil, cols: Int? = nil, rows: Int? = nil, colorFgBg: String? = nil) async throws -> Terminal {
         return try await callAsync(
             method: RPCMethod.terminalCreate,
-            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, resumeSessionID: resumeSessionID, overrideProfileID: overrideProfileID, cols: cols, rows: rows),
+            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, resumeSessionID: resumeSessionID, overrideProfileID: overrideProfileID, cols: cols, rows: rows, colorFgBg: colorFgBg),
             resultType: Terminal.self
         )
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -509,6 +509,16 @@ actor DaemonClient {
         )
     }
 
+    /// Update COLORFGBG environment variable in all known tmux servers.
+    /// This notifies running shells that the terminal color scheme has changed,
+    /// allowing tools like vim, less, fzf to auto-adjust their output.
+    func updateAppearanceColorFgBg(value: String) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.appearanceUpdateColorFgBg,
+            params: AppearanceUpdateColorFgBgParams(value: value)
+        )
+    }
+
     /// Delete a terminal (kills tmux window and removes DB record).
     func deleteTerminal(terminalID: UUID) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -91,6 +91,30 @@ final class AppearanceSettings: ObservableObject {
         NSFont(name: fontName, size: fontSize)
             ?? NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
     }
+
+    /// Computes the COLORFGBG environment variable value based on a color scheme's
+    /// background luminance. Returns "0;15" (black fg, white bg) for light backgrounds
+    /// (luminance > 0.5), or "15;0" (white fg, black bg) for dark backgrounds.
+    /// Uses the WCAG luminance formula: 0.2126*R + 0.7152*G + 0.0722*B
+    nonisolated static func colorFgBg(for scheme: TerminalColorScheme) -> String {
+        // Convert SwiftTerm.Color channels (0–65535 scale) to 0–1 range.
+        // Bundled scheme values are sRGB hex codes; use sRGB so wide-gamut
+        // displays (Display P3) don't drift from the spec.
+        let red = CGFloat(scheme.background.red) / 65535.0
+        let green = CGFloat(scheme.background.green) / 65535.0
+        let blue = CGFloat(scheme.background.blue) / 65535.0
+
+        let luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+        // Light background (luminance > 0.5) → use black foreground, white background hint
+        // Dark background (luminance ≤ 0.5) → use white foreground, black background hint
+        return luminance > 0.5 ? "0;15" : "15;0"
+    }
+
+    /// Computes COLORFGBG for the currently active terminal color scheme.
+    var currentColorFgBg: String {
+        let scheme = ColorSchemes.scheme(forID: schemeID)
+        return Self.colorFgBg(for: scheme)
+    }
 }
 
 // MARK: - CursorStyle <-> String

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -95,7 +95,10 @@ final class AppearanceSettings: ObservableObject {
     /// Computes the COLORFGBG environment variable value based on a color scheme's
     /// background luminance. Returns "0;15" (black fg, white bg) for light backgrounds
     /// (luminance > 0.5), or "15;0" (white fg, black bg) for dark backgrounds.
-    /// Uses the WCAG luminance formula: 0.2126*R + 0.7152*G + 0.0722*B
+    /// Uses an approximate luminance — the WCAG coefficients applied to raw sRGB values,
+    /// skipping the gamma-linearization step. Sufficient for a binary light/dark
+    /// threshold on near-black / near-white terminal backgrounds; do not use this
+    /// helper as a general-purpose accessibility-contrast check.
     nonisolated static func colorFgBg(for scheme: TerminalColorScheme) -> String {
         // Convert SwiftTerm.Color channels (0–65535 scale) to 0–1 range.
         // Bundled scheme values are sRGB hex codes; use sRGB so wide-gamut

--- a/Sources/TBDDaemon/Server/RPCRouter+AppearanceHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AppearanceHandlers.swift
@@ -11,8 +11,12 @@ extension RPCRouter {
     func handleAppearanceUpdateColorFgBg(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(AppearanceUpdateColorFgBgParams.self, from: paramsData)
 
-        // Discover all known tmux servers from worktrees.
-        let worktrees = try await db.worktrees.list()
+        // Discover tmux servers from active worktrees only. Archived worktrees
+        // have had their tmux servers killed, so attempting setenv -g against them
+        // spawns dead `tmux` processes that fail and log a warning on every
+        // debounce tick. `handleSetMainAreaSize` in this codebase filters the
+        // same way for the same reason.
+        let worktrees = try await db.worktrees.list(status: .active)
         var attemptedServers = Set<String>()
 
         // Build the deduplicated set of servers first (single pass).

--- a/Sources/TBDDaemon/Server/RPCRouter+AppearanceHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AppearanceHandlers.swift
@@ -14,23 +14,38 @@ extension RPCRouter {
         // Discover all known tmux servers from worktrees.
         let worktrees = try await db.worktrees.list()
         var attemptedServers = Set<String>()
-        var failureCount = 0
 
+        // Build the deduplicated set of servers first (single pass).
         for worktree in worktrees {
             let server = worktree.tmuxServer
             // Only attempt each server once (multiple worktrees may share a server).
-            guard !attemptedServers.contains(server) else { continue }
             attemptedServers.insert(server)
+        }
 
-            do {
-                // Use the public setGlobalEnv method to set the variable.
-                // This notifies all running shells that the color scheme has changed.
-                try await tmux.setGlobalEnv(server: server, name: "COLORFGBG", value: params.value)
-                logger.debug("Set COLORFGBG=\(params.value, privacy: .public) on server \(server, privacy: .public)")
-            } catch {
-                failureCount += 1
-                logger.warning("Failed to set COLORFGBG on server \(server, privacy: .public): \(error, privacy: .public)")
-                // Continue to next server on failure — best-effort fan-out.
+        // Parallelize the fan-out across servers using a TaskGroup.
+        var failureCount = 0
+        try await withThrowingTaskGroup(of: Bool.self) { group in
+            for server in attemptedServers {
+                group.addTask {
+                    do {
+                        // Use the public setGlobalEnv method to set the variable.
+                        // This notifies all running shells that the color scheme has changed.
+                        try await self.tmux.setGlobalEnv(server: server, name: "COLORFGBG", value: params.value)
+                        logger.debug("Set COLORFGBG=\(params.value, privacy: .public) on server \(server, privacy: .public)")
+                        return true
+                    } catch {
+                        logger.warning("Failed to set COLORFGBG on server \(server, privacy: .public): \(error, privacy: .public)")
+                        // Return false on failure — best-effort fan-out.
+                        return false
+                    }
+                }
+            }
+
+            // Collect results and count failures.
+            for try await result in group {
+                if !result {
+                    failureCount += 1
+                }
             }
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+AppearanceHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AppearanceHandlers.swift
@@ -1,0 +1,43 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "appearanceHandlers")
+
+extension RPCRouter {
+    /// Update the COLORFGBG environment variable in all known tmux servers.
+    /// This is a best-effort operation — failures on individual servers are logged
+    /// but do not prevent updates from being attempted on other servers.
+    func handleAppearanceUpdateColorFgBg(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(AppearanceUpdateColorFgBgParams.self, from: paramsData)
+
+        // Discover all known tmux servers from worktrees.
+        let worktrees = try await db.worktrees.list()
+        var attemptedServers = Set<String>()
+        var failureCount = 0
+
+        for worktree in worktrees {
+            let server = worktree.tmuxServer
+            // Only attempt each server once (multiple worktrees may share a server).
+            guard !attemptedServers.contains(server) else { continue }
+            attemptedServers.insert(server)
+
+            do {
+                // Use the public setGlobalEnv method to set the variable.
+                // This notifies all running shells that the color scheme has changed.
+                try await tmux.setGlobalEnv(server: server, name: "COLORFGBG", value: params.value)
+                logger.debug("Set COLORFGBG=\(params.value, privacy: .public) on server \(server, privacy: .public)")
+            } catch {
+                failureCount += 1
+                logger.warning("Failed to set COLORFGBG on server \(server, privacy: .public): \(error, privacy: .public)")
+                // Continue to next server on failure — best-effort fan-out.
+            }
+        }
+
+        if failureCount > 0 {
+            logger.debug("COLORFGBG update completed with \(failureCount) server failures out of \(attemptedServers.count)")
+        }
+
+        return .ok()
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -125,6 +125,12 @@ extension RPCRouter {
             // per-repo isolation: it pins deterministic behavior and lets the
             // TBD_TEST_CODEX_HOME test-isolation override flow through.
             codexEnv["CODEX_HOME"] = codexHome.path
+            // COLORFGBG isn't Claude-specific — Codex shells benefit from it too,
+            // so include it at spawn time. (Live updates also reach Codex via
+            // `tmux setenv -g COLORFGBG` fanned out by handleAppearanceUpdateColorFgBg.)
+            if let colorFgBg = params.colorFgBg {
+                codexEnv["COLORFGBG"] = colorFgBg
+            }
 
             let window = try await tmux.createWindow(
                 server: worktree.tmuxServer,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -100,6 +100,12 @@ extension RPCRouter {
         env["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
         env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
 
+        // Set COLORFGBG if provided (computed from terminal color scheme luminance).
+        // This allows CLI tools (vim, less, fzf, etc.) to auto-adjust to the active scheme.
+        if let colorFgBg = params.colorFgBg {
+            env["COLORFGBG"] = colorFgBg
+        }
+
         // Codex branch: minimal launch with TBD's profile plugin installed in
         // the user's global Codex home. No system prompt injection or token
         // resolution; Codex should keep using the user's normal auth/config.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -200,6 +200,8 @@ public final class RPCRouter: Sendable {
                 let params = try decoder.decode(AppSetForegroundStateParams.self, from: request.paramsData)
                 await claudeUsagePoller?.onFocusChanged(isForeground: params.isForeground)
                 return .ok()
+            case RPCMethod.appearanceUpdateColorFgBg:
+                return try await handleAppearanceUpdateColorFgBg(request.paramsData)
             case RPCMethod.setMainAreaSize:
                 return try await handleSetMainAreaSize(request.paramsData)
             case RPCMethod.sessionList:

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -214,6 +214,13 @@ public struct TmuxManager: Sendable {
         }
     }
 
+    /// Set a global environment variable in a tmux server (all panes inherit it).
+    public func setGlobalEnv(server: String, name: String, value: String) async throws {
+        if dryRun { return }
+        logger.debug("setGlobalEnv: setting \(name, privacy: .public)=\(value, privacy: .public) on server \(server, privacy: .public)")
+        try await runTmux(["-L", server, "setenv", "-g", name, value])
+    }
+
     /// Kills an entire tmux server and all its sessions.
     public func killServer(server: String) async throws {
         if dryRun { return }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -591,9 +591,12 @@ public struct TerminalCreateParams: Codable, Sendable {
     /// Initial tmux window size in cells (see WorktreeCreateParams).
     public let cols: Int?
     public let rows: Int?
-    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil, overrideProfileID: UUID? = nil, cols: Int? = nil, rows: Int? = nil) {
+    /// COLORFGBG environment variable value computed from active terminal color scheme's
+    /// background luminance. Format: "0;15" for light bg or "15;0" for dark bg.
+    public let colorFgBg: String?
+    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil, overrideProfileID: UUID? = nil, cols: Int? = nil, rows: Int? = nil, colorFgBg: String? = nil) {
         self.worktreeID = worktreeID; self.cmd = cmd; self.type = type; self.resumeSessionID = resumeSessionID; self.prompt = prompt; self.overrideProfileID = overrideProfileID
-        self.cols = cols; self.rows = rows
+        self.cols = cols; self.rows = rows; self.colorFgBg = colorFgBg
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -147,6 +147,7 @@ public enum RPCMethod {
     public static let tabSetOrder = "tab.setOrder"
     public static let tabList     = "tab.list"
     public static let worktreeSetActiveTab = "worktree.setActiveTab"
+    public static let appearanceUpdateColorFgBg = "appearance.updateColorFgBg"
 }
 
 // MARK: - Legacy Hook Detection / Removal
@@ -200,6 +201,15 @@ public struct SetMainAreaSizeParams: Codable, Sendable {
 public struct AppSetForegroundStateParams: Codable, Sendable {
     public let isForeground: Bool
     public init(isForeground: Bool) { self.isForeground = isForeground }
+}
+
+// MARK: - Appearance RPC
+
+public struct AppearanceUpdateColorFgBgParams: Codable, Sendable {
+    /// COLORFGBG environment variable value computed from terminal color scheme's
+    /// background luminance. Format: "0;15" for light bg or "15;0" for dark bg.
+    public let value: String
+    public init(value: String) { self.value = value }
 }
 
 // MARK: - Terminal Swap Profile

--- a/Tests/TBDAppTests/AppearanceDebounceTests.swift
+++ b/Tests/TBDAppTests/AppearanceDebounceTests.swift
@@ -1,0 +1,82 @@
+import Combine
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Test that rapid scheme changes are debounced to avoid spamming RPCs to the daemon.
+/// This test verifies that the debounce operator is applied to the schemeID publisher.
+/// We test the debounce behavior by subscribing directly to the appearance's $schemeID
+/// publisher and observing that rapid changes collapse to fewer emissions.
+@MainActor
+@Suite("AppState appearance debounce")
+struct AppearanceDebounceTests {
+    @Test("rapid scheme changes within debounce window collapse to single emission")
+    func rapidSchemeChangesDebounce() async {
+        // Use isolated UserDefaults so the test never touches the developer's app preferences.
+        let suiteName = "TBDAppTests.AppearanceDebounce.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let appearance = AppearanceSettings(defaults: defaults)
+
+        // Subscribe to the debounced schemeID emissions to count how many fire.
+        var debounceEmissions: [String] = []
+        let testSubscription = appearance.$schemeID
+            .removeDuplicates()
+            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
+            .sink { schemeID in
+                debounceEmissions.append(schemeID)
+            }
+
+        // Rapidly change the scheme within the debounce window.
+        // Since appearance starts with the default scheme, explicitly set three different ones
+        // in rapid succession without waiting.
+        appearance.schemeID = "scheme-a"
+        appearance.schemeID = "scheme-b"
+        appearance.schemeID = "scheme-c"
+
+        // Give the debounce timer time to fire (300ms > 200ms window).
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        // The debounce should coalesce the three changes into just one emission of the final value.
+        // Note: the initial value (default scheme) may also emit depending on timing, but we're
+        // testing that the three rapid changes don't produce three separate emissions.
+        let finalEmissions = debounceEmissions.filter { $0 == "scheme-c" }
+        #expect(finalEmissions.count == 1, "Final scheme change should emit exactly once")
+
+        testSubscription.cancel()
+    }
+
+    @Test("separated scheme changes produce separate emissions")
+    func separatedSchemeChangesProduceMultipleEmissions() async {
+        let suiteName = "TBDAppTests.AppearanceDebounceSpaced.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let appearance = AppearanceSettings(defaults: defaults)
+
+        var debounceEmissions: [String] = []
+        let testSubscription = appearance.$schemeID
+            .removeDuplicates()
+            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
+            .sink { schemeID in
+                debounceEmissions.append(schemeID)
+            }
+
+        // First scheme change and wait for debounce to complete.
+        appearance.schemeID = "scheme-a"
+        try? await Task.sleep(nanoseconds: 300_000_000) // 300ms > 200ms debounce
+        let countAfterFirst = debounceEmissions.count
+
+        // Second scheme change after debounce fired — should emit again.
+        appearance.schemeID = "scheme-b"
+        try? await Task.sleep(nanoseconds: 300_000_000) // Wait for second debounce window
+
+        // Should have more emissions now than before the second change.
+        let countAfterSecond = debounceEmissions.count
+        #expect(countAfterSecond > countAfterFirst, "Separated changes should produce multiple emissions")
+
+        testSubscription.cancel()
+    }
+}

--- a/Tests/TBDAppTests/AppearanceDebounceTests.swift
+++ b/Tests/TBDAppTests/AppearanceDebounceTests.swift
@@ -36,8 +36,10 @@ struct AppearanceDebounceTests {
         appearance.schemeID = "scheme-b"
         appearance.schemeID = "scheme-c"
 
-        // Give the debounce timer time to fire (300ms > 200ms window).
-        try? await Task.sleep(nanoseconds: 300_000_000)
+        // Give the debounce timer time to fire. 600ms vs the 200ms window leaves
+        // a 3x safety margin — `Task.sleep` has no lower-bound guarantee on
+        // constrained CI runners, and a tighter margin would risk flakes.
+        try? await Task.sleep(nanoseconds: 600_000_000)
 
         // The debounce should coalesce the three changes into just one emission of the final value.
         // Note: the initial value (default scheme) may also emit depending on timing, but we're
@@ -66,12 +68,12 @@ struct AppearanceDebounceTests {
 
         // First scheme change and wait for debounce to complete.
         appearance.schemeID = "scheme-a"
-        try? await Task.sleep(nanoseconds: 300_000_000) // 300ms > 200ms debounce
+        try? await Task.sleep(nanoseconds: 600_000_000) // 3x the 200ms debounce window
         let countAfterFirst = debounceEmissions.count
 
         // Second scheme change after debounce fired — should emit again.
         appearance.schemeID = "scheme-b"
-        try? await Task.sleep(nanoseconds: 300_000_000) // Wait for second debounce window
+        try? await Task.sleep(nanoseconds: 600_000_000) // Wait for second debounce window
 
         // Should have more emissions now than before the second change.
         let countAfterSecond = debounceEmissions.count

--- a/Tests/TBDAppTests/AppearanceSettingsTests.swift
+++ b/Tests/TBDAppTests/AppearanceSettingsTests.swift
@@ -139,4 +139,18 @@ struct AppearanceSettingsTests {
         let colorFgBg = AppearanceSettings.colorFgBg(for: scheme)
         #expect(colorFgBg == "15;0")
     }
+
+    @Test("currentColorFgBg property returns correct value for current scheme")
+    func currentColorFgBgProperty() {
+        withIsolatedDefaults { defaults in
+            let settings = AppearanceSettings(defaults: defaults)
+            settings.schemeID = "github-light"
+            let value = settings.currentColorFgBg
+            #expect(value == "0;15")
+
+            settings.schemeID = "nord"
+            let darkValue = settings.currentColorFgBg
+            #expect(darkValue == "15;0")
+        }
+    }
 }

--- a/Tests/TBDAppTests/AppearanceSettingsTests.swift
+++ b/Tests/TBDAppTests/AppearanceSettingsTests.swift
@@ -101,4 +101,42 @@ struct AppearanceSettingsTests {
                     settings.font.fontName.lowercased().contains("sf"))
         }
     }
+
+    @Test("colorFgBg for light schemes returns 0;15 (black fg, white bg)")
+    func colorFgBgLight() {
+        // Test with solarized-light which has a light background
+        let scheme = ColorSchemes.scheme(forID: "solarized-light")
+        let colorFgBg = AppearanceSettings.colorFgBg(for: scheme)
+        #expect(colorFgBg == "0;15")
+    }
+
+    @Test("colorFgBg for dark schemes returns 15;0 (white fg, black bg)")
+    func colorFgBgDark() {
+        // Test with solarized-dark which has a dark background
+        let scheme = ColorSchemes.scheme(forID: "solarized-dark")
+        let colorFgBg = AppearanceSettings.colorFgBg(for: scheme)
+        #expect(colorFgBg == "15;0")
+    }
+
+    @Test("colorFgBg for default tango scheme returns 15;0 (dark bg)")
+    func colorFgBgDefaultTango() {
+        // Tango has rgb(0,0,0) background (luminance 0)
+        let scheme = ColorSchemes.defaultScheme
+        let colorFgBg = AppearanceSettings.colorFgBg(for: scheme)
+        #expect(colorFgBg == "15;0")
+    }
+
+    @Test("colorFgBg for github-light returns 0;15 (light bg)")
+    func colorFgBgGithubLight() {
+        let scheme = ColorSchemes.scheme(forID: "github-light")
+        let colorFgBg = AppearanceSettings.colorFgBg(for: scheme)
+        #expect(colorFgBg == "0;15")
+    }
+
+    @Test("colorFgBg for nord returns 15;0 (dark bg)")
+    func colorFgBgNord() {
+        let scheme = ColorSchemes.scheme(forID: "nord")
+        let colorFgBg = AppearanceSettings.colorFgBg(for: scheme)
+        #expect(colorFgBg == "15;0")
+    }
 }

--- a/Tests/TBDDaemonTests/AppearanceHandlerTests.swift
+++ b/Tests/TBDDaemonTests/AppearanceHandlerTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+import TBDShared
+
+@Suite("Appearance RPC Handlers")
+struct AppearanceHandlerTests {
+    @Test("AppearanceUpdateColorFgBgParams encodes and decodes correctly")
+    func testParamsRoundTrip() throws {
+        let params = AppearanceUpdateColorFgBgParams(value: "0;15")
+        let encoder = JSONEncoder()
+        let encoded = try encoder.encode(params)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(AppearanceUpdateColorFgBgParams.self, from: encoded)
+
+        #expect(decoded.value == "0;15")
+    }
+
+    @Test("AppearanceUpdateColorFgBgParams accepts dark and light values")
+    func testParamsValues() throws {
+        let darkValue = AppearanceUpdateColorFgBgParams(value: "15;0")
+        let lightValue = AppearanceUpdateColorFgBgParams(value: "0;15")
+
+        let encoder = JSONEncoder()
+        let darkEncoded = try encoder.encode(darkValue)
+        let lightEncoded = try encoder.encode(lightValue)
+
+        let decoder = JSONDecoder()
+        let darkDecoded = try decoder.decode(AppearanceUpdateColorFgBgParams.self, from: darkEncoded)
+        let lightDecoded = try decoder.decode(AppearanceUpdateColorFgBgParams.self, from: lightEncoded)
+
+        #expect(darkDecoded.value == "15;0")
+        #expect(lightDecoded.value == "0;15")
+    }
+}


### PR DESCRIPTION
## Summary
- After #190 added 7 light terminal color schemes, Claude Code (and other CLIs) rendered tool-call diffs with near-invisible text on light backgrounds. Root cause was config drift — Claude Code's default `dark` theme emits light-coloured foregrounds designed for dark terminals; landed on a light TBD scheme, light-on-light text washes out. The palette wasn't actually broken; the two layers just didn't know about each other.
- This PR teaches TBD to **export `$COLORFGBG`** to every spawned shell, computed from the active terminal scheme's background luminance (WCAG formula). Value is `"0;15"` for light backgrounds, `"15;0"` for dark. CLI tools that respect the variable — Claude Code's `/theme auto`, vim, less, fzf, ranger — now adjust automatically.
- Two-phase implementation: (1) the value is included in the `terminal.create` RPC and injected into each new shell's env dict; (2) when the user toggles the scheme in Settings, AppState observes via Combine and fires a new `appearance.updateColorFgBg` RPC that fans out `tmux setenv -g COLORFGBG <value>` across all known tmux servers, so subsequent panes within an existing session also see the new value. Already-running shells keep their original value — env vars don't propagate to live processes; documented as a known limitation.

## Test plan
- [ ] Set Claude Code to `theme: "auto"` in `~/.claude/settings.json`. Open a new TBD terminal on a dark scheme (e.g. Tango), start `claude`, confirm dark theme renders. Switch TBD scheme to Solarized Light, open another new terminal, start `claude`, confirm it loads with light theme — diff context lines should be legible.
- [ ] In a TBD terminal, run `echo $COLORFGBG`. With a dark scheme active → `15;0`. Switch to a light scheme (Settings → Terminal), open a new terminal in the same worktree, run `echo $COLORFGBG` → `0;15`.
- [ ] In an existing TBD terminal with an open `vim` or `tmux` session, toggle TBD's scheme. Spawn a new pane inside that tmux session (`Ctrl-b c`) — `echo $COLORFGBG` should reflect the new scheme.
- [ ] `swift build` clean; `swift test` green for `AppearanceSettings` (16 tests inc. 6 new) and the new `AppearanceHandler` suite (RPC param round-trip). One pre-existing unrelated failure in `TabBarHitAreaTests` is on main and is not from this PR.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=AC84B81C-955A-4974-A548-8A507AFECDCE)