### PR TITLE
Feat: Run blocking setup hooks before the agent spawns, with live output instead of an empty panel

### DIFF
--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -145,7 +145,9 @@ extension AppState {
 
     /// Revive an archived worktree and resume the selected Claude session.
     /// Marks the row as `inFlight` immediately so the archived view can show
-    /// a status pill, then flips to `.done` on success or clears on failure.
+    /// a status pill, then flips to `.done` once the worktree is usable —
+    /// immediately when no blocking preSession hook gates it, otherwise via
+    /// `promoteRevivedWorktrees` when the row turns `.active`. Clears on failure.
     func reviveWithSession(worktreeID: UUID, sessionId: String) async {
         // Idempotency: ignore re-entrant calls (e.g. rapid double-click)
         // so a concurrent invocation can't overwrite the .done state with
@@ -168,13 +170,13 @@ extension AppState {
 
         do {
             let size = mainAreaTerminalSize()
-            try await daemonClient.reviveWorktree(
+            let revived = try await daemonClient.reviveWorktree(
                 id: worktreeID,
                 cols: size.cols,
                 rows: size.rows,
                 preferredSessionID: sessionId
             )
-            revivingArchived[worktreeID] = .done(snapshot: snapshot)
+            settleReviveState(id: worktreeID, snapshot: snapshot, revived: revived)
             await refreshWorktrees()
             await refreshArchivedWorktrees(repoID: snapshot.repoID)
         } catch {

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -17,6 +17,108 @@ extension AppState {
         terminal.kind == .codex || terminal.label == "Codex" ? terminal.label : nil
     }
 
+    // MARK: - Pre-session hook terminals
+
+    /// Label the daemon assigns to the blocking `preSession` hook terminal
+    /// (see WorktreeLifecycle+PreSession). The app keys "is this the
+    /// pre-session tab?" decisions off this label.
+    static let preSessionTerminalLabel = "pre-session"
+
+    /// True when a pre-session hook terminal exists in state for the worktree.
+    /// Drives the sidebar "Running setup…" subtitle while the worktree is
+    /// still `.creating`.
+    func hasPreSessionTerminal(worktreeID: UUID) -> Bool {
+        terminals[worktreeID]?.contains { $0.label == Self.preSessionTerminalLabel } ?? false
+    }
+
+    /// True when the terminal panel should show the thin "pre-session setup
+    /// running" banner: the worktree is still `.creating` AND the active tab
+    /// is the pre-session hook terminal.
+    func showsPreSessionBanner(for worktree: Worktree) -> Bool {
+        guard worktree.status == .creating,
+              let activeID = activeTabTerminalID(worktreeID: worktree.id) else { return false }
+        return terminal(id: activeID, in: worktree.id)?.label == Self.preSessionTerminalLabel
+    }
+
+    /// Terminal ID at the root of the active tab's content (nil for
+    /// note/file tabs or when no tabs exist). Mirrors the view layer's
+    /// `?? 0` default for an unset active index.
+    private func activeTabTerminalID(worktreeID: UUID) -> UUID? {
+        let arr = tabs[worktreeID] ?? []
+        guard !arr.isEmpty else { return nil }
+        let idx = min(activeTabIndices[worktreeID] ?? 0, arr.count - 1)
+        guard case .terminal(let id) = arr[idx].content else { return nil }
+        return id
+    }
+
+    // MARK: - terminalCreated delta
+
+    /// Handle a `.terminalCreated` broadcast (pre-session hook flow, another
+    /// client, or the echo of this app's own createTerminal RPC).
+    ///
+    /// Terminals never loaded for this worktree → a full refresh both loads
+    /// the list and reconciles tabs. Already loaded → fetch the new terminal
+    /// (the delta only carries ID + label) and append it.
+    func applyTerminalCreatedDelta(_ delta: TerminalDelta) {
+        guard let loaded = terminals[delta.worktreeID] else {
+            Task { [weak self] in
+                await self?.refreshTerminals(worktreeID: delta.worktreeID)
+            }
+            return
+        }
+        // Dedupe fast path: the direct-append in createTerminal et al. may
+        // have already landed this terminal (its RPC response races the delta).
+        guard !loaded.contains(where: { $0.id == delta.terminalID }) else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let fetched = try await self.daemonClient.listTerminals(worktreeID: delta.worktreeID)
+                guard let terminal = fetched.first(where: { $0.id == delta.terminalID }) else { return }
+                self.appendCreatedTerminal(terminal)
+            } catch {
+                logger.error("terminalCreated delta fetch failed for \(delta.terminalID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// Append a terminal announced by a `.terminalCreated` delta to state,
+    /// add a tab for it, and — when an agent terminal lands while the user is
+    /// still looking at the pre-session hook tab — move the selection to the
+    /// agent (matches the daemon's "active = primary" default).
+    ///
+    /// Idempotent: re-checks for the terminal so the direct-append path in
+    /// `createTerminal` (which races the delta) never produces duplicates.
+    func appendCreatedTerminal(_ terminal: Terminal) {
+        let worktreeID = terminal.worktreeID
+        guard !(terminals[worktreeID] ?? []).contains(where: { $0.id == terminal.id }) else { return }
+        terminals[worktreeID, default: []].append(terminal)
+
+        // Add a tab unless the terminal is already represented as a tab root
+        // or inside a split layout (same rule as reconcileTabs).
+        let represented = (tabs[worktreeID] ?? []).contains { tab in
+            (layouts[tab.id] ?? .pane(tab.content)).allTerminalIDs().contains(terminal.id)
+        }
+        if !represented {
+            tabs[worktreeID, default: []].append(
+                Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
+            )
+        }
+
+        // When the primary agent terminal arrives while the user is still on
+        // the pre-session hook tab, follow it. Any other active tab means the
+        // user navigated deliberately — leave the selection alone.
+        if terminal.kind == .claude || terminal.kind == .codex,
+           let activeID = activeTabTerminalID(worktreeID: worktreeID),
+           activeID != terminal.id,
+           self.terminal(id: activeID, in: worktreeID)?.label == Self.preSessionTerminalLabel,
+           let newIdx = tabs[worktreeID]?.firstIndex(where: { $0.id == terminal.id }) {
+            // The daemon already persisted the primary as the active tab
+            // (setActiveTabID in spawnPrimaryTerminals) — only the in-memory
+            // index needs to move, so skip setActiveTab's re-persist RPC.
+            activeTabIndices[worktreeID] = newIdx
+        }
+    }
+
     // MARK: - Terminal Actions
 
     /// Treat an explicit user interrupt as "not working" for Codex terminals.

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -14,19 +14,21 @@ extension AppState {
     }
 
     func initialTabLabel(for terminal: Terminal) -> String? {
-        terminal.kind == .codex || terminal.label == "Codex" ? terminal.label : nil
+        terminal.kind == .codex || terminal.label == TerminalLabel.codex ? terminal.label : nil
     }
 
     // MARK: - Pre-session hook terminals
 
     /// Label the daemon assigns to the blocking `preSession` hook terminal
     /// (see WorktreeLifecycle+PreSession). The app keys "is this the
-    /// pre-session tab?" decisions off this label.
-    static let preSessionTerminalLabel = "pre-session"
+    /// pre-session tab?" decisions off this label. Canonical definition
+    /// lives in `TBDShared.TerminalLabel`.
+    static let preSessionTerminalLabel = TerminalLabel.preSession
 
     /// Label the daemon assigns to the parallel `setup` hook terminal
-    /// (see spawnPrimaryTerminals in WorktreeLifecycle+Create).
-    static let setupTerminalLabel = "setup"
+    /// (see spawnPrimaryTerminals in WorktreeLifecycle+Create). Canonical
+    /// definition lives in `TBDShared.TerminalLabel`.
+    static let setupTerminalLabel = TerminalLabel.setup
 
     /// True when `terminal` is a PRIMARY terminal in the pre-session flow:
     /// the tab the daemon makes active once the hook finishes. That's the
@@ -194,7 +196,7 @@ extension AppState {
     func handleTerminalInterrupt(terminalID: UUID) {
         guard let terminal = terminals.values.flatMap({ $0 })
             .first(where: { $0.id == terminalID }),
-              terminal.kind == .codex || terminal.label == "Codex"
+              terminal.kind == .codex || terminal.label == TerminalLabel.codex
         else {
             return
         }

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -117,6 +117,57 @@ extension AppState {
             // index needs to move, so skip setActiveTab's re-persist RPC.
             activeTabIndices[worktreeID] = newIdx
         }
+
+        // Converging-from-creation reconcile: the daemon's pre-session flow
+        // persists tab order [primary, preSession, setup] behind the app's
+        // back, but the order this app cached (loaded while only the
+        // pre-session tab existed) is just [preSession] — so plain appends
+        // would show [preSession, primary, setup] until restart. When the
+        // primary lands and the cached order doesn't know it yet, re-fetch
+        // the persisted order and re-sort. applyStoredOrder follows the
+        // active tab by ID, so neither the hand-off above nor a deliberate
+        // user selection is clobbered.
+        if shouldReconcileTabOrderFromDaemon(after: terminal) {
+            Task { [weak self] in
+                await self?.refreshStoredTabOrder(worktreeID: worktreeID)
+            }
+        }
+    }
+
+    /// Gate for the converging-from-creation tab-order re-fetch: only a
+    /// primary agent terminal landing in a worktree that has a pre-session
+    /// hook terminal, while the cached order doesn't yet contain that
+    /// primary, warrants reconciling against the daemon's persisted order.
+    /// Anything else — user reorders, ordinary terminal creation, the
+    /// parallel `setup` shell — must leave the tab arrangement untouched.
+    func shouldReconcileTabOrderFromDaemon(after terminal: Terminal) -> Bool {
+        (terminal.kind == .claude || terminal.kind == .codex)
+            && hasPreSessionTerminal(worktreeID: terminal.worktreeID)
+            && worktreeTabOrders[terminal.worktreeID]?.contains(terminal.id) != true
+    }
+
+    /// Re-fetch the daemon's persisted tab order for a worktree and re-sort
+    /// the in-memory tabs against it. Failure just logs — the order then
+    /// converges on the next full refresh or restart, exactly as before.
+    func refreshStoredTabOrder(worktreeID: UUID) async {
+        do {
+            let response = try await daemonClient.listTabs(worktreeID: worktreeID)
+            adoptPersistedTabOrder(worktreeID: worktreeID, order: response.order)
+        } catch {
+            logger.error("tab order re-fetch failed for \(worktreeID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Synchronous core of the converging-from-creation reconcile: adopt the
+    /// daemon's persisted tab order and re-sort via the same applyStoredOrder
+    /// path loadTabStates uses. Split from the fetch so tests (which can't
+    /// stub the concrete DaemonClient actor) can drive it with a fixture
+    /// order. An empty order means the daemon has nothing persisted — keep
+    /// the current in-memory arrangement.
+    func adoptPersistedTabOrder(worktreeID: UUID, order: [UUID]) {
+        guard !order.isEmpty else { return }
+        worktreeTabOrders[worktreeID] = order
+        applyStoredOrder(worktreeID: worktreeID)
     }
 
     // MARK: - Terminal Actions

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -154,12 +154,18 @@ extension AppState {
 
     /// Gate for the converging-from-creation tab-order re-fetch: only a
     /// primary terminal (agent, or shell with skipClaude) landing in a
-    /// worktree that has a pre-session hook terminal, while the cached order
-    /// doesn't yet contain that primary, warrants reconciling against the
-    /// daemon's persisted order. Anything else — user reorders, the
-    /// parallel `setup` shell — must leave the tab arrangement untouched.
+    /// worktree that is still `.creating` and has a pre-session hook
+    /// terminal, while the cached order doesn't yet contain that primary,
+    /// warrants reconciling against the daemon's persisted order. The
+    /// `.creating` requirement scopes the gate to the creation phase: the
+    /// pre-session tab outlives setup, so without it the gate could fire for
+    /// terminals created long after the worktree went `.active`. Anything
+    /// else — user reorders, the parallel `setup` shell, a worktree not in
+    /// state — must leave the tab arrangement untouched.
     func shouldReconcileTabOrderFromDaemon(after terminal: Terminal) -> Bool {
-        isPrimaryTerminal(terminal)
+        guard let worktree = findWorktree(id: terminal.worktreeID),
+              worktree.status == .creating else { return false }
+        return isPrimaryTerminal(terminal)
             && hasPreSessionTerminal(worktreeID: terminal.worktreeID)
             && worktreeTabOrders[terminal.worktreeID]?.contains(terminal.id) != true
     }

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -24,6 +24,21 @@ extension AppState {
     /// pre-session tab?" decisions off this label.
     static let preSessionTerminalLabel = "pre-session"
 
+    /// Label the daemon assigns to the parallel `setup` hook terminal
+    /// (see spawnPrimaryTerminals in WorktreeLifecycle+Create).
+    static let setupTerminalLabel = "setup"
+
+    /// True when `terminal` is a PRIMARY terminal in the pre-session flow:
+    /// the tab the daemon makes active once the hook finishes. That's the
+    /// agent (Claude/Codex) or — with skipClaude — a plain shell; the only
+    /// non-primary phase-3 terminals are the pre-session hook tab itself and
+    /// the parallel `setup` hook window. Keyed off labels rather than kinds
+    /// because a skipClaude primary is kind `.shell`, same as `setup`.
+    func isPrimaryTerminal(_ terminal: Terminal) -> Bool {
+        terminal.label != Self.preSessionTerminalLabel
+            && terminal.label != Self.setupTerminalLabel
+    }
+
     /// True when a pre-session hook terminal exists in state for the worktree.
     /// Drives the sidebar "Running setup…" subtitle while the worktree is
     /// still `.creating`.
@@ -104,10 +119,11 @@ extension AppState {
             )
         }
 
-        // When the primary agent terminal arrives while the user is still on
-        // the pre-session hook tab, follow it. Any other active tab means the
-        // user navigated deliberately — leave the selection alone.
-        if terminal.kind == .claude || terminal.kind == .codex,
+        // When the primary terminal (agent, or shell with skipClaude) arrives
+        // while the user is still on the pre-session hook tab, follow it. Any
+        // other active tab means the user navigated deliberately — leave the
+        // selection alone. The parallel `setup` window never steals selection.
+        if isPrimaryTerminal(terminal),
            let activeID = activeTabTerminalID(worktreeID: worktreeID),
            activeID != terminal.id,
            self.terminal(id: activeID, in: worktreeID)?.label == Self.preSessionTerminalLabel,
@@ -135,13 +151,13 @@ extension AppState {
     }
 
     /// Gate for the converging-from-creation tab-order re-fetch: only a
-    /// primary agent terminal landing in a worktree that has a pre-session
-    /// hook terminal, while the cached order doesn't yet contain that
-    /// primary, warrants reconciling against the daemon's persisted order.
-    /// Anything else — user reorders, ordinary terminal creation, the
+    /// primary terminal (agent, or shell with skipClaude) landing in a
+    /// worktree that has a pre-session hook terminal, while the cached order
+    /// doesn't yet contain that primary, warrants reconciling against the
+    /// daemon's persisted order. Anything else — user reorders, the
     /// parallel `setup` shell — must leave the tab arrangement untouched.
     func shouldReconcileTabOrderFromDaemon(after terminal: Terminal) -> Bool {
-        (terminal.kind == .claude || terminal.kind == .codex)
+        isPrimaryTerminal(terminal)
             && hasPreSessionTerminal(worktreeID: terminal.worktreeID)
             && worktreeTabOrders[terminal.worktreeID]?.contains(terminal.id) != true
     }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -117,8 +117,8 @@ extension AppState {
 
         do {
             let size = mainAreaTerminalSize()
-            try await daemonClient.reviveWorktree(id: id, cols: size.cols, rows: size.rows)
-            revivingArchived[id] = .done(snapshot: snapshot)
+            let revived = try await daemonClient.reviveWorktree(id: id, cols: size.cols, rows: size.rows)
+            settleReviveState(id: id, snapshot: snapshot, revived: revived)
             recentlyArchivedWorktreeIDs.removeValue(forKey: id)
             await refreshWorktrees()
             await refreshArchivedWorktrees(repoID: snapshot.repoID)
@@ -127,6 +127,30 @@ extension AppState {
             logger.error("Failed to revive worktree: \(error)")
             showAlert("Couldn't revive worktree: \(error.localizedDescription)", isError: true)
             handleConnectionError(error)
+        }
+    }
+
+    /// Apply the revive RPC's returned worktree to `revivingArchived`.
+    /// With a blocking `preSession` hook, `beginReviveWorktree` returns
+    /// promptly with the row still `.creating` — marking `.done` then would
+    /// show "Revived" in the archived view while the sidebar still says
+    /// "Running setup…". Keep those entries `.inFlight`; the periodic
+    /// `refreshWorktrees` poll promotes them via `promoteRevivedWorktrees`
+    /// once the daemon reports the row `.active`.
+    func settleReviveState(id: UUID, snapshot: Worktree, revived: Worktree) {
+        guard revived.status != .creating else { return }
+        revivingArchived[id] = .done(snapshot: snapshot)
+    }
+
+    /// Promote lingering `.inFlight` revive entries to `.done` once the
+    /// daemon reports their worktree `.active` (i.e. the blocking
+    /// `preSession` hook finished). A `.creating` observation never
+    /// promotes — the hook is still running.
+    func promoteRevivedWorktrees(observing fetched: [Worktree]) {
+        for (id, state) in revivingArchived {
+            guard case .inFlight(let snapshot) = state else { continue }
+            guard fetched.contains(where: { $0.id == id && $0.status == .active }) else { continue }
+            revivingArchived[id] = .done(snapshot: snapshot)
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -120,7 +120,9 @@ extension AppState {
             let revived = try await daemonClient.reviveWorktree(id: id, cols: size.cols, rows: size.rows)
             settleReviveState(id: id, snapshot: snapshot, revived: revived)
             recentlyArchivedWorktreeIDs.removeValue(forKey: id)
-            await refreshWorktrees()
+            // No refreshWorktrees() here: the sidebar refresh arrives via the
+            // `.worktreeRevived` delta handler (AppState.swift handleDelta),
+            // same as createWorktree relies on its delta.
             await refreshArchivedWorktrees(repoID: snapshot.repoID)
         } catch {
             revivingArchived.removeValue(forKey: id)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1162,6 +1162,11 @@ final class AppState: ObservableObject {
                 tombstones: Set(recentlyArchivedWorktreeIDs.keys)
             )
 
+            // A revive that was gated by a blocking preSession hook lingers
+            // `.inFlight` until the daemon reports the row `.active` — this
+            // periodic refresh is where that flip is observed.
+            promoteRevivedWorktrees(observing: allWts)
+
             if let repoID {
                 // Preserve optimistic placeholders the daemon doesn't know about yet
                 let placeholders = (worktrees[repoID] ?? []).filter { pendingWorktreeIDs.contains($0.id) }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -782,6 +782,8 @@ final class AppState: ObservableObject {
             Task { [weak self] in await self?.loadModelProfiles() }
         case .terminalSessionUpdated(let d):
             applyTerminalSessionDelta(d)
+        case .terminalCreated(let d):
+            applyTerminalCreatedDelta(d)
         case .terminalActivityUpdated(let d):
             applyTerminalActivityDelta(d)
         case .worktreeMoved(let d):

--- a/Sources/TBDApp/AutoTabLabelResolver.swift
+++ b/Sources/TBDApp/AutoTabLabelResolver.swift
@@ -34,7 +34,7 @@ enum AutoTabLabelResolver {
         }
 
         if terminal?.isCodexTerminal == true {
-            return "Codex"
+            return TerminalLabel.codex
         }
 
         return "Terminal \(fallbackIndex + 1)"

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -458,11 +458,14 @@ actor DaemonClient {
         )
     }
 
-    /// Revive an archived worktree.
-    func reviveWorktree(id: UUID, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) async throws {
-        try await callVoidAsync(
+    /// Revive an archived worktree. Returns the revived worktree as the daemon
+    /// sees it when the RPC completes — still `.creating` while a blocking
+    /// `preSession` hook runs, `.active` otherwise.
+    func reviveWorktree(id: UUID, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) async throws -> Worktree {
+        try await callAsync(
             method: RPCMethod.worktreeRevive,
-            params: WorktreeReviveParams(worktreeID: id, cols: cols, rows: rows, preferredSessionID: preferredSessionID)
+            params: WorktreeReviveParams(worktreeID: id, cols: cols, rows: rows, preferredSessionID: preferredSessionID),
+            resultType: Worktree.self
         )
     }
 

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -123,7 +123,9 @@ struct WorktreeRowView: View {
                         .lineLimit(1)
                         .truncationMode(.tail)
                     if isPending {
-                        Text("Creating worktree…")
+                        Text(Self.creatingSubtitle(
+                            hasPreSessionTerminal: appState.hasPreSessionTerminal(worktreeID: worktree.id)
+                        ))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -190,6 +192,13 @@ struct WorktreeRowView: View {
                 appState.editingWorktreeID = nil
             }
         }
+    }
+
+    /// Subtitle under the name while the worktree is `.creating`. A visible
+    /// pre-session hook terminal means the git checkout is done and the
+    /// blocking setup hook is what the user is waiting on.
+    static func creatingSubtitle(hasPreSessionTerminal: Bool) -> String {
+        hasPreSessionTerminal ? "Running setup…" : "Creating worktree…"
     }
 
     func startRename() {

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -305,9 +305,13 @@ struct SingleWorktreeView: View {
 private struct PreSessionSetupBanner: View {
     var body: some View {
         HStack(spacing: 6) {
-            ProgressView()
-                .controlSize(.small)
-                .scaleEffect(0.75)
+            // Static icon, deliberately not a ProgressView: a spinner forces
+            // continuous CoreAnimation commits for the whole hook duration
+            // (minutes) for zero information gain — same rationale as the
+            // static sidebar status icons (c8769a8).
+            Image(systemName: "hammer")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
                 .frame(width: 12, height: 12)
             Text("Pre-session setup running — the agent will start when it completes.")
                 .font(.caption)

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -200,6 +200,14 @@ struct SingleWorktreeView: View {
 
                 Divider()
 
+                // Thin header while a blocking pre-session hook runs and the
+                // user is watching it: the worktree is still `.creating`, so
+                // explain why no agent terminal exists yet.
+                if appState.showsPreSessionBanner(for: worktree) {
+                    PreSessionSetupBanner()
+                    Divider()
+                }
+
                 // Split layout view for the active tab's layout. Publish its
                 // measured size to MainAreaSizeKey so the daemon-side tmux
                 // resize matches the actual SwiftTerm pane area (tab bar +
@@ -285,6 +293,28 @@ struct SingleWorktreeView: View {
 
     private func closeTab(at index: Int) {
         appState.closeTab(worktreeID: worktreeID, index: index)
+    }
+}
+
+// MARK: - PreSessionSetupBanner
+
+/// Slim header bar shown above the terminal while a blocking `preSession`
+/// hook is still running (worktree `.creating`, pre-session tab active).
+/// Same visual idiom as the proxy-unreachable banner in TerminalPanelView,
+/// but informational rather than warning-toned.
+private struct PreSessionSetupBanner: View {
+    var body: some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.small)
+                .scaleEffect(0.75)
+                .frame(width: 12, height: 12)
+            Text("Pre-session setup running — the agent will start when it completes.")
+                .font(.caption)
+            Spacer()
+        }
+        .padding(8)
+        .background(Color.accentColor.opacity(0.15))
     }
 }
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -241,6 +241,13 @@ public final class Daemon: Sendable {
         } catch {
             daemonLogger.warning("breakCyclicParents failed at startup: \(error.localizedDescription, privacy: .public)")
         }
+        // Resolve worktree rows stranded in `.creating` by a daemon restart
+        // mid-pre-session-wait. Must run BEFORE the per-repo reconcile loop so
+        // orphaned rows are deleted/flipped first — reconcile only sees
+        // `.active` rows and would otherwise trip the UNIQUE path constraint
+        // re-adopting a stranded checkout. Resumed waits run detached and
+        // never block startup.
+        await lifecycle.recoverCreatingWorktrees()
         do {
             let repos = try await database.repos.list()
             for repo in repos {

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -216,7 +216,7 @@ public struct TerminalStore: Sendable {
             record.transcriptPath = nil
             record.suspendedAt = nil
             record.suspendedSnapshot = nil
-            record.label = "shell"
+            record.label = TerminalLabel.shell
             record.kind = TerminalKind.shell.rawValue
             record.activityState = TerminalActivityState.unknown.rawValue
             try record.update(db)

--- a/Sources/TBDDaemon/Hooks/HookResolver.swift
+++ b/Sources/TBDDaemon/Hooks/HookResolver.swift
@@ -6,6 +6,7 @@ private let hooksLogger = Logger(subsystem: "com.tbd.daemon", category: "hooks")
 
 public enum HookEvent: String, Sendable {
     case setup
+    case preSession
     case archive
     case preMerge
     case postMerge
@@ -13,6 +14,7 @@ public enum HookEvent: String, Sendable {
     public var conductorKey: String {
         switch self {
         case .setup: return "setup"
+        case .preSession: return "preSession"
         case .archive: return "archive"
         case .preMerge: return "preMerge"
         case .postMerge: return "postMerge"
@@ -22,6 +24,7 @@ public enum HookEvent: String, Sendable {
     public var dmuxHookName: String {
         switch self {
         case .setup: return "worktree_created"
+        case .preSession: return "pre_session"
         case .archive: return "before_worktree_remove"
         case .preMerge: return "pre_merge"
         case .postMerge: return "post_merge"

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -289,7 +289,7 @@ extension WorktreeLifecycle {
             subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
                 terminalID: preSession.terminalID,
                 worktreeID: worktree.id,
-                label: "pre-session"
+                label: TerminalLabel.preSession
             )))
             // Flip to .creating AFTER the pre-session terminal exists so a
             // daemon crash in between leaves the row .archived (re-revivable)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -4,6 +4,28 @@ import TBDShared
 
 private let archiveLogger = Logger(subsystem: "com.tbd.daemon", category: "archive")
 
+/// Result of `beginReviveWorktree`. Mirrors `WorktreeCreateCompletion`: the
+/// pre-session path defers the primary terminal spawn to a detached task so
+/// the revive RPC isn't blocked for the duration of the hook.
+public enum WorktreeReviveCompletion: Sendable {
+    /// All terminals were spawned inline; the worktree is `.active`.
+    case ready(Worktree)
+    /// A blocking `preSession` hook terminal was spawned and the row flipped
+    /// to `.creating` (the app gates its pre-session UI on that status).
+    /// `phase3` awaits the hook, spawns the primary terminals, and finishes
+    /// the revive (status `.active`, `archivedAt`/session clearing).
+    case preSessionPending(worktree: Worktree, phase3: Task<Void, Never>)
+
+    /// The worktree row as of the moment the call returned (`.active` when
+    /// ready, `.creating` while the pre-session hook runs).
+    public var worktree: Worktree {
+        switch self {
+        case .ready(let worktree): return worktree
+        case .preSessionPending(let worktree, _): return worktree
+        }
+    }
+}
+
 /// Reorders `stored` so `preferred` is first, preserving the relative order of
 /// the rest. Returns `stored` unchanged when `preferred` is nil, when `stored`
 /// is nil, or when `stored` does not contain `preferred`.
@@ -152,11 +174,48 @@ extension WorktreeLifecycle {
 
     /// Revives an archived worktree, re-creating the git worktree and tmux windows.
     ///
+    /// Legacy synchronous contract (CLI + tests): the returned worktree is
+    /// fully set up and `.active`. When a `preSession` hook gates the primary
+    /// terminals, this awaits the detached phase-3 task INLINE — mirroring
+    /// `createWorktree`'s relationship to `completeCreateWorktree`.
+    ///
     /// - Parameters:
     ///   - worktreeID: The archived worktree to revive.
     ///   - skipClaude: If true, skip launching the primary agent in the first terminal window.
     /// - Returns: The revived worktree.
     public func reviveWorktree(worktreeID: UUID, skipClaude: Bool = false, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) async throws -> Worktree {
+        let completion = try await beginReviveWorktree(
+            worktreeID: worktreeID, skipClaude: skipClaude,
+            cols: cols, rows: rows, preferredSessionID: preferredSessionID
+        )
+        if case .preSessionPending(_, let phase3) = completion {
+            await phase3.value
+        }
+        guard let revived = try await db.worktrees.get(id: worktreeID) else {
+            throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
+        }
+        return revived
+    }
+
+    /// Non-blocking revive. Validates, re-adds the git worktree, then:
+    ///
+    /// - No `preSession` hook → spawns all terminals inline, flips the row to
+    ///   `.active`, and returns `.ready` (today's behavior, unchanged).
+    /// - `preSession` hook resolves → spawns ONLY the hook terminal, flips the
+    ///   row to `.creating` (the app gates its pre-session UI on that status),
+    ///   and returns `.preSessionPending` promptly. The detached phase-3 task
+    ///   awaits the hook's completion marker, spawns the primary terminals,
+    ///   and finishes with `db.worktrees.revive(id:clearSessions:)` so the
+    ///   archivedClaudeSessions-clearing semantics match the inline path.
+    ///
+    /// If the daemon restarts mid-wait, the row sits in `.creating` with a
+    /// pre-session terminal record; `recoverCreatingWorktrees()` resumes the
+    /// wait at next startup. That resume path flips the row with a plain
+    /// `.markActive` — acceptable, but it skips `revive()`'s extra writes:
+    /// `archivedAt` stays set and `archivedClaudeSessions` are neither
+    /// restored into terminals nor cleared (they remain available for a
+    /// later archive/revive cycle).
+    public func beginReviveWorktree(worktreeID: UUID, skipClaude: Bool = false, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) async throws -> WorktreeReviveCompletion {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -221,12 +280,51 @@ extension WorktreeLifecycle {
             try await db.worktrees.setArchivedClaudeSessions(id: worktreeID, sessions: sessions)
         }
 
-        try await setupTerminals(
+        // Gated path: a preSession hook must finish before the primary
+        // terminals spawn. Mirrors completeCreateWorktree's 5a branch.
+        if let preSession = try await spawnPreSessionTerminal(
             worktree: worktree, repo: repo,
+            worktreePath: worktree.path,
+            cols: cols, rows: rows
+        ) {
+            subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
+                terminalID: preSession.terminalID,
+                worktreeID: worktree.id,
+                label: "pre-session"
+            )))
+            // Flip to .creating AFTER the pre-session terminal exists so a
+            // daemon crash in between leaves the row .archived (re-revivable)
+            // rather than a terminal-less .creating row the recovery sweep
+            // would discard.
+            try await db.worktrees.updateStatus(id: worktreeID, status: .creating)
+            let phase3 = Task.detached { [self] in
+                await runPreSessionPhase3(
+                    preSession: preSession,
+                    worktree: worktree, repo: repo,
+                    worktreePath: worktree.path,
+                    skipClaude: skipClaude,
+                    archivedClaudeSessions: sessions,
+                    cols: cols, rows: rows,
+                    // Only clear archivedClaudeSessions if Claude was actually
+                    // restored — otherwise preserve them so a subsequent
+                    // revive (without skipClaude) can use them.
+                    completionAction: .revive(clearSessions: !skipClaude)
+                )
+            }
+            guard let pending = try await db.worktrees.get(id: worktreeID) else {
+                throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
+            }
+            return .preSessionPending(worktree: pending, phase3: phase3)
+        }
+
+        // No preSession hook → spawn all terminals inline (today's behavior).
+        _ = try await spawnPrimaryTerminals(
+            worktree: worktree, repo: repo,
+            worktreePath: worktree.path,
             skipClaude: skipClaude,
             archivedClaudeSessions: sessions,
-            cols: cols,
-            rows: rows
+            cols: cols, rows: rows,
+            preSessionTerminalID: nil
         )
 
         // Update status to active.
@@ -238,6 +336,6 @@ extension WorktreeLifecycle {
         guard let revived = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
-        return revived
+        return .ready(revived)
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -210,11 +210,10 @@ extension WorktreeLifecycle {
     ///
     /// If the daemon restarts mid-wait, the row sits in `.creating` with a
     /// pre-session terminal record; `recoverCreatingWorktrees()` resumes the
-    /// wait at next startup. That resume path flips the row with a plain
-    /// `.markActive` — acceptable, but it skips `revive()`'s extra writes:
-    /// `archivedAt` stays set and `archivedClaudeSessions` are neither
-    /// restored into terminals nor cleared (they remain available for a
-    /// later archive/revive cycle).
+    /// wait at next startup. The recovery sweep detects the interrupted
+    /// revive (the row still carries `archivedClaudeSessions`) and resumes
+    /// with revive semantics: the archived sessions are restored into
+    /// terminals and the row finishes via `.revive(clearSessions: true)`.
     public func beginReviveWorktree(worktreeID: UUID, skipClaude: Bool = false, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) async throws -> WorktreeReviveCompletion {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -4,6 +4,20 @@ import TBDShared
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "worktreeLifecycle")
 
+/// Result of `completeCreateWorktree`. The pre-session path defers the
+/// primary terminal spawn to a background task so the caller's serializer
+/// lane isn't blocked for the duration of the hook (e.g. an `npm install`).
+public enum WorktreeCreateCompletion: Sendable {
+    /// All terminals were spawned inline; the worktree is `.active` and the
+    /// caller should broadcast `.worktreeCreated` (today's behavior).
+    case ready
+    /// A blocking `preSession` hook terminal was spawned. The lifecycle has
+    /// already broadcast `.worktreeCreated` + `.terminalCreated`; `phase3`
+    /// awaits the hook, spawns the primary terminals, and flips the worktree
+    /// to `.active`. The worktree stays `.creating` until it finishes.
+    case preSessionPending(phase3: Task<Void, Never>)
+}
+
 extension WorktreeLifecycle {
     // MARK: - Create
 
@@ -16,7 +30,12 @@ extension WorktreeLifecycle {
         // Pass the original branch ref (may include `origin/` prefix) through
         // so phase 2 can dispatch to the correct git command.
         let existingBranchRef = useExistingBranch ? branch : nil
-        try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows, existingBranchRef: existingBranchRef)
+        let completion = try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows, existingBranchRef: existingBranchRef)
+        // Legacy synchronous contract: the returned worktree is fully set up.
+        // Await phase 3 inline when a preSession hook gated the primary spawn.
+        if case .preSessionPending(let phase3) = completion {
+            await phase3.value
+        }
         guard let completed = try await db.worktrees.get(id: pending.id) else {
             throw WorktreeLifecycleError.worktreeNotFound(pending.id)
         }
@@ -127,9 +146,15 @@ extension WorktreeLifecycle {
     /// Phase 2: Async. Performs git fetch, git worktree add, tmux setup,
     /// then updates status to `.active`. On failure, deletes the DB row.
     ///
+    /// When a `preSession` hook resolves, only the hook's terminal is created
+    /// here; the primary terminals are spawned by the returned
+    /// `.preSessionPending` task once the hook completes (or times out).
+    /// Phase-3 failures never delete the DB row — the checkout is valid.
+    ///
     /// When `existingBranchRef` is non-nil, the worktree is checked out from
     /// that existing ref (local or `origin/*`) — no fresh branch is created.
-    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil) async throws {
+    @discardableResult
+    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil) async throws -> WorktreeCreateCompletion {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -200,18 +225,58 @@ extension WorktreeLifecycle {
                 resultPath = result.path
             }
 
-            // 5. Setup tmux terminals
-            try await setupTerminals(
+            // 5. Setup tmux terminals.
+            // 5a. Blocking preSession hook: spawn its terminal FIRST and gate
+            // the primary terminals on its completion marker. The wait runs in
+            // a background task so the caller's RepoSerializer lane is freed
+            // immediately — never block it for the duration of the hook.
+            if let preSession = try await spawnPreSessionTerminal(
+                worktree: worktree, repo: repo,
+                worktreePath: resultPath,
+                cols: cols, rows: rows
+            ) {
+                // Broadcast early so the app refreshes and shows the live hook
+                // output instead of the empty state. The RPC handler skips its
+                // own `.worktreeCreated` for the `.preSessionPending` result,
+                // so this stays a single broadcast.
+                subscriptions?.broadcast(delta: .worktreeCreated(WorktreeDelta(
+                    worktreeID: worktree.id, repoID: worktree.repoID,
+                    name: worktree.name, path: resultPath
+                )))
+                subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
+                    terminalID: preSession.terminalID,
+                    worktreeID: worktree.id,
+                    label: "pre-session"
+                )))
+                let phase3 = Task.detached { [self] in
+                    await runPreSessionPhase3(
+                        preSession: preSession,
+                        worktree: worktree, repo: repo,
+                        worktreePath: resultPath,
+                        skipClaude: skipClaude,
+                        initialPrompt: initialPrompt,
+                        cols: cols, rows: rows,
+                        markActiveOnCompletion: true
+                    )
+                }
+                return .preSessionPending(phase3: phase3)
+            }
+
+            // 5b. No preSession hook: spawn primary terminals inline
+            // (behavior identical to before the preSession hook existed).
+            _ = try await spawnPrimaryTerminals(
                 worktree: worktree, repo: repo,
                 worktreePath: resultPath,
                 skipClaude: skipClaude,
                 initialPrompt: initialPrompt,
                 cols: cols,
-                rows: rows
+                rows: rows,
+                preSessionTerminalID: nil
             )
 
             // 6. Update status to active
             try await db.worktrees.updateStatus(id: worktreeID, status: .active)
+            return .ready
 
         } catch {
             // On failure, delete the DB row
@@ -308,7 +373,13 @@ extension WorktreeLifecycle {
     }
 
     /// Sets up tmux windows and terminal records for a worktree.
-    /// Shared by `finishCreate` and `reviveWorktree`.
+    /// Used by `reviveWorktree` (and the no-hook create path via
+    /// `spawnPrimaryTerminals` directly).
+    ///
+    /// When a `preSession` hook resolves, its terminal is created first and
+    /// this method awaits the hook's completion marker INLINE before spawning
+    /// the primary terminals. (`completeCreateWorktree` does the same dance
+    /// with the wait detached instead — revive is a synchronous RPC.)
     ///
     /// When `archivedClaudeSessions` is provided (revive path), the first session ID
     /// is reused for the primary Claude terminal to restore the conversation, and any
@@ -321,6 +392,60 @@ extension WorktreeLifecycle {
         cols: Int? = nil,
         rows: Int? = nil
     ) async throws {
+        let worktreePath = worktreePath ?? worktree.path
+        guard let preSession = try await spawnPreSessionTerminal(
+            worktree: worktree, repo: repo,
+            worktreePath: worktreePath,
+            cols: cols, rows: rows
+        ) else {
+            // No preSession hook → identical behavior to today.
+            _ = try await spawnPrimaryTerminals(
+                worktree: worktree, repo: repo,
+                worktreePath: worktreePath,
+                skipClaude: skipClaude,
+                archivedClaudeSessions: archivedClaudeSessions,
+                initialPrompt: initialPrompt,
+                cols: cols, rows: rows,
+                preSessionTerminalID: nil
+            )
+            return
+        }
+        subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
+            terminalID: preSession.terminalID,
+            worktreeID: worktree.id,
+            label: "pre-session"
+        )))
+        // Status transitions stay with the caller (revive sets its own).
+        await runPreSessionPhase3(
+            preSession: preSession,
+            worktree: worktree, repo: repo,
+            worktreePath: worktreePath,
+            skipClaude: skipClaude,
+            archivedClaudeSessions: archivedClaudeSessions,
+            initialPrompt: initialPrompt,
+            cols: cols, rows: rows,
+            markActiveOnCompletion: false
+        )
+    }
+
+    /// Spawns the primary agent terminal, the parallel `setup` hook terminal,
+    /// and any archived-session restores; persists tab order + active tab and
+    /// kills the untracked initial tmux window. This is the pre-existing
+    /// `setupTerminals` body, parameterized by an optional already-created
+    /// pre-session terminal (slotted second in the tab order).
+    ///
+    /// Returns the created terminals as `(id, label)` pairs so phase 3 can
+    /// broadcast `.terminalCreated` for each.
+    @discardableResult
+    func spawnPrimaryTerminals(
+        worktree: Worktree, repo: Repo,
+        worktreePath: String? = nil, skipClaude: Bool,
+        archivedClaudeSessions: [String]? = nil,
+        initialPrompt: String? = nil,
+        cols: Int? = nil,
+        rows: Int? = nil,
+        preSessionTerminalID: UUID?
+    ) async throws -> [(id: UUID, label: String)] {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
         let worktreePath = worktreePath ?? worktree.path
@@ -456,6 +581,9 @@ extension WorktreeLifecycle {
             profileID: primaryProfileID,
             kind: primaryTerminalKind
         )
+        var createdTerminals: [(id: UUID, label: String)] = [
+            (id: plannedTerminalID1, label: primaryLabel)
+        ]
 
         // Create terminal 2: setup hook
         let plannedTerminalID2 = UUID()
@@ -489,6 +617,7 @@ extension WorktreeLifecycle {
             label: "setup",
             kind: .shell
         )
+        createdTerminals.append((id: plannedTerminalID2, label: "setup"))
 
         // Restore any archived Claude sessions that were not consumed by the
         // primary terminal.
@@ -550,15 +679,25 @@ extension WorktreeLifecycle {
                     profileID: resolvedProfile?.profileID,
                     kind: .claude
                 )
+                createdTerminals.append((id: plannedID, label: "Claude Code"))
             }
         }
 
-        try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: createdTerminalIDs)
+        // Tab order: [primary, (preSession), setup, archived restores…],
+        // active = primary. Without a pre-session terminal this is exactly
+        // the pre-existing [primary, setup, …] order.
+        var tabOrder = createdTerminalIDs
+        if let preSessionTerminalID {
+            tabOrder.insert(preSessionTerminalID, at: 1)
+        }
+        try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: tabOrder)
         try await db.worktrees.setActiveTabID(worktreeID: worktreeID, tabID: plannedTerminalID1)
 
         // Kill the untracked initial window that new-session created
         if let windowID = initialWindowID {
             try? await tmux.killWindow(server: tmuxServer, windowID: windowID)
         }
+
+        return createdTerminals
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -248,7 +248,7 @@ extension WorktreeLifecycle {
                 subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
                     terminalID: preSession.terminalID,
                     worktreeID: worktree.id,
-                    label: "pre-session"
+                    label: TerminalLabel.preSession
                 )))
                 let phase3 = Task.detached { [self] in
                     await runPreSessionPhase3(
@@ -452,7 +452,7 @@ extension WorktreeLifecycle {
             primarySensitiveEnv = [:]
             primarySessionID = nil
             primaryProfileID = nil
-            primaryLabel = "shell"
+            primaryLabel = TerminalLabel.shell
         case .codex:
             let codexHome = try CodexHomeManager().ensureProfilePlugin()
             primaryCommand = CodexSpawnCommandBuilder.build(initialPrompt: initialPrompt)
@@ -464,7 +464,7 @@ extension WorktreeLifecycle {
             primarySensitiveEnv = [:]
             primarySessionID = nil
             primaryProfileID = nil
-            primaryLabel = "Codex"
+            primaryLabel = TerminalLabel.codex
         case .claude:
             let archivedSession = archivedSessions.first
             let sessionUUID = archivedSession ?? UUID().uuidString
@@ -505,7 +505,7 @@ extension WorktreeLifecycle {
             ]
             primarySensitiveEnv = spawn.sensitiveEnv
             primaryProfileID = resolvedProfile?.profileID
-            primaryLabel = "Claude Code"
+            primaryLabel = TerminalLabel.claudeCode
         }
         let window1 = try await tmux.createWindow(
             server: tmuxServer,
@@ -566,10 +566,10 @@ extension WorktreeLifecycle {
             worktreeID: worktreeID,
             tmuxWindowID: window2.windowID,
             tmuxPaneID: window2.paneID,
-            label: "setup",
+            label: TerminalLabel.setup,
             kind: .shell
         )
-        createdTerminals.append((id: plannedTerminalID2, label: "setup"))
+        createdTerminals.append((id: plannedTerminalID2, label: TerminalLabel.setup))
 
         // Restore any archived Claude sessions that were not consumed by the
         // primary terminal.
@@ -626,12 +626,12 @@ extension WorktreeLifecycle {
                     worktreeID: worktreeID,
                     tmuxWindowID: window.windowID,
                     tmuxPaneID: window.paneID,
-                    label: "Claude Code",
+                    label: TerminalLabel.claudeCode,
                     claudeSessionID: sessionID,
                     profileID: resolvedProfile?.profileID,
                     kind: .claude
                 )
-                createdTerminals.append((id: plannedID, label: "Claude Code"))
+                createdTerminals.append((id: plannedID, label: TerminalLabel.claudeCode))
             }
         }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -235,8 +235,10 @@ extension WorktreeLifecycle {
                 worktreePath: resultPath,
                 cols: cols, rows: rows
             ) {
-                // Broadcast early so the app refreshes and shows the live hook
-                // output instead of the empty state. The RPC handler skips its
+                // Broadcast early. `.worktreeCreated` is for non-app clients —
+                // the app's handleDelta ignores it (default: break); what makes
+                // the app load and show the live hook terminal is the
+                // `.terminalCreated` delta below. The RPC handler skips its
                 // own `.worktreeCreated` for the `.preSessionPending` result,
                 // so this stays a single broadcast.
                 subscriptions?.broadcast(delta: .worktreeCreated(WorktreeDelta(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -256,7 +256,7 @@ extension WorktreeLifecycle {
                         skipClaude: skipClaude,
                         initialPrompt: initialPrompt,
                         cols: cols, rows: rows,
-                        markActiveOnCompletion: true
+                        completionAction: .markActive
                     )
                 }
                 return .preSessionPending(phase3: phase3)
@@ -370,62 +370,6 @@ extension WorktreeLifecycle {
         if command == defaultShell { return command }
         let escaped = command.replacingOccurrences(of: "'", with: "'\\''")
         return "'\(escaped)'; exec \(defaultShell)"
-    }
-
-    /// Sets up tmux windows and terminal records for a worktree.
-    /// Used by `reviveWorktree` (and the no-hook create path via
-    /// `spawnPrimaryTerminals` directly).
-    ///
-    /// When a `preSession` hook resolves, its terminal is created first and
-    /// this method awaits the hook's completion marker INLINE before spawning
-    /// the primary terminals. (`completeCreateWorktree` does the same dance
-    /// with the wait detached instead — revive is a synchronous RPC.)
-    ///
-    /// When `archivedClaudeSessions` is provided (revive path), the first session ID
-    /// is reused for the primary Claude terminal to restore the conversation, and any
-    /// additional sessions get their own terminal windows.
-    func setupTerminals(
-        worktree: Worktree, repo: Repo,
-        worktreePath: String? = nil, skipClaude: Bool,
-        archivedClaudeSessions: [String]? = nil,
-        initialPrompt: String? = nil,
-        cols: Int? = nil,
-        rows: Int? = nil
-    ) async throws {
-        let worktreePath = worktreePath ?? worktree.path
-        guard let preSession = try await spawnPreSessionTerminal(
-            worktree: worktree, repo: repo,
-            worktreePath: worktreePath,
-            cols: cols, rows: rows
-        ) else {
-            // No preSession hook → identical behavior to today.
-            _ = try await spawnPrimaryTerminals(
-                worktree: worktree, repo: repo,
-                worktreePath: worktreePath,
-                skipClaude: skipClaude,
-                archivedClaudeSessions: archivedClaudeSessions,
-                initialPrompt: initialPrompt,
-                cols: cols, rows: rows,
-                preSessionTerminalID: nil
-            )
-            return
-        }
-        subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
-            terminalID: preSession.terminalID,
-            worktreeID: worktree.id,
-            label: "pre-session"
-        )))
-        // Status transitions stay with the caller (revive sets its own).
-        await runPreSessionPhase3(
-            preSession: preSession,
-            worktree: worktree, repo: repo,
-            worktreePath: worktreePath,
-            skipClaude: skipClaude,
-            archivedClaudeSessions: archivedClaudeSessions,
-            initialPrompt: initialPrompt,
-            cols: cols, rows: rows,
-            markActiveOnCompletion: false
-        )
     }
 
     /// Spawns the primary agent terminal, the parallel `setup` hook terminal,
@@ -594,11 +538,17 @@ extension WorktreeLifecycle {
             appHookPath: TBDConstants.hookPath(repoID: worktree.repoID, eventName: HookEvent.setup.rawValue)
         )
         let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
-        // Inject TBD_TERMINAL_ID + TBD_WORKTREE_ID so setup hooks and any
-        // tooling they run can identify their owning terminal.
+        // Full hook environment per docs/worktree-hooks.md (matches the
+        // preSession and archive hooks). TBD_WORKTREE_NAME uses
+        // `worktree.name` for consistency with the archive hook's env.
         let setupEnv: [String: String] = [
             "TBD_WORKTREE_ID": worktreeID.uuidString,
             "TBD_TERMINAL_ID": plannedTerminalID2.uuidString,
+            "TBD_EVENT": HookEvent.setup.rawValue,
+            "TBD_WORKTREE_NAME": worktree.name,
+            "TBD_WORKTREE_PATH": worktreePath,
+            "TBD_REPO_PATH": repo.path,
+            "TBD_BRANCH": worktree.branch,
         ]
         let window2 = try await tmux.createWindow(
             server: tmuxServer,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -25,6 +25,19 @@ enum PreSessionOutcome: Equatable, Sendable {
     case paneKilled
 }
 
+/// What `runPreSessionPhase3` does to the worktree row once the primary
+/// terminals are spawned. Phase 3 must always flip the status eventually —
+/// the row would otherwise be stuck in `.creating` forever.
+enum PreSessionCompletionAction: Sendable {
+    /// Create path: set status to `.active`.
+    case markActive
+    /// Revive path: `db.worktrees.revive(id:clearSessions:)` — flips to
+    /// `.active`, clears `archivedAt`, and (when `clearSessions` is true)
+    /// clears `archivedClaudeSessions`, preserving the legacy revive
+    /// semantics around session restoration.
+    case revive(clearSessions: Bool)
+}
+
 extension WorktreeLifecycle {
 
     // MARK: - Paths & command construction
@@ -106,10 +119,17 @@ extension WorktreeLifecycle {
             markerPath: markerPath,
             shell: defaultShell
         )
+        // Full hook environment per docs/worktree-hooks.md. TBD_WORKTREE_NAME
+        // uses `worktree.name` to match the archive hook's env (the display
+        // name can be renamed later; the folder name is the stable identity).
         let env: [String: String] = [
             "TBD_WORKTREE_ID": worktreeID.uuidString,
             "TBD_TERMINAL_ID": terminalID.uuidString,
             "TBD_EVENT": HookEvent.preSession.rawValue,
+            "TBD_WORKTREE_NAME": worktree.name,
+            "TBD_WORKTREE_PATH": worktreePath,
+            "TBD_REPO_PATH": repo.path,
+            "TBD_BRANCH": worktree.branch,
         ]
         let window = try await tmux.createWindow(
             server: tmuxServer,
@@ -149,6 +169,16 @@ extension WorktreeLifecycle {
 
     // MARK: - Phase 3: marker wait + primary spawn
 
+    /// Reads + deletes the marker file if present, returning the recorded
+    /// exit code. Returns nil when no marker exists yet.
+    private static func consumeMarker(atPath path: String) -> PreSessionOutcome? {
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        let content = (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+        try? FileManager.default.removeItem(atPath: path)
+        let code = Int(content.trimmingCharacters(in: .whitespacesAndNewlines)) ?? -1
+        return .completed(exitCode: code)
+    }
+
     /// Polls for the completion marker. Short-circuits when the hook's tmux
     /// window disappears (user killed the pane). Reads + deletes the marker.
     func waitForPreSessionCompletion(
@@ -159,21 +189,29 @@ extension WorktreeLifecycle {
         while Date() < deadline {
             // Marker check first: if the hook finished and the user then
             // closed the pane, the recorded exit code wins.
-            if FileManager.default.fileExists(atPath: preSession.markerPath) {
-                let content = (try? String(
-                    contentsOfFile: preSession.markerPath, encoding: .utf8
-                )) ?? ""
-                try? FileManager.default.removeItem(atPath: preSession.markerPath)
-                let code = Int(content.trimmingCharacters(in: .whitespacesAndNewlines)) ?? -1
-                return .completed(exitCode: code)
+            if let outcome = Self.consumeMarker(atPath: preSession.markerPath) {
+                return outcome
             }
             let windowAlive = await tmux.windowExists(
                 server: tmuxServer, windowID: preSession.windowID
             )
             if !windowAlive {
+                // Same-iteration race: the hook can write the marker after the
+                // fileExists check above and exit (closing the pane) before the
+                // windowExists check. Re-check the marker once so a hook that
+                // actually finished isn't misreported as a killed pane.
+                if let outcome = Self.consumeMarker(atPath: preSession.markerPath) {
+                    return outcome
+                }
                 return .paneKilled
             }
             try? await Task.sleep(nanoseconds: pollNanos)
+        }
+        // Deadline race: the marker may have landed during the final poll
+        // sleep. Honor a hook that finished (just barely too late) instead of
+        // reporting a timeout — and consume the marker so it never leaks.
+        if let outcome = Self.consumeMarker(atPath: preSession.markerPath) {
+            return outcome
         }
         return .timedOut
     }
@@ -183,8 +221,9 @@ extension WorktreeLifecycle {
     ///
     /// Never throws and never deletes the worktree row — by the time phase 3
     /// runs, the git checkout is valid. Spawn errors are logged + notified.
-    /// When `markActiveOnCompletion` is true (create path), the worktree status
-    /// is set to `.active` at the end no matter what happened.
+    /// `completionAction` decides the final status flip (`.markActive` on the
+    /// create path, `.revive` on the revive path); it always runs no matter
+    /// what happened, so the row never sticks in `.creating`.
     func runPreSessionPhase3(
         preSession: PreSessionSpawn,
         worktree: Worktree, repo: Repo,
@@ -193,11 +232,31 @@ extension WorktreeLifecycle {
         archivedClaudeSessions: [String]? = nil,
         initialPrompt: String? = nil,
         cols: Int? = nil, rows: Int? = nil,
-        markActiveOnCompletion: Bool
+        completionAction: PreSessionCompletionAction
     ) async {
         let outcome = await waitForPreSessionCompletion(
             preSession: preSession, tmuxServer: worktree.tmuxServer
         )
+        // The marker must never outlive the wait, whatever the outcome —
+        // `.completed` consumes it inside the wait; this catches any straggler
+        // written between the wait's last check and now.
+        try? FileManager.default.removeItem(atPath: preSession.markerPath)
+
+        // The worktree row can vanish mid-wait (repo remove cascades a
+        // deleteForRepo while phase 3 is parked on the marker). Spawning the
+        // primary terminals would then fail the terminal FK insert AFTER the
+        // tmux window (and its Claude process) was created — orphaning both.
+        // Bail out before any spawn: kill the pre-session window best-effort
+        // and clean the marker; there is no row left to flip or notify.
+        guard (try? await db.worktrees.get(id: worktree.id)) ?? nil != nil else {
+            logger.warning("phase-3: worktree \(worktree.id, privacy: .public) row disappeared mid-wait — skipping primary spawn and cleaning up")
+            try? await tmux.killWindow(
+                server: worktree.tmuxServer, windowID: preSession.windowID
+            )
+            try? FileManager.default.removeItem(atPath: preSession.markerPath)
+            return
+        }
+
         switch outcome {
         case .completed(exitCode: 0):
             logger.info("preSession hook completed for worktree \(worktree.id, privacy: .public)")
@@ -243,13 +302,16 @@ extension WorktreeLifecycle {
             )
         }
 
-        if markActiveOnCompletion {
-            // Never leave the worktree stuck in .creating — the checkout is valid.
-            do {
+        // Never leave the worktree stuck in .creating — the checkout is valid.
+        do {
+            switch completionAction {
+            case .markActive:
                 try await db.worktrees.updateStatus(id: worktree.id, status: .active)
-            } catch {
-                logger.error("phase-3 status update failed for worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            case .revive(let clearSessions):
+                try await db.worktrees.revive(id: worktree.id, clearSessions: clearSessions)
             }
+        } catch {
+            logger.error("phase-3 status update failed for worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -246,14 +246,23 @@ extension WorktreeLifecycle {
         // deleteForRepo while phase 3 is parked on the marker). Spawning the
         // primary terminals would then fail the terminal FK insert AFTER the
         // tmux window (and its Claude process) was created — orphaning both.
-        // Bail out before any spawn: kill the pre-session window best-effort
-        // and clean the marker; there is no row left to flip or notify.
-        guard (try? await db.worktrees.get(id: worktree.id)) ?? nil != nil else {
+        // Bail out before any spawn: kill the pre-session window best-effort;
+        // the marker is already gone (removed above), and there is no row
+        // left to flip or notify. A thrown DB error is NOT proof the row is
+        // gone — treat it as transient and proceed with the spawn rather
+        // than tear down a valid worktree.
+        let rowExists: Bool
+        do {
+            rowExists = try await db.worktrees.get(id: worktree.id) != nil
+        } catch {
+            logger.warning("phase-3: worktree existence check failed for \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public) — assuming the row still exists and proceeding")
+            rowExists = true
+        }
+        guard rowExists else {
             logger.warning("phase-3: worktree \(worktree.id, privacy: .public) row disappeared mid-wait — skipping primary spawn and cleaning up")
             try? await tmux.killWindow(
                 server: worktree.tmuxServer, windowID: preSession.windowID
             )
-            try? FileManager.default.removeItem(atPath: preSession.markerPath)
             return
         }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -145,7 +145,7 @@ extension WorktreeLifecycle {
             worktreeID: worktreeID,
             tmuxWindowID: window.windowID,
             tmuxPaneID: window.paneID,
-            label: "pre-session",
+            label: TerminalLabel.preSession,
             kind: .shell
         )
         // The pre-session terminal is the only tab until phase 3 runs.

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -1,0 +1,278 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "worktreeLifecycle")
+
+/// Descriptor for a spawned pre-session hook terminal. Phase 3 (the marker
+/// wait + primary terminal spawn) consumes it.
+struct PreSessionSpawn: Sendable {
+    let terminalID: UUID
+    let windowID: String
+    let paneID: String
+    let markerPath: String
+    let hookPath: String
+}
+
+/// How a pre-session hook run ended.
+enum PreSessionOutcome: Equatable, Sendable {
+    /// The hook wrote its exit code to the marker file.
+    case completed(exitCode: Int)
+    /// The marker never appeared within the timeout.
+    case timedOut
+    /// The hook's tmux window disappeared before the marker was written
+    /// (user killed the pane). Treated as failure.
+    case paneKilled
+}
+
+extension WorktreeLifecycle {
+
+    // MARK: - Paths & command construction
+
+    /// Directory holding pre-session completion markers. TBD_HOME-relative so
+    /// tests redirect automatically.
+    static var preSessionRuntimeDir: String {
+        TBDConstants.configDir
+            .appendingPathComponent("runtime")
+            .appendingPathComponent("presession")
+            .path
+    }
+
+    /// Marker file the wrapped hook command writes its exit code to.
+    static func preSessionMarkerPath(worktreeID: UUID) -> String {
+        (preSessionRuntimeDir as NSString)
+            .appendingPathComponent(worktreeID.uuidString)
+    }
+
+    /// Wraps the hook so its exit code lands in the marker file and the pane
+    /// stays alive as a usable shell afterward (same rationale as
+    /// `shellWrapped`). Single-quote escaping matches `shellWrapped`.
+    static func preSessionCommand(
+        hookPath: String, runtimeDir: String, markerPath: String, shell: String
+    ) -> String {
+        func quoted(_ s: String) -> String {
+            "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        }
+        return "\(quoted(hookPath)); __tbd_rc=$?; "
+            + "/bin/mkdir -p \(quoted(runtimeDir)); "
+            + "/bin/echo $__tbd_rc > \(quoted(markerPath)); "
+            + "exec \(shell)"
+    }
+
+    // MARK: - Phase 2b: spawn the pre-session terminal
+
+    /// Resolves the `preSession` hook and, if present, creates its terminal as
+    /// the FIRST window of the worktree's tmux session. Returns nil when no
+    /// hook resolves — callers then spawn the primary terminals directly
+    /// (today's behavior, unchanged).
+    func spawnPreSessionTerminal(
+        worktree: Worktree, repo: Repo,
+        worktreePath: String,
+        cols: Int? = nil, rows: Int? = nil
+    ) async throws -> PreSessionSpawn? {
+        guard let hookPath = hooks.resolve(
+            event: .preSession,
+            repoPath: worktreePath,
+            appHookPath: TBDConstants.hookPath(
+                repoID: worktree.repoID, eventName: HookEvent.preSession.rawValue
+            )
+        ) else {
+            return nil
+        }
+
+        let worktreeID = worktree.id
+        let tmuxServer = worktree.tmuxServer
+        let resolvedCols = cols ?? TmuxManager.defaultCols
+        let resolvedRows = rows ?? TmuxManager.defaultRows
+
+        // Ensure tmux server exists — capture initial window ID to kill once
+        // the first real window (the pre-session one) exists.
+        let initialWindowID = try await tmux.ensureServer(
+            server: tmuxServer,
+            session: "main",
+            cwd: worktreePath,
+            cols: resolvedCols,
+            rows: resolvedRows
+        )
+
+        let terminalID = UUID()
+        let markerPath = Self.preSessionMarkerPath(worktreeID: worktreeID)
+        // Delete any stale marker from a previous run of this worktree ID.
+        try? FileManager.default.removeItem(atPath: markerPath)
+
+        let command = Self.preSessionCommand(
+            hookPath: hookPath,
+            runtimeDir: Self.preSessionRuntimeDir,
+            markerPath: markerPath,
+            shell: defaultShell
+        )
+        let env: [String: String] = [
+            "TBD_WORKTREE_ID": worktreeID.uuidString,
+            "TBD_TERMINAL_ID": terminalID.uuidString,
+            "TBD_EVENT": HookEvent.preSession.rawValue,
+        ]
+        let window = try await tmux.createWindow(
+            server: tmuxServer,
+            session: "main",
+            cwd: worktreePath,
+            shellCommand: command,
+            env: env,
+            cols: resolvedCols,
+            rows: resolvedRows
+        )
+        _ = try await db.terminals.create(
+            id: terminalID,
+            worktreeID: worktreeID,
+            tmuxWindowID: window.windowID,
+            tmuxPaneID: window.paneID,
+            label: "pre-session",
+            kind: .shell
+        )
+        // The pre-session terminal is the only tab until phase 3 runs.
+        try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: [terminalID])
+        try await db.worktrees.setActiveTabID(worktreeID: worktreeID, tabID: terminalID)
+
+        // Kill the untracked initial window now that a real window exists.
+        if let initialWindowID {
+            try? await tmux.killWindow(server: tmuxServer, windowID: initialWindowID)
+        }
+
+        logger.info("preSession hook \(hookPath, privacy: .public) spawned for worktree \(worktreeID, privacy: .public); gating primary terminals on marker")
+        return PreSessionSpawn(
+            terminalID: terminalID,
+            windowID: window.windowID,
+            paneID: window.paneID,
+            markerPath: markerPath,
+            hookPath: hookPath
+        )
+    }
+
+    // MARK: - Phase 3: marker wait + primary spawn
+
+    /// Polls for the completion marker. Short-circuits when the hook's tmux
+    /// window disappears (user killed the pane). Reads + deletes the marker.
+    func waitForPreSessionCompletion(
+        preSession: PreSessionSpawn, tmuxServer: String
+    ) async -> PreSessionOutcome {
+        let deadline = Date().addingTimeInterval(preSessionTimeout)
+        let pollNanos = UInt64(max(preSessionPollInterval, 0.01) * 1_000_000_000)
+        while Date() < deadline {
+            // Marker check first: if the hook finished and the user then
+            // closed the pane, the recorded exit code wins.
+            if FileManager.default.fileExists(atPath: preSession.markerPath) {
+                let content = (try? String(
+                    contentsOfFile: preSession.markerPath, encoding: .utf8
+                )) ?? ""
+                try? FileManager.default.removeItem(atPath: preSession.markerPath)
+                let code = Int(content.trimmingCharacters(in: .whitespacesAndNewlines)) ?? -1
+                return .completed(exitCode: code)
+            }
+            let windowAlive = await tmux.windowExists(
+                server: tmuxServer, windowID: preSession.windowID
+            )
+            if !windowAlive {
+                return .paneKilled
+            }
+            try? await Task.sleep(nanoseconds: pollNanos)
+        }
+        return .timedOut
+    }
+
+    /// Phase 3: await the pre-session hook, notify on failure/timeout, then
+    /// spawn the primary terminals regardless of hook outcome.
+    ///
+    /// Never throws and never deletes the worktree row — by the time phase 3
+    /// runs, the git checkout is valid. Spawn errors are logged + notified.
+    /// When `markActiveOnCompletion` is true (create path), the worktree status
+    /// is set to `.active` at the end no matter what happened.
+    func runPreSessionPhase3(
+        preSession: PreSessionSpawn,
+        worktree: Worktree, repo: Repo,
+        worktreePath: String,
+        skipClaude: Bool,
+        archivedClaudeSessions: [String]? = nil,
+        initialPrompt: String? = nil,
+        cols: Int? = nil, rows: Int? = nil,
+        markActiveOnCompletion: Bool
+    ) async {
+        let outcome = await waitForPreSessionCompletion(
+            preSession: preSession, tmuxServer: worktree.tmuxServer
+        )
+        switch outcome {
+        case .completed(exitCode: 0):
+            logger.info("preSession hook completed for worktree \(worktree.id, privacy: .public)")
+        case .completed(let exitCode):
+            await notifyPreSessionProblem(
+                worktree: worktree, terminalID: preSession.terminalID,
+                message: "Pre-session hook failed (exit \(exitCode)) — starting the agent anyway"
+            )
+        case .timedOut:
+            await notifyPreSessionProblem(
+                worktree: worktree, terminalID: preSession.terminalID,
+                message: "Pre-session hook timed out after \(Int(preSessionTimeout))s — starting the agent anyway"
+            )
+        case .paneKilled:
+            await notifyPreSessionProblem(
+                worktree: worktree, terminalID: preSession.terminalID,
+                message: "Pre-session hook terminal closed before the hook finished — starting the agent anyway"
+            )
+        }
+
+        do {
+            let created = try await spawnPrimaryTerminals(
+                worktree: worktree, repo: repo,
+                worktreePath: worktreePath,
+                skipClaude: skipClaude,
+                archivedClaudeSessions: archivedClaudeSessions,
+                initialPrompt: initialPrompt,
+                cols: cols, rows: rows,
+                preSessionTerminalID: preSession.terminalID
+            )
+            for terminal in created {
+                subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
+                    terminalID: terminal.id,
+                    worktreeID: worktree.id,
+                    label: terminal.label
+                )))
+            }
+        } catch {
+            logger.error("phase-3 primary terminal spawn failed for worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            await notifyPreSessionProblem(
+                worktree: worktree, terminalID: preSession.terminalID,
+                message: "Failed to start agent terminals after the pre-session hook: \(error.localizedDescription)"
+            )
+        }
+
+        if markActiveOnCompletion {
+            // Never leave the worktree stuck in .creating — the checkout is valid.
+            do {
+                try await db.worktrees.updateStatus(id: worktree.id, status: .active)
+            } catch {
+                logger.error("phase-3 status update failed for worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// Records a daemon notification and broadcasts it (same pattern as
+    /// `handleNotify` in RPCRouter+TerminalHandlers).
+    private func notifyPreSessionProblem(
+        worktree: Worktree, terminalID: UUID, message: String
+    ) async {
+        logger.warning("preSession: \(message, privacy: .public) (worktree \(worktree.id, privacy: .public))")
+        do {
+            let notification = try await db.notifications.create(
+                worktreeID: worktree.id,
+                type: .error,
+                message: message,
+                terminalID: terminalID
+            )
+            subscriptions?.broadcast(delta: .notificationReceived(NotificationDelta(
+                notificationID: notification.id, worktreeID: notification.worktreeID,
+                type: notification.type, message: notification.message,
+                terminalID: notification.terminalID
+            )))
+        } catch {
+            logger.error("failed to record preSession notification: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -202,20 +202,30 @@ extension WorktreeLifecycle {
             }
         }
 
-        // Clean up orphaned tmux windows — windows not tracked by any terminal (active or main)
+        // Clean up orphaned tmux windows — windows not tracked by any terminal
+        // (active, main, or creating). `.creating` worktrees count as live: a
+        // pre-session hook wait that's still in flight (or just resumed by the
+        // startup recovery sweep) owns a real tmux window, and phase 3 spawns
+        // primary/setup windows before the row flips `.active`. Treating those
+        // rows as dead would kill the hook mid-run (interrupting e.g. a running
+        // npm install), fire a spurious `.paneKilled` notification, and spawn
+        // the agent prematurely.
         let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
         let activeWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
         let mainWorktreesForCleanup = try await db.worktrees.list(repoID: repoID, status: .main)
-        let allLiveWorktreesForCleanup = activeWorktrees + mainWorktreesForCleanup
+        let creatingWorktreesForCleanup = try await db.worktrees.list(repoID: repoID, status: .creating)
+        let allLiveWorktreesForCleanup = activeWorktrees + mainWorktreesForCleanup + creatingWorktreesForCleanup
         if allLiveWorktreesForCleanup.isEmpty {
-            // No live worktrees — kill the entire tmux server
+            // No live worktrees (including `.creating` ones) — kill the entire
+            // tmux server. A repo whose only live row is mid-pre-session must
+            // NOT land here, or the hook's window dies with the server.
             do {
                 try await tmux.killServer(server: tmuxServer)
             } catch {
                 logger.warning("reconcile: failed to kill tmux server \(tmuxServer, privacy: .public): \(error, privacy: .public)")
             }
         } else {
-            // Collect all tracked window IDs (active + main worktrees)
+            // Collect all tracked window IDs (active + main + creating worktrees)
             var trackedWindowIDs: Set<String> = []
             for wt in allLiveWorktreesForCleanup {
                 let terminals = try await db.terminals.list(worktreeID: wt.id)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -343,9 +343,9 @@ extension WorktreeLifecycle {
                 envSettingOverrides: claudeEnvOverrides
             )
         } else {
-            // Shell or custom-cmd terminal. Plain shell terminals have label nil or "shell";
-            // custom-cmd terminals store the command string directly in label.
-            let cmd = (terminal.label == "shell" || terminal.label == nil) ? nil : terminal.label
+            // Shell or custom-cmd terminal. Plain shell terminals have label nil or
+            // TerminalLabel.shell; custom-cmd terminals store the command string directly in label.
+            let cmd = (terminal.label == TerminalLabel.shell || terminal.label == nil) ? nil : terminal.label
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,
                 freshSessionID: nil,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -106,7 +106,15 @@ extension WorktreeLifecycle {
         dbWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
 
         let gitPaths = Set(gitWorktrees.map(\.path))
-        let dbPaths = Set(dbWorktrees.map(\.path))
+        // Include `.creating` rows so a worktree whose pre-session phase-3
+        // wait is still in flight (status flips to .active only when the hook
+        // finishes) isn't "unknown" to the re-adopt pass below — re-adopting
+        // its path would violate the UNIQUE path constraint and abort this
+        // repo's reconcile.
+        let creatingPaths = Set(
+            (try await db.worktrees.list(repoID: repoID, status: .creating)).map(\.path)
+        )
+        let dbPaths = Set(dbWorktrees.map(\.path)).union(creatingPaths)
 
         // Mark missing worktrees as archived — also kill their tmux windows
         for wt in dbWorktrees where !gitPaths.contains(wt.path) {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -33,6 +33,10 @@ extension WorktreeLifecycle {
     ///   `git worktree add` but before any tmux spawn. There is no hook
     ///   window to resume and no terminals to keep; delete the row and let
     ///   reconcile re-adopt the on-disk checkout as a fresh worktree.
+    /// - Checkout + pre-session terminal exist but the repo row is gone →
+    ///   the wait can never be resumed (phase 3 needs the repo) and nothing
+    ///   else ever resolves a `.creating` row, so skipping would strand it
+    ///   forever. Delete the row and its terminal/tab records.
     ///
     /// Returns the detached phase-3 resume tasks (for tests); the daemon
     /// ignores them.
@@ -83,7 +87,14 @@ extension WorktreeLifecycle {
             }
 
             guard let repo = (try? await db.repos.get(id: worktree.repoID)) ?? nil else {
-                logger.error("recovery: repo \(worktree.repoID, privacy: .public) missing for .creating worktree \(worktree.id, privacy: .public); skipping")
+                logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — repo \(worktree.repoID, privacy: .public) row is missing, so the pre-session wait can never be resumed")
+                do {
+                    try await db.terminals.deleteForWorktree(worktreeID: worktree.id)
+                    try await db.tabs.deleteForWorktree(worktreeID: worktree.id)
+                    try await db.worktrees.delete(id: worktree.id)
+                } catch {
+                    logger.warning("recovery: cleanup of repo-less worktree \(worktree.id, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+                }
                 continue
             }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -42,8 +42,8 @@ extension WorktreeLifecycle {
         var resumed: [Task<Void, Never>] = []
         for worktree in creating {
             let terminals = (try? await db.terminals.list(worktreeID: worktree.id)) ?? []
-            let preSessionTerminal = terminals.first { $0.label == "pre-session" }
-            let hasPrimaries = terminals.contains { $0.label != "pre-session" }
+            let preSessionTerminal = terminals.first { $0.label == TerminalLabel.preSession }
+            let hasPrimaries = terminals.contains { $0.label != TerminalLabel.preSession }
 
             guard FileManager.default.fileExists(atPath: worktree.path) else {
                 logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — checkout missing at \(worktree.path, privacy: .public)")
@@ -73,6 +73,8 @@ extension WorktreeLifecycle {
             guard let preSessionTerminal else {
                 logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — checkout exists but no terminals; reconcile will re-adopt it")
                 do {
+                    try await db.terminals.deleteForWorktree(worktreeID: worktree.id)
+                    try await db.tabs.deleteForWorktree(worktreeID: worktree.id)
                     try await db.worktrees.delete(id: worktree.id)
                 } catch {
                     logger.warning("recovery: failed to delete terminal-less worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -25,8 +25,10 @@ extension WorktreeLifecycle {
     /// - Checkout exists and ONLY a pre-session terminal exists → the daemon
     ///   died mid-wait. The tmux server and the hook process survive daemon
     ///   restarts, so resume the wait: rebuild the `PreSessionSpawn` from the
-    ///   terminal record and run phase 3 in a detached task, exactly like the
-    ///   create path. Never blocks startup.
+    ///   terminal record and run phase 3 in a detached task. A row that still
+    ///   carries `archivedClaudeSessions` was mid-REVIVE — resume it with
+    ///   revive semantics (restore the sessions, then clear them); otherwise
+    ///   resume exactly like the create path. Never blocks startup.
     /// - Checkout exists but no terminals at all → the daemon died after
     ///   `git worktree add` but before any tmux spawn. There is no hook
     ///   window to resume and no terminals to keep; delete the row and let
@@ -45,9 +47,13 @@ extension WorktreeLifecycle {
 
             guard FileManager.default.fileExists(atPath: worktree.path) else {
                 logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — checkout missing at \(worktree.path, privacy: .public)")
-                try? await db.terminals.deleteForWorktree(worktreeID: worktree.id)
-                try? await db.tabs.deleteForWorktree(worktreeID: worktree.id)
-                try? await db.worktrees.delete(id: worktree.id)
+                do {
+                    try await db.terminals.deleteForWorktree(worktreeID: worktree.id)
+                    try await db.tabs.deleteForWorktree(worktreeID: worktree.id)
+                    try await db.worktrees.delete(id: worktree.id)
+                } catch {
+                    logger.warning("recovery: cleanup of missing-checkout worktree \(worktree.id, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+                }
                 continue
             }
 
@@ -56,13 +62,21 @@ extension WorktreeLifecycle {
                 // final status flip was lost. Reconcile's dead-window pass
                 // will clean up any terminals whose windows didn't survive.
                 logger.info("recovery: activating .creating worktree \(worktree.id, privacy: .public) — primary terminals already exist")
-                try? await db.worktrees.updateStatus(id: worktree.id, status: .active)
+                do {
+                    try await db.worktrees.updateStatus(id: worktree.id, status: .active)
+                } catch {
+                    logger.warning("recovery: failed to activate worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
                 continue
             }
 
             guard let preSessionTerminal else {
                 logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — checkout exists but no terminals; reconcile will re-adopt it")
-                try? await db.worktrees.delete(id: worktree.id)
+                do {
+                    try await db.worktrees.delete(id: worktree.id)
+                } catch {
+                    logger.warning("recovery: failed to delete terminal-less worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
                 continue
             }
 
@@ -89,21 +103,29 @@ extension WorktreeLifecycle {
                     )
                 ) ?? ""
             )
-            logger.info("recovery: resuming pre-session wait for .creating worktree \(worktree.id, privacy: .public)")
+            // Distinguish an interrupted CREATE from an interrupted REVIVE:
+            // a mid-revive row still carries its archived Claude sessions
+            // (`beginReviveWorktree` only clears them in phase 3 via
+            // `.revive(clearSessions:)`). Resuming such a row with
+            // `.markActive` and no sessions would spawn a FRESH Claude
+            // session, and the next archive would unconditionally overwrite
+            // `archivedClaudeSessions` — silently losing the old transcript.
+            // So: restore the archived sessions and finish with revive
+            // semantics (flip `.active`, clear `archivedAt`, clear the
+            // session list). The other original params (skipClaude,
+            // initialPrompt, cols/rows) died with the previous daemon
+            // process — spawn with defaults.
+            let archivedSessions = worktree.archivedClaudeSessions ?? []
+            let isMidRevive = !archivedSessions.isEmpty
+            logger.info("recovery: resuming pre-session wait for .creating worktree \(worktree.id, privacy: .public) (\(isMidRevive ? "mid-revive" : "mid-create", privacy: .public))")
             let task = Task.detached { [self] in
-                // The original create/revive params (skipClaude, initialPrompt,
-                // cols/rows, archived sessions) died with the previous daemon
-                // process — spawn with defaults. For an interrupted revive
-                // this also means `.markActive` instead of `.revive`:
-                // `archivedAt` stays set and `archivedClaudeSessions` are
-                // neither restored nor cleared (they remain available for a
-                // later revive cycle); only the status flip is recovered.
                 await runPreSessionPhase3(
                     preSession: spawn,
                     worktree: worktree, repo: repo,
                     worktreePath: worktree.path,
                     skipClaude: false,
-                    completionAction: .markActive
+                    archivedClaudeSessions: isMidRevive ? archivedSessions : nil,
+                    completionAction: isMidRevive ? .revive(clearSessions: true) : .markActive
                 )
             }
             resumed.append(task)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -1,0 +1,113 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "worktreeLifecycle")
+
+extension WorktreeLifecycle {
+
+    // MARK: - Startup recovery for `.creating` rows
+
+    /// Resolves worktree rows stranded in `.creating` by a daemon restart.
+    ///
+    /// The pre-session phase-3 wait lives in an in-memory detached task; when
+    /// the daemon dies mid-wait the row stays `.creating` forever — reconcile
+    /// only lists `.active` rows, archive rejects `.creating`, and revive
+    /// requires `.archived`, so nothing else can ever resolve it. Call this at
+    /// startup BEFORE the per-repo reconcile loop.
+    ///
+    /// Per `.creating` row:
+    /// - Checkout missing on disk → creation never completed; delete the row
+    ///   (and its terminal/tab records).
+    /// - Checkout exists and primary (non-pre-session) terminals exist → the
+    ///   daemon died between the primary spawn and the final status flip;
+    ///   just flip to `.active`.
+    /// - Checkout exists and ONLY a pre-session terminal exists → the daemon
+    ///   died mid-wait. The tmux server and the hook process survive daemon
+    ///   restarts, so resume the wait: rebuild the `PreSessionSpawn` from the
+    ///   terminal record and run phase 3 in a detached task, exactly like the
+    ///   create path. Never blocks startup.
+    /// - Checkout exists but no terminals at all → the daemon died after
+    ///   `git worktree add` but before any tmux spawn. There is no hook
+    ///   window to resume and no terminals to keep; delete the row and let
+    ///   reconcile re-adopt the on-disk checkout as a fresh worktree.
+    ///
+    /// Returns the detached phase-3 resume tasks (for tests); the daemon
+    /// ignores them.
+    @discardableResult
+    public func recoverCreatingWorktrees() async -> [Task<Void, Never>] {
+        let creating = (try? await db.worktrees.list(status: .creating)) ?? []
+        var resumed: [Task<Void, Never>] = []
+        for worktree in creating {
+            let terminals = (try? await db.terminals.list(worktreeID: worktree.id)) ?? []
+            let preSessionTerminal = terminals.first { $0.label == "pre-session" }
+            let hasPrimaries = terminals.contains { $0.label != "pre-session" }
+
+            guard FileManager.default.fileExists(atPath: worktree.path) else {
+                logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — checkout missing at \(worktree.path, privacy: .public)")
+                try? await db.terminals.deleteForWorktree(worktreeID: worktree.id)
+                try? await db.tabs.deleteForWorktree(worktreeID: worktree.id)
+                try? await db.worktrees.delete(id: worktree.id)
+                continue
+            }
+
+            if hasPrimaries {
+                // Phase 3 already spawned the primary terminals; only the
+                // final status flip was lost. Reconcile's dead-window pass
+                // will clean up any terminals whose windows didn't survive.
+                logger.info("recovery: activating .creating worktree \(worktree.id, privacy: .public) — primary terminals already exist")
+                try? await db.worktrees.updateStatus(id: worktree.id, status: .active)
+                continue
+            }
+
+            guard let preSessionTerminal else {
+                logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — checkout exists but no terminals; reconcile will re-adopt it")
+                try? await db.worktrees.delete(id: worktree.id)
+                continue
+            }
+
+            guard let repo = (try? await db.repos.get(id: worktree.repoID)) ?? nil else {
+                logger.error("recovery: repo \(worktree.repoID, privacy: .public) missing for .creating worktree \(worktree.id, privacy: .public); skipping")
+                continue
+            }
+
+            // Resume the wait. The hook command wraps its exit code into the
+            // marker file, so a hook that finished while the daemon was down
+            // is picked up on the first poll.
+            let spawn = PreSessionSpawn(
+                terminalID: preSessionTerminal.id,
+                windowID: preSessionTerminal.tmuxWindowID,
+                paneID: preSessionTerminal.tmuxPaneID,
+                markerPath: Self.preSessionMarkerPath(worktreeID: worktree.id),
+                // Informational only in phase 3; best-effort re-resolve.
+                hookPath: hooks.resolve(
+                    event: .preSession,
+                    repoPath: worktree.path,
+                    appHookPath: TBDConstants.hookPath(
+                        repoID: worktree.repoID,
+                        eventName: HookEvent.preSession.rawValue
+                    )
+                ) ?? ""
+            )
+            logger.info("recovery: resuming pre-session wait for .creating worktree \(worktree.id, privacy: .public)")
+            let task = Task.detached { [self] in
+                // The original create/revive params (skipClaude, initialPrompt,
+                // cols/rows, archived sessions) died with the previous daemon
+                // process — spawn with defaults. For an interrupted revive
+                // this also means `.markActive` instead of `.revive`:
+                // `archivedAt` stays set and `archivedClaudeSessions` are
+                // neither restored nor cleared (they remain available for a
+                // later revive cycle); only the status flip is recovered.
+                await runPreSessionPhase3(
+                    preSession: spawn,
+                    worktree: worktree, repo: repo,
+                    worktreePath: worktree.path,
+                    skipClaude: false,
+                    completionAction: .markActive
+                )
+            }
+            resumed.append(task)
+        }
+        return resumed
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -53,6 +53,14 @@ public struct WorktreeLifecycle: Sendable {
     public let subscriptions: StateSubscriptionManager?
     public let modelProfileResolver: ModelProfileResolver?
     public let pendingQuestions: PendingQuestionStore
+    /// How long to wait for a blocking `preSession` hook before giving up and
+    /// spawning the primary terminals anyway. Injectable for tests.
+    public let preSessionTimeout: TimeInterval
+    /// Poll interval for the preSession completion marker file.
+    public let preSessionPollInterval: TimeInterval
+
+    /// Default `preSession` hook timeout (production value).
+    public static let defaultPreSessionTimeout: TimeInterval = 600
 
     /// The user's default shell (from $SHELL, falls back to /bin/zsh)
     var defaultShell: String {
@@ -66,7 +74,9 @@ public struct WorktreeLifecycle: Sendable {
         hooks: HookResolver,
         subscriptions: StateSubscriptionManager? = nil,
         modelProfileResolver: ModelProfileResolver? = nil,
-        pendingQuestions: PendingQuestionStore = PendingQuestionStore()
+        pendingQuestions: PendingQuestionStore = PendingQuestionStore(),
+        preSessionTimeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout,
+        preSessionPollInterval: TimeInterval = 0.5
     ) {
         self.db = db
         self.git = git
@@ -75,5 +85,7 @@ public struct WorktreeLifecycle: Sendable {
         self.subscriptions = subscriptions
         self.modelProfileResolver = modelProfileResolver
         self.pendingQuestions = pendingQuestions
+        self.preSessionTimeout = preSessionTimeout
+        self.preSessionPollInterval = preSessionPollInterval
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -147,7 +147,7 @@ extension RPCRouter {
                 worktreeID: params.worktreeID,
                 tmuxWindowID: window.windowID,
                 tmuxPaneID: window.paneID,
-                label: "Codex",
+                label: TerminalLabel.codex,
                 claudeSessionID: nil,
                 profileID: nil,
                 kind: .codex
@@ -198,7 +198,7 @@ extension RPCRouter {
             } else {
                 appendSystemPrompt = nil
             }
-            label = "Claude Code"
+            label = TerminalLabel.claudeCode
         } else if let cmd = params.cmd {
             claudeSessionID = nil
             freshSessionID = nil
@@ -338,7 +338,7 @@ extension RPCRouter {
         )
 
         // Branch on terminal kind: codex stays codex; shell/claude become shell
-        if terminal.kind == .codex || terminal.label == "Codex" {
+        if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
             // Recreate as codex — preserve identity
             let codexHome = try CodexHomeManager().ensureProfilePlugin()
             var codexEnv: [String: String] = [:]
@@ -983,7 +983,7 @@ extension RPCRouter {
             sessionID: params.sessionID,
             transcriptPath: cleanedPath
         )
-        if terminal.kind == .codex || terminal.label == "Codex" {
+        if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
             try await db.terminals.setActivityState(id: terminal.id, activityState: .idle)
         }
 
@@ -1001,7 +1001,7 @@ extension RPCRouter {
             sessionID: params.sessionID,
             transcriptPath: cleanedPath
         )))
-        if terminal.kind == .codex || terminal.label == "Codex" {
+        if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
             subscriptions.broadcast(delta: .terminalActivityUpdated(TerminalActivityDelta(
                 terminalID: terminal.id,
                 worktreeID: terminal.worktreeID,

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -39,11 +39,22 @@ extension RPCRouter {
         let existingBranchRef = useExistingBranch ? params.branch : nil
         await repoSerializer.submit(repoID: pending.repoID) {
             do {
-                try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef)
-                subs.broadcast(delta: .worktreeCreated(WorktreeDelta(
-                    worktreeID: pending.id, repoID: pending.repoID,
-                    name: pending.name, path: pending.path
-                )))
+                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef)
+                switch completion {
+                case .ready:
+                    subs.broadcast(delta: .worktreeCreated(WorktreeDelta(
+                        worktreeID: pending.id, repoID: pending.repoID,
+                        name: pending.name, path: pending.path
+                    )))
+                case .preSessionPending:
+                    // The lifecycle already broadcast `.worktreeCreated` (and
+                    // `.terminalCreated` for the pre-session terminal) so the
+                    // app refreshes early; the detached phase-3 task spawns
+                    // the primary terminals OUTSIDE this serializer lane and
+                    // broadcasts their `.terminalCreated` deltas itself.
+                    // Broadcasting again here would duplicate the row.
+                    break
+                }
             } catch {
                 // completeCreateWorktree already deletes the DB row on failure.
                 // Broadcast an archive delta so clients remove the pending entry.

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -125,10 +125,10 @@ extension RPCRouter {
         let params = try decoder.decode(WorktreeReviveParams.self, from: paramsData)
         // Non-blocking: when a preSession hook gates the primary terminals,
         // this returns promptly with the row in `.creating` (which is what
-        // the app gates its pre-session UI on) and the detached phase-3 task
-        // finishes the revive in the background. Blocking here for up to the
-        // hook timeout (600s) would starve the RPC connection AND keep the
-        // row `.archived`, so the pre-session UI never showed.
+        // the app gates its pre-session UI on — beginReviveWorktree flips it
+        // before returning) and the detached phase-3 task finishes the revive
+        // in the background. Blocking here for up to the hook timeout (600s)
+        // would starve the RPC connection.
         let completion = try await lifecycle.beginReviveWorktree(
             worktreeID: params.worktreeID,
             cols: params.cols,

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -123,12 +123,19 @@ extension RPCRouter {
 
     func handleWorktreeRevive(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeReviveParams.self, from: paramsData)
-        let worktree = try await lifecycle.reviveWorktree(
+        // Non-blocking: when a preSession hook gates the primary terminals,
+        // this returns promptly with the row in `.creating` (which is what
+        // the app gates its pre-session UI on) and the detached phase-3 task
+        // finishes the revive in the background. Blocking here for up to the
+        // hook timeout (600s) would starve the RPC connection AND keep the
+        // row `.archived`, so the pre-session UI never showed.
+        let completion = try await lifecycle.beginReviveWorktree(
             worktreeID: params.worktreeID,
             cols: params.cols,
             rows: params.rows,
             preferredSessionID: params.preferredSessionID
         )
+        let worktree = completion.worktree
 
         subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
             worktreeID: worktree.id, repoID: worktree.repoID,

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -16,6 +16,11 @@ public struct TmuxManager: Sendable {
     /// Without it, dryRun reports every window as alive, which makes paths
     /// like the pre-session `.paneKilled` short-circuit untestable.
     public let dryRunWindowIsDead: (@Sendable (String) -> Bool)?
+    /// Optional test hook consulted by `listWindows` in dryRun mode:
+    /// `(server, session)` → the window/pane pairs to report. Without it,
+    /// dryRun reports no windows, which makes reconcile's orphan-window
+    /// cleanup pass untestable.
+    public let dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])?
 
     // Thread-safe counter for generating unique mock IDs
     private final class Counter: Sendable {
@@ -30,11 +35,12 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil) {
         self.dryRun = dryRun
         self.counter = Counter()
         self.dryRunRecorder = dryRunRecorder
         self.dryRunWindowIsDead = dryRunWindowIsDead
+        self.dryRunListWindows = dryRunListWindows
     }
 
     // MARK: - Static Command Builders
@@ -229,7 +235,10 @@ public struct TmuxManager: Sendable {
 
     /// Kills an entire tmux server and all its sessions.
     public func killServer(server: String) async throws {
-        if dryRun { return }
+        if dryRun {
+            dryRunRecorder?(["-L", server, "kill-server"])
+            return
+        }
         logger.info("killServer: killing tmux server \(server, privacy: .public)")
         try await runTmux(["-L", server, "kill-server"])
     }
@@ -271,8 +280,11 @@ public struct TmuxManager: Sendable {
     }
 
     public func killWindow(server: String, windowID: String) async throws {
-        if dryRun { return }
         let args = Self.killWindowCommand(server: server, windowID: windowID)
+        if dryRun {
+            dryRunRecorder?(args)
+            return
+        }
         try await runTmux(args)
     }
 
@@ -350,7 +362,7 @@ public struct TmuxManager: Sendable {
     }
 
     public func listWindows(server: String, session: String) async throws -> [(windowID: String, paneID: String)] {
-        if dryRun { return [] }
+        if dryRun { return dryRunListWindows?(server, session) ?? [] }
         let args = Self.listWindowsCommand(server: server, session: session)
         let output = try await runTmux(args)
         return output

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -11,6 +11,11 @@ public struct TmuxManager: Sendable {
     /// have been passed to tmux. Used by spawn / swap integration tests to assert
     /// command shapes without spawning an actual tmux server.
     public let dryRunRecorder: (@Sendable ([String]) -> Void)?
+    /// Optional test hook consulted by `windowExists` in dryRun mode: return
+    /// `true` for a window ID to simulate that window having been killed.
+    /// Without it, dryRun reports every window as alive, which makes paths
+    /// like the pre-session `.paneKilled` short-circuit untestable.
+    public let dryRunWindowIsDead: (@Sendable (String) -> Bool)?
 
     // Thread-safe counter for generating unique mock IDs
     private final class Counter: Sendable {
@@ -25,10 +30,11 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil) {
         self.dryRun = dryRun
         self.counter = Counter()
         self.dryRunRecorder = dryRunRecorder
+        self.dryRunWindowIsDead = dryRunWindowIsDead
     }
 
     // MARK: - Static Command Builders
@@ -358,7 +364,7 @@ public struct TmuxManager: Sendable {
 
     /// Check whether a tmux window exists by querying list-panes.
     public func windowExists(server: String, windowID: String) async -> Bool {
-        if dryRun { return true }
+        if dryRun { return !(dryRunWindowIsDead?(windowID) ?? false) }
         do {
             let args = ["-L", server, "list-panes", "-t", windowID]
             _ = try await runTmux(args)

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -253,7 +253,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
 
 public extension Terminal {
     var isCodexTerminal: Bool {
-        kind == .codex || label == "Codex"
+        kind == .codex || label == TerminalLabel.codex
     }
 
     /// True only for Claude terminals whose session can be resumed through

--- a/Sources/TBDShared/TerminalLabel.swift
+++ b/Sources/TBDShared/TerminalLabel.swift
@@ -1,0 +1,15 @@
+/// Canonical labels the daemon assigns to terminals it creates. The app keys
+/// classification decisions (pre-session banner, primary-terminal detection,
+/// startup recovery) off these labels, so daemon and app must agree.
+public enum TerminalLabel {
+    /// Blocking `preSession` hook terminal (WorktreeLifecycle+PreSession).
+    public static let preSession = "pre-session"
+    /// Parallel `setup` hook terminal (spawnPrimaryTerminals in WorktreeLifecycle+Create).
+    public static let setup = "setup"
+    /// Plain shell terminal.
+    public static let shell = "shell"
+    /// Claude Code agent terminal.
+    public static let claudeCode = "Claude Code"
+    /// Codex agent terminal.
+    public static let codex = "Codex"
+}

--- a/Tests/TBDAppTests/PreSessionAppStateTests.swift
+++ b/Tests/TBDAppTests/PreSessionAppStateTests.swift
@@ -182,6 +182,116 @@ struct PreSessionAppStateTests {
         }
     }
 
+    // MARK: - Tab order convergence with the daemon's persisted order
+
+    @Test func tabOrderConvergesToDaemonPersistedOrderAfterPrimaryDelta() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            // The full refresh triggered by the pre-session terminal's delta
+            // cached the daemon's phase-1 order: just the pre-session tab.
+            state.worktreeTabOrders[worktreeID] = [pre.id]
+
+            // Phase-3 deltas land: primary agent, then the parallel setup shell.
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+            let setup = makeTerminal(worktreeID: worktreeID, label: "setup", kind: .shell)
+            state.appendCreatedTerminal(claude)
+            state.appendCreatedTerminal(setup)
+
+            // Plain appends leave the diverged [preSession, primary, setup]…
+            #expect(state.tabs[worktreeID]?.map(\.id) == [pre.id, claude.id, setup.id])
+            // …and the primary append arms the re-fetch.
+            #expect(state.shouldReconcileTabOrderFromDaemon(after: claude))
+
+            // The re-fetch lands the daemon's persisted [primary, preSession, setup].
+            state.adoptPersistedTabOrder(worktreeID: worktreeID, order: [claude.id, pre.id, setup.id])
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [claude.id, pre.id, setup.id])
+            #expect(state.worktreeTabOrders[worktreeID] == [claude.id, pre.id, setup.id])
+            // The selection hand-off survives the re-sort: still on the primary.
+            #expect(state.activeTabIndices[worktreeID] == 0)
+        }
+    }
+
+    @Test func adoptPersistedTabOrderFollowsDeliberateUserSelectionByID() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            state.worktreeTabOrders[worktreeID] = [pre.id]
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+            state.appendCreatedTerminal(claude)
+            // User deliberately clicked back to the pre-session tab before
+            // the order re-fetch landed.
+            state.activeTabIndices[worktreeID] = 0
+
+            state.adoptPersistedTabOrder(worktreeID: worktreeID, order: [claude.id, pre.id])
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [claude.id, pre.id])
+            // Selection follows the pre-session tab to its new index.
+            #expect(state.activeTabIndices[worktreeID] == 1)
+        }
+    }
+
+    @Test func adoptPersistedTabOrderIgnoresEmptyOrder() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            state.worktreeTabOrders[worktreeID] = [pre.id]
+
+            state.adoptPersistedTabOrder(worktreeID: worktreeID, order: [])
+
+            // Nothing persisted daemon-side — keep the cached order and tabs.
+            #expect(state.worktreeTabOrders[worktreeID] == [pre.id])
+            #expect(state.tabs[worktreeID]?.map(\.id) == [pre.id])
+        }
+    }
+
+    // MARK: - Re-fetch gate branches
+
+    @Test func reconcileGateArmsForPrimaryMissingFromCachedOrder() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            state.worktreeTabOrders[worktreeID] = [pre.id]
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+            #expect(state.shouldReconcileTabOrderFromDaemon(after: claude))
+            // Order not loaded at all yet counts as stale too.
+            state.worktreeTabOrders[worktreeID] = nil
+            #expect(state.shouldReconcileTabOrderFromDaemon(after: claude))
+            // Codex is also a primary.
+            let codex = makeTerminal(worktreeID: worktreeID, label: "Codex", kind: .codex)
+            #expect(state.shouldReconcileTabOrderFromDaemon(after: codex))
+        }
+    }
+
+    @Test func reconcileGateStaysOffForNonPrimaryTerminals() {
+        withAppState { state in
+            let worktreeID = UUID()
+            _ = seedPreSessionOnly(state, worktreeID: worktreeID)
+            let setup = makeTerminal(worktreeID: worktreeID, label: "setup", kind: .shell)
+            #expect(!state.shouldReconcileTabOrderFromDaemon(after: setup))
+        }
+    }
+
+    @Test func reconcileGateStaysOffWithoutPreSessionTerminal() {
+        withAppState { state in
+            let worktreeID = UUID()
+            state.terminals[worktreeID] = []
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+            #expect(!state.shouldReconcileTabOrderFromDaemon(after: claude))
+        }
+    }
+
+    @Test func reconcileGateStaysOffWhenCachedOrderAlreadyContainsPrimary() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+            state.worktreeTabOrders[worktreeID] = [claude.id, pre.id]
+            #expect(!state.shouldReconcileTabOrderFromDaemon(after: claude))
+        }
+    }
+
     // MARK: - Sidebar subtitle
 
     @Test func hasPreSessionTerminalTrueWhenHookTerminalLoaded() {

--- a/Tests/TBDAppTests/PreSessionAppStateTests.swift
+++ b/Tests/TBDAppTests/PreSessionAppStateTests.swift
@@ -1,0 +1,250 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// App-side behavior for the blocking `preSession` worktree hook:
+/// `.terminalCreated` delta consumption, tab selection hand-off from the
+/// pre-session tab to the agent, the sidebar "Running setup…" subtitle, and
+/// the terminal-panel banner gating.
+@MainActor
+@Suite("Pre-session hook app state")
+struct PreSessionAppStateTests {
+
+    /// Build an isolated AppState (never `UserDefaults.standard` — that's the
+    /// developer's real TBDApp.plist) and tear the suite down afterward.
+    private func withAppState(_ body: (AppState) throws -> Void) rethrows {
+        let suiteName = "PreSessionAppStateTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        try body(AppState(userDefaults: defaults))
+    }
+
+    private func makeTerminal(
+        id: UUID = UUID(), worktreeID: UUID, label: String, kind: TerminalKind
+    ) -> Terminal {
+        Terminal(
+            id: id,
+            worktreeID: worktreeID,
+            tmuxWindowID: "@w-\(id.uuidString.prefix(4))",
+            tmuxPaneID: "%p-\(id.uuidString.prefix(4))",
+            label: label,
+            kind: kind
+        )
+    }
+
+    /// Seed a worktree whose terminals are loaded with just the pre-session
+    /// hook terminal and its tab (the state right after the daemon's early
+    /// `.terminalCreated` broadcast was consumed).
+    private func seedPreSessionOnly(_ state: AppState, worktreeID: UUID) -> Terminal {
+        let pre = makeTerminal(worktreeID: worktreeID, label: AppState.preSessionTerminalLabel, kind: .shell)
+        state.terminals[worktreeID] = [pre]
+        state.tabs[worktreeID] = [Tab(id: pre.id, content: .terminal(terminalID: pre.id), label: nil)]
+        return pre
+    }
+
+    private func makeWorktree(status: WorktreeStatus) -> Worktree {
+        Worktree(
+            repoID: UUID(), name: "acme", displayName: "acme",
+            branch: "tbd/acme", path: "/tmp/acme", status: status,
+            tmuxServer: "tbd-test"
+        )
+    }
+
+    // MARK: - terminalCreated append + dedupe
+
+    @Test func appendCreatedTerminalAppendsTerminalAndTab() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+
+            state.appendCreatedTerminal(claude)
+
+            #expect(state.terminals[worktreeID]?.map(\.id) == [pre.id, claude.id])
+            #expect(state.tabs[worktreeID]?.map(\.id) == [pre.id, claude.id])
+            #expect(state.tabs[worktreeID]?.last?.content == .terminal(terminalID: claude.id))
+        }
+    }
+
+    @Test func appendCreatedTerminalDedupesAfterDirectAppend() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+            // Direct-append path (createTerminal RPC response) landed first.
+            state.terminals[worktreeID] = [claude]
+            state.tabs[worktreeID] = [Tab(id: claude.id, content: .terminal(terminalID: claude.id), label: nil)]
+
+            // The racing delta-driven append must be a no-op.
+            state.appendCreatedTerminal(claude)
+
+            #expect(state.terminals[worktreeID]?.count == 1)
+            #expect(state.tabs[worktreeID]?.count == 1)
+        }
+    }
+
+    @Test func terminalCreatedDeltaForKnownTerminalIsSynchronousNoOp() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+
+            // Routed through the real delta switch; the dedupe fast path is
+            // synchronous, so no daemon fetch fires and nothing duplicates.
+            state.handleDelta(.terminalCreated(TerminalDelta(
+                terminalID: pre.id, worktreeID: worktreeID, label: pre.label
+            )))
+
+            #expect(state.terminals[worktreeID]?.count == 1)
+            #expect(state.tabs[worktreeID]?.count == 1)
+        }
+    }
+
+    @Test func appendCreatedTerminalSkipsTabWhenTerminalLivesInASplitLayout() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let rootID = UUID()
+            let splitChild = makeTerminal(worktreeID: worktreeID, label: "shell", kind: .shell)
+            state.terminals[worktreeID] = []
+            state.tabs[worktreeID] = [Tab(id: rootID, content: .terminal(terminalID: rootID), label: nil)]
+            state.layouts[rootID] = .split(
+                direction: .horizontal,
+                children: [
+                    .pane(.terminal(terminalID: rootID)),
+                    .pane(.terminal(terminalID: splitChild.id)),
+                ],
+                ratios: [0.5, 0.5]
+            )
+
+            state.appendCreatedTerminal(splitChild)
+
+            #expect(state.terminals[worktreeID]?.map(\.id) == [splitChild.id])
+            // No new tab: the terminal is already represented inside a layout.
+            #expect(state.tabs[worktreeID]?.map(\.id) == [rootID])
+        }
+    }
+
+    // MARK: - Selection hand-off
+
+    @Test func selectionSwitchesFromPreSessionTabToNewClaudeTab() {
+        withAppState { state in
+            let worktreeID = UUID()
+            _ = seedPreSessionOnly(state, worktreeID: worktreeID)
+            // Unset index defaults to 0 at the view layer = the pre-session tab.
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+
+            state.appendCreatedTerminal(claude)
+
+            #expect(state.activeTabIndices[worktreeID] == 1)
+            #expect(state.tabs[worktreeID]?[1].id == claude.id)
+        }
+    }
+
+    @Test func selectionDoesNotSwitchWhenUserIsOnADifferentTab() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            let shell = makeTerminal(worktreeID: worktreeID, label: "shell", kind: .shell)
+            state.terminals[worktreeID] = [pre, shell]
+            state.tabs[worktreeID]?.append(Tab(id: shell.id, content: .terminal(terminalID: shell.id), label: nil))
+            // User deliberately navigated to the plain shell tab.
+            state.activeTabIndices[worktreeID] = 1
+
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+            state.appendCreatedTerminal(claude)
+
+            #expect(state.activeTabIndices[worktreeID] == 1)
+        }
+    }
+
+    @Test func setupShellTerminalDoesNotStealSelectionFromPreSessionTab() {
+        withAppState { state in
+            let worktreeID = UUID()
+            _ = seedPreSessionOnly(state, worktreeID: worktreeID)
+
+            // Phase 3 also broadcasts the parallel `setup` hook terminal —
+            // a plain shell must never steal the selection.
+            let setup = makeTerminal(worktreeID: worktreeID, label: "setup", kind: .shell)
+            state.appendCreatedTerminal(setup)
+
+            #expect(state.activeTabIndices[worktreeID] == nil)
+        }
+    }
+
+    @Test func codexTerminalAlsoTakesSelectionFromPreSessionTab() {
+        withAppState { state in
+            let worktreeID = UUID()
+            _ = seedPreSessionOnly(state, worktreeID: worktreeID)
+            let codex = makeTerminal(worktreeID: worktreeID, label: "Codex", kind: .codex)
+
+            state.appendCreatedTerminal(codex)
+
+            #expect(state.activeTabIndices[worktreeID] == 1)
+        }
+    }
+
+    // MARK: - Sidebar subtitle
+
+    @Test func hasPreSessionTerminalTrueWhenHookTerminalLoaded() {
+        withAppState { state in
+            let worktreeID = UUID()
+            _ = seedPreSessionOnly(state, worktreeID: worktreeID)
+            #expect(state.hasPreSessionTerminal(worktreeID: worktreeID))
+        }
+    }
+
+    @Test func hasPreSessionTerminalFalseWithoutHookTerminal() {
+        withAppState { state in
+            let worktreeID = UUID()
+            // Not loaded at all.
+            #expect(!state.hasPreSessionTerminal(worktreeID: worktreeID))
+            // Loaded, but only ordinary terminals.
+            state.terminals[worktreeID] = [
+                makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude),
+            ]
+            #expect(!state.hasPreSessionTerminal(worktreeID: worktreeID))
+        }
+    }
+
+    @Test func creatingSubtitleCoversBothBranches() {
+        #expect(WorktreeRowView.creatingSubtitle(hasPreSessionTerminal: true) == "Running setup…")
+        #expect(WorktreeRowView.creatingSubtitle(hasPreSessionTerminal: false) == "Creating worktree…")
+    }
+
+    // MARK: - Banner gating
+
+    @Test func bannerShowsWhileCreatingWithPreSessionTabActive() {
+        withAppState { state in
+            let worktree = makeWorktree(status: .creating)
+            _ = seedPreSessionOnly(state, worktreeID: worktree.id)
+            // Unset index defaults to 0 = the pre-session tab.
+            #expect(state.showsPreSessionBanner(for: worktree))
+        }
+    }
+
+    @Test func bannerHiddenOnceWorktreeIsActive() {
+        withAppState { state in
+            let worktree = makeWorktree(status: .active)
+            _ = seedPreSessionOnly(state, worktreeID: worktree.id)
+            #expect(!state.showsPreSessionBanner(for: worktree))
+        }
+    }
+
+    @Test func bannerHiddenWhenADifferentTabIsActive() {
+        withAppState { state in
+            let worktree = makeWorktree(status: .creating)
+            let pre = seedPreSessionOnly(state, worktreeID: worktree.id)
+            let claude = makeTerminal(worktreeID: worktree.id, label: "Claude Code", kind: .claude)
+            state.terminals[worktree.id] = [pre, claude]
+            state.tabs[worktree.id]?.append(Tab(id: claude.id, content: .terminal(terminalID: claude.id), label: nil))
+            state.activeTabIndices[worktree.id] = 1
+            #expect(!state.showsPreSessionBanner(for: worktree))
+        }
+    }
+
+    @Test func bannerHiddenWhenNoTabsExist() {
+        withAppState { state in
+            let worktree = makeWorktree(status: .creating)
+            #expect(!state.showsPreSessionBanner(for: worktree))
+        }
+    }
+}

--- a/Tests/TBDAppTests/PreSessionAppStateTests.swift
+++ b/Tests/TBDAppTests/PreSessionAppStateTests.swift
@@ -162,11 +162,27 @@ struct PreSessionAppStateTests {
             _ = seedPreSessionOnly(state, worktreeID: worktreeID)
 
             // Phase 3 also broadcasts the parallel `setup` hook terminal —
-            // a plain shell must never steal the selection.
+            // it must never steal the selection.
             let setup = makeTerminal(worktreeID: worktreeID, label: "setup", kind: .shell)
             state.appendCreatedTerminal(setup)
 
             #expect(state.activeTabIndices[worktreeID] == nil)
+        }
+    }
+
+    @Test func shellPrimaryTerminalTakesSelectionFromPreSessionTab() {
+        withAppState { state in
+            let worktreeID = UUID()
+            _ = seedPreSessionOnly(state, worktreeID: worktreeID)
+
+            // skipClaude worktrees spawn a plain shell as the PRIMARY terminal
+            // (label "shell", kind .shell) — it must take the hand-off exactly
+            // like an agent terminal would.
+            let shell = makeTerminal(worktreeID: worktreeID, label: "shell", kind: .shell)
+            state.appendCreatedTerminal(shell)
+
+            #expect(state.activeTabIndices[worktreeID] == 1)
+            #expect(state.tabs[worktreeID]?[1].id == shell.id)
         }
     }
 
@@ -261,6 +277,18 @@ struct PreSessionAppStateTests {
             // Codex is also a primary.
             let codex = makeTerminal(worktreeID: worktreeID, label: "Codex", kind: .codex)
             #expect(state.shouldReconcileTabOrderFromDaemon(after: codex))
+        }
+    }
+
+    @Test func reconcileGateArmsForShellPrimaryWhenSkipClaude() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            state.worktreeTabOrders[worktreeID] = [pre.id]
+            // skipClaude primary: kind .shell, label "shell" — still a primary,
+            // so the converging-from-creation re-fetch must arm.
+            let shell = makeTerminal(worktreeID: worktreeID, label: "shell", kind: .shell)
+            #expect(state.shouldReconcileTabOrderFromDaemon(after: shell))
         }
     }
 

--- a/Tests/TBDAppTests/PreSessionAppStateTests.swift
+++ b/Tests/TBDAppTests/PreSessionAppStateTests.swift
@@ -51,6 +51,15 @@ struct PreSessionAppStateTests {
         )
     }
 
+    /// Seed a worktree row into app state (keyed by repoID, as
+    /// `findWorktree(id:)` expects) so status-scoped gates can resolve it.
+    @discardableResult
+    private func seedWorktree(_ state: AppState, status: WorktreeStatus) -> Worktree {
+        let wt = makeWorktree(status: status)
+        state.worktrees[wt.repoID] = [wt]
+        return wt
+    }
+
     // MARK: - terminalCreated append + dedupe
 
     @Test func appendCreatedTerminalAppendsTerminalAndTab() {
@@ -202,7 +211,9 @@ struct PreSessionAppStateTests {
 
     @Test func tabOrderConvergesToDaemonPersistedOrderAfterPrimaryDelta() {
         withAppState { state in
-            let worktreeID = UUID()
+            // The reconcile gate is scoped to the creation phase: the
+            // worktree must be known to app state and still `.creating`.
+            let worktreeID = seedWorktree(state, status: .creating).id
             let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
             // The full refresh triggered by the pre-session terminal's delta
             // cached the daemon's phase-1 order: just the pre-session tab.
@@ -266,7 +277,7 @@ struct PreSessionAppStateTests {
 
     @Test func reconcileGateArmsForPrimaryMissingFromCachedOrder() {
         withAppState { state in
-            let worktreeID = UUID()
+            let worktreeID = seedWorktree(state, status: .creating).id
             let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
             state.worktreeTabOrders[worktreeID] = [pre.id]
             let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
@@ -282,7 +293,7 @@ struct PreSessionAppStateTests {
 
     @Test func reconcileGateArmsForShellPrimaryWhenSkipClaude() {
         withAppState { state in
-            let worktreeID = UUID()
+            let worktreeID = seedWorktree(state, status: .creating).id
             let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
             state.worktreeTabOrders[worktreeID] = [pre.id]
             // skipClaude primary: kind .shell, label "shell" — still a primary,
@@ -294,7 +305,7 @@ struct PreSessionAppStateTests {
 
     @Test func reconcileGateStaysOffForNonPrimaryTerminals() {
         withAppState { state in
-            let worktreeID = UUID()
+            let worktreeID = seedWorktree(state, status: .creating).id
             _ = seedPreSessionOnly(state, worktreeID: worktreeID)
             let setup = makeTerminal(worktreeID: worktreeID, label: "setup", kind: .shell)
             #expect(!state.shouldReconcileTabOrderFromDaemon(after: setup))
@@ -303,7 +314,9 @@ struct PreSessionAppStateTests {
 
     @Test func reconcileGateStaysOffWithoutPreSessionTerminal() {
         withAppState { state in
-            let worktreeID = UUID()
+            // Worktree seeded as .creating so the missing pre-session
+            // terminal is the only conjunct that can turn the gate off.
+            let worktreeID = seedWorktree(state, status: .creating).id
             state.terminals[worktreeID] = []
             let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
             #expect(!state.shouldReconcileTabOrderFromDaemon(after: claude))
@@ -312,10 +325,37 @@ struct PreSessionAppStateTests {
 
     @Test func reconcileGateStaysOffWhenCachedOrderAlreadyContainsPrimary() {
         withAppState { state in
-            let worktreeID = UUID()
+            let worktreeID = seedWorktree(state, status: .creating).id
             let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
             let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
             state.worktreeTabOrders[worktreeID] = [claude.id, pre.id]
+            #expect(!state.shouldReconcileTabOrderFromDaemon(after: claude))
+        }
+    }
+
+    @Test func reconcileGateStaysOffOnceWorktreeIsActive() {
+        withAppState { state in
+            // Same shape as the arming case — primary delta, pre-session tab
+            // present, primary missing from the cached order — but the
+            // worktree already finished creating. A pre-session tab the user
+            // kept around must not re-arm the reconcile for terminals
+            // created after setup.
+            let worktreeID = seedWorktree(state, status: .active).id
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            state.worktreeTabOrders[worktreeID] = [pre.id]
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+            #expect(!state.shouldReconcileTabOrderFromDaemon(after: claude))
+        }
+    }
+
+    @Test func reconcileGateStaysOffWhenWorktreeNotInState() {
+        withAppState { state in
+            // No worktree row seeded at all — the gate must resolve the
+            // worktree before trusting any other conjunct.
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            state.worktreeTabOrders[worktreeID] = [pre.id]
+            let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
             #expect(!state.shouldReconcileTabOrderFromDaemon(after: claude))
         }
     }

--- a/Tests/TBDAppTests/ReviveStateGatingTests.swift
+++ b/Tests/TBDAppTests/ReviveStateGatingTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Revive completion gating around the blocking `preSession` hook:
+/// `beginReviveWorktree` returns promptly with the row still `.creating`
+/// while the hook runs, so the archived view's `.done` ("Revived") state
+/// must wait until the worktree is actually usable. `settleReviveState`
+/// gates the immediate flip; `promoteRevivedWorktrees` performs the
+/// deferred flip when the periodic refresh observes the row `.active`.
+@MainActor
+@Suite("Revive state gating")
+struct ReviveStateGatingTests {
+
+    /// Build an isolated AppState (never `UserDefaults.standard` — that's the
+    /// developer's real TBDApp.plist) and tear the suite down afterward.
+    private func withAppState(_ body: (AppState) throws -> Void) rethrows {
+        let suiteName = "ReviveStateGatingTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        try body(AppState(userDefaults: defaults))
+    }
+
+    private func makeWorktree(id: UUID = UUID(), status: WorktreeStatus) -> Worktree {
+        Worktree(
+            id: id, repoID: UUID(), name: "acme", displayName: "acme",
+            branch: "tbd/acme", path: "/tmp/acme", status: status,
+            tmuxServer: "tbd-test"
+        )
+    }
+
+    // MARK: - settleReviveState (immediate flip on RPC return)
+
+    @Test func settleMarksDoneWhenRevivedWorktreeIsAlreadyUsable() {
+        withAppState { state in
+            let id = UUID()
+            let snapshot = makeWorktree(id: id, status: .archived)
+            state.revivingArchived[id] = .inFlight(snapshot: snapshot)
+
+            // No blocking preSession hook: the RPC returns the row `.active`.
+            state.settleReviveState(id: id, snapshot: snapshot, revived: makeWorktree(id: id, status: .active))
+
+            #expect(state.revivingArchived[id] == .done(snapshot: snapshot))
+        }
+    }
+
+    @Test func settleKeepsInFlightWhileHookStillRunning() {
+        withAppState { state in
+            let id = UUID()
+            let snapshot = makeWorktree(id: id, status: .archived)
+            state.revivingArchived[id] = .inFlight(snapshot: snapshot)
+
+            // Blocking preSession hook: the RPC returns the row `.creating`.
+            state.settleReviveState(id: id, snapshot: snapshot, revived: makeWorktree(id: id, status: .creating))
+
+            #expect(state.revivingArchived[id] == .inFlight(snapshot: snapshot))
+        }
+    }
+
+    // MARK: - promoteRevivedWorktrees (deferred flip via the refresh path)
+
+    @Test func inFlightRevivePromotesToDoneWhenRefreshObservesActiveRow() {
+        withAppState { state in
+            let id = UUID()
+            let snapshot = makeWorktree(id: id, status: .archived)
+            state.revivingArchived[id] = .inFlight(snapshot: snapshot)
+            // RPC returned `.creating` (hook running) — stays in flight.
+            state.settleReviveState(id: id, snapshot: snapshot, revived: makeWorktree(id: id, status: .creating))
+            #expect(state.revivingArchived[id] == .inFlight(snapshot: snapshot))
+
+            // Later poll observes the hook finished and the row flipped `.active`.
+            state.promoteRevivedWorktrees(observing: [makeWorktree(id: id, status: .active)])
+
+            #expect(state.revivingArchived[id] == .done(snapshot: snapshot))
+        }
+    }
+
+    @Test func creatingObservationDoesNotPromote() {
+        withAppState { state in
+            let id = UUID()
+            let snapshot = makeWorktree(id: id, status: .archived)
+            state.revivingArchived[id] = .inFlight(snapshot: snapshot)
+
+            // Hook still running: the poll sees the row `.creating`.
+            state.promoteRevivedWorktrees(observing: [makeWorktree(id: id, status: .creating)])
+
+            #expect(state.revivingArchived[id] == .inFlight(snapshot: snapshot))
+        }
+    }
+
+    @Test func promotionIgnoresUnrelatedWorktreesAndSettledEntries() {
+        withAppState { state in
+            let inFlightID = UUID()
+            let doneID = UUID()
+            let inFlightSnapshot = makeWorktree(id: inFlightID, status: .archived)
+            let doneSnapshot = makeWorktree(id: doneID, status: .archived)
+            state.revivingArchived[inFlightID] = .inFlight(snapshot: inFlightSnapshot)
+            state.revivingArchived[doneID] = .done(snapshot: doneSnapshot)
+
+            // A poll that doesn't contain the in-flight row leaves it alone,
+            // and already-done entries are never rewritten.
+            state.promoteRevivedWorktrees(observing: [makeWorktree(status: .active)])
+
+            #expect(state.revivingArchived[inFlightID] == .inFlight(snapshot: inFlightSnapshot))
+            #expect(state.revivingArchived[doneID] == .done(snapshot: doneSnapshot))
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -47,7 +47,8 @@ struct PreSessionHookTests {
         db: TBDDatabase,
         recorder: RecordedCommands? = nil,
         subscriptions: StateSubscriptionManager? = nil,
-        timeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout
+        timeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout,
+        windowIsDead: (@Sendable (String) -> Bool)? = nil
     ) -> WorktreeLifecycle {
         var dryRunRecorder: (@Sendable ([String]) -> Void)?
         if let recorder {
@@ -56,7 +57,11 @@ struct PreSessionHookTests {
         return WorktreeLifecycle(
             db: db,
             git: GitManager(),
-            tmux: TmuxManager(dryRun: true, dryRunRecorder: dryRunRecorder),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunRecorder: dryRunRecorder,
+                dryRunWindowIsDead: windowIsDead
+            ),
             hooks: HookResolver(),
             subscriptions: subscriptions,
             preSessionTimeout: timeout,
@@ -207,6 +212,14 @@ struct PreSessionHookTests {
                 "first window must be the primary agent")
         #expect(windowCalls[1].last?.contains("claude --session-id") == false,
                 "second window must be the setup hook/shell")
+        // Setup window carries the full documented hook env even with no
+        // preSession hook present.
+        let setupBody = windowCalls[1].last ?? ""
+        #expect(setupBody.contains("export TBD_EVENT='setup'"))
+        #expect(setupBody.contains("export TBD_WORKTREE_NAME='\(wt.name)'"))
+        #expect(setupBody.contains("export TBD_WORKTREE_PATH='\(wt.path)'"))
+        #expect(setupBody.contains("export TBD_REPO_PATH='\(repo.path)'"))
+        #expect(setupBody.contains("export TBD_BRANCH='\(wt.branch)'"))
 
         // Tab order [claude, setup], active = claude.
         #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [claude.id, setup.id])
@@ -279,8 +292,16 @@ struct PreSessionHookTests {
         let body = windowCalls[0].last ?? ""
         #expect(body.contains(".worktree-hooks/preSession"))
         #expect(body.contains("runtime/presession"))
-        // Hook env present on the window (exported in the command body).
+        // Full documented hook env present on the window (exported in the
+        // command body) — docs/worktree-hooks.md promises all of these.
+        let createdWtRow = try await db.worktrees.get(id: pending.id)
+        let createdWt = try #require(createdWtRow)
         #expect(body.contains("export TBD_EVENT='preSession'"))
+        #expect(body.contains("export TBD_WORKTREE_ID='\(createdWt.id.uuidString)'"))
+        #expect(body.contains("export TBD_WORKTREE_NAME='\(createdWt.name)'"))
+        #expect(body.contains("export TBD_WORKTREE_PATH='\(createdWt.path)'"))
+        #expect(body.contains("export TBD_REPO_PATH='\(repo.path)'"))
+        #expect(body.contains("export TBD_BRANCH='\(createdWt.branch)'"))
 
         // Still gated while the marker is absent.
         try await Task.sleep(nanoseconds: 200_000_000)
@@ -305,6 +326,18 @@ struct PreSessionHookTests {
         // Marker consumed.
         let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: pending.id)
         #expect(!FileManager.default.fileExists(atPath: markerPath))
+
+        // The parallel `setup` hook window gets the same documented env
+        // (TBD_EVENT=setup) — windows are [pre-session, claude, setup].
+        let allWindowCalls = recorder.snapshot().filter { $0.contains("new-window") }
+        #expect(allWindowCalls.count == 3)
+        let setupBody = allWindowCalls[2].last ?? ""
+        #expect(setupBody.contains("export TBD_EVENT='setup'"))
+        #expect(setupBody.contains("export TBD_TERMINAL_ID='\(setup.id.uuidString)'"))
+        #expect(setupBody.contains("export TBD_WORKTREE_NAME='\(createdWt.name)'"))
+        #expect(setupBody.contains("export TBD_WORKTREE_PATH='\(createdWt.path)'"))
+        #expect(setupBody.contains("export TBD_REPO_PATH='\(repo.path)'"))
+        #expect(setupBody.contains("export TBD_BRANCH='\(createdWt.branch)'"))
     }
 
     @Test func hookNonZeroExitStillSpawnsAndNotifies() async throws {
@@ -371,6 +404,161 @@ struct PreSessionHookTests {
         #expect(notifications.count == 1)
         #expect(notifications.first?.type == .error)
         #expect(notifications.first?.message?.contains("timed out") == true)
+        // No marker may remain after a timeout outcome.
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: pending.id)
+        #expect(!FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    // MARK: - Wait outcome races (marker vs. dead pane / deadline)
+
+    @Test func markerWinsWhenPaneDiesInSameIteration() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+
+        // The dead-window check fires AFTER the marker check in each poll
+        // iteration. Simulate the race deterministically: the windowExists
+        // probe itself writes the marker (hook finished + pane closed between
+        // the two checks) and reports the window dead. The wait must re-check
+        // the marker and honor its exit code instead of returning .paneKilled.
+        let worktreeID = UUID()
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
+        let lifecycle = makeLifecycle(db: db, windowIsDead: { _ in
+            try? FileManager.default.createDirectory(
+                atPath: (markerPath as NSString).deletingLastPathComponent,
+                withIntermediateDirectories: true
+            )
+            try? "0\n".write(toFile: markerPath, atomically: true, encoding: .utf8)
+            return true
+        })
+        let spawn = PreSessionSpawn(
+            terminalID: UUID(), windowID: "@mock-0", paneID: "%mock-0",
+            markerPath: markerPath, hookPath: "/dev/null"
+        )
+        let outcome = await lifecycle.waitForPreSessionCompletion(
+            preSession: spawn, tmuxServer: "tbd-test"
+        )
+        #expect(outcome == .completed(exitCode: 0),
+                "a marker written in the same iteration must beat .paneKilled")
+        #expect(!FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    @Test func markerPresentAtDeadlineBeatsTimeout() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+
+        // Deadline already expired (timeout 0) but the marker exists — the
+        // hook finished during the final poll sleep. The wait must consume
+        // the marker (no leak) and report .completed, not .timedOut.
+        let worktreeID = UUID()
+        try writeMarker(worktreeID: worktreeID, exitCode: 0)
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
+        let lifecycle = makeLifecycle(db: db, timeout: 0)
+        let spawn = PreSessionSpawn(
+            terminalID: UUID(), windowID: "@mock-0", paneID: "%mock-0",
+            markerPath: markerPath, hookPath: "/dev/null"
+        )
+        let outcome = await lifecycle.waitForPreSessionCompletion(
+            preSession: spawn, tmuxServer: "tbd-test"
+        )
+        #expect(outcome == .completed(exitCode: 0),
+                "a marker present at the deadline must beat .timedOut")
+        #expect(!FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    @Test func deadPaneWithoutMarkerIsPaneKilled() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+
+        let worktreeID = UUID()
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
+        let lifecycle = makeLifecycle(db: db, windowIsDead: { _ in true })
+        let spawn = PreSessionSpawn(
+            terminalID: UUID(), windowID: "@mock-0", paneID: "%mock-0",
+            markerPath: markerPath, hookPath: "/dev/null"
+        )
+        let outcome = await lifecycle.waitForPreSessionCompletion(
+            preSession: spawn, tmuxServer: "tbd-test"
+        )
+        #expect(outcome == .paneKilled)
+    }
+
+    // MARK: - Killed pane (end-to-end)
+
+    @Test func paneKilledStillSpawnsAndNotifies() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        // Every window reports dead and no marker is ever written → the wait
+        // short-circuits to .paneKilled (user closed the hook terminal).
+        let lifecycle = makeLifecycle(db: db, windowIsDead: { _ in true })
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id)
+        let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id)
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending")
+            return
+        }
+        await phase3.value
+
+        // Killed pane must still spawn the primary terminals and activate.
+        let terminals = try await db.terminals.list(worktreeID: pending.id)
+        #expect(terminals.count == 3, "killed pane must still spawn primary terminals")
+        #expect(try await db.worktrees.get(id: pending.id)?.status == .active)
+
+        let notifications = try await db.notifications.unread(worktreeID: pending.id)
+        #expect(notifications.count == 1)
+        #expect(notifications.first?.type == .error)
+        #expect(notifications.first?.message?.contains("closed") == true)
+        // No marker may remain after a paneKilled outcome.
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: pending.id)
+        #expect(!FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    // MARK: - Worktree row deleted mid-wait (repo remove)
+
+    @Test func rowDeletedMidWaitSkipsPrimarySpawnAndCleansUp() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = RecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id)
+        let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id)
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending")
+            return
+        }
+
+        // Repo removal mid-wait: deleteForRepo drops the .creating row (the
+        // terminal rows cascade). Phase 3 must notice and never spawn the
+        // primary terminals into the void.
+        try await db.worktrees.deleteForRepo(repoID: repo.id)
+        try writeMarker(worktreeID: pending.id, exitCode: 0)
+        await phase3.value
+
+        #expect(try await db.worktrees.get(id: pending.id) == nil)
+        #expect(try await db.terminals.list(worktreeID: pending.id).isEmpty,
+                "no terminal rows may be created for a deleted worktree")
+        let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
+        #expect(windowCalls.count == 1,
+                "only the pre-session window may exist — no primary windows after the row vanished")
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: pending.id)
+        #expect(!FileManager.default.fileExists(atPath: markerPath),
+                "marker must be cleaned up on the deleted-row early exit")
     }
 
     // MARK: - Legacy sync create + revive
@@ -395,7 +583,7 @@ struct PreSessionHookTests {
         #expect(terminals.contains { $0.label == "pre-session" })
     }
 
-    @Test func reviveWithHookSpawnsGatedTerminals() async throws {
+    @Test func legacyReviveWithHookAwaitsPhase3Inline() async throws {
         let (_, cleanup) = isolateTBDHome()
         defer { cleanup() }
         let (tempDir, repoDir) = try await createTestRepo()
@@ -409,11 +597,109 @@ struct PreSessionHookTests {
         let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
         try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
 
+        // Legacy synchronous contract: fully set up on return (the inline
+        // await rides the short timeout since dryRun tmux never runs the hook).
         let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
         #expect(revived.status == .active)
         let terminals = try await db.terminals.list(worktreeID: revived.id)
         #expect(terminals.count == 3)
         #expect(terminals.contains { $0.label == "pre-session" })
+    }
+
+    /// Creates a worktree gated on the preSession hook, completes the hook via
+    /// marker, and archives it — leaving an `.archived` row ready to revive.
+    private func makeArchivedWorktree(
+        lifecycle: WorktreeLifecycle, db: TBDDatabase, repo: Repo
+    ) async throws -> Worktree {
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
+        let completion = try await lifecycle.completeCreateWorktree(
+            worktreeID: pending.id, skipClaude: true
+        )
+        if case .preSessionPending(let phase3) = completion {
+            try writeMarker(worktreeID: pending.id, exitCode: 0)
+            await phase3.value
+        }
+        try await lifecycle.archiveWorktree(worktreeID: pending.id, force: true)
+        let archived = try await db.worktrees.get(id: pending.id)
+        return try #require(archived)
+    }
+
+    @Test func reviveWithHookReturnsPendingAndGatesPrimaries() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+        let wt = try await makeArchivedWorktree(lifecycle: lifecycle, db: db, repo: repo)
+        // Sessions stored on the archived row; skipClaude revive must keep them.
+        try await db.worktrees.setArchivedClaudeSessions(id: wt.id, sessions: ["aaaa-session"])
+
+        let completion = try await lifecycle.beginReviveWorktree(
+            worktreeID: wt.id, skipClaude: true
+        )
+        guard case .preSessionPending(let pendingWt, let phase3) = completion else {
+            Issue.record("expected .preSessionPending when a preSession hook resolves")
+            return
+        }
+        // RPC-visible state: returned promptly, row gating the app UI on .creating.
+        #expect(pendingWt.status == .creating)
+        var terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.count == 1)
+        #expect(terminals.first?.label == "pre-session")
+
+        // Hook finishes → primaries spawn, revive semantics applied.
+        try writeMarker(worktreeID: wt.id, exitCode: 0)
+        await phase3.value
+
+        let revived = try await db.worktrees.get(id: wt.id)
+        #expect(revived?.status == .active)
+        #expect(revived?.archivedAt == nil, "revive must clear archivedAt")
+        #expect(revived?.archivedClaudeSessions == ["aaaa-session"],
+                "skipClaude revive must preserve archived sessions for a later revive")
+        terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.count == 3)
+        #expect(terminals.contains { $0.label == "pre-session" })
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: wt.id)
+        #expect(!FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    @Test func reviveWithHookRestoresAndClearsSessions() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+        let wt = try await makeArchivedWorktree(lifecycle: lifecycle, db: db, repo: repo)
+        let sessionID = UUID().uuidString
+        try await db.worktrees.setArchivedClaudeSessions(id: wt.id, sessions: [sessionID])
+
+        let completion = try await lifecycle.beginReviveWorktree(
+            worktreeID: wt.id, skipClaude: false
+        )
+        guard case .preSessionPending(let pendingWt, let phase3) = completion else {
+            Issue.record("expected .preSessionPending")
+            return
+        }
+        #expect(pendingWt.status == .creating)
+        try writeMarker(worktreeID: wt.id, exitCode: 0)
+        await phase3.value
+
+        let revived = try await db.worktrees.get(id: wt.id)
+        #expect(revived?.status == .active)
+        #expect(revived?.archivedClaudeSessions == nil,
+                "restoring Claude must clear the archived session list")
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        let claude = terminals.first { $0.label == "Claude Code" }
+        #expect(claude?.claudeSessionID == sessionID,
+                "primary Claude terminal must resume the archived session")
     }
 
     // MARK: - Broadcasts
@@ -462,6 +748,140 @@ struct PreSessionHookTests {
         }
         #expect(terminalLabels.sorted() == ["Claude Code", "pre-session", "setup"],
                 "terminalCreated must fire for the pre-session AND each primary terminal")
+    }
+
+    // MARK: - Startup recovery of `.creating` rows
+
+    @Test func recoveryResumesOrphanedPreSessionWait() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Simulate a daemon that died mid-pre-session-wait: a .creating row
+        // whose checkout exists on disk and whose only terminal is the
+        // pre-session one (the tmux window + hook survive daemon restarts).
+        let checkout = tempDir.appendingPathComponent("orphan-checkout")
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "orphan", branch: "tbd/orphan",
+            path: checkout.path, tmuxServer: "tbd-test", status: .creating
+        )
+        _ = try await db.terminals.create(
+            id: UUID(), worktreeID: wt.id,
+            tmuxWindowID: "@mock-99", tmuxPaneID: "%mock-99",
+            label: "pre-session", kind: .shell
+        )
+
+        let resumed = await lifecycle.recoverCreatingWorktrees()
+        #expect(resumed.count == 1, "the stranded wait must be resumed")
+        // Row must still be .creating while the resumed wait runs.
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .creating)
+
+        // Hook finishes → primaries spawn and the row activates.
+        try writeMarker(worktreeID: wt.id, exitCode: 0)
+        for task in resumed { await task.value }
+
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .active)
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.count == 3,
+                "resumed phase 3 must spawn the primary terminals")
+        #expect(terminals.contains { $0.label == "Claude Code" })
+        #expect(terminals.contains { $0.label == "setup" })
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: wt.id)
+        #expect(!FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    @Test func recoveryDeletesCreatingRowWithoutCheckout() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Creation never completed: no checkout on disk.
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "ghost", branch: "tbd/ghost",
+            path: tempDir.appendingPathComponent("never-created").path,
+            tmuxServer: "tbd-test", status: .creating
+        )
+        _ = try await db.terminals.create(
+            id: UUID(), worktreeID: wt.id,
+            tmuxWindowID: "@mock-98", tmuxPaneID: "%mock-98",
+            label: "pre-session", kind: .shell
+        )
+
+        let resumed = await lifecycle.recoverCreatingWorktrees()
+        #expect(resumed.isEmpty)
+        #expect(try await db.worktrees.get(id: wt.id) == nil,
+                "a .creating row without a checkout must be deleted")
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test func recoveryActivatesCreatingRowWithPrimaries() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Daemon died between the primary spawn and the final status flip:
+        // checkout + pre-session + primary terminals all exist.
+        let checkout = tempDir.appendingPathComponent("almost-done")
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "almost", branch: "tbd/almost",
+            path: checkout.path, tmuxServer: "tbd-test", status: .creating
+        )
+        for (label, kind) in [("pre-session", TerminalKind.shell),
+                              ("Claude Code", .claude), ("setup", .shell)] {
+            _ = try await db.terminals.create(
+                id: UUID(), worktreeID: wt.id,
+                tmuxWindowID: "@mock-\(label)", tmuxPaneID: "%mock-\(label)",
+                label: label, kind: kind
+            )
+        }
+
+        let resumed = await lifecycle.recoverCreatingWorktrees()
+        #expect(resumed.isEmpty, "nothing to wait for — only the status flip was lost")
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .active)
+        #expect(try await db.terminals.list(worktreeID: wt.id).count == 3,
+                "existing terminals must be left untouched")
+    }
+
+    @Test func recoveryDeletesCreatingRowWithNoTerminals() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Daemon died after `git worktree add` but before any tmux spawn:
+        // checkout exists, zero terminals. Reconcile re-adopts the checkout.
+        let checkout = tempDir.appendingPathComponent("bare-checkout")
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "bare", branch: "tbd/bare",
+            path: checkout.path, tmuxServer: "tbd-test", status: .creating
+        )
+
+        let resumed = await lifecycle.recoverCreatingWorktrees()
+        #expect(resumed.isEmpty)
+        #expect(try await db.worktrees.get(id: wt.id) == nil,
+                "a terminal-less .creating row must be deleted for reconcile to re-adopt")
     }
 }
 }

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -1,0 +1,501 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: these tests mutate the process-global
+// `TBD_HOME` env var to isolate the hooks/default and runtime/presession
+// directories from the developer's real ~/tbd. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+@Suite("Pre-session hook")
+struct PreSessionHookTests {
+
+    // MARK: - Helpers
+
+    /// Creates a unique temp TBD_HOME and points the process at it.
+    /// Caller must call the returned cleanup closure (idempotent).
+    private func isolateTBDHome() -> (home: URL, cleanup: () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-presession-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        return (home, {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    /// Writes an executable `.worktree-hooks/preSession` into the repo and
+    /// commits it so fresh worktree checkouts contain it.
+    @discardableResult
+    private func installPreSessionHook(
+        repoDir: URL, script: String = "#!/bin/sh\nexit 0\n"
+    ) async throws -> String {
+        let hooksDir = repoDir.appendingPathComponent(".worktree-hooks")
+        try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+        let hookPath = hooksDir.appendingPathComponent("preSession")
+        try script.write(to: hookPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: hookPath.path
+        )
+        try await shell("git add -A && git commit -m 'add preSession hook'", at: repoDir)
+        return hookPath.path
+    }
+
+    private func makeLifecycle(
+        db: TBDDatabase,
+        recorder: RecordedCommands? = nil,
+        subscriptions: StateSubscriptionManager? = nil,
+        timeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout
+    ) -> WorktreeLifecycle {
+        var dryRunRecorder: (@Sendable ([String]) -> Void)?
+        if let recorder {
+            dryRunRecorder = { args in recorder.append(args) }
+        }
+        return WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true, dryRunRecorder: dryRunRecorder),
+            hooks: HookResolver(),
+            subscriptions: subscriptions,
+            preSessionTimeout: timeout,
+            preSessionPollInterval: 0.05
+        )
+    }
+
+    /// Writes the completion marker the wrapped hook command would write.
+    private func writeMarker(worktreeID: UUID, exitCode: Int) throws {
+        let path = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try "\(exitCode)\n".write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - HookEvent + resolution
+
+    @Test func preSessionEventNames() {
+        #expect(HookEvent.preSession.rawValue == "preSession")
+        #expect(HookEvent.preSession.conductorKey == "preSession")
+        #expect(HookEvent.preSession.dmuxHookName == "pre_session")
+    }
+
+    @Test func resolvesFromWorktreeHooksDir() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let hookPath = try await installPreSessionHook(repoDir: repoDir)
+
+        let resolved = HookResolver().resolve(
+            event: .preSession, repoPath: repoDir.path, appHookPath: nil
+        )
+        #expect(resolved == hookPath)
+    }
+
+    @Test func resolvesFromAppPerRepoPath() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let repoID = UUID()
+        let appPath = TBDConstants.hookPath(
+            repoID: repoID, eventName: HookEvent.preSession.rawValue
+        )
+        try FileManager.default.createDirectory(
+            atPath: (appPath as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try "#!/bin/sh\nexit 0\n".write(toFile: appPath, atomically: true, encoding: .utf8)
+
+        #expect(appPath.hasPrefix(TBDConstants.configDir.path),
+                "app per-repo hook path must live under TBD_HOME")
+        let resolved = HookResolver().resolve(
+            event: .preSession, repoPath: repoDir.path, appHookPath: appPath
+        )
+        #expect(resolved == appPath)
+    }
+
+    @Test func resolvesFromGlobalDefault() async throws {
+        let (home, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let globalDir = home.appendingPathComponent("hooks/default")
+        try FileManager.default.createDirectory(at: globalDir, withIntermediateDirectories: true)
+        let globalHook = globalDir.appendingPathComponent("preSession")
+        try "#!/bin/sh\nexit 0\n".write(to: globalHook, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: globalHook.path
+        )
+
+        let resolved = HookResolver().resolve(
+            event: .preSession, repoPath: repoDir.path, appHookPath: nil
+        )
+        #expect(resolved == globalHook.path)
+    }
+
+    @Test func absentHookResolvesNil() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let resolved = HookResolver().resolve(
+            event: .preSession, repoPath: repoDir.path, appHookPath: nil
+        )
+        #expect(resolved == nil)
+    }
+
+    // MARK: - Marker plumbing
+
+    @Test func markerPathRespectsTBDHome() {
+        let (home, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let id = UUID()
+        let path = WorktreeLifecycle.preSessionMarkerPath(worktreeID: id)
+        #expect(path.hasPrefix(home.path))
+        #expect(path.contains("runtime/presession"))
+        #expect(path.hasSuffix(id.uuidString))
+    }
+
+    @Test func preSessionCommandEscapesAndChains() {
+        let cmd = WorktreeLifecycle.preSessionCommand(
+            hookPath: "/tmp/it's here/preSession",
+            runtimeDir: "/r/dir",
+            markerPath: "/r/dir/marker",
+            shell: "/bin/zsh"
+        )
+        #expect(cmd.contains("'/tmp/it'\\''s here/preSession'"))
+        #expect(cmd.contains("__tbd_rc=$?"))
+        #expect(cmd.contains("/bin/mkdir -p '/r/dir'"))
+        #expect(cmd.contains("/bin/echo $__tbd_rc > '/r/dir/marker'"))
+        #expect(cmd.hasSuffix("exec /bin/zsh"))
+    }
+
+    // MARK: - No hook: behavior identical to today (gating off-branch)
+
+    @Test func noHookSpawnsClaudeFirstThenSetup() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = RecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+        #expect(wt.status == .active)
+
+        // Exactly the two historical terminals, no pre-session tab.
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.count == 2)
+        #expect(!terminals.contains { $0.label == "pre-session" })
+        let claude = try #require(terminals.first { $0.label == "Claude Code" })
+        let setup = try #require(terminals.first { $0.label == "setup" })
+
+        // Window creation order: claude window first, setup window second.
+        let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
+        #expect(windowCalls.count == 2)
+        #expect(windowCalls[0].last?.contains("claude --session-id") == true,
+                "first window must be the primary agent")
+        #expect(windowCalls[1].last?.contains("claude --session-id") == false,
+                "second window must be the setup hook/shell")
+
+        // Tab order [claude, setup], active = claude.
+        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [claude.id, setup.id])
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: wt.id) == claude.id)
+        #expect(try await db.notifications.unread(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test func noHookCreateFailureStillDeletesRow() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Occupy the branch, then force a user-specified-folder collision —
+        // phase 2 fails and must delete the DB row (today's behavior).
+        _ = try await lifecycle.createWorktree(
+            repoID: repo.id, folder: "first", branch: "feat/clash", skipClaude: true
+        )
+        let pending = try await lifecycle.beginCreateWorktree(
+            repoID: repo.id, folder: "second", branch: "feat/clash", skipClaude: true
+        )
+        await #expect(throws: WorktreeLifecycleError.self) {
+            try await lifecycle.completeCreateWorktree(
+                worktreeID: pending.id, skipClaude: true,
+                userSpecifiedFolder: true, userSpecifiedBranch: true
+            )
+        }
+        #expect(try await db.worktrees.get(id: pending.id) == nil,
+                "phase-2 failure must delete the DB row")
+    }
+
+    // MARK: - With hook: gated spawn
+
+    @Test func hookGatesPrimarySpawnUntilMarker() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = RecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id)
+        let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id)
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending when a preSession hook resolves")
+            return
+        }
+
+        // Pre-session terminal created FIRST — and it's the only one so far.
+        var terminals = try await db.terminals.list(worktreeID: pending.id)
+        #expect(terminals.count == 1)
+        let pre = try #require(terminals.first)
+        #expect(pre.label == "pre-session")
+        #expect(pre.kind == .shell)
+        #expect(try await db.worktrees.get(id: pending.id)?.status == .creating)
+        #expect(try await db.worktrees.getTabOrder(worktreeID: pending.id) == [pre.id])
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: pending.id) == pre.id)
+
+        // The single window so far runs the wrapped hook command.
+        let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
+        #expect(windowCalls.count == 1)
+        let body = windowCalls[0].last ?? ""
+        #expect(body.contains(".worktree-hooks/preSession"))
+        #expect(body.contains("runtime/presession"))
+        // Hook env present on the window (exported in the command body).
+        #expect(body.contains("export TBD_EVENT='preSession'"))
+
+        // Still gated while the marker is absent.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        terminals = try await db.terminals.list(worktreeID: pending.id)
+        #expect(terminals.count == 1, "primary terminals must not spawn before the marker")
+
+        // Hook "finishes" with exit 0.
+        try writeMarker(worktreeID: pending.id, exitCode: 0)
+        await phase3.value
+
+        terminals = try await db.terminals.list(worktreeID: pending.id)
+        #expect(terminals.count == 3)
+        let claude = try #require(terminals.first { $0.label == "Claude Code" })
+        let setup = try #require(terminals.first { $0.label == "setup" })
+        #expect(try await db.worktrees.getTabOrder(worktreeID: pending.id)
+                == [claude.id, pre.id, setup.id],
+                "tab order must be [claude, preSession, setup]")
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: pending.id) == claude.id)
+        #expect(try await db.worktrees.get(id: pending.id)?.status == .active)
+        // Exit 0 → no notification.
+        #expect(try await db.notifications.unread(worktreeID: pending.id).isEmpty)
+        // Marker consumed.
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: pending.id)
+        #expect(!FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    @Test func hookNonZeroExitStillSpawnsAndNotifies() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id)
+        let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id)
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending")
+            return
+        }
+
+        try writeMarker(worktreeID: pending.id, exitCode: 1)
+        await phase3.value
+
+        let terminals = try await db.terminals.list(worktreeID: pending.id)
+        #expect(terminals.count == 3, "non-zero exit must still spawn primary terminals")
+        #expect(try await db.worktrees.get(id: pending.id)?.status == .active)
+
+        let notifications = try await db.notifications.unread(worktreeID: pending.id)
+        #expect(notifications.count == 1)
+        #expect(notifications.first?.type == .error)
+        #expect(notifications.first?.message?.contains("exit 1") == true)
+    }
+
+    @Test func hookTimeoutStillSpawnsAndNotifies() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        // Short injected timeout; the marker is never written. (The killed-pane
+        // short-circuit can't fire under dryRun tmux — windowExists is always
+        // true — so the timeout path covers the no-completion case here.)
+        let lifecycle = makeLifecycle(db: db, timeout: 0.3)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id)
+        let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id)
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending")
+            return
+        }
+        await phase3.value
+
+        // Phase-3 problems must never delete the worktree row.
+        let wt = try await db.worktrees.get(id: pending.id)
+        #expect(wt != nil, "timeout must not delete the worktree row")
+        #expect(wt?.status == .active, "worktree must not be stuck in .creating")
+        let terminals = try await db.terminals.list(worktreeID: pending.id)
+        #expect(terminals.count == 3)
+
+        let notifications = try await db.notifications.unread(worktreeID: pending.id)
+        #expect(notifications.count == 1)
+        #expect(notifications.first?.type == .error)
+        #expect(notifications.first?.message?.contains("timed out") == true)
+    }
+
+    // MARK: - Legacy sync create + revive
+
+    @Test func legacyCreateWorktreeAwaitsPhase3Inline() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db, timeout: 0.3)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        // dryRun tmux never runs the hook, so phase 3 hits the short timeout;
+        // the synchronous method must still return a fully set-up worktree.
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+        #expect(wt.status == .active)
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.count == 3)
+        #expect(terminals.contains { $0.label == "pre-session" })
+    }
+
+    @Test func reviveWithHookSpawnsGatedTerminals() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db, timeout: 0.3)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+        try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+        let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
+        #expect(revived.status == .active)
+        let terminals = try await db.terminals.list(worktreeID: revived.id)
+        #expect(terminals.count == 3)
+        #expect(terminals.contains { $0.label == "pre-session" })
+    }
+
+    // MARK: - Broadcasts
+
+    @Test func broadcastsTerminalCreatedAndSingleWorktreeCreated() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let collected = CollectedDeltas()
+        let subs = StateSubscriptionManager()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                collected.append(delta)
+            }
+            return true
+        }
+        let lifecycle = makeLifecycle(db: db, subscriptions: subs)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id)
+        let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id)
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending")
+            return
+        }
+
+        // Early broadcasts: worktreeCreated + terminalCreated(pre-session).
+        var snapshot = collected.snapshot()
+        #expect(snapshot.contains { if case .worktreeCreated(let d) = $0 { return d.worktreeID == pending.id } else { return false } })
+        #expect(snapshot.contains { if case .terminalCreated(let d) = $0 { return d.label == "pre-session" } else { return false } })
+
+        try writeMarker(worktreeID: pending.id, exitCode: 0)
+        await phase3.value
+
+        snapshot = collected.snapshot()
+        let worktreeCreatedCount = snapshot.filter {
+            if case .worktreeCreated = $0 { return true } else { return false }
+        }.count
+        #expect(worktreeCreatedCount == 1, "worktreeCreated must be broadcast exactly once")
+        let terminalLabels = snapshot.compactMap { delta -> String? in
+            if case .terminalCreated(let d) = delta { return d.label } else { return nil }
+        }
+        #expect(terminalLabels.sorted() == ["Claude Code", "pre-session", "setup"],
+                "terminalCreated must fire for the pre-session AND each primary terminal")
+    }
+}
+}
+
+// MARK: - Helpers
+
+/// Thread-safe collector for TmuxManager dryRun recorded args.
+private final class RecordedCommands: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands: [[String]] = []
+
+    func append(_ args: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        commands.append(args)
+    }
+
+    func snapshot() -> [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return commands
+    }
+}
+
+/// Thread-safe collector for broadcast StateDeltas.
+private final class CollectedDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+}

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import TestSupport
 import Testing
 @testable import TBDDaemonLib
@@ -560,7 +561,46 @@ struct PreSessionHookTests {
                 "only the pre-session window may exist — no primary windows after the row vanished")
         let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: pending.id)
         #expect(!FileManager.default.fileExists(atPath: markerPath),
