### PR TITLE
Feat: Degrade to a fallback model on overload instead of hard-failing TBD sessions

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -41,12 +41,14 @@ extension AppState {
                          baseURL: String? = nil,
                          model: String? = nil,
                          awsRegion: String? = nil,
-                         awsProfile: String? = nil) async -> String? {
+                         awsProfile: String? = nil,
+                         fallbackModels: [String]? = nil) async -> String? {
         do {
             let result = try await daemonClient.addModelProfile(
                 name: name, kind: kind, token: token,
                 baseURL: baseURL, model: model,
-                awsRegion: awsRegion, awsProfile: awsProfile
+                awsRegion: awsRegion, awsProfile: awsProfile,
+                fallbackModels: fallbackModels
             )
             await loadModelProfiles()
             return result.warning
@@ -81,9 +83,12 @@ extension AppState {
 
     /// Update a model profile's proxy endpoint (baseURL + model). Pass nil to
     /// either field to clear it.
-    func updateModelProfileEndpoint(id: UUID, baseURL: String?, model: String?) async {
+    func updateModelProfileEndpoint(id: UUID, baseURL: String?, model: String?,
+                                    fallbackModels: [String]? = nil) async {
         do {
-            try await daemonClient.updateModelProfileEndpoint(id: id, baseURL: baseURL, model: model)
+            try await daemonClient.updateModelProfileEndpoint(
+                id: id, baseURL: baseURL, model: model, fallbackModels: fallbackModels
+            )
             await loadModelProfiles()
         } catch {
             logger.error("Failed to update model profile endpoint: \(error, privacy: .public)")
@@ -91,11 +96,13 @@ extension AppState {
         }
     }
 
-    /// Update a bedrock model profile's region, awsProfile, and model in-place.
-    func updateModelProfileBedrock(id: UUID, awsRegion: String, awsProfile: String?, model: String) async {
+    /// Update a bedrock model profile's region, awsProfile, model, and fallback list in-place.
+    func updateModelProfileBedrock(id: UUID, awsRegion: String, awsProfile: String?, model: String,
+                                   fallbackModels: [String]? = nil) async {
         do {
             try await daemonClient.updateModelProfileBedrock(
-                id: id, awsRegion: awsRegion, awsProfile: awsProfile, model: model
+                id: id, awsRegion: awsRegion, awsProfile: awsProfile, model: model,
+                fallbackModels: fallbackModels
             )
             await loadModelProfiles()
         } catch {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -836,10 +836,11 @@ actor DaemonClient {
                          baseURL: String? = nil,
                          model: String? = nil,
                          awsRegion: String? = nil,
-                         awsProfile: String? = nil) async throws -> ModelProfileAddResult {
+                         awsProfile: String? = nil,
+                         fallbackModels: [String]? = nil) async throws -> ModelProfileAddResult {
         return try await callAsync(
             method: RPCMethod.modelProfileAdd,
-            params: ModelProfileAddParams(name: name, kind: kind, token: token, baseURL: baseURL, model: model, awsRegion: awsRegion, awsProfile: awsProfile),
+            params: ModelProfileAddParams(name: name, kind: kind, token: token, baseURL: baseURL, model: model, awsRegion: awsRegion, awsProfile: awsProfile, fallbackModels: fallbackModels),
             resultType: ModelProfileAddResult.self
         )
     }
@@ -860,19 +861,21 @@ actor DaemonClient {
         )
     }
 
-    /// Update a model profile's proxy endpoint (baseURL + model).
-    func updateModelProfileEndpoint(id: UUID, baseURL: String?, model: String?) async throws {
+    /// Update a model profile's proxy endpoint (baseURL + model) and fallback list.
+    func updateModelProfileEndpoint(id: UUID, baseURL: String?, model: String?,
+                                    fallbackModels: [String]? = nil) async throws {
         try await callVoidAsync(
             method: RPCMethod.modelProfileUpdateEndpoint,
-            params: ModelProfileUpdateEndpointParams(id: id, baseURL: baseURL, model: model)
+            params: ModelProfileUpdateEndpointParams(id: id, baseURL: baseURL, model: model, fallbackModels: fallbackModels)
         )
     }
 
-    /// Update a bedrock model profile's region, awsProfile, and model.
-    func updateModelProfileBedrock(id: UUID, awsRegion: String, awsProfile: String?, model: String) async throws {
+    /// Update a bedrock model profile's region, awsProfile, model, and fallback list.
+    func updateModelProfileBedrock(id: UUID, awsRegion: String, awsProfile: String?, model: String,
+                                   fallbackModels: [String]? = nil) async throws {
         try await callVoidAsync(
             method: RPCMethod.modelProfileUpdateBedrock,
-            params: ModelProfileUpdateBedrockParams(id: id, awsRegion: awsRegion, awsProfile: awsProfile, model: model)
+            params: ModelProfileUpdateBedrockParams(id: id, awsRegion: awsRegion, awsProfile: awsProfile, model: model, fallbackModels: fallbackModels)
         )
     }
 

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -229,6 +229,11 @@ private struct LabeledField<Field: View>: View {
     }
 }
 
+/// Maximum number of fallback models Claude Code accepts (documented cap of 3).
+/// Top-level (nonisolated) so both the main-actor editor view and the
+/// nonisolated `normalizedFallbackModels` helper can reference one constant.
+let fallbackModelsMaxCount = 3
+
 /// Ordered editor for a profile's fallback model ids (capped at 3). Each row
 /// is a text field with a remove button; an "Add fallback model" button appends
 /// a row while under the cap. Order is significant — Claude Code tries the
@@ -238,12 +243,11 @@ private struct LabeledField<Field: View>: View {
 /// rows to `nil` before sending to the daemon (the daemon also normalizes).
 struct FallbackModelsEditor: View {
     @Binding var models: [String]
-    static let maxCount = 3
 
     var body: some View {
         LabeledField(
             "Fallback models (optional)",
-            caption: "Tried in order when the primary model is overloaded or unavailable. Up to \(Self.maxCount). e.g. claude-haiku-4-5-20251001"
+            caption: "Tried in order when the primary model is overloaded or unavailable. Up to \(fallbackModelsMaxCount). e.g. claude-haiku-4-5-20251001"
         ) {
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(models.indices, id: \.self) { index in
@@ -259,7 +263,7 @@ struct FallbackModelsEditor: View {
                             .textFieldStyle(.roundedBorder)
                             .frame(maxWidth: .infinity)
                         Button {
-                            models.remove(at: index)
+                            if index < models.count { models.remove(at: index) }
                         } label: {
                             Image(systemName: "minus.circle")
                         }
@@ -267,7 +271,7 @@ struct FallbackModelsEditor: View {
                         .help("Remove this fallback model")
                     }
                 }
-                if models.count < Self.maxCount {
+                if models.count < fallbackModelsMaxCount {
                     Button {
                         models.append("")
                     } label: {
@@ -287,7 +291,7 @@ func normalizedFallbackModels(_ rows: [String]) -> [String]? {
     let cleaned = rows
         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         .filter { !$0.isEmpty }
-        .prefix(FallbackModelsEditor.maxCount)
+        .prefix(fallbackModelsMaxCount)
     return cleaned.isEmpty ? nil : Array(cleaned)
 }
 

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -287,6 +287,10 @@ struct FallbackModelsEditor: View {
 
 /// Convert editor rows into the daemon payload: trim, drop blanks, cap at 3,
 /// and collapse an empty result to nil.
+///
+/// Deliberately duplicates the daemon-side `normalizeFallbackModels` in
+/// `Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift` —
+/// defense-in-depth at both layers. Keep the two in sync.
 func normalizedFallbackModels(_ rows: [String]) -> [String]? {
     let cleaned = rows
         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -229,6 +229,68 @@ private struct LabeledField<Field: View>: View {
     }
 }
 
+/// Ordered editor for a profile's fallback model ids (capped at 3). Each row
+/// is a text field with a remove button; an "Add fallback model" button appends
+/// a row while under the cap. Order is significant — Claude Code tries the
+/// models top-to-bottom when the primary is overloaded/unavailable.
+///
+/// Binds to a `[String]` of exactly the rows shown. Callers convert empty/blank
+/// rows to `nil` before sending to the daemon (the daemon also normalizes).
+struct FallbackModelsEditor: View {
+    @Binding var models: [String]
+    static let maxCount = 3
+
+    var body: some View {
+        LabeledField(
+            "Fallback models (optional)",
+            caption: "Tried in order when the primary model is overloaded or unavailable. Up to \(Self.maxCount). e.g. claude-haiku-4-5-20251001"
+        ) {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(models.indices, id: \.self) { index in
+                    HStack(spacing: 6) {
+                        Text("\(index + 1).")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 16, alignment: .trailing)
+                        TextField("", text: Binding(
+                            get: { index < models.count ? models[index] : "" },
+                            set: { if index < models.count { models[index] = $0 } }
+                        ), prompt: Text("model id"))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(maxWidth: .infinity)
+                        Button {
+                            models.remove(at: index)
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Remove this fallback model")
+                    }
+                }
+                if models.count < Self.maxCount {
+                    Button {
+                        models.append("")
+                    } label: {
+                        Label("Add fallback model", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                }
+            }
+        }
+    }
+}
+
+/// Convert editor rows into the daemon payload: trim, drop blanks, cap at 3,
+/// and collapse an empty result to nil.
+func normalizedFallbackModels(_ rows: [String]) -> [String]? {
+    let cleaned = rows
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+        .prefix(FallbackModelsEditor.maxCount)
+    return cleaned.isEmpty ? nil : Array(cleaned)
+}
+
 private enum AddPreset: String, CaseIterable, Identifiable {
     case claudeDirect = "Claude"
     case proxy        = "Proxy"
@@ -385,6 +447,7 @@ struct AddModelProfileSheet: View {
     @State private var awsProfile = ""
     @State private var awsProfileSuggestions: [String] = []
     @State private var modelDiscovery: BedrockModels.DiscoveryResult = .idle
+    @State private var fallbackModels: [String] = []
     @State private var isSaving = false
     @State private var errorMessage: String?
     @State private var probeStatus: ProbeStatus = .idle
@@ -489,6 +552,8 @@ struct AddModelProfileSheet: View {
                     }
                     modelDiscoveryStatus(profile: awsProfile, discovery: modelDiscovery)
                 }
+
+                FallbackModelsEditor(models: $fallbackModels)
             }
 
             probeView
@@ -606,7 +671,8 @@ struct AddModelProfileSheet: View {
                     baseURL: nil,
                     model: trimmedModel.isEmpty ? nil : trimmedModel,
                     awsRegion: trimmedRegion,
-                    awsProfile: trimmedAwsProfile.isEmpty ? nil : trimmedAwsProfile
+                    awsProfile: trimmedAwsProfile.isEmpty ? nil : trimmedAwsProfile,
+                    fallbackModels: normalizedFallbackModels(fallbackModels)
                 )
                 await MainActor.run {
                     isSaving = false
@@ -644,7 +710,8 @@ struct AddModelProfileSheet: View {
                 baseURL: preset == .proxy ? trimmedBase : nil,
                 // Bedrock returns early above, so only proxy/claudeDirect reach here —
                 // both carry an optional model.
-                model: trimmedModel.isEmpty ? nil : trimmedModel
+                model: trimmedModel.isEmpty ? nil : trimmedModel,
+                fallbackModels: normalizedFallbackModels(fallbackModels)
             )
             await MainActor.run {
                 isSaving = false
@@ -679,6 +746,7 @@ struct EditEndpointSheet: View {
     @State private var name: String
     @State private var baseURL: String
     @State private var model: String
+    @State private var fallbackModels: [String]
     @State private var isSaving = false
     @State private var probeStatus: ProbeStatus = .idle
     @State private var errorMessage: String?
@@ -688,6 +756,7 @@ struct EditEndpointSheet: View {
         _name = State(initialValue: profile.name)
         _baseURL = State(initialValue: profile.baseURL ?? "")
         _model = State(initialValue: profile.model ?? "")
+        _fallbackModels = State(initialValue: profile.fallbackModels ?? [])
     }
 
     var body: some View {
@@ -710,6 +779,7 @@ struct EditEndpointSheet: View {
                         .textFieldStyle(.roundedBorder)
                         .frame(maxWidth: .infinity)
                 }
+                FallbackModelsEditor(models: $fallbackModels)
             }
             probeLabel
             if let errorMessage {
@@ -792,7 +862,8 @@ struct EditEndpointSheet: View {
             await appState.updateModelProfileEndpoint(
                 id: profile.id,
                 baseURL: trimmedBase,
-                model: trimmedModel.isEmpty ? nil : trimmedModel
+                model: trimmedModel.isEmpty ? nil : trimmedModel,
+                fallbackModels: normalizedFallbackModels(fallbackModels)
             )
             await MainActor.run {
                 isSaving = false
@@ -821,6 +892,7 @@ struct EditBedrockSheet: View {
     @State private var awsRegion: String
     @State private var awsProfile: String
     @State private var model: String
+    @State private var fallbackModels: [String]
     @State private var isSaving = false
     @State private var errorMessage: String?
     @State private var awsProfileSuggestions: [String] = []
@@ -832,6 +904,7 @@ struct EditBedrockSheet: View {
         _awsRegion = State(initialValue: profile.awsRegion ?? "")
         _awsProfile = State(initialValue: profile.awsProfile ?? "")
         _model = State(initialValue: profile.model ?? "")
+        _fallbackModels = State(initialValue: profile.fallbackModels ?? [])
     }
 
     var body: some View {
@@ -882,6 +955,8 @@ struct EditBedrockSheet: View {
                 }
             }
             modelDiscoveryStatus(profile: awsProfile, discovery: modelDiscovery)
+
+            FallbackModelsEditor(models: $fallbackModels)
 
             if let errorMessage {
                 Text(errorMessage).font(.caption).foregroundStyle(.red)
@@ -961,7 +1036,8 @@ struct EditBedrockSheet: View {
                 id: profile.id,
                 awsRegion: trimmedRegion,
                 awsProfile: trimmedAwsProfile.isEmpty ? nil : trimmedAwsProfile,
-                model: trimmedModel
+                model: trimmedModel,
+                fallbackModels: normalizedFallbackModels(fallbackModels)
             )
             await MainActor.run {
                 isSaving = false
@@ -986,6 +1062,7 @@ struct EditClaudeDirectSheet: View {
 
     @State private var name: String
     @State private var model: String
+    @State private var fallbackModels: [String]
     @State private var isSaving = false
     @State private var errorMessage: String?
 
@@ -993,6 +1070,7 @@ struct EditClaudeDirectSheet: View {
         self.profile = profile
         _name = State(initialValue: profile.name)
         _model = State(initialValue: profile.model ?? "")
+        _fallbackModels = State(initialValue: profile.fallbackModels ?? [])
     }
 
     var body: some View {
@@ -1010,6 +1088,7 @@ struct EditClaudeDirectSheet: View {
                         .textFieldStyle(.roundedBorder)
                         .frame(maxWidth: .infinity)
                 }
+                FallbackModelsEditor(models: $fallbackModels)
             }
             if let errorMessage {
                 Text(errorMessage)
@@ -1061,7 +1140,8 @@ struct EditClaudeDirectSheet: View {
             await appState.updateModelProfileEndpoint(
                 id: profile.id,
                 baseURL: nil,
-                model: trimmedModel.isEmpty ? nil : trimmedModel
+                model: trimmedModel.isEmpty ? nil : trimmedModel,
+                fallbackModels: normalizedFallbackModels(fallbackModels)
             )
             await MainActor.run {
                 isSaving = false

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -254,6 +254,16 @@ public final class Daemon: Sendable {
             reconcileLogger.warning("Failed to list repos for reconciliation: \(error.localizedDescription, privacy: .public)")
         }
 
+        // 11a-pre. Prune per-session Claude `fallbackModel` overlay files
+        // orphaned by crashes or teardown paths that didn't clean up. Keep only
+        // files whose key matches a live terminal. Best-effort.
+        do {
+            let liveTerminalIDs = try await database.terminals.list().map { $0.id.uuidString }
+            ClaudeHookOverlay.pruneOrphanedSessionOverlays(liveSessionKeys: liveTerminalIDs)
+        } catch {
+            daemonLogger.warning("Failed to prune orphaned per-session overlays: \(error.localizedDescription, privacy: .public)")
+        }
+
         // 11a. Backfill archived worktrees whose branch is missing — repairs
         // rows whose branch was renamed before archive captured the new name.
         // Idempotent and best-effort; never throws.

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -526,6 +526,13 @@ public final class TBDDatabase: Sendable {
             )
         }
 
+        // Per-profile Claude `fallbackModel` list, stored as a JSON-encoded
+        // string array (e.g. `["claude-haiku-4-5-20251001"]`). Nullable so
+        // existing rows decode as "no fallback configured".
+        migrator.registerMigration("v30_model_profile_fallback_models") { db in
+            try db.addColumnIfMissing(table: "model_profiles", column: "fallback_models", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/ModelProfileRecord.swift
+++ b/Sources/TBDDaemon/Database/ModelProfileRecord.swift
@@ -13,6 +13,10 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
     var model: String?
     var aws_region: String?
     var aws_profile: String?
+    /// JSON-encoded `[String]` (the profile's ordered fallback model ids), or
+    /// nil when no fallback is configured. Stored as text so the array survives
+    /// a single column.
+    var fallback_models: String?
     var created_at: Date
     var last_used_at: Date?
 
@@ -25,6 +29,7 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
         self.model = profile.model
         self.aws_region = profile.awsRegion
         self.aws_profile = profile.awsProfile
+        self.fallback_models = Self.encodeFallbackModels(profile.fallbackModels)
         self.created_at = profile.createdAt
         self.last_used_at = profile.lastUsedAt
     }
@@ -38,9 +43,26 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
             model: model,
             awsRegion: aws_region,
             awsProfile: aws_profile,
+            fallbackModels: Self.decodeFallbackModels(fallback_models),
             createdAt: created_at,
             lastUsedAt: last_used_at
         )
+    }
+
+    /// Encode the fallback list to JSON text. Returns nil for nil/empty so the
+    /// column stays NULL and `toModel()` round-trips back to nil.
+    static func encodeFallbackModels(_ models: [String]?) -> String? {
+        guard let models, !models.isEmpty else { return nil }
+        guard let data = try? JSONEncoder().encode(models) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Decode the JSON-text fallback list. nil/empty/invalid → nil.
+    static func decodeFallbackModels(_ text: String?) -> [String]? {
+        guard let text, let data = text.data(using: .utf8),
+              let models = try? JSONDecoder().decode([String].self, from: data),
+              !models.isEmpty else { return nil }
+        return models
     }
 }
 
@@ -53,9 +75,11 @@ public struct ModelProfileStore: Sendable {
 
     public func create(name: String, kind: CredentialKind,
                        baseURL: String? = nil, model: String? = nil,
-                       awsRegion: String? = nil, awsProfile: String? = nil) async throws -> ModelProfile {
+                       awsRegion: String? = nil, awsProfile: String? = nil,
+                       fallbackModels: [String]? = nil) async throws -> ModelProfile {
         let profile = ModelProfile(name: name, kind: kind, baseURL: baseURL, model: model,
-                                   awsRegion: awsRegion, awsProfile: awsProfile)
+                                   awsRegion: awsRegion, awsProfile: awsProfile,
+                                   fallbackModels: fallbackModels)
         let record = ModelProfileRecord(from: profile)
         try await writer.write { db in
             try record.insert(db)

--- a/Sources/TBDDaemon/Database/ModelProfileRecord.swift
+++ b/Sources/TBDDaemon/Database/ModelProfileRecord.swift
@@ -117,23 +117,29 @@ public struct ModelProfileStore: Sendable {
         }
     }
 
-    /// Update the proxy fields. Pass nil to clear them.
-    public func updateEndpoint(id: UUID, baseURL: String?, model: String?) async throws {
+    /// Update the proxy fields. Pass nil to clear them. `fallbackModels`
+    /// nil/empty clears the stored list (column set to NULL).
+    public func updateEndpoint(id: UUID, baseURL: String?, model: String?,
+                               fallbackModels: [String]? = nil) async throws {
+        let fallbackJSON = ModelProfileRecord.encodeFallbackModels(fallbackModels)
         try await writer.write { db in
             try db.execute(
-                sql: "UPDATE model_profiles SET base_url = ?, model = ? WHERE id = ?",
-                arguments: [baseURL, model, id.uuidString]
+                sql: "UPDATE model_profiles SET base_url = ?, model = ?, fallback_models = ? WHERE id = ?",
+                arguments: [baseURL, model, fallbackJSON, id.uuidString]
             )
         }
     }
 
     /// Update the bedrock-specific fields on an existing profile. Pass
     /// `awsProfile == nil` to clear (use AWS SDK default chain).
-    public func updateBedrock(id: UUID, awsRegion: String, awsProfile: String?, model: String) async throws {
+    /// `fallbackModels` nil/empty clears the stored list (column set to NULL).
+    public func updateBedrock(id: UUID, awsRegion: String, awsProfile: String?, model: String,
+                              fallbackModels: [String]? = nil) async throws {
+        let fallbackJSON = ModelProfileRecord.encodeFallbackModels(fallbackModels)
         try await writer.write { db in
             try db.execute(
-                sql: "UPDATE model_profiles SET aws_region = ?, aws_profile = ?, model = ? WHERE id = ?",
-                arguments: [awsRegion, awsProfile, model, id.uuidString]
+                sql: "UPDATE model_profiles SET aws_region = ?, aws_profile = ?, model = ?, fallback_models = ? WHERE id = ?",
+                arguments: [awsRegion, awsProfile, model, fallbackJSON, id.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -161,40 +161,99 @@ public enum ClaudeHookOverlay {
     /// worktree-unique string) so concurrent sessions with different profiles
     /// don't race on the same file. Writes are idempotent — the same key
     /// overwrites in place.
+    ///
+    /// Never throws: if the per-session overlay write fails for any reason
+    /// (unwritable runtime dir, disk full, …), the error is logged and the
+    /// shared global `overlayPath` is returned instead. This guarantees a
+    /// spawn always has a usable `--settings` path — it degrades to "no
+    /// fallback models" rather than aborting the spawn.
     public static func resolveOverlayPath(
         fallbackModels: [String]?,
         sessionKey: String
-    ) throws -> String {
+    ) -> String {
         guard let fallbackModels, !fallbackModels.isEmpty else {
             return overlayPath
         }
         let path = perSessionOverlayPath(sessionKey: sessionKey)
-        let data = try generateBody(fallbackModels: fallbackModels)
-        let parent = (path as NSString).deletingLastPathComponent
-        try FileManager.default.createDirectory(
-            atPath: parent,
-            withIntermediateDirectories: true
-        )
-        try data.write(to: URL(fileURLWithPath: path), options: .atomic)
-        logger.info("Wrote per-session Claude overlay at \(path, privacy: .public)")
-        return path
+        do {
+            let data = try generateBody(fallbackModels: fallbackModels)
+            let parent = (path as NSString).deletingLastPathComponent
+            try FileManager.default.createDirectory(
+                atPath: parent,
+                withIntermediateDirectories: true
+            )
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+            logger.info("Wrote per-session Claude overlay at \(path, privacy: .public)")
+            return path
+        } catch {
+            logger.error(
+                "Failed to write per-session Claude overlay at \(path, privacy: .public); falling back to global overlay: \(error.localizedDescription, privacy: .public)"
+            )
+            return overlayPath
+        }
     }
 
     /// Path of a per-session overlay file. Lives alongside the global overlay
     /// under `~/tbd/runtime/`. The `sessionKey` is sanitized to stay
     /// filesystem-safe.
+    ///
+    /// Callers MUST pass a unique opaque id (the terminal UUID). The
+    /// character sanitization (non-`[A-Za-z0-9_-]` → `_`) is only
+    /// collision-safe for such inputs — two distinct human-readable strings
+    /// could sanitize to the same filename, but distinct UUIDs never do.
     static func perSessionOverlayPath(sessionKey: String) -> String {
-        let safe = sessionKey.unicodeScalars.map { scalar -> Character in
+        runtimeDir
+            .appendingPathComponent("\(perSessionPrefix)\(sanitize(sessionKey))\(perSessionSuffix)")
+            .path
+    }
+
+    /// Filename prefix/suffix for per-session overlay files. Shared between the
+    /// path builder and the orphan-prune sweep so the two never drift.
+    static let perSessionPrefix = "claude-overlay-session-"
+    static let perSessionSuffix = ".json"
+
+    private static var runtimeDir: URL {
+        TBDConstants.configDir.appendingPathComponent("runtime")
+    }
+
+    /// Filesystem-safe rendering of `sessionKey` (non-`[A-Za-z0-9_-]` → `_`).
+    static func sanitize(_ sessionKey: String) -> String {
+        String(sessionKey.unicodeScalars.map { scalar -> Character in
             let isSafe = scalar == "-" || scalar == "_"
                 || (scalar >= "0" && scalar <= "9")
                 || (scalar >= "a" && scalar <= "z")
                 || (scalar >= "A" && scalar <= "Z")
             return isSafe ? Character(scalar) : "_"
+        })
+    }
+
+    /// Delete the per-session overlay file for `sessionKey`, if present.
+    /// Best-effort — a missing file or removal error is ignored. Called on
+    /// terminal teardown so per-session overlays don't accumulate under
+    /// `~/tbd/runtime/`.
+    static func removePerSessionOverlay(sessionKey: String) {
+        let path = perSessionOverlayPath(sessionKey: sessionKey)
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    /// Startup sweep: delete every `claude-overlay-session-*.json` file whose
+    /// (sanitized) session key is NOT in `liveSessionKeys`. This reclaims
+    /// per-session overlays orphaned by crashes, worktree archive, or any
+    /// teardown path that didn't call `removePerSessionOverlay` — so cleanup
+    /// can't drift as new teardown paths are added. Best-effort.
+    static func pruneOrphanedSessionOverlays(liveSessionKeys: [String]) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: runtimeDir.path) else {
+            return
         }
-        return TBDConstants.configDir
-            .appendingPathComponent("runtime")
-            .appendingPathComponent("claude-overlay-session-\(String(safe)).json")
-            .path
+        let liveSanitized = Set(liveSessionKeys.map { sanitize($0) })
+        for entry in entries where entry.hasPrefix(perSessionPrefix) && entry.hasSuffix(perSessionSuffix) {
+            let key = String(entry.dropFirst(perSessionPrefix.count).dropLast(perSessionSuffix.count))
+            if liveSanitized.contains(key) { continue }
+            let path = runtimeDir.appendingPathComponent(entry).path
+            try? fm.removeItem(atPath: path)
+            logger.info("Pruned orphaned per-session Claude overlay \(entry, privacy: .public)")
+        }
     }
 
     /// Write the overlay to `overlayPath`, creating the parent directory if

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -84,8 +84,15 @@ public enum ClaudeHookOverlay {
         #"tbd ask-user-question post 2>/dev/null || true"#
 
     /// Build the JSON-encoded overlay body.
-    public static func generateBody() throws -> Data {
-        let body: [String: Any] = [
+    ///
+    /// When `fallbackModels` is non-nil and non-empty, a top-level
+    /// `"fallbackModel"` array (the ordered model ids) is included alongside
+    /// `hooks`. Claude Code's `--settings` flag takes the FIRST file's scalar
+    /// keys (it does NOT merge across multiple `--settings` flags), so the
+    /// fallback list MUST ride in the same file as the hooks — hence this
+    /// merged body rather than a second overlay.
+    public static func generateBody(fallbackModels: [String]? = nil) throws -> Data {
+        var body: [String: Any] = [
             "hooks": [
                 "SessionStart": [
                     [
@@ -132,10 +139,62 @@ public enum ClaudeHookOverlay {
                 ]
             ]
         ]
+        if let fallbackModels, !fallbackModels.isEmpty {
+            body["fallbackModel"] = fallbackModels
+        }
         return try JSONSerialization.data(
             withJSONObject: body,
             options: [.prettyPrinted, .sortedKeys]
         )
+    }
+
+    /// Resolve the `--settings` overlay path for a spawn.
+    ///
+    /// - No fallback models (nil/empty) → returns the shared global
+    ///   `overlayPath` unchanged (hooks-only, the pre-existing behavior).
+    /// - Fallback models present → writes a PER-SESSION overlay file that
+    ///   merges hooks + the `fallbackModel` array (because `fallbackModel` is
+    ///   per-profile and the global overlay is shared across all sessions),
+    ///   then returns that file's path.
+    ///
+    /// The per-session path is keyed by `sessionKey` (a session/terminal/
+    /// worktree-unique string) so concurrent sessions with different profiles
+    /// don't race on the same file. Writes are idempotent — the same key
+    /// overwrites in place.
+    public static func resolveOverlayPath(
+        fallbackModels: [String]?,
+        sessionKey: String
+    ) throws -> String {
+        guard let fallbackModels, !fallbackModels.isEmpty else {
+            return overlayPath
+        }
+        let path = perSessionOverlayPath(sessionKey: sessionKey)
+        let data = try generateBody(fallbackModels: fallbackModels)
+        let parent = (path as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(
+            atPath: parent,
+            withIntermediateDirectories: true
+        )
+        try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+        logger.info("Wrote per-session Claude overlay at \(path, privacy: .public)")
+        return path
+    }
+
+    /// Path of a per-session overlay file. Lives alongside the global overlay
+    /// under `~/tbd/runtime/`. The `sessionKey` is sanitized to stay
+    /// filesystem-safe.
+    static func perSessionOverlayPath(sessionKey: String) -> String {
+        let safe = sessionKey.unicodeScalars.map { scalar -> Character in
+            let isSafe = scalar == "-" || scalar == "_"
+                || (scalar >= "0" && scalar <= "9")
+                || (scalar >= "a" && scalar <= "z")
+                || (scalar >= "A" && scalar <= "Z")
+            return isSafe ? Character(scalar) : "_"
+        }
+        return TBDConstants.configDir
+            .appendingPathComponent("runtime")
+            .appendingPathComponent("claude-overlay-session-\(String(safe)).json")
+            .path
     }
 
     /// Write the overlay to `overlayPath`, creating the parent directory if

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -379,6 +379,13 @@ public actor SuspendResumeCoordinator {
         }
 
         let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
+        // If the per-session overlay write fails, fall back to the global
+        // hooks-only overlay so resume still proceeds (degrades to no fallback
+        // models rather than blocking).
+        let overlayPath = (try? ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: resolvedProfile?.fallbackModels,
+            sessionKey: terminal.id.uuidString
+        )) ?? ClaudeHookOverlay.overlayPath
         let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: sessionID,
             freshSessionID: nil,
@@ -393,7 +400,7 @@ public actor SuspendResumeCoordinator {
             profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
             cmd: nil,
             shellFallback: defaultShell,
-            settingsOverlayPath: ClaudeHookOverlay.overlayPath,
+            settingsOverlayPath: overlayPath,
             pluginDirPath: PluginDirWriter.pluginDirPath,
             envSettingOverrides: claudeEnvOverrides
         )

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -379,13 +379,12 @@ public actor SuspendResumeCoordinator {
         }
 
         let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
-        // If the per-session overlay write fails, fall back to the global
-        // hooks-only overlay so resume still proceeds (degrades to no fallback
-        // models rather than blocking).
-        let overlayPath = (try? ClaudeHookOverlay.resolveOverlayPath(
+        // resolveOverlayPath never throws — it degrades to the global hooks-only
+        // overlay if the per-session write fails, so resume always proceeds.
+        let overlayPath = ClaudeHookOverlay.resolveOverlayPath(
             fallbackModels: resolvedProfile?.fallbackModels,
             sessionKey: terminal.id.uuidString
-        )) ?? ClaudeHookOverlay.overlayPath
+        )
         let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: sessionID,
             freshSessionID: nil,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -420,7 +420,10 @@ extension WorktreeLifecycle {
                 profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
                 cmd: nil,
                 shellFallback: defaultShell,
-                settingsOverlayPath: ClaudeHookOverlay.overlayPath,
+                settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                    fallbackModels: resolvedProfile?.fallbackModels,
+                    sessionKey: plannedTerminalID1.uuidString
+                ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides
             )
@@ -516,7 +519,10 @@ extension WorktreeLifecycle {
                     profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
                     cmd: nil,
                     shellFallback: defaultShell,
-                    settingsOverlayPath: ClaudeHookOverlay.overlayPath,
+                    settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                        fallbackModels: resolvedProfile?.fallbackModels,
+                        sessionKey: plannedID.uuidString
+                    ),
                     pluginDirPath: PluginDirWriter.pluginDirPath,
                     envSettingOverrides: claudeEnvOverrides
                 )

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -420,7 +420,7 @@ extension WorktreeLifecycle {
                 profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
                 cmd: nil,
                 shellFallback: defaultShell,
-                settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolvedProfile?.fallbackModels,
                     sessionKey: plannedTerminalID1.uuidString
                 ),
@@ -519,7 +519,7 @@ extension WorktreeLifecycle {
                     profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
                     cmd: nil,
                     shellFallback: defaultShell,
-                    settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                    settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                         fallbackModels: resolvedProfile?.fallbackModels,
                         sessionKey: plannedID.uuidString
                     ),

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -125,6 +125,9 @@ extension WorktreeLifecycle {
             try await db.tabs.deleteForWorktree(worktreeID: wt.id)
             for terminal in terminals {
                 await pendingQuestions.clear(terminalID: terminal.id)
+                // Reclaim any per-session fallbackModel overlay (keyed by terminal
+                // id), mirroring handleTerminalDelete. No-op when none was written.
+                ClaudeHookOverlay.removePerSessionOverlay(sessionKey: terminal.id.uuidString)
             }
             try await db.worktrees.archive(id: wt.id)
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -314,7 +314,10 @@ extension WorktreeLifecycle {
                 profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
                 cmd: nil,
                 shellFallback: defaultShell,
-                settingsOverlayPath: ClaudeHookOverlay.overlayPath,
+                settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                    fallbackModels: resolvedProfile?.fallbackModels,
+                    sessionKey: terminal.id.uuidString
+                ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides
             )

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -314,7 +314,7 @@ extension WorktreeLifecycle {
                 profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
                 cmd: nil,
                 shellFallback: defaultShell,
-                settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolvedProfile?.fallbackModels,
                     sessionKey: terminal.id.uuidString
                 ),

--- a/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
+++ b/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
@@ -13,6 +13,9 @@ public struct ResolvedModelProfile: Sendable, Equatable {
     public let secret: String?
     public let awsRegion: String?
     public let awsProfile: String?
+    /// Ordered fallback model ids for the Claude `fallbackModel` setting.
+    /// nil/empty = no fallback configured for this profile.
+    public let fallbackModels: [String]?
 }
 
 public struct ModelProfileResolver: Sendable {
@@ -62,7 +65,8 @@ public struct ModelProfileResolver: Sendable {
             model: row.model,
             secret: secret,
             awsRegion: row.awsRegion,
-            awsProfile: row.awsProfile
+            awsProfile: row.awsProfile,
+            fallbackModels: row.fallbackModels
         )
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -7,6 +7,11 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "modelProfile
 /// Normalize a user-supplied fallback model list: trim each id, drop blanks,
 /// cap at 3 (Claude Code's documented maximum), and collapse an empty result
 /// to nil so the column stores NULL. Order is preserved.
+///
+/// Deliberately duplicates the app-side `normalizedFallbackModels` in
+/// `Sources/TBDApp/Settings/ModelProfilesSettingsView.swift` — defense-in-depth
+/// so the daemon normalizes even payloads from clients that skip the UI helper.
+/// Keep the two in sync.
 func normalizeFallbackModels(_ raw: [String]?) -> [String]? {
     guard let raw else { return nil }
     let cleaned = raw

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -4,6 +4,18 @@ import TBDShared
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "modelProfileHandlers")
 
+/// Normalize a user-supplied fallback model list: trim each id, drop blanks,
+/// cap at 3 (Claude Code's documented maximum), and collapse an empty result
+/// to nil so the column stores NULL. Order is preserved.
+func normalizeFallbackModels(_ raw: [String]?) -> [String]? {
+    guard let raw else { return nil }
+    let cleaned = raw
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+        .prefix(3)
+    return cleaned.isEmpty ? nil : Array(cleaned)
+}
+
 extension RPCRouter {
 
     // MARK: - List
@@ -27,6 +39,7 @@ extension RPCRouter {
     func handleModelProfileAdd(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ModelProfileAddParams.self, from: paramsData)
         let name = params.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallbackModels = normalizeFallbackModels(params.fallbackModels)
 
         guard !name.isEmpty else {
             return RPCResponse(error: "Name cannot be empty")
@@ -56,7 +69,8 @@ extension RPCRouter {
                 baseURL: nil,
                 model: model,
                 awsRegion: region,
-                awsProfile: awsProfile
+                awsProfile: awsProfile,
+                fallbackModels: fallbackModels
             )
             subscriptions.broadcast(delta: .modelProfilesChanged)
             return try RPCResponse(result: ModelProfileAddResult(profile: row, warning: nil))
@@ -75,7 +89,8 @@ extension RPCRouter {
                 name: name,
                 kind: .oauth,
                 baseURL: nil,
-                model: params.model
+                model: params.model,
+                fallbackModels: fallbackModels
             )
             subscriptions.broadcast(delta: .modelProfilesChanged)
             return try RPCResponse(result: ModelProfileAddResult(profile: profileRow, warning: nil))
@@ -116,7 +131,8 @@ extension RPCRouter {
             name: name,
             kind: kind,
             baseURL: params.baseURL,
-            model: params.model
+            model: params.model,
+            fallbackModels: fallbackModels
         )
 
         // Only store keychain for API key profiles; OAuth profiles don't store secrets.
@@ -213,7 +229,12 @@ extension RPCRouter {
         guard profile.kind != .bedrock else {
             return RPCResponse(error: "Cannot update endpoint on a bedrock profile")
         }
-        try await db.modelProfiles.updateEndpoint(id: params.id, baseURL: params.baseURL, model: params.model)
+        try await db.modelProfiles.updateEndpoint(
+            id: params.id,
+            baseURL: params.baseURL,
+            model: params.model,
+            fallbackModels: normalizeFallbackModels(params.fallbackModels)
+        )
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()
     }
@@ -246,7 +267,8 @@ extension RPCRouter {
             id: params.id,
             awsRegion: region,
             awsProfile: awsProfile,
-            model: model
+            model: model,
+            fallbackModels: normalizeFallbackModels(params.fallbackModels)
         )
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -226,7 +226,12 @@ extension RPCRouter {
             profileConfigDir: isClaudeType ? ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile) : nil,
             cmd: params.cmd,
             shellFallback: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
-            settingsOverlayPath: isClaudeType ? ClaudeHookOverlay.overlayPath : nil,
+            settingsOverlayPath: isClaudeType
+                ? try ClaudeHookOverlay.resolveOverlayPath(
+                    fallbackModels: resolvedProfile?.fallbackModels,
+                    sessionKey: plannedTerminalID.uuidString
+                  )
+                : nil,
             pluginDirPath: isClaudeType ? PluginDirWriter.pluginDirPath : nil,
             envSettingOverrides: claudeEnvOverrides
         )
@@ -610,7 +615,10 @@ extension RPCRouter {
                 profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolved),
                 cmd: nil,
                 shellFallback: "",
-                settingsOverlayPath: ClaudeHookOverlay.overlayPath,
+                settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                    fallbackModels: resolved?.fallbackModels,
+                    sessionKey: plannedTerminalID.uuidString
+                ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides
             )
@@ -635,7 +643,10 @@ extension RPCRouter {
                 profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolved),
                 cmd: nil,
                 shellFallback: "",
-                settingsOverlayPath: ClaudeHookOverlay.overlayPath,
+                settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                    fallbackModels: resolved?.fallbackModels,
+                    sessionKey: plannedTerminalID.uuidString
+                ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides
             )

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -227,7 +227,7 @@ extension RPCRouter {
             cmd: params.cmd,
             shellFallback: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
             settingsOverlayPath: isClaudeType
-                ? try ClaudeHookOverlay.resolveOverlayPath(
+                ? ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolvedProfile?.fallbackModels,
                     sessionKey: plannedTerminalID.uuidString
                   )
@@ -289,6 +289,10 @@ extension RPCRouter {
         try await db.terminals.delete(id: params.terminalID)
         try await db.tabs.delete(tabID: params.terminalID)
         await pendingQuestions.clear(terminalID: params.terminalID)
+
+        // Reclaim the per-session fallbackModel overlay (keyed by terminal id),
+        // if this terminal had one. No-op when the profile had no fallback.
+        ClaudeHookOverlay.removePerSessionOverlay(sessionKey: params.terminalID.uuidString)
 
         subscriptions.broadcast(delta: .terminalRemoved(TerminalIDDelta(
             terminalID: terminal.id
@@ -615,7 +619,7 @@ extension RPCRouter {
                 profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolved),
                 cmd: nil,
                 shellFallback: "",
-                settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolved?.fallbackModels,
                     sessionKey: plannedTerminalID.uuidString
                 ),
@@ -643,7 +647,7 @@ extension RPCRouter {
                 profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolved),
                 cmd: nil,
                 shellFallback: "",
-                settingsOverlayPath: try ClaudeHookOverlay.resolveOverlayPath(
+                settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolved?.fallbackModels,
                     sessionKey: plannedTerminalID.uuidString
                 ),

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -284,12 +284,19 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
     public var awsRegion: String?
     /// Named AWS profile to use for credential lookup. nil = use ambient credentials.
     public var awsProfile: String?
+    /// Ordered list of fallback model ids (up to three) written into the Claude
+    /// Code `fallbackModel` settings.json key, so spawned interactive sessions
+    /// degrade to an alternate model on overload instead of hard-failing. The
+    /// id namespace is profile-specific (bedrock/proxy/oauth differ), so this
+    /// lives on the profile, not globally. nil/empty = no fallback configured.
+    public var fallbackModels: [String]?
     public var createdAt: Date
     public var lastUsedAt: Date?
 
     public init(id: UUID = UUID(), name: String, kind: CredentialKind,
                 baseURL: String? = nil, model: String? = nil,
                 awsRegion: String? = nil, awsProfile: String? = nil,
+                fallbackModels: [String]? = nil,
                 createdAt: Date = Date(), lastUsedAt: Date? = nil) {
         self.id = id
         self.name = name
@@ -298,12 +305,13 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
         self.model = model
         self.awsRegion = awsRegion
         self.awsProfile = awsProfile
+        self.fallbackModels = fallbackModels
         self.createdAt = createdAt
         self.lastUsedAt = lastUsedAt
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, kind, baseURL, model, awsRegion, awsProfile, createdAt, lastUsedAt
+        case id, name, kind, baseURL, model, awsRegion, awsProfile, fallbackModels, createdAt, lastUsedAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -315,6 +323,7 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
         model = try c.decodeIfPresent(String.self, forKey: .model)
         awsRegion = try c.decodeIfPresent(String.self, forKey: .awsRegion)
         awsProfile = try c.decodeIfPresent(String.self, forKey: .awsProfile)
+        fallbackModels = try c.decodeIfPresent([String].self, forKey: .fallbackModels)
         createdAt = try c.decode(Date.self, forKey: .createdAt)
         lastUsedAt = try c.decodeIfPresent(Date.self, forKey: .lastUsedAt)
     }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -274,6 +274,9 @@ public struct ModelProfileAddParams: Codable, Sendable {
     public let model: String?
     public let awsRegion: String?
     public let awsProfile: String?
+    /// Ordered list of fallback model ids (tried in order on overload). nil =
+    /// none. Optional/decodeIfPresent so payloads from older clients still decode.
+    public let fallbackModels: [String]?
 
     public init(name: String,
                 kind: ModelProfileAddKind? = nil,
@@ -281,7 +284,8 @@ public struct ModelProfileAddParams: Codable, Sendable {
                 baseURL: String? = nil,
                 model: String? = nil,
                 awsRegion: String? = nil,
-                awsProfile: String? = nil) {
+                awsProfile: String? = nil,
+                fallbackModels: [String]? = nil) {
         self.kind = kind
         self.name = name
         self.token = token
@@ -289,6 +293,23 @@ public struct ModelProfileAddParams: Codable, Sendable {
         self.model = model
         self.awsRegion = awsRegion
         self.awsProfile = awsProfile
+        self.fallbackModels = fallbackModels
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind, name, token, baseURL, model, awsRegion, awsProfile, fallbackModels
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        kind = try c.decodeIfPresent(ModelProfileAddKind.self, forKey: .kind)
+        name = try c.decode(String.self, forKey: .name)
+        token = try c.decodeIfPresent(String.self, forKey: .token)
+        baseURL = try c.decodeIfPresent(String.self, forKey: .baseURL)
+        model = try c.decodeIfPresent(String.self, forKey: .model)
+        awsRegion = try c.decodeIfPresent(String.self, forKey: .awsRegion)
+        awsProfile = try c.decodeIfPresent(String.self, forKey: .awsProfile)
+        fallbackModels = try c.decodeIfPresent([String].self, forKey: .fallbackModels)
     }
 }
 
@@ -318,8 +339,24 @@ public struct ModelProfileUpdateEndpointParams: Codable, Sendable {
     public let id: UUID
     public let baseURL: String?
     public let model: String?
-    public init(id: UUID, baseURL: String?, model: String?) {
+    /// Ordered fallback model ids; nil = leave unset/clear. Optional/
+    /// decodeIfPresent so older payloads still decode.
+    public let fallbackModels: [String]?
+    public init(id: UUID, baseURL: String?, model: String?, fallbackModels: [String]? = nil) {
         self.id = id; self.baseURL = baseURL; self.model = model
+        self.fallbackModels = fallbackModels
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, baseURL, model, fallbackModels
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        baseURL = try c.decodeIfPresent(String.self, forKey: .baseURL)
+        model = try c.decodeIfPresent(String.self, forKey: .model)
+        fallbackModels = try c.decodeIfPresent([String].self, forKey: .fallbackModels)
     }
 }
 
@@ -328,11 +365,28 @@ public struct ModelProfileUpdateBedrockParams: Codable, Sendable {
     public let awsRegion: String
     public let awsProfile: String?
     public let model: String
-    public init(id: UUID, awsRegion: String, awsProfile: String?, model: String) {
+    /// Ordered fallback model ids; nil = leave unset/clear. Optional/
+    /// decodeIfPresent so older payloads still decode.
+    public let fallbackModels: [String]?
+    public init(id: UUID, awsRegion: String, awsProfile: String?, model: String, fallbackModels: [String]? = nil) {
         self.id = id
         self.awsRegion = awsRegion
         self.awsProfile = awsProfile
         self.model = model
+        self.fallbackModels = fallbackModels
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, awsRegion, awsProfile, model, fallbackModels
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        awsRegion = try c.decode(String.self, forKey: .awsRegion)
+        awsProfile = try c.decodeIfPresent(String.self, forKey: .awsProfile)
+        model = try c.decode(String.self, forKey: .model)
+        fallbackModels = try c.decodeIfPresent([String].self, forKey: .fallbackModels)
     }
 }
 

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -2,10 +2,12 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 
-// Serialized: the per-session overlay tests mutate the process-global
-// `TBD_HOME` env var to isolate the runtime dir; parallel execution would
-// race on that shared global.
-@Suite(.serialized) struct ClaudeHookOverlayTests {
+// Nested under TBDHomeSerialized: the per-session overlay tests mutate the
+// process-global `TBD_HOME` env var to isolate the runtime dir. Nesting (rather
+// than a bare per-suite `.serialized`) prevents cross-suite races with the other
+// TBD_HOME-mutating suites. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+@Suite struct ClaudeHookOverlayTests {
 
     @Test func generateBodyHasExpectedShape() throws {
         let data = try ClaudeHookOverlay.generateBody()
@@ -260,4 +262,5 @@ import Testing
         // Code's settings loader. JSONSerialization throws on invalid JSON.
         _ = try JSONSerialization.jsonObject(with: data, options: [])
     }
+}
 }

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -2,7 +2,10 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 
-@Suite struct ClaudeHookOverlayTests {
+// Serialized: the per-session overlay tests mutate the process-global
+// `TBD_HOME` env var to isolate the runtime dir; parallel execution would
+// race on that shared global.
+@Suite(.serialized) struct ClaudeHookOverlayTests {
 
     @Test func generateBodyHasExpectedShape() throws {
         let data = try ClaudeHookOverlay.generateBody()
@@ -87,7 +90,7 @@ import Testing
     }
 
     @Test func resolveOverlayPathWithoutFallbackReturnsGlobalPath() throws {
-        let path = try ClaudeHookOverlay.resolveOverlayPath(
+        let path = ClaudeHookOverlay.resolveOverlayPath(
             fallbackModels: nil,
             sessionKey: UUID().uuidString
         )
@@ -95,7 +98,7 @@ import Testing
     }
 
     @Test func resolveOverlayPathWithEmptyFallbackReturnsGlobalPath() throws {
-        let path = try ClaudeHookOverlay.resolveOverlayPath(
+        let path = ClaudeHookOverlay.resolveOverlayPath(
             fallbackModels: [],
             sessionKey: UUID().uuidString
         )
@@ -114,7 +117,7 @@ import Testing
 
         let key = UUID().uuidString
         let models = ["claude-haiku-4-5-20251001"]
-        let path = try ClaudeHookOverlay.resolveOverlayPath(
+        let path = ClaudeHookOverlay.resolveOverlayPath(
             fallbackModels: models,
             sessionKey: key
         )
@@ -141,10 +144,10 @@ import Testing
         }
 
         let key = UUID().uuidString
-        let p1 = try ClaudeHookOverlay.resolveOverlayPath(
+        let p1 = ClaudeHookOverlay.resolveOverlayPath(
             fallbackModels: ["a"], sessionKey: key
         )
-        let p2 = try ClaudeHookOverlay.resolveOverlayPath(
+        let p2 = ClaudeHookOverlay.resolveOverlayPath(
             fallbackModels: ["a", "b"], sessionKey: key
         )
         // Same session key → same path; second write overwrites with new content.
@@ -152,6 +155,103 @@ import Testing
         let data = try Data(contentsOf: URL(fileURLWithPath: p2))
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect((parsed?["fallbackModel"] as? [String]) == ["a", "b"])
+    }
+
+    @Test func resolveOverlayPathFallsBackToGlobalWhenPerSessionWriteFails() throws {
+        // Force the per-session write to fail: make the `runtime` dir an
+        // existing *regular file* so createDirectory(runtime) throws.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        // Block the `runtime` subdir by occupying its path with a file.
+        let runtimeAsFile = tmp.appendingPathComponent("runtime")
+        try Data("not a dir".utf8).write(to: runtimeAsFile)
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: ["claude-haiku-4-5-20251001"],
+            sessionKey: UUID().uuidString
+        )
+        // Degrades to the global overlay path instead of throwing/aborting.
+        #expect(path == ClaudeHookOverlay.overlayPath)
+    }
+
+    @Test func removePerSessionOverlayDeletesTheFile() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let key = UUID().uuidString
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: ["claude-haiku-4-5-20251001"],
+            sessionKey: key
+        )
+        #expect(FileManager.default.fileExists(atPath: path))
+
+        ClaudeHookOverlay.removePerSessionOverlay(sessionKey: key)
+        #expect(!FileManager.default.fileExists(atPath: path))
+
+        // Idempotent — removing again on a missing file is a no-op (no throw).
+        ClaudeHookOverlay.removePerSessionOverlay(sessionKey: key)
+    }
+
+    @Test func pruneOrphanedSessionOverlaysKeepsLiveDeletesOrphans() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let liveKey = UUID().uuidString
+        let orphanKey = UUID().uuidString
+        let livePath = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: ["a"], sessionKey: liveKey
+        )
+        let orphanPath = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: ["b"], sessionKey: orphanKey
+        )
+        // Also write the global overlay; the sweep must never touch it.
+        ClaudeHookOverlay.writeOverlay()
+        #expect(FileManager.default.fileExists(atPath: livePath))
+        #expect(FileManager.default.fileExists(atPath: orphanPath))
+
+        ClaudeHookOverlay.pruneOrphanedSessionOverlays(liveSessionKeys: [liveKey])
+
+        // Live key survives; orphan is gone; global overlay untouched.
+        #expect(FileManager.default.fileExists(atPath: livePath))
+        #expect(!FileManager.default.fileExists(atPath: orphanPath))
+        #expect(FileManager.default.fileExists(atPath: ClaudeHookOverlay.overlayPath))
+    }
+
+    @Test func pruneOrphanedSessionOverlaysWithEmptyLiveSetDeletesAll() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let p1 = ClaudeHookOverlay.resolveOverlayPath(fallbackModels: ["a"], sessionKey: UUID().uuidString)
+        let p2 = ClaudeHookOverlay.resolveOverlayPath(fallbackModels: ["b"], sessionKey: UUID().uuidString)
+        ClaudeHookOverlay.writeOverlay()
+
+        ClaudeHookOverlay.pruneOrphanedSessionOverlays(liveSessionKeys: [])
+
+        #expect(!FileManager.default.fileExists(atPath: p1))
+        #expect(!FileManager.default.fileExists(atPath: p2))
+        // Global overlay is not a per-session file → never pruned.
+        #expect(FileManager.default.fileExists(atPath: ClaudeHookOverlay.overlayPath))
     }
 
     @Test func roundtripsAsValidJSON() throws {

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -45,6 +45,115 @@ import Testing
         #expect(cmd?.contains("tbd notify --type error") == true)
     }
 
+    @Test func generateBodyWithoutFallbackModelsOmitsKey() throws {
+        // Default (no fallback) — body has hooks, no fallbackModel key.
+        let data = try ClaudeHookOverlay.generateBody()
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        #expect(parsed?["fallbackModel"] == nil)
+    }
+
+    @Test func generateBodyWithNilFallbackModelsOmitsKey() throws {
+        let data = try ClaudeHookOverlay.generateBody(fallbackModels: nil)
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        #expect(parsed?["fallbackModel"] == nil)
+    }
+
+    @Test func generateBodyWithEmptyFallbackModelsOmitsKey() throws {
+        let data = try ClaudeHookOverlay.generateBody(fallbackModels: [])
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        #expect(parsed?["fallbackModel"] == nil)
+    }
+
+    @Test func generateBodyWithFallbackModelsIncludesOrderedArrayAndKeepsHooks() throws {
+        let models = ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"]
+        let data = try ClaudeHookOverlay.generateBody(fallbackModels: models)
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        // The fallbackModel array is present, in the exact supplied order.
+        let fallback = parsed?["fallbackModel"] as? [String]
+        #expect(fallback == models)
+
+        // All the existing hooks are still present.
+        let hooks = parsed?["hooks"] as? [String: Any]
+        #expect(hooks != nil)
+        #expect(hooks?["SessionStart"] != nil)
+        #expect(hooks?["Stop"] != nil)
+        #expect(hooks?["StopFailure"] != nil)
+        #expect(hooks?["PreToolUse"] != nil)
+        #expect(hooks?["PostToolUse"] != nil)
+    }
+
+    @Test func resolveOverlayPathWithoutFallbackReturnsGlobalPath() throws {
+        let path = try ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString
+        )
+        #expect(path == ClaudeHookOverlay.overlayPath)
+    }
+
+    @Test func resolveOverlayPathWithEmptyFallbackReturnsGlobalPath() throws {
+        let path = try ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: [],
+            sessionKey: UUID().uuidString
+        )
+        #expect(path == ClaudeHookOverlay.overlayPath)
+    }
+
+    @Test func resolveOverlayPathWithFallbackWritesPerSessionFileWithMergedBody() throws {
+        // Isolate from the developer's ~/tbd.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let key = UUID().uuidString
+        let models = ["claude-haiku-4-5-20251001"]
+        let path = try ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: models,
+            sessionKey: key
+        )
+
+        // Per-session path, NOT the global overlay path.
+        #expect(path != ClaudeHookOverlay.overlayPath)
+        #expect(path.contains(key))
+        #expect(FileManager.default.fileExists(atPath: path))
+
+        // The written file merges hooks + fallbackModel.
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        #expect((parsed?["fallbackModel"] as? [String]) == models)
+    }
+
+    @Test func resolveOverlayPathIsIdempotentForSameSessionKey() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let key = UUID().uuidString
+        let p1 = try ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: ["a"], sessionKey: key
+        )
+        let p2 = try ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: ["a", "b"], sessionKey: key
+        )
+        // Same session key → same path; second write overwrites with new content.
+        #expect(p1 == p2)
+        let data = try Data(contentsOf: URL(fileURLWithPath: p2))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect((parsed?["fallbackModel"] as? [String]) == ["a", "b"])
+    }
+
     @Test func roundtripsAsValidJSON() throws {
         let data = try ClaudeHookOverlay.generateBody()
         // Must round-trip — a malformed overlay file would crash Claude

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -223,7 +223,8 @@ struct ClaudeProfileConfigDirManagerTests {
             model: "anthropic.claude-sonnet-4-5",
             secret: nil,
             awsRegion: "us-west-2",
-            awsProfile: nil
+            awsProfile: nil,
+            fallbackModels: nil
         )
         #expect(ClaudeProfileConfigDirManager.resolveConfigDir(for: profile) == nil)
     }
@@ -238,7 +239,8 @@ struct ClaudeProfileConfigDirManagerTests {
             model: nil,
             secret: nil,
             awsRegion: nil,
-            awsProfile: nil
+            awsProfile: nil,
+            fallbackModels: nil
         )
         #expect(ClaudeProfileConfigDirManager.resolveConfigDir(for: profile) == nil)
     }

--- a/Tests/TBDDaemonTests/ModelProfileMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileMigrationTests.swift
@@ -76,6 +76,34 @@ struct ModelProfileMigrationTests {
         }
     }
 
+    @Test("v30 adds fallback_models column")
+    func v30AddsFallbackModelsColumn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { conn in
+            let cols = try Row.fetchAll(conn, sql: "PRAGMA table_info(model_profiles)")
+                .map { $0["name"] as String }
+            #expect(cols.contains("fallback_models"))
+        }
+    }
+
+    @Test("ModelProfile round-trips fallbackModels through the store (nil and non-nil)")
+    func fallbackModelsRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        // nil — no fallback configured.
+        let none = try await db.modelProfiles.create(name: "None", kind: .oauth)
+        let noneReloaded = try await db.modelProfiles.get(id: none.id)
+        #expect(noneReloaded?.fallbackModels == nil)
+
+        // non-nil ordered array.
+        let withFallback = try await db.modelProfiles.create(
+            name: "WithFallback", kind: .oauth,
+            fallbackModels: ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"]
+        )
+        let reloaded = try await db.modelProfiles.get(id: withFallback.id)
+        #expect(reloaded?.fallbackModels == ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"])
+    }
+
     @Test("ModelProfile round-trips through the store with baseURL/model nil and non-nil")
     func dataPreservationRoundTrip() async throws {
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/ModelProfileMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileMigrationTests.swift
@@ -104,6 +104,55 @@ struct ModelProfileMigrationTests {
         #expect(reloaded?.fallbackModels == ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"])
     }
 
+    @Test("updateEndpoint persists fallbackModels (set, then clear)")
+    func updateEndpointPersistsFallbackModels() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let p = try await db.modelProfiles.create(name: "P", kind: .oauth)
+        #expect(try await db.modelProfiles.get(id: p.id)?.fallbackModels == nil)
+
+        // Set via updateEndpoint.
+        try await db.modelProfiles.updateEndpoint(
+            id: p.id, baseURL: nil, model: "opus",
+            fallbackModels: ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"]
+        )
+        let setReloaded = try await db.modelProfiles.get(id: p.id)
+        #expect(setReloaded?.model == "opus")
+        #expect(setReloaded?.fallbackModels == ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"])
+
+        // Clear via nil — column goes back to NULL.
+        try await db.modelProfiles.updateEndpoint(id: p.id, baseURL: nil, model: "opus", fallbackModels: nil)
+        #expect(try await db.modelProfiles.get(id: p.id)?.fallbackModels == nil)
+
+        // Clear via empty array also normalizes to nil.
+        try await db.modelProfiles.updateEndpoint(id: p.id, baseURL: nil, model: "opus", fallbackModels: ["x"])
+        #expect(try await db.modelProfiles.get(id: p.id)?.fallbackModels == ["x"])
+        try await db.modelProfiles.updateEndpoint(id: p.id, baseURL: nil, model: "opus", fallbackModels: [])
+        #expect(try await db.modelProfiles.get(id: p.id)?.fallbackModels == nil)
+    }
+
+    @Test("updateBedrock persists fallbackModels (set, then clear)")
+    func updateBedrockPersistsFallbackModels() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let p = try await db.modelProfiles.create(
+            name: "B", kind: .bedrock, model: "anthropic.claude-sonnet-4-5",
+            awsRegion: "us-west-2"
+        )
+
+        try await db.modelProfiles.updateBedrock(
+            id: p.id, awsRegion: "us-east-1", awsProfile: nil, model: "anthropic.claude-sonnet-4-5",
+            fallbackModels: ["anthropic.claude-haiku-4-5"]
+        )
+        let setReloaded = try await db.modelProfiles.get(id: p.id)
+        #expect(setReloaded?.awsRegion == "us-east-1")
+        #expect(setReloaded?.fallbackModels == ["anthropic.claude-haiku-4-5"])
+
+        try await db.modelProfiles.updateBedrock(
+            id: p.id, awsRegion: "us-east-1", awsProfile: nil, model: "anthropic.claude-sonnet-4-5",
+            fallbackModels: nil
+        )
+        #expect(try await db.modelProfiles.get(id: p.id)?.fallbackModels == nil)
+    }
+
     @Test("ModelProfile round-trips through the store with baseURL/model nil and non-nil")
     func dataPreservationRoundTrip() async throws {
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/ModelProfileModelTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileModelTests.swift
@@ -53,6 +53,23 @@ struct ModelProfileModelTests {
         #expect(p.model == nil)
     }
 
+    @Test func decodeModelProfileWithFallbackModels() throws {
+        let json = #"{"id":"11111111-1111-1111-1111-111111111111","name":"Personal","kind":"oauth","fallbackModels":["claude-haiku-4-5-20251001","claude-sonnet-4-5"],"createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+        let dec = JSONDecoder()
+        dec.dateDecodingStrategy = .iso8601
+        let p = try dec.decode(ModelProfile.self, from: json)
+        #expect(p.fallbackModels == ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"])
+    }
+
+    @Test func decodeModelProfileWithoutFallbackModels() throws {
+        // Existing persisted rows/JSON (pre-fallbackModels) must still decode.
+        let json = #"{"id":"11111111-1111-1111-1111-111111111111","name":"Personal","kind":"oauth","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
+        let dec = JSONDecoder()
+        dec.dateDecodingStrategy = .iso8601
+        let p = try dec.decode(ModelProfile.self, from: json)
+        #expect(p.fallbackModels == nil)
+    }
+
     @Test func repoDecodesWithoutOverride() throws {
         let json = #"{"id":"11111111-1111-1111-1111-111111111111","path":"/tmp/x","displayName":"x","defaultBranch":"main","createdAt":"2026-04-06T00:00:00Z"}"#.data(using: .utf8)!
         let dec = JSONDecoder()

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -860,4 +860,98 @@ struct ModelProfileRPCTests {
         #expect(resp.error?.lowercased().contains("not available") == true)
         #expect(stub.callCount == 0)
     }
+
+    // MARK: - fallbackModels (Idea 2: user-settable via RPC)
+
+    @Test("add: forwards fallbackModels to the stored oauth profile")
+    func addForwardsFallbackModels() async throws {
+        let (router, db, _) = makeRouter()
+        let req = try RPCRequest(
+            method: RPCMethod.modelProfileAdd,
+            params: ModelProfileAddParams(
+                name: "WithFallback", token: nil,
+                fallbackModels: ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"]
+            )
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ModelProfileAddResult.self)
+        #expect(result.profile.fallbackModels == ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"])
+        let reloaded = try await db.modelProfiles.get(id: result.profile.id)
+        #expect(reloaded?.fallbackModels == ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"])
+    }
+
+    @Test("add: normalizes fallbackModels — trims, drops blanks, caps at 3")
+    func addNormalizesFallbackModels() async throws {
+        let (router, db, _) = makeRouter()
+        let req = try RPCRequest(
+            method: RPCMethod.modelProfileAdd,
+            params: ModelProfileAddParams(
+                name: "Normalize", token: nil,
+                fallbackModels: ["  a  ", "", "b", "   ", "c", "d"]
+            )
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ModelProfileAddResult.self)
+        // Trimmed, blanks dropped, capped at 3, order preserved.
+        #expect(result.profile.fallbackModels == ["a", "b", "c"])
+        _ = db
+    }
+
+    @Test("add: nil fallbackModels stores nil")
+    func addNilFallbackModels() async throws {
+        let (router, _, _) = makeRouter()
+        let req = try RPCRequest(
+            method: RPCMethod.modelProfileAdd,
+            params: ModelProfileAddParams(name: "NoFallback", token: nil)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ModelProfileAddResult.self)
+        #expect(result.profile.fallbackModels == nil)
+    }
+
+    @Test("updateEndpoint: forwards fallbackModels (set then clear)")
+    func updateEndpointForwardsFallbackModels() async throws {
+        let (router, db, _) = makeRouter()
+        let row = try await db.modelProfiles.create(name: "P", kind: .oauth)
+
+        let setReq = try RPCRequest(
+            method: RPCMethod.modelProfileUpdateEndpoint,
+            params: ModelProfileUpdateEndpointParams(
+                id: row.id, baseURL: nil, model: "opus",
+                fallbackModels: ["claude-haiku-4-5-20251001"]
+            )
+        )
+        #expect(await router.handle(setReq).success)
+        #expect(try await db.modelProfiles.get(id: row.id)?.fallbackModels == ["claude-haiku-4-5-20251001"])
+
+        let clearReq = try RPCRequest(
+            method: RPCMethod.modelProfileUpdateEndpoint,
+            params: ModelProfileUpdateEndpointParams(
+                id: row.id, baseURL: nil, model: "opus", fallbackModels: nil
+            )
+        )
+        #expect(await router.handle(clearReq).success)
+        #expect(try await db.modelProfiles.get(id: row.id)?.fallbackModels == nil)
+    }
+
+    @Test("updateBedrock: forwards fallbackModels")
+    func updateBedrockForwardsFallbackModels() async throws {
+        let (router, db, _) = makeRouter()
+        let row = try await db.modelProfiles.create(
+            name: "B", kind: .bedrock, model: "anthropic.claude-sonnet-4-5", awsRegion: "us-west-2"
+        )
+        let req = try RPCRequest(
+            method: RPCMethod.modelProfileUpdateBedrock,
+            params: ModelProfileUpdateBedrockParams(
+                id: row.id, awsRegion: "us-east-1", awsProfile: nil,
+                model: "anthropic.claude-sonnet-4-5",
+                fallbackModels: ["anthropic.claude-haiku-4-5"]
+            )
+        )
+        #expect(await router.handle(req).success)
+        #expect(try await db.modelProfiles.get(id: row.id)?.fallbackModels == ["anthropic.claude-haiku-4-5"])
+    }
 }

--- a/Tests/TBDDaemonTests/ModelProfileResolverTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileResolverTests.swift
@@ -219,6 +219,50 @@ struct ModelProfileResolverTests {
         #expect(result?.secret == nil)
     }
 
+    @Test("resolver carries fallbackModels through the global default")
+    func resolve_globalDefault_carriesFallbackModels() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let g = try await db.modelProfiles.create(
+            name: "G", kind: .oauth,
+            fallbackModels: ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"]
+        )
+        try await db.config.setDefaultProfileID(g.id)
+        box.map[g.id.uuidString] = "secret-G"
+
+        let result = try await resolver.resolve(repoID: nil)
+        #expect(result?.profileID == g.id)
+        #expect(result?.fallbackModels == ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"])
+    }
+
+    @Test("resolver carries fallbackModels through the repo override")
+    func resolve_repoOverride_carriesFallbackModels() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let override = try await db.modelProfiles.create(
+            name: "Override", kind: .apiKey,
+            fallbackModels: ["claude-haiku-4-5-20251001"]
+        )
+        let global = try await db.modelProfiles.create(name: "Global", kind: .apiKey)
+        try await db.config.setDefaultProfileID(global.id)
+        let repo = try await makeRepo(db, override: override.id)
+        box.map[override.id.uuidString] = "secret-override"
+        box.map[global.id.uuidString] = "secret-global"
+
+        let result = try await resolver.resolve(repoID: repo.id)
+        #expect(result?.profileID == override.id)
+        #expect(result?.fallbackModels == ["claude-haiku-4-5-20251001"])
+    }
+
+    @Test("resolver leaves fallbackModels nil when the profile has none")
+    func resolve_noFallbackModels_isNil() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let g = try await db.modelProfiles.create(name: "G", kind: .oauth)
+        try await db.config.setDefaultProfileID(g.id)
+        box.map[g.id.uuidString] = "secret-G"
+
+        let result = try await resolver.resolve(repoID: nil)
+        #expect(result?.fallbackModels == nil)
+    }
+
     @Test("AC4.2: apiKey profile with missing keychain returns nil")
     func apiKeyProfile_keychainMissing_returnsNil() async throws {
         let (db, _, resolver) = try makeHarness()

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -3,7 +3,10 @@ import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
 
-@Suite("Claude Token Spawn + Swap")
+// Serialized: several tests mutate the process-global `TBD_HOME` env var
+// (via setenv/unsetenv) to isolate the overlay/runtime dir. Running them in
+// parallel would race on that shared global.
+@Suite("Claude Token Spawn + Swap", .serialized)
 struct ModelProfileSpawnTests {
 
     /// Recorder for tmux argv lists invoked during dryRun.
@@ -223,6 +226,48 @@ struct ModelProfileSpawnTests {
         // A per-session overlay file is used, NOT the shared global overlay.
         #expect(bodies.contains("claude-overlay-session-"))
         #expect(!bodies.contains(" --settings \(ClaudeHookOverlay.overlayPath)"))
+    }
+
+    @Test("delete: removes the per-session fallbackModel overlay on terminal teardown")
+    func deleteRemovesPerSessionOverlay() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-spawn-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        ClaudeHookOverlay.writeOverlay()
+
+        let (router, db, _) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let tok = try await db.modelProfiles.create(
+            name: "WithFallback", kind: .oauth,
+            fallbackModels: ["claude-haiku-4-5-20251001"]
+        )
+        try await db.config.setDefaultProfileID(tok.id)
+
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        ))
+        #expect(createResp.success)
+        let term = try createResp.decodeResult(Terminal.self)
+
+        // The per-session overlay was written, keyed by the terminal id.
+        let overlayPath = ClaudeHookOverlay.perSessionOverlayPath(sessionKey: term.id.uuidString)
+        #expect(FileManager.default.fileExists(atPath: overlayPath))
+
+        // Deleting the terminal reclaims the per-session overlay.
+        let delResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: term.id)
+        ))
+        #expect(delResp.success)
+        #expect(!FileManager.default.fileExists(atPath: overlayPath))
+        // The shared global overlay is left intact.
+        #expect(FileManager.default.fileExists(atPath: ClaudeHookOverlay.overlayPath))
     }
 
     // MARK: - Swap: to a different token

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -159,6 +159,72 @@ struct ModelProfileSpawnTests {
         #expect(!recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN"))
     }
 
+    // MARK: - Spawn: fallbackModels overlay routing
+
+    @Test("spawn: profile WITHOUT fallbackModels uses the global overlay path")
+    func spawnWithoutFallbackModelsUsesGlobalOverlay() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-spawn-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        // The --settings flag is only emitted when the overlay file exists.
+        ClaudeHookOverlay.writeOverlay()
+
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let tok = try await seedOAuthProfile(db, name: "NoFallback")
+        try await db.config.setDefaultProfileID(tok.id)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        ))
+        #expect(resp.success)
+
+        let bodies = recorder.shellBodies
+        #expect(bodies.contains("--settings"))
+        // Uses the shared global overlay, NOT a per-session file.
+        #expect(bodies.contains(ClaudeHookOverlay.overlayPath))
+        #expect(!bodies.contains("claude-overlay-session-"))
+    }
+
+    @Test("spawn: profile WITH fallbackModels uses a per-session overlay path")
+    func spawnWithFallbackModelsUsesPerSessionOverlay() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-spawn-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        ClaudeHookOverlay.writeOverlay()
+
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let tok = try await db.modelProfiles.create(
+            name: "WithFallback", kind: .oauth,
+            fallbackModels: ["claude-haiku-4-5-20251001"]
+        )
+        try await db.config.setDefaultProfileID(tok.id)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        ))
+        #expect(resp.success)
+
+        let bodies = recorder.shellBodies
+        #expect(bodies.contains("--settings"))
+        // A per-session overlay file is used, NOT the shared global overlay.
+        #expect(bodies.contains("claude-overlay-session-"))
+        #expect(!bodies.contains(" --settings \(ClaudeHookOverlay.overlayPath)"))
+    }
+
     // MARK: - Swap: to a different token
 
     @Test("swap on blank session: forks into a new tab with a fresh session id and new token")

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -3,10 +3,12 @@ import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
 
-// Serialized: several tests mutate the process-global `TBD_HOME` env var
-// (via setenv/unsetenv) to isolate the overlay/runtime dir. Running them in
-// parallel would race on that shared global.
-@Suite("Claude Token Spawn + Swap", .serialized)
+// Nested under TBDHomeSerialized: several tests mutate the process-global
+// `TBD_HOME` env var (via setenv/unsetenv) to isolate the overlay/runtime dir.
+// Nesting prevents cross-suite races with the other TBD_HOME-mutating suites.
+// See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+@Suite("Claude Token Spawn + Swap")
 struct ModelProfileSpawnTests {
 
     /// Recorder for tmux argv lists invoked during dryRun.
@@ -412,4 +414,5 @@ struct ModelProfileSpawnTests {
         ))
         #expect(!swapResp.success)
     }
+}
 }

--- a/Tests/TBDDaemonTests/TBDHomeSerializedSuites.swift
+++ b/Tests/TBDDaemonTests/TBDHomeSerializedSuites.swift
@@ -1,0 +1,17 @@
+import Testing
+
+/// Parent suite for every test suite that mutates the process-global `TBD_HOME`
+/// environment variable (via `setenv`/`unsetenv`) to isolate the overlay /
+/// runtime directory.
+///
+/// `.serialized` on a suite serializes its tests AND its descendant suites
+/// relative to one another. Nesting the `TBD_HOME`-mutating suites inside this
+/// parent is what prevents cross-suite races on that single shared global —
+/// per-suite `.serialized` alone only orders tests *within* a suite, so two
+/// sibling suites could still run concurrently and clobber each other's
+/// `TBD_HOME`.
+///
+/// To add a new `TBD_HOME`-mutating suite, declare it inside an
+/// `extension TBDHomeSerialized { ... }` so it becomes a nested (and therefore
+/// serialized) child of this suite.
+@Suite(.serialized) enum TBDHomeSerialized {}

--- a/Tests/TBDDaemonTests/WorktreeReconcileOverlayCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReconcileOverlayCleanupTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: mutates the process-global `TBD_HOME` env var
+// to isolate the runtime overlay dir. Nesting prevents cross-suite races with
+// the other TBD_HOME-mutating suites. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+@Suite("Reconcile overlay cleanup")
+struct WorktreeReconcileOverlayCleanupTests {
+
+    /// Reconcile-archival of a worktree whose git path has vanished must reclaim
+    /// the per-session fallbackModel overlay for each deleted terminal — mirroring
+    /// handleTerminalDelete — instead of leaking the file until the next prune.
+    @Test("reconcile archival removes per-session overlay for a Claude terminal")
+    func reconcileArchivalRemovesPerSessionOverlay() async throws {
+        // Isolate the overlay runtime dir from the developer's ~/tbd.
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-reconcile-overlay-\(UUID().uuidString)")
+        setenv("TBD_HOME", home.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: home)
+        }
+        ClaudeHookOverlay.writeOverlay()
+
+        // Real git repo with no extra worktrees, so any DB worktree row pointing
+        // at a non-git path will be archived by reconcile.
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver()
+        )
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "test", defaultBranch: "main"
+        )
+
+        // A worktree row whose path is NOT a live git worktree → reconcile archives it.
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "gone",
+            branch: "gone-branch",
+            path: tempDir.appendingPathComponent("vanished").path,
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%0",
+            label: "Claude Code",
+            claudeSessionID: UUID().uuidString,
+            kind: .claude
+        )
+
+        // Simulate the per-session overlay that a fallbackModel spawn would write.
+        let overlayPath = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: ["claude-haiku-4-5-20251001"],
+            sessionKey: terminal.id.uuidString
+        )
+        #expect(overlayPath != ClaudeHookOverlay.overlayPath)
+        #expect(FileManager.default.fileExists(atPath: overlayPath))
+
+        try await lifecycle.reconcile(repoID: repo.id)
+
+        // Worktree archived AND its per-session overlay reclaimed.
+        let reloaded = try await db.worktrees.get(id: wt.id)
+        #expect(reloaded?.status == .archived)
+        #expect(!FileManager.default.fileExists(atPath: overlayPath))
+        // The shared global overlay is untouched.
+        #expect(FileManager.default.fileExists(atPath: ClaudeHookOverlay.overlayPath))
+    }
+}
+}

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -124,6 +124,54 @@ import Testing
     #expect(decoded.primaryAgentPreference == .claude)
 }
 
+// MARK: - fallbackModels RPC param decode
+
+@Test func modelProfileAddParamsDecodesWithFallbackModels() throws {
+    let json = """
+    {"name":"P","kind":"claudeDirect","fallbackModels":["claude-haiku-4-5-20251001","claude-sonnet-4-5"]}
+    """.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(ModelProfileAddParams.self, from: json)
+    #expect(decoded.fallbackModels == ["claude-haiku-4-5-20251001", "claude-sonnet-4-5"])
+}
+
+@Test func modelProfileAddParamsDecodesWithoutFallbackModels() throws {
+    // Payload from an older client lacks the key — must still decode (nil).
+    let json = #"{"name":"P","kind":"claudeDirect"}"#.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(ModelProfileAddParams.self, from: json)
+    #expect(decoded.fallbackModels == nil)
+    #expect(decoded.name == "P")
+}
+
+@Test func modelProfileUpdateEndpointParamsDecodesWithAndWithoutFallbackModels() throws {
+    let id = "11111111-1111-1111-1111-111111111111"
+    let withJSON = """
+    {"id":"\(id)","baseURL":null,"model":"opus","fallbackModels":["claude-haiku-4-5-20251001"]}
+    """.data(using: .utf8)!
+    let withDecoded = try JSONDecoder().decode(ModelProfileUpdateEndpointParams.self, from: withJSON)
+    #expect(withDecoded.fallbackModels == ["claude-haiku-4-5-20251001"])
+    #expect(withDecoded.model == "opus")
+
+    let withoutJSON = #"{"id":"\#(id)","baseURL":null,"model":null}"#.data(using: .utf8)!
+    let withoutDecoded = try JSONDecoder().decode(ModelProfileUpdateEndpointParams.self, from: withoutJSON)
+    #expect(withoutDecoded.fallbackModels == nil)
+}
+
+@Test func modelProfileUpdateBedrockParamsDecodesWithAndWithoutFallbackModels() throws {
+    let id = "11111111-1111-1111-1111-111111111111"
+    let withJSON = """
+    {"id":"\(id)","awsRegion":"us-west-2","awsProfile":null,"model":"m","fallbackModels":["a","b"]}
+    """.data(using: .utf8)!
+    let withDecoded = try JSONDecoder().decode(ModelProfileUpdateBedrockParams.self, from: withJSON)
+    #expect(withDecoded.fallbackModels == ["a", "b"])
+
+    let withoutJSON = """
+    {"id":"\(id)","awsRegion":"us-west-2","awsProfile":null,"model":"m"}
+    """.data(using: .utf8)!
+    let withoutDecoded = try JSONDecoder().decode(ModelProfileUpdateBedrockParams.self, from: withoutJSON)
+    #expect(withoutDecoded.fallbackModels == nil)
+    #expect(withoutDecoded.awsRegion == "us-west-2")
+}
+
 @Test func testTerminalDecodesWithoutActivityState() throws {
     let json = """
     {

--- a/docs/changelog-watch/ideas/fallback-model.md
+++ b/docs/changelog-watch/ideas/fallback-model.md
@@ -1,0 +1,197 @@
+# Deep dive: Claude Code's `fallbackModel`
+
+*Scout doc — focused thinking on one setting. Lens and rules: [`../claude-code-kb.md`](../claude-code-kb.md).*
+
+## Problem framing
+
+TBD spawns and supervises a fleet of concurrent interactive `claude` sessions. A fleet
+hammering the API is exactly the scenario where the primary model gets overloaded —
+and today, when that happens, a TBD-spawned session hard-fails a turn instead of
+degrading. Claude Code's `fallbackModel` machinery is the lever: TBD can configure its
+spawned sessions to **drop to an alternate model on overload rather than failing**.
+That graceful-degradation win is the whole focus of this doc.
+
+*(Out of scope by decision: TBD does not need to observe or surface which model a
+session is actually running on. We're using `fallbackModel` to harden sessions, not to
+reflect live model state in the UI.)*
+
+## What `fallbackModel` actually is (with sources)
+
+It is a primary-model-degradation mechanism. When the primary model is overloaded or
+unavailable, Claude Code falls back to a configured alternate rather than failing.
+
+**The setting itself — v2.1.166** ([CHANGELOG](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21166)):
+
+> Added `fallbackModel` setting to configure up to three fallback models tried in
+> order when the primary model is overloaded or unavailable; `--fallback-model` now
+> also applies to interactive sessions
+
+Two things land here: a new **`settings.json` key (`fallbackModel`)** that takes an
+**ordered list of up to three models**, and the **`--fallback-model` CLI flag**. But
+**the flag and the setting are not interchangeable for TBD** — see the verified
+contract below; the `--print`-only restriction on the flag is the decisive fact.
+
+**When it kicks in.** Three distinct triggers, from three changelog entries:
+
+1. *Primary overloaded or unavailable* — the headline trigger above.
+2. *Primary not found → sticky for the session* — v2.1.152:
+   > Claude Code now switches to your configured `--fallback-model` for the rest of
+   > the session when the primary model is not found, instead of failing every request
+
+   The switch is **sticky for the rest of the session**, not per-turn. Once degraded,
+   it stays degraded.
+3. *Retry-once on unexpected error* — v2.1.166:
+   > Claude Code now retries a turn once on the fallback model when the API rejects an
+   > unexpected non-retryable error; auth, rate-limit, request-size, and transport
+   > errors still surface immediately
+
+   So fallback is **not** triggered by auth, rate-limit, request-size, or transport
+   errors — those surface immediately. Fallback is for overload / model-not-found /
+   unexpected-non-retryable.
+
+**It survives backgrounding** — v2.1.x:
+
+> `/bg` and `←`-detach now preserve `--fallback-model`, so backgrounded workers
+> degrade to the fallback model on overload instead of hard-failing.
+
+**Not yet in public docs.** The `fallbackModel` *setting* (v2.1.166) is not yet listed
+in the [settings reference](https://code.claude.com/docs/en/settings) — confirmed by
+fetching it. Treat the changelog + the verified CLI behavior below as the authority.
+
+### Verified locally (claude 2.1.167, this machine)
+
+Forced fallback by setting the **primary to a bogus model id** (the "primary not found"
+path), then read which model actually served the turn from `--output-format json`'s
+`modelUsage` key. Results:
+
+- **`--fallback-model` is `--print`-only.** Its `--help` text on 2.1.167:
+  > Enable automatic fallback to specified model(s) when the default model is
+  > overloaded or not available. **Accepts a comma-separated list to try each in
+  > order. Re-tries the primary at the start of each user turn. (only works with
+  > `--print`)**
+
+  This *contradicts* the v2.1.166 changelog line "`--fallback-model` now also applies
+  to interactive sessions." On 2.1.167 the help still restricts the flag to `--print`.
+  **TBD spawns interactive sessions, so the flag is the wrong lever for TBD.**
+- **The `fallbackModel` *setting* works and is the right lever.** With
+  `--model bogus-primary-1 --settings <file>` where the file is
+  `{"fallbackModel":["claude-haiku-4-5-20251001"]}` (array form) **and no flag**, the
+  turn was served by `claude-haiku-4-5-20251001` (`modelUsage` key). The setting is
+  honored and takes an **array**.
+- **Ordering confirmed.** `--fallback-model bogus-fallback-2,claude-haiku-4-5-20251001`
+  skipped the dead second-position model and landed on haiku — it tries each in order.
+- **Syntax differs by surface:** the *flag* takes a **comma-separated string**; the
+  *setting* takes a **JSON array**.
+- **Re-tries the primary each user turn** (per the help) — so it is *not* purely "sticky
+  for the rest of the session" as the v2.1.152 prose implied; it reattempts the primary
+  at the top of each turn and only falls back when the primary is still unavailable.
+
+*(All tests were in `--print` mode, the only mode scriptable from a shell. Whether the
+**setting** is honored in an **interactive** session is the one residual verify — see
+Risks. Settings keys normally apply across all modes, and only the *flag* is documented
+as `--print`-only, so this is expected to work.)*
+
+---
+
+## Ranked ideas
+
+### 1. Inject `fallbackModel` into the existing `--settings` overlay so TBD sessions degrade instead of hard-failing — **Integration** — effort **S**
+
+**TBD-side change:** Add a `fallbackModel` key (a JSON **array** of up to three model
+ids) to the overlay body in `ClaudeHookOverlay.generateBody()`
+(`Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift` ~L87–139, currently `hooks`-only).
+TBD already appends `--settings <overlay>` to every spawned `claude`, so this rides the
+mechanism that's already there — no new flag, no new spawn-arg plumbing. Source the
+array from a new optional `fallbackModels` field on `ModelProfile`.
+
+> Verified: `--model bogus --settings {"fallbackModel":["claude-haiku-4-5-20251001"]}`
+> served the turn on haiku (see "Verified locally" above).
+
+**Why the setting, not the flag:** the `--fallback-model` *flag* is `--print`-only on
+2.1.167 (verified). TBD spawns **interactive** sessions, so the flag would be ignored —
+the **setting** is the only lever that reaches TBD's sessions. This is actually the
+*cleaner* path: TBD's `--settings` overlay already exists for exactly this kind of
+non-invasive config injection.
+
+A multi-agent TBD fleet is the canonical overload scenario, so graceful degradation has
+outsized value here.
+
+**Touches:** `ModelProfile` (`Sources/TBDShared/Models.swift` ~L274–316, add optional
+`fallbackModels: [String]?` — must be optional/defaulted so existing rows decode),
+`ModelProfileResolver` (`Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift`,
+carry it through `ResolvedModelProfile`), and `ClaudeHookOverlay` (write the
+`fallbackModel` array into the overlay body, threading the resolved profile in). No new
+RPC, no UI required for a v1 with a single sensible default fallback.
+
+**Note:** TBD currently sets the *primary* model via the `ANTHROPIC_MODEL` env var, not
+`--model` (commit #253). The forced-fallback test used `--model`; confirm `fallbackModel`
+also engages when the primary is supplied via `ANTHROPIC_MODEL` (different layer — should
+be fine, but verify).
+
+---
+
+### 2. Per-worktree primary + ordered fallback list in the model-profile UI — **TBD-side** — effort **M**
+
+**TBD-side change:** Build on #253 ("let Claude-direct (OAuth) profiles set a model")
+by letting a profile/worktree carry the **ordered fallback list (up to three)**,
+surfaced in the model-profile editing UI. This is the configuration layer that makes
+Idea 1 user-settable rather than a single hard-coded default.
+
+> "configure up to three fallback models tried in order when the primary model is
+> overloaded or unavailable" — v2.1.166
+
+**Touches:** `ModelProfile` (the `fallbackModels` list from Idea 1), the model-profile
+editing UI (a small ordered-list editor capped at three), resolver, `ClaudeHookOverlay`.
+Lower priority — do it after Idea 1 proves the plumbing; a global default is enough to
+ship value first.
+
+---
+
+## Risks / open questions / verification needed
+
+1. **(Residual) Does `fallbackModel` (the setting) engage in an *interactive* session?**
+   All local tests were in `--print` mode — the only mode scriptable from a shell — and
+   the setting worked there. The *flag* is documented `--print`-only, but the *setting* is
+   not, and settings keys normally apply across modes, so this is expected to work. Still
+   worth a one-time confirmation via a real TBD-spawned interactive session: force a
+   fallback (bogus primary) and inspect the session transcript JSONL for the serving
+   model. **This is the gate before relying on Idea 1 in production.**
+
+2. **Interaction with OAuth / `ANTHROPIC_MODEL`.** TBD sets the *primary* via the
+   `ANTHROPIC_MODEL` env var (not `--model`); the forced-fallback test used `--model`.
+   Confirm `fallbackModel` engages when the primary comes from `ANTHROPIC_MODEL`, and that
+   the chosen fallback models are even *available* on the account tier in use (Max-plan
+   model availability has historically been finicky — cf. the old "Max users specifying
+   Opus still fell back to Sonnet" fix).
+
+3. **Overlay precedence for the `fallbackModel` key.** TBD's `--settings` overlay is
+   documented to *merge* the `hooks` array with the user's `~/.claude/settings.json`.
+   Confirm a scalar/array `fallbackModel` in the overlay isn't *overridden* by (or
+   silently overriding) a user-set `fallbackModel` in an unexpected way. Low risk — most
+   users won't set it — but worth a glance.
+
+4. **Contract not yet documented; flag/changelog mismatch.** `fallbackModel` is
+   changelog-only as of v2.1.166 and absent from the settings reference. The v2.1.166
+   changelog says the *flag* "now also applies to interactive sessions," but 2.1.167 help
+   still marks the flag `--print`-only. Pin to observed behavior, not the prose, and
+   re-check on CLI upgrades.
+
+## Resolved by local testing (claude 2.1.167)
+
+- **Syntax:** flag = comma-separated string; setting = JSON array. Both tried in order.
+- **Ordering:** dead models in the list are skipped; the first reachable one serves.
+- **Flag is `--print`-only** → not usable for TBD's interactive sessions; use the setting.
+- **`modelUsage` in `--output-format json` reveals the actual serving model** — the tool
+  for the residual interactive verification (Risk #1), if exposed there too.
+
+---
+
+## Recommendation
+
+**Ship a small spike of Idea 1, via the `--settings` overlay (not the flag).** Adding a
+`fallbackModel` array to TBD's existing overlay (sourced from a new optional
+`ModelProfile.fallbackModels`) is low-effort, rides machinery that already exists, needs
+no new flag/RPC/UI, and directly hardens TBD's core multi-agent-fleet use case against
+overload. Local testing confirms the setting + array form works in `--print`; gate the
+production rollout on the one residual check — that the setting also engages in an
+**interactive** TBD-spawned session (Risk #1) — then layer Idea 2's UI on top.


### PR DESCRIPTION
## Summary
- TBD-spawned `claude` sessions now support a per-profile **`fallbackModel`** — when the primary model is overloaded or unavailable, the session degrades to a configured alternate (up to 3, tried in order) instead of hard-failing a turn. This matters most for multi-agent fleets, the canonical overload scenario.
- Claude Code's `--fallback-model` **flag is `--print`-only** (verified on CLI 2.1.167), so it can't reach TBD's interactive sessions. The `fallbackModel` **setting** does work — and since multiple `--settings` don't merge scalar keys (first wins, verified), the fallback array is injected into a **per-session overlay that merges the existing hooks + the profile's fallback list**, written only when a profile has fallbacks. No-fallback profiles keep using the shared global overlay unchanged.
- Configurable from the app: a `FallbackModelsEditor` (ordered list, capped at 3) in the model-profile add/edit sheets, wired end-to-end through RPC → `DaemonClient` → store, for all profile kinds (Claude-direct/oauth, proxy/apiKey, bedrock).
- Hardened: `resolveOverlayPath` is non-throwing (write failure logs + degrades to the global overlay, never blocks a spawn); per-session overlay files are cleaned up on terminal teardown and swept for orphans at daemon startup.
- Includes a scout thinking doc (`docs/changelog-watch/ideas/fallback-model.md`) capturing the research, the verified CLI contract, and the design rationale.

## Implementation notes
- New optional `ModelProfile.fallbackModels: [String]?`; DB migration **v30** adds the nullable `fallback_models` column (GRDB record + shared Codable model updated in lockstep; field optional so existing rows/JSON decode).
- Resolver carries `fallbackModels` through the same repo-override → global-default precedence as `model`.
- RPC params (`Add`/`UpdateEndpoint`/`UpdateBedrock`) gain `fallbackModels` via `decodeIfPresent` for backward-compatible payloads; handler normalizes (trim, drop blanks, cap at 3, empty→nil).

## Test plan
- [x] `swift build` clean; `swiftlint --strict` 0 violations.
- [x] `swift test --filter 'ModelProfile|RPC|ClaudeHookOverlay'` → 205 pass (each gating branch covered: with/without fallbacks, per-session vs global overlay, write-failure degradation, teardown delete + orphan prune, RPC decode with/without field, set→clear persistence).
- [x] Full `swift test` green except the pre-existing unrelated `TabBarHitAreaTests` SwiftUI text-measurement flake (fails identically on baseline).
- [ ] **Manual (needs `scripts/restart.sh`):** set fallback models on a profile in the app, spawn a session, force a fallback (e.g. bogus primary) and confirm via the session transcript's `modelUsage` that the fallback engages in a live **interactive** session (the one runtime check not coverable by unit tests).

[20260606-ill-falcon](https://cheapsteak.github.io/tbd/open/?worktree=010DD1E3-58A3-461C-87F8-1A5558737C06)