### PR TITLE
feat(app): clickable PR status icon — opens PR, hover explains red/yellow state

### DIFF
--- a/Sources/TBDApp/Sidebar/RowTooltipPreference.swift
+++ b/Sources/TBDApp/Sidebar/RowTooltipPreference.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct RowTooltipPreference: Equatable {
+    let text: String
+    let anchor: Anchor<CGRect>
+
+    static func == (lhs: RowTooltipPreference, rhs: RowTooltipPreference) -> Bool {
+        // Compare only text; anchors are reference-equal so we can't use == directly.
+        lhs.text == rhs.text
+    }
+}
+
+struct RowTooltipPreferenceKey: PreferenceKey {
+    static let defaultValue: RowTooltipPreference? = nil
+
+    static func reduce(value: inout RowTooltipPreference?, nextValue: () -> RowTooltipPreference?) {
+        // Last non-nil wins: only the currently-hovered row element publishes a value.
+        if let next = nextValue() { value = next }
+    }
+}
+
+struct RowTooltipBubble: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 5))
+            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color.primary.opacity(0.12)))
+            .fixedSize()
+    }
+}

--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -33,6 +33,16 @@ struct SidebarView: View {
                     appState.pendingScrollToWorktreeID = nil
                 }
             }
+            .overlayPreferenceValue(RowTooltipPreferenceKey.self) { pref in
+                GeometryReader { geo in
+                    if let pref {
+                        let rect = geo[pref.anchor]
+                        RowTooltipBubble(text: pref.text)
+                            .offset(x: rect.minX, y: rect.maxY + 4)
+                    }
+                }
+                .allowsHitTesting(false)
+            }
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -10,6 +10,8 @@ struct WorktreeRowView: View {
     @EnvironmentObject var appState: AppState
     @State private var isEditing = false
     @State private var isRowHovered: Bool = false
+    @State private var isPRIconHovered: Bool = false
+    @State private var isNameTruncated = false
 
     private var isPending: Bool {
         worktree.status == .creating
@@ -83,13 +85,26 @@ struct WorktreeRowView: View {
                 .foregroundStyle(.secondary)
         case .prStatus:
             if let presentation = prPresentation,
-               let nsImage = loadIcon(presentation.iconName) {
-                Image(nsImage: nsImage)
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 12, height: 12)
-                    .foregroundStyle(presentation.color)
+               let nsImage = loadIcon(presentation.iconName),
+               let status = prStatus {
+                let reasonText = status.reason ?? status.state.displayReason
+                Button(action: openPR) {
+                    Image(nsImage: nsImage)
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 12, height: 12)
+                        .foregroundStyle(presentation.color)
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .onHover { isPRIconHovered = $0 }
+                .accessibilityLabel("PR #\(status.number): \(reasonText)")
+                .anchorPreference(key: RowTooltipPreferenceKey.self, value: .bounds) { anchor in
+                    isPRIconHovered
+                        ? RowTooltipPreference(text: "PR #\(status.number) · \(reasonText)", anchor: anchor)
+                        : nil
+                }
             }
         case nil:
             EmptyView()
@@ -122,6 +137,19 @@ struct WorktreeRowView: View {
                         .fontWeight(hasBoldNotification ? .bold : .regular)
                         .lineLimit(1)
                         .truncationMode(.tail)
+                        .background(
+                            GeometryReader { proxy in
+                                Color.clear
+                                    .onAppear { updateNameTruncation(availableWidth: proxy.size.width) }
+                                    .onChange(of: proxy.size.width) { _, w in updateNameTruncation(availableWidth: w) }
+                                    .onChange(of: worktree.displayName) { _, _ in updateNameTruncation(availableWidth: proxy.size.width) }
+                            }
+                        )
+                        .anchorPreference(key: RowTooltipPreferenceKey.self, value: .bounds) { anchor in
+                            (isRowHovered && !isPRIconHovered && isNameTruncated && !isEditing)
+                                ? RowTooltipPreference(text: worktree.displayName, anchor: anchor)
+                                : nil
+                        }
                     if isPending {
                         Text(Self.creatingSubtitle(
                             hasPreSessionTerminal: appState.hasPreSessionTerminal(worktreeID: worktree.id)
@@ -144,7 +172,6 @@ struct WorktreeRowView: View {
         .padding(.leading, CGFloat(indentLevel) * 16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: 28)
-        .help(isEditing ? "" : worktree.displayName)
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(appState.selectedWorktreeIDs.contains(worktree.id) ? Color.accentColor.opacity(0.2) : Color.clear)
@@ -211,5 +238,17 @@ struct WorktreeRowView: View {
               let image = NSImage(contentsOf: url) else { return nil }
         image.isTemplate = true
         return image
+    }
+
+    private func openPR() {
+        guard let prStatus = prStatus, let url = URL(string: prStatus.url) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func updateNameTruncation(availableWidth: CGFloat) {
+        let font = NSFont.systemFont(ofSize: 13, weight: hasBoldNotification ? .bold : .regular)
+        let ideal = (worktree.displayName as NSString).size(withAttributes: [.font: font]).width
+        let truncated = ideal > availableWidth + 0.5
+        if truncated != isNameTruncated { isNameTruncated = truncated }
     }
 }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -69,6 +69,13 @@ public actor PRStatusManager {
                         reviewDecision: node.reviewDecision,
                         isDraft: node.isDraft,
                         statusCheckRollupState: node.statusCheckRollupState
+                    ),
+                    reason: Self.computeReason(
+                        ghState: node.state,
+                        mergeStateStatus: node.mergeStateStatus,
+                        reviewDecision: node.reviewDecision,
+                        isDraft: node.isDraft,
+                        statusCheckRollupState: node.statusCheckRollupState
                     )
                 )
             }
@@ -90,14 +97,21 @@ public actor PRStatusManager {
                 continue
             }
 
+            let state = Self.mapState(ghState: obj.state,
+                                        mergeStateStatus: obj.mergeStateStatus,
+                                        reviewDecision: obj.reviewDecision ?? "",
+                                        isDraft: obj.isDraft,
+                                        statusCheckRollupState: obj.statusCheckRollup?.state)
+            let reason = Self.computeReason(ghState: obj.state,
+                                             mergeStateStatus: obj.mergeStateStatus,
+                                             reviewDecision: obj.reviewDecision ?? "",
+                                             isDraft: obj.isDraft,
+                                             statusCheckRollupState: obj.statusCheckRollup?.state)
             let status = PRStatus(
                 number: obj.number,
                 url: obj.url,
-                state: Self.mapState(ghState: obj.state,
-                                     mergeStateStatus: obj.mergeStateStatus,
-                                     reviewDecision: obj.reviewDecision ?? "",
-                                     isDraft: obj.isDraft,
-                                     statusCheckRollupState: obj.statusCheckRollup?.state)
+                state: state,
+                reason: reason
             )
             cache[worktreeID] = status
             return status
@@ -114,6 +128,68 @@ public actor PRStatusManager {
 
     // MARK: - State mapping (internal but static for testability)
 
+    /// Unified function that produces both state and reason in one pass.
+    /// This is the single source of truth — both mapState() and computeReason()
+    /// delegate to this to prevent drift.
+    public static func mapStateAndReason(
+        ghState: String,
+        mergeStateStatus: String,
+        reviewDecision: String = "",
+        isDraft: Bool = false,
+        statusCheckRollupState: String? = nil
+    ) -> (state: PRMergeableState, reason: String) {
+        switch ghState {
+        case "MERGED":
+            return (.merged, "Merged")
+        case "CLOSED":
+            return (.closed, "Closed")
+        default:
+            if isDraft || mergeStateStatus == "DRAFT" { return (.draft, "Draft") }
+            if reviewDecision == "CHANGES_REQUESTED" { return (.changesRequested, "Changes requested") }
+            // UNSTABLE = mergeable despite failing/pending NON-required checks (a failing *required*
+            // check surfaces as BLOCKED instead). Defer to the UNSTABLE arm so it isn't flagged red here.
+            if mergeStateStatus != "UNSTABLE", Self.isFailingStatusCheckRollup(statusCheckRollupState) {
+                return (.checksFailed, "Checks failing")
+            }
+
+            switch mergeStateStatus {
+            case "CLEAN", "HAS_HOOKS":
+                if Self.isPendingStatusCheckRollup(statusCheckRollupState) {
+                    return (.pending, "Checks pending")
+                } else {
+                    return (.mergeable, "Ready to merge")
+                }
+            case "BLOCKED":
+                if Self.isPendingStatusCheckRollup(statusCheckRollupState) {
+                    return (.pending, "Checks pending")
+                }
+                // Only blocker is a required (but not-yet-given) review while checks pass → ready to merge, show green.
+                if reviewDecision == "REVIEW_REQUIRED" {
+                    return (.mergeable, "Ready to merge")
+                }
+                return (.blocked, "Blocked")
+            case "DIRTY":
+                return (.blocked, "Merge conflicts")
+            case "BEHIND":
+                return (.blocked, "Behind base branch")
+            case "UNSTABLE":
+                if Self.isPendingStatusCheckRollup(statusCheckRollupState) {
+                    return (.pending, "Checks pending")
+                } else {
+                    return (.mergeable, "Ready to merge")
+                }
+            case "UNKNOWN":
+                return (.pending, "Checks pending")
+            default:
+                if Self.isPendingStatusCheckRollup(statusCheckRollupState) {
+                    return (.pending, "Checks pending")
+                } else {
+                    return (.blocked, "Blocked")
+                }
+            }
+        }
+    }
+
     public static func mapState(
         ghState: String,
         mergeStateStatus: String,
@@ -121,34 +197,13 @@ public actor PRStatusManager {
         isDraft: Bool = false,
         statusCheckRollupState: String? = nil
     ) -> PRMergeableState {
-        switch ghState {
-        case "MERGED": return .merged
-        case "CLOSED": return .closed
-        default:
-            if isDraft || mergeStateStatus == "DRAFT" { return .draft }
-            if reviewDecision == "CHANGES_REQUESTED" { return .changesRequested }
-            // UNSTABLE = mergeable despite failing/pending NON-required checks (a failing *required*
-            // check surfaces as BLOCKED instead). Defer to the UNSTABLE arm so it isn't flagged red here.
-            if mergeStateStatus != "UNSTABLE", Self.isFailingStatusCheckRollup(statusCheckRollupState) { return .checksFailed }
-
-            switch mergeStateStatus {
-            case "CLEAN", "HAS_HOOKS":
-                return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .mergeable
-            case "BLOCKED":
-                if Self.isPendingStatusCheckRollup(statusCheckRollupState) { return .pending }
-                // Only blocker is a required (but not-yet-given) review while checks pass → ready to merge, show green.
-                if reviewDecision == "REVIEW_REQUIRED" { return .mergeable }
-                return .blocked
-            case "DIRTY", "BEHIND":
-                return .blocked
-            case "UNSTABLE":
-                return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .mergeable
-            case "UNKNOWN":
-                return .pending
-            default:
-                return Self.isPendingStatusCheckRollup(statusCheckRollupState) ? .pending : .blocked
-            }
-        }
+        return Self.mapStateAndReason(
+            ghState: ghState,
+            mergeStateStatus: mergeStateStatus,
+            reviewDecision: reviewDecision,
+            isDraft: isDraft,
+            statusCheckRollupState: statusCheckRollupState
+        ).state
     }
 
     private static func isFailingStatusCheckRollup(_ state: String?) -> Bool {
@@ -159,6 +214,24 @@ public actor PRStatusManager {
     private static func isPendingStatusCheckRollup(_ state: String?) -> Bool {
         guard let state else { return false }
         return ["EXPECTED", "PENDING"].contains(state)
+    }
+
+    /// Compute human-readable reason string for the PR merge state.
+    /// Delegates to mapStateAndReason() for the single source of truth.
+    public static func computeReason(
+        ghState: String,
+        mergeStateStatus: String,
+        reviewDecision: String = "",
+        isDraft: Bool = false,
+        statusCheckRollupState: String? = nil
+    ) -> String {
+        return Self.mapStateAndReason(
+            ghState: ghState,
+            mergeStateStatus: mergeStateStatus,
+            reviewDecision: reviewDecision,
+            isDraft: isDraft,
+            statusCheckRollupState: statusCheckRollupState
+        ).reason
     }
 
     /// Priority for choosing between multiple PRs on the same branch.

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -541,17 +541,33 @@ public enum PRMergeableState: String, Codable, Sendable {
     case mergeable          // GitHub considers it clean (checks + reviews satisfied)
     case merged             // PR was merged
     case closed             // PR was closed without merging
+
+    /// Human-readable reason for this state (fallback when PRStatus.reason is nil).
+    public var displayReason: String {
+        switch self {
+        case .pending:          return "Checks pending"
+        case .blocked:          return "Blocked"
+        case .changesRequested: return "Changes requested"
+        case .draft:            return "Draft"
+        case .checksFailed:     return "Checks failing"
+        case .mergeable:        return "Ready to merge"
+        case .merged:           return "Merged"
+        case .closed:           return "Closed"
+        }
+    }
 }
 
 public struct PRStatus: Codable, Sendable, Equatable {
     public let number: Int
     public let url: String
     public let state: PRMergeableState
+    public let reason: String?
 
-    public init(number: Int, url: String, state: PRMergeableState) {
+    public init(number: Int, url: String, state: PRMergeableState, reason: String? = nil) {
         self.number = number
         self.url = url
         self.state = state
+        self.reason = reason
     }
 }
 

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -397,4 +397,193 @@ struct PRStatusManagerTests {
         let all = await manager.allStatuses()
         #expect(all[id] == nil)
     }
+
+    // MARK: - Reason computation
+
+    @Test("computeReason returns 'Merged' for merged state")
+    func reasonForMerged() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "MERGED",
+            mergeStateStatus: "UNKNOWN",
+            reviewDecision: "",
+            isDraft: false,
+            statusCheckRollupState: nil
+        )
+        #expect(reason == "Merged")
+    }
+
+    @Test("computeReason returns 'Closed' for closed state")
+    func reasonForClosed() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "CLOSED",
+            mergeStateStatus: "UNKNOWN",
+            reviewDecision: "",
+            isDraft: false,
+            statusCheckRollupState: nil
+        )
+        #expect(reason == "Closed")
+    }
+
+    @Test("computeReason returns 'Draft' for draft PRs")
+    func reasonForDraft() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "OPEN",
+            mergeStateStatus: "CLEAN",
+            reviewDecision: "",
+            isDraft: true,
+            statusCheckRollupState: nil
+        )
+        #expect(reason == "Draft")
+    }
+
+    @Test("computeReason returns 'Ready to merge' for mergeable state")
+    func reasonForMergeable() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "OPEN",
+            mergeStateStatus: "CLEAN",
+            reviewDecision: "",
+            isDraft: false,
+            statusCheckRollupState: nil
+        )
+        #expect(reason == "Ready to merge")
+    }
+
+    @Test("computeReason returns 'Merge conflicts' for DIRTY merge state")
+    func reasonForConflicts() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "OPEN",
+            mergeStateStatus: "DIRTY",
+            reviewDecision: "",
+            isDraft: false,
+            statusCheckRollupState: nil
+        )
+        #expect(reason == "Merge conflicts")
+    }
+
+    @Test("computeReason returns 'Behind base branch' for BEHIND merge state")
+    func reasonForBehind() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "OPEN",
+            mergeStateStatus: "BEHIND",
+            reviewDecision: "",
+            isDraft: false,
+            statusCheckRollupState: nil
+        )
+        #expect(reason == "Behind base branch")
+    }
+
+    @Test("computeReason returns 'Checks failing' for failed status checks")
+    func reasonForFailingChecks() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "OPEN",
+            mergeStateStatus: "CLEAN",
+            reviewDecision: "",
+            isDraft: false,
+            statusCheckRollupState: "FAILURE"
+        )
+        #expect(reason == "Checks failing")
+    }
+
+    @Test("computeReason returns 'Checks pending' for pending status checks")
+    func reasonForPendingChecks() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "OPEN",
+            mergeStateStatus: "CLEAN",
+            reviewDecision: "",
+            isDraft: false,
+            statusCheckRollupState: "PENDING"
+        )
+        #expect(reason == "Checks pending")
+    }
+
+    @Test("computeReason returns 'Changes requested' for CHANGES_REQUESTED review decision")
+    func reasonForChangesRequested() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            reviewDecision: "CHANGES_REQUESTED",
+            isDraft: false,
+            statusCheckRollupState: nil
+        )
+        #expect(reason == "Changes requested")
+    }
+
+    @Test("computeReason returns 'Ready to merge' for REVIEW_REQUIRED with no other blocker (green state)")
+    func reasonForReviewRequired() {
+        let reason = PRStatusManager.computeReason(
+            ghState: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            reviewDecision: "REVIEW_REQUIRED",
+            isDraft: false,
+            statusCheckRollupState: nil
+        )
+        // REVIEW_REQUIRED with passing checks is actually mergeable (green), never shows a red/yellow warning
+        #expect(reason == "Ready to merge")
+    }
+
+    // MARK: - Unified state+reason pairs (critical consistency tests)
+
+    @Test("BLOCKED + REVIEW_REQUIRED + passing checks → (.mergeable, 'Ready to merge')")
+    func stateAndReasonBlockedReviewRequiredMergeable() {
+        let (state, reason) = PRStatusManager.mapStateAndReason(
+            ghState: "OPEN",
+            mergeStateStatus: "BLOCKED",
+            reviewDecision: "REVIEW_REQUIRED",
+            statusCheckRollupState: "SUCCESS"
+        )
+        #expect(state == .mergeable)
+        #expect(reason == "Ready to merge")
+    }
+
+    @Test("UNSTABLE + nil checks → (.mergeable, 'Ready to merge')")
+    func stateAndReasonUnstableNilChecksMergeable() {
+        let (state, reason) = PRStatusManager.mapStateAndReason(
+            ghState: "OPEN",
+            mergeStateStatus: "UNSTABLE",
+            statusCheckRollupState: nil
+        )
+        #expect(state == .mergeable)
+        #expect(reason == "Ready to merge")
+    }
+
+    @Test("UNSTABLE + SUCCESS checks → (.mergeable, 'Ready to merge')")
+    func stateAndReasonUnstableSuccessMergeable() {
+        let (state, reason) = PRStatusManager.mapStateAndReason(
+            ghState: "OPEN",
+            mergeStateStatus: "UNSTABLE",
+            statusCheckRollupState: "SUCCESS"
+        )
+        #expect(state == .mergeable)
+        #expect(reason == "Ready to merge")
+    }
+
+    @Test("CLEAN + no pending checks → (.mergeable, 'Ready to merge')")
+    func stateAndReasonCleanMergeable() {
+        let (state, reason) = PRStatusManager.mapStateAndReason(
+            ghState: "OPEN",
+            mergeStateStatus: "CLEAN"
+        )
+        #expect(state == .mergeable)
+        #expect(reason == "Ready to merge")
+    }
+
+    @Test("DIRTY → (.blocked, 'Merge conflicts')")
+    func stateAndReasonDirtyConflicts() {
+        let (state, reason) = PRStatusManager.mapStateAndReason(
+            ghState: "OPEN",
+            mergeStateStatus: "DIRTY"
+        )
+        #expect(state == .blocked)
+        #expect(reason == "Merge conflicts")
+    }
+
+    @Test("BEHIND → (.blocked, 'Behind base branch')")
+    func stateAndReasonBehind() {
+        let (state, reason) = PRStatusManager.mapStateAndReason(
+            ghState: "OPEN",
+            mergeStateStatus: "BEHIND"
+        )
+        #expect(state == .blocked)
+        #expect(reason == "Behind base branch")
+    }
 }


