### PR TITLE
Fix Codex profile flag compatibility

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -253,8 +253,8 @@ enum CodexProfileWriter {
 
 enum CodexSpawnCommandBuilder {
     private static let detectedProfileFlag = profileFlag(
-        codexHelpOutput: codexCommandOutput(arguments: ["--help"]),
-        codexVersionOutput: codexCommandOutput(arguments: ["--version"])
+        codexHelpOutput: commandOutput(arguments: ["codex", "--help"], timeout: 3),
+        codexVersionOutput: commandOutput(arguments: ["codex", "--version"], timeout: 3)
     )
 
     static var command: String {
@@ -336,25 +336,70 @@ enum CodexSpawnCommandBuilder {
         return nil
     }
 
-    private static func codexCommandOutput(arguments: [String]) -> String? {
+    private final class LockedOutput: @unchecked Sendable {
+        private let lock = NSLock()
+        private var data = Data()
+
+        func append(_ newData: Data) {
+            lock.lock()
+            data.append(newData)
+            lock.unlock()
+        }
+
+        func snapshot() -> Data {
+            lock.lock()
+            defer { lock.unlock() }
+            return data
+        }
+    }
+
+    static func commandOutput(
+        executable: String = "/usr/bin/env",
+        arguments: [String],
+        timeout: TimeInterval
+    ) -> String? {
         let process = Process()
         let stdout = Pipe()
         let stderr = Pipe()
+        let output = LockedOutput()
+        let terminated = DispatchSemaphore(value: 0)
 
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["codex"] + arguments
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
         process.standardOutput = stdout
         process.standardError = stderr
+
+        let appendOutput: @Sendable (FileHandle) -> Void = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            output.append(data)
+        }
+        stdout.fileHandleForReading.readabilityHandler = appendOutput
+        stderr.fileHandleForReading.readabilityHandler = appendOutput
+        process.terminationHandler = { _ in
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
+            appendOutput(stdout.fileHandleForReading)
+            appendOutput(stderr.fileHandleForReading)
+            terminated.signal()
+        }
 
         do {
             try process.run()
         } catch {
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
             return nil
         }
 
-        process.waitUntilExit()
-        let output = stdout.fileHandleForReading.readDataToEndOfFile()
-            + stderr.fileHandleForReading.readDataToEndOfFile()
-        return String(data: output, encoding: .utf8)
+        if terminated.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            _ = terminated.wait(timeout: .now() + 1)
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
+            return nil
+        }
+
+        return String(data: output.snapshot(), encoding: .utf8)
     }
 }

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -252,10 +252,9 @@ enum CodexProfileWriter {
 }
 
 enum CodexSpawnCommandBuilder {
-    private static let detectedProfileFlag = profileFlag(
-        codexHelpOutput: commandOutput(arguments: ["codex", "--help"], timeout: 3),
-        codexVersionOutput: commandOutput(arguments: ["codex", "--version"], timeout: 3)
-    )
+    private static let detectedProfileFlag = detectProfileFlag { arguments in
+        commandOutput(arguments: arguments, timeout: 3)
+    }
 
     static var command: String {
         baseCommand(profileFlag: detectedProfileFlag)
@@ -303,6 +302,18 @@ enum CodexSpawnCommandBuilder {
         }
 
         return "--profile"
+    }
+
+    static func detectProfileFlag(commandOutput: ([String]) -> String?) -> String {
+        let helpOutput = commandOutput(["codex", "--help"])
+        if let helpOutput, helpOutput.contains("--profile-v2") || helpOutput.contains("--profile") {
+            return profileFlag(codexHelpOutput: helpOutput, codexVersionOutput: nil)
+        }
+
+        return profileFlag(
+            codexHelpOutput: helpOutput,
+            codexVersionOutput: commandOutput(["codex", "--version"])
+        )
     }
 
     private struct CodexVersion: Comparable {

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -6,7 +6,7 @@ private let codexLogger = Logger(subsystem: "com.tbd.daemon", category: "codex-i
 
 /// Installs TBD's Codex integration into the user's global Codex home.
 ///
-/// TBD uses the file-backed `codex --profile-v2 tbd` overlay instead of an
+/// TBD uses a file-backed `tbd` Codex profile overlay instead of an
 /// isolated per-repo `CODEX_HOME`, so user auth/config/plugins continue to
 /// merge with TBD's runtime integration while the TBD plugin remains
 /// profile-scoped.
@@ -252,12 +252,109 @@ enum CodexProfileWriter {
 }
 
 enum CodexSpawnCommandBuilder {
-    static let command = "unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox"
+    private static let detectedProfileFlag = profileFlag(
+        codexHelpOutput: codexCommandOutput(arguments: ["--help"]),
+        codexVersionOutput: codexCommandOutput(arguments: ["--version"])
+    )
+
+    static var command: String {
+        baseCommand(profileFlag: detectedProfileFlag)
+    }
 
     static func build(initialPrompt: String?) -> String {
+        build(initialPrompt: initialPrompt, profileFlag: detectedProfileFlag)
+    }
+
+    static func build(
+        initialPrompt: String?,
+        codexHelpOutput: String? = nil,
+        codexVersionOutput: String? = nil
+    ) -> String {
+        build(
+            initialPrompt: initialPrompt,
+            profileFlag: profileFlag(codexHelpOutput: codexHelpOutput, codexVersionOutput: codexVersionOutput)
+        )
+    }
+
+    private static func build(initialPrompt: String?, profileFlag: String) -> String {
+        let command = baseCommand(profileFlag: profileFlag)
         guard let initialPrompt, !initialPrompt.isEmpty else {
             return command
         }
         return "\(command) \(SystemPromptBuilder.shellEscape(initialPrompt))"
+    }
+
+    private static func baseCommand(profileFlag: String) -> String {
+        return "unset CODEX_CI CODEX_THREAD_ID; codex \(profileFlag) tbd --dangerously-bypass-approvals-and-sandbox"
+    }
+
+    static func profileFlag(codexHelpOutput: String?, codexVersionOutput: String?) -> String {
+        if let codexHelpOutput {
+            if codexHelpOutput.contains("--profile-v2") {
+                return "--profile-v2"
+            }
+            if codexHelpOutput.contains("--profile") {
+                return "--profile"
+            }
+        }
+
+        if let version = codexVersion(from: codexVersionOutput) {
+            return version >= CodexVersion(major: 0, minor: 134, patch: 0) ? "--profile" : "--profile-v2"
+        }
+
+        return "--profile"
+    }
+
+    private struct CodexVersion: Comparable {
+        let major: Int
+        let minor: Int
+        let patch: Int
+
+        static func < (lhs: CodexVersion, rhs: CodexVersion) -> Bool {
+            (lhs.major, lhs.minor, lhs.patch) < (rhs.major, rhs.minor, rhs.patch)
+        }
+    }
+
+    private static func codexVersion(from output: String?) -> CodexVersion? {
+        guard let output else { return nil }
+        let scanner = Scanner(string: output)
+        scanner.charactersToBeSkipped = CharacterSet(charactersIn: " \n\t")
+
+        while !scanner.isAtEnd {
+            _ = scanner.scanUpToCharacters(from: .decimalDigits)
+            guard let major = scanner.scanInt(),
+                  scanner.scanString(".") != nil,
+                  let minor = scanner.scanInt(),
+                  scanner.scanString(".") != nil,
+                  let patch = scanner.scanInt()
+            else {
+                continue
+            }
+            return CodexVersion(major: major, minor: minor, patch: patch)
+        }
+
+        return nil
+    }
+
+    private static func codexCommandOutput(arguments: [String]) -> String? {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["codex"] + arguments
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        process.waitUntilExit()
+        let output = stdout.fileHandleForReading.readDataToEndOfFile()
+            + stderr.fileHandleForReading.readDataToEndOfFile()
+        return String(data: output, encoding: .utf8)
     }
 }

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -264,7 +264,17 @@ import TBDShared
     }
 
     @Test func codexSpawnCommandUsesFileBackedProfileOverlay() {
-        #expect(CodexSpawnCommandBuilder.command.contains("codex --profile-v2 tbd"))
-        #expect(!CodexSpawnCommandBuilder.command.contains("codex --profile tbd"))
+        #expect(
+            CodexSpawnCommandBuilder.profileFlag(
+                codexHelpOutput: "      --profile-v2 <CONFIG_PROFILE_V2>",
+                codexVersionOutput: nil
+            ) == "--profile-v2"
+        )
+        #expect(
+            CodexSpawnCommandBuilder.profileFlag(
+                codexHelpOutput: "  -p, --profile <CONFIG_PROFILE_V2>",
+                codexVersionOutput: nil
+            ) == "--profile"
+        )
     }
 }

