### PR TITLE
fix(daemon): raise RLIMIT_NOFILE ceiling to 524k for monorepos

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -96,6 +96,11 @@ public final class Daemon: Sendable {
     /// daemon. A tmux server hosting dozens of pty panes can exhaust 256
     /// descriptors and `exit(1)`, taking every session with it.
     ///
+    /// Modern macOS shells default to 524,288. Large monorepos (e.g. Elastic
+    /// Path's commerce-manager with ~18k directories) cause Claude CLI to walk
+    /// past 10k file descriptors during startup, so a ceiling around the macOS
+    /// shell default keeps spawned `claude` processes from hitting that wall.
+    ///
     /// Best-effort: a `getrlimit`/`setrlimit` failure is logged and ignored —
     /// the daemon must still start. Returns the resulting limit (for tests).
     @discardableResult
@@ -105,7 +110,7 @@ public final class Daemon: Sendable {
             daemonLogger.warning("getrlimit(RLIMIT_NOFILE) failed: \(String(cString: strerror(errno)), privacy: .public)")
             return limit
         }
-        let target = min(limit.rlim_max, rlim_t(8192))
+        let target = min(limit.rlim_max, rlim_t(524_288))
         if limit.rlim_cur < target {
             let previous = limit.rlim_cur
             limit.rlim_cur = target

--- a/Tests/TBDDaemonTests/DaemonFileLimitTests.swift
+++ b/Tests/TBDDaemonTests/DaemonFileLimitTests.swift
@@ -2,17 +2,17 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 
-/// `raiseFileDescriptorLimit()` must lift the soft limit toward 8192 (capped
-/// by the hard limit) and never throw.
+/// `raiseFileDescriptorLimit()` must lift the soft limit toward 524,288
+/// (capped by the hard limit) and never throw.
 @Test func testRaiseFileDescriptorLimitRaisesSoftLimit() {
     let result = Daemon.raiseFileDescriptorLimit()
 
     var current = rlimit()
     #expect(getrlimit(RLIMIT_NOFILE, &current) == 0)
 
-    let target = min(current.rlim_max, rlim_t(8192))
+    let target = min(current.rlim_max, rlim_t(524_288))
     #expect(current.rlim_cur >= target,
-            "soft limit must be at least min(hard, 8192) after the call")
+            "soft limit must be at least min(hard, 524_288) after the call")
     #expect(result.rlim_cur == current.rlim_cur,
             "returned limit must match the live process limit")
 }


### PR DESCRIPTION
## Summary
- `raiseFileDescriptorLimit()` capped its bump at **8,192**. On machines where the daemon inherited a higher soft limit from the shell that ran `scripts/restart.sh`, the `rlim_cur < target` check failed and no bump occurred — spawned `tmux + zsh + claude` all inherited the shell's soft limit (commonly **10,496** on macOS).
- In a large monorepo, Claude CLI's startup walk blows through 10k FDs and dies with `An unknown error occurred, possibly due to low max file descriptors (Current limit: 10496)`. Reproduced live in a repo with ~18,000 directories — Claude works fine in the same dir from a host shell with `ulimit -n 1048576`, only the TBD-spawned chain hits it.
- Raise the in-code ceiling to **524,288** (modern macOS interactive-shell default). One-constant change. The existing `min(limit.rlim_max, target)` clamp and best-effort `setrlimit` fallback keep behaviour safe on kernels that refuse the request.
- Updated `DaemonFileLimitTests.testRaiseFileDescriptorLimitRaisesSoftLimit` to assert against the new ceiling. The companion `…NeverExceedsHardLimit` test is value-agnostic and unchanged.

## Why 524,288

It's what modern macOS interactive shells default to (`ulimit -n` in a fresh Terminal session), so this matches what a user running `claude` outside TBD already gets. Generous enough for `claude` to walk monorepos with tens of thousands of directories without the "low max file descriptors" wall, but still bounded so we never request `RLIM_INFINITY`. Kernels that reject the bump are handled by the existing fallback — the daemon still starts.

## Test plan
- [x] `swift build` passes (`Build complete! (34.12s)`)
- [x] Reproduced the symptom on the affected machine: tmux-pane `ulimit -n` reports `10496`; Claude in a ~18k-dir monorepo fails with the documented error
- [x] Verified the diagnosis: same Claude binary, same dir, from a host shell with `ulimit -n 1048576` → Claude runs cleanly (responds to `--print` one-shot)
- [x] Existing tests updated to match new ceiling
- [ ] `swift test` — pre-existing `Testing` module gap on this machine (Apple Swift 6.3.1 / no Xcode); affects all test targets on plain `main` too. Should run cleanly in CI.

## Follow-up suggestion (not in this PR)

Worth considering whether `raiseFileDescriptorLimit()` should *always* set the soft limit toward the target rather than only when `rlim_cur < target` — that would normalize behaviour across users regardless of what their `restart.sh` shell handed down. Happy to file a separate issue if useful.