### PR TITLE
Refresh Codex hooks at daemon startup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -71,7 +71,7 @@ let package = Package(
                 "TBDDaemonLib",
             ],
             path: "Sources/TBDDaemon",
-            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Keychain", "Claude", "ModelProfile", "AskUserQuestion", "Daemon.swift", "PIDFile.swift"],
+            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Keychain", "Claude", "Codex", "ModelProfile", "AskUserQuestion", "Daemon.swift", "PIDFile.swift"],
             sources: ["main.swift"]
         ),
         .executableTarget(

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -7,6 +7,33 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "AppState+Termin
 extension AppState {
     // MARK: - Terminal Actions
 
+    /// Treat an explicit user interrupt as "not working" for Codex terminals.
+    /// This clears the sidebar spinner immediately and mirrors the state to
+    /// the daemon best-effort.
+    func handleTerminalInterrupt(terminalID: UUID) {
+        guard let terminal = terminals.values.flatMap({ $0 })
+            .first(where: { $0.id == terminalID }),
+              terminal.kind == .codex || terminal.label == "Codex"
+        else {
+            return
+        }
+
+        if let idx = terminals[terminal.worktreeID]?.firstIndex(where: { $0.id == terminalID }) {
+            terminals[terminal.worktreeID]?[idx].activityState = .idle
+        }
+
+        Task {
+            do {
+                try await daemonClient.setTerminalActivity(
+                    terminalID: terminalID,
+                    activityState: .idle
+                )
+            } catch {
+                logger.debug("Failed to publish terminal interrupt state: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
     /// Create a terminal in a worktree and add a new tab for it.
     func createTerminal(worktreeID: UUID, cmd: String? = nil) async {
         do {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -570,6 +570,8 @@ final class AppState: ObservableObject {
             Task { [weak self] in await self?.loadModelProfiles() }
         case .terminalSessionUpdated(let d):
             applyTerminalSessionDelta(d)
+        case .terminalActivityUpdated(let d):
+            applyTerminalActivityDelta(d)
         case .worktreeMoved(let d):
             applyWorktreeMovedDelta(d)
         case .worktreeArchived(let d):
@@ -622,6 +624,13 @@ final class AppState: ObservableObject {
         if let tp = delta.transcriptPath {
             terminals[delta.worktreeID]?[idx].transcriptPath = tp
         }
+    }
+
+    private func applyTerminalActivityDelta(_ delta: TerminalActivityDelta) {
+        guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
+            return
+        }
+        terminals[delta.worktreeID]?[idx].activityState = delta.activityState
     }
 
     /// Update the in-place usage entry for a single profile. If no match,

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -549,6 +549,17 @@ actor DaemonClient {
         )
     }
 
+    /// Publish an explicit terminal activity state transition.
+    func setTerminalActivity(terminalID: UUID, activityState: TerminalActivityState) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminalID,
+                activityState: activityState
+            )
+        )
+    }
+
     /// Send a notification.
     func notify(worktreeID: UUID?, type: NotificationType, message: String? = nil,
                 terminalID: UUID? = nil) async throws {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -53,12 +53,21 @@ struct WorktreeRowView: View {
         return terminals.contains { $0.suspendedAt != nil }
     }
 
+    private var hasWorkingTerminal: Bool {
+        let terminals = appState.terminals[worktree.id] ?? []
+        return terminals.contains { $0.activityState == .working }
+    }
+
     @ViewBuilder
     private func rowIcons() -> some View {
         if hasSuspendedTerminal {
             Image(systemName: "pause.circle.fill")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+        }
+        if hasWorkingTerminal {
+            ProgressView()
+                .controlSize(.small)
         }
         if isPending && !isEditing {
             ProgressView()

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -525,7 +525,16 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         // MARK: - TerminalViewDelegate
 
         func send(source: TerminalView, data: ArraySlice<UInt8>) {
+            handleOutgoingInput(data)
             localProcess?.send(data: data)
+        }
+
+        func handleOutgoingInput(_ data: ArraySlice<UInt8>) {
+            guard data.contains(0x03) else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.appState?.handleTerminalInterrupt(terminalID: self.panelID)
+            }
         }
 
         func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {

--- a/Sources/TBDCLI/Commands/TerminalActivityEventCommand.swift
+++ b/Sources/TBDCLI/Commands/TerminalActivityEventCommand.swift
@@ -1,0 +1,62 @@
+import ArgumentParser
+import Foundation
+import os
+import TBDShared
+
+private let activityLogger = Logger(subsystem: "com.tbd.cli", category: "terminalActivity")
+
+/// Bridges agent hook events into TBD's terminal activity model. The command
+/// is intentionally generic so Codex hooks can publish explicit lifecycle
+/// changes without the app scraping tmux pane titles.
+struct TerminalActivityEventCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "terminal-activity",
+        abstract: "Internal: bridge terminal activity state changes into TBD",
+        shouldDisplay: false
+    )
+
+    enum ActivityArgument: String, ExpressibleByArgument {
+        case unknown
+        case working
+        case idle
+        case waitingForUser = "waiting_for_user"
+
+        var activityState: TerminalActivityState {
+            switch self {
+            case .unknown: return .unknown
+            case .working: return .working
+            case .idle: return .idle
+            case .waitingForUser: return .waitingForUser
+            }
+        }
+    }
+
+    @Argument(help: "Activity state to publish")
+    var state: ActivityArgument
+
+    mutating func run() async throws {
+        guard let terminalIDString = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+              let terminalID = UUID(uuidString: terminalIDString) else {
+            activityLogger.debug("suppressed reason=noTerminalID")
+            return
+        }
+
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            activityLogger.debug("suppressed reason=daemonDown")
+            return
+        }
+
+        do {
+            try client.callVoid(
+                method: RPCMethod.terminalActivityEvent,
+                params: TerminalActivityEventParams(
+                    terminalID: terminalID,
+                    activityState: state.activityState
+                )
+            )
+        } catch {
+            activityLogger.debug("suppressed reason=rpcFailed err=\(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -13,6 +13,7 @@ struct TBDCommand: AsyncParsableCommand {
             TerminalCommand.self,
             NotifyCommand.self,
             SessionEventCommand.self,
+            TerminalActivityEventCommand.self,
             AskUserQuestionEventCommand.self,
             DaemonCommand.self,
             HooksCommand.self,

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -55,10 +55,10 @@ enum CodexHookOverlay {
     static let relativePath = "hooks/hooks.json"
 
     static let sessionStartCommand =
-        #"tbd session-event 2>/dev/null || true"#
+        #"tbd session-event 2>/dev/null || true; tbd terminal-activity idle 2>/dev/null || true"#
 
     static let responseCompleteCommand =
-        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true"#
+        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; tbd terminal-activity idle 2>/dev/null || true"#
 
     static let stopRenameCheckCommand =
         #"tbd hooks stop-rename-check 2>/dev/null || true"#
@@ -66,6 +66,11 @@ enum CodexHookOverlay {
     static let stopCommand =
         #"PAYLOAD=$(cat); RENAME_RESULT=$(printf '%s' "$PAYLOAD" | \#(stopRenameCheckCommand)); if [ -n "$RENAME_RESULT" ]; then printf '%s\n' "$RENAME_RESULT"; else \#(responseCompleteCommand); fi"#
 
+    static let workingCommand =
+        #"tbd terminal-activity working 2>/dev/null || true"#
+
+    static let waitingForUserCommand =
+        #"tbd terminal-activity waiting_for_user 2>/dev/null || true"#
     static func hookPath(in pluginRoot: URL) -> URL {
         pluginRoot.appendingPathComponent(relativePath, isDirectory: false)
     }
@@ -84,7 +89,23 @@ enum CodexHookOverlay {
                 "Stop": [
                     [
                         "hooks": [
+                            // Run rename-check, and only publish
+                            // response_complete/idle when it does not block.
                             ["type": "command", "command": stopCommand]
+                        ]
+                    ]
+                ],
+                "UserPromptSubmit": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": workingCommand]
+                        ]
+                    ]
+                ],
+                "PermissionRequest": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": waitingForUserCommand]
                         ]
                     ]
                 ]

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -5,6 +5,47 @@ import os
 private let daemonLogger = Logger(subsystem: "com.tbd.daemon", category: "startup")
 private let reconcileLogger = Logger(subsystem: "com.tbd.daemon", category: "reconcile")
 
+struct RuntimeIntegrationRefresher {
+    var writeFallbackSkill: () throws -> Void
+    var writeClaudePlugin: () throws -> Void
+    var ensureCodexProfilePlugin: () throws -> Void
+    var writeClaudeHookOverlay: () -> Void
+
+    static func production() -> RuntimeIntegrationRefresher {
+        RuntimeIntegrationRefresher(
+            writeFallbackSkill: { try SkillFileWriter().writeFallback() },
+            writeClaudePlugin: { try PluginDirWriter().writePlugin() },
+            ensureCodexProfilePlugin: { _ = try CodexHomeManager().ensureProfilePlugin() },
+            writeClaudeHookOverlay: { ClaudeHookOverlay.writeOverlay() }
+        )
+    }
+
+    func refresh() {
+        do {
+            try writeFallbackSkill()
+        } catch {
+            Logger(subsystem: "com.tbd.daemon", category: "skill")
+                .error("Failed to write fallback skill file: \(String(describing: error), privacy: .public)")
+        }
+
+        do {
+            try writeClaudePlugin()
+        } catch {
+            Logger(subsystem: "com.tbd.daemon", category: "plugin")
+                .error("Failed to write TBD plugin: \(String(describing: error), privacy: .public)")
+        }
+
+        do {
+            try ensureCodexProfilePlugin()
+        } catch {
+            Logger(subsystem: "com.tbd.daemon", category: "codex-integration")
+                .error("Failed to refresh Codex profile plugin: \(String(describing: error), privacy: .public)")
+        }
+
+        writeClaudeHookOverlay()
+    }
+}
+
 /// Top-level daemon orchestrator.
 ///
 /// Coordinates all subsystems: database, managers, servers, and subscriptions.
@@ -107,32 +148,10 @@ public final class Daemon: Sendable {
         // 4. Write PID file
         try pidFile.write()
 
-        // Drop the canonical TBD skill body to the failsafe path so any
-        // Claude session can `Read` it even when no harness skill is registered.
-        // Failures here are non-fatal — the slim system-prompt pointer can still
-        // reference the path, and a missing file is recoverable on next boot.
-        do {
-            try SkillFileWriter().writeFallback()
-        } catch {
-            Logger(subsystem: "com.tbd.daemon", category: "skill")
-                .error("Failed to write fallback skill file: \(String(describing: error), privacy: .public)")
-        }
-
-        // Write the TBD-owned Claude plugin so newly spawned sessions can
-        // load the `tbd` skill via `--plugin-dir`. Idempotent; failures here
-        // are non-fatal (the slim system-prompt pointer still works).
-        do {
-            try PluginDirWriter().writePlugin()
-        } catch {
-            Logger(subsystem: "com.tbd.daemon", category: "plugin")
-                .error("Failed to write TBD plugin: \(String(describing: error), privacy: .public)")
-        }
-
-        // Refresh the TBD-owned Claude settings overlay so newly spawned
-        // Claude sessions register the SessionStart + Stop hooks. Idempotent;
-        // failures degrade gracefully to the legacy cwd-based transcript
-        // resolution (the bridge just won't fire).
-        ClaudeHookOverlay.writeOverlay()
+        // Refresh the agent runtime integration assets up front so both
+        // Claude and Codex sessions pick up the current TBD hook/plugin state
+        // even before any new terminal spawn path runs.
+        RuntimeIntegrationRefresher.production().refresh()
 
         // 4a. Scrub inherited TBD_* env vars before any tmux server is spawned.
         // The daemon may have been launched from inside a TBD-spawned shell (e.g.

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -517,6 +517,15 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "notification", column: "terminalID", type: .text)
         }
 
+        migrator.registerMigration("v29_terminal_activity_state") { db in
+            try db.addColumnIfMissing(
+                table: "terminal",
+                column: "activityState",
+                type: .text,
+                defaults: TerminalActivityState.unknown.rawValue
+            )
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -19,6 +19,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var profile_id: String?
     var transcriptPath: String?
     var kind: String?
+    var activityState: String?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -34,6 +35,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.profile_id = terminal.profileID?.uuidString
         self.transcriptPath = terminal.transcriptPath
         self.kind = terminal.kind?.rawValue
+        self.activityState = terminal.activityState.rawValue
     }
 
     func toModel() -> Terminal {
@@ -50,7 +52,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             suspendedSnapshot: suspendedSnapshot,
             profileID: profile_id.flatMap(UUID.init(uuidString:)),
             transcriptPath: transcriptPath,
-            kind: kind.flatMap(TerminalKind.init(rawValue:))
+            kind: kind.flatMap(TerminalKind.init(rawValue:)),
+            activityState: activityState.flatMap(TerminalActivityState.init(rawValue:)) ?? .unknown
         )
     }
 }
@@ -214,6 +217,7 @@ public struct TerminalStore: Sendable {
             record.suspendedSnapshot = nil
             record.label = "shell"
             record.kind = TerminalKind.shell.rawValue
+            record.activityState = TerminalActivityState.unknown.rawValue
             try record.update(db)
         }
     }
@@ -236,6 +240,17 @@ public struct TerminalStore: Sendable {
             }
             record.tmuxWindowID = windowID
             record.tmuxPaneID = paneID
+            try record.update(db)
+        }
+    }
+
+    /// Update the current activity state for a terminal.
+    public func setActivityState(id: UUID, activityState: TerminalActivityState) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.activityState = activityState.rawValue
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -357,6 +357,7 @@ extension RPCRouter {
                 windowID: window.windowID,
                 paneID: window.paneID
             )