--- a/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import TBDDaemonLib
 
 @Suite("CodexSpawnCommandBuilder")
@@ -59,5 +60,30 @@ struct CodexSpawnCommandBuilderTests {
             )
                 == "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox 'fix the failing test'"
         )
+    }
+
+    @Test("command output helper returns stdout and stderr")
+    func commandOutputCapturesStdoutAndStderr() {
+        let output = CodexSpawnCommandBuilder.commandOutput(
+            executable: "/bin/sh",
+            arguments: ["-c", "printf stdout; printf stderr >&2"],
+            timeout: 1
+        )
+
+        #expect(output?.contains("stdout") == true)
+        #expect(output?.contains("stderr") == true)
+    }
+
+    @Test("command output helper times out instead of blocking indefinitely")
+    func commandOutputTimesOut() {
+        let start = Date()
+        let output = CodexSpawnCommandBuilder.commandOutput(
+            executable: "/bin/sh",
+            arguments: ["-c", "sleep 5"],
+            timeout: 0.1
+        )
+
+        #expect(output == nil)
+        #expect(Date().timeIntervalSince(start) < 2)
     }
 }

--- a/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
@@ -51,6 +51,35 @@ struct CodexSpawnCommandBuilderTests {
         )
     }
 
+    @Test("runtime detection skips version probe when help identifies the profile flag")
+    func detectionSkipsVersionProbeWhenHelpIsEnough() {
+        var probedArguments: [[String]] = []
+
+        let flag = CodexSpawnCommandBuilder.detectProfileFlag { arguments in
+            probedArguments.append(arguments)
+            return "  -p, --profile <CONFIG_PROFILE_V2>"
+        }
+
+        #expect(flag == "--profile")
+        #expect(probedArguments == [["codex", "--help"]])
+    }
+
+    @Test("runtime detection uses version probe only when help is inconclusive")
+    func detectionUsesVersionProbeWhenHelpIsInconclusive() {
+        var probedArguments: [[String]] = []
+
+        let flag = CodexSpawnCommandBuilder.detectProfileFlag { arguments in
+            probedArguments.append(arguments)
+            if arguments == ["codex", "--version"] {
+                return "codex-cli 0.133.0"
+            }
+            return "Codex CLI"
+        }
+
+        #expect(flag == "--profile-v2")
+        #expect(probedArguments == [["codex", "--help"], ["codex", "--version"]])
+    }
+
     @Test("initial prompt is appended as a shell-escaped trailing argument")
     func appendsInitialPrompt() {
         #expect(

--- a/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
@@ -3,19 +3,61 @@ import Testing
 
 @Suite("CodexSpawnCommandBuilder")
 struct CodexSpawnCommandBuilderTests {
-    @Test("base command remains unchanged when no prompt is supplied")
-    func baseCommand() {
+    @Test("Codex 0.134 and newer use the renamed --profile flag")
+    func modernCodexUsesProfileFlag() {
         #expect(
-            CodexSpawnCommandBuilder.build(initialPrompt: nil)
+            CodexSpawnCommandBuilder.build(
+                initialPrompt: nil,
+                codexHelpOutput: "  -p, --profile <CONFIG_PROFILE_V2>",
+                codexVersionOutput: "codex-cli 0.134.0"
+            )
+                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox"
+        )
+        #expect(
+            CodexSpawnCommandBuilder.build(initialPrompt: nil, codexVersionOutput: "codex-cli 0.135.0-alpha.1")
+                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox"
+        )
+    }
+
+    @Test("profile-v2 help takes precedence because older Codex uses --profile for legacy profiles")
+    func helpWithProfileV2UsesProfileV2EvenWhenProfileAlsoExists() {
+        #expect(
+            CodexSpawnCommandBuilder.build(
+                initialPrompt: nil,
+                codexHelpOutput: """
+                  -p, --profile <CONFIG_PROFILE>
+                      --profile-v2 <CONFIG_PROFILE_V2>
+                """,
+                codexVersionOutput: nil
+            )
                 == "unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox"
+        )
+    }
+
+    @Test("Codex before 0.134 uses the legacy --profile-v2 flag")
+    func olderCodexUsesProfileV2Flag() {
+        #expect(
+            CodexSpawnCommandBuilder.build(initialPrompt: nil, codexVersionOutput: "codex-cli 0.133.0")
+                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox"
+        )
+    }
+
+    @Test("missing Codex version output falls back to the current --profile flag")
+    func missingVersionFallsBackToProfileFlag() {
+        #expect(
+            CodexSpawnCommandBuilder.build(initialPrompt: nil, codexVersionOutput: nil)
+                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox"
         )
     }
 
     @Test("initial prompt is appended as a shell-escaped trailing argument")
     func appendsInitialPrompt() {
         #expect(
-            CodexSpawnCommandBuilder.build(initialPrompt: "fix the failing test")
-                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox 'fix the failing test'"
+            CodexSpawnCommandBuilder.build(
+                initialPrompt: "fix the failing test",
+                codexVersionOutput: "codex-cli 0.134.0"
+            )
+                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox 'fix the failing test'"
         )
     }
 }

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -41,6 +41,11 @@ private func newWindowBodies(_ recorded: [[String]]) -> [String] {
     }
 }
 
