### PR TITLE
DX: Resync tbd-project docs with current source (migrations v29→v34, new RPC/CLI, transcript rebuild)

### DIFF
--- a/.claude/skills/tbd-project/references/architecture.md
+++ b/.claude/skills/tbd-project/references/architecture.md
@@ -13,7 +13,8 @@ Long-running headless process. Owns all state and logic.
 - **Git manager** — fetch, worktree add/remove/list, conflict check, headSHA, merge-base ancestry
 - **Hook resolver** — resolves and runs worktree lifecycle hooks per priority chain
 - **Worktree lifecycle** — orchestrates create/archive/revive/adopt/reconcile + conflict detection, parent/lineage resolution
-- **PR status manager** — polls GitHub for PR state (open/merged/closed, mergeable) per worktree
+- **PR status manager** — polls GitHub for PR state (open/merged/closed, mergeable) per worktree, persists last-known status to the DB so icons survive restart
+- **Auto-archive-on-merge coordinator** — archives a worktree automatically once its PR merges, when armed per-worktree or via the global default
 - **SSH agent resolver** — finds live SSH agent socket, maintains `~/.ssh/tbd-agent.sock` symlink
 - **Suspend/resume coordinator** — auto-suspends idle Claude sessions on worktree deselection, supports manual suspend/resume
 - **Model profile resolver** — picks the credential profile (oauth/apiKey/proxy/bedrock) for a spawned Claude session
@@ -43,7 +44,7 @@ Connects to daemon on launch (starts it if not running). Stateless except for UI
 Stateless. Connects to daemon socket, sends RPC, prints result, exits.
 - POSIX socket client (not NIO — simpler for one-shot connections)
 - Auto-resolves repo/worktree from `$PWD` via `resolve.path` RPC
-- Subcommands: `repo`, `worktree`, `terminal`, `notify`, `session-event`, `terminal-activity`, `ask-user-question`, `daemon`, `hooks`, `setup-hooks` (deprecated), `cleanup`, `link`, `doctor`
+- Subcommands: `repo`, `worktree`, `config`, `terminal`, `notify`, `session-event`, `terminal-activity`, `ask-user-question`, `daemon`, `hooks`, `setup-hooks` (deprecated), `cleanup`, `link`, `doctor`
 - `session-event`, `terminal-activity`, and `ask-user-question` are internal — invoked by the Claude settings-overlay hooks, not by humans
 
 ## Session Instrumentation
@@ -63,7 +64,7 @@ The `SessionStart` hook calls `tbd session-event`, which RPCs the daemon with th
 Tables: `repo`, `worktree`, `terminal`, `notification`, `note`, `tab`, `model_profile`, `model_profile_usage`, plus a `tbd_meta` key/value store. See `Sources/TBDShared/Models.swift` for struct definitions and `Sources/TBDDaemon/Database/` for GRDB stores.
 
 ### Migrations
-GRDB `DatabaseMigrator`, numbered sequentially. Never modify an existing migration — always add a new one. Current range: `v1`–`v29`. Notables:
+GRDB `DatabaseMigrator`, numbered sequentially. Never modify an existing migration — always add a new one, and route all schema changes through the idempotent helpers in `MigrationHelpers.swift` (`addColumnIfMissing`/`createTableIfNotExists`/`addIndexIfMissing`). Current range: `v1`–`v34`. Notables:
 - **v1–v13** — initial schema + incremental columns (gitStatus → hasConflicts, pinnedAt, claudeSessionID, suspend snapshots, notes, sortOrder, per-repo instructions, etc.)
 - **v14_worktree_location** — supports the canonical `~/tbd/worktrees/` location
 - **v15_model_profiles** / **v25_model_profiles_bedrock** — model profile table + bedrock fields
@@ -77,17 +78,22 @@ GRDB `DatabaseMigrator`, numbered sequentially. Never modify an existing migrati
 - **v27_primary_agent_preference** — adds `primary_agent_preference` column to `config`; global preference for claude vs. codex as the default spawned agent
 - **v28_notification_terminal_id** — adds `terminalID` (nullable) to `notification`; enables banner clicks to switch to the originating terminal tab
 - **v29_terminal_activity_state** — adds `activityState` column to `terminal` (`TerminalActivityState`: `unknown`, `working`, `idle`, `waitingForUser`)
