### PR TITLE
Feat: Configure environment variable overrides for spawned Claude/Codex sessions

### DIFF
--- a/.claude/skills/tbd-project/SKILL.md
+++ b/.claude/skills/tbd-project/SKILL.md
@@ -88,6 +88,8 @@ TBD instruments every `claude` (and `codex`) session it spawns so the app can ob
 
 The overlay and plugin are regenerated on every daemon startup; both writes are idempotent and non-fatal on failure (the session just loses instrumentation, it still runs).
 
+Spawned Claude/Codex sessions also receive free-form `KEY=VALUE` env overrides merged across three scopes (`global < repo < profile`), with the Claude builder's auth/routing env layered last so it can't be clobbered. See `docs/env-overrides.md`.
+
 ## Common Tasks
 
 ### Restart for testing

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -25,6 +25,9 @@ extension AppState {
             if result.primaryAgentPreference != primaryAgentPreference {
                 primaryAgentPreference = result.primaryAgentPreference
             }
+            if result.globalEnvOverrides != globalEnvOverrides {
+                globalEnvOverrides = result.globalEnvOverrides
+            }
         } catch {
             logger.error("Failed to list model profiles: \(error, privacy: .public)")
             handleConnectionError(error)
@@ -162,6 +165,49 @@ extension AppState {
         } catch {
             logger.error("Failed to set repo profile override: \(error, privacy: .public)")
             showAlert("Failed to set repo profile: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    // MARK: - Env Overrides
+
+    /// Set or clear the global free-form env overrides.
+    func setGlobalEnvOverrides(_ overrides: [String: String]) async {
+        do {
+            try await daemonClient.setGlobalEnvOverrides(overrides)
+            globalEnvOverrides = overrides
+        } catch {
+            logger.error("Failed to set global env overrides: \(error, privacy: .public)")
+            showAlert("Failed to set env overrides: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set or clear a repo's free-form env overrides.
+    func setRepoEnvOverrides(repoID: UUID, overrides: [String: String]) async {
+        do {
+            try await daemonClient.setRepoEnvOverrides(repoID: repoID, overrides: overrides)
+            if let idx = repos.firstIndex(where: { $0.id == repoID }) {
+                var repo = repos[idx]
+                repo.envOverrides = overrides
+                repos[idx] = repo
+            }
+        } catch {
+            logger.error("Failed to set repo env overrides: \(error, privacy: .public)")
+            showAlert("Failed to set env overrides: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set or clear a model profile's free-form env overrides.
+    func setProfileEnvOverrides(profileID: UUID, overrides: [String: String]) async {
+        do {
+            try await daemonClient.setProfileEnvOverrides(profileID: profileID, overrides: overrides)
+            if let idx = modelProfiles.firstIndex(where: { $0.profile.id == profileID }) {
+                var profile = modelProfiles[idx].profile
+                profile.envOverrides = overrides
+                modelProfiles[idx] = ModelProfileWithUsage(profile: profile, usage: modelProfiles[idx].usage)
+            }
+        } catch {
+            logger.error("Failed to set profile env overrides: \(error, privacy: .public)")
+            showAlert("Failed to set env overrides: \(error.localizedDescription)", isError: true)
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -357,6 +357,9 @@ final class AppState: ObservableObject {
     @Published var modelProfiles: [ModelProfileWithUsage] = []
     @Published var defaultProfileID: UUID? = nil
     @Published var primaryAgentPreference: PrimaryAgentPreference = .defaultValue
+    /// Global free-form env overrides (config scope). Loaded from the daemon
+    /// alongside `defaultProfileID` via `loadModelProfiles()`.
+    @Published var globalEnvOverrides: [String: String] = [:]
     /// Terminals where the user has dismissed the proxy-unreachable banner.
     /// Cleared on app relaunch (in-memory only — banners are advisory).
     @Published var dismissedProxyWarnings: Set<UUID> = []

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -650,6 +650,30 @@ actor DaemonClient {
         )
     }
 
+    /// Push the global free-form env overrides to the daemon.
+    func setGlobalEnvOverrides(_ overrides: [String: String]) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetEnvOverrides,
+            params: SetGlobalEnvOverridesParams(overrides: overrides)
+        )
+    }
+
+    /// Set or clear a repo's free-form env overrides.
+    func setRepoEnvOverrides(repoID: UUID, overrides: [String: String]) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.repoSetEnvOverrides,
+            params: SetRepoEnvOverridesParams(repoID: repoID, overrides: overrides)
+        )
+    }
+
+    /// Set or clear a model profile's free-form env overrides.
+    func setProfileEnvOverrides(profileID: UUID, overrides: [String: String]) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.modelProfileSetEnvOverrides,
+            params: SetProfileEnvOverridesParams(profileID: profileID, overrides: overrides)
+        )
+    }
+
     /// Manually suspend a single Claude terminal.
     func terminalSuspend(terminalID: UUID) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -33,6 +33,7 @@ struct RepoDetailView: View {
                     .id(repoID)
             case .settings:
                 RepoSettingsView(repoID: repoID)
+                    .id(repoID)
             }
         }
     }

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -67,6 +67,14 @@ struct RepoSettingsView: View {
                     Divider()
                         .padding(.vertical, 4)
 
+                    EnvOverridesEditor(
+                        initial: repo.envOverrides,
+                        caption: "Overrides global; overridden by the repo's model profile."
+                    ) { await appState.setRepoEnvOverrides(repoID: repo.id, overrides: $0) }
+
+                    Divider()
+                        .padding(.vertical, 4)
+
                     RepoHooksSettingsView(repoID: repoID)
                 }
                 .padding()

--- a/Sources/TBDApp/Settings/EnvOverridesEditor.swift
+++ b/Sources/TBDApp/Settings/EnvOverridesEditor.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+/// Reusable key/value editor for free-form environment overrides applied to
+/// spawned Claude/Codex sessions. Presentation-only: it owns the in-progress
+/// row state and hands the committed `[String: String]` back through `onSave`;
+/// the caller persists it (e.g. an RPC-backed `AppState` action). Modeled on
+/// `FallbackModelsEditor`. No validation/denylist/secret handling — values are
+/// free-form by design.
+struct EnvOverridesEditor: View {
+    /// Scope-specific precedence note shown under the title.
+    let caption: String
+    /// Hands the committed overrides to the caller for persistence.
+    let onSave: ([String: String]) async -> Void
+
+    @State private var rows: [Row]
+    @State private var isSaving = false
+    @State private var showSaved = false
+
+    private struct Row: Identifiable {
+        let id = UUID()
+        var key: String
+        var value: String
+    }
+
+    init(
+        initial: [String: String],
+        caption: String,
+        onSave: @escaping ([String: String]) async -> Void
+    ) {
+        self.caption = caption
+        self.onSave = onSave
+        _rows = State(initialValue: initial
+            .sorted { $0.key < $1.key }
+            .map { Row(key: $0.key, value: $0.value) })
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Environment overrides")
+                .font(.callout)
+                .fontWeight(.medium)
+            Text(caption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach($rows) { $row in
+                    HStack(spacing: 6) {
+                        TextField("KEY", text: $row.key)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(maxWidth: .infinity)
+                        Text("=")
+                            .foregroundStyle(.secondary)
+                        TextField("VALUE", text: $row.value)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(maxWidth: .infinity)
+                        Button {
+                            rows.removeAll { $0.id == row.id }
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Remove this variable")
+                    }
+                }
+
+                HStack {
+                    Button {
+                        rows.append(Row(key: "", value: ""))
+                    } label: {
+                        Label("Add variable", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+
+                    Spacer()
+
+                    if showSaved {
+                        Text("Saved")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .transition(.opacity)
+                    }
+
+                    Button("Save") { save() }
+                        .controlSize(.small)
+                        .disabled(isSaving)
+                }
+            }
+        }
+    }
+
+    /// Map non-empty-key rows back to a dict (last duplicate key wins). Keys are
+    /// trimmed; values are kept verbatim.
+    private func committedOverrides() -> [String: String] {
+        var result: [String: String] = [:]
+        for row in rows {
+            let key = row.key.trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else { continue }
+            result[key] = row.value
+        }
+        return result
+    }
+
+    private func save() {
+        isSaving = true
+        let overrides = committedOverrides()
+        Task {
+            await onSave(overrides)
+            isSaving = false
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }
+        }
+    }
+}

--- a/Sources/TBDApp/Settings/EnvOverridesEditor.swift
+++ b/Sources/TBDApp/Settings/EnvOverridesEditor.swift
@@ -108,6 +108,10 @@ struct EnvOverridesEditor: View {
         let overrides = committedOverrides()
         Task {
             await onSave(overrides)
+            // Reseed the displayed rows from the deduped map so duplicate-key
+            // rows collapse to match what was persisted, using the same
+            // sort/Row construction as the initializer for stable order.
+            rows = overrides.sorted { $0.key < $1.key }.map { Row(key: $0.key, value: $0.value) }
             isSaving = false
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
             try? await Task.sleep(for: .seconds(2))

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -789,6 +789,11 @@ struct EditEndpointSheet: View {
                 }
                 FallbackModelsEditor(models: $fallbackModels)
             }
+            Divider()
+            EnvOverridesEditor(
+                initial: profile.envOverrides,
+                caption: "Highest precedence. Cannot override the profile's own auth/routing (token, AWS region, model)."
+            ) { await appState.setProfileEnvOverrides(profileID: profile.id, overrides: $0) }
             probeLabel
             if let errorMessage {
                 Text(errorMessage)
@@ -966,6 +971,12 @@ struct EditBedrockSheet: View {
 
             FallbackModelsEditor(models: $fallbackModels)
 
+            Divider()
+            EnvOverridesEditor(
+                initial: profile.envOverrides,
+                caption: "Highest precedence. Cannot override the profile's own auth/routing (token, AWS region, model)."
+            ) { await appState.setProfileEnvOverrides(profileID: profile.id, overrides: $0) }
+
             if let errorMessage {
                 Text(errorMessage).font(.caption).foregroundStyle(.red)
             }
@@ -1098,6 +1109,11 @@ struct EditClaudeDirectSheet: View {
                 }
                 FallbackModelsEditor(models: $fallbackModels)
             }
+            Divider()
+            EnvOverridesEditor(
+                initial: profile.envOverrides,
+                caption: "Highest precedence. Cannot override the profile's own auth/routing (token, AWS region, model)."
+            ) { await appState.setProfileEnvOverrides(profileID: profile.id, overrides: $0) }
             if let errorMessage {
                 Text(errorMessage)
                     .font(.caption)

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -130,6 +130,13 @@ struct GeneralSettingsTab: View {
                     .help("Skip the interactive permission prompt when launching claude in new worktrees")
             }
 
+            Section {
+                EnvOverridesEditor(
+                    initial: appState.globalEnvOverrides,
+                    caption: "Applied to every spawned Claude/Codex session. Repo and model-profile overrides take precedence."
+                ) { await appState.setGlobalEnvOverrides($0) }
+            }
+
             Section("Experimental") {
                 Toggle("Auto-suspend idle Claude when switching worktrees", isOn: $autoSuspend)
                     .help("Experimental: exit idle Claude instances when you switch away and resume them when you switch back, freeing memory. Off by default — may interrupt long-running work.")

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -14,13 +14,16 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// JSON-encoded `[String: ClaudeEnvValue]` overrides map. Nil/absent
     /// means no overrides — every setting falls back to its registry default.
     var claude_env_settings: String?
+    /// JSON-encoded `[String: String]` free-form env overrides (global scope).
+    var env_overrides: String?
 
     func toModel() -> Config {
         Config(
             defaultProfileID: default_profile_id.flatMap(UUID.init(uuidString:)),
             primaryAgentPreference: primary_agent_preference
                 .flatMap(PrimaryAgentPreference.init(rawValue:)) ?? .defaultValue,
-            envSettingOverrides: ConfigStore.decodeOverrides(claude_env_settings)
+            envSettingOverrides: ConfigStore.decodeOverrides(claude_env_settings),
+            envOverrides: EnvOverridesCoding.decode(env_overrides)
         )
     }
 }
@@ -81,6 +84,17 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET claude_env_settings = ? WHERE id = ?",
+                arguments: [json, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the global free-form env overrides. Empty clears the column.
+    public func setEnvOverrides(_ overrides: [String: String]) async throws {
+        let json = EnvOverridesCoding.encode(overrides)
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET env_overrides = ? WHERE id = ?",
                 arguments: [json, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -533,6 +533,15 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "model_profiles", column: "fallback_models", type: .text)
         }
 
+        // Free-form env-var overrides applied to spawned Claude/Codex sessions.
+        // One JSON-encoded `[String: String]` per scope. Nullable so existing
+        // rows decode as "no overrides". See docs/env-overrides.md.
+        migrator.registerMigration("v31_env_overrides") { db in
+            try db.addColumnIfMissing(table: "config",         column: "env_overrides", type: .text)
+            try db.addColumnIfMissing(table: "repo",           column: "env_overrides", type: .text)
+            try db.addColumnIfMissing(table: "model_profiles", column: "env_overrides", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/ModelProfileRecord.swift
+++ b/Sources/TBDDaemon/Database/ModelProfileRecord.swift
@@ -17,6 +17,8 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
     /// nil when no fallback is configured. Stored as text so the array survives
     /// a single column.
     var fallback_models: String?
+    /// JSON-encoded `[String: String]` free-form env overrides (profile scope).
+    var env_overrides: String?
     var created_at: Date
     var last_used_at: Date?
 
@@ -30,6 +32,7 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
         self.aws_region = profile.awsRegion
         self.aws_profile = profile.awsProfile
         self.fallback_models = Self.encodeFallbackModels(profile.fallbackModels)
+        self.env_overrides = EnvOverridesCoding.encode(profile.envOverrides)
         self.created_at = profile.createdAt
         self.last_used_at = profile.lastUsedAt
     }
@@ -44,6 +47,7 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
             awsRegion: aws_region,
             awsProfile: aws_profile,
             fallbackModels: Self.decodeFallbackModels(fallback_models),
+            envOverrides: EnvOverridesCoding.decode(env_overrides),
             createdAt: created_at,
             lastUsedAt: last_used_at
         )
@@ -140,6 +144,17 @@ public struct ModelProfileStore: Sendable {
             try db.execute(
                 sql: "UPDATE model_profiles SET aws_region = ?, aws_profile = ?, model = ?, fallback_models = ? WHERE id = ?",
                 arguments: [awsRegion, awsProfile, model, fallbackJSON, id.uuidString]
+            )
+        }
+    }
+
+    /// Set or clear the per-profile free-form env overrides.
+    public func setEnvOverrides(id: UUID, overrides: [String: String]) async throws {
+        let json = EnvOverridesCoding.encode(overrides)
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE model_profiles SET env_overrides = ? WHERE id = ?",
+                arguments: [json, id.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -20,6 +20,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var status: String
     var hidden: Bool
     var expanded: Bool
+    var env_overrides: String?
 
     init(from repo: Repo) {
         self.id = repo.id.uuidString
@@ -36,6 +37,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.status = repo.status.rawValue
         self.hidden = repo.hidden
         self.expanded = repo.expanded
+        self.env_overrides = EnvOverridesCoding.encode(repo.envOverrides)
     }
 
     func toModel() -> Repo {
@@ -53,7 +55,8 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             worktreeRoot: worktree_root,
             status: RepoStatus(rawValue: status) ?? .ok,
             hidden: hidden,
-            expanded: expanded
+            expanded: expanded,
+            envOverrides: EnvOverridesCoding.decode(env_overrides)
         )
     }
 }
@@ -189,6 +192,17 @@ public struct RepoStore: Sendable {
             try db.execute(
                 sql: "UPDATE repo SET expanded = ? WHERE id = ?",
                 arguments: [expanded, id.uuidString]
+            )
+        }
+    }
+
+    /// Set or clear the per-repo free-form env overrides.
+    public func setEnvOverrides(id: UUID, overrides: [String: String]) async throws {
+        let json = EnvOverridesCoding.encode(overrides)
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET env_overrides = ? WHERE id = ?",
+                arguments: [json, id.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -378,7 +378,16 @@ public actor SuspendResumeCoordinator {
             }
         }
 
-        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
+        let resumeConfig = try? await db.config.get()
+        let claudeEnvOverrides = resumeConfig?.envSettingOverrides ?? [:]
+        // Free-form env overrides (global < repo < profile), layered under the
+        // builder's auth/routing env below so resumed sessions keep them too.
+        let resumeRepo = try? await db.repos.get(id: worktree.repoID)
+        let mergedEnvOverrides = EnvOverrideResolver.merge(
+            global: resumeConfig?.envOverrides,
+            repo: resumeRepo?.envOverrides,
+            profile: resolvedProfile?.envOverrides
+        )
         // resolveOverlayPath never throws — it degrades to the global hooks-only
         // overlay if the per-session write fails, so resume always proceeds.
         let overlayPath = ClaudeHookOverlay.resolveOverlayPath(
@@ -415,7 +424,7 @@ public actor SuspendResumeCoordinator {
                 server: server, session: "main",
                 cwd: worktree.path, shellCommand: spawn.command,
                 env: resumeEnv,
-                sensitiveEnv: spawn.sensitiveEnv
+                sensitiveEnv: mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
             )
             try await db.terminals.updateTmuxIDs(
                 id: terminal.id, windowID: window.windowID, paneID: window.paneID

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -433,6 +433,15 @@ extension WorktreeLifecycle {
             }
         }
 
+        // Free-form env overrides: global < repo < profile. Applied to both
+        // Claude and Codex. For Claude the builder's auth/routing env is layered
+        // on top (below), so it can't be clobbered. See docs/env-overrides.md.
+        let mergedEnvOverrides = EnvOverrideResolver.merge(
+            global: config.envOverrides,
+            repo: repo.envOverrides,
+            profile: resolvedProfile?.envOverrides
+        )
+
         // Create terminal 1: primary agent (or shell if skipped).
         let plannedTerminalID1 = UUID()
         var createdTerminalIDs = [plannedTerminalID1]
@@ -461,7 +470,7 @@ extension WorktreeLifecycle {
                 "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
                 "CODEX_HOME": codexHome.path,
             ]
-            primarySensitiveEnv = [:]
+            primarySensitiveEnv = mergedEnvOverrides
             primarySessionID = nil
             primaryProfileID = nil
             primaryLabel = TerminalLabel.codex
@@ -503,7 +512,9 @@ extension WorktreeLifecycle {
                 "TBD_WORKTREE_ID": worktreeID.uuidString,
                 "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
             ]
-            primarySensitiveEnv = spawn.sensitiveEnv
+            // Layer the builder's auth/routing env ON TOP of free-form overrides
+            // so auth/routing stays final and free-form vars can't clobber it.
+            primarySensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
             primaryProfileID = resolvedProfile?.profileID
             primaryLabel = TerminalLabel.claudeCode
         }
@@ -617,7 +628,8 @@ extension WorktreeLifecycle {
                     cwd: worktreePath,
                     shellCommand: spawn.command,
                     env: perTermEnv,
-                    sensitiveEnv: spawn.sensitiveEnv,
+                    // Same free-form-under-auth layering as the primary terminal.
+                    sensitiveEnv: mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder },
                     cols: resolvedCols,
                     rows: resolvedRows
                 )

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -291,13 +291,10 @@ extension WorktreeLifecycle {
         let claudeEnvOverrides = rebootConfig?.envSettingOverrides ?? [:]
         // Free-form env overrides applied to recreated agent panes (global <
         // repo < profile). Codex takes the merged map as-is; Claude layers the
-        // builder's auth/routing env on top; plain shells get nothing.
+        // builder's auth/routing env on top; plain shells get nothing. The repo
+        // record is fetched once here, but each agent branch performs its own
+        // merge so non-agent (shell/cmd) panes skip the work entirely.
         let rebootRepo = try? await db.repos.get(id: worktree.repoID)
-        let rebootGlobalRepoEnv = EnvOverrideResolver.merge(
-            global: rebootConfig?.envOverrides,
-            repo: rebootRepo?.envOverrides,
-            profile: nil
-        )
         let spawn: ClaudeSpawnCommandBuilder.Result
         // Per-branch free-form env layered into the recreated pane; defaults to
         // none (plain shells stay clean).
@@ -320,6 +317,11 @@ extension WorktreeLifecycle {
             let codexHome = try CodexHomeManager().ensureProfilePlugin()
             env["CODEX_HOME"] = codexHome.path
             // Codex: the merged free-form overrides ARE the entire sensitive env.
+            let rebootGlobalRepoEnv = EnvOverrideResolver.merge(
+                global: rebootConfig?.envOverrides,
+                repo: rebootRepo?.envOverrides,
+                profile: nil
+            )
             primarySensitiveEnv = rebootGlobalRepoEnv
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -287,8 +287,21 @@ extension WorktreeLifecycle {
             server: worktree.tmuxServer, session: "main", cwd: worktree.path
         )
 
-        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
+        let rebootConfig = try? await db.config.get()
+        let claudeEnvOverrides = rebootConfig?.envSettingOverrides ?? [:]
+        // Free-form env overrides applied to recreated agent panes (global <
+        // repo < profile). Codex takes the merged map as-is; Claude layers the
+        // builder's auth/routing env on top; plain shells get nothing.
+        let rebootRepo = try? await db.repos.get(id: worktree.repoID)
+        let rebootGlobalRepoEnv = EnvOverrideResolver.merge(
+            global: rebootConfig?.envOverrides,
+            repo: rebootRepo?.envOverrides,
+            profile: nil
+        )
         let spawn: ClaudeSpawnCommandBuilder.Result
+        // Per-branch free-form env layered into the recreated pane; defaults to
+        // none (plain shells stay clean).
+        var primarySensitiveEnv: [String: String] = [:]
         var env: [String: String] = [:]
         // Always announce the worktree to recreated panes. Without this, the
         // pane inherits whatever TBD_WORKTREE_ID the tmux server was spawned
@@ -306,6 +319,8 @@ extension WorktreeLifecycle {
             // presence of a captured session ID during reboot recovery.
             let codexHome = try CodexHomeManager().ensureProfilePlugin()
             env["CODEX_HOME"] = codexHome.path
+            // Codex: the merged free-form overrides ARE the entire sensitive env.
+            primarySensitiveEnv = rebootGlobalRepoEnv
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,
                 freshSessionID: nil,
@@ -342,6 +357,14 @@ extension WorktreeLifecycle {
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides
             )
+            // Claude: layer the builder's auth/routing env ON TOP of the merged
+            // free-form overrides (incl. this terminal's profile scope) so auth wins.
+            let mergedEnvOverrides = EnvOverrideResolver.merge(
+                global: rebootConfig?.envOverrides,
+                repo: rebootRepo?.envOverrides,
+                profile: resolvedProfile?.envOverrides
+            )
+            primarySensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
         } else {
             // Shell or custom-cmd terminal. Plain shell terminals have label nil or
             // TerminalLabel.shell; custom-cmd terminals store the command string directly in label.
@@ -365,7 +388,7 @@ extension WorktreeLifecycle {
                 cwd: worktree.path,
                 shellCommand: spawn.command,
                 env: env,
-                sensitiveEnv: spawn.sensitiveEnv
+                sensitiveEnv: primarySensitiveEnv
             )
         } catch {
             // If we just bootstrapped the server and createWindow failed, the

--- a/Sources/TBDDaemon/ModelProfile/EnvOverrideResolver.swift
+++ b/Sources/TBDDaemon/ModelProfile/EnvOverrideResolver.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Merges free-form env overrides across scopes. Precedence: global < repo <
+/// profile (a more specific scope wins collisions). Pure — unit-test seam for
+/// the precedence rule. NOTE: the Claude builder's auth/routing env is layered
+/// ON TOP of this result at spawn time (see WorktreeLifecycle+Create), so it is
+/// never overridden by free-form vars.
+enum EnvOverrideResolver {
+    static func merge(
+        global: [String: String]?,
+        repo: [String: String]?,
+        profile: [String: String]?
+    ) -> [String: String] {
+        var merged = global ?? [:]
+        if let repo { merged.merge(repo) { _, new in new } }
+        if let profile { merged.merge(profile) { _, new in new } }
+        return merged
+    }
+}

--- a/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
+++ b/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
@@ -16,6 +16,9 @@ public struct ResolvedModelProfile: Sendable, Equatable {
     /// Ordered fallback model ids for the Claude `fallbackModel` setting.
     /// nil/empty = no fallback configured for this profile.
     public let fallbackModels: [String]?
+    /// Free-form env overrides carried by this profile (profile scope). Merged
+    /// into the spawned session's env under `global < repo < profile` precedence.
+    public let envOverrides: [String: String]
 }
 
 public struct ModelProfileResolver: Sendable {
@@ -66,7 +69,8 @@ public struct ModelProfileResolver: Sendable {
             secret: secret,
             awsRegion: row.awsRegion,
             awsProfile: row.awsProfile,
-            fallbackModels: row.fallbackModels
+            fallbackModels: row.fallbackModels,
+            envOverrides: row.envOverrides
         )
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+EnvOverridesHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+EnvOverridesHandlers.swift
@@ -1,0 +1,26 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+    // These handlers intentionally do NOT broadcast a state delta: the merged
+    // overrides are read from the DB at the next Claude/Codex spawn, and the
+    // app treats its own published state as the display source of truth (mirrors
+    // handleSetClaudeSpawnPreferences).
+    func handleConfigSetEnvOverrides(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(SetGlobalEnvOverridesParams.self, from: data)
+        try await db.config.setEnvOverrides(params.overrides)
+        return .ok()
+    }
+
+    func handleRepoSetEnvOverrides(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(SetRepoEnvOverridesParams.self, from: data)
+        try await db.repos.setEnvOverrides(id: params.repoID, overrides: params.overrides)
+        return .ok()
+    }
+
+    func handleModelProfileSetEnvOverrides(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(SetProfileEnvOverridesParams.self, from: data)
+        try await db.modelProfiles.setEnvOverrides(id: params.profileID, overrides: params.overrides)
+        return .ok()
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -35,7 +35,8 @@ extension RPCRouter {
         return try RPCResponse(result: ModelProfileListResult(
             profiles: result,
             defaultID: config.defaultProfileID,
-            primaryAgentPreference: config.primaryAgentPreference
+            primaryAgentPreference: config.primaryAgentPreference,
+            globalEnvOverrides: config.envOverrides
         ))
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -89,6 +89,11 @@ extension RPCRouter {
         // Look up repo once for system prompt env vars and Claude session setup
         let repo = try await db.repos.get(id: worktree.repoID)
 
+        // Fetch config once for both the typed Claude env overrides and the
+        // free-form env overrides (global < repo < profile). The profile scope
+        // is folded in per-branch once the profile is resolved.
+        let createConfig = try? await db.config.get()
+
         // Pre-mint the terminal ID so we can inject it into the spawned env
         // as TBD_TERMINAL_ID. Claude's SessionStart hook (registered via the
         // TBD overlay file) reads this env var to route session events back
@@ -132,12 +137,20 @@ extension RPCRouter {
                 codexEnv["COLORFGBG"] = colorFgBg
             }
 
+            // Codex: the merged free-form overrides ARE the entire sensitive env.
+            // No profile is resolved for Codex, so the profile scope is nil.
+            let codexEnvOverrides = EnvOverrideResolver.merge(
+                global: createConfig?.envOverrides,
+                repo: repo?.envOverrides,
+                profile: nil
+            )
             let window = try await tmux.createWindow(
                 server: worktree.tmuxServer,
                 session: "main",
                 cwd: worktree.path,
                 shellCommand: CodexSpawnCommandBuilder.build(initialPrompt: params.prompt),
                 env: codexEnv,
+                sensitiveEnv: codexEnvOverrides,
                 cols: resolvedCols,
                 rows: resolvedRows
             )
@@ -211,7 +224,7 @@ extension RPCRouter {
             label = nil
         }
 
-        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
+        let claudeEnvOverrides = createConfig?.envSettingOverrides ?? [:]
         let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: params.resumeSessionID,
             freshSessionID: freshSessionID,
@@ -236,13 +249,27 @@ extension RPCRouter {
             envSettingOverrides: claudeEnvOverrides
         )
 
+        // For Claude terminals, layer the builder's auth/routing env ON TOP of
+        // the merged free-form overrides (global < repo < profile) so auth wins.
+        // Shell/custom-cmd terminals are out of scope and get no overrides.
+        let primarySensitiveEnv: [String: String]
+        if isClaudeType {
+            let mergedEnvOverrides = EnvOverrideResolver.merge(
+                global: createConfig?.envOverrides,
+                repo: repo?.envOverrides,
+                profile: resolvedProfile?.envOverrides
+            )
+            primarySensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
+        } else {
+            primarySensitiveEnv = spawn.sensitiveEnv
+        }
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
             session: "main",
             cwd: worktree.path,
             shellCommand: spawn.command,
             env: env,
-            sensitiveEnv: spawn.sensitiveEnv,
+            sensitiveEnv: primarySensitiveEnv,
             cols: resolvedCols,
             rows: resolvedRows
         )
@@ -350,12 +377,23 @@ extension RPCRouter {
             // TBD_TEST_CODEX_HOME test-isolation override flow through.
             codexEnv["CODEX_HOME"] = codexHome.path
 
+            // Codex: re-apply the merged free-form overrides (global < repo) so a
+            // recreated Codex pane keeps them. No profile is resolved here, so the
+            // profile scope is nil.
+            let recreateConfig = try? await db.config.get()
+            let recreateRepo = try? await db.repos.get(id: worktree.repoID)
+            let codexEnvOverrides = EnvOverrideResolver.merge(
+                global: recreateConfig?.envOverrides,
+                repo: recreateRepo?.envOverrides,
+                profile: nil
+            )
             let window = try await tmux.createWindow(
                 server: worktree.tmuxServer,
                 session: "main",
                 cwd: worktree.path,
                 shellCommand: CodexSpawnCommandBuilder.command,
                 env: codexEnv,
+                sensitiveEnv: codexEnvOverrides,
                 cols: resolvedCols,
                 rows: resolvedRows
             )
@@ -598,7 +636,15 @@ extension RPCRouter {
         )
         let plan = Self.planTerminalSwap(oldSessionID: sessionID, isBlank: blank)
 
-        let claudeEnvOverrides = (try? await db.config.get())?.envSettingOverrides ?? [:]
+        let swapConfig = try? await db.config.get()
+        let claudeEnvOverrides = swapConfig?.envSettingOverrides ?? [:]
+        // Free-form env overrides for the swapped-in Claude pane (global < repo <
+        // new profile), layered under the builder's auth/routing env below.
+        let mergedEnvOverrides = EnvOverrideResolver.merge(
+            global: swapConfig?.envOverrides,
+            repo: repo?.envOverrides,
+            profile: resolved?.envOverrides
+        )
         let spawn: ClaudeSpawnCommandBuilder.Result
         let storedSessionID: String
         let scheduleRecapture: Bool
@@ -669,7 +715,7 @@ extension RPCRouter {
             cwd: worktree.path,
             shellCommand: spawn.command,
             env: env,
-            sensitiveEnv: spawn.sensitiveEnv,
+            sensitiveEnv: mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder },
             cols: resolvedCols,
             rows: resolvedRows
         )

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -198,6 +198,12 @@ public final class RPCRouter: Sendable {
                 return try await handleModelProfileSetPrimaryAgentPreference(request.paramsData)
             case RPCMethod.modelProfileSetRepoOverride:
                 return try await handleModelProfileSetRepoOverride(request.paramsData)
+            case RPCMethod.configSetEnvOverrides:
+                return try await handleConfigSetEnvOverrides(request.paramsData)
+            case RPCMethod.repoSetEnvOverrides:
+                return try await handleRepoSetEnvOverrides(request.paramsData)
+            case RPCMethod.modelProfileSetEnvOverrides:
+                return try await handleModelProfileSetEnvOverrides(request.paramsData)
             case RPCMethod.modelProfileFetchUsage:
                 return try await handleModelProfileFetchUsage(request.paramsData)
             case RPCMethod.modelProfileHealthCheck:

--- a/Sources/TBDShared/EnvOverridesCoding.swift
+++ b/Sources/TBDShared/EnvOverridesCoding.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// JSON text <-> `[String: String]` for the `env_overrides` columns.
+/// nil/empty encode to nil (column stays NULL, round-trips back to nil);
+/// nil/corrupt JSON decodes to `[:]` so a bad row degrades to "no overrides".
+public enum EnvOverridesCoding {
+    public static func encode(_ overrides: [String: String]?) -> String? {
+        guard let overrides, !overrides.isEmpty else { return nil }
+        guard let data = try? JSONEncoder().encode(overrides) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    public static func decode(_ json: String?) -> [String: String] {
+        guard let json, let data = json.data(using: .utf8) else { return [:] }
+        return (try? JSONDecoder().decode([String: String].self, from: data)) ?? [:]
+    }
+}

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -297,6 +297,8 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
     /// id namespace is profile-specific (bedrock/proxy/oauth differ), so this
     /// lives on the profile, not globally. nil/empty = no fallback configured.
     public var fallbackModels: [String]?
+    /// Free-form env-var overrides applied to spawned sessions (profile scope).
+    public var envOverrides: [String: String]
     public var createdAt: Date
     public var lastUsedAt: Date?
 
@@ -304,6 +306,7 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
                 baseURL: String? = nil, model: String? = nil,
                 awsRegion: String? = nil, awsProfile: String? = nil,
                 fallbackModels: [String]? = nil,
+                envOverrides: [String: String] = [:],
                 createdAt: Date = Date(), lastUsedAt: Date? = nil) {
         self.id = id
         self.name = name
@@ -313,12 +316,14 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
         self.awsRegion = awsRegion
         self.awsProfile = awsProfile
         self.fallbackModels = fallbackModels
+        self.envOverrides = envOverrides
         self.createdAt = createdAt
         self.lastUsedAt = lastUsedAt
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, kind, baseURL, model, awsRegion, awsProfile, fallbackModels, createdAt, lastUsedAt
+        case id, name, kind, baseURL, model, awsRegion, awsProfile, fallbackModels
+        case envOverrides, createdAt, lastUsedAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -331,6 +336,8 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
         awsRegion = try c.decodeIfPresent(String.self, forKey: .awsRegion)
         awsProfile = try c.decodeIfPresent(String.self, forKey: .awsProfile)
         fallbackModels = try c.decodeIfPresent([String].self, forKey: .fallbackModels)
+        envOverrides = try c.decodeIfPresent(
+            [String: String].self, forKey: .envOverrides) ?? [:]
         createdAt = try c.decode(Date.self, forKey: .createdAt)
         lastUsedAt = try c.decodeIfPresent(Date.self, forKey: .lastUsedAt)
     }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -23,6 +23,8 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
     /// expanded (true). Collapsing hides the main worktree row and all child
     /// worktree rows beneath the repo header.
     public var expanded: Bool
+    /// Free-form env-var overrides applied to spawned sessions (repo scope).
+    public var envOverrides: [String: String]
 
     public init(id: UUID = UUID(), path: String, remoteURL: String? = nil,
                 displayName: String, defaultBranch: String = "main", createdAt: Date = Date(),
@@ -30,7 +32,8 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
                 profileOverrideID: UUID? = nil,
                 worktreeSlot: String? = nil, worktreeRoot: String? = nil,
                 status: RepoStatus = .ok, hidden: Bool = false,
-                expanded: Bool = true) {
+                expanded: Bool = true,
+                envOverrides: [String: String] = [:]) {
         self.id = id
         self.path = path
         self.remoteURL = remoteURL
@@ -45,12 +48,14 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         self.status = status
         self.hidden = hidden
         self.expanded = expanded
+        self.envOverrides = envOverrides
     }
 
     enum CodingKeys: String, CodingKey {
         case id, path, remoteURL, displayName, defaultBranch, createdAt
         case renamePrompt, customInstructions, profileOverrideID
         case worktreeSlot, worktreeRoot, status, hidden, expanded
+        case envOverrides
     }
 
     public init(from decoder: Decoder) throws {
@@ -69,6 +74,8 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         status = try c.decodeIfPresent(RepoStatus.self, forKey: .status) ?? .ok
         hidden = try c.decodeIfPresent(Bool.self, forKey: .hidden) ?? false
         expanded = try c.decodeIfPresent(Bool.self, forKey: .expanded) ?? true
+        envOverrides = try c.decodeIfPresent(
+            [String: String].self, forKey: .envOverrides) ?? [:]
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -397,13 +397,17 @@ public struct Config: Codable, Sendable, Equatable {
     public var primaryAgentPreference: PrimaryAgentPreference
     /// Claude spawn-env setting overrides, keyed by `ClaudeEnvSetting.id`.
     public var envSettingOverrides: [String: ClaudeEnvValue]
+    /// Free-form env-var overrides applied to spawned sessions (global scope).
+    public var envOverrides: [String: String]
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
-                envSettingOverrides: [String: ClaudeEnvValue] = [:]) {
+                envSettingOverrides: [String: ClaudeEnvValue] = [:],
+                envOverrides: [String: String] = [:]) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
+        self.envOverrides = envOverrides
     }
 
     public init(from decoder: Decoder) throws {
@@ -415,6 +419,8 @@ public struct Config: Codable, Sendable, Equatable {
         ) ?? .defaultValue
         envSettingOverrides = try c.decodeIfPresent(
             [String: ClaudeEnvValue].self, forKey: .envSettingOverrides) ?? [:]
+        envOverrides = try c.decodeIfPresent(
+            [String: String].self, forKey: .envOverrides) ?? [:]
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -420,14 +420,19 @@ public struct ModelProfileListResult: Codable, Sendable {
     public let profiles: [ModelProfileWithUsage]
     public let defaultID: UUID?
     public let primaryAgentPreference: PrimaryAgentPreference
+    /// The global free-form env overrides (config scope). Carried alongside the
+    /// other config-derived fields so the app loads it in one round-trip.
+    public let globalEnvOverrides: [String: String]
     public init(
         profiles: [ModelProfileWithUsage],
         defaultID: UUID? = nil,
-        primaryAgentPreference: PrimaryAgentPreference = .defaultValue
+        primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
+        globalEnvOverrides: [String: String] = [:]
     ) {
         self.profiles = profiles
         self.defaultID = defaultID
         self.primaryAgentPreference = primaryAgentPreference
+        self.globalEnvOverrides = globalEnvOverrides
     }
 
     public init(from decoder: Decoder) throws {
@@ -438,6 +443,10 @@ public struct ModelProfileListResult: Codable, Sendable {
             PrimaryAgentPreference.self,
             forKey: .primaryAgentPreference
         ) ?? .defaultValue
+        globalEnvOverrides = try c.decodeIfPresent(
+            [String: String].self,
+            forKey: .globalEnvOverrides
+        ) ?? [:]
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -151,6 +151,9 @@ public enum RPCMethod {
     public static let worktreeSetActiveTab = "worktree.setActiveTab"
     public static let appearanceUpdateColorFgBg = "appearance.updateColorFgBg"
     public static let repoListBranches = "repo.listBranches"
+    public static let configSetEnvOverrides       = "config.setEnvOverrides"
+    public static let repoSetEnvOverrides         = "repo.setEnvOverrides"
+    public static let modelProfileSetEnvOverrides = "modelProfile.setEnvOverrides"
 }
 
 // MARK: - Branch Listing
@@ -788,6 +791,32 @@ public struct ClaudeSpawnPreferences: Codable, Sendable, Equatable {
     public let settingOverrides: [String: ClaudeEnvValue]?
     public init(settingOverrides: [String: ClaudeEnvValue]? = nil) {
         self.settingOverrides = settingOverrides
+    }
+}
+
+/// Params for `config.setEnvOverrides` — the global free-form env overrides.
+public struct SetGlobalEnvOverridesParams: Codable, Sendable, Equatable {
+    public let overrides: [String: String]
+    public init(overrides: [String: String]) { self.overrides = overrides }
+}
+
+/// Params for `repo.setEnvOverrides` — per-repo free-form env overrides.
+public struct SetRepoEnvOverridesParams: Codable, Sendable, Equatable {
+    public let repoID: UUID
+    public let overrides: [String: String]
+    public init(repoID: UUID, overrides: [String: String]) {
+        self.repoID = repoID
+        self.overrides = overrides
+    }
+}
+
+/// Params for `modelProfile.setEnvOverrides` — per-profile free-form env overrides.
+public struct SetProfileEnvOverridesParams: Codable, Sendable, Equatable {
+    public let profileID: UUID
+    public let overrides: [String: String]
+    public init(profileID: UUID, overrides: [String: String]) {
+        self.profileID = profileID
+        self.overrides = overrides
     }
 }
 

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -224,7 +224,8 @@ struct ClaudeProfileConfigDirManagerTests {
             secret: nil,
             awsRegion: "us-west-2",
             awsProfile: nil,
-            fallbackModels: nil
+            fallbackModels: nil,
+            envOverrides: [:]
         )
         #expect(ClaudeProfileConfigDirManager.resolveConfigDir(for: profile) == nil)
     }
@@ -240,7 +241,8 @@ struct ClaudeProfileConfigDirManagerTests {
             secret: nil,
             awsRegion: nil,
             awsProfile: nil,
-            fallbackModels: nil
+            fallbackModels: nil,
+            envOverrides: [:]
         )
         #expect(ClaudeProfileConfigDirManager.resolveConfigDir(for: profile) == nil)
     }

--- a/Tests/TBDDaemonTests/ConfigEnvOverridesTests.swift
+++ b/Tests/TBDDaemonTests/ConfigEnvOverridesTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("config env_overrides")
+struct ConfigEnvOverridesTests {
+    @Test func defaultsEmpty() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.envOverrides.isEmpty)
+    }
+
+    @Test func configEnvOverridesRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setEnvOverrides(["CLAUDE_CODE_USE_BEDROCK": "1"])
+        let cfg = try await db.config.get()
+        #expect(cfg.envOverrides == ["CLAUDE_CODE_USE_BEDROCK": "1"])
+    }
+}

--- a/Tests/TBDDaemonTests/EnvOverrideResolverTests.swift
+++ b/Tests/TBDDaemonTests/EnvOverrideResolverTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct EnvOverrideResolverTests {
+    @Test func unionAcrossScopes() {
+        let merged = EnvOverrideResolver.merge(
+            global: ["G": "g"], repo: ["R": "r"], profile: ["P": "p"])
+        #expect(merged == ["G": "g", "R": "r", "P": "p"])
+    }
+    @Test func profileWinsThenRepoThenGlobal() {
+        let merged = EnvOverrideResolver.merge(
+            global: ["K": "global", "A": "ga"],
+            repo:   ["K": "repo",   "A": "ra"],
+            profile:["K": "profile"])
+        #expect(merged["K"] == "profile")   // profile > repo > global
+        #expect(merged["A"] == "ra")        // repo > global
+    }
+    @Test func nilScopesAreEmpty() {
+        #expect(EnvOverrideResolver.merge(global: nil, repo: nil, profile: nil) == [:])
+    }
+
+    // Mirrors the merge order in WorktreeLifecycle+Create.swift Task 7 Step 3:
+    // the Claude builder's auth/routing env is layered ON TOP of the merged
+    // free-form overrides, so it stays final and free-form vars can't clobber it.
+    @Test func claudeBuilderEnvWinsOverFreeForm() {
+        // Free-form tries to set AWS_REGION; builder (bedrock) also sets it → builder wins.
+        let freeForm = ["AWS_REGION": "us-east-1", "EXTRA": "x"]
+        let builder  = ["AWS_REGION": "us-west-2", "CLAUDE_CODE_USE_BEDROCK": "1"]
+        let final = freeForm.merging(builder) { _, b in b }
+        #expect(final["AWS_REGION"] == "us-west-2")   // auth/routing stays final
+        #expect(final["EXTRA"] == "x")                // free-form preserved
+    }
+}

--- a/Tests/TBDDaemonTests/ModelProfileEnvOverridesTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileEnvOverridesTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("model profile env_overrides")
+struct ModelProfileEnvOverridesTests {
+    @Test func defaultsEmpty() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let profile = try await db.modelProfiles.create(name: "P", kind: .oauth)
+        let fetched = try await db.modelProfiles.get(id: profile.id)
+        #expect(fetched?.envOverrides.isEmpty == true)
+    }
+
+    @Test func profileEnvOverridesRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let profile = try await db.modelProfiles.create(name: "P", kind: .oauth)
+        try await db.modelProfiles.setEnvOverrides(id: profile.id, overrides: ["FOO": "bar"])
+        let fetched = try await db.modelProfiles.get(id: profile.id)
+        #expect(fetched?.envOverrides == ["FOO": "bar"])
+    }
+
+    @Test func resolverCarriesProfileEnvOverrides() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let resolver = ModelProfileResolver(
+            profiles: db.modelProfiles,
+            repos: db.repos,
+            config: db.config,
+            keychain: { _ in nil }
+        )
+        let profile = try await db.modelProfiles.create(name: "Bedrock", kind: .bedrock,
+                                                        awsRegion: "us-west-2")
+        try await db.modelProfiles.setEnvOverrides(id: profile.id, overrides: ["CLAUDE_CODE_USE_BEDROCK": "1"])
+        try await db.config.setDefaultProfileID(profile.id)
+
+        let resolved = try await resolver.resolve(repoID: nil)
+        #expect(resolved?.envOverrides == ["CLAUDE_CODE_USE_BEDROCK": "1"])
+    }
+}

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -164,6 +164,82 @@ struct ModelProfileSpawnTests {
         #expect(!recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN"))
     }
 
+    // MARK: - Spawn: Codex free-form env overrides (branch-test rule)
+
+    /// Build a lifecycle + recorder fixture. Unlike `makeFixture`, this exposes
+    /// the `WorktreeLifecycle` so tests can drive `spawnPrimaryTerminals`
+    /// directly — the chokepoint where the Codex env branch lives.
+    private func makeLifecycleFixture() -> (WorktreeLifecycle, TBDDatabase, TmuxRecorder) {
+        let recorder = TmuxRecorder()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
+        let db = try! TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        return (lifecycle, db, recorder)
+    }
+
+    /// Codex's primary spawn carries the merged free-form env overrides
+    /// (global ∪ repo) via tmux `-e KEY=VALUE`. Covers the
+    /// `primarySensitiveEnv = mergedEnvOverrides` branch in spawnPrimaryTerminals.
+    @Test("spawn: Codex primary receives merged global+repo env overrides via -e")
+    func codexReceivesMergedEnvOverrides() async throws {
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-home-\(UUID().uuidString)")
+        setenv("TBD_TEST_CODEX_HOME", codexHome.path, 1)
+        defer {
+            unsetenv("TBD_TEST_CODEX_HOME")
+            try? FileManager.default.removeItem(at: codexHome)
+        }
+
+        let (lifecycle, db, recorder) = makeLifecycleFixture()
+        defer { Task { await cleanup(db) } }
+        let (repo, wt) = try await seedRepoAndWorktree(db)
+        try await db.config.setPrimaryAgentPreference(.codex)
+        try await db.config.setEnvOverrides(["FOO": "bar"])
+        try await db.repos.setEnvOverrides(id: repo.id, overrides: ["REPO_VAR": "rv"])
+        // Re-fetch so the repo passed to spawnPrimaryTerminals carries its
+        // freshly-persisted envOverrides (the spawn reads repo.envOverrides
+        // from the argument, not the DB).
+        let freshRepo = try #require(try await db.repos.get(id: repo.id))
+
+        _ = try await lifecycle.spawnPrimaryTerminals(
+            worktree: wt, repo: freshRepo, skipClaude: false, preSessionTerminalID: nil
+        )
+
+        // Both scopes reach the Codex pane as sensitive -e env.
+        #expect(recorder.joinedAll.contains("FOO=bar"))
+        #expect(recorder.joinedAll.contains("REPO_VAR=rv"))
+    }
+
+    /// With no env overrides configured, the Codex primary spawn injects no
+    /// sensitive `-e` env at all (the empty-config off branch).
+    @Test("spawn: empty config → Codex primary gets no -e env overrides")
+    func codexEmptyConfigInjectsNothing() async throws {
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-home-\(UUID().uuidString)")
+        setenv("TBD_TEST_CODEX_HOME", codexHome.path, 1)
+        defer {
+            unsetenv("TBD_TEST_CODEX_HOME")
+            try? FileManager.default.removeItem(at: codexHome)
+        }
+
+        let (lifecycle, db, recorder) = makeLifecycleFixture()
+        defer { Task { await cleanup(db) } }
+        let (repo, wt) = try await seedRepoAndWorktree(db)
+        try await db.config.setPrimaryAgentPreference(.codex)
+        // No global or repo env overrides configured.
+
+        _ = try await lifecycle.spawnPrimaryTerminals(
+            worktree: wt, repo: repo, skipClaude: false, preSessionTerminalID: nil
+        )
+
+        // The Codex `new-window` call exists and carries no `-e` env flag.
+        let codexCall = try #require(recorder.calls.first {
+            $0.contains("new-window") && ($0.last?.contains("codex") ?? false)
+        })
+        #expect(!codexCall.contains("-e"))
+        #expect(!recorder.joinedAll.contains("FOO=bar"))
+    }
+
     // MARK: - Spawn: fallbackModels overlay routing
 
     @Test("spawn: profile WITHOUT fallbackModels uses the global overlay path")

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -168,12 +168,21 @@ struct ModelProfileSpawnTests {
 
     /// Build a lifecycle + recorder fixture. Unlike `makeFixture`, this exposes
     /// the `WorktreeLifecycle` so tests can drive `spawnPrimaryTerminals`
-    /// directly — the chokepoint where the Codex env branch lives.
+    /// directly — the chokepoint where the env-injection branches live. A real
+    /// `ModelProfileResolver` is attached so the Claude branch resolves the
+    /// worktree's effective profile (Codex tests ignore it — Codex resolves no
+    /// profile).
     private func makeLifecycleFixture() -> (WorktreeLifecycle, TBDDatabase, TmuxRecorder) {
         let recorder = TmuxRecorder()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
         let db = try! TBDDatabase(inMemory: true)
-        let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let resolver = ModelProfileResolver(
+            profiles: db.modelProfiles, repos: db.repos, config: db.config
+        )
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+            modelProfileResolver: resolver
+        )
         return (lifecycle, db, recorder)
     }
 
@@ -238,6 +247,74 @@ struct ModelProfileSpawnTests {
         })
         #expect(!codexCall.contains("-e"))
         #expect(!recorder.joinedAll.contains("FOO=bar"))
+    }
+
+    // MARK: - Spawn: Claude free-form env overrides (branch-test rule)
+
+    /// Claude's primary spawn carries the merged free-form env overrides from
+    /// all three scopes (global ∪ repo ∪ resolved-profile) via tmux
+    /// `-e KEY=VALUE`. Covers the
+    /// `primarySensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv)`
+    /// branch in spawnPrimaryTerminals.
+    @Test("spawn: Claude primary receives merged global+repo+profile env overrides via -e")
+    func claudeReceivesMergedEnvOverrides() async throws {
+        let (lifecycle, db, recorder) = makeLifecycleFixture()
+        defer { Task { await cleanup(db) } }
+        let (repo, wt) = try await seedRepoAndWorktree(db)
+        try await db.config.setPrimaryAgentPreference(.claude)
+
+        // Profile scope: an OAuth profile carrying a free-form var, set as the
+        // global default so resolve(repoID:) returns it for this worktree.
+        let profile = try await seedOAuthProfile(db, name: "WithEnv")
+        try await db.modelProfiles.setEnvOverrides(id: profile.id, overrides: ["PROFILE_VAR": "pv"])
+        try await db.config.setDefaultProfileID(profile.id)
+
+        // Global + repo scopes.
+        try await db.config.setEnvOverrides(["GLOBAL_VAR": "gv"])
+        try await db.repos.setEnvOverrides(id: repo.id, overrides: ["REPO_VAR": "rv"])
+        // Re-fetch so the repo passed in carries its persisted envOverrides
+        // (the spawn reads repo.envOverrides from the argument, not the DB).
+        let freshRepo = try #require(try await db.repos.get(id: repo.id))
+
+        _ = try await lifecycle.spawnPrimaryTerminals(
+            worktree: wt, repo: freshRepo, skipClaude: false, preSessionTerminalID: nil
+        )
+
+        // All three scopes reach the Claude pane as sensitive -e env.
+        #expect(recorder.joinedAll.contains("GLOBAL_VAR=gv"))
+        #expect(recorder.joinedAll.contains("REPO_VAR=rv"))
+        #expect(recorder.joinedAll.contains("PROFILE_VAR=pv"))
+    }
+
+    /// The Claude builder's structured auth/routing env is layered ON TOP of the
+    /// free-form overrides, so a free-form var that collides with an auth var
+    /// cannot win. Exercises the auth-final invariant at the real spawn site
+    /// (not just `Dictionary.merging` in isolation): a Bedrock profile sets
+    /// AWS_REGION=us-west-2 while a free-form override tries AWS_REGION=us-east-1.
+    @Test("spawn: Claude auth/routing env wins over a free-form collision")
+    func claudeAuthEnvWinsOverFreeFormCollision() async throws {
+        let (lifecycle, db, recorder) = makeLifecycleFixture()
+        defer { Task { await cleanup(db) } }
+        let (repo, wt) = try await seedRepoAndWorktree(db)
+        try await db.config.setPrimaryAgentPreference(.claude)
+
+        // Bedrock profile emits AWS_REGION=us-west-2 + CLAUDE_CODE_USE_BEDROCK=1
+        // from its structured auth/routing fields. Its free-form override
+        // deliberately collides on AWS_REGION.
+        let bedrock = try await db.modelProfiles.create(
+            name: "Bedrock", kind: .bedrock, awsRegion: "us-west-2"
+        )
+        try await db.modelProfiles.setEnvOverrides(id: bedrock.id, overrides: ["AWS_REGION": "us-east-1"])
+        try await db.config.setDefaultProfileID(bedrock.id)
+
+        _ = try await lifecycle.spawnPrimaryTerminals(
+            worktree: wt, repo: repo, skipClaude: false, preSessionTerminalID: nil
+        )
+
+        // Builder's structured AWS_REGION is final; the free-form value loses.
+        #expect(recorder.joinedAll.contains("AWS_REGION=us-west-2"))
+        #expect(!recorder.joinedAll.contains("AWS_REGION=us-east-1"))
+        #expect(recorder.joinedAll.contains("CLAUDE_CODE_USE_BEDROCK=1"))
     }
 
     // MARK: - Spawn: fallbackModels overlay routing

--- a/Tests/TBDDaemonTests/RPCRouterEnvOverridesTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterEnvOverridesTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// RPC handlers for the three free-form env-override scopes
+// (config.setEnvOverrides / repo.setEnvOverrides / modelProfile.setEnvOverrides).
+// Each routes through `router.handle` and asserts the value persisted to the DB,
+// mirroring the round-trip style of RPCRouterRepoTests.
+extension RPCRouterTests {
+
+    @Test("config.setEnvOverrides persists the global overrides")
+    func configSetEnvOverrides() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetEnvOverrides,
+            params: SetGlobalEnvOverridesParams(overrides: ["CLAUDE_CODE_USE_BEDROCK": "1"])
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let config = try await db.config.get()
+        #expect(config.envOverrides == ["CLAUDE_CODE_USE_BEDROCK": "1"])
+    }
+
+    @Test("config.setEnvOverrides with empty dict clears the column")
+    func configSetEnvOverridesEmptyClears() async throws {
+        try await db.config.setEnvOverrides(["A": "1"])
+
+        let request = try RPCRequest(
+            method: RPCMethod.configSetEnvOverrides,
+            params: SetGlobalEnvOverridesParams(overrides: [:])
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let config = try await db.config.get()
+        #expect(config.envOverrides == [:])
+    }
+
+    @Test("repo.setEnvOverrides persists per-repo overrides")
+    func repoSetEnvOverrides() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+
+        let request = try RPCRequest(
+            method: RPCMethod.repoSetEnvOverrides,
+            params: SetRepoEnvOverridesParams(repoID: repo.id, overrides: ["FOO": "bar"])
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let stored = try await db.repos.get(id: repo.id)
+        #expect(stored?.envOverrides == ["FOO": "bar"])
+    }
+
+    @Test("modelProfile.setEnvOverrides persists per-profile overrides")
+    func modelProfileSetEnvOverrides() async throws {
+        let profile = try await db.modelProfiles.create(name: "P", kind: .oauth)
+
+        let request = try RPCRequest(
+            method: RPCMethod.modelProfileSetEnvOverrides,
+            params: SetProfileEnvOverridesParams(profileID: profile.id, overrides: ["X": "y"])
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let stored = try await db.modelProfiles.get(id: profile.id)
+        #expect(stored?.envOverrides == ["X": "y"])
+    }
+}

--- a/Tests/TBDDaemonTests/RepoEnvOverridesTests.swift
+++ b/Tests/TBDDaemonTests/RepoEnvOverridesTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("repo env_overrides")
+struct RepoEnvOverridesTests {
+    @Test func defaultsEmpty() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/env", displayName: "env", defaultBranch: "main")
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.envOverrides.isEmpty == true)
+    }
+
+    @Test func repoEnvOverridesRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/env2", displayName: "env2", defaultBranch: "main")
+        try await db.repos.setEnvOverrides(id: repo.id, overrides: ["CLAUDE_CODE_USE_BEDROCK": "1", "AWS_REGION": "us-west-2"])
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.envOverrides == ["CLAUDE_CODE_USE_BEDROCK": "1", "AWS_REGION": "us-west-2"])
+    }
+}

--- a/Tests/TBDSharedTests/EnvOverridesCodingTests.swift
+++ b/Tests/TBDSharedTests/EnvOverridesCodingTests.swift
@@ -1,0 +1,17 @@
+import Testing
+@testable import TBDShared
+
+@Suite struct EnvOverridesCodingTests {
+    @Test func roundTrips() throws {
+        let json = EnvOverridesCoding.encode(["A": "1", "B": "two"])
+        #expect(EnvOverridesCoding.decode(json) == ["A": "1", "B": "two"])
+    }
+    @Test func nilAndEmptyEncodeToNil() {
+        #expect(EnvOverridesCoding.encode(nil) == nil)
+        #expect(EnvOverridesCoding.encode([:]) == nil)
+    }
+    @Test func corruptDecodesToEmpty() {
+        #expect(EnvOverridesCoding.decode("not json") == [:])
+        #expect(EnvOverridesCoding.decode(nil) == [:])
+    }
+}

--- a/docs/env-overrides.md
+++ b/docs/env-overrides.md
@@ -1,0 +1,75 @@
+# Environment Overrides
+
+TBD lets you set arbitrary `KEY=VALUE` environment variables on the **primary agent** sessions it spawns — both `claude` and `codex`. The motivating case is routing a repo's Claude sessions through AWS Bedrock (`CLAUDE_CODE_USE_BEDROCK=1` and friends), but the mechanism is generic: any environment variable a spawned agent needs can be set without a code change.
+
+Overrides apply **only** to the spawned primary agent terminal. Plain shell terminals and `setup`/`preSession` hook terminals do **not** receive them.
+
+## Scopes
+
+Overrides can be set at three scopes, each edited in a different place in the app:
+
+| Scope       | What it covers                              | Where it's edited                                  |
+| ----------- | ------------------------------------------- | -------------------------------------------------- |
+| **Global**  | Every spawned session, in every repo        | Settings → General → "Environment overrides"       |
+| **Repo**    | Every session in one repository             | The per-repository settings pane                   |
+| **Profile** | Every session using one model profile       | The model-profile edit sheets                      |
+
+Each scope holds a free-form `[String: String]` map. The per-profile bag follows whatever profile the worktree actually resolves (repo override → global default → none), so per-profile env automatically tracks the worktree's effective profile.
+
+## Precedence
+
+Scopes are merged into one map with **`global < repo < profile`** — a more specific scope wins collisions, and non-colliding keys from every scope are unioned in. So a key set globally is overridden by the same key set on the repo, which is in turn overridden by the same key set on the profile.
+
+```
+// EnvOverrideResolver.merge(global:repo:profile:) -> [String: String]
+var merged = global ?? [:]
+merged.merge(repo ?? [:])     { _, new in new }   // repo overrides global
+merged.merge(profile ?? [:])  { _, new in new }   // profile overrides both
+return merged                                      // global < repo < profile
+```
+
+## Auth/routing is final
+
+For Claude sessions, the model profile's **structured auth/routing env is layered on top of the merged free-form result and cannot be overridden by a free-form var.** This is the env the Claude spawn builder emits from the resolved profile:
+
+- the OAuth `CLAUDE_CONFIG_DIR`,
+- the Bedrock `CLAUDE_CODE_USE_BEDROCK` / `AWS_REGION` / `AWS_PROFILE`,
+- `ANTHROPIC_MODEL` / `ANTHROPIC_BASE_URL`.
+
+The merge order is:
+
+```
+merged = global ∪ repo ∪ profile-freeform
+final  = merged ∪ builderAuthRouting        // auth/routing is final
+```
+
+A free-form var can set anything the builder does **not** already set, but it cannot clobber a key the builder owns. This keeps a stray free-form override from silently breaking model connectivity. (Codex does not get structured Claude routing env — its auth stays via `CODEX_HOME` — so for Codex the merged free-form map is the entirety of the injected env.)
+
+## Values are free-form
+
+The map is a plain `[String: String]`. There is **no** name validation, **no** denylist, **no** registry of allowed keys, and **no** secret handling. Whatever you type is what the session gets.
+
+> **Secrets:** override values are persisted as plain text in TBD's SQLite database (`~/tbd/state.db`), exactly like the rest of TBD's config. There is no encryption or redaction. Treat secret values accordingly.
+
+## Lifecycle
+
+Overrides are read fresh at spawn time, so they survive every path that respawns the primary agent: resume, reboot recovery, manual create, recreate-window, and a mid-conversation profile swap. Change an override and the next spawned (or respawned) session picks it up; already-running sessions keep the env they were spawned with.
+
+## Worked example: Bedrock
+
+The Bedrock launcher's env is split across two systems:
+
+- A **Bedrock model profile** already supplies the structured auth/routing fields — `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION` (from the profile's region), `AWS_PROFILE`, and the `ANTHROPIC_MODEL` / per-tier model IDs (from the profile's `model` / `fallbackModels`). These are emitted by the Claude spawn builder and are final.
+- **Free-form env overrides** cover whatever the structured fields don't — for example an `AWS_PROFILE` you'd rather pin per-repo, an `AWS_SESSION_TOKEN`, a custom `BEDROCK_*` tuning var, or a proxy setting.
+
+Because auth/routing is final, a free-form `AWS_REGION` set on the repo will **not** override the region baked into the Bedrock profile — the profile wins. Use the profile's own region field for that.
+
+## Storage
+
+Each scope persists its map as a JSON-encoded `[String: String]` in a nullable `env_overrides` TEXT column, added by migration `v31_env_overrides`:
+
+- `config.env_overrides` — global scope
+- `repo.env_overrides` — per-repo scope
+- `model_profiles.env_overrides` — per-profile scope
+
+An empty map clears the column back to `NULL`; a missing or corrupt value decodes to "no overrides", so old rows keep working.

--- a/docs/superpowers/specs/2026-06-16-env-overrides-design.md
+++ b/docs/superpowers/specs/2026-06-16-env-overrides-design.md
@@ -1,0 +1,125 @@
+# Free-form environment overrides for spawned sessions
+
+**Date:** 2026-06-16
+**Status:** Approved design, ready for implementation plan
+
+## Problem
+
+TBD spawns `claude` and `codex` sessions but gives the user no way to set arbitrary
+environment variables on them. The motivating case: routing a specific repo's Claude
+sessions through AWS Bedrock by setting `CLAUDE_CODE_USE_BEDROCK=1` (and friends). We
+want a generic mechanism — not a one-off Bedrock switch — so any future
+`KEY=VALUE` need is covered without code changes.
+
+### What already exists (and why it's not enough)
+
+- `Config.envSettingOverrides: [String: ClaudeEnvValue]` (`Sources/TBDShared/Models.swift:395`)
+  is a **global-only, registry-gated, typed** map persisted in the `config.claude_env_settings`
+  JSON column (migration `v26`). Only keys present in `ClaudeEnvRegistry.all` are allowed;
+  today that registry has exactly one entry (`fullscreenRendering → CLAUDE_CODE_NO_FLICKER`).
+  It is Claude-only and flows through `ClaudeSpawnCommandBuilder.build(envSettingOverrides:)`.
+- `ModelProfile` (`Models.swift:274`) already has `kind: .bedrock` with `awsRegion` / `awsProfile`
+  / `model` / `fallbackModels`, and the Claude builder emits structured auth/routing env from it.
+  This covers *part* of the Bedrock launcher's env (`AWS_REGION`, `ANTHROPIC_MODEL`, the per-tier
+  `ANTHROPIC_DEFAULT_*_MODEL` IDs map onto `fallbackModels`/`model`) but leaves no home for the rest.
+
+This design adds a **separate, free-form** layer rather than extending or replacing the typed
+registry — to avoid entangling the two systems.
+
+## Decisions (locked)
+
+1. **Shape:** pure free-form `KEY=VALUE` (`[String: String]`). No name validation, no denylist,
+   no secret flag, no preview, no registry repurposing — explicitly out of scope.
+2. **Scopes:** global, repo, model-profile.
+3. **Precedence:** `global < repo < profile` — a more specific scope wins collisions (union merge).
+4. **Auth tier is final:** the Claude builder's structured auth/routing output (OAuth token,
+   Bedrock `AWS_REGION`/`ANTHROPIC_*`) is applied **last** and is **not** overridable by free-form
+   vars, so a stray free-form var can't silently break model connectivity.
+5. **Both agents:** applies to spawned Claude **and** Codex primary sessions.
+
+## Architecture
+
+### 1. Data model — a new free-form bag, parallel to the typed one
+
+Add `envOverrides: [String: String]?` at three scopes. The existing typed
+`envSettingOverrides` / `ClaudeEnvRegistry` is left untouched.
+
+| Scope   | Shared model field (`Models.swift`)      | DB column                       |
+|---------|------------------------------------------|---------------------------------|
+| Global  | `Config.envOverrides` (`:395`)           | `config.env_overrides`          |
+| Repo    | `Repo.envOverrides` (`:8`)               | `repo.env_overrides`            |
+| Profile | `ModelProfile.envOverrides` (`:274`)     | `model_profiles.env_overrides`  |
+
+Each is a nullable `TEXT` column holding JSON-encoded `[String: String]`, mirroring exactly how
+`claude_env_settings` was added in `v26`. New model fields are optional (per the CLAUDE.md DB rule),
+so existing rows/JSON still decode.
+
+**Migration `v31_env_overrides`** adds the `env_overrides TEXT` column to all three tables in one
+migration (via `addColumnIfMissing`). Per the CLAUDE.md migration rule, the same commit updates:
+the migration, the GRDB records (`ConfigRecord`, `RepoRecord`, `ModelProfileRecord`), and the three
+shared models.
+
+### 2. Resolution — one pure, testable function
+
+A pure resolver returns the merged map:
+
+```swift
+// EnvOverrideResolver.merge(global:repo:profile:) -> [String: String]
+var merged = global ?? [:]
+merged.merge(repo ?? [:])     { _, new in new }   // repo overrides global
+merged.merge(profile ?? [:])  { _, new in new }   // profile overrides both
+return merged                                      // global < repo < profile
+```
+
+The `profile` argument is the env bag of whatever profile `ModelProfileResolver` already resolves
+for the worktree (repo override → global default → none), so per-profile env automatically follows
+the worktree's effective profile. This function is the unit-test seam for the precedence rule.
+
+### 3. Injection — single chokepoint, both agents
+
+Merge in `WorktreeLifecycle+Create.swift` where `primarySensitiveEnv` is assembled
+(~`:464` for Codex, ~`:510` for Claude) — the one place both agents converge — **not** inside the
+Claude builder.
+
+- **Claude:** layer the merged free-form env into `primarySensitiveEnv`, then apply the Claude
+  builder's structured auth/routing output **on top** so auth wins:
+  ```
+  merged   = global ∪ repo ∪ profile-freeform
+  final    = merged ∪ builderAuthRouting        // auth/routing is final
+  ```
+- **Codex:** `primarySensitiveEnv` is `[:]` today (`:464`); set it to the merged free-form map.
+  That is the entirety of Codex's new env support. (Codex auth stays via `CODEX_HOME`; Codex does
+  not get structured Claude routing env.)
+
+Both paths flow unchanged through `TmuxManager.newWindowCommand`'s `-e KEY=VALUE` injection (`:114`).
+
+### 4. UI — one reusable editor, three mount points
+
+A reusable `EnvOverridesEditor` SwiftUI view (KEY/VALUE rows with add/remove), modeled on the
+existing `FallbackModelsEditor` (`ModelProfilesSettingsView.swift:244`). Mounted in:
+
+- **Global:** a new section in `GeneralSettingsTab` (`SettingsView.swift`).
+- **Repo:** a section in the per-repo settings area (alongside `RepoHooksSettingsView`), but
+  persisted via **RPC** (it is a DB field, unlike the file-based hooks).
+- **Profile:** inside the profile edit sheets (`ModelProfilesSettingsView`).
+
+Three new void RPC methods following the existing `callVoidAsync` pattern:
+`configSetEnvOverrides`, `repoSetEnvOverrides`, `modelProfileSetEnvOverrides` — each with a
+param struct in `RPCProtocol.swift`, a handler, a `DaemonClient` method, and an `AppState` action.
+
+### 5. Docs & tests
+
+- **Docs:** new `docs/env-overrides.md` documenting the scopes, the `global < repo < profile`
+  precedence, the auth-tier-is-final rule, that values are free-form, and that they apply to both
+  Claude and Codex primary sessions. Link it from the `tbd-project` skill's conventions.
+- **Tests:**
+  - Unit-test `EnvOverrideResolver.merge`: union; profile wins collisions; nil/empty scopes; that
+    auth/routing is not overridden (layer ordering).
+  - Per the CLAUDE.md branch-test rule: Codex now receives the merged env (new branch), and an empty
+    config injects nothing for either agent.
+
+## Scope boundaries (YAGNI)
+
+Out of scope: per-worktree scope, env-name validation/denylist, secret marking, merge preview,
+any change to the typed `ClaudeEnvRegistry`. Applies only to the spawned **primary agent** session
+(Claude/Codex), not secondary shell terminals.