+            try await db.terminals.setActivityState(id: params.terminalID, activityState: .unknown)
 
             // Return updated terminal
             guard let updated = try await db.terminals.get(id: params.terminalID) else {
@@ -944,6 +945,9 @@ extension RPCRouter {
             sessionID: params.sessionID,
             transcriptPath: cleanedPath
         )
+        if terminal.kind == .codex || terminal.label == "Codex" {
+            try await db.terminals.setActivityState(id: terminal.id, activityState: .idle)
+        }
 
         // Invalidate cached transcript parse for the OLD session file (if any)
         // so a quick re-poll doesn't return stale entries.
@@ -959,9 +963,36 @@ extension RPCRouter {
             sessionID: params.sessionID,
             transcriptPath: cleanedPath
         )))
+        if terminal.kind == .codex || terminal.label == "Codex" {
+            subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
+                terminalID: terminal.id,
+                worktreeID: terminal.worktreeID,
+                activityState: .idle
+            )))
+        }
         return .ok()
     }
 
+    func handleTerminalActivityEvent(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalActivityEventParams.self, from: paramsData)
+
+        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+            logger.debug("activityEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
+            return .ok()
+        }
+
+        guard terminal.activityState != params.activityState else {
+            return .ok()
+        }
+
+        try await db.terminals.setActivityState(id: terminal.id, activityState: params.activityState)
+        subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            activityState: params.activityState
+        )))
+        return .ok()
+    }
     func handleTerminalTranscript(_ paramsData: Data) async throws -> RPCResponse {
         perfTranscriptLog.debug("rpc.handle.start method=terminalTranscript")
         let start = ContinuousClock.now

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -124,6 +124,8 @@ public final class RPCRouter: Sendable {
                 return try await handleTerminalSwapProfile(request.paramsData)
             case RPCMethod.terminalSessionEvent:
                 return try await handleTerminalSessionEvent(request.paramsData)
+            case RPCMethod.terminalActivityEvent:
+                return try await handleTerminalActivityEvent(request.paramsData)
             case RPCMethod.notify:
                 return try await handleNotify(request.paramsData)
             case RPCMethod.daemonStatus:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -175,6 +175,12 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
+public enum TerminalActivityState: String, Codable, Sendable {
+    case unknown
+    case working
+    case idle
+    case waitingForUser = "waiting_for_user"
+}
 public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var worktreeID: UUID
@@ -194,6 +200,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// `~/.claude/projects/` subdirectory than cwd would suggest).
     public var transcriptPath: String?
     public var kind: TerminalKind?
+    public var activityState: TerminalActivityState
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
@@ -201,7 +208,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 suspendedAt: Date? = nil, suspendedSnapshot: String? = nil,
                 profileID: UUID? = nil,
                 transcriptPath: String? = nil,
-                kind: TerminalKind? = nil) {
+                kind: TerminalKind? = nil,
+                activityState: TerminalActivityState = .unknown) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -215,11 +223,13 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.profileID = profileID
         self.transcriptPath = transcriptPath
         self.kind = kind
+        self.activityState = activityState
     }
 
     enum CodingKeys: String, CodingKey {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
+        case activityState
     }
 
     public init(from decoder: Decoder) throws {
@@ -237,6 +247,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         profileID = try c.decodeIfPresent(UUID.self, forKey: .profileID)
         transcriptPath = try c.decodeIfPresent(String.self, forKey: .transcriptPath)
         kind = try c.decodeIfPresent(TerminalKind.self, forKey: .kind)
+        activityState = try c.decodeIfPresent(TerminalActivityState.self, forKey: .activityState) ?? .unknown
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -131,6 +131,7 @@ public enum RPCMethod {
     public static let modelProfileHealthCheck = "modelProfile.healthCheck"
     public static let terminalSwapProfile = "terminal.swapProfile"
     public static let terminalSessionEvent = "terminal.sessionEvent"
+    public static let terminalActivityEvent = "terminal.activityEvent"
     public static let terminalAskUserQuestionPending = "terminal.askUserQuestionPending"
     public static let terminalAskUserQuestionCleared = "terminal.askUserQuestionCleared"
     public static let appSetForegroundState = "app.setForegroundState"
@@ -920,6 +921,15 @@ public struct TerminalSessionEventParams: Codable, Sendable {
         self.sessionID = sessionID
         self.transcriptPath = transcriptPath
         self.source = source
+    }
+}
+
+public struct TerminalActivityEventParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let activityState: TerminalActivityState
+    public init(terminalID: UUID, activityState: TerminalActivityState) {
+        self.terminalID = terminalID
+        self.activityState = activityState
     }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -22,6 +22,7 @@ public enum StateDelta: Codable, Sendable {
     case modelProfileUsageUpdated(ModelProfileUsage)
     case modelProfilesChanged
     case terminalSessionUpdated(TerminalSessionDelta)
+    case terminalActivityUpdated(TerminalActivityDelta)
     case worktreeMoved(WorktreeMovedDelta)
 }
 
@@ -38,6 +39,17 @@ public struct TerminalSessionDelta: Codable, Sendable {
         self.worktreeID = worktreeID
         self.sessionID = sessionID
         self.transcriptPath = transcriptPath
+    }
+}
+
+public struct TerminalActivityDelta: Codable, Sendable {
+    public let terminalID: UUID
+    public let worktreeID: UUID
+    public let activityState: TerminalActivityState
+    public init(terminalID: UUID, worktreeID: UUID, activityState: TerminalActivityState) {
+        self.terminalID = terminalID
+        self.worktreeID = worktreeID
+        self.activityState = activityState
     }
 }
 

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+@MainActor
+@Test func appState_handlesTerminalActivityUpdatedDeltaInPlace() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex
+            )
+        ]
+    ]
+
+    state.handleDelta(.terminalActivityUpdated(TerminalActivityDelta(
+        terminalID: terminalID,
+        worktreeID: worktreeID,
+        activityState: .working
+    )))
+
+    #expect(state.terminals[worktreeID]?[0].activityState == .working)
+}
+
+@MainActor
+@Test func appState_interruptClearsCodexActivityImmediately() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Codex",
+                kind: .codex,
+                activityState: .working
+            )
+        ]
+    ]
+
+    state.handleTerminalInterrupt(terminalID: terminalID)
+
+    #expect(state.terminals[worktreeID]?[0].activityState == .idle)
+}
+
+@MainActor
+@Test func appState_interruptDoesNotTouchShellTerminals() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "shell",
+                kind: .shell,
+                activityState: .working
+            )
+        ]
+    ]
+
+    state.handleTerminalInterrupt(terminalID: terminalID)
+
+    #expect(state.terminals[worktreeID]?[0].activityState == .working)
+}