### PR DESCRIPTION
## What

Makes the sidebar PR status icon **clickable** and **explains red/yellow states on hover**.

- **Click** the PR status icon → opens the pull request in your browser. Uses the already-fetched `PRStatus.url` via `NSWorkspace.shared.open`, so it's host-agnostic (whatever URL the remote provides — not hardcoded to github.com).
- **Hover** the icon → an **immediate** popover (no native ~1.5s tooltip delay) shows a human-readable reason: `PR #123 · Merge conflicts`. Most useful for understanding *why* an icon is red or yellow.

## Why

The colored PR icon previously told you the state but not the reason, and wasn't actionable — you had to leave the app to find the PR. Now red/yellow are self-explanatory and one click away from the PR.

## How

**Daemon** (`PRStatusManager`)
- Unified state + reason into a single source of truth `mapStateAndReason(...) -> (PRMergeableState, String)`; `mapState()` and `computeReason()` both delegate to it, so the icon color and the tooltip text can never drift apart.
- Reason is derived from already-fetched GitHub fields (`mergeStateStatus`, `reviewDecision`, `isDraft`, `statusCheckRollup.state`) — **no extra GraphQL**.
- Invariant: a `.mergeable` (green) PR always reads "Ready to merge" — never a scary reason — even when only a soft blocker (required review / non-required failing checks) is present.

