### PR TITLE
feat: add IntelliJ IDEA to open-in-editor buttons

### DIFF
--- a/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
+++ b/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
@@ -14,6 +14,8 @@ private let knownEditors: [ExternalEditor] = [
     ExternalEditor(name: "Tower",           bundleID: "com.fournova.Tower3"),
     ExternalEditor(name: "GitHub Desktop",  bundleID: "com.github.GitHubClient"),
     ExternalEditor(name: "DataGrip",        bundleID: "com.jetbrains.datagrip"),
+    ExternalEditor(name: "IntelliJ IDEA",   bundleID: "com.jetbrains.intellij"),
+    ExternalEditor(name: "IntelliJ IDEA CE", bundleID: "com.jetbrains.intellij.ce"),
     ExternalEditor(name: "Finder",          bundleID: "com.apple.finder"),
 ]
 
@@ -24,9 +26,30 @@ private func installedEditors() -> [(editor: ExternalEditor, appURL: URL)] {
     }
 }
 
+private let intelliJBundleIDs: Set<String> = ["com.jetbrains.intellij", "com.jetbrains.intellij.ce"]
+
+private func findIdeaCLIScript() -> String? {
+    let candidates = [
+        NSString(string: "~/Library/Application Support/JetBrains/Toolbox/scripts/idea").expandingTildeInPath,
+        NSString(string: "~/.local/bin/idea").expandingTildeInPath,
+        "/usr/local/bin/idea",
+        "/opt/homebrew/bin/idea",
+    ]
+    return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+}
+
 private func openInEditor(path: String, bundleID: String) {
     if bundleID == "com.apple.finder" {
         NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: path)
+        return
+    }
+    if intelliJBundleIDs.contains(bundleID), let script = findIdeaCLIScript() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: script)
+        process.arguments = [path]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try? process.run()
         return
     }
     guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else { return }


### PR DESCRIPTION
## What

Adds IntelliJ IDEA to the "open in editor" app-launch buttons in the bottom-right status bar (`Sources/TBDApp/Toolbar/OpenInEditorButton.swift`).

## Changes

- **Two new editor entries** in `knownEditors` (next to DataGrip, the existing JetBrains entry):
  - `IntelliJ IDEA` → `com.jetbrains.intellij` (Ultimate)
  - `IntelliJ IDEA CE` → `com.jetbrains.intellij.ce` (Community)

  The existing `installedEditors()` filter hides whichever isn't installed, so only present editions show up. Toolbox-installed copies are found fine via the `NSWorkspace` bundle-ID lookup.

- **`idea` CLI-script-preferred launch** for IntelliJ specifically. The JetBrains launcher handles project-window reuse / CLI semantics better than a bare document-open. Since GUI apps don't inherit the shell PATH, `openInEditor` probes known locations in order and fire-and-forgets `idea <absolute-worktree-path>` via `Process` (stdout/stderr discarded, no wait):
  1. `~/Library/Application Support/JetBrains/Toolbox/scripts/idea`
  2. `~/.local/bin/idea`
  3. `/usr/local/bin/idea`
  4. `/opt/homebrew/bin/idea`

- **Fallback**: when no `idea` script is found, it falls through to the existing `NSWorkspace` bundle-ID open — so IntelliJ launching works out of the box with a plain `/Applications` install, no script required.

Scoped change: editor-list and recents logic are untouched.

## Testing

- `swift build` — clean (only pre-existing unrelated warnings).
- Both paths are live-testable on a machine with IntelliJ + an `idea` wrapper: script-present (default) and the NSWorkspace fallback (move the script aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)