--- a/Tests/TBDAppTests/TerminalPanelViewTests.swift
+++ b/Tests/TBDAppTests/TerminalPanelViewTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import TBDApp
+import TBDShared
 
 @Suite("Terminal panel close context")
 struct TerminalPanelViewTests {
@@ -26,5 +27,65 @@ struct TerminalPanelViewTests {
         coordinator.syncTabCloseContext(noContext, for: terminalID)
         #expect(coordinator.tabCloseContext == nil)
         #expect(state.terminalTabCloseContexts[terminalID] == nil)
+    }
+
+    @MainActor
+    @Test("outgoing ctrl-c clears codex activity")
+    func outgoingCtrlCClearsCodexActivity() async {
+        let state = AppState()
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        state.terminals = [
+            worktreeID: [
+                Terminal(
+                    id: terminalID,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: "@1",
+                    tmuxPaneID: "%1",
+                    label: "Codex",
+                    kind: .codex,
+                    activityState: .working
+                )
+            ]
+        ]
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+
+        coordinator.handleOutgoingInput([0x03])
+        await Task.yield()
+
+        #expect(state.terminals[worktreeID]?[0].activityState == .idle)
+    }
+
+    @MainActor
+    @Test("non-interrupt input leaves codex activity unchanged")
+    func nonInterruptInputLeavesActivityUnchanged() async {
+        let state = AppState()
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        state.terminals = [
+            worktreeID: [
+                Terminal(
+                    id: terminalID,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: "@1",
+                    tmuxPaneID: "%1",
+                    label: "Codex",
+                    kind: .codex,
+                    activityState: .working
+                )
+            ]
+        ]
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+
+        coordinator.handleOutgoingInput([UInt8]("hello".utf8)[0...])
+        await Task.yield()
+
+        #expect(state.terminals[worktreeID]?[0].activityState == .working)
     }
 }

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("codex activity reconciliation")
+struct CodexActivityReconciliationTests {
+    let db: TBDDatabase
+    let router: RPCRouter
+
+    init() throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+    }
+
+    @Test("terminal.list does not infer codex activity from transcript path")
+    func terminalListDoesNotReconcileActivity() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-repo-\(UUID().uuidString)",
+            displayName: "car-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "main",
+            path: "/tmp/car-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-car"
+        )
+
+        let transcriptDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-codex-activity-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: transcriptDir) }
+
+        let transcriptPath = transcriptDir.appendingPathComponent("session.jsonl")
+        let jsonl = """
+        {"timestamp":"2026-05-26T13:20:25.252Z","type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}
+        """
+        try jsonl.write(to: transcriptPath, atomically: true, encoding: .utf8)
+
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Codex",
+            kind: .codex
+        )
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "codex-session",
+            transcriptPath: transcriptPath.path
+        )
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let terminals = try response.decodeResult([Terminal].self)
+        #expect(terminals.count == 1)
+        #expect(terminals[0].activityState == .unknown)
+
+        let persisted = try await db.terminals.get(id: terminal.id)
+        #expect(persisted?.activityState == .unknown)
+    }
+
+    @Test("terminal.list does not overwrite explicit idle with transcript working")
+    func terminalListPreservesExplicitIdle() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/car-idle-repo-\(UUID().uuidString)",
+            displayName: "car-idle-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "main",
+            path: "/tmp/car-idle-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-car-idle"
+        )
+
+        let transcriptDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-codex-activity-idle-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: transcriptDir) }
+
+        let transcriptPath = transcriptDir.appendingPathComponent("session.jsonl")
+        let jsonl = """
+        {"timestamp":"2026-05-26T13:20:25.252Z","type":"event_msg","payload":{"type":"task_started","turn_id":"a"}}
+        """
+        try jsonl.write(to: transcriptPath, atomically: true, encoding: .utf8)
+
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Codex",
+            kind: .codex
+        )
+        try await db.terminals.updateSession(
+            id: terminal.id,
+            sessionID: "codex-session",
+            transcriptPath: transcriptPath.path
+        )
+        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle)
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalList,
+            params: TerminalListParams(worktreeID: wt.id)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let terminals = try response.decodeResult([Terminal].self)
+        #expect(terminals.count == 1)
+        #expect(terminals[0].activityState == .idle)
+
+        let persisted = try await db.terminals.get(id: terminal.id)
+        #expect(persisted?.activityState == .idle)
+    }
+}

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -19,31 +19,48 @@ import TBDShared
 
         let stop = hooks?["Stop"] as? [[String: Any]]
         #expect(stop?.count == 1)
