### PR TITLE
Fix: Darken PR status icons so they don't blend into sidebar gray

### DIFF
--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -1,5 +1,12 @@
+import AppKit
 import SwiftUI
 import TBDShared
+
+private func adaptive(light: NSColor, dark: NSColor) -> Color {
+    Color(nsColor: NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+    })
+}
 
 struct PRStatusPresentation: Equatable {
     enum ColorSemantic: Equatable {
@@ -15,10 +22,22 @@ struct PRStatusPresentation: Equatable {
 
     var color: Color {
         switch colorSemantic {
-        case .pending:          return Color(red: 147 / 255, green: 105 / 255, blue: 33 / 255)
+        case .pending:
+            // Light: GitHub WIP olive #936921 — readable on light sidebar (~#F1F1F1).
+            // Dark:  GitHub attention.fg #D29922 — readable on dark sidebar (~#1E1E1E).
+            return adaptive(
+                light: NSColor(srgbRed: 147 / 255, green: 105 / 255, blue: 33 / 255, alpha: 1),
+                dark: NSColor(srgbRed: 210 / 255, green: 153 / 255, blue: 34 / 255, alpha: 1)
+            )
         case .nonMergeable:     return .red
         case .draft:            return .secondary
-        case .mergeable:        return Color(red: 61 / 255, green: 125 / 255, blue: 64 / 255)
+        case .mergeable:
+            // Light: muted forest #3D7D40.
+            // Dark:  GitHub success.fg #3FB950.
+            return adaptive(
+                light: NSColor(srgbRed: 61 / 255, green: 125 / 255, blue: 64 / 255, alpha: 1),
+                dark: NSColor(srgbRed: 63 / 255, green: 185 / 255, blue: 80 / 255, alpha: 1)
+            )
         case .merged:           return .purple
         }
     }

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -15,10 +15,10 @@ struct PRStatusPresentation: Equatable {
 
     var color: Color {
         switch colorSemantic {
-        case .pending:          return .yellow
+        case .pending:          return Color(red: 147 / 255, green: 105 / 255, blue: 33 / 255)
         case .nonMergeable:     return .red
         case .draft:            return .secondary
-        case .mergeable:        return .green
+        case .mergeable:        return Color(red: 61 / 255, green: 125 / 255, blue: 64 / 255)
         case .merged:           return .purple
         }
     }


### PR DESCRIPTION
## Summary
- System `.yellow` (#FFCC00) and `.green` (#34C759) blend into the (241, 241, 241) sidebar gray — the pending/mergeable PR dots are nearly invisible.
- Swap pending to GitHub's WIP olive `#936921` (rgb 147, 105, 33) and mergeable to a muted forest `#3D7D40` (rgb 61, 125, 64). Same desaturated character, readable contrast.
- Red/purple/secondary are unchanged — they already had enough luminance against the gray.

## Test plan
- [ ] Build and restart the app
- [ ] Open the worktree list with PRs in `.pending` and `.mergeable` states
- [ ] Confirm both icons are clearly distinguishable against the sidebar background

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=6E2E0307-283D-49EE-996F-19E5394FBF8D)