### PR TITLE
Feat: Show background-task notifications as clickable transcript rows

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
@@ -16,6 +16,7 @@ struct SystemReminderRow: View {
         case .environmentDetails: return "env"
         case .slashEnvelope: return "command"
         case .skillBody: return "skill"
+        case .taskNotification: return "background"
         case .other: return "info"
         }
     }

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -97,8 +97,8 @@ enum ActivityRowFormatter {
         switch node.kind {
         case .chatBubble:
             return nil
-        case let .systemReminder(id, kind, _, ts):
-            return systemReminder(id: id, kind: kind, timestamp: ts)
+        case let .systemReminder(id, kind, text, ts):
+            return systemReminder(id: id, kind: kind, text: text, timestamp: ts)
         case let .skillBody(id, text, ts):
             return skillBody(id: id, text: text, timestamp: ts)
         case let .toolCall(id, name, inputJSON, inputTruncatedTo, result, ts):
@@ -381,8 +381,14 @@ enum ActivityRowFormatter {
     // MARK: System reminder (SystemReminderRow)
 
     private static func systemReminder(
-        id: String, kind: SystemKind, timestamp: Date?
+        id: String, kind: SystemKind, text: String, timestamp: Date?
     ) -> ActivityRowPresentation {
+        // Background-task notifications get a richer presentation: a
+        // "Background · <summary>" title with the status surfaced as a badge.
+        if kind == .taskNotification {
+            return taskNotification(id: id, text: text, timestamp: timestamp)
+        }
+
         let label: String = {
             switch kind {
             case .toolReminder: return "system-reminder"
@@ -390,6 +396,7 @@ enum ActivityRowFormatter {
             case .environmentDetails: return "env"
             case .slashEnvelope: return "command"
             case .skillBody: return "skill"
+            case .taskNotification: return "background"
             case .other: return "info"
             }
         }()
@@ -401,6 +408,69 @@ enum ActivityRowFormatter {
             badges: [ActivityRowBadge(text: label, kind: .neutral)],
             openTargetID: id
         )
+    }
+
+    // MARK: Task notification (background-task activity row)
+
+    /// Builds the activity-row presentation for a background-task notification.
+    /// Surfaces the `<summary>` as the row title and the `<status>` as a badge;
+    /// the full original text remains available via the click-to-open overlay.
+    private static func taskNotification(
+        id: String, text: String, timestamp: Date?
+    ) -> ActivityRowPresentation {
+        let (summary, status) = parseTaskNotification(text)
+        let titleSegments: [ActivityRowSegment] = [
+            ActivityRowSegment(text: "Background", style: .primary),
+            ActivityRowSegment(text: "·", style: .tertiary),
+            ActivityRowSegment(text: summary, style: .secondary)
+        ]
+        var badges: [ActivityRowBadge] = []
+        if !status.isEmpty {
+            let lower = status.lowercased()
+            let kind: ActivityRowBadge.Kind =
+                (lower.contains("fail") || lower.contains("error")) ? .error : .neutral
+            badges.append(ActivityRowBadge(text: status, kind: kind))
+        }
+        return ActivityRowPresentation(
+            iconSystemName: "clock.arrow.circlepath",
+            titleSegments: titleSegments,
+            timestamp: timestamp,
+            isError: false,
+            badges: badges,
+            openTargetID: id,
+            titleTruncation: .byTruncatingTail
+        )
+    }
+
+    /// Extracts `(summary, status)` from a `<task-notification>` envelope using
+    /// plain string scanning (no regex). Returns the substrings between
+    /// `<summary>…</summary>` and `<status>…</status>`, trimmed. When `<summary>`
+    /// is absent, falls back to the status (or "Background task" if neither is
+    /// present). The status component is "" when absent.
+    static func parseTaskNotification(_ text: String) -> (summary: String, status: String) {
+        let summary = extractTagBody(in: text, tag: "summary") ?? ""
+        let status = extractTagBody(in: text, tag: "status") ?? ""
+        let resolvedSummary: String
+        if !summary.isEmpty {
+            resolvedSummary = summary
+        } else if !status.isEmpty {
+            resolvedSummary = status
+        } else {
+            resolvedSummary = "Background task"
+        }
+        return (resolvedSummary, status)
+    }
+
+    /// Returns the trimmed substring between `<tag>` and `</tag>`, or nil.
+    private static func extractTagBody(in text: String, tag: String) -> String? {
+        let open = "<\(tag)>"
+        let close = "</\(tag)>"
+        guard
+            let openRange = text.range(of: open),
+            let closeRange = text.range(of: close, range: openRange.upperBound..<text.endIndex)
+        else { return nil }
+        return text[openRange.upperBound..<closeRange.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: Skill body (SkillBodyRow)

--- a/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
@@ -161,6 +161,7 @@ struct TranscriptOverlayView: View {
             case .hookOutput:         return "hook"
             case .environmentDetails: return "env"
             case .slashEnvelope:      return "command"
+            case .taskNotification:   return "Background"
             case .other:              return "info"
             }
         case .userPrompt:   return "User"

--- a/Sources/TBDDaemon/Claude/UserMessageClassifier.swift
+++ b/Sources/TBDDaemon/Claude/UserMessageClassifier.swift
@@ -15,6 +15,10 @@ enum UserMessageClassifier {
         "<tool_result",
         "<local-command-",
         "<environment_details",
+        // Background-task notification envelopes injected into the user role
+        // (both the bare tag and the SYSTEM NOTIFICATION preamble form).
+        "<task-notification",
+        "[SYSTEM NOTIFICATION",
     ]
 
     /// Case-insensitive substrings that mark injected context blocks (checked after trimming leading `# `).
@@ -93,6 +97,13 @@ enum UserMessageClassifier {
             text = (array.first(where: { $0["type"] as? String == "text" })?["text"] as? String) ?? ""
         } else {
             return nil
+        }
+
+        // Background-task notifications are harness-injected into the user role.
+        // Surface them as a dedicated system kind so they render as a clickable
+        // activity row (with the full text available in the detail overlay).
+        if text.hasPrefix("<task-notification") || text.hasPrefix("[SYSTEM NOTIFICATION") {
+            return .taskNotification
         }
 
         if text.hasPrefix("Base directory for this skill:") { return .skillBody }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -649,6 +649,7 @@ public enum SystemKind: String, Codable, Sendable, Equatable, Hashable {
     case environmentDetails
     case slashEnvelope
     case skillBody
+    case taskNotification
     case other
 }
 

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -115,6 +115,49 @@ struct ActivityRowFormatterTests {
         #expect(p.openTargetID == "s1")
     }
 
+    @Test("Task notification → clock icon, 'Background · <summary>' title, status badge")
+    func taskNotification() throws {
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "t1", kind: .taskNotification,
+            text: "<task-notification>\n<status>completed</status>\n<summary>Agent \"X\" came to rest</summary>\n</task-notification>")
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(p.iconSystemName == "clock.arrow.circlepath")
+        #expect(titleText(p).contains("Background"))
+        #expect(titleText(p).contains("Agent \"X\" came to rest"))
+        #expect(p.badges == [ActivityRowBadge(text: "completed", kind: .neutral)])
+        #expect(p.openTargetID == "t1")
+        #expect(p.titleTruncation == .byTruncatingTail)
+    }
+
+    @Test("Task notification with no <summary> → falls back to status text")
+    func taskNotificationFallbackToStatus() throws {
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "t2", kind: .taskNotification,
+            text: "<task-notification>\n<status>running</status>\n</task-notification>")
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(titleText(p).contains("running"))
+        #expect(p.badges == [ActivityRowBadge(text: "running", kind: .neutral)])
+    }
+
+    @Test("Task notification with no summary or status → 'Background task', no badge")
+    func taskNotificationFallbackToDefault() throws {
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "t3", kind: .taskNotification,
+            text: "<task-notification>\n<task-id>abc</task-id>\n</task-notification>")
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(titleText(p).contains("Background task"))
+        #expect(p.badges.isEmpty)
+    }
+
+    @Test("Task notification with failing status → error badge kind")
+    func taskNotificationErrorBadge() throws {
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "t4", kind: .taskNotification,
+            text: "<task-notification>\n<status>failed</status>\n<summary>boom</summary>\n</task-notification>")
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(p.badges == [ActivityRowBadge(text: "failed", kind: .error)])
+    }
+
     @Test("Skill body → 'Skill' + skill-name segments")
     func skillBody() throws {
         let node = TranscriptRenderNode.makeSkillBody(

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -211,6 +211,47 @@ struct TranscriptParserTests {
         }
     }
 
+    @Test func task_notification_emits_system_reminder_with_full_text() throws {
+        // A real user prompt, then a background-task notification injected into
+        // the user role, then an assistant reply. The task-notification must
+        // produce a single .systemReminder(kind: .taskNotification) item whose
+        // text preserves the original <task-notification> content (for the
+        // detail overlay).
+        let lines = [
+            #"{"type":"user","uuid":"u1","timestamp":"2026-05-05T10:00:00Z","message":{"role":"user","content":"Please run the build."}}"#,
+            #"{"type":"user","uuid":"u2","timestamp":"2026-05-05T10:00:01Z","message":{"role":"user","content":"<task-notification>\n<status>completed</status>\n<summary>Build finished</summary>\n</task-notification>"}}"#,
+            #"{"type":"assistant","uuid":"a1","timestamp":"2026-05-05T10:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"Build started."}]}}"#,
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let items = TranscriptParser.parse(filePath: tmp)
+        #expect(items.count == 3, "task-notification line must produce a system reminder item")
+
+        let userPrompts = items.compactMap { item -> String? in
+            if case .userPrompt(_, let t, _) = item { return t }
+            return nil
+        }
+        #expect(userPrompts == ["Please run the build."])
+
+        let assistantTexts = items.compactMap { item -> String? in
+            if case .assistantText(_, let t, _, _) = item { return t }
+            return nil
+        }
+        #expect(assistantTexts == ["Build started."])
+
+        // Exactly one .systemReminder with kind .taskNotification preserving the
+        // full original notification text.
+        let reminders = items.compactMap { item -> (SystemKind, String)? in
+            if case .systemReminder(_, let kind, let text, _) = item { return (kind, text) }
+            return nil
+        }
+        #expect(reminders.count == 1)
+        #expect(reminders.first?.0 == .taskNotification)
+        #expect(reminders.first?.1.contains("<task-notification>") == true)
+        #expect(reminders.first?.1.contains("Build finished") == true)
+    }
+
     @Test func slash_envelope_emits_user_prompt_with_command_text() throws {
         let line = #"{"type":"user","uuid":"u1","timestamp":"2026-05-05T10:00:00Z","message":{"role":"user","content":"<command-name>/pr</command-name><command-message>pr</command-message><command-args></command-args>"}}"#
         let tmp = try writeTempJSONL(line)

--- a/Tests/TBDDaemonTests/UserMessageClassifierTests.swift
+++ b/Tests/TBDDaemonTests/UserMessageClassifierTests.swift
@@ -78,6 +78,26 @@ struct UserMessageClassifierTests {
         #expect(UserMessageClassifier.isRealUserMessage(l) == true)
         #expect(UserMessageClassifier.extractText(l) == nil)
     }
+
+    @Test("task-notification string is not a real user message")
+    func filtersTaskNotificationString() {
+        let l = line("user", role: "user", content: "<task-notification>\n<task-id>abc</task-id>\n</task-notification>")
+        #expect(UserMessageClassifier.isRealUserMessage(l) == false)
+    }
+
+    @Test("SYSTEM NOTIFICATION preamble string is not a real user message")
+    func filtersSystemNotificationPreambleString() {
+        let l = line("user", role: "user", content: "[SYSTEM NOTIFICATION - NOT USER INPUT]\nThis is an automated background-task event.\n<task-notification>\n<task-id>abc</task-id>\n</task-notification>")
+        #expect(UserMessageClassifier.isRealUserMessage(l) == false)
+    }
+
+    @Test("task-notification array content is not a real user message")
+    func filtersTaskNotificationArray() {
+        let l = line("user", role: "user", content: [
+            ["type": "text", "text": "<task-notification>\n<task-id>abc</task-id>\n</task-notification>"]
+        ])
+        #expect(UserMessageClassifier.isRealUserMessage(l) == false)
+    }
 }
 
 @Suite("UserMessageClassifier.classify")
@@ -163,5 +183,17 @@ struct UserMessageClassifierClassifyTests {
     @Test func user_typed_data_tag_prompt_returns_nil() {
         let line = userLine("<data>some xml</data>")
         #expect(UserMessageClassifier.classify(line) == nil)
+    }
+
+    @Test func task_notification_returns_task_notification_kind() {
+        let line = userLine("<task-notification>\n<task-id>abc</task-id>\n</task-notification>")
+        #expect(UserMessageClassifier.classify(line) == .taskNotification)
+        #expect(UserMessageClassifier.isRealUserMessage(line) == false)
+    }
+
+    @Test func system_notification_preamble_returns_task_notification_kind() {
+        let line = userLine("[SYSTEM NOTIFICATION - NOT USER INPUT]\nThis is an automated background-task event.\n<task-notification>\n<task-id>abc</task-id>\n</task-notification>")
+        #expect(UserMessageClassifier.classify(line) == .taskNotification)
+        #expect(UserMessageClassifier.isRealUserMessage(line) == false)
     }
 }


### PR DESCRIPTION
## Summary
- **What's broken:** background-task notifications showed up in the live transcript as stray **empty blue (user) chat bubbles**.
- **Why:** Claude Code injects background-task events into the *user* role as a plain string starting with `<task-notification>` (or a `[SYSTEM NOTIFICATION - NOT USER INPUT]` preamble). The classifier didn't recognize them, so they became `.userPrompt` items — and the markdown renderer stripped the XML to nothing.
- **What this does:** classify both forms as a new `SystemKind.taskNotification` and render them as a compact **clickable activity row** (like tool-call rows): a clock icon, the `<summary>` as the title, the `<status>` as a badge. Clicking opens the existing detail overlay with the full original text ("what was sent").

## Implementation
- `SystemKind.taskNotification` (TBDShared). Classifier returns it for both forms and keeps them out of the user-prompt path (`isRealUserMessage == false`). The full `<task-notification>` text is preserved on the emitted `.systemReminder` item for the overlay.
- App-side `ActivityRowFormatter` parses `<summary>`/`<status>` (no regex) to build the row; status badge turns `.error` on fail/error. Reuses the existing clickable activity-row + overlay plumbing — no new RPC.
- The deliberate bias that keeps *unknown* user-typed `<tags>` as real prompts is untouched; only these two known harness envelopes are reclassified.

## Test plan
- [x] `swift test --filter UserMessageClassifier` — both forms classify as `.taskNotification`, not user messages.
- [x] `swift test --filter TranscriptParser` — a `user → task-notification → assistant` JSONL yields a `.systemReminder(.taskNotification)` whose text retains the original summary, alongside the user/assistant items.
- [x] `swift test --filter ActivityRowFormatter` — row shows the summary title + status badge + clock icon + `openTargetID`; summary/error-badge fallbacks covered.
- [x] `swift build` clean; verified live (full daemon restart) — no empty bubbles; notifications render as "Background · …" rows.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=82B7BC00-B218-4984-B2B4-25B1BFB5B8E7)