### PR TITLE
Fix: Stop oh-my-zsh update prompts from blocking preSession and setup hook tabs

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -573,6 +573,10 @@ extension WorktreeLifecycle {
             appHookPath: TBDConstants.hookPath(repoID: worktree.repoID, eventName: HookEvent.setup.rawValue)
         )
         let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
+        // Suppress the omz update prompt only when a setup hook actually
+        // resolves — a hook-less "Setup" tab is just a regular shell and must
+        // keep oh-my-zsh update checks (see `hookPaneEnv`).
+        let setupSensitiveEnv = setupHookPath != nil ? Self.hookPaneEnv : [:]
         // Full hook environment per docs/worktree-hooks.md (matches the
         // preSession and archive hooks). TBD_WORKTREE_NAME uses
         // `worktree.name` for consistency with the archive hook's env.
@@ -591,7 +595,7 @@ extension WorktreeLifecycle {
             cwd: worktreePath,
             shellCommand: setupCommand,
             env: setupEnv,
-            sensitiveEnv: Self.hookPaneEnv,
+            sensitiveEnv: setupSensitiveEnv,
             cols: resolvedCols,
             rows: resolvedRows
         )

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -591,6 +591,7 @@ extension WorktreeLifecycle {
             cwd: worktreePath,
             shellCommand: setupCommand,
             env: setupEnv,
+            sensitiveEnv: Self.hookPaneEnv,
             cols: resolvedCols,
             rows: resolvedRows
         )

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -68,7 +68,9 @@ extension WorktreeLifecycle {
     /// "Would you like to update?" prompt that would otherwise block the hook
     /// command until the user answers or the preSession wait times out.
     /// Deliberately per-window (never `setenv -g`): regular shell/claude/codex
-    /// tabs must keep omz update checks.
+    /// tabs must keep omz update checks. Callers apply it only when the hook
+    /// actually resolves — a hook-less "Setup" tab is a plain shell and keeps
+    /// update checks.
     static let hookPaneEnv: [String: String] = ["DISABLE_AUTO_UPDATE": "true"]
 
     /// Wraps the hook so its exit code lands in the marker file and the pane

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -57,6 +57,20 @@ extension WorktreeLifecycle {
             .appendingPathComponent(worktreeID.uuidString)
     }
 
+    /// Environment for hook panes (preSession + setup), routed through
+    /// `createWindow(sensitiveEnv:)` so tmux injects it with `-e KEY=VALUE` —
+    /// i.e. into the PROCESS environment before zsh starts. The regular
+    /// `env:` dict is inlined as `export KEY='V'; ` statements inside the
+    /// `-c` command string, which runs AFTER `.zshrc` completes, so it cannot
+    /// affect anything the rc files do. oh-my-zsh's tools/check_for_upgrade.sh
+    /// honors the legacy `DISABLE_AUTO_UPDATE` var (mapped to
+    /// `zstyle ':omz:update' mode disabled`), so this skips its interactive
+    /// "Would you like to update?" prompt that would otherwise block the hook
+    /// command until the user answers or the preSession wait times out.
+    /// Deliberately per-window (never `setenv -g`): regular shell/claude/codex
+    /// tabs must keep omz update checks.
+    static let hookPaneEnv: [String: String] = ["DISABLE_AUTO_UPDATE": "true"]
+
     /// Wraps the hook so its exit code lands in the marker file and the pane
     /// stays alive as a usable shell afterward (same rationale as
     /// `shellWrapped`). Single-quote escaping matches `shellWrapped`.
@@ -137,6 +151,7 @@ extension WorktreeLifecycle {
             cwd: worktreePath,
             shellCommand: command,
             env: env,
+            sensitiveEnv: Self.hookPaneEnv,
             cols: resolvedCols,
             rows: resolvedRows
         )

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -105,12 +105,18 @@ public struct TmuxManager: Sendable {
             envPrefix += "export \(key)='\(escaped)'; "
         }
         let fullCommand = envPrefix.isEmpty ? shellCommand : "\(envPrefix)\(shellCommand)"
-        // Sensitive env vars use tmux's -e KEY=VALUE flag so the secret is set in
-        // the spawned window's environment directly, NOT inlined into the shell
-        // command argv. This keeps the secret out of `ps aux` for the
-        // long-running shell/claude process. (The secret still appears briefly
-        // in the tmux invocation's own argv during fork/exec, but tmux re-execs
-        // and its server process does not retain the original argv visibly.)
+        // `sensitiveEnv` carries values that must be in the spawned window's
+        // PROCESS environment before the shell starts, via tmux's -e KEY=VALUE
+        // flag — NOT inlined into the shell command argv like `env` above.
+        // Two kinds of callers rely on this:
+        //   - secrets: keeps the value out of `ps aux` for the long-running
+        //     shell/claude process. (The secret still appears briefly in the
+        //     tmux invocation's own argv during fork/exec, but tmux re-execs
+        //     and its server process does not retain the original argv
+        //     visibly.)
+        //   - rc-affecting toggles (e.g. DISABLE_AUTO_UPDATE on hook panes):
+        //     the `env` export-prefix runs after `.zshrc` completes, so only
+        //     -e values are visible while rc files execute.
         var eFlags: [String] = []
         for (key, value) in sensitiveEnv.sorted(by: { $0.key < $1.key }) {
             eFlags.append("-e")

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -215,6 +215,12 @@ struct PreSessionHookTests {
                 "first window must be the primary agent")
         #expect(windowCalls[1].last?.contains("claude --session-id") == false,
                 "second window must be the setup hook/shell")
+        // omz-update suppression is scoped to HOOK panes: the setup window
+        // gets `-e DISABLE_AUTO_UPDATE=true`, the primary agent does not.
+        #expect(!windowCalls[0].contains("DISABLE_AUTO_UPDATE=true"),
+                "primary terminal must keep oh-my-zsh update checks")
+        #expect(hasProcessEnvFlag(windowCalls[1], "DISABLE_AUTO_UPDATE=true"),
+                "setup hook window must suppress the oh-my-zsh update prompt via -e")
         // Setup window carries the full documented hook env even with no
         // preSession hook present.
         let setupBody = windowCalls[1].last ?? ""
