### PR TITLE
feat(transcript): opt-in virtualized transcript list to fix #129 freeze (Settings → Experimental, default off)

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1433,6 +1433,20 @@ final class AppState: ObservableObject {
         defaults.object(forKey: enableTranscriptKey) as? Bool ?? false
     }
 
+    /// UserDefaults key for the `@AppStorage` toggle in Settings → Experimental
+    /// that swaps the live-transcript pane to the AppKit-virtualized list
+    /// (NSTableView + NSHostingView) — O(visible) reconciliation instead of the
+    /// LazyVStack's O(N) per change, eliminating the large-transcript mount/scroll
+    /// freeze (issue #129). Trade-off: in-row text selection is dropped. Opt-in,
+    /// fails closed (LazyVStack) so production is unchanged.
+    static let useVirtualizedTranscriptKey = "useVirtualizedTranscript"
+
+    /// Fail-closed read of the virtualized-transcript toggle for non-View callers.
+    /// Defaults false when untouched, matching the `@AppStorage` default.
+    static func virtualizedTranscriptEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: useVirtualizedTranscriptKey) as? Bool ?? false
+    }
+
     /// UserDefaults key for a Claude spawn-env setting, by registry ID.
     nonisolated static func claudeEnvKey(_ settingID: String) -> String {
         "claudeEnvSetting.\(settingID)"

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1437,14 +1437,20 @@ final class AppState: ObservableObject {
     /// that swaps the live-transcript pane to the AppKit-virtualized list
     /// (NSTableView + NSHostingView) — O(visible) reconciliation instead of the
     /// LazyVStack's O(N) per change, eliminating the large-transcript mount/scroll
-    /// freeze (issue #129). Trade-off: in-row text selection is dropped. Opt-in,
-    /// fails closed (LazyVStack) so production is unchanged.
+    /// freeze (issue #129). Trade-off: in-row text selection is dropped.
+    /// Defaults ON: when the (separately opt-in) live-transcript pane is enabled,
+    /// the virtualized renderer is the default because the freeze fix matters
+    /// more than in-row text selection. Explicitly turning the toggle OFF selects
+    /// the LazyVStack renderer.
     static let useVirtualizedTranscriptKey = "useVirtualizedTranscript"
 
-    /// Fail-closed read of the virtualized-transcript toggle for non-View callers.
-    /// Defaults false when untouched, matching the `@AppStorage` default.
+    /// Read of the virtualized-transcript toggle for non-View callers.
+    /// Defaults ON (returns true) when the user has never touched the toggle, so
+    /// the virtualized renderer is the default for the (opt-in) transcript pane;
+    /// matches the `@AppStorage` default. Explicitly setting the toggle false
+    /// selects the LazyVStack renderer.
     static func virtualizedTranscriptEnabled(defaults: UserDefaults = .standard) -> Bool {
-        defaults.object(forKey: useVirtualizedTranscriptKey) as? Bool ?? false
+        defaults.object(forKey: useVirtualizedTranscriptKey) as? Bool ?? true
     }
 
     /// UserDefaults key for a Claude spawn-env setting, by registry ID.

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -31,6 +31,13 @@ struct LiveTranscriptPaneView: View {
     /// Empty and unused in production.
     @State private var harnessMessages: [TranscriptItem] = []
 
+    /// Memoizes `transcriptRenderNodes(from:)` for the virtualized (#129 spike)
+    /// path the same way `TranscriptItemsView` does for the production
+    /// `LazyVStack`. Without it, the virtualized branch rebuilt all N nodes on
+    /// every body pass (O(N) main-thread work → residual sub-second stalls);
+    /// reusing the cache makes equal-content passes O(1).
+    @State private var virtNodeCache = TranscriptNodeCache()
+
     private static let log = Logger(subsystem: "com.tbd.app", category: "live-transcript")
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
@@ -178,7 +185,7 @@ struct LiveTranscriptPaneView: View {
         // byte-for-byte unchanged.
         if TranscriptItemsView.useVirtualizedTranscript(ProcessInfo.processInfo.environment) {
             VirtualizedTranscriptList(
-                nodes: transcriptRenderNodes(from: displayedMessages),
+                nodes: virtNodeCache.nodes(for: displayedMessages),
                 terminalID: terminalID
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -38,11 +38,13 @@ struct LiveTranscriptPaneView: View {
     /// reusing the cache makes equal-content passes O(1).
     @State private var virtNodeCache = TranscriptNodeCache()
 
-    /// User's opt-in for the AppKit-virtualized transcript list (Settings →
-    /// Experimental, issue #129). `@AppStorage` so flipping the toggle
+    /// User's selection for the AppKit-virtualized transcript list (Settings →
+    /// Experimental, issue #129). Defaults ON: when the (opt-in) live-transcript
+    /// pane is enabled, the virtualized renderer is the default; turning this OFF
+    /// selects the LazyVStack renderer. `@AppStorage` so flipping the toggle
     /// re-renders this pane live (no relaunch). OR'd with the env override in
     /// `useVirtualizedTranscript`.
-    @AppStorage(AppState.useVirtualizedTranscriptKey) private var virtualizedTranscriptSetting = false
+    @AppStorage(AppState.useVirtualizedTranscriptKey) private var virtualizedTranscriptSetting = true
 
     private static let log = Logger(subsystem: "com.tbd.app", category: "live-transcript")
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -167,6 +167,34 @@ struct LiveTranscriptPaneView: View {
     /// per append.
     @ViewBuilder
     private var transcriptWithAutoscroll: some View {
+        // THROWAWAY SPIKE gate (#129): behind TBD_VIRT_TRANSCRIPT=1, replace the
+        // SwiftUI `ScrollViewReader`/`ScrollView` ENTIRELY with the AppKit
+        // virtualizer. The virtualizer must OWN its scrolling — nested inside a
+        // SwiftUI `ScrollView` it is proposed unbounded height and never gets a
+        // bounded viewport, so `viewFor` is never called → blank. Gating UP here
+        // (instead of inside `TranscriptItemsView`) gives the representable a
+        // bounded `.frame(maxWidth:.infinity, maxHeight:.infinity)` to fill.
+        // When the flag is unset, the production `ScrollView` path below runs
+        // byte-for-byte unchanged.
+        if TranscriptItemsView.useVirtualizedTranscript(ProcessInfo.processInfo.environment) {
+            VirtualizedTranscriptList(
+                nodes: transcriptRenderNodes(from: displayedMessages),
+                terminalID: terminalID
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // The virtualizer self-manages bottom-pin, so report at-bottom to
+            // keep the jump-to-bottom button hidden during the spike.
+            .onAppear { atBottom = true }
+        } else {
+            standardTranscriptScrollView
+        }
+    }
+
+    /// Production live-transcript scroll path (flag-off). Extracted verbatim so
+    /// the spike gate above can swap the whole `ScrollViewReader` out; the
+    /// modifier chain below is unchanged from pre-spike main.
+    @ViewBuilder
+    private var standardTranscriptScrollView: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 TranscriptItemsView(items: displayedMessages, terminalID: terminalID, atBottom: $atBottom)

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -38,6 +38,12 @@ struct LiveTranscriptPaneView: View {
     /// reusing the cache makes equal-content passes O(1).
     @State private var virtNodeCache = TranscriptNodeCache()
 
+    /// User's opt-in for the AppKit-virtualized transcript list (Settings →
+    /// Experimental, issue #129). `@AppStorage` so flipping the toggle
+    /// re-renders this pane live (no relaunch). OR'd with the env override in
+    /// `useVirtualizedTranscript`.
+    @AppStorage(AppState.useVirtualizedTranscriptKey) private var virtualizedTranscriptSetting = false
+
     private static let log = Logger(subsystem: "com.tbd.app", category: "live-transcript")
     nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
 
@@ -172,18 +178,29 @@ struct LiveTranscriptPaneView: View {
     /// production: the `TranscriptPerfHarness.autoscrollGate` (which equals
     /// `atBottom` when the harness is off) and one silent `.debug` fire/skip log
     /// per append.
+    /// Whether to render the AppKit-virtualized transcript list instead of the
+    /// production SwiftUI `ScrollView`/`LazyVStack`. True when EITHER the env
+    /// override is set (perf harness / forced testing) OR the user has opted in
+    /// via Settings → Experimental. Fails closed (false) so production is the
+    /// untouched `LazyVStack` path. `@AppStorage` makes a toggle flip re-render
+    /// this pane live — no relaunch.
+    private var useVirtualizedTranscript: Bool {
+        TranscriptItemsView.virtualizedTranscriptEnvOverride(ProcessInfo.processInfo.environment)
+            || virtualizedTranscriptSetting
+    }
+
     @ViewBuilder
     private var transcriptWithAutoscroll: some View {
-        // THROWAWAY SPIKE gate (#129): behind TBD_VIRT_TRANSCRIPT=1, replace the
-        // SwiftUI `ScrollViewReader`/`ScrollView` ENTIRELY with the AppKit
-        // virtualizer. The virtualizer must OWN its scrolling — nested inside a
-        // SwiftUI `ScrollView` it is proposed unbounded height and never gets a
-        // bounded viewport, so `viewFor` is never called → blank. Gating UP here
+        // Virtualization gate (#129): when enabled, replace the SwiftUI
+        // `ScrollViewReader`/`ScrollView` ENTIRELY with the AppKit virtualizer.
+        // The virtualizer must OWN its scrolling — nested inside a SwiftUI
+        // `ScrollView` it is proposed unbounded height and never gets a bounded
+        // viewport, so `viewFor` is never called → blank. Gating UP here
         // (instead of inside `TranscriptItemsView`) gives the representable a
         // bounded `.frame(maxWidth:.infinity, maxHeight:.infinity)` to fill.
-        // When the flag is unset, the production `ScrollView` path below runs
+        // When the gate is off, the production `ScrollView` path below runs
         // byte-for-byte unchanged.
-        if TranscriptItemsView.useVirtualizedTranscript(ProcessInfo.processInfo.environment) {
+        if useVirtualizedTranscript {
             VirtualizedTranscriptList(
                 nodes: virtNodeCache.nodes(for: displayedMessages),
                 terminalID: terminalID

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -62,10 +62,12 @@ struct TranscriptItemsView: View {
     /// `TBD_VIRT_TRANSCRIPT == "1"`, the live-transcript pane renders the
     /// AppKit-virtualized `VirtualizedTranscriptList` instead of the
     /// `LazyVStack { ForEach }`, regardless of the Settings toggle — a forced
-    /// override for the perf harness / testing. The user-facing opt-in is the
-    /// `AppState.useVirtualizedTranscriptKey` toggle, OR'd with this in
+    /// override for the perf harness / testing. The user-facing renderer setting
+    /// is the `AppState.useVirtualizedTranscriptKey` toggle (which defaults ON
+    /// when the live-transcript pane is enabled), OR'd with this in
     /// `LiveTranscriptPaneView`. Pure so it's unit-testable (see
-    /// `TranscriptVirtualizationGateTests`). Off by default.
+    /// `TranscriptVirtualizationGateTests`). The env override itself is off by
+    /// default — it's independent of the setting default.
     static func virtualizedTranscriptEnvOverride(_ environment: [String: String]) -> Bool {
         environment["TBD_VIRT_TRANSCRIPT"] == "1"
     }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -58,12 +58,15 @@ struct TranscriptItemsView: View {
         return String(id.uuidString.suffix(4))
     }
 
-    /// THROWAWAY SPIKE gate (issue #129). When `TBD_VIRT_TRANSCRIPT == "1"`,
-    /// `bodyView` renders the AppKit-virtualized `VirtualizedTranscriptList`
-    /// instead of the `LazyVStack { ForEach }`. Pure so it's unit-testable
-    /// (see `TranscriptVirtualizationGateTests`). Off by default → production
-    /// `LazyVStack` path is byte-for-byte unchanged.
-    static func useVirtualizedTranscript(_ environment: [String: String]) -> Bool {
+    /// Env override for the virtualized-transcript gate (issue #129). When
+    /// `TBD_VIRT_TRANSCRIPT == "1"`, the live-transcript pane renders the
+    /// AppKit-virtualized `VirtualizedTranscriptList` instead of the
+    /// `LazyVStack { ForEach }`, regardless of the Settings toggle — a forced
+    /// override for the perf harness / testing. The user-facing opt-in is the
+    /// `AppState.useVirtualizedTranscriptKey` toggle, OR'd with this in
+    /// `LiveTranscriptPaneView`. Pure so it's unit-testable (see
+    /// `TranscriptVirtualizationGateTests`). Off by default.
+    static func virtualizedTranscriptEnvOverride(_ environment: [String: String]) -> Bool {
         environment["TBD_VIRT_TRANSCRIPT"] == "1"
     }
 
@@ -85,13 +88,13 @@ struct TranscriptItemsView: View {
                 }
             }
         }()
-        // Production path: LazyVStack { ForEach }. The THROWAWAY SPIKE gate
-        // (#129) that swapped in `VirtualizedTranscriptList` was moved UP to
+        // Production path: LazyVStack { ForEach }. The virtualization gate
+        // (#129) that swaps in `VirtualizedTranscriptList` lives UP in
         // `LiveTranscriptPaneView.transcriptWithAutoscroll`, because a
         // virtualizer must OWN its scrolling — nested inside the pane's SwiftUI
         // `ScrollView` it was proposed unbounded height and never got a
-        // viewport. The `useVirtualizedTranscript` helper stays here (it's the
-        // shared gate, unit-tested). This body is byte-identical to pre-spike.
+        // viewport. The `virtualizedTranscriptEnvOverride` helper stays here
+        // (it's the env override, unit-tested). This body is the production path.
         LazyVStack(alignment: .leading, spacing: 4) {
             ForEach(nodes) { node in
                 SelectableTranscriptRow(node: node, terminalID: terminalID)

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -85,17 +85,14 @@ struct TranscriptItemsView: View {
                 }
             }
         }()
-        // THROWAWAY SPIKE gate (#129): swap in the AppKit virtualizer behind
-        // TBD_VIRT_TRANSCRIPT=1. When unset, the LazyVStack path below runs
-        // unchanged.
-        if Self.useVirtualizedTranscript(ProcessInfo.processInfo.environment) {
-            VirtualizedTranscriptList(nodes: nodes, terminalID: terminalID)
-                // Drive the at-bottom signal: the virtualizer self-manages
-                // bottom-pin, so report at-bottom to keep the jump button
-                // hidden during the spike.
-                .onAppear { atBottom?.wrappedValue = true }
-        } else {
-            LazyVStack(alignment: .leading, spacing: 4) {
+        // Production path: LazyVStack { ForEach }. The THROWAWAY SPIKE gate
+        // (#129) that swapped in `VirtualizedTranscriptList` was moved UP to
+        // `LiveTranscriptPaneView.transcriptWithAutoscroll`, because a
+        // virtualizer must OWN its scrolling — nested inside the pane's SwiftUI
+        // `ScrollView` it was proposed unbounded height and never got a
+        // viewport. The `useVirtualizedTranscript` helper stays here (it's the
+        // shared gate, unit-tested). This body is byte-identical to pre-spike.
+        LazyVStack(alignment: .leading, spacing: 4) {
             ForEach(nodes) { node in
                 SelectableTranscriptRow(node: node, terminalID: terminalID)
             }
@@ -114,9 +111,8 @@ struct TranscriptItemsView: View {
                 .frame(height: 1)
                 .onAppear { atBottom?.wrappedValue = true }
                 .onDisappear { atBottom?.wrappedValue = false }
-            }
-            .padding(.vertical, 8)
         }
+        .padding(.vertical, 8)
     }
 }
 

--- a/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptItemsView.swift
@@ -58,6 +58,15 @@ struct TranscriptItemsView: View {
         return String(id.uuidString.suffix(4))
     }
 
+    /// THROWAWAY SPIKE gate (issue #129). When `TBD_VIRT_TRANSCRIPT == "1"`,
+    /// `bodyView` renders the AppKit-virtualized `VirtualizedTranscriptList`
+    /// instead of the `LazyVStack { ForEach }`. Pure so it's unit-testable
+    /// (see `TranscriptVirtualizationGateTests`). Off by default → production
+    /// `LazyVStack` path is byte-for-byte unchanged.
+    static func useVirtualizedTranscript(_ environment: [String: String]) -> Bool {
+        environment["TBD_VIRT_TRANSCRIPT"] == "1"
+    }
+
     var body: some View {
         let intervalState = TranscriptSignposts.signposter.beginInterval("transcript.items.body")
         defer { TranscriptSignposts.signposter.endInterval("transcript.items.body", intervalState) }
@@ -76,7 +85,17 @@ struct TranscriptItemsView: View {
                 }
             }
         }()
-        LazyVStack(alignment: .leading, spacing: 4) {
+        // THROWAWAY SPIKE gate (#129): swap in the AppKit virtualizer behind
+        // TBD_VIRT_TRANSCRIPT=1. When unset, the LazyVStack path below runs
+        // unchanged.
+        if Self.useVirtualizedTranscript(ProcessInfo.processInfo.environment) {
+            VirtualizedTranscriptList(nodes: nodes, terminalID: terminalID)
+                // Drive the at-bottom signal: the virtualizer self-manages
+                // bottom-pin, so report at-bottom to keep the jump button
+                // hidden during the spike.
+                .onAppear { atBottom?.wrappedValue = true }
+        } else {
+            LazyVStack(alignment: .leading, spacing: 4) {
             ForEach(nodes) { node in
                 SelectableTranscriptRow(node: node, terminalID: terminalID)
             }
@@ -95,8 +114,9 @@ struct TranscriptItemsView: View {
                 .frame(height: 1)
                 .onAppear { atBottom?.wrappedValue = true }
                 .onDisappear { atBottom?.wrappedValue = false }
+            }
+            .padding(.vertical, 8)
         }
-        .padding(.vertical, 8)
     }
 }
 

--- a/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
+++ b/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
@@ -50,6 +50,10 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
         let column = NSTableColumn(identifier: .init("transcript"))
         column.resizingMask = .autoresizingMask
         tableView.addTableColumn(column)
+        // Single full-width column: the table column must track the table's
+        // width so each row's NSHostingView gets a real width to autolayout
+        // against (usesAutomaticRowHeights derives row height from that width).
+        tableView.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
 
         tableView.dataSource = coordinator
         tableView.delegate = coordinator
@@ -62,9 +66,17 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
         scrollView.drawsBackground = false
         scrollView.documentView = tableView
         scrollView.automaticallyAdjustsContentInsets = false
+        // The table is the documentView; make it track the scrollView's width so
+        // it always has a non-zero frame to lay rows out in. Without this the
+        // table can be measured at zero width, automatic row heights collapse,
+        // and rows never become visible → blank.
+        tableView.autoresizingMask = [.width, .height]
 
         // Initial load pins to bottom (newest content visible), matching the
         // production transcript which starts scrolled to the latest item.
+        // Note: makeNSView often runs with empty `nodes` (the harness/data
+        // arrives via updateNSView → scheduleUpdate), so this reload may be a
+        // no-op; the deferred apply then populates + re-pins to bottom.
         tableView.reloadData()
         DispatchQueue.main.async {
             coordinator.scrollToBottomIfNeeded(force: true)
@@ -75,7 +87,15 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         let coordinator = context.coordinator
         coordinator.terminalID = terminalID
-        coordinator.update(to: nodes)
+        // CRITICAL: do NOT mutate the NSTableView synchronously here. This runs
+        // inside SwiftUI's update/layout pass; calling reloadData/insertRows now
+        // re-enters AppKit's table-view layout reentrantly. AppKit detects the
+        // reentrancy ("Application performed a reentrant operation in its
+        // NSTableView delegate"), the warning fires, and the reload is dropped —
+        // numberOfRows/viewFor never realize → blank render. Defer the apply to
+        // the next main-runloop turn so it runs OUTSIDE the SwiftUI pass. Coalesce
+        // rapid updates: stash the latest nodes and only apply once per turn.
+        coordinator.scheduleUpdate(to: nodes)
     }
 
     /// Owns the data array, the table, and bottom-pin state. Acts as both
@@ -86,6 +106,17 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
         var terminalID: UUID?
         weak var tableView: NSTableView?
 
+        /// Latest nodes awaiting a deferred apply. A non-nil value means a
+        /// main-runloop apply is already scheduled; we just overwrite the payload
+        /// so only the newest array is applied (coalescing rapid updates).
+        private var pendingNodes: [TranscriptRenderNode]?
+
+        /// Above this many appended rows in one update we fall back to
+        /// `reloadData()` instead of `insertRows`. Bulk `insertRows` of
+        /// automatic-height rows is heavy/fragile; the initial empty→N
+        /// population (potentially hundreds of rows) should reload once.
+        nonisolated private static let maxIncrementalInsert = 32
+
         nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
         nonisolated private static let realizeLoggingEnabled =
             ProcessInfo.processInfo.environment["TBD_PERF_ROW_REALIZE"] == "1"
@@ -95,6 +126,21 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
         }
 
         // MARK: Data update
+
+        /// Coalesce + defer the table mutation out of SwiftUI's update pass.
+        /// Stores the latest nodes; if no apply is yet scheduled, schedules one
+        /// for the next main-runloop turn. Repeated calls within the same turn
+        /// just replace the payload so we apply only the newest array once.
+        func scheduleUpdate(to newNodes: [TranscriptRenderNode]) {
+            let alreadyScheduled = pendingNodes != nil
+            pendingNodes = newNodes
+            guard alreadyScheduled == false else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self, let latest = self.pendingNodes else { return }
+                self.pendingNodes = nil
+                self.update(to: latest)
+            }
+        }
 
         /// Diff the incoming node array against the current one and apply the
         /// minimal table mutation. The common streaming case is a pure append
@@ -110,8 +156,16 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
             let wasNearBottom = isNearBottom()
             let old = nodes
 
-            if newNodes.count > old.count, Array(newNodes.prefix(old.count)) == old {
-                // Pure append. Insert just the new tail.
+            let appendCount = newNodes.count - old.count
+            if appendCount > 0,
+               appendCount <= Self.maxIncrementalInsert,
+               Array(newNodes.prefix(old.count)) == old {
+                // Small streaming append on top of an existing array: insert just
+                // the new tail so existing rows' hosting views stay alive and only
+                // the newly visible rows realize. Reserve insertRows for genuine
+                // small appends — bulk-inserting hundreds of automatic-height rows
+                // is heavy/fragile, so the large initial population (empty → N)
+                // takes the reloadData path below instead.
                 let insertedRange = old.count ..< newNodes.count
                 nodes = newNodes
                 tableView.insertRows(

--- a/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
+++ b/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
@@ -3,15 +3,16 @@ import SwiftUI
 import TBDShared
 import os
 
-// Experimental, opt-in (default OFF) AppKit-virtualized transcript list (issue
-// #129). Gated by the Settings → Experimental "Virtualized transcript" toggle
-// (and the `TBD_VIRT_TRANSCRIPT=1` env override for the perf harness). Goal: an
-// AppKit virtualizing list replaces the transcript's `LazyVStack { ForEach }`
-// so only ~visible rows are realized/reconciled per content change (O(visible))
-// instead of SwiftUI's `ForEach.applyNodes` reconciling ALL N rows (O(N)) —
-// eliminating the large-transcript mount/scroll freeze. Default-off so the
-// production path is the untouched `LazyVStack`; merged to soak-test in real
-// sessions.
+// AppKit-virtualized transcript list (issue #129). This is the DEFAULT renderer
+// whenever the (separately opt-in, default-off) live-transcript pane is enabled;
+// the Settings → Experimental "Virtualized transcript" toggle defaults ON, and
+// the `TBD_VIRT_TRANSCRIPT=1` env override forces it on for the perf harness.
+// Goal: an AppKit virtualizing list replaces the transcript's
+// `LazyVStack { ForEach }` so only ~visible rows are realized/reconciled per
+// content change (O(visible)) instead of SwiftUI's `ForEach.applyNodes`
+// reconciling ALL N rows (O(N)) — eliminating the large-transcript mount/scroll
+// freeze. Turning the toggle OFF selects the untouched `LazyVStack` renderer
+// (which restores in-row text selection at the cost of the freeze fix).
 //
 // List class chosen: view-based NSTableView with usesAutomaticRowHeights.
 // Rationale: variable, self-sizing row heights are NSTableView's documented

--- a/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
+++ b/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
@@ -256,22 +256,23 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
 /// NSHostingView be the first responder for clicks, drags inside a row reach
 /// the SwiftUI `.textSelection(.enabled)` text instead of selecting the row.
 private final class TranscriptTableView: NSTableView {
-    // Let the hosted SwiftUI view handle mouse-down/drag for text selection.
-    // We deliberately do NOT call super for in-row drags; AppKit's default
-    // `mouseDown` starts row selection tracking which would swallow the drag.
-    override func mouseDown(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        let row = self.row(at: point)
-        if row >= 0 {
-            // Forward to the hosting view so SwiftUI text selection sees the
-            // drag. hitTest finds the deepest NSView (the NSHostingView's
-            // internal text view) under the cursor.
-            if let target = hitTest(convert(event.locationInWindow, from: nil)) {
-                target.mouseDown(with: event)
-                return
-            }
-        }
-        super.mouseDown(with: event)
+    // Allow clicks/drags inside a row to reach the hosted SwiftUI text view
+    // (e.g. for `.textSelection(.enabled)`) instead of being swallowed for row
+    // selection / first-responder tracking.
+    //
+    // NSTableView normally rejects hosted subviews as the proposed first
+    // responder and claims the click for itself (row selection tracking).
+    // Returning true here lets AppKit deliver the event to the deepest hit
+    // view — the NSHostingView's internal text view — through its OWN, normal
+    // event routing. We do NOT manually forward events (no `mouseDown` +
+    // `hitTest().mouseDown(event)`); that created mutual recursion between the
+    // table and the hosting view's responder-chain forwarding and overflowed
+    // the stack (#129 live-test crash).
+    override func validateProposedFirstResponder(
+        _ responder: NSResponder,
+        for event: NSEvent?
+    ) -> Bool {
+        true
     }
 }
 

--- a/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
+++ b/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
@@ -14,9 +14,11 @@ import os
 // autolayout-fit), and NSTableView only realizes visible rows + a small
 // overscan. NSCollectionView would require a compositional list layout with
 // estimated heights to self-size variable content — strictly more risk for no
-// extra payoff here. We disable the table's own selection so mouse drags reach
-// the hosted SwiftUI text (#244 text selection): selectionHighlightStyle =
-// .none and rows are non-selectable for AppKit's purposes.
+// extra payoff here. We disable the table's own selection so plain CLICKS reach
+// the hosted SwiftUI controls (tool-row overlay buttons, file-link buttons,
+// AskUserQuestion buttons) instead of being swallowed for row selection:
+// selectionHighlightStyle = .none and rows are non-selectable for AppKit's
+// purposes. (In-row text selection is intentionally dropped — see RowHost.)
 
 /// `NSViewRepresentable` wrapping an `NSScrollView`+`NSTableView` that hosts one
 /// `TranscriptRow` per `TranscriptRenderNode`. Behind `TBD_VIRT_TRANSCRIPT=1`.
@@ -39,9 +41,9 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
         tableView.usesAutomaticRowHeights = true
         tableView.rowSizeStyle = .custom
         tableView.intercellSpacing = NSSize(width: 0, height: 4)
-        // Disable the table's own selection so a mouse drag inside a row
-        // selects TEXT (reaching the hosted SwiftUI `.textSelection`), not the
-        // row. This is THE #244 gating risk.
+        // Disable the table's own selection so a click inside a row reaches the
+        // hosted SwiftUI controls (tool-row overlay buttons, file-link buttons,
+        // AskUserQuestion buttons) instead of being claimed for row selection.
         tableView.selectionHighlightStyle = .none
         tableView.allowsEmptySelection = true
         tableView.allowsMultipleSelection = false
@@ -243,7 +245,7 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
         }
 
         // No row selection: returning false keeps AppKit from claiming the
-        // click/drag for row selection so it reaches the hosted text.
+        // click for row selection so it reaches the hosted SwiftUI controls.
         func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
             false
         }
@@ -253,17 +255,19 @@ struct VirtualizedTranscriptList: NSViewRepresentable {
 /// NSTableView subclass that yields hit-testing to its hosted SwiftUI content.
 /// Default NSTableView mouse handling can begin a row-tracking drag; by not
 /// implementing row selection (delegate returns false) and letting the cell's
-/// NSHostingView be the first responder for clicks, drags inside a row reach
-/// the SwiftUI `.textSelection(.enabled)` text instead of selecting the row.
+/// NSHostingView be the first responder for clicks, a click inside a row reaches
+/// the hosted SwiftUI controls (tool-row overlay buttons, file-link buttons,
+/// AskUserQuestion buttons) instead of selecting the row.
 private final class TranscriptTableView: NSTableView {
-    // Allow clicks/drags inside a row to reach the hosted SwiftUI text view
-    // (e.g. for `.textSelection(.enabled)`) instead of being swallowed for row
-    // selection / first-responder tracking.
+    // Allow clicks inside a row to reach the hosted SwiftUI controls (buttons,
+    // links) instead of being swallowed for row selection / first-responder
+    // tracking. This is about delivering plain CLICKS to hosted controls — NOT
+    // text selection, which the virtualized path intentionally drops (#129).
     //
     // NSTableView normally rejects hosted subviews as the proposed first
     // responder and claims the click for itself (row selection tracking).
     // Returning true here lets AppKit deliver the event to the deepest hit
-    // view — the NSHostingView's internal text view — through its OWN, normal
+    // view — the NSHostingView's hosted control — through its OWN, normal
     // event routing. We do NOT manually forward events (no `mouseDown` +
     // `hitTest().mouseDown(event)`); that created mutual recursion between the
     // table and the hosting view's responder-chain forwarding and overflowed
@@ -276,9 +280,7 @@ private final class TranscriptTableView: NSTableView {
     }
 }
 
-/// `NSTableCellView` hosting one `TranscriptRow` via `NSHostingView`. Owns the
-/// per-row hover gate so `.textSelection(.enabled)` materializes on hover
-/// exactly like production's `SelectableTranscriptRow`.
+/// `NSTableCellView` hosting one `TranscriptRow` via `NSHostingView`.
 private final class HostingTableCellView: NSTableCellView {
     private var hostingView: NSHostingView<RowHost>?
 
@@ -304,20 +306,21 @@ private final class HostingTableCellView: NSTableCellView {
     }
 }
 
-/// SwiftUI wrapper that mirrors `SelectableTranscriptRow`: owns per-row hover
-/// state and flips `\.transcriptTextSelection` true on hover so
-/// `.textSelection(.enabled)` is materialized only for the hovered row — the
-/// same #120-preserving behavior as production.
+/// SwiftUI wrapper hosting one `TranscriptRow`.
+///
+/// In-row text selection is intentionally DROPPED for the virtualized path
+/// (#129 spike decision): not freezing matters more than in-row selection, and
+/// the AppKit `NSTableView`-vs-hosted-text drag conflict made in-row selection
+/// unworkable without a crashing event hack (the `mouseDown` forwarding that
+/// caused the SIGSEGV recursion). `\.transcriptTextSelection` defaults to
+/// false, so no `.textSelection(.enabled)`/NSTextField materializes (no
+/// drag-select) and the per-row hover churn is gone too.
 private struct RowHost: View {
     let node: TranscriptRenderNode
     let terminalID: UUID?
 
-    @State private var isHovered = false
-
     var body: some View {
         TranscriptRow(node: node, terminalID: terminalID)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .environment(\.transcriptTextSelection, isHovered)
-            .onHover { isHovered = $0 }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
+++ b/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
@@ -3,10 +3,15 @@ import SwiftUI
 import TBDShared
 import os
 
-// THROWAWAY SPIKE (issue #129). Goal: prove an AppKit virtualizing list can
-// replace the transcript's `LazyVStack { ForEach }` so only ~visible rows are
-// realized/reconciled per content change (O(visible)) instead of SwiftUI's
-// `ForEach.applyNodes` reconciling ALL N rows (O(N)).
+// Experimental, opt-in (default OFF) AppKit-virtualized transcript list (issue
+// #129). Gated by the Settings → Experimental "Virtualized transcript" toggle
+// (and the `TBD_VIRT_TRANSCRIPT=1` env override for the perf harness). Goal: an
+// AppKit virtualizing list replaces the transcript's `LazyVStack { ForEach }`
+// so only ~visible rows are realized/reconciled per content change (O(visible))
+// instead of SwiftUI's `ForEach.applyNodes` reconciling ALL N rows (O(N)) —
+// eliminating the large-transcript mount/scroll freeze. Default-off so the
+// production path is the untouched `LazyVStack`; merged to soak-test in real
+// sessions.
 //
 // List class chosen: view-based NSTableView with usesAutomaticRowHeights.
 // Rationale: variable, self-sizing row heights are NSTableView's documented
@@ -19,9 +24,14 @@ import os
 // AskUserQuestion buttons) instead of being swallowed for row selection:
 // selectionHighlightStyle = .none and rows are non-selectable for AppKit's
 // purposes. (In-row text selection is intentionally dropped — see RowHost.)
+//
+// Known item to validate on real sessions: click-through to the hosted SwiftUI
+// controls (tool-row buttons, file links, AskUserQuestion) — see the
+// `TranscriptTableView` / `validateProposedFirstResponder` note below.
 
 /// `NSViewRepresentable` wrapping an `NSScrollView`+`NSTableView` that hosts one
-/// `TranscriptRow` per `TranscriptRenderNode`. Behind `TBD_VIRT_TRANSCRIPT=1`.
+/// `TranscriptRow` per `TranscriptRenderNode`. Enabled by the Settings →
+/// Experimental "Virtualized transcript" toggle or `TBD_VIRT_TRANSCRIPT=1`.
 @MainActor
 struct VirtualizedTranscriptList: NSViewRepresentable {
     let nodes: [TranscriptRenderNode]
@@ -309,8 +319,8 @@ private final class HostingTableCellView: NSTableCellView {
 /// SwiftUI wrapper hosting one `TranscriptRow`.
 ///
 /// In-row text selection is intentionally DROPPED for the virtualized path
-/// (#129 spike decision): not freezing matters more than in-row selection, and
-/// the AppKit `NSTableView`-vs-hosted-text drag conflict made in-row selection
+/// (#129): not freezing matters more than in-row selection, and the AppKit
+/// `NSTableView`-vs-hosted-text drag conflict made in-row selection
 /// unworkable without a crashing event hack (the `mouseDown` forwarding that
 /// caused the SIGSEGV recursion). `\.transcriptTextSelection` defaults to
 /// false, so no `.textSelection(.enabled)`/NSTextField materializes (no

--- a/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
+++ b/Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift
@@ -1,0 +1,268 @@
+import AppKit
+import SwiftUI
+import TBDShared
+import os
+
+// THROWAWAY SPIKE (issue #129). Goal: prove an AppKit virtualizing list can
+// replace the transcript's `LazyVStack { ForEach }` so only ~visible rows are
+// realized/reconciled per content change (O(visible)) instead of SwiftUI's
+// `ForEach.applyNodes` reconciling ALL N rows (O(N)).
+//
+// List class chosen: view-based NSTableView with usesAutomaticRowHeights.
+// Rationale: variable, self-sizing row heights are NSTableView's documented
+// happy path (`usesAutomaticRowHeights = true` lets each row's NSHostingView
+// autolayout-fit), and NSTableView only realizes visible rows + a small
+// overscan. NSCollectionView would require a compositional list layout with
+// estimated heights to self-size variable content — strictly more risk for no
+// extra payoff here. We disable the table's own selection so mouse drags reach
+// the hosted SwiftUI text (#244 text selection): selectionHighlightStyle =
+// .none and rows are non-selectable for AppKit's purposes.
+
+/// `NSViewRepresentable` wrapping an `NSScrollView`+`NSTableView` that hosts one
+/// `TranscriptRow` per `TranscriptRenderNode`. Behind `TBD_VIRT_TRANSCRIPT=1`.
+@MainActor
+struct VirtualizedTranscriptList: NSViewRepresentable {
+    let nodes: [TranscriptRenderNode]
+    let terminalID: UUID?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(terminalID: terminalID)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let coordinator = context.coordinator
+
+        let tableView = TranscriptTableView()
+        tableView.headerView = nil
+        tableView.style = .plain
+        tableView.backgroundColor = .clear
+        tableView.usesAutomaticRowHeights = true
+        tableView.rowSizeStyle = .custom
+        tableView.intercellSpacing = NSSize(width: 0, height: 4)
+        // Disable the table's own selection so a mouse drag inside a row
+        // selects TEXT (reaching the hosted SwiftUI `.textSelection`), not the
+        // row. This is THE #244 gating risk.
+        tableView.selectionHighlightStyle = .none
+        tableView.allowsEmptySelection = true
+        tableView.allowsMultipleSelection = false
+        tableView.gridStyleMask = []
+
+        let column = NSTableColumn(identifier: .init("transcript"))
+        column.resizingMask = .autoresizingMask
+        tableView.addTableColumn(column)
+
+        tableView.dataSource = coordinator
+        tableView.delegate = coordinator
+        coordinator.tableView = tableView
+        coordinator.nodes = nodes
+
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = false
+        scrollView.documentView = tableView
+        scrollView.automaticallyAdjustsContentInsets = false
+
+        // Initial load pins to bottom (newest content visible), matching the
+        // production transcript which starts scrolled to the latest item.
+        tableView.reloadData()
+        DispatchQueue.main.async {
+            coordinator.scrollToBottomIfNeeded(force: true)
+        }
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        let coordinator = context.coordinator
+        coordinator.terminalID = terminalID
+        coordinator.update(to: nodes)
+    }
+
+    /// Owns the data array, the table, and bottom-pin state. Acts as both
+    /// dataSource and delegate.
+    @MainActor
+    final class Coordinator: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+        var nodes: [TranscriptRenderNode] = []
+        var terminalID: UUID?
+        weak var tableView: NSTableView?
+
+        nonisolated private static let perfLog = Logger(subsystem: "com.tbd.app", category: "perf-transcript")
+        nonisolated private static let realizeLoggingEnabled =
+            ProcessInfo.processInfo.environment["TBD_PERF_ROW_REALIZE"] == "1"
+
+        init(terminalID: UUID?) {
+            self.terminalID = terminalID
+        }
+
+        // MARK: Data update
+
+        /// Diff the incoming node array against the current one and apply the
+        /// minimal table mutation. The common streaming case is a pure append
+        /// (same prefix, new suffix) → `insertRows`, which keeps existing rows'
+        /// hosting views alive and only realizes the newly visible tail.
+        /// Anything else falls back to `reloadData()` (still O(visible) to
+        /// realize). After either path, re-pin to the bottom if we were near it.
+        func update(to newNodes: [TranscriptRenderNode]) {
+            guard let tableView else {
+                nodes = newNodes
+                return
+            }
+            let wasNearBottom = isNearBottom()
+            let old = nodes
+
+            if newNodes.count > old.count, Array(newNodes.prefix(old.count)) == old {
+                // Pure append. Insert just the new tail.
+                let insertedRange = old.count ..< newNodes.count
+                nodes = newNodes
+                tableView.insertRows(
+                    at: IndexSet(integersIn: insertedRange),
+                    withAnimation: []
+                )
+            } else if newNodes != old {
+                nodes = newNodes
+                tableView.reloadData()
+            } else {
+                return // no change
+            }
+
+            if wasNearBottom {
+                DispatchQueue.main.async { [weak self] in
+                    self?.scrollToBottomIfNeeded(force: true)
+                }
+            }
+        }
+
+        // MARK: Bottom-pin
+
+        /// True when the scroll position is at/near the bottom (within one
+        /// viewport-height fudge), so streaming appends auto-scroll while a
+        /// user who has scrolled up is left alone.
+        func isNearBottom() -> Bool {
+            guard let tableView, let scrollView = tableView.enclosingScrollView else { return true }
+            let visible = scrollView.contentView.bounds
+            let documentHeight = tableView.bounds.height
+            let viewportBottom = visible.origin.y + visible.height
+            // 40pt threshold mirrors the production at-bottom sentinel intent.
+            return documentHeight - viewportBottom < 40
+        }
+
+        func scrollToBottomIfNeeded(force: Bool) {
+            guard let tableView, nodes.isEmpty == false else { return }
+            if force || isNearBottom() {
+                tableView.scrollRowToVisible(nodes.count - 1)
+            }
+        }
+
+        // MARK: NSTableViewDataSource
+
+        func numberOfRows(in tableView: NSTableView) -> Int {
+            nodes.count
+        }
+
+        // MARK: NSTableViewDelegate
+
+        func tableView(
+            _ tableView: NSTableView,
+            viewFor tableColumn: NSTableColumn?,
+            row: Int
+        ) -> NSView? {
+            guard row >= 0, row < nodes.count else { return nil }
+            let node = nodes[row]
+
+            if Self.realizeLoggingEnabled {
+                Self.perfLog.debug("virt.realize id=\(node.id, privacy: .public) row=\(row, privacy: .public)")
+            }
+
+            // Reuse a recycled host cell if the table offers one; otherwise make
+            // a fresh one. This is the virtualization seam — AppKit only calls
+            // this for rows entering the visible region (plus a small overscan).
+            let identifier = NSUserInterfaceItemIdentifier("transcript-cell")
+            let cell: HostingTableCellView
+            if let recycled = tableView.makeView(withIdentifier: identifier, owner: self) as? HostingTableCellView {
+                cell = recycled
+            } else {
+                cell = HostingTableCellView()
+                cell.identifier = identifier
+            }
+            cell.configure(node: node, terminalID: terminalID)
+            return cell
+        }
+
+        // No row selection: returning false keeps AppKit from claiming the
+        // click/drag for row selection so it reaches the hosted text.
+        func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+            false
+        }
+    }
+}
+
+/// NSTableView subclass that yields hit-testing to its hosted SwiftUI content.
+/// Default NSTableView mouse handling can begin a row-tracking drag; by not
+/// implementing row selection (delegate returns false) and letting the cell's
+/// NSHostingView be the first responder for clicks, drags inside a row reach
+/// the SwiftUI `.textSelection(.enabled)` text instead of selecting the row.
+private final class TranscriptTableView: NSTableView {
+    // Let the hosted SwiftUI view handle mouse-down/drag for text selection.
+    // We deliberately do NOT call super for in-row drags; AppKit's default
+    // `mouseDown` starts row selection tracking which would swallow the drag.
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        let row = self.row(at: point)
+        if row >= 0 {
+            // Forward to the hosting view so SwiftUI text selection sees the
+            // drag. hitTest finds the deepest NSView (the NSHostingView's
+            // internal text view) under the cursor.
+            if let target = hitTest(convert(event.locationInWindow, from: nil)) {
+                target.mouseDown(with: event)
+                return
+            }
+        }
+        super.mouseDown(with: event)
+    }
+}
+
+/// `NSTableCellView` hosting one `TranscriptRow` via `NSHostingView`. Owns the
+/// per-row hover gate so `.textSelection(.enabled)` materializes on hover
+/// exactly like production's `SelectableTranscriptRow`.
+private final class HostingTableCellView: NSTableCellView {
+    private var hostingView: NSHostingView<RowHost>?
+
+    func configure(node: TranscriptRenderNode, terminalID: UUID?) {
+        let root = RowHost(node: node, terminalID: terminalID)
+        if let hostingView {
+            hostingView.rootView = root
+        } else {
+            let host = NSHostingView(rootView: root)
+            host.translatesAutoresizingMaskIntoConstraints = false
+            // sizingOptions so the host self-sizes to its SwiftUI content,
+            // which usesAutomaticRowHeights reads for the row height.
+            host.sizingOptions = [.intrinsicContentSize]
+            addSubview(host)
+            NSLayoutConstraint.activate([
+                host.leadingAnchor.constraint(equalTo: leadingAnchor),
+                host.trailingAnchor.constraint(equalTo: trailingAnchor),
+                host.topAnchor.constraint(equalTo: topAnchor),
+                host.bottomAnchor.constraint(equalTo: bottomAnchor)
+            ])
+            hostingView = host
+        }
+    }
+}
+
+/// SwiftUI wrapper that mirrors `SelectableTranscriptRow`: owns per-row hover
+/// state and flips `\.transcriptTextSelection` true on hover so
+/// `.textSelection(.enabled)` is materialized only for the hovered row — the
+/// same #120-preserving behavior as production.
+private struct RowHost: View {
+    let node: TranscriptRenderNode
+    let terminalID: UUID?
+
+    @State private var isHovered = false
+
+    var body: some View {
+        TranscriptRow(node: node, terminalID: terminalID)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .environment(\.transcriptTextSelection, isHovered)
+            .onHover { isHovered = $0 }
+    }
+}

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -143,8 +143,13 @@ struct GeneralSettingsTab: View {
                     .help("Experimental: exit idle Claude instances when you switch away and resume them when you switch back, freeing memory. Off by default — may interrupt long-running work.")
                 Toggle("Live transcript pane", isOn: $enableTranscript)
                     .help("Experimental: show a chat-style live transcript pane for Claude sessions. Off by default — may freeze the app on very large transcripts.")
-                Toggle("Virtualized transcript (no text selection)", isOn: $useVirtualizedTranscript)
-                    .help("Experimental: render the live transcript with an AppKit virtualizing list so large transcripts don't freeze the app. Trade-off: you can't select/copy text inside a message. Off by default; takes effect when you reopen or switch to a transcript pane.")
+                // Renderer sub-choice for the live transcript pane above. Only
+                // meaningful when the pane is enabled, so it's nested (indented)
+                // and disabled when "Live transcript pane" is off.
+                Toggle("Use virtualized renderer (no text selection)", isOn: $useVirtualizedTranscript)
+                    .help("Experimental: render the live transcript with an AppKit virtualizing list so large transcripts don't freeze the app — the fix for the freeze warned about above. Trade-off: you can't select/copy text inside a message. Takes effect when you reopen or switch to a transcript pane.")
+                    .disabled(!enableTranscript)
+                    .padding(.leading, 20)
             }
         }
         .formStyle(.grouped)

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -36,6 +36,7 @@ struct GeneralSettingsTab: View {
     @AppStorage("skipPermissions") private var skipPermissions: Bool = true
     @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = false
     @AppStorage(AppState.enableTranscriptKey) private var enableTranscript: Bool = false
+    @AppStorage(AppState.useVirtualizedTranscriptKey) private var useVirtualizedTranscript: Bool = false
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
@@ -142,6 +143,8 @@ struct GeneralSettingsTab: View {
                     .help("Experimental: exit idle Claude instances when you switch away and resume them when you switch back, freeing memory. Off by default — may interrupt long-running work.")
                 Toggle("Live transcript pane", isOn: $enableTranscript)
                     .help("Experimental: show a chat-style live transcript pane for Claude sessions. Off by default — may freeze the app on very large transcripts.")
+                Toggle("Virtualized transcript (no text selection)", isOn: $useVirtualizedTranscript)
+                    .help("Experimental: render the live transcript with an AppKit virtualizing list so large transcripts don't freeze the app. Trade-off: you can't select/copy text inside a message. Off by default; takes effect when you reopen or switch to a transcript pane.")
             }
         }
         .formStyle(.grouped)

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -36,7 +36,7 @@ struct GeneralSettingsTab: View {
     @AppStorage("skipPermissions") private var skipPermissions: Bool = true
     @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = false
     @AppStorage(AppState.enableTranscriptKey) private var enableTranscript: Bool = false
-    @AppStorage(AppState.useVirtualizedTranscriptKey) private var useVirtualizedTranscript: Bool = false
+    @AppStorage(AppState.useVirtualizedTranscriptKey) private var useVirtualizedTranscript: Bool = true
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""

--- a/Tests/TBDAppTests/TranscriptVirtualizationGateTests.swift
+++ b/Tests/TBDAppTests/TranscriptVirtualizationGateTests.swift
@@ -43,13 +43,13 @@ struct TranscriptVirtualizationGateTests {
     // developer's real `TBDApp.plist` (`.standard`); torn down with
     // `removePersistentDomain(forName:)` per CLAUDE.md.
 
-    @Test("setting fails closed (false) when the toggle is untouched")
-    func settingDefaultsFalseWhenUnset() {
+    @Test("setting defaults ON (true) when the toggle is untouched")
+    func settingDefaultsTrueWhenUnset() {
         let suite = "TranscriptVirtualizationGateTests.unset"
         let defaults = UserDefaults(suiteName: suite)!
         defer { defaults.removePersistentDomain(forName: suite) }
 
-        #expect(AppState.virtualizedTranscriptEnabled(defaults: defaults) == false)
+        #expect(AppState.virtualizedTranscriptEnabled(defaults: defaults) == true)
     }
 
     @Test("setting true when the toggle is on")

--- a/Tests/TBDAppTests/TranscriptVirtualizationGateTests.swift
+++ b/Tests/TBDAppTests/TranscriptVirtualizationGateTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// THROWAWAY SPIKE (issue #129). Tests the pure gate that decides whether
+/// `TranscriptItemsView` renders the AppKit `VirtualizedTranscriptList` instead
+/// of the production `LazyVStack { ForEach }`. Per CLAUDE.md "test each branch
+/// of a gated conditional": assert the off-by-default branches AND the on
+/// branch. The AppKit view itself is not exercised headlessly — only the gate
+/// decision.
+@Suite("Transcript virtualization gate")
+struct TranscriptVirtualizationGateTests {
+    @Test("off when TBD_VIRT_TRANSCRIPT is absent")
+    func offWhenAbsent() {
+        #expect(TranscriptItemsView.useVirtualizedTranscript([:]) == false)
+    }
+
+    @Test("off when TBD_VIRT_TRANSCRIPT is empty")
+    func offWhenEmpty() {
+        #expect(TranscriptItemsView.useVirtualizedTranscript(["TBD_VIRT_TRANSCRIPT": ""]) == false)
+    }
+
+    @Test("off when TBD_VIRT_TRANSCRIPT is a non-1 value")
+    func offWhenNotOne() {
+        #expect(TranscriptItemsView.useVirtualizedTranscript(["TBD_VIRT_TRANSCRIPT": "0"]) == false)
+        #expect(TranscriptItemsView.useVirtualizedTranscript(["TBD_VIRT_TRANSCRIPT": "true"]) == false)
+    }
+
+    @Test("on when TBD_VIRT_TRANSCRIPT == 1")
+    func onWhenOne() {
+        #expect(TranscriptItemsView.useVirtualizedTranscript(["TBD_VIRT_TRANSCRIPT": "1"]) == true)
+    }
+}

--- a/Tests/TBDAppTests/TranscriptVirtualizationGateTests.swift
+++ b/Tests/TBDAppTests/TranscriptVirtualizationGateTests.swift
@@ -2,32 +2,73 @@ import Foundation
 import Testing
 @testable import TBDApp
 
-/// THROWAWAY SPIKE (issue #129). Tests the pure gate that decides whether
-/// `TranscriptItemsView` renders the AppKit `VirtualizedTranscriptList` instead
-/// of the production `LazyVStack { ForEach }`. Per CLAUDE.md "test each branch
-/// of a gated conditional": assert the off-by-default branches AND the on
-/// branch. The AppKit view itself is not exercised headlessly — only the gate
-/// decision.
+/// Tests the virtualized-transcript gate (issue #129). The live-transcript pane
+/// renders the AppKit `VirtualizedTranscriptList` instead of the production
+/// `LazyVStack { ForEach }` when EITHER the `TBD_VIRT_TRANSCRIPT=1` env override
+/// is set OR the user opts in via the Settings → Experimental toggle
+/// (`AppState.useVirtualizedTranscriptKey`). Per CLAUDE.md "test each branch of
+/// a gated conditional": assert the off-by-default branches AND the on branch,
+/// for both inputs. The AppKit view itself is not exercised headlessly — only
+/// the gate decision.
+@MainActor
 @Suite("Transcript virtualization gate")
 struct TranscriptVirtualizationGateTests {
-    @Test("off when TBD_VIRT_TRANSCRIPT is absent")
-    func offWhenAbsent() {
-        #expect(TranscriptItemsView.useVirtualizedTranscript([:]) == false)
+
+    // MARK: Env override branch
+
+    @Test("env override off when TBD_VIRT_TRANSCRIPT is absent")
+    func envOffWhenAbsent() {
+        #expect(TranscriptItemsView.virtualizedTranscriptEnvOverride([:]) == false)
     }
 
-    @Test("off when TBD_VIRT_TRANSCRIPT is empty")
-    func offWhenEmpty() {
-        #expect(TranscriptItemsView.useVirtualizedTranscript(["TBD_VIRT_TRANSCRIPT": ""]) == false)
+    @Test("env override off when TBD_VIRT_TRANSCRIPT is empty")
+    func envOffWhenEmpty() {
+        #expect(TranscriptItemsView.virtualizedTranscriptEnvOverride(["TBD_VIRT_TRANSCRIPT": ""]) == false)
     }
 
-    @Test("off when TBD_VIRT_TRANSCRIPT is a non-1 value")
-    func offWhenNotOne() {
-        #expect(TranscriptItemsView.useVirtualizedTranscript(["TBD_VIRT_TRANSCRIPT": "0"]) == false)
-        #expect(TranscriptItemsView.useVirtualizedTranscript(["TBD_VIRT_TRANSCRIPT": "true"]) == false)
+    @Test("env override off when TBD_VIRT_TRANSCRIPT is a non-1 value")
+    func envOffWhenNotOne() {
+        #expect(TranscriptItemsView.virtualizedTranscriptEnvOverride(["TBD_VIRT_TRANSCRIPT": "0"]) == false)
+        #expect(TranscriptItemsView.virtualizedTranscriptEnvOverride(["TBD_VIRT_TRANSCRIPT": "true"]) == false)
     }
 
-    @Test("on when TBD_VIRT_TRANSCRIPT == 1")
-    func onWhenOne() {
-        #expect(TranscriptItemsView.useVirtualizedTranscript(["TBD_VIRT_TRANSCRIPT": "1"]) == true)
+    @Test("env override on when TBD_VIRT_TRANSCRIPT == 1")
+    func envOnWhenOne() {
+        #expect(TranscriptItemsView.virtualizedTranscriptEnvOverride(["TBD_VIRT_TRANSCRIPT": "1"]) == true)
+    }
+
+    // MARK: Settings (UserDefaults) branch
+    //
+    // Uses an injected `UserDefaults(suiteName:)` so the test never touches the
+    // developer's real `TBDApp.plist` (`.standard`); torn down with
+    // `removePersistentDomain(forName:)` per CLAUDE.md.
+
+    @Test("setting fails closed (false) when the toggle is untouched")
+    func settingDefaultsFalseWhenUnset() {
+        let suite = "TranscriptVirtualizationGateTests.unset"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(AppState.virtualizedTranscriptEnabled(defaults: defaults) == false)
+    }
+
+    @Test("setting true when the toggle is on")
+    func settingTrueWhenSet() {
+        let suite = "TranscriptVirtualizationGateTests.on"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set(true, forKey: AppState.useVirtualizedTranscriptKey)
+        #expect(AppState.virtualizedTranscriptEnabled(defaults: defaults) == true)
+    }
+
+    @Test("setting false when the toggle is explicitly off")
+    func settingFalseWhenSetFalse() {
+        let suite = "TranscriptVirtualizationGateTests.off"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set(false, forKey: AppState.useVirtualizedTranscriptKey)
+        #expect(AppState.virtualizedTranscriptEnabled(defaults: defaults) == false)
     }
 }

--- a/docs/spikes/2026-06-20-nscollectionview-transcript-spike.md
+++ b/docs/spikes/2026-06-20-nscollectionview-transcript-spike.md
@@ -1,0 +1,150 @@
+# Spike: AppKit virtualized transcript list (issue #129)
+
+Date: 2026-06-20 — branch `spike-nscollectionview-transcript`
+Status: THROWAWAY prototype. Compiles, gate unit-tested. Interactive
+verification (virtualization count, text selection, bottom-pin) is pending a
+human GUI run — see launch recipe + open risks below.
+
+## Goal (go/no-go)
+
+Prove an AppKit virtualizing list can replace the transcript's
+`LazyVStack { ForEach }` to fix #129's O(N) `ForEach.applyNodes` reconciliation.
+`LazyVStack` makes *body realization* lazy but NOT *list reconciliation* — every
+content change still diffs all N rows. A real AppKit virtualizer realizes and
+reconciles only ~visible rows → O(visible).
+
+Three proof points to validate live:
+1. **Virtualization** — with 500 synthetic items, only ~visible rows (~10–30)
+   realize, not 500.
+2. **Text selection vs row selection (#244)** — a mouse drag inside a row
+   selects TEXT (reaching the hosted SwiftUI `.textSelection`), not the row.
+3. **Bottom-pin / streaming** — appends auto-scroll when already at bottom; a
+   user scrolled up is left alone.
+
+## Approach chosen: view-based NSTableView (not NSCollectionView)
+
+`VirtualizedTranscriptList` (`Sources/TBDApp/Panes/Transcript/VirtualizedTranscriptList.swift`)
+is an `NSViewRepresentable` wrapping `NSScrollView` + a single-column
+`NSTableView` with `usesAutomaticRowHeights = true` and `style = .plain`. Each
+row is an `NSTableCellView` (`HostingTableCellView`) containing an
+`NSHostingView<RowHost>` that hosts one SwiftUI `TranscriptRow`.
+
+**Why NSTableView over NSCollectionView:** the transcript rows are
+variable-height self-sizing content. NSTableView's `usesAutomaticRowHeights`
+lets each row's `NSHostingView` autolayout-fit and reports that height to the
+table — the documented happy path for variable heights, and the table only
+realizes visible rows + a small overscan. NSCollectionView would require a
+compositional list layout with *estimated* heights to self-size, which is
+strictly more risk for variable content and no extra payoff here. NSCollectionView
+would only be worth it if NSTableView blocked us; it did not.
+
+## How the three proof points are wired
+
+### 1. Virtualization + realize counter
+- `tableView(_:viewFor:row:)` is the virtualization seam — AppKit calls it only
+  for rows entering the visible region (plus overscan). It reuses recycled
+  `HostingTableCellView`s via `makeView(withIdentifier:)`.
+- Each realize logs `virt.realize id=<nodeID> row=<n>` at `.debug` on
+  `Logger(subsystem: "com.tbd.app", category: "perf-transcript")`, gated by
+  `ProcessInfo...["TBD_PERF_ROW_REALIZE"] == "1"`. (No `print()` — SwiftLint
+  `no_print_in_sources` enforced; confirmed clean.)
+- Streaming updates diff in `Coordinator.update(to:)`: a pure append (same
+  prefix, longer) → `insertRows(at:withAnimation:[])`, keeping existing rows'
+  hosting views alive and realizing only the newly-visible tail; anything else
+  falls back to `reloadData()` (still O(visible) to realize).
+
+### 2. Text selection vs row selection (#244)
+- `tableView.selectionHighlightStyle = .none`, `shouldSelectRow` returns
+  `false` → AppKit never claims a click/drag for row selection.
+- `RowHost` mirrors production `SelectableTranscriptRow`: owns `@State isHovered`
+  and flips `\.transcriptTextSelection` true on hover, so
+  `.textSelection(.enabled)` materializes per-hovered-row exactly like
+  production (preserves the #120 single-live-NSTextField behavior).
+- `TranscriptTableView.mouseDown` forwards the event to the deepest `hitTest`
+  view under the cursor (the NSHostingView's internal text view) instead of
+  letting `super.mouseDown` start row-tracking. **This is the risky bit — see
+  open risks.**
+
+### 3. Bottom-pin / streaming
+- `Coordinator.isNearBottom()` checks `documentHeight - viewportBottom < 40pt`.
+- After an append/reload, if we *were* near bottom, `scrollRowToVisible(last)`
+  re-pins. Initial load force-pins to bottom (newest content visible).
+- The SwiftUI `atBottom` binding is set true `.onAppear` for the spike (the
+  jump-to-bottom button is driven by the virtualizer's own pin, not the
+  LazyVStack sentinel).
+
+## Gate
+
+`TranscriptItemsView.useVirtualizedTranscript(_ environment:) -> Bool` returns
+true only when `TBD_VIRT_TRANSCRIPT == "1"`. `bodyView` branches on it: ON →
+`VirtualizedTranscriptList`; OFF → the original `LazyVStack { ForEach }`,
+unchanged. Unit test: `Tests/TBDAppTests/TranscriptVirtualizationGateTests.swift`
+covers absent/empty/non-1 (false) and "1" (true). `swift test --filter
+TranscriptVirtualizationGateTests` → 4/4 pass.
+
+## Launch recipe (interactive verification — human required)
+
+Headless tests cannot verify virtualization/selection/pin; needs a running GUI.
+Build the bundled app first (do not run `swift run TBDApp` directly), then launch
+with the three env vars:
+
+```sh
+scripts/restart.sh          # builds .build/debug/TBD.app + restarts this worktree
+open .build/debug/TBD.app \
+  --env TBD_VIRT_TRANSCRIPT=1 \
+  --env TBD_TRANSCRIPT_PERF_HARNESS=1 \
+  --env TBD_PERF_PRESEED=500 \
+  --env TBD_PERF_ROW_REALIZE=1
+```
+
+Then stream the realize log (note: `log` is a zsh builtin here — use the full
+path):
+
+```sh
+/usr/bin/log stream --level debug \
+  --predicate 'subsystem == "com.tbd.app" AND category == "perf-transcript"'
+```
+
+(If `.debug` rows don't appear, once-per-subsystem:
+`sudo log config --subsystem com.tbd.app --mode "level:debug,persist:debug"`.)
+
+### What to look for
+- **Virtualization:** with 500 preseeded items, count distinct `virt.realize`
+  lines on initial display — expect ~10–30 (visible + overscan), NOT 500.
+  Scrolling emits more realize lines for newly-visible rows; that's expected
+  and is the whole point (O(visible) per viewport, not O(N) per change).
+- **Text selection:** hover a chat-bubble row, then click-drag across its text.
+  The TEXT should highlight (selection), and the row should NOT highlight as a
+  selected row. Cmd-C should copy the selected text.
+- **Bottom-pin:** with `TBD_PERF_INJECT_COUNT`/`TBD_PERF_INJECT_MS` streaming
+  appends, when scrolled to bottom new rows should auto-scroll into view; scroll
+  up a few rows and confirm appends no longer yank you down.
+
+## Open risks / things NOT resolved headlessly
+
+- **TEXT SELECTION IS THE GATING RISK and is UNVERIFIED.** The
+  `TranscriptTableView.mouseDown` → `hitTest` → forward approach is the standard
+  way to let a hosted view win the drag, but I could not confirm headlessly that
+  (a) `NSHostingView`'s internal SwiftUI text view actually receives the drag
+  sequence (down/dragged/up) cleanly, (b) selection doesn't get cancelled when
+  the table tries to autoscroll, or (c) drag that crosses a row boundary behaves
+  sanely (selection cannot span rows — each row is its own text view, same as
+  production). If the forward fights row tracking, fallbacks to try:
+  override `validateProposedFirstResponder`, or set the cell's hosting view as
+  the hit-test winner via `acceptsFirstMouse`. Document outcome after the live run.
+- **Row height churn during streaming:** `usesAutomaticRowHeights` recomputes
+  heights lazily; rapid appends + `insertRows` may cause visible reflow/jitter.
+  Acceptable for a spike; note severity after live run.
+- **Hover gate + recycled cells:** `HostingTableCellView` reuses its
+  `NSHostingView` and just swaps `rootView`. `RowHost`'s `@State isHovered`
+  belongs to the SwiftUI identity, which should reset on rootView swap — verify
+  no stale hover (wrong row showing selectable text) during fast scroll.
+- **Bottom-pin precision:** the 40pt `isNearBottom` threshold and the
+  `DispatchQueue.main.async` re-pin are coarse; fine for go/no-go.
+
+## Verdict criteria
+
+GO if: realize count ≈ visible (not 500) **and** in-row text selection works.
+NO-GO (or needs more work) if text selection cannot be made to win the drag from
+NSTableView row tracking — that would mean the #244 fix doesn't survive the AppKit
+list, which is the whole reason this proof point gates the decision.

--- a/docs/spikes/2026-06-20-nscollectionview-transcript-spike.md
+++ b/docs/spikes/2026-06-20-nscollectionview-transcript-spike.md
@@ -1,9 +1,33 @@
 # Spike: AppKit virtualized transcript list (issue #129)
 
-Date: 2026-06-20 — branch `spike-nscollectionview-transcript`
-Status: THROWAWAY prototype. Compiles, gate unit-tested. Interactive
-verification (virtualization count, text selection, bottom-pin) is pending a
-human GUI run — see launch recipe + open risks below.
+Date: 2026-06-20 (spike) / 2026-06-21 (live verification) — branch `spike-nscollectionview-transcript`
+Status: THROWAWAY prototype, LIVE-VERIFIED. **Verdict: virtualization GO, in-row
+text selection NO-GO via clean approaches** — see "Live verification results"
+below. The branch is a record, not for merge.
+
+## TL;DR verdict
+
+- **Virtualization works and is a big win.** With 500 preseeded rows the table
+  realized only **82 distinct rows** (visible + the bottom set after pin), and the
+  mount came up **fast with no freeze** — where the production `LazyVStack` path
+  hard-freezes for ~3.9 s reconciling all 500 (`ForEachState.applyNodes`). This is
+  the O(N)→O(visible) win #129 needs.
+- **In-row text selection is the blocker (#244).** The only implementation that
+  delivered drag-select (a manual `mouseDown` → forward) caused **infinite
+  recursion → SIGSEGV** (NSHostingView's responder chain forwards the event back
+  up to the table's `mouseDown`). The clean, non-recursive fix
+  (`validateProposedFirstResponder` + no forward) stops the crash **but selection
+  stops working** — the drag never reaches the hosted SwiftUI text. A diagnostic
+  that force-enabled `.textSelection` (bypassing the hover gate) **still** didn't
+  select, proving it's not hover routing but the deeper `NSTableView`-owns-the-mouse
+  vs hosted-text-wants-the-drag conflict. Making selection robust would require a
+  substantial custom event-tracking layer (manually driving the hosted text view's
+  selection without recursion) — not a quick win.
+- **Residual cost:** ~104 sub-second watchdog stalls during the run, from the pane
+  rebuilding `transcriptRenderNodes(from:)` O(N) per update (no cache) plus each
+  visible cell's own `NSHostingView` automatic-row-height SwiftUI layout. Tuning,
+  not a blocker for the virtualization question, but note the per-visible-cell
+  hosting overhead is real (≈visible-count hosting views, recycled — not 500).
 
 ## Goal (go/no-go)
 
@@ -142,9 +166,74 @@ path):
 - **Bottom-pin precision:** the 40pt `isNearBottom` threshold and the
   `DispatchQueue.main.async` re-pin are coarse; fine for go/no-go.
 
-## Verdict criteria
+## Live verification results (2026-06-21)
 
-GO if: realize count ≈ visible (not 500) **and** in-row text selection works.
-NO-GO (or needs more work) if text selection cannot be made to win the drag from
-NSTableView row tracking — that would mean the #244 fix doesn't survive the AppKit
-list, which is the whole reason this proof point gates the decision.
+Verified interactively with the perf harness (`TBD_VIRT_TRANSCRIPT=1` +
+`TBD_TRANSCRIPT_PERF_HARNESS=1`, preseed 500, `TBD_PERF_ROW_REALIZE=1`).
+
+**Render plumbing — two non-obvious bugs had to be fixed before anything showed:**
+1. *Reentrancy → blank.* `updateNSView` mutated the table (`reloadData`/`insertRows`)
+   synchronously inside SwiftUI's update pass → "reentrant operation in its
+   NSTableView delegate" → AppKit dropped the reload → `viewFor` never fired
+   (`virt.realize=0`), blank. Fix: defer a coalesced apply via `DispatchQueue.main.async`
+   (commit `0a41330`).
+2. *Nested scroll → blank.* The gate originally swapped the virtualizer in *inside*
+   `TranscriptItemsView`, which lives inside the pane's SwiftUI `ScrollView`. A
+   SwiftUI `ScrollView` proposes UNBOUNDED height to its content, so the
+   `NSViewRepresentable` never got a bounded viewport → no visible region → blank.
+   Fix: move the gate up to `LiveTranscriptPaneView.transcriptWithAutoscroll` so the
+   virtualizer *replaces* the `ScrollView` and fills the pane (commit `d95f6be`).
+
+   Lesson: a virtualizer must own its scrolling; never nest it in a SwiftUI ScrollView.
+
+**Proof point 1 — virtualization: ✅ CONFIRMED.** 82 distinct `virt.realize` rows
+out of 500 (rows 0–28 at top, 471+ at bottom after force-pin), no mount freeze.
+Production `LazyVStack` on the same 500 = a 3.9 s `ForEachState.applyNodes` freeze.
+
+**Proof point 2 — in-row text selection (#244): ❌ BLOCKED.**
+- The first attempt (`TranscriptTableView.mouseDown` → `hitTest` → forward the event
+  to the hosted view) *did* select text live, but then **crashed**: SIGSEGV, "stack
+  size exceeded due to excessive recursion", **27,948 levels** of
+  `TranscriptTableView.mouseDown → NSHostingView.mouseDown → forwardMethod → …`. The
+  hosted view's responder chain forwards the unhandled event back up to the table's
+  `mouseDown`, which forwards down again — unbounded mutual recursion (commit `f6b245f`
+  removed it).
+- The clean replacement (`validateProposedFirstResponder` returns true; no manual
+  forward; `selectionHighlightStyle=.none`, `shouldSelectRow=false`) **does not
+  crash but also does not select** — the drag never reaches the hosted text.
+- Diagnostic: forcing `.environment(\.transcriptTextSelection, true)` (selection
+  always-on, bypassing the hover gate) **still didn't select** → the cause is NOT
+  `.onHover` not firing; it's the deeper conflict that `NSTableView` owns the mouse
+  (each row is a separate `NSHostingView` that never becomes first responder / never
+  receives the down→dragged→up sequence). Note: even if solved, selection still can't
+  span rows (each cell is its own text view) — but that matches production, which
+  already gates selection to a single hovered row.
+
+**Proof point 3 — bottom-pin / streaming:** appends rendered and the view re-pinned
+to bottom (realize log showed bottom rows + injected rows). Not stress-tested;
+adequate-looking for the spike, coarse (40pt threshold).
+
+## Verdict & paths forward
+
+**Virtualization is proven and high-value; in-row text selection is a genuine
+blocker via every clean approach tried.** The approach is NOT adoptable as-is.
+
+Options for whoever picks this up (ranked):
+1. **SwiftUI-only windowing (lowest risk).** Keep the `LazyVStack` but cap rendered
+   items (e.g. last N + "load earlier", drop far-offscreen rows) so reconciliation N
+   is bounded without AppKit. Lower ceiling than true virtualization, but **preserves
+   native text selection** and avoids the entire #244 event conflict.
+2. **Virtualize + replace drag-select with a copy affordance.** Adopt the NSTableView
+   virtualizer (the big perf win) but drop in-row drag-select in favor of a per-message
+   "copy" button / "copy message" action — sidesteps the table-vs-text event conflict
+   entirely. UX change; needs product sign-off.
+3. **Custom event layer to make drag-select work (highest effort/risk).** Manually
+   drive the hosted text view's selection from the table's mouse events without
+   recursion (own tracking loop / explicit first-responder management). Uncertain it
+   can be made robust; this is the part the spike showed is hard.
+4. **Drop virtualization; pursue cheaper #129 levers** (node-array churn, per-update
+   cost) and accept O(N) reconciliation — only viable if windowing (#1) isn't enough.
+
+Recommendation: pursue **#1 (windowing)** first as a lower-risk partial fix, and only
+take on **#3** if true unbounded virtualization with full drag-select is a hard
+requirement.


### PR DESCRIPTION
## Problem

Issue #129's transcript freeze is dominated by **non-virtualized `ForEach` list reconciliation**: every transcript content change re-runs `ForEachState.applyNodes` over **all N rows** (O(N), heavy per-item constant). `LazyVStack` makes view-*body* realization lazy but **not** list reconciliation — three macOS spindumps all bottom out in `applyNodes`/`DynamicContainerInfo.updateItems`, and a 500-row mount hard-freezes the main thread ~3.9s. PR #287 (per-row layout flatten) bought ~3%; this is the structural lever.

## What this adds (opt-in, default OFF)

An **experimental Settings → Experimental toggle, "Virtualized transcript (no text selection)"** that swaps the live-transcript pane from `LazyVStack { ForEach }` to an AppKit virtualizer — `NSScrollView` + view-based `NSTableView` (`usesAutomaticRowHeights`) hosting one SwiftUI `TranscriptRow` per visible row via `NSHostingView`. Only ~visible rows realize/reconcile → **O(visible)**, not O(N).

- `@AppStorage`-backed → flipping the toggle switches the pane live (no relaunch). Env var `TBD_VIRT_TRANSCRIPT=1` remains as a harness/testing override.
- **Default off; the `LazyVStack` path is byte-for-byte unchanged when off** (mirrors the existing `enableTranscript` experimental toggle).

## Measured (perf harness, 500 preseed + streaming)

| Metric | `LazyVStack` (current) | Virtualized + cache |
|---|---|---|
| Mount of 500 rows | **3.94 s hard freeze** | **fast — max stall 299 ms** |
| Rows realized | all N (O(N)) | **32 / 600** (O(visible)) |
| Re-realization churn | ~6× per row | **~1×** |

The mount/activation freeze that motivates #129 is eliminated. The per-update O(N) node rebuild is avoided by reusing the existing `TranscriptNodeCache` (the same memoization the `LazyVStack` path already uses).

## Trade-offs / known limitations (intentional)

- **In-row text selection is dropped.** AppKit's `NSTableView` owns the mouse for row selection; making hosted SwiftUI `.textSelection` win the drag required an event hack that infinite-recursed (SIGSEGV), and the clean non-recursive path doesn't deliver selection. A diagnostic (force-enabled selection) confirmed it's the table-vs-text event conflict, not the hover gate. Per product call, in-row drag-select is **removed** (cross-row selection never worked in either path anyway — production gates selection to a single hovered row). The full investigation is in `docs/spikes/2026-06-20-nscollectionview-transcript-spike.md`.
- **Click-through to hosted controls (tool-row overlay buttons, file links, AskUserQuestion) is the one thing to validate during soak** — the synthetic harness only emits chat bubbles, so taps on interactive cards are unverified live. `validateProposedFirstResponder`/`shouldSelectRow` are wired for it; flagged in the file header.
- **Pre-existing, NOT introduced here:** a sustained ~1/sec ~250–290 ms idle stall after large transcripts — the `LazyVStack` baseline shows the same tail (111 vs 98 stalls over ~94 s). Separate follow-up.

## Why merge behind a toggle

The freeze isn't reliably reproducible synthetically; it needs real-session soak. This lands the alternative view default-off so it can be flipped on per-session, compared against the `LazyVStack`, and fall back instantly — with production untouched until it's proven.

## Implementation notes (for review)

- Gate moved to `LiveTranscriptPaneView.transcriptWithAutoscroll` so the virtualizer *replaces* the SwiftUI `ScrollView` and gets a bounded viewport (a virtualizer nested in a SwiftUI `ScrollView` is proposed unbounded height → blank).
- Table mutations are deferred out of SwiftUI's `updateNSView` pass (coalesced `DispatchQueue.main.async`) to avoid the "reentrant operation in NSTableView delegate" → dropped-reload → blank.
- `AppState.virtualizedTranscriptEnabled(defaults:)` is the fail-closed accessor; `TranscriptItemsView.virtualizedTranscriptEnvOverride(_:)` is the env override.

## Tests

`TranscriptVirtualizationGateTests` (7) covers the env override (on/off) and the `AppState` setting accessor (unset/true/false) via injected `UserDefaults(suiteName:)`. `swift build` green, `swiftlint --strict` clean. Full `swift test` green except the pre-existing environment-sensitive `TabBarHitAreaTests` (fails identically on `main`).

[🧪 NSCollectionView Spike](https://cheapsteak.github.io/tbd/open/?worktree=82B7BC00-B218-4984-B2B4-25B1BFB5B8E7)