### PR DESCRIPTION
## Summary

Lets you set arbitrary `KEY=VALUE` environment variables on the Claude/Codex sessions TBD spawns, at three scopes — **global**, **per-repo**, and **per-model-profile** — so things like routing a specific repo's Claude through Bedrock (`CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION`, …) become configurable instead of hard-coded.

- **Free-form `[String: String]`** at each scope, persisted in a new JSON `env_overrides` column on the `config`/`repo`/`model_profiles` tables (migration `v31`). No validation/denylist/secret machinery by design — kept deliberately simple.
- **Precedence `global < repo < profile`** (union merge; more specific scope wins collisions), computed by a small pure `EnvOverrideResolver.merge`. The Claude model profile's structured **auth/routing env stays final** and can't be clobbered by a free-form var (OAuth dir, Bedrock `CLAUDE_CODE_USE_BEDROCK`/`AWS_REGION`/`AWS_PROFILE`, `ANTHROPIC_MODEL`/`ANTHROPIC_BASE_URL`).
- Applies to **both Claude and Codex** primary sessions and survives every respawn path (resume, reboot-recovery, manual create, recreate-window, mid-conversation profile swap). Plain shell and setup/pre-session hook terminals are intentionally excluded.
- Edited from three UI surfaces via a reusable `EnvOverridesEditor`: Settings → General (global), the per-repo settings pane, and the model-profile edit sheets.
- Docs: `docs/env-overrides.md` (scopes, precedence, auth-tier rule, Bedrock worked example) + design spec under `docs/superpowers/specs/`.

## Test plan

- [x] `swift build`, `swiftlint --strict` (0 violations), `swift test` (green except the pre-existing `TabBarHitAreaTests` headless-rendering flake)
- [x] Unit: `EnvOverrideResolver.merge` precedence/union/nil; `EnvOverridesCoding` round-trip/corrupt; per-scope store round-trips; RPC round-trips persist to DB; resolver passthrough
- [x] Spawn: Claude builder env wins over free-form (auth final); **Codex on/off branch tests** (merged global+repo vars reach `-e`; empty config injects nothing)
- [ ] Manual GUI smoke (needs app restart): set an override at each scope, spawn a Claude **and** a Codex worktree, confirm `printenv` shows the merged result, that a profile var beats a colliding repo var, and that an auth var (e.g. `AWS_REGION`) is not overridable from repo/global

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=97D6FD5E-1AE3-4376-A4FC-B4254AFF6C96)