+private func containsCodexProfileLaunch(_ body: String) -> Bool {
+    body.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox")
+        || body.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox")
+}
+
 private let codexTestHomePath: String = {
     let path = FileManager.default.temporaryDirectory
         .appendingPathComponent("tbd-codex-home-tests-\(UUID().uuidString)", isDirectory: true)
@@ -183,7 +188,7 @@ func testRecreateAfterRebootCodexBranchSetsWorktreeID() async throws {
     #expect(bodies.contains { $0.contains("export CODEX_HOME=") },
             "codex-branch must still export CODEX_HOME; got bodies: \(bodies)")
     #expect(bodies.contains {
-        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox")
+        containsCodexProfileLaunch($0)
     }, "codex-branch must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "codex-branch must not use removed --full-auto flag; got bodies: \(bodies)")
@@ -375,7 +380,7 @@ func testHandleTerminalRecreateWindowCodexLaunchCommand() async throws {
 
     let bodies = newWindowBodies(recorded.snapshot())
     #expect(bodies.contains {
-        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox")
+        containsCodexProfileLaunch($0)
     }, "recreated codex tab must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "recreated codex tab must not use removed --full-auto flag; got bodies: \(bodies)")
@@ -550,7 +555,7 @@ func testHandleTerminalCreateCodexLaunchCommand() async throws {
     #expect(bodies.contains { $0.contains("export CODEX_HOME=") },
             "created codex tab must export CODEX_HOME; got bodies: \(bodies)")
     #expect(bodies.contains {
