### PR TITLE
fix(test): materialize KeyViewProxy in a window so TabBar hit-area test works headlessly

### DIFF
--- a/Tests/TBDAppTests/TabBarHitAreaTests.swift
+++ b/Tests/TBDAppTests/TabBarHitAreaTests.swift
@@ -66,16 +66,49 @@ struct TabBarHitAreaTests {
 
     private func keyViewProxyMaxWidth<Content: View>(_ rootView: Content) -> CGFloat {
         let host = NSHostingView(rootView: rootView)
+
+        // SwiftUI only instantiates the private `KeyViewProxy` button hit-target
+        // view once the host is inside a window that has been ordered in and
+        // given a display pass; `layoutSubtreeIfNeeded()` alone is not enough on
+        // macOS 26, where the proxy is created lazily at first render (so a bare
+        // hosting view yields zero proxies and a misleading 0-width measurement).
+        // Attach to a borderless window positioned far off-screen and order it
+        // in *regardless* — no app activation, no visible flash — so the
+        // measurement is reliable in a headless `swift test` process without
+        // disturbing the developer's desktop.
+        let window = NSWindow(
+            contentRect: NSRect(x: -20000, y: -20000, width: 220, height: 30),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        // ARC owns the local `window` reference, so closing must not also
+        // release it (the AppKit default would over-release and crash).
+        window.isReleasedWhenClosed = false
+        window.contentView = host
         host.frame = NSRect(x: 0, y: 0, width: 220, height: 30)
+        window.orderFrontRegardless()
         host.layoutSubtreeIfNeeded()
+        host.displayIfNeeded()
+        defer {
+            window.orderOut(nil)
+            window.contentView = nil
+            // `orderOut` alone leaves the window in `NSApp.windows`; close it so
+            // the two windows this helper creates per test don't accumulate
+            // across a parallel `swift test` run.
+            window.close()
+        }
+
         return keyViewProxyFrames(in: host).map(\.width).max() ?? 0
     }
 
     private func keyViewProxyFrames(in view: NSView) -> [CGRect] {
         // SwiftUI's AppKit button hit target is materialized as a private
-        // KeyViewProxy view. There's no public NSView API that exposes the
-        // same button hit-region frame directly, so this string match is a
-        // deliberate test seam rather than an accidental private dependency.
+        // KeyViewProxy view (see `keyViewProxyMaxWidth` for why the host must be
+        // in an ordered-in window for this view to exist). There's no public
+        // NSView API that exposes the same button hit-region frame directly, so
+        // this string match is a deliberate test seam rather than an accidental
+        // private dependency.
         let current = String(describing: type(of: view)) == "KeyViewProxy" ? [view.frame] : []
         return current + view.subviews.flatMap(keyViewProxyFrames(in:))
     }


### PR DESCRIPTION
## Problem

`TabBarHitAreaTests.selectionTargetIncludesTabPadding()` failed **deterministically** under headless `swift test` on macOS 26:

```
Expectation failed: (paddedWidth → 0.0) > (labelOnlyWidth + 2 → 2.0)
```

Both measured widths were `0.0`. The test measures the select button's AppKit hit region by recursively finding SwiftUI's private `KeyViewProxy` hit-target view and reading its frame (`max() ?? 0`). Instrumenting the `NSView` subtree showed **no `KeyViewProxy` was materialized at all** — only a `_FocusRingView`.

## Root cause

On macOS 26, SwiftUI creates the `KeyViewProxy` hit-target **lazily at first render**, not during `layoutSubtreeIfNeeded()`. A bare `NSHostingView` that is only laid out (never placed in a window / displayed) therefore yields zero proxies, so the search returns `0.0` for both the padded tab button and the label-only baseline → `0 > 2` is false.

Bisecting the materialization (8/8 deterministic trials) showed the trigger is **ordering the host's window in** — not a run-loop spin:

| materialization | KeyViewProxy width |
|---|---|
| `layoutSubtreeIfNeeded()` only | **0.0** |
| in window + `displayIfNeeded()` (no orderFront) | **0.0** |
| in window + `displayIfNeeded()` + run-loop spin (no orderFront) | **0.0** |
| in window + `orderFront`/`orderFrontRegardless` + `displayIfNeeded()` | 32.5 (tab) / 24.5 (baseline) |

CI runs the same headless `swift test --parallel -j 2`, but on **macos-15**, where the proxy still materializes under plain layout — which is why this regression went unnoticed. It surfaces on macOS 26 locally.

## Fix

Attach the `NSHostingView` to a borderless `NSWindow` positioned far off-screen, `orderFrontRegardless()` + `displayIfNeeded()` to force the genuine `KeyViewProxy` to materialize, measure, then tear the window down. This:

- **Keeps the exact seam the test documents** (the real `KeyViewProxy` hit target) — not a weakened proxy or a deleted assertion.
- **No app activation, no visible flash** (`orderFrontRegardless` + off-screen position), so it doesn't disturb a developer running `swift test` locally.
- **Cleans up** the window in `defer` (`orderOut` + `contentView = nil` + `close()`, with `isReleasedWhenClosed = false`) so windows don't accumulate across a parallel run.

The off-screen window approach is a superset of the macos-15 path (which already materializes the proxy more eagerly), so CI stays green while macOS 26 is now covered.

## Verification

- `swift build` clean, `swiftlint --strict` clean (0 violations).
- Ran the test **25/25 passes** after the fix (was 0/3 before). `KeyViewProxy` measures 32.5 (padded) vs 24.5 (label-only) — the 8px leading padding the #204 fix added — preserving the assertion with comfortable margin.
- Checked the sibling `TranscriptRowLayoutTests` (also `NSHostingView`-measured): its `fittingSize` does **not** collapse to 0 on macOS 26 (measures 56.0), so it provides real coverage and needs no change — the fragility is specific to `KeyViewProxy`'s lazy materialization.

## Scope

Independent **pre-existing** flake on `main`, noticed while working on PR #293 (the suspend/resume daemon test) but unrelated to it. Touches only `Tests/TBDAppTests/TabBarHitAreaTests.swift`.

[tabbar-hitarea-flake](https://cheapsteak.github.io/tbd/open/?worktree=D45E3CCF-2E8D-4086-AC3A-59A7E250E435)