### PR TITLE
fix(daemon): recover Claude session identity on live tmux-server death

### DIFF
--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -516,15 +516,18 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             debugLog("PANEL: process terminated, exitCode=\(exitCode ?? -1)")
             DispatchQueue.main.async { [weak self] in
                 // This fires when the *attach client* (the on-screen tmux
-                // viewer) dies — e.g. the view was torn down or detached. The
-                // underlying tmux window keeps running (`remain-on-exit on`),
-                // so the user's shell/agent is almost always still alive. Avoid
-                // the old "[Process exited with code 0]" wording, which read as
-                // if the user's work had died. Surface a non-zero code only when
-                // the viewer genuinely exited abnormally.
+                // viewer) dies. A clean exit (code 0) means the view was torn
+                // down or detached while the underlying tmux window keeps
+                // running (`remain-on-exit on`), so the user's shell/agent is
+                // still alive — reopening reattaches. A non-zero exit (e.g. the
+                // whole tmux server died on sleep/wake or OOM, exit 256) means
+                // the session is NOT still running; don't claim it is. Reopening
+                // triggers prepareSession → onDeadWindow → park → Resume (or
+                // reattaches if the window is somehow still alive), so "recover"
+                // is honest in both cases.
                 let message: String
                 if let code = exitCode, code != 0 {
-                    message = "\r\n[View detached (exit \(code)) — session is still running in the background. Reopen this tab to reattach.]\r\n"
+                    message = "\r\n[View disconnected (exit \(code)). Reopen this tab to recover the session.]\r\n"
                 } else {
                     message = "\r\n[View detached — session is still running in the background. Reopen this tab to reattach.]\r\n"
                 }

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -522,12 +522,13 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 // still alive — reopening reattaches. A non-zero exit (e.g. the
                 // whole tmux server died on sleep/wake or OOM, exit 256) means
                 // the session is NOT still running; don't claim it is. Reopening
-                // triggers prepareSession → onDeadWindow → park → Resume (or
-                // reattaches if the window is somehow still alive), so "recover"
-                // is honest in both cases.
+                // does the right thing for every tab kind — reattaches a live
+                // window, parks+resumes a dead Claude one, or respawns a
+                // shell/Codex — so use neutral "reconnect" wording that doesn't
+                // overpromise a session "recovery" for plain shell/Codex tabs.
                 let message: String
                 if let code = exitCode, code != 0 {
-                    message = "\r\n[View disconnected (exit \(code)). Reopen this tab to recover the session.]\r\n"
+                    message = "\r\n[View disconnected (exit \(code)). Reopen this tab to reconnect.]\r\n"
                 } else {
                     message = "\r\n[View detached — session is still running in the background. Reopen this tab to reattach.]\r\n"
                 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -349,6 +349,25 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
 
+        // A Claude-resumable terminal whose window died must NOT be recreated as a
+        // plain shell — that silently turns the tab into a shell and discards the
+        // session identity (claudeSessionID/transcriptPath), so TBD can no longer
+        // Resume and `/resume` finds nothing. Mirror reconcile(): park it as
+        // suspended, preserving identity, so the app renders the suspended (moon)
+        // state and offers Resume. Resume rebuilds a fresh window from the session
+        // ID on demand, so this is non-destructive even if the window were somehow
+        // still alive.
+        if terminal.isClaudeResumable, let sessionID = terminal.claudeSessionID {
+            // Clean up any lingering (almost always already-dead) window to avoid orphans.
+            try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
+            try await db.terminals.setSuspended(id: terminal.id, sessionID: sessionID)
+            guard let updated = try await db.terminals.get(id: params.terminalID) else {
+                return RPCResponse(error: "Terminal not found after suspend")
+            }
+            logger.info("recreateWindow: parked claude terminal \(terminal.id, privacy: .public) as suspended — window \(terminal.tmuxWindowID, privacy: .public) gone, session \(sessionID, privacy: .public) preserved")
+            return try RPCResponse(result: updated)
+        }
+
         // Kill the old window if it still exists (avoids orphans)
         try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -361,6 +361,9 @@ extension RPCRouter {
             // Clean up any lingering (almost always already-dead) window to avoid orphans.
             try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
             try await db.terminals.setSuspended(id: terminal.id, sessionID: sessionID)
+            // Drop any stale pending-question entry — the window the question
+            // belonged to is gone. Mirrors reconcile()/handleTerminalDelete.
+            await pendingQuestions.clear(terminalID: terminal.id)
             guard let updated = try await db.terminals.get(id: params.terminalID) else {
                 return RPCResponse(error: "Terminal not found after suspend")
             }

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -205,6 +205,115 @@ func testHandleTerminalRecreateWindowCodexLaunchCommand() async throws {
             "recreated codex tab must not use removed --full-auto flag; got bodies: \(bodies)")
 }
 
+// MARK: - Dead-window recovery: park resumable Claude terminals instead of wiping to shell
+
+/// When a Claude terminal's tmux window dies under a LIVE app+daemon (sleep/wake
+/// or OOM, no daemon restart), `handleTerminalRecreateWindow` must NOT recreate
+/// it as a plain shell — that nulls `claudeSessionID`/`transcriptPath` and flips
+/// `kind` to `.shell`, destroying the ability to Resume and breaking `/resume`.
+/// It must mirror reconcile(): park the terminal as suspended, preserving
+/// identity, so the app renders the moon state and offers Resume.
+@Test("handleTerminalRecreateWindow parks a resumable Claude terminal as suspended")
+func testHandleTerminalRecreateWindowParksClaudeAsSuspended() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let tmux = TmuxManager(dryRun: true)
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: tmux,
+            hooks: HookResolver()
+        ),
+        tmux: tmux
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-recreate-claude", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-recreate-claude",
+        branch: "tbd/wt-recreate-claude",
+        path: "/tmp/fake-repo-recreate-claude/wt-recreate-claude",
+        tmuxServer: "tbd-c1a0de00"
+    )
+    let sessionID = "11111111-2222-3333-4444-555555555555"
+    let transcriptPath = "/tmp/fake-repo-recreate-claude/.claude/projects/foo/\(sessionID).jsonl"
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@old-claude",
+        tmuxPaneID: "%old-claude",
+        label: "claude",
+        claudeSessionID: sessionID,
+        kind: .claude
+    )
+    // create() doesn't accept transcriptPath; set it via the SessionStart bridge API.
+    try await db.terminals.updateSession(id: terminal.id, sessionID: sessionID, transcriptPath: transcriptPath)
+
+    let request = try RPCRequest(
+        method: RPCMethod.terminalRecreateWindow,
+        params: TerminalRecreateWindowParams(terminalID: terminal.id)
+    )
+    let response = await router.handle(request)
+    #expect(response.success, "expected success; error: \(response.error ?? "nil")")
+
+    let updated = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(updated.suspendedAt != nil, "claude terminal must be parked as suspended, not recreated as shell")
+    #expect(updated.kind == .claude, "kind must stay .claude, not flip to .shell")
+    #expect(updated.claudeSessionID == sessionID, "claudeSessionID must be preserved")
+    #expect(updated.transcriptPath == transcriptPath, "transcriptPath must be preserved")
+    #expect(updated.isClaudeResumable, "parked terminal must remain Claude-resumable")
+}
+
+/// Regression guard for the OTHER branch: a plain shell terminal whose window
+/// died must still be recreated as a plain shell (NOT parked as suspended).
+@Test("handleTerminalRecreateWindow rebuilds a shell terminal as a shell")
+func testHandleTerminalRecreateWindowRebuildsShellAsShell() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let tmux = TmuxManager(dryRun: true)
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: tmux,
+            hooks: HookResolver()
+        ),
+        tmux: tmux
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-recreate-shell", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-recreate-shell",
+        branch: "tbd/wt-recreate-shell",
+        path: "/tmp/fake-repo-recreate-shell/wt-recreate-shell",
+        tmuxServer: "tbd-5be11000"
+    )
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@old-shell",
+        tmuxPaneID: "%old-shell",
+        label: "shell",
+        kind: .shell
+    )
+
+    let request = try RPCRequest(
+        method: RPCMethod.terminalRecreateWindow,
+        params: TerminalRecreateWindowParams(terminalID: terminal.id)
+    )
+    let response = await router.handle(request)
+    #expect(response.success, "expected success; error: \(response.error ?? "nil")")
+
+    let updated = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(updated.suspendedAt == nil, "shell terminal must not be parked as suspended")
+    #expect(updated.kind == .shell, "shell terminal must remain a shell")
+    #expect(updated.claudeSessionID == nil, "shell terminal has no session to preserve")
+}
+
 // MARK: - Fix 3: setupTerminals injects TBD_TERMINAL_ID + TBD_WORKTREE_ID on the setup tab
 
 /// Regression test for the bug where the auto-created "setup" tab that gets


