### PR TITLE
Perf: stop rebuilding the whole transcript node array on every hover (69 wasted rebuilds/sweep, #129)

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -39,15 +39,13 @@ struct TranscriptItemsView: View {
     /// need the signal.
     var atBottom: Binding<Bool>? = nil
 
-    /// Tracks the most recently hovered row. The latched row is the only
-    /// one that materializes `.textSelection(.enabled)` (via
-    /// `transcriptSelectableText` + `EnvironmentValues.transcriptTextSelection`)
-    /// — every other visible row renders plain `Text` to avoid the per-row
-    /// `NSTextField` tax that caused ~17 s layout hangs (see
-    /// `TranscriptSelectableText.swift`). The latch is intentional: we do NOT
-    /// clear on hover-exit so that drag-select still works when the cursor
-    /// briefly leaves the row geometry.
-    @State private var hoveredItemID: String? = nil
+    /// Per-`TranscriptItemsView`-instance memoization of the render-node array.
+    /// Returns the SAME `[TranscriptRenderNode]` instance when `items` is
+    /// unchanged so a `body` re-eval (data poll, parent re-render, etc.) does
+    /// not rebuild the array or force AttributeGraph to re-copy it (issue #129).
+    /// A reference type held in `@State` so its mutations persist across body
+    /// passes without themselves invalidating the view.
+    @State private var nodeCache = TranscriptNodeCache()
 
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
@@ -68,7 +66,7 @@ struct TranscriptItemsView: View {
 
     @ViewBuilder
     private var bodyView: some View {
-        let nodes = transcriptRenderNodes(from: items)
+        let nodes = nodeCache.nodes(for: items)
         let _ = {
             guard nodes.count > 100, let tid = terminalID else { return }
             Self.bodyLogged.withLock { logged in
@@ -80,11 +78,7 @@ struct TranscriptItemsView: View {
         }()
         LazyVStack(alignment: .leading, spacing: 4) {
             ForEach(nodes) { node in
-                TranscriptRow(node: node, terminalID: terminalID)
-                    .environment(\.transcriptTextSelection, hoveredItemID == node.id)
-                    .onHover { hovering in
-                        if hovering { hoveredItemID = node.id }
-                    }
+                SelectableTranscriptRow(node: node, terminalID: terminalID)
             }
             // 1pt sentinel that drives `atBottom`. Replaced the prior
             // `.onScrollGeometryChange(for: AtBottomGeometry.self)` reader that
@@ -103,5 +97,43 @@ struct TranscriptItemsView: View {
                 .onDisappear { atBottom?.wrappedValue = false }
         }
         .padding(.vertical, 8)
+    }
+}
+
+/// Wraps a single `TranscriptRow` and owns its own hover state, so a hover
+/// re-renders ONLY the entered/exited row — `TranscriptItemsView.body` never
+/// re-runs on hover. This is the load-bearing half of the issue #129
+/// hover-rebuild fix: previously the hovered-row id lived on
+/// `TranscriptItemsView` as `@State`, so every mouse crossing re-ran the whole
+/// list body (rebuilding the node array, re-diffing the `ForEach`, forcing
+/// AttributeGraph to deep-copy the input). Mirrors the per-row local-hover
+/// pattern already used by `ActivityRowChrome`.
+///
+/// The selection gate (`transcriptTextSelection`) is materialized only while
+/// this row is hovered, preserving the #120 fix that keeps at most one row's
+/// `NSTextField` alive at a time and avoids the ~17 s per-row-NSTextField storm.
+///
+/// Latch decision (issue #129): the previous gate was *latched* — it never
+/// cleared on hover-exit so a drag-select that wandered slightly outside the row
+/// survived. Per-row local state clears on exit instead, and that is safe:
+/// AppKit `NSTrackingArea`s (what SwiftUI `.onHover` is built on) do NOT post
+/// `mouseExited` during an active drag unless `.enabledDuringMouseDrag` is set,
+/// which `.onHover` does not. So while the button is held during a drag-select,
+/// `isHovered` stays `true` and the `NSTextField` is not torn down — the latch
+/// was only ever protecting a case AppKit already handles. Trade-off: if the
+/// pointer leaves the row with no button held, selection clears, which is
+/// acceptable since each row is its own `NSTextField` and selection cannot span
+/// rows anyway. This guarantee assumes the drag-select begins inside the row; a
+/// drag that starts outside never armed this row's selection in the first place.
+private struct SelectableTranscriptRow: View {
+    let node: TranscriptRenderNode
+    let terminalID: UUID?
+
+    @State private var isHovered = false
+
+    var body: some View {
+        TranscriptRow(node: node, terminalID: terminalID)
+            .environment(\.transcriptTextSelection, isHovered)
+            .onHover { isHovered = $0 }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptNodeCache.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptNodeCache.swift
@@ -1,0 +1,56 @@
+import Foundation
+import TBDShared
+import os
+
+/// Memoizes `transcriptRenderNodes(from:)` for a single `TranscriptItemsView`
+/// instance so repeated `body` evaluations with unchanged `items` return the
+/// SAME `[TranscriptRenderNode]` array instance.
+///
+/// Why (issue #129): `transcriptRenderNodes(from:)` walks every item, allocates
+/// a fresh node array, and folds each node's multi-KB payload into a
+/// `contentVersion` hash. Handing a *new* array identity to `ForEach` on every
+/// `body` pass also forces SwiftUI/AttributeGraph to deep-copy the input (the
+/// `TranscriptRenderNode` value-witness `initializeWithCopy` cost seen in hang
+/// captures). Returning the same instance when `items` is unchanged lets
+/// `ForEach` skip re-diffing and AttributeGraph skip the copy.
+///
+/// Cache key: value-equality of the `[TranscriptItem]` input. Both cheap and
+/// correct:
+///   - Cheap on the no-change path: `Array.==` checks `count` first, then
+///     short-circuits on COW buffer identity. The live transcript only swaps in
+///     a new array value when a poll detects a real change
+///     (`LiveTranscriptPaneView.pollOnce`), so the common re-eval reuses the same
+///     buffer → O(1).
+///   - Correct: on a genuine content change the buffer differs and `==` does an
+///     element compare, catching *every* mutation (result populating, text
+///     growing, isError flipping, timestamps). A count/length-only signature
+///     would silently drop a needed UI update, so we deliberately do NOT use a
+///     partial signature.
+///
+/// Not thread-safe; only touched from `body` on the main actor.
+@MainActor final class TranscriptNodeCache {
+    private var cachedItems: [TranscriptItem]?
+    private var cachedNodes: [TranscriptRenderNode] = []
+
+    /// Number of times the node array was actually rebuilt (cache misses).
+    /// Exposed for tests and as the before/after measurement signal for the
+    /// issue #129 hover-rebuild fix.
+    private(set) var rebuildCount = 0
+
+    nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
+
+    func nodes(for items: [TranscriptItem]) -> [TranscriptRenderNode] {
+        if let cachedItems, cachedItems == items {
+            return cachedNodes
+        }
+        let nodes = transcriptRenderNodes(from: items)
+        cachedItems = items
+        cachedNodes = nodes
+        rebuildCount &+= 1
+        // Cache MISS only — silent at default log levels, never fires on the hot
+        // (cache-hit) path. Counts rebuilds so a before/after mouse sweep is
+        // measurable (issue #129). Activate with `log stream --level debug`.
+        Self.perfLog.debug("nodes.rebuild seq=\(self.rebuildCount, privacy: .public) count=\(nodes.count, privacy: .public)")
+        return nodes
+    }
+}

--- a/Tests/TBDAppTests/TranscriptNodeCacheTests.swift
+++ b/Tests/TBDAppTests/TranscriptNodeCacheTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDApp
+
+/// Tests for `TranscriptNodeCache` — the issue #129 node-array memoization.
+///
+/// Two properties matter:
+///   1. Stability: unchanged `items` → the SAME array instance back (no rebuild),
+///      so `ForEach`/AttributeGraph skip re-diffing and re-copying.
+///   2. Correctness (the dangerous failure mode): a content change MUST invalidate
+///      the cache, or a needed SwiftUI re-render is silently dropped. We test that
+///      a same-count, same-id payload mutation still busts the cache.
+@Suite("TranscriptNodeCache")
+@MainActor
+struct TranscriptNodeCacheTests {
+
+    private func toolItem(id: String, result: ToolResult? = nil) -> TranscriptItem {
+        .toolCall(id: id, name: "Bash", inputJSON: "{}", inputTruncatedTo: nil,
+                  result: result, subagent: nil, timestamp: nil)
+    }
+
+    private func userItem(id: String, text: String) -> TranscriptItem {
+        .userPrompt(id: id, text: text, timestamp: nil)
+    }
+
+    /// Stable buffer base address of an array, for identity comparison.
+    private func baseAddress(_ nodes: [TranscriptRenderNode]) -> UnsafeRawPointer? {
+        nodes.withUnsafeBufferPointer { UnsafeRawPointer($0.baseAddress) }
+    }
+
+    // 1. Unchanged items → no rebuild, same instance.
+    @Test func unchangedItems_returnsCachedInstance_noRebuild() {
+        let cache = TranscriptNodeCache()
+        let items = [userItem(id: "u1", text: "hi"), toolItem(id: "t1")]
+
+        let r1 = cache.nodes(for: items)
+        let r2 = cache.nodes(for: items)
+
+        #expect(cache.rebuildCount == 1)
+        #expect(baseAddress(r1) == baseAddress(r2))
+    }
+
+    // 2. A genuinely new (but equal-valued) array still hits the cache, because
+    //    the key is value-equality, not buffer identity.
+    @Test func equalValuedItems_stillCacheHit() {
+        let cache = TranscriptNodeCache()
+        let itemsA = [userItem(id: "u1", text: "hi"), toolItem(id: "t1")]
+        let itemsB = [userItem(id: "u1", text: "hi"), toolItem(id: "t1")]
+
+        _ = cache.nodes(for: itemsA)
+        let r2 = cache.nodes(for: itemsB)
+
+        #expect(cache.rebuildCount == 1)
+        _ = r2
+    }
+
+    // 3. Count change → rebuild.
+    @Test func countChange_rebuilds() {
+        let cache = TranscriptNodeCache()
+        _ = cache.nodes(for: [toolItem(id: "t1")])
+        _ = cache.nodes(for: [toolItem(id: "t1"), toolItem(id: "t2")])
+        #expect(cache.rebuildCount == 2)
+    }
+
+    // 4. CORRECTNESS: same count + same id, but a payload mutation (result
+    //    nil → populated). Must invalidate, or the UI would silently miss the
+    //    tool result appearing.
+    @Test func sameCountSameId_payloadMutation_rebuilds() {
+        let cache = TranscriptNodeCache()
+        let before = [toolItem(id: "t1", result: nil)]
+        let after = [toolItem(id: "t1",
+                              result: ToolResult(text: "output", truncatedTo: nil, isError: false))]
+
+        let r1 = cache.nodes(for: before)
+        let r2 = cache.nodes(for: after)
+
+        #expect(cache.rebuildCount == 2)
+        #expect(r1 != r2)
+    }
+
+    // 5. CORRECTNESS: text edit under a stable id, same length, still busts cache.
+    @Test func sameLengthTextEdit_rebuilds() {
+        let cache = TranscriptNodeCache()
+        _ = cache.nodes(for: [userItem(id: "u1", text: "cat")])
+        _ = cache.nodes(for: [userItem(id: "u1", text: "dog")]) // same length, different content
+        #expect(cache.rebuildCount == 2)
+    }
+
+    // 6. Toggling back and forth between two distinct item arrays rebuilds each
+    //    time (single-slot cache) — documents the cache depth.
+    @Test func alternatingItems_rebuildEachTime() {
+        let cache = TranscriptNodeCache()
+        let a = [toolItem(id: "t1")]
+        let b = [toolItem(id: "t2")]
+        _ = cache.nodes(for: a)
+        _ = cache.nodes(for: b)
+        _ = cache.nodes(for: a)
+        #expect(cache.rebuildCount == 3)
+    }
+
+    // 7. CORRECTNESS: a subagent payload change under a stable toolCall id
+    //    (recursive Equatable) must still bust the cache.
+    @Test func subagentItemCountChange_rebuilds() {
+        let cache = TranscriptNodeCache()
+        let before = [TranscriptItem.toolCall(
+            id: "t1", name: "Agent", inputJSON: "{}", inputTruncatedTo: nil,
+            result: nil, subagent: Subagent(agentID: "a1", agentType: nil, items: []),
+            timestamp: nil)]
+        let after = [TranscriptItem.toolCall(
+            id: "t1", name: "Agent", inputJSON: "{}", inputTruncatedTo: nil,
+            result: nil,
+            subagent: Subagent(agentID: "a1", agentType: nil,
+                               items: [.userPrompt(id: "u1", text: "hi", timestamp: nil)]),
+            timestamp: nil)]
+        _ = cache.nodes(for: before)
+        _ = cache.nodes(for: after)
+        #expect(cache.rebuildCount == 2)
+    }
+}


### PR DESCRIPTION
## The problem (issue #129)

`TranscriptItemsView` owned `@State private var hoveredItemID` — its only job was to gate `.textSelection(.enabled)` so just the hovered row materializes an `NSTextField` (the #120 fix for the 17s "NSTextField-per-row storm"). But because that state lived on the **list-owning** view, every mouse crossing a row boundary re-ran the whole list body, which called `transcriptRenderNodes(from: items)` with **no memoization** — rebuilding the entire node array, re-hashing every node's multi-KB `contentVersion`, handing `ForEach` a fresh array identity, and forcing AttributeGraph to deep-copy the whole input (`initializeWithCopy` value-witness cost seen in hang captures).

**Confirmed probe (this worktree, throwaway instrumentation):** during a ~12s physical mouse sweep over a 105-item transcript, the node-array builder re-ran **70 times — 69 with byte-identical output** (`dataChanged=false`), only **1** real data change. At-or-worse-than one full rebuild per row-crossing, ~all waste.

## The fix — two layers

**Layer 1 — memoize the node array** (`TranscriptNodeCache`, safety net). A `@MainActor` reference type held in `@State` caches `transcriptRenderNodes(from:)` keyed on value-equality of the `[TranscriptItem]` input. Returns the **same array instance** when items are unchanged, so `ForEach` skips re-diffing and AttributeGraph skips the deep copy. Cheap on the no-change path (`Array.==` checks count then short-circuits on COW buffer identity — the poll only swaps in a new array on a real change) and correct on the change path (element compare catches *every* mutation — result populating, text growing, `isError` flipping, timestamps). We deliberately avoid a count/length-only signature, which could silently drop a UI update. Layer 1 also protects against *other* body-re-eval drivers (data polls, parent re-renders), not just hover.

**Layer 2 — stop the parent body re-running on hover at all** (`SelectableTranscriptRow`). The selection-gate state moves down to per-row local `@State isHovered`, mirroring `ActivityRowChrome`. Now a hover re-renders only the entered/exited row; `TranscriptItemsView.body` never runs on hover, killing the responder-graph rebuild and hit-test re-run too — not just the array rebuild.

### Latch design decision

The old gate was *latched* — it never cleared on hover-exit so a drag-select surviving a brief cursor excursion outside the row still worked. Per-row local state clears on exit instead, and that is **safe**: AppKit `NSTrackingArea`s (what SwiftUI `.onHover` is built on) do **not** post `mouseExited` during an active drag unless `.enabledDuringMouseDrag` is set, which `.onHover` does not. So while the button is held during a drag-select, `isHovered` stays `true` and the `NSTextField` is not torn down — the latch was only ever protecting a case AppKit already handles. Trade-off: if the pointer leaves a row with no button held, selection clears, which is fine since each row is its own `NSTextField` and selection can't span rows anyway.

## Measurement seam

`TranscriptNodeCache` logs `nodes.rebuild seq=… count=…` on cache **miss only** (silent at default levels, never on the hot cache-hit path) under the existing `perf-transcript` category, and exposes `rebuildCount` for tests. Capture a sweep with:
`log stream --level debug --predicate 'subsystem == "com.tbd.app" AND category == "perf-transcript"'`

## Verification

- `swift build` clean; `swift test` for transcript suites clean (40 tests). New `TranscriptNodeCacheTests` cover stability (unchanged items → same instance, no rebuild) and the dangerous false-equality failure mode (same-count/same-id payload mutation, same-length text edit, and subagent-payload changes all bust the cache).
- **Before:** ~70 builder runs per ~12s sweep, **69 of them pure hover waste** (`dataChanged=false`). **After (physical sweep, this build):** the `nodes.rebuild` log fired only on **mount** (`seq=1`) and on **genuine data changes** (`seq=2 count 69→70`, `seq=3 count 70→72`) — **zero hover-driven rebuilds**. The broad `perf-transcript` capture showed 46 `pollOnce` heartbeats over the same window, so the empty hover path is real, not a dead stream. Net: **69 wasted rebuilds → 0**.
- Text selection / drag-select still works during an active drag (per the latch reasoning above).

## Scope note

This removes the per-hover rebuild **driver** that all prior #129 fixes left untouched. The residual mount-time hit-test / `ButtonBehavior` costs (Group A in the latest #129 analysis) remain as separate future work.

**Observed during verification (out of scope, pre-existing):** opening a 64-item pane still produced a ~1.1s main-thread hang whose stack is pure SwiftUI layout — `LazyStack.place → … → _FlexFrameLayout.sizeThatFits → ScrollViewLayoutComputer.Engine.sizeThatFits` — i.e. the outer pane `ScrollView` measuring the whole `LazyVStack` to satisfy `.defaultScrollAnchor(.bottom)`. No `transcriptRenderNodes`/`TranscriptNodeCache`/hover frames appear, so this is the #129 umbrella's mount-time layout cost (the `List`-migration item), not a regression from or target of this PR.

Refs #129.

[confirm-hover-rebuild](https://cheapsteak.github.io/tbd/open/?worktree=8E2E6411-8A59-4A49-8AB7-538C7F6C28BF)
