### PR TITLE
Perf: Flatten transcript row layout so a full-list measure stops pinning the main thread (15s+ hover freeze at 143 items)

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/ActivityRowChrome.swift
+++ b/Sources/TBDApp/Panes/Transcript/ActivityRowChrome.swift
@@ -48,9 +48,13 @@ struct ActivityRowChrome<Header: View>: View {
             }
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        // Flattened (issue #129 per-row layout-depth): the inner HStack's greedy
+        // `Spacer(minLength: 8)` already stretches the row to full width, so the
+        // prior `.frame(maxWidth: .infinity, alignment: .leading)` was a redundant
+        // _FlexFrameLayout (proven pixel-identical when removed). Dropping it
+        // removes a flex-frame + its explicitAlignment recursion from every
+        // tool/thinking/system row's measure pass. Padding pair → single EdgeInsets.
+        .padding(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
         .background(Color(nsColor: .windowBackgroundColor).opacity(hovering ? 0.65 : 0.4))
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
@@ -99,5 +103,49 @@ struct PreviewFileButton: View {
         .buttonStyle(.plain)
         .padding(.top, 4)
         .help("Open \(path) in viewer")
+    }
+}
+
+// MARK: - Preview
+
+/// Exercises the ActivityRowChrome layout after the per-row flattening
+/// (issue #129). Uses `PreviewProvider` (not the `#Preview` macro) so the
+/// file still compiles under bare `swift build` — the SPM toolchain doesn't
+/// ship the `PreviewsMacros` plugin that Xcode injects.
+struct ActivityRowChrome_Previews: PreviewProvider {
+    static let sampleTS = Date(timeIntervalSinceReferenceDate: 800_000_000)
+
+    static var previews: some View {
+        VStack(spacing: 0) {
+            ActivityRowChrome(
+                icon: "hammer",
+                timestamp: sampleTS,
+                onOpen: {}
+            ) {
+                Text("Bash: swift build")
+            }
+            ActivityRowChrome(
+                icon: "brain",
+                timestamp: nil,
+                onOpen: {}
+            ) {
+                Text("Thinking…")
+            }
+            ActivityRowChrome(
+                icon: "info.circle",
+                timestamp: sampleTS,
+                onOpen: {}
+            ) {
+                Text("System: context window at 80 %")
+            }
+            ActivityRowChrome(
+                icon: "doc.text",
+                timestamp: nil,
+                onOpen: {}
+            ) {
+                Text("Read: Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift")
+            }
+        }
+        .frame(width: 560)
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
+++ b/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
@@ -25,19 +25,18 @@ struct ChatBubbleView: View {
     private var roleLabel: String { isUser ? "You" : "Claude" }
 
     var body: some View {
-        HStack(spacing: 0) {
-            if isUser { Spacer(minLength: 52) }
-
-            VStack(alignment: isUser ? .trailing : .leading, spacing: 3) {
-                roleHeader
-                bubbleBody
-            }
-            .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
-
-            if !isUser { Spacer(minLength: 52) }
+        // Flattened row wrapper (issue #129 per-row layout-depth): the prior
+        // `HStack { Spacer ; column.frame(maxWidth:.infinity) ; Spacer }` is
+        // layout-equivalent to a single column that fills width and reserves the
+        // 52pt opposite-side gutter via padding. Dropping the outer HStack +
+        // Spacer removes a StackLayout node from every bubble row's measure pass.
+        VStack(alignment: isUser ? .trailing : .leading, spacing: 3) {
+            roleHeader
+            bubbleBody
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
+        .padding(isUser ? .leading : .trailing, 52)
+        .padding(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
     }
 
     @ViewBuilder
@@ -53,7 +52,7 @@ struct ChatBubbleView: View {
                 Text(ts.absoluteShort).font(.caption2).foregroundStyle(.tertiary)
             }
         }
-        .padding(.horizontal, 4)
+        .padding(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 4))
     }
 
     private var bubbleBody: some View {
@@ -81,8 +80,7 @@ struct ChatBubbleView: View {
                 }
             }
         }
-        .padding(.horizontal, 11)
-        .padding(.vertical, 8)
+        .padding(EdgeInsets(top: 8, leading: 11, bottom: 8, trailing: 11))
         .background(
             isUser
                 ? Color.accentColor.opacity(0.15)
@@ -98,8 +96,7 @@ struct ChatBubbleView: View {
                 Text(language)
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
+                    .padding(EdgeInsets(top: 2, leading: 6, bottom: 2, trailing: 6))
                     .background(Color(nsColor: .quaternaryLabelColor).opacity(0.5))
                     .clipShape(Capsule())
             }

--- a/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
+++ b/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
@@ -35,8 +35,16 @@ struct ChatBubbleView: View {
             bubbleBody
         }
         .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
-        .padding(isUser ? .leading : .trailing, 52)
-        .padding(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
+        // Single EdgeInsets folds the 52pt opposite-side gutter into the 4/12
+        // chrome insets (12 + 52 = 64) — one _PaddingLayout instead of two,
+        // per bubble row. Nested uniform paddings compose additively, so this
+        // is layout-identical to the prior two-`.padding` chain.
+        .padding(EdgeInsets(
+            top: 4,
+            leading: isUser ? 64 : 12,
+            bottom: 4,
+            trailing: isUser ? 12 : 64
+        ))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Problem

The transcript freeze ( issue #129 ) is **not item-count-bound and not trigger-specific** — it's per-row layout-tree **depth**. The latest hang capture (`hang-20260618-131434Z-67437.txt`, archived `history` pane, **itemCount=143**, hung ≥15 s, force-quit) was sampled 4× across the full window. Every resample bottoms out in the same chain:

- **`NSHostingView.didRequestHoverUpdate` → `ViewGraph.responderNode` → `LazySubviewPlacements` invalidation** — a mouse **hover** (not `scrollTo`, not scroll — there is no scroll frame anywhere) forces SwiftUI to re-place every subview, which asks the `LazyVStack` for an ideal size.
- That descends into a deep **recursive per-row tower**: `_FlexFrameLayout → _FrameLayout → _PaddingLayout → StackLayout/VStackLayout`, with **`explicitAlignment` re-invoked at every nesting level** — the classic SwiftUI alignment-guide blow-up (each `.frame(…alignment:)` re-resolves its child's alignment by descending the whole subtree).

**~80 % of every resample is this per-row layout recursion.** Zero TBDApp frames appear in the hot path — it's pure SwiftUI layout-engine cost reacting to the **shape** of our per-row view tree. We can't stop SwiftUI from hit-testing on hover (hover/scroll/focus all force a measure), so the durable fix is to make each row's `sizeThatFits` **cheap**.

## Approach

Each row nested layout-affecting modifiers that each produce a layout-engine node — `.frame(maxWidth:.infinity, alignment:)` (a `_FlexFrameLayout`), stacked `.padding(.horizontal,_).padding(.vertical,_)` (two `_PaddingLayout`s), an extra `HStack` + `Spacer`. Flattening the two dominant inline archetypes (~85 % of a real transcript: chat bubbles ≈50 %, activity/tool/thinking/system headers ≈35 %) removes redundant nodes from the tower the full-list measure pays **once per row, on every measure pass**.

### `ChatBubbleView`
- Replaced the outer `HStack { Spacer ; column.frame(maxWidth:.infinity) ; Spacer }` with a **single column** that fills width and reserves the 52 pt opposite-side gutter via `.padding(.trailing/.leading, 52)` — drops a `StackLayout` + `Spacer` per bubble row.
- Collapsed **three** stacked `.padding(.horizontal,_).padding(.vertical,_)` pairs into single `.padding(EdgeInsets(…))` (one `_PaddingLayout` instead of two, each).

### `ActivityRowChrome`
- Dropped the **redundant** `.frame(maxWidth:.infinity, alignment:.leading)` — the inner greedy `Spacer(minLength:8)` already fills width, so the flex-frame did nothing for layout. Removing it deletes a `_FlexFrameLayout` + its `explicitAlignment` recursion from every tool/thinking/system row.
- Collapsed the padding pair to `EdgeInsets`.

## Evidence (measured, not asserted)

Per-row layout-engine node count / max depth, current → flattened:

| archetype | nodes | max depth |
|---|---|---|
| chat bubble (assistant **and** user) | ~16 → ~11 | 7 → 5 |
| activity chrome row | ~12 → ~10 | 5 → 4 |

A throwaway NSHostingView harness (built, run, then removed before this PR) measured a **cold full-list eager measure** at N ∈ {150, 300, 600}:

- **Chat bubble: consistent ~11 % wrapper-measure reduction** at every N (e.g. N=300: 447.8 ms → 397.0 ms).
- Activity row: flex-frame **proven redundant**, perf delta small (~4–6 %, noise at N=600) — kept for correctness/cleanliness.

**No visual regression — pixel-proven.** NSHostingView → `NSBitmapImageRep` bitmap diff of current vs flattened, single representative row:

| archetype | differing px / total | max channel Δ |
|---|---|---|
| chat bubble (assistant) | **0 / 341 600** | 0 |
| chat bubble (user, alignment flip) | **0 / 341 600** | 0 |
| activity chrome | **0 / 67 200** | 0 |

Byte-for-byte identical, including the user/trailing alignment-flip case.

## Scope & honesty

- This shaves the **wrapper** slice that is ours to control. A chat bubble's body is MarkdownUI-internal depth (out of our control short of the rejected Textual migration) — the ~11 % is a reduction on the wrapper tower, stacked on top of unchanged markdown cost, not 11 % of the whole row.
- The live freeze is **not reliably reproducible** (synthetic cursor warps don't fire SwiftUI hover, and the natural repro is intermittent), so the harness + bitmap-diff are the verification of record rather than a live before/after.
- Orthogonal to the in-flight `scrollTo`/measureEstimates work ("Track A1") — that kills a scroll trigger; this reduces per-row depth so any full-list measure (hover, scroll, focus) is cheaper. Both compose.
- Text selection (#244) unaffected. Added an `ActivityRowChrome` parity preview; `ChatBubbleView` parity previews already exist.

`swift build` clean; `swiftlint --strict` clean; transcript test suites green. The 3–5 failing tests on this run (`TabBarHitArea` geometry, `ThemeStore` FileWatcher, `AppearanceDebounce`) are pre-existing timing/geometry flakes in unrelated subsystems (the failing set varied run-to-run).

Refs #129.

---
🌳 [Open in TBD](tbd://open?worktree=501C9A1F-7C70-458E-B285-10E52BE1B3BB)
