### PR TITLE
Feat: Persist worktree PR status so icons survive restart

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1170,6 +1170,15 @@ final class AppState: ObservableObject {
                 tombstones: Set(recentlyArchivedWorktreeIDs.keys)
             )
 
+            // Seed PR status from the persisted value so the PR icon shows immediately
+            // on cold start. Only fill gaps — never overwrite a fresher live entry
+            // populated by refreshPRStatuses().
+            for wt in fetched where prStatuses[wt.id] == nil {
+                if let pr = wt.prStatus {
+                    prStatuses[wt.id] = pr
+                }
+            }
+
             // A revive that was gated by a blocking preSession hook lingers
             // `.inFlight` until the daemon reports the row `.active` — this
             // periodic refresh is where that flip is observed.

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -213,6 +213,14 @@ public final class Daemon: Sendable {
         )
         let prManager = PRStatusManager()
 
+        // Hydrate PR status cache from the DB so PR icons survive restart, then
+        // persist future updates back to the DB.
+        let persistedPRStatuses = (try? await database.worktrees.allPRStatuses()) ?? [:]
+        await prManager.hydrate(persistedPRStatuses)
+        await prManager.setOnStatusPersist { worktreeID, status in
+            try? await database.worktrees.setPRStatus(id: worktreeID, status: status)
+        }
+
         // 7a. Wire auto-archive-on-merge: when a worktree's cached PR state
         // transitions into `.merged`, the coordinator evaluates the effective
         // setting and archives the worktree (no active children) in the

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -552,6 +552,13 @@ public final class TBDDatabase: Sendable {
                 type: .boolean, defaults: false)
         }
 
+        // Last-known GitHub PR status per worktree, stored as a JSON-encoded
+        // `PRStatus`. Nullable so existing rows decode as "no status yet". Lets the
+        // PR icon survive app/daemon restarts (mirrors archivedClaudeSessions).
+        migrator.registerMigration("v34_worktree_pr_status") { db in
+            try db.addColumnIfMissing(table: "worktree", column: "prStatus", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -24,6 +24,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var activeTabID: String?
     var parentWorktreeID: String?
     var autoArchiveOnMerge: Bool?
+    var prStatus: String?  // JSON-encoded PRStatus, nil when never observed
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -47,6 +48,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.activeTabID = nil  // new worktrees start with no stored selection
         self.parentWorktreeID = wt.parentWorktreeID?.uuidString
         self.autoArchiveOnMerge = wt.autoArchiveOnMerge
+        self.prStatus = wt.prStatus.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
     }
 
     func toModel() -> Worktree {
@@ -54,6 +56,10 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         if let json = archivedClaudeSessions,
            let data = json.data(using: .utf8) {
             sessions = try? JSONDecoder().decode([String].self, from: data)
+        }
+        var pr: PRStatus?
+        if let json = prStatus, let data = json.data(using: .utf8) {
+            pr = try? JSONDecoder().decode(PRStatus.self, from: data)
         }
         return Worktree(
             id: UUID(uuidString: id)!,
@@ -71,7 +77,8 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             sortOrder: sortOrder,
             archivedHeadSHA: archivedHeadSHA,
             parentWorktreeID: parentWorktreeID.flatMap { UUID(uuidString: $0) },
-            autoArchiveOnMerge: autoArchiveOnMerge
+            autoArchiveOnMerge: autoArchiveOnMerge,
+            prStatus: pr
         )
     }
 }
@@ -654,6 +661,34 @@ public struct WorktreeStore: Sendable {
                 sql: "UPDATE worktree SET autoArchiveOnMerge = ? WHERE id = ?",
                 arguments: [value, id.uuidString]
             )
