### PR TITLE
fix(daemon): narrow auto-archive catch so DB errors surface at .error

### DIFF
--- a/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
+++ b/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
@@ -24,10 +24,12 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
             let effective = wt.autoArchiveOnMerge ?? config.autoArchiveOnMergeDefault
             guard effective else { return }
 
-            // Worktrees with active children are not auto-archivable.
+            // Worktrees with active children are not auto-archivable. Narrow the
+            // catch to the children guard so DB errors fall through to the outer
+            // catch and are logged at .error rather than silently swallowed.
             do {
                 try await db.worktrees.assertArchivable(id: worktreeID)
-            } catch {
+            } catch WorktreeArchiveError.hasActiveChildren {
                 logger.info("auto-archive skipped (active children): \(worktreeID, privacy: .public)")
                 return
             }


### PR DESCRIPTION
## Summary

Addresses the medium-severity review finding on #295 (merged before it was addressed).

The inner `do/catch` around `assertArchivable` in `AutoArchiveOnMergeCoordinator.handleMergedTransition` caught **all** errors and logged them at `.info` as `"auto-archive skipped (active children)"`. `assertArchivable` throws `WorktreeArchiveError.hasActiveChildren` for the children guard, but can also throw GRDB errors (connection failure, schema mismatch). Under the catch-all, a real DB error was silently swallowed — never reaching the outer `.error` catch, and mislabeled as "active children".

This narrows the catch to `catch WorktreeArchiveError.hasActiveChildren`, so DB errors fall through to the outer catch and surface at `.error`. If auto-archive ever silently stops firing, the `.error` log now points at the real cause.

## Review items not actioned

The remaining review items are acknowledged accepted tradeoffs from the original PR (no dedicated `.configChanged` delta; no per-worktree state-delta broadcast; no RPC/CLI path to reset an override back to `nil`). The two "not posted" items were assessed as non-actionable by the reviewer. Left as-is.

## Testing

- `swift build` — clean
- `swift test --filter AutoArchive` — 21/21 pass (the `doesNotArchiveWithActiveChildren` test continues to exercise the narrowed `hasActiveChildren` branch)
- `swiftlint --strict` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[🗄 Fix Auto Archive Catch Narrowing](https://cheapsteak.github.io/tbd/open/?worktree=D8EDD6CA-9248-46F5-915D-E93F1D5C1164)
