### PR TITLE
Fix: Show one right-sized status indicator per sidebar row

### DIFF
--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -9,13 +9,21 @@ enum RowStatusIndicator: Equatable {
     case suspended
     case prStatus
 
+    /// Notifications at or above this `NotificationType.severity` outrank the
+    /// working spinner: errors and attention/focus requests must not be hidden
+    /// behind a spinner that can run for minutes. Lower-severity completion
+    /// badges yield to the spinner, so a stale "done" dot never masks active work.
+    private static let highSeverityThreshold = 3
+
     /// Resolves which indicator (if any) a worktree row should show.
     ///
     /// Invariant: a worktree row shows at most one status indicator.
     /// Add new indicators as a branch in this priority chain — never as an
     /// additional stacked icon in `WorktreeRowView`.
     ///
-    /// Priority (highest first): pending > working > notification badge > suspended > PR status.
+    /// Priority (highest first): pending > high-severity badge (error,
+    /// attentionNeeded, focusRequest) > working > low-severity badge
+    /// (taskComplete, responseComplete) > suspended > PR status.
     static func resolve(
         isPending: Bool,
         isWorking: Bool,
@@ -25,6 +33,8 @@ enum RowStatusIndicator: Equatable {
     ) -> RowStatusIndicator? {
         if isPending {
             return .pendingSpinner
+        } else if let notification, notification.severity >= highSeverityThreshold {
+            return .notificationBadge(notification)
         } else if isWorking {
             return .workingSpinner
         } else if let notification {

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import TBDShared
+
+/// The single status indicator a sidebar worktree row may display.
+enum RowStatusIndicator: Equatable {
+    case pendingSpinner
+    case workingSpinner
+    case notificationBadge(NotificationType)
+    case suspended
+    case prStatus
+
+    /// Resolves which indicator (if any) a worktree row should show.
+    ///
+    /// Invariant: a worktree row shows at most one status indicator.
+    /// Add new indicators as a branch in this priority chain — never as an
+    /// additional stacked icon in `WorktreeRowView`.
+    ///
+    /// Priority (highest first): pending > working > notification badge > suspended > PR status.
+    static func resolve(
+        isPending: Bool,
+        isWorking: Bool,
+        notification: NotificationType?,
+        isSuspended: Bool,
+        hasPRStatus: Bool
+    ) -> RowStatusIndicator? {
+        if isPending {
+            return .pendingSpinner
+        } else if isWorking {
+            return .workingSpinner
+        } else if let notification {
+            return .notificationBadge(notification)
+        } else if isSuspended {
+            return .suspended
+        } else if hasPRStatus {
+            return .prStatus
+        }
+        return nil
+    }
+
+    /// Badge dot color for `notificationBadge` cases.
+    static func badgeColor(for notification: NotificationType) -> Color {
+        switch notification {
+        case .error:
+            return .red
+        case .attentionNeeded, .focusRequest:
+            return .orange
+        case .taskComplete:
+            return .green
+        case .responseComplete:
+            return .blue
+        }
+    }
+}

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -29,20 +29,6 @@ struct WorktreeRowView: View {
         return false
     }
 
-    private var badgeColor: Color? {
-        guard let n = notification else { return nil }
-        switch n {
-        case .error:
-            return .red
-        case .attentionNeeded, .focusRequest:
-            return .orange
-        case .taskComplete:
-            return .green
-        case .responseComplete:
-            return .blue
-        }
-    }
-
     private var prPresentation: PRStatusPresentation? {
         guard !isMain else { return nil }
         return PRStatusPresentation.make(for: prStatus)
@@ -58,33 +44,48 @@ struct WorktreeRowView: View {
         return terminals.contains { $0.activityState == .working }
     }
 
+    /// Spinner sized to visually match the 12×12 PR status icon.
+    /// The small `ProgressView` is ~16pt; scale by 0.75 and pin the layout frame.
+    private func spinner() -> some View {
+        ProgressView()
+            .controlSize(.small)
+            .scaleEffect(0.75)
+            .frame(width: 12, height: 12)
+    }
+
     @ViewBuilder
     private func rowIcons() -> some View {
-        if hasSuspendedTerminal {
+        // Resolved through RowStatusIndicator so at most one indicator renders.
+        // Add new indicators in RowStatusIndicator.resolve, never as stacked icons here.
+        switch RowStatusIndicator.resolve(
+            isPending: isPending && !isEditing,
+            isWorking: hasWorkingTerminal,
+            notification: notification,
+            isSuspended: hasSuspendedTerminal,
+            hasPRStatus: prPresentation != nil
+        ) {
+        case .pendingSpinner, .workingSpinner:
+            spinner()
+        case .notificationBadge(let n):
+            Circle()
+                .fill(RowStatusIndicator.badgeColor(for: n))
+                .frame(width: 8, height: 8)
+        case .suspended:
             Image(systemName: "pause.circle.fill")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
-        }
-        if hasWorkingTerminal {
-            ProgressView()
-                .controlSize(.small)
-        }
-        if isPending && !isEditing {
-            ProgressView()
-                .controlSize(.small)
-        } else if let color = badgeColor {
-            Circle()
-                .fill(color)
-                .frame(width: 8, height: 8)
-        }
-        if let presentation = prPresentation,
-           let nsImage = loadIcon(presentation.iconName) {
-            Image(nsImage: nsImage)
-                .renderingMode(.template)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 12, height: 12)
-                .foregroundStyle(presentation.color)
+        case .prStatus:
+            if let presentation = prPresentation,
+               let nsImage = loadIcon(presentation.iconName) {
+                Image(nsImage: nsImage)
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 12, height: 12)
+                    .foregroundStyle(presentation.color)
+            }
+        case nil:
+            EmptyView()
         }
     }
 

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -16,7 +16,7 @@ struct RowStatusIndicatorTests {
         #expect(result == .pendingSpinner)
     }
 
-    @Test func workingWinsOverNotificationSuspendedAndPR() {
+    @Test func workingWinsOverLowSeverityNotificationSuspendedAndPR() {
         let result = RowStatusIndicator.resolve(
             isPending: false,
             isWorking: true,
@@ -25,6 +25,41 @@ struct RowStatusIndicatorTests {
             hasPRStatus: true
         )
         #expect(result == .workingSpinner)
+    }
+
+    @Test(arguments: [NotificationType.error, .attentionNeeded, .focusRequest])
+    func highSeverityBadgeWinsOverWorkingSpinner(notification: NotificationType) {
+        let result = RowStatusIndicator.resolve(
+            isPending: false,
+            isWorking: true,
+            notification: notification,
+            isSuspended: false,
+            hasPRStatus: true
+        )
+        #expect(result == .notificationBadge(notification))
+    }
+
+    @Test(arguments: [NotificationType.taskComplete, .responseComplete])
+    func lowSeverityBadgeYieldsToWorkingSpinner(notification: NotificationType) {
+        let result = RowStatusIndicator.resolve(
+            isPending: false,
+            isWorking: true,
+            notification: notification,
+            isSuspended: false,
+            hasPRStatus: false
+        )
+        #expect(result == .workingSpinner)
+    }
+
+    @Test func pendingWinsOverHighSeverityBadge() {
+        let result = RowStatusIndicator.resolve(
+            isPending: true,
+            isWorking: false,
+            notification: .error,
+            isSuspended: false,
+            hasPRStatus: false
+        )
+        #expect(result == .pendingSpinner)
     }
 
     @Test func workingSpinnerHidesPRStatus() {

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -1,0 +1,84 @@
+import Testing
+
+@testable import TBDApp
+import TBDShared
+
+@Suite("RowStatusIndicator")
+struct RowStatusIndicatorTests {
+    @Test func pendingWinsOverEverything() {
+        let result = RowStatusIndicator.resolve(
+            isPending: true,
+            isWorking: true,
+            notification: .error,
+            isSuspended: true,
+            hasPRStatus: true
+        )
+        #expect(result == .pendingSpinner)
+    }
+
+    @Test func workingWinsOverNotificationSuspendedAndPR() {
+        let result = RowStatusIndicator.resolve(
+            isPending: false,
+            isWorking: true,
+            notification: .taskComplete,
+            isSuspended: true,
+            hasPRStatus: true
+        )
+        #expect(result == .workingSpinner)
+    }
+
+    @Test func workingSpinnerHidesPRStatus() {
+        let result = RowStatusIndicator.resolve(
+            isPending: false,
+            isWorking: true,
+            notification: nil,
+            isSuspended: false,
+            hasPRStatus: true
+        )
+        #expect(result == .workingSpinner)
+    }
+
+    @Test func notificationWinsOverSuspendedAndPR() {
+        let result = RowStatusIndicator.resolve(
+            isPending: false,
+            isWorking: false,
+            notification: .responseComplete,
+            isSuspended: true,
+            hasPRStatus: true
+        )
+        #expect(result == .notificationBadge(.responseComplete))
+    }
+
+    @Test func suspendedWinsOverPR() {
+        let result = RowStatusIndicator.resolve(
+            isPending: false,
+            isWorking: false,
+            notification: nil,
+            isSuspended: true,
+            hasPRStatus: true
+        )
+        #expect(result == .suspended)
+    }
+
+    @Test func prStatusAlone() {
+        let result = RowStatusIndicator.resolve(
+            isPending: false,
+            isWorking: false,
+            notification: nil,
+            isSuspended: false,
+            hasPRStatus: true
+        )
+        #expect(result == .prStatus)
+    }
+
+    @Test func nothingSetReturnsNil() {
+        let result = RowStatusIndicator.resolve(
+            isPending: false,
+            isWorking: false,
+            notification: nil,
+            isSuspended: false,
+            hasPRStatus: false
+        )
+        #expect(result == nil)
+    }
+}


### PR DESCRIPTION
## Summary

#256 added a thinking spinner to worktree rows, but it rendered ~16pt next to the 12×12 PR status icon and stacked alongside it (and the pause icon and notification dot), so a busy row could show four icons at once.

- Shrink both spinners (thinking + "creating worktree") to 12×12 to match the PR icon
- Introduce `RowStatusIndicator`, a pure resolver that picks **at most one** indicator per row — `rowIcons()` now switches on its result, so stacking two icons is structurally impossible, and a doc comment tells future contributors to add indicators as priority-chain branches, never stacked icons
- Priority: pending > high-severity badge (error / attention-needed / focus-request, via `NotificationType.severity`) > working spinner > completion badge > suspended > PR status — so the spinner hides the PR icon while work runs, but can't mask an unread error from a sibling session, and a stale "done" dot can't hide active work
- 10 unit tests cover every branch of the priority chain

## Test plan

- [ ] `swift test --filter RowStatusIndicatorTests` (10/10 passing locally)
- [ ] In the app: start a Claude session and confirm the spinner is the same size as PR icons and the PR icon disappears while it spins
- [ ] Create a worktree and confirm the creation spinner matches too

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=F5EC2327-3092-4453-9AD3-FBE482159BD6)