### PR TITLE
Fix: Stop showing "Process exited" on terminals whose session is still alive

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -216,6 +216,75 @@ final class AppState: ObservableObject {
         return ids
     }
 
+    /// Worktree IDs with at least one terminal currently in the `.working`
+    /// activity state (an agent is actively running). These must not have their
+    /// view trees torn down by keep-alive eviction — unmounting kills the
+    /// on-screen tmux viewer mid-run and shows a spurious detach message.
+    var workingWorktreeIDs: Set<UUID> {
+        var ids = Set<UUID>()
+        for (worktreeID, terminalList) in terminals
+        where terminalList.contains(where: { $0.activityState == .working }) {
+            ids.insert(worktreeID)
+        }
+        return ids
+    }
+
+    /// Worktrees that must never be evicted from the keep-alive mount set:
+    /// open (selected) plus actively working. Consumed by `keepAliveWorktreeIDs`.
+    ///
+    /// Pinned terminals are deliberately NOT force-protected here: `PinnedTerminalDock`
+    /// already keeps a pinned terminal's view alive independently. A worktree can
+    /// still be protected here for being selected or working even when its
+    /// active-tab terminal is pinned — the would-be double-mount of that terminal
+    /// (dock cell + kept-alive pager) is prevented structurally by the
+    /// `dockedTerminalIDs` dedup in `PanePlaceholder`, so the two viewers never
+    /// collide on the shared `tbd-view-<id>` tmux session.
+    var protectedWorktreeIDs: Set<UUID> {
+        selectedWorktreeIDs.union(workingWorktreeIDs)
+    }
+
+    /// Terminal IDs rendered in the active-tab layouts of the currently selected
+    /// worktree(s) — the terminals showing in the main content area. Single
+    /// source of truth shared by the dock filter (`dockedTerminalIDs`) and the
+    /// pager dedup. (Moved off `TerminalContainerView` so both consumers agree.)
+    var visibleTerminalIDs: Set<UUID> {
+        var ids = Set<UUID>()
+        for worktreeID in selectedWorktreeIDs {
+            let wtTabs = tabs[worktreeID] ?? []
+            guard !wtTabs.isEmpty else { continue }
+            let activeIndex = activeTabIndices[worktreeID] ?? 0
+            let tab = wtTabs[min(activeIndex, wtTabs.count - 1)]
+            let layout = layouts[tab.id] ?? .pane(tab.content)
+            for id in layout.allTerminalIDs() {
+                ids.insert(id)
+            }
+        }
+        return ids
+    }
+
+    /// Pinned terminal IDs that are NOT already visible in the main content area
+    /// — i.e. exactly the terminals `PinnedTerminalDock` renders. The keep-alive
+    /// pager must skip these (see `AppState.shouldSuppressTerminalInLayout` /
+    /// `PanePlaceholder`) so a docked terminal is never mounted a second time;
+    /// two `TerminalPanelView`s for one terminal would collide on the shared
+    /// `tbd-view-<id>` tmux session and thrash it.
+    var dockedTerminalIDs: Set<UUID> {
+        let visible = visibleTerminalIDs
+        return Set(pinnedTerminals.map(\.id).filter { !visible.contains($0) })
+    }
+
+    /// Whether a terminal rendered in a worktree-layout pane should be
+    /// suppressed (replaced by a lightweight placeholder) because it is already
+    /// owned by `PinnedTerminalDock`. Pure so the dedup decision is testable
+    /// without a view tree. Applies ONLY to the layout/pager path — the dock
+    /// cell renders `TerminalPanelView` directly and never routes through here.
+    static func shouldSuppressTerminalInLayout(
+        terminalID: UUID,
+        dockedTerminalIDs: Set<UUID>
+    ) -> Bool {
+        dockedTerminalIDs.contains(terminalID)
+    }
+
     @Published var dockRatio: CGFloat = 0.3 {
         didSet { userDefaults.set(Double(dockRatio), forKey: Self.dockRatioKey) }
     }