-                "marker must be cleaned up on the deleted-row early exit")
+                "the marker removed right after the wait must not reappear on the deleted-row early exit")
+    }
+
+    @Test func dbErrorDuringRowCheckDoesNotTearDownPreSessionWindow() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = RecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id)
+        let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id)
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending")
+            return
+        }
+        let terminalsBefore = try await db.terminals.list(worktreeID: pending.id)
+        let preTerminal = try #require(terminalsBefore.first)
+
+        // Close the underlying GRDB connection mid-wait so the phase-3 row
+        // existence check THROWS instead of returning nil. A thrown DB error
+        // is not proof the row is gone — phase 3 must take the spawn path,
+        // not the deleted-row teardown that kills the live pre-session
+        // window of a perfectly valid worktree. (The spawn attempt itself
+        // then fails on the closed DB and is logged/swallowed — what matters
+        // here is which branch the guard took.)
+        try db.writerForTests.close()
+        try writeMarker(worktreeID: pending.id, exitCode: 0)
+        await phase3.value
+
+        let kills = recorder.snapshot().filter { $0.contains("kill-window") }
+        #expect(!kills.contains { $0.contains(preTerminal.tmuxWindowID) },
+                "a transient DB error on the existence check must not kill the pre-session window")
+        let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: pending.id)
+        #expect(!FileManager.default.fileExists(atPath: markerPath))
     }
 
     // MARK: - Legacy sync create + revive