+- **v30_model_profile_fallback_models** — adds `fallback_models` (nullable, JSON string array) to `model_profiles` — per-profile Claude `fallbackModel` list
+- **v31_env_overrides** — adds `env_overrides` (nullable, JSON `[String: String]`) to `config`, `repo`, and `model_profiles` — free-form env vars applied to spawned sessions (see `docs/env-overrides.md`)
+- **v32_worktree_auto_archive** — adds `autoArchiveOnMerge` (bool) to `worktree`
+- **v33_config_auto_archive_default** — adds `auto_archive_on_merge_default` (bool, default false) to `config` — global default for the above
+- **v34_worktree_pr_status** — adds `prStatus` (nullable, JSON-encoded `PRStatus`) to `worktree`; lets the PR icon survive app/daemon restarts
 
 ### Key model types
 - `WorktreeStatus`: `.active`, `.archived`, `.main`, `.creating`
 - `RepoStatus`: `.ok`, `.missing` (stale path)
 - `Repo`: `renamePrompt` + `customInstructions` (per-repo prompt customization), `hidden`, `expanded`
-- `Worktree`: `hasConflicts`, `sortOrder`, `parentID` (lineage), `activeTabID`, `tabOrder`, `archivedHeadSHA`
+- `Worktree`: `hasConflicts`, `sortOrder`, `parentID` (lineage), `activeTabID`, `tabOrder`, `archivedHeadSHA`, `autoArchiveOnMerge`, `prStatus` (persisted last-known `PRStatus`)
 - `Terminal`: `kind` (`TerminalKind`), `pinnedAt`, `claudeSessionID`, `transcriptPath`, `suspendedAt`/`suspendedSnapshot`, `modelProfileID`, `activityState` (`TerminalActivityState`: `unknown`, `working`, `idle`, `waitingForUser`)
 - `TerminalKind` / `TerminalCreateType`: `shell`, `claude`, `codex`
 - `CredentialKind`: `oauth`, `apiKey`, `proxy`, `bedrock`
-- `ModelProfile`: named credential container — kind + routing fields (baseURL/model for proxy, awsRegion/awsProfile for bedrock)
-- `Config`: global config row — `defaultProfileID`, `primaryAgentPreference` (`PrimaryAgentPreference`: `.claude`/`.codex`), `envSettingOverrides` (map of `ClaudeEnvSetting.id` → `ClaudeEnvValue`)
+- `ModelProfile`: named credential container — kind + routing fields (baseURL/model for proxy, awsRegion/awsProfile for bedrock), `fallbackModels`, per-profile `envOverrides`
+- `Config`: global config row — `defaultProfileID`, `primaryAgentPreference` (`PrimaryAgentPreference`: `.claude`/`.codex`), `envSettingOverrides` (map of `ClaudeEnvSetting.id` → `ClaudeEnvValue`), `envOverrides` (free-form `[String: String]`), `autoArchiveOnMergeDefault`
 - `Notification`: gained `terminalID` (optional `UUID`) — the terminal that triggered the notification
 - `Note`: freeform editor content tied to a worktree
 - `TabState`: persisted tab metadata (label, order)
@@ -122,7 +128,7 @@ tmux server: tbd-<djb2-hash-of-repo-path>
 
 ## Worktree Lifecycle
 
-Split across files: base struct (`WorktreeLifecycle.swift`), `+Create`, `+Archive`, `+Reconcile`, `+Adopt`.
+Split across files: base struct (`WorktreeLifecycle.swift`), `+Create`, `+Archive`, `+Reconcile`, `+Adopt`, `+Forget` (untrack without disk removal), `+PreSession` (pre-session hook terminals), `+Recovery` (resolve rows stuck in `.creating` after a crash/restart).
 
 ### Create (two-phase async)
 **Phase 1 (beginCreateWorktree):** Resolve parent via `ParentResolver` → generate name → insert DB row with `status = .creating` → return immediately. App shows an optimistic placeholder before the RPC returns.