@@ -288,9 +357,12 @@ final class AppState: ObservableObject {
     @Published var sessionTranscripts: [String: [TranscriptItem]] = [:]  // sessionId → items
     @Published var sessionTranscriptLoading: Set<String> = []
 
-    /// Worktree IDs whose view trees we keep alive past their selection,
-    /// most-recent-first. Cap: keepAliveLimit. Older worktrees get evicted
-    /// (their SingleWorktreeView unmounts) when the cap is exceeded.
+    /// Raw most-recent-first log of recently-visited worktrees, the recency
+    /// input to the keep-alive policy. Bounded by `touchVisitedWorktree`, which
+    /// drops the oldest NON-protected entries past `keepAliveLimit`. The actual
+    /// mount set the view consumes is the computed `keepAliveWorktreeIDs`, which
+    /// re-merges the live protection set; do not feed this raw log to the pager
+    /// directly.
     @Published private(set) var recentlyVisitedWorktreeIDs: [UUID] = []
 
     /// LRU of recently-selected worktrees consumed by the cmd-K jump menu.
@@ -303,17 +375,77 @@ final class AppState: ObservableObject {
 
     private let keepAliveLimit = 8
 
-    /// Move `id` to the front of recentlyVisitedWorktreeIDs, evicting the
-    /// oldest entries if we exceed keepAliveLimit. Idempotent — calling
-    /// repeatedly with the same id only updates ordering.
+    /// Move `id` to the front of `recentlyVisitedWorktreeIDs`, then trim the LRU
+    /// so it never grows unbounded. Protected worktrees (`protectedWorktreeIDs`)
+    /// are never evicted here — only the oldest NON-protected entries past
+    /// `keepAliveLimit` are dropped. The live mount set is computed separately
+    /// by `keepAliveWorktreeIDs` (which re-merges the protection set), so this
+    /// trim only bounds the stored recency log. Idempotent.
     func touchVisitedWorktree(_ id: UUID) {
         recentlyVisitedWorktreeIDs.removeAll { $0 == id }
         recentlyVisitedWorktreeIDs.insert(id, at: 0)
-        if recentlyVisitedWorktreeIDs.count > keepAliveLimit {
-            recentlyVisitedWorktreeIDs.removeLast(
-                recentlyVisitedWorktreeIDs.count - keepAliveLimit
-            )
+        let protected = protectedWorktreeIDs
+        var nonProtectedKept = 0
+        recentlyVisitedWorktreeIDs.removeAll { entry in
+            if protected.contains(entry) { return false }
+            nonProtectedKept += 1
+            return nonProtectedKept > keepAliveLimit
         }
+    }
+
+    /// The worktree IDs whose view trees should be kept mounted, most-recent
+    /// first. This is what `WorktreePager` consumes.
+    ///
+    /// Semantics: protected worktrees (`protectedWorktreeIDs` — open/selected
+    /// or actively working) are ALWAYS kept, regardless of age, and do NOT
+    /// consume the non-protected budget. In addition, up to `keepAliveLimit`
+    /// most-recently-visited NON-protected worktrees are kept as a warm cache.
+    /// Decoupling the budgets means a burst of working background worktrees can
+    /// never starve the recency cache, and a freshly-protected worktree that had
+    /// aged out of the recency log is re-mounted. Because this is a computed
+    /// property, it is re-evaluated on every render, so eviction always reflects
+    /// the live protection set (a worktree that starts/stops working, or is
+    /// selected/deselected, is re-protected/released without needing an explicit
+    /// visit). Pinned-only worktrees are intentionally NOT protected here — see
+    /// `protectedWorktreeIDs` for why.
+    var keepAliveWorktreeIDs: [UUID] {
+        Self.keepAliveWorktreeIDs(
+            recentlyVisited: recentlyVisitedWorktreeIDs,
+            protected: protectedWorktreeIDs,
+            limit: keepAliveLimit
+        )
+    }
+
+    /// Pure keep-alive policy (see `keepAliveWorktreeIDs`). Extracted as a
+    /// static function so the eviction decision is unit-testable without an
+    /// AppKit/SwiftUI view tree.
+    static func keepAliveWorktreeIDs(
+        recentlyVisited: [UUID],
+        protected: Set<UUID>,
+        limit: Int
+    ) -> [UUID] {
+        var result: [UUID] = []
+        var seen = Set<UUID>()
+        var nonProtectedKept = 0
+        for id in recentlyVisited {
+            guard !seen.contains(id) else { continue }
+            if protected.contains(id) {
+                result.append(id)
+                seen.insert(id)
+            } else if nonProtectedKept < limit {
+                result.append(id)
+                seen.insert(id)
+                nonProtectedKept += 1
+            }
+            // Older non-protected entries beyond the cap are dropped (evicted).
+        }
+        // Protected worktrees that were never visited (or aged out of the
+        // recency log before becoming protected) must still be mounted.
+        for id in protected where !seen.contains(id) {
+            result.append(id)
+            seen.insert(id)
+        }
+        return result
     }
 
     /// Insertion/access order for `sessionTranscripts`. The most recently
@@ -460,7 +592,9 @@ final class AppState: ObservableObject {
         focusObservers = [active, resigned]
     }
 
-    /// Respond to system memory pressure by purging purgeable caches.
+    /// Observe system memory pressure. Currently only flushes window bitmap
+    /// caches and drains the autorelease pool — it deliberately does NOT tear
+    /// down terminal sessions or app caches.
     private nonisolated func startMemoryPressureMonitor() {
         let source = DispatchSource.makeMemoryPressureSource(
             eventMask: [.warning, .critical],
@@ -469,7 +603,7 @@ final class AppState: ObservableObject {
         source.setEventHandler { [weak self] in
             guard self != nil else { return }
             Task { @MainActor in
-                logger.warning("Memory pressure detected — purging caches")
+                logger.notice("Memory pressure detected — flushing window bitmap caches; terminal sessions left intact")
                 // Flush bitmap caches on all windows
                 for window in NSApp.windows {
                     window.displaysWhenScreenProfileChanges = true

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -274,7 +274,21 @@ struct PanePlaceholder: View {
 
     @ViewBuilder
     private func terminalContent(terminalID: UUID) -> some View {
-        if let terminal = terminal(for: terminalID) {
+        if AppState.shouldSuppressTerminalInLayout(
+            terminalID: terminalID,
+            dockedTerminalIDs: appState.dockedTerminalIDs
+        ) {
+            // This terminal is pinned and currently owned by PinnedTerminalDock.
+            // Rendering a second TerminalPanelView here (this is the worktree
+            // layout / keep-alive pager path) would mount the same terminal
+            // twice and collide on the shared `tbd-view-<id>` tmux session. The
+            // dock holds the live viewer; show a placeholder instead. This
+            // placeholder is only ever offscreen (a kept-alive non-selected
+            // worktree) — selecting the worktree moves the terminal into
+            // `visibleTerminalIDs`, so it leaves `dockedTerminalIDs` and renders
+            // for real in the main area.
+            pinnedInDockPlaceholder
+        } else if let terminal = terminal(for: terminalID) {
             if appState.suspendingTerminalIDs.contains(terminal.id) {
                 // Show screenshot (or black fallback) — no live tmux connection
                 Group {
@@ -389,6 +403,23 @@ struct PanePlaceholder: View {
                 }
             }
         }
+    }
+
+    /// Placeholder shown in the worktree-layout path for a terminal that is
+    /// currently pinned and rendered live in `PinnedTerminalDock`. Avoids a
+    /// second `TerminalPanelView` for the same terminal (which would fight over
+    /// the shared `tbd-view-<id>` tmux session). Never user-visible in practice
+    /// — only the offscreen kept-alive pager hits this branch.
+    private var pinnedInDockPlaceholder: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "pin.fill")
+                .font(.system(size: 32))
+                .foregroundStyle(.tertiary)
+            Text("Pinned — shown in the dock")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     /// Placeholder shown when a transcript pane exists but the feature flag is off.

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -29,27 +29,12 @@ struct MainAreaSizeKey: PreferenceKey {
 struct TerminalContainerView: View {
     @EnvironmentObject var appState: AppState
 
-    /// Terminal IDs currently visible in the active tab layouts of selected worktrees.
-    private var visibleTerminalIDs: Set<UUID> {
-        var ids = Set<UUID>()
-        for worktreeID in appState.selectedWorktreeIDs {
-            let tabs = appState.tabs[worktreeID] ?? []
-            guard !tabs.isEmpty else { continue }
-            let activeIndex = appState.activeTabIndices[worktreeID] ?? 0
-            let tab = tabs[min(activeIndex, tabs.count - 1)]
-            let layout = appState.layouts[tab.id] ?? .pane(tab.content)
-            for id in layout.allTerminalIDs() {
-                ids.insert(id)
-            }
-        }
-        return ids
-    }
-
     var body: some View {
-        let visible = visibleTerminalIDs
-        let dockTerminals = appState.pinnedTerminals.filter { terminal in
-            !visible.contains(terminal.id)
-        }
+        // `dockedTerminalIDs` (on AppState) is the single source of truth for
+        // which pinned terminals fall to the dock; the keep-alive pager dedups
+        // against the same set so a docked terminal is never mounted twice.
+        let docked = appState.dockedTerminalIDs
+        let dockTerminals = appState.pinnedTerminals.filter { docked.contains($0.id) }
 
         let activeWorktreeID: UUID? = appState.selectedWorktreeIDs.count == 1
             ? appState.selectedWorktreeIDs.first
@@ -67,7 +52,7 @@ struct TerminalContainerView: View {
                 // visited worktrees' views alive without resetting their @State or
                 // leaking AppKit events to inactive subtrees.
                 WorktreePager(
-                    worktreeIDs: appState.recentlyVisitedWorktreeIDs,
+                    worktreeIDs: appState.keepAliveWorktreeIDs,
                     activeID: activeWorktreeID
                 )
             }

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -497,7 +497,20 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
             debugLog("PANEL: process terminated, exitCode=\(exitCode ?? -1)")
             DispatchQueue.main.async { [weak self] in
-                self?.terminalView?.feed(text: "\r\n[Process exited with code \(exitCode ?? -1)]\r\n")
+                // This fires when the *attach client* (the on-screen tmux
+                // viewer) dies — e.g. the view was torn down or detached. The
+                // underlying tmux window keeps running (`remain-on-exit on`),
+                // so the user's shell/agent is almost always still alive. Avoid
+                // the old "[Process exited with code 0]" wording, which read as
+                // if the user's work had died. Surface a non-zero code only when
+                // the viewer genuinely exited abnormally.
+                let message: String
+                if let code = exitCode, code != 0 {
+                    message = "\r\n[View detached (exit \(code)) — session is still running in the background. Reopen this tab to reattach.]\r\n"
+                } else {
+                    message = "\r\n[View detached — session is still running in the background. Reopen this tab to reattach.]\r\n"
+                }
+                self?.terminalView?.feed(text: message)
             }
         }
 

--- a/Tests/TBDAppTests/KeepAliveEvictionTests.swift
+++ b/Tests/TBDAppTests/KeepAliveEvictionTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tests for activity/pin/visibility-aware keep-alive eviction.
+///
+/// The keep-alive mount set (`AppState.keepAliveWorktreeIDs`) protects
+/// worktrees the user must not lose — selected, pinned, or actively working —
+/// from being torn down, while still evicting the least-recently-visited
+/// *non-protected* worktrees once the cap is exceeded.
+///
+/// Every test constructs `AppState(userDefaults:)` against a unique throwaway
+/// suite — TBDApp ships as an unbundled SPM executable, so `UserDefaults.standard`
+/// is the running developer's real `TBDApp.plist`.
+@MainActor
+@Suite("Keep-alive eviction")
+struct KeepAliveEvictionTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.KeepAliveEviction.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func terminal(
+        worktreeID: UUID,
+        activityState: TerminalActivityState = .unknown,
+        pinnedAt: Date? = nil
+    ) -> Terminal {
+        Terminal(
+            id: UUID(),
+            worktreeID: worktreeID,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "Claude",
+            pinnedAt: pinnedAt,
+            kind: .claude,
+            activityState: activityState
+        )
+    }
+
+    // MARK: - Pure policy (static function)
+
+    @Test func nonProtectedWorktreeIsEvictedPastCap() {
+        // limit 2, three plain non-protected visits — oldest drops out.
+        let a = UUID(), b = UUID(), c = UUID()
+        let kept = AppState.keepAliveWorktreeIDs(
+            recentlyVisited: [c, b, a], // most-recent-first
+            protected: [],
+            limit: 2
+        )
+        #expect(kept == [c, b])
+        #expect(!kept.contains(a))
+    }
+
+    @Test func protectedWorktreeSurvivesPastCapAndDoesNotConsumeBudget() {
+        // `protectedOld` aged to the back of the recency log but is protected,
+        // so it stays — and the two most-recent non-protected entries are BOTH
+        // kept (protection doesn't eat the non-protected budget).
+        let protectedOld = UUID()
+        let recent1 = UUID(), recent2 = UUID()
+        let kept = AppState.keepAliveWorktreeIDs(
+            recentlyVisited: [recent2, recent1, protectedOld],
+            protected: [protectedOld],
+            limit: 2
+        )
+        #expect(kept.contains(protectedOld))
+        #expect(kept.contains(recent1))
+        #expect(kept.contains(recent2))
+    }
+
+    @Test func evictionPicksOldestNonProtected() {
+        // Oldest entry is protected; the oldest *non-protected* is evicted.
+        let protectedOldest = UUID()
+        let oldNonProtected = UUID()
+        let mid = UUID(), newest = UUID()
+        let kept = AppState.keepAliveWorktreeIDs(
+            recentlyVisited: [newest, mid, oldNonProtected, protectedOldest],
+            protected: [protectedOldest],
+            limit: 2
+        )
+        #expect(kept.contains(protectedOldest))
+        #expect(kept.contains(newest))
+        #expect(kept.contains(mid))
+        #expect(!kept.contains(oldNonProtected)) // oldest non-protected evicted
+    }
+
+    @Test func protectedWorktreeNeverVisitedIsStillMounted() {
+        // A worktree that became protected (e.g. started working) but is not in
+        // the recency log at all is still mounted.
+        let neverVisited = UUID()
+        let visited = UUID()
+        let kept = AppState.keepAliveWorktreeIDs(
+            recentlyVisited: [visited],
+            protected: [neverVisited],
+            limit: 8
+        )
+        #expect(kept.contains(neverVisited))
+        #expect(kept.contains(visited))
+    }
+
+    @Test func keepAliveSetAlwaysContainsProtectionSet() {
+        let p1 = UUID(), p2 = UUID(), p3 = UUID()
+        let n1 = UUID(), n2 = UUID()
+        let protected: Set<UUID> = [p1, p2, p3]
+        let kept = Set(AppState.keepAliveWorktreeIDs(
+            recentlyVisited: [n1, n2, p1], // only p1 visited; many non-protected
+            protected: protected,
+            limit: 1 // tight budget — protection must still win
+        ))
+        #expect(protected.isSubset(of: kept))
+    }
+
+    // MARK: - Integration through AppState computed properties
+
+    @Test func selectedWorktreeIsNotEvictedEvenPastCap() {
+        withState { state in
+            let selected = UUID()
+            // Fill the recency log beyond the cap with plain visits, then make
+            // `selected` the oldest entry and select it.
+            var ids: [UUID] = []
+            for _ in 0..<10 { ids.append(UUID()) }
+            ids.append(selected)
+            for id in ids.reversed() { state.touchVisitedWorktree(id) }
+            state.selectedWorktreeIDs = [selected]
+
+            #expect(state.protectedWorktreeIDs.contains(selected))
+            #expect(state.keepAliveWorktreeIDs.contains(selected))
+        }
+    }
+
+    @Test func pinnedOnlyWorktreeIsEvictedPastCapBecauseDockKeepsItAlive() {
+        withState { state in
+            // A worktree that is ONLY pinned (not selected, not working) is NOT
+            // protected by the pager keep-alive set: PinnedTerminalDock already
+            // keeps its pinned terminal's view alive, and protecting it here too
+            // would double-mount the shared `tbd-view-<id>` tmux session. So it
+            // is evictable once it ages past the cap.
+            let pinnedWT = UUID()
+            state.terminals = [pinnedWT: [terminal(worktreeID: pinnedWT, pinnedAt: Date())]]
+            state.touchVisitedWorktree(pinnedWT)
+            for _ in 0..<12 { state.touchVisitedWorktree(UUID()) }
+
+            // It is still "visible" (the dock shows it) but NOT pager-protected.
+            #expect(state.visibleWorktreeIDs.contains(pinnedWT))
+            #expect(!state.protectedWorktreeIDs.contains(pinnedWT))
+            #expect(!state.keepAliveWorktreeIDs.contains(pinnedWT))
+        }
+    }
+
+    @Test func workingWorktreeIsNotEvictedEvenWhenOlderThanCap() {
+        withState { state in
+            let workingWT = UUID()
+            state.terminals = [workingWT: [terminal(worktreeID: workingWT, activityState: .working)]]
+            // Visit it first (oldest), then bury it under many newer visits.
+            state.touchVisitedWorktree(workingWT)
+            for _ in 0..<12 { state.touchVisitedWorktree(UUID()) }
+
+            #expect(state.workingWorktreeIDs.contains(workingWT))
+            #expect(state.protectedWorktreeIDs.contains(workingWT))
+            #expect(state.keepAliveWorktreeIDs.contains(workingWT))
+        }
+    }
+
+    @Test func nonWorkingNonVisibleWorktreeIsEvictedPastCap() {
+        withState { state in
+            // Ungated behavior still works: a plain worktree (idle, unpinned,
+            // unselected) that aged past the cap is dropped from the mount set.
+            let plainOld = UUID()
+            state.terminals = [plainOld: [terminal(worktreeID: plainOld, activityState: .idle)]]
+            state.touchVisitedWorktree(plainOld)
+            for _ in 0..<12 { state.touchVisitedWorktree(UUID()) }
+
+            #expect(!state.protectedWorktreeIDs.contains(plainOld))
+            #expect(!state.keepAliveWorktreeIDs.contains(plainOld))
+        }
+    }
+
+    // MARK: - Dock dedup (prevents double-mount)
+
+    @Test func pinnedTerminalInNonSelectedWorktreeIsDockedAndSuppressedInLayout() {
+        withState { state in
+            let wt = UUID()
+            let term = terminal(worktreeID: wt, pinnedAt: Date())
+            state.terminals = [wt: [term]]
+            // Not selected → its pinned terminal is owned by the dock, not the
+            // main content area.
+            #expect(!state.visibleTerminalIDs.contains(term.id))
+            #expect(state.dockedTerminalIDs.contains(term.id))
+            #expect(AppState.shouldSuppressTerminalInLayout(
+                terminalID: term.id,
+                dockedTerminalIDs: state.dockedTerminalIDs
+            ))
+        }
+    }
+
+    @Test func pinnedTerminalInSelectedActiveTabIsNotDockedNorSuppressed() {
+        withState { state in
+            let wt = UUID()
+            let term = terminal(worktreeID: wt, pinnedAt: Date())
+            state.terminals = [wt: [term]]
+            state.tabs = [wt: [Tab(id: term.id, content: .terminal(terminalID: term.id), label: nil)]]
+            state.activeTabIndices = [wt: 0]
+            state.selectedWorktreeIDs = [wt]
+
+            // Selected & on the active tab → rendered for real in the main area,
+            // so it is NOT docked and must NOT be suppressed in the layout path.
+            #expect(state.visibleTerminalIDs.contains(term.id))
+            #expect(!state.dockedTerminalIDs.contains(term.id))
+            #expect(!AppState.shouldSuppressTerminalInLayout(
+                terminalID: term.id,
+                dockedTerminalIDs: state.dockedTerminalIDs
+            ))
+        }
+    }
+
+    @Test func dockedTerminalIsSuppressedInLayout() {
+        let id = UUID()
+        #expect(AppState.shouldSuppressTerminalInLayout(terminalID: id, dockedTerminalIDs: [id]))
+    }
+
+    @Test func nonDockedTerminalIsNotSuppressedInLayout() {
+        let id = UUID()
+        #expect(!AppState.shouldSuppressTerminalInLayout(terminalID: id, dockedTerminalIDs: [UUID()]))
+        #expect(!AppState.shouldSuppressTerminalInLayout(terminalID: id, dockedTerminalIDs: []))
+    }
+}


### PR DESCRIPTION
## Summary

Terminals (e.g. "oncall-roundsman", "Weekly OE deck") were showing `[exited]` / `[Process exited with code 0]` even though their Claude/shell processes were still running. Two root causes, both fixed here.

**1. The message was misleading.** Each terminal tab is a disposable tmux *view session* (`tbd-view-<id>`) attached to a persistent underlying window (which has `remain-on-exit on`). `TerminalPanelView.processTerminated` fires when that *attach client* dies — i.e. the on-screen viewer detached — not when the user's process exited. The old wording read as if work had died. It now reads:

> `[View detached — session is still running in the background. Reopen this tab to reattach.]`

(A non-zero exit code is still surfaced for genuinely abnormal viewer exits.)

**2. Keep-alive eviction was recency-only.** Worktree views are kept alive via an LRU capped at `keepAliveLimit = 8` (`AppState.recentlyVisitedWorktreeIDs`). Cycling through more than 8 worktrees on one repo evicted older ones, unmounting their panels and tearing down the view session — including worktrees where an agent was actively working. Eviction is now **activity/selection-aware**: worktrees that are **selected (open)** or have an **actively-working** terminal are protected from eviction; among the rest, the least-recently-opened are evicted as before. Protected worktrees don't consume the non-protected recency budget, so a burst of working worktrees can't starve the warm cache.

**Pinned terminals** are intentionally *not* protected in the pager — `PinnedTerminalDock` already keeps them alive independently. To make that safe, a **terminal-level dedup** now prevents the dock and the pager from both mounting the same terminal (which would collide on the shared `tbd-view-<id>` session and thrash): `AppState.dockedTerminalIDs` is the single source of truth, the dock renders exactly that set, and the worktree-layout path renders a placeholder for those terminals instead of a second `TerminalPanelView`. The dock cell builds its `TerminalPanelView` directly, so it is never blanked.

Also corrected a misleading log line: the memory-pressure handler logged "purging caches" but does almost nothing (it does not purge app caches or touch terminals) — the wording now matches reality.

## Known minor follow-ups (non-blocking)
- `.waitingForUser` terminals are not protected (only `.working`) — deliberate, tight scope for memory; reattaches cleanly on reopen.
- Multi-select grid: a *tab-less* selected worktree whose fallback terminal is pinned shows the dock placeholder in its grid cell (strictly better than the prior double-mount; narrow/transient).
- The detach message prints "session is still running" even on a non-zero exit where the session may genuinely be gone (rare; still clearer than the old wording).

## Test plan
- [x] `swift build` clean; `swiftlint --strict` clean (0 violations).
- [x] `swift test` — 13 keep-alive/dedup unit tests pass (protection for selected/working, eviction of idle/non-visible, oldest-non-protected eviction, docked-terminal suppression, dock/select handoff). Only failure is the pre-existing, unrelated `TabBarHitAreaTests` headless text-measurement case.
- [ ] Manual: with >8 worktrees on one repo, cycle through them; confirm a background worktree with a working agent stays attached (no `[View detached]`), and an idle background worktree still evicts and cleanly reattaches on reopen with the friendlier message.
- [ ] Manual: pin a working terminal, switch to another worktree; confirm the dock shows it live with no flicker/thrash and no duplicate attach.

[🔍 Diagnose Terminal Exit](https://cheapsteak.github.io/tbd/open/?worktree=E5D58BB0-7027-4C0E-B258-564F43E0D0A5)