@@ -305,6 +311,11 @@ struct PreSessionHookTests {
         #expect(body.contains("export TBD_WORKTREE_PATH='\(createdWt.path)'"))
         #expect(body.contains("export TBD_REPO_PATH='\(repo.path)'"))
         #expect(body.contains("export TBD_BRANCH='\(createdWt.branch)'"))
+        // The pre-session window must carry `-e DISABLE_AUTO_UPDATE=true` so
+        // oh-my-zsh's updater prompt (fired by .zshrc, BEFORE the -c command
+        // and its export-prefix run) can't block the hook.
+        #expect(hasProcessEnvFlag(windowCalls[0], "DISABLE_AUTO_UPDATE=true"),
+                "pre-session hook window must suppress the oh-my-zsh update prompt via -e")
 
         // Still gated while the marker is absent.
         try await Task.sleep(nanoseconds: 200_000_000)
@@ -334,6 +345,11 @@ struct PreSessionHookTests {
         // (TBD_EVENT=setup) — windows are [pre-session, claude, setup].
         let allWindowCalls = recorder.snapshot().filter { $0.contains("new-window") }
         #expect(allWindowCalls.count == 3)
+        // Hook panes suppress the omz updater; the primary agent doesn't.
+        #expect(!allWindowCalls[1].contains("DISABLE_AUTO_UPDATE=true"),
+                "primary terminal must keep oh-my-zsh update checks")
+        #expect(hasProcessEnvFlag(allWindowCalls[2], "DISABLE_AUTO_UPDATE=true"),
+                "setup hook window must suppress the oh-my-zsh update prompt via -e")
         let setupBody = allWindowCalls[2].last ?? ""
         #expect(setupBody.contains("export TBD_EVENT='setup'"))
         #expect(setupBody.contains("export TBD_TERMINAL_ID='\(setup.id.uuidString)'"))
@@ -1176,6 +1192,14 @@ struct PreSessionHookTests {
 }
 
 // MARK: - Helpers
+
+/// True when `args` sets `assignment` in the spawned window's process
+/// environment via tmux's `-e KEY=VALUE` flag (adjacency required — a bare
+/// substring match could false-positive on the shell command body).
+private func hasProcessEnvFlag(_ args: [String], _ assignment: String) -> Bool {
+    guard let index = args.firstIndex(of: assignment), index > 0 else { return false }
+    return args[index - 1] == "-e"
+}
 
 /// Thread-safe collector for TmuxManager dryRun recorded args.
 private final class RecordedCommands: @unchecked Sendable {

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -27,21 +27,28 @@ struct PreSessionHookTests {
         })
     }
 
-    /// Writes an executable `.worktree-hooks/preSession` into the repo and
+    /// Writes an executable `.worktree-hooks/<name>` into the repo and
     /// commits it so fresh worktree checkouts contain it.
     @discardableResult
