### PR TITLE
Ops: Relicense from all-rights-reserved to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chang Wang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ Adopt your existing Claude Code Desktop worktrees into TBD in place. Pass any pa
 
 ## License
 
-Private / All rights reserved.
+[MIT](LICENSE) © 2026 Chang Wang


### PR DESCRIPTION
## Summary
- Replaces the "Private / All rights reserved" note with a proper open-source license.
- Adds a standard `LICENSE` file (MIT, © 2026 Chang Wang).
- Updates the README License section to link to it.

MIT is permissive and attribution-only — anyone can use, modify, and redistribute (including commercially) so long as the copyright notice is retained. The repo's mixed human/AI authorship doesn't affect this: the license simply grants permission over whatever rights are held.

## Test plan
- [ ] `LICENSE` renders on the GitHub repo page and the "MIT" badge/label appears in the sidebar.
- [ ] README "License" section links to `LICENSE`.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=51555FBA-20A9-4780-B32E-074FAEA314D3)