@@ -1090,6 +1130,47 @@ struct PreSessionHookTests {
                 "a terminal-less .creating row must be deleted for reconcile to re-adopt")
         #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).isEmpty,
                 "tab rows must be deleted with the worktree row")
+    }
+
+    @Test func recoveryDeletesCreatingRowWhoseRepoVanished() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // A .creating row with a checkout on disk and a pre-session terminal,
+        // so recovery reaches the repo lookup (past the checkout-missing and
+        // no-terminals guards). Then orphan it: the repoID FK would either
+        // reject a made-up repoID or cascade-delete the worktree on
+        // `repos.remove`, so delete the repo row with foreign keys off —
+        // simulating a DB left inconsistent by an older daemon.
+        let checkout = tempDir.appendingPathComponent("repo-less")
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "repoless", branch: "tbd/repoless",
+            path: checkout.path, tmuxServer: "tbd-test", status: .creating
+        )
+        _ = try await db.terminals.create(
+            id: UUID(), worktreeID: wt.id,
+            tmuxWindowID: "@mock-97", tmuxPaneID: "%mock-97",
+            label: "pre-session", kind: .shell
+        )
+        try await db.writerForTests.writeWithoutTransaction { sqlDB in
+            try sqlDB.execute(sql: "PRAGMA foreign_keys = OFF")
+            try sqlDB.execute(sql: "DELETE FROM repo WHERE id = ?", arguments: [repo.id.uuidString])
+            try sqlDB.execute(sql: "PRAGMA foreign_keys = ON")
+        }
+
+        let resumed = await lifecycle.recoverCreatingWorktrees()
+        #expect(resumed.isEmpty, "a repo-less .creating row cannot be resumed")
+        #expect(try await db.worktrees.get(id: wt.id) == nil,
+                "the stranded row must be deleted, not skipped forever")
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty,
+                "its terminal rows must be deleted with it")
     }
 }
 }

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -48,7 +48,8 @@ struct PreSessionHookTests {
         recorder: RecordedCommands? = nil,
         subscriptions: StateSubscriptionManager? = nil,
         timeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout,
-        windowIsDead: (@Sendable (String) -> Bool)? = nil
+        windowIsDead: (@Sendable (String) -> Bool)? = nil,
+        listWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil
     ) -> WorktreeLifecycle {
         var dryRunRecorder: (@Sendable ([String]) -> Void)?
         if let recorder {
@@ -60,7 +61,8 @@ struct PreSessionHookTests {
             tmux: TmuxManager(
                 dryRun: true,
                 dryRunRecorder: dryRunRecorder,
-                dryRunWindowIsDead: windowIsDead
+                dryRunWindowIsDead: windowIsDead,
+                dryRunListWindows: listWindows
             ),
             hooks: HookResolver(),
             subscriptions: subscriptions,
@@ -786,7 +788,12 @@ struct PreSessionHookTests {
         try writeMarker(worktreeID: wt.id, exitCode: 0)
         for task in resumed { await task.value }
 
-        #expect(try await db.worktrees.get(id: wt.id)?.status == .active)
+        // Mid-CREATE branch: no archived sessions, so recovery uses
+        // `.markActive` — plain status flip, no archive fields involved.
+        let after = try await db.worktrees.get(id: wt.id)
+        #expect(after?.status == .active)
+        #expect(after?.archivedAt == nil)
+        #expect(after?.archivedClaudeSessions == nil)
         let terminals = try await db.terminals.list(worktreeID: wt.id)
         #expect(terminals.count == 3,
                 "resumed phase 3 must spawn the primary terminals")
@@ -794,6 +801,203 @@ struct PreSessionHookTests {
         #expect(terminals.contains { $0.label == "setup" })
         let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: wt.id)
         #expect(!FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    @Test func recoveryMidReviveRestoresAndClearsArchivedSessions() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Simulate a daemon that died mid-REVIVE-wait: beginReviveWorktree
+        // re-added the checkout, spawned the pre-session terminal, and flipped
+        // the row .archived → .creating — but its archive fields (archivedAt,
+        // archivedClaudeSessions) are only cleared in phase 3, so they're
+        // still set when the daemon dies.
+        let sessionID = UUID().uuidString
+        let checkout = tempDir.appendingPathComponent("revive-orphan")
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "revorph", branch: "tbd/revorph",
+            path: checkout.path, tmuxServer: "tbd-test"
+        )
+        try await db.worktrees.archive(id: wt.id, claudeSessionIDs: [sessionID])
+        try await db.worktrees.updateStatus(id: wt.id, status: .creating)
+        _ = try await db.terminals.create(
+            id: UUID(), worktreeID: wt.id,
+            tmuxWindowID: "@mock-rev", tmuxPaneID: "%mock-rev",
+            label: "pre-session", kind: .shell
+        )
+
+        let resumed = await lifecycle.recoverCreatingWorktrees()
+        #expect(resumed.count == 1, "the stranded mid-revive wait must be resumed")
+
+        try writeMarker(worktreeID: wt.id, exitCode: 0)
+        for task in resumed { await task.value }
+
+        // Mid-REVIVE branch: recovery must finish with revive semantics —
+        // restore the archived session into the primary terminal, clear
+        // archivedAt, and clear archivedClaudeSessions so the next archive
+        // can't silently orphan the old transcript.
+        let after = try await db.worktrees.get(id: wt.id)
+        #expect(after?.status == .active)
+        #expect(after?.archivedAt == nil, "revive semantics must clear archivedAt")
+        #expect(after?.archivedClaudeSessions == nil,
+                "restored sessions must be cleared, not left to be overwritten on the next archive")
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        let claude = terminals.first { $0.label == "Claude Code" }
+        #expect(claude?.claudeSessionID == sessionID,
+                "the primary Claude terminal must resume the archived transcript, not start fresh")
+    }
+
+    // MARK: - Reconcile must not kill live `.creating` windows
+
+    @Test func reconcileSparesCreatingWorktreePreSessionWindow() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = RecordedCommands()
+        // The tmux server reports the active agent window, the .creating
+        // worktree's pre-session window, and one genuinely orphaned window.
+        let lifecycle = makeLifecycle(db: db, recorder: recorder, listWindows: { _, _ in
+            [
+                (windowID: "@mock-agent", paneID: "%mock-agent"),
+                (windowID: "@mock-pre", paneID: "%mock-pre"),
+                (windowID: "@mock-orphan", paneID: "%mock-orphan"),
+            ]
+        })
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let server = TmuxManager.serverName(forRepoPath: repo.path)
+
+        // Active worktree at the main checkout path so `git worktree list`
+        // reports it and reconcile doesn't archive it as missing.
+        let active = try await db.worktrees.create(
+            repoID: repo.id, name: "main-wt", branch: "main",
+            path: repoDir.path, tmuxServer: server
+        )
+        _ = try await db.terminals.create(
+            id: UUID(), worktreeID: active.id,
+            tmuxWindowID: "@mock-agent", tmuxPaneID: "%mock-agent",
+            label: "Claude Code", kind: .claude
+        )
+        // A .creating worktree mid-pre-session-hook (e.g. a running npm
+        // install) — its window must survive the orphan cleanup pass.
+        let creating = try await db.worktrees.create(
+            repoID: repo.id, name: "hooked", branch: "tbd/hooked",
+            path: tempDir.appendingPathComponent("hooked").path,
+            tmuxServer: server, status: .creating
+        )
+        let preTerminal = try await db.terminals.create(
+            id: UUID(), worktreeID: creating.id,
+            tmuxWindowID: "@mock-pre", tmuxPaneID: "%mock-pre",
+            label: "pre-session", kind: .shell
+        )
+
+        try await lifecycle.reconcile(repoID: repo.id)
+
+        let kills = recorder.snapshot().filter { $0.contains("kill-window") }
+        #expect(!kills.contains { $0.contains("@mock-pre") },
+                "reconcile must not kill a .creating worktree's live pre-session window")
+        #expect(!kills.contains { $0.contains("@mock-agent") },
+                "tracked active windows must survive")
+        #expect(kills.contains { $0.contains("@mock-orphan") },
+                "genuinely untracked windows must still be cleaned up")
+        #expect(!recorder.snapshot().contains { $0.contains("kill-server") })
+        // The .creating row and its terminal are untouched.
+        #expect(try await db.worktrees.get(id: creating.id)?.status == .creating)
+        #expect(try await db.terminals.get(id: preTerminal.id) != nil)
+    }
+
+    @Test func reconcileKeepsServerWhenOnlyLiveRowIsCreating() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = RecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder, listWindows: { _, _ in
+            [(windowID: "@mock-pre", paneID: "%mock-pre")]
+        })
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let server = TmuxManager.serverName(forRepoPath: repo.path)
+
+        // The repo's ONLY live row is .creating — the kill-server branch must
+        // not fire (it would take the running hook's window down with it).
+        let creating = try await db.worktrees.create(
+            repoID: repo.id, name: "solo-hooked", branch: "tbd/solo-hooked",
+            path: tempDir.appendingPathComponent("solo-hooked").path,
+            tmuxServer: server, status: .creating
+        )
+        _ = try await db.terminals.create(
+            id: UUID(), worktreeID: creating.id,
+            tmuxWindowID: "@mock-pre", tmuxPaneID: "%mock-pre",
+            label: "pre-session", kind: .shell
+        )
+
+        try await lifecycle.reconcile(repoID: repo.id)
+
+        #expect(!recorder.snapshot().contains { $0.contains("kill-server") },
+                "a repo whose only live worktree is .creating must keep its tmux server")
+        #expect(!recorder.snapshot().contains { $0.contains("kill-window") && $0.contains("@mock-pre") },
+                "the pre-session window must not be treated as an orphan")
+    }
+
+    @Test func recoveryThenReconcileLeavesResumedWaitIntact() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = RecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder, listWindows: { _, _ in
+            [(windowID: "@mock-pre", paneID: "%mock-pre")]
+        })
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let server = TmuxManager.serverName(forRepoPath: repo.path)
+
+        // Daemon restarted mid-pre-session-wait: .creating row, checkout on
+        // disk, only the pre-session terminal.
+        let checkout = tempDir.appendingPathComponent("restart-survivor")
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "survivor", branch: "tbd/survivor",
+            path: checkout.path, tmuxServer: server, status: .creating
+        )
+        _ = try await db.terminals.create(
+            id: UUID(), worktreeID: wt.id,
+            tmuxWindowID: "@mock-pre", tmuxPaneID: "%mock-pre",
+            label: "pre-session", kind: .shell
+        )
+
+        // Startup sequence: recovery sweep first, then per-repo reconcile —
+        // exactly what Daemon.start() runs.
+        let resumed = await lifecycle.recoverCreatingWorktrees()
+        #expect(resumed.count == 1)
+        try await lifecycle.reconcile(repoID: repo.id)
+
+        #expect(!recorder.snapshot().contains { $0.contains("kill-window") && $0.contains("@mock-pre") },
+                "the just-resumed pre-session window must survive the startup reconcile")
+        #expect(!recorder.snapshot().contains { $0.contains("kill-server") })
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .creating,
+                "the resumed wait must still be in flight after reconcile")
+
+        // The hook finishes after reconcile — the resumed wait completes.
+        try writeMarker(worktreeID: wt.id, exitCode: 0)
+        for task in resumed { await task.value }
+
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .active)
+        #expect(try await db.terminals.list(worktreeID: wt.id).count == 3)
+        #expect(try await db.notifications.unread(worktreeID: wt.id).isEmpty,
+                "no spurious paneKilled notification may be recorded")
     }
 
     @Test func recoveryDeletesCreatingRowWithoutCheckout() async throws {

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -1081,11 +1081,15 @@ struct PreSessionHookTests {
             repoID: repo.id, name: "bare", branch: "tbd/bare",
             path: checkout.path, tmuxServer: "tbd-test", status: .creating
         )
+        // A stray tab row (user-set label) must be cleaned up alongside the row.
+        try await db.tabs.setLabel(tabID: UUID(), worktreeID: wt.id, label: "stray")
 
         let resumed = await lifecycle.recoverCreatingWorktrees()
         #expect(resumed.isEmpty)
         #expect(try await db.worktrees.get(id: wt.id) == nil,
                 "a terminal-less .creating row must be deleted for reconcile to re-adopt")
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).isEmpty,
+                "tab rows must be deleted with the worktree row")
     }
 }
 }

