### PR TITLE
Fix: Stop terminal tabs detaching with "sessions should be nested with care" when TBD launches from inside tmux

### DIFF
--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -128,6 +128,25 @@ struct TerminalPanelView: View {
             logger.debug("proxy unreachable for terminal \(terminalID, privacy: .public) base=\(baseURL, privacy: .public) detail=\(result.detail ?? "nil", privacy: .public)")
         }
     }
+
+    /// Builds the environment for the SwiftTerm PTY that runs the tmux attach client.
+    ///
+    /// The viewer environment must have `TMUX` and `TMUX_PANE` removed to prevent
+    /// nested-attach errors. When TBD.app itself is launched from inside a tmux session
+    /// (e.g., running `scripts/restart.sh` from a TBD pane), the parent environment
+    /// contains these variables. tmux's `attach` client refuses with:
+    /// "sessions should be nested with care, unset $TMUX to force" (exit 1) if run
+    /// in a nested context. The attach client must always be a fresh top-level tmux client.
+    ///
+    /// - Parameter base: Base environment dict (typically ProcessInfo.processInfo.environment)
+    /// - Returns: Cleaned environment with TMUX/TMUX_PANE removed and TERM set to xterm-256color
+    nonisolated static func makeViewerEnvironment(base: [String: String]) -> [String: String] {
+        var env = base
+        env.removeValue(forKey: "TMUX")
+        env.removeValue(forKey: "TMUX_PANE")
+        env["TERM"] = "xterm-256color"
+        return env
+    }
 }
 
 // MARK: - TerminalPanelRepresentable
@@ -306,9 +325,8 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
 
             debugLog("PANEL: Starting: \(tmuxPath) \(processArgs.joined(separator: " "))")
 
-            // Inherit environment with proper TERM
-            var env = ProcessInfo.processInfo.environment
-            env["TERM"] = "xterm-256color"
+            // Build viewer environment with TMUX/TMUX_PANE scrubbed and TERM set correctly
+            let env = TerminalPanelView.makeViewerEnvironment(base: ProcessInfo.processInfo.environment)
             let envPairs = env.map { "\($0.key)=\($0.value)" }
 
             let process = LocalProcess(delegate: self)

--- a/Tests/TBDAppTests/TerminalViewerEnvironmentTests.swift
+++ b/Tests/TBDAppTests/TerminalViewerEnvironmentTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tests for terminal viewer environment scrubbing.
+///
+/// The SwiftTerm PTY that displays terminal tabs must run `tmux attach`
+/// with a clean environment — specifically, TMUX and TMUX_PANE must be removed
+/// to prevent "sessions should be nested with care, unset $TMUX to force" errors
+/// when TBD.app itself was launched from within a tmux session.
+@Suite("Terminal viewer environment")
+struct TerminalViewerEnvironmentTests {
+
+    @Test func removeTMUXWhenPresent() {
+        let baseEnv = [
+            "TMUX": "/tmp/tmux-501/default",
+            "TMUX_PANE": "%0",
+            "PATH": "/usr/local/bin:/usr/bin",
+            "HOME": "/Users/test"
+        ]
+
+        let result = TerminalPanelView.makeViewerEnvironment(base: baseEnv)
+
+        #expect(result["TMUX"] == nil)
+        #expect(result["TMUX_PANE"] == nil)
+    }
+
+    @Test func setsTERMToXterm256color() {
+        let baseEnv = [
+            "PATH": "/usr/local/bin:/usr/bin",
+            "HOME": "/Users/test"
+        ]
+
+        let result = TerminalPanelView.makeViewerEnvironment(base: baseEnv)
+
+        #expect(result["TERM"] == "xterm-256color")
+    }
+
+    @Test func overridesTERMIfPresent() {
+        let baseEnv = [
+            "TERM": "screen",
+            "PATH": "/usr/local/bin:/usr/bin"
+        ]
+
+        let result = TerminalPanelView.makeViewerEnvironment(base: baseEnv)
+
+        #expect(result["TERM"] == "xterm-256color")
+    }
+
+    @Test func passesUnrelatedKeysThrough() {
+        let baseEnv = [
+            "PATH": "/usr/local/bin:/usr/bin",
+            "HOME": "/Users/test",
+            "LANG": "en_US.UTF-8",
+            "USER": "test"
+        ]
+
+        let result = TerminalPanelView.makeViewerEnvironment(base: baseEnv)
+
+        #expect(result["PATH"] == "/usr/local/bin:/usr/bin")
+        #expect(result["HOME"] == "/Users/test")
+        #expect(result["LANG"] == "en_US.UTF-8")
+        #expect(result["USER"] == "test")
+    }
+
+    @Test func handlesEmptyEnvironment() {
+        let baseEnv: [String: String] = [:]
+
+        let result = TerminalPanelView.makeViewerEnvironment(base: baseEnv)
+
+        #expect(result["TERM"] == "xterm-256color")
+        #expect(result.count == 1)
+    }
+
+    @Test func removeBothTMUXAndTMUXPaneWhenBothPresent() {
+        let baseEnv = [
+            "TMUX": "/tmp/tmux-501/default",
+            "TMUX_PANE": "%0",
+            "PATH": "/usr/local/bin",
+            "SHELL": "/bin/zsh"
+        ]
+
+        let result = TerminalPanelView.makeViewerEnvironment(base: baseEnv)
+
+        #expect(result["TMUX"] == nil)
+        #expect(result["TMUX_PANE"] == nil)
+        #expect(result["PATH"] == "/usr/local/bin")
+        #expect(result["SHELL"] == "/bin/zsh")
+        #expect(result["TERM"] == "xterm-256color")
+    }
+}


### PR DESCRIPTION
## Summary

- **What's broken:** Terminal tabs (claude/codex/shell) sometimes show `sessions should be nested with care, unset $TMUX to force` followed by `[View detached (exit 256) — session is still running in the background. Reopen this tab to reattach.]`, and never display the session.
- **Why it happens:** The viewer spawns a SwiftTerm PTY that runs `tmux -L <server> attach` (`TmuxBridge.swift:151`). `TerminalPanelView` passed TBD.app's **entire** environment to that PTY. When TBD.app itself was launched from inside a tmux session (the classic "run `scripts/restart.sh` from a TBD pane" footgun), that environment carries `$TMUX`/`$TMUX_PANE`, so tmux's nested-session guard refuses the attach and exits 1 → the viewer's `LocalProcess` terminates with status 256.
- **The fix:** Extract `TerminalPanelView.makeViewerEnvironment(base:)` which strips `TMUX`/`TMUX_PANE` (and sets `TERM`) so the attach client is always a fresh top-level tmux client, regardless of how TBD.app was launched. The other tmux call paths (`TmuxBridge.runTmux`, daemon `TmuxManager.runTmux`) issue only detached/control commands (`new-session -d`, `link-window`, `select-window`, …) and never attach, so they are unaffected.

## Test plan

- [x] `swift build` succeeds
- [x] `swift test --filter TerminalViewerEnvironment` — 6 tests pass (TMUX/TMUX_PANE scrubbed, TERM forced to `xterm-256color`, unrelated keys pass through)
- [ ] Manual: launch TBD.app from a shell **inside** a tmux session, open a worktree terminal tab, and confirm the session attaches normally instead of showing the nested-attach error.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=68EC7C78-32D5-4E1A-9A1A-4E30014CF021)