### PR TITLE
fix(test): stop manualResumeBootstrapsDeadServer flaking on CI without claude

### DIFF
--- a/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/SuspendResumeCoordinatorTests.swift
@@ -262,6 +262,22 @@ struct SuspendResumeCoordinatorTests {
     /// `ensureServer` always returns nil in dryRun, so the bootstrap/kill code
     /// added by this fix never engages. Modeled on
     /// `testRecreateAfterRebootBootstrapKillOrdering` in WorktreeLifecycleTests.
+    ///
+    /// The resume window tmux creates runs `$SHELL -ic 'claude --resume <id> …'`.
+    /// Its pane — and therefore the freshly-bootstrapped session and the whole
+    /// server — stays alive only while that `claude` process keeps running. CI
+    /// installs tmux but NOT the `claude` binary (see .github/workflows/test.yml),
+    /// so on CI the resume shell hits "command not found", exits immediately, and
+    /// the just-bootstrapped session collapses to zero windows — tearing down the
+    /// server *before* `serverExists` is queried below. That made this test fail
+    /// (flakily, racing tmux's async pane reaping) on CI while passing locally only
+    /// because the developer happens to have a long-running `claude` installed.
+    /// Remove that environmental dependency by shadowing `claude` with a stub that
+    /// blocks (`exec /bin/sleep`), so the resume window is deterministically
+    /// long-lived on any runner — the same trick the sibling real-tmux test uses
+    /// when it spawns `sleep 60`. The stub is put on the tmux server's inherited
+    /// PATH and the resume shell's rc is neutralized via ZDOTDIR; see the setup
+    /// block below for why those are the only reliable levers.
     @Test func manualResumeBootstrapsDeadServer() async throws {
         let socketName = "tbd-test-\(UUID().uuidString.prefix(8))"
         let realTmux = TmuxManager()
@@ -290,6 +306,52 @@ struct SuspendResumeCoordinatorTests {
         try await db.terminals.setSuspended(
             id: terminal.id, sessionID: "session-abc", snapshot: "fake snapshot"
         )
+
+        // Shadow `claude` with a blocking stub so the resume window's pane — and
+        // thus the bootstrapped session and server — stays alive on any runner,
+        // not just one that happens to have a long-running `claude` installed.
+        // See the test's doc comment for the full rationale.
+        //
+        // Mechanism (the only one that proved reliable; tmux's `new-window -e
+        // PATH=…` does NOT override the PATH a pane's shell ends up with):
+        //  1. Prepend the stub dir to the *test process* PATH. `ensureServer`
+        //     spawns the tmux server from this process, so the server — and every
+        //     pane it later forks, including the resume window — inherits it.
+        //  2. Point ZDOTDIR at an empty dir so the resume window's `$SHELL -ic`
+        //     sources no user `.zshrc`. Without this, a developer rc that rebuilds
+        //     PATH would drop the stub before `claude` is resolved (CI runners have
+        //     no such rc, which is why the stub is reached there unaided). `-ic` is
+        //     non-login, so /etc/zprofile's path_helper never runs.
+        // Both are process-global, so restore them in `defer`. Unlike the
+        // `setenv("TBD_HOME")` hazard CLAUDE.md calls out — where the flake was a
+        // *logic* race (another suite read TBD_HOME and derived a wrong path) — no
+        // test reads PATH or ZDOTDIR to make assertions, so that failure mode can't
+        // occur here. The only concurrent consumers are subprocess spawns, for which
+        // these values are additive/inert: prepending a `claude`-only dir changes no
+        // other binary's resolution, and the sibling real-tmux suites spawn `sleep`,
+        // which needs no rc. (Verified: these suites pass repeatedly under
+        // `swift test --parallel` alongside this mutation.) Caveat for future work:
+        // a new test that spawns an *interactive* shell expecting the user rc to
+        // have run could observe the empty ZDOTDIR during this window — serialize
+        // against this test if that ever becomes a concern.
+        let stubBinDir = tempDir.appendingPathComponent("stub-bin")
+        let emptyZDotDir = tempDir.appendingPathComponent("empty-zdotdir")
+        try FileManager.default.createDirectory(at: stubBinDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: emptyZDotDir, withIntermediateDirectories: true)
+        let claudeStub = stubBinDir.appendingPathComponent("claude")
+        // Absolute `/bin/sleep` so the stub does not itself depend on PATH.
+        try "#!/bin/sh\nexec /bin/sleep 120\n".write(to: claudeStub, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: claudeStub.path
+        )
+        let originalPath = ProcessInfo.processInfo.environment["PATH"]
+        let originalZDotDir = ProcessInfo.processInfo.environment["ZDOTDIR"]
+        setenv("PATH", "\(stubBinDir.path):\(originalPath ?? "/usr/bin:/bin")", 1)
+        setenv("ZDOTDIR", emptyZDotDir.path, 1)
+        defer {
+            if let originalPath { setenv("PATH", originalPath, 1) } else { unsetenv("PATH") }
+            if let originalZDotDir { setenv("ZDOTDIR", originalZDotDir, 1) } else { unsetenv("ZDOTDIR") }
+        }
 
         let coordinator = SuspendResumeCoordinator(db: db, tmux: realTmux)
 


### PR DESCRIPTION
## Summary

Independent fix for a pre-existing flaky test, `manualResumeBootstrapsDeadServer` in `SuspendResumeCoordinatorTests`, surfaced by PR #292's CI run but **unrelated to that PR's diff**. Branched off `origin/main`; does not depend on #292.

## Root cause

The test exercises the real `SuspendResumeCoordinator.manualResume` → `resumeTerminal` path, which bootstraps a dead tmux server and then creates a resume window running `$SHELL -ic 'claude --resume <id> …'`. That window's pane — and therefore the just-bootstrapped session and the **whole tmux server** — stays alive only while the spawned `claude` process keeps running.

CI installs tmux but **not** the `claude` binary (`.github/workflows/test.yml` only `brew install tmux`). So on CI the resume shell hits "command not found", exits immediately, and the bootstrapped session collapses to zero windows. The server dies *before* the test asserts `serverExists`, failing the "tmux server must be running after resume" check (and sometimes the `listWindows` probe with "no server running"). It looked flaky because tmux reaps the exited pane asynchronously, so the server-death occasionally lost the race against the assertion. Locally it always passed only because the developer happens to have a long-running `claude` on PATH.

Reproduced deterministically: **18/20 failures** when `claude` exits instantly under load; **0/30** after the fix with `claude` removed from PATH entirely (so the stub — not a real claude — is what keeps the window alive).

## Fix

Shadow `claude` with a blocking stub (`exec /bin/sleep 120`) so the resume window is deterministically long-lived on any runner — the same approach the sibling real-tmux test `testRecreateAfterRebootBootstrapKillOrdering` already uses with `sleep 60`. Two non-obvious details were needed to make the stub reliably resolved:

- tmux's `new-window -e PATH=…` does **not** override the PATH a pane's shell ends up with, so the stub instead rides on the tmux **server's** inherited PATH (the server is forked from the test process by `ensureServer`).
- the resume window's interactive `$SHELL -ic` re-sources the user's rc, which on a dev machine rebuilds PATH and drops the stub; `ZDOTDIR` is pointed at an empty dir so no rc runs (CI runners have no such rc, hence the stub is reached there unaided). `-ic` is non-login, so `path_helper` never runs.

Both env vars are set on the test process and restored in `defer`. Unlike the `setenv("TBD_HOME")` hazard CLAUDE.md calls out (a *logic* race where another suite reads the mutated var), no test reads PATH/ZDOTDIR for assertions, and the values are additive/inert to concurrent suites' subprocess spawns — verified by running the real-tmux suites repeatedly under `swift test --parallel`.

Every assertion is preserved (server alive, fresh window/pane IDs, `suspendedAt` cleared, bootstrap placeholder killed → exactly one window); they now verify the real tmux bootstrap dance instead of accidentally depending on a `claude` install.

## Verification

- `manualResumeBootstrapsDeadServer`: 0/30 failures with `claude` stripped from PATH + CPU load (was 18/20 before the fix).
- Full `SuspendResumeCoordinator` suite passes; `swiftlint --strict` clean.
- Full `swift test --parallel` clean except a pre-existing, unrelated `TabBarHitAreaTests` UI font-measurement flake (not touched by this PR).

[linguistic-impala](https://cheapsteak.github.io/tbd/open/?worktree=0F9C57E2-4D20-410A-B7DC-74FA6B83BCFE)