### PR TITLE
Perf: Stop scanning 14.5 MB and shipping 740 archived worktrees on every 2s poll

### DIFF
--- a/Sources/TBDApp/AppState+ArchiveTombstones.swift
+++ b/Sources/TBDApp/AppState+ArchiveTombstones.swift
@@ -8,11 +8,15 @@ extension AppState {
     nonisolated static let archiveTombstoneTTL: TimeInterval = 30
 
     /// Returns the tombstones that should still be kept. A tombstone is evicted
-    /// when the daemon confirms the archive (worktree reported `.archived` or
-    /// absent) or when it has outlived `archiveTombstoneTTL`.
+    /// when the daemon confirms the archive (worktree absent from the response, or
+    /// present with status `.archived`) or when it has outlived `archiveTombstoneTTL`.
     ///
-    /// - Parameter daemonWorktrees: the raw, unfiltered worktree list from the
-    ///   daemon (includes `.archived` rows).
+    /// - Parameter daemonWorktrees: the worktree list returned by the 2 s poll.
+    ///   The poll now passes `excludeArchived: true`, so archived rows are omitted
+    ///   and appear as absent (`.none` in `statusByID`). Both the `.archived` case
+    ///   and the `.none` case below map to "daemon confirmed gone", so tombstone
+    ///   semantics are identical whether the daemon returns the row with an
+    ///   `.archived` status or simply omits it.
     nonisolated static func reconcileTombstones(
         _ tombstones: [UUID: Date],
         daemonWorktrees: [Worktree],

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1136,11 +1136,14 @@ final class AppState: ObservableObject {
     }
 
     /// Refresh worktrees for all repos (or a specific repo).
-    /// Fetches both active and main worktrees.
+    /// Fetches active and main worktrees; archived rows are excluded here because
+    /// the archived view has its own paginated fetch (refreshArchivedWorktrees).
     func refreshWorktrees(repoID: UUID? = nil) async {
         do {
-            // Single RPC — fetch all worktrees (including archived)
-            let allWts = try await daemonClient.listWorktrees(repoID: repoID)
+            // Single RPC — fetch non-archived worktrees only.
+            // Absent rows satisfy reconcileTombstones identically to status==.archived
+            // (both confirm the tombstone), so tombstone reconciliation is unaffected.
+            let allWts = try await daemonClient.listWorktrees(repoID: repoID, excludeArchived: true)
             // Drop tombstones the daemon has confirmed (or that outlived the TTL) so a
             // stale poll predating an archive cannot resurrect the row.
             // Reconcile only on the unscoped path: a scoped allWts omits other repos'

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -222,8 +222,11 @@ actor DaemonClient {
                 throw DaemonClientError.sendFailed("Sent \(sent) of \(message.count) bytes")
             }
 
-            // Read response until newline or connection closes
-            var responseData = Data()
+            // Read response until newline or connection closes.
+            // NewlineFrameScanner scans only the just-received bytes for 0x0A
+            // via memchr, avoiding the O(n²/chunk) re-scan that the previous
+            // Data.contains call performed on the entire accumulated buffer.
+            var scanner = NewlineFrameScanner()
             let bufferSize = 65536
             let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
             defer { buffer.deallocate() }
@@ -247,16 +250,15 @@ actor DaemonClient {
                 if bytesRead == 0 {
                     break
                 }
-                responseData.append(buffer, count: bytesRead)
-                if responseData.contains(0x0A) {
+                scanner.append(buffer, count: bytesRead)
+                if scanner.hasNewline {
                     break
                 }
             }
 
-            // Trim trailing newline
-            if let newlineIndex = responseData.firstIndex(of: 0x0A) {
-                responseData = responseData[responseData.startIndex..<newlineIndex]
-            }
+            // frameData is everything before the first newline; falls back to
+            // the full buffer when no newline was received (connection closed).
+            let responseData = scanner.frameData
 
             guard !responseData.isEmpty else {
                 throw DaemonClientError.invalidResponse

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -428,10 +428,24 @@ actor DaemonClient {
     }
 
     /// List worktrees, optionally filtered by repo and/or status, with optional pagination.
-    func listWorktrees(repoID: UUID? = nil, status: WorktreeStatus? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> [Worktree] {
+    /// Pass `excludeArchived: true` to skip archived rows (used by the 2 s poll so
+    /// the 87 % of payload that is immediately dropped client-side never crosses the wire).
+    func listWorktrees(
+        repoID: UUID? = nil,
+        status: WorktreeStatus? = nil,
+        limit: Int? = nil,
+        offset: Int? = nil,
+        excludeArchived: Bool = false
+    ) async throws -> [Worktree] {
         return try await callAsync(
             method: RPCMethod.worktreeList,
-            params: WorktreeListParams(repoID: repoID, status: status, limit: limit, offset: offset),
+            params: WorktreeListParams(
+                repoID: repoID,
+                status: status,
+                limit: limit,
+                offset: offset,
+                excludeArchived: excludeArchived
+            ),
             resultType: [Worktree].self
         )
     }

--- a/Sources/TBDCLI/SocketClient.swift
+++ b/Sources/TBDCLI/SocketClient.swift
@@ -98,8 +98,11 @@ struct SocketClient: Sendable {
             throw SocketClientError.sendFailed("Sent \(sent) of \(message.count) bytes")
         }
 
-        // Read response (read until we get a newline or connection closes)
-        var responseData = Data()
+        // Read response (read until we get a newline or connection closes).
+        // NewlineFrameScanner scans only the just-received bytes for 0x0A
+        // via memchr, avoiding the O(n²/chunk) re-scan that the previous
+        // Data.contains call performed on the entire accumulated buffer.
+        var scanner = NewlineFrameScanner()
         let bufferSize = 65536
         let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         defer { buffer.deallocate() }
@@ -112,17 +115,15 @@ struct SocketClient: Sendable {
             if bytesRead == 0 {
                 break // Connection closed
             }
-            responseData.append(buffer, count: bytesRead)
-            // Check if we got a newline (end of JSON response)
-            if responseData.contains(0x0A) {
+            scanner.append(buffer, count: bytesRead)
+            if scanner.hasNewline {
                 break
             }
         }
 
-        // Trim trailing newline
-        if let newlineIndex = responseData.firstIndex(of: 0x0A) {
-            responseData = responseData[responseData.startIndex..<newlineIndex]
-        }
+        // frameData is everything before the first newline; falls back to
+        // the full buffer when no newline was received (connection closed).
+        let responseData = scanner.frameData
 
         guard !responseData.isEmpty else {
             throw SocketClientError.invalidResponse

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -267,7 +267,15 @@ public struct WorktreeStore: Sendable {
     }
 
     /// List worktrees, optionally filtered by repo and/or status, with optional pagination.
-    public func list(repoID: UUID? = nil, status: WorktreeStatus? = nil, limit: Int? = nil, offset: Int? = nil) async throws -> [Worktree] {
+    /// When `excludeArchived` is true, archived rows are excluded from the result.
+    /// This composes with `status`: both filters are applied when both are given.
+    public func list(
+        repoID: UUID? = nil,
+        status: WorktreeStatus? = nil,
+        excludeArchived: Bool = false,
+        limit: Int? = nil,
+        offset: Int? = nil
+    ) async throws -> [Worktree] {
         try await writer.read { db in
             var request = WorktreeRecord.all()
             if let repoID {
@@ -275,6 +283,9 @@ public struct WorktreeStore: Sendable {
             }
             if let status {
                 request = request.filter(Column("status") == status.rawValue)
+            }
+            if excludeArchived {
+                request = request.filter(Column("status") != WorktreeStatus.archived.rawValue)
             }
             if status == .archived {
                 request = request.order(Column("archivedAt").desc)

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -59,7 +59,13 @@ extension RPCRouter {
 
     func handleWorktreeList(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeListParams.self, from: paramsData)
-        var worktrees = try await db.worktrees.list(repoID: params.repoID, status: params.status, limit: params.limit, offset: params.offset)
+        var worktrees = try await db.worktrees.list(
+            repoID: params.repoID,
+            status: params.status,
+            excludeArchived: params.excludeArchived ?? false,
+            limit: params.limit,
+            offset: params.offset
+        )
         // Enrich archived worktrees with a real session-file count so the
         // client can filter on actual disk state, not stale stored IDs.
         //

--- a/Sources/TBDShared/NewlineFrameScanner.swift
+++ b/Sources/TBDShared/NewlineFrameScanner.swift
@@ -1,0 +1,89 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Accumulates recv chunks and scans only new bytes for a 0x0A newline delimiter,
+/// eliminating the O(n²/chunk) re-scan that `Data.contains` / `Data.firstIndex(of:)`
+/// triggers when the full accumulated buffer is re-walked after every recv call.
+///
+/// The caller appends each chunk immediately after recv; `memchr` inspects only
+/// those new bytes. The absolute newline index is recorded on first hit so
+/// subsequent appends (which callers should avoid after `hasNewline` is true)
+/// do not re-scan.
+///
+/// Connection-closed semantics (no newline received before EOF):
+/// `frameData` returns the entire accumulated buffer when `newlineIndex` is nil,
+/// matching the original read-loop behavior where the post-loop `firstIndex(of:)`
+/// found nothing and the full buffer was decoded as-is.
+///
+/// Usage:
+/// ```swift
+/// var scanner = NewlineFrameScanner()
+/// while !scanner.hasNewline {
+///     let n = recv(fd, buf, bufSize, 0)
+///     guard n > 0 else { break }
+///     scanner.append(buf, count: n)
+/// }
+/// let frame = scanner.frameData   // bytes before first newline, or all bytes if none
+/// ```
+public struct NewlineFrameScanner: Sendable {
+    public private(set) var buffer = Data()
+    /// Absolute byte offset of the first 0x0A found, or nil if no newline yet.
+    public private(set) var newlineIndex: Int?
+
+    public init() {}
+
+    /// Append `count` bytes starting at `ptr`, scanning only the new bytes for 0x0A.
+    ///
+    /// Returns `true` if a newline has been found (in this chunk or a prior one).
+    @discardableResult
+    public mutating func append(_ ptr: UnsafePointer<UInt8>, count: Int) -> Bool {
+        guard count > 0 else { return newlineIndex != nil }
+        guard newlineIndex == nil else {
+            // Newline already found — keep accumulating so the buffer stays coherent
+            // for callers that inspect it after the loop, but skip the scan.
+            buffer.append(ptr, count: count)
+            return true
+        }
+        let baseOffset = buffer.count
+        buffer.append(ptr, count: count)
+        // Scan only the just-received bytes via memchr (single pass, no iterator).
+        if let found = memchr(UnsafeRawPointer(ptr), Int32(0x0A), count) {
+            newlineIndex = baseOffset + UnsafeRawPointer(ptr).distance(to: found)
+            return true
+        }
+        return false
+    }
+
+    /// Convenience overload accepting `Data` (for testing and callers that already
+    /// hold a `Data` value rather than a raw pointer).
+    @discardableResult
+    public mutating func append(data: Data) -> Bool {
+        guard !data.isEmpty else { return newlineIndex != nil }
+        return data.withUnsafeBytes { rawBuf -> Bool in
+            guard let ptr = rawBuf.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                return newlineIndex != nil
+            }
+            return append(ptr, count: rawBuf.count)
+        }
+    }
+
+    /// `true` when a 0x0A byte has been observed.
+    public var hasNewline: Bool { newlineIndex != nil }
+
+    /// The framed response bytes — everything before the first newline.
+    ///
+    /// When no newline was received (connection closed without delimiter),
+    /// returns the entire accumulated buffer so the caller can attempt to
+    /// decode whatever partial frame arrived, matching the original semantics
+    /// where a post-loop `firstIndex(of:)` finding nothing left the buffer intact.
+    public var frameData: Data {
+        if let idx = newlineIndex {
+            return buffer[buffer.startIndex..<(buffer.startIndex + idx)]
+        }
+        return buffer
+    }
+}

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -605,8 +605,22 @@ public struct WorktreeListParams: Codable, Sendable {
     public let status: WorktreeStatus?
     public let limit: Int?
     public let offset: Int?
-    public init(repoID: UUID? = nil, status: WorktreeStatus? = nil, limit: Int? = nil, offset: Int? = nil) {
-        self.repoID = repoID; self.status = status; self.limit = limit; self.offset = offset
+    /// When true, the daemon omits archived worktrees from the result.
+    /// Optional (nil == false) for backward compatibility — old daemons
+    /// ignore the unknown key and return everything; old clients omit it.
+    public let excludeArchived: Bool?
+    public init(
+        repoID: UUID? = nil,
+        status: WorktreeStatus? = nil,
+        limit: Int? = nil,
+        offset: Int? = nil,
+        excludeArchived: Bool? = nil
+    ) {
+        self.repoID = repoID
+        self.status = status
+        self.limit = limit
+        self.offset = offset
+        self.excludeArchived = excludeArchived
     }
 }
 

--- a/Tests/TBDDaemonTests/WorktreeStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreTests.swift
@@ -285,4 +285,103 @@ import TBDShared
         let page3 = try await db.worktrees.list(repoID: repo.id, status: .archived, limit: 2, offset: 4)
         #expect(page3.map(\.id) == [worktreeIDs[0]])
     }
+
+    // MARK: - excludeArchived filter
+
+    @Test func excludeArchivedTrueReturnsOnlyNonArchived() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let active = try await db.worktrees.create(
+            repoID: repo.id, name: "active", branch: "b-active",
+            path: "/tmp/active-\(UUID())", tmuxServer: "srv"
+        )
+        let main = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main",
+            path: "/tmp/main-\(UUID())", tmuxServer: "srv"
+        )
+        let toArchive = try await db.worktrees.create(
+            repoID: repo.id, name: "archived-wt", branch: "b-arch",
+            path: "/tmp/arch-\(UUID())", tmuxServer: "srv"
+        )
+        try await db.worktrees.archive(id: toArchive.id)
+
+        let result = try await db.worktrees.list(repoID: repo.id, excludeArchived: true)
+        let ids = Set(result.map(\.id))
+        #expect(ids.contains(active.id))
+        #expect(ids.contains(main.id))
+        #expect(!ids.contains(toArchive.id))
+    }
+
+    @Test func excludeArchivedFalseReturnsEverything() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let active = try await db.worktrees.create(
+            repoID: repo.id, name: "active", branch: "b-active",
+            path: "/tmp/active-\(UUID())", tmuxServer: "srv"
+        )
+        let toArchive = try await db.worktrees.create(
+            repoID: repo.id, name: "archived-wt", branch: "b-arch",
+            path: "/tmp/arch-\(UUID())", tmuxServer: "srv"
+        )
+        try await db.worktrees.archive(id: toArchive.id)
+
+        // excludeArchived=false (the default) must return all rows
+        let result = try await db.worktrees.list(repoID: repo.id, excludeArchived: false)
+        let ids = Set(result.map(\.id))
+        #expect(ids.contains(active.id))
+        #expect(ids.contains(toArchive.id))
+    }
+
+    @Test func excludeArchivedComposesWithRepoIDFilter() async throws {
+        let db = try makeDB()
+        let repo1 = try await createRepo(db: db)
+        let repo2 = try await createRepo(db: db)
+
+        let active1 = try await db.worktrees.create(
+            repoID: repo1.id, name: "r1-active", branch: "b1",
+            path: "/tmp/r1a-\(UUID())", tmuxServer: "srv"
+        )
+        let arch1 = try await db.worktrees.create(
+            repoID: repo1.id, name: "r1-arch", branch: "b1-arch",
+            path: "/tmp/r1ar-\(UUID())", tmuxServer: "srv"
+        )
+        try await db.worktrees.archive(id: arch1.id)
+
+        let active2 = try await db.worktrees.create(
+            repoID: repo2.id, name: "r2-active", branch: "b2",
+            path: "/tmp/r2a-\(UUID())", tmuxServer: "srv"
+        )
+
+        let repo1Result = try await db.worktrees.list(repoID: repo1.id, excludeArchived: true)
+        let repo1IDs = Set(repo1Result.map(\.id))
+        #expect(repo1IDs.contains(active1.id))
+        #expect(!repo1IDs.contains(arch1.id))
+        #expect(!repo1IDs.contains(active2.id))
+    }
+
+    @Test func excludeArchivedOrderIsSortOrderAsc() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let wt1 = try await db.worktrees.create(
+            repoID: repo.id, name: "first", branch: "b1",
+            path: "/tmp/wt1-\(UUID())", tmuxServer: "srv"
+        )
+        let wt2 = try await db.worktrees.create(
+            repoID: repo.id, name: "second", branch: "b2",
+            path: "/tmp/wt2-\(UUID())", tmuxServer: "srv"
+        )
+        let arch = try await db.worktrees.create(
+            repoID: repo.id, name: "archived", branch: "b3",
+            path: "/tmp/arch-\(UUID())", tmuxServer: "srv"
+        )
+        try await db.worktrees.archive(id: arch.id)
+
+        let result = try await db.worktrees.list(repoID: repo.id, excludeArchived: true)
+        let ids = result.map(\.id)
+        #expect(ids == [wt1.id, wt2.id])
+        #expect(result.map(\.sortOrder) == [1, 2])
+    }
 }

--- a/Tests/TBDSharedTests/NewlineFrameScannerTests.swift
+++ b/Tests/TBDSharedTests/NewlineFrameScannerTests.swift
@@ -1,0 +1,154 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct NewlineFrameScannerTests {
+
+    // MARK: - Newline in first chunk
+
+    @Test("newline in first chunk records correct index and trims frame")
+    func newlineInFirstChunk() {
+        var scanner = NewlineFrameScanner()
+        let data = Data("hello\nworld".utf8)
+        let found = scanner.append(data: data)
+        #expect(found)
+        #expect(scanner.hasNewline)
+        #expect(scanner.newlineIndex == 5)
+        #expect(scanner.frameData == Data("hello".utf8))
+    }
+
+    @Test("newline at very start of first chunk yields empty frame")
+    func newlineAtStart() {
+        var scanner = NewlineFrameScanner()
+        scanner.append(data: Data([0x0A, 0x61, 0x62]))  // "\nab"
+        #expect(scanner.hasNewline)
+        #expect(scanner.newlineIndex == 0)
+        #expect(scanner.frameData.isEmpty)
+    }
+
+    // MARK: - Newline split across multiple chunks
+
+    @Test("newline arrives in chunk N — absolute index is correct")
+    func newlineAcrossChunks() {
+        var scanner = NewlineFrameScanner()
+        // Chunk 1: "abc" — no newline
+        let r1 = scanner.append(data: Data("abc".utf8))
+        #expect(!r1)
+        #expect(!scanner.hasNewline)
+        // Chunk 2: "def" — no newline
+        let r2 = scanner.append(data: Data("def".utf8))
+        #expect(!r2)
+        #expect(!scanner.hasNewline)
+        // Chunk 3: "ghi\n" — newline at absolute offset 9
+        let r3 = scanner.append(data: Data("ghi\n".utf8))
+        #expect(r3)
+        #expect(scanner.hasNewline)
+        #expect(scanner.newlineIndex == 9)
+        #expect(scanner.frameData == Data("abcdefghi".utf8))
+    }
+
+    @Test("many chunks before newline — correct index and frame content")
+    func manyChunksBeforeNewline() {
+        var scanner = NewlineFrameScanner()
+        let chunkCount = 10
+        let chunkSize = 8
+        for i in 0..<chunkCount {
+            let chunk = Data(repeating: UInt8(65 + i), count: chunkSize)  // 'A', 'B', ...
+            let found = scanner.append(data: chunk)
+            #expect(!found, "chunk \(i) should not contain newline")
+        }
+        // Final chunk: two payload bytes then newline, then trailing bytes
+        let finalChunk = Data([0x58, 0x59, 0x0A, 0x5A, 0x5A])  // "XY\nZZ"
+        scanner.append(data: finalChunk)
+        #expect(scanner.hasNewline)
+        #expect(scanner.newlineIndex == chunkCount * chunkSize + 2)
+        // frameData must equal all prior chunks + "XY"
+        var expected = Data()
+        for i in 0..<chunkCount {
+            expected.append(contentsOf: Array(repeating: UInt8(65 + i), count: chunkSize))
+        }
+        expected.append(contentsOf: [0x58, 0x59])  // "XY"
+        #expect(scanner.frameData == expected)
+    }
+
+    // MARK: - Newline mid-chunk with trailing bytes
+
+    @Test("newline mid-chunk — trailing bytes after newline are not included in frameData")
+    func newlineMidChunkTrailingBytes() {
+        var scanner = NewlineFrameScanner()
+        // "hello\nworld\nmore" — first newline at offset 5
+        scanner.append(data: Data("hello\nworld\nmore".utf8))
+        #expect(scanner.hasNewline)
+        #expect(scanner.newlineIndex == 5)
+        #expect(scanner.frameData == Data("hello".utf8))
+    }
+
+    @Test("appending after newline is found does not change newlineIndex")
+    func appendAfterNewlineDoesNotMove() {
+        var scanner = NewlineFrameScanner()
+        scanner.append(data: Data("abc\n".utf8))
+        #expect(scanner.newlineIndex == 3)
+        // Extra append — index must not shift
+        scanner.append(data: Data("more\nbytes".utf8))
+        #expect(scanner.newlineIndex == 3)
+        #expect(scanner.frameData == Data("abc".utf8))
+    }
+
+    // MARK: - No newline (connection-closed semantics)
+
+    @Test("no newline — frameData returns entire accumulated buffer")
+    func noNewline() {
+        var scanner = NewlineFrameScanner()
+        let data = Data("hello world".utf8)
+        let found = scanner.append(data: data)
+        #expect(!found)
+        #expect(!scanner.hasNewline)
+        #expect(scanner.frameData == data)
+    }
+
+    @Test("empty scanner has no newline and empty frameData")
+    func emptyScanner() {
+        let scanner = NewlineFrameScanner()
+        #expect(!scanner.hasNewline)
+        #expect(scanner.newlineIndex == nil)
+        #expect(scanner.frameData.isEmpty)
+    }
+
+    @Test("multiple chunks with no newline — full payload returned")
+    func multipleChunksNoNewline() {
+        var scanner = NewlineFrameScanner()
+        let chunks = ["foo", "bar", "baz"].map { Data($0.utf8) }
+        for chunk in chunks { scanner.append(data: chunk) }
+        #expect(!scanner.hasNewline)
+        #expect(scanner.frameData == Data("foobarbaz".utf8))
+    }
+
+    // MARK: - Multi-byte payload integrity
+
+    @Test("multi-byte JSON payload roundtrip")
+    func multiBytePayloadIntegrity() {
+        var scanner = NewlineFrameScanner()
+        let json = Data(#"{"success":true,"result":"{\"id\":\"abc\"}"}"#.utf8)
+        scanner.append(data: json)
+        scanner.append(data: Data([0x0A]))  // delimiter
+        #expect(scanner.hasNewline)
+        #expect(scanner.newlineIndex == json.count)
+        #expect(scanner.frameData == json)
+    }
+
+    @Test("payload split at every byte boundary — frame always correct")
+    func payloadSplitAtEveryByte() {
+        let payload = Data("ABCDEFGHIJ\nKLMN".utf8)
+        let expectedFrame = Data("ABCDEFGHIJ".utf8)
+        // Try splitting the payload at each possible byte boundary
+        for splitAt in 1..<payload.count {
+            var scanner = NewlineFrameScanner()
+            scanner.append(data: payload[..<splitAt])
+            scanner.append(data: payload[splitAt...])
+            #expect(scanner.hasNewline,
+                    "split at \(splitAt): expected newline")
+            #expect(scanner.frameData == expectedFrame,
+                    "split at \(splitAt): wrong frame")
+        }
+    }
+}

--- a/docs/perf/2026-06-11-rpc-hotspot-brainstorm.md
+++ b/docs/perf/2026-06-11-rpc-hotspot-brainstorm.md
@@ -1,0 +1,216 @@
+# RPC steady-state hotspot: investigation + fix brainstorm — 2026-06-11
+
+Follow-up to `2026-06-11-tbdapp-cpu-energy-investigation.md` (branch
+`tbd/20260611-junior-elk`), which measured ~2.9% of a core (~50 ms per 2 s
+poll cycle) spent in `Sequence.contains` / `Data.Iterator.next()` under
+`DaemonClient.sendRaw`, with the app fully quiet. This doc re-derives the
+cost from code + live measurements and ranks candidate fixes.
+
+All numbers measured 2026-06-11 against the live daemon
+(`~/tbd/sock`, this user's real DB) and a release-built synthetic benchmark.
+
+## What the cost actually is
+
+Three multiplicative factors:
+
+### 1. Quadratic newline scan in the read loop (the sampled hotspot)
+
+`DaemonClient.sendRaw` (`Sources/TBDApp/DaemonClient.swift:231-254`) reads
+the newline-delimited JSON response like this:
+
+```swift
+responseData.append(buffer, count: bytesRead)
+if responseData.contains(0x0A) { break }     // ← rescans EVERYTHING
+```
+
+`Data.contains` resolves to the generic `Sequence.contains` walking
+`Data.Iterator.next()` byte-by-byte (exactly the frames in the sample), and
+it rescans the *entire accumulated buffer* after every `recv`. The CLI has
+the identical loop in `Sources/TBDCLI/SocketClient.swift:107-120`.
+
+Measured against the live socket: `recv` on this Unix socket returns **8 KB
+chunks** (kernel buffer), not the 64 KB the code allocates. Today's
+`worktree.list` response is 475,666 bytes = **59 chunks**, so the loop scans
+sum(8K, 16K, … 472K) = **14,492,178 bytes — 30.5× the payload — through a
+generic iterator, per poll**. Cost is O(n²/chunkSize) in response size.
+
+Synthetic benchmark (`swiftc -O`, 64 KB chunks — i.e. *understating* the
+real 8 KB-chunk cost):
+
+| payload | current (`contains` per chunk) | `firstIndex` on new chunk | `memchr` on new chunk |
+|---|---|---|---|
+| 100 KB | 0.95 ms | 1.25 ms | 0.03 ms |
+| 475 KB | 10.2 ms | 1.4 ms | 0.08 ms |
+| 1 MB | 37.8 ms | 3.6 ms | 0.40 ms |
+
+With real 8 KB chunks the current path is ~8× worse than the 64 KB-chunk
+bench row (8× more rescans), which lands right on the measured ~50 ms per
+poll cycle. A scan-only-the-new-bytes `memchr` is effectively free at any
+payload size. Note `Data.firstIndex(of:)` is also generic/slow — the fix
+should be `withUnsafeBytes` + `memchr` (or track a scanned-offset and only
+scan appended bytes).
+
+This same loop frames **every** response, so it also taxes the transcript
+pane's 1.5 s full-transcript poll (state C in the prior writeup), where
+payloads are far larger than 475 KB.
+
+### 2. The poll ships 815 worktrees every 2 s and throws 87% away
+
+`AppState.refreshAll()` (every 2 s, `AppState.swift:961-987, 1119-1123`)
+fetches `repo.list` + `worktree.list` (unfiltered) + `terminal.list` +
+`note.list` + `notifications.list`. Live sizes today:
+
+| method | bytes | note |
+|---|---|---|
+| `worktree.list` | **475,666** | 815 rows: 68 active, 7 main, **740 archived** |
+| `terminal.list` | 99,214 | 158 rows; 45% of bytes = `suspendedSnapshot` blobs |
+| `note.list` | 10,914 | |
+| `repo.list` | 6,247 | |
+| `notifications.list` | 1,380 | |
+
+Of the 475 KB, **414 KB (87%) is archived rows** — which the app filters
+out *immediately* on arrival (`AppState.visibleWorktrees`,
+`AppState+ArchiveTombstones.swift:36-41` drops `.archived`). The archived
+view never reads from this poll: it has its own paginated fetch
+(`refreshArchivedWorktrees`, `AppState+Worktrees.swift:277-292`, pages of
+50 with `status: .archived`). The daemon handler even has a comment
+acknowledging the 2 s poll hits the unfiltered path
+(`RPCRouter+WorktreeHandlers.swift:60-85`).
+
+This payload grows forever — every archived worktree is shipped, parsed,
+equality-compared, and discarded ~43,000 times a day, and the quadratic
+scan multiplies on top of it.
+
+Tombstone reconciliation (`reconcileTombstones`) treats "absent from the
+response" identically to "status == .archived" (both confirm the tombstone),
+so excluding archived rows daemon-side does not change its semantics.
+
+### 3. Protocol overheads (smaller, certain)
+
+- **Double-encoded JSON**: `RPCResponse.result` is a JSON *string* inside
+  JSON (`RPCProtocol.swift`), so every response is parsed twice (once to
+  extract the giant escaped string, once to decode the models) and carries
+  escape overhead — measured **+48,695 bytes (10%)** on `worktree.list`.
+- **Connection per call**: each RPC opens a fresh Unix socket
+  (`makeConnectedSocket`). Cheap individually; the prior sample showed the
+  poll thread blocked in `recv` ~30-50% of wall time across the 5+
+  sequential calls per cycle.
+- **StateDelta subscription is underused**: the daemon broadcasts a
+  near-complete delta set (created/archived/revived/renamed/reordered/moved
+  worktrees, repo changes, terminal created/removed/pin, conflicts,
+  notifications, profiles — see `StateDelta.swift` and the
+  `subscriptions.broadcast` sites in `RPCRouter+*Handlers.swift`), but
+  `AppState.handleDelta` (`AppState.swift:775-797`) applies only ~7 cases
+  and `default: break`s the rest. The 2 s poll is still the actual
+  synchronization mechanism; the subscription is an accelerator for a few
+  paths.
+
+## Candidate directions, ranked
+
+### A. Scan only new bytes when framing (do it now)
+
+Track how far the buffer has been scanned; check only the appended chunk for
+`0x0A` via `withUnsafeBytes` + `memchr`. Apply identically to
+`DaemonClient.sendRaw` and `TBDCLI/SocketClient.swift`.
+
+- **Payoff**: kills the sampled hotspot outright (~50 ms → ≪1 ms per cycle;
+  ~125× less scan work at 475 KB, more at transcript sizes). Helps every
+  client, every method, including the transcript-pane fire.
+- **Risk**: near zero. Pure client-side read-loop change, no protocol or
+  daemon impact. Easily unit-tested (multi-chunk framing, newline split
+  across chunks, newline mid-buffer).
+- **Effort**: tiny.
+
+### B. Exclude archived rows from the 2 s poll (do it now)
+
+Add an opt-in filter so the poll fetches only non-archived rows — e.g.
+`WorktreeListParams.statuses: [WorktreeStatus]?` (or `excludeArchived:
+Bool?`) honored in `WorktreeStore.list` with a SQL filter; the app's
+`refreshWorktrees` passes it. The archived view's existing paginated path is
+untouched.
+
+- **Payoff**: poll payload 475 KB → ~37 KB (**13×**), and it stops growing
+  with archive history. Cuts daemon-side DB fetch + encode of 740 rows,
+  wire bytes, app-side double JSON parse, and the 815-element
+  equality-compare — every 2 s, forever. Even without A, it collapses the
+  quadratic scan (5 chunks instead of 59 → ~115 KB scanned, negligible).
+- **Risk**: low. New optional param — old daemons ignore unknown JSON keys
+  and return everything, and the app already filters client-side, so mixed
+  versions degrade gracefully to today's behavior. Tombstone reconcile is
+  unaffected (absent == archived, verified above). Needs tests for the new
+  filter branch per CLAUDE.md.
+- **Effort**: small (param + store filter + app call site + tests; CLI
+  could optionally expose it).
+
+### C. Make StateDelta the primary sync; demote the poll to slow reconciliation
+
+Extend `handleDelta` to apply the already-broadcast cases it currently
+drops (`worktreeCreated/Renamed/Reordered`, `terminalCreated/Removed`,
+`worktreeConflictsChanged`, repo deltas, …), then stretch the poll from 2 s
+to e.g. 30-60 s as an anti-entropy backstop (and/or poll fast only while a
+delta gap is suspected, immediately after reconnect, or after app
+foregrounding).
+
+- **Payoff**: removes ~95% of steady-state RPCs — the recv-blocked thread
+  time, the daemon's per-poll DB reads, JSON encode/decode, and compare
+  churn all shrink proportionally. This is the direction that makes the
+  steady-state cost *O(actual changes)* instead of *O(state size)*.
+- **Risk**: medium. Every delta type the app mishandles becomes a
+  staleness bug with up to a poll-interval window; some state has no delta
+  today (notes; `suspendedSnapshot`/label changes; anything mutated outside
+  the RPC handlers). Needs an audit of mutation sites vs broadcast sites,
+  and per-case tests. The subscription channel itself (long-lived
+  connection, reconnect behavior) becomes correctness-critical instead of
+  best-effort.
+- **Effort**: medium — incremental and shippable case-by-case (each delta
+  handled is one fewer reason to keep the poll fast; the poll interval is a
+  single constant to tune at the end).
+
+### D. Protocol redesign: length-prefixed framing + inline `result` JSON
+
+Replace newline framing with a 4-byte length prefix (no scan at all) and
+make `result` a raw JSON value instead of a double-encoded string (single
+parse, -10% wire).
+
+- **Payoff**: eliminates the framing scan *by construction* and the double
+  parse. Cleanest long-term protocol.
+- **Risk/effort**: highest. Touches `RPCProtocol.swift`, daemon server,
+  app client, CLI client; all three ship in lockstep but the *installed*
+  app and a dev daemon (or vice versa) routinely skew on this machine —
+  needs versioning/negotiation or a hard flag-day. A+B deliver ~all of the
+  measurable win without any of this; the remaining benefit (one JSON parse
+  instead of two on ~37 KB payloads) doesn't justify it today.
+
+## Recommendation
+
+**Do A + B together now** (independent, both small, both client/daemon-local,
+no migration concerns): A removes the measured hotspot for every payload
+including transcripts; B makes the recurring payload bounded and 13× smaller,
+which also shrinks decode/compare costs A doesn't touch. Expected result: the
+~2.9%-of-a-core steady-state RPC floor drops to noise (<0.2%), independent of
+archive history.
+
+**Queue C as a follow-up** — it's the structural fix for "cost scales with
+state size", best done incrementally per delta type, and it benefits from B
+landing first (smaller reconciliation payloads while it's in flight).
+
+**Skip D** unless/until a future feature needs big binary payloads or
+streaming responses.
+
+Worth fixing opportunistically alongside A/B (same files): the 64 KB recv
+buffer is misleading (kernel returns 8 KB — consider `SO_RCVBUF`/larger
+socket buffer if we care, though after A it no longer matters), and
+`terminal.list`'s `suspendedSnapshot` (45% of that payload) could move to a
+fetch-on-demand RPC like archived worktrees did.
+
+## Reproduction
+
+- Live payload sizes: connect to `~/tbd/sock`, send
+  `{"method":"worktree.list","params":"{}"}\n`, count bytes/chunks until
+  newline (python socket script; chunks observed at 8,192 B).
+- Scan cost: standalone Swift bench comparing `contains`-per-chunk vs
+  `memchr`-on-new-chunk at 100 KB/475 KB/1 MB (numbers above,
+  `swiftc -O`).
+- In-app attribution: `sample <TBDApp pid> 10` → frames
+  `DaemonClient.sendRaw` → `Sequence.contains` → `Data.Iterator.next`
+  (see prior writeup's gzipped captures).


### PR DESCRIPTION
## Summary

With the app fully quiet, a `sample` showed ~2.9% of a core (~50 ms per 2 s poll cycle) burned inside `DaemonClient.sendRaw` — forever, even with nothing happening. Investigation (full writeup in `docs/perf/2026-06-11-rpc-hotspot-brainstorm.md`) found two multiplying causes:

- **Quadratic framing scan.** The response read loop rescanned the *entire accumulated buffer* for the `\n` delimiter after every `recv` via generic `Data.contains` (byte-by-byte `Data.Iterator`). Real recv chunks are 8 KB, so reading today's 475 KB `worktree.list` response scanned **14.5 MB — 30× the payload**. Fixed by a new `NewlineFrameScanner` (TBDShared) that `memchr`s only newly received bytes; applied to both the app's `DaemonClient` and the CLI's `SocketClient`. Benchmarked ~125× less scan work at 475 KB; also relieves the much larger transcript-pane payloads.
- **87% of the poll payload was discarded on arrival.** The 2 s poll fetched all 815 worktrees (740 archived, 414 KB of 475 KB) and the app immediately filtered archived rows out — the archived view has its own paginated fetch. `WorktreeListParams` gains an optional, backward-compatible `excludeArchived` flag, filtered in SQL; the poll now ships ~37 KB (**13× smaller**) and no longer grows with archive history. Tombstone reconciliation is unaffected: absent-from-response already confirms tombstones the same way `.archived` status did.

Expected result: the steady-state RPC floor drops from ~2.9% of a core to noise, independent of how many worktrees have ever been archived.

## Test plan

- [x] `swift build` passes; `swiftlint --strict` clean
- [x] 11 new `NewlineFrameScanner` tests: delimiter in first chunk / split across chunks / mid-chunk with trailing bytes / absent (connection-closed semantics) / payload integrity at every split boundary
- [x] 4 new `WorktreeStore.list` tests covering both `excludeArchived` branches, composition with `repoID` filter, and ordering
- [x] `swift test` — only pre-existing failures unrelated to this change (flaky pagination-timing test, TabBar hit-area, ThemeStore file-watch), confirmed failing on base
- [ ] Re-`sample` the installed app after this ships to confirm the `Sequence.contains` frames are gone from the quiet-state profile

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=257F8845-48B7-46A4-82A5-274C0D35986A)