-        let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
-        #expect(stopHooks?.count == 1)
-        let stopCommand = stopHooks?.first?["command"] as? String
-        #expect(stopCommand?.contains("tbd hooks stop-rename-check") == true)
-        #expect(stopCommand?.contains("tbd notify --type response_complete") == true)
-        #expect(stopCommand?.contains("last_assistant_message") == true)
+        let stopCommands: [String] = (stop ?? []).flatMap { entry -> [String] in
+            let inner = entry["hooks"] as? [[String: Any]] ?? []
+            return inner.compactMap { $0["command"] as? String }
+        }
+        #expect(stopCommands.count == 1)
+        #expect(stopCommands.contains {
+            $0.contains("tbd hooks stop-rename-check")
+                && $0.contains("tbd notify --type response_complete")
+                && $0.contains("tbd terminal-activity idle")
+                && $0.contains("if [ -n \"$RENAME_RESULT\" ]")
+        })
+
+        let promptSubmit = hooks?["UserPromptSubmit"] as? [[String: Any]]
+        let promptCommands: [String] = (promptSubmit ?? []).flatMap { entry -> [String] in
+            let inner = entry["hooks"] as? [[String: Any]] ?? []
+            return inner.compactMap { $0["command"] as? String }
+        }
+        #expect(promptCommands.contains { $0.contains("tbd terminal-activity working") })
+
+        let permissionRequest = hooks?["PermissionRequest"] as? [[String: Any]]
+        let permissionCommands: [String] = (permissionRequest ?? []).flatMap { entry -> [String] in
+            let inner = entry["hooks"] as? [[String: Any]] ?? []
+            return inner.compactMap { $0["command"] as? String }
+        }
+        #expect(permissionCommands.contains { $0.contains("tbd terminal-activity waiting_for_user") })
     }
 
