### PR TITLE
DX: Reproducible streaming-transcript freeze harness for #129 — and proof scrollTo isn't the cause

### DIFF
--- a/Sources/TBDApp/Diagnostics/HangWatchdog.swift
+++ b/Sources/TBDApp/Diagnostics/HangWatchdog.swift
@@ -70,7 +70,7 @@ struct HangWatchdogSnapshot: Equatable {
 /// `mach_absolute_time` + `DispatchSourceTimer` only — no APIs that require
 /// `Bundle.main.bundleIdentifier` (TBDApp is unbundled — see CLAUDE.md).
 final class HangWatchdog: @unchecked Sendable {
-    static let shared = HangWatchdog()
+    static let shared = HangWatchdog(thresholdMs: HangWatchdog.thresholdMs(from: ProcessInfo.processInfo.environment))
 
     // MARK: Configuration
 
@@ -268,6 +268,21 @@ final class HangWatchdog: @unchecked Sendable {
     }
 
     // MARK: - Pure helpers (testable)
+
+    /// Resolve the hang threshold from the process environment. Reads
+    /// `TBD_HANG_THRESHOLD_MS`: a valid positive integer overrides the
+    /// default so a measurement run can surface sub-second stalls (e.g. set
+    /// it to 150 to catch the streaming-scroll freeze in issue #129). Absent,
+    /// empty, non-numeric, or zero falls back to `defaultThresholdMs`. Pure —
+    /// tests pass a synthetic dictionary, no `setenv`.
+    static func thresholdMs(from environment: [String: String]) -> UInt64 {
+        guard let raw = environment["TBD_HANG_THRESHOLD_MS"],
+              let parsed = UInt64(raw.trimmingCharacters(in: .whitespaces)),
+              parsed > 0 else {
+            return defaultThresholdMs
+        }
+        return parsed
+    }
 
     /// Decide whether this tick should log a transition. Pure — depends only
     /// on its arguments, not on `self` or any global state. Tests call this

--- a/Sources/TBDApp/Diagnostics/TranscriptPerfHarness.swift
+++ b/Sources/TBDApp/Diagnostics/TranscriptPerfHarness.swift
@@ -1,0 +1,273 @@
+import Foundation
+import TBDShared
+
+// MARK: - Config
+
+/// Parameters for one synthetic streaming run of the live-transcript pane.
+/// Built from the process environment by `TranscriptPerfHarness.config(from:)`.
+struct TranscriptPerfHarnessConfig: Equatable {
+    /// Number of heavy synthetic items present in the transcript at start.
+    var preseed: Int
+    /// Number of inject ticks during the run.
+    var injectCount: Int
+    /// Cadence between inject ticks, in milliseconds.
+    var injectIntervalMs: Int
+    /// Number of heavy items appended per inject tick. Production freezes when a
+    /// single poll lands MANY heavy items at once (issue #129 jumped 91→153 = 62
+    /// items in one poll), so the harness appends a batch per tick to drive ONE
+    /// `scrollTo(.bottom)` over many new heavy rows. Clamped `>= 1`.
+    var injectBatch: Int
+}
+
+// MARK: - Harness
+
+/// DEBUG/env-gated synthetic-streaming harness for measuring the issue #129
+/// transcript scroll freeze. Inert unless `TBD_TRANSCRIPT_PERF_HARNESS` is set:
+/// `config(from:)` returns `nil` and the live pane behaves exactly as in
+/// production. When active, the pane renders deterministic heavy synthetic
+/// items and appends to them on a fixed cadence, driving the real
+/// `.onChange(messages.last?.id) → proxy.scrollTo(anchor: .bottom)` path so the
+/// `measureEstimates`/`StackLayout.sizeThatFits` cost is reproducibly measured
+/// by `HangWatchdog` without touching real appState or the daemon.
+enum TranscriptPerfHarness {
+    /// Default heavy items present at start.
+    static let defaultPreseed = 500
+    /// Default number of inject ticks.
+    static let defaultInjectCount = 20
+    /// Default cadence between injections, in milliseconds.
+    static let defaultInjectIntervalMs = 800
+    /// Default heavy items appended per inject tick.
+    static let defaultInjectBatch = 10
+    /// Lower bound for items appended per tick. A tick must add at least one
+    /// item, otherwise the run makes no progress.
+    static let minInjectBatch = 1
+    /// Lower bound for the injection cadence. Below this the run would flood the
+    /// main thread faster than a layout pass can complete and stop being a
+    /// realistic "streaming" reproduction.
+    static let minInjectIntervalMs = 50
+
+    /// Gate key. When present and non-empty, the harness is active.
+    static let gateKey = "TBD_TRANSCRIPT_PERF_HARNESS"
+
+    /// Build a config when the gate key is set (non-empty), else `nil`.
+    /// Optional numeric overrides — `TBD_PERF_PRESEED`, `TBD_PERF_INJECT_COUNT`,
+    /// `TBD_PERF_INJECT_MS`, `TBD_PERF_INJECT_BATCH` — fall back to their defaults
+    /// when absent or invalid. Clamps: `preseed >= 0`, `injectCount >= 0`,
+    /// `injectIntervalMs >= minInjectIntervalMs`, `injectBatch >= minInjectBatch`.
+    /// Pure — tests pass a synthetic dictionary, no `setenv`.
+    static func config(from environment: [String: String]) -> TranscriptPerfHarnessConfig? {
+        guard let gate = environment[gateKey], !gate.isEmpty else { return nil }
+
+        let preseed = max(0, intOverride(environment["TBD_PERF_PRESEED"], default: defaultPreseed))
+        let injectCount = max(0, intOverride(environment["TBD_PERF_INJECT_COUNT"], default: defaultInjectCount))
+        let injectIntervalMs = max(
+            minInjectIntervalMs,
+            intOverride(environment["TBD_PERF_INJECT_MS"], default: defaultInjectIntervalMs)
+        )
+        let injectBatch = max(
+            minInjectBatch,
+            intOverride(environment["TBD_PERF_INJECT_BATCH"], default: defaultInjectBatch)
+        )
+
+        return TranscriptPerfHarnessConfig(
+            preseed: preseed,
+            injectCount: injectCount,
+            injectIntervalMs: injectIntervalMs,
+            injectBatch: injectBatch
+        )
+    }
+
+    /// Parse an optional override into an Int, falling back to `default` on
+    /// absent/empty/non-numeric input.
+    private static func intOverride(_ raw: String?, default fallback: Int) -> Int {
+        guard let raw = raw?.trimmingCharacters(in: .whitespaces),
+              !raw.isEmpty,
+              let value = Int(raw) else {
+            return fallback
+        }
+        return value
+    }
+
+    // MARK: - View-gating decision helpers (pure, tested)
+
+    /// Whether the auto-scroll onChange should fire. In harness mode the
+    /// transcript must behave like a user pinned at the bottom so the real
+    /// `proxy.scrollTo` path fires on EVERY injected batch — otherwise
+    /// the 1pt `atBottom` sentinel flips false the instant a batch lands below
+    /// the fold and we measure only append/reconcile cost, never the scroll
+    /// cost (issue #129). In production (`harnessActive == false`) this returns
+    /// `atBottom` unchanged, so behavior is identical when the harness is off.
+    static func autoscrollGate(harnessActive: Bool, atBottom: Bool) -> Bool {
+        return harnessActive ? true : atBottom
+    }
+
+    /// Which array the transcript view should render: synthetic items in
+    /// harness mode, the real appState-derived messages otherwise.
+    static func displayedMessages(
+        harnessActive: Bool,
+        harness: [TranscriptItem],
+        real: [TranscriptItem]
+    ) -> [TranscriptItem] {
+        return harnessActive ? harness : real
+    }
+
+    // MARK: - Synthetic items
+
+    /// Build `count` heavy synthetic `.assistantText` items with stable,
+    /// distinct ids (`perf-harness-<index>`). `startIndex` offsets the ids so a
+    /// preseed batch and a later injected batch never collide. Deterministic
+    /// given `(count, startIndex)` — no `Date.now()`/random — with `timestamp`
+    /// nil. Each item's body is a heavy ~15-40 KB markdown blob (several prose
+    /// paragraphs + at least TWO large 8×15 tables + multiple fenced code blocks)
+    /// so rows carry the representative `StyledTextLayoutEngine.lengthThatFits`
+    /// N×M layout cost that drives the issue #129 freeze. Content varies by index
+    /// so rows aren't byte-identical, mirroring a real transcript.
+    static func makeSyntheticItems(count: Int, startIndex: Int = 0) -> [TranscriptItem] {
+        guard count > 0 else { return [] }
+        return (0..<count).map { offset in
+            let index = startIndex + offset
+            return TranscriptItem.assistantText(
+                id: "perf-harness-\(index)",
+                text: syntheticBody(index: index),
+                timestamp: nil,
+                usage: nil
+            )
+        }
+    }
+
+    /// Deterministic heavy (~15-40 KB) markdown body for synthetic item `index`.
+    ///
+    /// Structure faithful to a heavy real assistant turn: several prose
+    /// paragraphs, TWO 8-column × 15-row tables (the N×M layout cost that tops
+    /// out `StyledTextLayoutEngine.lengthThatFits` in #129), and three ~20-40
+    /// line fenced code blocks. Index-varied throughout so no two rows are
+    /// byte-identical, but fully deterministic (no `Date.now()`/random).
+    private static func syntheticBody(index: Int) -> String {
+        var out = "## Synthetic item \(index)\n\n"
+        out += "_Variant token: \(variantWord(index)) / nonce \(index &* 2_654_435_761 % 1_000_000)_\n\n"
+
+        // Several prose paragraphs, varied by index.
+        for p in 0..<6 {
+            out += syntheticParagraph(index: index, paragraph: p)
+            out += "\n\n"
+        }
+
+        out += "### First data table\n\n"
+        out += syntheticTable(index: index, salt: 0)
+        out += "\n\n"
+
+        out += syntheticParagraph(index: index, paragraph: 6)
+        out += "\n\n"
+
+        out += syntheticCodeBlock(index: index, variant: 0)
+        out += "\n\n"
+
+        out += syntheticParagraph(index: index, paragraph: 7)
+        out += "\n\n"
+
+        out += syntheticCodeBlock(index: index, variant: 1)
+        out += "\n\n"
+
+        out += "### Second data table\n\n"
+        out += syntheticTable(index: index, salt: 1)
+        out += "\n\n"
+
+        out += syntheticParagraph(index: index, paragraph: 8)
+        out += "\n\n"
+
+        out += syntheticCodeBlock(index: index, variant: 2)
+        out += "\n\n"
+
+        for p in 9..<13 {
+            out += syntheticParagraph(index: index, paragraph: p)
+            out += "\n\n"
+        }
+
+        return out
+    }
+
+    /// A deterministic prose paragraph varied by `(index, paragraph)`.
+    private static func syntheticParagraph(index: Int, paragraph p: Int) -> String {
+        let topic = variantWord(index &+ p)
+        return """
+        Paragraph \(p) of synthetic transcript item \(index) (\(topic)). This body \
+        is deliberately heavy and structurally varied so each row carries a \
+        representative `StyledTextLayoutEngine.lengthThatFits` measurement cost \
+        when SwiftUI sizes the LazyVStack during a streaming append. Real \
+        assistant turns interleave dense prose with large tables and fenced code \
+        blocks, and that mixed N×M layout is exactly what stresses the layout \
+        pass behind issue #129. We restate the analysis here so the rendered \
+        height is non-trivial: the \(topic) pathway re-measures every glyph run, \
+        wraps across the available width, and resolves attributes for item \
+        \(index) before the scroll-to-bottom anchor can settle. The freeze \
+        manifests when one poll lands many such rows at once and every one must \
+        be measured on the main thread before the next frame can be drawn.
+        """
+    }
+
+    /// An 8-column × 15-row table, index- and salt-varied.
+    private static func syntheticTable(index: Int, salt: Int) -> String {
+        var rows = "| Metric | Variant | Count | State | Latency (ms) | Region | Owner | Notes |\n"
+        rows += "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+        for r in 0..<15 {
+            let seed = index &* 31 &+ salt &* 7 &+ r
+            rows += "| metric-\(index)-\(salt)-\(r) "
+            rows += "| \(variantWord(seed)) "
+            rows += "| \((seed &* 97) % 10_000) "
+            rows += "| \(r % 2 == 0 ? "enabled" : "disabled") "
+            rows += "| \((seed &* 13) % 2_500) "
+            rows += "| region-\(seed % 12) "
+            rows += "| owner-\(variantWord(seed &+ 3)) "
+            rows += "| row \(r) of table \(salt) for item \(index) re-measures glyphs |\n"
+        }
+        return rows
+    }
+
+    /// A ~20-40 line fenced Swift code block, varied by `(index, variant)`.
+    private static func syntheticCodeBlock(index: Int, variant: Int) -> String {
+        let fn = "process_\(index)_\(variant)"
+        return """
+        ```swift
+        // Representative fenced code block \(variant) for item \(index).
+        // Heavy enough to force a real layout/measure pass for the row.
+        struct Sample_\(index)_\(variant) {
+            let id: String
+            let weight: Int
+            let label: String
+        }
+
+        func \(fn)(_ items: [Sample_\(index)_\(variant)]) -> Int {
+            var total = 0
+            var seen: Set<String> = []
+            for (offset, item) in items.enumerated() {
+                guard !seen.contains(item.id) else { continue }
+                seen.insert(item.id)
+                let contribution = offset &* item.weight &+ item.label.count
+                total &+= contribution
+                if contribution % \(variant + 2) == 0 {
+                    total &-= item.weight
+                }
+            }
+            return total &* \(index % 7 + 1)
+        }
+
+        // Drive it deterministically so the snippet is non-trivial.
+        let samples = (0..<24).map { i in
+            Sample_\(index)_\(variant)(id: "s-\(index)-\\(i)", weight: i &* \(variant + 1), label: "row-\\(i)")
+        }
+        assert(\(fn)(samples) >= 0)
+        ```
+        """
+    }
+
+    /// Deterministic word picked from a small lexicon, varied by `seed`.
+    private static func variantWord(_ seed: Int) -> String {
+        let words = [
+            "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+            "hotel", "india", "juliet", "kilo", "lima", "mike", "november",
+            "oscar", "papa", "quebec", "romeo", "sierra", "tango"
+        ]
+        let i = ((seed % words.count) + words.count) % words.count
+        return words[i]
+    }
+}

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -27,6 +27,10 @@ struct LiveTranscriptPaneView: View {
     /// shown only when the user has consciously scrolled up.
     @State private var atBottom: Bool = true
 
+    /// Synthetic items rendered only when the perf harness is active (env-gated).
+    /// Empty and unused in production.
+    @State private var harnessMessages: [TranscriptItem] = []
+
     private static let log = Logger(subsystem: "com.tbd.app", category: "live-transcript")
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
@@ -54,6 +58,29 @@ struct LiveTranscriptPaneView: View {
         return appState.sessionTranscripts[sid] ?? []
     }
 
+    /// Process-lifetime cache of the perf-harness config. The process
+    /// environment is stable for the process lifetime, so resolve it ONCE
+    /// (mirroring the `HangWatchdog.shared` pattern) rather than re-parsing on
+    /// every `harnessConfig` access — `body` reads it 4+ times per pass, on the
+    /// very main thread the harness measures.
+    private static let harnessConfigCache: TranscriptPerfHarnessConfig? =
+        TranscriptPerfHarness.config(from: ProcessInfo.processInfo.environment)
+
+    /// Perf-harness config, resolved from the environment. `nil` (inert) in
+    /// production; non-nil only when `TBD_TRANSCRIPT_PERF_HARNESS` is set.
+    private var harnessConfig: TranscriptPerfHarnessConfig? { Self.harnessConfigCache }
+
+    /// The items the transcript view actually renders. When the harness is
+    /// active this is the synthetic `harnessMessages`; otherwise the real
+    /// appState-derived `messages`. The poll loop still reads `messages`.
+    private var displayedMessages: [TranscriptItem] {
+        TranscriptPerfHarness.displayedMessages(
+            harnessActive: harnessConfig != nil,
+            harness: harnessMessages,
+            real: messages
+        )
+    }
+
     var body: some View {
         let _ = Self.bodyLogged.withLock { logged in
             if !logged.contains(terminalID) {
@@ -62,7 +89,11 @@ struct LiveTranscriptPaneView: View {
             }
         }
         Group {
-            if let err = loadError {
+            if harnessConfig != nil {
+                // Perf-harness mode (env-gated): always show the transcript so
+                // the synthetic injector drives the real scroll path.
+                transcriptWithAutoscroll
+            } else if let err = loadError {
                 errorState(message: err)
             } else if currentSessionID == nil {
                 emptyState(text: "This terminal has no Claude session.")
@@ -75,7 +106,11 @@ struct LiveTranscriptPaneView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task(id: TaskKey(terminalID: terminalID, retryToken: retryToken)) {
             Self.perfLog.debug("task.start terminalID=\(Self.shortID(terminalID.uuidString), privacy: .public)")
-            await pollLoop()
+            if let cfg = harnessConfig {
+                await runPerfHarness(cfg)
+            } else {
+                await pollLoop()
+            }
         }
     }
 
@@ -119,55 +154,90 @@ struct LiveTranscriptPaneView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    /// Single live-transcript scroll path. Restored to the original (pre-A/B)
+    /// modifier chain after the issue #129 scroll-strategy experiment proved
+    /// scroll is not the lever (`.current ≈ .initialOnly`). The only deltas vs
+    /// pre-experiment main are measurement-only and default-identical in
+    /// production: the `TranscriptPerfHarness.autoscrollGate` (which equals
+    /// `atBottom` when the harness is off) and one silent `.debug` fire/skip log
+    /// per append.
     @ViewBuilder
     private var transcriptWithAutoscroll: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                TranscriptItemsView(items: messages, terminalID: terminalID, atBottom: $atBottom)
+                TranscriptItemsView(items: displayedMessages, terminalID: terminalID, atBottom: $atBottom)
             }
             .defaultScrollAnchor(.bottom, for: .initialOffset)
             .overlay(alignment: .bottomLeading) {
                 jumpToBottomButton(proxy: proxy)
                     .animation(.easeInOut(duration: 0.2), value: atBottom)
             }
-            .onAppear {
-                let sidShort = Self.shortID(currentSessionID ?? "")
-                Self.perfLog.debug("view.appear sid=\(sidShort, privacy: .public) count=\(messages.count, privacy: .public)")
-                // Feed the hang watchdog so a stall caught during transcript
-                // layout has the focused terminal + item count attached.
-                let tidShort = String(terminalID.uuidString.suffix(4))
-                let count = messages.count
-                HangWatchdog.shared.recordContext { snap in
-                    snap.focusedTerminalIDShort = tidShort
-                    snap.transcriptItemCount = count
-                    snap.paneLabel = "liveTranscript"
+            .onAppear { recordAppearContext() }
+            .onChange(of: displayedMessages.last?.id) { oldID, newID in
+                // Edge guard: only react when both ends exist (a real append),
+                // never on first paint or teardown.
+                guard oldID != nil, newID != nil else { return }
+                // `autoscrollGate` == `atBottom` in production; in harness mode
+                // it pins to bottom so the scroll fires on every injected batch
+                // (issue #129 measurement). One silent fire/skip debug log.
+                let gate = TranscriptPerfHarness.autoscrollGate(
+                    harnessActive: harnessConfig != nil,
+                    atBottom: atBottom
+                )
+                guard gate, let targetID = lastRenderedNodeID(for: displayedMessages) else {
+                    Self.perfLog.debug(
+                        "autoscroll fired=false atBottom=\(self.atBottom, privacy: .public) gate=\(gate, privacy: .public) count=\(self.displayedMessages.count, privacy: .public)"
+                    )
+                    return
                 }
-            }
-            .onChange(of: messages.last?.id) { oldID, newID in
-                guard let _ = oldID, let _ = newID, atBottom else { return }
-                guard let targetID = lastRenderedNodeID(for: messages) else { return }
+                Self.perfLog.debug(
+                    "autoscroll fired=true atBottom=\(self.atBottom, privacy: .public) gate=\(gate, privacy: .public) count=\(self.displayedMessages.count, privacy: .public)"
+                )
                 let scrollInterval = TranscriptSignposts.signposter.beginInterval("transcript.scrollTo")
                 proxy.scrollTo(targetID, anchor: .bottom)
                 TranscriptSignposts.signposter.endInterval("transcript.scrollTo", scrollInterval)
             }
-            .onChange(of: messages.count) { _, newCount in
-                let tidShort = String(terminalID.uuidString.suffix(4))
-                HangWatchdog.shared.recordContext { snap in
-                    snap.focusedTerminalIDShort = tidShort
-                    snap.transcriptItemCount = newCount
-                    snap.paneLabel = "liveTranscript"
-                }
+            .onChange(of: displayedMessages.count) { _, newCount in
+                recordCountContext(newCount)
             }
-            .onDisappear {
-                // Clear the pane-specific fields so a hang in another pane
-                // (terminal, file viewer, etc.) doesn't get logged with a
-                // stale `pane=liveTranscript` tag and old item count.
-                HangWatchdog.shared.recordContext { snap in
-                    snap.focusedTerminalIDShort = nil
-                    snap.transcriptItemCount = nil
-                    snap.paneLabel = nil
-                }
-            }
+            .onDisappear { clearContext() }
+        }
+    }
+
+    // MARK: - HangWatchdog context helpers
+
+    /// `.onAppear` context: log + feed the hang watchdog so a stall caught
+    /// during transcript layout has the focused terminal + item count attached.
+    private func recordAppearContext() {
+        let sidShort = Self.shortID(currentSessionID ?? "")
+        Self.perfLog.debug("view.appear sid=\(sidShort, privacy: .public) count=\(displayedMessages.count, privacy: .public)")
+        let tidShort = String(terminalID.uuidString.suffix(4))
+        let count = displayedMessages.count
+        HangWatchdog.shared.recordContext { snap in
+            snap.focusedTerminalIDShort = tidShort
+            snap.transcriptItemCount = count
+            snap.paneLabel = "liveTranscript"
+        }
+    }
+
+    /// `.onChange(displayedMessages.count)` context — unchanged across strategies.
+    private func recordCountContext(_ newCount: Int) {
+        let tidShort = String(terminalID.uuidString.suffix(4))
+        HangWatchdog.shared.recordContext { snap in
+            snap.focusedTerminalIDShort = tidShort
+            snap.transcriptItemCount = newCount
+            snap.paneLabel = "liveTranscript"
+        }
+    }
+
+    /// `.onDisappear` context: clear the pane-specific fields so a hang in
+    /// another pane (terminal, file viewer, etc.) doesn't get logged with a
+    /// stale `pane=liveTranscript` tag and old item count.
+    private func clearContext() {
+        HangWatchdog.shared.recordContext { snap in
+            snap.focusedTerminalIDShort = nil
+            snap.transcriptItemCount = nil
+            snap.paneLabel = nil
         }
     }
 
@@ -175,7 +245,7 @@ struct LiveTranscriptPaneView: View {
     private func jumpToBottomButton(proxy: ScrollViewProxy) -> some View {
         if !atBottom {
             Button {
-                guard let lastID = lastRenderedNodeID(for: messages) else { return }
+                guard let lastID = lastRenderedNodeID(for: displayedMessages) else { return }
                 let scrollInterval = TranscriptSignposts.signposter.beginInterval("transcript.scrollTo")
                 proxy.scrollTo(lastID, anchor: .bottom)
                 TranscriptSignposts.signposter.endInterval("transcript.scrollTo", scrollInterval)
@@ -192,6 +262,42 @@ struct LiveTranscriptPaneView: View {
             .transition(.scale(scale: 0.5).combined(with: .opacity))
             .help("Scroll to bottom")
         }
+    }
+
+    // MARK: - Perf harness (env-gated)
+
+    /// Drive a deterministic synthetic streaming run: seed `cfg.preseed` heavy
+    /// items, then append `cfg.injectBatch` heavy items every
+    /// `cfg.injectIntervalMs` for `cfg.injectCount` ticks. Each tick does ONE
+    /// `harnessMessages.append(contentsOf:)`, so it fires ONE
+    /// `displayedMessages.last?.id` change → ONE production
+    /// `.onChange → proxy.scrollTo(anchor: .bottom)` over `batch` new heavy rows.
+    /// This faithfully reproduces the issue #129 freeze (a poll landing many
+    /// heavy items at once) without touching real appState/daemon. Inert in
+    /// production — only reached when `harnessConfig != nil`.
+    @MainActor
+    private func runPerfHarness(_ cfg: TranscriptPerfHarnessConfig) async {
+        harnessMessages = TranscriptPerfHarness.makeSyntheticItems(count: cfg.preseed)
+        let tidShort = String(terminalID.uuidString.suffix(4))
+        HangWatchdog.shared.recordContext { snap in
+            snap.focusedTerminalIDShort = tidShort
+            snap.transcriptItemCount = cfg.preseed
+            snap.paneLabel = "liveTranscript"
+        }
+        let batch = cfg.injectBatch
+        Self.perfLog.debug("perf-harness run.start preseed=\(cfg.preseed, privacy: .public) inject=\(cfg.injectCount, privacy: .public) ms=\(cfg.injectIntervalMs, privacy: .public) batch=\(batch, privacy: .public)")
+
+        for i in 0..<cfg.injectCount {
+            if Task.isCancelled { break }
+            try? await Task.sleep(nanoseconds: UInt64(cfg.injectIntervalMs) * 1_000_000)
+            if Task.isCancelled { break }
+            let startIndex = cfg.preseed + i * batch
+            let next = TranscriptPerfHarness.makeSyntheticItems(count: batch, startIndex: startIndex)
+            harnessMessages.append(contentsOf: next)
+            Self.perfLog.debug("perf-harness inject seq=\(i + 1, privacy: .public)/\(cfg.injectCount, privacy: .public) batch=\(batch, privacy: .public) total=\(self.harnessMessages.count, privacy: .public)")
+        }
+
+        Self.perfLog.debug("perf-harness run.end total=\(self.harnessMessages.count, privacy: .public)")
     }
 
     // MARK: - Polling

--- a/Tests/TBDAppTests/HangWatchdogTests.swift
+++ b/Tests/TBDAppTests/HangWatchdogTests.swift
@@ -69,4 +69,31 @@ struct HangWatchdogTests {
         #expect(HangWatchdogSnapshot.empty.capturedAt == .distantPast)
         #expect(HangWatchdogSnapshot.empty.focusedTerminalIDShort == nil)
     }
+
+    // MARK: - thresholdMs(from:) — env override branches
+
+    @Test func thresholdMs_absent_isDefault() {
+        // No env var set → default 1000 ms (production launch).
+        #expect(HangWatchdog.thresholdMs(from: [:]) == 1000)
+    }
+
+    @Test func thresholdMs_validPositive_overrides() {
+        // A valid positive integer is honored so a run can catch sub-second stalls.
+        #expect(HangWatchdog.thresholdMs(from: ["TBD_HANG_THRESHOLD_MS": "150"]) == 150)
+    }
+
+    @Test func thresholdMs_invalid_isDefault() {
+        // Non-numeric junk falls back to the default rather than crashing.
+        #expect(HangWatchdog.thresholdMs(from: ["TBD_HANG_THRESHOLD_MS": "abc"]) == 1000)
+    }
+
+    @Test func thresholdMs_zero_isDefault() {
+        // Zero is not a usable threshold (every tick would be "hung") → default.
+        #expect(HangWatchdog.thresholdMs(from: ["TBD_HANG_THRESHOLD_MS": "0"]) == 1000)
+    }
+
+    @Test func thresholdMs_empty_isDefault() {
+        // Empty string → default.
+        #expect(HangWatchdog.thresholdMs(from: ["TBD_HANG_THRESHOLD_MS": ""]) == 1000)
+    }
 }

--- a/Tests/TBDAppTests/TranscriptPerfHarnessTests.swift
+++ b/Tests/TBDAppTests/TranscriptPerfHarnessTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDApp
+
+/// Tests for `TranscriptPerfHarness` — the pure, env-gated synthetic-streaming
+/// harness used to reproduce the issue #129 transcript scroll freeze.
+///
+/// CLAUDE.md: "When adding a branching conditional that gates behavior, add a
+/// test for each branch." The gate is `TBD_TRANSCRIPT_PERF_HARNESS` (active vs
+/// inert) plus the per-override fallbacks. All tests pass synthetic env
+/// dictionaries — no `setenv`.
+@Suite("TranscriptPerfHarness")
+struct TranscriptPerfHarnessTests {
+
+    // MARK: - config(from:) gate
+
+    @Test func config_gateAbsent_isNil() {
+        // No gate key → harness inert, production behavior preserved.
+        #expect(TranscriptPerfHarness.config(from: [:]) == nil)
+    }
+
+    @Test func config_gateEmpty_isNil() {
+        // Empty gate value counts as not-set.
+        #expect(TranscriptPerfHarness.config(from: ["TBD_TRANSCRIPT_PERF_HARNESS": ""]) == nil)
+    }
+
+    @Test func config_gateSet_defaults() {
+        // Gate set, no overrides → documented defaults (500/20/800/10).
+        let cfg = TranscriptPerfHarness.config(from: ["TBD_TRANSCRIPT_PERF_HARNESS": "1"])
+        #expect(cfg == TranscriptPerfHarnessConfig(
+            preseed: 500, injectCount: 20, injectIntervalMs: 800, injectBatch: 10
+        ))
+    }
+
+    @Test func config_overridesParsed() {
+        let cfg = TranscriptPerfHarness.config(from: [
+            "TBD_TRANSCRIPT_PERF_HARNESS": "yes",
+            "TBD_PERF_PRESEED": "120",
+            "TBD_PERF_INJECT_COUNT": "10",
+            "TBD_PERF_INJECT_MS": "300",
+            "TBD_PERF_INJECT_BATCH": "25"
+        ])
+        #expect(cfg == TranscriptPerfHarnessConfig(
+            preseed: 120, injectCount: 10, injectIntervalMs: 300, injectBatch: 25
+        ))
+    }
+
+    @Test func config_invalidOverrides_fallBackToDefaults() {
+        // Non-numeric overrides must not crash — fall back to defaults.
+        let cfg = TranscriptPerfHarness.config(from: [
+            "TBD_TRANSCRIPT_PERF_HARNESS": "1",
+            "TBD_PERF_PRESEED": "abc",
+            "TBD_PERF_INJECT_COUNT": "",
+            "TBD_PERF_INJECT_MS": "x",
+            "TBD_PERF_INJECT_BATCH": "nope"
+        ])
+        #expect(cfg == TranscriptPerfHarnessConfig(
+            preseed: 500, injectCount: 20, injectIntervalMs: 800, injectBatch: 10
+        ))
+    }
+
+    @Test func config_injectBatch_defaultWhenAbsent() {
+        let cfg = TranscriptPerfHarness.config(from: ["TBD_TRANSCRIPT_PERF_HARNESS": "1"])
+        #expect(cfg?.injectBatch == 10)
+    }
+
+    @Test func config_clampsInjectBatchFloor() {
+        // Zero and negative batch sizes clamp up to the minimum of 1.
+        let zero = TranscriptPerfHarness.config(from: [
+            "TBD_TRANSCRIPT_PERF_HARNESS": "1",
+            "TBD_PERF_INJECT_BATCH": "0"
+        ])
+        #expect(zero?.injectBatch == 1)
+
+        let negative = TranscriptPerfHarness.config(from: [
+            "TBD_TRANSCRIPT_PERF_HARNESS": "1",
+            "TBD_PERF_INJECT_BATCH": "-7"
+        ])
+        #expect(negative?.injectBatch == 1)
+    }
+
+    @Test func config_clampsInjectIntervalFloor() {
+        // Below the 50 ms floor clamps up to 50.
+        let cfg = TranscriptPerfHarness.config(from: [
+            "TBD_TRANSCRIPT_PERF_HARNESS": "1",
+            "TBD_PERF_INJECT_MS": "10"
+        ])
+        #expect(cfg?.injectIntervalMs == 50)
+    }
+
+    @Test func config_clampsNegativeCountsToZero() {
+        let cfg = TranscriptPerfHarness.config(from: [
+            "TBD_TRANSCRIPT_PERF_HARNESS": "1",
+            "TBD_PERF_PRESEED": "-5",
+            "TBD_PERF_INJECT_COUNT": "-3"
+        ])
+        #expect(cfg?.preseed == 0)
+        #expect(cfg?.injectCount == 0)
+    }
+
+    // MARK: - View-gating decision helpers (both branches)
+
+    @Test func autoscrollGate_harnessActive_alwaysTrue() {
+        // Harness pins to bottom: scroll must fire regardless of atBottom so
+        // every injected batch drives the real scroll path (issue #129).
+        #expect(TranscriptPerfHarness.autoscrollGate(harnessActive: true, atBottom: false) == true)
+        #expect(TranscriptPerfHarness.autoscrollGate(harnessActive: true, atBottom: true) == true)
+    }
+
+    @Test func autoscrollGate_harnessInactive_returnsAtBottom() {
+        // Production: gate == atBottom, so behavior is identical to before.
+        #expect(TranscriptPerfHarness.autoscrollGate(harnessActive: false, atBottom: false) == false)
+        #expect(TranscriptPerfHarness.autoscrollGate(harnessActive: false, atBottom: true) == true)
+    }
+
+    @Test func displayedMessages_branches() {
+        let real = TranscriptPerfHarness.makeSyntheticItems(count: 2, startIndex: 0)
+        let harness = TranscriptPerfHarness.makeSyntheticItems(count: 3, startIndex: 1000)
+
+        let whenOff = TranscriptPerfHarness.displayedMessages(harnessActive: false, harness: harness, real: real)
+        #expect(whenOff == real)
+
+        let whenOn = TranscriptPerfHarness.displayedMessages(harnessActive: true, harness: harness, real: real)
+        #expect(whenOn == harness)
+    }
+
+    // MARK: - makeSyntheticItems
+
+    @Test func makeSyntheticItems_honorsCount() {
+        #expect(TranscriptPerfHarness.makeSyntheticItems(count: 7).count == 7)
+        #expect(TranscriptPerfHarness.makeSyntheticItems(count: 0).isEmpty)
+    }
+
+    @Test func makeSyntheticItems_idsDistinctAndStable() {
+        let first = TranscriptPerfHarness.makeSyntheticItems(count: 5)
+        let second = TranscriptPerfHarness.makeSyntheticItems(count: 5)
+        let ids = first.map(\.id)
+        // Stable across calls.
+        #expect(ids == second.map(\.id))
+        // Distinct within a batch.
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test func makeSyntheticItems_startIndexAvoidsCollision() {
+        let preseed = TranscriptPerfHarness.makeSyntheticItems(count: 10, startIndex: 0)
+        let injected = TranscriptPerfHarness.makeSyntheticItems(count: 10, startIndex: 10)
+        let preseedIDs = Set(preseed.map(\.id))
+        let injectedIDs = Set(injected.map(\.id))
+        #expect(preseedIDs.isDisjoint(with: injectedIDs))
+    }
+
+    @Test func makeSyntheticItems_areHeavyAssistantText() {
+        for item in TranscriptPerfHarness.makeSyntheticItems(count: 3) {
+            guard case let .assistantText(_, text, timestamp, usage) = item else {
+                Issue.record("expected .assistantText, got \(item)")
+                continue
+            }
+            // Heavy rows: ~15-40 KB markdown each (prose + 2 tables + 3 code
+            // blocks) to drive the real #129 layout/measure cost.
+            #expect(text.count > 10_000)
+            #expect(timestamp == nil)
+            #expect(usage == nil)
+        }
+    }
+
+    @Test func makeSyntheticItems_idsOffsetByStartIndex() {
+        // startIndex offsets the numeric suffix of every id.
+        let items = TranscriptPerfHarness.makeSyntheticItems(count: 3, startIndex: 42)
+        #expect(items.map(\.id) == ["perf-harness-42", "perf-harness-43", "perf-harness-44"])
+    }
+
+    @Test func makeSyntheticItems_contentVariesByIndex() {
+        // Rows must not be byte-identical (realistic transcript).
+        let items = TranscriptPerfHarness.makeSyntheticItems(count: 2)
+        func body(_ item: TranscriptItem) -> String {
+            guard case let .assistantText(_, text, _, _) = item else { return "" }
+            return text
+        }
+        #expect(body(items[0]) != body(items[1]))
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **debug/env-gated** synthetic-streaming measurement harness for the live transcript pane so the issue #129 streaming freeze can finally be reproduced and measured A/B. The team previously had **no reproducible streaming baseline** (the #246 spike was abandoned for exactly that reason). This is **tooling + a measured finding — not a perf fix.** Nothing scroll-related ships, because the experiment showed scroll is not the lever.

### What
- **`TranscriptPerfHarness`** (`Sources/TBDApp/Diagnostics/`): env-gated config + a deterministic ~17 KB heavy synthetic-item builder + a batch injector. When active, the live pane renders synthetic items and injects batches (instead of polling), firing the **real** `onChange → proxy.scrollTo(anchor:.bottom)` path. `autoscrollGate` pins the harness to the bottom (simulates a user sitting at the latest message).
- **`HangWatchdog.thresholdMs(from:)`** reads `TBD_HANG_THRESHOLD_MS` so a run can lower the 1000 ms default and surface sub-second stalls.
- One silent `.debug` autoscroll fire/skip log per append (`perf-transcript`).
- Env vars: `TBD_TRANSCRIPT_PERF_HARNESS` (gate), `TBD_PERF_PRESEED` / `_INJECT_COUNT` / `_INJECT_MS` / `_INJECT_BATCH`, `TBD_HANG_THRESHOLD_MS`. Launch with `open --env …` — `restart.sh`'s `open` does **not** propagate shell env to the app.

### Inert in production
With no env vars set: `config(from:)` is `nil` → displayed messages == real messages, `autoscrollGate(false, atBottom) == atBottom`, the daemon poll loop runs, and the scroll modifier chain is identical to before. Verified by code review and branch tests (every gated decision tested both ways).

### Key finding — Track A1 (scrollTo) is refuted
A controlled experiment compared `current` (scrollTo fires every batch) against a no-scroll floor (anchor at first paint only, never re-scroll). Both produced the **same** per-batch stall (~270–290 ms for a batch of heavy rows). So the streaming freeze is the **per-row append layout cost** — `ForEach.applyNodes → StackLayout.sizeThatFits` measuring newly-arrived heavy rows for ScrollView content-sizing — **not** `proxy.scrollTo`. Since no scroll mechanism can beat the no-scroll floor, `scrollPosition` / `noAnchor` / coalescing are logically excluded too (and `.scrollPosition(id:)` was already removed once, design `2026-05-12`, as a regression). Track A1 (replace/coalesce `scrollTo`) is therefore not the lever, and nothing scroll-related is shipped.

### Numbers (batch=60, identical params, this machine)
| build | stalls (inject window) | mean | max | sum |
|---|---|---|---|---|
| pre-#278 `current` | 18 | 291 ms | 525 ms | 5.23 s |
| post-#278 `current` (rebased) | 14 | 283 ms | 423 ms | 3.96 s |

\#278 (per-row layout flattening, merged) bought ~24% but did not eliminate the per-batch cost. Mounting 500 heavy rows at once also froze ~12.5 s (a harness artifact — production accumulates gradually).

### Recommendation
Pursue the **per-row layout cost**, not scroll: extend #278's flattening, use fixed/precomputed row heights so layout is O(1)/row, or move to `NSCollectionView` + `NSHostingConfiguration` (the only true virtualizer on macOS 26, per the #246 spike). Refs #129.

## Test plan
- [ ] `swift build` and `swift test --filter "TranscriptPerfHarness|HangWatchdog"` pass (branch coverage for config / shouldRunPoll / autoscrollGate / displayedMessages and the env threshold).
- [ ] Normal launch (no env) behaves exactly as before: real transcript, auto-scroll, jump-to-bottom, text selection all unchanged.
- [ ] Harness launch reproduces the stall: `TBD_TRANSCRIPT_PERF_HARNESS=1 TBD_HANG_THRESHOLD_MS=250 TBD_PERF_PRESEED=500 TBD_PERF_INJECT_COUNT=8 TBD_PERF_INJECT_MS=1800 TBD_PERF_INJECT_BATCH=60 open /Applications/TBD.app --env …` then open a transcript pane; `hang detected … pane=liveTranscript` lines appear on the `hang-watchdog` log.

[transcript-scroll-measureestimates](https://cheapsteak.github.io/tbd/open/?worktree=76906748-922D-4C5B-BB87-D49D6D426CF3)