--- a/Tests/TBDDaemonTests/RPCRouterWorktreeCreateBroadcastTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterWorktreeCreateBroadcastTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: hook resolution and the pre-session
+// completion marker live under TBD_HOME, so these tests redirect it to a
+// temp dir (see TBDHomeSerializedSuites.swift).
+extension TBDHomeSerialized {
+/// Handler-level coverage for `handleWorktreeCreate`'s broadcast gate: the
+/// `.ready` completion is broadcast by the handler itself, while the
+/// `.preSessionPending` completion was already broadcast early by the
+/// lifecycle — the handler must NOT broadcast a duplicate.
+@Suite("worktree.create handler broadcast gate")
+struct RPCRouterWorktreeCreateBroadcastTests {
+
+    private func isolateTBDHome() -> (home: URL, cleanup: () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-create-broadcast-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        return (home, {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    /// Router whose lifecycle and handlers share one StateSubscriptionManager,
+    /// with every broadcast delta captured in `deltas`.
+    private func makeRouter(db: TBDDatabase) -> (router: RPCRouter, deltas: BroadcastDeltas) {
+        let deltas = BroadcastDeltas()
+        let subs = StateSubscriptionManager()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver(),
+            subscriptions: subs,
+            preSessionPollInterval: 0.05
+        )
+        let router = RPCRouter(
+            db: db,
+            lifecycle: lifecycle,
+            tmux: TmuxManager(dryRun: true),
+            subscriptions: subs
+        )
+        return (router, deltas)
+    }
+
+    private func installPreSessionHook(repoDir: URL) async throws {
+        let hooksDir = repoDir.appendingPathComponent(".worktree-hooks")
+        try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+        let hookPath = hooksDir.appendingPathComponent("preSession")
+        try "#!/bin/sh\nexit 0\n".write(to: hookPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: hookPath.path
+        )
+        try await shell("git add -A && git commit -m 'add preSession hook'", at: repoDir)
+    }
+
+    private func writeMarker(worktreeID: UUID, exitCode: Int) throws {
+        let path = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try "\(exitCode)\n".write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    /// Polls `condition` until it returns true or the deadline passes.
+    private func waitUntil(
+        timeout: TimeInterval = 10,
+        _ condition: @Sendable () async throws -> Bool
+    ) async throws -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if try await condition() { return true }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return try await condition()
+    }
+
+    @Test func readyCompletionBroadcastsExactlyOneWorktreeCreated() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // No preSession hook → phase 2 completes `.ready` and the HANDLER
+        // broadcasts `.worktreeCreated`.
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeCreate,
+            params: WorktreeCreateParams(repoID: repo.id)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        let pending = try response.decodeResult(Worktree.self)
+        #expect(pending.status == .creating)
+
+        // Background phase 2 runs on the repo serializer; wait for the flip.
+        let activated = try await waitUntil {
+            try await db.worktrees.get(id: pending.id)?.status == .active
+        }
+        #expect(activated, "background create must complete")
+
+        let created = deltas.snapshot().filter {
+            if case .worktreeCreated(let d) = $0 { return d.worktreeID == pending.id }
+            return false
+        }
+        #expect(created.count == 1,
+                ".ready completion must produce exactly one .worktreeCreated broadcast")
+    }
+
+    @Test func preSessionPendingCompletionBroadcastsExactlyOneWorktreeCreated() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        // preSession hook present → the lifecycle broadcasts `.worktreeCreated`
+        // early; the handler's `.preSessionPending` branch must NOT duplicate it.
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeCreate,
+            params: WorktreeCreateParams(repoID: repo.id)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        let pending = try response.decodeResult(Worktree.self)
+
+        // Wait for phase 2 to spawn the pre-session terminal (the marker file
+        // is wiped at spawn, so writing it after this point is race-free).
+        let hookSpawned = try await waitUntil {
+            try await db.terminals.list(worktreeID: pending.id)
+                .contains { $0.label == "pre-session" }
+        }
+        #expect(hookSpawned, "phase 2 must spawn the pre-session terminal")
+
+        // Finish the hook and wait for the detached phase 3 to activate the row.
+        try writeMarker(worktreeID: pending.id, exitCode: 0)
+        let activated = try await waitUntil {
+            try await db.worktrees.get(id: pending.id)?.status == .active
+        }
+        #expect(activated, "phase 3 must flip the row to .active")
+
+        let created = deltas.snapshot().filter {
+            if case .worktreeCreated(let d) = $0 { return d.worktreeID == pending.id }
+            return false
+        }
+        #expect(created.count == 1,
+                ".preSessionPending must produce exactly one .worktreeCreated total (no handler duplicate)")
+    }
+}
+}
+
+/// Thread-safe collector for broadcast StateDeltas.
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+}