-    @Test func stopHookRunsRenameCheckBeforeResponseComplete() throws {
+    @Test func stopHookGatesIdleBehindRenameCheck() throws {
         let data = try CodexHookOverlay.generateBody()
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let hooks = parsed?["hooks"] as? [String: Any]
         let stop = hooks?["Stop"] as? [[String: Any]]
-        let stopHooks = stop?.first?["hooks"] as? [[String: Any]]
-        let stopCommand = stopHooks?.first?["command"] as? String
-
-        let renameIndex = stopCommand?.range(of: "tbd hooks stop-rename-check")?.lowerBound
-        let notifyIndex = stopCommand?.range(of: "tbd notify --type response_complete")?.lowerBound
-
-        #expect(renameIndex != nil)
-        #expect(notifyIndex != nil)
-        if let renameIndex, let notifyIndex {
-            #expect(renameIndex < notifyIndex)
+        let stopCommands: [String] = (stop ?? []).flatMap { entry -> [String] in
+            let inner = entry["hooks"] as? [[String: Any]] ?? []
+            return inner.compactMap { $0["command"] as? String }
         }
-        #expect(stopCommand?.contains("if [ -n \"$RENAME_RESULT\" ]") == true)
+        #expect(stopCommands.count == 1)
+        let stopCommand = stopCommands.first
+        #expect(stopCommand?.contains("RENAME_RESULT=") == true)
+        #expect(stopCommand?.contains("printf '%s\\n' \"$RENAME_RESULT\"") == true)
+        #expect(stopCommand?.contains("tbd notify --type response_complete") == true)
+        #expect(stopCommand?.contains("tbd terminal-activity idle") == true)
     }
 
     @Test func roundtripsAsValidJSON() throws {
@@ -65,6 +82,8 @@ import TBDShared
         let hooks = parsed?["hooks"] as? [String: Any]
         #expect(hooks?["SessionStart"] != nil)
         #expect(hooks?["Stop"] != nil)
+        #expect(hooks?["UserPromptSubmit"] != nil)
+        #expect(hooks?["PermissionRequest"] != nil)
     }
 
     @Test func writePluginCreatesTBDSkillInCodexPlugin() throws {

--- a/Tests/TBDDaemonTests/MigrationV28Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV28Tests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+
+@Suite struct MigrationV28Tests {
+
+    @Test func activityStateColumnExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let columns = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(terminal)")
+            let names = columns.compactMap { $0["name"] as String? }
+            #expect(names.contains("activityState"))
+        }
+    }
+
+    @Test func activityStateDefaultsToUnknown() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v28-repo-\(UUID().uuidString)",
+            displayName: "V28",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "w",
+            branch: "b",
+            path: "/tmp/v28-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-v28"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1"
+        )
+
+        #expect(terminal.activityState == .unknown)
+
+        let fetched = try await db.terminals.get(id: terminal.id)
+        #expect(fetched?.activityState == .unknown)
+    }
+}

