### PR TITLE
Fix: Let users enter the pre-session hook from repo settings, not just a dotfile

### DIFF
--- a/Sources/TBDApp/Settings/RepoHooksSettingsView.swift
+++ b/Sources/TBDApp/Settings/RepoHooksSettingsView.swift
@@ -4,19 +4,36 @@ import TBDShared
 struct RepoHooksSettingsView: View {
     let repoID: UUID
 
+    @State private var preSessionDraft: String = ""
     @State private var setupDraft: String = ""
     @State private var archiveDraft: String = ""
+    @State private var preSessionSaved = false
     @State private var setupSaved = false
     @State private var archiveSaved = false
 
+    private var preSessionPath: String { TBDConstants.hookPath(repoID: repoID, eventName: "preSession") }
     private var setupPath: String { TBDConstants.hookPath(repoID: repoID, eventName: "setup") }
     private var archivePath: String { TBDConstants.hookPath(repoID: repoID, eventName: "archive") }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             hookSection(
+                title: "Pre-session hook",
+                description: "Runs in a visible terminal when a new worktree is created, and blocks "
+                    + "the agent (Claude/Codex) from starting until it finishes. Use for setup the agent "
+                    + "must not run without — copying env files, installing dependencies. Times out after "
+                    + "10 minutes; on failure the agent starts anyway.",
+                draft: $preSessionDraft,
+                filePath: preSessionPath,
+                showSaved: $preSessionSaved
+            )
+
+            Divider()
+
+            hookSection(
                 title: "Setup hook",
-                description: "Runs in Terminal 2 when a new worktree is created.",
+                description: "Runs in parallel alongside the agent when a new worktree is created. "
+                    + "Does not block the agent from starting.",
                 draft: $setupDraft,
                 filePath: setupPath,
                 showSaved: $setupSaved
@@ -33,6 +50,7 @@ struct RepoHooksSettingsView: View {
             )
         }
         .onAppear {
+            preSessionDraft = readHook(at: preSessionPath)
             setupDraft = readHook(at: setupPath)
             archiveDraft = readHook(at: archivePath)
         }

--- a/Tests/TBDSharedTests/ConstantsTests.swift
+++ b/Tests/TBDSharedTests/ConstantsTests.swift
@@ -8,6 +8,12 @@ import Foundation
     #expect(path == "/tmp/tbd-hooks/repos/12345678-1234-1234-1234-123456789ABC/hooks/setup")
 }
 
+@Test func hookPathPreSession() {
+    let repoID = UUID(uuidString: "12345678-1234-1234-1234-123456789abc")!
+    let path = TBDConstants.hookPath(repoID: repoID, eventName: "preSession", environment: ["TBD_HOME": "/tmp/tbd-hooks"])
+    #expect(path == "/tmp/tbd-hooks/repos/12345678-1234-1234-1234-123456789ABC/hooks/preSession")
+}
+
 @Test func hookPathArchive() {
     let repoID = UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!
     let path = TBDConstants.hookPath(repoID: repoID, eventName: "archive", environment: ["TBD_HOME": "/tmp/tbd-hooks"])


### PR DESCRIPTION
## Summary

PR #269 added the blocking `preSession` worktree hook and wired the daemon to resolve a per-repo script from the app settings path (`TBDConstants.hookPath(repoID:, eventName: "preSession")`) — but the per-repo **Settings → Hooks** page was never updated, so the only way to configure a pre-session hook was to hand-create a `.worktree-hooks/preSession` file. This adds the missing editor.

- New **"Pre-session hook"** section in `RepoHooksSettingsView`, placed first (it runs first in the lifecycle), using the same read/write/chmod-755/delete-on-empty pattern as the existing Setup and Archive sections.
- Clarified descriptions so the two creation-time hooks are distinguishable: pre-session **blocks** the agent until it finishes (10-min timeout, agent starts anyway on failure); setup runs **in parallel** and doesn't block. Removed the stale "Terminal 2" wording from the setup description.

## Test plan
- [ ] `swift build` clean; `swiftlint --strict` 0 violations
- [ ] `ConstantsTests.hookPathPreSession` asserts the per-repo path resolves to `eventName: "preSession"` (matches `HookEvent.preSession.rawValue`)
- [ ] Manual: Settings → a repo → Hooks shows three sections; type a script into Pre-session, Save, reopen → it persists; create a worktree in that repo → the script runs in the visible pre-session terminal before the agent starts; clear the editor + Save → file is removed and the hook no longer runs

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B8D31DBB-8049-438F-A808-74F350CBFEFC)