### PR TITLE
DX: Feed HangWatchdog from archived transcript pane so hang captures aren't blind

### DIFF
--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -394,6 +394,26 @@ struct SessionTranscriptView: View {
                         .animation(.easeInOut(duration: 0.2), value: atBottom)
                     }
                 }
+                .onAppear {
+                    HangWatchdog.shared.recordContext { snap in
+                        snap.focusedTerminalIDShort = nil
+                        snap.transcriptItemCount = messages.count
+                        snap.paneLabel = "history"
+                    }
+                }
+                .onChange(of: messages.count) { _, newCount in
+                    HangWatchdog.shared.recordContext { snap in
+                        snap.transcriptItemCount = newCount
+                        snap.paneLabel = "history"
+                    }
+                }
+                .onDisappear {
+                    HangWatchdog.shared.recordContext { snap in
+                        snap.focusedTerminalIDShort = nil
+                        snap.transcriptItemCount = nil
+                        snap.paneLabel = nil
+                    }
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
Wire `HistoryPaneView` into the `HangWatchdog` snapshot the same way `LiveTranscriptPaneView` does. Previously, hang captures from the archived transcript path were missing pane context (`pane=-`, `terminalID=-`, `itemCount=-1`), making them impossible to correlate with what the user was viewing.

The 2026-05-27 incident (hang-20260527-154302Z-49883.txt and hang-20260527-154306Z-49883.txt) showed this gap: both captures had `Pane: -` because only the live pane fed the watchdog.

## Changes
- Add three `recordContext` call sites to `HistoryPaneView`:
  - `onAppear`: Populate `paneLabel = "history"`, `transcriptItemCount = messages.count`, `focusedTerminalIDShort = nil`
  - `onChange(of: messages.count)`: Refresh `transcriptItemCount`
  - `onDisappear`: Clear all three fields to avoid bleeding context to subsequent hangs

## Verification
- `swift build`: clean
- `swift test`: existing test suite passes
- No log spam: snapshot populated silently, watchdog logs on hang

## Issue Reference
Ref: #129