### PR TITLE
Feat: Make the live transcript pane opt-in via Settings → Experimental to avoid UI freezes

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1106,6 +1106,22 @@ final class AppState: ObservableObject {
         defaults.object(forKey: autoSuspendClaudeKey) as? Bool ?? false
     }
 
+    /// UserDefaults key for the `@AppStorage` toggle in the
+    /// Settings → Experimental section that gates the experimental live
+    /// transcript pane. The View layer (`PanePlaceholder`) reads it directly
+    /// via `@AppStorage`; `transcriptFeatureEnabled(defaults:)` exposes the
+    /// same fail-closed read for non-View callers. The feature can freeze the
+    /// UI on very large transcripts, so it is opt-in and fails closed.
+    static let enableTranscriptKey = "enableTranscript"
+
+    /// Fail-closed read of the experimental live-transcript toggle for
+    /// non-View callers (the View layer uses `@AppStorage` directly).
+    /// Defaults to false when the user has never touched the toggle, matching
+    /// the `@AppStorage` default.
+    static func transcriptFeatureEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: enableTranscriptKey) as? Bool ?? false
+    }
+
     /// UserDefaults key for a Claude spawn-env setting, by registry ID.
     nonisolated static func claudeEnvKey(_ settingID: String) -> String {
         "claudeEnvSetting.\(settingID)"

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -39,6 +39,7 @@ struct PanePlaceholder: View {
     @State private var hasRenderableContent = false
     @StateObject private var webviewState = WebviewState()
     @State private var didCopyURL = false
+    @AppStorage(AppState.enableTranscriptKey) private var transcriptFeatureEnabled = false
 
     /// Find the Terminal model matching a terminal ID in this pane's worktree.
     private func terminal(for id: UUID) -> Terminal? {
@@ -188,7 +189,7 @@ struct PanePlaceholder: View {
             }
             .buttonStyle(.borderless)
 
-            if terminal(for: terminalID)?.isClaudeResumable == true {
+            if terminal(for: terminalID)?.isClaudeResumable == true && transcriptFeatureEnabled {
                 Button(action: { openTranscript(terminalID: terminalID) }) {
                     HStack(spacing: 2) {
                         Image(systemName: "text.bubble")
@@ -256,14 +257,18 @@ struct PanePlaceholder: View {
         case .note(let noteID):
             NotePaneView(noteID: noteID, worktreeID: worktree.id)
         case .liveTranscript(_, let terminalID):
-            LiveTranscriptPaneView(terminalID: terminalID, worktreeID: worktree.id)
-                .environment(\.openFilePreview, { path in
-                    let newContent = PaneContent.codeViewer(id: UUID(), path: path)
-                    layout = layout.splitPane(id: content.paneID, direction: .horizontal, newContent: newContent)
-                })
-                .environment(\.openTranscriptOverlay) { itemID in
-                    overlayCoordinator.open(terminalID: terminalID, itemID: itemID)
-                }
+            if transcriptFeatureEnabled {
+                LiveTranscriptPaneView(terminalID: terminalID, worktreeID: worktree.id)
+                    .environment(\.openFilePreview, { path in
+                        let newContent = PaneContent.codeViewer(id: UUID(), path: path)
+                        layout = layout.splitPane(id: content.paneID, direction: .horizontal, newContent: newContent)
+                    })
+                    .environment(\.openTranscriptOverlay) { itemID in
+                        overlayCoordinator.open(terminalID: terminalID, itemID: itemID)
+                    }
+            } else {
+                transcriptDisabledPlaceholder
+            }
         }
     }
 
@@ -384,6 +389,23 @@ struct PanePlaceholder: View {
                 }
             }
         }
+    }
+
+    /// Placeholder shown when a transcript pane exists but the feature flag is off.
+    /// Renders a centered message pointing the user to enable the feature in Settings.
+    private var transcriptDisabledPlaceholder: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "text.bubble")
+                .font(.system(size: 32))
+                .foregroundStyle(.tertiary)
+            Text("Transcript view is turned off")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Text("Enable it in Settings → Experimental")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Close

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -35,6 +35,7 @@ struct GeneralSettingsTab: View {
     @AppStorage("enableNotifications") private var enableNotifications: Bool = true
     @AppStorage("skipPermissions") private var skipPermissions: Bool = true
     @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = false
+    @AppStorage(AppState.enableTranscriptKey) private var enableTranscript: Bool = false
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
@@ -100,6 +101,8 @@ struct GeneralSettingsTab: View {
             Section("Experimental") {
                 Toggle("Auto-suspend idle Claude when switching worktrees", isOn: $autoSuspend)
                     .help("Experimental: exit idle Claude instances when you switch away and resume them when you switch back, freeing memory. Off by default — may interrupt long-running work.")
+                Toggle("Live transcript pane", isOn: $enableTranscript)
+                    .help("Experimental: show a chat-style live transcript pane for Claude sessions. Off by default — may freeze the app on very large transcripts.")
             }
         }
         .formStyle(.grouped)

--- a/Tests/TBDAppTests/TranscriptFeatureFlagTests.swift
+++ b/Tests/TBDAppTests/TranscriptFeatureFlagTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tests for the `enableTranscript` UserDefaults helper that gates the
+/// experimental live transcript pane. The live transcript feature can freeze
+/// the app UI on very large transcripts, so it is opt-in and fails closed.
+///
+/// Isolation matters: TBDApp ships as an unbundled SPM executable, so its
+/// `UserDefaults.standard` domain is `TBDApp.plist` in the developer's home
+/// — the SAME domain a running production TBDApp reads via `@AppStorage`.
+/// Every test below drives the helper through a per-test `UserDefaults(suiteName:)`
+/// so `.standard` is never touched.
+
+@MainActor
+@Suite("Transcript feature flag preference")
+struct TranscriptFeatureFlagTests {
+    private let key = AppState.enableTranscriptKey
+
+    /// Build an isolated UserDefaults domain, run the body with it, and tear
+    /// the domain down afterwards so nothing persists across tests.
+    private func withIsolatedDefaults(
+        seed: Bool?,
+        _ body: (UserDefaults) -> Void
+    ) {
+        let suiteName = "TBDAppTests.Transcript.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        if let seed {
+            defaults.set(seed, forKey: key)
+        }
+        body(defaults)
+    }
+
+    @Test("returns true when toggle is on")
+    func enabledWhenOn() {
+        withIsolatedDefaults(seed: true) { defaults in
+            #expect(AppState.transcriptFeatureEnabled(defaults: defaults) == true)
+        }
+    }
+
+    @Test("returns false when toggle is off — the gated-off branch")
+    func disabledWhenOff() {
+        withIsolatedDefaults(seed: false) { defaults in
+            #expect(AppState.transcriptFeatureEnabled(defaults: defaults) == false)
+        }
+    }
+
+    @Test("defaults to false when the user has never touched the toggle — fail-closed")
+    func defaultsToFalseWhenUnset() {
+        withIsolatedDefaults(seed: nil) { defaults in
+            #expect(AppState.transcriptFeatureEnabled(defaults: defaults) == false)
+        }
+    }
+}


### PR DESCRIPTION
## Why

The live transcript pane (the chat-style view of a Claude session's JSONL) can occasionally freeze the app UI. While it's open it runs a 1.5s poll loop that fetches the full transcript over RPC and then, on the main actor, diffs old vs. new items (`messagesEqual`) and swaps state. On very large transcripts that per-poll work is expensive enough to hang the UI. Until that's properly fixed, the feature shouldn't be on for everyone.

## What this PR does

Puts the live transcript pane behind an opt-in **"Live transcript pane"** toggle in **Settings → Experimental**, defaulting **OFF** and failing closed (matches the existing `autoSuspendClaude` toggle pattern).

Both entry points in `PanePlaceholder` are gated:

- **The "Transcript" button** (creation) — hidden when the toggle is off.
- **The render path** — when off, a `.liveTranscript` pane renders a small disabled placeholder instead of `LiveTranscriptPaneView`.

Gating the render path (not just the button) is the important part: restored saved layouts re-enter the render path on relaunch, so without it a "disabled" feature would silently revive the polling/diffing work that causes the freeze. A persisted transcript pane stays closable via the generic pane controls.

## Tests

Adds `TranscriptFeatureFlagTests` covering the on / off / unset branches of the fail-closed `transcriptFeatureEnabled` helper, per the repo rule to test each branch of a gating conditional.

## Notes

This gates the feature; it does not fix the underlying freeze. The poll-loop / main-actor-diff hot path remains the follow-up if/when the feature is promoted out of experimental.

[🧪 Transcript Experimental Toggle](https://cheapsteak.github.io/tbd/open/?worktree=4CB106C2-7197-40B7-92C3-4A368284B00B)