### PR TITLE
fix(app,daemon): bound DaemonClient recv + report real connected-client count

### DIFF
--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -51,7 +51,11 @@ actor DaemonClient {
     /// preSession hooks) still complete — it exists only to convert a
     /// half-dead-daemon hang into a bounded failure instead of a permanently
     /// parked background thread. Per-recv granularity is SO_RCVTIMEO (1s).
-    private static let rpcRecvDeadlineSeconds: TimeInterval = 120
+    /// 300s is deliberately generous: worktree create/revive can run a blocking
+    /// preSession hook (e.g. `npm install`) that legitimately exceeds 2 minutes,
+    /// so a shorter bound risks failing real work. The frequent poll path
+    /// returns in milliseconds and never approaches this ceiling.
+    private static let rpcRecvDeadlineSeconds: TimeInterval = 300
 
     init(socketPath: String? = nil) {
         // See HookResolver — resolve here, not at the caller's site.

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -45,6 +45,14 @@ actor DaemonClient {
     private let socketPath: String
     private(set) var connected: Bool = false
 
+    /// Upper bound a single one-shot RPC waits for the daemon's response
+    /// before failing. Generous so legitimately slow handlers (model-profile
+    /// add → Anthropic round-trip; worktree create/revive with blocking
+    /// preSession hooks) still complete — it exists only to convert a
+    /// half-dead-daemon hang into a bounded failure instead of a permanently
+    /// parked background thread. Per-recv granularity is SO_RCVTIMEO (1s).
+    private static let rpcRecvDeadlineSeconds: TimeInterval = 120
+
     init(socketPath: String? = nil) {
         // See HookResolver — resolve here, not at the caller's site.
         self.socketPath = socketPath ?? TBDConstants.socketPath
@@ -196,6 +204,15 @@ actor DaemonClient {
             throw DaemonClientError.daemonNotRunning
         }
 
+        // Bound every blocking recv() on this socket. Without this, a
+        // half-dead daemon (connection stays ESTABLISHED with no FIN — e.g.
+        // live tmux-server death) parks the reading thread in recv() forever,
+        // saturating the cooperative pool and freezing the app↔daemon loop.
+        // SO_RCVTIMEO makes recv() return -1/EAGAIN ~every second so callers
+        // can re-check Task cancellation and overall deadlines.
+        var recvTimeout = timeval(tv_sec: 1, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &recvTimeout, socklen_t(MemoryLayout<timeval>.size))
+
         return fd
     }
 
@@ -231,16 +248,22 @@ actor DaemonClient {
             let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
             defer { buffer.deallocate() }
 
+            let deadline = Date().addingTimeInterval(Self.rpcRecvDeadlineSeconds)
             while true {
                 let bytesRead = recv(fd, buffer, bufferSize, 0)
                 if bytesRead < 0 {
                     let savedErrno = errno
-                    // Retry transient interruptions. Blocking recv on a Unix
-                    // socket can be kicked out with EINTR when the app process
-                    // services signals (GCD timers, Combine, etc.) during a
-                    // long handler like modelProfile.add where the daemon is
-                    // itself waiting on a network round-trip to Anthropic.
-                    if savedErrno == EINTR || savedErrno == EAGAIN {
+                    // EINTR: signal interruption (GCD timers, Combine) while a
+                    // long daemon handler runs. EAGAIN/EWOULDBLOCK: SO_RCVTIMEO
+                    // idle tick. Both mean "no data yet, not an error" — keep
+                    // waiting until the overall deadline so a wedged daemon
+                    // can't park this background thread indefinitely.
+                    if savedErrno == EINTR || savedErrno == EAGAIN || savedErrno == EWOULDBLOCK {
+                        if Date() >= deadline {
+                            throw DaemonClientError.receiveFailed(
+                                "recv timed out after \(Int(Self.rpcRecvDeadlineSeconds))s (daemon unresponsive)"
+                            )
+                        }
                         continue
                     }
                     throw DaemonClientError.receiveFailed(
@@ -756,7 +779,17 @@ actor DaemonClient {
 
         while !Task.isCancelled {
             let bytesRead = recv(fd, buffer, bufferSize, 0)
-            if bytesRead <= 0 { break }
+            if bytesRead < 0 {
+                let e = errno
+                // SO_RCVTIMEO idle tick (EAGAIN/EWOULDBLOCK) or signal (EINTR):
+                // not a disconnect. Looping re-checks Task.isCancelled so a
+                // cancelled/reconnecting subscription unwinds and closes its fd
+                // (via the defer) instead of parking this thread in recv()
+                // forever on a half-dead daemon socket.
+                if e == EAGAIN || e == EWOULDBLOCK || e == EINTR { continue }
+                break   // genuine socket error → disconnect; AppState reconnects
+            }
+            if bytesRead == 0 { break }   // EOF → daemon closed the stream
 
             accumulated.append(buffer, count: bytesRead)
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -230,6 +230,9 @@ public final class Daemon: Sendable {
         // 9. Start socket server
         let sock = SocketServer(router: rpcRouter)
         self.socketServer = sock
+        // Wire the live connected-client count into daemon.status (the router
+        // is built above, before the server exists, so it can't be an init dep).
+        rpcRouter.connectedClientsProvider = { [weak sock] in sock?.connectedClients ?? 0 }
         try await sock.start()
 
         // 10. Start HTTP server

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -963,7 +963,7 @@ extension RPCRouter {
         let status = DaemonStatusResult(
             version: TBDConstants.version,
             uptime: uptime,
-            connectedClients: 0,  // Will be updated when socket server is implemented
+            connectedClients: connectedClientsProvider?() ?? 0,
             executablePath: Self.resolvedExecutablePath
         )
         return try RPCResponse(result: status)

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -18,6 +18,12 @@ public final class RPCRouter: Sendable {
     public let usageFetcher: ClaudeUsageFetcher
     public let modelProfileResolver: ModelProfileResolver
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
+    /// Live connected-client count, supplied by the SocketServer after it is
+    /// constructed (the router is built first in Daemon.swift, so it cannot
+    /// take the server as an init dependency). Mirrors `claudeUsagePoller`
+    /// post-construction wiring. `nil` for unit tests / HTTP-only paths, which
+    /// report 0.
+    public nonisolated(unsafe) var connectedClientsProvider: (@Sendable () -> Int)?
     public let pendingQuestions: PendingQuestionStore
     public let repoSerializer: RepoSerializer
     public let configDirManager: ClaudeProfileConfigDirManager

--- a/Tests/TBDAppTests/DaemonClientRecvTimeoutTests.swift
+++ b/Tests/TBDAppTests/DaemonClientRecvTimeoutTests.swift
@@ -1,0 +1,96 @@
+import Testing
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+@testable import TBDApp
+
+// BUG 1: the persistent subscribe() loop must unwind promptly when its Task is
+// cancelled, even if the daemon has gone silent without closing the socket
+// (the "half-dead / live tmux-server death" wedge). Before the fix, recv()
+// blocked forever and Task.isCancelled was never re-checked, parking a
+// cooperative-pool thread permanently. SO_RCVTIMEO (1s) + the isCancelled
+// re-check makes the loop return within ~1-2s.
+@Suite("DaemonClient recv timeout / cancellation")
+struct DaemonClientRecvTimeoutTests {
+
+    /// Stand up a raw AF_UNIX listener that accepts one connection, reads the
+    /// subscribe request, then STAYS SILENT (never sends, never closes) —
+    /// simulating a wedged daemon. The accepted fd is retained in `acceptedBox`
+    /// so it isn't closed early.
+    private final class FdBox: @unchecked Sendable {
+        var fd: Int32 = -1
+    }
+
+    @Test("subscribe() loop unwinds promptly on cancel against a silent daemon")
+    func subscribeCancelsPromptlyWhenDaemonSilent() async throws {
+        let socketPath = "/tmp/tbd-test-\(UUID().uuidString.prefix(8)).sock"
+
+        // 1. Raw listener bound to the short temp path. bind() creates the
+        //    socket file, which makeConnectedSocket() requires to exist.
+        let listenFd = socket(AF_UNIX, SOCK_STREAM, 0)
+        #expect(listenFd >= 0)
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        socketPath.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let raw = UnsafeMutableRawPointer(pathPtr)
+                raw.copyMemory(from: ptr, byteCount: strlen(ptr) + 1)
+            }
+        }
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                bind(listenFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        #expect(bindResult == 0)
+        #expect(listen(listenFd, 1) == 0)
+
+        let acceptedBox = FdBox()
+        defer {
+            if acceptedBox.fd >= 0 { close(acceptedBox.fd) }
+            close(listenFd)
+            unlink(socketPath)
+        }
+
+        // 2. Background: accept one connection, drain the subscribe request,
+        //    then stay silent (do not send, do not close). Hold the fd.
+        DispatchQueue.global().async {
+            let clientFd = accept(listenFd, nil, nil)
+            acceptedBox.fd = clientFd
+            if clientFd >= 0 {
+                var buf = [UInt8](repeating: 0, count: 4096)
+                _ = recv(clientFd, &buf, buf.count, 0) // read the subscribe bytes, then go silent
+            }
+        }
+
+        // 3-4. Connect and enter the subscribe recv loop.
+        let client = DaemonClient(socketPath: socketPath)
+        let task = Task { await client.subscribe { _ in } }
+
+        // 5. Let it connect and park in recv(), then cancel.
+        try await Task.sleep(nanoseconds: 300_000_000) // 300ms
+        task.cancel()
+
+        // 6. The cancelled subscription must finish promptly (within 3s).
+        //    Race task completion against a timeout.
+        let finishedInTime = await withTaskGroup(of: Bool.self) { group -> Bool in
+            group.addTask {
+                await task.value
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 3_000_000_000) // 3s
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+
+        #expect(finishedInTime, "subscribe() did not unwind within 3s after cancel — recv wedge not fixed")
+    }
+}

--- a/Tests/TBDDaemonTests/RPCRouterMiscTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterMiscTests.swift
@@ -64,6 +64,15 @@ extension RPCRouterTests {
         #expect(status.connectedClients == 0)
     }
 
+    @Test("daemon.status reports the live connected-client count when wired")
+    func daemonStatusReportsConnectedClients() async throws {
+        router.connectedClientsProvider = { 3 }
+        let response = await router.handle(RPCRequest(method: RPCMethod.daemonStatus))
+        #expect(response.success)
+        let status = try response.decodeResult(DaemonStatusResult.self)
+        #expect(status.connectedClients == 3)
+    }
+
     // MARK: - Resolve Path
 
     @Test("resolve.path finds repo by path")

--- a/Tests/TBDDaemonTests/SocketServerConnectedClientsTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerConnectedClientsTests.swift
@@ -1,0 +1,91 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// BUG 2: SocketServer must increment its connected-client count when a client
+// connects and decrement it when the client disconnects. The daemon.status
+// RPC reads this via connectedClientsProvider; if the atomic never moves, the
+// "Connected clients" counter is permanently 0.
+@Suite("SocketServer connected-client count")
+struct SocketServerConnectedClientsTests {
+
+    /// Build a throwaway RPCRouter the same way RPCRouterTestHelpers does:
+    /// in-memory DB + dryRun tmux so no real tmux server is contacted.
+    private func makeRouter() throws -> RPCRouter {
+        let db = try TBDDatabase(inMemory: true)
+        return RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+    }
+
+    /// Open a raw AF_UNIX/SOCK_STREAM client and connect() to `path`.
+    /// Returns the connected fd (caller closes it).
+    private func connectRawClient(to path: String) -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return -1 }
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        path.withCString { ptr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let rawPathPtr = UnsafeMutableRawPointer(pathPtr)
+                rawPathPtr.copyMemory(from: ptr, byteCount: strlen(ptr) + 1)
+            }
+        }
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if result != 0 {
+            close(fd)
+            return -1
+        }
+        return fd
+    }
+
+    /// Poll `condition` up to ~2s in small steps; return true once it holds.
+    private func poll(_ condition: () -> Bool) async -> Bool {
+        for _ in 0..<200 {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
+        return condition()
+    }
+
+    @Test("connectedClients tracks connect and disconnect")
+    func tracksConnectAndDisconnect() async throws {
+        // Short /tmp path well under the ~104-char sun_path limit. NOT ~/tbd/sock.
+        let socketPath = "/tmp/tbd-test-\(UUID().uuidString.prefix(8)).sock"
+        defer { unlink(socketPath) }
+
+        let router = try makeRouter()
+        let server = SocketServer(router: router, socketPath: socketPath)
+        try await server.start()
+
+        #expect(server.connectedClients == 0)
+
+        let clientFd = connectRawClient(to: socketPath)
+        #expect(clientFd >= 0)
+
+        let reachedOne = await poll { server.connectedClients == 1 }
+        #expect(reachedOne)
+        #expect(server.connectedClients == 1)
+
+        close(clientFd)
+
+        let backToZero = await poll { server.connectedClients == 0 }
+        #expect(backToZero)
+        #expect(server.connectedClients == 0)
+
+        await server.stop()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two daemon/app reliability bugs found during a daemon-reattach investigation. Together they produce the fleet's **"Connected clients: 0"** failures where suspended Claude sessions can't restore after a daemon restart — restore is app-render-driven, so a frozen app↔daemon loop never re-renders.

## BUG 1 — `DaemonClient` blocking recv wedge
`Sources/TBDApp/DaemonClient.swift`

**Root cause.** Both recv loops called `recv(fd, …)` with no socket timeout. On a half-dead daemon (connection stays `ESTABLISHED` with no FIN/EOF — the live tmux-server death scenario from #292) `recv` blocks forever. The persistent `subscribe()` loop's `while !Task.isCancelled` only re-checks cancellation **after** `recv` returns, so a cancelled/reconnecting subscription leaks a thread permanently parked in `recv()`, saturating the Swift cooperative pool and freezing the entire app↔daemon message loop. (This is the same `recv()`-saturation failure mode already documented in `AppStateTestModeGuardTests`.)

**Fix.**
- Set `SO_RCVTIMEO` (1s) on every client socket in `makeConnectedSocket()`, so `recv` returns roughly every second.
- `subscribe()` now treats `EAGAIN`/`EWOULDBLOCK`/`EINTR` as a non-disconnect idle tick — the loop re-checks `Task.isCancelled` and unwinds (closing its fd via the existing `defer`), and only breaks on EOF or a genuine socket error.
- The one-shot `sendRaw()` loop gains a **300s** overall deadline so a wedged daemon becomes a bounded failure instead of a permanently parked background thread.

**Note on the 300s `sendRaw` deadline.** Deliberately generous. `worktree create`/`revive` can run a blocking `preSession` hook (e.g. `npm install`) that legitimately exceeds 2 minutes, so a shorter ceiling risked failing real work. 300s still converts a half-dead-daemon hang into a bounded failure, and the frequent poll path returns in milliseconds so it never approaches the ceiling. It's a single named constant (`rpcRecvDeadlineSeconds`) — easy to tune if anyone's hooks run longer.

## BUG 2 — "Connected clients" counter hardcoded to 0
`Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift`

**Root cause.** `SocketServer` already keeps a correct atomic `connectedClients` (`channelActive` ++ / `channelInactive` --), but `handleDaemonStatus()` returned a literal `0` (`// Will be updated when socket server is implemented`) because `RPCRouter` is constructed **before** `SocketServer` and held no reference to it.

**Fix.** Add a `connectedClientsProvider` closure on `RPCRouter` (mirrors the existing `claudeUsagePoller` post-construction wiring), set it from the `SocketServer` in `Daemon.swift`, and read it in `handleDaemonStatus()`. Nil (unit tests / HTTP-only paths) still reports `0`. The `SocketServer` atomic logic is correct and was left untouched.

## How the two reinforce each other
A wedged subscription (BUG 1) never reached its `defer { close(fd) }`, so the daemon never observed the disconnect and the count drifted **upward** on reconnect. Bounding the client read makes stale sockets actually close, so the now-wired count (BUG 2) self-corrects on reconnect.

## Tests
- `RPCRouterMiscTests`: `daemon.status` reports the provider value when wired; the existing nil→0 test covers the other branch.
- `SocketServerConnectedClientsTests` (new): real `SocketServer` on an isolated `/tmp` socket — count goes 0→1 on connect, 1→0 on disconnect.
- `DaemonClientRecvTimeoutTests` (new): `subscribe()` against a silent (wedged) daemon unwinds within ~1s of cancel instead of hanging forever.

## Verification
- `swift build` — clean.
- All four targeted tests pass (BUG 1 cancel test completes in ~1.0s; would hit the 3s timeout before the fix).
- `swiftlint --strict` — 0 violations on touched files.
- No live daemon/app or tmux sessions were touched; tests use isolated temp sockets only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)