### PR TITLE
DX: Clarify tbd worktree create always branches off origin's default branch

### DIFF
--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -61,6 +61,8 @@ briefing here
 EOF
 ```
 
+**Where the new branch starts:** `tbd worktree create` always bases the new branch on the repo's **default branch from origin**, never on the caller's branch. It best-effort `git fetch`es, then branches off `origin/<default>` (e.g. `origin/main`), falling back to the local `<default>` only if the remote ref is missing. `--position` (child/sibling/root) controls only where the worktree sits in the UI tree — never the git base. So a worker spawned from a feature branch still starts clean off `origin/main`; to build on unmerged work, land that work on the default branch first (then rebase the new worktree onto it).
+
 ### Spawn worker worktrees from an orchestrator (most common fan-out)
 
 The default `--position=child` nests the new worktree under the caller. This
@@ -78,6 +80,7 @@ some parent and you want to spawn a peer alongside yourself — not when you
 want to spawn workers under yourself.
 
 Use `--position=root` to force the new worktree to be top-level.
+Remember all three positions only affect UI-tree placement — every new worktree branches off the default branch regardless (see above).
 
 ### Reparent a worktree
 


### PR DESCRIPTION
## Summary
- A prior agent session conflated `--position=sibling` (a UI-tree placement concept) with the git base branch, assuming a worktree spawned from a feature branch would inherit that branch's work. It doesn't.
- The `tbd` skill documented `--position` thoroughly but said nothing about where a new worktree's branch actually starts. This adds that.
- Verified behavior in `WorktreeLifecycle+Create.swift`: `completeCreateWorktree` best-effort `git fetch`es origin's default branch, then `attemptWorktreeAdd` bases the new branch on `["origin/<default>", "<default>"]` — `origin/main` first, local default as fallback. It never branches off the caller's worktree; `--position` only affects UI-tree placement.

Two edits to `TBDSkillContent.body` (the single source of truth for the skill, written out to the SKILL.md copies at daemon startup):
1. A **"Where the new branch starts"** note after the create example.
2. A one-line reinforcement at the end of the `--position` section, for readers who jump straight there.

## Test plan
- [x] `swift build` succeeds (string still compiles)
- [ ] After a full `scripts/restart.sh`, a freshly spawned session's `tbd:tbd` skill shows the clarified text
- [ ] Spawn a worktree from a feature branch and confirm it starts off `origin/main`, matching the doc

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B0EA225A-9733-45A5-BCBE-09196BE125FC)