### PR TITLE
perf(transcript): flatten per-row VStack to cut #129 layout depth (+ eager-measure bench)

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
@@ -43,6 +43,18 @@ struct TranscriptRow: View {
         // of the parent ForEach is unaffected: it still sees a single
         // SelectableTranscriptRow type; this _ConditionalContent lives entirely
         // behind TranscriptRow's `some View` boundary.
+        //
+        // Trade-off: because the whole body is now a _ConditionalContent, when a
+        // node's badgeUsage flips nil↔non-nil (the badge migrates row→row as new
+        // usage arrives during streaming) SwiftUI rebuilds the `content` subtree
+        // rather than just toggling the badge. This is acceptable because (a) a
+        // badgeUsage change also changes the node's digest, so the ForEach already
+        // re-realizes that row in the unflattened baseline — the flatten doesn't
+        // add re-realization frequency, only changes what's rebuilt within it; and
+        // (b) the badge attaches to the latest usage-carrying item (see
+        // TranscriptRenderNode.swift), almost always a stateless `.assistantText`
+        // chat bubble — and #129 already moved inline expand/collapse @State out to
+        // overlays, so no meaningful per-row state is lost on the toggle.
         if let usage = node.badgeUsage {
             VStack(alignment: .leading, spacing: 2) {
                 content

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
@@ -1,11 +1,17 @@
 import SwiftUI
 import TBDShared
 
-/// One row of the transcript. Constant view-shape: always a `VStack` with a
-/// content subview and an optional inlined `ContextUsageBadge`. The internal
-/// `switch` on `node.kind` lives behind this struct's type boundary so the
-/// parent `ForEach`'s body is homogeneous — see issue #129 / the
-/// transcript-render-node design doc.
+/// One row of the transcript. The view shape adapts to whether a usage badge
+/// is present: `content` is returned bare for the common badge-less row, and is
+/// wrapped in a `VStack` (content above an inlined `ContextUsageBadge`) only
+/// when `node.badgeUsage` is non-nil. Dropping the wrapper `VStack` from
+/// badge-less rows removes a redundant per-row `StackLayout` node from the
+/// measure pass — the dominant symbol in the issue #129 activation freeze.
+/// ForEach homogeneity is preserved: the parent `ForEach` still sees a single
+/// `SelectableTranscriptRow`/`TranscriptRow` type. Both the internal `switch`
+/// on `node.kind` and the badge `_ConditionalContent` live behind this struct's
+/// `some View` type boundary — see issue #129 / the transcript-render-node
+/// design doc.
 struct TranscriptRow: View {
     let node: TranscriptRenderNode
     let terminalID: UUID?
@@ -28,13 +34,24 @@ struct TranscriptRow: View {
 
     @ViewBuilder
     private var rowBody: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            content
-            if let usage = node.badgeUsage {
+        // Per-row layout-depth flattening (issue #129 / continuing PR #278):
+        // the wrapper VStack exists ONLY to stack an optional ContextUsageBadge
+        // under the content. The vast majority of rows have no badge
+        // (badgeUsage == nil), so returning `content` bare drops a redundant
+        // StackLayout node from every badge-less row's measure pass — the
+        // dominant symbol in the #129 activation-freeze spindump. Homogeneity
+        // of the parent ForEach is unaffected: it still sees a single
+        // SelectableTranscriptRow type; this _ConditionalContent lives entirely
+        // behind TranscriptRow's `some View` boundary.
+        if let usage = node.badgeUsage {
+            VStack(alignment: .leading, spacing: 2) {
+                content
                 ContextUsageBadge(total: usage.contextTotal)
                     .padding(.leading, 12)
                     .padding(.top, 2)
             }
+        } else {
+            content
         }
     }
 

--- a/Tests/TBDAppTests/TranscriptEagerMeasureBench.swift
+++ b/Tests/TBDAppTests/TranscriptEagerMeasureBench.swift
@@ -1,0 +1,171 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Env-gated, headless, deterministic eager-measure benchmark for issue #129
+/// (continuing PR #278). Force-measures the FULL list of transcript rows in
+/// plain `VStack`s (NOT `LazyVStack`) so EVERY row pays its cold layout cost in
+/// one pass, then reports wall-clock min/median over the measured iterations.
+/// Built to compare the per-row layout cost of candidate flattenings: build the
+/// same commit twice with and without a change and diff the `BENCH` lines.
+///
+/// ## Why LIGHT rows
+///
+/// The per-row layer #129 flattenings target is the row WRAPPER (e.g.
+/// `TranscriptRow`'s optional-badge `VStack`), which is body-weight-invariant.
+/// A heavy 15-40KB MarkdownUI body costs the same in every build, so it only
+/// adds a large change-invariant constant that dilutes the wrapper delta and
+/// makes each pass minutes-slow. Single-line prose rows make the wrapper the
+/// dominant per-row cost, so removing a wrapper node is a fast, high-signal
+/// delta. Caveat: a flat list under-represents the DEPTH recursion (nested
+/// alignment guides) seen in real hover/activation spindumps, so this bench is
+/// a lower bound on a flattening's real-world benefit, not the whole story.
+///
+/// Inert during normal `swift test`: the test early-returns unless
+/// `TBD_PERF_BENCH=1`, so it never slows the regular suite. Run explicitly:
+///
+///     TBD_PERF_BENCH=1 swift test --filter TranscriptEagerMeasureBench
+///
+/// ## Why chunked + autoreleasepool, not one giant VStack
+///
+/// SwiftUI/CoreGraphics aborts (SIGABRT) once a single hosted layout's realized
+/// geometry exceeds ~2.1M points. To keep the measure an honest EAGER full-list
+/// pass while staying under the cap for any row height, the rows are measured in
+/// fixed `chunkSize`-row plain `VStack`s, each hosted in its own `NSHostingView`
+/// inside an `autoreleasepool` so its backing store is freed before the next
+/// chunk. The per-iteration time is the SUM across all chunks — i.e. the cold
+/// eager layout cost of all N rows.
+@Suite("Transcript eager-measure bench")
+@MainActor
+struct TranscriptEagerMeasureBench {
+    /// Rows per hosted chunk — kept well under the ~2.1M-pt realized-geometry
+    /// cap that aborts a single hosting pass, with headroom for tall rows.
+    private static let chunkSize = 100
+    /// Render width matching the transcript pane's typical content column.
+    private static let width: CGFloat = 700
+
+    @Test("eager full-list NSHostingView measure (gated by TBD_PERF_BENCH=1)")
+    func eagerMeasure() {
+        // GATE: do nothing (pass trivially) unless explicitly enabled. Keeps the
+        // normal test suite fast — this bench measures hundreds of rows per pass.
+        guard ProcessInfo.processInfo.environment["TBD_PERF_BENCH"] == "1" else {
+            #expect(true)
+            return
+        }
+
+        for count in [500, 1000] {
+            // Build items + render nodes ONCE per N. Node construction is not
+            // what we measure — the cold EAGER SwiftUI layout over all rows is —
+            // so reusing the nodes across iterations isolates the layout cost.
+            //
+            // LIGHT rows (single short prose line), NOT the heavy 15-40KB
+            // generator: the per-row layer that PR #278 / changes A & B flatten
+            // is the WRAPPER (TranscriptRow's VStack, ChatBubbleView's
+            // flex-frame), which is body-weight-invariant. Heavy MarkdownUI
+            // bodies cost the same in every build, so they only add a large
+            // A/B-invariant constant that dilutes the wrapper delta and makes
+            // the measure minutes-slow. Light bodies make the wrapper the
+            // dominant per-row cost, so removing wrapper nodes is a clean,
+            // fast, high-signal delta. All `.assistantText` (badge-less, so
+            // change A's VStack-drop applies to every row; assistant, so change
+            // B's flex-frame-drop applies to every row) to maximize sensitivity.
+            let items: [TranscriptItem] = (0..<count).map { i in
+                .assistantText(
+                    id: "bench-\(i)",
+                    text: "Short assistant reply \(i): one line of prose with **bold**, `code`, and a [link](https://example.com).",
+                    timestamp: nil,
+                    usage: nil
+                )
+            }
+            let nodes = transcriptRenderNodes(from: items)
+
+            let iterations = 20
+            let warmup = 4
+            var samplesMs: [Double] = []
+
+            for iter in 0..<iterations {
+                let result = measureEagerLayout(nodes: nodes)
+
+                // Guard: the bench is useless if layout produced a degenerate
+                // size. A full list of heavy rows must measure to a tall extent.
+                #expect(
+                    result.totalHeight > 1,
+                    "summed fittingSize height was \(result.totalHeight) for N=\(count) — headless layout did not measure content"
+                )
+
+                if iter >= warmup {
+                    samplesMs.append(result.milliseconds)
+                }
+            }
+
+            let sorted = samplesMs.sorted()
+            let minMs = sorted.first ?? 0
+            let medianMs = median(sorted)
+
+            print(String(
+                format: "BENCH N=%d iters=%d min=%.2f ms median=%.2f ms",
+                count, samplesMs.count, minMs, medianMs
+            ))
+            fflush(stdout)
+        }
+
+        #expect(true)
+    }
+
+    /// One cold eager full-list measure of `nodes`: hosts the rows in
+    /// `chunkSize`-row plain `VStack`s (fresh `NSHostingView` per chunk inside an
+    /// `autoreleasepool`) and reads `fittingSize` to force a full content-extent
+    /// layout. Returns the wall-clock duration summed across chunks and the
+    /// summed measured height (a degenerate-layout sentinel).
+    private func measureEagerLayout(
+        nodes: [TranscriptRenderNode]
+    ) -> (milliseconds: Double, totalHeight: CGFloat) {
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        var totalHeight: CGFloat = 0
+        var index = 0
+        while index < nodes.count {
+            autoreleasepool {
+                let upper = min(index + Self.chunkSize, nodes.count)
+                let slice = Array(nodes[index..<upper])
+
+                // Plain VStack (NOT LazyVStack) so the whole chunk is eagerly
+                // force-measured in one pass — the "cold full-list eager
+                // measure" of PR #278.
+                let root = VStack(alignment: .leading, spacing: 4) {
+                    ForEach(slice) { node in
+                        TranscriptRow(node: node, terminalID: nil)
+                    }
+                }
+                .frame(width: Self.width)
+
+                // Fresh hosting view per chunk so SwiftUI cannot reuse a cached
+                // layout. A modest viewport frame keeps the realized backing
+                // store small; `fittingSize` still forces the full content
+                // extent to be measured.
+                let hostingView = NSHostingView(rootView: root)
+                hostingView.frame = NSRect(x: 0, y: 0, width: Self.width, height: 800)
+                totalHeight += hostingView.fittingSize.height
+            }
+            index += Self.chunkSize
+        }
+
+        let elapsed = start.duration(to: clock.now)
+        let ms = Double(elapsed.components.seconds) * 1000.0
+            + Double(elapsed.components.attoseconds) / 1_000_000_000_000_000.0
+        return (ms, totalHeight)
+    }
+
+    /// Median of a pre-sorted, non-empty array; 0 for empty input.
+    private func median(_ sorted: [Double]) -> Double {
+        guard !sorted.isEmpty else { return 0 }
+        let mid = sorted.count / 2
+        if sorted.count % 2 == 0 {
+            return (sorted[mid - 1] + sorted[mid]) / 2.0
+        }
+        return sorted[mid]
+    }
+}

--- a/Tests/TBDAppTests/TranscriptEagerMeasureBench.swift
+++ b/Tests/TBDAppTests/TranscriptEagerMeasureBench.swift
@@ -105,7 +105,7 @@ struct TranscriptEagerMeasureBench {
             let medianMs = median(sorted)
 
             print(String(
-                format: "BENCH N=%d iters=%d min=%.2f ms median=%.2f ms",
+                format: "BENCH N=%d samples=%d min=%.2f ms median=%.2f ms",
                 count, samplesMs.count, minMs, medianMs
             ))
             fflush(stdout)

--- a/Tests/TBDAppTests/TranscriptRowLayoutTests.swift
+++ b/Tests/TBDAppTests/TranscriptRowLayoutTests.swift
@@ -1,0 +1,45 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Covers both branches of `TranscriptRow.rowBody` (issue #129 per-row
+/// layout-depth flattening): a badge-less node returns `content` bare, while a
+/// node carrying `badgeUsage` wraps `content` in a `VStack` above the inlined
+/// `ContextUsageBadge`. Each branch is hosted in an `NSHostingView`, laid out,
+/// and asserted to produce a positive fitting height — a smoke proof that both
+/// `_ConditionalContent` legs build and lay out under AppKit.
+@Suite("Transcript row layout")
+@MainActor
+struct TranscriptRowLayoutTests {
+    @Test("badge-less row (content returned bare) builds and lays out")
+    func badgeLessRowLaysOut() {
+        let node = TranscriptRenderNode(
+            id: "a",
+            kind: .chatBubble(.assistantText(id: "a", text: "hello", timestamp: nil, usage: nil)),
+            badgeUsage: nil
+        )
+        #expect(node.badgeUsage == nil)
+        #expect(fittingHeight(for: node) > 0)
+    }
+
+    @Test("badge row (VStack-wrapped) builds and lays out")
+    func badgeRowLaysOut() {
+        let usage = TokenUsage(inputTokens: 1000, cacheCreationTokens: 2000, cacheReadTokens: 3000)
+        let node = TranscriptRenderNode(
+            id: "b",
+            kind: .chatBubble(.assistantText(id: "b", text: "hello", timestamp: nil, usage: usage)),
+            badgeUsage: usage
+        )
+        #expect(node.badgeUsage != nil)
+        #expect(fittingHeight(for: node) > 0)
+    }
+
+    private func fittingHeight(for node: TranscriptRenderNode) -> CGFloat {
+        let host = NSHostingView(rootView: TranscriptRow(node: node, terminalID: nil))
+        host.frame = NSRect(x: 0, y: 0, width: 560, height: 200)
+        host.layoutSubtreeIfNeeded()
+        return host.fittingSize.height
+    }
+}

--- a/Tests/TBDAppTests/TranscriptRowLayoutTests.swift
+++ b/Tests/TBDAppTests/TranscriptRowLayoutTests.swift
@@ -7,33 +7,50 @@ import TBDShared
 /// Covers both branches of `TranscriptRow.rowBody` (issue #129 per-row
 /// layout-depth flattening): a badge-less node returns `content` bare, while a
 /// node carrying `badgeUsage` wraps `content` in a `VStack` above the inlined
-/// `ContextUsageBadge`. Each branch is hosted in an `NSHostingView`, laid out,
-/// and asserted to produce a positive fitting height — a smoke proof that both
-/// `_ConditionalContent` legs build and lay out under AppKit.
+/// `ContextUsageBadge`. Both legs are constructed and measured via
+/// `NSHostingView` at the same width (560); the badge branch must reserve extra
+/// vertical space, proving the badge is actually rendered AND that the two
+/// `_ConditionalContent` legs differ (a dropped-badge regression would make
+/// them equal).
 @Suite("Transcript row layout")
 @MainActor
 struct TranscriptRowLayoutTests {
-    @Test("badge-less row (content returned bare) builds and lays out")
-    func badgeLessRowLaysOut() {
-        let node = TranscriptRenderNode(
+    @Test("badge branch reserves more height than badge-less branch")
+    func badgeBranchIsTallerThanBadgeless() {
+        // Badge-LESS leg: assistantText chat bubble, no usage badge.
+        let badgelessNode = TranscriptRenderNode(
             id: "a",
             kind: .chatBubble(.assistantText(id: "a", text: "hello", timestamp: nil, usage: nil)),
             badgeUsage: nil
         )
-        #expect(node.badgeUsage == nil)
-        #expect(fittingHeight(for: node) > 0)
-    }
+        #expect(badgelessNode.badgeUsage == nil)
 
-    @Test("badge row (VStack-wrapped) builds and lays out")
-    func badgeRowLaysOut() {
+        // Badge-PRESENT leg: same kind, non-nil TokenUsage → VStack-wrapped
+        // content above an inlined ContextUsageBadge.
         let usage = TokenUsage(inputTokens: 1000, cacheCreationTokens: 2000, cacheReadTokens: 3000)
-        let node = TranscriptRenderNode(
+        let badgeNode = TranscriptRenderNode(
             id: "b",
             kind: .chatBubble(.assistantText(id: "b", text: "hello", timestamp: nil, usage: usage)),
             badgeUsage: usage
         )
-        #expect(node.badgeUsage != nil)
-        #expect(fittingHeight(for: node) > 0)
+        #expect(badgeNode.badgeUsage != nil)
+
+        let badgelessHeight = fittingHeight(for: badgelessNode)
+        let badgeHeight = fittingHeight(for: badgeNode)
+
+        // DEFENSIVE SKIP: NSHostingView.fittingSize collapses to 0 in a
+        // non-rendering / headless environment (the same failure mode the
+        // repo's TabBarHitAreaTests hits). Treat that as inconclusive rather
+        // than a failure.
+        guard badgelessHeight > 0 else { return }
+
+        // The badge branch wraps `content` in a VStack with an extra inlined
+        // ContextUsageBadge, so it must measure taller. Equal heights would
+        // mean the badge was dropped (regression).
+        #expect(
+            badgeHeight > badgelessHeight,
+            "badge branch (\(badgeHeight)) must reserve more vertical space than badge-less branch (\(badgelessHeight)); equal heights indicate a dropped badge"
+        )
     }
 
     private func fittingHeight(for node: TranscriptRenderNode) -> CGFloat {


### PR DESCRIPTION
## Problem

Continuing the issue #129 / PR #278 work on transcript per-row **layout depth**. The 2026-06-20 captures show every trigger (activation / streaming-append / scroll / hover) funnels into *sizing the `LazyVStack` content* → recursing each row's nested layout containers, so the durable lever is making each row's `sizeThatFits` cheaper by removing layout nodes from the per-row tower.

## What changed (kept)

**Drop the per-row wrapper `VStack` when there's no usage badge** (`TranscriptRow.rowBody`). The wrapper `VStack(spacing: 2)` existed only to stack an *optional* `ContextUsageBadge` under the content. The vast majority of rows carry no badge, so they now return `content` bare — removing one `StackLayout` node per badge-less row (the dominant symbol in the #129 activation-freeze spindump). ForEach homogeneity is preserved: the parent `ForEach` still emits one `SelectableTranscriptRow` per node; the `_ConditionalContent` lives entirely behind `TranscriptRow`'s `some View` boundary.

### Measured (deterministic eager-measure bench, min of 3 contiguous passes)

| N rows | baseline | this change | Δ |
|---|---|---|---|
| 500 | 309.0 ms | 296.9 ms | **−3.9%** |
| 1000 | 616.5 ms | 598.3 ms | **−3.0%** |

Consistent, repeatable, never adverse.

## What was tried and **reverted**

**Dropping the assistant chat-bubble `.frame(maxWidth:.infinity)` flex-frame.** Sound in theory (removes a `_FlexFrameLayout` + `explicitAlignment` recursion from assistant rows), but removing it requires a conditional, which trades the flex-frame for a `_ConditionalContent` branch. Across the same 3 contiguous bench passes it was a **consistent ~1.5% regression on top of the VStack drop (6/6 measurements)** — no measurable benefit — so it was reverted per "keep what measurably reduces, revert what doesn't."

## New instrument

A gated, headless, deterministic **`NSHostingView` eager full-list measure** (`TranscriptEagerMeasureBench`, inert unless `TBD_PERF_BENCH=1`) — the deterministic complement to #280's interactive streaming harness. It force-measures N light rows in plain `VStack`s so the per-row *wrapper* cost (the layer flattenings target) dominates, giving a fast, low-noise before/after for future per-row-layout work. Run: `TBD_PERF_BENCH=1 swift test --filter TranscriptEagerMeasureBench`.

## Spindump finding (separate lever, not addressed here)

A fresh 1.35 s `hang` spindump of the `PRESEED=500` synthetic **mount** has **zero** per-row layout frames — it's 100% `ForEachState.applyNodes` / `DynamicContainerInfo.updateItems` (ForEach structural reconciliation of 500 items appearing at once) + `responderNode`. So the synchronous-mount freeze is orthogonal to per-row layout depth (it wants virtualization / incremental insertion, not flattening). Worth tracking separately under #129.

## Honest caveats

- Like #278, the **live** freeze is not reliably reproducible (synthetic cursor warps don't fire SwiftUI hover; the natural repro is intermittent), so the eager-measure bench + structural node reduction are the verification of record, not a live before/after.
- The flat-list bench **under-represents** the DEPTH recursion (nested alignment guides) seen in real hover/activation spindumps, so the measured ~3% is a lower bound on real-world benefit.

## Tests

- `TranscriptRowLayoutTests` covers both branches (badge present / absent) and asserts the badge branch measures **taller** than the badge-less branch (catches a dropped-badge regression), with a defensive skip if `fittingSize` collapses to 0 in a non-rendering environment.
- `swift build` green; `swiftlint --strict` clean; full `swift test` green except the pre-existing, environment-sensitive `TabBarHitAreaTests` (fails identically on `main`).

## Review

Reviewed; the one moderate finding (badge-toggle rebuilds the content subtree) is documented in-code as an accepted trade-off — it coincides with a node-digest change that already re-realizes the row in the baseline, and the badge lands on a stateless `.assistantText` row (#129 moved inline expand/collapse state to overlays).

[🪜 Transcript Row Flatten](https://cheapsteak.github.io/tbd/open/?worktree=82B7BC00-B218-4984-B2B4-25B1BFB5B8E7)
