### PR TITLE
Feat: Let users author and import their own terminal color themes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6b4ef2d7b9f338239f06147a86fb81a991fbd5c88195513612158d4b48138aad",
+  "originHash" : "6ebf41beb952f187440ec3dcaebee7ad6c5e65b852409658d919d27e12dc9392",
   "pins" : [
     {
       "identity" : "grdb.swift",
@@ -106,6 +106,15 @@
       "state" : {
         "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "tomlkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/LebJe/TOMLKit",
+      "state" : {
+        "revision" : "ec6198d37d495efc6acd4dffbd262cdca7ff9b3f",
+        "version" : "0.6.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
         .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),
+        .package(url: "https://github.com/LebJe/TOMLKit", from: "0.6.0"),
     ],
     targets: [
         .target(
@@ -92,6 +93,7 @@ let package = Package(
                 .product(name: "Highlightr", package: "Highlightr"),
                 .product(name: "SwiftUIIntrospect", package: "swiftui-introspect"),
                 .product(name: "MarkdownUI", package: "swift-markdown-ui"),
+                .product(name: "TOMLKit", package: "TOMLKit"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
             ],

--- a/Package.swift
+++ b/Package.swift
@@ -131,6 +131,9 @@ let package = Package(
             name: "TBDAppTests",
             dependencies: [
                 "TBDApp",
+            ],
+            resources: [
+                .copy("Fixtures")
             ]
         ),
         .testTarget(

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -37,6 +37,7 @@ final class AppState: ObservableObject {
     var appearance: AppearanceSettings? {
         didSet {
             if let appearance {
+                appearance.themeStore = themeStore
                 setupAppearanceSubscriptions(appearance)
             }
         }
@@ -324,6 +325,8 @@ final class AppState: ObservableObject {
     @Published var alertMessage: String? = nil
     @Published var alertIsError: Bool = false
 
+    let themeStore = ThemeStore()
+
     let daemonClient = DaemonClient()
     let tmuxBridge = TmuxBridge()
     lazy var cliInstallerCoordinator = CLIInstallerCoordinator(daemonClient: daemonClient, userDefaults: userDefaults)
@@ -357,6 +360,8 @@ final class AppState: ObservableObject {
         // can call navigateToWorktree. All stored properties are now
         // initialized, so `self` is fully usable here.
         macNotificationManager.configure(appState: self)
+        themeStore.reloadFromDisk()
+        themeStore.startWatching()
         // Under `swift test`, the per-test `AppState()` instances would each
         // spawn a subscription Task that blocks indefinitely in `recv()` on
         // the daemon socket. With enough tests the Swift cooperative thread

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -489,6 +489,7 @@ final class AppState: ObservableObject {
         // the active schemeID so a deleted theme falls back to the default rather
         // than leaving the UI pointing at an unknown id.
         themeStoreSubscription = themeStore.$userThemes
+            .dropFirst()  // skip subscriber-time emission, match appearanceSubscription pattern
             .sink { [weak appearance] _ in
                 appearance?.reconcileWithStore()
             }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -44,6 +44,8 @@ final class AppState: ObservableObject {
     }
     /// Subscription to appearance.$schemeID changes for pushing COLORFGBG updates to running tmux servers.
     private var appearanceSubscription: AnyCancellable?
+    /// Subscription to themeStore.$userThemes changes for reconciling the active scheme.
+    private var themeStoreSubscription: AnyCancellable?
 
     @Published var repos: [Repo] = []
     @Published var worktrees: [UUID: [Worktree]] = [:]
@@ -481,6 +483,14 @@ final class AppState: ObservableObject {
             .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 self?.broadcastAppearanceColorFgBg(appearance)
+            }
+
+        // When the theme store reloads (external file add/delete/edit), reconcile
+        // the active schemeID so a deleted theme falls back to the default rather
+        // than leaving the UI pointing at an unknown id.
+        themeStoreSubscription = themeStore.$userThemes
+            .sink { [weak appearance] _ in
+                appearance?.reconcileWithStore()
             }
     }
 

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -280,6 +280,12 @@ struct TerminalSettingsView: View {
                 pendingSchemeSwitch = nil
             }
             return true
+        } catch ThemeStore.SaveError.bundledIDCollision(let slug) {
+            errorTitle = "Name already taken"
+            importError = "\"\(slug)\" is a built-in theme ID. Please choose a different name."
+            // Leave pendingSchemeSwitch alone on failure so the user can decide
+            // what to do next.
+            return false
         } catch {
             errorTitle = "Save as failed"
             importError = String(describing: error)

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -286,7 +286,12 @@ struct TerminalSettingsView: View {
 
     private func performDelete() {
         let active = appearance.schemeID
-        try? appState.themeStore.delete(id: active)
+        do {
+            try appState.themeStore.delete(id: active)
+        } catch {
+            importError = "Delete failed: \(error)"
+            return
+        }
         appearance.schemeID = ColorSchemes.defaultScheme.id
         syncEditorWithScheme()
     }

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -333,7 +333,10 @@ struct TerminalSettingsView: View {
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 240)
             HStack {
-                Button("Cancel") { showingSaveAsDialog = false }
+                Button("Cancel") {
+                    showingSaveAsDialog = false
+                    pendingSchemeSwitch = nil
+                }
                 Button("Save") {
                     if performSaveAs(name: saveAsName) {
                         showingSaveAsDialog = false

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -13,6 +13,7 @@ struct TerminalSettingsView: View {
     @State private var saveAsName = ""
     @State private var deleteConfirmation = false
     @State private var importError: String?
+    @State private var pendingSchemeSwitch: String?
 
     var body: some View {
         Form {
@@ -150,6 +151,33 @@ struct TerminalSettingsView: View {
             get: { importError != nil },
             set: { if !$0 { importError = nil } }
         )) { Button("OK") {} } message: { Text(importError ?? "") }
+        .confirmationDialog(
+            "Unsaved changes to \(editorVM.displayName)",
+            isPresented: Binding(
+                get: { pendingSchemeSwitch != nil },
+                set: { if !$0 { pendingSchemeSwitch = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if editorVM.canSave {
+                Button("Save") {
+                    performSave()
+                    commitPendingSwitch()
+                }
+            }
+            Button("Save as…") {
+                saveAsName = editorVM.displayName + " Copy"
+                showingSaveAsDialog = true
+                // pendingSchemeSwitch will be resolved when the save-as completes
+            }
+            Button("Discard", role: .destructive) {
+                editorVM.reset()
+                commitPendingSwitch()
+            }
+            Button("Cancel", role: .cancel) {
+                pendingSchemeSwitch = nil
+            }
+        }
     }
 
     // MARK: - Computed helpers
@@ -166,12 +194,23 @@ struct TerminalSettingsView: View {
         Binding(
             get: { appearance.schemeID },
             set: { newID in
-                // Unsaved-draft confirmation is added in Task 14 by overriding this setter.
-                appearance.schemeID = newID
-                appearance.draftSchemeOverride = nil
-                syncEditorWithScheme()
+                if editorVM.isDirty {
+                    pendingSchemeSwitch = newID
+                } else {
+                    appearance.schemeID = newID
+                    appearance.draftSchemeOverride = nil
+                    syncEditorWithScheme()
+                }
             }
         )
+    }
+
+    private func commitPendingSwitch() {
+        guard let target = pendingSchemeSwitch else { return }
+        pendingSchemeSwitch = nil
+        appearance.schemeID = target
+        appearance.draftSchemeOverride = nil
+        syncEditorWithScheme()
     }
 
     // MARK: - Editor sync
@@ -208,6 +247,7 @@ struct TerminalSettingsView: View {
             let newID = try appState.themeStore.saveAs(draft, suggestedDisplayName: name)
             appearance.schemeID = newID
             syncEditorWithScheme()
+            pendingSchemeSwitch = nil
         } catch {
             importError = "Save as failed: \(error)"
         }

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -2,6 +2,7 @@ import AppKit
 import SwiftTerm
 import SwiftUI
 import TBDShared
+import UniformTypeIdentifiers
 
 private typealias SwiftUIColor = SwiftUI.Color
 
@@ -328,7 +329,9 @@ struct TerminalSettingsView: View {
 
     private func performImport() {
         let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.init(filenameExtension: "toml")!]
+        if let tomlType = UTType(filenameExtension: "toml") {
+            panel.allowedContentTypes = [tomlType]
+        }
         panel.allowsMultipleSelection = false
         guard panel.runModal() == .OK, let url = panel.url else { return }
         do {

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -8,6 +8,12 @@ struct TerminalSettingsView: View {
     @EnvironmentObject var appState: AppState
     @AppStorage(AppState.terminalAutoResizeKey) private var enableTerminalAutoResize: Bool = false
 
+    @StateObject private var editorVM = TerminalThemeEditorViewModel()
+    @State private var showingSaveAsDialog = false
+    @State private var saveAsName = ""
+    @State private var deleteConfirmation = false
+    @State private var importError: String?
+
     var body: some View {
         Form {
             Section("Font") {
@@ -35,22 +41,59 @@ struct TerminalSettingsView: View {
                     .help("Disables font smoothing for thinner text on Retina displays. Matches iTerm's 'Thin Strokes' setting.")
             }
 
-            Section {
-                HStack {
-                    Picker("Scheme", selection: $appearance.schemeID) {
+            Section("Color Scheme") {
+                Picker("Scheme", selection: schemeBinding) {
+                    Section("Bundled") {
                         ForEach(ColorSchemes.bundled, id: \.id) { scheme in
                             Text(scheme.displayName).tag(scheme.id)
                         }
                     }
-                    .pickerStyle(.menu)
-                    if appearance.hasTmuxStyleOverrides {
-                        Image(systemName: "info.circle")
-                            .foregroundStyle(.secondary)
-                            .help("Your ~/.tmux.conf sets window-style or a similar option that paints every cell with explicit colors. tmux's paint will override the scheme's foreground/background. To let this scheme drive the appearance, unset those options in your tmux config (e.g. `set -gu window-style`).")
+                    if !appState.themeStore.userThemes.isEmpty {
+                        Section("My Themes") {
+                            ForEach(appState.themeStore.userThemes, id: \.id) { scheme in
+                                Text(scheme.displayName + (editorVM.isDirty && scheme.id == appearance.schemeID ? " — Draft" : ""))
+                                    .tag(scheme.id)
+                            }
+                        }
                     }
                 }
-            } header: {
-                Text("Color Scheme")
+                .pickerStyle(.menu)
+
+                HStack {
+                    if editorVM.isDirty {
+                        if editorVM.canSave {
+                            Button("Save") { performSave() }
+                        }
+                        Button("Save as…") {
+                            saveAsName = editorVM.displayName + " Copy"
+                            showingSaveAsDialog = true
+                        }
+                        Button("Reset") {
+                            editorVM.reset()
+                            appearance.draftSchemeOverride = nil
+                        }
+                    } else {
+                        Button("Save as…") {
+                            saveAsName = editorVM.displayName + " Copy"
+                            showingSaveAsDialog = true
+                        }
+                    }
+                    if currentSourceKind == .user {
+                        Button("Delete", role: .destructive) { deleteConfirmation = true }
+                    }
+                    Button("Import…") { performImport() }
+                }
+
+                if !appState.themeStore.loadErrors.isEmpty {
+                    Text("\(appState.themeStore.loadErrors.count) theme(s) failed to load — see console")
+                        .font(.caption).foregroundStyle(.orange)
+                }
+
+                TerminalThemeEditorView(viewModel: editorVM)
+                    .onAppear { syncEditorWithScheme() }
+                    .onChange(of: appearance.schemeID) { _, _ in syncEditorWithScheme() }
+                    .onChange(of: editorVM.draftHex) { _, _ in updateDraftOverride() }
+                    .onChange(of: editorVM.displayNameDraft) { _, _ in updateDraftOverride() }
             }
 
             Section("Cursor") {
@@ -92,7 +135,127 @@ struct TerminalSettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+        .sheet(isPresented: $showingSaveAsDialog) { saveAsDialog }
+        .confirmationDialog(
+            "Delete \(editorVM.displayName)?",
+            isPresented: $deleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) { performDelete() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This theme will be moved to .trash/; your terminals will revert to Tango.")
+        }
+        .alert("Import failed", isPresented: Binding(
+            get: { importError != nil },
+            set: { if !$0 { importError = nil } }
+        )) { Button("OK") {} } message: { Text(importError ?? "") }
     }
+
+    // MARK: - Computed helpers
+
+    private var currentScheme: TerminalColorScheme {
+        ColorSchemes.scheme(forID: appearance.schemeID, store: appState.themeStore)
+    }
+
+    private var currentSourceKind: TerminalThemeEditorViewModel.SourceKind {
+        ColorSchemes.bundled.contains { $0.id == appearance.schemeID } ? .bundled : .user
+    }
+
+    private var schemeBinding: Binding<String> {
+        Binding(
+            get: { appearance.schemeID },
+            set: { newID in
+                // Unsaved-draft confirmation is added in Task 14 by overriding this setter.
+                appearance.schemeID = newID
+                appearance.draftSchemeOverride = nil
+                syncEditorWithScheme()
+            }
+        )
+    }
+
+    // MARK: - Editor sync
+
+    private func syncEditorWithScheme() {
+        editorVM.load(source: currentScheme, kind: currentSourceKind)
+        appearance.draftSchemeOverride = nil
+    }
+
+    private func updateDraftOverride() {
+        if editorVM.isDirty {
+            appearance.draftSchemeOverride = try? editorVM.snapshot(id: appearance.schemeID).toScheme()
+        } else {
+            appearance.draftSchemeOverride = nil
+        }
+    }
+
+    // MARK: - Actions
+
+    private func performSave() {
+        do {
+            let theme = editorVM.snapshot(id: appearance.schemeID)
+            try appState.themeStore.save(theme)
+            editorVM.load(source: try theme.toScheme(), kind: .user)
+            appearance.draftSchemeOverride = nil
+        } catch {
+            importError = "Save failed: \(error)"
+        }
+    }
+
+    private func performSaveAs(name: String) {
+        do {
+            let draft = editorVM.snapshot(id: "")
+            let newID = try appState.themeStore.saveAs(draft, suggestedDisplayName: name)
+            appearance.schemeID = newID
+            syncEditorWithScheme()
+        } catch {
+            importError = "Save as failed: \(error)"
+        }
+    }
+
+    private func performDelete() {
+        let active = appearance.schemeID
+        try? appState.themeStore.delete(id: active)
+        appearance.schemeID = ColorSchemes.defaultScheme.id
+        syncEditorWithScheme()
+    }
+
+    private func performImport() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.init(filenameExtension: "toml")!]
+        panel.allowsMultipleSelection = false
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            let imported = try AlacrittyImporter().importFile(url)
+            let id = try appState.themeStore.saveAs(imported, suggestedDisplayName: imported.displayName)
+            appearance.schemeID = id
+            syncEditorWithScheme()
+        } catch {
+            importError = "Import failed: \(error)"
+        }
+    }
+
+    // MARK: - Save-as dialog
+
+    private var saveAsDialog: some View {
+        VStack(spacing: 12) {
+            Text("Save as new theme").font(.headline)
+            TextField("Name", text: $saveAsName)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 240)
+            HStack {
+                Button("Cancel") { showingSaveAsDialog = false }
+                Button("Save") {
+                    performSaveAs(name: saveAsName)
+                    showingSaveAsDialog = false
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+    }
+
+    // MARK: - Font name
 
     private var displayFontName: String {
         // Use the resolved font's display name so a poisoned/missing font name

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -15,6 +15,7 @@ struct TerminalSettingsView: View {
     @State private var saveAsName = ""
     @State private var deleteConfirmation = false
     @State private var importError: String?
+    @State private var errorTitle: String = "Error"
     @State private var pendingSchemeSwitch: String?
     @State private var showingPendingSwitchConfirm = false
 
@@ -165,7 +166,7 @@ struct TerminalSettingsView: View {
         } message: {
             Text("This theme will be moved to .trash/; your terminals will revert to Tango.")
         }
-        .alert("Import failed", isPresented: Binding(
+        .alert(errorTitle, isPresented: Binding(
             get: { importError != nil },
             set: { if !$0 { importError = nil } }
         )) { Button("OK") {} } message: { Text(importError ?? "") }
@@ -257,11 +258,13 @@ struct TerminalSettingsView: View {
             editorVM.load(source: try theme.toScheme(), kind: .user)
             appearance.draftSchemeOverride = nil
         } catch {
-            importError = "Save failed: \(error)"
+            errorTitle = "Save failed"
+            importError = String(describing: error)
         }
     }
 
-    private func performSaveAs(name: String) {
+    @discardableResult
+    private func performSaveAs(name: String) -> Bool {
         do {
             let draft = editorVM.snapshot(id: "")
             let newID = try appState.themeStore.saveAs(draft, suggestedDisplayName: name)
@@ -276,10 +279,13 @@ struct TerminalSettingsView: View {
             } else {
                 pendingSchemeSwitch = nil
             }
+            return true
         } catch {
-            importError = "Save as failed: \(error)"
+            errorTitle = "Save as failed"
+            importError = String(describing: error)
             // Leave pendingSchemeSwitch alone on failure so the user can decide
             // what to do next.
+            return false
         }
     }
 
@@ -288,7 +294,8 @@ struct TerminalSettingsView: View {
         do {
             try appState.themeStore.delete(id: active)
         } catch {
-            importError = "Delete failed: \(error)"
+            errorTitle = "Delete failed"
+            importError = String(describing: error)
             return
         }
         appearance.schemeID = ColorSchemes.defaultScheme.id
@@ -306,7 +313,8 @@ struct TerminalSettingsView: View {
             appearance.schemeID = id
             syncEditorWithScheme()
         } catch {
-            importError = "Import failed: \(error)"
+            errorTitle = "Import failed"
+            importError = String(describing: error)
         }
     }
 
@@ -321,8 +329,9 @@ struct TerminalSettingsView: View {
             HStack {
                 Button("Cancel") { showingSaveAsDialog = false }
                 Button("Save") {
-                    performSaveAs(name: saveAsName)
-                    showingSaveAsDialog = false
+                    if performSaveAs(name: saveAsName) {
+                        showingSaveAsDialog = false
+                    }
                 }
                 .keyboardShortcut(.defaultAction)
             }

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -238,11 +238,15 @@ struct TerminalSettingsView: View {
     }
 
     private func updateDraftOverride() {
-        if editorVM.isDirty {
-            appearance.draftSchemeOverride = try? editorVM.snapshot(id: appearance.schemeID).toScheme()
-        } else {
+        guard editorVM.isDirty else {
             appearance.draftSchemeOverride = nil
+            return
         }
+        if let valid = try? editorVM.snapshot(id: appearance.schemeID).toScheme() {
+            appearance.draftSchemeOverride = valid
+        }
+        // Otherwise: keep the previous valid override in place — don't snap back
+        // to source mid-typing. The next valid edit will refresh it.
     }
 
     // MARK: - Actions
@@ -264,9 +268,19 @@ struct TerminalSettingsView: View {
             let newID = try appState.themeStore.saveAs(draft, suggestedDisplayName: name)
             appearance.schemeID = newID
             syncEditorWithScheme()
-            pendingSchemeSwitch = nil
+            // If the user invoked Save as… from the unsaved-draft confirm dialog,
+            // they had also picked a different scheme they wanted to switch to.
+            // The save-as activated the new user theme; honor their original
+            // switch intent unless they meant to stay on the new theme.
+            if let target = pendingSchemeSwitch, target != newID {
+                commitPendingSwitch()
+            } else {
+                pendingSchemeSwitch = nil
+            }
         } catch {
             importError = "Save as failed: \(error)"
+            // Leave pendingSchemeSwitch alone on failure so the user can decide
+            // what to do next.
         }
     }
 

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -3,6 +3,8 @@ import SwiftTerm
 import SwiftUI
 import TBDShared
 
+private typealias SwiftUIColor = SwiftUI.Color
+
 struct TerminalSettingsView: View {
     @EnvironmentObject var appearance: AppearanceSettings
     @EnvironmentObject var appState: AppState
@@ -86,8 +88,23 @@ struct TerminalSettingsView: View {
                 }
 
                 if !appState.themeStore.loadErrors.isEmpty {
-                    Text("\(appState.themeStore.loadErrors.count) theme(s) failed to load — see console")
-                        .font(.caption).foregroundStyle(.orange)
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+                        Text("\(appState.themeStore.loadErrors.count) theme file(s) failed to load")
+                        Spacer()
+                        Button("Show in Finder") {
+                            NSWorkspace.shared.activateFileViewerSelecting(
+                                appState.themeStore.loadErrors.map {
+                                    appState.themeStore.themesDirectory.appendingPathComponent($0.filename)
+                                }
+                            )
+                        }
+                        .controlSize(.small)
+                    }
+                    .padding(8)
+                    .background(SwiftUIColor.orange.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .help(appState.themeStore.loadErrors.map { "\($0.filename): \($0.message)" }.joined(separator: "\n"))
                 }
 
                 TerminalThemeEditorView(viewModel: editorVM)

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -17,6 +17,7 @@ struct TerminalSettingsView: View {
     @State private var importError: String?
     @State private var errorTitle: String = "Error"
     @State private var pendingSchemeSwitch: String?
+    @State private var saveAsError: String?
     @State private var showingPendingSwitchConfirm = false
 
     var body: some View {
@@ -72,6 +73,7 @@ struct TerminalSettingsView: View {
                         }
                         Button("Save as…") {
                             saveAsName = editorVM.displayName + " Copy"
+                            saveAsError = nil
                             showingSaveAsDialog = true
                         }
                         Button("Reset") {
@@ -81,6 +83,7 @@ struct TerminalSettingsView: View {
                     } else {
                         Button("Save as…") {
                             saveAsName = editorVM.displayName + " Copy"
+                            saveAsError = nil
                             showingSaveAsDialog = true
                         }
                     }
@@ -184,6 +187,7 @@ struct TerminalSettingsView: View {
             }
             Button("Save as…") {
                 saveAsName = editorVM.displayName + " Copy"
+                saveAsError = nil
                 showingSaveAsDialog = true
                 // pendingSchemeSwitch is intentionally left set — performSaveAs reads it.
             }
@@ -282,14 +286,24 @@ struct TerminalSettingsView: View {
             }
             return true
         } catch ThemeStore.SaveError.bundledIDCollision(let slug) {
-            errorTitle = "Name already taken"
-            importError = "\"\(slug)\" is a built-in theme ID. Please choose a different name."
+            let msg = "\"\(slug)\" is a built-in theme ID. Please choose a different name."
+            if showingSaveAsDialog {
+                saveAsError = msg
+            } else {
+                errorTitle = "Name already taken"
+                importError = msg
+            }
             // Leave pendingSchemeSwitch alone on failure so the user can decide
             // what to do next.
             return false
         } catch {
-            errorTitle = "Save as failed"
-            importError = String(describing: error)
+            let msg = String(describing: error)
+            if showingSaveAsDialog {
+                saveAsError = msg
+            } else {
+                errorTitle = "Save as failed"
+                importError = msg
+            }
             // Leave pendingSchemeSwitch alone on failure so the user can decide
             // what to do next.
             return false
@@ -333,12 +347,20 @@ struct TerminalSettingsView: View {
             TextField("Name", text: $saveAsName)
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 240)
+            if let err = saveAsError {
+                Text(err)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .frame(width: 240)
+            }
             HStack {
                 Button("Cancel") {
                     showingSaveAsDialog = false
                     pendingSchemeSwitch = nil
+                    saveAsError = nil
                 }
                 Button("Save") {
+                    saveAsError = nil
                     if performSaveAs(name: saveAsName) {
                         showingSaveAsDialog = false
                     }

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -50,7 +50,8 @@ struct TerminalSettingsView: View {
                 Picker("Scheme", selection: schemeBinding) {
                     Section("Bundled") {
                         ForEach(ColorSchemes.bundled, id: \.id) { scheme in
-                            Text(scheme.displayName).tag(scheme.id)
+                            Text(scheme.displayName + (editorVM.isDirty && scheme.id == appearance.schemeID ? " — Draft" : ""))
+                                .tag(scheme.id)
                         }
                     }
                     if !appState.themeStore.userThemes.isEmpty {

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -16,6 +16,7 @@ struct TerminalSettingsView: View {
     @State private var deleteConfirmation = false
     @State private var importError: String?
     @State private var pendingSchemeSwitch: String?
+    @State private var showingPendingSwitchConfirm = false
 
     var body: some View {
         Form {
@@ -170,10 +171,7 @@ struct TerminalSettingsView: View {
         )) { Button("OK") {} } message: { Text(importError ?? "") }
         .confirmationDialog(
             "Unsaved changes to \(editorVM.displayName)",
-            isPresented: Binding(
-                get: { pendingSchemeSwitch != nil },
-                set: { if !$0 { pendingSchemeSwitch = nil } }
-            ),
+            isPresented: $showingPendingSwitchConfirm,
             titleVisibility: .visible
         ) {
             if editorVM.canSave {
@@ -185,7 +183,7 @@ struct TerminalSettingsView: View {
             Button("Save as…") {
                 saveAsName = editorVM.displayName + " Copy"
                 showingSaveAsDialog = true
-                // pendingSchemeSwitch will be resolved when the save-as completes
+                // pendingSchemeSwitch is intentionally left set — performSaveAs reads it.
             }
             Button("Discard", role: .destructive) {
                 editorVM.reset()
@@ -213,6 +211,7 @@ struct TerminalSettingsView: View {
             set: { newID in
                 if editorVM.isDirty {
                     pendingSchemeSwitch = newID
+                    showingPendingSwitchConfirm = true
                 } else {
                     appearance.schemeID = newID
                     appearance.draftSchemeOverride = nil

--- a/Sources/TBDApp/Settings/TerminalSettingsView.swift
+++ b/Sources/TBDApp/Settings/TerminalSettingsView.swift
@@ -159,7 +159,10 @@ struct TerminalSettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
-        .sheet(isPresented: $showingSaveAsDialog) { saveAsDialog }
+        .sheet(isPresented: $showingSaveAsDialog, onDismiss: {
+            pendingSchemeSwitch = nil
+            saveAsError = nil
+        }) { saveAsDialog }
         .confirmationDialog(
             "Delete \(editorVM.displayName)?",
             isPresented: $deleteConfirmation,

--- a/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
+++ b/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
@@ -138,6 +138,8 @@ struct TerminalThemeEditorView: View {
             return "Expected 16 ANSI colors, got \(count)."
         case .invalidID(let id):
             return "\"\(id)\" isn't a valid theme id (lowercase letters, digits, and hyphens only)."
+        case .unsupportedSchemaVersion(let v):
+            return "Theme file uses schema version \(v), which this version of TBD doesn't support."
         }
     }
 }

--- a/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
+++ b/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
@@ -88,23 +88,22 @@ struct TerminalThemeEditorView: View {
         }
     }
 
-    /// Per-slot ↺ button. Visible only when the slot has a draft override; the
-    /// container always reserves layout space (20×20 frame) so the row doesn't
-    /// shift as slots dirty/clean.
+    /// Per-slot ↺ button. Always rendered at opacity 0 when clean to avoid
+    /// insertion animation. The container always reserves layout space (20×20 frame)
+    /// so the row doesn't shift as slots dirty/clean.
     @ViewBuilder
     private func resetCell(for slot: TerminalThemeEditorViewModel.Slot) -> some View {
-        Group {
-            if viewModel.isSlotDirty(slot) {
-                Button {
-                    viewModel.unsetSlot(slot)
-                } label: {
-                    Image(systemName: "arrow.uturn.backward")
-                        .font(.caption2)
-                }
-                .buttonStyle(.borderless)
-                .help("Revert this color to the source")
-            }
+        let dirty = viewModel.isSlotDirty(slot)
+        Button {
+            viewModel.unsetSlot(slot)
+        } label: {
+            Image(systemName: "arrow.uturn.backward")
+                .font(.caption2)
         }
+        .buttonStyle(.borderless)
+        .help("Revert this color to the source")
+        .opacity(dirty ? 1 : 0)
+        .allowsHitTesting(dirty)
         .frame(width: 20, height: 20)
     }
 

--- a/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
+++ b/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
@@ -1,0 +1,104 @@
+// Sources/TBDApp/Settings/TerminalThemeEditorView.swift
+import SwiftUI
+import SwiftTerm
+
+private typealias SwiftUIColor = SwiftUI.Color
+
+/// Inline editor below the Color Scheme picker in Settings → Terminal.
+/// Always visible; touching any field enters draft state on the bound view-model.
+/// Action buttons (Save / Save as / Reset) and surrounding affordances (Import /
+/// Delete) are rendered by the parent so they sit in the same row as the picker.
+@MainActor
+struct TerminalThemeEditorView: View {
+    @ObservedObject var viewModel: TerminalThemeEditorViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Name:")
+                    .frame(width: 100, alignment: .trailing)
+                TextField("Display name", text: nameBinding)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 280)
+            }
+
+            slotRow("Foreground", slot: .foreground)
+            slotRow("Background", slot: .background)
+            slotRow("Cursor",     slot: .cursor)
+            slotRow("Selection",  slot: .selection)
+
+            Divider().padding(.vertical, 4)
+
+            Text("ANSI 0 – 7").font(.caption).foregroundStyle(.secondary)
+            HStack(spacing: 6) { ForEach(0..<8, id: \.self) { i in ansiSwatch(i) } }
+            Text("ANSI 8 – 15").font(.caption).foregroundStyle(.secondary)
+            HStack(spacing: 6) { ForEach(8..<16, id: \.self) { i in ansiSwatch(i) } }
+
+            if let err = viewModel.lastValidationError {
+                Text("Invalid hex: \(String(describing: err))")
+                    .font(.caption).foregroundStyle(.red)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(SwiftUIColor.secondary.opacity(0.3))
+        )
+    }
+
+    private var nameBinding: Binding<String> {
+        Binding(
+            get: { viewModel.displayName },
+            set: { viewModel.setDisplayName($0) }
+        )
+    }
+
+    @ViewBuilder
+    private func slotRow(_ label: String, slot: TerminalThemeEditorViewModel.Slot) -> some View {
+        HStack {
+            Text(label)
+                .frame(width: 100, alignment: .trailing)
+            TextField("", text: hexBinding(for: slot))
+                .textFieldStyle(.roundedBorder)
+                .font(.system(.body, design: .monospaced))
+                .frame(width: 100)
+            ColorPicker("", selection: colorBinding(for: slot), supportsOpacity: false)
+                .labelsHidden()
+        }
+    }
+
+    @ViewBuilder
+    private func ansiSwatch(_ index: Int) -> some View {
+        let slot = TerminalThemeEditorViewModel.Slot.ansi(index)
+        ColorPicker(
+            "",
+            selection: colorBinding(for: slot),
+            supportsOpacity: false
+        )
+        .labelsHidden()
+        .help("ANSI \(index) — \(viewModel.hex(slot: slot))")
+    }
+
+    private func hexBinding(for slot: TerminalThemeEditorViewModel.Slot) -> Binding<String> {
+        Binding(
+            get: { viewModel.hex(slot: slot) },
+            set: { viewModel.setHex(slot: slot, hex: $0) }
+        )
+    }
+
+    private func colorBinding(for slot: TerminalThemeEditorViewModel.Slot) -> Binding<SwiftUIColor> {
+        Binding(
+            get: {
+                let (r, g, b) = UserTerminalTheme.parseHex(viewModel.hex(slot: slot)) ?? (0, 0, 0)
+                return SwiftUIColor(red: Double(r)/255, green: Double(g)/255, blue: Double(b)/255)
+            },
+            set: { newColor in
+                let nsColor = NSColor(newColor).usingColorSpace(.sRGB) ?? .black
+                let r = Int((nsColor.redComponent * 255).rounded())
+                let g = Int((nsColor.greenComponent * 255).rounded())
+                let b = Int((nsColor.blueComponent * 255).rounded())
+                viewModel.setHex(slot: slot, hex: String(format: "#%02x%02x%02x", r, g, b))
+            }
+        )
+    }
+}

--- a/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
+++ b/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
@@ -35,7 +35,7 @@ struct TerminalThemeEditorView: View {
             HStack(spacing: 6) { ForEach(8..<16, id: \.self) { i in ansiSwatch(i) } }
 
             if let err = viewModel.lastValidationError {
-                Text("Invalid hex: \(String(describing: err))")
+                Text(humanMessage(for: err))
                     .font(.caption).foregroundStyle(.red)
             }
         }
@@ -100,5 +100,16 @@ struct TerminalThemeEditorView: View {
                 viewModel.setHex(slot: slot, hex: String(format: "#%02x%02x%02x", r, g, b))
             }
         )
+    }
+
+    private func humanMessage(for error: UserTerminalTheme.ValidationError) -> String {
+        switch error {
+        case .invalidHex(let field, let value):
+            return "\"\(value)\" isn't a valid #rrggbb color for \(field)."
+        case .wrongAnsiCount(let count):
+            return "Expected 16 ANSI colors, got \(count)."
+        case .invalidID(let id):
+            return "\"\(id)\" isn't a valid theme id (lowercase letters, digits, and hyphens only)."
+        }
     }
 }

--- a/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
+++ b/Sources/TBDApp/Settings/TerminalThemeEditorView.swift
@@ -30,9 +30,29 @@ struct TerminalThemeEditorView: View {
             Divider().padding(.vertical, 4)
 
             Text("ANSI 0 – 7").font(.caption).foregroundStyle(.secondary)
-            HStack(spacing: 6) { ForEach(0..<8, id: \.self) { i in ansiSwatch(i) } }
+            HStack(spacing: 6) {
+                ForEach(0..<8, id: \.self) { i in
+                    VStack(spacing: 2) {
+                        let slot = TerminalThemeEditorViewModel.Slot.ansi(i)
+                        ColorPicker("", selection: colorBinding(for: slot), supportsOpacity: false)
+                            .labelsHidden()
+                            .help("ANSI \(i) — \(viewModel.hex(slot: slot))")
+                        resetCell(for: slot)
+                    }
+                }
+            }
             Text("ANSI 8 – 15").font(.caption).foregroundStyle(.secondary)
-            HStack(spacing: 6) { ForEach(8..<16, id: \.self) { i in ansiSwatch(i) } }
+            HStack(spacing: 6) {
+                ForEach(8..<16, id: \.self) { i in
+                    VStack(spacing: 2) {
+                        let slot = TerminalThemeEditorViewModel.Slot.ansi(i)
+                        ColorPicker("", selection: colorBinding(for: slot), supportsOpacity: false)
+                            .labelsHidden()
+                            .help("ANSI \(i) — \(viewModel.hex(slot: slot))")
+                        resetCell(for: slot)
+                    }
+                }
+            }
 
             if let err = viewModel.lastValidationError {
                 Text(humanMessage(for: err))
@@ -64,19 +84,28 @@ struct TerminalThemeEditorView: View {
                 .frame(width: 100)
             ColorPicker("", selection: colorBinding(for: slot), supportsOpacity: false)
                 .labelsHidden()
+            resetCell(for: slot)
         }
     }
 
+    /// Per-slot ↺ button. Visible only when the slot has a draft override; the
+    /// container always reserves layout space (20×20 frame) so the row doesn't
+    /// shift as slots dirty/clean.
     @ViewBuilder
-    private func ansiSwatch(_ index: Int) -> some View {
-        let slot = TerminalThemeEditorViewModel.Slot.ansi(index)
-        ColorPicker(
-            "",
-            selection: colorBinding(for: slot),
-            supportsOpacity: false
-        )
-        .labelsHidden()
-        .help("ANSI \(index) — \(viewModel.hex(slot: slot))")
+    private func resetCell(for slot: TerminalThemeEditorViewModel.Slot) -> some View {
+        Group {
+            if viewModel.isSlotDirty(slot) {
+                Button {
+                    viewModel.unsetSlot(slot)
+                } label: {
+                    Image(systemName: "arrow.uturn.backward")
+                        .font(.caption2)
+                }
+                .buttonStyle(.borderless)
+                .help("Revert this color to the source")
+            }
+        }
+        .frame(width: 20, height: 20)
     }
 
     private func hexBinding(for slot: TerminalThemeEditorViewModel.Slot) -> Binding<String> {

--- a/Sources/TBDApp/Settings/TerminalThemeEditorViewModel.swift
+++ b/Sources/TBDApp/Settings/TerminalThemeEditorViewModel.swift
@@ -75,6 +75,19 @@ final class TerminalThemeEditorViewModel: ObservableObject {
         lastValidationError = nil
     }
 
+    /// Revert a single slot's draft back to the source value. No-op if the slot
+    /// isn't currently drafted.
+    func unsetSlot(_ slot: Slot) {
+        draftHex.removeValue(forKey: slot)
+        // Don't touch displayNameDraft or lastValidationError — those are scoped
+        // to other affordances.
+    }
+
+    /// Whether the given slot currently has a draft override.
+    func isSlotDirty(_ slot: Slot) -> Bool {
+        draftHex[slot] != nil
+    }
+
     func snapshot(id: String) -> UserTerminalTheme {
         UserTerminalTheme(
             schemaVersion: 1,

--- a/Sources/TBDApp/Settings/TerminalThemeEditorViewModel.swift
+++ b/Sources/TBDApp/Settings/TerminalThemeEditorViewModel.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Combine
+import SwiftUI
+
+@MainActor
+final class TerminalThemeEditorViewModel: ObservableObject {
+
+    enum SourceKind { case bundled, user }
+
+    enum Slot: Hashable {
+        case foreground, background, cursor, selection, ansi(Int)
+    }
+
+    private(set) var source: TerminalColorScheme = ColorSchemes.defaultScheme
+    private(set) var sourceKind: SourceKind = .bundled
+
+    @Published private(set) var draftHex: [Slot: String] = [:]
+    @Published private(set) var displayNameDraft: String?
+    @Published private(set) var lastValidationError: UserTerminalTheme.ValidationError?
+
+    var isDirty: Bool { !draftHex.isEmpty || displayNameDraft != nil }
+    var canReset: Bool { isDirty }
+    var canSaveAs: Bool { true }
+    var canSave: Bool { isDirty && sourceKind == .user }
+
+    func load(source: TerminalColorScheme, kind: SourceKind) {
+        self.source = source
+        self.sourceKind = kind
+        self.draftHex = [:]
+        self.displayNameDraft = nil
+        self.lastValidationError = nil
+    }
+
+    func hex(slot: Slot) -> String {
+        if let drafted = draftHex[slot] { return drafted }
+        switch slot {
+        case .foreground: return UserTerminalTheme.hex(from: source.foreground)
+        case .background: return UserTerminalTheme.hex(from: source.background)
+        case .cursor:     return UserTerminalTheme.hex(from: source.cursor)
+        case .selection:  return UserTerminalTheme.hex(from: source.selection)
+        case .ansi(let i): return UserTerminalTheme.hex(from: source.ansi[i])
+        }
+    }
+
+    var displayName: String { displayNameDraft ?? source.displayName }
+
+    func setDisplayName(_ name: String) {
+        displayNameDraft = (name == source.displayName) ? nil : name
+    }
+
+    func setHex(slot: Slot, hex: String) {
+        guard UserTerminalTheme.parseHex(hex) != nil else {
+            lastValidationError = .invalidHex(field: "\(slot)", value: hex)
+            return
+        }
+        lastValidationError = nil
+        let srcHex: String
+        switch slot {
+        case .foreground: srcHex = UserTerminalTheme.hex(from: source.foreground)
+        case .background: srcHex = UserTerminalTheme.hex(from: source.background)
+        case .cursor:     srcHex = UserTerminalTheme.hex(from: source.cursor)
+        case .selection:  srcHex = UserTerminalTheme.hex(from: source.selection)
+        case .ansi(let i): srcHex = UserTerminalTheme.hex(from: source.ansi[i])
+        }
+        if hex == srcHex {
+            draftHex.removeValue(forKey: slot)
+        } else {
+            draftHex[slot] = hex
+        }
+    }
+
+    func reset() {
+        draftHex = [:]
+        displayNameDraft = nil
+        lastValidationError = nil
+    }
+
+    func snapshot(id: String) -> UserTerminalTheme {
+        UserTerminalTheme(
+            schemaVersion: 1,
+            id: id,
+            displayName: displayName,
+            ansi: (0..<16).map { hex(slot: .ansi($0)) },
+            foreground: hex(slot: .foreground),
+            background: hex(slot: .background),
+            cursor: hex(slot: .cursor),
+            selection: hex(slot: .selection)
+        )
+    }
+}

--- a/Sources/TBDApp/Settings/TerminalThemeEditorViewModel.swift
+++ b/Sources/TBDApp/Settings/TerminalThemeEditorViewModel.swift
@@ -50,7 +50,7 @@ final class TerminalThemeEditorViewModel: ObservableObject {
 
     func setHex(slot: Slot, hex: String) {
         guard UserTerminalTheme.parseHex(hex) != nil else {
-            lastValidationError = .invalidHex(field: "\(slot)", value: hex)
+            lastValidationError = .invalidHex(field: slot.humanName, value: hex)
             return
         }
         lastValidationError = nil
@@ -99,5 +99,17 @@ final class TerminalThemeEditorViewModel: ObservableObject {
             cursor: hex(slot: .cursor),
             selection: hex(slot: .selection)
         )
+    }
+}
+
+extension TerminalThemeEditorViewModel.Slot {
+    var humanName: String {
+        switch self {
+        case .foreground: return "Foreground"
+        case .background: return "Background"
+        case .cursor: return "Cursor"
+        case .selection: return "Selection"
+        case .ansi(let i): return "ANSI \(i)"
+        }
     }
 }

--- a/Sources/TBDApp/Settings/TerminalThemeEditorViewModel.swift
+++ b/Sources/TBDApp/Settings/TerminalThemeEditorViewModel.swift
@@ -79,8 +79,9 @@ final class TerminalThemeEditorViewModel: ObservableObject {
     /// isn't currently drafted.
     func unsetSlot(_ slot: Slot) {
         draftHex.removeValue(forKey: slot)
-        // Don't touch displayNameDraft or lastValidationError — those are scoped
-        // to other affordances.
+        if case .invalidHex(let field, _) = lastValidationError, field == slot.humanName {
+            lastValidationError = nil
+        }
     }
 
     /// Whether the given slot currently has a draft override.

--- a/Sources/TBDApp/Terminal/AlacrittyImporter.swift
+++ b/Sources/TBDApp/Terminal/AlacrittyImporter.swift
@@ -83,11 +83,13 @@ struct AlacrittyImporter {
         guard let raw = table[key]?.string else {
             throw ImportError.missingKey(section: section, key: key)
         }
-        let stripped = raw
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .replacingOccurrences(of: "0x", with: "")
-            .replacingOccurrences(of: "0X", with: "")
-            .lowercased()
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let stripped: String
+        if trimmed.hasPrefix("0x") {
+            stripped = String(trimmed.dropFirst(2))
+        } else {
+            stripped = trimmed
+        }
         let withHash = stripped.hasPrefix("#") ? stripped : "#" + stripped
         guard UserTerminalTheme.parseHex(withHash) != nil else {
             throw ImportError.invalidHex(section: section, key: key, value: raw)

--- a/Sources/TBDApp/Terminal/AlacrittyImporter.swift
+++ b/Sources/TBDApp/Terminal/AlacrittyImporter.swift
@@ -1,0 +1,97 @@
+import Foundation
+import TOMLKit
+
+struct AlacrittyImporter {
+
+    enum ImportError: Error, Equatable {
+        case fileUnreadable(String)
+        case tomlParseFailed(String)
+        case missingSection(String)
+        case missingKey(section: String, key: String)
+        case invalidHex(section: String, key: String, value: String)
+    }
+
+    func importFile(_ url: URL) throws -> UserTerminalTheme {
+        let raw: String
+        do {
+            raw = try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            throw ImportError.fileUnreadable(String(describing: error))
+        }
+        return try importString(raw, suggestedDisplayName: url.deletingPathExtension().lastPathComponent)
+    }
+
+    func importString(_ raw: String, suggestedDisplayName: String) throws -> UserTerminalTheme {
+        let table: TOMLTable
+        do {
+            table = try TOMLTable(string: raw)
+        } catch {
+            throw ImportError.tomlParseFailed(String(describing: error))
+        }
+
+        let colors = try requireTable(table, path: ["colors"])
+        let primary = try requireSubtable(colors, name: "primary", path: "colors.primary")
+        let normal = try requireSubtable(colors, name: "normal", path: "colors.normal")
+        let bright = try requireSubtable(colors, name: "bright", path: "colors.bright")
+
+        let foreground = try requireHex(primary, key: "foreground", section: "colors.primary")
+        let background = try requireHex(primary, key: "background", section: "colors.primary")
+
+        let cursorTable = colors["cursor"]?.table
+        let cursor = (try? requireHex(cursorTable, key: "cursor", section: "colors.cursor"))
+            ?? (try? requireHex(cursorTable, key: "text", section: "colors.cursor"))
+            ?? foreground
+
+        let selectionTable = colors["selection"]?.table
+        let selection = (try? requireHex(selectionTable, key: "background", section: "colors.selection"))
+            ?? "#505050"
+
+        let normalKeys = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
+        let ansi = try (normalKeys.map { try requireHex(normal, key: $0, section: "colors.normal") }
+                       + normalKeys.map { try requireHex(bright, key: $0, section: "colors.bright") })
+
+        return UserTerminalTheme(
+            schemaVersion: 1,
+            id: "",
+            displayName: suggestedDisplayName,
+            ansi: ansi,
+            foreground: foreground,
+            background: background,
+            cursor: cursor,
+            selection: selection
+        )
+    }
+
+    private func requireTable(_ table: TOMLTable, path: [String]) throws -> TOMLTable {
+        var cur = table
+        for segment in path {
+            guard let next = cur[segment]?.table else {
+                throw ImportError.missingSection(path.joined(separator: "."))
+            }
+            cur = next
+        }
+        return cur
+    }
+
+    private func requireSubtable(_ parent: TOMLTable, name: String, path: String) throws -> TOMLTable {
+        guard let t = parent[name]?.table else { throw ImportError.missingSection(path) }
+        return t
+    }
+
+    private func requireHex(_ table: TOMLTable?, key: String, section: String) throws -> String {
+        guard let table else { throw ImportError.missingSection(section) }
+        guard let raw = table[key]?.string else {
+            throw ImportError.missingKey(section: section, key: key)
+        }
+        let stripped = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "0x", with: "")
+            .replacingOccurrences(of: "0X", with: "")
+            .lowercased()
+        let withHash = stripped.hasPrefix("#") ? stripped : "#" + stripped
+        guard UserTerminalTheme.parseHex(withHash) != nil else {
+            throw ImportError.invalidHex(section: section, key: key, value: raw)
+        }
+        return withHash
+    }
+}

--- a/Sources/TBDApp/Terminal/AlacrittyImporter.swift
+++ b/Sources/TBDApp/Terminal/AlacrittyImporter.swift
@@ -32,7 +32,11 @@ struct AlacrittyImporter {
         let colors = try requireTable(table, path: ["colors"])
         let primary = try requireSubtable(colors, name: "primary", path: "colors.primary")
         let normal = try requireSubtable(colors, name: "normal", path: "colors.normal")
-        let bright = try requireSubtable(colors, name: "bright", path: "colors.bright")
+        // Some real-world Alacritty themes omit [colors.bright] and rely on the
+        // terminal emulator to derive bright variants from normal. Match that
+        // behavior: when bright is absent, copy normal into the bright half of
+        // the ANSI array.
+        let bright: TOMLTable = colors["bright"]?.table ?? normal
 
         let foreground = try requireHex(primary, key: "foreground", section: "colors.primary")
         let background = try requireHex(primary, key: "background", section: "colors.primary")

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -144,6 +144,18 @@ final class AppearanceSettings: ObservableObject {
         let scheme = ColorSchemes.scheme(forID: schemeID, store: themeStore)
         return Self.colorFgBg(for: scheme)
     }
+
+    /// Call when ThemeStore reloads. If the active schemeID no longer points
+    /// at a bundled or a known user theme, fall back to the default. Handles
+    /// externally-deleted theme files (vim `:!rm`, `git pull` that removed a
+    /// tracked theme, etc.).
+    func reconcileWithStore() {
+        let bundledHit = ColorSchemes.bundled.contains { $0.id == schemeID }
+        let userHit = themeStore?.userThemes.contains { $0.id == schemeID } ?? false
+        if !bundledHit && !userHit {
+            schemeID = ColorSchemes.defaultScheme.id
+        }
+    }
 }
 
 // MARK: - CursorStyle <-> String

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -154,6 +154,7 @@ final class AppearanceSettings: ObservableObject {
         let userHit = themeStore?.userThemes.contains { $0.id == schemeID } ?? false
         if !bundledHit && !userHit {
             schemeID = ColorSchemes.defaultScheme.id
+            draftSchemeOverride = nil
         }
     }
 }

--- a/Sources/TBDApp/Terminal/AppearanceSettings.swift
+++ b/Sources/TBDApp/Terminal/AppearanceSettings.swift
@@ -2,6 +2,7 @@ import AppKit
 import Combine
 import Foundation
 import SwiftTerm
+import TBDShared
 
 /// Global user-customizable terminal appearance settings.
 ///
@@ -36,6 +37,20 @@ final class AppearanceSettings: ObservableObject {
     @Published var fontName: String { didSet { defaults.set(fontName, forKey: Keys.fontName) } }
     @Published var fontSize: CGFloat { didSet { defaults.set(Double(fontSize), forKey: Keys.fontSize) } }
     @Published var schemeID: String { didSet { defaults.set(schemeID, forKey: Keys.schemeID) } }
+
+    /// Optional in-memory draft of the current scheme. When non-nil, the
+    /// renderer uses this instead of the persisted scheme — used while the
+    /// user has unsaved edits in the theme editor.
+    @Published var draftSchemeOverride: TerminalColorScheme?
+
+    /// Injected by `AppState`; let `effectiveScheme` see user themes.
+    weak var themeStore: ThemeStore?
+
+    /// Single accessor terminal views should use. Returns the draft override
+    /// when one's active, otherwise the saved scheme (bundled or user).
+    var effectiveScheme: TerminalColorScheme {
+        draftSchemeOverride ?? ColorSchemes.scheme(forID: schemeID, store: themeStore)
+    }
     @Published var cursorStyle: CursorStyle { didSet { defaults.set(cursorStyle.rawString, forKey: Keys.cursorStyle) } }
     @Published var thinStrokes: Bool { didSet { defaults.set(thinStrokes, forKey: Keys.thinStrokes) } }
 
@@ -57,9 +72,20 @@ final class AppearanceSettings: ObservableObject {
 
         // Scheme ID — normalize unknown ids to the default so the Settings Picker
         // always has a matching tag selected (otherwise it renders empty).
+        // Accept the stored id if EITHER it's bundled OR a user-theme JSON file
+        // with that id exists on disk. Without the on-disk check, init would
+        // overwrite a legitimate user-theme selection with `Defaults.schemeID`
+        // before `ThemeStore.reloadFromDisk()` ever ran, silently reverting
+        // the user to Tango on every relaunch. Filesystem check is intentional
+        // (not a ThemeStore dependency) so this stays a pure init step.
         let storedScheme = defaults.string(forKey: Keys.schemeID) ?? Defaults.schemeID
-        self.schemeID = ColorSchemes.bundled.contains(where: { $0.id == storedScheme })
-            ? storedScheme : Defaults.schemeID
+        let bundledHit = ColorSchemes.bundled.contains(where: { $0.id == storedScheme })
+        let userFileHit = FileManager.default.fileExists(
+            atPath: TBDConstants.configDir
+                .appendingPathComponent("terminal-themes/\(storedScheme).json")
+                .path
+        )
+        self.schemeID = (bundledHit || userFileHit) ? storedScheme : Defaults.schemeID
 
         // Cursor — round-trip via rawString; fall back on unknown.
         let storedCursor = defaults.string(forKey: Keys.cursorStyle) ?? ""
@@ -115,7 +141,7 @@ final class AppearanceSettings: ObservableObject {
 
     /// Computes COLORFGBG for the currently active terminal color scheme.
     var currentColorFgBg: String {
-        let scheme = ColorSchemes.scheme(forID: schemeID)
+        let scheme = ColorSchemes.scheme(forID: schemeID, store: themeStore)
         return Self.colorFgBg(for: scheme)
     }
 }

--- a/Sources/TBDApp/Terminal/ColorSchemes.swift
+++ b/Sources/TBDApp/Terminal/ColorSchemes.swift
@@ -21,8 +21,11 @@ enum ColorSchemes {
     /// on different schemes.
     static let defaultScheme: TerminalColorScheme = tango
 
-    static func scheme(forID id: String) -> TerminalColorScheme {
-        bundled.first { $0.id == id } ?? defaultScheme
+    @MainActor
+    static func scheme(forID id: String, store: ThemeStore? = nil) -> TerminalColorScheme {
+        if let bundled = bundled.first(where: { $0.id == id }) { return bundled }
+        if let user = store?.userThemes.first(where: { $0.id == id }) { return user }
+        return defaultScheme
     }
 
     static let bundled: [TerminalColorScheme] = [

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -103,7 +103,7 @@ class TBDTerminalView: TerminalView {
     }
 
     private func applyScheme() {
-        let scheme = ColorSchemes.scheme(forID: appearanceSettings.schemeID)
+        let scheme = appearanceSettings.effectiveScheme
         // SwiftTerm's `installColors` takes `[SwiftTerm.Color]`; the per-view
         // foreground/background/caret/selection setters take `NSColor`. We can't
         // use SwiftTerm's internal `NSColor.make(color:)` bridge, so convert

--- a/Sources/TBDApp/Terminal/ThemeDirectoryWatcher.swift
+++ b/Sources/TBDApp/Terminal/ThemeDirectoryWatcher.swift
@@ -1,0 +1,70 @@
+import Foundation
+import CoreServices
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "themes")
+
+@MainActor
+final class ThemeDirectoryWatcher {
+    // nonisolated(unsafe): we only ever read/write this from the main thread
+    // (start/stop are @MainActor; deinit also runs synchronously after the last
+    // main-thread release). The `nonisolated` annotation lets deinit access it
+    // without crossing an actor boundary.
+    nonisolated(unsafe) private var stream: FSEventStreamRef?
+    private let onChange: @MainActor () -> Void
+
+    init(onChange: @escaping @MainActor () -> Void) {
+        self.onChange = onChange
+    }
+
+    func start(directory: URL) {
+        stopStream()
+        try? FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true
+        )
+
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil, release: nil, copyDescription: nil
+        )
+
+        let callback: FSEventStreamCallback = { _, info, _, _, _, _ in
+            guard let info else { return }
+            let watcher = Unmanaged<ThemeDirectoryWatcher>.fromOpaque(info).takeUnretainedValue()
+            Task { @MainActor in watcher.onChange() }
+        }
+
+        let paths = [directory.path] as CFArray
+        guard let s = FSEventStreamCreate(
+            kCFAllocatorDefault, callback, &context, paths,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.1,
+            FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer)
+        ) else {
+            logger.warning("ThemeDirectoryWatcher: FSEventStreamCreate failed for \(directory.path, privacy: .public)")
+            return
+        }
+        FSEventStreamSetDispatchQueue(s, DispatchQueue.main)
+        FSEventStreamStart(s)
+        stream = s
+    }
+
+    func stop() {
+        stopStream()
+    }
+
+    // nonisolated so deinit can call it directly.
+    nonisolated private func stopStream() {
+        if let s = stream {
+            FSEventStreamStop(s)
+            FSEventStreamInvalidate(s)
+            FSEventStreamRelease(s)
+            stream = nil
+        }
+    }
+
+    deinit {
+        stopStream()
+    }
+}

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Combine
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "themes")
+
+@MainActor
+final class ThemeStore: ObservableObject {
+
+    @Published private(set) var userThemes: [TerminalColorScheme] = []
+    @Published private(set) var loadErrors: [LoadError] = []
+
+    struct LoadError: Equatable, Identifiable {
+        let id = UUID()
+        let filename: String
+        let message: String
+
+        static func == (lhs: LoadError, rhs: LoadError) -> Bool {
+            lhs.filename == rhs.filename && lhs.message == rhs.message
+        }
+    }
+
+    var themesDirectory: URL {
+        TBDConstants.configDir.appendingPathComponent("terminal-themes")
+    }
+
+    func reloadFromDisk() {
+        var loaded: [TerminalColorScheme] = []
+        var errors: [LoadError] = []
+
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: themesDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            self.userThemes = []
+            self.loadErrors = []
+            return
+        }
+
+        for url in entries where url.pathExtension == "json" {
+            do {
+                let data = try Data(contentsOf: url)
+                let theme = try JSONDecoder().decode(UserTerminalTheme.self, from: data)
+                let scheme = try theme.toScheme()
+                loaded.append(scheme)
+            } catch {
+                logger.warning("Failed to load theme \(url.lastPathComponent, privacy: .public): \(error, privacy: .public)")
+                errors.append(LoadError(
+                    filename: url.lastPathComponent,
+                    message: String(describing: error)
+                ))
+            }
+        }
+
+        self.userThemes = loaded.sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
+        self.loadErrors = errors
+    }
+}

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -131,6 +131,7 @@ final class ThemeStore: ObservableObject {
             cursor: draft.cursor,
             selection: draft.selection
         )
+        _ = try theme.validated()
         try persist(theme)
         reloadFromDisk()
         return id
@@ -148,6 +149,7 @@ final class ThemeStore: ObservableObject {
         guard fileExists(forID: theme.id) else {
             throw SaveError.ioFailed("save called for unknown id \(theme.id); use saveAs for new themes")
         }
+        _ = try theme.validated()
         try persist(theme)
         reloadFromDisk()
     }

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -85,6 +85,15 @@ final class ThemeStore: ObservableObject {
         return id
     }
 
+    /// Overwrite an existing user theme by id. For new themes use `saveAs`.
+    func save(_ theme: UserTerminalTheme) throws {
+        guard fileExists(forID: theme.id) else {
+            throw SaveError.ioFailed("save called for unknown id \(theme.id); use saveAs for new themes")
+        }
+        try persist(theme)
+        reloadFromDisk()
+    }
+
     private func uniqueID(basedOn slug: String) throws -> String {
         if ColorSchemes.bundled.contains(where: { $0.id == slug }) {
             throw SaveError.bundledIDCollision(slug)

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -59,3 +59,12 @@ final class ThemeStore: ObservableObject {
         self.loadErrors = errors
     }
 }
+
+#if DEBUG
+extension ThemeStore {
+    /// Test seam: inject user themes without touching disk.
+    func injectForTest(userThemes: [TerminalColorScheme]) {
+        self.userThemes = userThemes
+    }
+}
+#endif

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -58,6 +58,81 @@ final class ThemeStore: ObservableObject {
         self.userThemes = loaded.sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
         self.loadErrors = errors
     }
+
+    // MARK: - Save
+
+    enum SaveError: Error, Equatable {
+        case bundledIDCollision(String)
+        case ioFailed(String)
+    }
+
+    @discardableResult
+    func saveAs(_ draft: UserTerminalTheme, suggestedDisplayName: String) throws -> String {
+        let baseSlug = Self.slugify(suggestedDisplayName)
+        let id = try uniqueID(basedOn: baseSlug)
+        let theme = UserTerminalTheme(
+            schemaVersion: draft.schemaVersion,
+            id: id,
+            displayName: suggestedDisplayName,
+            ansi: draft.ansi,
+            foreground: draft.foreground,
+            background: draft.background,
+            cursor: draft.cursor,
+            selection: draft.selection
+        )
+        try persist(theme)
+        reloadFromDisk()
+        return id
+    }
+
+    private func uniqueID(basedOn slug: String) throws -> String {
+        if ColorSchemes.bundled.contains(where: { $0.id == slug }) {
+            throw SaveError.bundledIDCollision(slug)
+        }
+        if !fileExists(forID: slug) { return slug }
+        for n in 2...999 {
+            let candidate = "\(slug)-\(n)"
+            if ColorSchemes.bundled.contains(where: { $0.id == candidate }) { continue }
+            if !fileExists(forID: candidate) { return candidate }
+        }
+        throw SaveError.ioFailed("could not find a unique id for slug \(slug)")
+    }
+
+    private func fileExists(forID id: String) -> Bool {
+        let url = themesDirectory.appendingPathComponent("\(id).json")
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    private func persist(_ theme: UserTerminalTheme) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: themesDirectory, withIntermediateDirectories: true)
+        let url = themesDirectory.appendingPathComponent("\(theme.id).json")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            try encoder.encode(theme).write(to: url, options: .atomic)
+        } catch {
+            throw SaveError.ioFailed(String(describing: error))
+        }
+    }
+
+    /// "My Cool Theme!" → "my-cool-theme"
+    static func slugify(_ name: String) -> String {
+        let lowered = name.lowercased()
+        var out = ""
+        var prevWasDash = true
+        for char in lowered {
+            if char.isLetter || char.isNumber {
+                out.append(char)
+                prevWasDash = false
+            } else if !prevWasDash {
+                out.append("-")
+                prevWasDash = true
+            }
+        }
+        while out.hasSuffix("-") { out.removeLast() }
+        return out
+    }
 }
 
 #if DEBUG

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -105,6 +105,9 @@ final class ThemeStore: ObservableObject {
     @discardableResult
     func saveAs(_ draft: UserTerminalTheme, suggestedDisplayName: String) throws -> String {
         let baseSlug = Self.slugify(suggestedDisplayName)
+        guard !baseSlug.isEmpty else {
+            throw SaveError.ioFailed("display name must contain at least one letter or number")
+        }
         let id = try uniqueID(basedOn: baseSlug)
         let theme = UserTerminalTheme(
             schemaVersion: draft.schemaVersion,

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -11,6 +11,12 @@ final class ThemeStore: ObservableObject {
     @Published private(set) var userThemes: [TerminalColorScheme] = []
     @Published private(set) var loadErrors: [LoadError] = []
 
+    private var watcher: ThemeDirectoryWatcher?
+    // Snapshot of themesDirectory taken at startWatching() time.
+    // Keeps the FSEvents callback pointing at the correct directory even if
+    // TBD_HOME changes (test isolation via setenv).
+    private var watchedDirectory: URL?
+
     struct LoadError: Equatable, Identifiable {
         let id = UUID()
         let filename: String
@@ -26,12 +32,16 @@ final class ThemeStore: ObservableObject {
     }
 
     func reloadFromDisk() {
+        reloadFromDisk(at: themesDirectory)
+    }
+
+    private func reloadFromDisk(at directory: URL) {
         var loaded: [TerminalColorScheme] = []
         var errors: [LoadError] = []
 
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
-            at: themesDirectory,
+            at: directory,
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles]
         ) else {
@@ -57,6 +67,27 @@ final class ThemeStore: ObservableObject {
 
         self.userThemes = loaded.sorted { $0.displayName.localizedCompare($1.displayName) == .orderedAscending }
         self.loadErrors = errors
+    }
+
+    // MARK: - Watching
+
+    func startWatching() {
+        guard watcher == nil else { return }
+        // Snapshot the directory URL now so the FSEvents callback reloads from
+        // the same path even if TBD_HOME changes (e.g. setenv in tests).
+        let dir = themesDirectory
+        watchedDirectory = dir
+        let w = ThemeDirectoryWatcher { [weak self] in
+            self?.reloadFromDisk(at: dir)
+        }
+        w.start(directory: dir)
+        self.watcher = w
+    }
+
+    func stopWatching() {
+        watcher?.stop()
+        watcher = nil
+        watchedDirectory = nil
     }
 
     // MARK: - Save

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -66,6 +66,11 @@ final class ThemeStore: ObservableObject {
         case ioFailed(String)
     }
 
+    enum DeleteError: Error, Equatable {
+        case notFound(String)
+        case ioFailed(String)
+    }
+
     @discardableResult
     func saveAs(_ draft: UserTerminalTheme, suggestedDisplayName: String) throws -> String {
         let baseSlug = Self.slugify(suggestedDisplayName)
@@ -123,6 +128,25 @@ final class ThemeStore: ObservableObject {
         } catch {
             throw SaveError.ioFailed(String(describing: error))
         }
+    }
+
+    // MARK: - Delete
+
+    func delete(id: String) throws {
+        let src = themesDirectory.appendingPathComponent("\(id).json")
+        guard FileManager.default.fileExists(atPath: src.path) else {
+            throw DeleteError.notFound(id)
+        }
+        let trashDir = themesDirectory.appendingPathComponent(".trash", isDirectory: true)
+        try FileManager.default.createDirectory(at: trashDir, withIntermediateDirectories: true)
+        let ts = Int(Date().timeIntervalSince1970 * 1000)
+        let dst = trashDir.appendingPathComponent("\(id)-\(ts).json")
+        do {
+            try FileManager.default.moveItem(at: src, to: dst)
+        } catch {
+            throw DeleteError.ioFailed(String(describing: error))
+        }
+        reloadFromDisk()
     }
 
     /// "My Cool Theme!" → "my-cool-theme"

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -40,13 +40,25 @@ final class ThemeStore: ObservableObject {
         var errors: [LoadError] = []
 
         let fm = FileManager.default
-        guard let entries = try? fm.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        ) else {
+        let entries: [URL]
+        do {
+            entries = try fm.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+        } catch let nsError as NSError where nsError.code == NSFileReadNoSuchFileError {
+            // Dir hasn't been created yet — expected on first launch. Silent.
             self.userThemes = []
             self.loadErrors = []
+            return
+        } catch {
+            logger.warning("Failed to enumerate themes dir \(directory.path, privacy: .public): \(error, privacy: .public)")
+            self.userThemes = []
+            self.loadErrors = [LoadError(
+                filename: directory.lastPathComponent + "/",
+                message: "directory unreadable: \(error.localizedDescription)"
+            )]
             return
         }
 

--- a/Sources/TBDApp/Terminal/ThemeStore.swift
+++ b/Sources/TBDApp/Terminal/ThemeStore.swift
@@ -138,6 +138,13 @@ final class ThemeStore: ObservableObject {
 
     /// Overwrite an existing user theme by id. For new themes use `saveAs`.
     func save(_ theme: UserTerminalTheme) throws {
+        // Match `saveAs`'s precedent: don't overwrite a file whose id collides
+        // with a bundled scheme, even if a stray JSON happens to live under that
+        // name (manual cp, dotfiles sync, future import paths). UI keeps callers
+        // honest today, but the data layer shouldn't rely on caller discipline.
+        guard !ColorSchemes.bundled.contains(where: { $0.id == theme.id }) else {
+            throw SaveError.bundledIDCollision(theme.id)
+        }
         guard fileExists(forID: theme.id) else {
             throw SaveError.ioFailed("save called for unknown id \(theme.id); use saveAs for new themes")
         }

--- a/Sources/TBDApp/Terminal/UserTerminalTheme.swift
+++ b/Sources/TBDApp/Terminal/UserTerminalTheme.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SwiftTerm
+
+/// Codable representation of a user-authored terminal color scheme as stored
+/// on disk in `~/tbd/terminal-themes/<id>.json`. Converts to a runtime
+/// `TerminalColorScheme` for the renderer. See the user-custom-terminal-themes
+/// design doc.
+struct UserTerminalTheme: Codable, Equatable, Hashable {
+    let schemaVersion: Int
+    let id: String
+    let displayName: String
+    let ansi: [String]
+    let foreground: String
+    let background: String
+    let cursor: String
+    let selection: String
+
+    enum ValidationError: Error, Equatable {
+        case wrongAnsiCount(Int)
+        case invalidHex(field: String, value: String)
+        case invalidID(String)
+    }
+
+    func validated() throws -> UserTerminalTheme {
+        guard ansi.count == 16 else { throw ValidationError.wrongAnsiCount(ansi.count) }
+        for (i, hex) in ansi.enumerated() {
+            guard Self.parseHex(hex) != nil else {
+                throw ValidationError.invalidHex(field: "ansi[\(i)]", value: hex)
+            }
+        }
+        for (name, hex) in [
+            ("foreground", foreground), ("background", background),
+            ("cursor", cursor), ("selection", selection)
+        ] {
+            guard Self.parseHex(hex) != nil else {
+                throw ValidationError.invalidHex(field: name, value: hex)
+            }
+        }
+        guard !id.isEmpty, id.range(of: "^[a-z0-9-]+$", options: .regularExpression) != nil else {
+            throw ValidationError.invalidID(id)
+        }
+        return self
+    }
+
+    func toScheme() throws -> TerminalColorScheme {
+        _ = try validated()
+        return TerminalColorScheme(
+            id: id,
+            displayName: displayName,
+            ansi: ansi.map { Self.color(fromHex: $0)! },
+            foreground: Self.color(fromHex: foreground)!,
+            background: Self.color(fromHex: background)!,
+            cursor: Self.color(fromHex: cursor)!,
+            selection: Self.color(fromHex: selection)!
+        )
+    }
+
+    static func parseHex(_ hex: String) -> (UInt8, UInt8, UInt8)? {
+        guard hex.hasPrefix("#"), hex.count == 7 else { return nil }
+        let scanner = Scanner(string: String(hex.dropFirst()))
+        var value: UInt64 = 0
+        guard scanner.scanHexInt64(&value), scanner.isAtEnd else { return nil }
+        return (UInt8((value >> 16) & 0xff), UInt8((value >> 8) & 0xff), UInt8(value & 0xff))
+    }
+
+    static func color(fromHex hex: String) -> SwiftTerm.Color? {
+        guard let (r, g, b) = parseHex(hex) else { return nil }
+        return SwiftTerm.Color(red: UInt16(r) * 257, green: UInt16(g) * 257, blue: UInt16(b) * 257)
+    }
+
+    static func hex(from color: SwiftTerm.Color) -> String {
+        let r = Int(color.red / 257)
+        let g = Int(color.green / 257)
+        let b = Int(color.blue / 257)
+        return String(format: "#%02x%02x%02x", r, g, b)
+    }
+}

--- a/Sources/TBDApp/Terminal/UserTerminalTheme.swift
+++ b/Sources/TBDApp/Terminal/UserTerminalTheme.swift
@@ -19,9 +19,13 @@ struct UserTerminalTheme: Codable, Equatable, Hashable {
         case wrongAnsiCount(Int)
         case invalidHex(field: String, value: String)
         case invalidID(String)
+        case unsupportedSchemaVersion(Int)
     }
 
     func validated() throws -> UserTerminalTheme {
+        guard schemaVersion == 1 else {
+            throw ValidationError.unsupportedSchemaVersion(schemaVersion)
+        }
         guard ansi.count == 16 else { throw ValidationError.wrongAnsiCount(ansi.count) }
         for (i, hex) in ansi.enumerated() {
             guard Self.parseHex(hex) != nil else {

--- a/Tests/TBDAppTests/AlacrittyImporterTests.swift
+++ b/Tests/TBDAppTests/AlacrittyImporterTests.swift
@@ -124,4 +124,30 @@ struct AlacrittyImporterTests {
         #expect(theme.background == "#ffffff")
         #expect(theme.foreground == "#000000")
     }
+
+    @Test("missing [colors.bright] falls back to [colors.normal] values")
+    func missingBrightFallsBackToNormal() throws {
+        let toml = """
+        [colors.primary]
+        background = "#000000"
+        foreground = "#ffffff"
+        [colors.normal]
+        black = "#111111"
+        red = "#220000"
+        green = "#002200"
+        yellow = "#222200"
+        blue = "#000022"
+        magenta = "#220022"
+        cyan = "#002222"
+        white = "#222222"
+        # No [colors.bright] section.
+        """
+        let theme = try AlacrittyImporter().importString(toml, suggestedDisplayName: "no-bright")
+        // Normal and bright slots should be identical.
+        for i in 0..<8 {
+            #expect(theme.ansi[i] == theme.ansi[i + 8])
+        }
+        #expect(theme.ansi[0] == "#111111")
+        #expect(theme.ansi[8] == "#111111")
+    }
 }

--- a/Tests/TBDAppTests/AlacrittyImporterTests.swift
+++ b/Tests/TBDAppTests/AlacrittyImporterTests.swift
@@ -44,4 +44,17 @@ struct AlacrittyImporterTests {
         #expect(theme.background == "#e1e2e7")
         #expect(theme.ansi.count == 16)
     }
+
+    @Test("missing [colors.normal] throws missingSection with the section name in the error")
+    func missingNormalSection() throws {
+        let url = try fixtureURL("malformed-no-normal")
+        do {
+            _ = try AlacrittyImporter().importFile(url)
+            Issue.record("expected import to throw")
+        } catch let AlacrittyImporter.ImportError.missingSection(section) {
+            #expect(section == "colors.normal")
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
 }

--- a/Tests/TBDAppTests/AlacrittyImporterTests.swift
+++ b/Tests/TBDAppTests/AlacrittyImporterTests.swift
@@ -57,4 +57,71 @@ struct AlacrittyImporterTests {
             Issue.record("unexpected error: \(error)")
         }
     }
+
+    @Test("interior 0x substring in a hex value is NOT stripped")
+    func interior0xNotStripped() throws {
+        // "#a0xbcdef" is 9 chars — invalid hex regardless. The fix means the
+        // importer no longer collapses it to a valid-looking "#abcdef".
+        let toml = """
+        [colors.primary]
+        background = "#ffffff"
+        foreground = "#a0xbcdef"
+        [colors.normal]
+        black = "#000000"
+        red = "#ff0000"
+        green = "#00ff00"
+        yellow = "#ffff00"
+        blue = "#0000ff"
+        magenta = "#ff00ff"
+        cyan = "#00ffff"
+        white = "#cccccc"
+        [colors.bright]
+        black = "#666666"
+        red = "#ff6666"
+        green = "#66ff66"
+        yellow = "#ffff66"
+        blue = "#6666ff"
+        magenta = "#ff66ff"
+        cyan = "#66ffff"
+        white = "#ffffff"
+        """
+        do {
+            _ = try AlacrittyImporter().importString(toml, suggestedDisplayName: "x")
+            Issue.record("expected importString to throw on invalid hex")
+        } catch AlacrittyImporter.ImportError.invalidHex(_, let key, _) {
+            #expect(key == "foreground")
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test("leading 0x prefix is still stripped correctly")
+    func leading0xStripped() throws {
+        let toml = """
+        [colors.primary]
+        background = "0xffffff"
+        foreground = "0x000000"
+        [colors.normal]
+        black = "#000000"
+        red = "#ff0000"
+        green = "#00ff00"
+        yellow = "#ffff00"
+        blue = "#0000ff"
+        magenta = "#ff00ff"
+        cyan = "#00ffff"
+        white = "#cccccc"
+        [colors.bright]
+        black = "#666666"
+        red = "#ff6666"
+        green = "#66ff66"
+        yellow = "#ffff66"
+        blue = "#6666ff"
+        magenta = "#ff66ff"
+        cyan = "#66ffff"
+        white = "#ffffff"
+        """
+        let theme = try AlacrittyImporter().importString(toml, suggestedDisplayName: "x")
+        #expect(theme.background == "#ffffff")
+        #expect(theme.foreground == "#000000")
+    }
 }

--- a/Tests/TBDAppTests/AlacrittyImporterTests.swift
+++ b/Tests/TBDAppTests/AlacrittyImporterTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("AlacrittyImporter")
+struct AlacrittyImporterTests {
+    private func fixtureURL(_ name: String) throws -> URL {
+        let bundle = Bundle.module
+        guard let url = bundle.url(forResource: name, withExtension: "toml", subdirectory: "Fixtures/alacritty") else {
+            Issue.record("missing fixture \(name).toml")
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return url
+    }
+
+    @Test("catppuccin-latte fixture decodes to expected hex tuple")
+    func catppuccinLatte() throws {
+        let url = try fixtureURL("catppuccin-latte")
+        let theme = try AlacrittyImporter().importFile(url)
+        #expect(theme.background == "#eff1f5")
+        #expect(theme.foreground == "#4c4f69")
+        #expect(theme.ansi.count == 16)
+        // ansi[0] = normal black
+        #expect(theme.ansi[0] == "#bcc0cc")
+        // ansi[4] = normal blue
+        #expect(theme.ansi[4] == "#1e66f5")
+    }
+
+    @Test("rose-pine-dawn fixture decodes with bright == normal where the source has it")
+    func rosePineDawn() throws {
+        let url = try fixtureURL("rose-pine-dawn")
+        let theme = try AlacrittyImporter().importFile(url)
+        #expect(theme.background == "#faf4ed")
+        // normal red (ansi[1]) == bright red (ansi[9]) in this theme
+        #expect(theme.ansi[1] == theme.ansi[9])
+        // ansi[8] = bright black
+        #expect(theme.ansi[8] == "#9893a5")
+    }
+
+    @Test("tokyonight-day fixture decodes")
+    func tokyonightDay() throws {
+        let url = try fixtureURL("tokyonight-day")
+        let theme = try AlacrittyImporter().importFile(url)
+        #expect(theme.background == "#e1e2e7")
+        #expect(theme.ansi.count == 16)
+    }
+}

--- a/Tests/TBDAppTests/AppearanceSettingsTests.swift
+++ b/Tests/TBDAppTests/AppearanceSettingsTests.swift
@@ -178,4 +178,27 @@ struct AppearanceSettingsTests {
             #expect(darkValue == "15;0")
         }
     }
+
+    @Test("currentColorFgBg uses user-theme bg luminance when a user theme is active")
+    func currentColorFgBgForUserTheme() throws {
+        let suiteName = "tbd.test.fgbg-user.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = ThemeStore()
+        let lightUser = TerminalColorScheme(
+            id: "light-user", displayName: "Light U",
+            ansi: Array(repeating: SwiftTerm.Color(red: 0, green: 0, blue: 0), count: 16),
+            foreground: SwiftTerm.Color(red: 0, green: 0, blue: 0),
+            background: SwiftTerm.Color(red: 65535, green: 65535, blue: 65535),
+            cursor: SwiftTerm.Color(red: 0, green: 0, blue: 0),
+            selection: SwiftTerm.Color(red: 32000, green: 32000, blue: 32000)
+        )
+        store.injectForTest(userThemes: [lightUser])
+
+        let appearance = AppearanceSettings(defaults: defaults)
+        appearance.themeStore = store
+        appearance.schemeID = "light-user"
+        #expect(appearance.currentColorFgBg == "0;15")
+    }
 }

--- a/Tests/TBDAppTests/AppearanceSettingsTests.swift
+++ b/Tests/TBDAppTests/AppearanceSettingsTests.swift
@@ -89,6 +89,31 @@ struct AppearanceSettingsTests {
         }
     }
 
+    @Test("user theme id is preserved at init when a matching JSON file exists")
+    func preservesUserThemeIDWithMatchingFile() throws {
+        // Regression test: init used to reject any non-bundled id, which
+        // silently clobbered legitimate user-theme selections back to Tango
+        // on every relaunch (the on-disk file load races init).
+        let home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-appearance-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        defer {
+            try? FileManager.default.removeItem(at: home)
+            unsetenv("TBD_HOME")
+        }
+        let themesDir = home.appendingPathComponent("terminal-themes")
+        try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
+        // Contents don't need to be a valid theme — init only checks file existence.
+        try Data().write(to: themesDir.appendingPathComponent("my-theme.json"))
+
+        withIsolatedDefaults { defaults in
+            defaults.set("my-theme", forKey: "terminal.scheme.id")
+            let settings = AppearanceSettings(defaults: defaults)
+            #expect(settings.schemeID == "my-theme")
+        }
+    }
+
     @Test("computed font falls back to system mono when fontName is bogus")
     func fallbackFontResolution() {
         withIsolatedDefaults { defaults in

--- a/Tests/TBDAppTests/ColorSchemesTests.swift
+++ b/Tests/TBDAppTests/ColorSchemesTests.swift
@@ -1,6 +1,8 @@
 import Testing
+import SwiftTerm
 @testable import TBDApp
 
+@MainActor
 @Suite("ColorSchemes")
 struct ColorSchemesTests {
     @Test("bundled list is non-empty and contains tbd-default and tango")
@@ -51,5 +53,43 @@ struct ColorSchemesTests {
             "rose-pine-dawn", "flexoki-light", "tokyo-night-day",
         ]
         #expect(ids == expected)
+    }
+
+    @Test("scheme(forID:) returns a user theme when bundled has no match")
+    func resolvesUserTheme() {
+        let store = ThemeStore()
+        let userScheme = TerminalColorScheme(
+            id: "my-user-theme", displayName: "Mine",
+            ansi: Array(repeating: SwiftTerm.Color(red: 0, green: 0, blue: 0), count: 16),
+            foreground: SwiftTerm.Color(red: 65535, green: 65535, blue: 65535),
+            background: SwiftTerm.Color(red: 0, green: 0, blue: 0),
+            cursor: SwiftTerm.Color(red: 65535, green: 65535, blue: 65535),
+            selection: SwiftTerm.Color(red: 20000, green: 20000, blue: 20000)
+        )
+        store.injectForTest(userThemes: [userScheme])
+        let resolved = ColorSchemes.scheme(forID: "my-user-theme", store: store)
+        #expect(resolved.id == "my-user-theme")
+    }
+
+    @Test("bundled wins on id collision with a user theme")
+    func bundledWinsOnCollision() {
+        let store = ThemeStore()
+        let conflicting = TerminalColorScheme(
+            id: "gruvbox-dark", displayName: "Hijack",
+            ansi: Array(repeating: SwiftTerm.Color(red: 65535, green: 0, blue: 0), count: 16),
+            foreground: SwiftTerm.Color(red: 65535, green: 0, blue: 0),
+            background: SwiftTerm.Color(red: 65535, green: 0, blue: 0),
+            cursor: SwiftTerm.Color(red: 65535, green: 0, blue: 0),
+            selection: SwiftTerm.Color(red: 65535, green: 0, blue: 0)
+        )
+        store.injectForTest(userThemes: [conflicting])
+        let resolved = ColorSchemes.scheme(forID: "gruvbox-dark", store: store)
+        #expect(resolved.displayName == "Gruvbox Dark")
+    }
+
+    @Test("scheme(forID:) falls back to default when neither bundled nor user has a match")
+    func fallsBackToDefault() {
+        let resolved = ColorSchemes.scheme(forID: "nonexistent-9999")
+        #expect(resolved.id == ColorSchemes.defaultScheme.id)
     }
 }

--- a/Tests/TBDAppTests/Fixtures/alacritty/catppuccin-latte.toml
+++ b/Tests/TBDAppTests/Fixtures/alacritty/catppuccin-latte.toml
@@ -1,0 +1,65 @@
+[colors.primary]
+background = "#eff1f5"
+foreground = "#4c4f69"
+dim_foreground = "#8c8fa1"
+bright_foreground = "#4c4f69"
+
+[colors.cursor]
+text = "#eff1f5"
+cursor = "#dc8a78"
+
+[colors.vi_mode_cursor]
+text = "#eff1f5"
+cursor = "#7287fd"
+
+[colors.search.matches]
+foreground = "#eff1f5"
+background = "#6c6f85"
+
+[colors.search.focused_match]
+foreground = "#eff1f5"
+background = "#40a02b"
+
+[colors.footer_bar]
+foreground = "#eff1f5"
+background = "#6c6f85"
+
+[colors.hints.start]
+foreground = "#eff1f5"
+background = "#df8e1d"
+
+[colors.hints.end]
+foreground = "#eff1f5"
+background = "#6c6f85"
+
+[colors.selection]
+text = "#eff1f5"
+background = "#dc8a78"
+
+[colors.normal]
+black = "#bcc0cc"
+red = "#d20f39"
+green = "#40a02b"
+yellow = "#df8e1d"
+blue = "#1e66f5"
+magenta = "#ea76cb"
+cyan = "#179299"
+white = "#5c5f77"
+
+[colors.bright]
+black = "#acb0be"
+red = "#d20f39"
+green = "#40a02b"
+yellow = "#df8e1d"
+blue = "#1e66f5"
+magenta = "#ea76cb"
+cyan = "#179299"
+white = "#6c6f85"
+
+[[colors.indexed_colors]]
+index = 16
+color = "#fe640b"
+
+[[colors.indexed_colors]]
+index = 17
+color = "#dc8a78"

--- a/Tests/TBDAppTests/Fixtures/alacritty/malformed-no-normal.toml
+++ b/Tests/TBDAppTests/Fixtures/alacritty/malformed-no-normal.toml
@@ -1,0 +1,13 @@
+[colors.primary]
+background = "#ffffff"
+foreground = "#000000"
+# [colors.normal] intentionally missing
+[colors.bright]
+black = "#222222"
+red = "#aa0000"
+green = "#00aa00"
+yellow = "#aaaa00"
+blue = "#0000aa"
+magenta = "#aa00aa"
+cyan = "#00aaaa"
+white = "#aaaaaa"

--- a/Tests/TBDAppTests/Fixtures/alacritty/rose-pine-dawn.toml
+++ b/Tests/TBDAppTests/Fixtures/alacritty/rose-pine-dawn.toml
@@ -1,0 +1,75 @@
+# Colors section of "Alacritty - TOML configuration file format"
+# https://github.com/alacritty/alacritty/blob/master/extra/man/alacritty.5.scd#colors
+
+[colors.primary]
+foreground = "#575279"
+background = "#faf4ed"
+dim_foreground = "#797593"
+bright_foreground = "#575279"
+
+[colors.cursor]
+text = "#575279"
+cursor = "#cecacd"
+
+[colors.vi_mode_cursor]
+text = "#575279"
+cursor = "#cecacd"
+
+[colors.search.matches]
+foreground = "#797593"
+background = "#f2e9e1"
+
+[colors.search.focused_match]
+foreground = "#faf4ed"
+background = "#d7827e"
+
+[colors.hints.start]
+foreground = "#797593"
+background = "#fffaf3"
+
+[colors.hints.end]
+foreground = "#9893a5"
+background = "#fffaf3"
+
+[colors.line_indicator]
+foreground = "None"
+background = "None"
+
+[colors.footer_bar]
+foreground = "#575279"
+background = "#fffaf3"
+
+[colors.selection]
+text = "#575279"
+background = "#dfdad9"
+
+[colors.normal]
+black = "#f2e9e1"
+red = "#b4637a"
+green = "#286983"
+yellow = "#ea9d34"
+blue = "#56949f"
+magenta = "#907aa9"
+cyan = "#d7827e"
+white = "#575279"
+
+[colors.bright]
+black = "#9893a5"
+red = "#b4637a"
+green = "#286983"
+yellow = "#ea9d34"
+blue = "#56949f"
+magenta = "#907aa9"
+cyan = "#d7827e"
+white = "#575279"
+
+[colors.dim]
+black = "#9893a5"
+red = "#b4637a"
+green = "#286983"
+yellow = "#ea9d34"
+blue = "#56949f"
+magenta = "#907aa9"
+cyan = "#d7827e"
+white = "#575279"
+

--- a/Tests/TBDAppTests/Fixtures/alacritty/tokyonight-day.toml
+++ b/Tests/TBDAppTests/Fixtures/alacritty/tokyonight-day.toml
@@ -1,0 +1,32 @@
+# -----------------------------------------------------------------------------
+# TokyoNight Alacritty Colors
+# Theme: Tokyo Night Day
+# Upstream: https://github.com/folke/tokyonight.nvim/raw/main/extras/alacritty/tokyonight_day.toml
+# -----------------------------------------------------------------------------
+
+# Default colors
+[colors.primary]
+background = '#e1e2e7'
+foreground = '#3760bf'
+
+# Normal colors
+[colors.normal]
+black = '#b4b5b9'
+red = '#f52a65'
+green = '#587539'
+yellow = '#8c6c3e'
+blue = '#2e7de9'
+magenta = '#9854f1'
+cyan = '#007197'
+white = '#6172b0'
+
+# Bright colors
+[colors.bright]
+black = '#a1a6c5'
+red = '#ff4774'
+green = '#5c8524'
+yellow = '#a27629'
+blue = '#358aff'
+magenta = '#a463ff'
+cyan = '#007ea8'
+white = '#3760bf'

--- a/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
+++ b/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+@MainActor
+@Suite("TerminalThemeEditorViewModel")
+struct TerminalThemeEditorViewModelTests {
+
+    private func bundledSource() -> TerminalColorScheme { ColorSchemes.scheme(forID: "gruvbox-dark") }
+
+    @Test("starts not-dirty for a freshly loaded source")
+    func notDirtyAtStart() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .bundled)
+        #expect(!vm.isDirty)
+        #expect(vm.canSave == false)
+        #expect(vm.canSaveAs == true)
+        #expect(vm.canReset == false)
+    }
+
+    @Test("editing a color enters dirty/draft state")
+    func editEntersDraft() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .bundled)
+        vm.setHex(slot: .foreground, hex: "#123456")
+        #expect(vm.isDirty)
+        #expect(vm.canReset == true)
+        #expect(vm.canSaveAs == true)
+        #expect(vm.canSave == false)
+    }
+
+    @Test("editing a user-source theme enables Save")
+    func userSourceEnablesSave() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .user)
+        vm.setHex(slot: .background, hex: "#abcdef")
+        #expect(vm.canSave)
+    }
+
+    @Test("reset clears the draft and snaps back to source")
+    func resetClears() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .bundled)
+        vm.setHex(slot: .foreground, hex: "#123456")
+        vm.reset()
+        #expect(!vm.isDirty)
+        #expect(vm.hex(slot: .foreground) == UserTerminalTheme.hex(from: bundledSource().foreground))
+    }
+
+    @Test("invalid hex is rejected without entering draft state")
+    func invalidHexRejected() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .bundled)
+        vm.setHex(slot: .foreground, hex: "not-a-color")
+        #expect(!vm.isDirty)
+        #expect(vm.lastValidationError != nil)
+    }
+}

--- a/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
+++ b/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
@@ -75,6 +75,29 @@ struct TerminalThemeEditorViewModelTests {
         #expect(!vm.isDirty)  // last dirty slot cleared → editor clean again
     }
 
+    @Test("unsetSlot clears a matching invalid-hex validation error")
+    func unsetSlotClearsMatchingError() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .bundled)
+        vm.setHex(slot: .foreground, hex: "not-a-color")
+        #expect(vm.lastValidationError != nil)
+
+        vm.unsetSlot(.foreground)
+        #expect(vm.lastValidationError == nil)
+    }
+
+    @Test("unsetSlot keeps a validation error scoped to a DIFFERENT slot")
+    func unsetSlotKeepsUnrelatedError() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .bundled)
+        vm.setHex(slot: .background, hex: "garbage")  // error scoped to Background
+        vm.setHex(slot: .foreground, hex: "#abcdef")   // valid; foreground draft entered
+        #expect(vm.lastValidationError != nil)
+
+        vm.unsetSlot(.foreground)
+        #expect(vm.lastValidationError != nil) // background error still there
+    }
+
     @Test("isSlotDirty returns false for clean slots")
     func isSlotDirtyFalseWhenClean() {
         let vm = TerminalThemeEditorViewModel()

--- a/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
+++ b/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
@@ -91,9 +91,9 @@ struct TerminalThemeEditorViewModelTests {
         let vm = TerminalThemeEditorViewModel()
         vm.load(source: bundledSource(), kind: .bundled)
         vm.setHex(slot: .background, hex: "garbage")  // error scoped to Background
-        vm.setHex(slot: .foreground, hex: "#abcdef")   // valid; foreground draft entered
         #expect(vm.lastValidationError != nil)
 
+        // Unsetting a different slot must not clear the background error.
         vm.unsetSlot(.foreground)
         #expect(vm.lastValidationError != nil) // background error still there
     }

--- a/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
+++ b/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
@@ -55,4 +55,31 @@ struct TerminalThemeEditorViewModelTests {
         #expect(!vm.isDirty)
         #expect(vm.lastValidationError != nil)
     }
+
+    @Test("unsetSlot reverts only the named slot")
+    func unsetSlotRevertsOne() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .bundled)
+        vm.setHex(slot: .foreground, hex: "#111111")
+        vm.setHex(slot: .background, hex: "#222222")
+        #expect(vm.isSlotDirty(.foreground))
+        #expect(vm.isSlotDirty(.background))
+
+        vm.unsetSlot(.foreground)
+        #expect(!vm.isSlotDirty(.foreground))
+        #expect(vm.isSlotDirty(.background))
+        #expect(vm.hex(slot: .foreground) == UserTerminalTheme.hex(from: bundledSource().foreground))
+        #expect(vm.isDirty)  // background still dirty → whole editor still dirty
+
+        vm.unsetSlot(.background)
+        #expect(!vm.isDirty)  // last dirty slot cleared → editor clean again
+    }
+
+    @Test("isSlotDirty returns false for clean slots")
+    func isSlotDirtyFalseWhenClean() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .bundled)
+        #expect(!vm.isSlotDirty(.foreground))
+        #expect(!vm.isSlotDirty(.ansi(0)))
+    }
 }

--- a/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
+++ b/Tests/TBDAppTests/TerminalThemeEditorViewModelTests.swift
@@ -82,4 +82,22 @@ struct TerminalThemeEditorViewModelTests {
         #expect(!vm.isSlotDirty(.foreground))
         #expect(!vm.isSlotDirty(.ansi(0)))
     }
+
+    @Test("invalid hex uses human-readable field labels")
+    func invalidHexFieldLabelsAreHuman() {
+        let vm = TerminalThemeEditorViewModel()
+        vm.load(source: bundledSource(), kind: .bundled)
+        vm.setHex(slot: .ansi(3), hex: "garbage")
+        if case .invalidHex(let field, _) = vm.lastValidationError {
+            #expect(field == "ANSI 3")
+        } else {
+            Issue.record("expected invalidHex error")
+        }
+        vm.setHex(slot: .foreground, hex: "garbage")
+        if case .invalidHex(let field, _) = vm.lastValidationError {
+            #expect(field == "Foreground")
+        } else {
+            Issue.record("expected invalidHex error")
+        }
+    }
 }

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -173,4 +173,34 @@ struct ThemeStoreTests {
         #expect(trashed.count == 1)
         #expect(trashed[0].hasPrefix("\(id)-"))
     }
+
+    @Test("external file additions trigger a reload via the watcher")
+    func watcherReloadsOnExternalAdd() async throws {
+        let home = makeIsolatedHome()
+        let themesDir = home.appendingPathComponent("terminal-themes")
+        try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
+
+        let store = ThemeStore()
+        store.startWatching()
+        store.reloadFromDisk()
+        #expect(store.userThemes.isEmpty)
+
+        let theme = UserTerminalTheme(
+            schemaVersion: 1, id: "ext", displayName: "Ext",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        try JSONEncoder().encode(theme)
+            .write(to: themesDir.appendingPathComponent("ext.json"))
+
+        let deadline = Date().addingTimeInterval(5)
+        while store.userThemes.isEmpty && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        #expect(store.userThemes.count == 1)
+        #expect(store.userThemes.first?.id == "ext")
+
+        store.stopWatching()
+    }
 }

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -219,6 +219,21 @@ struct ThemeStoreTests {
         }
     }
 
+    @Test("save throws when called for an id that has no file on disk")
+    func saveThrowsForUnknownID() async {
+        _ = makeIsolatedHome()
+        let store = ThemeStore()
+        let theme = UserTerminalTheme(
+            schemaVersion: 1, id: "ghost", displayName: "Ghost",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        #expect(throws: ThemeStore.SaveError.self) {
+            try store.save(theme)
+        }
+    }
+
     @Test("when the active theme file vanishes, the schemeID reverts to default")
     func activeThemeVanishesFallsBack() async throws {
         let home = makeIsolatedHome()

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -203,4 +203,37 @@ struct ThemeStoreTests {
 
         store.stopWatching()
     }
+
+    @Test("when the active theme file vanishes, the schemeID reverts to default")
+    func activeThemeVanishesFallsBack() async throws {
+        let home = makeIsolatedHome()
+        let themesDir = home.appendingPathComponent("terminal-themes")
+        try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
+
+        let suiteName = "tbd.test.fallback.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let appearance = AppearanceSettings(defaults: defaults)
+        let store = ThemeStore()
+        appearance.themeStore = store
+
+        // Create a user theme and select it.
+        let theme = UserTerminalTheme(
+            schemaVersion: 1, id: "ephemeral", displayName: "Ephemeral",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        try JSONEncoder().encode(theme)
+            .write(to: themesDir.appendingPathComponent("ephemeral.json"))
+        store.reloadFromDisk()
+        appearance.schemeID = "ephemeral"
+
+        // Externally delete the file (simulates `rm`).
+        try FileManager.default.removeItem(at: themesDir.appendingPathComponent("ephemeral.json"))
+        store.reloadFromDisk()
+        appearance.reconcileWithStore()
+
+        #expect(appearance.schemeID == ColorSchemes.defaultScheme.id)
+    }
 }

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -75,4 +75,56 @@ struct ThemeStoreTests {
         #expect(store.userThemes.isEmpty)
         #expect(store.loadErrors.isEmpty)
     }
+
+    @Test("saveAs slugifies the display name and writes JSON")
+    func saveAsSlugifies() async throws {
+        let home = makeIsolatedHome()
+        let store = ThemeStore()
+
+        let id = try store.saveAs(
+            UserTerminalTheme(
+                schemaVersion: 1, id: "", displayName: "My Cool Theme!",
+                ansi: Array(repeating: "#000000", count: 16),
+                foreground: "#ffffff", background: "#000000",
+                cursor: "#ffffff", selection: "#505050"
+            ),
+            suggestedDisplayName: "My Cool Theme!"
+        )
+        #expect(id == "my-cool-theme")
+        let file = home.appendingPathComponent("terminal-themes/my-cool-theme.json")
+        #expect(FileManager.default.fileExists(atPath: file.path))
+    }
+
+    @Test("saveAs deduplicates by appending -2, -3 etc.")
+    func saveAsDedupes() async throws {
+        _ = makeIsolatedHome()
+        let store = ThemeStore()
+        let draft = UserTerminalTheme(
+            schemaVersion: 1, id: "", displayName: "Gruvbox Dark Copy",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        let id1 = try store.saveAs(draft, suggestedDisplayName: "Gruvbox Dark Copy")
+        let id2 = try store.saveAs(draft, suggestedDisplayName: "Gruvbox Dark Copy")
+        let id3 = try store.saveAs(draft, suggestedDisplayName: "Gruvbox Dark Copy")
+        #expect(id1 == "gruvbox-dark-copy")
+        #expect(id2 == "gruvbox-dark-copy-2")
+        #expect(id3 == "gruvbox-dark-copy-3")
+    }
+
+    @Test("saveAs refuses ids that collide with bundled schemes")
+    func saveAsRefusesBundledCollision() async {
+        _ = makeIsolatedHome()
+        let store = ThemeStore()
+        let draft = UserTerminalTheme(
+            schemaVersion: 1, id: "", displayName: "Gruvbox Dark",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        #expect(throws: ThemeStore.SaveError.self) {
+            try store.saveAs(draft, suggestedDisplayName: "Gruvbox Dark")
+        }
+    }
 }

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -204,6 +204,21 @@ struct ThemeStoreTests {
         store.stopWatching()
     }
 
+    @Test("saveAs rejects display names that slugify to empty")
+    func saveAsRejectsEmptySlug() async {
+        _ = makeIsolatedHome()
+        let store = ThemeStore()
+        let draft = UserTerminalTheme(
+            schemaVersion: 1, id: "", displayName: "!!!",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        #expect(throws: ThemeStore.SaveError.self) {
+            try store.saveAs(draft, suggestedDisplayName: "!!!")
+        }
+    }
+
     @Test("when the active theme file vanishes, the schemeID reverts to default")
     func activeThemeVanishesFallsBack() async throws {
         let home = makeIsolatedHome()

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -127,4 +127,27 @@ struct ThemeStoreTests {
             try store.saveAs(draft, suggestedDisplayName: "Gruvbox Dark")
         }
     }
+
+    @Test("save overwrites the existing file for the same id")
+    func saveOverwrites() async throws {
+        _ = makeIsolatedHome()
+        let store = ThemeStore()
+        let draft = UserTerminalTheme(
+            schemaVersion: 1, id: "", displayName: "Foo",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        let id = try store.saveAs(draft, suggestedDisplayName: "Foo")
+
+        let edited = UserTerminalTheme(
+            schemaVersion: 1, id: id, displayName: "Foo",
+            ansi: Array(repeating: "#ff0000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        try store.save(edited)
+        store.reloadFromDisk()
+        #expect(store.userThemes.first?.ansi[0].red == UInt16(0xff) * 257)
+    }
 }

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -243,6 +243,7 @@ struct ThemeStoreTests {
             .write(to: themesDir.appendingPathComponent("ephemeral.json"))
         store.reloadFromDisk()
         appearance.schemeID = "ephemeral"
+        appearance.draftSchemeOverride = ColorSchemes.scheme(forID: "tango")
 
         // Externally delete the file (simulates `rm`).
         try FileManager.default.removeItem(at: themesDir.appendingPathComponent("ephemeral.json"))
@@ -250,5 +251,6 @@ struct ThemeStoreTests {
         appearance.reconcileWithStore()
 
         #expect(appearance.schemeID == ColorSchemes.defaultScheme.id)
+        #expect(appearance.draftSchemeOverride == nil)
     }
 }

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -150,4 +150,27 @@ struct ThemeStoreTests {
         store.reloadFromDisk()
         #expect(store.userThemes.first?.ansi[0].red == UInt16(0xff) * 257)
     }
+
+    @Test("delete moves the file into .trash/ with a timestamp suffix")
+    func deleteSoftDeletes() async throws {
+        let home = makeIsolatedHome()
+        let store = ThemeStore()
+        let draft = UserTerminalTheme(
+            schemaVersion: 1, id: "", displayName: "Throwaway",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        let id = try store.saveAs(draft, suggestedDisplayName: "Throwaway")
+
+        try store.delete(id: id)
+
+        let originalPath = home.appendingPathComponent("terminal-themes/\(id).json")
+        #expect(!FileManager.default.fileExists(atPath: originalPath.path))
+
+        let trashDir = home.appendingPathComponent("terminal-themes/.trash")
+        let trashed = try FileManager.default.contentsOfDirectory(atPath: trashDir.path)
+        #expect(trashed.count == 1)
+        #expect(trashed[0].hasPrefix("\(id)-"))
+    }
 }

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -234,6 +234,34 @@ struct ThemeStoreTests {
         }
     }
 
+    @Test("save refuses to overwrite a file whose id collides with a bundled scheme")
+    func saveRefusesBundledCollision() async throws {
+        let home = makeIsolatedHome()
+        let themesDir = home.appendingPathComponent("terminal-themes")
+        try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
+
+        // Plant a stray JSON named after a bundled scheme (simulates a manual cp
+        // or a future import path) so the fileExists guard would otherwise pass.
+        let stray = UserTerminalTheme(
+            schemaVersion: 1, id: "gruvbox-dark", displayName: "Stray",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        try JSONEncoder().encode(stray)
+            .write(to: themesDir.appendingPathComponent("gruvbox-dark.json"))
+
+        let store = ThemeStore()
+        do {
+            try store.save(stray)
+            Issue.record("expected SaveError.bundledIDCollision")
+        } catch let ThemeStore.SaveError.bundledIDCollision(id) {
+            #expect(id == "gruvbox-dark")
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
     @Test("when the active theme file vanishes, the schemeID reverts to default")
     func activeThemeVanishesFallsBack() async throws {
         let home = makeIsolatedHome()

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+@MainActor
+@Suite("ThemeStore")
+struct ThemeStoreTests {
+    private func makeIsolatedHome() -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-themestore-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        setenv("TBD_HOME", dir.path, 1)
+        return dir
+    }
+
+    @Test("returns empty when the themes dir doesn't exist yet")
+    func emptyWhenDirMissing() async {
+        _ = makeIsolatedHome()
+        let store = ThemeStore()
+        store.reloadFromDisk()
+        #expect(store.userThemes.isEmpty)
+    }
+
+    @Test("loads all valid JSON theme files")
+    func loadsValidThemes() async throws {
+        let home = makeIsolatedHome()
+        let themesDir = home.appendingPathComponent("terminal-themes")
+        try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
+
+        let theme = UserTerminalTheme(
+            schemaVersion: 1, id: "my-test", displayName: "My Test",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        let data = try JSONEncoder().encode(theme)
+        try data.write(to: themesDir.appendingPathComponent("my-test.json"))
+
+        let store = ThemeStore()
+        store.reloadFromDisk()
+        #expect(store.userThemes.count == 1)
+        #expect(store.userThemes.first?.id == "my-test")
+    }
+
+    @Test("skips malformed JSON files and records the error")
+    func skipsMalformed() async throws {
+        let home = makeIsolatedHome()
+        let themesDir = home.appendingPathComponent("terminal-themes")
+        try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
+        try "{ not json".write(
+            to: themesDir.appendingPathComponent("bad.json"),
+            atomically: true, encoding: .utf8
+        )
+
+        let store = ThemeStore()
+        store.reloadFromDisk()
+        #expect(store.userThemes.isEmpty)
+        #expect(store.loadErrors.count == 1)
+        #expect(store.loadErrors.first?.filename == "bad.json")
+    }
+
+    @Test("ignores files that aren't .json")
+    func ignoresNonJSON() async throws {
+        let home = makeIsolatedHome()
+        let themesDir = home.appendingPathComponent("terminal-themes")
+        try FileManager.default.createDirectory(at: themesDir, withIntermediateDirectories: true)
+        try "ignored".write(
+            to: themesDir.appendingPathComponent("foo.toml"),
+            atomically: true, encoding: .utf8
+        )
+
+        let store = ThemeStore()
+        store.reloadFromDisk()
+        #expect(store.userThemes.isEmpty)
+        #expect(store.loadErrors.isEmpty)
+    }
+}

--- a/Tests/TBDAppTests/UserTerminalThemeTests.swift
+++ b/Tests/TBDAppTests/UserTerminalThemeTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("UserTerminalTheme")
+struct UserTerminalThemeTests {
+    @Test("decodes a canonical JSON file")
+    func decodeCanonical() throws {
+        let json = """
+        {
+          "schemaVersion": 1,
+          "id": "my-gruvbox",
+          "displayName": "My Gruvbox",
+          "ansi": [
+            "#282828","#cc241d","#98971a","#d79921",
+            "#458588","#b16286","#689d6a","#a89984",
+            "#928374","#fb4934","#b8bb26","#fabd2f",
+            "#83a598","#d3869b","#8ec07c","#ebdbb2"
+          ],
+          "foreground": "#ebdbb2",
+          "background": "#282828",
+          "cursor": "#ebdbb2",
+          "selection": "#3c3836"
+        }
+        """.data(using: .utf8)!
+        let theme = try JSONDecoder().decode(UserTerminalTheme.self, from: json)
+        #expect(theme.id == "my-gruvbox")
+        #expect(theme.displayName == "My Gruvbox")
+        #expect(theme.ansi.count == 16)
+        #expect(theme.ansi[0] == "#282828")
+        #expect(theme.background == "#282828")
+    }
+
+    @Test("round-trips through encode/decode")
+    func roundTrip() throws {
+        let theme = UserTerminalTheme(
+            schemaVersion: 1,
+            id: "x", displayName: "X",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        let data = try JSONEncoder().encode(theme)
+        let decoded = try JSONDecoder().decode(UserTerminalTheme.self, from: data)
+        #expect(decoded == theme)
+    }
+
+    @Test("rejects wrong-length ansi array on validation")
+    func validatesAnsiLength() {
+        let theme = UserTerminalTheme(
+            schemaVersion: 1, id: "x", displayName: "X",
+            ansi: Array(repeating: "#000000", count: 15),
+            foreground: "#fff", background: "#000",
+            cursor: "#fff", selection: "#505050"
+        )
+        #expect(throws: UserTerminalTheme.ValidationError.self) {
+            try theme.validated()
+        }
+    }
+
+    @Test("rejects invalid hex on validation")
+    func validatesHex() {
+        var ansi = Array(repeating: "#000000", count: 16)
+        ansi[3] = "red"
+        let theme = UserTerminalTheme(
+            schemaVersion: 1, id: "x", displayName: "X", ansi: ansi,
+            foreground: "#fff", background: "#000",
+            cursor: "#fff", selection: "#505050"
+        )
+        #expect(throws: UserTerminalTheme.ValidationError.self) {
+            try theme.validated()
+        }
+    }
+
+    @Test("rejects invalid id patterns on validation")
+    func validatesID() {
+        let cases = ["MY-THEME", "my theme", "my_theme", "", "ünicode"]
+        for badID in cases {
+            let theme = UserTerminalTheme(
+                schemaVersion: 1, id: badID, displayName: "X",
+                ansi: Array(repeating: "#000000", count: 16),
+                foreground: "#ffffff", background: "#000000",
+                cursor: "#ffffff", selection: "#505050"
+            )
+            #expect(throws: UserTerminalTheme.ValidationError.self) {
+                try theme.validated()
+            }
+        }
+    }
+
+    @Test("converts to a TerminalColorScheme with matching RGB")
+    func convertsToScheme() throws {
+        let theme = UserTerminalTheme(
+            schemaVersion: 1, id: "x", displayName: "X",
+            ansi: Array(repeating: "#101010", count: 16),
+            foreground: "#abcdef", background: "#202020",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        let scheme = try theme.toScheme()
+        #expect(scheme.id == "x")
+        #expect(scheme.displayName == "X")
+        #expect(scheme.ansi.count == 16)
+        #expect(scheme.foreground.red == 171 * 257)
+        #expect(scheme.foreground.green == 205 * 257)
+        #expect(scheme.foreground.blue == 239 * 257)
+    }
+}

--- a/Tests/TBDAppTests/UserTerminalThemeTests.swift
+++ b/Tests/TBDAppTests/UserTerminalThemeTests.swift
@@ -88,6 +88,25 @@ struct UserTerminalThemeTests {
         }
     }
 
+    @Test("rejects unsupported schemaVersion on validation")
+    func rejectsFutureSchemaVersion() {
+        let theme = UserTerminalTheme(
+            schemaVersion: 99,
+            id: "x", displayName: "X",
+            ansi: Array(repeating: "#000000", count: 16),
+            foreground: "#ffffff", background: "#000000",
+            cursor: "#ffffff", selection: "#505050"
+        )
+        do {
+            _ = try theme.validated()
+            Issue.record("expected unsupportedSchemaVersion error")
+        } catch UserTerminalTheme.ValidationError.unsupportedSchemaVersion(let v) {
+            #expect(v == 99)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
     @Test("converts to a TerminalColorScheme with matching RGB")
     func convertsToScheme() throws {
         let theme = UserTerminalTheme(

--- a/docs/superpowers/specs/2026-05-27-user-custom-terminal-themes-design.md
+++ b/docs/superpowers/specs/2026-05-27-user-custom-terminal-themes-design.md
@@ -1,0 +1,228 @@
+# User custom terminal themes — design
+
+**Status:** Drafted, pending user review
+**Date:** 2026-05-27
+**Branch:** `user-custom-themes`
+**Related:** PR #190 (added 7 bundled light themes), PR #225 (COLORFGBG broadcast on scheme change)
+
+## Problem
+
+TBD bundles 15 terminal color schemes (8 dark + 7 light) baked into the Swift binary at `Sources/TBDApp/Terminal/ColorSchemes.swift`. Users who want a scheme that isn't bundled have to either submit a PR or live without. There's no way to:
+
+- Import an existing scheme they like from a popular format (Alacritty TOML).
+- Tweak an existing scheme's bright-black, accent, or background and save it as their own.
+- Manage a personal palette across machines via dotfiles.
+
+## Goals
+
+- Let users **tweak any scheme's 20 color slots** (16 ANSI + foreground / background / cursor / selection) in a built-in editor. Editing diverges into an in-memory draft; the user decides to Save as a new user theme, Save (overwrite, user themes only), or Reset.
+- Let users **import an Alacritty TOML** file (the de-facto modern theme distribution format) and have it appear as a selectable scheme.
+- Persist user themes to the filesystem in a portable JSON format so they can be shared, version-controlled in a dotfiles repo, and inspected with `cat`.
+- Live-preview every edit in all open terminal panes; debounced disk writes; explicit Save/Revert.
+- Compose cleanly with the existing scheme-switch machinery: COLORFGBG broadcast (#225), Combine-driven `TBDTerminalView` repaints, the Settings → Terminal picker.
+
+## Non-goals
+
+- iTerm2 `.itermcolors`, Kitty `.conf`, Ghostty `.conf` importers. (Each is a follow-up parser if/when demanded.)
+- Export to Alacritty TOML. (Workaround: the JSON file itself is portable; share it.)
+- Sharing UI, cloud sync, theme marketplace.
+- Per-pane or per-worktree theme override; scheme remains app-global.
+- Auto-switch theme based on macOS appearance. (Could compose nicely with this work later — out of scope here.)
+- Editing **bundled** themes. They're read-only; Duplicate is the only path to mutation.
+
+## Architecture
+
+### Filesystem as source of truth
+
+User themes live in `~/tbd/terminal-themes/`, one JSON file per theme. The directory name explicitly scopes to "terminal" because these themes only affect the terminal renderer's colors — not the SwiftUI app chrome (sidebar, toolbar, etc.). Deleted themes move to `~/tbd/terminal-themes/.trash/<id>-<timestamp>.json` (soft delete; a future "undo" affordance can mine it).
+
+### `ThemeStore`
+
+A new `@MainActor` singleton in `Sources/TBDApp/Terminal/ThemeStore.swift`:
+
+- Enumerates `~/tbd/terminal-themes/*.json` at launch, decodes each, holds an `[id: TerminalColorScheme]` dict.
+- Watches the directory via the macOS `FSEventStream` API (CoreServices) so external edits — `vim ~/tbd/terminal-themes/foo.json`, `cp` of a file from a teammate, `git pull` of a dotfiles repo — appear in the picker without restarting the app.
+- Publishes changes via a `@Published var userThemes: [TerminalColorScheme]`. Consumers (`TerminalSettingsView`, `ColorSchemes.scheme(forID:)`) react via Combine.
+
+### Resolution: `ColorSchemes.scheme(forID:)` extended
+
+Today `ColorSchemes.scheme(forID:)` looks up only the static `bundled` array. The extension:
+
+1. Check `bundled` first (bundled IDs are reserved).
+2. Fall back to `ThemeStore.userThemes`.
+3. Fall back to `defaultScheme` (Tango).
+
+Collisions where a user file's `id` matches a bundled id are skipped at load time with a logged warning. The user can't shadow `gruvbox-dark`; the editor enforces this at save time.
+
+### Live edit flow — clone-on-change
+
+There is no explicit "enter editing mode" gesture. The editor is always visible below the picker, showing the selected scheme's current colors with editable fields. The flow is:
+
+1. The user has any scheme selected (bundled or user). The editor displays its colors.
+2. The user changes any field — a hex value, an `NSColorWell`, the name. The moment a field diverges from the saved/bundled source, the editor view-model enters **draft mode**: it holds an in-memory copy of the scheme that overrides the source for live preview. The picker label gets a "— Draft" suffix while drafting.
+3. The draft is bound to every hex-text-field / `NSColorWell` slot. Mutations publish via `AppearanceSettings`'s existing `@Published` path → all `TBDTerminalView` instances re-render immediately. Same plumbing already used for scheme switching, just at finer granularity.
+4. No disk write happens during drafting — the draft is in-memory only. Disk writes are explicit, triggered by Save / Save as….
+5. Action buttons at the bottom of the editor adapt to source type:
+   - **Bundled source, drafting:** `[ Save as… ]` `[ Reset ]`. Bundled themes are immutable — Save as is the only way to persist.
+   - **User-theme source, drafting:** `[ Save ]` `[ Save as… ]` `[ Reset ]`. Save overwrites the existing `<id>.json` in place; Save as creates a new file alongside.
+   - **No draft:** `[ Save as… ]` only — verbatim clone of the current source into a new user theme. This replaces the old "Duplicate" button cleanly.
+6. **Save as…** opens a small dialog pre-filled with `"{Source displayName} Copy"` (or just the current name field if the user has edited it). On confirm, `ThemeStore` writes `<slug>.json`, switches `AppearanceSettings.schemeID` to the new id, draft state ends. The slug appends `-2`, `-3` etc. for re-clones.
+7. **Save** (user-theme drafts only) writes the draft back to the existing `<id>.json`; draft state ends; picker label loses the "— Draft" suffix.
+8. **Reset** discards the in-memory draft; panes snap back to the saved source colors; `schemeID` unchanged.
+9. Switching to another scheme in the picker, or another Settings tab, while a draft is unsaved → confirm dialog. For bundled-source drafts: *"You have unsaved changes to Gruvbox Dark. Save as new theme / Discard / Cancel."* For user-source drafts: *"You have unsaved changes to My Gruvbox. Save / Save as… / Discard / Cancel."*
+10. Quitting the app with an unsaved draft → same confirm. (No autosave for drafts; they're ephemeral by design.)
+
+### COLORFGBG continuity
+
+The existing broadcast path from PR #225 (`AppState.broadcastAppearanceColorFgBg` → `appearance.updateColorFgBg` RPC → `tmux setenv -g COLORFGBG`) re-fires on every scheme change, debounced. Live-editing the active theme's `background` is "just another scheme change" from that path's perspective — no new code, no new tests needed for COLORFGBG behavior. The bundled and user-theme code paths converge on `AppearanceSettings.currentColorFgBg` which already takes a `TerminalColorScheme`.
+
+## JSON schema
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "my-gruvbox",
+  "displayName": "My Gruvbox",
+  "ansi": [
+    "#282828", "#cc241d", "#98971a", "#d79921",
+    "#458588", "#b16286", "#689d6a", "#a89984",
+    "#928374", "#fb4934", "#b8bb26", "#fabd2f",
+    "#83a598", "#d3869b", "#8ec07c", "#ebdbb2"
+  ],
+  "foreground": "#ebdbb2",
+  "background": "#282828",
+  "cursor": "#ebdbb2",
+  "selection": "#3c3836"
+}
+```
+
+- `schemaVersion` (int): forward-compat; lets us add fields later without breaking old files.
+- `id` (string): canonical handle stored in `UserDefaults` (`terminal.scheme.id`); must match `^[a-z0-9-]+$` and not collide with a bundled id.
+- `displayName` (string): free-form Unicode; what shows in the picker.
+- `ansi` (array of 16 strings): lowercase 7-char hex (`#rrggbb`).
+- `foreground`, `background`, `cursor`, `selection` (string): same hex format.
+- Filename = `<id>.json`. Slug derived from `displayName` on Duplicate when the user hasn't customized the id.
+
+All fields required. No optional fields in v1 — keeps validation simple.
+
+## Alacritty TOML → TBD JSON mapping
+
+The importer (a new `AlacrittyThemeImporter`) parses one of the canonical Alacritty section layouts:
+
+| Alacritty section + key | TBD JSON field |
+| --- | --- |
+| `[colors.primary]` `foreground` | `foreground` |
+| `[colors.primary]` `background` | `background` |
+| `[colors.cursor]` `cursor` (fallback: `text`) | `cursor` |
+| `[colors.selection]` `background` | `selection` |
+| `[colors.normal]` `black`/`red`/`green`/`yellow`/`blue`/`magenta`/`cyan`/`white` | `ansi[0..7]` |
+| `[colors.bright]` same 8 names | `ansi[8..15]` |
+
+Many published Alacritty configs (Catppuccin Latte/Mocha, Flexoki, Rosé Pine variants) intentionally make `[colors.bright]` identical to `[colors.normal]`. The importer copies both halves verbatim — no special-casing.
+
+Missing required sections → import fails with a specific, actionable error: *"`[colors.normal]` section not found; this doesn't look like an Alacritty colors config."* No silent fallback.
+
+The Import button in Settings → Terminal opens a file picker filtered to `.toml`. On successful parse, the importer writes the converted JSON to `~/tbd/terminal-themes/<slug>.json` and `ThemeStore`'s FSEvents watcher does the rest (the new theme appears in the picker without further action).
+
+Foreign-format files dropped directly into `~/tbd/terminal-themes/` (e.g. a `.toml` file) are ignored — only `.json` is loaded. To consume a foreign file in the dir, the user goes through Import (which converts).
+
+## Editor UX
+
+Inline expansion in Settings → Terminal — same tab as the scheme picker; the editor is always visible beneath the picker, showing the selected scheme's colors. There is no separate "edit" gesture; touching any field starts a draft. ASCII layout (showing a draft of a bundled scheme — the most common entry point):
+
+```
+Settings  >  Terminal
+----------------------------------------------
+Scheme:    [ Gruvbox Dark — Draft        v ]
+           [ Import… ]
+
++--------- Editing: Gruvbox Dark -----------+
+| Name:  [ Gruvbox Dark                  ]   |
+|                                            |
+| Foreground   [ #ebdbb2 ]  ◼                |
+| Background   [ #282828 ]  ◼                |
+| Cursor       [ #ebdbb2 ]  ◼                |
+| Selection    [ #3c3836 ]  ◼                |
+|                                            |
+| ANSI 0-7   ◼  ◼  ◼  ◼  ◼  ◼  ◼  ◼          |
+| ANSI 8-15  ◼  ◼  ◼  ◼  ◼  ◼  ◼  ◼          |
+|                                            |
+| (changes apply live to all panes)          |
+|                                            |
+|             [ Save as… ]   [ Reset ]       |
++--------------------------------------------+
+
+Font family:    [ SF Mono              v ]
+Font size:      [ 12 ]
+(rest of Terminal settings below)
+```
+
+For a user theme being drafted, the action bar becomes `[ Save ] [ Save as… ] [ Reset ]` and a `[ Delete ]` appears next to `[ Import… ]` above the editor. When no draft is in progress, the action bar collapses to just `[ Save as… ]` — a one-click "fork this scheme into a new user theme" affordance that replaces the old explicit Duplicate button.
+
+Each color slot is a **hex text field + `NSColorWell`** pair, two-way bound. Hex is power-user copy-pasteable; the NSColorWell opens the standard macOS color panel for users who'd rather pick visually. The ANSI rows compress to swatch-only (with hover-tooltips showing the role name + hex) to keep vertical space tight.
+
+`[ Save ]`, `[ Save as… ]`, and `[ Reset ]` only appear when relevant per the rules above. The Name field is editable in both no-draft and drafting states; editing it counts as a draft change just like a color edit.
+
+## Validation & edge cases
+
+| Situation | Behavior |
+| --- | --- |
+| Malformed JSON in a `~/tbd/terminal-themes/*.json` file | Skip the file, log a warning (`os.Logger`, category `themes`), surface a "*N* theme(s) failed to load — see logs" banner at the top of Settings → Terminal |
+| Missing required field (e.g. `ansi` has 12 entries) | Same as malformed |
+| User file's `id` collides with a bundled id | Skip with logged warning; bundled wins. Editor's Save also refuses such an id (form-level validation). |
+| Two user files with the same `id` | First one encountered wins (load order is implementation-defined); both files get a logged warning naming the conflicting filenames. In practice this only happens if a user manually copies a file without changing the inner `id`; the editor would never produce this state. |
+| `id` field absent | Slugify from `displayName`; the field gets persisted on the next save |
+| Invalid hex string (`#abcd`, `red`, `0xffffff`) | Field fails validation; Save disabled while invalid; offending field gets a red border + tooltip |
+| Active theme's file is deleted externally (`rm`) | FSEvents → `ThemeStore` drops the entry → `schemeID` reverts to default (Tango); banner surfaces |
+| Active theme's file is mutated externally | Reload, panes repaint via the existing publisher chain. No editor-state collision because editing-state is only entered via the in-app Duplicate button; an externally-edited file is "the new saved truth." If the user is editing in the app *and* something mutates the file from outside, the in-app draft wins until Save / Revert. |
+| Save as… while drafting a bundled `gruvbox-dark` | Dialog pre-fills with `"Gruvbox Dark Copy"`; on confirm a new `gruvbox-dark-copy.json` (or `-copy-2`, `-copy-3` for re-clones) is written and `schemeID` switches to it |
+| Save as… on a no-draft bundled scheme | One-click "verbatim clone" — same path as above, the draft just happens to equal the source |
+| Quit / app crash with an unsaved draft | Draft is in-memory; lost on next launch. No autosave. Confirm dialog on user-initiated quit. |
+| Delete an active user theme | Confirm dialog → on confirm, file moves to `.trash/<id>-<timestamp>.json`, `schemeID` → `tango`, banner offers a (future) undo affordance |
+
+## Testing plan
+
+Per CLAUDE.md "branching conditional needs a test for each branch":
+
+- **`ThemeStoreTests`**
+  - Round-trip a JSON file (write → enumerate → read → equality).
+  - FSEvents-driven reload: write a file under `TBD_HOME`-isolated tmp, expect `userThemes` to update.
+  - Collision avoidance on Save as…: invoke Save as twice against `gruvbox-dark` → second file is `gruvbox-dark-copy-2.json`.
+  - Draft → Reset reverts in-memory state without touching disk (no file written, source scheme intact).
+  - Delete-active fallback to Tango: write a user file, set `schemeID` to it, move the file → expect `schemeID == "tango"`.
+- **`AlacrittyImporterTests`**
+  - Feed canonical TOMLs from `catppuccin/alacritty`, `rose-pine/alacritty`, `folke/tokyonight.nvim` (committed as `Tests/TBDAppTests/Fixtures/alacritty/*.toml`).
+  - Assert resulting `TerminalColorScheme` matches the expected hex tuple.
+  - One malformed TOML missing `[colors.normal]` → expect a typed `AlacrittyImporter.Error.missingSection` with a message containing `"[colors.normal]"`.
+- **`ColorSchemes.scheme(forID:)` branch coverage** (extending the existing tests)
+  - Bundled-only lookup (existing behavior preserved).
+  - User-only lookup (new branch).
+  - Bundled-vs-user collision → bundled wins (new branch).
+- **No SwiftUI view tests for the editor.** This codebase doesn't reliably exercise SwiftUI views in test; the `ThemeStore` + importer tests cover all the data-layer correctness. Editor wiring is verified manually per the existing project convention.
+
+All tests use `setenv("TBD_HOME", ...)` isolation per CLAUDE.md, and `UserDefaults(suiteName:)` if they touch `AppearanceSettings`.
+
+## File list (proposed)
+
+New:
+- `Sources/TBDApp/Terminal/ThemeStore.swift`
+- `Sources/TBDApp/Terminal/UserTerminalTheme.swift` (the Codable struct + JSON encode/decode)
+- `Sources/TBDApp/Terminal/AlacrittyImporter.swift`
+- `Sources/TBDApp/Settings/TerminalThemeEditorView.swift` (the inline editor SwiftUI view)
+- `Tests/TBDAppTests/ThemeStoreTests.swift`
+- `Tests/TBDAppTests/AlacrittyImporterTests.swift`
+- `Tests/TBDAppTests/Fixtures/alacritty/{catppuccin-latte,rose-pine-dawn,tokyonight-day}.toml`
+
+Modified:
+- `Sources/TBDApp/Terminal/ColorSchemes.swift` — extend `scheme(forID:)` to consult `ThemeStore`
+- `Sources/TBDApp/Terminal/AppearanceSettings.swift` — pick up `ThemeStore` for the active scheme lookup; no other API change
+- `Sources/TBDApp/Settings/TerminalSettingsView.swift` — Duplicate / Delete / Import buttons + embed `TerminalThemeEditorView`
+- `Sources/TBDShared/CLAUDE.md` (if any new path constant lands in `TBDConstants`) — mention `~/tbd/terminal-themes/`
+
+## Open questions for future work (explicitly deferred)
+
+- **Auto-switch theme on macOS appearance change.** Bind a "light scheme" + "dark scheme" pair, follow the OS. Composes naturally with COLORFGBG broadcast (the broadcast already re-fires on the new bg). Out of scope here.
+- **iTerm2 `.itermcolors` import.** XML plist; trivial to add a second importer once the converted-JSON pipeline is in place.
+- **Export to Alacritty TOML.** Symmetric with import; nice-to-have for users who want to round-trip TBD themes back to other terminals.
+- **Theme search / filter** in the picker once the list grows past ~20 entries.
+


### PR DESCRIPTION
## Summary
- Adds a built-in **terminal color theme editor** plus **Alacritty TOML import**. Users can tweak any of the 15 bundled schemes' 20 color slots (16 ANSI + foreground / background / cursor / selection), Save as a new theme, or Import a `.toml` from popular theme repos (Catppuccin, Rosé Pine, Tokyo Night, etc.). Themes live as JSON files in `~/tbd/terminal-themes/` so they're shareable, dotfile-friendly, and inspectable with `cat`.
- **Clone-on-change** editor flow: the editor is always visible under the picker, touching any field starts an in-memory draft (no upfront "Duplicate" gesture). Picker label gets a "— Draft" suffix; action buttons adapt to source kind (bundled drafts → `[ Save as… ] [ Reset ]`; user-theme drafts → `[ Save ] [ Save as… ] [ Reset ]`). Live preview updates every open terminal pane on each color change. No disk writes during drafting; Save / Save as… commit explicitly. Reset / Discard never touch disk.
- **Source-of-truth is the filesystem.** `ThemeStore` enumerates `~/tbd/terminal-themes/*.json` at launch and watches the dir via `FSEventStream`, so external edits (vim, `cp`, `git pull` of a dotfiles repo) appear in the picker without an app restart. Bundled scheme ids are reserved — a user theme can't shadow `gruvbox-dark`. Deletes soft-move to `.trash/<id>-<timestamp>.json`. If the active theme file vanishes externally, the renderer falls back to Tango.

## Architecture
- **Data layer** — `UserTerminalTheme` (Codable, hex parsing, conversion to existing `TerminalColorScheme`); `ThemeStore` (load / saveAs / save / delete / FSEvents); `AlacrittyImporter` (TOMLKit-backed, accepts `#rrggbb` and `0xrrggbb` and tolerates missing optional sections).
- **Lookup** — `ColorSchemes.scheme(forID:, store:)` extended to consult `ThemeStore.userThemes` after `bundled`. Bundled wins on collision.
- **Editor** — `TerminalThemeEditorViewModel` (state machine: source kind, draft hex dict, validation, snapshot); `TerminalThemeEditorView` (SwiftUI; hex `TextField` + native `ColorPicker` per slot, ANSI rows as compact swatches).
- **Settings wiring** — `TerminalSettingsView` embeds the editor, owns the Save / Save as / Reset / Delete / Import action row, and prompts on scheme switch when a draft is unsaved. `AppearanceSettings.effectiveScheme` is the single read-site for the renderer; `draftSchemeOverride` powers live preview without committing.
- **COLORFGBG continuity** — the existing PR #225 broadcast picks up user-theme luminance automatically; covered by a new regression test.

## Test plan
- [ ] `swift build` clean; `swift test` green (the one pre-existing `TabBarHitAreaTests` failure is on `origin/main` and unrelated)
- [ ] `scripts/restart.sh` from the worktree
- [ ] Settings → Terminal: editor sits below the picker, shows current scheme's 20 colors
- [ ] Edit any slot → panes update live, picker label shows "— Draft"
- [ ] Save as… "Test Theme" → `~/tbd/terminal-themes/test-theme.json` appears, theme is selected
- [ ] Edit Test Theme, hit Save → file overwrites
- [ ] Pick another scheme while dirty → confirm dialog with Save / Save as… / Discard / Cancel
- [ ] Delete Test Theme → soft-moves to `~/tbd/terminal-themes/.trash/`, scheme reverts to Tango
- [ ] Import… any `Tests/TBDAppTests/Fixtures/alacritty/*.toml` → new theme imports and selects
- [ ] `rm ~/tbd/terminal-themes/<theme>.json` from a shell → FSEvents drops it from the picker within ~1s
- [ ] User-theme selection persists across app restart (init-time `~/tbd/terminal-themes/<id>.json` check)
- [ ] `echo $COLORFGBG` in a new TBD terminal reflects the active theme's bg luminance (`0;15` light, `15;0` dark)

## Deferred to follow-ups (documented in the spec)
- iTerm2 `.itermcolors` and Kitty `.conf` importers
- Export to Alacritty TOML
- Confirm prompts on Settings tab-switch and app-quit (only scheme-switch ships here; needs `NSApplicationDelegateAdaptor` + a TabView binding interceptor)
- Auto-switch theme on macOS appearance change

Spec: `docs/superpowers/specs/2026-05-27-user-custom-terminal-themes-design.md`

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=AC84B81C-955A-4974-A548-8A507AFECDCE)