### PR TITLE
Feat: Untangle the worktree row icon so PR status is always visible

### DIFF
--- a/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuRow.swift
@@ -17,38 +17,19 @@ struct JumpMenuRow: Identifiable, Equatable {
     let section: Section
 }
 
-/// Color the severity dot. Mirrors WorktreeRowView's logic so the two views
-/// stay visually consistent.
-private func severityColor(_ type: NotificationType) -> Color {
-    switch type {
-    case .error:            return .red
-    case .attentionNeeded, .focusRequest: return .orange
-    case .taskComplete:     return .green
-    case .responseComplete: return .blue
-    }
-}
-
-/// A 6pt dot in the severity color, or a transparent spacer of the same
-/// width so rows without unread notifications still align with rows that
-/// have one.
-private struct SeverityDot: View {
-    let severity: NotificationType?
-    var body: some View {
-        Circle()
-            .fill(severity.map(severityColor) ?? .clear)
-            .frame(width: 6, height: 6)
-    }
-}
-
 struct JumpMenuRowView: View {
     let row: JumpMenuRow
     let isSelected: Bool
 
+    private var suffix: SuffixRowIndicator? {
+        RowStatusIndicator.suffix(notification: row.severity, isWorking: false, isSuspended: false)
+    }
+
     var body: some View {
         HStack(spacing: 8) {
-            SeverityDot(severity: row.severity)
             Text(row.displayName)
                 .font(.system(size: 13))
+                .fontWeight(RowStatusIndicator.shouldBoldName(row.severity) ? .bold : .regular)
                 .lineLimit(1)
                 .truncationMode(.tail)
             Text(row.repoName)
@@ -56,6 +37,12 @@ struct JumpMenuRowView: View {
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
             Spacer()
+            if let indicator = suffix, let symbol = indicator.systemImage {
+                Image(systemName: symbol)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(indicator.color)
+                    .frame(width: 12, height: 12)
+            }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 5)

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -41,10 +41,7 @@ enum SuffixRowIndicator: Equatable {
                 dark: NSColor(srgbRed: 210 / 255, green: 153 / 255, blue: 34 / 255, alpha: 1)
             )
         case .working:
-            return adaptiveColor(
-                light: NSColor(srgbRed: 176 / 255, green: 87 / 255, blue: 48 / 255, alpha: 1),
-                dark: NSColor(srgbRed: 217 / 255, green: 119 / 255, blue: 87 / 255, alpha: 1)
-            )
+            return .secondary
         case .suspended:
             return .secondary
         }

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -1,64 +1,92 @@
 import SwiftUI
 import TBDShared
 
-/// The single status indicator a sidebar worktree row may display.
-enum RowStatusIndicator: Equatable {
+/// Indicator shown in the leading (identity / PR) slot of a sidebar row.
+/// Mutually exclusive with `SuffixRowIndicator` — they occupy different
+/// regions of the row and may both be present.
+enum LeadingRowIndicator: Equatable {
     case pending
-    case working
-    case notificationBadge(NotificationType)
-    case suspended
     case prStatus
+}
 
-    /// Notifications at or above this `NotificationType.severity` outrank the
-    /// working icon: errors and attention/focus requests must not be hidden
-    /// behind a working indicator that can show for minutes. Lower-severity
-    /// completion badges yield to the working icon, so a stale "done" dot
-    /// never masks active work.
-    private static let highSeverityThreshold = 3
+/// Indicator shown in the trailing (activity / attention) suffix slot.
+enum SuffixRowIndicator: Equatable {
+    case error
+    case attention
+    case working
+    case suspended
 
-    /// Resolves which indicator (if any) a worktree row should show.
-    ///
-    /// Invariant: a worktree row shows at most one status indicator.
-    /// Add new indicators as a branch in this priority chain — never as an
-    /// additional stacked icon in `WorktreeRowView`.
-    ///
-    /// Priority (highest first): pending > high-severity badge (error,
-    /// attentionNeeded, focusRequest) > working > low-severity badge
-    /// (taskComplete, responseComplete) > suspended > PR status.
-    static func resolve(
-        isPending: Bool,
-        isWorking: Bool,
-        notification: NotificationType?,
-        isSuspended: Bool,
-        hasPRStatus: Bool
-    ) -> RowStatusIndicator? {
-        if isPending {
-            return .pending
-        } else if let notification, notification.severity >= highSeverityThreshold {
-            return .notificationBadge(notification)
-        } else if isWorking {
-            return .working
-        } else if let notification {
-            return .notificationBadge(notification)
-        } else if isSuspended {
-            return .suspended
-        } else if hasPRStatus {
+    /// SF Symbol for glyph-based suffixes. `.working` is `nil` because it is
+    /// rendered as an animated `TypingDotsView`, not a static symbol.
+    var systemImage: String? {
+        switch self {
+        case .error:     return "exclamationmark.octagon.fill"
+        case .attention: return "hand.raised.fill"
+        case .working:   return nil
+        case .suspended: return "pause.circle.fill"
+        }
+    }
+
+    /// Tint for the suffix glyph. `.working` reuses Claude's coral; the
+    /// `TypingDotsView` reads this same value for its dots.
+    var color: Color {
+        switch self {
+        case .error:
+            return .red
+        case .attention:
+            // Light: amber #B7791F readable on light sidebar (~#F1F1F1).
+            // Dark:  GitHub attention.fg #D29922 readable on dark sidebar.
+            return adaptiveColor(
+                light: NSColor(srgbRed: 183 / 255, green: 121 / 255, blue: 31 / 255, alpha: 1),
+                dark: NSColor(srgbRed: 210 / 255, green: 153 / 255, blue: 34 / 255, alpha: 1)
+            )
+        case .working:
+            return adaptiveColor(
+                light: NSColor(srgbRed: 176 / 255, green: 87 / 255, blue: 48 / 255, alpha: 1),
+                dark: NSColor(srgbRed: 217 / 255, green: 119 / 255, blue: 87 / 255, alpha: 1)
+            )
+        case .suspended:
+            return .secondary
+        }
+    }
+}
+
+/// Pure resolvers for the two independent sidebar-row indicator regions.
+///
+/// The row no longer collapses every state onto one slot. PR status lives in
+/// the leading region and is never hidden by activity; the suffix region shows
+/// at most one of error / attention / working / suspended.
+enum RowStatusIndicator {
+    /// Leading slot. PR status (when present) always wins so it stays visible
+    /// and clickable; a `.creating` worktree (which has no PR yet) shows the
+    /// pending glyph. `hasPRStatus` is expected to already exclude the main
+    /// worktree at the call site.
+    static func leading(isPending: Bool, hasPRStatus: Bool) -> LeadingRowIndicator? {
+        if hasPRStatus {
             return .prStatus
+        } else if isPending {
+            return .pending
         }
         return nil
     }
 
-    /// Badge dot color for `notificationBadge` cases.
-    static func badgeColor(for notification: NotificationType) -> Color {
-        switch notification {
-        case .error:
-            return .red
-        case .attentionNeeded, .focusRequest:
-            return .orange
-        case .taskComplete:
-            return .green
-        case .responseComplete:
-            return .blue
+    /// Suffix slot. Priority (highest first): error > attention > working >
+    /// suspended. `taskComplete` produces no suffix; `responseComplete` is
+    /// surfaced as a bold name in the view, not as a suffix.
+    static func suffix(
+        notification: NotificationType?,
+        isWorking: Bool,
+        isSuspended: Bool
+    ) -> SuffixRowIndicator? {
+        if notification == .error {
+            return .error
+        } else if notification == .attentionNeeded || notification == .focusRequest {
+            return .attention
+        } else if isWorking {
+            return .working
+        } else if isSuspended {
+            return .suspended
         }
+        return nil
     }
 }

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -67,6 +67,19 @@ enum RowStatusIndicator {
         return nil
     }
 
+    /// Whether the worktree name should be bold for the given unread
+    /// notification. Bold tracks "you should look here" — a completed response
+    /// or an attention request. Shared by the sidebar row and the jump menu so
+    /// they stay consistent.
+    static func shouldBoldName(_ notification: NotificationType?) -> Bool {
+        switch notification {
+        case .responseComplete, .attentionNeeded, .focusRequest:
+            return true
+        case .error, .taskComplete, .none:
+            return false
+        }
+    }
+
     /// Suffix slot. Priority (highest first): error > attention > working >
     /// suspended. `taskComplete` produces no suffix; `responseComplete` is
     /// surfaced as a bold name in the view, not as a suffix.

--- a/Sources/TBDApp/Sidebar/TypingDotsView.swift
+++ b/Sources/TBDApp/Sidebar/TypingDotsView.swift
@@ -1,0 +1,124 @@
+import AppKit
+import SwiftUI
+
+/// Layer-backed dancing-dots ("typing…") indicator. The pulse is driven by
+/// `CAKeyframeAnimation`s committed once to the render server, so it costs no
+/// per-frame main-thread or SwiftUI work — unlike the `ProgressView` spinner
+/// it replaces (#266). Animations are paused while the window is occluded.
+final class TypingDotsNSView: NSView {
+    private static let dotDiameter: CGFloat = 4
+    private static let dotSpacing: CGFloat = 3
+    private static let pulseKey = "typingPulse"
+    private let dotLayers: [CALayer]
+    // nonisolated(unsafe): Swift 6 deinit is nonisolated; NSView deinit
+    // always runs on the main thread in practice, so this is safe.
+    nonisolated(unsafe) private var occlusionObserver: (any NSObjectProtocol)?
+
+    init(dotColor: NSColor) {
+        self.dotLayers = (0..<3).map { _ in CALayer() }
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.masksToBounds = false
+
+        for (index, dot) in dotLayers.enumerated() {
+            dot.backgroundColor = dotColor.cgColor
+            dot.cornerRadius = Self.dotDiameter / 2
+            dot.frame = CGRect(
+                x: CGFloat(index) * (Self.dotDiameter + Self.dotSpacing),
+                y: 0,
+                width: Self.dotDiameter,
+                height: Self.dotDiameter
+            )
+            dot.opacity = 0.3
+
+            let pulse = CAKeyframeAnimation(keyPath: "opacity")
+            pulse.values = [0.3, 1.0, 0.3]
+            pulse.keyTimes = [0, 0.5, 1]
+            pulse.duration = 1.2
+            pulse.beginTime = CACurrentMediaTime() + Double(index) * 0.2
+            pulse.repeatCount = .infinity
+            pulse.isRemovedOnCompletion = false
+            dot.add(pulse, forKey: Self.pulseKey)
+
+            layer?.addSublayer(dot)
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override var intrinsicContentSize: NSSize {
+        let width = CGFloat(dotLayers.count) * Self.dotDiameter
+            + CGFloat(dotLayers.count - 1) * Self.dotSpacing
+        return NSSize(width: width, height: Self.dotDiameter)
+    }
+
+    func updateColor(_ color: NSColor) {
+        for dot in dotLayers { dot.backgroundColor = color.cgColor }
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let observer = occlusionObserver {
+            NotificationCenter.default.removeObserver(observer)
+            occlusionObserver = nil
+        }
+        guard let window else {
+            setPaused(true)
+            return
+        }
+        setPaused(!window.occlusionState.contains(.visible))
+        occlusionObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeOcclusionStateNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            // queue: .main guarantees this runs on the main thread.
+            // Avoid capturing note (non-Sendable NSWindow object); read
+            // self.window directly inside the main-actor-isolated closure.
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.setPaused(!(self.window?.occlusionState.contains(.visible) ?? false))
+            }
+        }
+    }
+
+    deinit {
+        if let observer = occlusionObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    /// Freeze/thaw the render-server animation without removing it: a paused
+    /// layer does zero render-server work.
+    private func setPaused(_ paused: Bool) {
+        guard let layer else { return }
+        if paused {
+            guard layer.speed != 0 else { return }
+            let pausedTime = layer.convertTime(CACurrentMediaTime(), from: nil)
+            layer.speed = 0
+            layer.timeOffset = pausedTime
+        } else {
+            guard layer.speed == 0 else { return }
+            let pausedTime = layer.timeOffset
+            layer.speed = 1
+            layer.timeOffset = 0
+            layer.beginTime = 0
+            let timeSincePause = layer.convertTime(CACurrentMediaTime(), from: nil) - pausedTime
+            layer.beginTime = timeSincePause
+        }
+    }
+}
+
+/// SwiftUI wrapper for `TypingDotsNSView`.
+struct TypingDotsView: NSViewRepresentable {
+    let color: Color
+
+    func makeNSView(context: Context) -> TypingDotsNSView {
+        TypingDotsNSView(dotColor: NSColor(color))
+    }
+
+    func updateNSView(_ nsView: TypingDotsNSView, context: Context) {
+        nsView.updateColor(NSColor(color))
+    }
+}

--- a/Sources/TBDApp/Sidebar/TypingDotsView.swift
+++ b/Sources/TBDApp/Sidebar/TypingDotsView.swift
@@ -47,6 +47,27 @@ final class TypingDotsNSView: NSView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
+    override func layout() {
+        super.layout()
+        let count = dotLayers.count
+        guard count > 0 else { return }
+        let contentWidth = CGFloat(count) * Self.dotDiameter
+            + CGFloat(count - 1) * Self.dotSpacing
+        let startX = ((bounds.width - contentWidth) / 2).rounded()
+        let dotY = ((bounds.height - Self.dotDiameter) / 2).rounded()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        for (index, dot) in dotLayers.enumerated() {
+            dot.frame = CGRect(
+                x: startX + CGFloat(index) * (Self.dotDiameter + Self.dotSpacing),
+                y: dotY,
+                width: Self.dotDiameter,
+                height: Self.dotDiameter
+            )
+        }
+        CATransaction.commit()
+    }
+
     override var intrinsicContentSize: NSSize {
         let width = CGFloat(dotLayers.count) * Self.dotDiameter
             + CGFloat(dotLayers.count - 1) * Self.dotSpacing

--- a/Sources/TBDApp/Sidebar/TypingDotsView.swift
+++ b/Sources/TBDApp/Sidebar/TypingDotsView.swift
@@ -10,18 +10,20 @@ final class TypingDotsNSView: NSView {
     private static let dotSpacing: CGFloat = 2
     private static let pulseKey = "typingPulse"
     private let dotLayers: [CALayer]
+    private var dotColor: NSColor
     // nonisolated(unsafe): Swift 6 deinit is nonisolated; NSView deinit
     // always runs on the main thread in practice, so this is safe.
     nonisolated(unsafe) private var occlusionObserver: (any NSObjectProtocol)?
 
     init(dotColor: NSColor) {
         self.dotLayers = (0..<3).map { _ in CALayer() }
+        self.dotColor = dotColor
         super.init(frame: .zero)
         wantsLayer = true
         layer?.masksToBounds = false
 
         for (index, dot) in dotLayers.enumerated() {
-            dot.backgroundColor = dotColor.cgColor
+            dot.backgroundColor = self.dotColor.cgColor
             dot.cornerRadius = Self.dotDiameter / 2
             dot.frame = CGRect(
                 x: CGFloat(index) * (Self.dotDiameter + Self.dotSpacing),
@@ -75,7 +77,19 @@ final class TypingDotsNSView: NSView {
     }
 
     func updateColor(_ color: NSColor) {
-        for dot in dotLayers { dot.backgroundColor = color.cgColor }
+        dotColor = color
+        applyDotColor()
+    }
+
+    private func applyDotColor() {
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            for dot in dotLayers { dot.backgroundColor = dotColor.cgColor }
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyDotColor()
     }
 
     override func viewDidMoveToWindow() {

--- a/Sources/TBDApp/Sidebar/TypingDotsView.swift
+++ b/Sources/TBDApp/Sidebar/TypingDotsView.swift
@@ -6,8 +6,8 @@ import SwiftUI
 /// per-frame main-thread or SwiftUI work — unlike the `ProgressView` spinner
 /// it replaces (#266). Animations are paused while the window is occluded.
 final class TypingDotsNSView: NSView {
-    private static let dotDiameter: CGFloat = 4
-    private static let dotSpacing: CGFloat = 3
+    private static let dotDiameter: CGFloat = 3
+    private static let dotSpacing: CGFloat = 2
     private static let pulseKey = "typingPulse"
     private let dotLayers: [CALayer]
     // nonisolated(unsafe): Swift 6 deinit is nonisolated; NSView deinit

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -98,7 +98,7 @@ struct WorktreeRowView: View {
                 .frame(width: 14, height: 12)
                 .padding(.leading, -3)
                 .offset(y: 2)
-                .help("Agent is working")
+                .help(Self.suffixHelp(.working))
         case let indicator?:
             if let symbol = indicator.systemImage {
                 Image(systemName: symbol)

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -26,10 +26,7 @@ struct WorktreeRowView: View {
     }
 
     private var hasBoldNotification: Bool {
-        if let n = notification {
-            return n == .responseComplete || n == .attentionNeeded || n == .focusRequest
-        }
-        return false
+        RowStatusIndicator.shouldBoldName(notification)
     }
 
     private var prPresentation: PRStatusPresentation? {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -27,7 +27,7 @@ struct WorktreeRowView: View {
 
     private var hasBoldNotification: Bool {
         if let n = notification {
-            return n == .responseComplete
+            return n == .responseComplete || n == .attentionNeeded || n == .focusRequest
         }
         return false
     }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -95,7 +95,7 @@ struct WorktreeRowView: View {
         ) {
         case .working:
             TypingDotsView(color: SuffixRowIndicator.working.color)
-                .frame(width: 18, height: 12)
+                .frame(width: 14, height: 12)
                 .help("Agent is working")
         case let indicator?:
             if let symbol = indicator.systemImage {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -48,41 +48,11 @@ struct WorktreeRowView: View {
     }
 
     @ViewBuilder
-    private func rowIcons() -> some View {
-        // Resolved through RowStatusIndicator so at most one indicator renders.
-        // Add new indicators in RowStatusIndicator.resolve, never as stacked icons here.
-        switch RowStatusIndicator.resolve(
+    private func leadingIcon() -> some View {
+        switch RowStatusIndicator.leading(
             isPending: isPending && !isEditing,
-            isWorking: hasWorkingTerminal,
-            notification: notification,
-            isSuspended: hasSuspendedTerminal,
             hasPRStatus: prPresentation != nil
         ) {
-        case .pending:
-            // Static dotted-circle sized to match the 12×12 PR status icon.
-            Image(systemName: "circle.dotted")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 12, height: 12)
-        case .working:
-            // Static asterisk (echoes Claude's ✳ working glyph) sized to match the 12×12 PR status icon.
-            // Light: terracotta #B05730 — readable on light sidebar (~#F1F1F1).
-            // Dark:  Claude coral #D97757 — readable on dark sidebar (~#1E1E1E).
-            Image(systemName: "asterisk")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(adaptiveColor(
-                    light: NSColor(srgbRed: 176 / 255, green: 87 / 255, blue: 48 / 255, alpha: 1),
-                    dark: NSColor(srgbRed: 217 / 255, green: 119 / 255, blue: 87 / 255, alpha: 1)
-                ))
-                .frame(width: 12, height: 12)
-        case .notificationBadge(let n):
-            Circle()
-                .fill(RowStatusIndicator.badgeColor(for: n))
-                .frame(width: 8, height: 8)
-        case .suspended:
-            Image(systemName: "pause.circle.fill")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
         case .prStatus:
             if let presentation = prPresentation,
                let nsImage = loadIcon(presentation.iconName),
@@ -106,14 +76,52 @@ struct WorktreeRowView: View {
                         : nil
                 }
             }
+        case .pending:
+            Image(systemName: "circle.dotted")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 12, height: 12)
         case nil:
             EmptyView()
         }
     }
 
+    @ViewBuilder
+    private func suffixIcon() -> some View {
+        switch RowStatusIndicator.suffix(
+            notification: notification,
+            isWorking: hasWorkingTerminal,
+            isSuspended: hasSuspendedTerminal
+        ) {
+        case .working:
+            TypingDotsView(color: SuffixRowIndicator.working.color)
+                .frame(width: 16, height: 12)
+                .help("Agent is working")
+        case let indicator?:
+            if let symbol = indicator.systemImage {
+                Image(systemName: symbol)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(indicator.color)
+                    .frame(width: 12, height: 12)
+                    .help(Self.suffixHelp(indicator))
+            }
+        case nil:
+            EmptyView()
+        }
+    }
+
+    private static func suffixHelp(_ indicator: SuffixRowIndicator) -> String {
+        switch indicator {
+        case .error:     return "Error"
+        case .attention: return "Needs your attention"
+        case .working:   return "Agent is working"
+        case .suspended: return "Suspended"
+        }
+    }
+
     var body: some View {
         HStack(spacing: 6) {
-            rowIcons()
+            leadingIcon()
             RenameableLabel(
                 text: worktree.displayName,
                 isEditing: $isEditing,
@@ -159,6 +167,7 @@ struct WorktreeRowView: View {
                     }
                 }
             }
+            suffixIcon()
             if let sectionRepoID, sectionRepoID != worktree.repoID,
                let homeRepo = appState.repoName(for: worktree.repoID) {
                 let short = homeRepo.count > 5 ? String(homeRepo.prefix(5)) + "…" : homeRepo

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -95,7 +95,7 @@ struct WorktreeRowView: View {
         ) {
         case .working:
             TypingDotsView(color: SuffixRowIndicator.working.color)
-                .frame(width: 16, height: 12)
+                .frame(width: 18, height: 12)
                 .help("Agent is working")
         case let indicator?:
             if let symbol = indicator.systemImage {

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -96,6 +96,8 @@ struct WorktreeRowView: View {
         case .working:
             TypingDotsView(color: SuffixRowIndicator.working.color)
                 .frame(width: 14, height: 12)
+                .padding(.leading, -3)
+                .offset(y: 2)
                 .help("Agent is working")
         case let indicator?:
             if let symbol = indicator.systemImage {

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -3,117 +3,71 @@ import Testing
 @testable import TBDApp
 import TBDShared
 
-@Suite("RowStatusIndicator")
-struct RowStatusIndicatorTests {
-    @Test func pendingWinsOverEverything() {
-        let result = RowStatusIndicator.resolve(
-            isPending: true,
-            isWorking: true,
-            notification: .error,
-            isSuspended: true,
-            hasPRStatus: true
-        )
-        #expect(result == .pending)
-    }
-
-    @Test func workingWinsOverLowSeverityNotificationSuspendedAndPR() {
-        let result = RowStatusIndicator.resolve(
-            isPending: false,
-            isWorking: true,
-            notification: .taskComplete,
-            isSuspended: true,
-            hasPRStatus: true
-        )
-        #expect(result == .working)
-    }
-
-    @Test(arguments: [NotificationType.error, .attentionNeeded, .focusRequest])
-    func highSeverityBadgeWinsOverWorkingIcon(notification: NotificationType) {
-        let result = RowStatusIndicator.resolve(
-            isPending: false,
-            isWorking: true,
-            notification: notification,
-            isSuspended: false,
-            hasPRStatus: true
-        )
-        #expect(result == .notificationBadge(notification))
-    }
-
-    @Test(arguments: [NotificationType.taskComplete, .responseComplete])
-    func lowSeverityBadgeYieldsToWorkingIcon(notification: NotificationType) {
-        let result = RowStatusIndicator.resolve(
-            isPending: false,
-            isWorking: true,
-            notification: notification,
-            isSuspended: false,
-            hasPRStatus: false
-        )
-        #expect(result == .working)
-    }
-
-    @Test func pendingWinsOverHighSeverityBadge() {
-        let result = RowStatusIndicator.resolve(
-            isPending: true,
-            isWorking: false,
-            notification: .error,
-            isSuspended: false,
-            hasPRStatus: false
-        )
-        #expect(result == .pending)
-    }
-
-    @Test func workingIconHidesPRStatus() {
-        let result = RowStatusIndicator.resolve(
-            isPending: false,
-            isWorking: true,
-            notification: nil,
-            isSuspended: false,
-            hasPRStatus: true
-        )
-        #expect(result == .working)
-    }
-
-    @Test func notificationWinsOverSuspendedAndPR() {
-        let result = RowStatusIndicator.resolve(
-            isPending: false,
-            isWorking: false,
-            notification: .responseComplete,
-            isSuspended: true,
-            hasPRStatus: true
-        )
-        #expect(result == .notificationBadge(.responseComplete))
-    }
-
-    @Test func suspendedWinsOverPR() {
-        let result = RowStatusIndicator.resolve(
-            isPending: false,
-            isWorking: false,
-            notification: nil,
-            isSuspended: true,
-            hasPRStatus: true
-        )
-        #expect(result == .suspended)
+@Suite("RowStatusIndicator.leading")
+struct LeadingRowIndicatorTests {
+    @Test func prStatusWinsOverPending() {
+        #expect(RowStatusIndicator.leading(isPending: true, hasPRStatus: true) == .prStatus)
     }
 
     @Test func prStatusAlone() {
-        let result = RowStatusIndicator.resolve(
-            isPending: false,
-            isWorking: false,
-            notification: nil,
-            isSuspended: false,
-            hasPRStatus: true
-        )
-        #expect(result == .prStatus)
+        #expect(RowStatusIndicator.leading(isPending: false, hasPRStatus: true) == .prStatus)
     }
 
-    @Test func nothingSetReturnsNil() {
-        let result = RowStatusIndicator.resolve(
-            isPending: false,
-            isWorking: false,
-            notification: nil,
-            isSuspended: false,
-            hasPRStatus: false
-        )
-        #expect(result == nil)
+    @Test func pendingWhenNoPR() {
+        #expect(RowStatusIndicator.leading(isPending: true, hasPRStatus: false) == .pending)
+    }
+
+    @Test func nothingLeading() {
+        #expect(RowStatusIndicator.leading(isPending: false, hasPRStatus: false) == nil)
+    }
+}
+
+@Suite("RowStatusIndicator.suffix")
+struct SuffixRowIndicatorTests {
+    @Test func errorOutranksEverything() {
+        #expect(RowStatusIndicator.suffix(notification: .error, isWorking: true, isSuspended: true) == .error)
+    }
+
+    @Test(arguments: [NotificationType.attentionNeeded, .focusRequest])
+    func attentionFromAttentionAndFocus(notification: NotificationType) {
+        #expect(RowStatusIndicator.suffix(notification: notification, isWorking: true, isSuspended: true) == .attention)
+    }
+
+    @Test func errorOutranksAttentionSource() {
+        // A single notification is one type; verify error type beats working/suspended.
+        #expect(RowStatusIndicator.suffix(notification: .error, isWorking: false, isSuspended: false) == .error)
+    }
+
+    @Test func workingWhenNoErrorOrAttention() {
+        #expect(RowStatusIndicator.suffix(notification: nil, isWorking: true, isSuspended: true) == .working)
+    }
+
+    @Test(arguments: [NotificationType.taskComplete, .responseComplete])
+    func completionNotificationsDoNotProduceSuffix(notification: NotificationType) {
+        // taskComplete -> nothing; responseComplete -> bold name (handled in view), no suffix.
+        #expect(RowStatusIndicator.suffix(notification: notification, isWorking: false, isSuspended: false) == nil)
+    }
+
+    @Test func completionNotificationYieldsToWorking() {
+        #expect(RowStatusIndicator.suffix(notification: .responseComplete, isWorking: true, isSuspended: false) == .working)
+    }
+
+    @Test func completionNotificationYieldsToSuspended() {
+        #expect(RowStatusIndicator.suffix(notification: .taskComplete, isWorking: false, isSuspended: true) == .suspended)
+    }
+
+    @Test func suspendedWhenIdle() {
+        #expect(RowStatusIndicator.suffix(notification: nil, isWorking: false, isSuspended: true) == .suspended)
+    }
+
+    @Test func nothingSuffix() {
+        #expect(RowStatusIndicator.suffix(notification: nil, isWorking: false, isSuspended: false) == nil)
+    }
+
+    @Test func glyphMapping() {
+        #expect(SuffixRowIndicator.error.systemImage == "exclamationmark.octagon.fill")
+        #expect(SuffixRowIndicator.attention.systemImage == "hand.raised.fill")
+        #expect(SuffixRowIndicator.suspended.systemImage == "pause.circle.fill")
+        #expect(SuffixRowIndicator.working.systemImage == nil)
     }
 }

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -71,3 +71,20 @@ struct SuffixRowIndicatorTests {
         #expect(SuffixRowIndicator.working.systemImage == nil)
     }
 }
+
+@Suite("RowStatusIndicator.shouldBoldName")
+struct ShouldBoldNameTests {
+    @Test(arguments: [NotificationType.responseComplete, .attentionNeeded, .focusRequest])
+    func boldsForResponseAndAttention(notification: NotificationType) {
+        #expect(RowStatusIndicator.shouldBoldName(notification) == true)
+    }
+
+    @Test(arguments: [NotificationType.error, .taskComplete])
+    func doesNotBoldForErrorOrTaskComplete(notification: NotificationType) {
+        #expect(RowStatusIndicator.shouldBoldName(notification) == false)
+    }
+
+    @Test func doesNotBoldForNoNotification() {
+        #expect(RowStatusIndicator.shouldBoldName(nil) == false)
+    }
+}

--- a/Tests/TBDAppTests/TypingDotsViewTests.swift
+++ b/Tests/TBDAppTests/TypingDotsViewTests.swift
@@ -1,0 +1,19 @@
+import AppKit
+import Testing
+
+@testable import TBDApp
+
+@Suite("TypingDotsView")
+struct TypingDotsViewTests {
+    @MainActor
+    @Test func nsViewIsLayerBackedWithThreeAnimatedDots() {
+        let view = TypingDotsNSView(dotColor: .systemRed)
+        #expect(view.wantsLayer)
+        let dots = view.layer?.sublayers ?? []
+        #expect(dots.count == 3)
+        // Each dot carries a repeating opacity animation added at construction.
+        for dot in dots {
+            #expect(dot.animation(forKey: "typingPulse") != nil)
+        }
+    }
+}

--- a/docs/superpowers/specs/2026-06-30-worktree-row-icon-untangle-design.md
+++ b/docs/superpowers/specs/2026-06-30-worktree-row-icon-untangle-design.md
@@ -63,7 +63,9 @@ mutually exclusive in practice:
 ### Name
 
 - **Bold** when the unread notification is `responseComplete` (replaces the
-  blue dot). Otherwise regular weight. Existing `hasBoldNotification` logic and
+  blue dot) **or the worktree needs attention** (`attentionNeeded` /
+  `focusRequest` — bold tracks the attention suffix so the two read
+  consistently). Otherwise regular weight. The `hasBoldNotification` logic and
   the truncation-measurement font weight stay in sync with this.
 
 ### Activity suffix — single priority-resolved slot (trailing)
@@ -74,17 +76,23 @@ Resolved highest-first; renders at most one:
 | --- | --- | --- | --- |
 | 1 | error | `exclamationmark.octagon.fill` | red (adaptive) |
 | 2 | attention — `attentionNeeded` **or** `focusRequest` | `hand.raised.fill` | amber (adaptive) |
-| 3 | working — any terminal `activityState == .working` | **dancing dots** (CALayer animation) | terracotta/coral (same adaptive pair as today's asterisk) |
+| 3 | working — any terminal `activityState == .working` | **dancing dots** (CALayer animation), small (3px dots / 2px gap), nudged closer to the name and slightly lower | `.secondary` gray (revised from coral after live review — coral read as too loud) |
 | 4 | suspended — any terminal `suspendedAt != nil` | `pause.circle.fill` | `.secondary` (**unchanged glyph + color**) |
 | — | none | — | — |
+
+> **Live-review revisions (2026-06-30):** the working dots were changed from
+> the terracotta/coral pair to `.secondary` gray and made smaller, then nudged
+> `-3px` toward the name and `+2px` down; and the name now also bolds for the
+> attention state (not just `responseComplete`). The tables above reflect the
+> shipped result.
 
 ### Notification mapping (replaces `badgeColor(for:)`)
 
 | `NotificationType` | Old (dot) | New |
 | --- | --- | --- |
 | `error` (sev 4) | red dot | error suffix (octagon) |
-| `attentionNeeded` (sev 3) | orange dot | attention suffix (hand) |
-| `focusRequest` (sev 3) | orange dot | attention suffix (hand) |
+| `attentionNeeded` (sev 3) | orange dot | attention suffix (hand) **+ bold name** |
+| `focusRequest` (sev 3) | orange dot | attention suffix (hand) **+ bold name** |
 | `taskComplete` (sev 2) | green dot | **nothing** |
 | `responseComplete` (sev 1) | blue dot | **bold name only** |
 

--- a/docs/superpowers/specs/2026-06-30-worktree-row-icon-untangle-design.md
+++ b/docs/superpowers/specs/2026-06-30-worktree-row-icon-untangle-design.md
@@ -129,8 +129,10 @@ reintroduce the main-thread cost.
 work for working rows. This is cheap insurance; the core correctness does not
 depend on it.
 
-Dot color uses the same `adaptiveColor(light:dark:)` pair as today's working
-asterisk (terracotta `#B05730` light / coral `#D97757` dark).
+Dot color is `.secondary` gray (revised from the original terracotta/coral
+during live review — see the "Live-review revisions" note above). The
+`NSColor` is re-baked on `viewDidChangeEffectiveAppearance()` so the dots track
+a live light↔dark switch.
 
 ## Components
 
@@ -168,7 +170,13 @@ Per the repo rule "add a test for each branch of a gating conditional":
 - **`suffixIndicator`** priority: `error ≻ attention ≻ working ≻ suspended`;
   `focusRequest` resolves to `.attention`; `taskComplete` ⇒ `nil`;
   `responseComplete` ⇒ `nil` (suffix); no state ⇒ `nil`.
-- **Bold name**: `responseComplete` ⇒ bold; every other type ⇒ regular.
+- **Bold name** (`RowStatusIndicator.shouldBoldName`, shared by the sidebar
+  row and the jump menu): `responseComplete` / `attentionNeeded` /
+  `focusRequest` ⇒ bold; `error` / `taskComplete` / none ⇒ regular. Covered by
+  `ShouldBoldNameTests`.
+- **Jump menu** (`JumpMenuRow`): the old colored severity dot is removed too;
+  it now bolds the name and shows the same error/attention suffix glyph via the
+  shared resolver, so the two views stay consistent.
 - **`TypingDotsView`** smoke test: constructs, is layer-backed, holds no
   SwiftUI `@State`. Animation smoothness + the occlusion pause/resume are
   verified live (headless tests can't see CA render-server output).

--- a/docs/superpowers/specs/2026-06-30-worktree-row-icon-untangle-design.md
+++ b/docs/superpowers/specs/2026-06-30-worktree-row-icon-untangle-design.md
@@ -1,0 +1,177 @@
+# Worktree Row Icon Untangle — Design
+
+**Date:** 2026-06-30
+**Status:** Approved (design), pending implementation plan
+
+## Problem
+
+The per-worktree sidebar row has a single icon slot resolved by a strict
+priority chain (`RowStatusIndicator.resolve`). That one slot is asked to
+express three orthogonal axes at once:
+
+1. **Lifecycle** — creating, suspended
+2. **Activity / attention** — working, plus four notification severities
+3. **PR status** — eight states
+
+Because they share one slot, a higher-priority axis *hides* the others. The
+most painful consequence: **PR status is lowest priority, so it disappears
+whenever the agent is working, suspended, or has an unread notification** —
+even though the PR icon is the most useful thing to click. On top of that,
+four differently-colored notification dots (red/orange/green/blue) require the
+user to memorize a color→meaning map.
+
+## Goals
+
+- **PR icon is always visible and clickable**, independent of all other state.
+- **Remove all colored notification dots** — no color-memorization.
+- Replace the dots with self-explanatory treatments: bold name, or a glyph
+  suffix whose *shape* carries the meaning.
+- Replace the static `asterisk` working glyph with a **dancing-dots typing
+  animation** that does **not** reintroduce the CPU cost that got the previous
+  `ProgressView` spinner removed (#266).
+- Keep the suspended indicator's glyph and color exactly as they are today.
+
+## Non-goals
+
+- Redesigning PR-state icons/colors (`PRStatusPresentation` is unchanged).
+- Changing repo-header decorations, hierarchy guides, selection, hover "+",
+  or the home-repo tag.
+- Changing notification *generation* in the daemon — only how the app
+  *presents* existing `NotificationType` values on a row.
+
+## Design
+
+### New layout
+
+```
+[leading icon]  Worktree name  [activity suffix]  (repo)
+```
+
+Two independent regions replace the single shared slot.
+
+### Leading icon — identity / PR (clickable)
+
+Pulled out of the shared priority chain so it is never suppressed. Cases are
+mutually exclusive in practice:
+
+| Condition | Rendering |
+| --- | --- |
+| PR exists and `!isMain` | PR status icon — clickable `Button`, hover tooltip, colored by `PRStatusPresentation`. **Unchanged** styling/behavior; only no longer gated by other state. |
+| `status == .creating` (and not editing) | `circle.dotted`, `.secondary`, 12×12 (a creating worktree has no PR yet, so no conflict). |
+| otherwise | empty |
+
+### Name
+
+- **Bold** when the unread notification is `responseComplete` (replaces the
+  blue dot). Otherwise regular weight. Existing `hasBoldNotification` logic and
+  the truncation-measurement font weight stay in sync with this.
+
+### Activity suffix — single priority-resolved slot (trailing)
+
+Resolved highest-first; renders at most one:
+
+| Priority | State | Glyph | Color |
+| --- | --- | --- | --- |
+| 1 | error | `exclamationmark.octagon.fill` | red (adaptive) |
+| 2 | attention — `attentionNeeded` **or** `focusRequest` | `hand.raised.fill` | amber (adaptive) |
+| 3 | working — any terminal `activityState == .working` | **dancing dots** (CALayer animation) | terracotta/coral (same adaptive pair as today's asterisk) |
+| 4 | suspended — any terminal `suspendedAt != nil` | `pause.circle.fill` | `.secondary` (**unchanged glyph + color**) |
+| — | none | — | — |
+
+### Notification mapping (replaces `badgeColor(for:)`)
+
+| `NotificationType` | Old (dot) | New |
+| --- | --- | --- |
+| `error` (sev 4) | red dot | error suffix (octagon) |
+| `attentionNeeded` (sev 3) | orange dot | attention suffix (hand) |
+| `focusRequest` (sev 3) | orange dot | attention suffix (hand) |
+| `taskComplete` (sev 2) | green dot | **nothing** |
+| `responseComplete` (sev 1) | blue dot | **bold name only** |
+
+The colored `Circle()` badge case is removed entirely.
+
+### Working-state animation — CPU-safe dancing dots
+
+**Why the old one was removed:** the previous indicator was a SwiftUI
+`ProgressView()` spinner. Per #266 / `cdd0cea` and the 2026-06-11 CPU
+investigation, it "forced continuous CoreAnimation commits on the main thread"
+— ~10% of a core *per working row*, because in a SwiftUI hosting context every
+animated frame drags in `GraphHost.flushTransactions`.
+
+**How the new one avoids it:** a `TypingDotsView: NSViewRepresentable`
+wrapping a layer-backed `NSView`:
+
+- 3 small `CALayer` dots laid out horizontally (~3 px each).
+- One `CAKeyframeAnimation` on `opacity` (e.g. 0.3 → 1.0 → 0.3),
+  `repeatCount = .infinity`, duration ~1.2 s, staggered via `beginTime`
+  (0 / 0.2 / 0.4 s) for the typing "wave".
+- Animations are added **once** in `makeNSView` and never touched again.
+
+A committed `CAAnimation` runs on the **render server (a separate process)** —
+no per-frame main-thread work, no SwiftUI body re-evaluation, no
+`flushTransactions`. The render server only recomposites the dirty ~12×12
+region. This is categorically different from `ProgressView`,
+`Timer`+`@State`, or `withAnimation(.repeatForever)`, all of which would
+reintroduce the main-thread cost.
+
+**Visibility guard:** observe `NSWindow.didChangeOcclusionStateNotification`
+(and view `window` membership); pause the layer animation
+(`layer.speed = 0`) when the window is occluded/miniaturized and resume
+(`layer.speed = 1`) when visible, so a backgrounded TBD does no render-server
+work for working rows. This is cheap insurance; the core correctness does not
+depend on it.
+
+Dot color uses the same `adaptiveColor(light:dark:)` pair as today's working
+asterisk (terracotta `#B05730` light / coral `#D97757` dark).
+
+## Components
+
+1. **`RowStatusIndicator`** (`Sources/TBDApp/Sidebar/RowStatusIndicator.swift`)
+   — refactor the single `resolve(...)` into two pure resolvers:
+   - `leadingIndicator(isPending:hasPRStatus:) -> Leading?` → `.pending` |
+     `.prStatus` | `nil`
+   - `suffixIndicator(notification:isWorking:isSuspended:) -> Suffix?` →
+     `.error` | `.attention` | `.working` | `.suspended` | `nil`
+
+   `badgeColor(for:)` is removed. Suffix glyph/color live in the view (or a
+   small presentation helper), mirroring how `PRStatusPresentation` is
+   structured.
+
+2. **`TypingDotsView`** (new, `Sources/TBDApp/Sidebar/`) —
+   `NSViewRepresentable` described above. No SwiftUI state; `updateNSView` is
+   a no-op (or only toggles color on appearance change).
+
+3. **`WorktreeRowView`** (`Sources/TBDApp/Sidebar/WorktreeRowView.swift`) —
+   restructure the `HStack` into leading icon → name → suffix. `rowIcons()`
+   splits into `leadingIcon()` and `suffixIcon()`. Bold-name logic and the
+   truncation measurement are unchanged. Remove the `.notificationBadge`
+   `Circle()` rendering.
+
+4. **Color helpers** — amber-attention and red-error adaptive pairs via the
+   existing `adaptiveColor(light:dark:)`.
+
+## Testing
+
+Per the repo rule "add a test for each branch of a gating conditional":
+
+- **`leadingIndicator`**: PR present ⇒ `.prStatus` regardless of working /
+  suspended / any notification; creating + no PR ⇒ `.pending`; neither ⇒ `nil`;
+  `isMain` suppression verified at the call site (PR hidden on main).
+- **`suffixIndicator`** priority: `error ≻ attention ≻ working ≻ suspended`;
+  `focusRequest` resolves to `.attention`; `taskComplete` ⇒ `nil`;
+  `responseComplete` ⇒ `nil` (suffix); no state ⇒ `nil`.
+- **Bold name**: `responseComplete` ⇒ bold; every other type ⇒ regular.
+- **`TypingDotsView`** smoke test: constructs, is layer-backed, holds no
+  SwiftUI `@State`. Animation smoothness + the occlusion pause/resume are
+  verified live (headless tests can't see CA render-server output).
+
+## Risks / notes
+
+- **Two regions can now co-occur** (e.g. PR icon + working dots). That is the
+  intended untangling; it is bounded — leading is one icon, suffix is one icon.
+- **Live verification required** for the animation and overall row look — per
+  project experience, transcript/sidebar visual + animation behavior is
+  LIVE-only; a green headless test does not prove the dots animate or that CPU
+  stays flat. Verify via `scripts/restart.sh`, eyes on the sidebar, and a CPU
+  sample of a working row (compare against the static-asterisk baseline).
+- `PRStatusPresentation` and the suspended glyph are deliberately untouched.


### PR DESCRIPTION
## Summary

The per-worktree sidebar row had a **single icon slot** resolved by a strict priority chain, asked to express three orthogonal axes at once — lifecycle (creating/suspended), activity (working + four notification severities), and PR status. Because they shared one slot, a higher-priority axis *hid* the others. Worst of all, **PR status was lowest priority**, so the most useful thing to click vanished whenever an agent was working, suspended, or had an unread notification — and four differently-colored dots forced you to memorize a color→meaning map.

This splits the row into two independent regions:

- **Leading icon — PR status, always visible & clickable** (or the `circle.dotted` creating glyph). No longer suppressed by anything; suppressed only on the main worktree.
- **Trailing activity suffix — one priority-resolved slot:** `error` > `attention` > `working` > `suspended`.
  - `error` → `exclamationmark.octagon.fill` (red)
  - `attention` (`attentionNeeded`/`focusRequest`) → `hand.raised.fill` (amber) **+ bold name**
  - `working` → **render-server dancing dots** (gray, small)
  - `suspended` → `pause.circle.fill` (unchanged)
- **All colored notification dots removed.** `responseComplete` → bold name; `taskComplete` → nothing.

**The dancing-dots animation is CPU-safe.** The previous working indicator was a SwiftUI `ProgressView` spinner, removed in #266 because it forced continuous CoreAnimation commits on the main thread (~10% of a core *per working row* via `GraphHost.flushTransactions`). The new `TypingDotsView` is a layer-backed `NSView` whose `CAKeyframeAnimation`s are committed once and run entirely on the Core Animation **render server** — zero per-frame main-thread / SwiftUI work — and pause when the window is occluded.

Resolver logic is split into two pure functions (`RowStatusIndicator.leading` / `.suffix`) with full per-branch test coverage. Design doc: `docs/superpowers/specs/2026-06-30-worktree-row-icon-untangle-design.md`.

## Test plan

- [x] `swift build` clean, `swift test` green (1869 tests)
- [x] Live-verified via `scripts/restart.sh`: PR icon stays visible/clickable while an agent works; dancing dots animate (gray, small); attention shows hand icon + bold name; suspended unchanged; no colored dots
- [ ] Confirm CPU stays flat on a working row (no `ProgressView`-era regression)
- [ ] Confirm dots track a live light↔dark theme switch

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=63276AD0-437F-4FDA-ADA5-3BE3D4180EBB)