@@ -158,13 +164,14 @@ Maintains a stable symlink at `~/.ssh/tbd-agent.sock` pointing to a live SSH age
 JSON-RPC style over Unix socket (newline-delimited) and HTTP POST `/rpc`. Method families (see `Sources/TBDDaemon/Server/RPCRouter+*Handlers.swift`):
 
 - **Repo**: `repo.add`, `repo.remove`, `repo.list`, `repo.rename`, `repo.relocate`, `repo.updateInstructions`, `repo.listBranches`, hidden/expanded toggles
-- **Worktree**: `worktree.create`, `.list`, `.archive`, `.revive`, `.adopt`, `.rename`, `.reorder`, `.move` (reparent), `.selectionChanged`, `.suspend`, `.resume`
-- **Terminal**: `terminal.create` (`type`/`prompt`), `.list`, `.send` (`submit`), `.delete`, `.setPin`, `.output`, `.conversation`, `.transcript`, `.transcriptItemFullBody`, `.suspend`, `.resume`, `.recreateWindow`, `.swapProfile`, `.activityEvent` (internal — fired by the terminal-activity hook)
+- **Worktree**: `worktree.create`, `.list`, `.archive`, `.revive`, `.adopt`, `.forget` (untrack without `git worktree remove`), `.rename`, `.reorder`, `.move` (reparent), `.selectionChanged`, `.suspend`, `.resume`, `.setAutoArchive`
+- **Terminal**: `terminal.create` (`type`/`prompt`), `.list`, `.send` (`submit`), `.focus`, `.delete`, `.setPin`, `.output`, `.conversation`, `.transcript`, `.transcriptItemFullBody`, `.suspend`, `.resume`, `.recreateWindow`, `.swapProfile`, `.activityEvent` (internal — fired by the terminal-activity hook)
 - **Tab**: `tab.setLabel`, `tab.setOrder`, `tab.list`, `worktree.setActiveTab`
 - **Session**: `session.list`, `session.messages` — list/parse Claude JSONL transcripts; plus `terminal.sessionEvent` (SessionStart hook bridge)
 - **AskUserQuestion**: `terminal.askUserQuestionPending` / `terminal.askUserQuestionCleared`, backed by `PendingQuestionStore`
 - **Model profile**: `modelProfile.list`/`.add`/`.delete`/`.rename`/`.updateEndpoint`/`.updateBedrock`/`.setGlobalDefault`/`.setPrimaryAgentPreference`/`.setRepoOverride`/`.fetchUsage`/`.healthCheck`
 - **Claude preferences**: `claude.setSpawnPreferences` — stores Claude spawn-env overrides (`ClaudeSpawnPreferences`) into the config row; handled by `RPCRouter+ClaudePreferencesHandlers.swift`
+- **Env overrides**: `config.setEnvOverrides`, `repo.setEnvOverrides`, `modelProfile.setEnvOverrides` — persist free-form `[String: String]` env vars per scope; `config.get` reads the config row; `config.setAutoArchiveOnMergeDefault` sets the global auto-archive default. Handled by `RPCRouter+EnvOverridesHandlers.swift`
 - **Appearance**: `appearance.updateColorFgBg` — fans out `COLORFGBG` env update to all active tmux servers; handled by `RPCRouter+AppearanceHandlers.swift`
 - **Notification**: `notify`, `notifications.list`, `notifications.markRead`
 - **PR**: `pr.list`, `pr.refresh`
@@ -175,10 +182,11 @@ JSON-RPC style over Unix socket (newline-delimited) and HTTP POST `/rpc`. Method
 ## CLI Commands
 
 See `Sources/TBDCLI/Commands/`. Highlights:
-- `tbd worktree create [--position child|sibling|root] [--branch] [--prompt|--prompt-file] [--no-wait] [--json]`, plus `list`, `adopt`, `archive`, `revive`, `rename`, `reparent`
+- `tbd worktree create [--position child|sibling|root] [--branch] [--prompt|--prompt-file] [--no-wait] [--json]`, plus `list`, `adopt`, `archive`, `revive`, `rename`, `reparent`, `forget` (untrack without removing from disk), `auto-archive` (toggle archive-on-PR-merge)
 - `tbd terminal create <worktree> [--type shell|claude|codex] [--cmd] [--prompt|--prompt-file] [--json]`, `send --terminal <id> --text <t> [--submit]`, `list`, `output`, `conversation`
 - `tbd hooks status` — show the Claude overlay + legacy hook state; `tbd hooks stop-rename-check` — internal Stop-hook
 - `tbd session-event`, `tbd terminal-activity`, `tbd ask-user-question pre|post` — internal hooks fired by the settings overlay
+- `tbd config get|set` — show/set global settings (e.g. auto-archive-on-merge default, env overrides)
 - `tbd link` — print a `tbd://` deep link for the current worktree
 - `tbd doctor [--dry-run]` — diagnose and repair the `~/.local/bin/tbd` CLI install (checks that it is a hard link to the TBDCLI binary sibling of the running daemon; repairs stale or missing links)
 - `tbd notify`, `tbd daemon status`, `tbd cleanup`, `tbd setup-hooks` (deprecated)

--- a/.claude/skills/tbd-project/references/file-map.md
+++ b/.claude/skills/tbd-project/references/file-map.md
@@ -18,6 +18,9 @@ Key source files and what they do. Not exhaustive — see the directory listing 
 - `RepoConstants.swift` — default rename-prompt template
 - `EmojiData.swift` — emoji dataset for worktree-name autocomplete
 - `ClaudeEnvRegistry.swift` — registry of user-configurable spawn-time Claude env settings (`ClaudeEnvValue`: bool/int/string, frozen JSON format; `ClaudeEnvRegistry.all` is the single source of truth)
+- `EnvOverridesCoding.swift` — JSON encode/decode for the free-form env-override `[String: String]` maps (config/repo/profile scopes)
+- `NewlineFrameScanner.swift` — incremental newline-delimited frame scanner for socket recv buffers
+- `TerminalLabel.swift` — canonical terminal display-label derivation shared by daemon + app
 
 ## Sources/TBDAppIcon/ & Sources/IconBaker/
 - `TBDAppIcon/AppIcon.swift` — programmatic AppKit/CoreGraphics/CoreText icon drawing; per-worktree ribbon variant at runtime, shared by TBDApp and IconBaker
@@ -47,7 +50,7 @@ Key source files and what they do. Not exhaustive — see the directory listing 
 - `LegacyHookScanner.swift` — detects legacy globally-installed `tbd` hook entries in user/repo settings.json
 
 ### Lifecycle/
-- `WorktreeLifecycle.swift` (+`Create`/`Archive`/`Reconcile`/`Adopt`) — worktree create/archive/revive/adopt/reconcile orchestration
+- `WorktreeLifecycle.swift` (+`Create`/`Archive`/`Reconcile`/`Adopt`/`Forget`/`PreSession`/`Recovery`) — worktree create/archive/revive/adopt/reconcile orchestration; `+Forget` untracks without deleting from disk, `+PreSession` runs pre-session hook terminals, `+Recovery` resolves rows stuck in `.creating` on restart
 - `ParentResolver.swift` — resolves a new worktree's parent (lineage)
 - `WorktreeLayout.swift` — canonical (`~/tbd/worktrees/`) + legacy path resolution, name sanitization
 - `SystemPromptBuilder.swift` — builds `TBD_PROMPT_*` layers + `--append-system-prompt`
@@ -58,8 +61,8 @@ Key source files and what they do. Not exhaustive — see the directory listing 
 - `RepoHealthValidator.swift` — flips repos with stale paths to `.missing`
 
 ### Database/
