### PR TITLE
feat(app): clear Claude spinner on Esc/Ctrl+C interrupt

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -196,17 +196,26 @@ extension AppState {
 
     // MARK: - Terminal Actions
 
-    /// Treat an explicit user interrupt as "not working" for Codex terminals.
-    /// This clears the sidebar spinner immediately and mirrors the state to
-    /// the daemon best-effort.
-    func handleTerminalInterrupt(terminalID: UUID) {
+    /// Treat an explicit user interrupt (Ctrl+C, or Esc for Claude) as "not
+    /// working" for Claude and Codex terminals. This clears the sidebar spinner
+    /// immediately and mirrors the state to the daemon best-effort. Shell
+    /// terminals are never affected.
+    func handleTerminalInterrupt(terminalID: UUID, viaEscape: Bool = false) {
         guard let terminal = terminals.values.flatMap({ $0 })
-            .first(where: { $0.id == terminalID }),
-              terminal.kind == .codex || terminal.label == TerminalLabel.codex
+            .first(where: { $0.id == terminalID })
         else {
             return
         }
 
+        // Shells have no agent spinner to clear.
+        guard terminal.kind != .shell else { return }
+
+        let isCodex = terminal.kind == .codex || terminal.label == TerminalLabel.codex
+        // Esc is Claude's interrupt key, not Codex's. Ignoring Esc for Codex avoids
+        // falsely idling a still-working Codex session.
+        if viaEscape && isCodex { return }
+
+        // Remaining terminals: Codex (Ctrl+C), Claude, or legacy nil-kind sessions.
         if let idx = terminals[terminal.worktreeID]?.firstIndex(where: { $0.id == terminalID }) {
             terminals[terminal.worktreeID]?[idx].activityState = .idle
         }

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -565,10 +565,16 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         }
 
         func handleOutgoingInput(_ data: ArraySlice<UInt8>) {
-            guard data.contains(0x03) else { return }
+            let isCtrlC = data.contains(0x03)
+            // A standalone Escape keypress arrives as a single 0x1b byte. Arrow keys,
+            // Alt-combos, and other escape sequences arrive as multi-byte ESC sequences
+            // (0x1b 0x5b ...), so requiring count == 1 keeps navigation keys from being
+            // mistaken for a halt.
+            let isEsc = data.count == 1 && data.first == 0x1b
+            guard isCtrlC || isEsc else { return }
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                self.appState?.handleTerminalInterrupt(terminalID: self.panelID)
+                self.appState?.handleTerminalInterrupt(terminalID: self.panelID, viaEscape: isEsc)
             }
         }
 

--- a/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalActivityAppStateTests.swift
@@ -77,3 +77,27 @@ import TBDShared
 
     #expect(state.terminals[worktreeID]?[0].activityState == .working)
 }
+
+@MainActor
+@Test func appState_escInterruptClearsClaudeActivityImmediately() {
+    let state = AppState()
+    let worktreeID = UUID()
+    let terminalID = UUID()
+    state.terminals = [
+        worktreeID: [
+            Terminal(
+                id: terminalID,
+                worktreeID: worktreeID,
+                tmuxWindowID: "@1",
+                tmuxPaneID: "%1",
+                label: "Claude",
+                kind: .claude,
+                activityState: .working
+            )
+        ]
+    ]
+
+    state.handleTerminalInterrupt(terminalID: terminalID, viaEscape: true)
+
+    #expect(state.terminals[worktreeID]?[0].activityState == .idle)
+}

--- a/Tests/TBDAppTests/TerminalPanelViewTests.swift
+++ b/Tests/TBDAppTests/TerminalPanelViewTests.swift
@@ -88,4 +88,125 @@ struct TerminalPanelViewTests {
 
         #expect(state.terminals[worktreeID]?[0].activityState == .working)
     }