### PR DESCRIPTION
## Problem

After a sleep/wake or OOM that killed tmux servers **without** a daemon restart, Claude tabs showed `[server exited unexpectedly]` / `[View detached … session is still running … reopen to reattach]`, but reopening did **not** reattach — the tab silently flipped from "claude" to a plain "shell", and `/resume` could no longer find the conversation.

Root cause: two recovery paths disagreed.

- **reconcile()** (daemon startup) correctly **parks** resumable Claude terminals as suspended, preserving `claudeSessionID`/`transcriptPath`. But it only runs at daemon startup — a server dying under a *live* app+daemon never triggers it.
- The **live** app-side path (`handleTerminalRecreateWindow`) took the claude/shell else-branch: it recreated a **plain shell** and called `db.terminals.clearRecreated()`, which NULLs `claudeSessionID` + `transcriptPath` and sets `kind=.shell`, `label=shell`. That wipe explains every symptom — the tab flips to a shell, TBD can no longer Resume, and `/resume` finds nothing.

## Fix

Make the live dead-window path behave like `reconcile()`:

- In `handleTerminalRecreateWindow`, a Claude-resumable terminal (`isClaudeResumable`, with a `claudeSessionID`) is now **parked as suspended** via `db.terminals.setSuspended(...)` — preserving `claudeSessionID`/`transcriptPath`/`kind` — instead of being recreated as a plain shell. Pending tool-use questions are cleared too, matching reconcile()/delete. Genuine shell and Codex terminals keep their existing branches unchanged.
- **No app-side change needed:** the RPC already returns the full `Terminal`; the app applies it directly and renders the suspended (moon) / Resume state purely from `suspendedAt != nil`, skipping the tmux attach. Resume rebuilds a fresh window from the session ID on demand, so parking is non-destructive even if the window were somehow still alive.
- Reworded the misleading detach message so it no longer claims the session is "still running in the background" on an abnormal (non-zero) exit; neutral "reconnect" wording is honest for every terminal kind.

## Tests

Per the branching-conditional rule, a test for each side of the claude-vs-shell branch in `handleTerminalRecreateWindow`:

- `recreateWindowParksClaudeAsSuspended` — claude terminal → `suspendedAt != nil`, `claudeSessionID`/`transcriptPath` preserved, `kind == .claude` (confirmed RED before the fix).
- `recreateWindowRebuildsShellAsShell` — shell terminal → stays a shell, not suspended (regression guard for the unchanged branch).

`swift build` clean, `swiftlint --strict` clean, full `swift test` green (sole failure is the known pre-existing `TabBarHitArea` headless-measurement flake in untouched `TabBar.swift`).

[20260622-inland-cephalopod](https://cheapsteak.github.io/tbd/open/?worktree=7159AB9B-01D1-4CDE-8326-E9764AD71A1A)
