### PR TITLE
Fix: Render Session History through the NSTableView renderer to stop hard hangs on long sessions

### DIFF
--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -289,6 +289,15 @@ struct SessionTranscriptView: View {
     /// shown only when the user has consciously scrolled up.
     @State private var atBottom: Bool = true
 
+    /// Incremented by the jump-to-bottom button to ask the table to scroll to
+    /// the last row (NSTableView renderer path).
+    @State private var scrollToBottomToken: Int = 0
+
+    /// Route the history viewer through the same `TableTranscriptView` the live
+    /// pane uses (default), keeping the legacy SwiftUI `ScrollView`/`LazyVStack`
+    /// path as the toggle-off fallback. (#129)
+    @AppStorage(AppState.useTableViewTranscriptKey) private var useTableViewTranscript = true
+
     private var messages: [TranscriptItem] {
         appState.sessionTranscripts[sessionId] ?? []
     }
@@ -356,6 +365,64 @@ struct SessionTranscriptView: View {
                         .font(.callout)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if useTableViewTranscript {
+                TableTranscriptView(
+                    context: TranscriptCardContext(
+                        terminalID: nil,
+                        openTranscriptOverlay: { itemID in
+                            overlayCoordinator.open(
+                                terminalID: nil,
+                                itemID: itemID,
+                                historySessionID: sessionId
+                            )
+                        },
+                        appState: appState
+                    ),
+                    atBottom: $atBottom,
+                    scrollToBottomToken: scrollToBottomToken,
+                    nodesProvider: { transcriptRenderNodes(from: messages) }
+                )
+                // Rebuild the stateful Coordinator when the selected session changes.
+                .id(sessionId)
+                .overlay(alignment: .bottomTrailing) {
+                    if !atBottom {
+                        Button {
+                            scrollToBottomToken &+= 1
+                        } label: {
+                            Image(systemName: "arrow.down.circle.fill")
+                                .font(.system(size: 28))
+                                .symbolRenderingMode(.palette)
+                                .foregroundStyle(.white, Color.accentColor)
+                                .background(.ultraThinMaterial, in: Circle())
+                                .shadow(radius: 4)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(16)
+                        .transition(.scale(scale: 0.5).combined(with: .opacity))
+                        .help("Scroll to bottom")
+                    }
+                }
+                .animation(.easeInOut(duration: 0.2), value: atBottom)
+                .onAppear {
+                    HangWatchdog.shared.recordContext { snap in
+                        snap.focusedTerminalIDShort = nil
+                        snap.transcriptItemCount = messages.count
+                        snap.paneLabel = "history"
+                    }
+                }
+                .onChange(of: messages.count) { _, newCount in
+                    HangWatchdog.shared.recordContext { snap in
+                        snap.transcriptItemCount = newCount
+                        snap.paneLabel = "history"
+                    }
+                }
+                .onDisappear {
+                    HangWatchdog.shared.recordContext { snap in
+                        snap.focusedTerminalIDShort = nil
+                        snap.transcriptItemCount = nil
+                        snap.paneLabel = nil
+                    }
+                }
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {


### PR DESCRIPTION
## Summary
- **What's broken:** opening a long old session in the **Session History** viewer **hard-hangs the app** (force-quit required).
- **Why:** the live transcript pane was migrated to `TableTranscriptView` to fix the #129 main-thread freezes, but `SessionTranscriptView` was missed — it still renders through the legacy SwiftUI `ScrollView { TranscriptItemsView }` (`LazyVStack`) path. On a long session that deep-recurses in SwiftUI layout (`LazyStack.place` → `ForEachList.applyNodes` → `_ViewList_TemporarySublistTransform.withPushedItem`) and locks the main thread. Confirmed against a user stackshot.
- **Fix:** route `SessionTranscriptView` through the same `TableTranscriptView` the live pane uses (AppKit row virtualization + cached exact heights), gated by the same `useTableViewTranscript` toggle (default on). The legacy SwiftUI path stays as the toggle-off fallback for comparison.

## Notes
- `terminalID` is `nil` for history (unchanged); the click-to-overlay closure carries `historySessionID` for full-body fetch, exactly as the legacy path did. Verified the table renderer never force-unwraps `context.terminalID`.
- Single-file change (`HistoryPaneView.swift`); reuses the existing `transcriptRenderNodes(from:)` builder and `TranscriptCardContext`.

## Test plan
- [x] `swift build` clean; `swift test --filter Transcript` — 212 tests pass (incl. the `useTableViewTranscript` gate suite).
- [ ] Live: open the long old session that previously hung → renders without freezing; scroll, jump-to-bottom, and click-to-expand a tool card work; toggling the renderer off falls back to the legacy view.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=82B7BC00-B218-4984-B2B4-25B1BFB5B8E7)