--- a/docs/worktree-hooks.md
+++ b/docs/worktree-hooks.md
@@ -1,6 +1,6 @@
 # Worktree Hooks
 
-TBD can run scripts at key points in a worktree's lifecycle: when it's created (`setup`) and just before it's archived (`archive`). The canonical place to declare them is the `.worktree-hooks/` directory at the root of your repo.
+TBD can run scripts at key points in a worktree's lifecycle: before the agent session starts (`preSession`), when the worktree is created (`setup`), and just before it's archived (`archive`). The canonical place to declare them is the `.worktree-hooks/` directory at the root of your repo.
 
 ## Convention
 
@@ -9,11 +9,23 @@ Each hook is an executable file inside `.worktree-hooks/`, named after the event
 ```
 my-repo/
   .worktree-hooks/
-    setup       # runs in the new worktree right after it's created
+    preSession  # runs to completion BEFORE the agent terminal spawns (blocking)
+    setup       # runs in the new worktree right after it's created (parallel)
     archive     # runs in the worktree just before `git worktree remove`
 ```
 
 Files must be executable (`chmod +x .worktree-hooks/setup`). They can be in any language — TBD just executes them.
+
+## `preSession` vs `setup`
+
+Both run on worktree creation, but they sequence differently:
+
+- **`preSession` is blocking.** Its terminal is created first, and the agent (Claude/Codex/shell) does not spawn until the hook exits. Use it for anything the agent must not start without — copying `.env` files, writing local config, linking caches.
+- **`setup` is parallel.** It runs in its own terminal alongside the agent, which is already started. Use it for slow work the agent doesn't need on its first turn — `npm install`, warming build caches.
+
+The split is your repo's choice; the rule of thumb is *preSession = "the agent must not start before this finishes"*. The `preSession` hook runs in a visible terminal tab (labeled `pre-session`), so you can watch its output live; the pane drops into a regular shell when the hook exits.
+
+`preSession` has a 600-second timeout. A non-zero exit status or a timeout does **not** abort worktree creation or block the agent forever — TBD posts a notification and starts the agent anyway.
 
 ## Environment
 
