### PR TITLE
fix(app): drop the CLI-install success confirmation alert

### DIFF
--- a/Sources/TBDApp/CLIInstallerCoordinator.swift
+++ b/Sources/TBDApp/CLIInstallerCoordinator.swift
@@ -184,28 +184,28 @@ final class CLIInstallerCoordinator {
         // Re-arm the launch prompt for any future unintended deletion.
         notInstalledDismissed = false
 
+        // No success confirmation when the install is fully usable — the prompt
+        // is gone and `tbd` just works, so a "done!" alert is pure noise. Only
+        // surface a follow-up when there's an action left: the install dir isn't
+        // on PATH, so the user still needs to add the export line.
+        guard !result.onPath else { return }
+
         let alert = NSAlert()
         alert.alertStyle = .informational
-        if result.onPath {
-            alert.messageText = "tbd installed"
-            alert.informativeText = "`tbd` is now available at \(result.installPath). You can run it from any terminal."
-            alert.addButton(withTitle: "OK")
-        } else {
-            alert.messageText = "tbd installed — one more step"
-            let rc = result.suggestedShellRC ?? "your shell rc file"
-            let line = result.exportLine ?? ""
-            alert.informativeText = """
-            `tbd` is now available at \(result.installPath).
+        alert.messageText = "tbd installed — one more step"
+        let rc = result.suggestedShellRC ?? "your shell rc file"
+        let line = result.exportLine ?? ""
+        alert.informativeText = """
+        `tbd` is now available at \(result.installPath).
 
-            \(installDir) is not on your shell's PATH. Add this line to \(rc) and restart your shell:
+        \(installDir) is not on your shell's PATH. Add this line to \(rc) and restart your shell:
 
-            \(line)
-            """
-            alert.addButton(withTitle: "Copy export line")
-            alert.addButton(withTitle: "OK")
-        }
+        \(line)
+        """
+        alert.addButton(withTitle: "Copy export line")
+        alert.addButton(withTitle: "OK")
         let response = alert.runModal()
-        if !result.onPath, response == .alertFirstButtonReturn, let line = result.exportLine {
+        if response == .alertFirstButtonReturn, let line = result.exportLine {
             let pb = NSPasteboard.general
             pb.clearContents()
             pb.setString(line, forType: .string)


### PR DESCRIPTION
## Summary

Installing the `tbd` CLI fired two alerts back-to-back: one asking permission to install/refresh, and a second confirming success. The confirmation added no value when the install was fully usable (the prompt is gone and `tbd` just works) — it was pure noise.

This suppresses the success alert when the install lands on PATH. The follow-up alert is kept **only** when there's an action left for the user: the install dir isn't on PATH, so they still need the export line (and the "Copy export line" button).

## Behavior change

- Auto-launch install/refresh that succeeds and is on PATH → now silent (was: "tbd installed" alert).
- Install where the dir isn't on PATH → unchanged; still shows the actionable "one more step" alert with the export line.
- Explicit menu "Reinstall" on a healthy on-PATH setup → also now silent (a direct, intended consequence of removing the success alert).

## Testing

- `swift build` passes with no new warnings.

[🔕 Remove CLI Install Success Alert](https://cheapsteak.github.io/tbd/open/?worktree=D3ADBCCD-8679-469E-AC40-FE4C25E2B29B)