+        }
+    }
+
+    /// Persist (or clear with nil) the last-known GitHub PR status for a worktree.
+    public func setPRStatus(id: UUID, status: PRStatus?) async throws {
+        let json: String?
+        if let status {
+            json = String(data: try JSONEncoder().encode(status), encoding: .utf8)
+        } else {
+            json = nil
+        }
+        try await writer.write { db in
+            try db.execute(sql: "UPDATE worktree SET prStatus = ? WHERE id = ?",
+                           arguments: [json, id.uuidString])
+        }
+    }
+
+    /// All persisted PR statuses, keyed by worktree id. Used to hydrate the
+    /// in-memory PR cache at daemon startup so icons survive restart.
+    public func allPRStatuses() async throws -> [UUID: PRStatus] {
+        try await writer.read { db in
+            var result: [UUID: PRStatus] = [:]
+            for record in try WorktreeRecord.fetchAll(db) {
+                guard let wtID = UUID(uuidString: record.id),
+                      let model = record.toModel().prStatus else { continue }
+                result[wtID] = model
+            }
+            return result
         }
     }
 }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -12,6 +12,8 @@ public actor PRStatusManager {
 
     private var onMergedTransition: (@Sendable (UUID, Int) async -> Void)?
 
+    private var onStatusPersist: (@Sendable (UUID, PRStatus) async -> Void)?
+
     public init() {}
 
     // MARK: - Public interface
@@ -26,19 +28,52 @@ public actor PRStatusManager {
         self.onMergedTransition = cb
     }
 
+    /// Register a callback fired whenever a worktree's cached PR status actually
+    /// changes, so the daemon can persist it to the DB.
+    public func setOnStatusPersist(_ cb: @escaping @Sendable (UUID, PRStatus) async -> Void) {
+        self.onStatusPersist = cb
+    }
+
+    /// Seed the cache from persisted DB state at startup. Writes directly (not via
+    /// `apply`) so it never fires `onMergedTransition` or `onStatusPersist`.
+    /// `.merged` is never persisted (see `apply`), so in practice nothing here is
+    /// ever `.merged`; the direct write is still required so that a real merge
+    /// observed after startup is detected against the correct hydrated baseline.
+    public func hydrate(_ statuses: [UUID: PRStatus]) {
+        for (id, status) in statuses { cache[id] = status }
+    }
+
     /// Assigns `status` to the cache and fires `onMergedTransition` when the
-    /// state moves from non-merged (or absent) to `.merged`. All cache writes
-    /// route through here so the transition is detected uniformly.
+    /// state moves from non-merged (or absent) to `.merged`. Also fires
+    /// `onStatusPersist` whenever a NON-merged status actually changes, so the
+    /// new value is written to the DB. All cache writes route through here
+    /// (except the startup `hydrate`, which writes the cache directly) so the
+    /// transition and persistence are detected uniformly.
     ///
-    /// Note: the cache is in-memory only, so after a daemon restart the first
-    /// observation of an already-merged PR counts as a nil→merged transition and
-    /// fires `onMergedTransition`. This is intentional — a PR that merged while
-    /// the daemon was down should still auto-archive its (armed) worktree on the
-    /// next poll. Re-archive loops are prevented because archived worktrees leave
-    /// the active poll set and revive disarms the override.
+    /// The cache is hydrated from the DB at startup via `hydrate`, so PR icons
+    /// survive a restart. Crucially, `.merged` is NEVER persisted (see the gate
+    /// below): merged is the terminal state that triggers auto-archive. If it
+    /// were persisted and the archive failed/early-returned (momentarily-active
+    /// child, effective=false, error) before a daemon crash, `hydrate` would
+    /// restore `.merged` and the next poll would see `wasMerged == true` and
+    /// never re-fire `onMergedTransition` — permanently losing the auto-archive
+    /// (a regression vs #295's in-memory-only cache). By not persisting
+    /// `.merged`, a still-active merged worktree is hydrated with its last
+    /// non-merged status (or nothing), so the next post-restart poll re-observes
+    /// the merge as a non-merged→merged transition and re-fires — preserving the
+    /// merge-while-daemon-down recovery guarantee. Re-archive loops are still
+    /// prevented because archived worktrees leave the active poll set and revive
+    /// disarms the override.
     private func apply(_ status: PRStatus, for worktreeID: UUID) async {
-        let wasMerged = (cache[worktreeID]?.state == .merged)
+        let previous = cache[worktreeID]
+        let wasMerged = (previous?.state == .merged)
         cache[worktreeID] = status
+        // Persist every non-terminal change so the PR icon survives restart, but
+        // deliberately skip `.merged` (the auto-archive trigger) — see the doc
+        // comment above for why persisting it would break #295's recovery.
+        if previous != status && status.state != .merged {
+            await onStatusPersist?(worktreeID, status)
+        }
         if !wasMerged && status.state == .merged {
             await onMergedTransition?(worktreeID, status.number)
         }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -132,6 +132,10 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// explicit. Only set explicitly by user action (toolbar toggle / CLI);
     /// there is no UI to return to `nil`.
     public var autoArchiveOnMerge: Bool?
+    /// Last-known GitHub PR status, persisted in the DB so the PR icon survives
+    /// app/daemon restarts. nil = never observed. Refreshed live by the daemon's
+    /// PR poll; the app seeds from this only when it has no fresher live value.
+    public var prStatus: PRStatus?
 
     public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
@@ -141,7 +145,8 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 archivedHeadSHA: String? = nil,
                 liveClaudeSessionCount: Int? = nil,
                 parentWorktreeID: UUID? = nil,
-                autoArchiveOnMerge: Bool? = nil) {
+                autoArchiveOnMerge: Bool? = nil,
+                prStatus: PRStatus? = nil) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -159,13 +164,14 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.liveClaudeSessionCount = liveClaudeSessionCount
         self.parentWorktreeID = parentWorktreeID
         self.autoArchiveOnMerge = autoArchiveOnMerge
+        self.prStatus = prStatus
     }
 
     enum CodingKeys: String, CodingKey {
         case id, repoID, name, displayName, branch, path, status
         case hasConflicts, createdAt, archivedAt, tmuxServer
         case archivedClaudeSessions, sortOrder, archivedHeadSHA
-        case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge
+        case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge, prStatus
     }
 
     public init(from decoder: Decoder) throws {
@@ -187,6 +193,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         liveClaudeSessionCount = try c.decodeIfPresent(Int.self, forKey: .liveClaudeSessionCount)
         parentWorktreeID = try c.decodeIfPresent(UUID.self, forKey: .parentWorktreeID)
         autoArchiveOnMerge = try c.decodeIfPresent(Bool.self, forKey: .autoArchiveOnMerge)
+        prStatus = try c.decodeIfPresent(PRStatus.self, forKey: .prStatus)
     }
 }
 

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -586,4 +586,93 @@ struct PRStatusManagerTests {
         #expect(state == .blocked)
         #expect(reason == "Behind base branch")
     }
