### PR TITLE
feat(cli): expose `tbd terminal pin`/`unpin` and document in bundled skill

### DIFF
--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -6,7 +6,7 @@ struct TerminalCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "terminal",
         abstract: "Manage terminals",
-        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalOutput.self, TerminalConversation.self, TerminalFocus.self]
+        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalOutput.self, TerminalConversation.self, TerminalFocus.self, TerminalPin.self, TerminalUnpin.self]
     )
 }
 
@@ -175,6 +175,58 @@ struct TerminalFocus: AsyncParsableCommand {
         )
 
         print(activate ? "Focused (activated)." : "Focus push sent.")
+    }
+}
+
+// MARK: - terminal pin
+
+struct TerminalPin: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "pin",
+        abstract: "Pin a terminal to the dock"
+    )
+
+    @Argument(help: "Terminal ID")
+    var terminal: String
+
+    mutating func run() async throws {
+        guard let terminalID = UUID(uuidString: terminal) else {
+            throw CLIError.invalidArgument("Invalid terminal ID: \(terminal)")
+        }
+
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.terminalSetPin,
+            params: TerminalSetPinParams(terminalID: terminalID, pinned: true)
+        )
+
+        print("Terminal pinned.")
+    }
+}
+
+// MARK: - terminal unpin
+
+struct TerminalUnpin: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "unpin",
+        abstract: "Unpin a terminal from the dock"
+    )
+
+    @Argument(help: "Terminal ID")
+    var terminal: String
+
+    mutating func run() async throws {
+        guard let terminalID = UUID(uuidString: terminal) else {
+            throw CLIError.invalidArgument("Invalid terminal ID: \(terminal)")
+        }
+
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.terminalSetPin,
+            params: TerminalSetPinParams(terminalID: terminalID, pinned: false)
+        )
+
+        print("Terminal unpinned.")
     }
 }
 

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -100,6 +100,15 @@ tbd terminal send --terminal <id> --text "..." [--submit]
 tbd terminal output <id> [--lines N]
 ```
 
+### Pin / unpin a terminal
+
+Pin a terminal to keep it docked and quickly reachable; unpin to remove it from the dock.
+
+```bash
+tbd terminal pin <id>
+tbd terminal unpin <id>
+```
+
 ### Pull the user's attention to a worker's tab
 
 Use when an orchestrator wants the user to look at a specific child tab (e.g. a

--- a/Tests/TBDCLITests/TerminalPinCommandTests.swift
+++ b/Tests/TBDCLITests/TerminalPinCommandTests.swift
@@ -1,0 +1,28 @@
+import Testing
+import ArgumentParser
+@testable import TBDCLI
+
+@Suite("tbd terminal pin parsing")
+struct TerminalPinCommandTests {
+    @Test func pinParsesTerminalArgument() throws {
+        let cmd = try TerminalPin.parse(["ABC"])
+        #expect(cmd.terminal == "ABC")
+    }
+
+    @Test func unpinParsesTerminalArgument() throws {
+        let cmd = try TerminalUnpin.parse(["ABC"])
+        #expect(cmd.terminal == "ABC")
+    }
+
+    @Test func pinRequiresTerminal() {
+        #expect(throws: (any Error).self) {
+            _ = try TerminalPin.parse([])
+        }
+    }
+
+    @Test func unpinRequiresTerminal() {
+        #expect(throws: (any Error).self) {
+            _ = try TerminalUnpin.parse([])
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds `tbd terminal pin <id>` and `tbd terminal unpin <id>` CLI subcommands, and documents them in the bundled `tbd` skill.

## Why

Terminal pinning was already fully wired through the daemon (`RPCMethod.terminalSetPin`), the database (`TerminalStore.setPin`), state deltas, and the app UI (dock + pane header buttons) — but there was **no CLI surface** for it, and it wasn't mentioned in `TBDSkillContent` (the skill loaded into TBD-spawned Claude/Codex sessions). So agents and scripts had no discoverable way to pin/unpin a terminal.

## Changes

- **`Sources/TBDCLI/Commands/TerminalCommands.swift`** — two new `AsyncParsableCommand` subcommands (`pin`, `unpin`) following the existing terminal-command pattern: positional terminal-UUID argument, validated, calling `RPCMethod.terminalSetPin` with `pinned: true`/`false`.
- **`Sources/TBDShared/TBDSkillContent.swift`** — new "Pin / unpin a terminal" workflow subsection so the commands are discoverable to TBD-spawned sessions.
- **`Tests/TBDCLITests/TerminalPinCommandTests.swift`** — ArgumentParser parsing tests mirroring `TerminalFocusCommandTests`.

No daemon/database/app changes — the backend was already complete.

## Verification

- `swift build` ✅
- `swiftlint --strict` ✅ (0 violations)
- `swift test --filter TerminalPinCommandTests` ✅ (4/4)
- `tbd terminal pin --help` / `tbd terminal unpin --help` show correct usage

[📌 Pin Terminal CLI](https://cheapsteak.github.io/tbd/open/?worktree=D5A4F9D7-C355-4551-BB1F-259710C3C0EE)