-- `Database.swift` — `TBDDatabase`, GRDB setup, WAL, migrations v1–v25
-- `MigrationHelpers.swift` — shared migration utilities
+- `Database.swift` — `TBDDatabase`, GRDB setup, WAL, migrations v1–v34
+- `MigrationHelpers.swift` — idempotent schema-change helpers (`addColumnIfMissing`/`createTableIfNotExists`/`addIndexIfMissing`) — required for all new migrations
 - `RepoStore` / `WorktreeStore` / `TerminalStore` / `NotificationStore` / `NoteStore` / `TabStore` — GRDB CRUD stores
 - `ConfigStore.swift` / `TBDMetaStore.swift` — global config + key/value meta
 - `ModelProfileRecord.swift` / `ModelProfileUsageRecord.swift` — model profile GRDB records
@@ -67,10 +70,15 @@ Key source files and what they do. Not exhaustive — see the directory listing 
 ### ModelProfile/
 - `ModelProfileResolver.swift` — picks a profile per spawn (terminal → repo → global default)
 - `ModelProfileHealthProbe.swift` — validates a profile's credentials
+- `EnvOverrideResolver.swift` — merges free-form env overrides across scopes (global → repo → profile) with precedence
+
+### Process/
+- `AgentReaper.swift` — detects and reaps orphaned agent child processes
+- `ProcessSignaller.swift` — injectable protocol wrapping OS process operations (signals, liveness checks)
 
 ### Server/
 - `RPCRouter.swift` — method dispatch, owns subsystem references
-- `RPCRouter+*Handlers.swift` — Repo, Worktree, Terminal, Tab, Session, Note, ModelProfile, AskUserQuestion, ManualSuspend, Selection, Subscription, LegacyHook, Relocate, Appearance (terminal COLORFGBG), ClaudePreferences (spawn-time env overrides) handlers
+- `RPCRouter+*Handlers.swift` — Repo, Worktree, Terminal, Tab, Session, Note, ModelProfile, AskUserQuestion, ManualSuspend, Selection, Subscription, LegacyHook, Relocate, Appearance (terminal COLORFGBG), ClaudePreferences (spawn-time Claude env settings), EnvOverrides (free-form env overrides per scope, `config.get`) handlers
 - `SocketServer.swift` / `HTTPServer.swift` — NIO Unix-socket + HTTP RPC servers
 - `StateSubscription.swift` — `StateDelta` broadcasting to subscribed clients
 - `RepoSerializer.swift` — repo serialization for RPC results
@@ -81,12 +89,12 @@ Key source files and what they do. Not exhaustive — see the directory listing 
 - `SSH/SSHAgentResolver.swift` — `~/.ssh/tbd-agent.sock` symlink maintenance
 - `Keychain/ModelProfileKeychain.swift` — stores apiKey profile secrets (0600 token files)
 - `AskUserQuestion/PendingQuestionStore.swift` — in-memory store bridging AskUserQuestion hook payloads
-- `PR/PRStatusManager.swift` — GitHub PR status polling
+- `PR/PRStatusManager.swift` — GitHub PR status polling; `PR/AutoArchiveOnMergeCoordinator.swift` — auto-archives a worktree when its PR merges (if armed)
 
 ## Sources/TBDCLI/
 - `TBD.swift` — `@main`, registers subcommands
 - `SocketClient.swift` / `PathResolver.swift` / `Utilities.swift` — POSIX RPC client, `$PWD`→repo/worktree resolution, helpers
-- `Commands/` — `RepoCommands`, `WorktreeCommands` (+`WorktreePosition`), `TerminalCommands`, `NotifyCommand`, `HooksCommand`, `SetupHooksCommand` (deprecated), `SessionEventCommand`, `AskUserQuestionEventCommand`, `StopRenameCheckCommand`, `LinkCommand`, `CleanupCommand`, `DaemonCommands`, `DoctorCommand` (`tbd doctor` — diagnose/repair CLI install), `TerminalActivityEventCommand` (agent hook → terminal-activity bridge)
+- `Commands/` — `RepoCommands`, `WorktreeCommands` (+`WorktreePosition`), `ConfigCommands` (`tbd config get|set`), `TerminalCommands`, `NotifyCommand`, `HooksCommand`, `SetupHooksCommand` (deprecated), `SessionEventCommand`, `AskUserQuestionEventCommand`, `StopRenameCheckCommand`, `StopFailureCommand` (`tbd hooks stop-failure` — notify on API-error turn death), `LinkCommand`, `CleanupCommand`, `DaemonCommands`, `DoctorCommand` (`tbd doctor` — diagnose/repair CLI install), `TerminalActivityEventCommand` (agent hook → terminal-activity bridge)
 
 ## Sources/TBDApp/
 - `TBDApp.swift` — `@main` App + AppDelegate
