### PR TITLE
feat: add Cmd+R to reload webview pane

### DIFF
--- a/Sources/TBDApp/Panes/WebviewPaneView.swift
+++ b/Sources/TBDApp/Panes/WebviewPaneView.swift
@@ -6,6 +6,11 @@ protocol WebviewFindClient: AnyObject {
     func find(_ string: String, backwards: Bool, completionHandler: @escaping (Bool) -> Void)
 }
 
+@MainActor
+protocol WebviewReloadClient: AnyObject {
+    func reload()
+}
+
 extension WKWebView: WebviewFindClient {
     func find(_ string: String, backwards: Bool, completionHandler: @escaping (Bool) -> Void) {
         let config = WKFindConfiguration()
@@ -14,6 +19,16 @@ extension WKWebView: WebviewFindClient {
         find(string, configuration: config) { result in
             completionHandler(result.matchFound)
         }
+    }
+}
+
+extension WKWebView: WebviewReloadClient {
+    func reload() {
+        // Disambiguate from WKWebView.reload() -> WKNavigation? — calling
+        // reload() inside this extension would recurse, so route through a
+        // typed reference to the original method.
+        let webkitReload: (WKWebView) -> () -> WKNavigation? = WKWebView.reload
+        _ = webkitReload(self)()
     }
 }
 
@@ -47,13 +62,15 @@ final class WebviewPaneHostView: NSView, NSUserInterfaceValidations {
     ]
 
     private let findClient: WebviewFindClient
+    private let reloadClient: WebviewReloadClient
 
-    init(url: URL, findClient: WebviewFindClient? = nil) {
+    init(url: URL, findClient: WebviewFindClient? = nil, reloadClient: WebviewReloadClient? = nil) {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .default()
 
         webView = WKWebView(frame: .zero, configuration: config)
         self.findClient = findClient ?? webView
+        self.reloadClient = reloadClient ?? webView
 
         super.init(frame: .zero)
 
@@ -78,6 +95,34 @@ final class WebviewPaneHostView: NSView, NSUserInterfaceValidations {
     }
 
     override var acceptsFirstResponder: Bool { true }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // performKeyEquivalent walks the whole view hierarchy, so without this
+        // guard an unfocused webview pane would steal Cmd+R from whichever
+        // pane the user actually clicked. The first responder is normally the
+        // WKWebView or one of its descendants, not the host itself — walk up
+        // from the first responder and only handle when self is an ancestor.
+        guard isFirstResponderInHierarchy() else {
+            return super.performKeyEquivalent(with: event)
+        }
+        let flags = event.modifierFlags.intersection([.command, .shift, .option, .control])
+        guard flags == .command else { return super.performKeyEquivalent(with: event) }
+        guard event.charactersIgnoringModifiers?.lowercased() == "r" else {
+            return super.performKeyEquivalent(with: event)
+        }
+        reloadClient.reload()
+        return true
+    }
+
+    private func isFirstResponderInHierarchy() -> Bool {
+        guard let responder = window?.firstResponder as? NSView else { return false }
+        var current: NSView? = responder
+        while let view = current {
+            if view === self { return true }
+            current = view.superview
+        }
+        return false
+    }
 
     override func performTextFinderAction(_ sender: Any?) {
         guard let action = textFinderAction(from: sender) else { return }

--- a/Tests/TBDAppTests/WebviewPaneReloadTests.swift
+++ b/Tests/TBDAppTests/WebviewPaneReloadTests.swift
@@ -1,0 +1,106 @@
+import AppKit
+import Testing
+import WebKit
+@testable import TBDApp
+
+@MainActor
+struct WebviewPaneReloadTests {
+    @Test("cmd+r triggers reload when host is in the first responder chain")
+    func commandRTriggersReloadWhenHostIsInFirstResponderChain() {
+        let recorder = RecordingReloadClient()
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!, reloadClient: recorder)
+        let window = makeWindow(host: host)
+        window.makeFirstResponder(host.webView)
+
+        let handled = host.performKeyEquivalent(with: keyEvent(characters: "r", modifiers: .command))
+
+        #expect(handled)
+        #expect(recorder.reloadCount == 1)
+    }
+
+    @Test("cmd+t does not trigger reload")
+    func commandTDoesNotTriggerReload() {
+        let recorder = RecordingReloadClient()
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!, reloadClient: recorder)
+        let window = makeWindow(host: host)
+        window.makeFirstResponder(host.webView)
+
+        _ = host.performKeyEquivalent(with: keyEvent(characters: "t", modifiers: .command))
+
+        #expect(recorder.reloadCount == 0)
+    }
+
+    @Test("cmd+shift+r does not trigger reload")
+    func commandShiftRDoesNotTriggerReload() {
+        let recorder = RecordingReloadClient()
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!, reloadClient: recorder)
+        let window = makeWindow(host: host)
+        window.makeFirstResponder(host.webView)
+
+        _ = host.performKeyEquivalent(with: keyEvent(characters: "r", modifiers: [.command, .shift]))
+
+        #expect(recorder.reloadCount == 0)
+    }
+
+    @Test("cmd+r does not trigger reload when host is not in the first responder chain")
+    func commandRDoesNotTriggerReloadWhenHostNotInFirstResponderChain() {
+        let recorder = RecordingReloadClient()
+        let host = WebviewPaneHostView(url: URL(string: "https://example.com")!, reloadClient: recorder)
+        let other = FocusableTestView(frame: .zero)
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 200))
+        container.addSubview(host)
+        container.addSubview(other)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        window.makeFirstResponder(other)
+
+        let handled = host.performKeyEquivalent(with: keyEvent(characters: "r", modifiers: .command))
+
+        #expect(!handled)
+        #expect(recorder.reloadCount == 0)
+    }
+
+    private func makeWindow(host: WebviewPaneHostView) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        return window
+    }
+
+    private func keyEvent(characters: String, modifiers: NSEvent.ModifierFlags) -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters.lowercased(),
+            isARepeat: false,
+            keyCode: 15
+        )!
+    }
+}
+
+@MainActor
+private final class RecordingReloadClient: WebviewReloadClient {
+    var reloadCount = 0
+
+    func reload() {
+        reloadCount += 1
+    }
+}
+
+private final class FocusableTestView: NSView {
+    override var acceptsFirstResponder: Bool { true }
+}


### PR DESCRIPTION
## Summary
- Cmd+R now reloads the page inside TBD's webview pane (matches Chrome/Safari/Finder muscle memory).
- Added `WebviewReloadClient` DI protocol that mirrors the existing `WebviewFindClient` pattern so the action is unit-testable without touching `WKWebView`.
- Gated on the first-responder chain so an unfocused webview pane can't steal Cmd+R from another pane (same shape as the Cmd+W gating in `TBDTerminalView`).

## Test plan
- [x] `swift test --filter WebviewPaneReload` — 4 new tests pass (Cmd+R reloads when focused, Cmd+T ignored, Cmd+Shift+R ignored, Cmd+R ignored when unfocused).
- [x] `swift test --filter WebviewPaneFind` — 9 existing tests still pass.
- [ ] Manual: open a webview pane in TBD, press Cmd+R, confirm the page reloads.
- [ ] Manual: with two panes side-by-side (terminal + webview), focus the terminal and press Cmd+R — confirm the webview does not reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)