### PR TITLE
feat: add non-destructive `tbd worktree forget` command

### DIFF
--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -11,6 +11,7 @@ struct WorktreeCommand: ParsableCommand {
             WorktreeList.self,
             WorktreeAdopt.self,
             WorktreeArchive.self,
+            WorktreeForget.self,
             WorktreeRevive.self,
             WorktreeRename.self,
             WorktreeReparent.self,
@@ -380,6 +381,51 @@ struct WorktreeArchive: AsyncParsableCommand {
             printJSON(["status": "archived", "id": worktreeID.uuidString])
         } else {
             print("Worktree archived.")
+        }
+    }
+}
+
+// MARK: - worktree forget
+
+struct WorktreeForget: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "forget",
+        abstract: "Stop tracking a worktree WITHOUT deleting its directory from disk",
+        discussion: """
+            Unlike `archive`, `forget` does not run `git worktree remove`, so the
+            worktree directory and all its files (including uncommitted and
+            gitignored content) stay exactly in place. The worktree is removed
+            from TBD entirely — it will not appear in either the active or
+            archived listings.
+
+            Note: a forgotten worktree whose directory lives under one of TBD's
+            own worktree prefixes may be re-adopted on the next reconcile.
+            """
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var nameOrID: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeNameOrID(nameOrID, client: client)
+
+        let result: WorktreeForgetResult = try client.call(
+            method: RPCMethod.worktreeForget,
+            params: WorktreeForgetParams(worktreeID: worktreeID),
+            resultType: WorktreeForgetResult.self
+        )
+
+        if json {
+            printJSON(result)
+        } else {
+            print("Worktree forgotten (directory left in place).")
+            if !result.path.isEmpty {
+                print("  Path: \(result.path)")
+            }
         }
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
@@ -1,0 +1,86 @@
+import Foundation
+import os
+import TBDShared
+
+private let forgetLogger = Logger(subsystem: "com.tbd.daemon", category: "forget")
+
+extension WorktreeLifecycle {
+    // MARK: - Forget
+
+    /// Removes a worktree from TBD's tracking **without** deleting the directory
+    /// from disk. Contrast with `archiveWorktree`, which runs `git worktree
+    /// remove --force` and deletes the folder. `forget` deliberately skips that
+    /// git removal so the folder and its files (including uncommitted and
+    /// gitignored content like `.context`) stay exactly in place.
+    ///
+    /// What `forget` does (mirrors the archive/reconcile cleanup, minus the disk
+    /// removal and the archive hook):
+    /// 1. Kills the worktree's tmux windows.
+    /// 2. Deletes its terminals + tabs and clears their pending questions and
+    ///    per-session ClaudeHookOverlay files.
+    /// 3. Hard-deletes the worktree row (so it's gone from BOTH the active and
+    ///    archived lists — not merely flipped to `.archived`).
+    ///
+    /// What `forget` does NOT do:
+    /// - It does not call `git.worktreeRemove` (the directory survives).
+    /// - It does not run the `archive` lifecycle hook ("before_worktree_remove"),
+    ///   because nothing is being removed from disk.
+    ///
+    /// CAVEAT — reconcile re-adoption: `reconcile` re-adopts on-disk git
+    /// worktrees whose path is under one of TBD's own prefixes
+    /// (`~/tbd/worktrees/<slot>/` or `<repo>/.tbd/worktrees/`). A forgotten
+    /// worktree whose path is under such a prefix WILL reappear on the next
+    /// reconcile (it's re-created as a fresh `.active` row). Worktrees living
+    /// outside those prefixes (e.g. `~/conductor/workspaces/...`) are never
+    /// re-adopted, so forget sticks for them. A tombstone/ignore-list to make
+    /// forget stick for TBD-managed paths is a follow-up; this pass only logs a
+    /// warning when forgetting such a worktree.
+    public func forgetWorktree(worktreeID: UUID) async throws {
+        guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+            throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
+        }
+
+        if worktree.status == .main {
+            throw WorktreeLifecycleError.invalidOperation("Cannot forget the main branch worktree")
+        }
+
+        // Warn (best-effort) when the path is under a TBD-managed prefix, since
+        // reconcile would re-adopt it. Repo lookup is best-effort — a missing
+        // repo row doesn't block forget (we still want the row gone).
+        if let repo = try? await db.repos.get(id: worktree.repoID) {
+            let acceptablePrefixes = WorktreeLayout().legacyAndCanonicalPrefixes(for: repo)
+                .map { $0.hasSuffix("/") ? $0 : $0 + "/" }
+            if acceptablePrefixes.contains(where: { worktree.path.hasPrefix($0) }) {
+                forgetLogger.warning(
+                    "forget: worktree \(worktreeID, privacy: .public) at \(worktree.path, privacy: .public) is under a TBD-managed prefix; reconcile will re-adopt it (follow-up: tombstone/ignore-list)"
+                )
+            }
+        }
+
+        // Mirror the archive/reconcile cleanup: kill tmux windows, delete
+        // terminals + tabs, clear pending questions, and reclaim per-session
+        // ClaudeHookOverlay files. Deliberately NO git worktree remove and NO
+        // archive hook.
+        let terminals = try await db.terminals.list(worktreeID: worktreeID)
+        for terminal in terminals {
+            try? await tmux.killWindow(
+                server: worktree.tmuxServer,
+                windowID: terminal.tmuxWindowID
+            )
+        }
+
+        try await db.terminals.deleteForWorktree(worktreeID: worktreeID)
+        try await db.tabs.deleteForWorktree(worktreeID: worktreeID)
+        for terminal in terminals {
+            await pendingQuestions.clear(terminalID: terminal.id)
+            ClaudeHookOverlay.removePerSessionOverlay(sessionKey: terminal.id.uuidString)
+        }
+
+        // Hard-delete the worktree row so it's absent from active AND archived
+        // listings. (Child terminal/tab rows are already gone above; the
+        // worktree table also has onDelete:.cascade FKs as a backstop.)
+        try await db.worktrees.delete(id: worktreeID)
+
+        forgetLogger.info("forget: removed worktree \(worktreeID, privacy: .public) from tracking; directory left in place at \(worktree.path, privacy: .public)")
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -121,6 +121,29 @@ extension RPCRouter {
         return .ok()
     }
 
+    func handleWorktreeForget(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeForgetParams.self, from: paramsData)
+
+        // Capture the path before the row is deleted so the result can report
+        // the directory we deliberately left on disk.
+        let path = try await db.worktrees.get(id: params.worktreeID)?.path
+
+        try await lifecycle.forgetWorktree(worktreeID: params.worktreeID)
+
+        // Reuse the archive delta — from the client's perspective the row has
+        // left the active list, which is exactly what `.worktreeArchived`
+        // signals. (forget hard-deletes, so it never appears in the archived
+        // list either.)
+        subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(
+            worktreeID: params.worktreeID
+        )))
+
+        return try RPCResponse(result: WorktreeForgetResult(
+            worktreeID: params.worktreeID,
+            path: path ?? ""
+        ))
+    }
+
     func handleWorktreeRevive(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeReviveParams.self, from: paramsData)
         // Non-blocking: when a preSession hook gates the primary terminals,

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -110,6 +110,8 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeReorder(request.paramsData)
             case RPCMethod.worktreeMove:
                 return try await handleWorktreeMove(request.paramsData)
