### PR TITLE
Feat: Surface the real API-error text (session limit vs rate limit) and give errors a distinct sound

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -742,7 +742,7 @@ final class AppState: ObservableObject {
         }
 
         // Fire sound + macOS notification
-        notificationSoundPlayer.playIfEnabled()
+        notificationSoundPlayer.playIfEnabled(for: notification.type)
         macNotificationManager.postIfEnabled(
             worktreeID: notification.worktreeID,
             message: notification.message,

--- a/Sources/TBDApp/Services/NotificationSoundPlayer.swift
+++ b/Sources/TBDApp/Services/NotificationSoundPlayer.swift
@@ -1,26 +1,51 @@
 import AppKit
 import SwiftUI
+import TBDShared
 
 @MainActor
 final class NotificationSoundPlayer {
     @AppStorage("enableNotificationSounds") private var enabled: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
+    @AppStorage("errorNotificationSoundName") private var errorSoundName: String = "Sosumi"
+    @AppStorage("errorNotificationSoundCustomPath") private var errorCustomPath: String = ""
 
-    func playIfEnabled() {
+    func playIfEnabled(for type: NotificationType) {
         guard enabled else { return }
-        resolveSound()?.play()
+        let config = Self.resolveSoundConfig(
+            for: type,
+            defaultName: soundName, defaultCustomPath: customPath,
+            errorName: errorSoundName, errorCustomPath: errorCustomPath
+        )
+        Self.makeSound(name: config.name, customPath: config.customPath)?.play()
     }
 
     func playTest() {
-        resolveSound()?.play()
+        Self.makeSound(name: soundName, customPath: customPath)?.play()
     }
 
-    private func resolveSound() -> NSSound? {
+    func playTestError() {
+        Self.makeSound(name: errorSoundName, customPath: errorCustomPath)?.play()
+    }
+
+    /// Pure: pick which (name, customPath) pair to use for a notification
+    /// type. `.error` uses the error sound; everything else uses the default.
+    nonisolated static func resolveSoundConfig(
+        for type: NotificationType,
+        defaultName: String, defaultCustomPath: String,
+        errorName: String, errorCustomPath: String
+    ) -> (name: String, customPath: String) {
+        if type == .error {
+            return (errorName, errorCustomPath)
+        }
+        return (defaultName, defaultCustomPath)
+    }
+
+    private static func makeSound(name: String, customPath: String) -> NSSound? {
         if !customPath.isEmpty {
             return NSSound(contentsOf: URL(fileURLWithPath: customPath), byReference: true)
         }
-        return NSSound(named: NSSound.Name(soundName))
+        return NSSound(named: NSSound.Name(name))
     }
 
     static func systemSoundNames() -> [String] {

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -39,6 +39,8 @@ struct GeneralSettingsTab: View {
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
+    @AppStorage("errorNotificationSoundName") private var errorSoundName: String = "Sosumi"
+    @AppStorage("errorNotificationSoundCustomPath") private var errorCustomPath: String = ""
 
     private var systemSounds: [String] { NotificationSoundPlayer.systemSoundNames() }
     private let soundPlayer = NotificationSoundPlayer()
@@ -78,6 +80,36 @@ struct GeneralSettingsTab: View {
 
                         Button("Test") {
                             soundPlayer.playTest()
+                        }
+                        .controlSize(.small)
+                    }
+
+                    HStack {
+                        Picker("Error sound", selection: Binding(
+                            get: { errorCustomPath.isEmpty ? errorSoundName : "__custom__" },
+                            set: { newValue in
+                                if newValue == "__custom__" {
+                                    pickErrorCustomSound()
+                                } else {
+                                    errorSoundName = newValue
+                                    errorCustomPath = ""
+                                }
+                            }
+                        )) {
+                            ForEach(systemSounds, id: \.self) { name in
+                                Text(name).tag(name)
+                            }
+                            Divider()
+                            Text("Custom…").tag("__custom__")
+                            if !errorCustomPath.isEmpty {
+                                Text(URL(fileURLWithPath: errorCustomPath).lastPathComponent)
+                                    .tag("__custom__")
+                            }
+                        }
+                        .frame(maxWidth: 200)
+
+                        Button("Test") {
+                            soundPlayer.playTestError()
                         }
                         .controlSize(.small)
                     }
@@ -128,6 +160,19 @@ struct GeneralSettingsTab: View {
 
         if panel.runModal() == .OK, let url = panel.url {
             customPath = url.path
+        }
+    }
+
+    private func pickErrorCustomSound() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = ["aiff", "mp3", "wav", "m4a"]
+            .compactMap { UTType(filenameExtension: $0) }
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.message = "Choose an error notification sound"
+
+        if panel.runModal() == .OK, let url = panel.url {
+            errorCustomPath = url.path
         }
     }
 }

--- a/Sources/TBDCLI/Commands/HooksCommand.swift
+++ b/Sources/TBDCLI/Commands/HooksCommand.swift
@@ -8,7 +8,7 @@ struct HooksCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "hooks",
         abstract: "Inspect and manage TBD's Claude Code hook integration",
-        subcommands: [HooksStatusCommand.self, StopRenameCheckCommand.self],
+        subcommands: [HooksStatusCommand.self, StopRenameCheckCommand.self, StopFailureCommand.self],
         defaultSubcommand: HooksStatusCommand.self
     )
 }

--- a/Sources/TBDCLI/Commands/StopFailureCommand.swift
+++ b/Sources/TBDCLI/Commands/StopFailureCommand.swift
@@ -1,6 +1,5 @@
 import ArgumentParser
 import Foundation
-import TBDShared
 
 /// `tbd hooks stop-failure` — handler for Claude Code's StopFailure hook,
 /// which fires (unlike Stop) when a turn ends due to an API error. It reads

--- a/Sources/TBDCLI/Commands/StopFailureCommand.swift
+++ b/Sources/TBDCLI/Commands/StopFailureCommand.swift
@@ -1,0 +1,87 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+/// `tbd hooks stop-failure` — handler for Claude Code's StopFailure hook,
+/// which fires (unlike Stop) when a turn ends due to an API error. It reads
+/// the verbatim error text Claude wrote to the transcript so the notification
+/// distinguishes a session limit ("You've hit your session limit · resets
+/// 3pm") from a transient rate limit ("Server is temporarily limiting
+/// requests") — both of which arrive as error_type=rate_limit, so the type
+/// alone is not enough.
+///
+/// Prints the message to stdout; the overlay pipes it into `tbd notify
+/// --type error`. Prints nothing when stdin can't be parsed. Every failure is
+/// a silent no-op so the agent is never wedged.
+struct StopFailureCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "stop-failure",
+        abstract: "StopFailure-hook handler: emit a notification message for an API-error turn death"
+    )
+
+    mutating func run() async throws {
+        let stdin = FileHandle.standardInput.readDataToEndOfFile()
+        if let message = StopFailureMessage.compute(
+            stdinData: stdin,
+            readFile: { path in try? Data(contentsOf: URL(fileURLWithPath: path)) }
+        ) {
+            print(message)
+        }
+    }
+}
+
+// MARK: - Pure core (testable)
+
+/// Pure message-construction logic for `stop-failure`. Factored out so unit
+/// tests exercise every branch without touching the filesystem.
+enum StopFailureMessage {
+
+    /// Build the notification message for a StopFailure payload.
+    /// - Returns: the verbatim API-error text from the transcript when
+    ///   available; else a generic fallback naming the `error_type`; else nil
+    ///   when the stdin payload can't be parsed (caller prints nothing).
+    static func compute(stdinData: Data, readFile: (String) -> Data?) -> String? {
+        guard
+            let payload = try? JSONSerialization.jsonObject(with: stdinData) as? [String: Any]
+        else {
+            return nil
+        }
+
+        let errorType = (payload["error_type"] as? String) ?? "unknown"
+        let fallback = "Claude stopped: API error (\(errorType))"
+
+        guard
+            let transcriptPath = payload["transcript_path"] as? String,
+            let data = readFile(transcriptPath),
+            let text = lastApiErrorText(in: data)
+        else {
+            return fallback
+        }
+        return text
+    }
+
+    /// Scan transcript JSONL lines from the end; return the first
+    /// `isApiErrorMessage == true` entry's first non-empty text block.
+    static func lastApiErrorText(in data: Data) -> String? {
+        guard let contents = String(data: data, encoding: .utf8) else { return nil }
+        let lines = contents.split(separator: "\n", omittingEmptySubsequences: true)
+        for line in lines.reversed() {
+            guard
+                let lineData = line.data(using: .utf8),
+                let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                obj["isApiErrorMessage"] as? Bool == true,
+                let message = obj["message"] as? [String: Any],
+                let content = message["content"] as? [[String: Any]]
+            else {
+                continue
+            }
+            for block in content where block["type"] as? String == "text" {
+                if let text = block["text"] as? String,
+                   !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return text
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -61,16 +61,15 @@ public enum ClaudeHookOverlay {
     static let stopRenameCheckCommand =
         #"tbd hooks stop-rename-check 2>/dev/null || true"#
 
-    /// The shell command for the StopFailure hook. Claude Code fires
-    /// StopFailure (not Stop) when a turn ends due to an API error — rate
-    /// limit, server overload, auth/billing failure, etc. By the time it
-    /// fires, Claude has already auto-retried ~10×, so it is a genuine
-    /// "this turn is dead" signal. We extract `error_type` from the hook
-    /// payload and raise an `error`-severity notification so the otherwise
-    /// silent thread death surfaces. Silent failure so we never wedge the
-    /// agent, consistent with the other hooks.
+    /// The shell command for the StopFailure hook. Delegates to
+    /// `tbd hooks stop-failure`, which reads the verbatim API-error text from
+    /// the transcript (so a session limit reads "You've hit your session limit
+    /// · resets 3pm" rather than a generic "rate_limit"), then pipes the
+    /// message into `tbd notify --type error`. Mirrors the `Stop` hook's
+    /// `MSG=$(…); tbd notify …` shape. Trailing `; true` keeps the hook exit 0
+    /// so it never wedges the agent.
     static let stopFailureCommand =
-        #"TYPE=$(jq -r '.error_type // "unknown"' 2>/dev/null); tbd notify --type error --message "Claude stopped: API error ($TYPE)" 2>/dev/null || true"#
+        #"MSG=$(tbd hooks stop-failure 2>/dev/null); [ -n "$MSG" ] && tbd notify --type error --message "$MSG" 2>/dev/null; true"#
 
     /// Bridges the `PreToolUse:AskUserQuestion` hook into TBD. Captures the
     /// tool input and tool_use_id so the transcript pane can render the

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -21,9 +21,9 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-overl
 ///     legacy globally-installed hook.
 ///   - `tbd hooks stop-rename-check`, which prompts the agent to rename
 ///     a still-default worktree/branch at end-of-turn.
-/// - `StopFailure`: `tbd notify --type error` when a turn dies on an API
-///   error (rate limit, server overload, etc.), which the `Stop` hook does
-///   not catch — `Stop` fires only on normal completion.
+/// - `StopFailure`: runs `tbd hooks stop-failure` to read the verbatim
+///   API-error text from the transcript, then pipes that into
+///   `tbd notify --type error` — `Stop` fires only on normal completion.
 /// - `PreToolUse:AskUserQuestion` / `PostToolUse:AskUserQuestion`:
 ///   bridge tool input and `tool_use_id` so the transcript pane can
 ///   render the question before Claude flushes the assistant message

--- a/Tests/TBDAppTests/NotificationSoundPlayerTests.swift
+++ b/Tests/TBDAppTests/NotificationSoundPlayerTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+@Suite("NotificationSoundPlayer.resolveSoundConfig")
+struct NotificationSoundPlayerTests {
+
+    @Test func errorTypeResolvesErrorSound() {
+        let r = NotificationSoundPlayer.resolveSoundConfig(
+            for: .error,
+            defaultName: "Blow", defaultCustomPath: "",
+            errorName: "Sosumi", errorCustomPath: ""
+        )
+        #expect(r.name == "Sosumi")
+        #expect(r.customPath == "")
+    }
+
+    @Test func nonErrorTypeResolvesDefaultSound() {
+        let r = NotificationSoundPlayer.resolveSoundConfig(
+            for: .responseComplete,
+            defaultName: "Blow", defaultCustomPath: "",
+            errorName: "Sosumi", errorCustomPath: ""
+        )
+        #expect(r.name == "Blow")
+    }
+
+    @Test func errorCustomPathIsCarried() {
+        let r = NotificationSoundPlayer.resolveSoundConfig(
+            for: .error,
+            defaultName: "Blow", defaultCustomPath: "",
+            errorName: "Sosumi", errorCustomPath: "/tmp/alarm.aiff"
+        )
+        #expect(r.customPath == "/tmp/alarm.aiff")
+    }
+}

--- a/Tests/TBDCLITests/StopFailureMessageTests.swift
+++ b/Tests/TBDCLITests/StopFailureMessageTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+@testable import TBDCLI
+
+@Suite("StopFailureMessage")
+struct StopFailureMessageTests {
+
+    /// Build a one-line transcript JSONL containing a single API-error
+    /// assistant entry with the given text.
+    private static func transcript(text: String) -> Data {
+        let line = """
+        {"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"rate_limit","message":{"role":"assistant","content":[{"type":"text","text":"\(text)"}]}}
+        """
+        return Data((line + "\n").utf8)
+    }
+
+    private static func stdin(errorType: String, transcriptPath: String?) -> Data {
+        var obj: [String: Any] = ["error_type": errorType, "hook_event_name": "StopFailure"]
+        if let transcriptPath { obj["transcript_path"] = transcriptPath }
+        return try! JSONSerialization.data(withJSONObject: obj)
+    }
+
+    @Test func sessionLimitReturnsVerbatimText() {
+        let text = "You've hit your session limit · resets 3pm (America/Toronto)"
+        let result = StopFailureMessage.compute(
+            stdinData: Self.stdin(errorType: "rate_limit", transcriptPath: "/x.jsonl"),
+            readFile: { _ in Self.transcript(text: text) }
+        )
+        #expect(result == text)
+    }
+
+    @Test func serverRateLimitReturnsVerbatimText() {
+        let text = "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited"
+        let result = StopFailureMessage.compute(
+            stdinData: Self.stdin(errorType: "rate_limit", transcriptPath: "/x.jsonl"),
+            readFile: { _ in Self.transcript(text: text) }
+        )
+        #expect(result == text)
+    }
+
+    @Test func unreadableTranscriptFallsBackToErrorType() {
+        let result = StopFailureMessage.compute(
+            stdinData: Self.stdin(errorType: "rate_limit", transcriptPath: "/missing.jsonl"),
+            readFile: { _ in nil }
+        )
+        #expect(result == "Claude stopped: API error (rate_limit)")
+    }
+
+    @Test func noApiErrorLineFallsBackToErrorType() {
+        let plain = Data(#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}"#.utf8)
+        let result = StopFailureMessage.compute(
+            stdinData: Self.stdin(errorType: "server_error", transcriptPath: "/x.jsonl"),
+            readFile: { _ in plain }
+        )
+        #expect(result == "Claude stopped: API error (server_error)")
+    }
+
+    @Test func missingErrorTypeFallsBackToUnknown() {
+        let obj: [String: Any] = ["hook_event_name": "StopFailure"]
+        let data = try! JSONSerialization.data(withJSONObject: obj)
+        let result = StopFailureMessage.compute(stdinData: data, readFile: { _ in nil })
+        #expect(result == "Claude stopped: API error (unknown)")
+    }
+
+    @Test func unparseableStdinReturnsNil() {
+        let result = StopFailureMessage.compute(
+            stdinData: Data("not json".utf8),
+            readFile: { _ in nil }
+        )
+        #expect(result == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -36,16 +36,13 @@ import Testing
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let hooks = parsed?["hooks"] as? [String: Any]
 
-        // StopFailure fires when a turn dies on an API error (rate limit,
-        // server error, etc.). It must shell out to `tbd notify --type error`
-        // so the dead thread surfaces instead of dying silently.
         let stopFailure = hooks?["StopFailure"] as? [[String: Any]]
         #expect(stopFailure?.count == 1)
         let inner = stopFailure?.first?["hooks"] as? [[String: Any]]
         let cmd = inner?.first?["command"] as? String
+        // Delegates message construction to the subcommand, then pipes into notify.
+        #expect(cmd?.contains("tbd hooks stop-failure") == true)
         #expect(cmd?.contains("tbd notify --type error") == true)
-        // Surfaces the error_type so the message is actionable.
-        #expect(cmd?.contains("error_type") == true)
     }
 
     @Test func roundtripsAsValidJSON() throws {

--- a/docs/superpowers/specs/2026-06-02-session-limit-notification-design.md
+++ b/docs/superpowers/specs/2026-06-02-session-limit-notification-design.md
@@ -1,0 +1,150 @@
+# Distinguish session-limit API errors + distinct error sound
+
+**Date:** 2026-06-02
+**Status:** Approved (brainstorming → ready for implementation plan)
+**Builds on:** `2026-06-02-claude-api-error-notification-design.md` (the `StopFailure` hook, merged in #248)
+
+## Problem
+
+PR #248 added a `StopFailure` hook so a turn killed by an API error raises an
+`.error` notification instead of dying silently. Two gaps remain, surfaced by a
+real session-limit event in the "⛏️ pyright-ratchet" worktree
+(`You've hit your session limit · resets 3pm (America/Toronto)`):
+
+1. **The message can't distinguish a session limit from a transient blip.**
+   Verified against the installed Claude Code binary (v2.1.160): the only
+   `error_type` values that exist are `authentication_failed`, `billing_error`,
+   `invalid_request`, `max_output_tokens`, `model_not_found`,
+   `oauth_org_not_allowed`, `rate_limit`, `server_error`. There is **no**
+   `session_limit` / `usage_limit` type. A session limit and a transient 429
+   both arrive as `error_type: rate_limit` (confirmed in the transcript:
+   `isApiErrorMessage: true`, `apiErrorStatus: 429`, `error: "rate_limit"`). So
+   the current generic `Claude stopped: API error (rate_limit)` message is
+   actively misleading — it implies "retry soon" when the user is actually
+   blocked for hours. The only signal that distinguishes the two is the verbatim
+   error text Claude wrote to the transcript.
+
+2. **Error notifications sound identical to routine completions.**
+   `NotificationSoundPlayer.playIfEnabled()` plays one configured sound (default
+   `Blow`) for every notification regardless of type, so an API-error death is
+   as easy to miss as a "response complete" chime.
+
+## Goal
+
+Make an API-error turn death impossible to miss: surface the verbatim,
+case-appropriate message ("You've hit your session limit · resets 3pm" vs.
+"Server is temporarily limiting requests"), and play a distinct, user-configurable
+error sound.
+
+## Component A — Useful, distinct message
+
+The `StopFailure` stdin payload includes `transcript_path`. The verbatim text is
+the most recent transcript entry with `isApiErrorMessage: true`, under
+`message.content[0].text`. Extracting that (plus a fallback) is real branching
+that warrants unit tests — the established `stop-rename-check` shape.
+
+### New subcommand `tbd hooks stop-failure`
+
+File: `Sources/TBDCLI/Commands/StopFailureCommand.swift`. Mirrors
+`StopRenameCheckCommand`:
+
+- `run()`: read StopFailure JSON from stdin → `StopFailureMessage.compute(...)` →
+  `print` the message if non-nil (nothing otherwise).
+- Pure core `enum StopFailureMessage { static func compute(stdinData: Data, readFile: (String) -> Data?) -> String? }`:
+  - Parse stdin JSON. Unparseable → return `nil` (print nothing → no notification).
+  - Read `error_type` (default `"unknown"`) and `transcript_path`.
+  - If `transcript_path` is present and `readFile` returns data: scan the lines
+    from the end; for the first line that decodes to an object with
+    `isApiErrorMessage == true`, extract the first `message.content` element of
+    `type == "text"` and return its `text` (when non-empty).
+  - Otherwise return the fallback `"Claude stopped: API error (\(errorType))"`.
+- `readFile` is injected (production: `try? Data(contentsOf:)`); tests pass a
+  fixture so no real filesystem or daemon is touched.
+
+Register `StopFailureCommand.self` in `HooksCommand.configuration.subcommands`.
+
+### Overlay command change
+
+In `Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift`, replace the inline-`jq`
+`stopFailureCommand` with the same `MSG=$(…); tbd notify …` composition the
+existing `Stop` hook (`stopCommand`) already uses:
+
+```sh
+MSG=$(tbd hooks stop-failure 2>/dev/null); [ -n "$MSG" ] && tbd notify --type error --message "$MSG" 2>/dev/null; true
+```
+
+`tbd hooks stop-failure` inherits the hook's stdin (the StopFailure JSON). The
+trailing `; true` guarantees exit 0 so the hook never wedges the agent. This
+**reuses `tbd notify` wholesale** — worktree/terminal resolution, the
+`RPCMethod.notify` call, `state.db` persistence, the broadcast, and the macOS
+banner are all unchanged. The subcommand only computes the message string. Still
+no matcher (catches every `error_type`), still `.error` severity.
+
+Resulting banner: `⛏️ pyright-ratchet — You've hit your session limit · resets 3pm (America/Toronto)`.
+
+## Component B — Distinct, configurable error sound
+
+Independent of Component A; can ship as its own commit.
+
+### `Sources/TBDApp/Services/NotificationSoundPlayer.swift`
+
+- Add `import TBDShared` (for `NotificationType`).
+- Add storage: `@AppStorage("errorNotificationSoundName") private var errorSoundName: String = "Sosumi"` and
+  `@AppStorage("errorNotificationSoundCustomPath") private var errorCustomPath: String = ""`.
+- Replace `playIfEnabled()` with `playIfEnabled(for type: NotificationType)`:
+  resolve the error sound (`errorSoundName` / `errorCustomPath`) when
+  `type == .error`, else the existing sound (`soundName` / `customPath`).
+- Factor sound resolution to take the (name, customPath) pair so both the
+  default and error paths share it. Keep `playTest()` for the default sound and
+  add `playTestError()` (or `playTest(for:)`) for the error sound.
+
+### `Sources/TBDApp/AppState.swift`
+
+At the single call site in `handleNotificationDelta`, pass the type:
+`notificationSoundPlayer.playIfEnabled(for: notification.type)`.
+
+### `Sources/TBDApp/Settings/SettingsView.swift`
+
+Add a second picker + Test button labeled "Error sound", shown under the
+existing "Sound" picker when `enableSounds` is true, with the same
+system-sounds + "Custom…" affordance bound to the new `@AppStorage` keys.
+
+## Testing
+
+- **`StopFailureMessage.compute`** (new test file, `TBDCLI` test target) — one
+  test per branch:
+  - session-limit fixture transcript → returns the verbatim
+    `You've hit your session limit · resets 3pm (America/Toronto)`.
+  - server-rate-limit fixture → returns the verbatim
+    `API Error: Server is temporarily limiting requests …`.
+  - `transcript_path` missing / file unreadable / no `isApiErrorMessage` line →
+    returns `Claude stopped: API error (rate_limit)` (fallback uses `error_type`).
+  - unparseable stdin → returns `nil`.
+- **`ClaudeHookOverlayTests`** — update `registersStopFailureNotifyHook`: the
+  `StopFailure` command now contains `tbd hooks stop-failure` and
+  `tbd notify --type error`, and no longer contains an inline `error_type`.
+- **`NotificationSoundPlayer`** — verify `.error` resolves the error sound and a
+  non-error type resolves the default. Per CLAUDE.md's UserDefaults-isolation
+  rule, drive `@AppStorage` through a `UserDefaults(suiteName:)` test suite and
+  tear it down with `removePersistentDomain(forName:)` — never touch
+  `UserDefaults.standard`. (If `@AppStorage` proves awkward to isolate, the
+  resolution logic may be extracted to a pure helper that takes the
+  name/custom-path pair and is tested directly.)
+
+## Out of scope
+
+- No reset-time parsing or message reformatting — the verbatim text already
+  carries the reset time (explicit design choice).
+- No new `NotificationType`, RPC method, or DB column.
+- Codex sessions remain uncovered (separate hook system; deferred).
+
+## Affected files
+
+- Create: `Sources/TBDCLI/Commands/StopFailureCommand.swift`
+- Modify: `Sources/TBDCLI/Commands/HooksCommand.swift` (register subcommand)
+- Modify: `Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift` (`stopFailureCommand`)
+- Modify: `Sources/TBDApp/Services/NotificationSoundPlayer.swift`
+- Modify: `Sources/TBDApp/AppState.swift` (pass type at call site)
+- Modify: `Sources/TBDApp/Settings/SettingsView.swift` (error-sound picker)
+- Tests: new `StopFailureMessage` tests (TBDCLI test target);
+  `Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift`; `NotificationSoundPlayer` test.


### PR DESCRIPTION
Follow-up to #248 (which added the `StopFailure` hook so API-error turn deaths notify at all). Two gaps surfaced by a real session-limit event in the "⛏️ pyright-ratchet" worktree (`You've hit your session limit · resets 3pm (America/Toronto)`).

## What was wrong

**1. The notification couldn't tell a session limit from a transient blip.** Verified against the installed Claude Code binary (v2.1.160): the only `error_type` values that exist are `authentication_failed`, `billing_error`, `invalid_request`, `max_output_tokens`, `model_not_found`, `oauth_org_not_allowed`, `rate_limit`, `server_error` — there is **no** `session_limit`/`usage_limit` type. A session limit and a transient 429 both arrive as `error_type: rate_limit` (confirmed in the transcript: `isApiErrorMessage: true`, `apiErrorStatus: 429`, `error: "rate_limit"`). So #248's generic `Claude stopped: API error (rate_limit)` was actively misleading — it implies "retry soon" when the user is blocked for hours.

**2. Error notifications sounded identical to routine completions.** `NotificationSoundPlayer.playIfEnabled()` played one sound (default `Blow`) for every notification type, so an API-error death was as easy to miss as a "response complete" chime.

## What this PR does

**Component A — verbatim, case-appropriate message.** The only signal that distinguishes the two cases is the text Claude wrote to the transcript, and the `StopFailure` payload hands us `transcript_path`. New `tbd hooks stop-failure` subcommand (mirroring the existing `stop-rename-check` shape — thin `run()` + pure, fully-tested `StopFailureMessage.compute`) reads the last `isApiErrorMessage: true` transcript entry and prints its verbatim text, falling back to `Claude stopped: API error (<error_type>)` when the transcript is unreadable. The overlay swaps its inline-`jq` command for the same `MSG=$(…); tbd notify …` composition the `Stop` hook already uses — so `tbd notify --type error` and the whole notify→`state.db`→banner pipeline are reused unchanged.

Result: `⛏️ pyright-ratchet — You've hit your session limit · resets 3pm (America/Toronto)`.

**Component B — distinct, configurable error sound (default Sosumi).** `NotificationSoundPlayer` gains a separate error sound selected by `NotificationType` via a pure `nonisolated static resolveSoundConfig(for:)`; `AppState` passes `notification.type`; Settings → General gets a second "Error sound" picker + Test button, mirroring the existing one.

## Notably not doing
- No reset-time parsing — the verbatim text already carries it.
- No new `NotificationType`, RPC method, or DB column. Component A only computes a string; Component B is app-local.
- Codex sessions still uncovered (separate hook system).

## Testing
- `StopFailureMessage.compute`: one test per branch — session-limit → verbatim; server-rate-limit → verbatim; unreadable/no-error-line → `API error (<type>)`; missing type → `unknown`; unparseable stdin → nil.
- `ClaudeHookOverlayTests`: updated to assert the StopFailure command routes through `tbd hooks stop-failure` + `tbd notify --type error`.
- `NotificationSoundPlayer.resolveSoundConfig`: `.error` → error sound, other types → default, custom path carried. (Pure function — no `UserDefaults.standard`, per CLAUDE.md.)
- `swift build` clean; 12 tests pass; code review clean.

A live API-error isn't reliably reproducible on demand, so verification is the branch tests plus the already-tested `tbd notify` path. After a `scripts/restart.sh`, `tbd hooks stop-failure` is on PATH and the overlay command reflects the new flow.

[⛔ Notify Session Limit](https://cheapsteak.github.io/tbd/open/?worktree=59CA26EA-0474-4104-8303-80A53A84A261)