+
+    @MainActor
+    @Test("outgoing esc clears claude activity")
+    func outgoingEscClearsClaudeActivity() async {
+        let state = AppState()
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        state.terminals = [
+            worktreeID: [
+                Terminal(
+                    id: terminalID,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: "@1",
+                    tmuxPaneID: "%1",
+                    label: "Claude",
+                    kind: .claude,
+                    activityState: .working
+                )
+            ]
+        ]
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+
+        coordinator.handleOutgoingInput([0x1b])
+        await Task.yield()
+
+        #expect(state.terminals[worktreeID]?[0].activityState == .idle)
+    }
+
+    @MainActor
+    @Test("outgoing ctrl-c clears claude activity")
+    func outgoingCtrlCClearsClaudeActivity() async {
+        let state = AppState()
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        state.terminals = [
+            worktreeID: [
+                Terminal(
+                    id: terminalID,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: "@1",
+                    tmuxPaneID: "%1",
+                    label: "Claude",
+                    kind: .claude,
+                    activityState: .working
+                )
+            ]
+        ]
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+
+        coordinator.handleOutgoingInput([0x03])
+        await Task.yield()
+
+        #expect(state.terminals[worktreeID]?[0].activityState == .idle)
+    }
+
+    @MainActor
+    @Test("multi-byte esc sequence leaves claude activity unchanged")
+    func multiByteEscSequenceLeavesClaudeActivityUnchanged() async {
+        let state = AppState()
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        state.terminals = [
+            worktreeID: [
+                Terminal(
+                    id: terminalID,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: "@1",
+                    tmuxPaneID: "%1",
+                    label: "Claude",
+                    kind: .claude,
+                    activityState: .working
+                )
+            ]
+        ]
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+
+        // Up arrow: ESC [ A — a multi-byte escape sequence, not a halt.
+        coordinator.handleOutgoingInput([0x1b, 0x5b, 0x41])
+        await Task.yield()
+
+        #expect(state.terminals[worktreeID]?[0].activityState == .working)
+    }
+
+    @MainActor
+    @Test("outgoing esc leaves codex activity unchanged")
+    func outgoingEscLeavesCodexActivityUnchanged() async {
+        let state = AppState()
+        let worktreeID = UUID()
+        let terminalID = UUID()
+        state.terminals = [
+            worktreeID: [
+                Terminal(
+                    id: terminalID,
+                    worktreeID: worktreeID,
+                    tmuxWindowID: "@1",
+                    tmuxPaneID: "%1",
+                    label: "Codex",
+                    kind: .codex,
+                    activityState: .working
+                )
+            ]
+        ]
+
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        coordinator.appState = state
+        coordinator.panelID = terminalID
+
+        coordinator.handleOutgoingInput([0x1b])
+        await Task.yield()
+
+        #expect(state.terminals[worktreeID]?[0].activityState == .working)
+    }
 }


### PR DESCRIPTION
## Problem

TBD's sidebar "thinking" spinner is driven by the `working` activity state, which Claude's `UserPromptSubmit` hook sets and only the `Stop`/`StopFailure` hooks clear. Those Stop hooks **don't fire when a response is interrupted** (Esc / Ctrl+C), so the spinner gets stuck on `working` indefinitely.

Codex already handled this — it clears its spinner when it sees Ctrl+C in the outgoing PTY bytes — but the path was fenced off to Codex terminals only.

## Fix

Extend the existing interrupt detection to Claude, accounting for the fact that **Esc is Claude's interrupt key** (Codex only interrupts on Ctrl+C).

- **`TerminalPanelView.handleOutgoingInput`** now flags both Ctrl+C (`0x03`) and a *standalone* Esc (single-byte `0x1b`), passing `viaEscape:` to the handler. Multi-byte ESC sequences (arrow keys, Alt-combos) are deliberately excluded so navigation keys aren't read as a halt.
- **`AppState.handleTerminalInterrupt(terminalID:viaEscape:)`** now clears Claude (and legacy nil-kind) terminals in addition to Codex. Shell terminals stay untouched, and Esc is ignored for Codex (`viaEscape && isCodex` → return) so a still-working Codex session can't be falsely idled.

Behavior is optimistic, matching Codex: the spinner clears immediately on the keystroke; if the keypress didn't actually interrupt, the next real hook event corrects the state. No daemon/shared changes — the `setTerminalActivity` RPC already exists.

## Tests

5 new tests covering each branch:
- Claude `working` + Esc → idle
- Claude `working` + Ctrl+C → idle
- Claude `working` + arrow-key escape sequence → stays working
- Codex `working` + lone Esc → stays working (regression guard)
- handler-level Claude + `viaEscape: true` → idle

`swift build` succeeds; `swift test --filter TBDAppTests` passes (609 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