+            case RPCMethod.worktreeForget:
+                return try await handleWorktreeForget(request.paramsData)
             case RPCMethod.terminalCreate:
                 return try await handleTerminalCreate(request.paramsData)
             case RPCMethod.terminalList:

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -87,6 +87,7 @@ public enum RPCMethod {
     public static let worktreeRename = "worktree.rename"
     public static let worktreeReorder = "worktree.reorder"
     public static let worktreeMove = "worktree.move"
+    public static let worktreeForget = "worktree.forget"
     public static let terminalCreate = "terminal.create"
     public static let terminalList = "terminal.list"
     public static let terminalSend = "terminal.send"
@@ -685,6 +686,24 @@ public struct WorktreeMoveParams: Codable, Sendable {
         self.worktreeID = worktreeID
         self.newParentID = newParentID
         self.newSortOrder = newSortOrder
+    }
+}
+
+/// Params for `worktree.forget`: remove a worktree from TBD's tracking without
+/// deleting its on-disk directory (no `git worktree remove`).
+public struct WorktreeForgetParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public init(worktreeID: UUID) { self.worktreeID = worktreeID }
+}
+
+/// Result for `worktree.forget`. Echoes the forgotten worktree's id and the
+/// path that was deliberately left in place on disk.
+public struct WorktreeForgetResult: Codable, Sendable {
+    public let worktreeID: UUID
+    public let path: String
+    public init(worktreeID: UUID, path: String) {
+        self.worktreeID = worktreeID
+        self.path = path
     }
 }
 

