### PR TITLE
feat: label worktree setup-script terminal tab as "Setup"

### DIFF
--- a/Sources/TBDApp/AutoTabLabelResolver.swift
+++ b/Sources/TBDApp/AutoTabLabelResolver.swift
@@ -37,6 +37,10 @@ enum AutoTabLabelResolver {
             return "Codex"
         }
 
+        if terminal?.label == "setup" {
+            return "Setup"
+        }
+
         return "Terminal \(fallbackIndex + 1)"
     }
 }

--- a/Tests/TBDAppTests/AutoTabLabelResolverTests.swift
+++ b/Tests/TBDAppTests/AutoTabLabelResolverTests.swift
@@ -46,6 +46,26 @@ struct AutoTabLabelResolverTests {
         #expect(label == "Terminal 3")
     }
 
+    @Test func setupTerminalUsesSetupLabel() {
+        let terminal = Terminal(
+            worktreeID: UUID(),
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "setup",
+            kind: .shell
+        )
+
+        let label = AutoTabLabelResolver.terminalLabel(
+            terminal: terminal,
+            fallbackIndex: 2,
+            modelProfiles: [],
+            worktreeTabs: [],
+            worktreeTerminals: []
+        )
+
+        #expect(label == "Setup")
+    }
+
     @Test func claudeProfileUsesProfileNameAndPosition() {
         let worktreeID = UUID()
         let profileID = UUID()


### PR DESCRIPTION
## Summary
<img width="351" height="72" alt="image" src="https://github.com/user-attachments/assets/ee8fbffc-7984-4159-813b-361dc25d24ff" />

The worktree setup-script terminal now displays its tab label as **"Setup"** instead of the generic "Terminal N".

The setup terminal was already created with the internal label `"setup"` (in `WorktreeLifecycle+Create.swift`), but the UI's `AutoTabLabelResolver` never read that field for shell terminals, so it fell through to the generic "Terminal N" fallback. This teaches the resolver to recognize it.

## Changes

- `Sources/TBDApp/AutoTabLabelResolver.swift` — return `"Setup"` when `terminal.label == "setup"`, before the generic numbered fallback.
- `Tests/TBDAppTests/AutoTabLabelResolverTests.swift` — added `setupTerminalUsesSetupLabel`; the existing shell test (label `nil` → "Terminal 3") still passes.

## Testing

- `swift build` ✅
- `swift test --filter AutoTabLabelResolver` ✅ (all 4 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)