### PR TITLE
feat: add existing branch as worktree via option-click

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -13,14 +13,28 @@ extension AppState {
     /// real worktree once the daemon responds.
     /// When `parentWorktreeID` is non-nil, the new worktree is created as a
     /// nested child of that worktree (must be in the same repo).
-    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil) {
-        // Optimistic placeholder so the row appears instantly
-        let placeholderName = NameGenerator.generate()
+    /// When `existingBranch` is non-nil, the daemon checks out that branch
+    /// into a new worktree (no auto-generated `tbd/*` branch); the optimistic
+    /// placeholder uses the branch's local name so the row looks right
+    /// immediately.
+    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil, existingBranch: BranchInfo? = nil) {
+        // Optimistic placeholder so the row appears instantly. When picking an
+        // existing branch we use its local name so the placeholder name
+        // doesn't briefly show a fake `tbd/*` value.
+        let placeholderName: String
+        let placeholderBranch: String
+        if let existingBranch {
+            placeholderName = existingBranch.localName
+            placeholderBranch = existingBranch.localName
+        } else {
+            placeholderName = NameGenerator.generate()
+            placeholderBranch = "tbd/\(placeholderName)"
+        }
         let placeholder = Worktree(
             repoID: repoID,
             name: placeholderName,
             displayName: placeholderName,
-            branch: "tbd/\(placeholderName)",
+            branch: placeholderBranch,
             path: "",
             status: .creating,
             tmuxServer: "",
@@ -36,8 +50,11 @@ extension AppState {
             do {
                 let size = mainAreaTerminalSize()
                 let wt = try await daemonClient.createWorktree(
-                    repoID: repoID, cols: size.cols, rows: size.rows,
-                    parentWorktreeID: parentWorktreeID
+                    repoID: repoID,
+                    branch: existingBranch?.name,
+                    cols: size.cols, rows: size.rows,
+                    parentWorktreeID: parentWorktreeID,
+                    useExistingBranch: existingBranch != nil
                 )
                 // Replace the placeholder with the real worktree
                 if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == placeholder.id }) {
@@ -51,6 +68,18 @@ extension AppState {
                 logger.error("Failed to create worktree: \(error)")
                 handleConnectionError(error)
             }
+        }
+    }
+
+    /// List local + remote tracking branches for a repo, for the existing-
+    /// branch picker on the sidebar `+` button.
+    func listBranches(repoID: UUID) async -> [BranchInfo] {
+        do {
+            return try await daemonClient.listBranches(repoID: repoID)
+        } catch {
+            logger.error("Failed to list branches: \(error)")
+            handleConnectionError(error)
+            return []
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -72,14 +72,15 @@ extension AppState {
     }
 
     /// List local + remote tracking branches for a repo, for the existing-
-    /// branch picker on the sidebar `+` button.
-    func listBranches(repoID: UUID) async -> [BranchInfo] {
+    /// branch picker on the sidebar `+` button. Rethrows so the picker can
+    /// distinguish a fetch failure from a genuinely empty branch list.
+    func listBranches(repoID: UUID) async throws -> [BranchInfo] {
         do {
             return try await daemonClient.listBranches(repoID: repoID)
         } catch {
             logger.error("Failed to list branches: \(error)")
             handleConnectionError(error)
-            return []
+            throw error
         }
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -403,12 +403,26 @@ actor DaemonClient {
     }
 
     /// Create a new worktree in a repo.
-    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil) async throws -> Worktree {
+    /// When `useExistingBranch` is true, `branch` MUST be set to an existing
+    /// ref name (local like `foo` or remote like `origin/foo`) — the daemon
+    /// checks it out instead of creating a new `tbd/*` branch.
+    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, useExistingBranch: Bool = false) async throws -> Worktree {
         return try await callAsync(
             method: RPCMethod.worktreeCreate,
-            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID),
+            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID, useExistingBranch: useExistingBranch),
             resultType: Worktree.self
         )
+    }
+
+    /// List local + `origin/*` branches for a repo. Used by the existing-
+    /// branch picker on the sidebar `+` button.
+    func listBranches(repoID: UUID) async throws -> [BranchInfo] {
+        let result = try await callAsync(
+            method: RPCMethod.repoListBranches,
+            params: RepoListBranchesParams(repoID: repoID),
+            resultType: RepoListBranchesResult.self
+        )
+        return result.branches
     }
 
     /// List worktrees, optionally filtered by repo and/or status, with optional pagination.

--- a/Sources/TBDApp/Sidebar/BranchPickerView.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+import TBDShared
+
+/// Popover content rendered when the user option-clicks the `+` button next
+/// to a repo in the sidebar. Lists local + `origin/*` branches with a
+/// text-field filter; selecting one creates a worktree from that existing
+/// branch instead of auto-generating a `tbd/*` name.
+struct BranchPickerView: View {
+    let repoID: UUID
+    @EnvironmentObject var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var branches: [BranchInfo] = []
+    @State private var query: String = ""
+    @State private var isLoading: Bool = true
+    @FocusState private var searchFocused: Bool
+
+    private var filteredBranches: [BranchInfo] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces).lowercased()
+        if trimmed.isEmpty { return branches }
+        return branches.filter { branch in
+            branch.name.lowercased().contains(trimmed) ||
+                branch.localName.lowercased().contains(trimmed)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TextField("Filter branches", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .focused($searchFocused)
+                .padding(8)
+                .onSubmit { selectFirstMatch() }
+
+            Divider()
+
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                    Spacer()
+                }
+                .padding(16)
+            } else if filteredBranches.isEmpty {
+                Text(branches.isEmpty ? "No branches found" : "No matches")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(16)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(filteredBranches) { branch in
+                            BranchPickerRow(branch: branch) {
+                                pick(branch)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .frame(width: 300, height: 400)
+        .task {
+            isLoading = true
+            branches = await appState.listBranches(repoID: repoID)
+            isLoading = false
+            searchFocused = true
+        }
+    }
+
+    private func pick(_ branch: BranchInfo) {
+        dismiss()
+        appState.createWorktree(repoID: repoID, existingBranch: branch)
+    }
+
+    private func selectFirstMatch() {
+        if let first = filteredBranches.first {
+            pick(first)
+        }
+    }
+}
+
+private struct BranchPickerRow: View {
+    let branch: BranchInfo
+    let onSelect: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 6) {
+                Image(systemName: branch.isRemote ? "cloud" : "arrow.triangle.branch")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14)
+                Text(branch.name)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 4)
+                if branch.isCurrent {
+                    Text("current")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(Color.secondary.opacity(0.15))
+                        )
+                } else if branch.isRemote {
+                    Text("remote")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(Color.secondary.opacity(0.10))
+                        )
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isHovered ? Color.accentColor.opacity(0.15) : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}