--- a/Tests/TBDDaemonTests/RuntimeIntegrationRefresherTests.swift
+++ b/Tests/TBDDaemonTests/RuntimeIntegrationRefresherTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("RuntimeIntegrationRefresher")
+struct RuntimeIntegrationRefresherTests {
+
+    @Test("refresh installs Codex hooks alongside the other runtime assets")
+    func refreshInvokesAllInstallers() {
+        var calls: [String] = []
+        let refresher = RuntimeIntegrationRefresher(
+            writeFallbackSkill: { calls.append("skill") },
+            writeClaudePlugin: { calls.append("claude-plugin") },
+            ensureCodexProfilePlugin: { calls.append("codex-plugin") },
+            writeClaudeHookOverlay: { calls.append("claude-hooks") }
+        )
+
+        refresher.refresh()
+
+        #expect(calls == ["skill", "claude-plugin", "codex-plugin", "claude-hooks"])
+    }
+
+    @Test("refresh keeps going when Codex plugin install fails")
+    func refreshContinuesPastCodexFailure() {
+        var calls: [String] = []
+        let refresher = RuntimeIntegrationRefresher(
+            writeFallbackSkill: { calls.append("skill") },
+            writeClaudePlugin: { calls.append("claude-plugin") },
+            ensureCodexProfilePlugin: {
+                calls.append("codex-plugin")
+                struct Failure: Error {}
+                throw Failure()
+            },
+            writeClaudeHookOverlay: { calls.append("claude-hooks") }
+        )
+
+        refresher.refresh()
+
+        #expect(calls == ["skill", "claude-plugin", "codex-plugin", "claude-hooks"])
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("terminal.activityEvent handler")
+struct TerminalActivityEventHandlerTests {
+    let db: TBDDatabase
+    let router: RPCRouter
+
+    init() throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+    }
+
+    private func makeTerminal() async throws -> Terminal {
+        let repo = try await db.repos.create(
+            path: "/tmp/ta-repo-\(UUID().uuidString)",
+            displayName: "ta-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "main",
+            path: "/tmp/ta-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-ta"
+        )
+        return try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Codex",
+            kind: .codex
+        )
+    }
+
+    @Test("updates activity state in DB")
+    func updatesActivityState() async throws {
+        let terminal = try await makeTerminal()
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: terminal.id,
+                activityState: .working
+            )
+        )
+
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let updated = try await db.terminals.get(id: terminal.id)
+        #expect(updated?.activityState == .working)
+    }
+
+    @Test("unknown terminalID is a soft no-op")
+    func unknownTerminalSoftSuccess() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(
+                terminalID: UUID(),
+                activityState: .idle
+            )
+        )
+
+        let response = await router.handle(request)
+        #expect(response.success)
+        #expect(response.error == nil)
+    }
+}

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -58,13 +58,15 @@ import Testing
         tmuxWindowID: "@1",
         tmuxPaneID: "%3",
         label: "editor",