-    private func installPreSessionHook(
-        repoDir: URL, script: String = "#!/bin/sh\nexit 0\n"
+    private func installHook(
+        named name: String, repoDir: URL, script: String = "#!/bin/sh\nexit 0\n"
     ) async throws -> String {
         let hooksDir = repoDir.appendingPathComponent(".worktree-hooks")
         try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
-        let hookPath = hooksDir.appendingPathComponent("preSession")
+        let hookPath = hooksDir.appendingPathComponent(name)
         try script.write(to: hookPath, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o755], ofItemAtPath: hookPath.path
         )
-        try await shell("git add -A && git commit -m 'add preSession hook'", at: repoDir)
+        try await shell("git add -A && git commit -m 'add \(name) hook'", at: repoDir)
         return hookPath.path
+    }
+
+    @discardableResult
+    private func installPreSessionHook(
+        repoDir: URL, script: String = "#!/bin/sh\nexit 0\n"
+    ) async throws -> String {
+        try await installHook(named: "preSession", repoDir: repoDir, script: script)
     }
 
     private func makeLifecycle(
@@ -215,12 +222,13 @@ struct PreSessionHookTests {
                 "first window must be the primary agent")
         #expect(windowCalls[1].last?.contains("claude --session-id") == false,
                 "second window must be the setup hook/shell")
-        // omz-update suppression is scoped to HOOK panes: the setup window
-        // gets `-e DISABLE_AUTO_UPDATE=true`, the primary agent does not.
+        // omz-update suppression is scoped to windows that actually run a
+        // hook: with no setup hook configured, the "Setup" tab is a plain
+        // shell and must keep update checks, same as the primary agent.
         #expect(!windowCalls[0].contains("DISABLE_AUTO_UPDATE=true"),
                 "primary terminal must keep oh-my-zsh update checks")
-        #expect(hasProcessEnvFlag(windowCalls[1], "DISABLE_AUTO_UPDATE=true"),
-                "setup hook window must suppress the oh-my-zsh update prompt via -e")
+        #expect(!windowCalls[1].contains("DISABLE_AUTO_UPDATE=true"),
+                "hook-less setup tab is a regular shell and must keep omz update checks")
         // Setup window carries the full documented hook env even with no
         // preSession hook present.
         let setupBody = windowCalls[1].last ?? ""
@@ -234,6 +242,35 @@ struct PreSessionHookTests {
         #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [claude.id, setup.id])
         #expect(try await db.worktrees.getActiveTabID(worktreeID: wt.id) == claude.id)
         #expect(try await db.notifications.unread(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test func setupHookWindowSuppressesOmzUpdatePrompt() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = RecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installHook(named: "setup", repoDir: repoDir)
+
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: false)
+        #expect(wt.status == .active)
+
+        // Windows: [claude, setup]. With a setup hook resolved, the setup
+        // window must carry `-e DISABLE_AUTO_UPDATE=true` (process env, set
+        // before .zshrc runs) so the omz updater prompt can't delay the hook;
+        // the primary agent window must not.
+        let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
+        #expect(windowCalls.count == 2)
+        #expect(!windowCalls[0].contains("DISABLE_AUTO_UPDATE=true"),
+                "primary terminal must keep oh-my-zsh update checks")
+        #expect(hasProcessEnvFlag(windowCalls[1], "DISABLE_AUTO_UPDATE=true"),
+                "setup hook window must suppress the oh-my-zsh update prompt via -e")
+        #expect(windowCalls[1].last?.contains(".worktree-hooks/setup") == true,
+                "second window must run the setup hook")
     }
 
     @Test func noHookCreateFailureStillDeletesRow() async throws {
@@ -345,11 +382,13 @@ struct PreSessionHookTests {
         // (TBD_EVENT=setup) — windows are [pre-session, claude, setup].
         let allWindowCalls = recorder.snapshot().filter { $0.contains("new-window") }
         #expect(allWindowCalls.count == 3)
-        // Hook panes suppress the omz updater; the primary agent doesn't.
+        // Only windows that actually run a hook suppress the omz updater:
+        // this fixture has no setup hook, so the "Setup" tab is a plain shell
+        // and keeps update checks, same as the primary agent.
         #expect(!allWindowCalls[1].contains("DISABLE_AUTO_UPDATE=true"),
                 "primary terminal must keep oh-my-zsh update checks")
-        #expect(hasProcessEnvFlag(allWindowCalls[2], "DISABLE_AUTO_UPDATE=true"),
-                "setup hook window must suppress the oh-my-zsh update prompt via -e")
+        #expect(!allWindowCalls[2].contains("DISABLE_AUTO_UPDATE=true"),
+                "hook-less setup tab is a regular shell and must keep omz update checks")
         let setupBody = allWindowCalls[2].last ?? ""
         #expect(setupBody.contains("export TBD_EVENT='setup'"))
         #expect(setupBody.contains("export TBD_TERMINAL_ID='\(setup.id.uuidString)'"))

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -61,6 +61,35 @@ import Testing
     #expect(args.contains("claude --dangerously-skip-permissions"))
 }
 
