### PR TITLE
Feat: Let orchestrators push you to a child worktree's tab without stealing focus

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -720,10 +720,11 @@ final class AppState: ObservableObject {
         }
 
         // Record a background-tab arrival so its tab label bolds. Fires for any
-        // terminal-stamped delta (response completions AND focus pushes), as
-        // long as it isn't the tab the user is already looking at. Done BEFORE
-        // the visible-worktree early-return because a worktree can be "visible"
-        // (selected) while the stamped terminal lives on a background tab.
+        // terminal-stamped delta (any type — response completions, errors, focus
+        // pushes, etc.), as long as it isn't the tab the user is already looking
+        // at. Done BEFORE the visible-worktree early-return because a worktree
+        // can be "visible" (selected) while the stamped terminal lives on a
+        // background tab.
         if let tid = notification.terminalID,
            !isActiveTabTerminal(tid, inFocusedWorktree: notification.worktreeID) {
             unreadTerminals.insert(tid)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -747,6 +747,7 @@ final class AppState: ObservableObject {
             worktreeID: notification.worktreeID,
             message: notification.message,
             worktrees: allWorktrees,
+            type: notification.type,
             terminalID: notification.terminalID
         )
     }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -711,12 +711,20 @@ final class AppState: ObservableObject {
     }
 
     private func handleNotificationDelta(_ notification: NotificationDelta) {
-        // Record a background-tab completion so its tab label bolds. Done
-        // BEFORE the visible-worktree early-return because a worktree can be
-        // "visible" (selected) while the completing terminal lives on a
-        // background tab — that tab should still bold. The
-        // isActiveTabTerminal guard excludes the tab the user is looking at.
-        if notification.type == .responseComplete, let tid = notification.terminalID,
+        // Loud focus push: foreground + select the originating tab immediately,
+        // regardless of what the user is currently looking at. Done before any
+        // unread/bold bookkeeping (we're navigating there, so it's moot).
+        if notification.activate {
+            navigateToWorktree(notification.worktreeID, terminalID: notification.terminalID)
+            return
+        }
+
+        // Record a background-tab arrival so its tab label bolds. Fires for any
+        // terminal-stamped delta (response completions AND focus pushes), as
+        // long as it isn't the tab the user is already looking at. Done BEFORE
+        // the visible-worktree early-return because a worktree can be "visible"
+        // (selected) while the stamped terminal lives on a background tab.
+        if let tid = notification.terminalID,
            !isActiveTabTerminal(tid, inFocusedWorktree: notification.worktreeID) {
             unreadTerminals.insert(tid)
         }

--- a/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
@@ -22,7 +22,7 @@ struct JumpMenuRow: Identifiable, Equatable {
 private func severityColor(_ type: NotificationType) -> Color {
     switch type {
     case .error:            return .red
-    case .attentionNeeded:  return .orange
+    case .attentionNeeded, .focusRequest: return .orange
     case .taskComplete:     return .green
     case .responseComplete: return .blue
     }

--- a/Sources/TBDApp/Services/MacNotificationManager.swift
+++ b/Sources/TBDApp/Services/MacNotificationManager.swift
@@ -56,6 +56,17 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         type == .focusRequest ? "🎯 \(worktreeName)" : worktreeName
     }
 
+    /// The banner body. Falls back to a type-appropriate default when no
+    /// message was supplied. Mirrors `bannerTitle` as a pure, testable seam
+    /// (`postIfEnabled` early-returns unbundled, so the logic can't be tested
+    /// through it).
+    nonisolated static func bannerBody(message: String?, type: NotificationType) -> String {
+        if let msg = message, !msg.isEmpty {
+            return msg.count > 200 ? String(msg.prefix(200)) + "…" : msg
+        }
+        return type == .focusRequest ? "Attention needed." : "Claude has finished responding."
+    }
+
     func postIfEnabled(worktreeID: UUID, message: String?, worktrees: [Worktree],
                        type: NotificationType, terminalID: UUID? = nil) {
         guard enabled, isAvailable else { return }
@@ -64,12 +75,7 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         let worktreeName = worktrees.first(where: { $0.id == worktreeID })?.displayName
             ?? worktreeID.uuidString
 
-        let truncatedMessage: String
-        if let msg = message, !msg.isEmpty {
-            truncatedMessage = msg.count > 200 ? String(msg.prefix(200)) + "…" : msg
-        } else {
-            truncatedMessage = "Claude has finished responding."
-        }
+        let truncatedMessage = Self.bannerBody(message: message, type: type)
 
         let content = UNMutableNotificationContent()
         content.title = Self.bannerTitle(worktreeName: worktreeName, type: type)

--- a/Sources/TBDApp/Services/MacNotificationManager.swift
+++ b/Sources/TBDApp/Services/MacNotificationManager.swift
@@ -48,8 +48,16 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         }
     }
 
+    /// The banner title for a notification. Focus pushes get a distinguishing
+    /// emoji prefix so they're recognizable in the banner / Notification Center;
+    /// macOS does not allow swapping the left-side app icon. All other types
+    /// render the worktree name unchanged.
+    nonisolated static func bannerTitle(worktreeName: String, type: NotificationType) -> String {
+        type == .focusRequest ? "🎯 \(worktreeName)" : worktreeName
+    }
+
     func postIfEnabled(worktreeID: UUID, message: String?, worktrees: [Worktree],
-                       terminalID: UUID? = nil) {
+                       type: NotificationType, terminalID: UUID? = nil) {
         guard enabled, isAvailable else { return }
         requestPermissionIfNeeded()
 
@@ -64,7 +72,7 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         }
 
         let content = UNMutableNotificationContent()
-        content.title = worktreeName
+        content.title = Self.bannerTitle(worktreeName: worktreeName, type: type)
         content.body = truncatedMessage
         content.sound = nil
         // The request `identifier` must stay as worktreeID so re-posting

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -34,7 +34,7 @@ struct WorktreeRowView: View {
         switch n {
         case .error:
             return .red
-        case .attentionNeeded:
+        case .attentionNeeded, .focusRequest:
             return .orange
         case .taskComplete:
             return .green

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -6,7 +6,7 @@ struct TerminalCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "terminal",
         abstract: "Manage terminals",
-        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalOutput.self, TerminalConversation.self]
+        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalOutput.self, TerminalConversation.self, TerminalFocus.self]
     )
 }
 
