### PR TITLE
feat: auto-archive worktree when its PR merges

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -28,6 +28,9 @@ extension AppState {
             if result.globalEnvOverrides != globalEnvOverrides {
                 globalEnvOverrides = result.globalEnvOverrides
             }
+            if result.autoArchiveOnMergeDefault != autoArchiveOnMergeDefault {
+                autoArchiveOnMergeDefault = result.autoArchiveOnMergeDefault
+            }
         } catch {
             logger.error("Failed to list model profiles: \(error, privacy: .public)")
             handleConnectionError(error)
@@ -150,6 +153,17 @@ extension AppState {
         } catch {
             logger.error("Failed to set primary agent preference: \(error, privacy: .public)")
             showAlert("Failed to set primary agent: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set the global default for auto-archive-on-PR-merge.
+    func setAutoArchiveOnMergeDefault(_ enabled: Bool) async {
+        do {
+            try await daemonClient.setAutoArchiveOnMergeDefault(enabled)
+            autoArchiveOnMergeDefault = enabled
+        } catch {
+            logger.error("Failed to set auto-archive default: \(error, privacy: .public)")
+            showAlert("Failed to set default: \(error.localizedDescription)", isError: true)
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -452,6 +452,30 @@ extension AppState {
         return nil
     }
 
+    /// Resolve the effective auto-archive-on-merge setting for a worktree.
+    /// Returns the per-worktree override when explicitly set; otherwise falls
+    /// back to the global default (`autoArchiveOnMergeDefault`).
+    func effectiveAutoArchive(for worktree: Worktree) -> Bool {
+        worktree.autoArchiveOnMerge ?? autoArchiveOnMergeDefault
+    }
+
+    /// Set the per-worktree auto-archive override and update local state optimistically.
+    func setAutoArchive(worktreeID: UUID, enabled: Bool) async {
+        do {
+            try await daemonClient.setWorktreeAutoArchive(id: worktreeID, enabled: enabled)
+            // Optimistic local update so the toolbar reflects it immediately.
+            for (key, list) in worktrees {
+                if let idx = list.firstIndex(where: { $0.id == worktreeID }) {
+                    worktrees[key]?[idx].autoArchiveOnMerge = enabled
+                    break
+                }
+            }
+        } catch {
+            logger.error("Failed to set auto-archive: \(error, privacy: .public)")
+            showAlert("Couldn't update auto-archive: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Repo ID of the repo containing the given worktree, if any.
     private func repoIDForWorktree(_ id: UUID) -> UUID? {
         for (rid, rows) in worktrees where rows.contains(where: { $0.id == id }) {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -360,6 +360,9 @@ final class AppState: ObservableObject {
     /// Global free-form env overrides (config scope). Loaded from the daemon
     /// alongside `defaultProfileID` via `loadModelProfiles()`.
     @Published var globalEnvOverrides: [String: String] = [:]
+    /// Global default for auto-archive-on-PR-merge. Loaded from the daemon
+    /// alongside `globalEnvOverrides` via `loadModelProfiles()`.
+    @Published var autoArchiveOnMergeDefault: Bool = false
     /// Terminals where the user has dismissed the proxy-unreachable banner.
     /// Cleared on app relaunch (in-memory only — banners are advisory).
     @Published var dismissedProxyWarnings: Set<UUID> = []

--- a/Sources/TBDApp/CLAUDE.md
+++ b/Sources/TBDApp/CLAUDE.md
@@ -1,0 +1,28 @@
+# TBDApp
+
+SwiftUI app target. See the repo-root `CLAUDE.md` and the `tbd-project` skill for architecture.
+
+## macOS 26 (Tahoe) Liquid Glass toolbars — grouping rules
+
+macOS 26 redesigned toolbars: items render on **Liquid Glass capsules**, and **adjacent toolbar items are automatically fused onto one shared capsule**. Getting items onto *separate* capsules is non-obvious and cost a long trial-and-error loop — here is what actually works (verified against WWDC25 session 323 "Build a SwiftUI app with the new design" and confirmed live in this app). The working example is the PR split button in `ContentView.swift`.
+
+### What separates vs. fuses
+
+- **`ToolbarItemGroup` FUSES its children by design** — it is a shared-background cluster, NOT a separator. Wrapping each segment in its own single-child `ToolbarItemGroup` does **not** put them on separate capsules.
+- **`ControlGroup` is the reliable capsule BOUNDARY.** It lowers to an `NSToolbarItemGroup` (a first-class grouped item with a hard glass boundary), so its content never fuses with outside neighbors. **To isolate one control into its own capsule, make it the *sole child* of a `ControlGroup`** — single child means no internal gap. (A `ControlGroup` with *two* children separates correctly too, but its inter-member spacing is system-controlled with no public API, so it looks too gappy.)
+- **`ToolbarSpacer` separates two items _only_ when it carries the same `placement` as them** and sits directly between them in source order. `ToolbarSpacer(.fixed, placement: .primaryAction)` between two `.primaryAction` items splits the capsule; a placement-less `ToolbarSpacer(.fixed)` lands in a different bucket and silently does nothing. `.fixed` = snug gap, `.flexible` = pushes items to opposite edges. `ToolbarSpacer` is **macOS 26.0+** — guard with `if #available(macOS 26.0, *)`.
+- A bare `Menu` / `Menu(primaryAction:)` toolbar item (an `NSMenuToolbarItem`) is greedy: it tends to fuse with an adjacent bordered item even with a spacer. Putting it inside a `ControlGroup` (boundary) is what reliably isolates it.
+- Last-resort escape hatches if SwiftUI keeps fusing: `.sharedBackgroundVisibility(.hidden)` (removes an item's glass entirely — separate grouping but no background), or drop to a custom `NSToolbar` + `NSToolbarDelegate` with `NSMenuToolbarItem` and explicit space items.
+
+### Split button (primary action + dropdown)
+
+`Menu(content:label:primaryAction:)` is the toolbar **split button**: the label is the primary click; an attached **chevron** opens the menu. Per Apple's HIG this chevron is the correct affordance for a labeled action with options (an ellipsis "More" is discouraged for discoverability, and there is no native vertical-ellipsis SF Symbol).
+
+### Colored icon inside a toolbar Menu / split-button label
+
+A toolbar `Menu` label renders **template** images monochrome (AppKit tints them with the control color and ignores SwiftUI `.foregroundStyle`). To show a status-colored icon (see `PRButtonLabel` + `PRStatusPresentation.nsColor`):
+
+1. Bake the color into a **non-template** `NSImage` (draw the template, then `NSColor.set()` + `rect.fill(using: .sourceAtop)`; set `isTemplate = false`).
+2. Render it with `Image(nsImage:).renderingMode(.original)`.
+3. Re-bake on light/dark changes by reading `@Environment(\.colorScheme)` in the view body.
+4. Use `.tint(.primary)` on the `Menu` to keep adjacent label text neutral (the split button otherwise accent-tints it); `.renderingMode(.original)` images ignore the tint, so the baked color survives.

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -140,6 +140,21 @@ struct ContentView: View {
                             PRButtonLabel(prStatus: prStatus)
                         }
                         .help("Open PR in browser pane")
+
+                        if let worktree = appState.findWorktree(id: worktreeID) {
+                            let armed = appState.effectiveAutoArchive(for: worktree)
+                            let blocked = !appState.children(of: worktreeID).isEmpty
+                            Button {
+                                Task { await appState.setAutoArchive(worktreeID: worktreeID, enabled: !armed) }
+                            } label: {
+                                Image(systemName: armed ? "archivebox.fill" : "archivebox")
+                                    .foregroundStyle(armed ? Color.accentColor : Color.secondary)
+                            }
+                            .disabled(blocked)
+                            .help(blocked
+                                ? "Can't auto-archive: this worktree has active children"
+                                : "Auto-archive this worktree when PR #\(prStatus.number) merges")
+                        }
                     }
 
                     Button {

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -106,7 +106,14 @@ struct ContentView: View {
                     .keyboardShortcut("]", modifiers: .command)
                 }
 
-                ToolbarItemGroup(placement: .primaryAction) {
+                // macOS 26 fuses ADJACENT bare toolbar items onto one Liquid Glass
+                // capsule, and `ToolbarItemGroup` fuses on purpose. The reliable
+                // capsule BOUNDARY is `ControlGroup` (→ NSToolbarItemGroup): the PR
+                // split button is its sole child, which separates it from both
+                // neighbors (confirmed earlier) with no internal gap, while keeping
+                // the split-button chevron + status-colored icon. Plain `Button`s
+                // for the filter / sidebar separate via placement-matched spacers.
+                ToolbarItem(placement: .primaryAction) {
                     Picker("Filter", selection: $appState.repoFilter) {
                         Text("All Repos").tag(UUID?.none)
                         Divider()
@@ -116,47 +123,64 @@ struct ContentView: View {
                     }
                     .pickerStyle(.menu)
                     .help("Filter sidebar by repository")
+                }
 
-                    if let worktreeID = appState.selectedWorktreeIDs.first,
-                       appState.selectedWorktreeIDs.count == 1,
-                       let prStatus = appState.prStatuses[worktreeID],
-                       let prURL = URL(string: prStatus.url) {
-                        Button {
-                            let existingTabs = appState.tabs[worktreeID] ?? []
-                            if let existingIndex = existingTabs.firstIndex(where: {
-                                if case .webview(_, let url) = $0.content { return url == prURL }
-                                return false
-                            }) {
-                                // Focus existing PR tab
-                                appState.activeTabIndices[worktreeID] = existingIndex
-                            } else {
-                                // Create and focus new PR tab
-                                let webviewID = UUID()
-                                let tab = Tab(id: UUID(), content: .webview(id: webviewID, url: prURL), label: "PR #\(prStatus.number)")
-                                appState.tabs[worktreeID, default: []].append(tab)
-                                appState.activeTabIndices[worktreeID] = (appState.tabs[worktreeID]?.count ?? 1) - 1
-                            }
-                        } label: {
-                            PRButtonLabel(prStatus: prStatus)
-                        }
-                        .help("Open PR in browser pane")
+                if #available(macOS 26.0, *) {
+                    ToolbarSpacer(.fixed, placement: .primaryAction)
+                }
 
-                        if let worktree = appState.findWorktree(id: worktreeID) {
-                            let armed = appState.effectiveAutoArchive(for: worktree)
-                            let blocked = !appState.children(of: worktreeID).isEmpty
-                            Button {
-                                Task { await appState.setAutoArchive(worktreeID: worktreeID, enabled: !armed) }
+                if let worktreeID = appState.selectedWorktreeIDs.first,
+                   appState.selectedWorktreeIDs.count == 1,
+                   let prStatus = appState.prStatuses[worktreeID],
+                   let prURL = URL(string: prStatus.url) {
+                    ToolbarItem(placement: .primaryAction) {
+                        ControlGroup {
+                            // Split button: label = primary click (open PR); the
+                            // attached chevron opens the menu.
+                            Menu {
+                                if let worktree = appState.findWorktree(id: worktreeID) {
+                                    let armed = appState.effectiveAutoArchive(for: worktree)
+                                    let blocked = !appState.children(of: worktreeID).isEmpty
+                                    Toggle("Auto-archive worktree on PR merge", isOn: Binding(
+                                        get: { armed },
+                                        set: { newValue in
+                                            Task { await appState.setAutoArchive(worktreeID: worktreeID, enabled: newValue) }
+                                        }
+                                    ))
+                                    .disabled(blocked)
+                                }
                             } label: {
-                                Image(systemName: armed ? "archivebox.fill" : "archivebox")
-                                    .foregroundStyle(armed ? Color.accentColor : Color.secondary)
+                                PRButtonLabel(prStatus: prStatus)
+                            } primaryAction: {
+                                let existingTabs = appState.tabs[worktreeID] ?? []
+                                if let existingIndex = existingTabs.firstIndex(where: {
+                                    if case .webview(_, let url) = $0.content { return url == prURL }
+                                    return false
+                                }) {
+                                    // Focus existing PR tab
+                                    appState.activeTabIndices[worktreeID] = existingIndex
+                                } else {
+                                    // Create and focus new PR tab
+                                    let webviewID = UUID()
+                                    let tab = Tab(id: UUID(), content: .webview(id: webviewID, url: prURL), label: "PR #\(prStatus.number)")
+                                    appState.tabs[worktreeID, default: []].append(tab)
+                                    appState.activeTabIndices[worktreeID] = (appState.tabs[worktreeID]?.count ?? 1) - 1
+                                }
                             }
-                            .disabled(blocked)
-                            .help(blocked
-                                ? "Can't auto-archive: this worktree has active children"
-                                : "Auto-archive this worktree when PR #\(prStatus.number) merges")
+                            // Keep "#123" neutral like the original plain Button (the
+                            // split button otherwise accent-tints it); the icon keeps
+                            // its baked status color via renderingMode(.original).
+                            .tint(.primary)
+                            .help("Open PR #\(prStatus.number) · more options")
                         }
                     }
 
+                    if #available(macOS 26.0, *) {
+                        ToolbarSpacer(.fixed, placement: .primaryAction)
+                    }
+                }
+
+                ToolbarItem(placement: .primaryAction) {
                     Button {
                         // Defer the toggle one run-loop tick and skip the explicit
                         // withAnimation wrapper. Stacking an easeInOut animation
@@ -323,17 +347,19 @@ private func overlayFrameIsWindowRoot(
 
 private struct PRButtonLabel: View {
     let prStatus: PRStatus
+    // Re-bake the colored icon when the appearance flips (the baked image is
+    // non-template, so it can't auto-adapt the way a tinted template would).
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         HStack(spacing: 3) {
             if let presentation = PRStatusPresentation.make(for: prStatus),
-               let nsImage = loadIcon(presentation.iconName) {
+               let nsImage = coloredIcon(presentation.iconName, nsColor: presentation.nsColor) {
                 Image(nsImage: nsImage)
-                    .renderingMode(.template)
+                    .renderingMode(.original)
                     .resizable()
                     .scaledToFit()
                     .frame(width: 12, height: 12)
-                    .foregroundStyle(presentation.color)
             }
             Text(verbatim: "#\(prStatus.number)")
                 .font(.caption)
@@ -341,11 +367,23 @@ private struct PRButtonLabel: View {
         }
     }
 
-    private func loadIcon(_ name: String) -> NSImage? {
+    /// Bakes the status color into a NON-template image. Toolbar `Menu` /
+    /// split-button labels render template images monochrome (AppKit tints
+    /// them with the control color and ignores `.foregroundStyle`), so the
+    /// icon must carry its own color and be drawn with `.renderingMode(.original)`.
+    private func coloredIcon(_ name: String, nsColor: NSColor) -> NSImage? {
+        _ = colorScheme  // establish a dependency so we re-bake on light/dark change
         guard let url = Bundle.module.url(forResource: name, withExtension: "svg", subdirectory: "Icons"),
-              let image = NSImage(contentsOf: url) else { return nil }
-        image.isTemplate = true
-        return image
+              let base = NSImage(contentsOf: url) else { return nil }
+        base.isTemplate = true
+        let img = NSImage(size: NSSize(width: 12, height: 12), flipped: false) { rect in
+            base.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1)
+            nsColor.set()
+            rect.fill(using: .sourceAtop)
+            return true
+        }
+        img.isTemplate = false
+        return img
     }
 }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -658,6 +658,22 @@ actor DaemonClient {
         )
     }
 
+    /// Set the per-worktree auto-archive-on-PR-merge override.
+    func setWorktreeAutoArchive(id: UUID, enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.worktreeSetAutoArchive,
+            params: WorktreeSetAutoArchiveParams(worktreeID: id, enabled: enabled)
+        )
+    }
+
+    /// Set the global default for auto-archive-on-PR-merge.
+    func setAutoArchiveOnMergeDefault(_ enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetAutoArchiveOnMergeDefault,
+            params: ConfigSetAutoArchiveDefaultParams(enabled: enabled)
+        )
+    }
+
     /// Set or clear a repo's free-form env overrides.
     func setRepoEnvOverrides(repoID: UUID, overrides: [String: String]) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -36,6 +36,29 @@ struct PRStatusPresentation: Equatable {
         }
     }
 
+    /// AppKit equivalent of `color`, for baking a pre-tinted (non-template)
+    /// NSImage — toolbar `Menu`/split-button labels strip color from template
+    /// images, so the icon must carry its own color via `.renderingMode(.original)`.
+    var nsColor: NSColor {
+        switch colorSemantic {
+        case .pending:
+            return NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                    ? NSColor(srgbRed: 210 / 255, green: 153 / 255, blue: 34 / 255, alpha: 1)
+                    : NSColor(srgbRed: 147 / 255, green: 105 / 255, blue: 33 / 255, alpha: 1)
+            }
+        case .nonMergeable:     return .systemRed
+        case .draft:            return .secondaryLabelColor
+        case .mergeable:
+            return NSColor(name: nil) { appearance in
+                appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+                    ? NSColor(srgbRed: 63 / 255, green: 185 / 255, blue: 80 / 255, alpha: 1)
+                    : NSColor(srgbRed: 61 / 255, green: 125 / 255, blue: 64 / 255, alpha: 1)
+            }
+        case .merged:           return .systemPurple
+        }
+    }
+
     static func make(for prStatus: PRStatus?) -> PRStatusPresentation? {
         guard let prStatus else { return nil }
         switch prStatus.state {

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -125,6 +125,14 @@ struct GeneralSettingsTab: View {
                 .help("Used when TBD needs to choose the primary agent for a worktree and there is no prior agent state to restore.")
             }
 
+            Section("Worktrees") {
+                Toggle("Auto-archive worktrees when their PR merges", isOn: Binding(
+                    get: { appState.autoArchiveOnMergeDefault },
+                    set: { newValue in Task { await appState.setAutoArchiveOnMergeDefault(newValue) } }
+                ))
+                .help("Default for new worktrees. Each worktree can override this from its toolbar toggle.")
+            }
+
             Section("Claude") {
                 Toggle("Launch claude with --dangerously-skip-permissions", isOn: $skipPermissions)
                     .help("Skip the interactive permission prompt when launching claude in new worktrees")

--- a/Sources/TBDCLI/Commands/ConfigCommands.swift
+++ b/Sources/TBDCLI/Commands/ConfigCommands.swift
@@ -1,0 +1,51 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct ConfigCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "config",
+        abstract: "Get or set global TBD settings",
+        subcommands: [ConfigGet.self, ConfigSet.self]
+    )
+}
+
+struct ConfigGet: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "get", abstract: "Show global settings")
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let config = try client.call(method: RPCMethod.configGet, resultType: Config.self)
+        if json {
+            printJSON(config)
+        } else {
+            print("auto-archive-on-merge: \(config.autoArchiveOnMergeDefault ? "on" : "off")")
+        }
+    }
+}
+
+struct ConfigSet: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "set", abstract: "Set a global setting")
+
+    @Argument(help: "Setting key (currently: auto-archive-on-merge)")
+    var key: String
+
+    @Argument(help: "on or off")
+    var value: OnOffArgument
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        switch key {
+        case "auto-archive-on-merge":
+            try client.callVoid(
+                method: RPCMethod.configSetAutoArchiveOnMergeDefault,
+                params: ConfigSetAutoArchiveDefaultParams(enabled: value.boolValue))
+            print("Set auto-archive-on-merge default to \(value.rawValue).")
+        default:
+            throw CLIError.invalidArgument("Unknown config key '\(key)'. Known keys: auto-archive-on-merge")
+        }
+    }
+}

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -418,7 +418,8 @@ struct WorktreeAutoArchive: AsyncParsableCommand {
             params: WorktreeSetAutoArchiveParams(worktreeID: worktreeID, enabled: state.boolValue)
         )
         if json {
-            printJSON(["status": "auto-archive", "id": worktreeID.uuidString, "enabled": String(state.boolValue)])
+            struct Result: Encodable { let status: String; let id: String; let enabled: Bool }
+            printJSON(Result(status: "auto-archive", id: worktreeID.uuidString, enabled: state.boolValue))
         } else {
             print("Auto-archive \(state.rawValue) for worktree.")
         }

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -2,6 +2,13 @@ import ArgumentParser
 import Foundation
 import TBDShared
 
+// Shared by `worktree auto-archive` and `config` commands.
+enum OnOffArgument: String, ExpressibleByArgument {
+    case on
+    case off
+    var boolValue: Bool { self == .on }
+}
+
 struct WorktreeCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "worktree",
@@ -11,6 +18,7 @@ struct WorktreeCommand: ParsableCommand {
             WorktreeList.self,
             WorktreeAdopt.self,
             WorktreeArchive.self,
+            WorktreeAutoArchive.self,
             WorktreeForget.self,
             WorktreeRevive.self,
             WorktreeRename.self,
@@ -381,6 +389,38 @@ struct WorktreeArchive: AsyncParsableCommand {
             printJSON(["status": "archived", "id": worktreeID.uuidString])
         } else {
             print("Worktree archived.")
+        }
+    }
+}
+
+// MARK: - worktree auto-archive
+
+struct WorktreeAutoArchive: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "auto-archive",
+        abstract: "Set whether a worktree auto-archives when its PR merges"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var nameOrID: String
+
+    @Argument(help: "on or off")
+    var state: OnOffArgument
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeNameOrID(nameOrID, client: client)
+        try client.callVoid(
+            method: RPCMethod.worktreeSetAutoArchive,
+            params: WorktreeSetAutoArchiveParams(worktreeID: worktreeID, enabled: state.boolValue)
+        )
+        if json {
+            printJSON(["status": "auto-archive", "id": worktreeID.uuidString, "enabled": String(state.boolValue)])
+        } else {
+            print("Auto-archive \(state.rawValue) for worktree.")
         }
     }
 }

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -10,6 +10,7 @@ struct TBDCommand: AsyncParsableCommand {
         subcommands: [
             RepoCommand.self,
             WorktreeCommand.self,
+            ConfigCommand.self,
             TerminalCommand.self,
             NotifyCommand.self,
             SessionEventCommand.self,

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -213,6 +213,16 @@ public final class Daemon: Sendable {
         )
         let prManager = PRStatusManager()
 
+        // 7a. Wire auto-archive-on-merge: when a worktree's cached PR state
+        // transitions into `.merged`, the coordinator evaluates the effective
+        // setting and archives the worktree (no active children) in the
+        // background.
+        let autoArchiveCoordinator = AutoArchiveOnMergeCoordinator(
+            db: database, lifecycle: lifecycle, subscriptions: subs)
+        await prManager.setOnMergedTransition { worktreeID, prNumber in
+            await autoArchiveCoordinator.handleMergedTransition(worktreeID: worktreeID, prNumber: prNumber)
+        }
+
         // 8. Initialize RPC router
         let rpcRouter = RPCRouter(
             db: database,

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -16,6 +16,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var claude_env_settings: String?
     /// JSON-encoded `[String: String]` free-form env overrides (global scope).
     var env_overrides: String?
+    var auto_archive_on_merge_default: Bool?
 
     func toModel() -> Config {
         Config(
@@ -23,7 +24,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             primaryAgentPreference: primary_agent_preference
                 .flatMap(PrimaryAgentPreference.init(rawValue:)) ?? .defaultValue,
             envSettingOverrides: ConfigStore.decodeOverrides(claude_env_settings),
-            envOverrides: EnvOverridesCoding.decode(env_overrides)
+            envOverrides: EnvOverridesCoding.decode(env_overrides),
+            autoArchiveOnMergeDefault: auto_archive_on_merge_default ?? false
         )
     }
 }
@@ -96,6 +98,18 @@ public struct ConfigStore: Sendable {
             try db.execute(
                 sql: "UPDATE config SET env_overrides = ? WHERE id = ?",
                 arguments: [json, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the global auto-archive-on-merge default. When true, every
+    /// worktree that hasn't overridden `autoArchiveOnMerge` will be archived
+    /// when its PR merges.
+    public func setAutoArchiveOnMergeDefault(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_archive_on_merge_default = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -542,6 +542,16 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "model_profiles", column: "env_overrides", type: .text)
         }
 
+        migrator.registerMigration("v32_worktree_auto_archive") { db in
+            try db.addColumnIfMissing(table: "worktree", column: "autoArchiveOnMerge", type: .boolean)
+        }
+
+        migrator.registerMigration("v33_config_auto_archive_default") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "auto_archive_on_merge_default",
+                type: .boolean, defaults: false)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -23,6 +23,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var tabOrder: String  // JSON array of UUID strings, e.g. "[]" or "[\"...\",\"...\"]"
     var activeTabID: String?
     var parentWorktreeID: String?
+    var autoArchiveOnMerge: Bool?
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -45,6 +46,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.tabOrder = "[]"  // overwritten by GRDB when fetched; only "new worktree" path uses this initializer
         self.activeTabID = nil  // new worktrees start with no stored selection
         self.parentWorktreeID = wt.parentWorktreeID?.uuidString
+        self.autoArchiveOnMerge = wt.autoArchiveOnMerge
     }
 
     func toModel() -> Worktree {
@@ -68,7 +70,8 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             archivedClaudeSessions: sessions,
             sortOrder: sortOrder,
             archivedHeadSHA: archivedHeadSHA,
-            parentWorktreeID: parentWorktreeID.flatMap { UUID(uuidString: $0) }
+            parentWorktreeID: parentWorktreeID.flatMap { UUID(uuidString: $0) },
+            autoArchiveOnMerge: autoArchiveOnMerge
         )
     }
 }
@@ -641,5 +644,16 @@ public struct WorktreeStore: Sendable {
         guard let data = try? JSONEncoder().encode(strings),
               let s = String(data: data, encoding: .utf8) else { return "[]" }
         return s
+    }
+
+    /// Set or clear the per-worktree auto-archive-on-merge override.
+    /// `nil` means follow the global default; `true`/`false` override it.
+    public func setAutoArchiveOnMerge(id: UUID, value: Bool?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE worktree SET autoArchiveOnMerge = ? WHERE id = ?",
+                arguments: [value, id.uuidString]
+            )
+        }
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -335,7 +335,11 @@ extension WorktreeLifecycle {
 
         // Deliberate revive: disarm auto-archive so a still-merged PR doesn't
         // immediately re-archive the worktree the user just revived.
-        try? await db.worktrees.setAutoArchiveOnMerge(id: worktreeID, value: false)
+        do {
+            try await db.worktrees.setAutoArchiveOnMerge(id: worktreeID, value: false)
+        } catch {
+            archiveLogger.warning("failed to disarm auto-archive for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+        }
 
         // Return updated worktree
         guard let revived = try await db.worktrees.get(id: worktreeID) else {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -333,6 +333,10 @@ extension WorktreeLifecycle {
         // otherwise preserve them so a subsequent revive (without skipClaude) can use them.
         try await db.worktrees.revive(id: worktreeID, clearSessions: !skipClaude)
 
+        // Deliberate revive: disarm auto-archive so a still-merged PR doesn't
+        // immediately re-archive the worktree the user just revived.
+        try? await db.worktrees.setAutoArchiveOnMerge(id: worktreeID, value: false)
+
         // Return updated worktree
         guard let revived = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -64,7 +64,11 @@ extension WorktreeLifecycle {
 
         // A worktree with active children isn't auto-archivable; disarm the parent.
         if let parentID = resolvedParent {
-            try? await db.worktrees.setAutoArchiveOnMerge(id: parentID, value: false)
+            do {
+                try await db.worktrees.setAutoArchiveOnMerge(id: parentID, value: false)
+            } catch {
+                logger.warning("failed to disarm auto-archive for \(parentID, privacy: .public): \(error, privacy: .public)")
+            }
         }
 
         // 2. Generate name and construct path

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -62,6 +62,11 @@ extension WorktreeLifecycle {
             suppressAutoParent: suppressAutoParent
         )
 
+        // A worktree with active children isn't auto-archivable; disarm the parent.
+        if let parentID = resolvedParent {
+            try? await db.worktrees.setAutoArchiveOnMerge(id: parentID, value: false)
+        }
+
         // 2. Generate name and construct path
         let resolvedName: String
         let resolvedBranch: String

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -318,6 +318,9 @@ extension WorktreeLifecycle {
                 try await db.worktrees.updateStatus(id: worktree.id, status: .active)
             case .revive(let clearSessions):
                 try await db.worktrees.revive(id: worktree.id, clearSessions: clearSessions)
+                // Deliberate revive: disarm auto-archive so a still-merged PR
+                // doesn't immediately re-archive the worktree the user just revived.
+                try? await db.worktrees.setAutoArchiveOnMerge(id: worktree.id, value: false)
             }
         } catch {
             logger.error("phase-3 status update failed for worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -320,7 +320,11 @@ extension WorktreeLifecycle {
                 try await db.worktrees.revive(id: worktree.id, clearSessions: clearSessions)
                 // Deliberate revive: disarm auto-archive so a still-merged PR
                 // doesn't immediately re-archive the worktree the user just revived.
-                try? await db.worktrees.setAutoArchiveOnMerge(id: worktree.id, value: false)
+                do {
+                    try await db.worktrees.setAutoArchiveOnMerge(id: worktree.id, value: false)
+                } catch {
+                    logger.warning("failed to disarm auto-archive for \(worktree.id, privacy: .public): \(error, privacy: .public)")
+                }
             }
         } catch {
             logger.error("phase-3 status update failed for worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
+++ b/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
@@ -1,0 +1,59 @@
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "AutoArchiveOnMerge")
+
+/// Evaluates the effective auto-archive decision when a worktree's PR merges and
+/// archives it when armed. Wired to `PRStatusManager.onMergedTransition`.
+public struct AutoArchiveOnMergeCoordinator: Sendable {
+    let db: TBDDatabase
+    let lifecycle: WorktreeLifecycle
+    let subscriptions: StateSubscriptionManager
+
+    public init(db: TBDDatabase, lifecycle: WorktreeLifecycle, subscriptions: StateSubscriptionManager) {
+        self.db = db
+        self.lifecycle = lifecycle
+        self.subscriptions = subscriptions
+    }
+
+    public func handleMergedTransition(worktreeID: UUID, prNumber: Int) async {
+        do {
+            guard let wt = try await db.worktrees.get(id: worktreeID), wt.status == .active else { return }
+            let config = try await db.config.get()
+            let effective = wt.autoArchiveOnMerge ?? config.autoArchiveOnMergeDefault
+            guard effective else { return }
+
+            // Worktrees with active children are not auto-archivable.
+            do {
+                try await db.worktrees.assertArchivable(id: worktreeID)
+            } catch {
+                logger.info("auto-archive skipped (active children): \(worktreeID, privacy: .public)")
+                return
+            }
+
+            let (worktree, repo) = try await lifecycle.beginArchiveWorktree(worktreeID: worktreeID)
+            subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: worktreeID)))
+
+            // Surface it: persist + broadcast a notification (non-activating).
+            let notification = try await db.notifications.create(
+                worktreeID: worktreeID,
+                type: .taskComplete,
+                message: "Archived \(worktree.displayName) — PR #\(prNumber) merged",
+                terminalID: nil)
+            subscriptions.broadcast(delta: .notificationReceived(NotificationDelta(
+                notificationID: notification.id, worktreeID: notification.worktreeID,
+                type: notification.type, message: notification.message,
+                terminalID: notification.terminalID, activate: false)))
+
+            // Slow phase (hook + git worktree remove) in background, like the archive RPC handler.
+            let lifecycle = self.lifecycle
+            Task.detached {
+                await lifecycle.completeArchiveWorktree(worktree: worktree, repo: repo, force: false)
+            }
+            logger.info("auto-archived \(worktreeID, privacy: .public) on PR #\(prNumber, privacy: .public) merge")
+        } catch {
+            logger.error("auto-archive failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+        }
+    }
+}

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -10,6 +10,8 @@ public actor PRStatusManager {
 
     private var cache: [UUID: PRStatus] = [:]
 
+    private var onMergedTransition: (@Sendable (UUID, Int) async -> Void)?
+
     public init() {}
 
     // MARK: - Public interface
@@ -17,6 +19,23 @@ public actor PRStatusManager {
     public func allStatuses() -> [UUID: PRStatus] { cache }
 
     public func invalidate(worktreeID: UUID) { cache.removeValue(forKey: worktreeID) }
+
+    /// Register a callback fired when a worktree's cached PR state transitions
+    /// from non-merged (or absent) into `.merged`. Passes `(worktreeID, prNumber)`.
+    public func setOnMergedTransition(_ cb: @escaping @Sendable (UUID, Int) async -> Void) {
+        self.onMergedTransition = cb
+    }
+
+    /// Assigns `status` to the cache and fires `onMergedTransition` when the
+    /// state moves from non-merged (or absent) to `.merged`. All cache writes
+    /// route through here so the transition is detected uniformly.
+    private func apply(_ status: PRStatus, for worktreeID: UUID) async {
+        let wasMerged = (cache[worktreeID]?.state == .merged)
+        cache[worktreeID] = status
+        if !wasMerged && status.state == .merged {
+            await onMergedTransition?(worktreeID, status.number)
+        }
+    }
 
     /// Fetch all viewer PRs in one GraphQL call and update cache for all known worktrees.
     /// worktrees: list of (id, branch, upstreamBranch, worktreePath) for active non-main worktrees.
@@ -60,7 +79,7 @@ public actor PRStatusManager {
                 upstreamBranch: wt.upstreamBranch
             )
             if let node = candidates.compactMap({ byBranch[$0] }).first {
-                cache[wt.id] = PRStatus(
+                await apply(PRStatus(
                     number: node.number,
                     url: node.url,
                     state: Self.mapState(
@@ -77,7 +96,7 @@ public actor PRStatusManager {
                         isDraft: node.isDraft,
                         statusCheckRollupState: node.statusCheckRollupState
                     )
-                )
+                ), for: wt.id)
             }
         }
     }
@@ -113,7 +132,7 @@ public actor PRStatusManager {
                 state: state,
                 reason: reason
             )
-            cache[worktreeID] = status
+            await apply(status, for: worktreeID)
             return status
         }
 
@@ -121,9 +140,10 @@ public actor PRStatusManager {
         return cache[worktreeID]
     }
 
-    /// For tests only: seed a cache entry directly.
-    public func seedForTesting(worktreeID: UUID, status: PRStatus) {
-        cache[worktreeID] = status
+    /// For tests only: seed a cache entry. Routes through `apply` so the
+    /// merge-transition logic is exercised exactly as in production.
+    public func seedForTesting(worktreeID: UUID, status: PRStatus) async {
+        await apply(status, for: worktreeID)
     }
 
     // MARK: - State mapping (internal but static for testability)

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -29,6 +29,13 @@ public actor PRStatusManager {
     /// Assigns `status` to the cache and fires `onMergedTransition` when the
     /// state moves from non-merged (or absent) to `.merged`. All cache writes
     /// route through here so the transition is detected uniformly.
+    ///
+    /// Note: the cache is in-memory only, so after a daemon restart the first
+    /// observation of an already-merged PR counts as a nil→merged transition and
+    /// fires `onMergedTransition`. This is intentional — a PR that merged while
+    /// the daemon was down should still auto-archive its (armed) worktree on the
+    /// next poll. Re-archive loops are prevented because archived worktrees leave
+    /// the active poll set and revive disarms the override.
     private func apply(_ status: PRStatus, for worktreeID: UUID) async {
         let wasMerged = (cache[worktreeID]?.state == .merged)
         cache[worktreeID] = status

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -1,0 +1,17 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+    func handleConfigGet() async throws -> RPCResponse {
+        let config = try await db.config.get()
+        return try RPCResponse(result: config)
+    }
+
+    func handleConfigSetAutoArchiveDefault(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetAutoArchiveDefaultParams.self, from: paramsData)
+        try await db.config.setAutoArchiveOnMergeDefault(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -36,7 +36,8 @@ extension RPCRouter {
             profiles: result,
             defaultID: config.defaultProfileID,
             primaryAgentPreference: config.primaryAgentPreference,
-            globalEnvOverrides: config.envOverrides
+            globalEnvOverrides: config.envOverrides,
+            autoArchiveOnMergeDefault: config.autoArchiveOnMergeDefault
         ))
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -231,7 +231,11 @@ extension RPCRouter {
 
         // A worktree with active children isn't auto-archivable; disarm the new parent.
         if let newParentID = params.newParentID {
-            try? await db.worktrees.setAutoArchiveOnMerge(id: newParentID, value: false)
+            do {
+                try await db.worktrees.setAutoArchiveOnMerge(id: newParentID, value: false)
+            } catch {
+                logger.warning("failed to disarm auto-archive for \(newParentID, privacy: .public): \(error, privacy: .public)")
+            }
         }
 
         subscriptions.broadcast(delta: .worktreeMoved(WorktreeMovedDelta(

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -237,4 +237,10 @@ extension RPCRouter {
 
         return .ok()
     }
+
+    func handleWorktreeSetAutoArchive(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeSetAutoArchiveParams.self, from: paramsData)
+        try await db.worktrees.setAutoArchiveOnMerge(id: params.worktreeID, value: params.enabled)
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -229,6 +229,11 @@ extension RPCRouter {
             newSortOrder: params.newSortOrder
         )
 
+        // A worktree with active children isn't auto-archivable; disarm the new parent.
+        if let newParentID = params.newParentID {
+            try? await db.worktrees.setAutoArchiveOnMerge(id: newParentID, value: false)
+        }
+
         subscriptions.broadcast(delta: .worktreeMoved(WorktreeMovedDelta(
             worktreeID: params.worktreeID,
             newParentID: params.newParentID,

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -236,6 +236,12 @@ public final class RPCRouter: Sendable {
                 return try await handleTabList(request.paramsData)
             case RPCMethod.worktreeSetActiveTab:
                 return try await handleWorktreeSetActiveTab(request.paramsData)
+            case RPCMethod.worktreeSetAutoArchive:
+                return try await handleWorktreeSetAutoArchive(request.paramsData)
+            case RPCMethod.configGet:
+                return try await handleConfigGet()
+            case RPCMethod.configSetAutoArchiveOnMergeDefault:
+                return try await handleConfigSetAutoArchiveDefault(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -127,6 +127,11 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// project dir could not be resolved).
     public var liveClaudeSessionCount: Int?
     public var parentWorktreeID: UUID?
+    /// Per-worktree auto-archive-on-PR-merge override. `nil` = follow the
+    /// global default (`Config.autoArchiveOnMergeDefault`); `true`/`false` =
+    /// explicit. Only set explicitly by user action (toolbar toggle / CLI);
+    /// there is no UI to return to `nil`.
+    public var autoArchiveOnMerge: Bool?
 
     public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
@@ -135,7 +140,8 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 archivedClaudeSessions: [String]? = nil, sortOrder: Int = 0,
                 archivedHeadSHA: String? = nil,
                 liveClaudeSessionCount: Int? = nil,
-                parentWorktreeID: UUID? = nil) {
+                parentWorktreeID: UUID? = nil,
+                autoArchiveOnMerge: Bool? = nil) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -152,13 +158,14 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.archivedHeadSHA = archivedHeadSHA
         self.liveClaudeSessionCount = liveClaudeSessionCount
         self.parentWorktreeID = parentWorktreeID
+        self.autoArchiveOnMerge = autoArchiveOnMerge
     }
 
     enum CodingKeys: String, CodingKey {
         case id, repoID, name, displayName, branch, path, status
         case hasConflicts, createdAt, archivedAt, tmuxServer
         case archivedClaudeSessions, sortOrder, archivedHeadSHA
-        case liveClaudeSessionCount, parentWorktreeID
+        case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge
     }
 
     public init(from decoder: Decoder) throws {
@@ -179,6 +186,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         archivedHeadSHA = try c.decodeIfPresent(String.self, forKey: .archivedHeadSHA)
         liveClaudeSessionCount = try c.decodeIfPresent(Int.self, forKey: .liveClaudeSessionCount)
         parentWorktreeID = try c.decodeIfPresent(UUID.self, forKey: .parentWorktreeID)
+        autoArchiveOnMerge = try c.decodeIfPresent(Bool.self, forKey: .autoArchiveOnMerge)
     }
 }
 
@@ -413,15 +421,20 @@ public struct Config: Codable, Sendable, Equatable {
     public var envSettingOverrides: [String: ClaudeEnvValue]
     /// Free-form env-var overrides applied to spawned sessions (global scope).
     public var envOverrides: [String: String]
+    /// Global default for auto-archive-on-PR-merge, applied to worktrees whose
+    /// per-worktree override is `nil`.
+    public var autoArchiveOnMergeDefault: Bool
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
                 envSettingOverrides: [String: ClaudeEnvValue] = [:],
-                envOverrides: [String: String] = [:]) {
+                envOverrides: [String: String] = [:],
+                autoArchiveOnMergeDefault: Bool = false) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
         self.envOverrides = envOverrides
+        self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
     }
 
     public init(from decoder: Decoder) throws {
@@ -435,6 +448,8 @@ public struct Config: Codable, Sendable, Equatable {
             [String: ClaudeEnvValue].self, forKey: .envSettingOverrides) ?? [:]
         envOverrides = try c.decodeIfPresent(
             [String: String].self, forKey: .envOverrides) ?? [:]
+        autoArchiveOnMergeDefault = try c.decodeIfPresent(
+            Bool.self, forKey: .autoArchiveOnMergeDefault) ?? false
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -155,6 +155,9 @@ public enum RPCMethod {
     public static let configSetEnvOverrides       = "config.setEnvOverrides"
     public static let repoSetEnvOverrides         = "repo.setEnvOverrides"
     public static let modelProfileSetEnvOverrides = "modelProfile.setEnvOverrides"
+    public static let worktreeSetAutoArchive = "worktree.setAutoArchive"
+    public static let configGet = "config.get"
+    public static let configSetAutoArchiveOnMergeDefault = "config.setAutoArchiveOnMergeDefault"
 }
 
 // MARK: - Branch Listing
@@ -424,16 +427,19 @@ public struct ModelProfileListResult: Codable, Sendable {
     /// The global free-form env overrides (config scope). Carried alongside the
     /// other config-derived fields so the app loads it in one round-trip.
     public let globalEnvOverrides: [String: String]
+    public let autoArchiveOnMergeDefault: Bool
     public init(
         profiles: [ModelProfileWithUsage],
         defaultID: UUID? = nil,
         primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
-        globalEnvOverrides: [String: String] = [:]
+        globalEnvOverrides: [String: String] = [:],
+        autoArchiveOnMergeDefault: Bool = false
     ) {
         self.profiles = profiles
         self.defaultID = defaultID
         self.primaryAgentPreference = primaryAgentPreference
         self.globalEnvOverrides = globalEnvOverrides
+        self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
     }
 
     public init(from decoder: Decoder) throws {
@@ -448,6 +454,8 @@ public struct ModelProfileListResult: Codable, Sendable {
             [String: String].self,
             forKey: .globalEnvOverrides
         ) ?? [:]
+        autoArchiveOnMergeDefault = try c.decodeIfPresent(
+            Bool.self, forKey: .autoArchiveOnMergeDefault) ?? false
     }
 }
 
@@ -826,6 +834,19 @@ public struct ClaudeSpawnPreferences: Codable, Sendable, Equatable {
 public struct SetGlobalEnvOverridesParams: Codable, Sendable, Equatable {
     public let overrides: [String: String]
     public init(overrides: [String: String]) { self.overrides = overrides }
+}
+
+public struct WorktreeSetAutoArchiveParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let enabled: Bool
+    public init(worktreeID: UUID, enabled: Bool) {
+        self.worktreeID = worktreeID; self.enabled = enabled
+    }
+}
+
+public struct ConfigSetAutoArchiveDefaultParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
 }
 
 /// Params for `repo.setEnvOverrides` — per-repo free-form env overrides.

--- a/Tests/TBDAppTests/EffectiveAutoArchiveTests.swift
+++ b/Tests/TBDAppTests/EffectiveAutoArchiveTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tests for `effectiveAutoArchive(for:)` — the per-worktree auto-archive resolver.
+///
+/// The rule is simple: return the worktree's per-worktree override when set;
+/// otherwise fall back to the global default (`autoArchiveOnMergeDefault`).
+///
+/// Every test constructs `AppState(userDefaults:)` against a unique throwaway
+/// suite — TBDApp ships as an unbundled SPM executable, so `UserDefaults.standard`
+/// is the running developer's real `TBDApp.plist`.
+@MainActor
+@Suite("EffectiveAutoArchive")
+struct EffectiveAutoArchiveTests {
+
+    private func withAppState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.EffectiveAutoArchive.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func sampleWorktree(autoArchiveOnMerge: Bool? = nil) -> Worktree {
+        Worktree(
+            repoID: UUID(),
+            name: "acme",
+            displayName: "acme",
+            branch: "tbd/acme",
+            path: "/tmp/acme",
+            tmuxServer: "tbd-test",
+            autoArchiveOnMerge: autoArchiveOnMerge
+        )
+    }
+
+    @Test func nilFollowsDefaultOff() {
+        withAppState { app in
+            app.autoArchiveOnMergeDefault = false
+            let wt = sampleWorktree(autoArchiveOnMerge: nil)
+            #expect(app.effectiveAutoArchive(for: wt) == false)
+        }
+    }
+
+    @Test func nilFollowsDefaultOn() {
+        withAppState { app in
+            app.autoArchiveOnMergeDefault = true
+            let wt = sampleWorktree(autoArchiveOnMerge: nil)
+            #expect(app.effectiveAutoArchive(for: wt) == true)
+        }
+    }
+
+    @Test func explicitFalseOverridesDefaultOn() {
+        withAppState { app in
+            app.autoArchiveOnMergeDefault = true
+            let wt = sampleWorktree(autoArchiveOnMerge: false)
+            #expect(app.effectiveAutoArchive(for: wt) == false)
+        }
+    }
+
+    @Test func explicitTrueOverridesDefaultOff() {
+        withAppState { app in
+            app.autoArchiveOnMergeDefault = false
+            let wt = sampleWorktree(autoArchiveOnMerge: true)
+            #expect(app.effectiveAutoArchive(for: wt) == true)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/AutoArchiveRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveRPCTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct AutoArchiveRPCTests {
+
+    private func makeRouter() throws -> (RPCRouter, TBDDatabase) {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+        return (router, db)
+    }
+
+    @Test func setWorktreeAutoArchivePersists() async throws {
+        let (router, db) = try makeRouter()
+        let repo = try await db.repos.create(
+            path: "/tmp/repoB-\(UUID().uuidString)",
+            displayName: "repoB",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "w",
+            branch: "b",
+            path: "/tmp/repoB-w-\(UUID().uuidString)",
+            tmuxServer: "s"
+        )
+
+        let req = try RPCRequest(
+            method: RPCMethod.worktreeSetAutoArchive,
+            params: WorktreeSetAutoArchiveParams(worktreeID: wt.id, enabled: true)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let after = try await db.worktrees.get(id: wt.id)
+        #expect(after?.autoArchiveOnMerge == true)
+    }
+
+    @Test func configGetAndSetDefault() async throws {
+        let (router, db) = try makeRouter()
+        let setReq = try RPCRequest(
+            method: RPCMethod.configSetAutoArchiveOnMergeDefault,
+            params: ConfigSetAutoArchiveDefaultParams(enabled: true)
+        )
+        #expect(await router.handle(setReq).success)
+
+        let getReq = RPCRequest(method: RPCMethod.configGet)
+        let getResp = await router.handle(getReq)
+        let cfg = try getResp.decodeResult(Config.self)
+        #expect(cfg.autoArchiveOnMergeDefault == true)
+        _ = db
+    }
+}

--- a/Tests/TBDDaemonTests/AutoArchiveRuleTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveRuleTests.swift
@@ -1,0 +1,179 @@
+import Testing
+import Foundation
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// MARK: - Child-creation + reparent rules (no git repo needed)
+
+@Suite struct AutoArchiveRuleTests {
+
+    private func makeDB() throws -> TBDDatabase {
+        try TBDDatabase(inMemory: true)
+    }
+
+    private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
+        WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver()
+        )
+    }
+
+    // MARK: - Child-creation disarms parent
+
+    /// Creating a child worktree with an explicit parent should flip the
+    /// parent's autoArchiveOnMerge override to false (disarm it).
+    @Test func creatingChildDisarmsParent() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.create(
+            path: "/tmp/repoG-\(UUID().uuidString)", displayName: "repoG", defaultBranch: "main")
+        let parent = try await db.worktrees.create(
+            repoID: repo.id, name: "p", branch: "bp",
+            path: "/tmp/repoG/p-\(UUID().uuidString)", tmuxServer: "s")
+        try await db.worktrees.setAutoArchiveOnMerge(id: parent.id, value: true)
+
+        let lifecycle = makeLifecycle(db: db)
+        _ = try await lifecycle.beginCreateWorktree(
+            repoID: repo.id,
+            parentWorktreeID: parent.id)
+
+        let after = try await db.worktrees.get(id: parent.id)
+        #expect(after?.autoArchiveOnMerge == false,
+                "parent armed with auto-archive must be disarmed when a child is created")
+    }
+
+    /// Creating a worktree without a parent should not affect an unrelated armed
+    /// worktree in the same repo.
+    @Test func creatingWorktreeWithoutParentPreservesOtherArmedWorktrees() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.create(
+            path: "/tmp/repoG2-\(UUID().uuidString)", displayName: "repoG2", defaultBranch: "main")
+        let unrelated = try await db.worktrees.create(
+            repoID: repo.id, name: "u", branch: "bu",
+            path: "/tmp/repoG2/u-\(UUID().uuidString)", tmuxServer: "s")
+        try await db.worktrees.setAutoArchiveOnMerge(id: unrelated.id, value: true)
+
+        let lifecycle = makeLifecycle(db: db)
+        _ = try await lifecycle.beginCreateWorktree(
+            repoID: repo.id,
+            suppressAutoParent: true)
+
+        let after = try await db.worktrees.get(id: unrelated.id)
+        #expect(after?.autoArchiveOnMerge == true,
+                "an unrelated armed worktree must remain armed when no parent is resolved")
+    }
+
+    // MARK: - Reparent disarms new parent
+
+    /// Moving a child under a new parent via the RPC handler should disarm
+    /// the new parent's auto-archive setting.
+    @Test func reparentingDisarmsNewParent() async throws {
+        let db = try makeDB()
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+
+        let repo = try await db.repos.create(
+            path: "/tmp/repoI-\(UUID().uuidString)", displayName: "repoI", defaultBranch: "main")
+        let newParent = try await db.worktrees.create(
+            repoID: repo.id, name: "np", branch: "bnp",
+            path: "/tmp/repoI/np-\(UUID().uuidString)", tmuxServer: "s")
+        let child = try await db.worktrees.create(
+            repoID: repo.id, name: "c", branch: "bc",
+            path: "/tmp/repoI/c-\(UUID().uuidString)", tmuxServer: "s")
+        try await db.worktrees.setAutoArchiveOnMerge(id: newParent.id, value: true)
+
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeMove,
+            params: WorktreeMoveParams(
+                worktreeID: child.id,
+                newParentID: newParent.id,
+                newSortOrder: 0))
+        let response = await router.handle(request)
+        #expect(response.success, "worktree.move RPC must succeed")
+
+        let after = try await db.worktrees.get(id: newParent.id)
+        #expect(after?.autoArchiveOnMerge == false,
+                "new parent armed with auto-archive must be disarmed when a child is moved under it")
+    }
+
+    /// Moving a worktree to top-level (newParentID = nil) should not disarm
+    /// any worktree.
+    @Test func movingToTopLevelDoesNotDisarmAnything() async throws {
+        let db = try makeDB()
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+
+        let repo = try await db.repos.create(
+            path: "/tmp/repoJ-\(UUID().uuidString)", displayName: "repoJ", defaultBranch: "main")
+        let oldParent = try await db.worktrees.create(
+            repoID: repo.id, name: "op", branch: "bop",
+            path: "/tmp/repoJ/op-\(UUID().uuidString)", tmuxServer: "s")
+        let child = try await db.worktrees.create(
+            repoID: repo.id, name: "c", branch: "bc",
+            path: "/tmp/repoJ/c-\(UUID().uuidString)", tmuxServer: "s",
+            parentWorktreeID: oldParent.id)
+        try await db.worktrees.setAutoArchiveOnMerge(id: oldParent.id, value: true)
+
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeMove,
+            params: WorktreeMoveParams(
+                worktreeID: child.id,
+                newParentID: nil,
+                newSortOrder: 0))
+        let response = await router.handle(request)
+        #expect(response.success, "worktree.move to top-level must succeed")
+
+        let after = try await db.worktrees.get(id: oldParent.id)
+        #expect(after?.autoArchiveOnMerge == true,
+                "old parent must remain armed when child is moved to top-level (no new parent)")
+    }
+}
+
+// MARK: - Revive disarms worktree (requires real git repo)
+
+@Test func reviveDisarmsWorktree() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // Create and archive a worktree, then arm it.
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await db.worktrees.setAutoArchiveOnMerge(id: wt.id, value: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    // Revive it — this should disarm the auto-archive flag.
+    let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
+
+    #expect(revived.status == .active)
+    let after = try await db.worktrees.get(id: wt.id)
+    #expect(after?.autoArchiveOnMerge == false,
+            "reviving a worktree must disarm its auto-archive flag so a still-merged PR can't re-archive it immediately")
+}

--- a/Tests/TBDDaemonTests/AutoArchiveStoreTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveStoreTests.swift
@@ -1,0 +1,33 @@
+import Testing
+import Foundation
+import TBDShared
+@testable import TBDDaemonLib
+
+@Suite struct AutoArchiveStoreTests {
+
+    @Test func worktreeAutoArchiveRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/repoA", displayName: "repoA", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", displayName: "w", branch: "b",
+            path: "/tmp/repoA/w", tmuxServer: "s", status: .active)
+        #expect(wt.autoArchiveOnMerge == nil)
+
+        try await db.worktrees.setAutoArchiveOnMerge(id: wt.id, value: true)
+        let on = try await db.worktrees.get(id: wt.id)
+        #expect(on?.autoArchiveOnMerge == true)
+
+        try await db.worktrees.setAutoArchiveOnMerge(id: wt.id, value: false)
+        let off = try await db.worktrees.get(id: wt.id)
+        #expect(off?.autoArchiveOnMerge == false)
+    }
+
+    @Test func configDefaultPersistsAndDefaultsFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let initial = try await db.config.get()
+        #expect(initial.autoArchiveOnMergeDefault == false)
+        try await db.config.setAutoArchiveOnMergeDefault(true)
+        let updated = try await db.config.get()
+        #expect(updated.autoArchiveOnMergeDefault == true)
+    }
+}

--- a/Tests/TBDDaemonTests/AutoArchiveTriggerTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveTriggerTests.swift
@@ -1,0 +1,104 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct AutoArchiveTriggerTests {
+    @Test func firesOnTransitionIntoMerged() async throws {
+        let mgr = PRStatusManager()
+        let box = FiredBox()
+        await mgr.setOnMergedTransition { id, num in await box.record(id, num) }
+
+        let wtID = UUID()
+        // First observation: open → no fire.
+        await mgr.seedForTesting(worktreeID: wtID,
+            status: PRStatus(number: 7, url: "u", state: .mergeable, reason: "ok"))
+        #expect(await box.count == 0)
+
+        // Transition into merged → fires once with the PR number.
+        await mgr.seedForTesting(worktreeID: wtID,
+            status: PRStatus(number: 7, url: "u", state: .merged, reason: "Merged"))
+        #expect(await box.count == 1)
+        #expect(await box.lastNumber == 7)
+
+        // Stays merged → no second fire.
+        await mgr.seedForTesting(worktreeID: wtID,
+            status: PRStatus(number: 7, url: "u", state: .merged, reason: "Merged"))
+        #expect(await box.count == 1)
+    }
+}
+
+actor FiredBox {
+    var count = 0
+    var lastNumber = 0
+    func record(_ id: UUID, _ number: Int) { count += 1; lastNumber = number }
+}
+
+@Suite struct AutoArchiveCoordinatorTests {
+    private func makeDeps() throws -> (AutoArchiveOnMergeCoordinator, TBDDatabase) {
+        let db = try TBDDatabase(inMemory: true)
+        let subs = StateSubscriptionManager()
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver(),
+            subscriptions: subs
+        )
+        let coord = AutoArchiveOnMergeCoordinator(db: db, lifecycle: lifecycle, subscriptions: subs)
+        return (coord, db)
+    }
+
+    @Test func archivesWhenEffectiveOnAndNoChildren() async throws {
+        let (coord, db) = try makeDeps()
+        let repo = try await db.repos.create(
+            path: "/tmp/repoC-\(UUID().uuidString)", displayName: "repoC", defaultBranch: "main")
+        let wt = try await db.worktrees.create(repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/repoC/w-\(UUID().uuidString)", tmuxServer: "s")
+        try await db.worktrees.setAutoArchiveOnMerge(id: wt.id, value: true)
+
+        await coord.handleMergedTransition(worktreeID: wt.id, prNumber: 5)
+
+        let after = try await db.worktrees.get(id: wt.id)
+        #expect(after?.status == .archived)
+    }
+
+    @Test func doesNotArchiveWhenEffectiveOff() async throws {
+        let (coord, db) = try makeDeps()
+        let repo = try await db.repos.create(
+            path: "/tmp/repoD-\(UUID().uuidString)", displayName: "repoD", defaultBranch: "main")
+        let wt = try await db.worktrees.create(repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/repoD/w-\(UUID().uuidString)", tmuxServer: "s")
+        try await db.worktrees.setAutoArchiveOnMerge(id: wt.id, value: false)
+
+        await coord.handleMergedTransition(worktreeID: wt.id, prNumber: 5)
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .active)
+    }
+
+    @Test func doesNotArchiveWithActiveChildren() async throws {
+        let (coord, db) = try makeDeps()
+        let repo = try await db.repos.create(
+            path: "/tmp/repoE-\(UUID().uuidString)", displayName: "repoE", defaultBranch: "main")
+        let parent = try await db.worktrees.create(repoID: repo.id, name: "p", branch: "bp",
+            path: "/tmp/repoE/p-\(UUID().uuidString)", tmuxServer: "s")
+        _ = try await db.worktrees.create(repoID: repo.id, name: "c", branch: "bc",
+            path: "/tmp/repoE/c-\(UUID().uuidString)", tmuxServer: "s",
+            parentWorktreeID: parent.id)
+        try await db.worktrees.setAutoArchiveOnMerge(id: parent.id, value: true)
+
+        await coord.handleMergedTransition(worktreeID: parent.id, prNumber: 5)
+        #expect(try await db.worktrees.get(id: parent.id)?.status == .active)
+    }
+
+    @Test func respectsGlobalDefaultWhenOverrideNil() async throws {
+        let (coord, db) = try makeDeps()
+        try await db.config.setAutoArchiveOnMergeDefault(true)
+        let repo = try await db.repos.create(
+            path: "/tmp/repoF-\(UUID().uuidString)", displayName: "repoF", defaultBranch: "main")
+        let wt = try await db.worktrees.create(repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/repoF/w-\(UUID().uuidString)", tmuxServer: "s")
+        // override stays nil → follows global default (on)
+        await coord.handleMergedTransition(worktreeID: wt.id, prNumber: 9)
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .archived)
+    }
+}

--- a/Tests/TBDDaemonTests/AutoArchiveTriggerTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveTriggerTests.swift
@@ -61,6 +61,11 @@ actor FiredBox {
 
         let after = try await db.worktrees.get(id: wt.id)
         #expect(after?.status == .archived)
+
+        let notifications = try await db.notifications.unread(worktreeID: wt.id)
+        #expect(notifications.count == 1)
+        #expect(notifications.first?.type == .taskComplete)
+        #expect(notifications.first?.message?.contains("#5") == true)
     }
 
     @Test func doesNotArchiveWhenEffectiveOff() async throws {

--- a/Tests/TBDSharedTests/AutoArchiveCodableTests.swift
+++ b/Tests/TBDSharedTests/AutoArchiveCodableTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct AutoArchiveCodableTests {
+    @Test func worktreeDefaultsToNilWhenKeyMissing() throws {
+        // JSON without the new key must still decode (backward compat).
+        let json = """
+        {"id":"\(UUID().uuidString)","repoID":"\(UUID().uuidString)","name":"w",
+         "displayName":"w","branch":"b","path":"/p","status":"active",
+         "createdAt":0,"tmuxServer":"s"}
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let wt = try decoder.decode(Worktree.self, from: json)
+        #expect(wt.autoArchiveOnMerge == nil)
+    }
+
+    @Test func worktreeRoundTripsExplicitValues() throws {
+        for value: Bool? in [nil, true, false] {
+            var wt = Worktree(repoID: UUID(), name: "w", displayName: "w",
+                              branch: "b", path: "/p", tmuxServer: "s")
+            wt.autoArchiveOnMerge = value
+            let data = try JSONEncoder().encode(wt)
+            let back = try JSONDecoder().decode(Worktree.self, from: data)
+            #expect(back.autoArchiveOnMerge == value)
+        }
+    }
+
+    @Test func configDefaultsToFalseWhenKeyMissing() throws {
+        let data = "{}".data(using: .utf8)!
+        let cfg = try JSONDecoder().decode(Config.self, from: data)
+        #expect(cfg.autoArchiveOnMergeDefault == false)
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in, per-worktree setting to **auto-archive a worktree when its associated PR is detected as merged**, plus a global default. Resolves the request to split the compound PR/files-panel toolbar control and add an auto-archive toggle.

**Effective decision:** `worktree.autoArchiveOnMerge ?? config.autoArchiveOnMergeDefault`
- Per-worktree override is tri-state in storage (`nil` = follow global, `true`/`false` = explicit). The UI/CLI write only `true`/`false`; untouched worktrees follow the global default live.
- Global default is **daemon-owned** (single source of truth) so both the app and the CLI can read/write it. Default is **off**.

## What's included

**Toolbar** — the PR button is now its own segment; a standalone `archivebox` toggle sits next to it (filled/tinted = armed), shown only when a single worktree with a PR is selected, disabled when the worktree has active children.

**Settings → General** — "Auto-archive worktrees when their PR merges" global-default toggle (bound through `AppState`, daemon-backed).

**Daemon trigger** — `PRStatusManager` fires on a transition into the merged state; `AutoArchiveOnMergeCoordinator` evaluates the effective decision + child check, archives, notifies (`Archived <name> — PR #N merged`), and runs the slow archive phase detached. Revive remains the safety net.

**Disarm rules** — a worktree with active children isn't auto-archivable: creating a child disarms the parent, reparenting disarms the new parent, and reviving disarms the worktree (so a still-merged PR can't re-archive it).

**CLI**
- `tbd worktree auto-archive <nameOrID> <on|off> [--json]`
- `tbd config get [--json]` / `tbd config set auto-archive-on-merge <on|off>`

## Data model / migrations

- `Worktree.autoArchiveOnMerge: Bool?` (migration v32, nullable) and `Config.autoArchiveOnMergeDefault: Bool` (migration v33, default 0). GRDB records + shared Codable models updated in the same commits; all new fields decode backward-compatibly.

## Testing

21 feature tests across shared/daemon/app: Codable backward-compat, store round-trips, RPC dispatch, merge-transition firing (fires once on transition, not on sustained-merged), coordinator decision matrix (effective on/off, children, global-default fallback), all disarm rules, and the app-side effective-value resolver. `swift build`, `swift test --filter AutoArchive` (21/21), and `swiftlint --strict` (0 violations) all green.

## Notes / accepted tradeoffs

- **No "reset to follow-default"** once a worktree's toggle is touched — deliberate (binary, sticky) per design.
- The per-worktree set doesn't broadcast a state delta (mirrors `config.setEnvOverrides`); the acting window updates optimistically.
- After a daemon restart, a PR that merged during downtime fires on first observation (documented as intentional in `PRStatusManager`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[📦 Auto Archive On Merge](https://cheapsteak.github.io/tbd/open/?worktree=1078B6A2-6992-4FE7-ADD0-6D58570EE725)