### PR TITLE
Fix: Go back to the previous worktree when archiving the focused one

### DIFF
--- a/Sources/TBDApp/AppState+ArchiveTombstones.swift
+++ b/Sources/TBDApp/AppState+ArchiveTombstones.swift
@@ -49,7 +49,15 @@ extension AppState {
         for repoID in worktrees.keys {
             worktrees[repoID]?.removeAll { $0.id == id }
         }
-        selectedWorktreeIDs.remove(id)
+        // If the archived worktree was the *only* selection, dropping it would
+        // leave an empty detail pane — instead navigate back through history
+        // to the previous still-valid view. Multi-select and not-selected
+        // cases keep the plain removal behavior.
+        if selectedWorktreeIDs == [id], navigateBackPastArchived(id) {
+            // Selection was replaced by the applied history entry.
+        } else {
+            selectedWorktreeIDs.remove(id)
+        }
         terminals.removeValue(forKey: id)
     }
 }

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -35,21 +35,25 @@ extension AppState {
         updateNavigationFlags()
     }
 
-    /// Move back one entry in the history and apply it. No-op if no prior entry.
+    /// Move back to the nearest usable prior entry and apply it. Skips stale
+    /// entries (archived/gone worktrees, removed repos) so back never lands on
+    /// a dead view. No-op if no usable prior entry exists.
     func navigateBack() {
         guard canGoBack else { return }
-        navigationIndex -= 1
-        let entry = navigationEntries[navigationIndex]
-        withNavigating { applyNavigationEntry(entry) }
+        guard let index = usableEntryIndex(from: navigationIndex - 1, step: -1) else { return }
+        navigationIndex = index
+        withNavigating { applyNavigationEntry(navigationEntries[index]) }
         updateNavigationFlags()
     }
 
-    /// Move forward one entry in the history and apply it. No-op if no next entry.
+    /// Move forward to the nearest usable next entry and apply it. Skips stale
+    /// entries (archived/gone worktrees, removed repos) so forward never lands
+    /// on a dead view. No-op if no usable next entry exists.
     func navigateForward() {
         guard canGoForward else { return }
-        navigationIndex += 1
-        let entry = navigationEntries[navigationIndex]
-        withNavigating { applyNavigationEntry(entry) }
+        guard let index = usableEntryIndex(from: navigationIndex + 1, step: 1) else { return }
+        navigationIndex = index
+        withNavigating { applyNavigationEntry(navigationEntries[index]) }
         updateNavigationFlags()
     }
 