@@ -21,24 +33,31 @@ Hooks run with `cwd` set to the worktree path and receive these environment vari
 
 | Variable | Value |
 | --- | --- |
-| `TBD_EVENT` | `setup` or `archive` |
+| `TBD_EVENT` | `preSession`, `setup`, or `archive` |
 | `TBD_WORKTREE_ID` | UUID of the worktree |
 | `TBD_WORKTREE_NAME` | Display name |
 | `TBD_WORKTREE_PATH` | Absolute path to the worktree checkout |
 | `TBD_REPO_PATH` | Absolute path to the source repo |
 | `TBD_BRANCH` | Branch name |
 
-Hooks have a 60-second timeout. A non-zero exit status is logged but does not block the lifecycle action.
+Hooks have a 60-second timeout (`preSession`: 600 seconds). A non-zero exit status is logged but does not block the lifecycle action.
 
 ## Example
 
 ```bash
 #!/bin/bash
-# .worktree-hooks/setup
+# .worktree-hooks/preSession — the agent waits for this
+set -euo pipefail
+
+cp ../main-checkout/.env .env 2>/dev/null || true
+```
+
+```bash
+#!/bin/bash
+# .worktree-hooks/setup — runs in parallel with the agent
 set -euo pipefail
 
 npm install
-cp ../main-checkout/.env .env 2>/dev/null || true
 ```
 
 ## Resolution Priority

