### PR TITLE
Feat: Right-click a preview pane header to copy path, reveal, or open the file

### DIFF
--- a/Sources/TBDApp/Panes/HeaderFileActions.swift
+++ b/Sources/TBDApp/Panes/HeaderFileActions.swift
@@ -1,0 +1,77 @@
+import AppKit
+import Foundation
+
+// MARK: - Header menu target resolution (pure)
+
+/// The file a pane header's context menu acts on, plus the wording of its
+/// copy button. `nil` from `headerMenuTarget` means the pane has no associated
+/// file and should show no context menu at all.
+struct HeaderMenuTarget: Equatable {
+    let path: String
+    let copyLabel: String
+}
+
+/// Resolve the header context-menu target for a pane.
+///
+/// - `.codeViewer` acts on its file path ("Copy Path").
+/// - `.liveTranscript` acts on the session `.jsonl` (passed in as
+///   `transcriptPath`, since resolving it needs the terminal model) and keeps
+///   the existing "Copy Conversation Path" wording.
+/// - All other panes (and empty/nil paths) return `nil` → no menu.
+func headerMenuTarget(for content: PaneContent, transcriptPath: String?) -> HeaderMenuTarget? {
+    switch content {
+    case .codeViewer(_, let path):
+        return path.isEmpty ? nil : HeaderMenuTarget(path: path, copyLabel: "Copy Path")
+    case .liveTranscript:
+        guard let transcriptPath, !transcriptPath.isEmpty else { return nil }
+        return HeaderMenuTarget(path: transcriptPath, copyLabel: "Copy Conversation Path")
+    case .terminal, .webview, .note:
+        return nil
+    }
+}
+
+// MARK: - Open With app resolution
+
+/// An application that can open a file, as offered by the "Open With" submenu.
+struct OpenWithApp: Identifiable, Equatable {
+    let url: URL
+    var id: URL { url }
+    var displayName: String { appDisplayName(for: url) }
+}
+
+/// Applications registered to open the file at `path`, default app first
+/// (the same ordered set Finder shows). Empty when the file does not exist or
+/// no apps are registered — callers omit the submenu in that case.
+func openWithApps(forPath path: String) -> [OpenWithApp] {
+    guard FileManager.default.fileExists(atPath: path) else { return [] }
+    let fileURL = URL(fileURLWithPath: path)
+    return NSWorkspace.shared.urlsForApplications(toOpen: fileURL).map(OpenWithApp.init)
+}
+
+/// Human-readable app name from its bundle URL
+/// ("Visual Studio Code.app" → "Visual Studio Code").
+func appDisplayName(for appURL: URL) -> String {
+    appURL.deletingPathExtension().lastPathComponent
+}
+
+// MARK: - Actions
+
+/// Replace the general pasteboard contents with `string`.
+func copyToPasteboard(_ string: String) {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(string, forType: .string)
+}
+
+/// Reveal the file at `path` in Finder with it selected.
+func revealInFinder(path: String) {
+    NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+}
+
+/// Open the file at `path` with the application bundle at `appURL`.
+func openFile(path: String, withApp appURL: URL) {
+    NSWorkspace.shared.open(
+        [URL(fileURLWithPath: path)],
+        withApplicationAt: appURL,
+        configuration: NSWorkspace.OpenConfiguration()
+    )
+}

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -111,7 +111,7 @@ struct PanePlaceholder: View {
         .onHover { hovering in
             isHeaderHovering = hovering
         }
-        .applyTranscriptCopyPathContextMenu(path: transcriptPath)
+        .headerFileContextMenu(for: content, transcriptPath: transcriptPath)
     }
 
     /// Resolved Claude session JSONL path for liveTranscript panes; nil otherwise.
@@ -523,19 +523,37 @@ struct PanePlaceholder: View {
     }
 }
 
