### PR TITLE
Fix: Stop AppearanceDebounceTests flaking on the RunLoop.main scheduler

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -492,7 +492,13 @@ final class AppState: ObservableObject {
             // only react to actual user-driven scheme changes.
             .dropFirst()
             .removeDuplicates()
-            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
+            // `DispatchQueue.main` rather than `RunLoop.main`: Combine's RunLoop
+            // scheduler fires its debounce Timer in `.default` mode only, so while
+            // the user scrubs the scheme picker (run loop in `.eventTracking` mode)
+            // the trailing emission stalls until the drag ends. The dispatch
+            // scheduler delivers regardless of run-loop mode — and is reliably
+            // serviced under structured concurrency, which the unit test depends on.
+            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.broadcastAppearanceColorFgBg(appearance)
             }

--- a/Tests/TBDAppTests/AppearanceDebounceTests.swift
+++ b/Tests/TBDAppTests/AppearanceDebounceTests.swift
@@ -4,10 +4,22 @@ import Testing
 @testable import TBDApp
 import TBDShared
 
-/// Test that rapid scheme changes are debounced to avoid spamming RPCs to the daemon.
-/// This test verifies that the debounce operator is applied to the schemeID publisher.
-/// We test the debounce behavior by subscribing directly to the appearance's $schemeID
-/// publisher and observing that rapid changes collapse to fewer emissions.
+/// Tests that scheme changes are debounced before they turn into daemon RPCs.
+///
+/// These tests reconstruct the same Combine pipeline that
+/// `AppState.setupAppearanceSubscriptions` wires onto `appearance.$schemeID`
+/// (`dropFirst().removeDuplicates().debounce(for: .milliseconds(200),
+/// scheduler: DispatchQueue.main)`) and observe its emissions directly, so the
+/// debounce contract is verified without standing up a daemon connection.
+///
+/// Why `DispatchQueue.main` + condition-based waiting: a `RunLoop.main` Combine
+/// scheduler fires its debounce `Timer` in `.default` mode, which only advances
+/// while a `CFRunLoop` is actively spinning. Under `swift test` there is no
+/// `NSApplication.run()` pumping the main run loop, so those timers fire
+/// unreliably while the test is suspended in `Task.sleep` — the original flake.
+/// `DispatchQueue.main` blocks are serviced by the main-actor executor
+/// regardless, so the emission always lands; we then poll for it instead of
+/// sleeping a fixed window and asserting blind.
 @MainActor
 @Suite("AppState appearance debounce")
 struct AppearanceDebounceTests {
@@ -23,29 +35,25 @@ struct AppearanceDebounceTests {
         // Subscribe to the debounced schemeID emissions to count how many fire.
         var debounceEmissions: [String] = []
         let testSubscription = appearance.$schemeID
+            .dropFirst()
             .removeDuplicates()
-            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
-            .sink { schemeID in
-                debounceEmissions.append(schemeID)
-            }
+            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
+            .sink { debounceEmissions.append($0) }
 
-        // Rapidly change the scheme within the debounce window.
-        // Since appearance starts with the default scheme, explicitly set three different ones
-        // in rapid succession without waiting.
+        // Three changes with no suspension between them stay inside one debounce
+        // window, so the operator must coalesce them into a single trailing emission.
         appearance.schemeID = "scheme-a"
         appearance.schemeID = "scheme-b"
         appearance.schemeID = "scheme-c"
 
-        // Give the debounce timer time to fire. 600ms vs the 200ms window leaves
-        // a 3x safety margin — `Task.sleep` has no lower-bound guarantee on
-        // constrained CI runners, and a tighter margin would risk flakes.
-        try? await Task.sleep(nanoseconds: 600_000_000)
+        // Wait (condition-based) for the coalesced emission rather than sleeping a
+        // fixed window then asserting — no wall-clock dependency.
+        let landed = await poll { debounceEmissions.contains("scheme-c") }
+        #expect(landed, "Debounced emission of the final scheme should land within the deadline")
 
-        // The debounce should coalesce the three changes into just one emission of the final value.
-        // Note: the initial value (default scheme) may also emit depending on timing, but we're
-        // testing that the three rapid changes don't produce three separate emissions.
-        let finalEmissions = debounceEmissions.filter { $0 == "scheme-c" }
-        #expect(finalEmissions.count == 1, "Final scheme change should emit exactly once")
+        // The three rapid changes collapsed to exactly one emission of the last value;
+        // the intermediate values were never emitted on their own.
+        #expect(debounceEmissions == ["scheme-c"], "Rapid changes should coalesce to a single final emission")
 
         testSubscription.cancel()
     }
@@ -60,25 +68,42 @@ struct AppearanceDebounceTests {
 
         var debounceEmissions: [String] = []
         let testSubscription = appearance.$schemeID
+            .dropFirst()
             .removeDuplicates()
-            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
-            .sink { schemeID in
-                debounceEmissions.append(schemeID)
-            }
+            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
+            .sink { debounceEmissions.append($0) }
 
-        // First scheme change and wait for debounce to complete.
+        // First change: wait for its debounced emission to land.
         appearance.schemeID = "scheme-a"
-        try? await Task.sleep(nanoseconds: 600_000_000) // 3x the 200ms debounce window
+        let first = await poll { debounceEmissions.count >= 1 }
+        #expect(first, "First separated change should produce an emission")
         let countAfterFirst = debounceEmissions.count
 
-        // Second scheme change after debounce fired — should emit again.
+        // Second change after the first window settled: must emit again.
         appearance.schemeID = "scheme-b"
-        try? await Task.sleep(nanoseconds: 600_000_000) // Wait for second debounce window
-
-        // Should have more emissions now than before the second change.
-        let countAfterSecond = debounceEmissions.count
-        #expect(countAfterSecond > countAfterFirst, "Separated changes should produce multiple emissions")
+        let second = await poll { debounceEmissions.count > countAfterFirst }
+        #expect(second, "Second separated change should produce another emission")
+        #expect(debounceEmissions.count > countAfterFirst, "Separated changes should produce multiple emissions")
 
         testSubscription.cancel()
     }
+}
+
+/// Polls `condition` on the main actor until it returns true or `timeout`
+/// elapses, returning the final result. Used instead of a fixed `Task.sleep`
+/// so the test proceeds the instant the asynchronous debounce emission arrives
+/// and never depends on a wall-clock window. The `Task.sleep` suspension points
+/// let `DispatchQueue.main` debounce blocks drain between checks.
+@MainActor
+private func poll(
+    timeout: Duration = .seconds(5),
+    interval: Duration = .milliseconds(10),
+    _ condition: () -> Bool
+) async -> Bool {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while ContinuousClock.now < deadline {
+        if condition() { return true }
+        try? await Task.sleep(for: interval)
+    }
+    return condition()
 }


