### PR TITLE
feat: show full live URL with copy button in webview top bar

### DIFF
--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -37,6 +37,8 @@ struct PanePlaceholder: View {
     @State private var isHeaderHovering = false
     @State private var showSourceCode = false
     @State private var hasRenderableContent = false
+    @StateObject private var webviewState = WebviewState()
+    @State private var didCopyURL = false
 
     /// Find the Terminal model matching a terminal ID across all worktree terminals.
     private func terminal(for id: UUID) -> Terminal? {
@@ -149,7 +151,9 @@ struct PanePlaceholder: View {
                 }
             }
         case .webview(_, let url):
-            Text(url.host ?? url.absoluteString)
+            Text(webviewState.currentURL?.absoluteString ?? url.absoluteString)
+                .truncationMode(.tail)
+                .help(webviewState.currentURL?.absoluteString ?? url.absoluteString)
         case .codeViewer(_, let path):
             Text(URL(fileURLWithPath: path).lastPathComponent)
         case .note(let noteID):
@@ -217,6 +221,13 @@ struct PanePlaceholder: View {
             .buttonStyle(.borderless)
             .disabled(true)
 
+            Button(action: copyWebviewURL) {
+                Image(systemName: didCopyURL ? "checkmark" : "doc.on.doc")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .help("Copy URL")
+
         case .codeViewer:
             if hasRenderableContent {
                 Button(action: { showSourceCode.toggle() }) {
@@ -244,7 +255,7 @@ struct PanePlaceholder: View {
         case .terminal(let terminalID):
             terminalContent(terminalID: terminalID)
         case .webview(_, let url):
-            WebviewPaneView(url: url)
+            WebviewPaneView(url: url, state: webviewState)
         case .codeViewer(_, let path):
             CodeViewerPaneView(path: path, worktreePath: worktree.path, showSourceCode: showSourceCode)
         case .note(let noteID):
@@ -397,6 +408,21 @@ struct PanePlaceholder: View {
                 appState.tabs[worktreeID]?.remove(at: tabIndex)
                 appState.layouts.removeValue(forKey: content.paneID)
             }
+        }
+    }
+
+    // MARK: - Webview Actions
+
+    private func copyWebviewURL() {
+        guard case .webview(_, let initialURL) = content else { return }
+        let urlString = (webviewState.currentURL ?? initialURL).absoluteString
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(urlString, forType: .string)
+        didCopyURL = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            didCopyURL = false
         }
     }
 

--- a/Sources/TBDApp/Panes/WebviewPaneView.swift
+++ b/Sources/TBDApp/Panes/WebviewPaneView.swift
@@ -32,14 +32,21 @@ extension WKWebView: WebviewReloadClient {
     }
 }
 
+@MainActor
+final class WebviewState: ObservableObject {
+    @Published var currentURL: URL?
+}
+
 struct WebviewPaneView: NSViewRepresentable {
     let url: URL
+    let state: WebviewState
 
-    func makeCoordinator() -> Coordinator { Coordinator() }
+    func makeCoordinator() -> Coordinator { Coordinator(state: state) }
 
     func makeNSView(context: Context) -> WebviewPaneHostView {
         let host = WebviewPaneHostView(url: url)
         host.webView.navigationDelegate = context.coordinator
+        context.coordinator.observe(host.webView)
         return host
     }
 
@@ -47,7 +54,22 @@ struct WebviewPaneView: NSViewRepresentable {
         // Don't reload on SwiftUI updates — only initial load matters
     }
 
-    class Coordinator: NSObject, WKNavigationDelegate {}
+    @MainActor
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        private let state: WebviewState
+        private var urlObservation: NSKeyValueObservation?
+
+        init(state: WebviewState) {
+            self.state = state
+        }
+
+        func observe(_ webView: WKWebView) {
+            urlObservation = webView.observe(\.url, options: [.initial, .new]) { [weak state] webView, _ in
+                let newURL = webView.url
+                Task { @MainActor in state?.currentURL = newURL }
+            }
+        }
+    }
 }
 
 final class WebviewPaneHostView: NSView, NSUserInterfaceValidations {


### PR DESCRIPTION

<img width="1221" height="47" alt="image" src="https://github.com/user-attachments/assets/7c443fe6-d96d-4146-b291-132471ac93da" />   

## What

The webview pane's top bar showed only the host (e.g. `github.com`). It now shows the **full current URL**, updating live as you navigate within the page, and adds a **copy-to-clipboard button**.

## Changes

- **`WebviewPaneView.swift`** — Added a `WebviewState` observable model holding the live `currentURL`. The coordinator KVO-observes `webView.url`, so the bar tracks the actual page as you browse, including SPA/pushState changes that don't fire navigation delegates.
- **`PanePlaceholder.swift`**
  - Top-bar label now shows the full URL (tail-truncated to one line, with the full URL as a hover tooltip).
  - Added a copy button (`doc.on.doc`, flips to a `checkmark` for ~1.5s after copying) that writes the current URL to `NSPasteboard`.

The tab title (in `TabBar.swift`) is intentionally left as the host — a full URL would be too long for a tab.

## Behavior decisions
- **Live current URL** (not just the initial URL) — reflects in-page navigation.
- **Tail truncation** — keeps the domain/start visible; copy always copies the full URL.

## Testing
- `swift build` clean.
- View-layer (AppKit/SwiftUI) change; not exercised by `swift test`. Manual verification of live update + copy in the running app still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)