--- a/docs/worktree-hooks.md
+++ b/docs/worktree-hooks.md
@@ -18,7 +18,7 @@ Files must be executable (`chmod +x .worktree-hooks/setup`). They can be in any 
 
 ## `preSession` vs `setup`
 
-Both run on worktree creation, but they sequence differently:
+Both run on worktree creation — and again when an archived worktree is revived — but they sequence differently:
 
 - **`preSession` is blocking.** Its terminal is created first, and the agent (Claude/Codex/shell) does not spawn until the hook exits. Use it for anything the agent must not start without — copying `.env` files, writing local config, linking caches.
 - **`setup` is parallel.** It runs in its own terminal alongside the agent, which is already started. Use it for slow work the agent doesn't need on its first turn — `npm install`, warming build caches.
@@ -35,6 +35,7 @@ Hooks run with `cwd` set to the worktree path and receive these environment vari
 | --- | --- |
 | `TBD_EVENT` | `preSession`, `setup`, or `archive` |
 | `TBD_WORKTREE_ID` | UUID of the worktree |
+| `TBD_TERMINAL_ID` | UUID of the terminal the hook runs in (`preSession` and `setup` only — `archive` runs outside a terminal and does not receive it) |
 | `TBD_WORKTREE_NAME` | Worktree name (the stable checkout folder name, not the renameable display name) |
 | `TBD_WORKTREE_PATH` | Absolute path to the worktree checkout |
 | `TBD_REPO_PATH` | Absolute path to the source repo |

