### PR TITLE
fix(daemon): show green for mergeable PRs with failing non-required checks (UNSTABLE)

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -127,7 +127,9 @@ public actor PRStatusManager {
         default:
             if isDraft || mergeStateStatus == "DRAFT" { return .draft }
             if reviewDecision == "CHANGES_REQUESTED" { return .changesRequested }
-            if Self.isFailingStatusCheckRollup(statusCheckRollupState) { return .checksFailed }
+            // UNSTABLE = mergeable despite failing/pending NON-required checks (a failing *required*
+            // check surfaces as BLOCKED instead). Defer to the UNSTABLE arm so it isn't flagged red here.
+            if mergeStateStatus != "UNSTABLE", Self.isFailingStatusCheckRollup(statusCheckRollupState) { return .checksFailed }
 
             switch mergeStateStatus {
             case "CLEAN", "HAS_HOOKS":
@@ -140,7 +142,7 @@ public actor PRStatusManager {
             case "DIRTY", "BEHIND":
                 return .blocked
             case "UNSTABLE":
-                return .checksFailed
+                return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .mergeable
             case "UNKNOWN":
                 return .pending
             default:

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -117,9 +117,53 @@ struct PRStatusManagerTests {
         #expect(status == .mergeable)
     }
 
-    @Test("maps UNSTABLE to .checksFailed")
-    func mapsUnstable() {
-        let status = PRStatusManager.mapState(ghState: "OPEN", mergeStateStatus: "UNSTABLE")
+    @Test("maps OPEN + UNSTABLE + FAILURE checks to .mergeable (non-required checks failing)")
+    func mapsUnstableWithFailingChecksToMergeable() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "UNSTABLE",
+            statusCheckRollupState: "FAILURE"
+        )
+        #expect(status == .mergeable)
+    }
+
+    @Test("maps OPEN + UNSTABLE + SUCCESS checks to .mergeable")
+    func mapsUnstableWithSuccessChecksToMergeable() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "UNSTABLE",
+            statusCheckRollupState: "SUCCESS"
+        )
+        #expect(status == .mergeable)
+    }
+
+    @Test("maps OPEN + UNSTABLE + PENDING checks to .pending (pending wins)")
+    func mapsUnstableWithPendingChecksToPending() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "UNSTABLE",
+            statusCheckRollupState: "PENDING"
+        )
+        #expect(status == .pending)
+    }
+
+    @Test("maps OPEN + UNSTABLE + nil checks to .mergeable")
+    func mapsUnstableWithNilChecksToMergeable() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "UNSTABLE",
+            statusCheckRollupState: nil
+        )
+        #expect(status == .mergeable)
+    }
+
+    @Test("maps OPEN + BLOCKED + FAILURE checks to .checksFailed (required-check failure stays red)")
+    func mapsBlockedWithFailingChecksToChecksFailed() {
+        let status = PRStatusManager.mapState(
+            ghState: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            statusCheckRollupState: "FAILURE"
+        )
         #expect(status == .checksFailed)
     }
 


### PR DESCRIPTION
## What

A PR that GitHub reports as `mergeStateStatus == UNSTABLE` (mergeable, but with failing or pending **non-required** checks) showed a **red** pull-request icon in TBD. It now shows **green**.

## Why

GitHub emits `UNSTABLE` only when a PR *is* mergeable but has failing/pending non-required checks — a failing **required** check downgrades the state to `BLOCKED` instead. So `UNSTABLE` is itself the "non-required" signal; no per-check `isRequired` data is needed.

In `PRStatusManager.mapState()` two things forced `UNSTABLE` to red:

1. The early `isFailingStatusCheckRollup` guard fired before the `mergeStateStatus` switch — an `UNSTABLE` PR has a `FAILURE` rollup, so it returned `.checksFailed` before the switch ran.
2. The `case "UNSTABLE"` arm returned `.checksFailed` unconditionally.

The fix makes the early guard skip `UNSTABLE` and routes the `UNSTABLE` arm through the same pending-vs-mergeable logic as `CLEAN`/`HAS_HOOKS`:

- `UNSTABLE` + pending checks → `.pending`
- `UNSTABLE` + anything else → `.mergeable`

Genuinely failing **required** checks (`BLOCKED`/`DIRTY`/`BEHIND`/`UNKNOWN` + `FAILURE`) still return red — the early guard fires for everything except `UNSTABLE`.

This complements #257, which handled the sibling case (`BLOCKED` + `REVIEW_REQUIRED` with green checks → mergeable). #257 was correct but scoped only to the `BLOCKED` arm; this covers the `UNSTABLE` arm.

## Tests

Added one case per branch of the modified conditional in `PRStatusManagerTests`:

- `UNSTABLE` + `FAILURE` checks → `.mergeable` (the actual bug — mirrors a real approved+mergeable PR with failing E2E)
- `UNSTABLE` + `SUCCESS` checks → `.mergeable`
- `UNSTABLE` + `PENDING` checks → `.pending` (pending wins)
- `UNSTABLE` + nil checks → `.mergeable`
- Regression guard: `BLOCKED` + `FAILURE` checks → `.checksFailed` (required-check failure stays red; pins the other side of the new `!= "UNSTABLE"` condition)

The old `UNSTABLE → .checksFailed` test was updated, not left stale. `swift build` and all 35 `PRStatusManager` tests pass.

[🔴 Diagnose Red PR Icon](https://cheapsteak.github.io/tbd/open/?worktree=BB188A68-5F35-42B4-864A-91850A7488CB)
