### PR TITLE
Fix: Drop the extra blank line after a blockquote in the transcript

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/Renderer/MarkdownAttributedRenderer.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/MarkdownAttributedRenderer.swift
@@ -89,19 +89,8 @@ enum MarkdownAttributedRenderer {
         // prose ends with a hard line break that `usedRect` counts as an extra
         // empty line fragment — ~one line of dead space at the bottom of every
         // block. Trim the trailing run of newlines/whitespace so the prose ends
-        // at its last visible glyph. Guard the all-whitespace/empty case so we
-        // never delete an empty range. (#129)
-        let whitespace = CharacterSet.whitespacesAndNewlines
-        let ns = run.string as NSString
-        var end = ns.length
-        while end > 0,
-              let scalar = Unicode.Scalar(ns.character(at: end - 1)),
-              whitespace.contains(scalar) {
-            end -= 1
-        }
-        if end < ns.length {
-            run.deleteCharacters(in: NSRange(location: end, length: ns.length - end))
-        }
+        // at its last visible glyph. (#129)
+        AttributedStringVisitor.trimTrailingNewlines(run)
         return NSAttributedString(attributedString: run)
     }
 }
@@ -221,6 +210,12 @@ extension AttributedStringVisitor: @preconcurrency MarkupVisitor {
         inner.enumerateAttribute(.foregroundColor, in: full, options: []) { value, range, _ in
             if value == nil { inner.addAttribute(.foregroundColor, value: theme.blockquoteColor, range: range) }
         }
+        // The blockquote's child paragraph already appended its own trailing "\n"
+        // (every block visitor does). The `paragraph()` wrapper below appends one
+        // more, so the quote ended with "\n\n" — a blank line before the following
+        // block. Trim the inner trailing newline run so the wrapper's single
+        // terminator is the only one.
+        Self.trimTrailingNewlines(inner)
         let style = NSMutableParagraphStyle()
         style.headIndent = theme.listIndent
         style.firstLineHeadIndent = theme.listIndent
@@ -272,6 +267,24 @@ extension AttributedStringVisitor: @preconcurrency MarkupVisitor {
         inner.addAttribute(.paragraphStyle, value: style, range: full)
         inner.append(NSAttributedString(string: "\n"))
         return inner
+    }
+
+    /// Removes the trailing run of whitespace/newline characters from `s` in
+    /// place. Block visitors append a paragraph-terminating "\n"; callers that
+    /// wrap or finalize a block use this to drop a redundant terminator (which
+    /// would otherwise render as a blank line / dead bottom space).
+    static func trimTrailingNewlines(_ s: NSMutableAttributedString) {
+        let whitespace = CharacterSet.whitespacesAndNewlines
+        let ns = s.string as NSString
+        var end = ns.length
+        while end > 0,
+              let scalar = Unicode.Scalar(ns.character(at: end - 1)),
+              whitespace.contains(scalar) {
+            end -= 1
+        }
+        if end < ns.length {
+            s.deleteCharacters(in: NSRange(location: end, length: ns.length - end))
+        }
     }
 
     private mutating func visitListItem(_ item: ListItem, marker: String) -> NSAttributedString {

--- a/Tests/TBDAppTests/MarkdownAttributedRendererTests.swift
+++ b/Tests/TBDAppTests/MarkdownAttributedRendererTests.swift
@@ -226,6 +226,21 @@ struct MarkdownAttributedRendererTests {
         #expect(measured < oneLine * 1.6)
     }
 
+    @Test("renderBlocks: a blockquote is separated from the next paragraph by a single newline, not a blank line")
+    func blocksBlockquoteSingleTrailingNewline() {
+        let blocks = MarkdownAttributedRenderer.renderBlocks("> quoted line\n\nNext paragraph.")
+        #expect(blocks.count == 1)
+        guard case .prose(let s) = blocks[0] else {
+            Issue.record("expected a single prose block")
+            return
+        }
+        // The blockquote's child paragraph appends its own "\n" and the blockquote
+        // wrapper appended another, so the quote ended with "\n\n" — a blank line
+        // before the following paragraph. It must now be a single line break.
+        #expect(s.string.contains("quoted line\nNext paragraph"))
+        #expect(!s.string.contains("quoted line\n\n"))
+    }
+
     @Test("renderBlocks: a table becomes its own table block, splitting surrounding prose")
     func blocksProseTableProse() {
         let md = """


### PR DESCRIPTION
## Summary
- **What's broken:** a blockquote in a transcript message rendered with an extra **blank line** between the quoted text and the following paragraph.
- **Why:** every block visitor appends a paragraph-terminating `\n`. A blockquote's child paragraph already ended in `\n` (from `visitParagraph`), and then `visitBlockQuote`'s own `paragraph()` wrapper appended a *second* one — so the quote ended with `\n\n`, i.e. a blank line.
- **Fix:** trim the inner trailing-newline run before the wrapper adds its single terminator, so a blockquote ends with exactly one `\n`. Factored the trailing-newline trim (already used by `finalizedProse`) into a shared helper.

## Test plan
- [x] New regression test: `renderBlocks("> quoted line\n\nNext paragraph.")` yields prose containing `quoted line\nNext paragraph` and **not** `quoted line\n\n`.
- [x] `swift test --filter MarkdownAttributedRenderer` — all 18 pass (existing blockquote color/nesting tests still green).
- [x] `swift build` clean.

Reported from a transcript where a single-line blockquote was followed by a paragraph and showed one extra newline between them.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=82B7BC00-B218-4984-B2B4-25B1BFB5B8E7)