### PR TITLE
Fix: Surface auto-archive-on-merge state on the PR toolbar button

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -138,11 +138,13 @@ struct ContentView: View {
                             // Split button: label = primary click (open PR); the
                             // attached chevron opens the menu.
                             Menu {
-                                if let worktree = appState.findWorktree(id: worktreeID) {
-                                    let armed = appState.effectiveAutoArchive(for: worktree)
+                                if appState.findWorktree(id: worktreeID) != nil {
                                     let blocked = !appState.children(of: worktreeID).isEmpty
                                     Toggle("Auto-archive worktree on PR merge", isOn: Binding(
-                                        get: { armed },
+                                        get: {
+                                            appState.findWorktree(id: worktreeID)
+                                                .map { appState.effectiveAutoArchive(for: $0) } ?? false
+                                        },
                                         set: { newValue in
                                             Task { await appState.setAutoArchive(worktreeID: worktreeID, enabled: newValue) }
                                         }
@@ -150,7 +152,9 @@ struct ContentView: View {
                                     .disabled(blocked)
                                 }
                             } label: {
-                                PRButtonLabel(prStatus: prStatus)
+                                let armed = appState.findWorktree(id: worktreeID)
+                                    .map { appState.effectiveAutoArchive(for: $0) } ?? false
+                                PRButtonLabel(prStatus: prStatus, isAutoArchiveArmed: armed)
                             } primaryAction: {
                                 let existingTabs = appState.tabs[worktreeID] ?? []
                                 if let existingIndex = existingTabs.firstIndex(where: {
@@ -347,6 +351,7 @@ private func overlayFrameIsWindowRoot(
 
 private struct PRButtonLabel: View {
     let prStatus: PRStatus
+    let isAutoArchiveArmed: Bool
     // Re-bake the colored icon when the appearance flips (the baked image is
     // non-template, so it can't auto-adapt the way a tinted template would).
     @Environment(\.colorScheme) private var colorScheme
@@ -364,6 +369,18 @@ private struct PRButtonLabel: View {
             Text(verbatim: "#\(prStatus.number)")
                 .font(.caption)
                 .fontWeight(.medium)
+            if isAutoArchiveArmed {
+                // At-a-glance indicator that auto-archive-on-merge is armed for
+                // this worktree. A toolbar Menu label renders SF Symbols
+                // monochrome (AppKit tints them) — that's fine and desirable
+                // here, so a plain template Image needs no baked color.
+                Image(systemName: "archivebox")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 11, height: 11)
+                    .help("Auto-archive on PR merge is on")
+                    .accessibilityLabel("Auto-archive on PR merge is on")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- The per-worktree **Auto-archive worktree on PR merge** setting was only visible as a checkmark inside the PR split-button dropdown. Because the menu closes the instant you click the item, toggling it gave **no at-a-glance feedback** — the toolbar looked identical whether armed or not. (The value *did* persist correctly; this was purely a surfacing gap.)
- Adds an `archivebox` badge to the PR toolbar button whenever auto-archive is armed for the selected worktree, so the state is visible without reopening the dropdown. The dropdown checkmark is kept.
- Also fixes a latent wart: the dropdown `Toggle`'s `isOn` binding read a constant captured at view-build time (`get: { armed }`) instead of a live value; it now reads `effectiveAutoArchive` live, so the toggle and the new badge stay in lockstep with optimistic updates.

A blocked worktree (one with children) is disarmed by the daemon writing `autoArchiveOnMerge = false` (an explicit override, not `nil`), so `effectiveAutoArchive` returns `false` and the badge correctly stays hidden there.

## Test plan
- [x] `swift build` — green
- [x] `swift test --filter EffectiveAutoArchive` — all 4 branch cases pass (override true/false, nil→default on/off)
- [ ] Live: open a worktree that has a PR, open the PR split-button dropdown, toggle **Auto-archive worktree on PR merge** on → archivebox badge appears next to `#number`; toggle off → badge disappears; reopen dropdown → checkmark reflects current state

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=E1FEB243-8879-4794-9196-12AFBD9AE24C)