### PR TITLE
fix: show green for PRs blocked only by a required review

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -133,7 +133,10 @@ public actor PRStatusManager {
             case "CLEAN", "HAS_HOOKS":
                 return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .mergeable
             case "BLOCKED":
-                return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .blocked
+                if Self.isPendingStatusCheckRollup(statusCheckRollupState) { return .pending }
+                // Only blocker is a required (but not-yet-given) review while checks pass → ready to merge, show green.
+                if reviewDecision == "REVIEW_REQUIRED" { return .mergeable }
+                return .blocked
             case "DIRTY", "BEHIND":
                 return .blocked
             case "UNSTABLE":

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -68,6 +68,49 @@ struct PRStatusManagerTests {
         #expect(status == .pending)
     }
 
+    @Test("maps OPEN + BLOCKED + REVIEW_REQUIRED + SUCCESS checks to .mergeable")
+    func mapsReviewRequiredWithPassingChecksToMergeable() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            reviewDecision: "REVIEW_REQUIRED",
+            statusCheckRollupState: "SUCCESS"
+        )
+        #expect(status == .mergeable)
+    }
+
+    @Test("maps OPEN + BLOCKED + REVIEW_REQUIRED + nil checks to .mergeable")
+    func mapsReviewRequiredWithNilChecksToMergeable() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            reviewDecision: "REVIEW_REQUIRED",
+            statusCheckRollupState: nil
+        )
+        #expect(status == .mergeable)
+    }
+
+    @Test("maps OPEN + BLOCKED + REVIEW_REQUIRED + pending checks to .pending (pending wins)")
+    func mapsReviewRequiredWithPendingChecksToPending() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            reviewDecision: "REVIEW_REQUIRED",
+            statusCheckRollupState: "PENDING"
+        )
+        #expect(status == .pending)
+    }
+
+    @Test("maps OPEN + BLOCKED + empty reviewDecision to .blocked (review-required branch off)")
+    func mapsBlockedWithEmptyReviewDecisionToBlocked() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            reviewDecision: ""
+        )
+        #expect(status == .blocked)
+    }
+
     @Test("maps HAS_HOOKS to .mergeable")
     func mapsHasHooks() {
         let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "HAS_HOOKS")


### PR DESCRIPTION
## What

When a PR's CI checks all pass but it's still blocked solely because it **requires a review** (not yet approved), TBD showed the status as red. It now shows green.

## Why

GitHub returns `mergeStateStatus == "BLOCKED"` when a PR is waiting on a required review, even though CI is green. In `PRStatusManager.mapState()`, the `BLOCKED` case unconditionally returned `.blocked` (red).

Since `CHANGES_REQUESTED` and failing checks already return earlier in the function, reaching `BLOCKED` with `reviewDecision == "REVIEW_REQUIRED"` and non-pending checks means the PR is otherwise ready to merge — so it now maps to `.mergeable` (green). Pending checks still take precedence and show `.pending`.

## Tests

Added one case per branch in `PRStatusManagerTests`:
- BLOCKED + REVIEW_REQUIRED + SUCCESS checks → `.mergeable`
- BLOCKED + REVIEW_REQUIRED + nil checks → `.mergeable`
- BLOCKED + REVIEW_REQUIRED + PENDING checks → `.pending` (pending wins)
- BLOCKED + empty reviewDecision → `.blocked` (unchanged)

Existing `CHANGES_REQUESTED → .changesRequested` test serves as a regression guard. Build passes; all 31 PRStatusManager tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)