### PR TITLE
Feat: Bold background tabs when their Claude session finishes

### DIFF
--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -54,6 +54,8 @@ extension AppState {
     func setActiveTab(worktreeID: UUID, tabIndex: Int) {
         activeTabIndices[worktreeID] = tabIndex
         guard let arr = tabs[worktreeID], arr.indices.contains(tabIndex) else { return }
+        // Activating a tab clears its unread-completion bold.
+        unreadTerminals.subtract(terminalIDs(in: arr[tabIndex]))
         let tabID = arr[tabIndex].id
         Task {
             do {
@@ -140,6 +142,11 @@ extension AppState {
            focusedTabCloseContext?.tabID == tab.id {
             focusedTabCloseContext = nil
         }
+
+        // Drop any pending unread-completion bold for this tab's terminals so a
+        // background tab that completed and was closed without being activated
+        // doesn't leak stale UUIDs into `unreadTerminals`.
+        unreadTerminals.subtract(terminalIDsInTab)
 
         layouts.removeValue(forKey: tab.id)
         arr.remove(at: index)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -58,6 +58,12 @@ final class AppState: ObservableObject {
     /// from this dictionary because `refreshNotifications` auto-marks them
     /// read on every poll.
     @Published var unreadByWorktree: [UUID: UnreadSummary] = [:]
+    /// Terminal IDs that fired a `.responseComplete` notification while their
+    /// tab was NOT the active tab of a focused worktree. Drives the bold tab
+    /// label in `TabBar`, mirroring the worktree-row bold. App-local and
+    /// in-memory only — cleared when the user activates the tab (or focuses the
+    /// worktree on that tab); intentionally not persisted across app restarts.
+    @Published var unreadTerminals: Set<UUID> = []
     @Published var selectedWorktreeIDs: Set<UUID> = [] {
         didSet {
             // If the List selected a repo header tag (not a worktree), treat it
@@ -76,6 +82,13 @@ final class AppState: ObservableObject {
             for id in selectedWorktreeIDs where !selectionOrder.contains(id) {
                 selectionOrder.append(id)
             }
+            // When a single worktree becomes the focused selection, the user is
+            // now viewing its active tab — clear that tab's unread-completion
+            // bold. Single-select only: tab bars only render in single-select.
+            if selectedWorktreeIDs.count == 1, let only = selectedWorktreeIDs.first {
+                clearUnreadForActiveTab(worktreeID: only)
+            }
+
             // Clear repo selection when a worktree is selected
             if !selectedWorktreeIDs.isEmpty {
                 if let leaving = selectedRepoID { clearRevivingArchived(repoID: leaving) }
@@ -643,7 +656,65 @@ final class AppState: ObservableObject {
         modelProfiles[idx] = ModelProfileWithUsage(profile: existing.profile, usage: usage)
     }
 
+    /// The terminal ID(s) a `Tab` renders. A tab with a stored split layout in
+    /// `layouts[tab.id]` can render multiple terminals across its panes; a tab
+    /// without one renders the single surface in `tab.content`. Both `.terminal`
+    /// and `.liveTranscript` panes reference a terminal; everything else (notes,
+    /// webviews, code viewers) has none.
+    ///
+    /// Consults the split layout first via the same resolution the close path
+    /// uses (`layouts[tab.id] ?? .pane(tab.content)` then `allTerminalIDs()`),
+    /// then unions the `tab.content` terminal so `.liveTranscript` tabs — whose
+    /// IDs `allTerminalIDs()` does not enumerate — stay covered.
+    func terminalIDs(in tab: Tab) -> Set<UUID> {
+        let layout = layouts[tab.id] ?? .pane(tab.content)
+        var ids = Set(layout.allTerminalIDs())
+        switch tab.content {
+        case .terminal(let tid):
+            ids.insert(tid)
+        case .liveTranscript(_, let tid):
+            ids.insert(tid)
+        default:
+            break
+        }
+        return ids
+    }
+
+    /// True iff `worktreeID` is the single selection AND its active tab renders
+    /// `terminalID`. Used to decide whether a `.responseComplete` arrival should
+    /// be recorded as unread — a completion on the tab the user is already
+    /// looking at must never bold.
+    func isActiveTabTerminal(_ terminalID: UUID, inFocusedWorktree worktreeID: UUID) -> Bool {
+        guard selectedWorktreeIDs == [worktreeID] else { return false }
+        guard let arr = tabs[worktreeID], !arr.isEmpty else { return false }
+        let activeIndex = activeTabIndices[worktreeID] ?? 0
+        guard arr.indices.contains(activeIndex) else { return false }
+        return terminalIDs(in: arr[activeIndex]).contains(terminalID)
+    }
+
+    /// Remove the active tab's terminal(s) from `unreadTerminals` for the given
+    /// worktree. Called when the user activates a tab or focuses a worktree so
+    /// the surface they're now looking at clears its bold.
+    func clearUnreadForActiveTab(worktreeID: UUID) {
+        guard let arr = tabs[worktreeID], !arr.isEmpty else { return }
+        let activeIndex = activeTabIndices[worktreeID] ?? 0
+        guard arr.indices.contains(activeIndex) else { return }
+        let tids = terminalIDs(in: arr[activeIndex])
+        guard !tids.isEmpty else { return }
+        unreadTerminals.subtract(tids)
+    }
+
     private func handleNotificationDelta(_ notification: NotificationDelta) {
+        // Record a background-tab completion so its tab label bolds. Done
+        // BEFORE the visible-worktree early-return because a worktree can be
+        // "visible" (selected) while the completing terminal lives on a
+        // background tab — that tab should still bold. The
+        // isActiveTabTerminal guard excludes the tab the user is looking at.
+        if notification.type == .responseComplete, let tid = notification.terminalID,
+           !isActiveTabTerminal(tid, inFocusedWorktree: notification.worktreeID) {
+            unreadTerminals.insert(tid)
+        }
+
         let visible = visibleWorktreeIDs
         guard !visible.contains(notification.worktreeID) else { return }
 

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -448,6 +448,16 @@ private struct TabBarItem: View {
         terminal?.suspendedAt != nil
     }
 
+    /// Bold this tab's label when its terminal fired a `.responseComplete`
+    /// while in the background. Never bold the active/selected tab — activating
+    /// it clears the unread state, but guard here too so the active tab can
+    /// never render bold even for a frame. Mirrors WorktreeRowView's bold.
+    private var hasUnreadCompletion: Bool {
+        guard !isSelected else { return false }
+        let tids = appState.terminalIDs(in: tab)
+        return tids.contains { appState.unreadTerminals.contains($0) }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             // Clickable tab content area
@@ -489,6 +499,7 @@ private struct TabBarItem: View {
                             displayContent: {
                                 Text(tabLabel)
                                     .font(.system(size: 11))
+                                    .fontWeight(hasUnreadCompletion ? .bold : .regular)
                                     .lineLimit(1)
                                     .fixedSize()
                                     .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))
@@ -499,6 +510,7 @@ private struct TabBarItem: View {
                     } else {
                         Text(tabLabel)
                             .font(.system(size: 11))
+                            .fontWeight(hasUnreadCompletion ? .bold : .regular)
                             .lineLimit(1)
                             .fixedSize()
                             .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))

--- a/Tests/TBDAppTests/TabUnreadCompletionTests.swift
+++ b/Tests/TBDAppTests/TabUnreadCompletionTests.swift
@@ -1,0 +1,354 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tests for the background-tab unread-completion bold feature. A
+/// `.responseComplete` notification for a terminal whose tab is NOT the
+/// currently-active tab of the focused worktree records the terminal in
+/// `unreadTerminals` (driving the bold tab label). Activating the tab or
+/// focusing the worktree on that tab clears it.
+///
+/// Every test constructs `AppState(userDefaults:)` against a unique throwaway
+/// suite — TBDApp ships as an unbundled SPM executable, so `UserDefaults.standard`
+/// is the running developer's real `TBDApp.plist`. Using it from tests would
+/// clobber live UI preferences.
+@MainActor
+@Suite("Tab unread completion")
+struct TabUnreadCompletionTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.TabUnreadCompletion.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func makeDelta(
+        worktreeID: UUID,
+        terminalID: UUID?,
+        type: NotificationType = .responseComplete
+    ) -> StateDelta {
+        .notificationReceived(NotificationDelta(
+            notificationID: UUID(),
+            worktreeID: worktreeID,
+            type: type,
+            message: nil,
+            terminalID: terminalID
+        ))
+    }
+
+    @Test func responseComplete_forBackgroundTab_recordsUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let activeTerminal = UUID()
+            let backgroundTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: activeTerminal, content: .terminal(terminalID: activeTerminal), label: nil),
+                    Tab(id: backgroundTerminal, content: .terminal(terminalID: backgroundTerminal), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.selectedWorktreeIDs = [worktreeID]
+
+            state.handleDelta(makeDelta(worktreeID: worktreeID, terminalID: backgroundTerminal))
+
+            #expect(state.unreadTerminals.contains(backgroundTerminal))
+        }
+    }
+
+    @Test func responseComplete_forActiveTab_doesNotRecordUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let activeTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: activeTerminal, content: .terminal(terminalID: activeTerminal), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.selectedWorktreeIDs = [worktreeID]
+
+            state.handleDelta(makeDelta(worktreeID: worktreeID, terminalID: activeTerminal))
+
+            #expect(!state.unreadTerminals.contains(activeTerminal))
+        }
+    }
+
+    @Test func responseComplete_forLiveTranscriptActiveTab_doesNotRecordUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: UUID(), content: .liveTranscript(id: UUID(), terminalID: terminalID), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.selectedWorktreeIDs = [worktreeID]
+
+            state.handleDelta(makeDelta(worktreeID: worktreeID, terminalID: terminalID))
+
+            #expect(!state.unreadTerminals.contains(terminalID))
+        }
+    }
+
+    @Test func nonResponseComplete_doesNotRecordUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let backgroundTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil),
+                    Tab(id: backgroundTerminal, content: .terminal(terminalID: backgroundTerminal), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.selectedWorktreeIDs = [worktreeID]
+
+            state.handleDelta(makeDelta(worktreeID: worktreeID, terminalID: backgroundTerminal, type: .error))
+
+            #expect(!state.unreadTerminals.contains(backgroundTerminal))
+        }
+    }
+
+    /// A `.responseComplete` whose delta carries no terminalID must be a no-op:
+    /// the recording branch is gated on `notification.terminalID` so nothing is
+    /// inserted (and nothing crashes).
+    @Test func responseComplete_withNilTerminalID_isNoOp() {
+        withState { state in
+            let worktreeID = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.selectedWorktreeIDs = [worktreeID]
+
+            state.handleDelta(makeDelta(worktreeID: worktreeID, terminalID: nil))
+
+            #expect(state.unreadTerminals.isEmpty)
+        }
+    }
+
+    @Test func activatingTab_clearsUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let activeTerminal = UUID()
+            let backgroundTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: activeTerminal, content: .terminal(terminalID: activeTerminal), label: nil),
+                    Tab(id: backgroundTerminal, content: .terminal(terminalID: backgroundTerminal), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.unreadTerminals = [backgroundTerminal]
+
+            state.setActiveTab(worktreeID: worktreeID, tabIndex: 1)
+
+            #expect(!state.unreadTerminals.contains(backgroundTerminal))
+        }
+    }
+
+    @Test func focusingWorktree_clearsActiveTabUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let activeTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: activeTerminal, content: .terminal(terminalID: activeTerminal), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.unreadTerminals = [activeTerminal]
+
+            // Focusing the worktree (single selection) clears its active tab's unread.
+            state.selectedWorktreeIDs = [worktreeID]
+
+            #expect(!state.unreadTerminals.contains(activeTerminal))
+        }
+    }
+
+    @Test func focusingWorktree_keepsBackgroundTabUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let activeTerminal = UUID()
+            let backgroundTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: activeTerminal, content: .terminal(terminalID: activeTerminal), label: nil),
+                    Tab(id: backgroundTerminal, content: .terminal(terminalID: backgroundTerminal), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.unreadTerminals = [backgroundTerminal]
+
+            state.selectedWorktreeIDs = [worktreeID]
+
+            // Background tab's unread survives focusing the worktree.
+            #expect(state.unreadTerminals.contains(backgroundTerminal))
+        }
+    }
+
+    // MARK: - Record-before-early-return ordering
+
+    /// The recording branch in `handleNotificationDelta` runs BEFORE the
+    /// visible-worktree early-return, so a completion on a background tab of a
+    /// worktree that IS focused/visible still bolds. This pins that load-bearing
+    /// ordering: the worktree is in `visibleWorktreeIDs`, yet the background
+    /// tab's terminal is still recorded.
+    @Test func responseComplete_recordsEvenWhenWorktreeVisible() {
+        withState { state in
+            let worktreeID = UUID()
+            let activeTerminal = UUID()
+            let backgroundTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: activeTerminal, content: .terminal(terminalID: activeTerminal), label: nil),
+                    Tab(id: backgroundTerminal, content: .terminal(terminalID: backgroundTerminal), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            // Single-selecting makes the worktree visible (in visibleWorktreeIDs).
+            state.selectedWorktreeIDs = [worktreeID]
+            #expect(state.visibleWorktreeIDs.contains(worktreeID))
+
+            state.handleDelta(makeDelta(worktreeID: worktreeID, terminalID: backgroundTerminal))
+
+            #expect(state.unreadTerminals.contains(backgroundTerminal))
+        }
+    }
+
+    // MARK: - Tab close cleanup (finding #1)
+
+    /// Closing a background tab that has a pending unread-completion bold must
+    /// remove that tab's terminal from `unreadTerminals` — otherwise the UUID
+    /// leaks forever once the tab (and its terminal) are gone.
+    @Test func closingBackgroundTabWithUnread_removesFromUnreadTerminals() {
+        withState { state in
+            let worktreeID = UUID()
+            let activeTerminal = UUID()
+            let backgroundTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: activeTerminal, content: .terminal(terminalID: activeTerminal), label: nil),
+                    Tab(id: backgroundTerminal, content: .terminal(terminalID: backgroundTerminal), label: nil),
+                ]
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.unreadTerminals = [backgroundTerminal]
+
+            state.closeTab(worktreeID: worktreeID, index: 1)
+
+            #expect(!state.unreadTerminals.contains(backgroundTerminal))
+        }
+    }
+
+    /// Closing a split-layout tab clears unread for ALL of its panes, not just
+    /// the primary `tab.content` terminal.
+    @Test func closingSplitTab_removesAllPaneUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let primaryTerminal = UUID()
+            let secondaryTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: tabID, content: .terminal(terminalID: primaryTerminal), label: nil),
+                ]
+            ]
+            state.layouts = [
+                tabID: .split(
+                    direction: .horizontal,
+                    children: [
+                        .pane(.terminal(terminalID: primaryTerminal)),
+                        .pane(.terminal(terminalID: secondaryTerminal)),
+                    ],
+                    ratios: [0.5, 0.5]
+                )
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.unreadTerminals = [primaryTerminal, secondaryTerminal]
+
+            state.closeTab(worktreeID: worktreeID, index: 0)
+
+            #expect(!state.unreadTerminals.contains(primaryTerminal))
+            #expect(!state.unreadTerminals.contains(secondaryTerminal))
+        }
+    }
+
+    // MARK: - Split-layout active tab (finding #2)
+
+    /// A `.responseComplete` for a SECONDARY pane of the *active* split tab must
+    /// NOT record unread — the user is looking at that split, so no pane of it
+    /// should bold. Before the fix, `isActiveTabTerminal` only consulted
+    /// `tab.content`, missing the secondary pane and wrongly bolding.
+    @Test func responseComplete_forSecondaryPaneOfActiveSplitTab_doesNotRecordUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let tabID = UUID()
+            let primaryTerminal = UUID()
+            let secondaryTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: tabID, content: .terminal(terminalID: primaryTerminal), label: nil),
+                ]
+            ]
+            state.layouts = [
+                tabID: .split(
+                    direction: .horizontal,
+                    children: [
+                        .pane(.terminal(terminalID: primaryTerminal)),
+                        .pane(.terminal(terminalID: secondaryTerminal)),
+                    ],
+                    ratios: [0.5, 0.5]
+                )
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.selectedWorktreeIDs = [worktreeID]
+
+            state.handleDelta(makeDelta(worktreeID: worktreeID, terminalID: secondaryTerminal))
+
+            #expect(!state.unreadTerminals.contains(secondaryTerminal))
+        }
+    }
+
+    /// Activating a split tab clears unread for ALL its panes, including the
+    /// secondary one.
+    @Test func activatingSplitTab_clearsAllPaneUnread() {
+        withState { state in
+            let worktreeID = UUID()
+            let plainTabID = UUID()
+            let plainTerminal = UUID()
+            let splitTabID = UUID()
+            let primaryTerminal = UUID()
+            let secondaryTerminal = UUID()
+            state.tabs = [
+                worktreeID: [
+                    Tab(id: plainTabID, content: .terminal(terminalID: plainTerminal), label: nil),
+                    Tab(id: splitTabID, content: .terminal(terminalID: primaryTerminal), label: nil),
+                ]
+            ]
+            state.layouts = [
+                splitTabID: .split(
+                    direction: .horizontal,
+                    children: [
+                        .pane(.terminal(terminalID: primaryTerminal)),
+                        .pane(.terminal(terminalID: secondaryTerminal)),
+                    ],
+                    ratios: [0.5, 0.5]
+                )
+            ]
+            state.activeTabIndices = [worktreeID: 0]
+            state.unreadTerminals = [primaryTerminal, secondaryTerminal]
+
+            state.setActiveTab(worktreeID: worktreeID, tabIndex: 1)
+
+            #expect(!state.unreadTerminals.contains(primaryTerminal))
+            #expect(!state.unreadTerminals.contains(secondaryTerminal))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- When a Claude session in a **background tab** fires a `responseComplete` notification, that tab's label now goes **bold** in the TabBar — so you can tell at a glance which tab needs attention, the same way the worktree row already bolds.
- The tab you're actively viewing **never** bolds; activating a bolded tab (or focusing the worktree onto it) clears the bold. Recording happens before the visible-worktree early-return, so a background tab in the *currently focused* worktree still bolds (the existing worktree-level unread suppresses that case).
- State is app-local and in-memory (`AppState.unreadTerminals`), driven entirely by notification deltas — **no daemon/DB/RPC changes**. Split-layout tabs resolve all their pane terminals, and unread is dropped on tab close to avoid leaking stale terminal IDs.

## Test plan
- [ ] Open a worktree with 2+ Claude tabs. Work in tab 1; let tab 2's Claude finish → tab 2's label bolds, tab 1 stays normal.
- [ ] Click the bolded tab → bold clears.
- [ ] Let a background tab finish, then close it without visiting → no lingering state.
- [ ] Split a tab into multiple panes; a completion in a secondary pane of the *active* tab does not bold the active tab.
- [ ] `swift test` (new `TabUnreadCompletionTests`, 13 cases) passes.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7AB85310-8304-4959-A837-FBBABA0B5302)