### PR TITLE
feat(app): click pinned terminal's worktree name to navigate to that worktree

### DIFF
--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -129,6 +129,12 @@ private struct PinnedTerminalCell: View {
                         .font(.caption)
                         .fontWeight(.medium)
                         .lineLimit(1)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            appState.navigateToActiveWorktree(terminal.worktreeID, terminalID: terminal.id)
+                        }
+                        .cursor(.pointingHand)
+                        .help("Go to \(worktree.displayName)")
                 }
                 Spacer()
             }


### PR DESCRIPTION
## What

The worktree display name shown on a pinned terminal cell (in the pinned-terminal dock) is now a clickable affordance. Clicking it navigates the user back to that worktree.

Previously only the pin icon on the cell was interactive (unpin); the name was inert text.

## Behavior

Tapping the name calls the existing `navigateToActiveWorktree(_:terminalID:)`, which:
- selects the worktree in the sidebar
- expands its containing repo
- scrolls the sidebar to the row
- focuses the tab rendering that terminal (graceful fallback when the terminal is surfaced only via the dock)
- foregrounds the app

## Implementation

Single-file change in `Sources/TBDApp/Terminal/PinnedTerminalDock.swift` (`PinnedTerminalCell`): added `.contentShape(Rectangle())` + `.onTapGesture` to the name, plus a `.cursor(.pointingHand)` and a `.help(...)` tooltip to signal clickability. The pin-icon tap gesture is unchanged; the two gestures are on separate sibling views so they don't conflict.

`navigateToActiveWorktree` (not the public `navigateToWorktree`) is the correct call here: a pinned terminal always backs an active, already-loaded worktree, so the cold-start buffer and archived-lookup routing in the public entry point are unnecessary.

## Verification

- `swift build` — clean
- `swiftlint --strict` — 0 violations
- Code review — approved, no significant findings

UI gesture wiring with no testable pure logic, so no automated test added (consistent with the rest of this view).

[🧭 Pinned Tab Name Nav](https://cheapsteak.github.io/tbd/open/?worktree=B217B68A-8A78-4F53-BFBE-CE570B2B39F8)