Reason mapping: Merged / Closed / Draft / Ready to merge / Merge conflicts (DIRTY) / Behind base branch (BEHIND) / Checks failing / Checks pending / Changes requested / Blocked.

**Shared** (`Models.swift`)
- Added optional, defaulted `reason: String?` to `PRStatus` (RPC payload — backward compatible, no DB migration).
- Added `PRMergeableState.displayReason` as the nil-reason fallback (e.g. for a stale cached payload).

**App** (`WorktreeRowView`)
- Icon wrapped in a `Button(.plain)` scoped to the 12×12 icon (rest of the row still selects; row context menu unaffected).
- Hover tooltip via `.popover(isPresented:arrowEdge:.bottom)` — renders in its own window so it isn't clipped by the `List` row, and appears immediately (not `.help()`, which has the native delay). `.accessibilityLabel` preserves VoiceOver.

## Tests

- `mapStateAndReason` branch coverage for every reason string.
- State+reason **pairing** tests pin the "green never shows a scary reason" rule: BLOCKED+REVIEW_REQUIRED and UNSTABLE both assert `(.mergeable, "Ready to merge")`.
- `swift build`, full `swift test`, and `swiftlint --strict` all clean.

## Note / not assuming GitHub

PR data is still fetched via `gh` (GitHub). The *click-to-open* uses the stored URL string and is host-agnostic; broader GitLab/other-host support would be a separate change.

## Manual verification

Hover behavior can't be exercised by synthetic input in CI/headless; please verify in-app after `scripts/restart.sh`:
- Hover a yellow/red icon → tooltip appears promptly with the reason.
- Click the icon → PR opens in browser.
- Clicking elsewhere on the row still selects it; right-click still shows the context menu.
- Watch for any popover flicker on hover (known SwiftUI caveat with hover-driven popovers).

[🔗 Clickable Git Status Icon](https://cheapsteak.github.io/tbd/open/?worktree=A5EFC51C-47F6-40E5-ABCF-157129989EE5)
