### PR TITLE
Feat: Toggle the transcript pane from the Transcript button instead of stacking new ones

### DIFF
--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -193,7 +193,7 @@ struct PanePlaceholder: View {
 
             if terminal(for: terminalID)?.isClaudeResumable == true && transcriptFeatureEnabled {
                 let transcriptOpen = isTranscriptOpen(terminalID: terminalID)
-                Button(action: { openTranscript(terminalID: terminalID) }) {
+                Button(action: { toggleTranscriptPane(terminalID: terminalID) }) {
                     HStack(spacing: 2) {
                         Image(systemName: transcriptOpen ? "text.bubble.fill" : "text.bubble")
                         Text("Transcript")
@@ -502,7 +502,7 @@ struct PanePlaceholder: View {
         }
     }
 
-    private func openTranscript(terminalID: UUID) {
+    private func toggleTranscriptPane(terminalID: UUID) {
         layout = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: content.paneID)
     }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -192,15 +192,19 @@ struct PanePlaceholder: View {
             .buttonStyle(.borderless)
 
             if terminal(for: terminalID)?.isClaudeResumable == true && transcriptFeatureEnabled {
+                let transcriptOpen = isTranscriptOpen(terminalID: terminalID)
                 Button(action: { openTranscript(terminalID: terminalID) }) {
                     HStack(spacing: 2) {
-                        Image(systemName: "text.bubble")
+                        Image(systemName: transcriptOpen ? "text.bubble.fill" : "text.bubble")
                         Text("Transcript")
                     }
                     .font(.caption)
+                    .foregroundStyle(transcriptOpen ? Color.accentColor : Color.primary)
                 }
                 .buttonStyle(.borderless)
-                .help("Open a chat-style live transcript pane")
+                .help(transcriptOpen
+                    ? "Hide the chat-style live transcript pane"
+                    : "Show the chat-style live transcript pane")
             }
 
         case .webview:
@@ -499,11 +503,11 @@ struct PanePlaceholder: View {
     }
 
     private func openTranscript(terminalID: UUID) {
-        layout = layout.splitPane(
-            id: content.paneID,
-            direction: .horizontal,
-            newContent: .liveTranscript(id: UUID(), terminalID: terminalID)
-        )
+        layout = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: content.paneID)
+    }
+
+    private func isTranscriptOpen(terminalID: UUID) -> Bool {
+        layout.firstPaneID(where: { isLiveTranscriptPane($0, for: terminalID) }) != nil
     }
 
     /// Creates a real terminal via the daemon, then inserts it as a split pane.

--- a/Sources/TBDApp/Panes/TranscriptRouting.swift
+++ b/Sources/TBDApp/Panes/TranscriptRouting.swift
@@ -1,0 +1,38 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "TranscriptRouting")
+
+/// True when `content` is the live-transcript pane for `terminalID`.
+///
+/// Shared by `toggleTranscript` and the toolbar button's open-state check so
+/// the two never drift apart.
+func isLiveTranscriptPane(_ content: PaneContent, for terminalID: UUID) -> Bool {
+    if case .liveTranscript(_, let tid) = content { return tid == terminalID }
+    return false
+}
+
+/// Toggles the live-transcript pane for `terminalID`.
+///
+/// If the tab's layout already contains a `.liveTranscript` pane for this
+/// terminal, that pane is removed (toggle off). Otherwise a new transcript
+/// pane is split horizontally off `fromPaneID` (toggle on), matching the
+/// original always-open behavior.
+func toggleTranscript(into layout: LayoutNode, terminalID: UUID, fromPaneID: UUID) -> LayoutNode {
+    if let transcriptID = layout.firstPaneID(where: { isLiveTranscriptPane($0, for: terminalID) }) {
+        if let updated = layout.removePane(id: transcriptID) {
+            logger.debug("toggleTranscript[close]: transcriptID=\(transcriptID, privacy: .public)")
+            return updated
+        }
+        // The toggle is driven from a sibling terminal pane, so a transcript is
+        // never the sole pane here — this branch is defensive and unreachable.
+        return layout
+    }
+
+    logger.debug("toggleTranscript[open]: terminalID=\(terminalID, privacy: .public) fromPaneID=\(fromPaneID, privacy: .public)")
+    return layout.splitPane(
+        id: fromPaneID,
+        direction: .horizontal,
+        newContent: .liveTranscript(id: UUID(), terminalID: terminalID)
+    )
+}

--- a/Tests/TBDAppTests/TranscriptRoutingTests.swift
+++ b/Tests/TBDAppTests/TranscriptRoutingTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+
+@Suite("TranscriptRouting")
+struct TranscriptRoutingTests {
+
+    @Test func toggleTranscript_opensWhenNoExistingTranscript() {
+        let terminalID = UUID()
+        let layout = LayoutNode.pane(.terminal(terminalID: terminalID))
+
+        let result = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: terminalID)
+
+        guard case .split(let dir, let children, _) = result else {
+            Issue.record("Expected split result"); return
+        }
+        #expect(dir == .horizontal)
+        #expect(children.count == 2)
+        #expect(children[0] == .pane(.terminal(terminalID: terminalID)))
+        guard case .pane(.liveTranscript(_, let tid)) = children[1] else {
+            Issue.record("Expected liveTranscript leaf"); return
+        }
+        #expect(tid == terminalID, "new transcript must carry the same terminalID")
+    }
+
+    @Test func toggleTranscript_closesExistingTranscriptForTerminal() {
+        let terminalID = UUID()
+        let transcriptID = UUID()
+        let layout = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(.liveTranscript(id: transcriptID, terminalID: terminalID)),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: terminalID)
+
+        // removePane collapses a 2-child split to the surviving child.
+        #expect(result == .pane(.terminal(terminalID: terminalID)))
+    }
+
+    @Test func toggleTranscript_opensWhenExistingTranscriptIsForDifferentTerminal() {
+        let terminalA = UUID()
+        let terminalB = UUID()
+        let transcriptForB = UUID()
+        let layout = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalA)),
+                .pane(.liveTranscript(id: transcriptForB, terminalID: terminalB)),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = toggleTranscript(into: layout, terminalID: terminalA, fromPaneID: terminalA)
+
+        // B's transcript must survive untouched.
+        let transcriptIDs = transcriptTerminalIDs(in: result)
+        #expect(transcriptIDs.contains(terminalB), "B's transcript must not be closed")
+        #expect(transcriptIDs.contains(terminalA), "a new transcript for A must be added")
+        #expect(transcriptIDs.count == 2, "exactly two transcript panes expected")
+    }
+
+    /// Collects the `terminalID` carried by every `.liveTranscript` pane in the tree.
+    private func transcriptTerminalIDs(in node: LayoutNode) -> [UUID] {
+        switch node {
+        case .pane(let content):
+            if case .liveTranscript(_, let tid) = content { return [tid] }
+            return []
+        case .split(_, let children, _):
+            return children.flatMap { transcriptTerminalIDs(in: $0) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- The Claude pane's **Transcript** toolbar button used to *always* split open a new live-transcript pane — clicking it again stacked another one, with no way to dismiss it from the same control.
- It now **toggles**: if a live-transcript pane for that terminal is already open it closes it, otherwise it opens it.
- The button reflects state so open/closed is visible at a glance — filled icon (`text.bubble.fill`) + accent tint when open, hollow icon + default tint when closed, and the tooltip switches between **Show** and **Hide**.

## Implementation
- Toggle logic lives in a pure, unit-tested routing function `toggleTranscript(into:terminalID:fromPaneID:)` (`Sources/TBDApp/Panes/TranscriptRouting.swift`), mirroring the existing `routeFileClick` pattern: find the matching pane via `LayoutNode.firstPaneID(where:)`, `removePane` to close or `splitPane` to open.
- A shared `isLiveTranscriptPane(_:for:)` predicate backs both the toggle and the button's open-state check so the two can't drift.
- Matching is keyed on `terminalID`, so a transcript open for a *different* terminal is left untouched.

## Test plan
- [x] `swift test --filter TranscriptRouting` — 3 tests cover both branches: opens when none exists, closes the existing one for the terminal, and opens (not closes) when the only transcript belongs to a different terminal.
- [x] `swift build` clean.
- [ ] Live: open a Claude pane → click **Transcript** (pane opens, icon fills + tints, tooltip reads "Hide") → click again (pane closes, icon hollows, tooltip reads "Show").

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=82B7BC00-B218-4984-B2B4-25B1BFB5B8E7)