### PR TITLE
Fix: Highlight transcript code blocks off the main thread to stop multi-second JSC-VM hangs

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/Renderer/CodeHighlightService.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/CodeHighlightService.swift
@@ -76,7 +76,6 @@ final class CodeHighlightService {
     func highlight(
         code: String,
         language: String,
-        theme: TranscriptTextTheme,
         completion: @escaping @MainActor ([HighlightColorRun]) -> Void
     ) {
         let utf16Count = code.utf16.count

--- a/Sources/TBDApp/Panes/Transcript/Renderer/CodeHighlightService.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/CodeHighlightService.swift
@@ -1,0 +1,126 @@
+import AppKit
+import Highlightr
+import os
+
+/// One foreground-color run produced by syntax highlighting. Ranges are LOCAL to
+/// the code string the run was computed from (the caller offsets them into the
+/// surrounding attributed string).
+struct HighlightColorRun {
+    let range: NSRange
+    let color: NSColor
+}
+
+/// Off-main syntax highlighter for fenced code blocks. (#129 freeze fix.)
+///
+/// `Highlightr` wraps highlight.js inside a JavaScriptCore VM. Creating that VM —
+/// and running highlight.js — is expensive, and under memory pressure the lazy
+/// `JSVirtualMachine` init can stall the calling thread for tens of seconds. The
+/// transcript open path used to do this synchronously on the MAIN thread (height
+/// precompute + first paint), producing a hard force-quit-level freeze.
+///
+/// This service moves all JavaScriptCore work onto a DEDICATED serial queue and
+/// NEVER touches `Highlightr`/`JSContext` from any other thread (JSContext is
+/// thread-confined). Code blocks render as plain monospaced text synchronously;
+/// the colors computed here are applied later, over the SAME fixed monospaced font,
+/// so they change only `.foregroundColor` and never the layout/height.
+final class CodeHighlightService {
+    /// Process singleton. `nonisolated(unsafe)` because the type's only mutable
+    /// state (the lazy `Highlightr`) is confined to `queue`, so access is
+    /// serialized at runtime rather than checked by the compiler — the same pattern
+    /// the sibling `DiffSyntaxHighlighter` uses for its shared `Highlightr`s.
+    nonisolated(unsafe) static let shared = CodeHighlightService()
+
+    /// Dedicated serial queue. The lazily-created `Highlightr` and EVERY call into
+    /// it happen only here — JSContext is thread-confined, so confining all access
+    /// to one serial queue is the thread-safety guarantee.
+    private let queue = DispatchQueue(label: "com.tbd.code-highlight", qos: .userInitiated)
+    private let log = Logger(subsystem: "com.tbd.app", category: "code-highlight")
+
+    /// Skip highlighting inputs larger than this — highlight.js is pathologically
+    /// slow on huge blobs (history transcripts contain big file/tool-output dumps).
+    private let maxUTF16Count = 30_000
+    private let maxLineCount = 2_000
+
+    /// The single `Highlightr`, created lazily ON `queue` and only ever touched
+    /// there. Plain stored properties guarded solely by `queue` serialization.
+    private var highlightr: Highlightr?
+    private var didCreateHighlightr = false
+
+    private init() {}
+
+    /// Lazily create the `Highlightr` (MUST run on `queue`).
+    private func makeHighlightrIfNeeded() -> Highlightr? {
+        if !didCreateHighlightr {
+            didCreateHighlightr = true
+            let h = Highlightr()
+            h?.setTheme(to: "xcode")
+            highlightr = h
+        }
+        return highlightr
+    }
+
+    /// Best-effort warm: create the `Highlightr` (and thus the JSCore VM) off-main,
+    /// ahead of first use, so the first real highlight doesn't pay the VM-init cost.
+    func warm() {
+        queue.async { [self] in
+            _ = makeHighlightrIfNeeded()
+        }
+    }
+
+    /// Highlight `code` as `language` off the main thread and deliver the resulting
+    /// foreground-color runs (local to `code`) back on the main thread.
+    ///
+    /// Skips (returns `[]`) for inputs over the size cap. If highlighting fails or
+    /// produces nothing, also returns `[]`. The completion always runs on the main
+    /// thread (it is `@MainActor`).
+    func highlight(
+        code: String,
+        language: String,
+        theme: TranscriptTextTheme,
+        completion: @escaping @MainActor ([HighlightColorRun]) -> Void
+    ) {
+        let utf16Count = code.utf16.count
+        if utf16Count > maxUTF16Count {
+            log.debug(
+                "code-highlight skip: utf16=\(utf16Count, privacy: .public) > cap=\(self.maxUTF16Count, privacy: .public) lang=\(language, privacy: .public)")
+            DispatchQueue.main.async { MainActor.assumeIsolated { completion([]) } }
+            return
+        }
+        // Cheap line-count guard (count newlines without splitting the whole string).
+        let lineCount = code.reduce(into: 1) { count, ch in if ch == "\n" { count += 1 } }
+        if lineCount > maxLineCount {
+            log.debug(
+                "code-highlight skip: lines=\(lineCount, privacy: .public) > cap=\(self.maxLineCount, privacy: .public) lang=\(language, privacy: .public)")
+            DispatchQueue.main.async { MainActor.assumeIsolated { completion([]) } }
+            return
+        }
+
+        queue.async { [self] in
+            guard let highlightr = makeHighlightrIfNeeded(),
+                  let highlighted = highlightr.highlight(code, as: language) else {
+                DispatchQueue.main.async { MainActor.assumeIsolated { completion([]) } }
+                return
+            }
+            let runs = Self.colorRuns(from: highlighted)
+            DispatchQueue.main.async { MainActor.assumeIsolated { completion(runs) } }
+        }
+    }
+
+    /// Enumerate `.foregroundColor` over `highlighted` and collect the non-nil
+    /// color runs. Runs WITHOUT a foreground color (highlight.js's default text)
+    /// are skipped — the plain render already carries the theme body color there.
+    /// Ranges are local to the highlighted string (== the input `code`).
+    ///
+    /// Pure string/attribute work — no JSContext access — but it still runs on
+    /// `queue` so we never read the `NSAttributedString` `highlight` returned from
+    /// the main thread concurrently.
+    private static func colorRuns(from highlighted: NSAttributedString) -> [HighlightColorRun] {
+        var runs: [HighlightColorRun] = []
+        let full = NSRange(location: 0, length: highlighted.length)
+        highlighted.enumerateAttribute(.foregroundColor, in: full, options: []) { value, range, _ in
+            guard let color = value as? NSColor else { return }
+            runs.append(HighlightColorRun(range: range, color: color))
+        }
+        return runs
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Renderer/MarkdownCodeBlock.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/MarkdownCodeBlock.swift
@@ -1,49 +1,49 @@
 import AppKit
-import Highlightr
 
-/// Renders a fenced code block as a syntax-highlighted `NSAttributedString`.
+extension NSAttributedString.Key {
+    /// Marks a fenced code-block run (range == the block's code characters) that
+    /// SHOULD be syntax-highlighted later, off the main thread. Its value is the
+    /// language `String`. Present only when the block declared a language; a
+    /// language-less block stays plain forever and carries no marker. (#129)
+    static let tbdCodeHighlight = NSAttributedString.Key("tbdCodeHighlight")
+}
+
+/// Renders a fenced code block as a PLAIN monospaced `NSAttributedString`.
 ///
-/// Highlightr wraps highlight.js and its init is expensive (~300 ms on first call
-/// because it loads the full highlight.js runtime). A single `@MainActor` static
-/// instance is cached so subsequent calls are fast. (#129)
+/// Syntax highlighting (JavaScriptCore / highlight.js) is intentionally NOT done
+/// here: doing it synchronously on the main thread — in height measurement and
+/// first paint — caused a hard freeze (the lazy JSCore VM init can stall tens of
+/// seconds under memory pressure). Instead this renders plain text and, when the
+/// block has a language, attaches a `.tbdCodeHighlight` marker over the code range
+/// so the cell can colorize it asynchronously via `CodeHighlightService`. Because
+/// the font (`theme.codeFont`) is fixed here and the async pass only adds
+/// `.foregroundColor`, layout/height never changes — `render == measure` holds. (#129)
 @MainActor
 enum MarkdownCodeBlock {
-    private static let highlightr: Highlightr? = {
-        let h = Highlightr()
-        h?.setTheme(to: "xcode")
-        return h
-    }()
-
-    /// Returns an `NSAttributedString` for the given fenced code block.
+    /// Returns a PLAIN monospaced `NSAttributedString` for the given fenced code block.
     ///
-    /// - Colors come from Highlightr/highlight.js (syntax highlighting).
-    /// - Font is always `theme.codeFont` (monospaced, project-size) — overrides
-    ///   whatever font Highlightr set so we stay on the design system.
+    /// - Font is `theme.codeFont` (monospaced, project-size).
     /// - Background (`theme.codeBackground`) is applied as `.backgroundColor`.
     /// - A paragraph style with head/tail indent (8 pt) indents the block visually.
+    /// - When `language != nil`, a `.tbdCodeHighlight` marker (value = the language)
+    ///   is attached over the code's characters so the cell can highlight it later.
     static func attributed(code: String, language: String?, theme: TranscriptTextTheme) -> NSAttributedString {
-        // Try syntax highlighting; fall back to plain monospaced if unavailable.
-        let base: NSMutableAttributedString
-        if let h = highlightr,
-           let lang = language,
-           let highlighted = h.highlight(code, as: lang) {
-            base = NSMutableAttributedString(attributedString: highlighted)
-        } else {
-            base = NSMutableAttributedString(
-                string: code,
-                attributes: [.font: theme.codeFont]
-            )
-        }
+        let base = NSMutableAttributedString(
+            string: code,
+            attributes: [.font: theme.codeFont]
+        )
 
         let full = NSRange(location: 0, length: base.length)
 
-        // Override font: keep highlight COLORS but impose our mono font/size.
-        base.enumerateAttribute(.font, in: full, options: []) { _, range, _ in
-            base.addAttribute(.font, value: theme.codeFont, range: range)
-        }
-
         // Apply code background across the entire block.
         base.addAttribute(.backgroundColor, value: theme.codeBackground, range: full)
+
+        // Mark the code range for async syntax highlighting — only when a language
+        // is present (matches the old "highlight only when language present"
+        // behavior; language-less blocks stay plain forever).
+        if let language, full.length > 0 {
+            base.addAttribute(.tbdCodeHighlight, value: language, range: full)
+        }
 
         // Inset the block with a paragraph style.
         let style = NSMutableParagraphStyle()

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
@@ -120,7 +120,11 @@ struct TableTranscriptView: NSViewRepresentable {
             }
         }
 
-        Self.warmHighlightrOnce()
+        // Create the syntax-highlighting JSCore VM OFF the main thread, ahead of
+        // the first code cell. The open path (height precompute + first paint)
+        // renders code blocks as plain monospaced text and never touches
+        // JavaScriptCore — colors are applied asynchronously after display. (#129)
+        CodeHighlightService.shared.warm()
 
         // One-time runtime verification of FIX 1(a): with the app-launch register
         // in place, `canEstimate` must read false by the time any table is set up.
@@ -133,19 +137,6 @@ struct TableTranscriptView: NSViewRepresentable {
         Self.log.debug(
             "table.open.makeNSViewDone ms=\(makeNSViewMs, format: .fixed(precision: 1), privacy: .public) rows=\(nodes.count, privacy: .public)")
         return scrollView
-    }
-
-    /// Highlightr's first init costs ~300ms (it loads the full highlight.js
-    /// runtime). It's `@MainActor`, so we can't move it off the main thread —
-    /// but we can pay it asynchronously at pane install, before the first real
-    /// code bubble needs it. Runs exactly once per process.
-    private static var didWarmHighlightr = false
-    private static func warmHighlightrOnce() {
-        guard !didWarmHighlightr else { return }
-        didWarmHighlightr = true
-        DispatchQueue.main.async {
-            _ = MarkdownCodeBlock.attributed(code: "x", language: "swift", theme: .chatBubble)
-        }
     }
 
     func updateNSView(_ nsView: NSScrollView, context ctx: Context) {
@@ -391,8 +382,9 @@ struct TableTranscriptView: NSViewRepresentable {
                 // equal the cell's drawn block-stack height by construction.
                 //
                 // Instrumented in two phases so we know whether the cost is
-                // RENDERING (markdown → attributed string, incl. Highlightr syntax
-                // highlighting of fenced code) or MEASURING (TK1 `usedRect`). (#129)
+                // RENDERING (markdown → attributed string; fenced code is rendered
+                // PLAIN here — syntax highlighting is async + off-main) or
+                // MEASURING (TK1 `usedRect`). (#129)
                 let branchStart = DispatchTime.now().uptimeNanoseconds
                 let renderStart = DispatchTime.now().uptimeNanoseconds
                 let blocks = composedBubbleBlocks(for: node, item: item)

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
@@ -547,7 +547,7 @@ final class TranscriptBubbleCellView: NSTableCellView {
             let code = ns.substring(with: range)
             let captured = highlightGeneration
             CodeHighlightService.shared.highlight(
-                code: code, language: language, theme: .chatBubble
+                code: code, language: language
             ) { [weak self, weak textView] colorRuns in
                 guard let self, let textView, self.highlightGeneration == captured else { return }
                 guard let storage = textView.textStorage else { return }

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
@@ -335,6 +335,12 @@ final class TranscriptBubbleCellView: NSTableCellView {
     /// Source text of the whole message, for ⌘C / "Copy message".
     private var messageSourceText: String = ""
 
+    /// Monotonic token bumped on every (re)build of the block stack. Async syntax-
+    /// highlight completions capture the value current when they were dispatched
+    /// and bail if it changed (scroll-reuse / reconfigure recycled the cell onto a
+    /// different message), so colors never land on a stale/detached text view. (#129)
+    private var highlightGeneration = 0
+
     // Cell-box + role-dependent anchoring constraints (assigned post-super.init).
     private var widthConstraint: NSLayoutConstraint!
     private var heightConstraint: NSLayoutConstraint!
@@ -467,6 +473,11 @@ final class TranscriptBubbleCellView: NSTableCellView {
     /// (a missing/short `blockHeights` array) re-measures the affected block so the
     /// cell can never render at a wrong height. (#129)
     private func rebuildBlockStack(blocks: [MessageBlock], blockHeights: [CGFloat], bodyWidth: CGFloat) {
+        // Invalidate any in-flight async syntax-highlight completions targeting the
+        // previous content: a recycled cell rebuilds onto a different message, so
+        // those completions must become no-ops (see `applyAsyncHighlights`).
+        highlightGeneration &+= 1
+
         for view in blockStack.arrangedSubviews {
             blockStack.removeArrangedSubview(view)
             view.removeFromSuperview()
@@ -519,7 +530,40 @@ final class TranscriptBubbleCellView: NSTableCellView {
             width: max(bodyWidth, 1), height: CGFloat.greatestFiniteMagnitude)
         textView.textStorage?.setAttributedString(string)
         textView.setSelectedRange(NSRange(location: 0, length: 0))
+        applyAsyncHighlights(in: string, textView: textView)
         return textView
+    }
+
+    /// Finds every `.tbdCodeHighlight`-marked code run in `string` and asks the
+    /// off-main `CodeHighlightService` to syntax-highlight it. Each completion
+    /// (already on the main thread) re-applies only `.foregroundColor` over the
+    /// run's characters — colors only, so no relayout — guarded against scroll-reuse
+    /// staleness via the generation token + a weak text-view capture. (#129)
+    private func applyAsyncHighlights(in string: NSAttributedString, textView: NSTextView) {
+        let ns = string.string as NSString
+        let full = NSRange(location: 0, length: string.length)
+        string.enumerateAttribute(.tbdCodeHighlight, in: full, options: []) { value, range, _ in
+            guard let language = value as? String, range.length > 0 else { return }
+            let code = ns.substring(with: range)
+            let captured = highlightGeneration
+            CodeHighlightService.shared.highlight(
+                code: code, language: language, theme: .chatBubble
+            ) { [weak self, weak textView] colorRuns in
+                guard let self, let textView, self.highlightGeneration == captured else { return }
+                guard let storage = textView.textStorage else { return }
+                let storageLength = storage.length
+                storage.beginEditing()
+                for run in colorRuns {
+                    let offset = NSRange(location: range.location + run.range.location, length: run.range.length)
+                    // Clamp defensively: the storage must still contain the offset
+                    // range (it does unless the content changed, which the
+                    // generation guard already rules out).
+                    guard offset.location + offset.length <= storageLength else { continue }
+                    storage.addAttribute(.foregroundColor, value: run.color, range: offset)
+                }
+                storage.endEditing()
+            }
+        }
     }
 
     /// A table block hosted in an `NSHostingView` over the native grid.

--- a/Tests/TBDAppTests/CodeHighlightServiceTests.swift
+++ b/Tests/TBDAppTests/CodeHighlightServiceTests.swift
@@ -1,0 +1,47 @@
+import Testing
+import AppKit
+@testable import TBDApp
+
+@MainActor
+@Suite("Code highlight service (async, off-main)")
+struct CodeHighlightServiceTests {
+    /// The size cap is a pure guard (no JSContext), so it returns `[]` quickly and
+    /// deterministically — assert it via a bounded async wait. A code blob over the
+    /// 30k-UTF16 cap must be skipped (highlight.js is pathologically slow on huge
+    /// inputs; the open path must never pay it).
+    @Test("oversized input is skipped (returns no color runs)")
+    func sizeCapSkips() async {
+        let huge = String(repeating: "let x = 1\n", count: 4_000) // ~40k UTF-16
+        let runs: [HighlightColorRun] = await withCheckedContinuation { continuation in
+            CodeHighlightService.shared.highlight(
+                code: huge, language: "swift", theme: .chatBubble
+            ) { result in
+                continuation.resume(returning: result)
+            }
+        }
+        #expect(runs.isEmpty)
+    }
+
+    /// Live highlight.js path: a small Swift snippet eventually yields ≥1 foreground
+    /// color run, delivered on the main thread, with ranges local to the input.
+    /// Exercises the dedicated serial queue + JSContext confinement end to end.
+    @Test("small swift snippet eventually returns at least one color run")
+    func liveHighlightProducesColorRuns() async {
+        let code = "let x = 1"
+        let runs: [HighlightColorRun] = await withCheckedContinuation { continuation in
+            CodeHighlightService.shared.highlight(
+                code: code, language: "swift", theme: .chatBubble
+            ) { result in
+                continuation.resume(returning: result)
+            }
+        }
+        // Highlightr/highlight.js should color at least the `let` keyword.
+        #expect(!runs.isEmpty)
+        // Ranges are LOCAL to the input string (never out of bounds).
+        let length = (code as NSString).length
+        for run in runs {
+            #expect(run.range.location >= 0)
+            #expect(run.range.location + run.range.length <= length)
+        }
+    }
+}

--- a/Tests/TBDAppTests/CodeHighlightServiceTests.swift
+++ b/Tests/TBDAppTests/CodeHighlightServiceTests.swift
@@ -14,7 +14,7 @@ struct CodeHighlightServiceTests {
         let huge = String(repeating: "let x = 1\n", count: 4_000) // ~40k UTF-16
         let runs: [HighlightColorRun] = await withCheckedContinuation { continuation in
             CodeHighlightService.shared.highlight(
-                code: huge, language: "swift", theme: .chatBubble
+                code: huge, language: "swift"
             ) { result in
                 continuation.resume(returning: result)
             }
@@ -30,7 +30,7 @@ struct CodeHighlightServiceTests {
         let code = "let x = 1"
         let runs: [HighlightColorRun] = await withCheckedContinuation { continuation in
             CodeHighlightService.shared.highlight(
-                code: code, language: "swift", theme: .chatBubble
+                code: code, language: "swift"
             ) { result in
                 continuation.resume(returning: result)
             }

--- a/Tests/TBDAppTests/MarkdownAttributedRendererTests.swift
+++ b/Tests/TBDAppTests/MarkdownAttributedRendererTests.swift
@@ -75,12 +75,35 @@ struct MarkdownAttributedRendererTests {
         #expect(seeColor == TranscriptTextTheme.chatBubble.blockquoteColor)
     }
 
-    @Test("fenced code uses a monospaced font and a background")
+    @Test("fenced code renders plain monospaced and marks a language block for async highlight")
     func codeBlock() {
         let s = MarkdownAttributedRenderer.render("```swift\nlet x = 1\n```")
         let f = s.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        // Plain render: monospaced font + the literal code text survive. Syntax
+        // highlighting is now applied asynchronously off the main thread (#129), so
+        // the synchronous render carries NO highlight colors — only the marker.
         #expect(f?.fontDescriptor.symbolicTraits.contains(.monoSpace) == true)
         #expect(s.string.contains("let x = 1"))
+
+        // A fenced block WITH a language carries the `.tbdCodeHighlight` marker
+        // (value == the language) over its code characters.
+        let codeRange = (s.string as NSString).range(of: "let x = 1")
+        let marker = s.attribute(.tbdCodeHighlight, at: codeRange.location, effectiveRange: nil) as? String
+        #expect(marker == "swift")
+    }
+
+    @Test("fenced code WITHOUT a language is plain and carries no async-highlight marker")
+    func codeBlockNoLanguage() {
+        let s = MarkdownAttributedRenderer.render("```\nplain text\n```")
+        let f = s.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(f?.fontDescriptor.symbolicTraits.contains(.monoSpace) == true)
+        #expect(s.string.contains("plain text"))
+        // No language → stays plain forever → no marker anywhere.
+        var foundMarker = false
+        s.enumerateAttribute(.tbdCodeHighlight, in: NSRange(location: 0, length: s.length)) { v, _, _ in
+            if v != nil { foundMarker = true }
+        }
+        #expect(!foundMarker)
     }
 
     @Test("GFM table becomes a single grid-view attachment carrying its cell text")


### PR DESCRIPTION
## Summary
- **What's broken:** opening a transcript — most reliably a long **Session History** session with code blocks — **hard-hangs the app** (40+s, force-quit). Confirmed by two stackshots + the in-app HangWatchdog (16 resamples).
- **Why:** the open path precomputes row heights **synchronously on the main thread**; for a code block that calls `Highlightr`, which lazily creates a **JavaScriptCore VM on the main thread** (`-[JSVirtualMachine init]` → `JSC::VM::VM` → `bmalloc`). Under memory pressure that allocation stalls for tens of seconds. The first visible code *cell* render hit the same path, so neither a size cap nor deferring measurement alone was enough.
- **Fix:** get JavaScriptCore off the main thread entirely.
  - Code blocks render as **plain monospaced text synchronously** (measurement AND first paint never touch JSC), with highlightable runs tagged by a `.tbdCodeHighlight` attribute.
  - A new **`CodeHighlightService`** owns the `Highlightr`/`JSContext` on a dedicated serial queue and returns syntax colors **asynchronously**; the bubble cell applies them in place (color-only over the already-fixed mono font → no relayout, guarded against scroll reuse).
  - **Size cap** (>30k chars / >2k lines) skips highlighting huge code dumps that choke highlight.js (common in historic transcripts).
  - Fixes both the **history viewer** and the **live pane** (same latent first-code-block VM-init hit).

## Invariant
`render == measure`: both consume the same plain `NSAttributedString` (same `theme.codeFont`, text, wrapping → identical heights); the async pass only adds `.foregroundColor`, which can't change glyph metrics. Table render==measure harness passes.

## Test plan
- [x] `swift build` clean; `Highlightr` now referenced only by `CodeHighlightService` in the transcript path.
- [x] `swift test --filter Transcript` (212), `--filter MarkdownAttributedRenderer` (18, incl. plain-render + marker-attribute assertions), `--filter CodeHighlightService` (2, size-cap + live-JS color run), `--filter TableTranscript` (7) — all pass.
- [ ] Live: open the long history session that previously hung → renders instantly, no freeze; code shows plain then colors fade in; scrolling/reuse keeps colors correct; `log stream … category == "code-highlight"` shows highlighting (never blocking the main thread).

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=82B7BC00-B218-4984-B2B4-25B1BFB5B8E7)