### PR TITLE
fix(worktree): de-dup folder name against archived row paths when opening existing branch

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -103,8 +103,14 @@ extension WorktreeLifecycle {
                 : providedBranch
             let sanitized = WorktreeLayout.sanitize(localBranch)
             let baseFolder = sanitized.isEmpty ? "branch" : sanitized
+            // Mirror the global UNIQUE constraint on `worktree.path`: avoid
+            // paths already reserved by ANY row (active, archived, creating,
+            // main). An archived worktree keeps its `path` even after its
+            // directory is deleted, so a filesystem-only check would collide
+            // and the insert would throw `UNIQUE constraint failed`.
+            let reserved = Set(try await db.worktrees.list().map(\.path))
             resolvedName = Self.uniqueFolderName(
-                base: baseFolder, in: canonicalBase
+                base: baseFolder, in: canonicalBase, reserved: reserved
             )
             // The on-disk local branch ends up as `localBranch` (for remote
             // tracking, `--track -b <localName>` creates it; for plain local,
@@ -133,18 +139,24 @@ extension WorktreeLifecycle {
     }
 
     /// Returns `<base>`, or `<base>-2`, `<base>-3`, … — the first folder name
-    /// under `parentDir` that does not yet exist on disk. Caps at -1000 to
-    /// avoid pathological infinite loops; throws via the underlying
+    /// under `parentDir` whose absolute path neither exists on disk NOR is
+    /// already reserved by an existing worktree row (`reserved`). Caps at -1000
+    /// to avoid pathological infinite loops; throws via the underlying
     /// `git worktree add` if every candidate is taken.
-    private static func uniqueFolderName(base: String, in parentDir: String) -> String {
+    private static func uniqueFolderName(
+        base: String, in parentDir: String, reserved: Set<String>
+    ) -> String {
+        func isTaken(_ path: String) -> Bool {
+            FileManager.default.fileExists(atPath: path) || reserved.contains(path)
+        }
         let firstCandidate = (parentDir as NSString).appendingPathComponent(base)
-        if !FileManager.default.fileExists(atPath: firstCandidate) {
+        if !isTaken(firstCandidate) {
             return base
         }
         for suffix in 2...1000 {
             let candidate = "\(base)-\(suffix)"
             let path = (parentDir as NSString).appendingPathComponent(candidate)
-            if !FileManager.default.fileExists(atPath: path) {
+            if !isTaken(path) {
                 return candidate
             }
         }

--- a/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
@@ -136,6 +136,76 @@ import Testing
     })
 }
 
+@Test func testCreateWorktreeForExistingBranchDeDupesAgainstArchivedRowPath() async throws {
+    // Regression: re-opening an existing branch whose PREVIOUS worktree was
+    // archived must not collide with the archived row's `path` (the
+    // `worktree.path` column is globally UNIQUE, including archived rows).
+    // Archived worktrees keep their `path` but have no directory on disk, so
+    // the old filesystem-only uniqueness check returned the base name
+    // unchanged and the insert threw `UNIQUE constraint failed: worktree.path`.
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    try await shell("git branch existing-feature", at: repoDir)
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // Simulate the archived previous worktree: a row whose `path` is exactly
+    // what beginCreateWorktree would compute for `existing-feature`, archived,
+    // with NO directory on disk.
+    let layout = WorktreeLayout()
+    let basePath = layout.basePath(for: repo)
+    let archivedPath = (basePath as NSString).appendingPathComponent("existing-feature")
+    #expect(!FileManager.default.fileExists(atPath: archivedPath))
+    _ = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "existing-feature",
+        branch: "existing-feature",
+        path: archivedPath,
+        tmuxServer: "tbd-test",
+        status: .archived
+    )
+
+    // Re-open the same branch. This must NOT throw and must pick a de-duped
+    // folder name distinct from the archived row's path.
+    let pending = try await lifecycle.beginCreateWorktree(
+        repoID: repo.id,
+        branch: "existing-feature",
+        skipClaude: true,
+        useExistingBranch: true
+    )
+    #expect(pending.name == "existing-feature-2")
+    #expect(pending.path != archivedPath)
+    #expect(pending.path.hasSuffix("/existing-feature-2"))
+
+    // Drive completion and confirm the worktree goes active with a real
+    // checkout at the de-duped path.
+    let completion = try await lifecycle.completeCreateWorktree(
+        worktreeID: pending.id,
+        skipClaude: true,
+        existingBranchRef: "existing-feature"
+    )
+    if case .preSessionPending(let phase3) = completion {
+        await phase3.value
+    }
+    let completed = try #require(try await db.worktrees.get(id: pending.id))
+    #expect(completed.status == .active)
+    #expect(FileManager.default.fileExists(atPath: completed.path))
+
+    let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+    #expect(listed.contains { entry in
+        entry.branch == "existing-feature" && entry.path.hasSuffix("/existing-feature-2")
+    })
+}
+
 @Test func testCreateWorktreeWithExistingBranchFolderConflictAppendsSuffix() async throws {
     let (tempDir, repoDir) = try await createTestRepo()
     defer { try? FileManager.default.removeItem(at: tempDir) }


### PR DESCRIPTION
## Problem

Using **open existing branch** for a branch whose previous worktree was archived made the new worktree row appear in the sidebar and then immediately vanish ("finds it → starts creating it → disappears").

## Root cause

Archived worktrees keep their `path` in the DB even after their directory is deleted, and `worktree.path` is **globally `UNIQUE`** (archived rows included). But `uniqueFolderName` only checked the **filesystem** when picking a folder name. With the archived directory already gone, it returned the base name unchanged, so phase‑1 `db.worktrees.create(path:)` threw `UNIQUE constraint failed: worktree.path`. The create RPC errored and the app removed its optimistic placeholder — the row "disappeared."

This was deterministic and specific to any branch that has a colliding archived row (e.g. re-opening a branch you previously archived).

## Fix

Make folder naming DB‑aware: a candidate name is "taken" if its absolute path exists on disk **or** is already reserved by any worktree row (active, archived, creating, main) — mirroring the global UNIQUE constraint. The branch now de‑dupes to `<name>-2` instead of throwing.

- `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift`: `uniqueFolderName` takes a `reserved: Set<String>`; `beginCreateWorktree` fetches all worktree paths regardless of status and passes them in. No schema change; single call site (the `useExistingBranch` path).

## Test

Added `testCreateWorktreeForExistingBranchDeDupesAgainstArchivedRowPath` — sets up an archived row reserving the computed path (no dir on disk), re-opens the branch, and asserts creation succeeds with a de-duped `-2` name and a real checkout. Fails with the UNIQUE error before the fix, passes after.

## Verification

- `swift build` clean
- Full daemon suite: **933 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)