-        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox")
+        containsCodexProfileLaunch($0)
     }, "created codex tab must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "created codex tab must not use removed --full-auto flag; got bodies: \(bodies)")
@@ -601,6 +606,6 @@ func testHandleTerminalCreateCodexInitialPrompt() async throws {
 
     let bodies = newWindowBodies(recorded.snapshot())
     #expect(bodies.contains {
-        $0.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox 'don'\\''t ship regressions'")
+        containsCodexProfileLaunch($0) && $0.contains("'don'\\''t ship regressions'")
     }, "fresh codex tab must append the initial prompt as a shell-escaped positional argument; got bodies: \(bodies)")
 }


### PR DESCRIPTION
## Summary
- Detect the supported Codex profile flag from `codex --help`, preferring `--profile-v2` when available for pre-0.134 profile-v2 support.
- Fall back to `codex --version` with the 0.134.0 rename boundary, then default to current `--profile` behavior if probing fails.
- Update Codex spawn tests to cover old and new flag behavior without pinning higher-level tests to one installed CLI generation.

## Background
Codex CLI renamed the profile-v2 selector in the 0.134.0 release. The release notes include `cli: rename profile v2 flag to --profile` and list `--profile` as the primary selector for config profiles.

Relevant upstream links:
- Codex releases: https://github.com/openai/codex/releases
- Rename PR: https://github.com/openai/codex/pull/23883
- 0.133.0 source, before the rename: https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/utils/cli/src/shared_options.rs
- 0.134.0 source, after the rename: https://github.com/openai/codex/blob/rust-v0.134.0/codex-rs/utils/cli/src/shared_options.rs

## Compatibility Strategy
This uses capability detection first instead of pure version detection. Older Codex builds can expose both `--profile` and `--profile-v2`, but in those builds `--profile` refers to the legacy profile path while TBD needs the profile-v2 overlay. Checking for `--profile-v2` in `codex --help` is therefore the safer discriminator.

Fallback behavior:
- `codex --help` contains `--profile-v2` → use `--profile-v2 tbd`
- otherwise `codex --help` contains `--profile` → use `--profile tbd`
- if help probing fails, parse `codex --version`
- `>= 0.134.0` → use `--profile tbd`
- `< 0.134.0` → use `--profile-v2 tbd`
- if both probes fail, default to current `--profile` behavior

## Local Evidence
On the currently installed CLI:
- `codex --version` reports `codex-cli 0.134.0`
- `codex --profile tbd --help` exits 0
- `codex --profile-v2 tbd --help` exits 2 with `unexpected argument '--profile-v2'` and suggests `--profile`

## Test Plan
- `codex --profile tbd --help`
- `codex --profile-v2 tbd --help`
- `swift test --filter CodexSpawnCommandBuilderTests`
- `swift test --filter TBDWorktreeIDLeakTests`
- `swift test --filter CodexHookOverlayTests`
- `swift build`
- `swift test`