@@ -96,18 +104,23 @@ Key source files and what they do. Not exhaustive — see the directory listing 
 - `DaemonClient.swift` — actor, POSIX RPC client; `DeepLinkHandler.swift` — `tbd://` routing
 - `ContentView.swift` / `RepoDetailView.swift` / `RepoInstructionsView.swift` / `TabBar.swift` / `ArchivedWorktreesView.swift`
 - `CLIInstallerCoordinator.swift` / `LegacyHooksCoordinator.swift` — launch-time install + legacy-hook migration prompts
-- `Sidebar/` — repo sections, nested worktree rows/subtrees, context menu, emoji picker, inline rename, `BranchPickerView` (option-click `+` to create worktree from an existing branch)
+- `Sidebar/` — repo sections, nested worktree rows/subtrees, context menu, emoji picker, inline rename, `BranchPickerView` (option-click `+` to create worktree from an existing branch), `RowStatusIndicator` (single priority-ranked status dot per row), `RowTooltipPreference` (hover-tooltip preference key + bubble)
 - `Terminal/` — TmuxBridge, TBDTerminalView, panels, split layout, LayoutNode, PaneContent, pinned dock, appearance/color schemes, WorktreePager; custom/importable terminal themes: `ThemeStore`, `UserTerminalTheme`, `AlacrittyImporter` (TOML), `ThemeDirectoryWatcher`, `TmuxConfigStyleDetector`
-- `Panes/` — code viewer, note, webview, history, `LiveTranscriptPaneView`, `Transcript/` (per-tool cards with body/header split files, chat bubbles, context-usage badge, markdown; file-preview overlay: `TranscriptOverlayView`, `TranscriptOverlayCoordinator`, `TranscriptOverlayEnvironment`, `OverlayFileView`, `OverlayFileLinkAction`, `LocalFileLinker`, `TranscriptNodeCache`)
+- `Panes/` — code viewer, note, webview, history, `LiveTranscriptPaneView`, `ViewerRouting` (routes file clicks to reuse/split the code viewer), `Transcript/` (per-tool cards with body/header split files, chat bubbles, context-usage badge, markdown; file-preview overlay: `TranscriptOverlayView`, `TranscriptOverlayCoordinator`, `TranscriptOverlayEnvironment`, `OverlayFileView`, `OverlayFileLinkAction`, `LocalFileLinker`, `TranscriptNodeCache`)
+- `Panes/Transcript/TextKit/` — the #129 native transcript rebuild (env-gated): `STTextViewTranscriptPaneView`/`STTextViewTranscriptView` (TextKit 2 / STTextView renderer), `TranscriptDocumentBuilder` (nodes → `NSAttributedString`), `TranscriptDocument` (bubble role classification + background drawing), `TranscriptCardFactory`/`TranscriptCardAttachment`/`TranscriptCardContext` (SwiftUI tool cards hosted inline via `NSTextAttachment`), `TranscriptStreamPlan` (classifies incremental TextKit edits from polls)
+- `Panes/Transcript/Table/` — alternate `NSTableView` transcript renderer (`TableTranscriptPaneView`/`TableTranscriptView`) with per-row cells (`TranscriptBubbleCellView`, `ActivityRowCellView`, `ActivityRowPresentation`)
+- `Panes/Transcript/Renderer/` — Markdown → `NSAttributedString` (`MarkdownAttributedRenderer`), fenced code blocks (`MarkdownCodeBlock`), GFM tables (`MarkdownTable`/`TranscriptTableView`), visual spec (`TranscriptTextTheme`)
 - `JumpMenu/` — Cmd-K worktree jump palette