--- a/Sources/TBDApp/Sidebar/BranchPickerView.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerView.swift
@@ -13,6 +13,7 @@ struct BranchPickerView: View {
     @State private var branches: [BranchInfo] = []
     @State private var query: String = ""
     @State private var isLoading: Bool = true
+    @State private var loadError: Bool = false
     @FocusState private var searchFocused: Bool
 
     private var filteredBranches: [BranchInfo] {
@@ -43,7 +44,7 @@ struct BranchPickerView: View {
                 }
                 .padding(16)
             } else if filteredBranches.isEmpty {
-                Text(branches.isEmpty ? "No branches found" : "No matches")
+                Text(emptyStateMessage)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .padding(16)
@@ -62,10 +63,24 @@ struct BranchPickerView: View {
         .frame(width: 300, height: 400)
         .task {
             isLoading = true
-            branches = await appState.listBranches(repoID: repoID)
+            loadError = false
+            do {
+                branches = try await appState.listBranches(repoID: repoID)
+            } catch {
+                loadError = true
+            }
             isLoading = false
             searchFocused = true
         }
+    }
+
+    /// Distinguish "we tried and failed to load" from a query-filtered empty
+    /// state or a genuinely empty repo, so the user can tell a load failure
+    /// apart from "no matching branches".
+    private var emptyStateMessage: String {
+        if !branches.isEmpty { return "No matches" }
+        if loadError { return "Failed to load branches" }
+        return "No branches found"
     }
 
     private func pick(_ branch: BranchInfo) {
@@ -98,17 +113,7 @@ private struct BranchPickerRow: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
                 Spacer(minLength: 4)
-                if branch.isCurrent {
-                    Text("current")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
-                        .background(
-                            RoundedRectangle(cornerRadius: 3)
-                                .fill(Color.secondary.opacity(0.15))
-                        )
-                } else if branch.isRemote {
+                if branch.isRemote {
                     Text("remote")
                         .font(.system(size: 10))
                         .foregroundStyle(.secondary)

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -33,6 +33,7 @@ struct RepoSectionView: View {
     @State private var isChevronHovered = false
     @State private var hoverDebounceTask: Task<Void, Error>?
     @State private var showRemoveConfirm = false
+    @State private var showBranchPicker = false
 
     private func onSectionHoverChange(_ hovering: Bool) {
         if hovering {
@@ -133,15 +134,19 @@ struct RepoSectionView: View {
             Spacer()
 
             Group {
-                if isSectionHovered {
-                    Button(action: createWorktree) {
+                if isSectionHovered || showBranchPicker {
+                    Button(action: handlePlusButton) {
                         Image(systemName: "plus")
                             .font(.caption)
                             .frame(width: 20, height: 20)
                     }
                     .buttonStyle(HoverPressButtonStyle())
-                    .help("New worktree")
+                    .help("New worktree (\u{2325}-click to pick existing branch)")
                     .disabled(repo.status == .missing)
+                    .popover(isPresented: $showBranchPicker, arrowEdge: .trailing) {
+                        BranchPickerView(repoID: repo.id)
+                            .environmentObject(appState)
+                    }
                 } else {
                     Color.clear
                 }
@@ -213,6 +218,16 @@ struct RepoSectionView: View {
                     toOffset: destination
                 )
             }
+        }
+    }
+
+    private func handlePlusButton() {
+        // Option-click opens the existing-branch picker; plain click creates
+        // a fresh `tbd/*` worktree (existing behavior).
+        if NSEvent.modifierFlags.contains(.option) {
+            showBranchPicker = true
+        } else {
+            createWorktree()
         }
     }
 

--- a/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
+++ b/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
@@ -10,10 +10,15 @@ import TBDShared
 /// 1. Read the Stop hook JSON payload from stdin.
 /// 2. Resolve the worktree for `cwd` via the daemon.
 /// 3. Skip if status is .main, displayName != name (already customized),
-///    branch doesn't start with `tbd/`, or we've already fired > 2 times
-///    this session.
+///    the current branch can't be resolved, or we've already fired > 2
+///    times this session.
 /// 4. Otherwise emit `{"decision":"block","reason":"<directive>"}` so
-///    the agent stays in-turn and sees the directive.
+///    the agent stays in-turn and sees the directive. The directive shape
+///    depends on the branch: `tbd/*` branches are auto-generated and the
+///    directive suggests renaming both the branch and the display name;
+///    non-`tbd/*` branches were chosen deliberately (and may be shared
+///    with collaborators), so the directive only suggests renaming the
+///    display name.
 struct StopRenameCheckCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "stop-rename-check",
@@ -150,8 +155,9 @@ enum StopRenameCheckCore {
             return nil
         }
 
-        // 3c. Branch must be tbd/<...> for us to suggest renaming it.
-        guard let branch = dependencies.fetchBranch(cwd), branch.hasPrefix("tbd/") else {
+        // 3c. Resolve the branch. Skip silently on git failure; the directive
+        // shape downstream branches on whether it starts with `tbd/`.
+        guard let branch = dependencies.fetchBranch(cwd) else {
             return nil
         }
 
@@ -193,8 +199,21 @@ enum StopRenameCheckCore {
     }
 
     /// Build the directive shown to the agent. Mirrors the spec verbatim
-    /// except for branch/folder substitution.
+    /// except for branch/folder substitution. `tbd/*` branches are
+    /// auto-generated and safe to rename; other branches were chosen
+    /// deliberately and may be shared with collaborators, so we only
+    /// suggest renaming the display name.
     static func buildDirective(branch: String, folder: String) -> String {
+        if branch.hasPrefix("tbd/") {
+            return tbdBranchDirective(branch: branch, folder: folder)
+        } else {
+            return displayOnlyDirective(branch: branch, folder: folder)
+        }
+    }
+
+    /// Directive for auto-generated `tbd/*` branches: suggest renaming both
+    /// the branch and the display name.
+    static func tbdBranchDirective(branch: String, folder: String) -> String {
         """
         Before stopping: this worktree is still named \(branch). Now that the work is done, rename it to reflect what was accomplished:
 
@@ -208,6 +227,28 @@ enum StopRenameCheckCore {
         Examples:
           fix-login-timeout  →  ⏱ Fix Login Timeout
           add-export-csv     →  📊 Add Export CSV
+
+        Then you may stop.
+        """
+    }
+
+    /// Directive for branches that already had a meaningful name (created
+    /// from an existing branch, not auto-generated). Only suggests renaming
+    /// the display name — the branch is left alone.
+    static func displayOnlyDirective(branch: String, folder: String) -> String {
+        """
+        Before stopping: the worktree folder is still named "\(folder)". Now that the work is done, rename it to reflect what was accomplished:
+
+          tbd worktree rename \(folder) "<emoji> <Title Case>"
+
+        Format:
+          Display: a relevant emoji + a Title Case summary, under ~30 chars.
+
+        Examples:
+          ⏱ Fix Login Timeout
+          📊 Add Export CSV
+
+        The branch (\(branch)) is intentionally not renamed — it may be shared with others.
 
         Then you may stop.
         """

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -227,12 +227,15 @@ public struct GitManager: Sendable {
     /// Dedupe rule: when a local branch and a remote `origin/<same>` both exist,
     /// the remote duplicate is dropped — the local branch is more directly
     /// usable for creating a worktree (`git worktree add <path> <branch>`).
-    /// Skips `origin/HEAD` (it's an alias, not a real branch).
+    /// Skips symbolic refs like `origin/HEAD` (an alias, not a real branch).
     public func listBranches(repoPath: String) async throws -> [BranchRef] {
+        // %(symref) is non-empty for symbolic refs (e.g. refs/remotes/origin/HEAD,
+        // which short-names to bare "origin"). Filtering by symref catches it
+        // regardless of how the short name renders.
         let output = try await run(
             arguments: [
                 "for-each-ref",
-                "--format=%(refname:short)|%(HEAD)",
+                "--format=%(refname:short)|%(HEAD)|%(symref)",
                 "refs/heads",
                 "refs/remotes/origin",
             ],
@@ -245,14 +248,15 @@ public struct GitManager: Sendable {
         for line in output.components(separatedBy: "\n") {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if trimmed.isEmpty { continue }
-            // for-each-ref format: "<name>|<HEAD-marker>" where HEAD-marker is
-            // "*" for the current branch, " " (space) otherwise.
-            let parts = trimmed.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
+            // for-each-ref format: "<name>|<HEAD-marker>|<symref>" where
+            // HEAD-marker is "*" for the current branch (space otherwise), and
+            // symref is the target ref for symbolic refs (empty for normal branches).
+            let parts = trimmed.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
             guard let nameSlice = parts.first else { continue }
             let name = String(nameSlice)
             if name.isEmpty { continue }
-            // Skip the origin/HEAD alias — it's not a real branch.
-            if name == "origin/HEAD" { continue }
+            let symref = parts.count > 2 ? String(parts[2]).trimmingCharacters(in: .whitespaces) : ""
+            if !symref.isEmpty { continue }
             let headMarker = parts.count > 1 ? String(parts[1]) : ""
             let isCurrent = headMarker.trimmingCharacters(in: .whitespaces) == "*"
             let isRemote = name.hasPrefix("origin/")

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -222,12 +222,16 @@ public struct GitManager: Sendable {
         _ = try await run(arguments: ["worktree", "prune"], at: repoPath)
     }
 
-    /// Lists local branches and `origin/*` remote tracking branches.
+    /// Lists local branches and `origin/*` remote tracking branches that are
+    /// available to check out into a new worktree.
     ///
-    /// Dedupe rule: when a local branch and a remote `origin/<same>` both exist,
-    /// the remote duplicate is dropped — the local branch is more directly
-    /// usable for creating a worktree (`git worktree add <path> <branch>`).
-    /// Skips symbolic refs like `origin/HEAD` (an alias, not a real branch).
+    /// Filtering:
+    /// - Symbolic refs like `origin/HEAD` are skipped (they're aliases).
+    /// - Branches already checked out in any worktree are skipped — git refuses
+    ///   to check the same branch out twice, and for a remote ref `origin/foo`
+    ///   we'd `-b foo` which would also collide.
+    /// - When a local `foo` and `origin/foo` both exist, the remote duplicate
+    ///   is dropped — the local is directly usable via `git worktree add <path> <branch>`.
     public func listBranches(repoPath: String) async throws -> [BranchRef] {
         // %(symref) is non-empty for symbolic refs (e.g. refs/remotes/origin/HEAD,
         // which short-names to bare "origin"). Filtering by symref catches it
@@ -240,6 +244,14 @@ public struct GitManager: Sendable {
                 "refs/remotes/origin",
             ],
             at: repoPath
+        )
+
+        // Branches already checked out in any worktree (main repo + linked
+        // worktrees) — git rejects a second checkout of the same branch.
+        let inUse = Set(
+            (try? await worktreeList(repoPath: repoPath))?
+                .map(\.branch)
+                .filter { !$0.isEmpty } ?? []
         )
 
         var refs: [BranchRef] = []
@@ -267,6 +279,9 @@ public struct GitManager: Sendable {
                 localName = name
                 localNames.insert(name)
             }
+            // Drop branches already checked out somewhere — applies to local
+            // refs directly, and to remote refs whose local counterpart is taken.
+            if inUse.contains(localName) { continue }
             refs.append(BranchRef(
                 name: name,
                 isRemote: isRemote,

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -12,14 +12,11 @@ public struct BranchRef: Sendable, Equatable {
     public let isRemote: Bool
     /// For remote: stripped of the `origin/` prefix. For local: same as `name`.
     public let localName: String
-    /// True for the currently checked-out local branch (per `git for-each-ref`'s `%(HEAD)`).
-    public let isCurrent: Bool
 
-    public init(name: String, isRemote: Bool, localName: String, isCurrent: Bool) {
+    public init(name: String, isRemote: Bool, localName: String) {
         self.name = name
         self.isRemote = isRemote
         self.localName = localName
-        self.isCurrent = isCurrent
     }
 }
 
@@ -239,7 +236,7 @@ public struct GitManager: Sendable {
         let output = try await run(
             arguments: [
                 "for-each-ref",
-                "--format=%(refname:short)|%(HEAD)|%(symref)",
+                "--format=%(refname:short)|%(symref)",
                 "refs/heads",
                 "refs/remotes/origin",
             ],
@@ -248,10 +245,12 @@ public struct GitManager: Sendable {
 
         // Branches already checked out in any worktree (main repo + linked
         // worktrees) — git rejects a second checkout of the same branch.
+        // Errors propagate: a silent failure here would leak in-use branches
+        // and the user would see a confusing `git worktree add` failure later.
         let inUse = Set(
-            (try? await worktreeList(repoPath: repoPath))?
+            try await worktreeList(repoPath: repoPath)
                 .map(\.branch)
-                .filter { !$0.isEmpty } ?? []
+                .filter { !$0.isEmpty }
         )
 
         var refs: [BranchRef] = []
@@ -260,17 +259,14 @@ public struct GitManager: Sendable {
         for line in output.components(separatedBy: "\n") {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             if trimmed.isEmpty { continue }
-            // for-each-ref format: "<name>|<HEAD-marker>|<symref>" where
-            // HEAD-marker is "*" for the current branch (space otherwise), and
-            // symref is the target ref for symbolic refs (empty for normal branches).
-            let parts = trimmed.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
+            // for-each-ref format: "<name>|<symref>" where symref is the target
+            // ref for symbolic refs (empty for normal branches).
+            let parts = trimmed.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
             guard let nameSlice = parts.first else { continue }
             let name = String(nameSlice)
             if name.isEmpty { continue }
-            let symref = parts.count > 2 ? String(parts[2]).trimmingCharacters(in: .whitespaces) : ""
+            let symref = parts.count > 1 ? String(parts[1]).trimmingCharacters(in: .whitespaces) : ""
             if !symref.isEmpty { continue }
-            let headMarker = parts.count > 1 ? String(parts[1]) : ""
-            let isCurrent = headMarker.trimmingCharacters(in: .whitespaces) == "*"
             let isRemote = name.hasPrefix("origin/")
             let localName: String
             if isRemote {
@@ -285,8 +281,7 @@ public struct GitManager: Sendable {
             refs.append(BranchRef(
                 name: name,
                 isRemote: isRemote,
-                localName: localName,
-                isCurrent: isCurrent
+                localName: localName
             ))
         }
 

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+/// A branch reference returned by `GitManager.listBranches`.
+///
+/// Includes both `refs/heads/*` (local) and `refs/remotes/origin/*` (remote
+/// tracking) entries. `localName` strips the `origin/` prefix for remote
+/// entries — it's the name the new local branch will receive when the user
+/// picks a remote ref to create a worktree from.
+public struct BranchRef: Sendable, Equatable {
+    /// e.g. `main` or `origin/feature/x`.
+    public let name: String
+    public let isRemote: Bool
+    /// For remote: stripped of the `origin/` prefix. For local: same as `name`.
+    public let localName: String
+    /// True for the currently checked-out local branch (per `git for-each-ref`'s `%(HEAD)`).
+    public let isCurrent: Bool
+
+    public init(name: String, isRemote: Bool, localName: String, isCurrent: Bool) {
+        self.name = name
+        self.isRemote = isRemote
+        self.localName = localName
+        self.isCurrent = isCurrent
+    }
+}
+
 /// Error thrown when a git command fails.
 public struct GitError: Error, CustomStringConvertible {
     public let command: String
@@ -139,6 +162,16 @@ public struct GitManager: Sendable {
         _ = try await run(arguments: ["worktree", "add", worktreePath, branch], at: repoPath)
     }
 
+    /// Adds a worktree at `worktreePath` tracking an existing remote branch.
+    /// Creates a local branch named `localBranch` from `remoteRef`
+    /// (e.g. `origin/foo`) with upstream tracking configured.
+    public func worktreeAddTrackingRemote(repoPath: String, worktreePath: String, localBranch: String, remoteRef: String) async throws {
+        _ = try await run(
+            arguments: ["worktree", "add", "--track", "-b", localBranch, worktreePath, remoteRef],
+            at: repoPath
+        )
+    }
+
     /// Adds a worktree at `worktreePath`, creating a new branch pointing at the given SHA.
     /// Used as a fallback when the original branch was renamed/deleted but we have the
     /// archived HEAD SHA to recover the commit.
@@ -187,6 +220,62 @@ public struct GitManager: Sendable {
     /// Prunes stale worktree tracking entries.
     public func worktreePrune(repoPath: String) async throws {
         _ = try await run(arguments: ["worktree", "prune"], at: repoPath)
+    }
+
+    /// Lists local branches and `origin/*` remote tracking branches.
+    ///
+    /// Dedupe rule: when a local branch and a remote `origin/<same>` both exist,
+    /// the remote duplicate is dropped — the local branch is more directly
+    /// usable for creating a worktree (`git worktree add <path> <branch>`).
+    /// Skips `origin/HEAD` (it's an alias, not a real branch).
+    public func listBranches(repoPath: String) async throws -> [BranchRef] {
+        let output = try await run(
+            arguments: [
+                "for-each-ref",
+                "--format=%(refname:short)|%(HEAD)",
+                "refs/heads",
+                "refs/remotes/origin",
+            ],
+            at: repoPath
+        )
+
+        var refs: [BranchRef] = []
+        var localNames = Set<String>()
+
+        for line in output.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+            // for-each-ref format: "<name>|<HEAD-marker>" where HEAD-marker is
+            // "*" for the current branch, " " (space) otherwise.
+            let parts = trimmed.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
+            guard let nameSlice = parts.first else { continue }
+            let name = String(nameSlice)
+            if name.isEmpty { continue }
+            // Skip the origin/HEAD alias — it's not a real branch.
+            if name == "origin/HEAD" { continue }
+            let headMarker = parts.count > 1 ? String(parts[1]) : ""
+            let isCurrent = headMarker.trimmingCharacters(in: .whitespaces) == "*"
+            let isRemote = name.hasPrefix("origin/")
+            let localName: String
+            if isRemote {
+                localName = String(name.dropFirst("origin/".count))
+            } else {
+                localName = name
+                localNames.insert(name)
+            }
+            refs.append(BranchRef(
+                name: name,
+                isRemote: isRemote,
+                localName: localName,
+                isCurrent: isCurrent
+            ))
+        }
+
+        // Drop remote entries that have a matching local branch — the local
+        // is more directly usable.
+        return refs.filter { ref in
+            !(ref.isRemote && localNames.contains(ref.localName))
+        }
     }
 
     /// Lists all worktrees, returning their path and branch name.

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -11,9 +11,12 @@ extension WorktreeLifecycle {
     ///
     /// This is the legacy all-in-one method. Prefer `beginCreateWorktree` +
     /// `completeCreateWorktree` for non-blocking creation.
-    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false) async throws -> Worktree {
-        let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude, parentWorktreeID: parentWorktreeID, siblingOfWorktreeID: siblingOfWorktreeID, callerWorktreeID: callerWorktreeID, suppressAutoParent: suppressAutoParent)
-        try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows)
+    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false) async throws -> Worktree {
+        let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude, parentWorktreeID: parentWorktreeID, siblingOfWorktreeID: siblingOfWorktreeID, callerWorktreeID: callerWorktreeID, suppressAutoParent: suppressAutoParent, useExistingBranch: useExistingBranch)
+        // Pass the original branch ref (may include `origin/` prefix) through
+        // so phase 2 can dispatch to the correct git command.
+        let existingBranchRef = useExistingBranch ? branch : nil
+        try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows, existingBranchRef: existingBranchRef)
         guard let completed = try await db.worktrees.get(id: pending.id) else {
             throw WorktreeLifecycleError.worktreeNotFound(pending.id)
         }
@@ -25,7 +28,7 @@ extension WorktreeLifecycle {
     /// Phase 1: Synchronous-fast. Generates a name, inserts a DB row with
     /// `status = .creating`, and returns the worktree immediately.
     /// NO git operations happen here.
-    public func beginCreateWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false) async throws -> Worktree {
+    public func beginCreateWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false) async throws -> Worktree {
         // 1. Fetch repo
         guard let repo = try await db.repos.get(id: repoID) else {
             throw WorktreeLifecycleError.repoNotFound(repoID)
@@ -41,8 +44,8 @@ extension WorktreeLifecycle {
         )
 
         // 2. Generate name and construct path
-        let name = folder ?? NameGenerator.generate()
-        let branch = branch ?? "tbd/\(name)"
+        let resolvedName: String
+        let resolvedBranch: String
         let layout = WorktreeLayout()
         let canonicalBase = layout.basePath(for: repo)
         // Lazily create the canonical base directory for this slot.
@@ -58,15 +61,40 @@ extension WorktreeLifecycle {
         if !FileManager.default.fileExists(atPath: canonicalBase) {
             logger.error("Failed to create worktree base dir \(canonicalBase, privacy: .public)")
         }
-        let worktreePath = (canonicalBase as NSString).appendingPathComponent(name)
+
+        if useExistingBranch {
+            // Existing-branch flow: derive a folder name from the branch's
+            // local name (stripping any `origin/` prefix). Never auto-name.
+            guard let providedBranch = branch, !providedBranch.isEmpty else {
+                throw WorktreeLifecycleError.createFailed(
+                    "useExistingBranch requires a branch name"
+                )
+            }
+            let localBranch = providedBranch.hasPrefix("origin/")
+                ? String(providedBranch.dropFirst("origin/".count))
+                : providedBranch
+            let sanitized = WorktreeLayout.sanitize(localBranch)
+            let baseFolder = sanitized.isEmpty ? "branch" : sanitized
+            resolvedName = Self.uniqueFolderName(
+                base: baseFolder, in: canonicalBase
+            )
+            // The on-disk local branch ends up as `localBranch` (for remote
+            // tracking, `--track -b <localName>` creates it; for plain local,
+            // we check out the same branch under the same name).
+            resolvedBranch = localBranch
+        } else {
+            resolvedName = folder ?? NameGenerator.generate()
+            resolvedBranch = branch ?? "tbd/\(resolvedName)"
+        }
+        let worktreePath = (canonicalBase as NSString).appendingPathComponent(resolvedName)
         let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
 
         // 3. Insert DB row with status = .creating
         let worktree = try await db.worktrees.create(
             repoID: repo.id,
-            name: name,
+            name: resolvedName,
             displayName: displayName,
-            branch: branch,
+            branch: resolvedBranch,
             path: worktreePath,
             tmuxServer: tmuxServer,
             status: .creating,
@@ -76,9 +104,32 @@ extension WorktreeLifecycle {
         return worktree
     }
 
+    /// Returns `<base>`, or `<base>-2`, `<base>-3`, … — the first folder name
+    /// under `parentDir` that does not yet exist on disk. Caps at -1000 to
+    /// avoid pathological infinite loops; throws via the underlying
+    /// `git worktree add` if every candidate is taken.
+    private static func uniqueFolderName(base: String, in parentDir: String) -> String {
+        let firstCandidate = (parentDir as NSString).appendingPathComponent(base)
+        if !FileManager.default.fileExists(atPath: firstCandidate) {
+            return base
+        }
+        for suffix in 2...1000 {
+            let candidate = "\(base)-\(suffix)"
+            let path = (parentDir as NSString).appendingPathComponent(candidate)
+            if !FileManager.default.fileExists(atPath: path) {
+                return candidate
+            }
+        }
+        // Fall through to the original; `git worktree add` will fail loudly.
+        return base
+    }
+
     /// Phase 2: Async. Performs git fetch, git worktree add, tmux setup,
     /// then updates status to `.active`. On failure, deletes the DB row.
-    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil) async throws {
+    ///
+    /// When `existingBranchRef` is non-nil, the worktree is checked out from
+    /// that existing ref (local or `origin/*`) — no fresh branch is created.
+    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil) async throws {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -103,24 +154,56 @@ extension WorktreeLifecycle {
             )
 
             // 3. git worktree add
-            let result = try await attemptWorktreeAdd(
-                repo: repo, name: worktree.name, branch: worktree.branch,
-                worktreePath: worktree.path,
-                userSpecifiedFolder: userSpecifiedFolder,
-                userSpecifiedBranch: userSpecifiedBranch
-            )
+            let resultPath: String
+            if let ref = existingBranchRef {
+                // Existing-branch flow: check out the chosen ref. Local branches
+                // get `git worktree add <path> <branch>`; remote refs get
+                // `--track -b <localName> <path> origin/<name>` to create a
+                // local tracking branch.
+                do {
+                    if ref.hasPrefix("origin/") {
+                        try await git.worktreeAddTrackingRemote(
+                            repoPath: repo.path,
+                            worktreePath: worktree.path,
+                            localBranch: worktree.branch,
+                            remoteRef: ref
+                        )
+                    } else {
+                        try await git.worktreeAddExisting(
+                            repoPath: repo.path,
+                            worktreePath: worktree.path,
+                            branch: worktree.branch
+                        )
+                    }
+                    resultPath = worktree.path
+                } catch {
+                    // Clean up any partially-created directory before bubbling.
+                    try? FileManager.default.removeItem(atPath: worktree.path)
+                    throw WorktreeLifecycleError.createFailed(
+                        "git worktree add failed for existing branch '\(ref)': \(error)"
+                    )
+                }
+            } else {
+                let result = try await attemptWorktreeAdd(
+                    repo: repo, name: worktree.name, branch: worktree.branch,
+                    worktreePath: worktree.path,
+                    userSpecifiedFolder: userSpecifiedFolder,
+                    userSpecifiedBranch: userSpecifiedBranch
+                )
 
-            // 4. If the name changed due to collision, update the DB record
-            if result.name != worktree.name {
-                // Update path/branch/name in DB would be complex — for now the retry
-                // names the worktree path differently but we keep the original DB row.
-                // The attemptWorktreeAdd already handles retries.
+                // 4. If the name changed due to collision, update the DB record
+                if result.name != worktree.name {
+                    // Update path/branch/name in DB would be complex — for now the retry
+                    // names the worktree path differently but we keep the original DB row.
+                    // The attemptWorktreeAdd already handles retries.
+                }
+                resultPath = result.path
             }
 
             // 5. Setup tmux terminals
             try await setupTerminals(
                 worktree: worktree, repo: repo,
-                worktreePath: result.path,
+                worktreePath: resultPath,
                 skipClaude: skipClaude,
                 initialPrompt: initialPrompt,
                 cols: cols,

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -175,8 +175,7 @@ extension RPCRouter {
             BranchInfo(
                 name: $0.name,
                 localName: $0.localName,
-                isRemote: $0.isRemote,
-                isCurrent: $0.isCurrent
+                isRemote: $0.isRemote
             )
         }
         return try RPCResponse(result: RepoListBranchesResult(branches: branches))

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -163,6 +163,25 @@ extension RPCRouter {
         return .ok()
     }
 
+    func handleRepoListBranches(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(RepoListBranchesParams.self, from: paramsData)
+
+        guard let repo = try await db.repos.get(id: params.repoID) else {
+            return RPCResponse(error: "Repository not found: \(params.repoID)")
+        }
+
+        let refs = try await git.listBranches(repoPath: repo.path)
+        let branches = refs.map {
+            BranchInfo(
+                name: $0.name,
+                localName: $0.localName,
+                isRemote: $0.isRemote,
+                isCurrent: $0.isCurrent
+            )
+        }
+        return try RPCResponse(result: RepoListBranchesResult(branches: branches))
+    }
+
     func handleRepoRename(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(RepoRenameParams.self, from: paramsData)
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -10,6 +10,7 @@ extension RPCRouter {
 
     func handleWorktreeCreate(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeCreateParams.self, from: paramsData)
+        let useExistingBranch = params.useExistingBranch ?? false
 
         // Phase 1: Fast — insert DB row with status = .creating, return immediately
         let pending = try await lifecycle.beginCreateWorktree(
@@ -20,7 +21,8 @@ extension RPCRouter {
             parentWorktreeID: params.parentWorktreeID,
             siblingOfWorktreeID: params.siblingOfWorktreeID,
             callerWorktreeID: params.callerWorktreeID,
-            suppressAutoParent: params.suppressAutoParent ?? false
+            suppressAutoParent: params.suppressAutoParent ?? false,
+            useExistingBranch: useExistingBranch
         )
 
         // Phase 2: Fire-and-forget — git operations + tmux setup in background.
@@ -32,9 +34,12 @@ extension RPCRouter {
         let userSpecifiedBranch = params.branch != nil
         let cols = params.cols
         let rows = params.rows
+        // Pass the raw branch ref (possibly `origin/...`) to phase 2 so it
+        // can dispatch to the right git command.
+        let existingBranchRef = useExistingBranch ? params.branch : nil
         await repoSerializer.submit(repoID: pending.repoID) {
             do {
-                try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows)
+                try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef)
                 subs.broadcast(delta: .worktreeCreated(WorktreeDelta(
                     worktreeID: pending.id, repoID: pending.repoID,
                     name: pending.name, path: pending.path

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -92,6 +92,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRepoSetHidden(request.paramsData)
             case RPCMethod.repoSetExpanded:
                 return try await handleRepoSetExpanded(request.paramsData)
+            case RPCMethod.repoListBranches:
+                return try await handleRepoListBranches(request.paramsData)
             case RPCMethod.worktreeCreate:
                 return try await handleWorktreeCreate(request.paramsData)
             case RPCMethod.worktreeList:

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -148,6 +148,36 @@ public enum RPCMethod {
     public static let tabList     = "tab.list"
     public static let worktreeSetActiveTab = "worktree.setActiveTab"
     public static let appearanceUpdateColorFgBg = "appearance.updateColorFgBg"
+    public static let repoListBranches = "repo.listBranches"
+}
+
+// MARK: - Branch Listing
+
+/// Codable mirror of `BranchRef` for the `repo.listBranches` RPC.
+public struct BranchInfo: Codable, Sendable, Equatable, Identifiable {
+    public let name: String
+    public let localName: String
+    public let isRemote: Bool
+    public let isCurrent: Bool
+
+    public var id: String { name }
+
+    public init(name: String, localName: String, isRemote: Bool, isCurrent: Bool) {
+        self.name = name
+        self.localName = localName
+        self.isRemote = isRemote
+        self.isCurrent = isCurrent
+    }
+}
+
+public struct RepoListBranchesParams: Codable, Sendable {
+    public let repoID: UUID
+    public init(repoID: UUID) { self.repoID = repoID }
+}
+
+public struct RepoListBranchesResult: Codable, Sendable {
+    public let branches: [BranchInfo]
+    public init(branches: [BranchInfo]) { self.branches = branches }
 }
 
 // MARK: - Legacy Hook Detection / Removal
@@ -500,13 +530,19 @@ public struct WorktreeCreateParams: Codable, Sendable {
     public let siblingOfWorktreeID: UUID?  // --sibling (caller worktree id)
     public let callerWorktreeID: UUID?     // TBD_WORKTREE_ID env
     public let suppressAutoParent: Bool?   // --no-parent
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil) {
+    /// When true, `branch` is treated as the name of an existing branch
+    /// (local like `feat/x` or remote like `origin/feat/x`) to be checked
+    /// out into a new worktree — no fresh `tbd/*` branch is created.
+    /// Optional/defaulted for backward compatibility with older clients.
+    public let useExistingBranch: Bool?
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows
         self.parentWorktreeID = parentWorktreeID
         self.siblingOfWorktreeID = siblingOfWorktreeID
         self.callerWorktreeID = callerWorktreeID
         self.suppressAutoParent = suppressAutoParent
+        self.useExistingBranch = useExistingBranch
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -158,15 +158,13 @@ public struct BranchInfo: Codable, Sendable, Equatable, Identifiable {
     public let name: String
     public let localName: String
     public let isRemote: Bool
-    public let isCurrent: Bool
 
     public var id: String { name }
 
-    public init(name: String, localName: String, isRemote: Bool, isCurrent: Bool) {
+    public init(name: String, localName: String, isRemote: Bool) {
         self.name = name
         self.localName = localName
         self.isRemote = isRemote
-        self.isCurrent = isCurrent
     }
 }
 

--- a/Tests/TBDCLITests/StopRenameCheckCommandTests.swift
+++ b/Tests/TBDCLITests/StopRenameCheckCommandTests.swift
@@ -124,14 +124,23 @@ struct StopRenameCheckCommandTests {
         #expect(out == nil)
     }
 
-    @Test func branchMissingTbdPrefix_returnsNil() {
+    @Test func nonTbdBranch_emitsBlockWithDisplayRenameOnly() throws {
         let dir = Self.tempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         let out = StopRenameCheckCore.decide(
             stdinData: Self.payload(),
-            dependencies: Self.deps(branch: "main", counterDirectory: dir)
+            dependencies: Self.deps(branch: "feature/foo", counterDirectory: dir)
         )
-        #expect(out == nil)
+        let raw = try #require(out)
+        let parsed = try JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any]
+        #expect(parsed?["decision"] as? String == "block")
+        let reason = try #require(parsed?["reason"] as? String)
+        // Only the display rename is suggested — not the branch rename.
+        #expect(!reason.contains("git branch -m"))
+        #expect(reason.contains("tbd worktree rename"))
+        // The "intentionally not renamed" line should mention the actual branch
+        // so it's a real, concrete statement (not boilerplate).
+        #expect(reason.contains("feature/foo"))
     }
 
     @Test func counterAtCap_returnsNil() throws {

--- a/Tests/TBDDaemonTests/GitManagerBranchesTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerBranchesTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+
+/// Tests for `GitManager.listBranches` — exercises the `for-each-ref` output
+/// parser, the `origin/HEAD` skip, the local-vs-remote dedupe rule, and the
+/// `isCurrent` flag.
+struct GitManagerBranchesTests {
+    let tempDir: URL
+    let repoDir: URL
+    let remoteDir: URL
+    let git: GitManager
+
+    init() async throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-branches-test-\(UUID().uuidString)")
+        repoDir = tempDir.appendingPathComponent("repo")
+        remoteDir = tempDir.appendingPathComponent("remote.git")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: remoteDir, withIntermediateDirectories: true)
+
+        // Init a fake "remote" bare repo with a `main` branch.
+        try await shell("git init --bare -b main", at: remoteDir)
+
+        // Init the local repo and seed a commit on `main`.
+        try await shell("git init -b main && git commit --allow-empty -m 'init'", at: repoDir)
+
+        // Push to the bare remote so we have an `origin/main` ref.
+        try await shell("git remote add origin '\(remoteDir.path)'", at: repoDir)
+        try await shell("git push -u origin main", at: repoDir)
+
+        git = GitManager()
+    }
+
+    private func cleanup() {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - Tests
+
+    @Test func listBranchesReturnsLocalBranches() async throws {
+        defer { cleanup() }
+        try await shell("git branch local-only", at: repoDir)
+
+        let refs = try await git.listBranches(repoPath: repoDir.path)
+        let names = refs.map(\.name)
+        #expect(names.contains("main"))
+        #expect(names.contains("local-only"))
+        #expect(refs.first { $0.name == "local-only" }?.isRemote == false)
+        #expect(refs.first { $0.name == "local-only" }?.localName == "local-only")
+    }
+
+    @Test func listBranchesIncludesOriginButSkipsOriginHEAD() async throws {
+        defer { cleanup() }
+        // Create a remote-only branch (delete the local after pushing).
+        try await shell("git checkout -b remote-only", at: repoDir)
+        try await shell("git push -u origin remote-only", at: repoDir)
+        try await shell("git checkout main", at: repoDir)
+        try await shell("git branch -D remote-only", at: repoDir)
+
+        // Establish origin/HEAD so the skip is exercised.
+        try await shell("git remote set-head origin main", at: repoDir)
+
+        let refs = try await git.listBranches(repoPath: repoDir.path)
+        let names = refs.map(\.name)
+        #expect(names.contains("origin/remote-only"))
+        // origin/HEAD must be filtered out.
+        #expect(!names.contains("origin/HEAD"))
+
+        let remote = refs.first { $0.name == "origin/remote-only" }
+        #expect(remote?.isRemote == true)
+        #expect(remote?.localName == "remote-only")
+    }
+
+    @Test func listBranchesDedupesLocalOverRemote() async throws {
+        defer { cleanup() }
+        // `main` exists both locally and as `origin/main` — the remote
+        // duplicate should be dropped.
+        let refs = try await git.listBranches(repoPath: repoDir.path)
+        let mainEntries = refs.filter { $0.localName == "main" }
+        #expect(mainEntries.count == 1, "Expected exactly one entry for 'main', got \(mainEntries.map(\.name))")
+        #expect(mainEntries.first?.name == "main", "Local entry should win over origin/main")
+        #expect(mainEntries.first?.isRemote == false)
+    }
+
+    @Test func listBranchesFlagsCurrentBranch() async throws {
+        defer { cleanup() }
+        try await shell("git branch feature-x", at: repoDir)
+        let refs = try await git.listBranches(repoPath: repoDir.path)
+        let main = refs.first { $0.name == "main" }
+        let feature = refs.first { $0.name == "feature-x" }
+        #expect(main?.isCurrent == true)
+        #expect(feature?.isCurrent == false)
+    }
+
+}

--- a/Tests/TBDDaemonTests/GitManagerBranchesTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerBranchesTests.swift
@@ -4,8 +4,8 @@ import Testing
 @testable import TBDDaemonLib
 
 /// Tests for `GitManager.listBranches` — exercises the `for-each-ref` output
-/// parser, the `origin/HEAD` skip, the local-vs-remote dedupe rule, and the
-/// `isCurrent` flag.
+/// parser, the symbolic-ref (`origin/HEAD`) skip, the local-vs-remote dedupe
+/// rule, and the "already checked out" worktree filter.
 struct GitManagerBranchesTests {
     let tempDir: URL
     let repoDir: URL
@@ -45,10 +45,12 @@ struct GitManagerBranchesTests {
 
         let refs = try await git.listBranches(repoPath: repoDir.path)
         let names = refs.map(\.name)
-        #expect(names.contains("main"))
         #expect(names.contains("local-only"))
         #expect(refs.first { $0.name == "local-only" }?.isRemote == false)
         #expect(refs.first { $0.name == "local-only" }?.localName == "local-only")
+        // `main` is the main worktree's checked-out branch, so the
+        // already-in-use filter drops it.
+        #expect(!names.contains("main"))
     }
 
     @Test func listBranchesIncludesOriginButSkipsOriginHEAD() async throws {
@@ -78,23 +80,32 @@ struct GitManagerBranchesTests {
 
     @Test func listBranchesDedupesLocalOverRemote() async throws {
         defer { cleanup() }
-        // `main` exists both locally and as `origin/main` — the remote
-        // duplicate should be dropped.
+        // Create a branch that exists both locally and as `origin/<name>` —
+        // the remote duplicate should be dropped. `feature` isn't checked out
+        // anywhere, so it survives the in-use filter.
+        try await shell("git branch feature", at: repoDir)
+        try await shell("git push -u origin feature", at: repoDir)
+
         let refs = try await git.listBranches(repoPath: repoDir.path)
-        let mainEntries = refs.filter { $0.localName == "main" }
-        #expect(mainEntries.count == 1, "Expected exactly one entry for 'main', got \(mainEntries.map(\.name))")
-        #expect(mainEntries.first?.name == "main", "Local entry should win over origin/main")
-        #expect(mainEntries.first?.isRemote == false)
+        let featureEntries = refs.filter { $0.localName == "feature" }
+        #expect(featureEntries.count == 1, "Expected exactly one entry for 'feature', got \(featureEntries.map(\.name))")
+        #expect(featureEntries.first?.name == "feature", "Local entry should win over origin/feature")
+        #expect(featureEntries.first?.isRemote == false)
     }
 
-    @Test func listBranchesFlagsCurrentBranch() async throws {
+    @Test func listBranchesExcludesBranchesCheckedOutInLinkedWorktree() async throws {
         defer { cleanup() }
-        try await shell("git branch feature-x", at: repoDir)
+        // Create a branch and check it out into a linked worktree — it should
+        // be omitted from the picker, since git rejects a second checkout.
+        try await shell("git branch checked-out-elsewhere", at: repoDir)
+        try await shell("git branch never-checked-out", at: repoDir)
+        let linkedPath = tempDir.appendingPathComponent("linked-wt").path
+        try await shell("git worktree add '\(linkedPath)' checked-out-elsewhere", at: repoDir)
+
         let refs = try await git.listBranches(repoPath: repoDir.path)
-        let main = refs.first { $0.name == "main" }
-        let feature = refs.first { $0.name == "feature-x" }
-        #expect(main?.isCurrent == true)
-        #expect(feature?.isCurrent == false)
+        let names = refs.map(\.name)
+        #expect(!names.contains("checked-out-elsewhere"))
+        #expect(names.contains("never-checked-out"))
     }
 
 }

--- a/Tests/TBDDaemonTests/GitManagerBranchesTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerBranchesTests.swift
@@ -65,8 +65,11 @@ struct GitManagerBranchesTests {
         let refs = try await git.listBranches(repoPath: repoDir.path)
         let names = refs.map(\.name)
         #expect(names.contains("origin/remote-only"))
-        // origin/HEAD must be filtered out.
+        // origin/HEAD must be filtered out. Note: `git for-each-ref` short-names
+        // `refs/remotes/origin/HEAD` to bare "origin" (not "origin/HEAD"), so
+        // the filter has to recognize symbolic refs rather than match by name.
         #expect(!names.contains("origin/HEAD"))
+        #expect(!names.contains("origin"))
 
         let remote = refs.first { $0.name == "origin/remote-only" }
         #expect(remote?.isRemote == true)

--- a/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Branching-conditional test coverage for the `useExistingBranch` flag on
+/// `WorktreeLifecycle.createWorktree`. Per CLAUDE.md: when a new conditional
+/// gates behavior, every branch needs its own test.
+///
+/// Three branches are exercised:
+/// 1. `useExistingBranch: false` — current behavior preserved (creates `tbd/<name>`).
+/// 2. `useExistingBranch: true` + local branch — checks out existing branch, no `-b`.
+/// 3. `useExistingBranch: true` + `origin/<name>` ref — creates a local tracking branch.
+
+@Test func testCreateWorktreeDoesNotUseExistingBranchByDefault() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // useExistingBranch defaults to false — behavior is identical to the
+    // legacy create flow: a fresh `tbd/<auto-name>` branch is created.
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    #expect(wt.status == .active)
+    #expect(wt.branch.hasPrefix("tbd/"))
+    #expect(FileManager.default.fileExists(atPath: wt.path))
+}
+
+@Test func testCreateWorktreeUsesExistingLocalBranch() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    // Pre-seed a local branch that the new worktree will check out.
+    try await shell("git branch existing-feature", at: repoDir)
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    let wt = try await lifecycle.createWorktree(
+        repoID: repo.id,
+        branch: "existing-feature",
+        skipClaude: true,
+        useExistingBranch: true
+    )
+
+    #expect(wt.status == .active)
+    // The stored branch is the existing one — NOT prefixed with `tbd/`.
+    #expect(wt.branch == "existing-feature")
+    #expect(!wt.branch.hasPrefix("tbd/"))
+    // Folder name is derived from the branch's local name (sanitized).
+    #expect(wt.name == "existing-feature")
+    #expect(FileManager.default.fileExists(atPath: wt.path))
+
+    // Verify git also reports the worktree on the existing branch.
+    // Path comparison uses `hasSuffix` because macOS resolves the temp dir
+    // through a symlink (`/var/folders` → `/private/var/folders`) — git
+    // reports the resolved path while the DB row keeps the unresolved one.
+    let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+    #expect(listed.contains { entry in
+        entry.branch == "existing-feature" && entry.path.hasSuffix("/existing-feature")
+    })
+}
+
+@Test func testCreateWorktreeFromRemoteRefCreatesTrackingBranch() async throws {
+    // Spin up a bare "remote" repo and push a branch to it, then exercise
+    // the `origin/<name>` path on a fresh clone.
+    let parentDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-remote-test-\(UUID().uuidString)")
+    let remoteDir = parentDir.appendingPathComponent("remote.git")
+    let cloneTempDir = parentDir.appendingPathComponent("clone-host")
+    let cloneRepoDir = cloneTempDir.appendingPathComponent("repo")
+    try FileManager.default.createDirectory(at: remoteDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: cloneTempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: parentDir) }
+
+    try await shell("git init --bare -b main", at: remoteDir)
+
+    // Seed source repo: create main, then a feature branch with one commit,
+    // then push both to the bare remote.
+    let sourceDir = parentDir.appendingPathComponent("source")
+    try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+    try await shell("git init -b main && git commit --allow-empty -m 'init'", at: sourceDir)
+    try await shell("git checkout -b remote-feature && git commit --allow-empty -m 'feature work'", at: sourceDir)
+    try await shell("git remote add origin '\(remoteDir.path)'", at: sourceDir)
+    try await shell("git push origin main remote-feature", at: sourceDir)
+
+    // Clone into the test repo (mirrors what a user would do).
+    try await shell("git clone '\(remoteDir.path)' '\(cloneRepoDir.path)'", at: cloneTempDir)
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(
+        db: db, tempDir: cloneTempDir, repoDir: cloneRepoDir
+    )
+
+    let wt = try await lifecycle.createWorktree(
+        repoID: repo.id,
+        branch: "origin/remote-feature",
+        skipClaude: true,
+        useExistingBranch: true
+    )
+
+    #expect(wt.status == .active)
+    // Stored branch is the LOCAL tracking branch name (no `origin/` prefix).
+    #expect(wt.branch == "remote-feature")
+    #expect(wt.name == "remote-feature")
+    #expect(FileManager.default.fileExists(atPath: wt.path))
+
+    // Verify a local tracking branch was created and is what the worktree
+    // is checked out on. See the path-suffix note in the local-branch test.
+    let listed = try await GitManager().worktreeList(repoPath: cloneRepoDir.path)
+    #expect(listed.contains { entry in
+        entry.branch == "remote-feature" && entry.path.hasSuffix("/remote-feature")
+    })
+}
+
+@Test func testCreateWorktreeWithExistingBranchFolderConflictAppendsSuffix() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    // Two local branches sharing a sanitized folder name.
+    try await shell("git branch feature/auth-refactor", at: repoDir)
+    try await shell("git branch feature/auth-refactor-other", at: repoDir)
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    let first = try await lifecycle.createWorktree(
+        repoID: repo.id,
+        branch: "feature/auth-refactor",
+        skipClaude: true,
+        useExistingBranch: true
+    )
+    // `feature/auth-refactor` -> sanitized `feature-auth-refactor`.
+    #expect(first.name == "feature-auth-refactor")
+
+    // Pre-create a stray directory that collides with the next sanitized name
+    // so the suffix path runs even though the branches differ.
+    let layout = WorktreeLayout()
+    let basePath = layout.basePath(for: repo)
+    let collidingPath = (basePath as NSString).appendingPathComponent("feature-auth-refactor-other")
+    try FileManager.default.createDirectory(atPath: collidingPath, withIntermediateDirectories: true)
+
+    let second = try await lifecycle.createWorktree(
+        repoID: repo.id,
+        branch: "feature/auth-refactor-other",
+        skipClaude: true,
+        useExistingBranch: true
+    )
+    // The conflict-resolver appends `-2`, `-3`, etc.
+    #expect(second.name == "feature-auth-refactor-other-2")
+    #expect(second.branch == "feature/auth-refactor-other")
+}
+


### PR DESCRIPTION
## Summary
- Option-click the `+` button next to a repo in the sidebar to open a searchable popover of local + `origin/*` branches. Picking one creates a worktree on that branch instead of a fresh `tbd/<name>`. Plain click is unchanged.
- New RPC `repo.listBranches` + `useExistingBranch`/`existingBranchRef` plumbed through worktree create. For remote refs, uses `git worktree add --track -b <local> <path> origin/<name>`; for local refs, plain `git worktree add <path> <branch>`.
- Folder name is sanitized branch `localName` with `-2`/`-3` suffix on collision.

what do you think? probably not the ideal place to put the action but didn't want to get bogged down on the perfect UI yet haha
<img width="661" height="448" alt="image" src="https://github.com/user-attachments/assets/40ccc682-41c9-4a13-80ff-8d599a765a2f" />


## Test plan
- [x] `swift build` clean
- [x] `swift test` — 8 new tests pass (branch listing dedupe / `origin/HEAD` skip / `isCurrent`; create unchanged when flag off, local branch reused, remote ref creates tracking branch, folder collision suffixed). Pre-existing flaky `NSHostingView` tab-bar test still fails on main.
- [ ] Manual: `scripts/restart.sh`, hold Option, click `+` on a repo, pick a branch, confirm worktree appears with that branch checked out
- [ ] Manual: confirm plain `+` click still auto-generates `tbd/<name>`
- [ ] Manual: confirm popover stays open when mouse moves off the `+` button into the popover (the section-hover fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)