+
+    // MARK: - Hydration & persistence
+
+    /// Thread-safe fire counter for `@Sendable` callbacks.
+    private actor FireCounter {
+        private(set) var count = 0
+        func bump() { count += 1 }
+    }
+
+    @Test("hydrate populates allStatuses without firing callbacks")
+    func hydratePopulatesAllStatuses() async {
+        let manager = PRStatusManager()
+        let id = UUID()
+        let status = PRStatus(number: 7, url: "https://example.com/pr/7", state: .mergeable, reason: "Ready to merge")
+        await manager.hydrate([id: status])
+        let all = await manager.allStatuses()
+        #expect(all[id] == status)
+    }
+
+    @Test("hydrating merged then applying same merged does NOT fire onMergedTransition")
+    func hydratedMergedDoesNotRefireTransition() async {
+        let manager = PRStatusManager()
+        let id = UUID()
+        let counter = FireCounter()
+        await manager.setOnMergedTransition { _, _ in await counter.bump() }
+
+        let merged = PRStatus(number: 11, url: "https://example.com/pr/11", state: .merged, reason: "Merged")
+        await manager.hydrate([id: merged])
+        await manager.seedForTesting(worktreeID: id, status: merged)
+
+        #expect(await counter.count == 0)
+    }
+
+    @Test("hydrating non-merged then applying merged DOES fire onMergedTransition once")
+    func hydratedNonMergedFiresTransitionOnMerge() async {
+        let manager = PRStatusManager()
+        let id = UUID()
+        let counter = FireCounter()
+        await manager.setOnMergedTransition { _, _ in await counter.bump() }
+
+        let open = PRStatus(number: 12, url: "https://example.com/pr/12", state: .mergeable, reason: "Ready to merge")
+        let merged = PRStatus(number: 12, url: "https://example.com/pr/12", state: .merged, reason: "Merged")
+        await manager.hydrate([id: open])
+        await manager.seedForTesting(worktreeID: id, status: merged)
+
+        #expect(await counter.count == 1)
+    }
+
+    @Test("apply fires onStatusPersist on change, not on identical status")
+    func persistFiresOnChangeOnly() async {
+        let manager = PRStatusManager()
+        let id = UUID()
+        let counter = FireCounter()
+        await manager.setOnStatusPersist { _, _ in await counter.bump() }
+
+        let statusA = PRStatus(number: 20, url: "https://example.com/pr/20", state: .mergeable, reason: "Ready to merge")
+        let statusB = PRStatus(number: 20, url: "https://example.com/pr/20", state: .blocked, reason: "Blocked")
+
+        await manager.seedForTesting(worktreeID: id, status: statusA)
+        #expect(await counter.count == 1)
+
+        // Identical status — no persist.
+        await manager.seedForTesting(worktreeID: id, status: statusA)
+        #expect(await counter.count == 1)
+
+        // Different status — persist again.
+        await manager.seedForTesting(worktreeID: id, status: statusB)
+        #expect(await counter.count == 2)
+    }
+
+    @Test("apply does NOT fire onStatusPersist for a .merged status even though it changed")
+    func persistSkipsMergedState() async {
+        let manager = PRStatusManager()
+        let id = UUID()
+        let counter = FireCounter()
+        await manager.setOnStatusPersist { _, _ in await counter.bump() }
+
+        // Applying a .merged status is a genuine change (cache was empty), but
+        // merged is the auto-archive trigger and must NOT be persisted —
+        // persisting + hydrating it would defeat #295's archive-while-down
+        // recovery (see PRStatusManager.apply doc comment).
+        let merged = PRStatus(number: 30, url: "https://example.com/pr/30", state: .merged, reason: "Merged")
+        await manager.seedForTesting(worktreeID: id, status: merged)
+        #expect(await counter.count == 0)
+
+        // The cache still updated, even though nothing was persisted.
+        let all = await manager.allStatuses()
+        #expect(all[id] == merged)
+    }
 }