@@ -59,29 +63,42 @@ extension AppState {
     /// and applies the first usable one. Returns `false` (leaving selection
     /// untouched) when no usable entry exists, so callers can fall back to the
     /// plain empty-selection behavior.
-    @discardableResult
     func navigateBackPastArchived(_ archivedID: UUID) -> Bool {
         guard navigationIndex >= 0, !navigationEntries.isEmpty else { return false }
         let start = min(navigationIndex, navigationEntries.count - 1)
-        for index in stride(from: start, through: 0, by: -1) {
-            let entry = navigationEntries[index]
-            guard isUsableEntry(entry, excluding: archivedID) else { continue }
-            navigationIndex = index
-            withNavigating { applyNavigationEntry(entry) }
-            updateNavigationFlags()
-            return true
+        guard let index = usableEntryIndex(from: start, step: -1, excluding: archivedID) else {
+            return false
         }
-        return false
+        navigationIndex = index
+        withNavigating { applyNavigationEntry(navigationEntries[index]) }
+        updateNavigationFlags()
+        return true
     }
 
-    /// Whether a history entry is still a valid landing spot once `archivedID`
-    /// is gone: worktree entries must not reference the archived ID and every
-    /// referenced worktree must still exist; repo entries must reference a
-    /// repo we still know about.
-    private func isUsableEntry(_ entry: NavigationEntry, excluding archivedID: UUID) -> Bool {
+    /// Walk `navigationEntries` from `start` in `step` direction (+1/-1) and
+    /// return the index of the first usable entry, or nil if none.
+    private func usableEntryIndex(
+        from start: Int,
+        step: Int,
+        excluding archivedID: UUID? = nil
+    ) -> Int? {
+        var index = start
+        while index >= 0 && index < navigationEntries.count {
+            if isUsableEntry(navigationEntries[index], excluding: archivedID) { return index }
+            index += step
+        }
+        return nil
+    }
+
+    /// Whether a history entry is still a valid landing spot: worktree entries
+    /// must not reference `archivedID` (when given) and every referenced
+    /// worktree must still exist; repo entries must reference a repo we still
+    /// know about.
+    private func isUsableEntry(_ entry: NavigationEntry, excluding archivedID: UUID? = nil) -> Bool {
         switch entry {
         case .worktrees(let ids):
-            guard !ids.isEmpty, !ids.contains(archivedID) else { return false }
+            guard !ids.isEmpty else { return false }
+            if let archivedID, ids.contains(archivedID) { return false }
             let existing = Set(worktrees.values.flatMap { $0 }.map(\.id))
             return ids.allSatisfy { existing.contains($0) }
         case .repo(let id):

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -53,6 +53,42 @@ extension AppState {
         updateNavigationFlags()
     }
 
+    /// Navigate back to the most recent usable history entry after `archivedID`
+    /// was archived. Walks backwards from the current index, skipping entries
+    /// that reference the archived worktree or worktrees that no longer exist,
+    /// and applies the first usable one. Returns `false` (leaving selection
+    /// untouched) when no usable entry exists, so callers can fall back to the
+    /// plain empty-selection behavior.
+    @discardableResult
+    func navigateBackPastArchived(_ archivedID: UUID) -> Bool {
+        guard navigationIndex >= 0, !navigationEntries.isEmpty else { return false }
+        let start = min(navigationIndex, navigationEntries.count - 1)
+        for index in stride(from: start, through: 0, by: -1) {
+            let entry = navigationEntries[index]
+            guard isUsableEntry(entry, excluding: archivedID) else { continue }
+            navigationIndex = index
+            withNavigating { applyNavigationEntry(entry) }
+            updateNavigationFlags()
+            return true
+        }
+        return false
+    }
+
+    /// Whether a history entry is still a valid landing spot once `archivedID`
+    /// is gone: worktree entries must not reference the archived ID and every
+    /// referenced worktree must still exist; repo entries must reference a
+    /// repo we still know about.
+    private func isUsableEntry(_ entry: NavigationEntry, excluding archivedID: UUID) -> Bool {
+        switch entry {
+        case .worktrees(let ids):
+            guard !ids.isEmpty, !ids.contains(archivedID) else { return false }
+            let existing = Set(worktrees.values.flatMap { $0 }.map(\.id))
+            return ids.allSatisfy { existing.contains($0) }
+        case .repo(let id):
+            return repos.contains { $0.id == id }
+        }
+    }
+
     /// Run `block` with `isNavigating` set so the resulting selection mutations
     /// don't get recorded as new history entries.
     private func withNavigating(_ block: () -> Void) {

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -40,7 +40,13 @@ extension AppState {
     /// a dead view. No-op if no usable prior entry exists.
     func navigateBack() {
         guard canGoBack else { return }
-        guard let index = usableEntryIndex(from: navigationIndex - 1, step: -1) else { return }
+        guard let index = usableEntryIndex(from: navigationIndex - 1, step: -1) else {
+            // Entries went stale since the flags were last computed (e.g. a
+            // worktree vanished without a navigation event) — refresh them so
+            // the dead button disables itself instead of staying enabled.
+            updateNavigationFlags()
+            return
+        }
         navigationIndex = index
         withNavigating { applyNavigationEntry(navigationEntries[index]) }
         updateNavigationFlags()
@@ -51,7 +57,11 @@ extension AppState {
     /// on a dead view. No-op if no usable next entry exists.
     func navigateForward() {
         guard canGoForward else { return }
-        guard let index = usableEntryIndex(from: navigationIndex + 1, step: 1) else { return }
+        guard let index = usableEntryIndex(from: navigationIndex + 1, step: 1) else {
+            // See navigateBack: refresh stale flags on the dead-end path.
+            updateNavigationFlags()
+            return
+        }
         navigationIndex = index
         withNavigating { applyNavigationEntry(navigationEntries[index]) }
         updateNavigationFlags()
@@ -77,7 +87,10 @@ extension AppState {
 
     /// Walk `navigationEntries` from `start` in `step` direction (+1/-1) and
     /// return the index of the first usable entry, or nil if none.
-    private func usableEntryIndex(
+    /// Internal (not private) because `updateNavigationFlags()` lives in
+    /// AppState.swift (next to its `private(set)` flags) and needs the walker
+    /// to compute usability-aware values.
+    func usableEntryIndex(
         from start: Int,
         step: Int,
         excluding archivedID: UUID? = nil

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -146,11 +146,15 @@ final class AppState: ObservableObject {
     var isNavigating: Bool = false
 
     /// Refresh the @Published `canGoBack` / `canGoForward` flags from the index.
+    /// Usability-aware: a flag is only true when an actually-usable entry exists
+    /// in that direction, so the toolbar buttons don't render enabled when
+    /// back/forward would skip-walk past every remaining entry and no-op.
     /// Lives in the same file as the @Published properties so the `private(set)`
     /// setters are reachable.
     func updateNavigationFlags() {
-        let back = navigationIndex > 0
-        let forward = navigationIndex >= 0 && navigationIndex < navigationEntries.count - 1
+        let back = usableEntryIndex(from: navigationIndex - 1, step: -1) != nil
+        let forward = navigationIndex >= 0
+            && usableEntryIndex(from: navigationIndex + 1, step: 1) != nil
         if back != canGoBack { canGoBack = back }
         if forward != canGoForward { canGoForward = forward }
     }

--- a/Tests/TBDAppTests/ArchiveNavigateBackTests.swift
+++ b/Tests/TBDAppTests/ArchiveNavigateBackTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tests for back-navigation on archive: when the archived worktree is the
+/// *only* selected worktree, `removeArchivedWorktreeFromState` walks back
+/// through navigation history to the most recent entry that neither
+/// references the archived worktree nor points at gone worktrees. All other
+/// cases (not selected, multi-select, no usable history) keep the plain
+/// remove-from-selection behavior.
+///
+/// Every test constructs `AppState(userDefaults:)` against a unique throwaway
+/// suite — TBDApp ships as an unbundled SPM executable, so `UserDefaults.standard`
+/// is the running developer's real `TBDApp.plist`. Using it from tests would
+/// clobber live UI preferences.
+@MainActor
+@Suite("Archive navigates back")
+struct ArchiveNavigateBackTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.ArchiveNavigateBack.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func makeWorktree(id: UUID, repoID: UUID) -> Worktree {
+        Worktree(
+            id: id,
+            repoID: repoID,
+            name: "test-\(id.uuidString.prefix(8))",
+            displayName: "Test \(id.uuidString.prefix(8))",
+            branch: "main",
+            path: "/tmp/test",
+            status: .active,
+            tmuxServer: "test-server"
+        )
+    }
+
+    // MARK: - Sole selection: navigate back to previous entry
+
+    @Test func archivingSolelyFocusedWorktree_navigatesToPreviousEntry() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let b = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: b, repoID: repoID)]]
+
+            // History: [A], [B]; B is the current sole selection.
+            state.selectedWorktreeIDs = [a]
+            state.selectedWorktreeIDs = [b]
+
+            state.removeArchivedWorktreeFromState(id: b)
+
+            #expect(state.selectedWorktreeIDs == [a])
+            #expect(state.selectionOrder == [a])
+            #expect(state.navigationEntries[state.navigationIndex] == .worktrees([a]))
+        }
+    }
+
+    // MARK: - Not selected: behavior unchanged, no navigation
+
+    @Test func archivingNonSelectedWorktree_leavesSelectionUntouched() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let b = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: b, repoID: repoID)]]
+
+            state.selectedWorktreeIDs = [a]
+            let indexBefore = state.navigationIndex
+            let entriesBefore = state.navigationEntries
+
+            state.removeArchivedWorktreeFromState(id: b)
+
+            #expect(state.selectedWorktreeIDs == [a])
+            #expect(state.selectionOrder == [a])
+            #expect(state.navigationIndex == indexBefore)
+            #expect(state.navigationEntries == entriesBefore)
+        }
+    }
+
+    // MARK: - Multi-select: drop the archived ID, keep the rest, no back-nav
+
+    @Test func archivingWorktreeInMultiSelect_keepsRemainingSelection() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let b = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: b, repoID: repoID)]]
+
+            state.selectedWorktreeIDs = [a]
+            state.selectedWorktreeIDs = [a, b]
+
+            state.removeArchivedWorktreeFromState(id: b)
+
+            #expect(state.selectedWorktreeIDs == [a])
+            #expect(state.selectionOrder == [a])
+            // No back-navigation: the head entry reflects the reduced
+            // selection, not an earlier history entry re-applied.
+            #expect(state.navigationEntries[state.navigationIndex] == .worktrees([a]))
+            #expect(state.navigationIndex == state.navigationEntries.count - 1)
+        }
+    }
+
+    // MARK: - Skips history entries that reference the archived worktree
+
+    @Test func walkBack_skipsEntriesReferencingArchivedWorktree() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let b = UUID()
+            let c = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: b, repoID: repoID),
+                                        makeWorktree(id: c, repoID: repoID)]]
+
+            // History: [A], [B, C] (contains B — must be skipped), [B].
+            state.selectedWorktreeIDs = [a]
+            state.selectedWorktreeIDs = [b, c]
+            state.selectedWorktreeIDs = [b]
+
+            state.removeArchivedWorktreeFromState(id: b)
+
+            #expect(state.selectedWorktreeIDs == [a])
+            #expect(state.selectionOrder == [a])
+        }
+    }
+
+    // MARK: - Skips history entries whose worktrees no longer exist
+
+    @Test func walkBack_skipsEntriesForGoneWorktrees() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let b = UUID()
+            let gone = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: b, repoID: repoID),
+                                        makeWorktree(id: gone, repoID: repoID)]]
+
+            // History: [A], [gone], [B] — then `gone` disappears (e.g. archived
+            // earlier from another client).
+            state.selectedWorktreeIDs = [a]
+            state.selectedWorktreeIDs = [gone]
+            state.selectedWorktreeIDs = [b]
+            state.worktrees[repoID]?.removeAll { $0.id == gone }
+
+            state.removeArchivedWorktreeFromState(id: b)
+
+            #expect(state.selectedWorktreeIDs == [a])
+            #expect(state.selectionOrder == [a])
+        }
+    }
+
+    // MARK: - No usable history: selection ends up empty, no crash
+
+    @Test func noUsableHistory_fallsBackToEmptySelection() {
+        withState { state in
+            let repoID = UUID()
+            let b = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: b, repoID: repoID)]]
+
+            // Only history entry is the archived worktree itself.
+            state.selectedWorktreeIDs = [b]
+
+            state.removeArchivedWorktreeFromState(id: b)
+
+            #expect(state.selectedWorktreeIDs.isEmpty)
+            #expect(state.selectionOrder.isEmpty)
+        }
+    }
+
+    // MARK: - Empty history: no crash
+
+    @Test func emptyHistory_fallsBackToEmptySelection() {
+        withState { state in
+            let repoID = UUID()
+            let b = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: b, repoID: repoID)]]
+
+            // Selection seeded without going through didSet recording.
+            state.isNavigating = true
+            state.selectedWorktreeIDs = [b]
+            state.isNavigating = false
+
+            state.removeArchivedWorktreeFromState(id: b)
+
+            #expect(state.selectedWorktreeIDs.isEmpty)
+        }
+    }
+}

