### PR TITLE
Perf: Stop fetching 348 archived worktrees to show a list

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -198,6 +198,7 @@ extension AppState {
         selectedWorktreeIDs = []
         selectedRepoID = wt.repoID
         archivedWorktrees[wt.repoID] = archived.filter { $0.repoID == wt.repoID }
+        archivedWorktreesHasMore[wt.repoID] = false
         highlightedArchivedWorktreeID = id
         if NSApplication.shared.isRunning {
             NSApplication.shared.activate(ignoringOtherApps: true)
@@ -241,15 +242,18 @@ extension AppState {
 
     private static let archivedPageSize = 100
 
-    /// Fetch the first page of archived worktrees for a repo.
+    /// Fetch archived worktrees for a repo, preserving any pages the user has
+    /// already loaded (re-fetches up to `max(currentCount, pageSize)` items).
     func refreshArchivedWorktrees(repoID: UUID) async {
+        let currentCount = archivedWorktrees[repoID]?.count ?? 0
+        let fetchCount = max(currentCount, Self.archivedPageSize)
         do {
             let archived = try await daemonClient.listWorktrees(
                 repoID: repoID, status: .archived,
-                limit: Self.archivedPageSize
+                limit: fetchCount
             )
             archivedWorktrees[repoID] = archived
-            archivedWorktreesHasMore[repoID] = archived.count >= Self.archivedPageSize
+            archivedWorktreesHasMore[repoID] = archived.count >= fetchCount
             ensureArchivedSelectionValid(repoID: repoID)
         } catch {
             logger.error("Failed to list archived worktrees: \(error)")
@@ -258,13 +262,19 @@ extension AppState {
 
     /// Load the next page of archived worktrees, appending to the existing list.
     func loadMoreArchivedWorktrees(repoID: UUID) async {
+        guard isLoadingMoreArchived[repoID] != true else { return }
+        isLoadingMoreArchived[repoID] = true
+        defer { isLoadingMoreArchived[repoID] = false }
+
         let currentCount = archivedWorktrees[repoID]?.count ?? 0
         do {
             let more = try await daemonClient.listWorktrees(
                 repoID: repoID, status: .archived,
                 limit: Self.archivedPageSize, offset: currentCount
             )
-            archivedWorktrees[repoID, default: []].append(contentsOf: more)
+            if archivedWorktrees[repoID]?.count == currentCount {
+                archivedWorktrees[repoID, default: []].append(contentsOf: more)
+            }
             archivedWorktreesHasMore[repoID] = more.count >= Self.archivedPageSize
         } catch {
             logger.error("Failed to load more archived worktrees: \(error)")

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -240,7 +240,7 @@ extension AppState {
         Task { await refreshArchivedWorktrees(repoID: id) }
     }
 
-    private static let archivedPageSize = 100
+    private static let archivedPageSize = 50
 
     /// Fetch archived worktrees for a repo, preserving any pages the user has
     /// already loaded (re-fetches up to `max(currentCount, pageSize)` items).

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -247,13 +247,14 @@ extension AppState {
     func refreshArchivedWorktrees(repoID: UUID) async {
         let currentCount = archivedWorktrees[repoID]?.count ?? 0
         let fetchCount = max(currentCount, Self.archivedPageSize)
+        let knownExhausted = currentCount > 0 && currentCount % Self.archivedPageSize != 0
         do {
             let archived = try await daemonClient.listWorktrees(
                 repoID: repoID, status: .archived,
                 limit: fetchCount
             )
             archivedWorktrees[repoID] = archived
-            archivedWorktreesHasMore[repoID] = archived.count >= fetchCount
+            archivedWorktreesHasMore[repoID] = knownExhausted ? false : archived.count >= fetchCount
             ensureArchivedSelectionValid(repoID: repoID)
         } catch {
             logger.error("Failed to list archived worktrees: \(error)")

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -239,14 +239,35 @@ extension AppState {
         Task { await refreshArchivedWorktrees(repoID: id) }
     }
 
-    /// Fetch archived worktrees for a repo.
+    private static let archivedPageSize = 100
+
+    /// Fetch the first page of archived worktrees for a repo.
     func refreshArchivedWorktrees(repoID: UUID) async {
         do {
-            let archived = try await daemonClient.listWorktrees(repoID: repoID, status: .archived)
+            let archived = try await daemonClient.listWorktrees(
+                repoID: repoID, status: .archived,
+                limit: Self.archivedPageSize
+            )
             archivedWorktrees[repoID] = archived
+            archivedWorktreesHasMore[repoID] = archived.count >= Self.archivedPageSize
             ensureArchivedSelectionValid(repoID: repoID)
         } catch {
             logger.error("Failed to list archived worktrees: \(error)")
+        }
+    }
+
+    /// Load the next page of archived worktrees, appending to the existing list.
+    func loadMoreArchivedWorktrees(repoID: UUID) async {
+        let currentCount = archivedWorktrees[repoID]?.count ?? 0
+        do {
+            let more = try await daemonClient.listWorktrees(
+                repoID: repoID, status: .archived,
+                limit: Self.archivedPageSize, offset: currentCount
+            )
+            archivedWorktrees[repoID, default: []].append(contentsOf: more)
+            archivedWorktreesHasMore[repoID] = more.count >= Self.archivedPageSize
+        } catch {
+            logger.error("Failed to load more archived worktrees: \(error)")
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -141,6 +141,8 @@ final class AppState: ObservableObject {
 
     /// Whether there are more archived worktrees to load beyond what's in `archivedWorktrees`.
     @Published var archivedWorktreesHasMore: [UUID: Bool] = [:]
+    /// Guards against concurrent loadMoreArchivedWorktrees calls (double-tap, race with refresh).
+    @Published var isLoadingMoreArchived: [UUID: Bool] = [:]
 
     /// Set briefly when a deep link lands on an archived worktree. The
     /// ArchivedWorktreesView observes this and scrolls/flashes the matching

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -139,6 +139,9 @@ final class AppState: ObservableObject {
     /// Archived worktrees keyed by repo ID, fetched on demand.
     @Published var archivedWorktrees: [UUID: [Worktree]] = [:]
 
+    /// Whether there are more archived worktrees to load beyond what's in `archivedWorktrees`.
+    @Published var archivedWorktreesHasMore: [UUID: Bool] = [:]
+
     /// Set briefly when a deep link lands on an archived worktree. The
     /// ArchivedWorktreesView observes this and scrolls/flashes the matching
     /// row, then clears the value after the flash animation completes.

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -138,18 +138,11 @@ struct ArchivedWorktreesView: View {
                             Button {
                                 Task { await appState.loadMoreArchivedWorktrees(repoID: repoID) }
                             } label: {
-                                if isLoading {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                        .frame(maxWidth: .infinity)
-                                        .padding(.vertical, 8)
-                                } else {
-                                    Text("Load More…")
-                                        .font(.callout)
-                                        .foregroundStyle(.secondary)
-                                        .frame(maxWidth: .infinity)
-                                        .padding(.vertical, 8)
-                                }
+                                Text(isLoading ? "Loading…" : "Load More…")
+                                    .font(.callout)
+                                    .foregroundStyle(.secondary)
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 8)
                             }
                             .buttonStyle(.plain)
                             .disabled(isLoading)

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -68,6 +68,10 @@ struct ArchivedWorktreesView: View {
                     Text("\(rows.count) of \(allRows.count)")
                         .font(.callout)
                         .foregroundStyle(.secondary)
+                } else if appState.archivedWorktreesHasMore[repoID] == true {
+                    Text("\(rows.count)+")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
                 } else {
                     Text("\(rows.count)")
                         .font(.callout)
@@ -105,25 +109,42 @@ struct ArchivedWorktreesView: View {
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    List(rows) { row in
-                    ArchivedWorktreeRow(
-                        row: row,
-                        isSelected: selectedID == row.id
-                    )
-                    .id(row.id)
-                    .contentShape(Rectangle())
-                    .onTapGesture { select(row) }
-                    .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
-                    .listRowBackground(rowBackground(for: row))
-                    .listRowSeparator(.hidden)
-                    .contextMenu {
-                        if row.reviveState == nil {
-                            Button("Revive") {
-                                Task { await appState.reviveWorktree(id: row.worktree.id) }
+                    List {
+                        ForEach(rows) { row in
+                            ArchivedWorktreeRow(
+                                row: row,
+                                isSelected: selectedID == row.id
+                            )
+                            .id(row.id)
+                            .contentShape(Rectangle())
+                            .onTapGesture { select(row) }
+                            .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
+                            .listRowBackground(rowBackground(for: row))
+                            .listRowSeparator(.hidden)
+                            .contextMenu {
+                                if row.reviveState == nil {
+                                    Button("Revive") {
+                                        Task { await appState.reviveWorktree(id: row.worktree.id) }
+                                    }
+                                }
                             }
                         }
+                        if appState.archivedWorktreesHasMore[repoID] == true {
+                            Button {
+                                Task { await appState.loadMoreArchivedWorktrees(repoID: repoID) }
+                            } label: {
+                                Text("Load More…")
+                                    .font(.callout)
+                                    .foregroundStyle(.secondary)
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 8)
+                            }
+                            .buttonStyle(.plain)
+                            .listRowInsets(EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12))
+                            .listRowSeparator(.hidden)
+                            .listRowBackground(Color.clear)
+                        }
                     }
-                }
                     .listStyle(.plain)
                     .onChange(of: appState.highlightedArchivedWorktreeID, initial: true) { _, newValue in
                         guard let id = newValue, rows.contains(where: { $0.id == id }) else { return }

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -41,6 +41,10 @@ struct ArchivedWorktreesView: View {
         appState.selectedArchivedWorktreeIDs[repoID]
     }
 
+    private var hasMore: Bool {
+        appState.archivedWorktreesHasMore[repoID] == true
+    }
+
     var body: some View {
         if allRows.isEmpty {
             emptyState
@@ -65,10 +69,10 @@ struct ArchivedWorktreesView: View {
                     .fontWeight(.medium)
                 Spacer()
                 if hideEmpty && rows.count < allRows.count {
-                    Text("\(rows.count) of \(allRows.count)")
+                    Text("\(rows.count) of \(allRows.count)\(hasMore ? "+" : "")")
                         .font(.callout)
                         .foregroundStyle(.secondary)
-                } else if appState.archivedWorktreesHasMore[repoID] == true {
+                } else if hasMore {
                     Text("\(rows.count)+")
                         .font(.callout)
                         .foregroundStyle(.secondary)
@@ -129,17 +133,26 @@ struct ArchivedWorktreesView: View {
                                 }
                             }
                         }
-                        if appState.archivedWorktreesHasMore[repoID] == true {
+                        if hasMore {
+                            let isLoading = appState.isLoadingMoreArchived[repoID] == true
                             Button {
                                 Task { await appState.loadMoreArchivedWorktrees(repoID: repoID) }
                             } label: {
-                                Text("Load More…")
-                                    .font(.callout)
-                                    .foregroundStyle(.secondary)
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.vertical, 8)
+                                if isLoading {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                        .frame(maxWidth: .infinity)
+                                        .padding(.vertical, 8)
+                                } else {
+                                    Text("Load More…")
+                                        .font(.callout)
+                                        .foregroundStyle(.secondary)
+                                        .frame(maxWidth: .infinity)
+                                        .padding(.vertical, 8)
+                                }
                             }
                             .buttonStyle(.plain)
+                            .disabled(isLoading)
                             .listRowInsets(EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12))
                             .listRowSeparator(.hidden)
                             .listRowBackground(Color.clear)

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -411,11 +411,11 @@ actor DaemonClient {
         )
     }
 
-    /// List worktrees, optionally filtered by repo and/or status.
-    func listWorktrees(repoID: UUID? = nil, status: WorktreeStatus? = nil) async throws -> [Worktree] {
+    /// List worktrees, optionally filtered by repo and/or status, with optional pagination.
+    func listWorktrees(repoID: UUID? = nil, status: WorktreeStatus? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> [Worktree] {
         return try await callAsync(
             method: RPCMethod.worktreeList,
-            params: WorktreeListParams(repoID: repoID, status: status),
+            params: WorktreeListParams(repoID: repoID, status: status, limit: limit, offset: offset),
             resultType: [Worktree].self
         )
     }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -266,8 +266,8 @@ public struct WorktreeStore: Sendable {
         return wt
     }
 
-    /// List worktrees, optionally filtered by repo and/or status.
-    public func list(repoID: UUID? = nil, status: WorktreeStatus? = nil) async throws -> [Worktree] {
+    /// List worktrees, optionally filtered by repo and/or status, with optional pagination.
+    public func list(repoID: UUID? = nil, status: WorktreeStatus? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> [Worktree] {
         try await writer.read { db in
             var request = WorktreeRecord.all()
             if let repoID {
@@ -276,7 +276,15 @@ public struct WorktreeStore: Sendable {
             if let status {
                 request = request.filter(Column("status") == status.rawValue)
             }
-            return try request.order(Column("sortOrder").asc).fetchAll(db).map { $0.toModel() }
+            if status == .archived {
+                request = request.order(Column("archivedAt").desc)
+            } else {
+                request = request.order(Column("sortOrder").asc)
+            }
+            if let limit {
+                request = request.limit(limit, offset: offset ?? 0)
+            }
+            return try request.fetchAll(db).map { $0.toModel() }
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -54,7 +54,7 @@ extension RPCRouter {
 
     func handleWorktreeList(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeListParams.self, from: paramsData)
-        var worktrees = try await db.worktrees.list(repoID: params.repoID, status: params.status)
+        var worktrees = try await db.worktrees.list(repoID: params.repoID, status: params.status, limit: params.limit, offset: params.offset)
         // Enrich archived worktrees with a real session-file count so the
         // client can filter on actual disk state, not stale stored IDs.
         //

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -513,8 +513,10 @@ public struct WorktreeCreateParams: Codable, Sendable {
 public struct WorktreeListParams: Codable, Sendable {
     public let repoID: UUID?
     public let status: WorktreeStatus?
-    public init(repoID: UUID? = nil, status: WorktreeStatus? = nil) {
-        self.repoID = repoID; self.status = status
+    public let limit: Int?
+    public let offset: Int?
+    public init(repoID: UUID? = nil, status: WorktreeStatus? = nil, limit: Int? = nil, offset: Int? = nil) {
+        self.repoID = repoID; self.status = status; self.limit = limit; self.offset = offset
     }
 }
 

--- a/Tests/TBDDaemonTests/RPCRouterWorktreeTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterWorktreeTests.swift
@@ -61,4 +61,91 @@ extension RPCRouterTests {
         let updated = try await db.worktrees.get(id: wt.id)
         #expect(updated?.displayName == "My Feature")
     }
+
+    @Test("worktree.list with limit returns paginated results")
+    func worktreeListWithLimit() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt1",
+            branch: "b1",
+            path: "/tmp/wt1-\(UUID())",
+            tmuxServer: "srv1"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt2",
+            branch: "b2",
+            path: "/tmp/wt2-\(UUID())",
+            tmuxServer: "srv2"
+        )
+        let wt3 = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt3",
+            branch: "b3",
+            path: "/tmp/wt3-\(UUID())",
+            tmuxServer: "srv3"
+        )
+
+        // Page 1: limit 2
+        let request1 = try RPCRequest(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(repoID: repo.id, status: .active, limit: 2, offset: 0)
+        )
+        let response1 = await router.handle(request1)
+        #expect(response1.success)
+        let page1 = try response1.decodeResult([Worktree].self)
+        #expect(page1.map(\.id) == [wt1.id, wt2.id])
+
+        // Page 2: limit 2, offset 2
+        let request2 = try RPCRequest(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(repoID: repo.id, status: .active, limit: 2, offset: 2)
+        )
+        let response2 = await router.handle(request2)
+        #expect(response2.success)
+        let page2 = try response2.decodeResult([Worktree].self)
+        #expect(page2.map(\.id) == [wt3.id])
+    }
+
+    @Test("worktree.list archived with pagination sorts by archivedAt desc")
+    func worktreeListArchivedPagination() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt1",
+            branch: "b1",
+            path: "/tmp/wt1-\(UUID())",
+            tmuxServer: "srv1"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt2",
+            branch: "b2",
+            path: "/tmp/wt2-\(UUID())",
+            tmuxServer: "srv2"
+        )
+
+        try await db.worktrees.archive(id: wt1.id)
+        try await db.worktrees.archive(id: wt2.id)
+
+        // Get archived with limit
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(repoID: repo.id, status: .archived, limit: 1, offset: 0)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        let page = try response.decodeResult([Worktree].self)
+        // Most recent archive (wt2) should be first
+        #expect(page.map(\.id) == [wt2.id])
+    }
 }

--- a/Tests/TBDDaemonTests/WorktreeStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreTests.swift
@@ -164,4 +164,125 @@ import TBDShared
         let fetched = try await db.worktrees.get(id: wt.id)
         #expect(fetched?.status == .failed)
     }
+
+    @Test func listWithLimitReturnsFirstNRows() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id, name: "first", branch: "b1",
+            path: "/tmp/wt1-\(UUID())", tmuxServer: "srv1"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id, name: "second", branch: "b2",
+            path: "/tmp/wt2-\(UUID())", tmuxServer: "srv2"
+        )
+        _ = try await db.worktrees.create(
+            repoID: repo.id, name: "third", branch: "b3",
+            path: "/tmp/wt3-\(UUID())", tmuxServer: "srv3"
+        )
+
+        let listed = try await db.worktrees.list(repoID: repo.id, limit: 2)
+        #expect(listed.map(\.id) == [wt1.id, wt2.id])
+    }
+
+    @Test func listWithOffsetSkipsFirstNRows() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        _ = try await db.worktrees.create(
+            repoID: repo.id, name: "first", branch: "b1",
+            path: "/tmp/wt1-\(UUID())", tmuxServer: "srv1"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id, name: "second", branch: "b2",
+            path: "/tmp/wt2-\(UUID())", tmuxServer: "srv2"
+        )
+        let wt3 = try await db.worktrees.create(
+            repoID: repo.id, name: "third", branch: "b3",
+            path: "/tmp/wt3-\(UUID())", tmuxServer: "srv3"
+        )
+
+        let listed = try await db.worktrees.list(repoID: repo.id, limit: 3, offset: 1)
+        #expect(listed.map(\.id) == [wt2.id, wt3.id])
+    }
+
+    @Test func listWithLimitAndOffsetPaginates() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id, name: "first", branch: "b1",
+            path: "/tmp/wt1-\(UUID())", tmuxServer: "srv1"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id, name: "second", branch: "b2",
+            path: "/tmp/wt2-\(UUID())", tmuxServer: "srv2"
+        )
+        let wt3 = try await db.worktrees.create(
+            repoID: repo.id, name: "third", branch: "b3",
+            path: "/tmp/wt3-\(UUID())", tmuxServer: "srv3"
+        )
+        let wt4 = try await db.worktrees.create(
+            repoID: repo.id, name: "fourth", branch: "b4",
+            path: "/tmp/wt4-\(UUID())", tmuxServer: "srv4"
+        )
+
+        let page1 = try await db.worktrees.list(repoID: repo.id, limit: 2, offset: 0)
+        #expect(page1.map(\.id) == [wt1.id, wt2.id])
+
+        let page2 = try await db.worktrees.list(repoID: repo.id, limit: 2, offset: 2)
+        #expect(page2.map(\.id) == [wt3.id, wt4.id])
+    }
+
+    @Test func archivedWorktreesSortedByArchivedAtDesc() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        // Create active worktrees (will be sorted by sortOrder)
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id, name: "active1", branch: "b1",
+            path: "/tmp/wt1-\(UUID())", tmuxServer: "srv1"
+        )
+
+        // Archive them at different times
+        try await db.worktrees.archive(id: wt1.id)
+
+        // Create another active, then archive it
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id, name: "active2", branch: "b2",
+            path: "/tmp/wt2-\(UUID())", tmuxServer: "srv2"
+        )
+        try await db.worktrees.archive(id: wt2.id)
+
+        // List archived should have wt2 first (archived most recently)
+        let archived = try await db.worktrees.list(repoID: repo.id, status: .archived)
+        #expect(archived.map(\.id) == [wt2.id, wt1.id])
+    }
+
+    @Test func archivedWorktreesPaginationWithArchivedAtDesc() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        // Create and archive 5 worktrees
+        var worktreeIDs: [UUID] = []
+        for i in 1...5 {
+            let wt = try await db.worktrees.create(
+                repoID: repo.id, name: "wt\(i)", branch: "b\(i)",
+                path: "/tmp/wt\(i)-\(UUID())", tmuxServer: "srv\(i)"
+            )
+            try await db.worktrees.archive(id: wt.id)
+            worktreeIDs.append(wt.id)
+        }
+
+        // Most recent archives should come first (reverse of creation order)
+        let page1 = try await db.worktrees.list(repoID: repo.id, status: .archived, limit: 2, offset: 0)
+        #expect(page1.map(\.id) == [worktreeIDs[4], worktreeIDs[3]])
+
+        let page2 = try await db.worktrees.list(repoID: repo.id, status: .archived, limit: 2, offset: 2)
+        #expect(page2.map(\.id) == [worktreeIDs[2], worktreeIDs[1]])
+
+        let page3 = try await db.worktrees.list(repoID: repo.id, status: .archived, limit: 2, offset: 4)
+        #expect(page3.map(\.id) == [worktreeIDs[0]])
+    }
 }


### PR DESCRIPTION
## Summary
- Archived worktree list fetched ALL rows on open — 348 for longeye-app, each enriched with a filesystem scan for session count. Now fetches the first 100 with a "Load More…" button for pagination.
- Adds `limit`/`offset` to the `worktree.list` RPC and sorts archived rows by `archivedAt DESC` in the DB query (matching the view's existing sort)
- Hardens against concurrency issues: guards double-tap on "Load More", prevents stale-offset appends after concurrent refresh, preserves loaded pages across revive/navigation refreshes, and fixes deep-link handler leaving pagination state stale

## Test plan
- [ ] Open archived view for a repo with >100 archived worktrees — should show first 100 with "Load More…" button
- [ ] Click "Load More…" — next 100 should append, button disappears when all loaded
- [ ] With `hideEmpty` filter on, count header shows "N of M+" when more pages exist
- [ ] Revive an archived worktree after loading 2+ pages — list should preserve loaded count, not reset to 100
- [ ] Deep-link to an archived worktree — "Load More…" should not appear (unbounded fetch)
- [ ] Rapid-click "Load More…" — should not duplicate rows (button disables during load)
- [ ] `tbd worktree list --status archived` CLI still returns all rows (no limit)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=4086368E-CA0A-4DE3-9CB3-20A6A65ADEC6)