### PR TITLE
Feat: Let Claude messages use the full transcript width instead of a wasted right gutter

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
@@ -397,7 +397,8 @@ struct TableTranscriptView: NSViewRepresentable {
                 let renderStart = DispatchTime.now().uptimeNanoseconds
                 let blocks = composedBubbleBlocks(for: node, item: item)
                 let renderEnd = DispatchTime.now().uptimeNanoseconds
-                let bodyWidth = TranscriptBubbleGeometry.bodyWidth(columnWidth: width)
+                let bodyWidth = TranscriptBubbleGeometry.bodyWidth(
+                    columnWidth: width, role: TranscriptBubbleGeometry.role(for: item))
                 // Measure each block once and CACHE the per-block heights so the
                 // realized cell reuses them (no NSHostingController re-alloc for a
                 // table block on scroll). The row's body height is the SAME summed-
@@ -614,7 +615,7 @@ struct TableTranscriptView: NSViewRepresentable {
                 sourceText: TranscriptBubbleGeometry.text(for: item),
                 role: role,
                 header: TranscriptBubbleGeometry.header(for: item),
-                bodyWidth: TranscriptBubbleGeometry.bodyWidth(columnWidth: width),
+                bodyWidth: TranscriptBubbleGeometry.bodyWidth(columnWidth: width, role: role),
                 columnWidth: width,
                 cachedHeight: height
             )
@@ -780,7 +781,8 @@ struct TableTranscriptView: NSViewRepresentable {
             badgeUsage: TokenUsage?,
             columnWidth: CGFloat
         ) -> CGFloat {
-            let bodyWidth = TranscriptBubbleGeometry.bodyWidth(columnWidth: columnWidth)
+            let bodyWidth = TranscriptBubbleGeometry.bodyWidth(
+                columnWidth: columnWidth, role: TranscriptBubbleGeometry.role(for: item))
             let charsPerLine = max(Int(bodyWidth / avgBubbleCharWidth), 12)
             let text = TranscriptBubbleGeometry.text(for: item)
 

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
@@ -6,9 +6,11 @@ import TBDShared
 ///
 /// A message is an ordered list of typed `MessageBlock`s (prose / table) rendered
 /// into ONE bubble as a vertical stack. `heightOfRow` (measure) and `viewFor`
-/// (render) both flow through the SAME `bodyWidth(columnWidth:)` and the SAME
-/// `[MessageBlock]`, so the row height and the cell's drawn height cannot drift.
-/// Mirrors `ChatBubbleView`'s chrome (#129).
+/// (render) both flow through the SAME `bodyWidth(columnWidth:role:)` — called with
+/// the SAME role — and the SAME `[MessageBlock]`, so the row height and the cell's
+/// drawn height cannot drift. The body width is now role-dependent (see
+/// `outerHorizontal(for:)`), but measure and render still agree because they share
+/// the role. Mirrors `ChatBubbleView`'s chrome (#129).
 @MainActor
 enum TranscriptBubbleGeometry {
     enum Role {
@@ -18,11 +20,19 @@ enum TranscriptBubbleGeometry {
 
     // MARK: Chrome constants (mirror ChatBubbleView)
 
-    /// Outer leading+trailing padding folds the 52pt opposite-side gutter into
-    /// the 12pt chrome inset: 12 + 64 == 76 regardless of role.
-    static let outerHorizontal: CGFloat = 76
-    /// Chrome inset on the bubble's own side (12pt). The opposite side carries
-    /// the 64pt gutter (12 + 52).
+    /// Outer leading+trailing padding. User bubbles fold a 52pt opposite-side
+    /// gutter into the far inset (12 + 64 = 76) so they read as a right-anchored
+    /// chat bubble. Assistant messages drop the gutter entirely (12 + 12 = 24) and
+    /// span the full column width.
+    static func outerHorizontal(for role: Role) -> CGFloat {
+        switch role {
+        case .user: return 76
+        case .assistant: return 24
+        }
+    }
+    /// Chrome inset on the bubble's own side (12pt). For a user bubble the opposite
+    /// side additionally carries the 52pt gutter (12 + 52 = 64); an assistant bubble
+    /// carries just the 12pt chrome inset on the opposite side (no gutter).
     static let outerNear: CGFloat = 12
     /// Outer top/bottom padding.
     static let outerVertical: CGFloat = 4
@@ -40,11 +50,12 @@ enum TranscriptBubbleGeometry {
     static let interBlockSpacing: CGFloat = 6
 
     /// Single source of truth for the text container width used by BOTH the
-    /// measurer and the cell's NSTextView. Role-independent — the body width
-    /// folds the same opposite-side gutter into the chrome inset regardless of
-    /// which side the bubble anchors to.
-    static func bodyWidth(columnWidth: CGFloat) -> CGFloat {
-        max(columnWidth - outerHorizontal - bodyHorizontal, 1)
+    /// measurer and the cell's NSTextView. Role-dependent — a user bubble folds the
+    /// 52pt opposite-side gutter into its outer inset (narrower body), while an
+    /// assistant bubble drops the gutter and spans the full column. Measure and
+    /// render pass the SAME role, so heights can't drift.
+    static func bodyWidth(columnWidth: CGFloat, role: Role) -> CGFloat {
+        max(columnWidth - outerHorizontal(for: role) - bodyHorizontal, 1)
     }
 
     /// Total row height: summed block heights + inter-block spacing + fixed chrome

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
@@ -36,8 +36,16 @@ enum TranscriptBubbleGeometry {
     static let outerNear: CGFloat = 12
     /// Outer top/bottom padding.
     static let outerVertical: CGFloat = 4
-    /// bubbleBody inner horizontal insets (11 leading + 11 trailing).
-    static let bodyHorizontal: CGFloat = 22
+    /// bubbleBody inner horizontal insets. User bubbles keep an 11pt inset on each
+    /// side (visible chat-bubble padding). Assistant messages have no visible bubble,
+    /// so they use ZERO horizontal inset — content sits flush at the box edge so it
+    /// aligns with the header and the 12pt tool-row inset.
+    static func bodyHorizontal(for role: Role) -> CGFloat {
+        switch role {
+        case .user: return 22
+        case .assistant: return 0
+        }
+    }
     /// bubbleBody inner vertical insets (8 top + 8 bottom).
     static let bodyVertical: CGFloat = 16
     /// VStack header→body spacing.
@@ -55,7 +63,7 @@ enum TranscriptBubbleGeometry {
     /// assistant bubble drops the gutter and spans the full column. Measure and
     /// render pass the SAME role, so heights can't drift.
     static func bodyWidth(columnWidth: CGFloat, role: Role) -> CGFloat {
-        max(columnWidth - outerHorizontal(for: role) - bodyHorizontal, 1)
+        max(columnWidth - outerHorizontal(for: role) - bodyHorizontal(for: role), 1)
     }
 
     /// Total row height: summed block heights + inter-block spacing + fixed chrome
@@ -335,6 +343,8 @@ final class TranscriptBubbleCellView: NSTableCellView {
     private var boxLeading: NSLayoutConstraint!
     private var boxTrailing: NSLayoutConstraint!
     private var boxWidth: NSLayoutConstraint!
+    private var blockLeading: NSLayoutConstraint!
+    private var blockTrailing: NSLayoutConstraint!
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -375,6 +385,10 @@ final class TranscriptBubbleCellView: NSTableCellView {
         boxLeading = backgroundBox.leadingAnchor.constraint(equalTo: leadingAnchor)
         boxTrailing = backgroundBox.trailingAnchor.constraint(equalTo: trailingAnchor)
         boxWidth = backgroundBox.widthAnchor.constraint(equalToConstant: 1)
+        // Block-stack↔box horizontal insets, role-adjustable in `configure`
+        // (initial constant 0 is fine — `configure` sets the real per-role value).
+        blockLeading = blockStack.leadingAnchor.constraint(equalTo: backgroundBox.leadingAnchor, constant: 0)
+        blockTrailing = blockStack.trailingAnchor.constraint(equalTo: backgroundBox.trailingAnchor, constant: 0)
 
         NSLayoutConstraint.activate([
             widthConstraint,
@@ -386,10 +400,8 @@ final class TranscriptBubbleCellView: NSTableCellView {
             // rounded-rect frame; the stack sits inside it with symmetric padding.
             blockStack.topAnchor.constraint(
                 equalTo: backgroundBox.topAnchor, constant: g.bodyVertical / 2),
-            blockStack.leadingAnchor.constraint(
-                equalTo: backgroundBox.leadingAnchor, constant: g.bodyHorizontal / 2),
-            blockStack.trailingAnchor.constraint(
-                equalTo: backgroundBox.trailingAnchor, constant: -g.bodyHorizontal / 2),
+            blockLeading,
+            blockTrailing,
             // Pin the box bottom to the stack so the rounded fill encloses ALL
             // blocks with symmetric inner padding.
             backgroundBox.bottomAnchor.constraint(
@@ -426,12 +438,17 @@ final class TranscriptBubbleCellView: NSTableCellView {
         rebuildBlockStack(blocks: blocks, blockHeights: blockHeights, bodyWidth: bodyWidth)
 
         // Box width: user bubbles shrink-to-fit (right-anchored), assistant fills.
-        let bubbleWidth = bodyWidth + g.bodyHorizontal
+        // Per-role block-stack inset: user keeps the 11pt-per-side bubble padding,
+        // assistant sits flush at the box edge (0) so content aligns with the header.
+        let bodyInset = g.bodyHorizontal(for: role) / 2
+        blockLeading.constant = bodyInset
+        blockTrailing.constant = -bodyInset
+        let bubbleWidth = bodyWidth + g.bodyHorizontal(for: role)
         switch role {
         case .user:
             // Measure the widest prose block and clamp to the available bubble.
             let usedWidth = userContentWidth(blocks: blocks, bodyWidth: bodyWidth)
-            let fitWidth = min(usedWidth + g.bodyHorizontal, bubbleWidth)
+            let fitWidth = min(usedWidth + g.bodyHorizontal(for: role), bubbleWidth)
             applyUserAnchor(width: max(fitWidth, 1))
         case .assistant:
             applyAssistantAnchor(bubbleWidth: bubbleWidth)
@@ -557,7 +574,9 @@ final class TranscriptBubbleCellView: NSTableCellView {
 
         headerTrailing.isActive = false
         headerLeading.isActive = true
-        headerLeading.constant = g.outerNear + g.headerInset
+        // Header sits flush at `outerNear` (12) — the same x as the assistant body
+        // (zero body inset) and the 12pt tool-row inset — forming one vertical line.
+        headerLeading.constant = g.outerNear
         header.alignment = .left
     }
 

--- a/Tests/TBDAppTests/TableTranscriptHarness.swift
+++ b/Tests/TBDAppTests/TableTranscriptHarness.swift
@@ -405,7 +405,8 @@ struct TableTranscriptHarness {
         // SwiftUI hosting oracle.
         if case .chatBubble(let item) = node.kind {
             let blocks = TranscriptBubbleGeometry.composedBlocks(for: item, badgeUsage: node.badgeUsage)
-            let bodyWidth = TranscriptBubbleGeometry.bodyWidth(columnWidth: Self.width)
+            let bodyWidth = TranscriptBubbleGeometry.bodyWidth(
+                columnWidth: Self.width, role: TranscriptBubbleGeometry.role(for: item))
             let blocksHeight = MessageBlockMeasurer().blocksHeight(blocks, bodyWidth: bodyWidth)
             return TranscriptBubbleGeometry.rowHeight(blocksHeight: blocksHeight)
         }

--- a/Tests/TBDAppTests/TranscriptBubbleGeometryTests.swift
+++ b/Tests/TBDAppTests/TranscriptBubbleGeometryTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Locks in the role-dependent horizontal geometry of the table-based chat
+/// bubble: assistant messages drop the 52pt opposite-side gutter and span the
+/// full column, while user messages keep the gutter (right-anchored bubble).
+@MainActor
+struct TranscriptBubbleGeometryTests {
+    private let columnWidth: CGFloat = 600
+
+    @Test func assistantBodyWidthDropsGutter() {
+        let g = TranscriptBubbleGeometry.self
+        let expected = columnWidth - g.outerHorizontal(for: .assistant) - g.bodyHorizontal
+        #expect(g.bodyWidth(columnWidth: columnWidth, role: .assistant) == expected)
+    }
+
+    @Test func userBodyWidthKeepsGutter() {
+        let g = TranscriptBubbleGeometry.self
+        let expected = columnWidth - g.outerHorizontal(for: .user) - g.bodyHorizontal
+        #expect(g.bodyWidth(columnWidth: columnWidth, role: .user) == expected)
+    }
+
+    @Test func assistantIsWiderThanUserByTheRemovedGutter() {
+        let g = TranscriptBubbleGeometry.self
+        let assistant = g.bodyWidth(columnWidth: columnWidth, role: .assistant)
+        let user = g.bodyWidth(columnWidth: columnWidth, role: .user)
+        // The only difference between the two is the 52pt gutter folded into the
+        // user bubble's outer inset (76 vs 24 == 52).
+        #expect(assistant - user == 52)
+    }
+
+    @Test func outerHorizontalIsRoleDependent() {
+        let g = TranscriptBubbleGeometry.self
+        #expect(g.outerHorizontal(for: .assistant) == 24)
+        #expect(g.outerHorizontal(for: .user) == 76)
+    }
+}

--- a/Tests/TBDAppTests/TranscriptBubbleGeometryTests.swift
+++ b/Tests/TBDAppTests/TranscriptBubbleGeometryTests.swift
@@ -11,23 +11,36 @@ struct TranscriptBubbleGeometryTests {
 
     @Test func assistantBodyWidthDropsGutter() {
         let g = TranscriptBubbleGeometry.self
-        let expected = columnWidth - g.outerHorizontal(for: .assistant) - g.bodyHorizontal
+        // 600 - 24 - 0 == 576 (assistant: no gutter, no body inset).
+        let expected = columnWidth - g.outerHorizontal(for: .assistant) - g.bodyHorizontal(for: .assistant)
         #expect(g.bodyWidth(columnWidth: columnWidth, role: .assistant) == expected)
+        #expect(g.bodyWidth(columnWidth: columnWidth, role: .assistant) == 576)
     }
 
     @Test func userBodyWidthKeepsGutter() {
         let g = TranscriptBubbleGeometry.self
-        let expected = columnWidth - g.outerHorizontal(for: .user) - g.bodyHorizontal
+        // 600 - 76 - 22 == 502 (user: gutter + 11pt-per-side bubble padding).
+        let expected = columnWidth - g.outerHorizontal(for: .user) - g.bodyHorizontal(for: .user)
         #expect(g.bodyWidth(columnWidth: columnWidth, role: .user) == expected)
+        #expect(g.bodyWidth(columnWidth: columnWidth, role: .user) == 502)
     }
 
-    @Test func assistantIsWiderThanUserByTheRemovedGutter() {
+    @Test func bodyHorizontalIsRoleDependent() {
+        let g = TranscriptBubbleGeometry.self
+        // Assistant content sits flush at the box edge (aligns with header + tool
+        // rows); user keeps the visible 11pt-per-side chat-bubble padding.
+        #expect(g.bodyHorizontal(for: .assistant) == 0)
+        #expect(g.bodyHorizontal(for: .user) == 22)
+    }
+
+    @Test func assistantIsWiderThanUser() {
         let g = TranscriptBubbleGeometry.self
         let assistant = g.bodyWidth(columnWidth: columnWidth, role: .assistant)
         let user = g.bodyWidth(columnWidth: columnWidth, role: .user)
-        // The only difference between the two is the 52pt gutter folded into the
-        // user bubble's outer inset (76 vs 24 == 52).
-        #expect(assistant - user == 52)
+        // Assistant is wider by the 52pt gutter folded into the user's outer inset
+        // (76 vs 24 == 52) PLUS the 22pt user bubble padding the assistant drops
+        // (22 vs 0) == 74.
+        #expect(assistant - user == 74)
     }
 
     @Test func outerHorizontalIsRoleDependent() {


### PR DESCRIPTION
## Summary
- Assistant ("Claude") messages in the table-based live transcript reserved a **52pt empty gutter on their right edge**, so they didn't use the full horizontal space — they looked oddly inset on the right.
- **Why:** the chat-bubble geometry folds an opposite-side gutter into the horizontal inset so user messages read as right-anchored bubbles. That same fold was applied role-independently, and for the left-anchored assistant bubble the gutter landed on the **right**.
- **Fix:** make the horizontal inset role-dependent. User bubbles keep the gutter (unchanged right-anchored chat-bubble look); assistant messages drop it and use only the normal 12pt chrome inset on each side, spanning the full column width.

## Implementation
- `TranscriptBubbleGeometry.outerHorizontal` is now a function of `Role` (`.user` → 76 = 12 + 64; `.assistant` → 24 = 12 + 12), and `bodyWidth(columnWidth:role:)` takes the role.
- Both the measurement path and the render path flow through the **same role-aware `bodyWidth`**, so the row height and the cell's drawn height stay in lockstep (the #129 measure==render invariant holds).
- The assistant cell's box anchor already derives its width from the passed-in `bodyWidth`, so it auto-fills to `columnWidth - 24` with no anchor changes.

## Test plan
- [x] New `TranscriptBubbleGeometryTests` — asserts assistant `bodyWidth` is exactly 52pt wider than user, and `outerHorizontal(for:)` returns 24/76 (both branches).
- [x] `swift test --filter TableTranscript` — the render==measure harness still passes with the role-correct width.
- [x] `swift build` clean.
- [x] Verified live (screenshot): Claude messages now run to the same right margin as everything else; the user bubble is unchanged.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=82B7BC00-B218-4984-B2B4-25B1BFB5B8E7)