### PR TITLE
Perf: Stop sidebar spinners from burning CPU for minutes per working row

### DIFF
--- a/Sources/TBDApp/ColorHelpers.swift
+++ b/Sources/TBDApp/ColorHelpers.swift
@@ -1,0 +1,9 @@
+import AppKit
+import SwiftUI
+
+/// Resolves an `NSColor` per appearance so SwiftUI sees the correct value in light/dark mode.
+func adaptiveColor(light: NSColor, dark: NSColor) -> Color {
+    Color(nsColor: NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+    })
+}

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -2,12 +2,6 @@ import AppKit
 import SwiftUI
 import TBDShared
 
-private func adaptive(light: NSColor, dark: NSColor) -> Color {
-    Color(nsColor: NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
-    })
-}
-
 struct PRStatusPresentation: Equatable {
     enum ColorSemantic: Equatable {
         case pending
@@ -25,7 +19,7 @@ struct PRStatusPresentation: Equatable {
         case .pending:
             // Light: GitHub WIP olive #936921 — readable on light sidebar (~#F1F1F1).
             // Dark:  GitHub attention.fg #D29922 — readable on dark sidebar (~#1E1E1E).
-            return adaptive(
+            return adaptiveColor(
                 light: NSColor(srgbRed: 147 / 255, green: 105 / 255, blue: 33 / 255, alpha: 1),
                 dark: NSColor(srgbRed: 210 / 255, green: 153 / 255, blue: 34 / 255, alpha: 1)
             )
@@ -34,7 +28,7 @@ struct PRStatusPresentation: Equatable {
         case .mergeable:
             // Light: muted forest #3D7D40.
             // Dark:  GitHub success.fg #3FB950.
-            return adaptive(
+            return adaptiveColor(
                 light: NSColor(srgbRed: 61 / 255, green: 125 / 255, blue: 64 / 255, alpha: 1),
                 dark: NSColor(srgbRed: 63 / 255, green: 185 / 255, blue: 80 / 255, alpha: 1)
             )

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -3,16 +3,17 @@ import TBDShared
 
 /// The single status indicator a sidebar worktree row may display.
 enum RowStatusIndicator: Equatable {
-    case pendingSpinner
-    case workingSpinner
+    case pending
+    case working
     case notificationBadge(NotificationType)
     case suspended
     case prStatus
 
     /// Notifications at or above this `NotificationType.severity` outrank the
-    /// working spinner: errors and attention/focus requests must not be hidden
-    /// behind a spinner that can run for minutes. Lower-severity completion
-    /// badges yield to the spinner, so a stale "done" dot never masks active work.
+    /// working icon: errors and attention/focus requests must not be hidden
+    /// behind a working indicator that can show for minutes. Lower-severity
+    /// completion badges yield to the working icon, so a stale "done" dot
+    /// never masks active work.
     private static let highSeverityThreshold = 3
 
     /// Resolves which indicator (if any) a worktree row should show.
@@ -32,11 +33,11 @@ enum RowStatusIndicator: Equatable {
         hasPRStatus: Bool
     ) -> RowStatusIndicator? {
         if isPending {
-            return .pendingSpinner
+            return .pending
         } else if let notification, notification.severity >= highSeverityThreshold {
             return .notificationBadge(notification)
         } else if isWorking {
-            return .workingSpinner
+            return .working
         } else if let notification {
             return .notificationBadge(notification)
         } else if isSuspended {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -44,15 +44,6 @@ struct WorktreeRowView: View {
         return terminals.contains { $0.activityState == .working }
     }
 
-    /// Spinner sized to visually match the 12×12 PR status icon.
-    /// The small `ProgressView` is ~16pt; scale by 0.75 and pin the layout frame.
-    private func spinner() -> some View {
-        ProgressView()
-            .controlSize(.small)
-            .scaleEffect(0.75)
-            .frame(width: 12, height: 12)
-    }
-
     @ViewBuilder
     private func rowIcons() -> some View {
         // Resolved through RowStatusIndicator so at most one indicator renders.
@@ -64,8 +55,18 @@ struct WorktreeRowView: View {
             isSuspended: hasSuspendedTerminal,
             hasPRStatus: prPresentation != nil
         ) {
-        case .pendingSpinner, .workingSpinner:
-            spinner()
+        case .pending:
+            // Static dotted-circle sized to match the 12×12 PR status icon.
+            Image(systemName: "circle.dotted")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 12, height: 12)
+        case .working:
+            // Static asterisk (echoes Claude's ✳ working glyph) sized to match the 12×12 PR status icon.
+            Image(systemName: "asterisk")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 12, height: 12)
         case .notificationBadge(let n):
             Circle()
                 .fill(RowStatusIndicator.badgeColor(for: n))

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -1,5 +1,12 @@
+import AppKit
 import SwiftUI
 import TBDShared
+
+private func adaptive(light: NSColor, dark: NSColor) -> Color {
+    Color(nsColor: NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+    })
+}
 
 struct WorktreeRowView: View {
     let worktree: Worktree
@@ -63,9 +70,14 @@ struct WorktreeRowView: View {
                 .frame(width: 12, height: 12)
         case .working:
             // Static asterisk (echoes Claude's ✳ working glyph) sized to match the 12×12 PR status icon.
+            // Light: terracotta #B05730 — readable on light sidebar (~#F1F1F1).
+            // Dark:  Claude coral #D97757 — readable on dark sidebar (~#1E1E1E).
             Image(systemName: "asterisk")
                 .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(adaptive(
+                    light: NSColor(srgbRed: 176 / 255, green: 87 / 255, blue: 48 / 255, alpha: 1),
+                    dark: NSColor(srgbRed: 217 / 255, green: 119 / 255, blue: 87 / 255, alpha: 1)
+                ))
                 .frame(width: 12, height: 12)
         case .notificationBadge(let n):
             Circle()

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -2,12 +2,6 @@ import AppKit
 import SwiftUI
 import TBDShared
 
-private func adaptive(light: NSColor, dark: NSColor) -> Color {
-    Color(nsColor: NSColor(name: nil) { appearance in
-        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
-    })
-}
-
 struct WorktreeRowView: View {
     let worktree: Worktree
     var isMain: Bool = false
@@ -74,7 +68,7 @@ struct WorktreeRowView: View {
             // Dark:  Claude coral #D97757 — readable on dark sidebar (~#1E1E1E).
             Image(systemName: "asterisk")
                 .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(adaptive(
+                .foregroundStyle(adaptiveColor(
                     light: NSColor(srgbRed: 176 / 255, green: 87 / 255, blue: 48 / 255, alpha: 1),
                     dark: NSColor(srgbRed: 217 / 255, green: 119 / 255, blue: 87 / 255, alpha: 1)
                 ))

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -13,7 +13,7 @@ struct RowStatusIndicatorTests {
             isSuspended: true,
             hasPRStatus: true
         )
-        #expect(result == .pendingSpinner)
+        #expect(result == .pending)
     }
 
     @Test func workingWinsOverLowSeverityNotificationSuspendedAndPR() {
@@ -24,7 +24,7 @@ struct RowStatusIndicatorTests {
             isSuspended: true,
             hasPRStatus: true
         )
-        #expect(result == .workingSpinner)
+        #expect(result == .working)
     }
 
     @Test(arguments: [NotificationType.error, .attentionNeeded, .focusRequest])
@@ -48,7 +48,7 @@ struct RowStatusIndicatorTests {
             isSuspended: false,
             hasPRStatus: false
         )
-        #expect(result == .workingSpinner)
+        #expect(result == .working)
     }
 
     @Test func pendingWinsOverHighSeverityBadge() {
@@ -59,7 +59,7 @@ struct RowStatusIndicatorTests {
             isSuspended: false,
             hasPRStatus: false
         )
-        #expect(result == .pendingSpinner)
+        #expect(result == .pending)
     }
 
     @Test func workingSpinnerHidesPRStatus() {
@@ -70,7 +70,7 @@ struct RowStatusIndicatorTests {
             isSuspended: false,
             hasPRStatus: true
         )
-        #expect(result == .workingSpinner)
+        #expect(result == .working)
     }
 
     @Test func notificationWinsOverSuspendedAndPR() {

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -28,7 +28,7 @@ struct RowStatusIndicatorTests {
     }
 
     @Test(arguments: [NotificationType.error, .attentionNeeded, .focusRequest])
-    func highSeverityBadgeWinsOverWorkingSpinner(notification: NotificationType) {
+    func highSeverityBadgeWinsOverWorkingIcon(notification: NotificationType) {
         let result = RowStatusIndicator.resolve(
             isPending: false,
             isWorking: true,
@@ -40,7 +40,7 @@ struct RowStatusIndicatorTests {
     }
 
     @Test(arguments: [NotificationType.taskComplete, .responseComplete])
-    func lowSeverityBadgeYieldsToWorkingSpinner(notification: NotificationType) {
+    func lowSeverityBadgeYieldsToWorkingIcon(notification: NotificationType) {
         let result = RowStatusIndicator.resolve(
             isPending: false,
             isWorking: true,
@@ -62,7 +62,7 @@ struct RowStatusIndicatorTests {
         #expect(result == .pending)
     }
 
-    @Test func workingSpinnerHidesPRStatus() {
+    @Test func workingIconHidesPRStatus() {
         let result = RowStatusIndicator.resolve(
             isPending: false,
             isWorking: true,


### PR DESCRIPTION
## Summary
- The working/pending sidebar indicator was a continuously-animating `ProgressView` — it spins for minutes per worktree row (several rows at once during multi-agent use), forcing nonstop CoreAnimation commits + WindowServer recomposites for zero information gain after the first second. Identified as part of TBDApp's permanent energy floor in the 2026-06-11 CPU/energy investigation.
- Replaced with fully static SF Symbols: `asterisk` in Claude coral (#B05730 light / #D97757 dark — echoes Claude's own ✳ working glyph) for the working state, and `circle.dotted` in secondary gray for the pending (worktree-creating) state. Both sized to match the 12×12 PR status icon per #259.
- Enum cases renamed `pendingSpinner`/`workingSpinner` → `pending`/`working`. The indicator priority semantics (errors/attention outrank the working icon; completion badges yield to it) are unchanged and still covered by the existing test suite.

## Test plan
- [x] `swift build`, `swift test` (RowStatusIndicator suite 10/10), `swiftlint --strict` clean
- [x] Rebuilt via `scripts/restart.sh`; `sample TBDApp 5` with a working row on screen shows **zero** NSProgressIndicator/animation frames
- [ ] Visual check of working (coral asterisk) + pending (dotted circle) rows in light and dark mode

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=86868A09-1900-4D42-AA20-09940C3F8B67)