### PR TITLE
Feat: Switch to the originating tab when a notification is clicked

### DIFF
--- a/Sources/TBDApp/AppState+Notifications.swift
+++ b/Sources/TBDApp/AppState+Notifications.swift
@@ -8,9 +8,11 @@ extension AppState {
     // MARK: - Notification Actions
 
     /// Send a notification.
-    func notify(worktreeID: UUID?, type: NotificationType, message: String? = nil) async {
+    func notify(worktreeID: UUID?, type: NotificationType, message: String? = nil,
+                terminalID: UUID? = nil) async {
         do {
-            try await daemonClient.notify(worktreeID: worktreeID, type: type, message: message)
+            try await daemonClient.notify(worktreeID: worktreeID, type: type,
+                                          message: message, terminalID: terminalID)
         } catch {
             logger.error("Failed to send notification: \(error)")
             handleConnectionError(error)

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -128,9 +128,12 @@ extension AppState {
     // MARK: - Archived Worktrees
 
     /// Active-worktree path for deep-link navigation. Caller is responsible
-    /// for verifying the id exists in `self.worktrees` first.
+    /// for verifying the id exists in `self.worktrees` first. When
+    /// `terminalID` is non-nil, also switches the worktree's active tab to
+    /// the one rendering that terminal (live transcript or terminal pane);
+    /// silently falls back to current selection when no tab matches.
     @MainActor
-    func navigateToActiveWorktree(_ id: UUID) {
+    func navigateToActiveWorktree(_ id: UUID, terminalID: UUID? = nil) {
         highlightedArchivedWorktreeID = nil
         selectedWorktreeIDs = [id]
         // Expand the containing repo so the row is part of the rendered list
@@ -144,6 +147,23 @@ extension AppState {
             Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
         }
         pendingScrollToWorktreeID = id
+        // Switch to the originating terminal's tab when one matches. Both
+        // `.terminal` and `.liveTranscript` panes count as matches — clicking
+        // the banner should land the user on whichever surface the worktree
+        // currently exposes for that terminal. If neither match exists (e.g.
+        // the terminal was deleted, or surfaced only via the pinned dock),
+        // we silently keep whatever tab was active before.
+        if let terminalID, let arr = tabs[id] {
+            if let idx = arr.firstIndex(where: { tab in
+                switch tab.content {
+                case .terminal(let tid): return tid == terminalID
+                case .liveTranscript(_, let tid): return tid == terminalID
+                default: return false
+                }
+            }) {
+                setActiveTab(worktreeID: id, tabIndex: idx)
+            }
+        }
         // Only foreground when the AppKit run loop is live — `NSApp` is nil
         // under unit tests, which would crash on the implicit unwrap.
         if NSApplication.shared.isRunning {
@@ -186,9 +206,11 @@ extension AppState {
 
     /// Public entry point for deep-link navigation. Synchronous fast path
     /// for active worktrees; falls through to the async archived path on a
-    /// miss.
+    /// miss. When `terminalID` is non-nil, the active-worktree path also
+    /// switches to the originating tab. The archived path silently drops
+    /// `terminalID` — archived worktrees have no live terminals to focus.
     @MainActor
-    func navigateToWorktree(_ id: UUID) {
+    func navigateToWorktree(_ id: UUID, terminalID: UUID? = nil) {
         // Cold-start guard: a tbd:// click can arrive between AppState.init()
         // and the daemon RPC populating `worktrees`. If we fall through to
         // archived lookup now we'll miss real active worktrees. Buffer
@@ -202,7 +224,7 @@ extension AppState {
             .flatMap { $0 }
             .contains(where: { $0.id == id })
         if activeMatch {
-            navigateToActiveWorktree(id)
+            navigateToActiveWorktree(id, terminalID: terminalID)
         } else {
             Task { await navigateToArchivedWorktree(id) }
         }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -217,6 +217,7 @@ extension AppState {
         // instead and let connectAndLoadInitialState drain at the end.
         if !isInitialStateLoaded {
             pendingDeepLinkID = id
+            pendingDeepLinkTerminalID = terminalID
             return
         }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -632,7 +632,8 @@ final class AppState: ObservableObject {
         macNotificationManager.postIfEnabled(
             worktreeID: notification.worktreeID,
             message: notification.message,
-            worktrees: allWorktrees
+            worktrees: allWorktrees,
+            terminalID: notification.terminalID
         )
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -164,6 +164,13 @@ final class AppState: ObservableObject {
     /// outside the AppState extension that consumes it.
     var pendingDeepLinkID: UUID?
 
+    /// Companion to `pendingDeepLinkID`: buffers the originating terminal so
+    /// cold-start clicks land on the right tab after the drain. Drained
+    /// alongside `pendingDeepLinkID` at the end of
+    /// `connectAndLoadInitialState()`. Internal-only — never written from
+    /// outside the AppState extension that consumes it.
+    var pendingDeepLinkTerminalID: UUID?
+
     /// The first selected worktree, if any.
     var selectedWorktree: Worktree? {
         guard let id = selectedWorktreeIDs.first else { return nil }
@@ -694,8 +701,10 @@ final class AppState: ObservableObject {
         }
         isInitialStateLoaded = true
         if let pendingID = pendingDeepLinkID {
+            let pendingTerminalID = pendingDeepLinkTerminalID
             pendingDeepLinkID = nil
-            navigateToWorktree(pendingID)
+            pendingDeepLinkTerminalID = nil
+            navigateToWorktree(pendingID, terminalID: pendingTerminalID)
         }
         if didConnect {
             Task { [weak self] in

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -536,10 +536,12 @@ actor DaemonClient {
     }
 
     /// Send a notification.
-    func notify(worktreeID: UUID?, type: NotificationType, message: String? = nil) async throws {
+    func notify(worktreeID: UUID?, type: NotificationType, message: String? = nil,
+                terminalID: UUID? = nil) async throws {
         try await callVoidAsync(
             method: RPCMethod.notify,
-            params: NotifyParams(worktreeID: worktreeID, type: type, message: message)
+            params: NotifyParams(worktreeID: worktreeID, type: type, message: message,
+                                 terminalID: terminalID)
         )
     }
 

--- a/Sources/TBDApp/Services/MacNotificationManager.swift
+++ b/Sources/TBDApp/Services/MacNotificationManager.swift
@@ -48,7 +48,8 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
-    func postIfEnabled(worktreeID: UUID, message: String?, worktrees: [Worktree]) {
+    func postIfEnabled(worktreeID: UUID, message: String?, worktrees: [Worktree],
+                       terminalID: UUID? = nil) {
         guard enabled, isAvailable else { return }
         requestPermissionIfNeeded()
 
@@ -66,6 +67,13 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         content.title = worktreeName
         content.body = truncatedMessage
         content.sound = nil
+        // The request `identifier` must stay as worktreeID so re-posting
+        // collapses banners (one outstanding banner per worktree). Stash the
+        // originating terminal in userInfo so the click handler can route to
+        // the specific tab.
+        if let terminalID {
+            content.userInfo = ["terminalID": terminalID.uuidString]
+        }
 
         let request = UNNotificationRequest(
             identifier: worktreeID.uuidString,
@@ -105,15 +113,38 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
     /// Factored out of the delegate method so it's testable without faking
     /// `UNNotificationResponse` (which has no public initializer).
     func handleClick(identifier: String) {
+        handleClick(identifier: identifier, terminalIDString: nil)
+    }
+
+    /// Same as `handleClick(identifier:)` but also routes to a specific
+    /// terminal tab when `terminalIDString` is a valid UUID string. Both
+    /// parameters are strings to mirror the on-the-wire shapes the
+    /// `UNNotificationResponse` exposes (request identifier + userInfo dict).
+    func handleClick(identifier: String, terminalIDString: String?) {
         guard let worktreeID = UUID(uuidString: identifier) else {
             logger.error("Banner click identifier is not a UUID: \(identifier, privacy: .public)")
             return
         }
+        let terminalID: UUID?
+        if let terminalIDString {
+            terminalID = UUID(uuidString: terminalIDString)
+            if terminalID == nil {
+                logger.warning("Banner click userInfo terminalID is not a UUID: \(terminalIDString, privacy: .public)")
+            }
+        } else {
+            terminalID = nil
+        }
+        handleClick(worktreeID: worktreeID, terminalID: terminalID)
+    }
+
+    /// Strongly-typed entry point — used by tests to drive the click path
+    /// without faking string parsing.
+    func handleClick(worktreeID: UUID, terminalID: UUID?) {
         guard let appState else {
             logger.error("Banner click ignored: appState not configured")
             return
         }
-        appState.navigateToWorktree(worktreeID)
+        appState.navigateToWorktree(worktreeID, terminalID: terminalID)
     }
 
     /// Banner click → focus the worktree the notification was about.
@@ -125,11 +156,13 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let identifier = response.notification.request.identifier
+        let terminalIDString = response.notification.request.content
+            .userInfo["terminalID"] as? String
         // Call the completion handler synchronously to satisfy its
         // non-Sendable isolation, then hop to the main actor for navigation.
         completionHandler()
         Task { @MainActor in
-            self.handleClick(identifier: identifier)
+            self.handleClick(identifier: identifier, terminalIDString: terminalIDString)
         }
     }
 }

--- a/Sources/TBDCLI/Commands/NotifyCommand.swift
+++ b/Sources/TBDCLI/Commands/NotifyCommand.swift
@@ -17,6 +17,9 @@ struct NotifyCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Worktree ID (auto-detected from PWD if not specified)")
     var worktree: String?
 
+    @Option(name: .long, help: "Terminal ID (auto-detected from TBD_TERMINAL_ID env if not specified)")
+    var terminal: String?
+
     mutating func run() async throws {
         guard let notificationType = NotificationType(rawValue: type) else {
             // Exit silently for unknown types (be lenient for hook usage)
@@ -58,13 +61,24 @@ struct NotifyCommand: AsyncParsableCommand {
             return
         }
 
+        // Resolve terminal ID: --terminal flag → TBD_TERMINAL_ID env → nil.
+        // Invalid UUID strings are ignored silently (matches worktree handling).
+        var terminalID: UUID?
+        if let terminal = terminal {
+            terminalID = UUID(uuidString: terminal)
+        } else if let envID = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+                  let id = UUID(uuidString: envID) {
+            terminalID = id
+        }
+
         do {
             try client.callVoid(
                 method: RPCMethod.notify,
                 params: NotifyParams(
                     worktreeID: resolvedWorktreeID,
                     type: notificationType,
-                    message: message
+                    message: message,
+                    terminalID: terminalID
                 )
             )
         } catch {

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -509,6 +509,14 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "config", column: "primary_agent_preference", type: .text)
         }
 
+        // Records the originating terminal for a notification so banner
+        // clicks can switch to the specific tab, not just select the
+        // worktree. Nullable for backwards compat with rows inserted by
+        // pre-v28 daemons.
+        migrator.registerMigration("v28_notification_terminal_id") { db in
+            try db.addColumnIfMissing(table: "notification", column: "terminalID", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/NotificationStore.swift
+++ b/Sources/TBDDaemon/Database/NotificationStore.swift
@@ -12,6 +12,7 @@ struct NotificationRecord: Codable, FetchableRecord, PersistableRecord, Sendable
     var message: String?
     var read: Bool
     var createdAt: Date
+    var terminalID: String?
 
     init(from notification: TBDNotification) {
         self.id = notification.id.uuidString
@@ -20,6 +21,7 @@ struct NotificationRecord: Codable, FetchableRecord, PersistableRecord, Sendable
         self.message = notification.message
         self.read = notification.read
         self.createdAt = notification.createdAt
+        self.terminalID = notification.terminalID?.uuidString
     }
 
     func toModel() -> TBDNotification {
@@ -29,7 +31,8 @@ struct NotificationRecord: Codable, FetchableRecord, PersistableRecord, Sendable
             type: NotificationType(rawValue: type)!,
             message: message,
             read: read,
-            createdAt: createdAt
+            createdAt: createdAt,
+            terminalID: terminalID.flatMap(UUID.init(uuidString:))
         )
     }
 }
@@ -46,12 +49,14 @@ public struct NotificationStore: Sendable {
     public func create(
         worktreeID: UUID,
         type: NotificationType,
-        message: String? = nil
+        message: String? = nil,
+        terminalID: UUID? = nil
     ) async throws -> TBDNotification {
         let notification = TBDNotification(
             worktreeID: worktreeID,
             type: type,
-            message: message
+            message: message,
+            terminalID: terminalID
         )
         let record = NotificationRecord(from: notification)
         try await writer.write { db in

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -776,12 +776,14 @@ extension RPCRouter {
         let notification = try await db.notifications.create(
             worktreeID: worktreeID,
             type: params.type,
-            message: params.message
+            message: params.message,
+            terminalID: params.terminalID
         )
 
         subscriptions.broadcast(delta: .notificationReceived(NotificationDelta(
             notificationID: notification.id, worktreeID: notification.worktreeID,
-            type: notification.type, message: notification.message
+            type: notification.type, message: notification.message,
+            terminalID: notification.terminalID
         )))
 
         // Signal the suspend/resume coordinator that Claude finished a response

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -440,15 +440,37 @@ public struct TBDNotification: Codable, Sendable, Identifiable {
     public var message: String?
     public var read: Bool
     public var createdAt: Date
+    /// Optional terminal that triggered the notification. When present, the
+    /// app can route a banner click to the originating tab rather than just
+    /// selecting the worktree. Nil for older rows or for notifications that
+    /// don't originate from a specific terminal.
+    public var terminalID: UUID?
 
     public init(id: UUID = UUID(), worktreeID: UUID, type: NotificationType,
-                message: String? = nil, read: Bool = false, createdAt: Date = Date()) {
+                message: String? = nil, read: Bool = false, createdAt: Date = Date(),
+                terminalID: UUID? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.type = type
         self.message = message
         self.read = read
         self.createdAt = createdAt
+        self.terminalID = terminalID
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, worktreeID, type, message, read, createdAt, terminalID
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        worktreeID = try c.decode(UUID.self, forKey: .worktreeID)
+        type = try c.decode(NotificationType.self, forKey: .type)
+        message = try c.decodeIfPresent(String.self, forKey: .message)
+        read = try c.decodeIfPresent(Bool.self, forKey: .read) ?? false
+        createdAt = try c.decode(Date.self, forKey: .createdAt)
+        terminalID = try c.decodeIfPresent(UUID.self, forKey: .terminalID)
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -642,8 +642,15 @@ public struct NotifyParams: Codable, Sendable {
     public let worktreeID: UUID?
     public let type: NotificationType
     public let message: String?
-    public init(worktreeID: UUID? = nil, type: NotificationType, message: String? = nil) {
+    /// Originating terminal id. Optional for backwards compatibility — older
+    /// CLI callers and clients won't include it. The daemon persists it on
+    /// the notification row and forwards it on the broadcast delta so the
+    /// app's banner-click handler can switch to the right tab.
+    public let terminalID: UUID?
+    public init(worktreeID: UUID? = nil, type: NotificationType, message: String? = nil,
+                terminalID: UUID? = nil) {
         self.worktreeID = worktreeID; self.type = type; self.message = message
+        self.terminalID = terminalID
     }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -75,9 +75,29 @@ public struct NotificationDelta: Codable, Sendable {
     public let worktreeID: UUID
     public let type: NotificationType
     public let message: String?
-    public init(notificationID: UUID, worktreeID: UUID, type: NotificationType, message: String?) {
+    /// Optional terminal that triggered the notification. The app uses this
+    /// to route a banner click to the originating tab. Nil when the
+    /// notification didn't come from a specific terminal or from an older
+    /// daemon that didn't include the field.
+    public let terminalID: UUID?
+    public init(notificationID: UUID, worktreeID: UUID, type: NotificationType,
+                message: String?, terminalID: UUID? = nil) {
         self.notificationID = notificationID; self.worktreeID = worktreeID
         self.type = type; self.message = message
+        self.terminalID = terminalID
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case notificationID, worktreeID, type, message, terminalID
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        notificationID = try c.decode(UUID.self, forKey: .notificationID)
+        worktreeID = try c.decode(UUID.self, forKey: .worktreeID)
+        type = try c.decode(NotificationType.self, forKey: .type)
+        message = try c.decodeIfPresent(String.self, forKey: .message)
+        terminalID = try c.decodeIfPresent(UUID.self, forKey: .terminalID)
     }
 }
 

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -159,3 +159,18 @@ import TBDShared
     // No buffering once initial state is loaded.
     #expect(appState.pendingDeepLinkID == nil)
 }
+
+@MainActor
+@Test func navigateToWorktree_beforeInitialLoad_buffersTerminalID() async {
+    let appState = AppState()
+    let id = UUID()
+    let terminalID = UUID()
+    // Default: isInitialStateLoaded == false on a fresh AppState.
+    appState.worktrees = [:]
+
+    appState.navigateToWorktree(id, terminalID: terminalID)
+
+    #expect(appState.pendingDeepLinkID == id)
+    #expect(appState.pendingDeepLinkTerminalID == terminalID)
+    #expect(appState.selectedWorktreeIDs.isEmpty)
+}

--- a/Tests/TBDAppTests/MacNotificationManagerClickTests.swift
+++ b/Tests/TBDAppTests/MacNotificationManagerClickTests.swift
@@ -178,6 +178,38 @@ private func makeAppStateWithTabs(
 }
 
 @MainActor
+@Test func handleClick_withTerminalID_matchesLiveTranscriptTab() async {
+    // Mirror of `handleClick_withTerminalID_setsActiveTab` but the second
+    // tab is a `.liveTranscript` pane — both arms of the tab-match switch
+    // should select the originating terminal's surface.
+    let worktreeID = UUID()
+    let repoID = UUID()
+    let terminalID = UUID()
+    let (appState, suite) = makeIsolatedAppState()
+    defer { tearDown(suite) }
+    appState.isInitialStateLoaded = true
+    appState.worktrees = [
+        repoID: [
+            Worktree(id: worktreeID, repoID: repoID, name: "x", displayName: "X",
+                     branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x"),
+        ],
+    ]
+    let tab0 = Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil)
+    let tab1 = Tab(id: UUID(),
+                   content: .liveTranscript(id: UUID(), terminalID: terminalID),
+                   label: nil)
+    appState.tabs[worktreeID] = [tab0, tab1]
+    appState.activeTabIndices[worktreeID] = 0
+
+    appState.macNotificationManager.handleClick(
+        worktreeID: worktreeID, terminalID: terminalID
+    )
+
+    #expect(appState.selectedWorktreeIDs == [worktreeID])
+    #expect(appState.activeTabIndices[worktreeID] == 1)
+}
+
+@MainActor
 @Test func handleClick_userInfoTerminalIDString_routesToTab() async {
     // Mirrors the string-parsing path used by the UN delegate callback.
     let worktreeID = UUID()

--- a/Tests/TBDAppTests/MacNotificationManagerClickTests.swift
+++ b/Tests/TBDAppTests/MacNotificationManagerClickTests.swift
@@ -92,3 +92,106 @@ private func tearDown(_ suiteName: String) {
     let manager = MacNotificationManager()
     manager.dismissDelivered(worktreeIDs: [UUID()])
 }
+
+// MARK: - terminalID routing tests
+
+/// Build a fixture appState with one worktree and a two-tab layout. The
+/// second tab is a `.terminal(terminalID:)` pane for `terminalID` so tests
+/// can verify the click handler selects it.
+@MainActor
+private func makeAppStateWithTabs(
+    worktreeID: UUID,
+    repoID: UUID,
+    terminalID: UUID
+) -> (AppState, String) {
+    let (state, suite) = makeIsolatedAppState()
+    state.isInitialStateLoaded = true
+    state.worktrees = [
+        repoID: [
+            Worktree(id: worktreeID, repoID: repoID, name: "x", displayName: "X",
+                     branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x"),
+        ],
+    ]
+    let tab0 = Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil)
+    let tab1 = Tab(id: UUID(), content: .terminal(terminalID: terminalID), label: nil)
+    state.tabs[worktreeID] = [tab0, tab1]
+    state.activeTabIndices[worktreeID] = 0
+    return (state, suite)
+}
+
+@MainActor
+@Test func handleClick_withTerminalID_setsActiveTab() async {
+    let worktreeID = UUID()
+    let repoID = UUID()
+    let terminalID = UUID()
+    let (appState, suite) = makeAppStateWithTabs(
+        worktreeID: worktreeID, repoID: repoID, terminalID: terminalID
+    )
+    defer { tearDown(suite) }
+
+    appState.macNotificationManager.handleClick(
+        worktreeID: worktreeID, terminalID: terminalID
+    )
+
+    #expect(appState.selectedWorktreeIDs == [worktreeID])
+    #expect(appState.activeTabIndices[worktreeID] == 1)
+}
+
+@MainActor
+@Test func handleClick_withTerminalID_terminalNotInTabs_fallsBackSilently() async {
+    let worktreeID = UUID()
+    let repoID = UUID()
+    let terminalID = UUID()
+    let (appState, suite) = makeAppStateWithTabs(
+        worktreeID: worktreeID, repoID: repoID, terminalID: terminalID
+    )
+    defer { tearDown(suite) }
+
+    // Pass a terminal ID that isn't in any tab.
+    let strangerID = UUID()
+    appState.macNotificationManager.handleClick(
+        worktreeID: worktreeID, terminalID: strangerID
+    )
+
+    // Selection still set; active tab unchanged (remains 0 from setup).
+    #expect(appState.selectedWorktreeIDs == [worktreeID])
+    #expect(appState.activeTabIndices[worktreeID] == 0)
+}
+
+@MainActor
+@Test func handleClick_withoutTerminalID_behavesAsBefore() async {
+    let worktreeID = UUID()
+    let repoID = UUID()
+    let terminalID = UUID()
+    let (appState, suite) = makeAppStateWithTabs(
+        worktreeID: worktreeID, repoID: repoID, terminalID: terminalID
+    )
+    defer { tearDown(suite) }
+
+    appState.macNotificationManager.handleClick(
+        worktreeID: worktreeID, terminalID: nil
+    )
+
+    // Selection set, active tab unchanged.
+    #expect(appState.selectedWorktreeIDs == [worktreeID])
+    #expect(appState.activeTabIndices[worktreeID] == 0)
+}
+
+@MainActor
+@Test func handleClick_userInfoTerminalIDString_routesToTab() async {
+    // Mirrors the string-parsing path used by the UN delegate callback.
+    let worktreeID = UUID()
+    let repoID = UUID()
+    let terminalID = UUID()
+    let (appState, suite) = makeAppStateWithTabs(
+        worktreeID: worktreeID, repoID: repoID, terminalID: terminalID
+    )
+    defer { tearDown(suite) }
+
+    appState.macNotificationManager.handleClick(
+        identifier: worktreeID.uuidString,
+        terminalIDString: terminalID.uuidString
+    )
+
+    #expect(appState.activeTabIndices[worktreeID] == 1)
+}


### PR DESCRIPTION
## Summary
- Notification banner clicks already navigated to the right worktree but dropped you on whatever tab was last active. Now they switch to the tab that actually produced the notification (terminal pane or live transcript), so you land on the message you came to see.
- Plumbing: `tbd notify` auto-detects `$TBD_TERMINAL_ID` from the spawned shell's env, threads it through `NotifyParams` → daemon → `NotificationDelta` → app, where `MacNotificationManager` stashes it in `UNNotificationContent.userInfo` and `navigateToActiveWorktree(_:terminalID:)` calls `setActiveTab` on the matching tab.
- Silent fallback when the terminal was deleted or only lives in the pinned dock — selection still moves, active tab stays put.

## Test plan
- [x] Unit tests cover: tab match, no-match fallback, missing terminalID regression, userInfo string-parsing path.
- [x] Manual: triggered `tbd notify` from terminal A, clicked banner from terminal B in a different worktree → landed on terminal A's tab.
- [ ] Repeat with a worktree where the originating terminal has been deleted → selection moves, active tab unchanged, no crash.

DB: new migration `v28_notification_terminal_id` adds a nullable `terminalID TEXT` to the notification table.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7F52662E-9945-4437-B79D-68633804F100)