--- a/Tests/TBDAppTests/ArchiveNavigateBackTests.swift
+++ b/Tests/TBDAppTests/ArchiveNavigateBackTests.swift
@@ -175,6 +175,85 @@ struct ArchiveNavigateBackTests {
         }
     }
 
+    // MARK: - Forward after archive-back must not re-select the archived ID
+
+    @Test func forwardAfterArchiveBack_doesNotReselectArchivedWorktree() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let b = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: b, repoID: repoID)]]
+
+            // History: [A], [B]; archive B auto-navigates back to [A] and
+            // leaves [B] as (stale) forward history.
+            state.selectedWorktreeIDs = [a]
+            state.selectedWorktreeIDs = [b]
+            state.removeArchivedWorktreeFromState(id: b)
+            #expect(state.selectedWorktreeIDs == [a])
+
+            state.navigateForward()
+
+            // Forward skips the dead [B] entry — selection must not become
+            // the archived (now nonexistent) worktree or go empty.
+            #expect(state.selectedWorktreeIDs == [a])
+            #expect(state.selectionOrder == [a])
+        }
+    }
+
+    // MARK: - navigateBack skips stale entries
+
+    @Test func navigateBack_skipsStaleEntries() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let b = UUID()
+            let gone = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: b, repoID: repoID),
+                                        makeWorktree(id: gone, repoID: repoID)]]
+
+            // History: [A], [gone], [B] — then `gone` disappears.
+            state.selectedWorktreeIDs = [a]
+            state.selectedWorktreeIDs = [gone]
+            state.selectedWorktreeIDs = [b]
+            state.worktrees[repoID]?.removeAll { $0.id == gone }
+
+            state.navigateBack()
+
+            #expect(state.selectedWorktreeIDs == [a])
+            #expect(state.selectionOrder == [a])
+        }
+    }
+
+    // MARK: - navigateForward skips stale entries
+
+    @Test func navigateForward_skipsStaleEntries() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let c = UUID()
+            let gone = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: c, repoID: repoID),
+                                        makeWorktree(id: gone, repoID: repoID)]]
+
+            // History: [A], [gone], [C] — then `gone` disappears.
+            state.selectedWorktreeIDs = [a]
+            state.selectedWorktreeIDs = [gone]
+            state.selectedWorktreeIDs = [c]
+            state.worktrees[repoID]?.removeAll { $0.id == gone }
+
+            state.navigateBack()    // lands on [A], skipping [gone]
+            #expect(state.selectedWorktreeIDs == [a])
+
+            state.navigateForward() // skips [gone], lands on [C]
+
+            #expect(state.selectedWorktreeIDs == [c])
+            #expect(state.selectionOrder == [c])
+        }
+    }
+
     // MARK: - Empty history: no crash
 
     @Test func emptyHistory_fallsBackToEmptySelection() {

--- a/Tests/TBDAppTests/ArchiveNavigateBackTests.swift
+++ b/Tests/TBDAppTests/ArchiveNavigateBackTests.swift
@@ -191,6 +191,9 @@ struct ArchiveNavigateBackTests {
             state.selectedWorktreeIDs = [b]
             state.removeArchivedWorktreeFromState(id: b)
             #expect(state.selectedWorktreeIDs == [a])
+            // The only forward entry is the dead [B] — the toolbar forward
+            // button must render disabled, not as an enabled no-op.
+            #expect(state.canGoForward == false)
 
             state.navigateForward()
 
@@ -198,6 +201,59 @@ struct ArchiveNavigateBackTests {
             // the archived (now nonexistent) worktree or go empty.
             #expect(state.selectedWorktreeIDs == [a])
             #expect(state.selectionOrder == [a])
+        }
+    }
+
+    // MARK: - Back flag false when every prior entry is stale
+
+    @Test func archiveBackNav_withOnlyStaleEntriesBehind_disablesBack() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let b = UUID()
+            let gone = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: b, repoID: repoID),
+                                        makeWorktree(id: gone, repoID: repoID)]]
+
+            // History: [gone], [A], [B] — then `gone` disappears and B is
+            // archived. Back-nav lands on [A]; the only entry behind it is
+            // the stale [gone], so canGoBack must be false.
+            state.selectedWorktreeIDs = [gone]
+            state.selectedWorktreeIDs = [a]
+            state.selectedWorktreeIDs = [b]
+            state.worktrees[repoID]?.removeAll { $0.id == gone }
+
+            state.removeArchivedWorktreeFromState(id: b)
+
+            #expect(state.selectedWorktreeIDs == [a])
+            #expect(state.canGoBack == false)
+        }
+    }
+
+    // MARK: - Stale-flag dead button disables itself on first click
+
+    @Test func navigateBack_withFlagsGoneStale_noOpsAndDisablesBack() {
+        withState { state in
+            let repoID = UUID()
+            let a = UUID()
+            let gone = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: a, repoID: repoID),
+                                        makeWorktree(id: gone, repoID: repoID)]]
+
+            // History: [gone], [A]; then `gone` vanishes with no navigation
+            // event (e.g. daemon poll), leaving canGoBack stale-true.
+            state.selectedWorktreeIDs = [gone]
+            state.selectedWorktreeIDs = [a]
+            #expect(state.canGoBack == true)
+            state.worktrees[repoID]?.removeAll { $0.id == gone }
+
+            state.navigateBack()
+
+            // No usable prior entry: selection untouched, and the dead
+            // button disables itself on the first click.
+            #expect(state.selectedWorktreeIDs == [a])
+            #expect(state.canGoBack == false)
         }
     }
 