@@ -143,6 +143,38 @@ struct TerminalSend: AsyncParsableCommand {
         } else {
             print("Text sent.")
         }
+    }
+}
+
+// MARK: - terminal focus
+
+struct TerminalFocus: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "focus",
+        abstract: "Push the user's attention to a terminal's tab (soft by default; --activate foregrounds)"
+    )
+
+    @Option(name: .long, help: "Terminal ID")
+    var terminal: String
+
+    @Option(name: .long, help: "Notification message")
+    var message: String?
+
+    @Flag(name: .long, help: "Foreground and select the tab immediately instead of a soft push")
+    var activate = false
+
+    mutating func run() async throws {
+        guard let terminalID = UUID(uuidString: terminal) else {
+            throw CLIError.invalidArgument("Invalid terminal ID: \(terminal)")
+        }
+
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.terminalFocus,
+            params: TerminalFocusParams(terminalID: terminalID, message: message, activate: activate)
+        )
+
+        print(activate ? "Focused (activated)." : "Focus push sent.")
     }
 }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -796,6 +796,29 @@ extension RPCRouter {
         return try RPCResponse(result: notification)
     }
 
+    func handleTerminalFocus(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalFocusParams.self, from: paramsData)
+
+        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+            return RPCResponse(error: "Unknown terminal: \(params.terminalID.uuidString)")
+        }
+
+        let notification = try await db.notifications.create(
+            worktreeID: terminal.worktreeID,
+            type: .focusRequest,
+            message: params.message,
+            terminalID: terminal.id
+        )
+
+        subscriptions.broadcast(delta: .notificationReceived(NotificationDelta(
+            notificationID: notification.id, worktreeID: notification.worktreeID,
+            type: notification.type, message: notification.message,
+            terminalID: notification.terminalID, activate: params.activate
+        )))
+
+        return try RPCResponse(result: notification)
+    }
+
     // MARK: - Notifications List
 
     func handleNotificationsList() async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -128,6 +128,8 @@ public final class RPCRouter: Sendable {
                 return try await handleTerminalActivityEvent(request.paramsData)
             case RPCMethod.notify:
                 return try await handleNotify(request.paramsData)
+            case RPCMethod.terminalFocus:
+                return try await handleTerminalFocus(request.paramsData)
             case RPCMethod.daemonStatus:
                 return try handleDaemonStatus()
             case RPCMethod.resolvePath:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -433,11 +433,15 @@ public enum NotificationType: String, Codable, Sendable {
     case error
     case taskComplete = "task_complete"
     case attentionNeeded = "attention_needed"
+    /// A focus push from `tbd terminal focus`. Rendered like `.attentionNeeded`
+    /// in-app; the macOS banner adds a distinguishing title prefix.
+    case focusRequest = "focus_request"
 
     public var severity: Int {
         switch self {
         case .error: 4
         case .attentionNeeded: 3
+        case .focusRequest: 3
         case .taskComplete: 2
         case .responseComplete: 1
         }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -90,6 +90,7 @@ public enum RPCMethod {
     public static let terminalCreate = "terminal.create"
     public static let terminalList = "terminal.list"
     public static let terminalSend = "terminal.send"
+    public static let terminalFocus = "terminal.focus"
     public static let terminalDelete = "terminal.delete"
     public static let terminalSetPin = "terminal.setPin"
     public static let notify = "notify"
@@ -688,6 +689,21 @@ public struct NotifyParams: Codable, Sendable {
                 terminalID: UUID? = nil) {
         self.worktreeID = worktreeID; self.type = type; self.message = message
         self.terminalID = terminalID
+    }
+}
+
+public struct TerminalFocusParams: Codable, Sendable {
+    /// Target terminal. The daemon resolves the owning worktree from this.
+    public let terminalID: UUID
+    /// Banner text. Falls back to a generic message when nil.
+    public let message: String?
+    /// When true, foreground + select the tab immediately (loud pull).
+    /// When false (default), soft push: banner + unread, no focus steal.
+    public let activate: Bool
+    public init(terminalID: UUID, message: String? = nil, activate: Bool = false) {
+        self.terminalID = terminalID
+        self.message = message
+        self.activate = activate
     }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -92,15 +92,20 @@ public struct NotificationDelta: Codable, Sendable {
     /// notification didn't come from a specific terminal or from an older
     /// daemon that didn't include the field.
     public let terminalID: UUID?
+    /// When true, the app foregrounds and selects the originating tab
+    /// immediately (the `--activate` "loud" focus push). Defaults false so
+    /// existing notify broadcasts and older daemons keep the soft behavior.
+    public let activate: Bool
     public init(notificationID: UUID, worktreeID: UUID, type: NotificationType,
-                message: String?, terminalID: UUID? = nil) {
+                message: String?, terminalID: UUID? = nil, activate: Bool = false) {
         self.notificationID = notificationID; self.worktreeID = worktreeID
         self.type = type; self.message = message
         self.terminalID = terminalID
+        self.activate = activate
     }
 
     enum CodingKeys: String, CodingKey {
-        case notificationID, worktreeID, type, message, terminalID
+        case notificationID, worktreeID, type, message, terminalID, activate
     }
 
     public init(from decoder: Decoder) throws {
@@ -110,6 +115,7 @@ public struct NotificationDelta: Codable, Sendable {
         type = try c.decode(NotificationType.self, forKey: .type)
         message = try c.decodeIfPresent(String.self, forKey: .message)
         terminalID = try c.decodeIfPresent(UUID.self, forKey: .terminalID)
+        activate = try c.decodeIfPresent(Bool.self, forKey: .activate) ?? false
     }
 }
 

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -97,6 +97,27 @@ tbd terminal send --terminal <id> --text "..." [--submit]
 tbd terminal output <id> [--lines N]
 ```
 
+### Pull the user's attention to a worker's tab
+
+Use when an orchestrator wants the user to look at a specific child tab (e.g. a
+worker needs input). Default is a **soft push** — a banner + an unread mark on
+that worktree; the user lands on the tab when they choose to look. It does NOT
+steal focus.
+
+```bash
+tbd terminal focus --terminal <id> [--message "..."]
+```
+
+Add `--activate` ONLY when the user has explicitly asked to be taken there — it
+foregrounds the app and switches to the tab immediately, interrupting whatever
+they're doing:
+
+```bash
+tbd terminal focus --terminal <id> --activate
+```
+
+Get `<id>` from `tbd terminal list <worktree>` or the output of `tbd terminal create`.
+
 ### Notify the TBD UI
 
 ```bash

--- a/Tests/TBDAppTests/MacNotificationBannerTitleTests.swift
+++ b/Tests/TBDAppTests/MacNotificationBannerTitleTests.swift
@@ -14,4 +14,24 @@ struct MacNotificationBannerTitleTests {
             #expect(MacNotificationManager.bannerTitle(worktreeName: "acme", type: type) == "acme")
         }
     }
+
+    @Test func focusRequestFallbackIsAttentionNeeded() {
+        #expect(MacNotificationManager.bannerBody(message: nil, type: .focusRequest) == "Attention needed.")
+    }
+
+    @Test func responseCompleteFallbackIsFinishedResponding() {
+        #expect(MacNotificationManager.bannerBody(message: nil, type: .responseComplete)
+            == "Claude has finished responding.")
+    }
+
+    @Test func suppliedMessageIsUsedVerbatim() {
+        #expect(MacNotificationManager.bannerBody(message: "hi", type: .focusRequest) == "hi")
+    }
+
+    @Test func longMessageIsTruncatedTo200CharsPlusEllipsis() {
+        let input = String(repeating: "a", count: 250)
+        let body = MacNotificationManager.bannerBody(message: input, type: .responseComplete)
+        #expect(body.count == 201)
+        #expect(body.hasSuffix("…"))
+    }
 }

--- a/Tests/TBDAppTests/MacNotificationBannerTitleTests.swift
+++ b/Tests/TBDAppTests/MacNotificationBannerTitleTests.swift
@@ -1,0 +1,17 @@
+import Testing
+@testable import TBDApp
+import TBDShared
+
+@Suite("MacNotificationManager.bannerTitle")
+struct MacNotificationBannerTitleTests {
+    @Test func focusRequestGetsEmojiPrefix() {
+        let title = MacNotificationManager.bannerTitle(worktreeName: "acme", type: .focusRequest)
+        #expect(title == "🎯 acme")
+    }
+
+    @Test func otherTypesAreUnchanged() {
+        for type: NotificationType in [.responseComplete, .error, .taskComplete, .attentionNeeded] {
+            #expect(MacNotificationManager.bannerTitle(worktreeName: "acme", type: type) == "acme")
+        }
+    }
+}

--- a/Tests/TBDAppTests/TabUnreadCompletionTests.swift
+++ b/Tests/TBDAppTests/TabUnreadCompletionTests.swift
@@ -94,7 +94,10 @@ struct TabUnreadCompletionTests {
         }
     }
 
-    @Test func nonResponseComplete_doesNotRecordUnread() {
+    /// Bolding is generalized to ANY terminal-stamped delta (not just
+    /// `.responseComplete`): a background-tab `.error` records unread so its tab
+    /// label bolds, matching the focus-push behavior.
+    @Test func nonResponseComplete_forBackgroundTab_recordsUnread() {
         withState { state in
             let worktreeID = UUID()
             let backgroundTerminal = UUID()
@@ -109,7 +112,7 @@ struct TabUnreadCompletionTests {
 
             state.handleDelta(makeDelta(worktreeID: worktreeID, terminalID: backgroundTerminal, type: .error))
 
-            #expect(!state.unreadTerminals.contains(backgroundTerminal))
+            #expect(state.unreadTerminals.contains(backgroundTerminal))
         }
     }
 

--- a/Tests/TBDAppTests/TerminalFocusDeltaTests.swift
+++ b/Tests/TBDAppTests/TerminalFocusDeltaTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+@MainActor
+@Suite("Focus-push delta handling")
+struct TerminalFocusDeltaTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.FocusDelta.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func focusDelta(worktreeID: UUID, terminalID: UUID, activate: Bool) -> StateDelta {
+        .notificationReceived(NotificationDelta(
+            notificationID: UUID(), worktreeID: worktreeID,
+            type: .focusRequest, message: "look", terminalID: terminalID, activate: activate
+        ))
+    }
+
+    @Test func softFocus_forBackgroundTab_recordsUnread_doesNotNavigate() {
+        withState { state in
+            state.isInitialStateLoaded = true
+            let other = UUID()
+            let worktreeID = UUID()
+            let activeTerminal = UUID()
+            let backgroundTerminal = UUID()
+            state.tabs = [worktreeID: [
+                Tab(id: activeTerminal, content: .terminal(terminalID: activeTerminal), label: nil),
+                Tab(id: backgroundTerminal, content: .terminal(terminalID: backgroundTerminal), label: nil),
+            ]]
+            state.activeTabIndices = [worktreeID: 0]
+            // Focus is on a different worktree, so worktreeID is NOT visible.
+            state.selectedWorktreeIDs = [other]
+
+            state.handleDelta(focusDelta(worktreeID: worktreeID, terminalID: backgroundTerminal, activate: false))
+
+            #expect(state.unreadTerminals.contains(backgroundTerminal))
+            #expect(state.selectedWorktreeIDs == [other])   // no navigation
+        }
+    }
+
+    @Test func softFocus_forActiveTab_doesNotBold() {
+        withState { state in
+            state.isInitialStateLoaded = true
+            let worktreeID = UUID()
+            let activeTerminal = UUID()
+            state.tabs = [worktreeID: [
+                Tab(id: activeTerminal, content: .terminal(terminalID: activeTerminal), label: nil),
+            ]]
+            state.activeTabIndices = [worktreeID: 0]
+            state.selectedWorktreeIDs = [worktreeID]
+
+            state.handleDelta(focusDelta(worktreeID: worktreeID, terminalID: activeTerminal, activate: false))
+
+            #expect(!state.unreadTerminals.contains(activeTerminal))
+        }
+    }
+
+    @Test func activateFocus_navigatesToWorktreeAndTab() {
+        withState { state in
+            state.isInitialStateLoaded = true
+            let repoID = UUID()
+            let worktreeID = UUID()
+            let targetTerminal = UUID()
+            state.worktrees = [repoID: [
+                Worktree(id: worktreeID, repoID: repoID, name: "x", displayName: "X",
+                         branch: "tbd/x", path: "/tmp/x", tmuxServer: "tbd-x"),
+            ]]
+            state.tabs = [worktreeID: [
+                Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil),
+                Tab(id: targetTerminal, content: .terminal(terminalID: targetTerminal), label: nil),
+            ]]
+            state.activeTabIndices = [worktreeID: 0]
+            state.selectedWorktreeIDs = []
+
+            state.handleDelta(focusDelta(worktreeID: worktreeID, terminalID: targetTerminal, activate: true))
+
+            #expect(state.selectedWorktreeIDs == [worktreeID])
+            #expect(state.activeTabIndices[worktreeID] == 1)   // switched to the target tab
+        }
+    }
+}

--- a/Tests/TBDCLITests/TerminalFocusCommandTests.swift
+++ b/Tests/TBDCLITests/TerminalFocusCommandTests.swift
@@ -1,0 +1,25 @@
+import Testing
+import ArgumentParser
+@testable import TBDCLI
+
+@Suite("tbd terminal focus parsing")
+struct TerminalFocusCommandTests {
+    @Test func parsesTerminalMessageAndActivate() throws {
+        let cmd = try TerminalFocus.parse(["--terminal", "ABC", "--message", "look", "--activate"])
+        #expect(cmd.terminal == "ABC")
+        #expect(cmd.message == "look")
+        #expect(cmd.activate == true)
+    }
+
+    @Test func activateDefaultsFalseAndMessageOptional() throws {
+        let cmd = try TerminalFocus.parse(["--terminal", "ABC"])
+        #expect(cmd.activate == false)
+        #expect(cmd.message == nil)
+    }
+
+    @Test func requiresTerminal() {
+        #expect(throws: (any Error).self) {
+            _ = try TerminalFocus.parse([])
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/RPCRouterTerminalFocusTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTerminalFocusTests.swift
@@ -1,0 +1,97 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Thread-safe capture box. `SendableBox` is declared `private` in other test
+/// files, so this suite needs its own copy.
+private final class CaptureBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _values: [T] = []
+    func append(_ value: T) { lock.lock(); defer { lock.unlock() }; _values.append(value) }
+    var values: [T] { lock.lock(); defer { lock.unlock() }; return _values }
+    var count: Int { values.count }
+}
+
+// Uses the shared RPCRouterTests fixture (db + router, in-memory, dryRun tmux).
+extension RPCRouterTests {
+
+    private func seedTerminal() async throws -> (worktreeID: UUID, terminalID: UUID) {
+        let repo = try await db.repos.create(
+            path: "/tmp/focus-repo-\(UUID().uuidString)",
+            displayName: "focus-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "focus-wt",
+            branch: "tbd/focus-wt",
+            path: "/tmp/focus-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-focus"
+        )
+        let term = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@focus-0",
+            tmuxPaneID: "%focus-0"
+        )
+        return (wt.id, term.id)
+    }
+
+    @Test("terminal.focus broadcasts a focusRequest delta resolving worktree from terminal")
+    func focusBroadcastsDelta() async throws {
+        let (worktreeID, terminalID) = try await seedTerminal()
+
+        let captured = CaptureBox<Data>()
+        router.subscriptions.addSubscriber { data in
+            captured.append(data)
+            return true
+        }
+
+        let params = TerminalFocusParams(terminalID: terminalID, message: "look", activate: true)
+        let request = try RPCRequest(method: RPCMethod.terminalFocus, params: params)
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        #expect(captured.count == 1)
+        let delta = try JSONDecoder().decode(StateDelta.self, from: captured.values[0])
+        guard case let .notificationReceived(n) = delta else {
+            Issue.record("expected .notificationReceived, got \(delta)")
+            return
+        }
+        #expect(n.worktreeID == worktreeID)
+        #expect(n.terminalID == terminalID)
+        #expect(n.type == .focusRequest)
+        #expect(n.activate == true)
+        #expect(n.message == "look")
+    }
+
+    @Test("terminal.focus soft push defaults activate to false")
+    func focusSoftDefaultsActivateFalse() async throws {
+        let (_, terminalID) = try await seedTerminal()
+
+        let captured = CaptureBox<Data>()
+        router.subscriptions.addSubscriber { data in
+            captured.append(data)
+            return true
+        }
+
+        let params = TerminalFocusParams(terminalID: terminalID)
+        let request = try RPCRequest(method: RPCMethod.terminalFocus, params: params)
+        _ = await router.handle(request)
+
+        let delta = try JSONDecoder().decode(StateDelta.self, from: captured.values[0])
+        guard case let .notificationReceived(n) = delta else {
+            Issue.record("expected .notificationReceived")
+            return
+        }
+        #expect(n.activate == false)
+    }
+
+    @Test("terminal.focus errors for an unknown terminal")
+    func focusUnknownTerminalErrors() async throws {
+        let params = TerminalFocusParams(terminalID: UUID())
+        let request = try RPCRequest(method: RPCMethod.terminalFocus, params: params)
+        let response = await router.handle(request)
+        #expect(!response.success)
+    }
+}

--- a/Tests/TBDSharedTests/NotificationDeltaActivateTests.swift
+++ b/Tests/TBDSharedTests/NotificationDeltaActivateTests.swift
@@ -1,0 +1,32 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite("NotificationDelta.activate")
+struct NotificationDeltaActivateTests {
+    @Test func defaultsToFalse() {
+        let delta = NotificationDelta(
+            notificationID: UUID(), worktreeID: UUID(),
+            type: .focusRequest, message: nil, terminalID: UUID()
+        )
+        #expect(delta.activate == false)
+    }
+
+    @Test func roundTripsThroughJSON() throws {
+        let original = NotificationDelta(
+            notificationID: UUID(), worktreeID: UUID(),
+            type: .focusRequest, message: "hi", terminalID: UUID(), activate: true
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(NotificationDelta.self, from: data)
+        #expect(decoded.activate == true)
+        #expect(decoded.type == .focusRequest)
+    }
+
+    @Test func missingActivateDecodesToFalse() throws {
+        // Simulate an older daemon that didn't send `activate`.
+        let json = #"{"notificationID":"\#(UUID().uuidString)","worktreeID":"\#(UUID().uuidString)","type":"focus_request"}"#
+        let decoded = try JSONDecoder().decode(NotificationDelta.self, from: Data(json.utf8))
+        #expect(decoded.activate == false)
+    }
+}

--- a/Tests/TBDSharedTests/NotificationFocusTypeTests.swift
+++ b/Tests/TBDSharedTests/NotificationFocusTypeTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import TBDShared
+
+@Suite("NotificationType.focusRequest")
+struct NotificationFocusTypeTests {
+    @Test func rawValueIsFocusRequest() {
+        #expect(NotificationType.focusRequest.rawValue == "focus_request")
+    }
+
+    @Test func decodesFromRawValue() {
+        #expect(NotificationType(rawValue: "focus_request") == .focusRequest)
+    }
+
+    @Test func severityMatchesAttentionNeeded() {
+        #expect(NotificationType.focusRequest.severity == NotificationType.attentionNeeded.severity)
+        #expect(NotificationType.focusRequest.severity == 3)
+    }
+}

--- a/Tests/TBDSharedTests/TBDSkillContentTests.swift
+++ b/Tests/TBDSharedTests/TBDSkillContentTests.swift
@@ -26,6 +26,8 @@ import Foundation
     #expect(body.contains("tbd link"))
     #expect(body.contains("tbd terminal send"))
     #expect(body.contains("tbd terminal output"))
+    #expect(body.contains("tbd terminal focus"))
+    #expect(body.contains("--activate"))
 }
 
 @Test func bodyDelegatesFlagDetailToHelp() {

--- a/Tests/TBDSharedTests/TerminalFocusParamsTests.swift
+++ b/Tests/TBDSharedTests/TerminalFocusParamsTests.swift
@@ -1,0 +1,26 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite("TerminalFocusParams")
+struct TerminalFocusParamsTests {
+    @Test func methodNameIsStable() {
+        #expect(RPCMethod.terminalFocus == "terminal.focus")
+    }
+
+    @Test func roundTripsThroughJSON() throws {
+        let id = UUID()
+        let params = TerminalFocusParams(terminalID: id, message: "look here", activate: true)
+        let data = try JSONEncoder().encode(params)
+        let decoded = try JSONDecoder().decode(TerminalFocusParams.self, from: data)
+        #expect(decoded.terminalID == id)
+        #expect(decoded.message == "look here")
+        #expect(decoded.activate == true)
+    }
+
+    @Test func defaultsActivateFalseAndMessageNil() {
+        let params = TerminalFocusParams(terminalID: UUID())
+        #expect(params.activate == false)
+        #expect(params.message == nil)
+    }
+}

--- a/docs/superpowers/specs/2026-06-05-terminal-focus-cli-design.md
+++ b/docs/superpowers/specs/2026-06-05-terminal-focus-cli-design.md
@@ -72,7 +72,7 @@ existing logic.
 ```
 CLI terminal focus ──RPC terminalFocus{terminalID, message?, activate}──▶ daemon
   daemon: terminals.get(id) → worktreeID
-          notifications.create(type: .attentionNeeded, message, terminalID)
+          notifications.create(type: .focusRequest, message, terminalID)
           broadcast .notificationReceived(NotificationDelta{…, activate})
   app subscribe handler (handleNotificationDelta):
     activate == false → record unread on W + bold T's tab + fire banner/sound   (soft)
@@ -80,11 +80,34 @@ CLI terminal focus ──RPC terminalFocus{terminalID, message?, activate}──
 ```
 
 The only new transport field is a single `activate` bool on `NotificationDelta`. Notification
-persistence, the unread summary, the banner, and the sound are all reused unchanged.
+persistence, the unread summary, and the sound are all reused unchanged; the banner gains a
+focus-specific title prefix (see "Distinguishing the banner" below).
+
+### Distinguishing the banner
+
+A focus push must be recognizable in the macOS banner / Notification Center, separate from a
+normal `tbd notify` message. macOS does not let an app swap a notification's left-side icon
+(it is always TBD's app icon), so the distinction is carried by a **dedicated
+`NotificationType.focusRequest`** plus an **emoji prefix on the banner title** (e.g.
+`🎯 worktree-name`).
+
+Decisions:
+
+- **New type, not a flag.** `.focusRequest` (rawValue `focus_request`) is an additive enum
+  case — safe for existing DB rows, and Swift's exhaustive switches force every site to give
+  it a treatment.
+- **No new in-app look.** By explicit choice, the in-app surfaces (sidebar dot, jump-menu
+  dot, bolding) do **not** need to distinguish a focus push. `.focusRequest` therefore maps
+  to the same presentation as `.attentionNeeded` (orange dot, `severity` 3) at every in-app
+  switch. Only the banner differs.
+- **Banner only.** The emoji prefix is applied in the banner builder when the type is
+  `.focusRequest`; all other types render unchanged.
 
 ### Changes by layer
 
 1. **TBDShared**
+   - `NotificationType.focusRequest` (rawValue `focus_request`), with `severity` matching
+     `.attentionNeeded` (3) (`Sources/TBDShared/Models.swift`).
    - `NotificationDelta.activate: Bool`, defaulting to `false` so existing broadcasts and
      any in-flight decoders are unaffected (`Sources/TBDShared/StateDelta.swift:85`).
    - `RPCMethod.terminalFocus` (`Sources/TBDShared/RPCProtocol.swift`).
@@ -93,8 +116,8 @@ persistence, the unread summary, the banner, and the sound are all reused unchan
 
 2. **TBDDaemon**
    - `handleTerminalFocus`: decode params, resolve the terminal via
-     `db.terminals.get(id:)` (return an error response if not found), persist an
-     `attention_needed` notification carrying the terminalID (mirroring `handleNotify`),
+     `db.terminals.get(id:)` (return an error response if not found), persist a
+     `.focusRequest` notification carrying the terminalID (mirroring `handleNotify`),
      and broadcast `.notificationReceived(NotificationDelta(…, activate: params.activate))`.
    - Route `RPCMethod.terminalFocus` in `RPCRouter`.
 
@@ -103,13 +126,22 @@ persistence, the unread summary, the banner, and the sound are all reused unchan
      registered in `TerminalCommand.subcommands`. Validates the terminal UUID and prints
      a clear error on failure (non-silent).
 
-4. **TBDApp** — `handleNotificationDelta` (`Sources/TBDApp/AppState.swift`):
-   - **Generalize tab bolding (gap 2):** insert into `unreadTerminals` whenever the delta
-     carries a `terminalID` and that terminal is not the active focused tab — today this is
-     gated to `.responseComplete`. This keeps the in-app cue as precise as the banner.
-   - **Activate branch (gap 1):** handled *before* the existing visible-worktree
-     early-return; when `delta.activate` is set, call
-     `navigateToWorktree(worktreeID, terminalID:)` (which foregrounds + selects) and return.
+4. **TBDApp**
+   - `handleNotificationDelta` (`Sources/TBDApp/AppState.swift`):
+     - **Generalize tab bolding (gap 2):** insert into `unreadTerminals` whenever the delta
+       carries a `terminalID` and that terminal is not the active focused tab — today this is
+       gated to `.responseComplete`. This keeps the in-app cue as precise as the banner.
+     - **Activate branch (gap 1):** handled *before* the existing visible-worktree
+       early-return; when `delta.activate` is set, call
+       `navigateToWorktree(worktreeID, terminalID:)` (which foregrounds + selects) and return.
+     - Pass the notification `type` through to `postIfEnabled` so the banner can prefix.
+   - `MacNotificationManager.postIfEnabled` gains a `type:` parameter; when the type is
+     `.focusRequest`, prefix `content.title` with the focus emoji (`🎯`). All other types
+     render unchanged.
+   - **Exhaustive-switch sites** that must add the `.focusRequest` case, mapping it to the
+     same presentation as `.attentionNeeded` (no new in-app look): `WorktreeRowView`
+     (`badgeColor`, `hasBoldNotification`), `JumpMenuRow.severityColor`,
+     `NotificationSoundPlayer.playIfEnabled`, and any other `switch` over `NotificationType`.
 
 5. **Docs** — add `tbd terminal focus` to the command list in
    `Sources/TBDShared/TBDSkillContent.swift`.
@@ -124,9 +156,12 @@ Every gated branch gets a test for both states:
   - Bolding: a terminalID-bearing soft push bolds a *background* tab but **not** the active
     focused tab.
 - **Daemon**: `terminalFocus` resolves the worktree from the terminal and broadcasts a delta
-  with the right `activate` value; an unknown terminal yields an error response.
+  with the right `activate` value, persisting a `.focusRequest` notification; an unknown
+  terminal yields an error response.
 - **CLI**: arg parsing for `--terminal` / `--message` / `--activate`; an invalid terminal
   UUID errors.
+- **Banner**: `postIfEnabled` prefixes the title with the focus emoji for `.focusRequest`
+  and leaves every other type's title unchanged.
 
 ### Edge cases
 

--- a/docs/superpowers/specs/2026-06-05-terminal-focus-cli-design.md
+++ b/docs/superpowers/specs/2026-06-05-terminal-focus-cli-design.md
@@ -1,0 +1,150 @@
+# `tbd terminal focus` — push the user to a child worktree's tab
+
+## Problem
+
+An orchestration session (a parent Claude agent) spawns child worktrees and wants
+to direct the user's attention to a *specific tab* in one of those children — e.g.
+"the child working on the migration needs your input, look at its tab." Today there
+is no CLI command that focuses a worktree, let alone a particular tab.
+
+The constraint that shapes the whole design: **push, don't pull.** The orchestrator
+should be able to *flag* a tab for attention without yanking the user out of whatever
+they are doing. Stealing OS focus (foregrounding the app) is disruptive and must be
+opt-in, not the default.
+
+## What already exists (and what the gap actually is)
+
+Most of the machinery is already shipping via `tbd notify`:
+
+- `tbd notify --worktree W --terminal T --type … --message …` fires a banner + sound,
+  records unread on W, and stamps the terminal UUID into the notification record.
+- The macOS banner click already calls `navigateToWorktree(W, terminalID: T)`, which
+  selects the exact tab **and** foregrounds the app
+  (`Sources/TBDApp/Services/MacNotificationManager.swift:147`). That is the
+  "user explicitly asked → pulling is fine" path, for free.
+- For `response_complete`, the originating tab even bolds in the sidebar while
+  backgrounded (`unreadTerminals`).
+
+So the soft "mark + notify, land on the tab when the user chooses to look" behavior is
+~90% implemented. The genuine gaps:
+
+1. **No immediate loud push** — nothing foregrounds + selects *without* a user click.
+2. **Tab bolding is `response_complete`-only** — an attention push won't bold the
+   specific child tab in-app (only worktree-level unread + banner).
+3. **Discoverability/semantics** — an orchestrator reaches for *"focus the user on this
+   child's tab,"* not *"notify."*
+
+This feature closes gaps 1–3 with a thin, intent-revealing command that reuses the
+notify path end to end.
+
+## Design
+
+### Command
+
+```
+tbd terminal focus --terminal <uuid> [--message <text>] [--activate]
+```
+
+- `--terminal <uuid>` (required) — the target tab's terminal. The worktree is derived
+  daemon-side from the terminal record, so the orchestrator only needs the terminal
+  UUID it already has from `tbd terminal list` / `tbd terminal create`.
+- `--message <text>` (optional) — banner / notification text.
+- `--activate` — escalate from the soft push to an immediate foreground + select.
+
+Lives under the existing `terminal` command group, alongside `send` / `output` /
+`conversation`.
+
+Unlike `tbd notify` (deliberately silent and lenient for hook usage), `focus` is an
+**explicit orchestrator command**, so it surfaces errors (e.g. unknown terminal) rather
+than swallowing them.
+
+### Addressing primitive
+
+The terminal UUID is the addressing primitive, consistent with the rest of the CLI
+(`tbd terminal send --terminal <uuid>`) and with the app's tab-matching code, which
+already resolves a terminal UUID to the tab whose content references it
+(`Sources/TBDApp/AppState+Worktrees.swift:186`). A "tab" can be a split with several
+terminals or a non-terminal pane; matching by terminal UUID is well-defined and reuses
+existing logic.
+
+### Data flow
+
+```
+CLI terminal focus ──RPC terminalFocus{terminalID, message?, activate}──▶ daemon
+  daemon: terminals.get(id) → worktreeID
+          notifications.create(type: .attentionNeeded, message, terminalID)
+          broadcast .notificationReceived(NotificationDelta{…, activate})
+  app subscribe handler (handleNotificationDelta):
+    activate == false → record unread on W + bold T's tab + fire banner/sound   (soft)
+    activate == true  → navigateToWorktree(W, terminalID: T) → foreground+select (loud)
+```
+
+The only new transport field is a single `activate` bool on `NotificationDelta`. Notification
+persistence, the unread summary, the banner, and the sound are all reused unchanged.
+
+### Changes by layer
+
+1. **TBDShared**
+   - `NotificationDelta.activate: Bool`, defaulting to `false` so existing broadcasts and
+     any in-flight decoders are unaffected (`Sources/TBDShared/StateDelta.swift:85`).
+   - `RPCMethod.terminalFocus` (`Sources/TBDShared/RPCProtocol.swift`).
+   - `TerminalFocusParams { terminalID: UUID, message: String?, activate: Bool }`
+     (`Sources/TBDShared/RPCProtocol.swift`).
+
+2. **TBDDaemon**
+   - `handleTerminalFocus`: decode params, resolve the terminal via
+     `db.terminals.get(id:)` (return an error response if not found), persist an
+     `attention_needed` notification carrying the terminalID (mirroring `handleNotify`),
+     and broadcast `.notificationReceived(NotificationDelta(…, activate: params.activate))`.
+   - Route `RPCMethod.terminalFocus` in `RPCRouter`.
+
+3. **TBDCLI**
+   - `TerminalFocus` subcommand in `Sources/TBDCLI/Commands/TerminalCommands.swift`,
+     registered in `TerminalCommand.subcommands`. Validates the terminal UUID and prints
+     a clear error on failure (non-silent).
+
+4. **TBDApp** — `handleNotificationDelta` (`Sources/TBDApp/AppState.swift`):
+   - **Generalize tab bolding (gap 2):** insert into `unreadTerminals` whenever the delta
+     carries a `terminalID` and that terminal is not the active focused tab — today this is
+     gated to `.responseComplete`. This keeps the in-app cue as precise as the banner.
+   - **Activate branch (gap 1):** handled *before* the existing visible-worktree
+     early-return; when `delta.activate` is set, call
+     `navigateToWorktree(worktreeID, terminalID:)` (which foregrounds + selects) and return.
+
+5. **Docs** — add `tbd terminal focus` to the command list in
+   `Sources/TBDShared/TBDSkillContent.swift`.
+
+### Testing (per CLAUDE.md branch-coverage rule)
+
+Every gated branch gets a test for both states:
+
+- **App** (`AppState.handleNotificationDelta`, mirroring existing NotificationDelta tests):
+  - `activate == true` → selection moves to W and the active tab resolves to T's tab.
+  - `activate == false` → selection unchanged, `unreadTerminals` contains T, no foreground.
+  - Bolding: a terminalID-bearing soft push bolds a *background* tab but **not** the active
+    focused tab.
+- **Daemon**: `terminalFocus` resolves the worktree from the terminal and broadcasts a delta
+  with the right `activate` value; an unknown terminal yields an error response.
+- **CLI**: arg parsing for `--terminal` / `--message` / `--activate`; an invalid terminal
+  UUID errors.
+
+### Edge cases
+
+- **Target tab closed / surfaced only via the pinned dock:** `navigateToActiveWorktree`
+  already keeps the current tab when no match exists; soft-path bolding of a now-absent
+  terminal is harmless.
+- **Archived worktree:** `navigateToWorktree` routes to the archived path. Acceptable —
+  the orchestrator targeting an archived child is already an unusual case.
+- **`activate` while the app is not running / cold-start:** the existing `pendingDeepLink`
+  buffering and `NSApplication.isRunning` guard already cover this.
+
+### Out of scope (deferred)
+
+- Pre-setting `activeTabIndices[W]` so that *non-banner* entry paths (e.g. a sidebar click)
+  also land on T. This mutates a worktree's active tab out from under the user, which cuts
+  against "don't be disruptive," and is unnecessary for the push use case.
+
+## Operational note
+
+Touches TBDShared + the daemon, so a full `scripts/restart.sh` (not `--app`) is required to
+pick up the new RPC and delta field.

--- a/docs/superpowers/specs/2026-06-05-terminal-focus-cli-design.md
+++ b/docs/superpowers/specs/2026-06-05-terminal-focus-cli-design.md
@@ -143,8 +143,20 @@ Decisions:
      (`badgeColor`, `hasBoldNotification`), `JumpMenuRow.severityColor`,
      `NotificationSoundPlayer.playIfEnabled`, and any other `switch` over `NotificationType`.
 
-5. **Docs** — add `tbd terminal focus` to the command list in
-   `Sources/TBDShared/TBDSkillContent.swift`.
+5. **The `tbd` skill** (`Sources/TBDShared/TBDSkillContent.swift`) — this is the single
+   source of truth for the agent-facing `tbd` skill, written out as `SKILL.md` for
+   Claude/Codex; it is the surface orchestration sessions actually read, so it is a
+   first-class deliverable here, not a command-list footnote. Add a `tbd terminal focus`
+   section that covers:
+   - the command + flags (`--terminal`, `--message`, `--activate`);
+   - **orchestration guidance** — the default is a *soft push* (banner + unread, the user
+     lands on the tab when they choose to look). Use `--activate` only when the user has
+     explicitly asked to be pulled over, because it steals focus and interrupts whatever
+     they are doing;
+   - where the terminal UUID comes from (`tbd terminal list` / `tbd terminal create`).
+
+   The `tbd-project` developer skill does not enumerate CLI subcommands, so it needs no
+   change for this feature.
 
 ### Testing (per CLAUDE.md branch-coverage rule)
 


### PR DESCRIPTION
## Summary

Adds `tbd terminal focus --terminal <uuid> [--message <text>] [--activate]` so an orchestration session can direct your attention to a specific child worktree's tab.

- **Soft by default (push, not pull):** fires a banner + marks the worktree unread + bolds the target tab. It does **not** steal OS focus — you land on the tab when *you* choose to look.
- **`--activate` opts into the loud pull:** foregrounds the app and selects the tab immediately. Reserved for when the user explicitly asked to be taken there.
- **Distinct banner:** a new `NotificationType.focusRequest` gives focus pushes a `🎯` title prefix so they're recognizable in the macOS banner / Notification Center. In-app it reuses `attention_needed`'s look by design (no new dot color).
- Reuses the existing `notify` RPC/delta/persistence path end to end; the only new transport field is one `activate` bool on `NotificationDelta`. The daemon resolves the owning worktree from the terminal id.
- Generalizes background-tab bolding from `response_complete`-only to **any** terminal-stamped notification, so error/attention/task pushes also bold their originating tab (intentional consistency improvement).
- Documents the command in the agent-facing `tbd` skill (`TBDSkillContent.swift`) with push-don't-pull guidance.

Design spec: `docs/superpowers/specs/2026-06-05-terminal-focus-cli-design.md`.

## Test plan

- [x] `swift build` clean; `swiftlint --strict` clean (0 violations).
- [x] New unit tests pass: Shared (`focusRequest` severity/raw value, `NotificationDelta.activate` round-trip + back-compat default, `TerminalFocusParams`), daemon (`terminal.focus` resolves worktree from terminal, broadcasts `focusRequest` + `activate`, errors on unknown terminal), CLI (arg parsing), app (banner emoji prefix; activate navigates; soft push bolds background tab but not the active tab).
- [x] Existing `TabUnreadCompletionTests` updated for the intentional bolding generalization; full suite green (one pre-existing unrelated `TabBarHitAreaTests` geometry flake on `main`).
- [ ] Manual: from one worktree, `tbd terminal focus --terminal <bg-tab-id> --message "hi"` against another worktree → `🎯`-prefixed banner, unread mark, bolded tab, **no focus steal**; clicking the banner lands on that exact tab.
- [ ] Manual: `--activate` foregrounds and selects the tab immediately.
- [ ] Manual: invalid / unknown terminal id prints a non-silent error.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=58F93DC7-BBC0-4B53-A9F3-A2401E653435)