### PR TITLE
Fix: Stop a daemon RPC storm from freezing the app after a WindowServer crash

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -73,7 +73,7 @@ let package = Package(
                 "TBDDaemonLib",
             ],
             path: "Sources/TBDDaemon",
-            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Keychain", "Claude", "Codex", "ModelProfile", "AskUserQuestion", "Daemon.swift", "PIDFile.swift"],
+            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Keychain", "Claude", "Codex", "ModelProfile", "AskUserQuestion", "Diagnostics", "Process", "Daemon.swift", "PIDFile.swift"],
             sources: ["main.swift"]
         ),
         .executableTarget(

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -6,6 +6,10 @@ import TBDShared
 import os
 
 private let logger = Logger(subsystem: "com.tbd.app", category: "AppState")
+/// Dedicated channel for RPC/poll-cadence observability (storm diagnostics).
+/// Silent by default; activate with `log stream --level debug`.
+private let perfRPCLogger = Logger(subsystem: "com.tbd.app", category: "perf-rpc")
+private let perfRPCSignposter = OSSignposter(subsystem: "com.tbd.app", category: "perf-rpc")
 
 /// Transition state for a worktree being revived from the archived view.
 /// Holds a snapshot of the `Worktree` so the row can keep rendering even
@@ -507,6 +511,13 @@ final class AppState: ObservableObject {
     lazy var legacyHooksCoordinator = LegacyHooksCoordinator(daemonClient: daemonClient, userDefaults: userDefaults)
     private var pollTimer: Timer?
     private var pollCycle = 0
+    /// True while a poll refresh cycle (the list RPCs) is running. The 2s poll
+    /// timer skips its refresh when this is set, so overlapping cycles can't
+    /// stack into an RPC storm when the daemon is slow (Layer A guard).
+    private var pollCycleInFlight = false
+    /// Count of poll ticks skipped because a previous cycle was still in flight.
+    /// Storm indicator for observability and tests.
+    private(set) var skippedPollCycles = 0
     private var subscriptionTask: Task<Void, Never>?
     let notificationSoundPlayer = NotificationSoundPlayer()
     let macNotificationManager = MacNotificationManager()
@@ -966,11 +977,40 @@ final class AppState: ObservableObject {
         worktrees.values.flatMap { $0 }
     }
 
+    /// Runs `body` only if no poll cycle is currently in flight. Returns true if
+    /// it ran, false if skipped because a previous cycle was still running.
+    ///
+    /// This is the Layer A storm guard: the 2s poll timer frees the main actor
+    /// whenever its refresh `await`s a slow daemon RPC, so without this guard the
+    /// next tick (and the next, and the next) would each spawn another overlapping
+    /// refresh cycle — a positive-feedback RPC storm. Holding a single in-flight
+    /// flag collapses every tick that fires mid-cycle into a cheap skip.
+    @discardableResult
+    func runPollCycleIfIdle(_ body: () async -> Void) async -> Bool {
+        if pollCycleInFlight {
+            skippedPollCycles += 1
+            perfRPCLogger.debug(
+                "poll cycle skipped (in-flight); totalSkipped=\(self.skippedPollCycles, privacy: .public)"
+            )
+            return false
+        }
+        pollCycleInFlight = true
+        defer { pollCycleInFlight = false }
+        let signpostID = perfRPCSignposter.makeSignpostID()
+        let interval = perfRPCSignposter.beginInterval("rpc.pollCycle", id: signpostID)
+        await body()
+        perfRPCSignposter.endInterval("rpc.pollCycle", interval)
+        return true
+    }
+
     /// Poll daemon for state changes every 2 seconds.
     private func startPolling() {
         pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                // Connection/reconnection stays OUTSIDE the in-flight guard so a
+                // dropped socket is retried every tick even while a slow refresh
+                // is still draining; only the refresh (the list RPCs) is guarded.
                 if !self.isConnected {
                     // Try to start the daemon if socket doesn't exist
                     if !FileManager.default.fileExists(atPath: TBDConstants.socketPath) {
@@ -982,13 +1022,21 @@ final class AppState: ObservableObject {
                     }
                     if !self.isConnected { return }
                 }
-                await self.refreshAll()
-                if self.subscriptionTask == nil || self.subscriptionTask?.isCancelled == true {
-                    self.startSubscription()
-                }
-                self.pollCycle += 1
-                if self.pollCycle % 15 == 0 {
-                    await self.refreshPRStatuses()
+                // Guard the whole refresh cycle (refreshAll + the every-15th
+                // pr.list) so a slow daemon can never stack overlapping cycles or
+                // run them concurrently. pollCycle is advanced only when a cycle
+                // actually RUNS — skipped ticks don't burn the PR counter, so the
+                // expensive pr.list still lands ~every 15 executed cycles rather
+                // than drifting earlier off wall-clock ticks that did no work.
+                await self.runPollCycleIfIdle {
+                    await self.refreshAll()
+                    if self.subscriptionTask == nil || self.subscriptionTask?.isCancelled == true {
+                        self.startSubscription()
+                    }
+                    self.pollCycle += 1
+                    if self.pollCycle % 15 == 0 {
+                        await self.refreshPRStatuses()
+                    }
                 }
             }
         }

--- a/Sources/TBDDaemon/Diagnostics/RPCSignposts.swift
+++ b/Sources/TBDDaemon/Diagnostics/RPCSignposts.swift
@@ -1,0 +1,15 @@
+import os
+
+/// Signpost regions emitted by the daemon's RPC server.
+///
+/// Use Instruments (or `xctrace`) with the "com.tbd.daemon" / "perf-rpc"
+/// signpost subsystem to inspect these intervals.
+///
+/// Regions:
+/// - `rpc.handle` — one interval per non-subscribe RPC, spanning the call to
+///   `RPCRouter.handleRaw`. The interval's message carries the RPC method name,
+///   so a storm of overlapping `pr.list` calls shows up as a pile of
+///   concurrent `rpc.handle` intervals tagged `pr.list`.
+enum RPCSignposts {
+    static let signposter = OSSignposter(subsystem: "com.tbd.daemon", category: "perf-rpc")
+}

--- a/Sources/TBDDaemon/Git/UpstreamBranchCache.swift
+++ b/Sources/TBDDaemon/Git/UpstreamBranchCache.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// TTL cache for a worktree branch's upstream (tracking) branch name.
+///
+/// `GitManager.upstreamBranchName` shells out to `git config --get` on every
+/// call. `pr.list` invokes it once per worktree on every poll, so under a poll
+/// storm the daemon spawns dozens of concurrent `git config` subprocesses.
+///
+/// There is NO daemon-side FileWatcher and `GitManager` is a stateless struct,
+/// so this cache cannot invalidate on filesystem git events — it relies on a
+/// short TTL (default 60s) to bound staleness. The upstream tracking config is
+/// only mutated outside the daemon (e.g. when the user pushes with `-u`), so a
+/// 60s window is an acceptable lag for PR-list enrichment.
+///
+/// `nil` results (a branch with no upstream) are cached too; the TTL bounds how
+/// long a freshly-pushed branch waits before its upstream is observed.
+actor UpstreamBranchCache {
+    private struct Entry {
+        let value: String?
+        let fetchedAt: Date
+    }
+
+    private let ttl: TimeInterval
+    private let now: @Sendable () -> Date
+    private var entries: [String: Entry] = [:]
+
+    /// - Parameters:
+    ///   - ttl: How long a cached value stays fresh, in seconds.
+    ///   - now: Clock seam for tests; defaults to wall-clock `Date()`.
+    init(ttl: TimeInterval = 60, now: @Sendable @escaping () -> Date = { Date() }) {
+        self.ttl = ttl
+        self.now = now
+    }
+
+    private func key(worktreePath: String, branch: String) -> String {
+        // NUL delimiter so one worktree path can't be a prefix of another's key.
+        "\(worktreePath)\u{0}\(branch)"
+    }
+
+    /// Return the cached upstream branch name if fresh, otherwise call `fetch`,
+    /// store the result (including `nil`), and return it.
+    func upstreamBranchName(
+        worktreePath: String,
+        branch: String,
+        fetch: @Sendable () async -> String?
+    ) async -> String? {
+        let k = key(worktreePath: worktreePath, branch: branch)
+        if let entry = entries[k], now().timeIntervalSince(entry.fetchedAt) < ttl {
+            return entry.value
+        }
+        let value = await fetch()
+        entries[k] = Entry(value: value, fetchedAt: now())
+        return value
+    }
+
+    /// Drop all cached entries for a worktree path (any branch).
+    func invalidate(worktreePath: String) {
+        let prefix = "\(worktreePath)\u{0}"
+        for k in entries.keys where k.hasPrefix(prefix) {
+            entries.removeValue(forKey: k)
+        }
+    }
+
+    /// Drop every cached entry.
+    func invalidateAll() {
+        entries.removeAll()
+    }
+
+    /// Drop cached entries whose (worktreePath, branch) is not in `active`,
+    /// bounding the cache to currently-active worktree branches so entries for
+    /// archived/removed worktrees don't leak across a long-lived daemon.
+    func retain(active: [(worktreePath: String, branch: String)]) {
+        let keep = Set(active.map { key(worktreePath: $0.worktreePath, branch: $0.branch) })
+        entries = entries.filter { keep.contains($0.key) }
+    }
+}

--- a/Sources/TBDDaemon/Server/PRListCoordinator.swift
+++ b/Sources/TBDDaemon/Server/PRListCoordinator.swift
@@ -1,0 +1,34 @@
+import TBDShared
+
+/// Collapses concurrent `pr.list` RPCs into a single computation.
+///
+/// The app polls `pr.list` on a timer with no in-flight guard, so overlapping
+/// polls would each start a fresh git enumeration (a `git config` subprocess
+/// per worktree) plus a gh GraphQL fetch. This coordinator ensures that while
+/// one computation is in flight, every other caller awaits it and receives the
+/// SAME snapshot instead of launching a second enumeration. Once the in-flight
+/// computation resolves, the next call starts a fresh one.
+///
+/// Errors propagate: the computation is `throws`, so a DB enumeration failure
+/// surfaces to the app as an RPC error rather than a silently-stale snapshot.
+/// A thrown error reaches every caller awaiting the in-flight task (they share
+/// the same failure), and `defer` clears the in-flight slot even on throw — so a
+/// transient failure does not poison subsequent polls.
+actor PRListCoordinator {
+    private var inFlight: Task<PRListResult, Error>?
+
+    /// Run `compute`, or — if a computation is already in flight — await the
+    /// existing one and return its result. Rethrows whatever `compute` throws.
+    func run(_ compute: @Sendable @escaping () async throws -> PRListResult) async throws -> PRListResult {
+        if let existing = inFlight {
+            return try await existing.value
+        }
+        let task = Task { try await compute() }
+        inFlight = task
+        // The creator clears the slot so the next wave starts fresh — even when
+        // `compute` throws. Callers that piled onto `task` while it ran already
+        // observed the same result or error.
+        defer { inFlight = nil }
+        return try await task.value
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCConcurrencyLimiter.swift
+++ b/Sources/TBDDaemon/Server/RPCConcurrencyLimiter.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Bounds the number of RPC handlers running concurrently.
+///
+/// Each in-flight handler can fan out into git / gh subprocesses (e.g.
+/// `pr.list` enumerates `git config` for every worktree and then issues a gh
+/// GraphQL call). The socket server spawns one `Task` per received line with no
+/// bound, so a burst of client connections — or a client that opens a fresh
+/// socket per poll — could spawn an unbounded number of concurrent
+/// subprocesses that never drain, pegging the daemon. This limiter gates the
+/// normal-request path so at most `maxConcurrentRPCs` handlers run at once;
+/// additional requests suspend FIFO until a slot frees.
+///
+/// The long-lived `state.subscribe` stream deliberately BYPASSES the limiter —
+/// it holds its socket open indefinitely and must never occupy a slot.
+actor RPCConcurrencyLimiter {
+    /// Maximum number of RPC handlers allowed to run concurrently.
+    ///
+    /// Caps the concurrent git/gh subprocess fan-out from a connection burst.
+    /// Sized comfortably above the steady-state RPC rate (a handful of polls)
+    /// while still bounding the worst case to a few simultaneous subprocesses.
+    static let maxConcurrentRPCs = 8
+
+    private let limit: Int
+
+    /// Number of slots currently held (acquired and not yet released). Serves
+    /// as the in-flight gauge — it never exceeds `limit`.
+    private(set) var inFlight = 0
+
+    /// Highest `inFlight` value observed since construction.
+    private(set) var highWaterMark = 0
+
+    /// FIFO queue of callers suspended waiting for a slot.
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(limit: Int = RPCConcurrencyLimiter.maxConcurrentRPCs) {
+        precondition(limit > 0, "RPCConcurrencyLimiter requires a positive limit")
+        self.limit = limit
+    }
+
+    /// Acquire a slot, suspending FIFO when the limiter is at capacity.
+    ///
+    /// Returns the in-flight count *after* acquiring, so the caller can cheaply
+    /// check a high-water threshold without a second actor hop.
+    ///
+    /// NOT cancellation-safe: a task cancelled while suspended in `acquire()`
+    /// would leak its continuation (the `withCheckedContinuation` never resumes)
+    /// and permanently consume a slot, since the slot is only ever reclaimed by a
+    /// matching `release()`. Callers therefore MUST NOT cancel a task parked in
+    /// `acquire()`, and MUST pair every successful `acquire()` with exactly one
+    /// `release()`. The sole caller — SocketServer's fire-and-forget, non-cancelled
+    /// per-line `Task` driving a non-throwing `handleRaw` — satisfies this.
+    @discardableResult
+    func acquire() async -> Int {
+        if inFlight < limit {
+            inFlight += 1
+            if inFlight > highWaterMark { highWaterMark = inFlight }
+            return inFlight
+        }
+        // At capacity: suspend until release() hands us the slot. The releaser
+        // does NOT decrement inFlight when it resumes a waiter — the slot is
+        // transferred directly, so inFlight stays pinned at `limit`.
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            waiters.append(cont)
+        }
+        return inFlight
+    }
+
+    /// Release a slot, waking the oldest waiter (if any).
+    func release() {
+        if waiters.isEmpty {
+            inFlight -= 1
+        } else {
+            // Transfer the slot to the oldest waiter; inFlight is unchanged.
+            let cont = waiters.removeFirst()
+            cont.resume()
+        }
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -28,6 +28,13 @@ public final class RPCRouter: Sendable {
     public let repoSerializer: RepoSerializer
     public let configDirManager: ClaudeProfileConfigDirManager
 
+    /// Single-flights concurrent `pr.list` RPCs so a poll storm collapses into
+    /// one git enumeration + gh fetch instead of N overlapping ones.
+    let prListCoordinator = PRListCoordinator()
+    /// TTL cache for per-worktree upstream branch lookups, so `pr.list` stops
+    /// spawning a `git config` subprocess per worktree on every poll.
+    let upstreamBranchCache = UpstreamBranchCache()
+
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
 
@@ -260,16 +267,33 @@ public final class RPCRouter: Sendable {
     // MARK: - PR Status
 
     private func handlePRList() async throws -> RPCResponse {
+        // Single-flight: while one enumeration is in flight, concurrent polls
+        // await it and share the snapshot instead of each starting their own
+        // git enumeration + gh fetch.
+        let result = try await prListCoordinator.run { [self] in
+            try await computePRList()
+        }
+        return try RPCResponse(result: result)
+    }
+
+    /// Enumerate active worktrees, enrich each with its (cached) upstream branch,
+    /// refresh PR status, and return the snapshot. Throws on a DB enumeration
+    /// failure so the app sees an RPC error instead of a silently-stale snapshot;
+    /// `PRListCoordinator` propagates the error to every concurrent caller.
+    private func computePRList() async throws -> PRListResult {
         // Fetch fresh PR data for all active worktrees before returning the cache.
-        // This is called every ~30s by the app, so one GraphQL call per poll is acceptable.
         let worktrees = try await db.worktrees.list(status: .active)
         var infos: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String)] = []
         infos.reserveCapacity(worktrees.count)
         for wt in worktrees {
-            let upstreamBranch = await git.upstreamBranchName(
+            // Route the per-worktree `git config` lookup through the TTL cache
+            // so a poll storm doesn't spawn one subprocess per worktree per poll.
+            let upstreamBranch = await upstreamBranchCache.upstreamBranchName(
                 worktreePath: wt.path,
                 branch: wt.branch
-            )
+            ) { [git] in
+                await git.upstreamBranchName(worktreePath: wt.path, branch: wt.branch)
+            }
             infos.append((
                 id: wt.id,
                 branch: wt.branch,
@@ -278,8 +302,9 @@ public final class RPCRouter: Sendable {
             ))
         }
         await prManager.fetchAll(worktrees: infos)
-        let statuses = await prManager.allStatuses()
-        return try RPCResponse(result: PRListResult(statuses: statuses))
+        // Prune at the END so we never drop an entry this pass just populated.
+        await upstreamBranchCache.retain(active: infos.map { (worktreePath: $0.worktreePath, branch: $0.branch) })
+        return PRListResult(statuses: await prManager.allStatuses())
     }
 
     private func handlePRRefresh(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/SocketServer.swift
+++ b/Sources/TBDDaemon/Server/SocketServer.swift
@@ -5,6 +5,7 @@ import TBDShared
 import os
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "socket")
+private let perfLogger = Logger(subsystem: "com.tbd.daemon", category: "perf-rpc")
 
 /// A Unix domain socket server that accepts newline-delimited JSON RPC requests.
 ///
@@ -18,6 +19,10 @@ public final class SocketServer: Sendable {
 
     /// Number of currently connected clients. Updated atomically.
     private let _connectedClients = ManagedAtomic<Int>(0)
+
+    /// Bounds the number of concurrently-running RPC handlers (and thus the
+    /// concurrent git/gh subprocess fan-out) across all connections.
+    private let limiter = RPCConcurrencyLimiter()
 
     public var connectedClients: Int {
         _connectedClients.load(ordering: .relaxed)
@@ -40,12 +45,17 @@ public final class SocketServer: Sendable {
 
         let router = self.router
         let connectedClients = self._connectedClients
+        let limiter = self.limiter
 
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(.backlog, value: 64)
             .childChannelInitializer { channel in
                 channel.eventLoop.makeCompletedFuture {
-                    let handler = SocketRPCHandler(router: router, connectedClients: connectedClients)
+                    let handler = SocketRPCHandler(
+                        router: router,
+                        connectedClients: connectedClients,
+                        limiter: limiter
+                    )
                     try channel.pipeline.syncOperations.addHandler(handler)
                 }
             }
@@ -129,11 +139,13 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
 
     private let router: RPCRouter
     private let connectedClients: ManagedAtomic<Int>
+    private let limiter: RPCConcurrencyLimiter
     private var buffer: String = ""
 
-    init(router: RPCRouter, connectedClients: ManagedAtomic<Int>) {
+    init(router: RPCRouter, connectedClients: ManagedAtomic<Int>, limiter: RPCConcurrencyLimiter) {
         self.router = router
         self.connectedClients = connectedClients
+        self.limiter = limiter
     }
 
     func channelActive(context: ChannelHandlerContext) {
@@ -160,18 +172,29 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
 
             let wrappedCtx = SendableContext(context: context)
             let router = self.router
+            let limiter = self.limiter
             Task {
-                await Self.processLine(trimmed, router: router, wrappedCtx: wrappedCtx)
+                await Self.processLine(trimmed, router: router, limiter: limiter, wrappedCtx: wrappedCtx)
             }
         }
     }
 
-    private static func processLine(_ line: String, router: RPCRouter, wrappedCtx: SendableContext) async {
+    private static func processLine(
+        _ line: String,
+        router: RPCRouter,
+        limiter: RPCConcurrencyLimiter,
+        wrappedCtx: SendableContext
+    ) async {
         guard let data = line.data(using: .utf8) else { return }
 
-        // Check for state.subscribe — handle as a streaming subscription
-        if let request = try? JSONDecoder().decode(RPCRequest.self, from: data),
-           request.method == RPCMethod.stateSubscribe {
+        // Decode once: the subscribe check needs the method, and the normal
+        // path reuses it for the signpost label + in-flight gauge.
+        let request = try? JSONDecoder().decode(RPCRequest.self, from: data)
+
+        // Check for state.subscribe — handle as a streaming subscription.
+        // This path BYPASSES the concurrency limiter: it holds its socket open
+        // indefinitely and must never occupy a limiter slot.
+        if request?.method == RPCMethod.stateSubscribe {
             let sendableCtx = wrappedCtx
 
             // Register subscriber; callback streams deltas as newline-delimited JSON.
@@ -218,8 +241,28 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
             return
         }
 
-        // Normal (non-subscribe) request path
+        // Normal (non-subscribe) request path. Gate on the concurrency limiter
+        // so a connection burst can't spawn unbounded concurrent handlers (and
+        // their git/gh subprocesses). The expensive work is `handleRaw`; the
+        // slot is released as soon as it returns (response encoding below does
+        // no subprocess fan-out). `release()` is an actor method and so cannot
+        // run from a `defer`, but there is no throwing/early-exit point between
+        // acquire and release, so the slot is always returned.
+        let method = request?.method ?? "unknown"
+        let inFlight = await limiter.acquire()
+        // Cheap in-flight gauge: only log when contention is notable, never at
+        // info on every request.
+        if inFlight > RPCConcurrencyLimiter.maxConcurrentRPCs / 2 {
+            perfLogger.debug("rpc in-flight high: \(inFlight, privacy: .public)")
+        }
+
+        let signposter = RPCSignposts.signposter
+        let signpostID = signposter.makeSignpostID()
+        let intervalState = signposter.beginInterval("rpc.handle", id: signpostID, "\(method, privacy: .public)")
         let response = await router.handleRaw(data)
+        signposter.endInterval("rpc.handle", intervalState)
+
+        await limiter.release()
 
         do {
             let responseData = try JSONEncoder().encode(response)

--- a/Tests/TBDAppTests/PollCycleGuardTests.swift
+++ b/Tests/TBDAppTests/PollCycleGuardTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tests for the Layer A in-flight poll guard (`AppState.runPollCycleIfIdle`).
+///
+/// The 2s poll timer frees the main actor whenever its refresh awaits a slow
+/// daemon RPC, so without a guard each subsequent tick would spawn another
+/// overlapping refresh cycle — an RPC storm. `runPollCycleIfIdle` collapses any
+/// tick that fires while a cycle is still running into a cheap skip.
+///
+/// Every test constructs `AppState(userDefaults:)` against a unique throwaway
+/// suite — TBDApp ships as an unbundled SPM executable, so `UserDefaults.standard`
+/// is the running developer's real `TBDApp.plist`. Using it from tests would
+/// clobber live UI preferences.
+@MainActor
+@Suite("Poll cycle guard")
+struct PollCycleGuardTests {
+
+    private func makeState() -> (AppState, String, UserDefaults) {
+        let suiteName = "TBDAppTests.PollCycleGuard.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return (AppState(userDefaults: defaults), suiteName, defaults)
+    }
+
+    // Idle path: a fresh AppState runs the body and reports it ran; no skips.
+    @Test func idleCycle_runsBody_andReturnsTrue() async {
+        let (state, suiteName, defaults) = makeState()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        var didRun = false
+        let ran = await state.runPollCycleIfIdle {
+            didRun = true
+        }
+
+        #expect(ran)
+        #expect(didRun)
+        #expect(state.skippedPollCycles == 0)
+    }
+
+    // In-flight path: while one cycle is suspended on a continuation we control,
+    // a second concurrent call must return false WITHOUT running its body and
+    // bump skippedPollCycles. After the first completes, a third call runs again
+    // — proving the in-flight flag was cleared by the `defer`.
+    @Test func overlappingCycle_isSkipped_thenFlagClears() async {
+        let (state, suiteName, defaults) = makeState()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        // Coordinates handoff between the test and the first (suspended) cycle
+        // without sleeps: the first cycle signals it has entered (so the flag is
+        // set) and then parks until the test releases it.
+        let gate = ContinuationGate()
+
+        // Launch the first cycle; it enters the guard, signals, then awaits.
+        async let firstRan: Bool = state.runPollCycleIfIdle {
+            await gate.enterAndWait()
+        }
+
+        // Wait until the first cycle is provably inside the guarded body.
+        await gate.waitUntilEntered()
+
+        // Second call fires while the first is still in flight: must be skipped.
+        var secondBodyRan = false
+        let secondRan = await state.runPollCycleIfIdle {
+            secondBodyRan = true
+        }
+        #expect(secondRan == false)
+        #expect(secondBodyRan == false)
+        #expect(state.skippedPollCycles == 1)
+
+        // Release the first cycle and let it finish.
+        await gate.release()
+        let firstResult = await firstRan
+        #expect(firstResult)
+
+        // Flag cleared: a third call runs again.
+        var thirdBodyRan = false
+        let thirdRan = await state.runPollCycleIfIdle {
+            thirdBodyRan = true
+        }
+        #expect(thirdRan)
+        #expect(thirdBodyRan)
+        // Still only the one skip from the overlapping call.
+        #expect(state.skippedPollCycles == 1)
+    }
+}
+
+/// Deterministic two-phase rendezvous used to hold one poll cycle "in flight"
+/// while a second call races it. `enterAndWait()` signals entry then parks until
+/// `release()`; `waitUntilEntered()` lets the test block until entry is observed.
+/// No sleeps, no polling — every wait resumes off an explicit signal.
+private actor ContinuationGate {
+    private var enteredContinuation: CheckedContinuation<Void, Never>?
+    private var hasEntered = false
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+    private var isReleased = false
+
+    /// Called from inside the first guarded body: marks entry (waking any
+    /// `waitUntilEntered()`) then suspends until `release()`.
+    func enterAndWait() async {
+        hasEntered = true
+        enteredContinuation?.resume()
+        enteredContinuation = nil
+        if isReleased { return }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    /// Resumes once the first body has entered the guard.
+    func waitUntilEntered() async {
+        if hasEntered { return }
+        await withCheckedContinuation { continuation in
+            enteredContinuation = continuation
+        }
+    }
+
+    /// Releases the parked first body.
+    func release() {
+        isReleased = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}

--- a/Tests/TBDDaemonTests/PRListCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PRListCoordinatorTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDDaemonLib
+
+/// Counts how many times `compute` actually ran.
+private actor CallCounter {
+    private(set) var count = 0
+    @discardableResult
+    func increment() -> Int { count += 1; return count }
+}
+
+/// A one-shot gate the test opens to release a parked `compute`.
+private actor Gate {
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var opened = false
+
+    func wait() async {
+        if opened { return }
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            waiters.append(cont)
+        }
+    }
+
+    func open() {
+        opened = true
+        let pending = waiters
+        waiters.removeAll()
+        for cont in pending { cont.resume() }
+    }
+}
+
+struct PRListCoordinatorTests {
+
+    private func sentinel(_ marker: Int) -> PRListResult {
+        // Encode the marker in a deterministic UUID so callers can prove they
+        // received the SAME snapshot.
+        let uuid = UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012d", marker))")!
+        return PRListResult(statuses: [uuid: PRStatus(number: marker, url: "u", state: .mergeable)])
+    }
+
+    @Test func concurrentCallsCollapseIntoSingleComputation() async {
+        let coordinator = PRListCoordinator()
+        let counter = CallCounter()
+        let started = CallCounter()
+        let gate = Gate()
+        let result = sentinel(1)
+
+        let n = 24
+        async let collected: [PRListResult] = await withTaskGroup(of: PRListResult.self) { group in
+            for _ in 0..<n {
+                group.addTask {
+                    await started.increment()
+                    // `run` is throwing now; these computes never throw, so a
+                    // `try?` keeps the harness simple while still exercising the
+                    // single-flight collapse.
+                    return (try? await coordinator.run {
+                        await counter.increment()
+                        await gate.wait()   // park every compute that actually runs
+                        return result
+                    }) ?? self.sentinel(-1)
+                }
+            }
+            var out: [PRListResult] = []
+            for await r in group { out.append(r) }
+            return out
+        }
+
+        // Wait until every caller's body has begun, then drain the scheduler so
+        // all run() calls have collapsed onto the single in-flight task.
+        while await started.count < n { await Task.yield() }
+        for _ in 0..<200 { await Task.yield() }
+
+        // Gate is still closed: only ONE compute could have run its increment.
+        // A failed collapse would have started a second compute, whose own
+        // increment would push the counter to 2 BEFORE we open the gate.
+        #expect(await counter.count == 1)
+
+        await gate.open()
+        let results = await collected
+
+        #expect(results.count == n)
+        #expect(results.allSatisfy { $0.statuses == result.statuses })
+        // Still exactly one compute after everyone resolved.
+        #expect(await counter.count == 1)
+    }
+
+    @Test func secondWaveAfterResolutionRunsComputeAgain() async throws {
+        let coordinator = PRListCoordinator()
+        let counter = CallCounter()
+
+        // First wave: no gating, resolves immediately.
+        let first = try await coordinator.run {
+            await counter.increment()
+            return self.sentinel(1)
+        }
+        #expect(first.statuses == sentinel(1).statuses)
+        #expect(await counter.count == 1)
+
+        // Second wave after the first cleared: compute runs again.
+        let second = try await coordinator.run {
+            await counter.increment()
+            return self.sentinel(2)
+        }
+        #expect(second.statuses == sentinel(2).statuses)
+        #expect(await counter.count == 2)
+    }
+
+    private struct ComputeError: Error {}
+
+    @Test func thrownErrorPropagatesToAllCallersAndClearsInFlight() async throws {
+        let coordinator = PRListCoordinator()
+        let counter = CallCounter()
+        let started = CallCounter()
+        let gate = Gate()
+
+        // First wave: many concurrent callers collapse onto one compute that
+        // throws. Every caller must observe the SAME thrown error.
+        let n = 12
+        async let outcomes: [Bool] = await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<n {
+                group.addTask {
+                    await started.increment()
+                    do {
+                        _ = try await coordinator.run {
+                            await counter.increment()
+                            await gate.wait()      // hold the in-flight task open
+                            throw ComputeError()
+                        }
+                        return false               // unexpected success
+                    } catch is ComputeError {
+                        return true
+                    } catch {
+                        return false
+                    }
+                }
+            }
+            var out: [Bool] = []
+            for await r in group { out.append(r) }
+            return out
+        }
+
+        while await started.count < n { await Task.yield() }
+        for _ in 0..<200 { await Task.yield() }
+        // Single-flight collapse: only one compute ran despite the throw.
+        #expect(await counter.count == 1)
+
+        await gate.open()
+        let results = await outcomes
+        #expect(results.count == n)
+        #expect(results.allSatisfy { $0 })   // every caller saw ComputeError
+
+        // The slot was cleared on throw (defer), so a fresh wave runs a NEW
+        // compute that can succeed — a transient failure didn't poison the slot.
+        let recovered = try await coordinator.run {
+            await counter.increment()
+            return self.sentinel(7)
+        }
+        #expect(recovered.statuses == sentinel(7).statuses)
+        #expect(await counter.count == 2)   // the first throwing compute + this one
+    }
+}

--- a/Tests/TBDDaemonTests/RPCConcurrencyLimiterTests.swift
+++ b/Tests/TBDDaemonTests/RPCConcurrencyLimiterTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Tracks how many holders are inside the limiter at once.
+private actor PeakTracker {
+    private(set) var current = 0
+    private(set) var peak = 0
+    func enter() { current += 1; if current > peak { peak = current } }
+    func leave() { current -= 1 }
+}
+
+private actor BoolFlag {
+    private(set) var value = false
+    func set() { value = true }
+}
+
+struct RPCConcurrencyLimiterTests {
+
+    @Test func peakHoldersNeverExceedCapAndAllComplete() async {
+        let cap = 3
+        let limiter = RPCConcurrencyLimiter(limit: cap)
+        let tracker = PeakTracker()
+        let n = 60
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<n {
+                group.addTask {
+                    await limiter.acquire()
+                    await tracker.enter()
+                    for _ in 0..<8 { await Task.yield() }   // hold the slot briefly
+                    await tracker.leave()
+                    await limiter.release()
+                }
+            }
+        }
+
+        // No interleaving ever exceeded the cap...
+        #expect(await tracker.peak <= cap)
+        // ...and concurrency genuinely happened (waiters were woken to refill).
+        #expect(await tracker.peak >= 1)
+        // The group draining proves no task deadlocked.
+        #expect(await tracker.current == 0)
+        // All slots returned: nothing left in flight.
+        #expect(await limiter.inFlight == 0)
+        #expect(await limiter.highWaterMark <= cap)
+    }
+
+    @Test func acquireBeyondCapBlocksUntilRelease() async {
+        let limiter = RPCConcurrencyLimiter(limit: 1)
+        let flag = BoolFlag()
+
+        // Main holds the only slot.
+        await limiter.acquire()
+
+        let waiter = Task {
+            await limiter.acquire()
+            await flag.set()
+        }
+
+        // Give the waiter ample opportunity to (fail to) acquire.
+        for _ in 0..<300 { await Task.yield() }
+        #expect(await flag.value == false)       // parked, slot not granted
+        #expect(await limiter.inFlight == 1)     // still pinned at the cap
+
+        // Releasing wakes the parked waiter.
+        await limiter.release()
+        await waiter.value
+        #expect(await flag.value == true)
+        // Slot was transferred, not double-counted.
+        #expect(await limiter.inFlight == 1)
+
+        await limiter.release()
+        #expect(await limiter.inFlight == 0)
+    }
+}

--- a/Tests/TBDDaemonTests/UpstreamBranchCacheTests.swift
+++ b/Tests/TBDDaemonTests/UpstreamBranchCacheTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Mutable clock + fetch-call counter, both isolated for concurrency safety.
+private actor FetchCounter {
+    private(set) var count = 0
+    func increment() -> Int { count += 1; return count }
+}
+
+private final class MutableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+    init(_ start: Date) { self.value = start }
+    func now() -> Date { lock.lock(); defer { lock.unlock() }; return value }
+    func advance(by seconds: TimeInterval) { lock.lock(); value = value.addingTimeInterval(seconds); lock.unlock() }
+}
+
+struct UpstreamBranchCacheTests {
+
+    @Test func freshHitDoesNotRefetch() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let cache = UpstreamBranchCache(ttl: 60, now: { clock.now() })
+        let counter = FetchCounter()
+
+        let first = await cache.upstreamBranchName(worktreePath: "/wt", branch: "feat") {
+            _ = await counter.increment()
+            return "main"
+        }
+        #expect(first == "main")
+        #expect(await counter.count == 1)
+
+        // Within TTL: served from cache, fetch NOT called again.
+        clock.advance(by: 59)
+        let second = await cache.upstreamBranchName(worktreePath: "/wt", branch: "feat") {
+            _ = await counter.increment()
+            return "main"
+        }
+        #expect(second == "main")
+        #expect(await counter.count == 1)
+    }
+
+    @Test func expiryRefetches() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let cache = UpstreamBranchCache(ttl: 60, now: { clock.now() })
+        let counter = FetchCounter()
+
+        _ = await cache.upstreamBranchName(worktreePath: "/wt", branch: "feat") {
+            _ = await counter.increment(); return "main"
+        }
+        #expect(await counter.count == 1)
+
+        // Past TTL: refetch.
+        clock.advance(by: 61)
+        let again = await cache.upstreamBranchName(worktreePath: "/wt", branch: "feat") {
+            _ = await counter.increment(); return "develop"
+        }
+        #expect(again == "develop")
+        #expect(await counter.count == 2)
+    }
+
+    @Test func invalidateForcesRefetch() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let cache = UpstreamBranchCache(ttl: 60, now: { clock.now() })
+        let counter = FetchCounter()
+
+        _ = await cache.upstreamBranchName(worktreePath: "/wt", branch: "feat") {
+            _ = await counter.increment(); return "main"
+        }
+        #expect(await counter.count == 1)
+
+        await cache.invalidate(worktreePath: "/wt")
+
+        // Still within TTL, but invalidated → refetch.
+        let after = await cache.upstreamBranchName(worktreePath: "/wt", branch: "feat") {
+            _ = await counter.increment(); return "main"
+        }
+        #expect(after == "main")
+        #expect(await counter.count == 2)
+    }
+
+    @Test func nilValuesAreCached() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let cache = UpstreamBranchCache(ttl: 60, now: { clock.now() })
+        let counter = FetchCounter()
+
+        let first = await cache.upstreamBranchName(worktreePath: "/wt", branch: "feat") {
+            _ = await counter.increment(); return nil
+        }
+        #expect(first == nil)
+        #expect(await counter.count == 1)
+
+        // A cached nil must NOT trigger a refetch within the TTL.
+        clock.advance(by: 30)
+        let second = await cache.upstreamBranchName(worktreePath: "/wt", branch: "feat") {
+            _ = await counter.increment(); return "shouldNotBeReturned"
+        }
+        #expect(second == nil)
+        #expect(await counter.count == 1)
+    }
+
+    @Test func invalidateAllClearsEveryEntry() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let cache = UpstreamBranchCache(ttl: 60, now: { clock.now() })
+        let counter = FetchCounter()
+
+        _ = await cache.upstreamBranchName(worktreePath: "/a", branch: "x") {
+            _ = await counter.increment(); return "main"
+        }
+        _ = await cache.upstreamBranchName(worktreePath: "/b", branch: "y") {
+            _ = await counter.increment(); return "main"
+        }
+        #expect(await counter.count == 2)
+
+        await cache.invalidateAll()
+
+        _ = await cache.upstreamBranchName(worktreePath: "/a", branch: "x") {
+            _ = await counter.increment(); return "main"
+        }
+        #expect(await counter.count == 3)
+    }
+
+    @Test func retainDropsEntriesOutsideActiveSet() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let cache = UpstreamBranchCache(ttl: 60, now: { clock.now() })
+        let counter = FetchCounter()
+
+        // Seed entries for two worktree paths A and B.
+        _ = await cache.upstreamBranchName(worktreePath: "/a", branch: "x") {
+            _ = await counter.increment(); return "main"
+        }
+        _ = await cache.upstreamBranchName(worktreePath: "/b", branch: "y") {
+            _ = await counter.increment(); return "main"
+        }
+        #expect(await counter.count == 2)
+
+        // Retain only A: B's entry is dropped, A's is kept (still within TTL).
+        await cache.retain(active: [(worktreePath: "/a", branch: "x")])
+
+        // A still served from cache → fetch NOT called.
+        let aHit = await cache.upstreamBranchName(worktreePath: "/a", branch: "x") {
+            _ = await counter.increment(); return "shouldNotBeReturned"
+        }
+        #expect(aHit == "main")
+        #expect(await counter.count == 2)
+
+        // B was dropped → refetch.
+        let bMiss = await cache.upstreamBranchName(worktreePath: "/b", branch: "y") {
+            _ = await counter.increment(); return "develop"
+        }
+        #expect(bMiss == "develop")
+        #expect(await counter.count == 3)
+    }
+}


### PR DESCRIPTION
## Summary

**What froze.** After a WindowServer crash/wake, the TBD window went unresponsive while its main thread sat idle in the normal AppKit event loop (`_DPSNextEvent` → `mach_msg`). It was not the #129 transcript freeze — the UI was waiting on a **saturated daemon**: TBDDaemon was pegged at ~190% CPU (state R), flooded with list-RPCs, and never drained on its own. Only a full daemon restart cleared it.

**Why it happened — a positive-feedback loop across four layers:**
1. **App poll had no in-flight guard.** `AppState.startPolling()` fired a 2s `Timer` that spawned a fresh refresh `Task` each tick; because it `await`s (freeing the main actor), overlapping refresh cycles stacked whenever the daemon lagged.
2. **New socket + 300s recv per RPC.** `DaemonClient.sendRaw` opens a fresh connection per call and blocks `recv` for up to `rpcRecvDeadlineSeconds = 300`, so a slow daemon surfaced no error for 5 minutes while the 2s timer kept piling on connections.
3. **Uncapped daemon dispatch.** `SocketServer.channelRead` spawned an unbounded `Task` per line onto a `final class RPCRouter` (not an actor), so N stacked connections ran N concurrent handlers.
4. **`handlePRList` re-ran git per worktree, every call.** It looped ~12 worktrees calling `git.upstreamBranchName` (a `git config` subprocess each), outside the only existing guard — so each concurrent `pr.list` spawned 12 git subprocesses. Captured `sample`: 121 `posix_spawn`, 307 `Process` frames, 59 concurrent `processLine`.

**What this PR does** (defense-in-depth — each layer independently dampens the loop):
- **App:** `runPollCycleIfIdle()` skips a poll tick while the previous refresh cycle is still running, capping app→daemon request rate to one cycle at a time regardless of daemon latency. Adds a skipped-cycle counter + `perf-rpc` debug log/signpost.
- **Daemon — single-flight `pr.list`:** `PRListCoordinator` collapses concurrent polls into one git enumeration + gh fetch. Throwing, so a DB enumeration failure still surfaces as an RPC error instead of a silently-stale snapshot.
- **Daemon — TTL upstream cache:** `UpstreamBranchCache` (60s) stops respawning a `git config` subprocess per worktree per poll; pruned to the active worktree set each pass so entries can't leak. (The daemon has no `.git` FileWatcher and `GitManager` is a stateless struct, so TTL — plus the uncached per-worktree `pr.refresh` escape hatch — is the correct invalidation strategy.)
- **Daemon — concurrency cap:** `RPCConcurrencyLimiter` (cap 8) bounds concurrent handlers so a connection burst can't fan out unbounded git/gh subprocesses. The long-lived `state.subscribe` stream bypasses it.
- **Daemon — observability:** `perf-rpc` `OSSignpost` intervals around `handleRaw` + an in-flight gauge, so the storm is measurable next time.

## Test plan

- [x] `swift build` clean; `swift test` → 1856 tests in 207 suites pass; `swiftlint --strict` → 0 violations.
- [x] New branch-gated unit tests: poll in-flight guard (both branches), single-flight collapse + throw-clears-inflight, TTL cache hit/expiry/invalidate/`retain`, concurrency limiter peak ≤ cap + no deadlock.
- [ ] Manual: with ~12 worktrees, force a list-refresh burst and confirm daemon CPU stays low (watch `log stream --level debug --predicate 'subsystem == "com.tbd.daemon" AND category == "perf-rpc"'` for the in-flight gauge); confirm the app no longer freezes and recovers without a daemon restart.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7EFFBFE3-1227-43C5-B091-D49100DA70A7)