### PR TITLE
feat: let Claude-direct (OAuth) profiles set a model

### DIFF
--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -642,7 +642,9 @@ struct AddModelProfileSheet: View {
                 name: trimmedName,
                 token: preset == .claudeDirect ? nil : tokenValue,
                 baseURL: preset == .proxy ? trimmedBase : nil,
-                model: (preset == .proxy || preset == .claudeDirect) ? (trimmedModel.isEmpty ? nil : trimmedModel) : nil
+                // Bedrock returns early above, so only proxy/claudeDirect reach here —
+                // both carry an optional model.
+                model: trimmedModel.isEmpty ? nil : trimmedModel
             )
             await MainActor.run {
                 isSaving = false

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -73,6 +73,7 @@ struct ModelProfileRow: View {
     @State private var showDeleteConfirm = false
     @State private var showEditEndpoint = false
     @State private var showEditBedrock = false
+    @State private var showEditClaudeDirect = false
 
     private var profile: ModelProfile { entry.profile }
     private var usage: ModelProfileUsage? { entry.usage }
@@ -83,12 +84,16 @@ struct ModelProfileRow: View {
                 nameView
                 kindBadge
                 Spacer()
-                if profile.baseURL != nil && profile.kind != .bedrock {
-                    Button("Edit") { showEditEndpoint = true }
-                        .controlSize(.small)
-                }
+                // Exactly one Edit button per row, partitioned by profile shape:
+                // bedrock → proxy (non-bedrock with a baseURL) → Claude-direct (the rest).
                 if profile.kind == .bedrock {
                     Button("Edit") { showEditBedrock = true }
+                        .controlSize(.small)
+                } else if profile.baseURL != nil {
+                    Button("Edit") { showEditEndpoint = true }
+                        .controlSize(.small)
+                } else {
+                    Button("Edit") { showEditClaudeDirect = true }
                         .controlSize(.small)
                 }
                 menuButton
@@ -114,6 +119,10 @@ struct ModelProfileRow: View {
         }
         .sheet(isPresented: $showEditBedrock) {
             EditBedrockSheet(profile: profile)
+                .environmentObject(appState)
+        }
+        .sheet(isPresented: $showEditClaudeDirect) {
+            EditClaudeDirectSheet(profile: profile)
                 .environmentObject(appState)
         }
     }
@@ -411,6 +420,14 @@ struct AddModelProfileSheet: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
+                    LabeledField(
+                        "Model (optional)",
+                        caption: "Leave blank to use Claude Code's default model."
+                    ) {
+                        TextField("", text: $model, prompt: Text("e.g. opus"))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(maxWidth: .infinity)
+                    }
 
                 case .proxy:
                     LabeledField("Token") {
@@ -625,7 +642,7 @@ struct AddModelProfileSheet: View {
                 name: trimmedName,
                 token: preset == .claudeDirect ? nil : tokenValue,
                 baseURL: preset == .proxy ? trimmedBase : nil,
-                model: preset == .proxy ? (trimmedModel.isEmpty ? nil : trimmedModel) : nil
+                model: (preset == .proxy || preset == .claudeDirect) ? (trimmedModel.isEmpty ? nil : trimmedModel) : nil
             )
             await MainActor.run {
                 isSaving = false
@@ -950,6 +967,106 @@ struct EditBedrockSheet: View {
                 if newAlert != priorAlert, let msg = newAlert {
                     errorMessage = msg
                     appState.alertMessage = priorAlert
+                    return
+                }
+                dismiss()
+            }
+        }
+    }
+}
+
+// MARK: - Edit Claude (direct) sheet
+
+struct EditClaudeDirectSheet: View {
+    @EnvironmentObject var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+    let profile: ModelProfile
+
+    @State private var name: String
+    @State private var model: String
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    init(profile: ModelProfile) {
+        self.profile = profile
+        _name = State(initialValue: profile.name)
+        _model = State(initialValue: profile.model ?? "")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Edit Claude Profile").font(.headline)
+            VStack(alignment: .leading, spacing: 14) {
+                LabeledField("Name") {
+                    TextField("", text: $name).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
+                }
+                LabeledField(
+                    "Model (optional)",
+                    caption: "Leave blank to use Claude Code's default model."
+                ) {
+                    TextField("", text: $model, prompt: Text("e.g. opus"))
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button(action: save) {
+                    if isSaving { ProgressView().controlSize(.small) } else { Text("Save") }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSave)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+    }
+
+    private var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty && !isSaving
+    }
+
+    private func save() {
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let trimmedModel = model.trimmingCharacters(in: .whitespaces)
+        isSaving = true
+        errorMessage = nil
+        Task {
+            let priorAlert = await MainActor.run { appState.alertMessage }
+
+            // Rename first if changed; bail on conflict so we don't update
+            // fields under a stale name.
+            if trimmedName != profile.name {
+                await appState.renameModelProfile(id: profile.id, name: trimmedName)
+                let postRenameAlert = await MainActor.run { appState.alertMessage }
+                if postRenameAlert != priorAlert, let msg = postRenameAlert {
+                    await MainActor.run {
+                        isSaving = false
+                        errorMessage = msg
+                        appState.alertMessage = priorAlert
+                    }
+                    return
+                }
+            }
+
+            let priorAlert2 = await MainActor.run { appState.alertMessage }
+            await appState.updateModelProfileEndpoint(
+                id: profile.id,
+                baseURL: nil,
+                model: trimmedModel.isEmpty ? nil : trimmedModel
+            )
+            await MainActor.run {
+                isSaving = false
+                let newAlert = appState.alertMessage
+                if newAlert != priorAlert2, let msg = newAlert {
+                    errorMessage = msg
+                    appState.alertMessage = priorAlert2
                     return
                 }
                 dismiss()

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -688,11 +688,18 @@ extension ModelProfile {
         switch kind {
         case .oauth:
             // OAuth profiles need a one-time /login to establish credentials
-            // in the isolated config dir. Show this hint even for simple OAuth.
-            if let baseURL { return "Run /login once · via \(baseURL)" }
-            return "Run /login once"
+            // in the isolated config dir. Show this hint even for simple OAuth,
+            // plus the pinned model (if any) so the Edit sheet's effect is visible.
+            var parts = ["Run /login once"]
+            if let baseURL { parts.append("via \(baseURL)") }
+            if let model, !model.isEmpty { parts.append(model) }
+            return parts.joined(separator: " · ")
         case .apiKey:
-            guard let baseURL else { return nil }
+            guard let baseURL else {
+                // Direct api-key profile: nothing to show unless a model is pinned.
+                if let model, !model.isEmpty { return model }
+                return nil
+            }
             if let model, !model.isEmpty { return "via \(baseURL) · \(model)" }
             return "via \(baseURL)"
         case .bedrock:

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -206,6 +206,42 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv["ANTHROPIC_MODEL"] == "gpt-5-codex")
     }
 
+    @Test("oauth profile with model emits ANTHROPIC_MODEL")
+    func oauthProfileWithModelEmitsModel() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "abc",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            profileKind: .oauth,
+            profileBaseURL: nil,
+            profileModel: "opus",
+            profileConfigDir: "/Users/me/tbd/profiles/abc/claude",
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(r.sensitiveEnv["ANTHROPIC_MODEL"] == "opus")
+    }
+
+    @Test("oauth profile without model does not emit ANTHROPIC_MODEL")
+    func oauthProfileWithoutModelOmitsModel() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "abc",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            profileKind: .oauth,
+            profileBaseURL: nil,
+            profileModel: nil,
+            profileConfigDir: "/Users/me/tbd/profiles/abc/claude",
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(r.sensitiveEnv["ANTHROPIC_MODEL"] == nil)
+    }
+
     @Test("oauth profile without configDir → no token, no config dir")
     func oauthWithoutConfigDirInjectsNothing() {
         let r = ClaudeSpawnCommandBuilder.build(

--- a/Tests/TBDSharedTests/ModelProfileDisplayTests.swift
+++ b/Tests/TBDSharedTests/ModelProfileDisplayTests.swift
@@ -81,10 +81,16 @@ struct ModelProfileDisplayTests {
         #expect(p.detailCaption == "? · anthropic.claude-sonnet-4-5")
     }
 
-    @Test("detailCaption: direct apiKey with model set → nil (model not shown without proxy)")
-    func detailDirectApiKeyWithModelNil() {
+    @Test("detailCaption: direct apiKey with model set → model")
+    func detailDirectApiKeyWithModel() {
         let p = ModelProfile(name: "x", kind: .apiKey, model: "claude-opus-4")
-        #expect(p.detailCaption == nil)
+        #expect(p.detailCaption == "claude-opus-4")
+    }
+
+    @Test("detailCaption: oauth with model → login hint + model")
+    func detailOAuthWithModel() {
+        let p = ModelProfile(name: "x", kind: .oauth, model: "opus")
+        #expect(p.detailCaption == "Run /login once · opus")
     }
 
     @Test("detailCaption: bedrock with both region and model nil → bare \"?\"")


### PR DESCRIPTION
## What

Lets **Claude (direct) / OAuth** model profiles carry an optional model, so `ANTHROPIC_MODEL` is emitted for them when spawning a `claude` session.

## Why

The daemon already supported a per-profile model end-to-end — `handleModelProfileAdd` stored it for OAuth profiles, `ModelProfileResolver` passed it through, and `ClaudeSpawnCommandBuilder` emitted `ANTHROPIC_MODEL` for non-bedrock profiles. The only missing piece was the UI: Claude-direct profiles had no field to set or edit a model, so the value was always `nil`. This is therefore a **UI-only** change — no RPC, daemon, or DB-migration work.

## Changes

- **Create sheet** (`AddModelProfileSheet`): added an optional **Model** field to the Claude-direct preset; `save()` now persists it (previously forced to `nil`).
- **Edit path**: new `EditClaudeDirectSheet` (name + optional model), reachable via an **Edit** button on Claude-direct profile rows (`kind != .bedrock && baseURL == nil`, covering OAuth and direct API-key). It reuses the existing `updateModelProfileEndpoint` RPC with `baseURL: nil`, which updates only the `base_url`/`model` columns and leaves `kind` intact.
- **Tests**: two `ClaudeSpawnCommandBuilder` tests locking the contract — OAuth + model emits `ANTHROPIC_MODEL`; OAuth without a model does not.

## Verification

- `swift build` ✅
- `swift test --filter ClaudeSpawnCommandBuilder` ✅ (37 passed, including the 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)