--- a/docs/worktree-hooks.md
+++ b/docs/worktree-hooks.md
@@ -35,7 +35,7 @@ Hooks run with `cwd` set to the worktree path and receive these environment vari
 | --- | --- |
 | `TBD_EVENT` | `preSession`, `setup`, or `archive` |
 | `TBD_WORKTREE_ID` | UUID of the worktree |
-| `TBD_WORKTREE_NAME` | Display name |
+| `TBD_WORKTREE_NAME` | Worktree name (the stable checkout folder name, not the renameable display name) |
 | `TBD_WORKTREE_PATH` | Absolute path to the worktree checkout |
 | `TBD_REPO_PATH` | Absolute path to the source repo |
 | `TBD_BRANCH` | Branch name |


### PR DESCRIPTION
## Summary

**What's wrong today:** when a worktree is created, the Claude window and the `setup` hook window are spawned as two parallel fire-and-forget tmux windows — Claude always starts *before* the hook even launches, so hooks that copy `.env` files or install dependencies race against the agent. Meanwhile the app shows the "No terminals" empty state for the whole creation, and hook output/status is visible nowhere except its own pane.

**This PR adds a blocking `preSession` worktree hook** (`.worktree-hooks/preSession`, same resolution chain as the other events) that runs to completion *before* the primary agent terminal spawns — and surfaces it:

- The hook runs in a **visible terminal** created first, so the panel shows its live output instead of the empty state; the sidebar reads "Running setup…" and a slim banner explains the agent will start when setup completes.
- Completion is signaled by a marker file under `~/tbd/runtime/presession/` polled by the daemon (600s timeout). Non-zero exit, timeout, or a killed pane → daemon notification, and the agent **spawns anyway** — failure sequences the spawn, it never blocks it forever.
- The wait runs in a detached phase-3 task so the per-repo creation lane (RepoSerializer) is never blocked; revive gets the same non-blocking treatment (`archived → creating → active`).
- Startup recovery resumes orphaned `.creating` rows after a daemon restart mid-hook (the tmux server and hook survive restarts), including mid-revive rows whose archived Claude sessions are restored, not replaced.
- The existing `setup` hook is unchanged: still parallel and non-blocking. **No `preSession` hook → behavior identical to before** (covered by tests on both branches).
- App consumes `terminalCreated` deltas (previously ignored): live tab updates with dedupe, tab-order convergence with the daemon, and selection hand-off to the agent tab when it appears.

Hardened through three internal review rounds (commits `a50b9ea`, `ed114cd`): reconcile no longer kills live `.creating` windows, repo-remove mid-wait can't leak agent processes, marker race/leak fixes, hook env vars (`TBD_WORKTREE_NAME/PATH`, `TBD_REPO_PATH`, `TBD_BRANCH`, `TBD_EVENT`, `TBD_TERMINAL_ID`), static banner icon (no always-animating spinner), and the revive "✓" pill now waits for the worktree to actually be usable.

**Known minor follow-ups** (reviewed, judged shippable): the revive pill can strand at in-flight if a phase-3 DB write fails (self-heals on daemon restart); a worktree archived with zero Claude sessions is treated as mid-create by crash recovery (cosmetic, self-healing); terminal label strings could move to a shared constant; `TestSupport` could be a `.testTarget`.

## Test plan
- [ ] 51 new tests across daemon + app cover: hook resolution, gated spawn ordering, marker exit-code/timeout/killed-pane paths, daemon-restart recovery (mid-create and mid-revive), reconcile sparing `.creating` windows, broadcast exactly-once gates, app dedupe/selection/tab-order/banner/subtitle/revive-pill branches — `swift test` (1550 tests) green apart from the known pre-existing TabBarHitAreaTests failure on this machine
- [ ] Manual: add `.worktree-hooks/preSession` with `sleep 15; touch /tmp/presession-done` to a repo, create a worktree → panel shows the hook terminal running, sidebar says "Running setup…", Claude tab appears and takes focus only after 15s
- [ ] Manual: same with `exit 1` → notification fires, Claude still spawns
- [ ] Manual: repo without the hook → creation behaves exactly as before

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B8D31DBB-8049-438F-A808-74F350CBFEFC)