### PR TITLE
fix: stop PR number rendering with grouping separator

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -320,7 +320,7 @@ private struct PRButtonLabel: View {
                     .frame(width: 12, height: 12)
                     .foregroundStyle(presentation.color)
             }
-            Text("#\(prStatus.number)")
+            Text(verbatim: "#\(prStatus.number)")
                 .font(.caption)
                 .fontWeight(.medium)
         }


### PR DESCRIPTION
## Summary
Comma looks weird in PR numbers, no comma? <img width="87" height="41" alt="image" src="https://github.com/user-attachments/assets/4aa51038-39fc-434f-abf5-ebf482f045a1" />

The PR number badge rendered with a thousands separator — a PR like `#1234` showed as `#1,234`.

**Root cause:** `Text("#\(prStatus.number)")` is interpreted by SwiftUI as a `LocalizedStringKey` initializer. Interpolating an `Int` into a `LocalizedStringKey` applies the locale's default decimal format, which inserts grouping separators.

**Fix:** Use `Text(verbatim:)` to skip localization/number formatting (`ContentView.swift:323`).

The tab-label site (`ContentView.swift:135`) was already safe since it builds a plain `String`.

## Testing

- `swift build` passes (pre-existing unrelated warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)