+@Test func testNewWindowCommandSensitiveEnvUsesEFlag() {
+    // sensitiveEnv must land in the process environment via tmux's
+    // `-e KEY=VALUE` flag (visible while .zshrc runs), never as an
+    // `export` prefix inside the -c command string (which runs after).
+    let args = TmuxManager.newWindowCommand(
+        server: "tbd-a1b2c3d4",
+        session: "main",
+        cwd: "/tmp/worktree",
+        shellCommand: "echo hi",
+        sensitiveEnv: ["DISABLE_AUTO_UPDATE": "true"]
+    )
+    let index = args.firstIndex(of: "DISABLE_AUTO_UPDATE=true")
+    #expect(index != nil)
+    if let index, index > 0 {
+        #expect(args[index - 1] == "-e")
+    }
+    #expect(args.last == "echo hi",
+            "sensitiveEnv must not be exported inside the shell command")
+
+    // Without sensitiveEnv, no -e flag is emitted at all.
+    let plain = TmuxManager.newWindowCommand(
+        server: "tbd-a1b2c3d4",
+        session: "main",
+        cwd: "/tmp/worktree",
+        shellCommand: "echo hi"
+    )
+    #expect(!plain.contains("-e"))
+}
+
 @Test func testKillWindowCommand() {
     let args = TmuxManager.killWindowCommand(
         server: "tbd-a1b2c3d4",

--- a/docs/worktree-hooks.md
+++ b/docs/worktree-hooks.md
@@ -43,7 +43,7 @@ Hooks run with `cwd` set to the worktree path and receive these environment vari
 
 Hooks have a 60-second timeout (`preSession`: 600 seconds). A non-zero exit status is logged but does not block the lifecycle action.
 
-`preSession` and `setup` terminals additionally run with `DISABLE_AUTO_UPDATE=true` in their process environment, so oh-my-zsh's interactive "Would you like to update?" prompt can't block the hook. Regular shell/agent tabs are unaffected and keep omz update checks.
+`preSession` and `setup` hook terminals additionally run with `DISABLE_AUTO_UPDATE=true` in their process environment, so oh-my-zsh's interactive "Would you like to update?" prompt can't block the hook. This applies only when the hook actually exists — a hook-less "Setup" tab is a plain shell — and regular shell/agent tabs are unaffected and keep omz update checks.
 
 ## Example
 

--- a/docs/worktree-hooks.md
+++ b/docs/worktree-hooks.md
@@ -43,6 +43,8 @@ Hooks run with `cwd` set to the worktree path and receive these environment vari
 
 Hooks have a 60-second timeout (`preSession`: 600 seconds). A non-zero exit status is logged but does not block the lifecycle action.
 
+`preSession` and `setup` terminals additionally run with `DISABLE_AUTO_UPDATE=true` in their process environment, so oh-my-zsh's interactive "Would you like to update?" prompt can't block the hook. Regular shell/agent tabs are unaffected and keep omz update checks.
+
 ## Example
 
 ```bash


### PR DESCRIPTION
## Summary

**What's broken:** When oh-my-zsh decides it's time to ask "Would you like to update?", the prompt fires from `.zshrc` in every TBD-spawned tab. In preSession/setup hook tabs that's fatal to automation: the hook command runs *after* `.zshrc`, so the daemon's marker-gate polls until the user notices and answers the prompt — or the hook times out and the agent starts without its setup.

**Why it happens:** Tabs spawn via `zsh -ic "<command>"`. The env vars TBD passes through the `env:` dict are injected as `export` statements inside the `-c` command string, which runs after `.zshrc` completes — too late to influence omz's updater.

**What this does:** Pass `DISABLE_AUTO_UPDATE=true` through tmux's `-e KEY=VALUE` flag (the only path that lands in the process environment *before* zsh starts) for the preSession hook window and the setup hook window. oh-my-zsh's `check_for_upgrade.sh` honors this var and skips the update check entirely. Scoped strictly to hook panes: regular shell/claude/codex tabs — and the Setup tab when no hook is configured — keep their normal omz update behavior.

## Test plan
- [ ] `swift test` — 1939 tests pass, including new assertions that the preSession and setup hook windows carry `-e DISABLE_AUTO_UPDATE=true`, that the primary agent window does not, and that a hook-less Setup tab does not
- [ ] Manual: configure a `preSession` hook in a repo where omz is due for an update check, create a worktree, confirm the hook runs immediately with no update prompt; open a regular shell tab and confirm omz still checks there

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B5E6CA92-9EEF-4CF6-B0E1-0075E7668B78)