### PR TITLE
fix: scope terminal layouts to worktrees

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -5,6 +5,18 @@ import os
 private let logger = Logger(subsystem: "com.tbd.app", category: "AppState+Terminals")
 
 extension AppState {
+    /// Resolve a terminal only within its owning worktree bucket. Terminal IDs
+    /// are globally unique in normal operation, but persisted split layouts can
+    /// outlive terminal/worktree churn; scoped lookup prevents stale layouts
+    /// from rendering another worktree's tmux window.
+    func terminal(id: UUID, in worktreeID: UUID) -> Terminal? {
+        terminals[worktreeID]?.first { $0.id == id }
+    }
+
+    func initialTabLabel(for terminal: Terminal) -> String? {
+        terminal.kind == .codex || terminal.label == "Codex" ? terminal.label : nil
+    }
+
     // MARK: - Terminal Actions
 
     /// Create a terminal in a worktree and add a new tab for it.
@@ -14,7 +26,7 @@ extension AppState {
             let colorFgBg = appearance?.currentColorFgBg
             let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cmd: cmd, cols: size.cols, rows: size.rows, colorFgBg: colorFgBg)
             terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
             tabs[worktreeID, default: []].append(tab)
         } catch {
             logger.error("Failed to create terminal: \(error)")
@@ -99,7 +111,7 @@ extension AppState {
                 colorFgBg: colorFgBg
             )
             terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
             tabs[worktreeID, default: []].append(tab)
         } catch {
             logger.error("Failed to create Claude terminal: \(error)")
@@ -121,7 +133,7 @@ extension AppState {
                 colorFgBg: colorFgBg
             )
             terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
             tabs[worktreeID, default: []].append(tab)
         } catch {
             logger.error("Failed to create Codex terminal: \(error)")
@@ -143,7 +155,7 @@ extension AppState {
                 colorFgBg: colorFgBg
             )
             terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
             tabs[worktreeID, default: []].append(tab)
         } catch {
             logger.error("Failed to fork Claude terminal: \(error)")

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -893,7 +893,7 @@ final class AppState: ObservableObject {
     /// Removes tabs whose root terminal no longer exists. Adds tabs for
     /// terminals that aren't already represented (either as a tab root or
     /// embedded in another tab's split layout).
-    private func reconcileTabs(worktreeID: UUID, terminals: [Terminal]) {
+    func reconcileTabs(worktreeID: UUID, terminals: [Terminal]) {
         let alreadyLoadedOrder = worktreeTabOrders[worktreeID] != nil
         var currentTabs = tabs[worktreeID] ?? []
         let terminalIDs = Set(terminals.map(\.id))
@@ -912,13 +912,27 @@ final class AppState: ObservableObject {
         //    This must happen AFTER pruning so that dead tabs' children
         //    don't mask still-alive terminals that need new tabs.
         var terminalIDsInLayouts = Set<UUID>()
-        for tab in currentTabs {
+        for index in currentTabs.indices {
+            let tab = currentTabs[index]
             if let layout = layouts[tab.id] {
-                for id in layout.allTerminalIDs() {
+                guard let scopedLayout = layout.removingTerminalPanes(notIn: terminalIDs) else {
+                    layouts.removeValue(forKey: tab.id)
+                    if case .terminal(let id) = tab.content, terminalIDs.contains(id) {
+                        terminalIDsInLayouts.insert(id)
+                    }
+                    continue
+                }
+                if scopedLayout != layout {
+                    layouts[tab.id] = scopedLayout
+                    if case .pane(let content) = scopedLayout {
+                        currentTabs[index].content = content
+                    }
+                }
+                for id in scopedLayout.allTerminalIDs() {
                     terminalIDsInLayouts.insert(id)
                 }
             } else {
-                if case .terminal(let id) = tab.content {
+                if case .terminal(let id) = tab.content, terminalIDs.contains(id) {
                     terminalIDsInLayouts.insert(id)
                 }
             }
@@ -926,7 +940,11 @@ final class AppState: ObservableObject {
 
         // 3. Add tabs for terminals not already in any surviving layout.
         for terminal in terminals where !terminalIDsInLayouts.contains(terminal.id) {
-            currentTabs.append(Tab(id: terminal.id, content: .terminal(terminalID: terminal.id)))
+            currentTabs.append(Tab(
+                id: terminal.id,
+                content: .terminal(terminalID: terminal.id),
+                label: initialTabLabel(for: terminal)
+            ))
         }
 
         tabs[worktreeID] = currentTabs

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -38,14 +38,9 @@ struct PanePlaceholder: View {
     @State private var showSourceCode = false
     @State private var hasRenderableContent = false
 
-    /// Find the Terminal model matching a terminal ID across all worktree terminals.
+    /// Find the Terminal model matching a terminal ID in this pane's worktree.
     private func terminal(for id: UUID) -> Terminal? {
-        for (_, terms) in appState.terminals {
-            if let t = terms.first(where: { $0.id == id }) {
-                return t
-            }
-        }
-        return nil
+        appState.terminal(id: id, in: worktree.id)
     }
 
     var body: some View {

--- a/Sources/TBDApp/Terminal/LayoutNode.swift
+++ b/Sources/TBDApp/Terminal/LayoutNode.swift
@@ -103,6 +103,44 @@ indirect enum LayoutNode: Equatable, Sendable {
             return children.flatMap { $0.allTerminalIDs() }
         }
     }
+
+    /// Returns a copy of the layout with terminal panes outside `allowedIDs`
+    /// removed. Non-terminal panes are preserved. If every pane is removed,
+    /// returns nil.
+    func removingTerminalPanes(notIn allowedIDs: Set<UUID>) -> LayoutNode? {
+        switch self {
+        case .pane(let content):
+            if case .terminal(let id) = content, !allowedIDs.contains(id) {
+                return nil
+            }
+            return self
+
+        case .split(let direction, let children, let ratios):
+            var keptChildren: [LayoutNode] = []
+            var keptRatios: [CGFloat] = []
+
+            for (index, child) in children.enumerated() {
+                if let kept = child.removingTerminalPanes(notIn: allowedIDs) {
+                    keptChildren.append(kept)
+                    keptRatios.append(ratios[index])
+                }
+            }
+
+            if keptChildren.isEmpty {
+                return nil
+            }
+            if keptChildren.count == 1 {
+                return keptChildren[0]
+            }
+
+            let total = keptRatios.reduce(0, +)
+            if total > 0 {
+                keptRatios = keptRatios.map { $0 / total }
+            }
+
+            return .split(direction: direction, children: keptChildren, ratios: keptRatios)
+        }
+    }
 }
 
 // MARK: - Pane lookup / replacement helpers

--- a/Sources/TBDApp/Terminal/WorktreePager.swift
+++ b/Sources/TBDApp/Terminal/WorktreePager.swift
@@ -17,6 +17,13 @@ struct WorktreePager: NSViewControllerRepresentable {
     let activeID: UUID?
     @EnvironmentObject var appState: AppState
 
+    static func mountedWorktreeIDs(recentIDs: [UUID], activeID: UUID?) -> [UUID] {
+        guard let activeID else { return recentIDs }
+        var ids = recentIDs.filter { $0 != activeID }
+        ids.insert(activeID, at: 0)
+        return ids
+    }
+
     func makeNSViewController(context: Context) -> NSTabViewController {
         let vc = NSTabViewController()
         vc.tabStyle = .unspecified
@@ -25,17 +32,18 @@ struct WorktreePager: NSViewControllerRepresentable {
     }
 
     func updateNSViewController(_ vc: NSTabViewController, context: Context) {
+        let mountedIDs = Self.mountedWorktreeIDs(recentIDs: worktreeIDs, activeID: activeID)
         let currentIDs = vc.tabViewItems.compactMap { $0.identifier as? UUID }
 
         // 1. Remove tab items whose worktree IDs were evicted.
         for (idx, id) in currentIDs.enumerated().reversed() {
-            if !worktreeIDs.contains(id) {
+            if !mountedIDs.contains(id) {
                 vc.removeTabViewItem(vc.tabViewItems[idx])
             }
         }
 
         // 2. Add tab items for new worktree IDs.
-        for id in worktreeIDs where !currentIDs.contains(id) {
+        for id in mountedIDs where !currentIDs.contains(id) {
             let host = NSHostingController(
                 rootView: SingleWorktreeView(worktreeID: id)
                     .environmentObject(appState)

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -103,6 +103,7 @@ public struct TerminalStore: Sendable {
             if let worktreeID {
                 request = request.filter(Column("worktreeID") == worktreeID.uuidString)
             }
+            request = request.order(Column("createdAt").asc, Column("id").asc)
             return try request.fetchAll(db).map { $0.toModel() }
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -281,6 +281,7 @@ extension WorktreeLifecycle {
 
         // Create terminal 1: primary agent (or shell if skipped).
         let plannedTerminalID1 = UUID()
+        var createdTerminalIDs = [plannedTerminalID1]
         let primaryCommand: String
         let primaryEnv: [String: String]
         let primarySensitiveEnv: [String: String]
@@ -372,6 +373,7 @@ extension WorktreeLifecycle {
 
         // Create terminal 2: setup hook
         let plannedTerminalID2 = UUID()
+        createdTerminalIDs.append(plannedTerminalID2)
         let setupHookPath = hooks.resolve(
             event: .setup,
             repoPath: worktreePath,
@@ -416,6 +418,7 @@ extension WorktreeLifecycle {
         if !skipClaude {
             for sessionID in additionalArchivedClaudeSessions {
                 let plannedID = UUID()
+                createdTerminalIDs.append(plannedID)
                 let spawn = ClaudeSpawnCommandBuilder.build(
                     resumeID: sessionID,
                     freshSessionID: nil,
@@ -460,6 +463,9 @@ extension WorktreeLifecycle {
                 )
             }
         }
+
+        try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: createdTerminalIDs)
+        try await db.worktrees.setActiveTabID(worktreeID: worktreeID, tabID: plannedTerminalID1)
 
         // Kill the untracked initial window that new-session created
         if let windowID = initialWindowID {

--- a/Tests/TBDAppTests/AppStateTerminalReconciliationTests.swift
+++ b/Tests/TBDAppTests/AppStateTerminalReconciliationTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+@MainActor
+@Suite("AppState terminal reconciliation")
+struct AppStateTerminalReconciliationTests {
+    @Test func reconcileTabsPrunesForeignTerminalFromPersistedSplitLayout() {
+        let state = AppState()
+        let worktreeID = UUID()
+        let localID = UUID()
+        let foreignID = UUID()
+        let localTerminal = Terminal(
+            id: localID,
+            worktreeID: worktreeID,
+            tmuxWindowID: "@local",
+            tmuxPaneID: "%local",
+            label: "Claude Code",
+            kind: .claude
+        )
+        state.tabs[worktreeID] = [
+            Tab(id: localID, content: .terminal(terminalID: localID), label: nil),
+        ]
+        state.layouts[localID] = .split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: localID)),
+                .pane(.terminal(terminalID: foreignID)),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        state.reconcileTabs(worktreeID: worktreeID, terminals: [localTerminal])
+
+        #expect(state.layouts[localID] == .pane(.terminal(terminalID: localID)))
+        #expect(state.tabs[worktreeID]?.map(\.id) == [localID])
+    }
+
+    @Test func reconcileTabsDoesNotLetForeignLayoutPaneMaskLocalTerminalNeedingATab() {
+        let state = AppState()
+        let worktreeID = UUID()
+        let staleTabID = UUID()
+        let localID = UUID()
+        let foreignID = UUID()
+        let localTerminal = Terminal(
+            id: localID,
+            worktreeID: worktreeID,
+            tmuxWindowID: "@local",
+            tmuxPaneID: "%local",
+            label: "Codex",
+            kind: .codex
+        )
+        state.tabs[worktreeID] = [
+            Tab(id: staleTabID, content: .codeViewer(id: staleTabID, path: "/tmp/file.swift"), label: "file.swift"),
+        ]
+        state.layouts[staleTabID] = .pane(.terminal(terminalID: foreignID))
+
+        state.reconcileTabs(worktreeID: worktreeID, terminals: [localTerminal])
+
+        #expect(state.layouts[staleTabID] == nil)
+        #expect(state.tabs[worktreeID]?.map(\.content) == [
+            .codeViewer(id: staleTabID, path: "/tmp/file.swift"),
+            .terminal(terminalID: localID),
+        ])
+        #expect(state.tabs[worktreeID]?.last?.label == "Codex")
+    }
+
+    @Test func reconcileTabsKeepsNonTerminalPanesWhilePruningForeignTerminalChildren() {
+        let state = AppState()
+        let worktreeID = UUID()
+        let tabID = UUID()
+        let localID = UUID()
+        let foreignID = UUID()
+        let webID = UUID()
+        let localTerminal = Terminal(
+            id: localID,
+            worktreeID: worktreeID,
+            tmuxWindowID: "@local",
+            tmuxPaneID: "%local",
+            label: "shell",
+            kind: .shell
+        )
+        state.tabs[worktreeID] = [
+            Tab(id: tabID, content: .terminal(terminalID: localID), label: nil),
+        ]
+        state.layouts[tabID] = .split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: localID)),
+                .pane(.webview(id: webID, url: URL(string: "https://example.com")!)),
+                .pane(.terminal(terminalID: foreignID)),
+            ],
+            ratios: [0.25, 0.5, 0.25]
+        )
+
+        state.reconcileTabs(worktreeID: worktreeID, terminals: [localTerminal])
+
+        #expect(state.layouts[tabID] == .split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: localID)),
+                .pane(.webview(id: webID, url: URL(string: "https://example.com")!)),
+            ],
+            ratios: [1.0 / 3.0, 2.0 / 3.0]
+        ))
+    }
+}

--- a/Tests/TBDAppTests/LayoutNodeTests.swift
+++ b/Tests/TBDAppTests/LayoutNodeTests.swift
@@ -165,6 +165,40 @@ struct LayoutNodeTests {
         #expect(ids == [termID])
     }
 
+    @Test func removingTerminalPanesNotInAllowedSetDropsForeignTerminalPane() {
+        let localID = UUID()
+        let foreignID = UUID()
+        let node = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: localID)),
+                .pane(.terminal(terminalID: foreignID)),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = node.removingTerminalPanes(notIn: Set([localID]))
+
+        #expect(result == .pane(.terminal(terminalID: localID)))
+    }
+
+    @Test func removingTerminalPanesNotInAllowedSetKeepsNonTerminalPanes() {
+        let localID = UUID()
+        let webID = UUID()
+        let node = LayoutNode.split(
+            direction: .vertical,
+            children: [
+                .pane(.terminal(terminalID: localID)),
+                .pane(.webview(id: webID, url: URL(string: "https://example.com")!)),
+            ],
+            ratios: [0.4, 0.6]
+        )
+
+        let result = node.removingTerminalPanes(notIn: Set([localID]))
+
+        #expect(result == node)
+    }
+
     // MARK: - Codable backward compat
 
     @Test func codable_backwardCompat_oldTerminalFormat() throws {

--- a/Tests/TBDAppTests/WorktreePagerTests.swift
+++ b/Tests/TBDAppTests/WorktreePagerTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("WorktreePager")
+@MainActor
+struct WorktreePagerTests {
+    @Test func mountedWorktreeIDsAlwaysIncludeActiveWorktreeFirst() {
+        let mainID = UUID()
+        let activeID = UUID()
+
+        #expect(WorktreePager.mountedWorktreeIDs(recentIDs: [mainID], activeID: activeID) == [
+            activeID,
+            mainID,
+        ])
+    }
+
+    @Test func mountedWorktreeIDsDeduplicateActiveWorktree() {
+        let mainID = UUID()
+        let activeID = UUID()
+
+        #expect(WorktreePager.mountedWorktreeIDs(recentIDs: [mainID, activeID], activeID: activeID) == [
+            activeID,
+            mainID,
+        ])
+    }
+}

--- a/Tests/TBDDaemonTests/DatabaseTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseTests.swift
@@ -168,6 +168,40 @@ struct DatabaseTests {
         #expect(terminals.count == 1)
     }
 
+    @Test func listTerminalsOrdersByCreationTime() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/test-terminal-order", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+            path: "/tmp/test-terminal-order/.tbd/worktrees/test-wt", tmuxServer: "tbd-a1b2c3d4"
+        )
+        let firstID = UUID()
+        let secondID = UUID()
+
+        try await db.writerForTests.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO terminal
+                        (id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt, kind)
+                    VALUES
+                        (?, ?, '@2', '%2', 'setup', ?, 'shell'),
+                        (?, ?, '@1', '%1', 'Codex', ?, 'codex')
+                    """,
+                arguments: [
+                    secondID.uuidString,
+                    wt.id.uuidString,
+                    Date(timeIntervalSince1970: 20),
+                    firstID.uuidString,
+                    wt.id.uuidString,
+                    Date(timeIntervalSince1970: 10),
+                ]
+            )
+        }
+
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.map(\.id) == [firstID, secondID])
+    }
+
     @Test func deleteTerminal() async throws {
         let db = try TBDDatabase(inMemory: true)
         let repo = try await db.repos.create(path: "/tmp/test", displayName: "test", defaultBranch: "main")

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -51,6 +51,30 @@ import Testing
     #expect(!terminals.contains { $0.kind == .claude || $0.label == "Claude Code" })
 }
 
+@Test func testCreateWorktreePersistsPrimaryAgentAsFirstAndActiveTab() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    try await db.config.setPrimaryAgentPreference(.codex)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let result = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+    let terminals = try await db.terminals.list(worktreeID: result.id)
+    let primary = try #require(terminals.first)
+
+    #expect(primary.kind == .codex)
+    #expect(primary.label == "Codex")
+    #expect(try await db.worktrees.getTabOrder(worktreeID: result.id) == terminals.map(\.id))
+    #expect(try await db.worktrees.getActiveTabID(worktreeID: result.id) == primary.id)
+}
+
 @Test func testCreateWorktreeWithCodexPreferenceDoesNotResolveClaudeProfile() async throws {
     let (tempDir, repoDir) = try await createTestRepo()
     defer { try? FileManager.default.removeItem(at: tempDir) }


### PR DESCRIPTION
## Summary
- scope terminal lookup to the active worktree when rendering panes
- prune stale or foreign terminal panes from persisted layouts during tab reconciliation
- preserve Codex tab labels when reconciled tabs are created

## Verification
- swift test --filter 'AppStateTerminalReconciliationTests|LayoutNodeTests/removingTerminalPanes'
- swift build
- swift test