-- `MenuBar/ModelProfileMenu.swift`, `Settings/` (general, terminal incl. `TerminalThemeEditorView`/`TerminalThemeEditorViewModel`, repo hooks, model profiles, AWS/Bedrock pickers)
-- `Diagnostics/` — hang watchdog, main-thread sampler, transcript signposts
+- `MenuBar/ModelProfileMenu.swift`, `Settings/` (general, terminal incl. `TerminalThemeEditorView`/`TerminalThemeEditorViewModel`, repo hooks, model profiles, env-overrides editor (`EnvOverridesEditor`), AWS/Bedrock pickers: `AWSProfiles`/`BedrockModels`/`BedrockRegions`/`ComboBoxField`)
+- `Diagnostics/` — hang watchdog, hang stack writer, main-thread sampler, transcript signposts, transcript perf harness
 - `Services/` — Mac notifications, notification sounds
+- `Helpers/` — `KeyboardShortcuts` (text-finder action routing via responder chain), `StatusBarView` (source/selection status display)
+- `Toolbar/OpenInEditorButton.swift` — lists installed editors, opens the worktree externally
 - `FileViewer/FileViewerPanel.swift` — git status file viewer
 
 ## Tests/
 Swift Testing framework. `TBDDaemonTests/` (database, git, lifecycle, tmux, hooks, RPC routing, model profiles, sessions, transcripts, suspend/resume, ...), `TBDSharedTests/` (models, emoji), `TBDAppTests/` (layout, pane content).
 
 ## Scripts & Docs
-- `scripts/restart.sh` — rebuild + restart; `install-hooks.sh` — git hooks; `import-conductor.sh` / `import-claude-code-desktop.sh` — one-script migrations into TBD; `move-home-dir.sh`
-- `docs/` — `tmux-integration.md`, `diagnostics-strategy.md`, `worktree-hooks.md`, `worktree-location-design.md`, `transcript-context-usage.md`, plus `specs/` & `plans/`
+- `scripts/restart.sh` — rebuild + restart; `install-hooks.sh` — git hooks; `import-conductor.sh` / `import-claude-code-desktop.sh` — one-script migrations into TBD; `move-home-dir.sh`; `recipe-check.sh`; `git-hooks/`
+- `docs/` — `tmux-integration.md`, `diagnostics-strategy.md`, `worktree-hooks.md`, `worktree-location-design.md`, `transcript-context-usage.md`, `env-overrides.md`, `tcc-signing.md`, plus `specs/`, `plans/` & `perf/`


### PR DESCRIPTION
## Summary
- Regenerated `.claude/skills/tbd-project/references/architecture.md` and `file-map.md` from the current source tree via `/update-project-docs` — the docs had drifted across several PRs.
- **New source documented:** `Process/` (AgentReaper, ProcessSignaller), `ModelProfile/EnvOverrideResolver`, `PR/AutoArchiveOnMergeCoordinator`, `WorktreeLifecycle +Forget/+PreSession/+Recovery`, `RPCRouter+EnvOverridesHandlers`, TBDShared `EnvOverridesCoding`/`NewlineFrameScanner`/`TerminalLabel`, the #129 transcript rebuild (TextKit/Table/Renderer), and new App Settings (Bedrock/AWS pickers, env-overrides editor) + Helpers/Toolbar.
- **Architecture facts refreshed:** migrations range `v1–v29` → `v1–v34` (fallback models, env overrides, worktree auto-archive, config default, persisted PR status); new model fields; new RPC methods (`worktree.forget`/`.setAutoArchive`, `terminal.focus`, `config.get`/`.setEnvOverrides`, `repo`/`modelProfile.setEnvOverrides`, `config.setAutoArchiveOnMergeDefault`); new CLI (`tbd config get|set`, `worktree forget`, `worktree auto-archive`).

## Test plan
- [ ] Docs-only change — no build impact. Spot-checked claims against source: RPC constants in `RPCProtocol.swift`, migrations in `Database.swift` (v34), `AutoArchiveOnMergeCoordinator` arming logic, `WorktreeLifecycle+Recovery` `.creating`-row handling, and CLI subcommand registration in `TBD.swift`.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=1A63A174-D252-447E-84AE-B60AB04B3342)