### PR DESCRIPTION
## Summary

- **What's broken:** `AppearanceDebounceTests` intermittently failed in CI (it flaked an unrelated PR, #247) with `(countAfterSecond → 1) > (countAfterFirst → 1)` — the second debounced emission never landed inside the test's fixed 600ms wait window.
- **Why it happens:** the test used Combine's `.debounce(scheduler: RunLoop.main)`. That scheduler fires its debounce `Timer` in `.default` run-loop mode, which only advances while a `CFRunLoop` is actively spinning. Under `swift test` there is no `NSApplication.run()` pumping `RunLoop.main`, so the debounced emission fired unreliably while the test was suspended in `Task.sleep`. The fixed-window `sleep`-then-assert pattern then caught the missed emission as a failure. The first emission usually landed; the second was the one that slipped — exactly the observed symptom.
- **What this PR does:**
  - **Production** (`AppState.swift`): switches the scheme-change debounce from `RunLoop.main` to `DispatchQueue.main`, whose blocks are serviced by the main-actor executor regardless of run-loop state. This is also a genuine user-facing improvement — a `RunLoop.main` `.default`-mode timer stalls while the user scrubs the scheme picker (run loop in `.eventTracking` mode), so the COLORFGBG broadcast was being delayed until the drag ended; `DispatchQueue.main` delivers regardless of mode.
  - **Tests**: both tests now mirror the production pipeline exactly (`dropFirst().removeDuplicates().debounce(scheduler: DispatchQueue.main)`) and replace the fixed `Task.sleep` windows with condition-based polling, removing the wall-clock timing dependency entirely. The coalescing assertion was also tightened from a lenient filtered count to a full-sequence `== ["scheme-c"]` check.

## Test plan

- [x] `swift build` — Build complete
- [x] `swiftlint --strict` — 0 violations across 210 files
- [x] `swift test --filter AppearanceDebounceTests` looped **50×** with **0 failures**
- [x] Red/green check (during review): removing the `.debounce` operator from the rapid-changes test makes the `== ["scheme-c"]` assertion fail, confirming it genuinely enforces the coalescing contract rather than passing tautologically

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=A659B2AE-A17D-4770-A825-ADEA37EB9BF3)