### PR TITLE
Feat: Copy worktree path from the status bar, show it on hover

### DIFF
--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -1,8 +1,12 @@
+import AppKit
 import SwiftUI
 import TBDShared
 
 struct StatusBarView: View {
     @EnvironmentObject var appState: AppState
+
+    /// Transient "Copied" feedback shown after the left label copies a path.
+    @State private var didCopy = false
 
     private var selectedWorktreeInfo: (path: String, repoID: UUID)? {
         guard appState.selectedWorktreeIDs.count == 1,
@@ -79,6 +83,34 @@ struct StatusBarView: View {
         }
     }
 
+    /// What the left-side status-bar label does when clicked, and the tooltip it
+    /// shows on hover.
+    ///
+    /// - A single worktree selected (non-nil path): clicking copies the absolute
+    ///   path; the tooltip is that path.
+    /// - Otherwise (repo-only or multi-worktree selection): clicking reveals the
+    ///   selection in the sidebar; the tooltip is `"Reveal in sidebar"`.
+    enum LeftLabelBehavior: Equatable {
+        case copyPath(String)
+        case revealInSidebar
+
+        var tooltip: String {
+            switch self {
+            case .copyPath(let path): return path
+            case .revealInSidebar: return "Reveal in sidebar"
+            }
+        }
+    }
+
+    /// Decide the left-label behavior from the selected worktree's path
+    /// (`nil` when there is no single selected worktree).
+    nonisolated static func leftLabelBehavior(selectedWorktreePath: String?) -> LeftLabelBehavior {
+        if let path = selectedWorktreePath {
+            return .copyPath(path)
+        }
+        return .revealInSidebar
+    }
+
     var body: some View {
         HStack {
             if let label = Self.focusLabel(
@@ -87,12 +119,23 @@ struct StatusBarView: View {
                 repos: appState.repos,
                 selectedRepoID: appState.selectedRepoID
             ) {
-                Button(action: { appState.revealSelectionInSidebar() }) {
-                    Text(label)
-                        .foregroundStyle(.secondary)
+                let behavior = Self.leftLabelBehavior(selectedWorktreePath: selectedWorktreeInfo?.path)
+                switch behavior {
+                case .copyPath(let path):
+                    Button(action: { copyPath(path) }) {
+                        Text(didCopy ? "Copied" : label)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help(behavior.tooltip)
+                case .revealInSidebar:
+                    Button(action: { appState.revealSelectionInSidebar() }) {
+                        Text(label)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help(behavior.tooltip)
                 }
-                .buttonStyle(.plain)
-                .help("Reveal in sidebar")
             }
             Spacer()
             if let info = selectedWorktreeInfo {
@@ -112,5 +155,15 @@ struct StatusBarView: View {
         .padding(.horizontal)
         .padding(.vertical, 4)
         .background(.bar)
+    }
+
+    private func copyPath(_ path: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(path, forType: .string)
+        didCopy = true
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.2))
+            didCopy = false
+        }
     }
 }

--- a/Tests/TBDAppTests/StatusBarFocusLabelTests.swift
+++ b/Tests/TBDAppTests/StatusBarFocusLabelTests.swift
@@ -114,3 +114,23 @@ struct StatusBarFocusLabelTests {
         #expect(label == nil)
     }
 }
+
+@Suite("StatusBarView.leftLabelBehavior")
+struct StatusBarLeftLabelBehaviorTests {
+
+    @Test("single worktree selected copies its path with path tooltip")
+    func singleWorktreeCopiesPath() {
+        let behavior = StatusBarView.leftLabelBehavior(selectedWorktreePath: "/tmp/feat-branch")
+
+        #expect(behavior == .copyPath("/tmp/feat-branch"))
+        #expect(behavior.tooltip == "/tmp/feat-branch")
+    }
+
+    @Test("no single worktree selected reveals in sidebar")
+    func noSingleWorktreeReveals() {
+        let behavior = StatusBarView.leftLabelBehavior(selectedWorktreePath: nil)
+
+        #expect(behavior == .revealInSidebar)
+        #expect(behavior.tooltip == "Reveal in sidebar")
+    }
+}


### PR DESCRIPTION
## Summary
- The bottom-left status-bar label now **copies the selected worktree's absolute path** on click, with a transient "Copied" confirmation.
- **Hovering** the label shows the worktree's absolute path as a tooltip.
- Behavior is gated on a single-worktree selection. For repo-only or multi-worktree selections (where there's no single worktree path), the existing **reveal-in-sidebar** click + tooltip is preserved.

## Implementation notes
- Extracted a `nonisolated static` pure helper `leftLabelBehavior(selectedWorktreePath:)` returning a `.copyPath`/`.revealInSidebar` enum, mirroring the existing `focusLabel` seam so the branch is unit-testable.
- Copy uses the established `NSPasteboard.general` idiom; the "Copied" reset uses a non-blocking `Task.sleep` (no `Timer`).

## Test plan
- [ ] Select a single worktree → bottom-left label tooltip shows the absolute path; clicking copies it and briefly shows "Copied".
- [ ] Select a repo (no worktree) or multiple worktrees → label still reveals the selection in the sidebar with the "Reveal in sidebar" tooltip.
- [x] `swift build` clean; `swift test --filter StatusBar` → 15 tests pass (incl. 2 new branch tests); `swiftlint --strict` → 0 violations.

[📋 Worktree Path Status Bar](https://cheapsteak.github.io/tbd/open/?worktree=C8367C9B-2604-480D-A7C4-3848DFB2C315)