-        createdAt: Date()
+        createdAt: Date(),
+        activityState: .working
     )
     let data = try JSONEncoder().encode(terminal)
     let decoded = try JSONDecoder().decode(Terminal.self, from: data)
     #expect(terminal.id == decoded.id)
     #expect(decoded.tmuxWindowID == "@1")
     #expect(decoded.label == "editor")
+    #expect(decoded.activityState == .working)
 }
 
 @Test func testNotificationRoundTrip() throws {
@@ -120,6 +122,22 @@ import Testing
     """.data(using: .utf8)!
     let decoded = try JSONDecoder().decode(ModelProfileListResult.self, from: json)
     #expect(decoded.primaryAgentPreference == .claude)
+}
+
+@Test func testTerminalDecodesWithoutActivityState() throws {
+    let json = """
+    {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "worktreeID": "22222222-2222-2222-2222-222222222222",
+        "tmuxWindowID": "@1",
+        "tmuxPaneID": "%1",
+        "label": "Codex",
+        "createdAt": 0
+    }
+    """.data(using: .utf8)!
+
+    let decoded = try JSONDecoder().decode(Terminal.self, from: json)
+    #expect(decoded.activityState == .unknown)
 }
 
 // MARK: - NotificationType Severity Ordering


### PR DESCRIPTION
## Summary
- refresh Codex's TBD-managed plugin and hook install during daemon startup
- prevent stale global hook installs from leaving worktrees stuck in the working state
- stacked on #227

## Test Plan
- [x] `swift test`