### PR DESCRIPTION
## Summary

**What's broken:** archiving the worktree you're currently looking at drops you into an awkward empty state — the selection is simply cleared and no terminals are visible until you manually pick another worktree.

**Why:** `removeArchivedWorktreeFromState` just did `selectedWorktreeIDs.remove(id)` with no fallback.

**What this PR does:**
- When the archived worktree is the *sole* selection, the app now walks back through navigation history to the most recent entry that doesn't reference the archived worktree (or any worktree that no longer exists) and lands there — same as pressing Back. Applies to both in-app archives and CLI/daemon-initiated ones, since both funnel through the same state cleanup.
- Multi-select and not-selected archives behave exactly as before; with no usable history the selection goes empty as it does today.
- Hardened the surrounding history machinery so the feature can't immediately undo itself: `navigateBack()`/`navigateForward()` (Cmd+[ / Cmd+]) skip entries referencing gone worktrees, and `canGoBack`/`canGoForward` are computed from whether a *usable* entry exists rather than raw index position — so Forward can't re-select the worktree you just archived, and the toolbar buttons don't render enabled while pointing only at dead entries.

12 tests cover each branch (sole-focus back-nav, multi-select, not-selected, stale-entry skipping in both directions, flag computation, empty/no-usable-history fallbacks).

## Test plan
- [ ] `swift test` — `ArchiveNavigateBackTests` (12 tests) plus existing suites pass
- [ ] In the app: focus a worktree, archive it via the sidebar context menu → you land on the previously-viewed worktree instead of an empty pane
- [ ] After that archive, the Forward toolbar button is disabled (doesn't re-open the archived worktree)
- [ ] Archive a worktree you're *not* viewing → current view unchanged

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=BE6BBCF9-C49F-47F1-A840-EF8B40E632EE)