### PR TITLE
Feat: Click the status-bar focus label to jump back to the worktree in the sidebar

### DIFF
--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -1,10 +1,68 @@
 import Foundation
+import TBDShared
 
 /// A single navigable view state — either a worktree selection (one or more)
 /// or a repo selection (showing archived worktrees in the detail pane).
 enum NavigationEntry: Equatable {
     case worktrees([UUID])
     case repo(UUID)
+}
+
+// MARK: - Sidebar reveal
+
+extension AppState {
+    /// Pick which sidebar row a status-bar click should reveal.
+    ///
+    /// - Exactly one worktree selected → that worktree's ID.
+    /// - Multiple selected → the selected worktree whose UUID string sorts
+    ///   first alphabetically. UUID strings are stable across runs, so this
+    ///   gives a deterministic choice without requiring the caller to know
+    ///   sidebar ordering across repos.
+    /// - No worktree selected but `selectedRepoID` set → the repo ID (the repo
+    ///   header row is tagged with repo.id so scrolling to it works).
+    /// - Otherwise → nil.
+    nonisolated static func sidebarRevealTarget(
+        selectedWorktreeIDs: Set<UUID>,
+        worktrees: [UUID: [Worktree]],
+        selectedRepoID: UUID?
+    ) -> UUID? {
+        if selectedWorktreeIDs.count == 1 {
+            return selectedWorktreeIDs.first
+        } else if selectedWorktreeIDs.count > 1 {
+            // Sort by uuidString for a stable, deterministic pick.
+            let allWorktreeIDs = Set(worktrees.values.flatMap { $0 }.map(\.id))
+            let candidates = selectedWorktreeIDs.filter { allWorktreeIDs.contains($0) }
+            return candidates.min(by: { $0.uuidString < $1.uuidString })
+                ?? selectedWorktreeIDs.min(by: { $0.uuidString < $1.uuidString })
+        } else if let repoID = selectedRepoID {
+            return repoID
+        } else {
+            return nil
+        }
+    }
+
+    /// Expand the containing repo (if collapsed) and set `pendingScrollToWorktreeID`
+    /// so the sidebar scrolls to reveal the currently selected worktree or repo.
+    /// Does NOT change selection.
+    @MainActor
+    func revealSelectionInSidebar() {
+        guard let target = Self.sidebarRevealTarget(
+            selectedWorktreeIDs: selectedWorktreeIDs,
+            worktrees: worktrees,
+            selectedRepoID: selectedRepoID
+        ) else { return }
+
+        // If the target is a worktree, expand its containing repo before scrolling.
+        if let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == target }),
+           let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
+           !repos[repoIdx].expanded {
+            repos[repoIdx].expanded = true
+            let repoID = worktree.repoID
+            Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
+        }
+
+        pendingScrollToWorktreeID = target
+    }
 }
 
 extension AppState {

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -15,9 +15,8 @@ extension AppState {
     ///
     /// - Exactly one worktree selected → that worktree's ID.
     /// - Multiple selected → the selected worktree whose UUID string sorts
-    ///   first alphabetically. UUID strings are stable across runs, so this
-    ///   gives a deterministic choice without requiring the caller to know
-    ///   sidebar ordering across repos.
+    ///   first alphabetically among those that still exist in `worktrees`.
+    ///   Returns `nil` when none of the selected IDs exist (all stale).
     /// - No worktree selected but `selectedRepoID` set → the repo ID (the repo
     ///   header row is tagged with repo.id so scrolling to it works).
     /// - Otherwise → nil.
@@ -33,7 +32,6 @@ extension AppState {
             let allWorktreeIDs = Set(worktrees.values.flatMap { $0 }.map(\.id))
             let candidates = selectedWorktreeIDs.filter { allWorktreeIDs.contains($0) }
             return candidates.min(by: { $0.uuidString < $1.uuidString })
-                ?? selectedWorktreeIDs.min(by: { $0.uuidString < $1.uuidString })
         } else if let repoID = selectedRepoID {
             return repoID
         } else {

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -87,8 +87,12 @@ struct StatusBarView: View {
                 repos: appState.repos,
                 selectedRepoID: appState.selectedRepoID
             ) {
-                Text(label)
-                    .foregroundStyle(.secondary)
+                Button(action: { appState.revealSelectionInSidebar() }) {
+                    Text(label)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Reveal in sidebar")
             }
             Spacer()
             if let info = selectedWorktreeInfo {

--- a/Tests/TBDAppTests/SidebarRevealTargetTests.swift
+++ b/Tests/TBDAppTests/SidebarRevealTargetTests.swift
@@ -1,0 +1,111 @@
+import Testing
+import Foundation
+@testable import TBDApp
+import TBDShared
+
+// MARK: - Helpers
+
+private func makeWorktree(id: UUID = UUID(), repoID: UUID, displayName: String) -> Worktree {
+    Worktree(
+        id: id,
+        repoID: repoID,
+        name: displayName.lowercased().replacingOccurrences(of: " ", with: "-"),
+        displayName: displayName,
+        branch: "tbd/\(displayName)",
+        path: "/tmp/\(displayName)",
+        tmuxServer: "tmux-\(id.uuidString)"
+    )
+}
+
+// MARK: - Tests
+
+@Suite("AppState.sidebarRevealTarget")
+struct SidebarRevealTargetTests {
+
+    @Test("single selection returns that worktree's ID")
+    func singleSelectionReturnsWorktreeID() {
+        let repoID = UUID()
+        let wtID = UUID()
+        let wt = makeWorktree(id: wtID, repoID: repoID, displayName: "feat")
+
+        let target = AppState.sidebarRevealTarget(
+            selectedWorktreeIDs: [wtID],
+            worktrees: [repoID: [wt]],
+            selectedRepoID: nil
+        )
+
+        #expect(target == wtID)
+    }
+
+    @Test("multi-selection returns the UUID-string-sorted-first candidate deterministically")
+    func multiSelectionReturnsDeterministicID() {
+        let repoID = UUID()
+        let id1 = UUID()
+        let id2 = UUID()
+        let id3 = UUID()
+        let worktrees: [UUID: [Worktree]] = [
+            repoID: [
+                makeWorktree(id: id1, repoID: repoID, displayName: "wt1"),
+                makeWorktree(id: id2, repoID: repoID, displayName: "wt2"),
+                makeWorktree(id: id3, repoID: repoID, displayName: "wt3"),
+            ]
+        ]
+
+        let target = AppState.sidebarRevealTarget(
+            selectedWorktreeIDs: [id1, id2, id3],
+            worktrees: worktrees,
+            selectedRepoID: nil
+        )
+
+        // Expected: the ID whose uuidString sorts first alphabetically.
+        let expected = [id1, id2, id3].min(by: { $0.uuidString < $1.uuidString })
+        #expect(target == expected)
+    }
+
+    @Test("multi-selection is deterministic across calls with same inputs")
+    func multiSelectionIsDeterministic() {
+        let repoID = UUID()
+        let ids = (0..<5).map { _ in UUID() }
+        let worktrees: [UUID: [Worktree]] = [
+            repoID: ids.map { makeWorktree(id: $0, repoID: repoID, displayName: "wt-\($0.uuidString.prefix(4))") }
+        ]
+        let selectedSet = Set(ids)
+
+        let first = AppState.sidebarRevealTarget(
+            selectedWorktreeIDs: selectedSet,
+            worktrees: worktrees,
+            selectedRepoID: nil
+        )
+        let second = AppState.sidebarRevealTarget(
+            selectedWorktreeIDs: selectedSet,
+            worktrees: worktrees,
+            selectedRepoID: nil
+        )
+
+        #expect(first == second)
+    }
+
+    @Test("no worktree selected but repo selected returns repo ID")
+    func repoOnlySelectionReturnsRepoID() {
+        let repoID = UUID()
+
+        let target = AppState.sidebarRevealTarget(
+            selectedWorktreeIDs: [],
+            worktrees: [:],
+            selectedRepoID: repoID
+        )
+
+        #expect(target == repoID)
+    }
+
+    @Test("nothing selected returns nil")
+    func nothingSelectedReturnsNil() {
+        let target = AppState.sidebarRevealTarget(
+            selectedWorktreeIDs: [],
+            worktrees: [:],
+            selectedRepoID: nil
+        )
+
+        #expect(target == nil)
+    }
+}

--- a/Tests/TBDAppTests/SidebarRevealTargetTests.swift
+++ b/Tests/TBDAppTests/SidebarRevealTargetTests.swift
@@ -108,4 +108,24 @@ struct SidebarRevealTargetTests {
 
         #expect(target == nil)
     }
+
+    @Test("multi-selection with all stale IDs returns nil")
+    func multiSelectionAllStaleReturnsNil() {
+        let repoID = UUID()
+        let staleID1 = UUID()
+        let staleID2 = UUID()
+        // worktrees dict has a different worktree — neither stale ID is present
+        let otherID = UUID()
+        let worktrees: [UUID: [Worktree]] = [
+            repoID: [makeWorktree(id: otherID, repoID: repoID, displayName: "other")]
+        ]
+
+        let target = AppState.sidebarRevealTarget(
+            selectedWorktreeIDs: [staleID1, staleID2],
+            worktrees: worktrees,
+            selectedRepoID: nil
+        )
+
+        #expect(target == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- The bottom-left status bar shows the focused "repo / worktree" label (added recently), but it was inert — with long sidebars and collapsed repo sections it could be hard to find where the focused worktree actually lives.
- Clicking the label now reveals the selection in the sidebar: it expands the containing repo section if collapsed and scrolls the worktree list to center the row, reusing the existing `pendingScrollToWorktreeID` / ScrollViewReader mechanism.
- Target selection lives in a pure `AppState.sidebarRevealTarget` helper (single selection → that worktree; multi-select → a deterministic pick; repo-only selection → the repo header row) with unit tests covering each branch. Selection is never changed — this is reveal-only.

## Test plan
- [ ] `swift test` — 5 new `SidebarRevealTargetTests` pass (full suite green except a pre-existing unrelated `TabBarHitAreaTests` failure)
- [ ] Manual: select a worktree, collapse its repo section, scroll the sidebar away, click the bottom-left label → repo expands and the list scrolls the worktree row into view
- [ ] Manual: select a repo (no worktree) → clicking the label scrolls to the repo header

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=AEBB3C28-2561-4FD9-8245-CA5C50C74C89)