-// MARK: - Transcript Copy Path Context Menu
+// MARK: - Header File Context Menu
 
 private extension View {
-    /// Attach the "Copy Conversation Path" context menu only when a transcript
-    /// path is available — non-transcript panes get no contextMenu at all so
-    /// right-click is a true no-op rather than showing an empty menu.
+    /// Attach the pane-header file context menu (Copy Path / Reveal in Finder /
+    /// Open With) only when the pane has an associated file — other panes get no
+    /// contextMenu at all so right-click is a true no-op rather than an empty
+    /// menu. `transcriptPath` supplies the `.jsonl` path for live-transcript
+    /// panes (resolving it needs the terminal model, so the caller passes it in).
     @ViewBuilder
-    func applyTranscriptCopyPathContextMenu(path: String?) -> some View {
-        if let path {
+    func headerFileContextMenu(for content: PaneContent, transcriptPath: String?) -> some View {
+        if let target = headerMenuTarget(for: content, transcriptPath: transcriptPath) {
             self.contextMenu {
-                Button("Copy Conversation Path") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(path, forType: .string)
+                Button(target.copyLabel) { copyToPasteboard(target.path) }
+                Button("Reveal in Finder") { revealInFinder(path: target.path) }
+
+                let apps = openWithApps(forPath: target.path)
+                if !apps.isEmpty {
+                    Menu("Open With") {
+                        ForEach(apps) { app in
+                            Button {
+                                openFile(path: target.path, withApp: app.url)
+                            } label: {
+                                Label {
+                                    Text(app.displayName)
+                                } icon: {
+                                    Image(nsImage: NSWorkspace.shared.icon(forFile: app.url.path))
+                                        .renderingMode(.original)
+                                }
+                            }
+                        }
+                    }
                 }
             }
         } else {

--- a/Tests/TBDAppTests/HeaderFileActionsTests.swift
+++ b/Tests/TBDAppTests/HeaderFileActionsTests.swift
@@ -1,0 +1,59 @@
+import AppKit
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("Header file actions")
+struct HeaderFileActionsTests {
+    // MARK: headerMenuTarget
+
+    @Test("codeViewer with a path → Copy Path target")
+    func codeViewerTarget() {
+        let content = PaneContent.codeViewer(id: UUID(), path: "/abs/foo.md")
+        let target = headerMenuTarget(for: content, transcriptPath: nil)
+        #expect(target == HeaderMenuTarget(path: "/abs/foo.md", copyLabel: "Copy Path"))
+    }
+
+    @Test("codeViewer with empty path → no target")
+    func codeViewerEmptyPath() {
+        let content = PaneContent.codeViewer(id: UUID(), path: "")
+        #expect(headerMenuTarget(for: content, transcriptPath: nil) == nil)
+    }
+
+    @Test("liveTranscript with a transcript path → Copy Conversation Path target")
+    func transcriptTarget() {
+        let content = PaneContent.liveTranscript(id: UUID(), terminalID: UUID())
+        let target = headerMenuTarget(for: content, transcriptPath: "/abs/session.jsonl")
+        #expect(target == HeaderMenuTarget(path: "/abs/session.jsonl", copyLabel: "Copy Conversation Path"))
+    }
+
+    @Test("liveTranscript with nil/empty transcript path → no target")
+    func transcriptNoPath() {
+        let content = PaneContent.liveTranscript(id: UUID(), terminalID: UUID())
+        #expect(headerMenuTarget(for: content, transcriptPath: nil) == nil)
+        #expect(headerMenuTarget(for: content, transcriptPath: "") == nil)
+    }
+
+    @Test("non-file panes → no target")
+    func otherPanesNoTarget() {
+        #expect(headerMenuTarget(for: .terminal(terminalID: UUID()), transcriptPath: nil) == nil)
+        #expect(headerMenuTarget(for: .note(noteID: UUID()), transcriptPath: nil) == nil)
+        #expect(headerMenuTarget(for: .webview(id: UUID(), url: URL(string: "https://example.com")!), transcriptPath: nil) == nil)
+    }
+
+    // MARK: appDisplayName
+
+    @Test("appDisplayName strips the .app extension")
+    func displayName() {
+        #expect(appDisplayName(for: URL(fileURLWithPath: "/Applications/Visual Studio Code.app")) == "Visual Studio Code")
+        #expect(appDisplayName(for: URL(fileURLWithPath: "/System/Applications/TextEdit.app")) == "TextEdit")
+    }
+
+    // MARK: openWithApps
+
+    @Test("openWithApps returns empty for a non-existent file")
+    func openWithMissingFile() {
+        let missing = NSTemporaryDirectory() + "tbd-does-not-exist-\(UUID().uuidString).md"
+        #expect(openWithApps(forPath: missing).isEmpty)
+    }
+}

--- a/docs/superpowers/specs/2026-06-30-pane-header-context-menu-design.md
+++ b/docs/superpowers/specs/2026-06-30-pane-header-context-menu-design.md
@@ -1,0 +1,172 @@
+# Pane Header Context Menu — Design
+
+**Date:** 2026-06-30
+**Status:** Approved for planning
+
+## Summary
+
+Add a right-click context menu to the pane **header** of the code/markdown
+preview pane and the live-transcript pane. The menu exposes file actions:
+**Copy Path** (absolute path), **Reveal in Finder**, and an **Open With ▸**
+submenu (the same candidate apps Finder offers, each with its icon).
+
+Today the header only displays the file's last path component as static text.
+The full absolute path is already in scope at the header render site, so these
+actions are a thin addition over existing data.
+
+## Motivation
+
+Users viewing a file (markdown render, source, or a conversation `.jsonl`) often
+want to act on the underlying file — copy its path to paste elsewhere, reveal it
+in Finder, or open it in another app — without leaving TBD or hunting for the
+path. The header is the natural anchor for those actions.
+
+## Scope
+
+### In scope
+- Right-click context menu on the **main pane toolbar header** for:
+  - `.codeViewer(_, path)` panes (markdown preview + code/source preview share
+    this pane).
+  - `.liveTranscript` panes (path = the session `.jsonl`).
+- Three actions per menu: Copy Path, Reveal in Finder, Open With ▸.
+- The live-transcript header already has a "Copy Conversation Path" context
+  menu; this work **folds that into the new shared seam** and adds Reveal in
+  Finder + Open With to it.
+
+### Out of scope (YAGNI)
+- The **multi-file internal headers** inside `CodeViewerPaneView` — the small
+  per-file caption bars (`fileHeader(_:)`) shown only when the optional code
+  viewer sidebar is enabled *and* 2+ files are selected (`selectedFiles.count >
+  1`). This is an opt-in power-user mode that is off by default; adding actions
+  there is a reasonable future follow-up but is a separate surface with its own
+  per-file path.
+- Finder's "App Store…" and "Other…" entries in Open With.
+- Any new top-level menu-bar or toolbar buttons; this is right-click only.
+
+## Current State (reference)
+
+- **Header render site:** `Sources/TBDApp/Panes/PanePlaceholder.swift`
+  - `paneLabel`, `.codeViewer(_, let path)` case (~lines 155-156) shows
+    `Text(URL(fileURLWithPath: path).lastPathComponent)` — the full `path` is in
+    scope.
+  - The toolbar currently carries `.applyTranscriptCopyPathContextMenu(path:)`
+    (~lines 528-545), a `@ViewBuilder` extension that attaches a `.contextMenu`
+    with a single "Copy Conversation Path" button **only** when a transcript
+    path exists (`transcriptPath`, ~lines 118-124), otherwise returns `self`.
+- **Path origin:** `PaneContent.codeViewer(id:, path:)`
+  (`Sources/TBDApp/Terminal/PaneContent.swift:8`). The path is constructed as an
+  absolute path at click time (`FileViewerPanel.handleFileClick` ~lines 213-214;
+  `ViewerRouting.routeFileClick`).
+- **Established clipboard pattern:** the 2-line
+  `NSPasteboard.general.clearContents()` / `setString(_, forType: .string)` is
+  used in `FileViewerPanel` (`copyPathToPasteboard`, ~lines 5-8), `TabBar`
+  (~lines 662-663), `SidebarContextMenu`, `HistoryPaneView`, and others.
+- **Existing "Copy Path" context menus** for reference: `FileViewerPanel`
+  per-row (~lines 340-344, 424-429) and `TabBar` (~lines 658-666).
+
+## Design
+
+### Single header context-menu seam
+
+Replace the transcript-only `.applyTranscriptCopyPathContextMenu(path:)` on the
+toolbar with **one** context-menu modifier keyed on the pane's `PaneContent`:
+
+- `.codeViewer(_, path)` → menu with actions for `path`, copy label **"Copy
+  Path"**.
+- `.liveTranscript` (with a transcript path) → menu with actions for the
+  `.jsonl` path, copy label **"Copy Conversation Path"** (preserves existing
+  wording).
+- any other case (or no path available) → **no menu** (returns `self`, matching
+  today's behavior exactly).
+
+Rationale: two stacked `.contextMenu` modifiers conflict (the last wins), so a
+single seam that branches by pane content is both correct and the clearest place
+to own "what does right-clicking a pane header do."
+
+### Shared action builder
+
+A single reusable `@ViewBuilder` produces the three menu items given a path and
+a copy label:
+
+```
+headerFileActions(path:, copyLabel:) ->
+  Button(copyLabel)          // Copy Path / Copy Conversation Path
+  Button("Reveal in Finder")
+  Menu("Open With") { ... }  // submenu, see below
+```
+
+- **Copy Path:** `NSPasteboard.general.clearContents()` then
+  `setString(path, forType: .string)` — the established pattern. Copies the
+  absolute path verbatim.
+- **Reveal in Finder:**
+  `NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])`.
+- **Open With ▸:** see below.
+
+### Open With submenu (with icons)
+
+- **Candidate apps:** `NSWorkspace.shared.urlsForApplications(toOpen:)` (macOS
+  12+) for the file URL. This returns the same ordered set Finder shows, default
+  app first. If the list is empty (e.g. file missing), the submenu is omitted.
+- **Each item:** a `Button` whose label is a `Label` with the app display name
+  (derived from the app bundle / `lastPathComponent` sans `.app`) and the app
+  icon via `Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))` with
+  `.renderingMode(.original)`.
+- **Action:** `NSWorkspace.shared.open([fileURL], withApplicationAt: appURL,
+  configuration: NSWorkspace.OpenConfiguration())`.
+
+**Known risk:** icon rendering inside SwiftUI context-menu items is inconsistent
+on macOS (SwiftUI sometimes strips images from menus). The implementation
+attempts `.renderingMode(.original)` icons; if they prove unreliable in the live
+app, text-only app names are the acceptable fallback. App **names** are
+rock-solid regardless. This must be confirmed by live visual verification (see
+Testing).
+
+### No bundle-identifier hazard
+
+All APIs used (`NSPasteboard`, `NSWorkspace.activateFileViewerSelecting`,
+`urlsForApplications(toOpen:)`, `icon(forFile:)`, `open(_:withApplicationAt:_:)`)
+work in an unbundled SPM executable and do not require `CFBundleIdentifier`, so
+the project's unbundled-executable constraint does not apply.
+
+## Error Handling
+
+- **Missing/moved file:** Copy Path still copies the string. Reveal in Finder
+  and Open With degrade gracefully — `urlsForApplications` returns an empty list
+  (submenu omitted), and reveal simply does nothing. No crashes, no alerts.
+- **Open failure:** `NSWorkspace.open` reports asynchronously; failures are not
+  surfaced with UI (consistent with the rest of the app's fire-and-forget
+  open/reveal actions).
+- **No path / non-file pane:** no menu is attached at all.
+
+## Testing
+
+Following the project rule that a behavior-gating branch gets a test per branch:
+
+- **Pure helpers (unit, headless):**
+  - Pane-content → menu-applicability: `.codeViewer` and `.liveTranscript` (with
+    a path) yield actions; other cases / nil path yield none.
+  - App-candidate resolution returns a list shape that the menu can consume, and
+    an empty/missing-file path yields an empty list (submenu omitted).
+  - Copy uses the absolute path string unchanged.
+- **Live visual verify (manual, per project convention for SwiftUI menu
+  visuals):** right-click each header; confirm the menu appears, Copy Path
+  populates the clipboard with the absolute path, Reveal in Finder selects the
+  file, and the Open With submenu lists apps — and specifically whether icons
+  render (decides whether icons stay or fall back to text-only). Verified via
+  screenshot + `log stream`, trusting the live app over headless numbers.
+
+## Files Likely Touched
+
+- `Sources/TBDApp/Panes/PanePlaceholder.swift` — replace the transcript-only
+  context-menu modifier with the consolidated seam; add the shared
+  `headerFileActions` builder and the Open With submenu (or a small companion
+  file/helper if cleaner).
+- Possibly a small new helper file for the Open With app-resolution logic (pure,
+  testable) under `Sources/TBDApp/` (e.g. `Helpers/`), to keep `PanePlaceholder`
+  focused and the resolution unit-testable.
+- Tests under `Tests/` covering the pure helpers above.
+
+## Open Questions
+
+None blocking. The icons-vs-text-only decision for Open With is resolved
+empirically during live verification.


### PR DESCRIPTION

<img width="350" height="129" alt="image" src="https://github.com/user-attachments/assets/c6f2b0d9-cbcd-4bb7-bf04-d0f8d0d5444f" />

## Summary
- Adds a right-click context menu to the **code/markdown preview** pane header and the **live-transcript** pane header. The header already showed the filename but offered no actions; the absolute path was right there in scope.
- Three actions: **Copy Path** (absolute path), **Reveal in Finder**, and an **Open With ▸** submenu listing the apps that can open the file (default first, with icons) — the same set Finder offers.
- Consolidates the previous transcript-only "Copy Conversation Path" menu into one `PaneContent`-keyed seam (`headerFileContextMenu`), so there's a single place that owns header right-click behavior. Transcript panes keep their "Copy Conversation Path" wording and gain Reveal/Open With; non-file panes (terminal, note) still get no menu.

## Implementation
- New `Sources/TBDApp/Panes/HeaderFileActions.swift` holds the pure, unit-tested logic: `headerMenuTarget(for:transcriptPath:)` (which file a pane acts on + the copy label), `openWithApps(forPath:)` (via `NSWorkspace.urlsForApplications(toOpen:)`, empty when the file is missing → submenu omitted), and thin action wrappers. All APIs are bundle-id-independent, safe for the unbundled SPM executable.
- `PanePlaceholder` swaps its old context-menu modifier for the new seam; the old `applyTranscriptCopyPathContextMenu` extension is removed (no stacked menus).

## Test plan
- [x] `swift test --filter HeaderFileActionsTests` — 7/7 passing (covers every `headerMenuTarget` branch + empty/missing-file cases)
- [x] `swift build` clean, `swiftlint --strict` clean
- [x] Live: right-click a code-viewer header → Copy Path / Reveal in Finder / Open With (icons render); right-click a transcript header → "Copy Conversation Path" + Reveal + Open With on the `.jsonl`; right-click a terminal/note header → no menu

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7A57982E-B877-4A11-8BA5-2EC90B97D2B4)