--- a/Tests/TBDDaemonTests/WorktreeForgetTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeForgetTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// `forget` removes a worktree from TBD's tracking but, unlike `archive`,
+/// leaves the directory on disk. These tests pin both branches of that gating
+/// behavior:
+///   - forget KEEPS the directory (and removes the row from every listing).
+///   - archive REMOVES the directory (the contrasting branch).
+
+@Test func testForgetKeepsDirectoryAndRemovesFromTracking() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    #expect(FileManager.default.fileExists(atPath: wt.path))
+
+    // Drop a gitignored-style artifact to prove forget preserves on-disk files.
+    let marker = (wt.path as NSString).appendingPathComponent("keep-me.txt")
+    try "preserve".write(toFile: marker, atomically: true, encoding: .utf8)
+
+    // Seed a tab override row so the tab-cleanup assertion is meaningful.
+    let terminalsBefore = try await db.terminals.list(worktreeID: wt.id)
+    let firstTerminal = try #require(terminalsBefore.first)
+    try await db.tabs.setLabel(tabID: firstTerminal.id, worktreeID: wt.id, label: "Renamed")
+    #expect(!(try await db.tabs.listForWorktree(worktreeID: wt.id)).isEmpty)
+
+    try await lifecycle.forgetWorktree(worktreeID: wt.id)
+
+    // 1. Directory (and its files) still on disk — forget did NOT run
+    //    `git worktree remove`.
+    #expect(FileManager.default.fileExists(atPath: wt.path),
+            "forget must NOT delete the worktree directory")
+    #expect(FileManager.default.fileExists(atPath: marker),
+            "forget must preserve files inside the worktree directory")
+
+    // 2. Row is hard-deleted — absent from active AND archived listings.
+    #expect(try await db.worktrees.get(id: wt.id) == nil,
+            "forget must hard-delete the worktree row")
+    let active = try await db.worktrees.list(repoID: repo.id, status: .active)
+    #expect(!active.contains { $0.id == wt.id },
+            "forgotten worktree must not appear in the active list")
+    let archived = try await db.worktrees.list(repoID: repo.id, status: .archived)
+    #expect(!archived.contains { $0.id == wt.id },
+            "forgotten worktree must not appear in the archived list")
+
+    // 3. Terminals + tabs cleaned up — no orphan rows.
+    let terminals = try await db.terminals.list(worktreeID: wt.id)
+    #expect(terminals.isEmpty, "forget must delete the worktree's terminals")
+    let tabs = try await db.tabs.listForWorktree(worktreeID: wt.id)
+    #expect(tabs.isEmpty, "forget must delete the worktree's tabs")
+}
+
+/// Contrasting branch: `archive` DOES delete the directory. This anchors the
+/// behavioral difference forget is built to invert.
+@Test func testArchiveRemovesDirectoryUnlikeForget() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    #expect(FileManager.default.fileExists(atPath: wt.path))
+
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    #expect(!FileManager.default.fileExists(atPath: wt.path),
+            "archive must delete the worktree directory (contrast with forget)")
+}
+
+@Test func testForgetWorktreeNotFound() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    await #expect(throws: WorktreeLifecycleError.self) {
+        try await lifecycle.forgetWorktree(worktreeID: UUID())
+    }
+}
+
+@Test func testForgetRefusesMainWorktree() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let main = try await db.worktrees.createMain(
+        repoID: repo.id,
+        name: "main",
+        branch: "main",
+        path: repoDir.path,
+        tmuxServer: TmuxManager.serverName(forRepoPath: repo.path)
+    )
+
+    await #expect(throws: WorktreeLifecycleError.self) {
+        try await lifecycle.forgetWorktree(worktreeID: main.id)
+    }
+
+    // The main row must survive a refused forget.
+    #expect(try await db.worktrees.get(id: main.id) != nil)
+}


### PR DESCRIPTION
## What
Adds `tbd worktree forget <name-or-id>` — removes a worktree from TBD's tracking but **keeps its directory on disk**. Unlike `archive` (which runs `git worktree remove --force` and deletes the folder), `forget` deliberately skips the git removal, so the folder and all its files — including uncommitted and gitignored content like `.context/` — stay exactly in place.

## Why
Archiving is destructive: it deletes the working directory. Sometimes you want a worktree gone from the TBD sidebar but its files preserved on disk to reference later. `forget` provides that non-destructive path.

## Behavior
- Mirrors archive's cleanup: kills tmux windows, deletes terminals + tabs, clears pending questions, reclaims per-session `ClaudeHookOverlay`.
- **Hard-deletes** the worktree row → absent from both the active and archived lists.
- Does **not** call `git worktree remove`; does **not** run the `before_worktree_remove` archive hook.
- Broadcasts the `.worktreeArchived` StateDelta so the app updates live.

## Caveat (documented in code + CLI help)
`reconcile` re-adopts on-disk git worktrees whose path is under one of TBD's own prefixes (`~/tbd/worktrees/<slot>/`, `<repo>/.tbd/worktrees/`), so a forgotten worktree under those paths reappears on the next reconcile. Worktrees outside those prefixes (e.g. `~/conductor/workspaces/...`) are never re-adopted, so forget sticks for them. An `os.Logger` warning fires when forgetting a TBD-prefixed worktree; a tombstone/ignore-list to make it stick everywhere is a noted follow-up (not built here).

## Files (6)
- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift` (new) — `forgetWorktree(worktreeID:)`
- `Sources/TBDShared/RPCProtocol.swift` — `worktree.forget` method + `WorktreeForgetParams`/`WorktreeForgetResult`
- `Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift` + `RPCRouter.swift` — handler + dispatch case
- `Sources/TBDCLI/Commands/WorktreeCommands.swift` — `forget` subcommand (mirrors `archive`)
- `Tests/TBDDaemonTests/WorktreeForgetTests.swift` (new) — both gating branches (forget **keeps** the dir + removes from both lists + cleans terminals/tabs; archive **removes** the dir), plus not-found and main-worktree-refused guards

## Testing
- `swift build` passes locally.
- `swift test` could **not** be run in the dev environment (CommandLineTools only, no full Xcode → `import Testing` fails repo-wide; pre-existing and unrelated to this change). The new tests use verified APIs and should run under CI/Xcode.

## Usage
```
tbd worktree forget <name-or-id> [--json]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