--- a/Tests/TBDDaemonTests/WorktreeStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreTests.swift
@@ -384,4 +384,34 @@ import TBDShared
         #expect(ids == [wt1.id, wt2.id])
         #expect(result.map(\.sortOrder) == [1, 2])
     }
+
+    @Test func prStatusRoundTripsThroughDB() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "pr-wt", branch: "pr-branch",
+            path: "/tmp/pr-wt-\(UUID())", tmuxServer: "srv"
+        )
+
+        // Newly created worktree has no PR status.
+        #expect(try await db.worktrees.get(id: wt.id)?.prStatus == nil)
+
+        let status = PRStatus(
+            number: 42,
+            url: "https://example.com/pr/42",
+            state: .mergeable,
+            reason: "Ready to merge"
+        )
+        try await db.worktrees.setPRStatus(id: wt.id, status: status)
+
+        let reloaded = try await db.worktrees.get(id: wt.id)
+        #expect(reloaded?.prStatus == status)
+        #expect(try await db.worktrees.allPRStatuses()[wt.id] == status)
+
+        // Clearing with nil removes the persisted status.
+        try await db.worktrees.setPRStatus(id: wt.id, status: nil)
+        #expect(try await db.worktrees.get(id: wt.id)?.prStatus == nil)
+        #expect(try await db.worktrees.allPRStatuses()[wt.id] == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- PR status was held in memory only (daemon `PRStatusManager` cache + app `AppState.prStatuses`), so restarting the app or daemon made every PR icon disappear until the next `gh` fetch landed ~30s later.
- Persist each worktree's last-known `PRStatus` to SQLite (migration `v34_worktree_pr_status`, JSON column on `worktree`). The daemon hydrates its cache from the DB at startup and writes back on change; the app seeds the PR icon from the persisted value on cold start (gap-fill only — never clobbers a live entry).
- The terminal `.merged` state is deliberately **not** persisted. It triggers auto-archive; hydrating it back would suppress the post-restart re-fire of `onMergedTransition`, permanently losing the auto-archive of a worktree that merged while the daemon was down (regression vs #295). Skipping merged persistence means the next poll re-observes the merge as a genuine non-merged→merged transition and re-fires.

## Implementation
- **Migration** `v34_worktree_pr_status` — nullable `prStatus` TEXT (JSON) column via `addColumnIfMissing`.
- **Shared model** `Worktree.prStatus: PRStatus?` (optional, `decodeIfPresent` → backward-compatible).
- **WorktreeStore** — `WorktreeRecord` JSON encode/decode, plus `setPRStatus(id:status:)` and `allPRStatuses()`.
- **PRStatusManager** — `hydrate(_:)` (direct cache write, no transition fire) + a change-gated `onStatusPersist` callback; `apply` persist gate is `if previous != status && status.state != .merged`.
- **Daemon** — hydrate from `database.worktrees.allPRStatuses()` at startup, wire `setOnStatusPersist` → `setPRStatus`.
- **App** — gap-only seed of `prStatuses` from `worktree.prStatus` in `refreshWorktrees`.

## Test plan
- [x] `swift build` green; `swiftlint --strict` clean.
- [x] New tests: `WorktreeStore` round-trip (`prStatusRoundTripsThroughDB`), `PRStatusManager` hydrate/persist + merged-transition baseline (`persistSkipsMergedState`, hydrate-merged-no-refire, non-merged→merged fires once, persist-on-change-only).
- [ ] Live: `scripts/restart.sh` (full restart — touches daemon + shared code), open a worktree with an active PR, confirm the icon shows, then restart the app and confirm the icon is present immediately on launch.
- [ ] Live: confirm a PR that merges while the daemon is stopped still auto-archives its armed worktree on the next poll after restart.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=0371EBB8-39FE-4EFF-8255-D9C16DFE473C)