### PR TITLE
Model profiles: login identity, one-click login, tbd profile CLI, keychain cleanup — plus daemon liveness/skew robustness

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -286,6 +286,25 @@ extension AppState {
         }
     }
 
+    /// Open a Claude session pinned to `profileID` in the currently selected
+    /// worktree so the user can run `/login` there (the profile's isolated
+    /// config dir captures the credentials). Returns false and shows a
+    /// non-error alert when no worktree is selected — callers normally disable
+    /// the affordance in that case, so this is a fallback.
+    ///
+    /// Refreshes the profile list afterwards; the completed login itself is
+    /// picked up later via the daemon's `modelProfilesChanged` delta.
+    @discardableResult
+    func openLoginSession(profileID: UUID) async -> Bool {
+        guard let worktree = selectedWorktree else {
+            showAlert("Select a worktree first, then open a login session.", isError: false)
+            return false
+        }
+        await createClaudeTerminal(worktreeID: worktree.id, profileID: profileID)
+        await loadModelProfiles()
+        return true
+    }
+
     /// Fetch fresh usage for a single profile and merge it into local state.
     func fetchProfileUsage(id: UUID) async {
         do {

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import TBDShared
 import os
@@ -286,23 +287,59 @@ extension AppState {
         }
     }
 
-    /// Open a Claude session pinned to `profileID` in the currently selected
-    /// worktree so the user can run `/login` there (the profile's isolated
-    /// config dir captures the credentials). Returns false and shows a
-    /// non-error alert when no worktree is selected — callers normally disable
-    /// the affordance in that case, so this is a fallback.
+    /// Open (or focus) a Claude *login session* pinned to `profileID` so the
+    /// user can complete `/login` there — the daemon labels the terminal as a
+    /// login session, auto-types `/login` once Claude is up, and pushes a
+    /// `modelProfilesChanged` delta when the profile's isolated config dir
+    /// gains an account, flipping the Settings badge live.
     ///
-    /// Refreshes the profile list afterwards; the completed login itself is
-    /// picked up later via the daemon's `modelProfilesChanged` delta.
+    /// Duplicate-safe: if a live login session for this profile already
+    /// exists, it is focused instead of spawning another; while a spawn RPC
+    /// is in flight, repeat clicks are dropped. Returns true when a session
+    /// was opened or focused (callers dismiss the Settings surface on true).
     @discardableResult
     func openLoginSession(profileID: UUID) async -> Bool {
+        // Focus an existing live login session for this profile, if any —
+        // five clicks should mean one session.
+        if let existing = Self.existingLoginSessionTerminal(profileID: profileID, terminals: terminals) {
+            navigateToActiveWorktree(existing.worktreeID, terminalID: existing.id)
+            NSApplication.shared.activate(ignoringOtherApps: true)
+            return true
+        }
+
         guard let worktree = selectedWorktree else {
             showAlert("Select a worktree first, then open a login session.", isError: false)
             return false
         }
-        await createClaudeTerminal(worktreeID: worktree.id, profileID: profileID)
+        guard !loginSessionSpawnsInFlight.contains(profileID) else { return false }
+        loginSessionSpawnsInFlight.insert(profileID)
+        defer { loginSessionSpawnsInFlight.remove(profileID) }
+
+        guard let terminal = await createClaudeTerminal(
+            worktreeID: worktree.id, profileID: profileID, loginSession: true
+        ) else {
+            // createClaudeTerminal already surfaced the error as an alert.
+            return false
+        }
+        navigateToActiveWorktree(worktree.id, terminalID: terminal.id)
+        NSApplication.shared.activate(ignoringOtherApps: true)
         await loadModelProfiles()
         return true
+    }
+
+    /// First live (non-suspended) login-session terminal pinned to
+    /// `profileID`, across all worktrees. Static + pure for unit testing.
+    nonisolated static func existingLoginSessionTerminal(
+        profileID: UUID,
+        terminals: [UUID: [Terminal]]
+    ) -> Terminal? {
+        terminals.values
+            .flatMap { $0 }
+            .first {
+                $0.profileID == profileID
+                    && $0.label == TerminalLabel.login
+                    && $0.suspendedAt == nil
+            }
     }
 
     /// Fetch fresh usage for a single profile and merge it into local state.

--- a/Sources/TBDApp/AppState+Notifications.swift
+++ b/Sources/TBDApp/AppState+Notifications.swift
@@ -46,6 +46,33 @@ extension AppState {
         }
     }
 
+    /// Compare the daemon's reported executable path against the daemon
+    /// builds this app could legitimately be paired with, and publish a
+    /// banner message on mismatch (see `DaemonBuildSkew`). Called on every
+    /// successful connect. Visibility only — never restarts the daemon.
+    func checkDaemonBuildIdentity() async {
+        guard let status = try? await daemonClient.daemonStatus() else { return }
+        let siblingDaemonPath = Bundle.main.executableURL?
+            .deletingLastPathComponent()
+            .appendingPathComponent("TBDDaemon").path
+        let sourceWorktreePath = StatusBarView.resolveSourceWorktreePath(
+            bundleURL: Bundle.main.bundleURL,
+            executablePath: Bundle.main.executablePath
+        )
+        let message = DaemonBuildSkew.warningMessage(
+            daemonExecutablePath: status.executablePath,
+            appSiblingDaemonPath: siblingDaemonPath,
+            sourceWorktreePath: sourceWorktreePath
+        )
+        guard message != daemonBuildMismatchMessage else { return }
+        daemonBuildMismatchMessage = message
+        // A new (or cleared) verdict invalidates a previous dismissal.
+        daemonBuildMismatchDismissed = false
+        if let message {
+            logger.warning("Daemon build skew detected: \(message, privacy: .public)")
+        }
+    }
+
     // MARK: - Helpers
 
     func handleConnectionError(_ error: Error) {

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -309,8 +309,15 @@ extension AppState {
     /// Create a Claude terminal in a worktree and add a new tab for it.
     /// `profileID` pins the session to a specific model profile; when nil the
     /// daemon resolves the profile normally (repo override → global default →
-    /// keychain login).
-    func createClaudeTerminal(worktreeID: UUID, profileID: UUID? = nil) async {
+    /// keychain login). `loginSession` marks the terminal as a profile login
+    /// session (daemon auto-types `/login`); it requires `profileID`.
+    ///
+    /// Returns the created terminal, or nil on failure — the daemon fails
+    /// loud for broken login sessions (e.g. deleted profile), and surfacing
+    /// that here prevents "ghost tab" states where the UI shows a session
+    /// that the daemon never fully registered.
+    @discardableResult
+    func createClaudeTerminal(worktreeID: UUID, profileID: UUID? = nil, loginSession: Bool = false) async -> Terminal? {
         do {
             let size = mainAreaTerminalSize()
             let colorFgBg = appearance?.currentColorFgBg
@@ -319,6 +326,7 @@ extension AppState {
                 cmd: nil,
                 type: .claude,
                 overrideProfileID: profileID,
+                loginSession: loginSession ? true : nil,
                 cols: size.cols,
                 rows: size.rows,
                 colorFgBg: colorFgBg
@@ -326,9 +334,14 @@ extension AppState {
             terminals[worktreeID, default: []].append(terminal)
             let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
             tabs[worktreeID, default: []].append(tab)
+            return terminal
         } catch {
             logger.error("Failed to create Claude terminal: \(error)")
+            if loginSession {
+                showAlert("Failed to open login session: \(error.localizedDescription)", isError: true)
+            }
             handleConnectionError(error)
+            return nil
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -384,6 +384,15 @@ final class AppState: ObservableObject {
     /// Terminals where the user has dismissed the proxy-unreachable banner.
     /// Cleared on app relaunch (in-memory only — banners are advisory).
     @Published var dismissedProxyWarnings: Set<UUID> = []
+    /// Non-nil when the connected daemon reports an executable path that
+    /// doesn't belong to this app's build (another worktree's restart.sh won
+    /// the shared daemon). Rendered as a persistent, non-blocking banner in
+    /// ContentView. Set by `checkDaemonBuildIdentity()` on every connect, so
+    /// it self-clears once a matching daemon is connected.
+    @Published var daemonBuildMismatchMessage: String?
+    /// User dismissed the build-mismatch banner. In-memory only (advisory);
+    /// reset whenever the mismatch message changes.
+    @Published var daemonBuildMismatchDismissed = false
     @Published var historyActiveWorktrees: Set<UUID> = []
     @Published var historyLoadStates: [UUID: HistoryLoadState] = [:]
     @Published var selectedSessionIDs: [UUID: String] = [:]       // worktreeID → sessionId
@@ -1039,7 +1048,18 @@ final class AppState: ObservableObject {
                     } else {
                         let didConnect = await self.daemonClient.connect()
                         self.isConnected = didConnect
-                        if didConnect { self.pushClaudeSpawnPreferences() }
+                        if didConnect {
+                            self.pushClaudeSpawnPreferences()
+                        } else if !AppState.pidFilePointsAtLiveDaemon() {
+                            // The socket file exists but nothing accepted the
+                            // connection, and the pid file doesn't name a live
+                            // TBDDaemon — stale leftovers (e.g. after a
+                            // reboot). Let startDaemonAndConnect clean them up
+                            // and respawn. A live daemon is never touched:
+                            // transient connect failures with a healthy pid
+                            // stay on the plain retry path above.
+                            await self.startDaemonAndConnect()
+                        }
                     }
                     if !self.isConnected { return }
                 }
@@ -1111,6 +1131,10 @@ final class AppState: ObservableObject {
         if didConnect {
             Task { [weak self] in
                 guard let self else { return }
+                await self.checkDaemonBuildIdentity()
+            }
+            Task { [weak self] in
+                guard let self else { return }
                 await self.cliInstallerCoordinator.checkOnLaunch()
             }
             Task { [weak self] in
@@ -1133,14 +1157,28 @@ final class AppState: ObservableObject {
 
     /// Launch the daemon process and connect.
     func startDaemonAndConnect() async {
-        // Check if daemon is already running (PID file + process alive)
+        // Check if daemon is already running. The pid file alone can't be
+        // trusted: it survives reboots and the recorded pid can be recycled
+        // by an unrelated process, which made the app skip spawning and fail
+        // to connect to a dead socket forever. Validate that the pid is a
+        // live TBDDaemon before skipping the spawn.
         let pidPath = TBDConstants.pidFilePath
         if let pidStr = try? String(contentsOfFile: pidPath, encoding: .utf8),
-           let pid = pid_t(pidStr.trimmingCharacters(in: .whitespacesAndNewlines)),
-           kill(pid, 0) == 0 {
-            // Daemon is running, just connect
-            await connectAndLoadInitialState()
-            return
+           let pid = DaemonLiveness.pid(fromPidFileContents: pidStr) {
+            if DaemonLiveness.isLiveTBDDaemon(pid: pid) {
+                // Daemon is running, just connect
+                await connectAndLoadInitialState()
+                return
+            }
+            // Stale artifacts — dead pid, or pid recycled by another process
+            // (e.g. after a reboot). Remove them so the spawn below starts
+            // from a clean slate instead of tripping over a dead socket.
+            logger.warning("""
+            Stale daemon pid file: pid \(pid, privacy: .public) is not a live \
+            TBDDaemon — removing pid file and socket before spawning
+            """)
+            try? FileManager.default.removeItem(atPath: pidPath)
+            try? FileManager.default.removeItem(atPath: TBDConstants.socketPath)
         }
 
         // Find TBDDaemon binary next to this executable
@@ -1187,6 +1225,19 @@ final class AppState: ObservableObject {
         }
 
         await connectAndLoadInitialState()
+    }
+
+    /// True when the daemon pid file exists and names a live TBDDaemon
+    /// process. Used by the reconnect poll to distinguish "daemon busy /
+    /// transient connect failure" (retry) from "stale socket + pid file left
+    /// behind by a reboot or crash" (clean up and respawn).
+    nonisolated static func pidFilePointsAtLiveDaemon(
+        pidFilePath: String = TBDConstants.pidFilePath
+    ) -> Bool {
+        guard let contents = try? String(contentsOfFile: pidFilePath, encoding: .utf8),
+              let pid = DaemonLiveness.pid(fromPidFileContents: contents)
+        else { return false }
+        return DaemonLiveness.isLiveTBDDaemon(pid: pid)
     }
 
     // MARK: - Refresh

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -219,6 +219,12 @@ final class AppState: ObservableObject {
     /// outside the AppState extension that consumes it.
     var pendingDeepLinkTerminalID: UUID?
 
+    /// Profile IDs with an "Open login session" spawn currently in flight.
+    /// Guards rapid repeat clicks: the first click spawns, subsequent clicks
+    /// during the RPC are dropped, and once the terminal lands in state the
+    /// dedupe path in `openLoginSession` focuses it instead of spawning again.
+    var loginSessionSpawnsInFlight: Set<UUID> = []
+
     /// The first selected worktree, if any.
     var selectedWorktree: Worktree? {
         guard let id = selectedWorktreeIDs.first else { return nil }

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -32,6 +32,25 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            // Persistent, non-blocking cross-build warning: the shared daemon
+            // was started from a different worktree's build than this app.
+            // Advisory only — the app keeps working with whatever RPCs still
+            // decode; the user decides when to restart.
+            if let warning = appState.daemonBuildMismatchMessage,
+               !appState.daemonBuildMismatchDismissed {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.yellow)
+                    Text(warning).font(.caption)
+                    Spacer()
+                    Button("Dismiss") {
+                        appState.daemonBuildMismatchDismissed = true
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(8)
+                .background(Color.yellow.opacity(0.2))
+            }
             NavigationSplitView {
                 SidebarView()
                     .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 400)

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -597,10 +597,10 @@ actor DaemonClient {
     }
 
     /// Create a terminal in a worktree.
-    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, overrideProfileID: UUID? = nil, cols: Int? = nil, rows: Int? = nil, colorFgBg: String? = nil) async throws -> Terminal {
+    func createTerminal(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, overrideProfileID: UUID? = nil, loginSession: Bool? = nil, cols: Int? = nil, rows: Int? = nil, colorFgBg: String? = nil) async throws -> Terminal {
         return try await callAsync(
             method: RPCMethod.terminalCreate,
-            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, resumeSessionID: resumeSessionID, overrideProfileID: overrideProfileID, cols: cols, rows: rows, colorFgBg: colorFgBg),
+            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, resumeSessionID: resumeSessionID, overrideProfileID: overrideProfileID, loginSession: loginSession, cols: cols, rows: rows, colorFgBg: colorFgBg),
             resultType: Terminal.self
         )
     }

--- a/Sources/TBDApp/Helpers/DaemonBuildSkew.swift
+++ b/Sources/TBDApp/Helpers/DaemonBuildSkew.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Detects cross-build skew between this app and the connected daemon.
+///
+/// Every worktree's `scripts/restart.sh` installs ITS build to
+/// /Applications/TBD.app and restarts the ONE shared daemon, so a running app
+/// can silently end up talking to a daemon built from a different worktree —
+/// RPC decode mismatches and "Unknown method" errors that feel like "TBD is
+/// out of sync". The daemon reports its own executable path in
+/// `daemon.status`; comparing it against the builds this app could
+/// legitimately be paired with makes the skew visible. Visibility only — the
+/// app never kills or restarts a mismatched daemon.
+enum DaemonBuildSkew {
+    /// Human-readable warning when the daemon binary doesn't belong to this
+    /// app's build; nil when it matches or when identity can't be established
+    /// (older daemon without the field, unbundled app with no source path).
+    ///
+    /// Acceptable daemon locations for this app:
+    /// - `appSiblingDaemonPath`: TBDDaemon next to the app executable — the
+    ///   binary `startDaemonAndConnect()` itself would spawn.
+    /// - `<sourceWorktreePath>/.build/debug/TBDDaemon`: the binary
+    ///   `scripts/restart.sh` of the worktree that built this app launches
+    ///   (the app itself runs from /Applications, not from that worktree).
+    ///
+    /// `resolvePath` is an injection seam so tests can exercise both branches
+    /// with fabricated paths; production uses `defaultResolvePath`.
+    static func warningMessage(
+        daemonExecutablePath: String?,
+        appSiblingDaemonPath: String?,
+        sourceWorktreePath: String?,
+        resolvePath: (String) -> String = defaultResolvePath
+    ) -> String? {
+        guard let daemonPath = daemonExecutablePath, !daemonPath.isEmpty else {
+            // Older daemon that predates the field — can't tell, stay quiet.
+            return nil
+        }
+        var candidates: [String] = []
+        if let sibling = appSiblingDaemonPath, !sibling.isEmpty {
+            candidates.append(sibling)
+        }
+        if let worktree = sourceWorktreePath, !worktree.isEmpty {
+            candidates.append(worktree + "/.build/debug/TBDDaemon")
+        }
+        guard !candidates.isEmpty else { return nil }
+        let resolvedDaemon = resolvePath(daemonPath)
+        if candidates.contains(where: { resolvePath($0) == resolvedDaemon }) {
+            return nil
+        }
+        return "Daemon is from a different build: \(daemonPath). "
+            + "Run scripts/restart.sh from the worktree you're working in."
+    }
+
+    /// Resolve symlinks and standardize so equivalent spellings of the same
+    /// binary compare equal (restart.sh and the daemon both report
+    /// symlink-resolved absolute paths, but belt-and-suspenders).
+    static func defaultResolvePath(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+    }
+}

--- a/Sources/TBDApp/Helpers/DaemonLiveness.swift
+++ b/Sources/TBDApp/Helpers/DaemonLiveness.swift
@@ -1,0 +1,52 @@
+import Darwin
+import Foundation
+
+/// Validates that a pid recorded in the daemon pid file really is a live
+/// TBDDaemon process.
+///
+/// The pid file alone cannot be trusted: it survives reboots, and after a
+/// reboot the recorded pid can be recycled by an arbitrary unrelated process.
+/// A bare `kill(pid, 0) == 0` check then reports "daemon running", the app
+/// skips spawning its sibling daemon, and every connect to the dead socket
+/// fails with no recovery path. Checking the pid's executable name via
+/// libproc closes that hole.
+enum DaemonLiveness {
+    /// Last path component every real daemon binary has, wherever it was
+    /// built (`<worktree>/.build/debug/TBDDaemon`, a bundle sibling, ...).
+    static let daemonExecutableName = "TBDDaemon"
+
+    /// True when `pid` is a live process whose executable's last path
+    /// component is `TBDDaemon`.
+    ///
+    /// `isAlive` and `executablePath` are injection seams so both branches
+    /// are unit-testable without real processes; production callers use the
+    /// defaults (`kill(pid, 0)` + `proc_pidpath`).
+    static func isLiveTBDDaemon(
+        pid: pid_t,
+        isAlive: (pid_t) -> Bool = { kill($0, 0) == 0 },
+        executablePath: (pid_t) -> String? = processExecutablePath
+    ) -> Bool {
+        guard pid > 0 else { return false }
+        guard isAlive(pid) else { return false }
+        guard let path = executablePath(pid), !path.isEmpty else { return false }
+        return (path as NSString).lastPathComponent == daemonExecutableName
+    }
+
+    /// Parse the daemon pid file's contents. Nil when malformed. Pure — the
+    /// caller reads the file so tests never need one on disk.
+    static func pid(fromPidFileContents contents: String) -> pid_t? {
+        pid_t(contents.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Resolve a pid's executable path via libproc's `proc_pidpath`.
+    /// Nil when the pid is dead or the kernel refuses (e.g. another user's
+    /// process) — callers must treat that as "not our daemon".
+    static func processExecutablePath(pid: pid_t) -> String? {
+        // PROC_PIDPATHINFO_MAXSIZE (4 * MAXPATHLEN); the macro itself is
+        // unavailable to Swift's Clang importer.
+        var buffer = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
+        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard length > 0 else { return nil }
+        return String(cString: buffer)
+    }
+}

--- a/Sources/TBDApp/Helpers/ProfileLoginPresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileLoginPresentation.swift
@@ -1,0 +1,66 @@
+import Foundation
+import TBDShared
+
+/// App-side presentation of a model profile's login identity — the
+/// `ModelProfileWithUsage.loginIdentity` email the daemon reads from the
+/// profile's isolated config dir at list time.
+///
+/// Pure string composition, extracted from the views (Settings rows, the "+"
+/// new-tab menu, the menu-bar profile switcher) so the badge/caption/suffix
+/// rules are unit-testable without UI.
+///
+/// A nil identity is ambiguous: the profile may genuinely need `/login`, or
+/// the daemon may predate the field. The two are indistinguishable, so the
+/// nil-case copy is phrased as an observation ("no login detected") rather
+/// than a hard claim.
+enum ProfileLoginPresentation {
+    /// Trimmed, non-empty identity — nil when the daemon reported no login.
+    static func normalizedIdentity(_ loginIdentity: String?) -> String? {
+        guard let trimmed = loginIdentity?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    /// True when this is an oauth profile with no detected login — the state
+    /// that warrants the "needs /login" hint and the one-click login affordance.
+    static func needsLogin(kind: CredentialKind, loginIdentity: String?) -> Bool {
+        kind == .oauth && normalizedIdentity(loginIdentity) == nil
+    }
+
+    /// Short suffix for menu rows: " — <email>" / " — needs /login" for oauth
+    /// profiles, "" for every other kind. Kept terse — NSMenu width is precious.
+    static func menuTitleSuffix(kind: CredentialKind, loginIdentity: String?) -> String {
+        guard kind == .oauth else { return "" }
+        if let identity = normalizedIdentity(loginIdentity) { return " — \(identity)" }
+        return " — needs /login"
+    }
+
+    /// Full menu-row title for a profile entry.
+    static func menuItemTitle(for entry: ModelProfileWithUsage) -> String {
+        entry.profile.tabDisplayName
+            + menuTitleSuffix(kind: entry.profile.kind, loginIdentity: entry.loginIdentity)
+    }
+
+    /// Identity fragment for the Settings row caption. nil for non-oauth kinds.
+    static func identityCaption(kind: CredentialKind, loginIdentity: String?) -> String? {
+        guard kind == .oauth else { return nil }
+        if let identity = normalizedIdentity(loginIdentity) { return "Logged in as \(identity)" }
+        return "No login detected — run /login once"
+    }
+
+    /// Settings-row caption. For oauth profiles this replaces the static
+    /// "Run /login once" prefix of `ModelProfile.detailCaption` with the live
+    /// identity fragment while keeping the endpoint details (via baseURL ·
+    /// model) in the same order. Other kinds fall back to `detailCaption`.
+    static func settingsCaption(for entry: ModelProfileWithUsage) -> String? {
+        let profile = entry.profile
+        guard profile.kind == .oauth else { return profile.detailCaption }
+        var parts: [String] = []
+        if let identity = identityCaption(kind: profile.kind, loginIdentity: entry.loginIdentity) {
+            parts.append(identity)
+        }
+        if let baseURL = profile.baseURL { parts.append("via \(baseURL)") }
+        if let model = profile.model, !model.isEmpty { parts.append(model) }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/Sources/TBDApp/MenuBar/ModelProfileMenu.swift
+++ b/Sources/TBDApp/MenuBar/ModelProfileMenu.swift
@@ -66,7 +66,9 @@ private struct ModelProfileMenuContent: View {
         }
     }
 
+    /// Profile name plus a short login-identity suffix (" — email" /
+    /// " — needs /login") for oauth profiles; bare name for other kinds.
     private static func formatRow(entry: ModelProfileWithUsage) -> String {
-        entry.profile.tabDisplayName
+        ProfileLoginPresentation.menuItemTitle(for: entry)
     }
 }

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -1,5 +1,22 @@
+import AppKit
 import SwiftUI
 import TBDShared
+
+/// Closes the SwiftUI `Settings` scene window so "Open login session" lands
+/// the user directly on the newly focused terminal tab in the main window
+/// instead of leaving Settings floating over it.
+@MainActor
+enum SettingsWindowCloser {
+    static func close() {
+        // The SwiftUI Settings scene window carries the stable identifier
+        // "com_apple_SwiftUI_Settings_window"; match on the substring so a
+        // future macOS rename of the prefix doesn't silently break this.
+        for window in NSApplication.shared.windows
+        where window.identifier?.rawValue.contains("Settings") == true {
+            window.performClose(nil)
+        }
+    }
+}
 
 struct ModelProfilesSettingsView: View {
     @EnvironmentObject var appState: AppState
@@ -105,14 +122,18 @@ struct ModelProfileRow: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Button("Open login session") {
-                            Task { await appState.openLoginSession(profileID: profile.id) }
+                            Task {
+                                if await appState.openLoginSession(profileID: profile.id) {
+                                    SettingsWindowCloser.close()
+                                }
+                            }
                         }
                         .buttonStyle(.link)
                         .font(.caption)
                         .disabled(appState.selectedWorktree == nil)
                         .help(appState.selectedWorktree == nil
                               ? "Select a worktree in the main window first"
-                              : "Open a Claude session with this profile so you can run /login")
+                              : "Open a Claude session with this profile — /login is typed for you")
                     }
                 } else {
                     Text(caption)
@@ -196,7 +217,11 @@ struct ModelProfileRow: View {
             }
             if needsLogin {
                 Button("Open login session") {
-                    Task { await appState.openLoginSession(profileID: profile.id) }
+                    Task {
+                        if await appState.openLoginSession(profileID: profile.id) {
+                            SettingsWindowCloser.close()
+                        }
+                    }
                 }
                 .disabled(appState.selectedWorktree == nil)
             }
@@ -539,8 +564,11 @@ struct AddModelProfileSheet: View {
                 Button("Open login session") {
                     let profileID = entry.profile.id
                     Task {
-                        await appState.openLoginSession(profileID: profileID)
+                        let opened = await appState.openLoginSession(profileID: profileID)
                         dismiss()
+                        if opened {
+                            SettingsWindowCloser.close()
+                        }
                     }
                 }
                 .keyboardShortcut(.defaultAction)

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -99,9 +99,26 @@ struct ModelProfileRow: View {
                 menuButton
             }
             if let caption = endpointCaption {
-                Text(caption)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if needsLogin {
+                    HStack(spacing: 8) {
+                        Text(caption)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Button("Open login session") {
+                            Task { await appState.openLoginSession(profileID: profile.id) }
+                        }
+                        .buttonStyle(.link)
+                        .font(.caption)
+                        .disabled(appState.selectedWorktree == nil)
+                        .help(appState.selectedWorktree == nil
+                              ? "Select a worktree in the main window first"
+                              : "Open a Claude session with this profile so you can run /login")
+                    }
+                } else {
+                    Text(caption)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
         .contentShape(Rectangle())
@@ -127,7 +144,13 @@ struct ModelProfileRow: View {
         }
     }
 
-    private var endpointCaption: String? { profile.detailCaption }
+    private var endpointCaption: String? { ProfileLoginPresentation.settingsCaption(for: entry) }
+
+    /// True for oauth profiles with no detected login — drives the inline
+    /// "Open login session" affordance next to the caption.
+    private var needsLogin: Bool {
+        ProfileLoginPresentation.needsLogin(kind: profile.kind, loginIdentity: entry.loginIdentity)
+    }
 
     @ViewBuilder
     private var nameView: some View {
@@ -170,6 +193,12 @@ struct ModelProfileRow: View {
             Button("Rename…") {
                 draftName = profile.name
                 isEditingName = true
+            }
+            if needsLogin {
+                Button("Open login session") {
+                    Task { await appState.openLoginSession(profileID: profile.id) }
+                }
+                .disabled(appState.selectedWorktree == nil)
             }
             Divider()
             Button("Delete…", role: .destructive) {
@@ -459,8 +488,68 @@ struct AddModelProfileSheet: View {
     @State private var isSaving = false
     @State private var errorMessage: String?
     @State private var probeStatus: ProbeStatus = .idle
+    /// Set after a NEW oauth (Claude-direct) profile is saved: swaps the sheet
+    /// content to a follow-up step offering a one-click login session.
+    @State private var createdOAuthProfile: ModelProfileWithUsage?
 
     var body: some View {
+        Group {
+            if let created = createdOAuthProfile {
+                loginFollowUp(created)
+            } else {
+                formBody
+            }
+        }
+        .padding(20)
+        .frame(width: 520)
+        .onAppear { awsProfileSuggestions = AWSProfiles.discover() }
+        .task(id: "\(preset)|\(awsRegion)|\(awsProfile)") {
+            guard preset == .bedrock else { return }
+            // Debounce so rapid keystrokes don't spam subprocess calls.
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            if Task.isCancelled { return }
+            modelDiscovery = .loading
+            modelDiscovery = await BedrockModels.discover(
+                region: awsRegion,
+                awsProfile: awsProfile.isEmpty ? nil : awsProfile
+            )
+        }
+    }
+
+    /// Post-save step for new oauth profiles: the profile exists but has no
+    /// login yet — offer to open a Claude session pinned to it so the user can
+    /// run /login immediately.
+    private func loginFollowUp(_ entry: ModelProfileWithUsage) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Profile Created").font(.headline)
+            (Text("“\(entry.profile.name)” is ready. Open a Claude session with it and run ")
+                + Text("/login").font(.system(.caption, design: .monospaced))
+                + Text(" once to connect an account — TBD keeps the login isolated to this profile."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if appState.selectedWorktree == nil {
+                Text("Select a worktree in the main window to open a login session.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+            HStack {
+                Spacer()
+                Button("Later") { dismiss() }
+                Button("Open login session") {
+                    let profileID = entry.profile.id
+                    Task {
+                        await appState.openLoginSession(profileID: profileID)
+                        dismiss()
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(appState.selectedWorktree == nil)
+            }
+        }
+    }
+
+    private var formBody: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Add Model Profile").font(.headline)
 
@@ -585,20 +674,6 @@ struct AddModelProfileSheet: View {
                 .keyboardShortcut(.defaultAction)
                 .disabled(!canSave)
             }
-        }
-        .padding(20)
-        .frame(width: 520)
-        .onAppear { awsProfileSuggestions = AWSProfiles.discover() }
-        .task(id: "\(preset)|\(awsRegion)|\(awsProfile)") {
-            guard preset == .bedrock else { return }
-            // Debounce so rapid keystrokes don't spam subprocess calls.
-            try? await Task.sleep(nanoseconds: 500_000_000)
-            if Task.isCancelled { return }
-            modelDiscovery = .loading
-            modelDiscovery = await BedrockModels.discover(
-                region: awsRegion,
-                awsProfile: awsProfile.isEmpty ? nil : awsProfile
-            )
         }
     }
 
@@ -736,6 +811,15 @@ struct AddModelProfileSheet: View {
                 // open so the user can acknowledge before deciding to keep the profile.
                 if let warning {
                     errorMessage = warning
+                    return
+                }
+                if preset == .claudeDirect,
+                   let created = appState.modelProfiles.first(where: {
+                       $0.profile.kind == .oauth && $0.profile.name == trimmedName
+                   }) {
+                    // New oauth profile: swap the sheet to the follow-up step
+                    // offering a one-click login session instead of closing.
+                    createdOAuthProfile = created
                     return
                 }
                 dismiss()

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -335,14 +335,16 @@ enum AddTabMenu {
             claudeItem.target = coordinator
             menu.addItem(claudeItem)
 
-            // One item per profile, titled with the profile's display name. Each
-            // gets a transparent placeholder icon the same size as the Claude
-            // asterisk so its title lines up in the same title column as "Claude"
-            // — the empty icon slot is the visual nesting cue. The profile id
-            // rides along in `representedObject` for MenuCoordinator.addClaudeProfile.
+            // One item per profile, titled with the profile's display name plus
+            // a short login-identity suffix (" — email" / " — needs /login" for
+            // oauth profiles). Each gets a transparent placeholder icon the same
+            // size as the Claude asterisk so its title lines up in the same
+            // title column as "Claude" — the empty icon slot is the visual
+            // nesting cue. The profile id rides along in `representedObject`
+            // for MenuCoordinator.addClaudeProfile.
             for entry in profiles {
                 let item = NSMenuItem(
-                    title: entry.profile.name,
+                    title: ProfileLoginPresentation.menuItemTitle(for: entry),
                     action: #selector(MenuCoordinator.addClaudeProfile(_:)),
                     keyEquivalent: ""
                 )

--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -1,0 +1,282 @@
+import ArgumentParser
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+import TBDShared
+
+// MARK: - tbd profile
+
+struct ProfileCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "profile",
+        abstract: "Manage model profiles (the accounts spawned Claude sessions run under)",
+        subcommands: [
+            ProfileList.self,
+            ProfileSetDefault.self,
+            ProfileLogin.self,
+        ]
+    )
+}
+
+// MARK: - Pure helpers (internal so TBDCLITests can exercise them)
+
+/// Render the IDENTITY column for a profile row. OAuth profiles show the
+/// logged-in account email, or "needs /login" when nobody has logged into
+/// the profile's isolated config dir yet. Non-OAuth kinds (apiKey, bedrock)
+/// have no login identity and render an em dash.
+func profileIdentityCell(kind: CredentialKind, loginIdentity: String?) -> String {
+    guard kind == .oauth else { return "—" }
+    if let loginIdentity, !loginIdentity.isEmpty { return loginIdentity }
+    return "needs /login"
+}
+
+/// Resolve a user-supplied profile reference against the daemon's profile
+/// list. Accepts an exact name, a unique case-insensitive name, or a profile
+/// UUID (escape hatch for scripting). Throws a `CLIError` with actionable
+/// text when nothing (or more than one thing) matches.
+func resolveProfile(
+    named reference: String,
+    in profiles: [ModelProfileWithUsage]
+) throws -> ModelProfileWithUsage {
+    if let id = UUID(uuidString: reference),
+       let byID = profiles.first(where: { $0.profile.id == id }) {
+        return byID
+    }
+    if let exact = profiles.first(where: { $0.profile.name == reference }) {
+        return exact
+    }
+    let folded = profiles.filter {
+        $0.profile.name.lowercased() == reference.lowercased()
+    }
+    if folded.count == 1 {
+        return folded[0]
+    }
+    if folded.count > 1 {
+        let names = folded.map(\.profile.name).sorted().joined(separator: ", ")
+        throw CLIError.invalidArgument(
+            "Profile name '\(reference)' is ambiguous (matches: \(names)). Use the exact name.")
+    }
+    guard !profiles.isEmpty else {
+        throw CLIError.invalidArgument(
+            "No model profiles exist yet. Create one in TBD Settings → Model Profiles.")
+    }
+    let available = profiles.map(\.profile.name).sorted().joined(separator: ", ")
+    throw CLIError.invalidArgument("No profile named '\(reference)'. Available: \(available)")
+}
+
+/// Env vars that would poison an OAuth `/login` if inherited from the calling
+/// shell: they force API-key auth, token auth, a proxy base URL, or Bedrock
+/// routing onto the spawned `claude`, overriding the isolated config dir's
+/// OAuth credentials.
+let loginPoisonEnvVars = [
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_USE_BEDROCK",
+]
+
+/// Copy of `base` with every login-poisoning variable removed.
+func sanitizedLoginEnvironment(base: [String: String]) -> [String: String] {
+    var env = base
+    for key in loginPoisonEnvVars {
+        env.removeValue(forKey: key)
+    }
+    return env
+}
+
+/// Find an executable by name on a colon-separated search path
+/// (defaults to the process's `PATH`). Returns its absolute path, or nil.
+func findExecutable(named name: String, searchPath: String? = nil) -> String? {
+    let path = searchPath ?? ProcessInfo.processInfo.environment["PATH"] ?? ""
+    for dir in path.split(separator: ":") where !dir.isEmpty {
+        let candidate = "\(dir)/\(name)"
+        if FileManager.default.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+    }
+    return nil
+}
+
+/// Replace the current process image with `executablePath` via `execve`,
+/// handing the controlling TTY over cleanly (no wrapper process lingers).
+/// Only returns by throwing, when exec itself fails.
+func execReplacingCurrentProcess(
+    executablePath: String,
+    arguments: [String],
+    environment: [String: String]
+) throws -> Never {
+    fflush(stdout)
+    fflush(stderr)
+    var argv: [UnsafeMutablePointer<CChar>?] = ([executablePath] + arguments).map { strdup($0) }
+    argv.append(nil)
+    var envp: [UnsafeMutablePointer<CChar>?] = environment.map { strdup("\($0.key)=\($0.value)") }
+    envp.append(nil)
+    execve(executablePath, argv, envp)
+    // execve only returns on failure — clean up and surface errno.
+    let reason = String(cString: strerror(errno))
+    for pointer in argv { free(pointer) }
+    for pointer in envp { free(pointer) }
+    throw CLIError.invalidArgument("Failed to exec \(executablePath): \(reason)")
+}
+
+// MARK: - profile list
+
+struct ProfileList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List model profiles and their login state"
+    )
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let result = try client.call(
+            method: RPCMethod.modelProfileList,
+            resultType: ModelProfileListResult.self
+        )
+
+        if json {
+            printJSON(result)
+            return
+        }
+        if result.profiles.isEmpty {
+            print("No model profiles configured. Create one in TBD Settings → Model Profiles.")
+            return
+        }
+        print(tableRow([("NAME", 24), ("KIND", 8), ("IDENTITY", 0)]))
+        print(String(repeating: "-", count: 78))
+        for entry in result.profiles {
+            let identity = profileIdentityCell(
+                kind: entry.profile.kind,
+                loginIdentity: entry.loginIdentity
+            )
+            let isDefault = entry.profile.id == result.defaultID
+            // The [default] marker gets its own zero-width trailing cell so
+            // non-default rows end at the identity column with no trailing
+            // padding.
+            let cells: [(String, Int)] = isDefault
+                ? [(entry.profile.name, 24), (entry.profile.kind.rawValue, 8),
+                   (identity, 32), ("[default]", 0)]
+                : [(entry.profile.name, 24), (entry.profile.kind.rawValue, 8),
+                   (identity, 0)]
+            print(tableRow(cells))
+        }
+    }
+}
+
+// MARK: - profile set-default
+
+struct ProfileSetDefault: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set-default",
+        abstract: "Set (or clear) the global default profile for new sessions"
+    )
+
+    @Argument(help: "Profile name or UUID (omit with --clear)")
+    var name: String?
+
+    @Flag(name: .long, help: "Clear the global default instead of setting one")
+    var clear = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+
+        if clear {
+            guard name == nil else {
+                throw CLIError.invalidArgument("Cannot combine a profile name with --clear")
+            }
+            try client.callVoid(
+                method: RPCMethod.modelProfileSetGlobalDefault,
+                params: ModelProfileSetGlobalDefaultParams(id: nil)
+            )
+            print("Cleared the global default profile.")
+            print("New sessions will use ambient credentials unless a repo-level override applies.")
+            return
+        }
+
+        guard let name else {
+            throw CLIError.invalidArgument(
+                "Provide a profile name, or pass --clear to unset the default.")
+        }
+
+        let list = try client.call(
+            method: RPCMethod.modelProfileList,
+            resultType: ModelProfileListResult.self
+        )
+        let entry = try resolveProfile(named: name, in: list.profiles)
+        try client.callVoid(
+            method: RPCMethod.modelProfileSetGlobalDefault,
+            params: ModelProfileSetGlobalDefaultParams(id: entry.profile.id)
+        )
+        let identity = profileIdentityCell(
+            kind: entry.profile.kind,
+            loginIdentity: entry.loginIdentity
+        )
+        print("Global default profile is now '\(entry.profile.name)' (\(entry.profile.kind.rawValue), \(identity)).")
+        print("New sessions will use it unless a repo-level override applies.")
+    }
+}
+
+// MARK: - profile login
+
+struct ProfileLogin: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "login",
+        abstract: "Open claude inside a profile's isolated config dir so /login lands on the right account",
+        discussion: """
+            Replaces this process with `claude` running under the profile's \
+            CLAUDE_CONFIG_DIR, so the OAuth credential written by /login is \
+            stored for that profile — not for whatever account your shell \
+            happens to be logged into.
+            """
+    )
+
+    @Argument(help: "OAuth profile name or UUID")
+    var name: String
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let list = try client.call(
+            method: RPCMethod.modelProfileList,
+            resultType: ModelProfileListResult.self
+        )
+        let entry = try resolveProfile(named: name, in: list.profiles)
+
+        guard entry.profile.kind == .oauth else {
+            let detail = entry.profile.kind == .bedrock
+                ? "Bedrock profiles authenticate with AWS credentials"
+                : "API-key profiles carry their own key"
+            throw CLIError.invalidArgument(
+                "Profile '\(entry.profile.name)' is a \(entry.profile.kind.rawValue) profile. "
+                    + "Only OAuth profiles log in via /login — \(detail), so there is nothing to log into.")
+        }
+
+        // Provision (or re-verify) the isolated config dir daemon-side.
+        let prepared = try client.call(
+            method: RPCMethod.modelProfilePrepareConfigDir,
+            params: ModelProfilePrepareConfigDirParams(id: entry.profile.id),
+            resultType: ModelProfilePrepareConfigDirResult.self
+        )
+
+        guard let claudePath = findExecutable(named: "claude") else {
+            throw CLIError.invalidArgument(
+                "Could not find `claude` on PATH. Install Claude Code first (https://claude.com/claude-code).")
+        }
+
+        let current = entry.loginIdentity.map { "currently logged in as \($0)" }
+            ?? "not logged in yet"
+        print("Opening claude for profile '\(entry.profile.name)' (\(current)) — "
+            + "run /login inside this session, then /status to verify, then exit.")
+
+        var env = sanitizedLoginEnvironment(base: ProcessInfo.processInfo.environment)
+        env["CLAUDE_CONFIG_DIR"] = prepared.configDirPath
+        try execReplacingCurrentProcess(
+            executablePath: claudePath,
+            arguments: [],
+            environment: env
+        )
+    }
+}

--- a/Sources/TBDCLI/Commands/RepoCommands.swift
+++ b/Sources/TBDCLI/Commands/RepoCommands.swift
@@ -103,16 +103,17 @@ struct RepoList: AsyncParsableCommand {
                 print("No repositories. Use 'tbd repo add <path>' to add one.")
                 return
             }
-            let header = String(format: "%-36s  %-20s  %-9s  %s", "ID", "NAME", "STATUS", "PATH")
+            let header = tableRow([("ID", 36), ("NAME", 20), ("STATUS", 9), ("PATH", 0)])
             print(header)
             print(String(repeating: "-", count: 90))
             for repo in repos {
                 let tag = repo.status == .missing ? "[missing]" : "[ok]"
-                let line = String(format: "%-36s  %-20s  %-9s  %s",
-                    repo.id.uuidString as NSString,
-                    repo.displayName as NSString,
-                    tag as NSString,
-                    repo.path as NSString)
+                let line = tableRow([
+                    (repo.id.uuidString, 36),
+                    (repo.displayName, 20),
+                    (tag, 9),
+                    (repo.path, 0)
+                ])
                 print(line)
             }
         }

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -92,15 +92,16 @@ struct TerminalList: AsyncParsableCommand {
                 print("No terminals found.")
                 return
             }
-            let header = String(format: "%-36s  %-10s  %-10s  %s", "ID", "WINDOW", "PANE", "LABEL")
+            let header = tableRow([("ID", 36), ("WINDOW", 10), ("PANE", 10), ("LABEL", 0)])
             print(header)
             print(String(repeating: "-", count: 80))
             for term in terminals {
-                let line = String(format: "%-36s  %-10s  %-10s  %s",
-                    term.id.uuidString as NSString,
-                    term.tmuxWindowID as NSString,
-                    term.tmuxPaneID as NSString,
-                    (term.label ?? "-") as NSString)
+                let line = tableRow([
+                    (term.id.uuidString, 36),
+                    (term.tmuxWindowID, 10),
+                    (term.tmuxPaneID, 10),
+                    (term.label ?? "-", 0)
+                ])
                 print(line)
             }
         }

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -231,15 +231,16 @@ struct WorktreeList: AsyncParsableCommand {
             }
             let repos: [Repo] = try client.call(method: RPCMethod.repoList, resultType: [Repo].self)
             let missingRepoIDs = Set(repos.filter { $0.status == .missing }.map { $0.id })
-            let header = String(format: "%-36s  %-24s  %-8s  %s", "ID", "NAME", "STATUS", "BRANCH")
+            let header = tableRow([("ID", 36), ("NAME", 24), ("STATUS", 8), ("BRANCH", 0)])
             print(header)
             print(String(repeating: "-", count: 100))
             for wt in worktrees {
-                let line = String(format: "%-36s  %-24s  %-8s  %s",
-                    wt.id.uuidString as NSString,
-                    wt.displayName as NSString,
-                    wt.status.rawValue as NSString,
-                    wt.branch as NSString)
+                let line = tableRow([
+                    (wt.id.uuidString, 36),
+                    (wt.displayName, 24),
+                    (wt.status.rawValue, 8),
+                    (wt.branch, 0)
+                ])
                 // Scratch spaces (repoID == nil) have no repo to be missing.
                 let tag = (wt.repoID.map(missingRepoIDs.contains) ?? false) ? "  [missing]" : ""
                 print(line + tag)

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -12,6 +12,7 @@ struct TBDCommand: AsyncParsableCommand {
             WorktreeCommand.self,
             ScratchCommand.self,
             ConfigCommand.self,
+            ProfileCommand.self,
             TerminalCommand.self,
             NotifyCommand.self,
             SessionEventCommand.self,

--- a/Sources/TBDCLI/Utilities.swift
+++ b/Sources/TBDCLI/Utilities.swift
@@ -21,6 +21,21 @@ func printJSON(_ dict: [String: String]) {
     }
 }
 
+/// Format a table row for plain-text list output: each value is
+/// left-justified (space-padded, never truncated) to its column width,
+/// and columns are joined with two spaces. Use a width of 0 for the
+/// final column so it isn't right-padded.
+///
+/// This replaces `String(format: "%-36s ...", ...)`, which is undefined
+/// behavior on Darwin when handed Swift String/NSString arguments (`%s`
+/// expects a C string pointer) and crashed with SIGSEGV.
+func tableRow(_ cells: [(value: String, width: Int)]) -> String {
+    cells.map { cell in
+        let padding = cell.width - cell.value.count
+        return padding > 0 ? cell.value + String(repeating: " ", count: padding) : cell.value
+    }.joined(separator: "  ")
+}
+
 /// Resolve a path relative to the current working directory.
 func resolvePath(_ path: String) -> String {
     if path.hasPrefix("/") {

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -413,6 +413,27 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         return dir
     }
 
+    /// Read the login identity for a profile from its isolated config dir:
+    /// the `oauthAccount.emailAddress` that Claude Code writes into
+    /// `<configDir>/.claude.json` after the user completes `/login` inside a
+    /// session using this profile.
+    ///
+    /// Returns nil when the profile dir or `.claude.json` is missing, the JSON
+    /// is malformed, or no `oauthAccount` has been written yet — all of which
+    /// mean "not logged in" for TBD-owned profile dirs. Best-effort and
+    /// read-only; never throws.
+    public func loginIdentity(forProfileID profileID: UUID) -> String? {
+        let claudeJSONPath = configDirectory(forProfileID: profileID)
+            .appendingPathComponent(".claude.json")
+        guard let data = try? Data(contentsOf: claudeJSONPath),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let account = parsed["oauthAccount"] as? [String: Any],
+              let email = account["emailAddress"] as? String,
+              !email.isEmpty
+        else { return nil }
+        return email
+    }
+
     /// Claude Code stores approved keys as the last 20 chars of the key
     /// (confirmed by inspecting `~/.claude.json#customApiKeyResponses.approved`).
     /// For keys shorter than 20 chars (unusual but possible in tests), use the

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -97,11 +97,15 @@ enum ClaudeSpawnCommandBuilder {
         }
 
         var env: [String: String] = [:]
+        // Profile routing env assigned below is ALSO re-exported inline in
+        // the returned command (see `inlineExports`); track its keys here.
+        var routingKeys: Set<String> = []
         if profileKind == .bedrock {
             env["CLAUDE_CODE_USE_BEDROCK"] = "1"
             if let r = profileAwsRegion { env["AWS_REGION"] = r }
             if let p = profileAwsProfile { env["AWS_PROFILE"] = p }
             if let m = profileModel { env["ANTHROPIC_MODEL"] = m }
+            routingKeys.formUnion(["CLAUDE_CODE_USE_BEDROCK", "AWS_REGION", "AWS_PROFILE", "ANTHROPIC_MODEL"])
             // Intentionally no ANTHROPIC_API_KEY / CLAUDE_CONFIG_DIR /
             // ANTHROPIC_BASE_URL for bedrock.
         } else {
@@ -111,6 +115,8 @@ enum ClaudeSpawnCommandBuilder {
                 // parsing), so we don't need shell-escape allowlists here.
                 // Storage-time validation rejects newlines / NULL bytes that would
                 // break tmux's single-line arg parsing.
+                // NEVER a routing key — secrets must not be inlined into the
+                // command string (visible in `ps` for the pane's lifetime).
                 env["ANTHROPIC_API_KEY"] = secret
             }
             // For oauth profiles, no auth token — they use the isolated
@@ -123,6 +129,7 @@ enum ClaudeSpawnCommandBuilder {
             if let configDir = profileConfigDir {
                 env["CLAUDE_CONFIG_DIR"] = configDir
             }
+            routingKeys.formUnion(["ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL", "CLAUDE_CONFIG_DIR"])
         }
         // Registry-driven Claude spawn-env settings. This block only runs in
         // the Claude branches — the `cmd` / `shellFallback` branches return
@@ -133,6 +140,28 @@ enum ClaudeSpawnCommandBuilder {
                 env[setting.envVar] = envValue
             }
         }
-        return Result(command: base, sensitiveEnv: env)
+
+        // Re-export the profile ROUTING env inline, ahead of the claude
+        // invocation. tmux's `-e KEY=VALUE` seeds the pane's initial process
+        // environment, but the window runs `$SHELL -ic <command>` and an
+        // interactive shell sources rc files (~/.zshenv, ~/.zshrc) BEFORE the
+        // -c command — any `export CLAUDE_CONFIG_DIR=...` in those files
+        // silently clobbers the -e value. That is exactly what broke profile
+        // login sessions for users running a shell-based Claude account
+        // switcher: every "isolated" session inherited the rc file's config
+        // dir instead of the profile's. Inline exports execute AFTER rc files,
+        // so they deterministically win.
+        //
+        // Scope: only the profile routing keys (config dir, base URL, model,
+        // bedrock/AWS vars) — they are non-secret and are what account
+        // switchers clobber. ANTHROPIC_API_KEY stays -e-only: inlining it
+        // would leak the secret into the long-running shell's `ps` argv.
+        let inlineExports = env
+            .filter { routingKeys.contains($0.key) }
+            .sorted(by: { $0.key < $1.key })
+            .map { "export \($0.key)=\(SystemPromptBuilder.shellEscape($0.value));" }
+            .joined(separator: " ")
+        let command = inlineExports.isEmpty ? base : "\(inlineExports) \(base)"
+        return Result(command: command, sensitiveEnv: env)
     }
 }

--- a/Sources/TBDDaemon/Claude/LoginSessionCoordinator.swift
+++ b/Sources/TBDDaemon/Claude/LoginSessionCoordinator.swift
@@ -8,17 +8,16 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "loginSession
 /// "Open login session"): a Claude pane pinned to an OAuth profile where the
 /// user completes `/login` into the profile's isolated `CLAUDE_CONFIG_DIR`.
 ///
-/// Two responsibilities, both keyed off `handleTerminalCreate`'s
+/// Two responsibilities, both armed by `handleTerminalCreate`'s
 /// `loginSession` branch:
 ///
-/// 1. **Auto-typing `/login`** — a terminal registers as "pending auto-login"
-///    at spawn. The send fires from whichever trigger comes first:
-///    - the Claude SessionStart hook event (`terminal.sessionEvent` RPC),
-///      delayed by `delays.afterSessionStart` so Claude's TUI input loop is up;
-///    - a spawn-time fallback after `delays.spawnFallback`, covering sessions
-///      whose hook never fires (missing overlay, old Claude build).
-///    `consumePendingAutoLogin` is consume-once, so double-sends are
-///    structurally impossible no matter how the triggers race.
+/// 1. **Auto-typing `/login`** via a *verified pump* (`startAutoLoginPump`):
+///    poll the pane text until Claude's TUI is interactive, type `/login` +
+///    Enter, then VERIFY the login dialog actually appeared before declaring
+///    success — re-sending (capped) if the input was swallowed. Fixed-delay
+///    sends were tried first and failed in practice: the SessionStart hook
+///    fires before the TUI's input loop reliably consumes pty input, and a
+///    send that lands in that window vanishes without a trace.
 ///
 /// 2. **Login-completion watching** — `watchLoginIdentity` polls the
 ///    profile's isolated `.claude.json` for an `oauthAccount` and invokes
@@ -36,28 +35,34 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "loginSession
 ///    user completes `/login` after the watcher expires, the badge catches up
 ///    on the next `modelProfile.list` (app relaunch or any profile mutation).
 public actor LoginSessionCoordinator {
-    /// Trigger timings. Injectable so handler-level tests can zero them out.
+    /// Pump/watcher timings. Injectable so tests can shrink them.
     public struct Delays: Sendable {
-        /// Wait after the SessionStart hook event before typing `/login` —
-        /// the hook fires early in Claude startup, slightly before the TUI
-        /// input loop reliably consumes pty input.
-        public var afterSessionStart: Duration
-        /// Fallback wait after spawn for sessions whose SessionStart hook
-        /// never reaches the daemon.
-        public var spawnFallback: Duration
+        /// Minimum wait after spawn before the pump first reads the pane.
+        public var pumpInitialDelay: Duration
+        /// Poll cadence while the pane is not ready / dialog not visible.
+        public var pumpPollInterval: Duration
+        /// Wait after typing `/login` before verifying the dialog appeared.
+        public var pumpPostSendDelay: Duration
+        /// Pump lifetime cap — after this the user types `/login` themselves
+        /// (the pane footer already hints "Not logged in · Run /login").
+        public var pumpTimeout: Duration
         /// Poll cadence for the login-identity watcher.
         public var identityPollInterval: Duration
         /// Watcher lifetime cap — after this, the badge catches up on the
         /// next `modelProfile.list` instead.
         public var identityPollTimeout: Duration
         public init(
-            afterSessionStart: Duration = .milliseconds(1500),
-            spawnFallback: Duration = .seconds(8),
+            pumpInitialDelay: Duration = .seconds(2),
+            pumpPollInterval: Duration = .seconds(1),
+            pumpPostSendDelay: Duration = .seconds(2),
+            pumpTimeout: Duration = .seconds(45),
             identityPollInterval: Duration = .seconds(2),
             identityPollTimeout: Duration = .seconds(1800)
         ) {
-            self.afterSessionStart = afterSessionStart
-            self.spawnFallback = spawnFallback
+            self.pumpInitialDelay = pumpInitialDelay
+            self.pumpPollInterval = pumpPollInterval
+            self.pumpPostSendDelay = pumpPostSendDelay
+            self.pumpTimeout = pumpTimeout
             self.identityPollInterval = identityPollInterval
             self.identityPollTimeout = identityPollTimeout
         }
@@ -65,30 +70,102 @@ public actor LoginSessionCoordinator {
 
     public let delays: Delays
     private var pendingAutoLogin: Set<UUID> = []
+    private var activePumps: Set<UUID> = []
     private var watchedProfiles: Set<UUID> = []
 
     public init(delays: Delays = Delays()) {
         self.delays = delays
     }
 
-    // MARK: - Auto-login pending set
+    // MARK: - Pane classification
 
-    /// Mark a freshly spawned login-session terminal as awaiting its one
-    /// auto-typed `/login`.
+    /// What the login-session pane currently shows, derived from its text.
+    public enum PaneLoginState: Sendable, Equatable {
+        /// Claude still booting (or pane text unavailable) — don't type yet.
+        case notReady
+        /// The TUI is interactive (input prompt / logged-out footer hint
+        /// visible) but no login dialog yet — safe to type `/login`.
+        case promptReady
+        /// The `/login` method picker is on screen — the send took; done.
+        case loginDialogVisible
+    }
+
+    /// Pure classifier for pump decisions (unit-testable without tmux).
+    public static func classifyPane(_ text: String) -> PaneLoginState {
+        // The /login picker's distinctive copy.
+        if text.contains("Select login method") { return .loginDialogVisible }
+        // Interactive markers: the input caret and/or the logged-out footer
+        // hint Claude renders once the TUI accepts input.
+        if text.contains("Run /login") || text.contains("❯") { return .promptReady }
+        return .notReady
+    }
+
+    // MARK: - Auto-login pump
+
+    /// Mark a freshly spawned login-session terminal as awaiting its
+    /// auto-typed `/login`. The pump only runs for registered terminals.
     public func registerPendingAutoLogin(terminalID: UUID) {
         pendingAutoLogin.insert(terminalID)
     }
 
-    /// Consume-once claim on the auto-login send. Returns true exactly once
-    /// per registered terminal — the SessionStart trigger and the spawn
-    /// fallback both call this, and only the winner sends.
-    public func consumePendingAutoLogin(terminalID: UUID) -> Bool {
-        pendingAutoLogin.remove(terminalID) != nil
-    }
-
-    /// Drop a pending auto-login without sending (terminal deleted).
+    /// Stop auto-login for a terminal (deleted / no longer relevant). An
+    /// active pump observes this on its next iteration and exits.
     public func cancelPendingAutoLogin(terminalID: UUID) {
         pendingAutoLogin.remove(terminalID)
+    }
+
+    /// True while the terminal still awaits its auto-typed `/login`.
+    public func isPendingAutoLogin(terminalID: UUID) -> Bool {
+        pendingAutoLogin.contains(terminalID)
+    }
+
+    /// Run the verified auto-`/login` pump for a registered terminal.
+    ///
+    /// Loop (bounded by `delays.pumpTimeout`):
+    ///  - pane `notReady` → wait `pumpPollInterval`, re-read;
+    ///  - pane `promptReady` → `typeLogin()` (at most `maxSends` times, so a
+    ///    pathological pane can't get its input stuffed), wait
+    ///    `pumpPostSendDelay`, re-read to VERIFY;
+    ///  - pane `loginDialogVisible` → success, stop.
+    ///
+    /// Single-flighted per terminal; exits early when the registration is
+    /// cancelled (terminal deleted).
+    public func startAutoLoginPump(
+        terminalID: UUID,
+        maxSends: Int = 3,
+        paneText: @escaping @Sendable () async -> String,
+        typeLogin: @escaping @Sendable () async -> Void
+    ) {
+        guard pendingAutoLogin.contains(terminalID) else { return }
+        guard !activePumps.contains(terminalID) else { return }
+        activePumps.insert(terminalID)
+        Task {
+            defer {
+                activePumps.remove(terminalID)
+                pendingAutoLogin.remove(terminalID)
+            }
+            try? await Task.sleep(for: delays.pumpInitialDelay)
+            var elapsed: Duration = .zero
+            var sends = 0
+            while elapsed < delays.pumpTimeout {
+                guard pendingAutoLogin.contains(terminalID) else { return }
+                switch Self.classifyPane(await paneText()) {
+                case .loginDialogVisible:
+                    logger.info("auto-login: login dialog visible in terminal \(terminalID, privacy: .public) after \(sends, privacy: .public) send(s)")
+                    return
+                case .promptReady where sends < maxSends:
+                    sends += 1
+                    logger.info("auto-login: typing /login into terminal \(terminalID, privacy: .public) (attempt \(sends, privacy: .public))")
+                    await typeLogin()
+                    try? await Task.sleep(for: delays.pumpPostSendDelay)
+                    elapsed += delays.pumpPostSendDelay
+                case .promptReady, .notReady:
+                    try? await Task.sleep(for: delays.pumpPollInterval)
+                    elapsed += delays.pumpPollInterval
+                }
+            }
+            logger.debug("auto-login: pump for terminal \(terminalID, privacy: .public) timed out (sends=\(sends, privacy: .public))")
+        }
     }
 
     // MARK: - Login-identity watcher

--- a/Sources/TBDDaemon/Claude/LoginSessionCoordinator.swift
+++ b/Sources/TBDDaemon/Claude/LoginSessionCoordinator.swift
@@ -1,0 +1,129 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "loginSession")
+
+/// Coordinates the daemon side of a profile *login session* (Settings →
+/// "Open login session"): a Claude pane pinned to an OAuth profile where the
+/// user completes `/login` into the profile's isolated `CLAUDE_CONFIG_DIR`.
+///
+/// Two responsibilities, both keyed off `handleTerminalCreate`'s
+/// `loginSession` branch:
+///
+/// 1. **Auto-typing `/login`** — a terminal registers as "pending auto-login"
+///    at spawn. The send fires from whichever trigger comes first:
+///    - the Claude SessionStart hook event (`terminal.sessionEvent` RPC),
+///      delayed by `delays.afterSessionStart` so Claude's TUI input loop is up;
+///    - a spawn-time fallback after `delays.spawnFallback`, covering sessions
+///      whose hook never fires (missing overlay, old Claude build).
+///    `consumePendingAutoLogin` is consume-once, so double-sends are
+///    structurally impossible no matter how the triggers race.
+///
+/// 2. **Login-completion watching** — `watchLoginIdentity` polls the
+///    profile's isolated `.claude.json` for an `oauthAccount` and invokes
+///    `onLogin` (the caller broadcasts `.modelProfilesChanged`) when it
+///    appears, so the Settings badge flips to "Logged in as …" live.
+///
+///    Design choice — bounded polling over FSEvents/DispatchSource: Claude
+///    writes `.claude.json` via atomic rename, which breaks per-file vnode
+///    watchers (the watched inode is replaced); a correct watcher must
+///    monitor the directory and re-arm, and a daemon-lifetime watcher per
+///    profile is standing complexity for an event that happens at most once
+///    per profile. A 2s poll scoped to an active login attempt (started on
+///    login-session spawn, single-flighted per profile, capped at 30 min) is
+///    simpler, self-terminating, and robust against atomic replaces. If the
+///    user completes `/login` after the watcher expires, the badge catches up
+///    on the next `modelProfile.list` (app relaunch or any profile mutation).
+public actor LoginSessionCoordinator {
+    /// Trigger timings. Injectable so handler-level tests can zero them out.
+    public struct Delays: Sendable {
+        /// Wait after the SessionStart hook event before typing `/login` —
+        /// the hook fires early in Claude startup, slightly before the TUI
+        /// input loop reliably consumes pty input.
+        public var afterSessionStart: Duration
+        /// Fallback wait after spawn for sessions whose SessionStart hook
+        /// never reaches the daemon.
+        public var spawnFallback: Duration
+        /// Poll cadence for the login-identity watcher.
+        public var identityPollInterval: Duration
+        /// Watcher lifetime cap — after this, the badge catches up on the
+        /// next `modelProfile.list` instead.
+        public var identityPollTimeout: Duration
+        public init(
+            afterSessionStart: Duration = .milliseconds(1500),
+            spawnFallback: Duration = .seconds(8),
+            identityPollInterval: Duration = .seconds(2),
+            identityPollTimeout: Duration = .seconds(1800)
+        ) {
+            self.afterSessionStart = afterSessionStart
+            self.spawnFallback = spawnFallback
+            self.identityPollInterval = identityPollInterval
+            self.identityPollTimeout = identityPollTimeout
+        }
+    }
+
+    public let delays: Delays
+    private var pendingAutoLogin: Set<UUID> = []
+    private var watchedProfiles: Set<UUID> = []
+
+    public init(delays: Delays = Delays()) {
+        self.delays = delays
+    }
+
+    // MARK: - Auto-login pending set
+
+    /// Mark a freshly spawned login-session terminal as awaiting its one
+    /// auto-typed `/login`.
+    public func registerPendingAutoLogin(terminalID: UUID) {
+        pendingAutoLogin.insert(terminalID)
+    }
+
+    /// Consume-once claim on the auto-login send. Returns true exactly once
+    /// per registered terminal — the SessionStart trigger and the spawn
+    /// fallback both call this, and only the winner sends.
+    public func consumePendingAutoLogin(terminalID: UUID) -> Bool {
+        pendingAutoLogin.remove(terminalID) != nil
+    }
+
+    /// Drop a pending auto-login without sending (terminal deleted).
+    public func cancelPendingAutoLogin(terminalID: UUID) {
+        pendingAutoLogin.remove(terminalID)
+    }
+
+    // MARK: - Login-identity watcher
+
+    /// Poll `identity()` every `interval` until it returns non-nil (login
+    /// completed → fire `onLogin` once and stop) or `timeout` elapses.
+    /// Single-flighted per profile: while a watcher is active, further
+    /// `watchLoginIdentity` calls for the same profile are no-ops, so five
+    /// clicks on "Open login session" cost one poll loop.
+    public func watchLoginIdentity(
+        profileID: UUID,
+        interval: Duration = .seconds(2),
+        timeout: Duration = .seconds(1800),
+        identity: @escaping @Sendable () -> String?,
+        onLogin: @escaping @Sendable () -> Void
+    ) {
+        guard !watchedProfiles.contains(profileID) else { return }
+        watchedProfiles.insert(profileID)
+        Task {
+            defer { unwatch(profileID: profileID) }
+            var elapsed: Duration = .zero
+            while elapsed < timeout {
+                if let email = identity() {
+                    logger.info("login detected for profile \(profileID, privacy: .public) (\(email, privacy: .private)); broadcasting profile refresh")
+                    onLogin()
+                    return
+                }
+                try? await Task.sleep(for: interval)
+                elapsed += interval
+            }
+            logger.debug("login watcher for profile \(profileID, privacy: .public) timed out without a login")
+        }
+    }
+
+    private func unwatch(profileID: UUID) {
+        watchedProfiles.remove(profileID)
+    }
+}

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -20,6 +20,7 @@ public final class TBDDatabase: Sendable {
     public let config: ConfigStore
     public let meta: TBDMetaStore
     public let tabs: TabStore
+    public let forgottenWorktrees: ForgottenWorktreeStore
 
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
@@ -48,6 +49,7 @@ public final class TBDDatabase: Sendable {
         self.config = ConfigStore(writer: pool)
         self.meta = TBDMetaStore(writer: pool)
         self.tabs = TabStore(writer: pool)
+        self.forgottenWorktrees = ForgottenWorktreeStore(writer: pool)
 
         let migrator = Self.buildMigrator()
         if fileExisted {
@@ -76,6 +78,7 @@ public final class TBDDatabase: Sendable {
         self.config = ConfigStore(writer: queue)
         self.meta = TBDMetaStore(writer: queue)
         self.tabs = TabStore(writer: queue)
+        self.forgottenWorktrees = ForgottenWorktreeStore(writer: queue)
         try Self.buildMigrator().migrate(queue)
     }
 
@@ -626,6 +629,32 @@ public final class TBDDatabase: Sendable {
         migrator.registerMigration("v37_config_scratch_rename_and_profile") { db in
             try db.addColumnIfMissing(table: "config", column: "scratch_rename_prompt", type: .text)
             try db.addColumnIfMissing(table: "config", column: "scratch_profile_override_id", type: .text)
+        }
+
+        // Tombstones for `tbd worktree forget`: reconcile skips re-adopting a
+        // git worktree whose path has a tombstone, so forget sticks even for
+        // paths under a TBD-managed prefix. Keyed by exact absolute path;
+        // cleared when the path is deliberately re-added via adopt/create.
+        //
+        // NOTE: identifier says "v35" but registers after v37 — this migration
+        // shipped as v35_forgotten_worktree on pre-rebase deployments before
+        // upstream took v35–v37, and GRDB identifies migrations by string, so
+        // renaming it would orphan databases that already applied it. New
+        // databases simply apply it here, in registration order. (Precedent:
+        // v33_channel_message_sender_kind already registers after
+        // v33_config_auto_archive_default.) Idempotent via IfNotExists/IfMissing.
+        migrator.registerMigration("v35_forgotten_worktree") { db in
+            try db.createTableIfNotExists("forgotten_worktree") { t in
+                t.primaryKey("path", .text).notNull()
+                t.column("repoID", .text).notNull()
+                t.column("forgottenAt", .datetime).notNull()
+                    .defaults(sql: "CURRENT_TIMESTAMP")
+            }
+            try db.addIndexIfMissing(
+                "idx_forgotten_worktree_repoID",
+                on: "forgotten_worktree",
+                columns: ["repoID"]
+            )
         }
 
         return migrator

--- a/Sources/TBDDaemon/Database/ForgottenWorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/ForgottenWorktreeStore.swift
@@ -1,0 +1,69 @@
+import Foundation
+import GRDB
+
+/// GRDB Record type for the `forgotten_worktree` table.
+///
+/// A tombstone row records that the user explicitly ran `tbd worktree forget`
+/// on a worktree at `path`. Reconcile consults these rows so a forgotten
+/// worktree that still lives under a TBD-managed prefix (and is still
+/// registered with git) is NOT re-adopted on the next sweep. The tombstone is
+/// keyed by exact absolute path — the directory is the thing being ignored,
+/// not any particular worktree row.
+struct ForgottenWorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "forgotten_worktree"
+
+    var path: String
+    var repoID: String
+    var forgottenAt: Date
+}
+
+/// CRUD for worktree-forget tombstones. Daemon-internal — tombstones are not
+/// exposed over RPC and have no mirror in `TBDShared.Models`.
+public struct ForgottenWorktreeStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Insert (or refresh) a tombstone for `path`. Idempotent: re-forgetting
+    /// the same path updates `forgottenAt` instead of throwing on the
+    /// primary-key conflict.
+    public func insert(path: String, repoID: UUID) async throws {
+        let record = ForgottenWorktreeRecord(
+            path: path,
+            repoID: repoID.uuidString,
+            forgottenAt: Date()
+        )
+        try await writer.write { db in
+            try record.save(db)
+        }
+    }
+
+    /// Whether a tombstone exists for the exact path.
+    public func contains(path: String) async throws -> Bool {
+        try await writer.read { db in
+            try ForgottenWorktreeRecord.fetchOne(db, key: path) != nil
+        }
+    }
+
+    /// All tombstoned paths, loaded as a set for O(1) membership checks in
+    /// reconcile's re-adopt loop. Deliberately NOT scoped to a repo: the
+    /// tombstone's semantic key is the directory path, and matching globally
+    /// keeps forget sticky even if the repo row is ever deleted and re-added
+    /// under a new UUID.
+    public func allPaths() async throws -> Set<String> {
+        try await writer.read { db in
+            Set(try String.fetchAll(db, sql: "SELECT path FROM forgotten_worktree"))
+        }
+    }
+
+    /// Remove the tombstone for `path` (exact match). No-op when absent.
+    /// Called when a worktree is deliberately re-added at a tombstoned path
+    /// (adopt or create), so the ignore doesn't outlive the user's intent.
+    public func delete(path: String) async throws {
+        _ = try await writer.write { db in
+            try ForgottenWorktreeRecord.deleteOne(db, key: path)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Keychain/ClaudeCodeCredentialsKeychain.swift
+++ b/Sources/TBDDaemon/Keychain/ClaudeCodeCredentialsKeychain.swift
@@ -1,0 +1,71 @@
+import CryptoKit
+import Foundation
+import Security
+
+/// Claude Code stores OAuth credentials in the login keychain as a generic
+/// password whose service name is derived from the `CLAUDE_CONFIG_DIR` path:
+///
+///     "Claude Code-credentials-<first 8 lowercase hex chars of sha256(path)>"
+///
+/// Known vector (verified empirically): sha256 of
+/// "/Users/zionts/.claude-profiles/zadam" starts with `db64a81f`, and the
+/// keychain item "Claude Code-credentials-db64a81f" pairs with that dir.
+///
+/// The bare "Claude Code-credentials" item (no suffix) belongs to the user's
+/// default `~/.claude` and must NEVER be touched by TBD. Every service name
+/// produced here always carries a path-derived suffix, so deleting through
+/// this namespace can never target the bare item.
+public enum ClaudeCodeCredentialsKeychain {
+    /// Base service name used by Claude Code. The unsuffixed form belongs to
+    /// the user's default config dir — TBD only ever appends a suffix to it.
+    public static let baseServiceName = "Claude Code-credentials"
+
+    /// First 8 lowercase-hex characters of sha256 of the config dir path
+    /// string (the exact string, no normalization — matches how Claude Code
+    /// hashes `CLAUDE_CONFIG_DIR`).
+    public static func serviceSuffix(forConfigDirPath path: String) -> String {
+        let digest = SHA256.hash(data: Data(path.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return String(hex.prefix(8))
+    }
+
+    /// Full keychain service name for the credentials item belonging to the
+    /// given config dir. Always suffixed — never returns the bare item name.
+    public static func serviceName(forConfigDirPath path: String) -> String {
+        "\(baseServiceName)-\(serviceSuffix(forConfigDirPath: path))"
+    }
+}
+
+/// Injection seam for deleting Claude Code credential items, so tests can
+/// assert "delete was requested with the right service name" without touching
+/// the real login keychain.
+public protocol ClaudeCredentialsKeychainDeleting: Sendable {
+    /// Delete the generic-password item with the given service name.
+    /// Returns the raw `SecItemDelete`-style status; `errSecItemNotFound`
+    /// counts as success for callers (nothing to clean).
+    func deleteGenericPassword(service: String) -> OSStatus
+}
+
+extension ClaudeCredentialsKeychainDeleting {
+    /// Delete the Claude Code credentials item for the given config dir path.
+    /// The service name is always derived (suffixed) from the path, so this
+    /// can never target the bare "Claude Code-credentials" item.
+    public func deleteCredentials(forConfigDirPath path: String) -> OSStatus {
+        deleteGenericPassword(
+            service: ClaudeCodeCredentialsKeychain.serviceName(forConfigDirPath: path)
+        )
+    }
+}
+
+/// Live implementation backed by the Security framework.
+public struct SecItemClaudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting {
+    public init() {}
+
+    public func deleteGenericPassword(service: String) -> OSStatus {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+        ]
+        return SecItemDelete(query as CFDictionary)
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/PluginDirWriter.swift
+++ b/Sources/TBDDaemon/Lifecycle/PluginDirWriter.swift
@@ -74,6 +74,39 @@ struct PluginDirWriter {
             encoding: .utf8
         )
 
+        // Bundled `nightwatch` skill (quota-lean fleet babysitter). Ships its
+        // SKILL.md + scripts/tick.py + config/* so it works against a TBD fleet
+        // out of the box. Dormant until its description matches a babysitting task.
+        try writeNightwatch(pluginDir: pluginDir)
+
         Self.logger.info("Wrote TBD plugin at \(pluginDir, privacy: .public)")
+    }
+
+    /// Install the `nightwatch` skill into the plugin's skills dir. `tick.py`
+    /// is written with the executable bit so cron/launchd can run it directly.
+    private func writeNightwatch(pluginDir: String) throws {
+        let fm = FileManager.default
+        let root = pluginDir + "/skills/nightwatch"
+        let scripts = root + "/scripts"
+        let config = root + "/config"
+        try fm.createDirectory(atPath: scripts, withIntermediateDirectories: true)
+        try fm.createDirectory(atPath: config, withIntermediateDirectories: true)
+
+        try NightwatchSkillContent.skillMd.write(toFile: root + "/SKILL.md", atomically: true, encoding: .utf8)
+        try NightwatchSkillContent.prioritiesTxt.write(toFile: config + "/priorities.txt", atomically: true, encoding: .utf8)
+        try NightwatchSkillContent.safeWedgesTxt.write(toFile: config + "/safe_wedges.txt", atomically: true, encoding: .utf8)
+        try NightwatchSkillContent.dontTouchTxt.write(toFile: config + "/dont_touch.txt", atomically: true, encoding: .utf8)
+
+        // Scripts ship executable. NOTE: the scheduler (scheduler.sh / tick-cron.sh)
+        // is installed but NEVER auto-loaded — durable scheduling is opt-in via
+        // `scheduler.sh enable`.
+        for (name, body) in [("tick.py", NightwatchSkillContent.tickPy),
+                             ("judge.py", NightwatchSkillContent.judgePy),
+                             ("tick-cron.sh", NightwatchSkillContent.tickCronSh),
+                             ("scheduler.sh", NightwatchSkillContent.schedulerSh)] {
+            let path = scripts + "/" + name
+            try body.write(toFile: path, atomically: true, encoding: .utf8)
+            try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        }
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Adopt.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Adopt.swift
@@ -53,6 +53,11 @@ extension WorktreeLifecycle {
             throw WorktreeAdoptError.notInGitWorktreeList(path: path)
         }
 
+        // Adopting is an explicit "track this path again" — clear any forget
+        // tombstone so reconcile resumes treating the path normally. Runs on
+        // every adopt outcome (inserted/revived/unchanged); no-op when absent.
+        try await db.forgottenWorktrees.delete(path: path)
+
         let name = (path as NSString).lastPathComponent
         let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -123,6 +123,11 @@ extension WorktreeLifecycle {
         let worktreePath = (canonicalBase as NSString).appendingPathComponent(resolvedName)
         let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
 
+        // Creating at this path is an explicit "track it again" — clear any
+        // forget tombstone so reconcile resumes treating the path normally.
+        // No-op when the path was never forgotten.
+        try await db.forgottenWorktrees.delete(path: worktreePath)
+
         // 3. Insert DB row with status = .creating
         let worktree = try await db.worktrees.create(
             repoID: repo.id,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
@@ -15,10 +15,11 @@ extension WorktreeLifecycle {
     ///
     /// What `forget` does (mirrors the archive/reconcile cleanup, minus the disk
     /// removal and the archive hook):
-    /// 1. Kills the worktree's tmux windows.
-    /// 2. Deletes its terminals + tabs and clears their pending questions and
+    /// 1. Inserts a `forgotten_worktree` tombstone for the path (see below).
+    /// 2. Kills the worktree's tmux windows.
+    /// 3. Deletes its terminals + tabs and clears their pending questions and
     ///    per-session ClaudeHookOverlay files.
-    /// 3. Hard-deletes the worktree row (so it's gone from BOTH the active and
+    /// 4. Hard-deletes the worktree row (so it's gone from BOTH the active and
     ///    archived lists — not merely flipped to `.archived`).
     ///
     /// What `forget` does NOT do:
@@ -26,15 +27,14 @@ extension WorktreeLifecycle {
     /// - It does not run the `archive` lifecycle hook ("before_worktree_remove"),
     ///   because nothing is being removed from disk.
     ///
-    /// CAVEAT — reconcile re-adoption: `reconcile` re-adopts on-disk git
-    /// worktrees whose path is under one of TBD's own prefixes
-    /// (`~/tbd/worktrees/<slot>/` or `<repo>/.tbd/worktrees/`). A forgotten
-    /// worktree whose path is under such a prefix WILL reappear on the next
-    /// reconcile (it's re-created as a fresh `.active` row). Worktrees living
-    /// outside those prefixes (e.g. `~/conductor/workspaces/...`) are never
-    /// re-adopted, so forget sticks for them. A tombstone/ignore-list to make
-    /// forget stick for TBD-managed paths is a follow-up; this pass only logs a
-    /// warning when forgetting such a worktree.
+    /// Reconcile re-adoption is suppressed via a tombstone: `reconcile`
+    /// re-adopts on-disk git worktrees whose path is under one of TBD's own
+    /// prefixes (`~/tbd/worktrees/<slot>/` or `<repo>/.tbd/worktrees/`), so
+    /// `forget` also inserts a `forgotten_worktree` tombstone row keyed by the
+    /// worktree's absolute path. Reconcile skips tombstoned paths, making
+    /// forget stick even for TBD-managed locations. The tombstone is cleared
+    /// when the user deliberately re-adds the path (adopt or create), which
+    /// restores normal reconcile behavior.
     public func forgetWorktree(worktreeID: UUID) async throws {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
@@ -44,17 +44,19 @@ extension WorktreeLifecycle {
             throw WorktreeLifecycleError.invalidOperation("Cannot forget the main branch worktree")
         }
 
-        // Warn (best-effort) when the path is under a TBD-managed prefix, since
-        // reconcile would re-adopt it. Repo lookup is best-effort — a missing
-        // repo row doesn't block forget (we still want the row gone).
-        if let rid = worktree.repoID, let repo = try? await db.repos.get(id: rid) {
-            let acceptablePrefixes = WorktreeLayout().legacyAndCanonicalPrefixes(for: repo)
-                .map { $0.hasSuffix("/") ? $0 : $0 + "/" }
-            if acceptablePrefixes.contains(where: { worktree.path.hasPrefix($0) }) {
-                forgetLogger.warning(
-                    "forget: worktree \(worktreeID, privacy: .public) at \(worktree.path, privacy: .public) is under a TBD-managed prefix; reconcile will re-adopt it (follow-up: tombstone/ignore-list)"
-                )
-            }
+        // Tombstone the path so reconcile won't re-adopt it. Inserted for any
+        // repo-backed worktree regardless of prefix: for paths outside
+        // TBD-managed prefixes it's inert (reconcile never adopts them anyway),
+        // and skipping the prefix check keeps forget simple and future-proof
+        // against layout changes. Scratch spaces (repoID == nil) need no
+        // tombstone — reconcile only enumerates repo worktrees, so a repo-less
+        // path can never be re-adopted. (Replaces the earlier warning-only
+        // prefix check that pointed at this exact follow-up.)
+        if let repoID = worktree.repoID {
+            try await db.forgottenWorktrees.insert(path: worktree.path, repoID: repoID)
+            forgetLogger.debug(
+                "forget: tombstoned path \(worktree.path, privacy: .public) for worktree \(worktreeID, privacy: .public); reconcile will not re-adopt it"
+            )
         }
 
         // Mirror the archive/reconcile cleanup: kill tmux windows, delete

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -148,8 +148,18 @@ extension WorktreeLifecycle {
         let layout = WorktreeLayout()
         let acceptablePrefixes = layout.legacyAndCanonicalPrefixes(for: repo)
             .map { $0.hasSuffix("/") ? $0 : $0 + "/" }
+        // Paths the user explicitly forgot (`tbd worktree forget`) must NOT be
+        // re-adopted, even though they still sit under a TBD-managed prefix
+        // and remain registered with git. Loaded once per reconcile pass.
+        // Tombstones are cleared by the adopt/create flows when the user
+        // deliberately re-adds a path.
+        let forgottenPaths = try await db.forgottenWorktrees.allPaths()
         for gitWt in gitWorktrees where !dbPaths.contains(gitWt.path) {
             guard acceptablePrefixes.contains(where: { gitWt.path.hasPrefix($0) }) else { continue }
+            if forgottenPaths.contains(gitWt.path) {
+                logger.debug("reconcile: skipping forgotten worktree path \(gitWt.path, privacy: .public)")
+                continue
+            }
 
             let name = (gitWt.path as NSString).lastPathComponent
             let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 import os
 import TBDShared
 
@@ -28,8 +29,24 @@ extension RPCRouter {
     func handleModelProfileList() async throws -> RPCResponse {
         let profiles = try await db.modelProfiles.list()
         let usageByID = try await db.modelProfileUsage.fetchAll()
-        let result = profiles.map { profile in
-            ModelProfileWithUsage(profile: profile, usage: usageByID[profile.id])
+        let result = profiles.map { profile -> ModelProfileWithUsage in
+            // Bedrock profiles have no isolated config dir; everything else
+            // gets one at ~/tbd/profiles/<uuid>/claude. loginIdentity is only
+            // meaningful for OAuth profiles (Claude Code writes oauthAccount
+            // into the isolated .claude.json after /login). Computed fresh on
+            // every list call — this RPC is infrequent, so no caching.
+            let configDirPath: String? = profile.kind == .bedrock
+                ? nil
+                : configDirManager.configDirectory(forProfileID: profile.id).path
+            let loginIdentity: String? = profile.kind == .oauth
+                ? configDirManager.loginIdentity(forProfileID: profile.id)
+                : nil
+            return ModelProfileWithUsage(
+                profile: profile,
+                usage: usageByID[profile.id],
+                loginIdentity: loginIdentity,
+                configDirPath: configDirPath
+            )
         }
         let config = try await db.config.get()
         return try RPCResponse(result: ModelProfileListResult(
@@ -198,6 +215,25 @@ extension RPCRouter {
         // Remove the per-profile config directory. Non-bedrock profiles have an
         // isolated config dir at ~/tbd/profiles/<uuid>/; bedrock profiles do not.
         if profile.kind != .bedrock {
+            // Also delete the Claude Code OAuth credential item that /login
+            // wrote into the login keychain for this profile's isolated config
+            // dir ("Claude Code-credentials-<sha256-prefix-of-configDir>").
+            // The service name is always suffixed with the path-derived hash of
+            // OUR config dir, so this can never touch the user's bare
+            // "Claude Code-credentials" item (default ~/.claude). Done for
+            // apiKey-kind profiles too — harmless if the item doesn't exist.
+            // errSecItemNotFound is success: there was nothing to clean.
+            let configDir = self.configDirManager.configDirectory(forProfileID: params.id)
+            let status = claudeCredentialsKeychain.deleteCredentials(forConfigDirPath: configDir.path)
+            switch status {
+            case errSecSuccess:
+                logger.info("Deleted Claude Code keychain credentials for profile \(params.id, privacy: .public)")
+            case errSecItemNotFound:
+                logger.debug("No Claude Code keychain credentials to delete for profile \(params.id, privacy: .public)")
+            default:
+                logger.warning("Failed to delete Claude Code keychain credentials for profile \(params.id, privacy: .public): OSStatus \(status, privacy: .public)")
+            }
+
             do {
                 let profileDir = self.configDirManager.profileDirectory(forProfileID: params.id)
                 try FileManager.default.removeItem(at: profileDir)

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -407,4 +407,23 @@ extension RPCRouter {
         let result = await ModelProfileHealthProbe.probe(baseURL: params.baseURL)
         return try RPCResponse(result: result)
     }
+
+    // MARK: - Prepare Config Dir
+
+    /// Ensure an OAuth profile's isolated `CLAUDE_CONFIG_DIR` exists and is
+    /// seeded, and return its absolute path. Idempotent — safe to call before
+    /// every `tbd profile login`. OAuth-only: apiKey dirs need the secret for
+    /// pre-approval seeding (that provisioning stays on the spawn path), and
+    /// bedrock profiles have no config dir at all.
+    func handleModelProfilePrepareConfigDir(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ModelProfilePrepareConfigDirParams.self, from: paramsData)
+        guard let profile = try await db.modelProfiles.get(id: params.id) else {
+            return RPCResponse(error: "Profile not found")
+        }
+        guard profile.kind == .oauth else {
+            return RPCResponse(error: "Profile '\(profile.name)' is a \(profile.kind.rawValue) profile — only OAuth profiles use an isolated login config dir")
+        }
+        let dir = try configDirManager.ensureOAuthDir(forProfileID: profile.id)
+        return try RPCResponse(result: ModelProfilePrepareConfigDirResult(configDirPath: dir.path))
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -182,6 +182,10 @@ extension RPCRouter {
         }
 
         let isClaudeType = params.type == .claude || params.resumeSessionID != nil
+        // Login sessions are always fresh Claude spawns pinned to a profile:
+        // the whole point is capturing `/login` credentials into that
+        // profile's isolated config dir.
+        let isLoginSession = params.loginSession == true && params.resumeSessionID == nil
         let claudeSessionID: String?
         let label: String?
 
@@ -201,6 +205,22 @@ extension RPCRouter {
             }
         }
 
+        // A login session without its profile is meaningless — spawning a
+        // default-credential Claude here would look like it worked while the
+        // `/login` lands in the wrong config dir. Fail loud so the app can
+        // surface the error instead of leaving a ghost tab.
+        if isLoginSession {
+            guard isClaudeType else {
+                return RPCResponse(error: "Login sessions must be Claude terminals (type: claude)")
+            }
+            guard params.overrideProfileID != nil else {
+                return RPCResponse(error: "Login sessions require a profile (overrideProfileID)")
+            }
+            guard resolvedProfile != nil else {
+                return RPCResponse(error: "Profile not found or unreadable — cannot open a login session for it")
+            }
+        }
+
         // Build the spawn command via the pure helper.
         let appendSystemPrompt: String?
         let freshSessionID: String?
@@ -217,7 +237,7 @@ extension RPCRouter {
                 repo: repo, worktree: worktree, isResume: false,
                 scratchInstructions: createConfig?.scratchInstructions,
                 scratchRenamePrompt: createConfig?.scratchRenamePrompt)
-            label = TerminalLabel.claudeCode
+            label = isLoginSession ? TerminalLabel.login : TerminalLabel.claudeCode
         } else if let cmd = params.cmd {
             claudeSessionID = nil
             freshSessionID = nil
@@ -296,7 +316,62 @@ extension RPCRouter {
             terminalID: terminal.id, worktreeID: terminal.worktreeID, label: terminal.label
         )))
 
+        if isLoginSession, let profile = resolvedProfile {
+            await armLoginSession(terminalID: terminal.id, profile: profile)
+        }
+
         return try RPCResponse(result: terminal)
+    }
+
+    /// Post-spawn wiring for a profile login session:
+    /// 1. registers the terminal for the one-shot auto-typed `/login`
+    ///    (fired by the SessionStart hook event, with a spawn-time fallback);
+    /// 2. starts the login-identity watcher so the Settings badge flips to
+    ///    "Logged in as …" the moment the profile's isolated `.claude.json`
+    ///    gains an `oauthAccount`.
+    private func armLoginSession(terminalID: UUID, profile: ResolvedModelProfile) async {
+        await loginSessions.registerPendingAutoLogin(terminalID: terminalID)
+
+        // Fallback trigger: if the SessionStart hook never reaches us
+        // (missing overlay, older Claude build), still type /login after a
+        // conservative delay. Consume-once semantics in the coordinator make
+        // this race-free against the hook trigger.
+        let fallbackDelay = loginSessions.delays.spawnFallback
+        Task { [weak self] in
+            try? await Task.sleep(for: fallbackDelay)
+            await self?.performAutoLoginSend(terminalID: terminalID, trigger: "spawn-fallback")
+        }
+
+        let configDirManager = self.configDirManager
+        let subscriptions = self.subscriptions
+        let profileID = profile.profileID
+        await loginSessions.watchLoginIdentity(
+            profileID: profileID,
+            interval: loginSessions.delays.identityPollInterval,
+            timeout: loginSessions.delays.identityPollTimeout,
+            identity: { configDirManager.loginIdentity(forProfileID: profileID) },
+            onLogin: { subscriptions.broadcast(delta: .modelProfilesChanged) }
+        )
+    }
+
+    /// Type `/login` + Enter into a pending login-session terminal. Consume-
+    /// once: only the first caller per terminal actually sends; later
+    /// triggers (hook vs. fallback race) are no-ops, as is a terminal that
+    /// was deleted in the meantime.
+    func performAutoLoginSend(terminalID: UUID, trigger: String) async {
+        guard await loginSessions.consumePendingAutoLogin(terminalID: terminalID) else { return }
+        guard let terminal = try? await db.terminals.get(id: terminalID),
+              let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+            logger.debug("auto-login: terminal \(terminalID, privacy: .public) vanished before send (trigger=\(trigger, privacy: .public))")
+            return
+        }
+        do {
+            try await tmux.sendKeys(server: worktree.tmuxServer, paneID: terminal.tmuxPaneID, text: "/login")
+            try await tmux.sendKey(server: worktree.tmuxServer, paneID: terminal.tmuxPaneID, key: "Enter")
+            logger.info("auto-login: typed /login into terminal \(terminalID, privacy: .public) (trigger=\(trigger, privacy: .public))")
+        } catch {
+            logger.warning("auto-login: send failed for terminal \(terminalID, privacy: .public): \(error, privacy: .public)")
+        }
     }
 
     func handleTerminalList(_ paramsData: Data) async throws -> RPCResponse {
@@ -322,6 +397,7 @@ extension RPCRouter {
         try await db.terminals.delete(id: params.terminalID)
         try await db.tabs.delete(tabID: params.terminalID)
         await pendingQuestions.clear(terminalID: params.terminalID)
+        await loginSessions.cancelPendingAutoLogin(terminalID: params.terminalID)
 
         // Reclaim the per-session fallbackModel overlay (keyed by terminal id),
         // if this terminal had one. No-op when the profile had no fallback.
@@ -1118,6 +1194,19 @@ extension RPCRouter {
 
         let source = params.source ?? "unknown"
         logger.info("sessionEvent: terminal \(terminal.id.uuidString, privacy: .public) -> session \(params.sessionID, privacy: .public) (source=\(source, privacy: .public))")
+
+        // Login-session terminals get `/login` auto-typed once Claude is up.
+        // The SessionStart hook is our readiness signal; wait a beat so the
+        // TUI's input loop is consuming pty input, then send. Consume-once in
+        // the coordinator dedupes against the spawn-time fallback trigger.
+        if terminal.label == TerminalLabel.login {
+            let terminalID = terminal.id
+            let delay = loginSessions.delays.afterSessionStart
+            Task { [weak self] in
+                try? await Task.sleep(for: delay)
+                await self?.performAutoLoginSend(terminalID: terminalID, trigger: "session-start")
+            }
+        }
 
         subscriptions.broadcast(delta: .terminalSessionUpdated(TerminalSessionDelta(
             terminalID: terminal.id,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -317,30 +317,47 @@ extension RPCRouter {
         )))
 
         if isLoginSession, let profile = resolvedProfile {
-            await armLoginSession(terminalID: terminal.id, profile: profile)
+            await armLoginSession(
+                terminalID: terminal.id,
+                paneID: window.paneID,
+                server: worktree.tmuxServer,
+                profile: profile
+            )
         }
 
         return try RPCResponse(result: terminal)
     }
 
     /// Post-spawn wiring for a profile login session:
-    /// 1. registers the terminal for the one-shot auto-typed `/login`
-    ///    (fired by the SessionStart hook event, with a spawn-time fallback);
+    /// 1. starts the verified auto-`/login` pump — poll the pane until
+    ///    Claude's TUI is interactive, type `/login` + Enter, then verify the
+    ///    login dialog actually appeared (retrying, capped) so a send that
+    ///    lands before the input loop is ready doesn't silently vanish;
     /// 2. starts the login-identity watcher so the Settings badge flips to
     ///    "Logged in as …" the moment the profile's isolated `.claude.json`
     ///    gains an `oauthAccount`.
-    private func armLoginSession(terminalID: UUID, profile: ResolvedModelProfile) async {
+    private func armLoginSession(
+        terminalID: UUID,
+        paneID: String,
+        server: String,
+        profile: ResolvedModelProfile
+    ) async {
+        let tmux = self.tmux
         await loginSessions.registerPendingAutoLogin(terminalID: terminalID)
-
-        // Fallback trigger: if the SessionStart hook never reaches us
-        // (missing overlay, older Claude build), still type /login after a
-        // conservative delay. Consume-once semantics in the coordinator make
-        // this race-free against the hook trigger.
-        let fallbackDelay = loginSessions.delays.spawnFallback
-        Task { [weak self] in
-            try? await Task.sleep(for: fallbackDelay)
-            await self?.performAutoLoginSend(terminalID: terminalID, trigger: "spawn-fallback")
-        }
+        await loginSessions.startAutoLoginPump(
+            terminalID: terminalID,
+            paneText: {
+                (try? await tmux.capturePaneOutput(server: server, paneID: paneID)) ?? ""
+            },
+            typeLogin: {
+                do {
+                    try await tmux.sendKeys(server: server, paneID: paneID, text: "/login")
+                    try await tmux.sendKey(server: server, paneID: paneID, key: "Enter")
+                } catch {
+                    logger.warning("auto-login: send failed for terminal \(terminalID, privacy: .public): \(error, privacy: .public)")
+                }
+            }
+        )
 
         let configDirManager = self.configDirManager
         let subscriptions = self.subscriptions
@@ -352,26 +369,6 @@ extension RPCRouter {
             identity: { configDirManager.loginIdentity(forProfileID: profileID) },
             onLogin: { subscriptions.broadcast(delta: .modelProfilesChanged) }
         )
-    }
-
-    /// Type `/login` + Enter into a pending login-session terminal. Consume-
-    /// once: only the first caller per terminal actually sends; later
-    /// triggers (hook vs. fallback race) are no-ops, as is a terminal that
-    /// was deleted in the meantime.
-    func performAutoLoginSend(terminalID: UUID, trigger: String) async {
-        guard await loginSessions.consumePendingAutoLogin(terminalID: terminalID) else { return }
-        guard let terminal = try? await db.terminals.get(id: terminalID),
-              let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
-            logger.debug("auto-login: terminal \(terminalID, privacy: .public) vanished before send (trigger=\(trigger, privacy: .public))")
-            return
-        }
-        do {
-            try await tmux.sendKeys(server: worktree.tmuxServer, paneID: terminal.tmuxPaneID, text: "/login")
-            try await tmux.sendKey(server: worktree.tmuxServer, paneID: terminal.tmuxPaneID, key: "Enter")
-            logger.info("auto-login: typed /login into terminal \(terminalID, privacy: .public) (trigger=\(trigger, privacy: .public))")
-        } catch {
-            logger.warning("auto-login: send failed for terminal \(terminalID, privacy: .public): \(error, privacy: .public)")
-        }
     }
 
     func handleTerminalList(_ paramsData: Data) async throws -> RPCResponse {
@@ -1194,19 +1191,6 @@ extension RPCRouter {
 
         let source = params.source ?? "unknown"
         logger.info("sessionEvent: terminal \(terminal.id.uuidString, privacy: .public) -> session \(params.sessionID, privacy: .public) (source=\(source, privacy: .public))")
-
-        // Login-session terminals get `/login` auto-typed once Claude is up.
-        // The SessionStart hook is our readiness signal; wait a beat so the
-        // TUI's input loop is consuming pty input, then send. Consume-once in
-        // the coordinator dedupes against the spawn-time fallback trigger.
-        if terminal.label == TerminalLabel.login {
-            let terminalID = terminal.id
-            let delay = loginSessions.delays.afterSessionStart
-            Task { [weak self] in
-                try? await Task.sleep(for: delay)
-                await self?.performAutoLoginSend(terminalID: terminalID, trigger: "session-start")
-            }
-        }
 
         subscriptions.broadcast(delta: .terminalSessionUpdated(TerminalSessionDelta(
             terminalID: terminal.id,

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -253,6 +253,8 @@ public final class RPCRouter: Sendable {
                 return try await handleModelProfileFetchUsage(request.paramsData)
             case RPCMethod.modelProfileHealthCheck:
                 return try await handleModelProfileHealthCheck(request.paramsData)
+            case RPCMethod.modelProfilePrepareConfigDir:
+                return try await handleModelProfilePrepareConfigDir(request.paramsData)
             case RPCMethod.appSetForegroundState:
                 let params = try decoder.decode(AppSetForegroundStateParams.self, from: request.paramsData)
                 await claudeUsagePoller?.onFocusChanged(isForeground: params.isForeground)

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -27,6 +27,10 @@ public final class RPCRouter: Sendable {
     public let pendingQuestions: PendingQuestionStore
     public let repoSerializer: RepoSerializer
     public let configDirManager: ClaudeProfileConfigDirManager
+    /// Deletes per-profile Claude Code OAuth credential items from the login
+    /// keychain on profile delete. Injected so tests can record the requested
+    /// service name instead of touching the real keychain.
+    public let claudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting
 
     /// Single-flights concurrent `pr.list` RPCs so a poll storm collapses into
     /// one git enumeration + gh fetch instead of N overlapping ones.
@@ -57,7 +61,8 @@ public final class RPCRouter: Sendable {
         modelProfileResolver: ModelProfileResolver? = nil,
         pendingQuestions: PendingQuestionStore = PendingQuestionStore(),
         repoSerializer: RepoSerializer = RepoSerializer(),
-        configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager()
+        configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager(),
+        claudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain()
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -80,6 +85,7 @@ public final class RPCRouter: Sendable {
         self.repoSerializer = repoSerializer
         self.configDirManager = configDirManager
         self.controlMode = nil
+        self.claudeCredentialsKeychain = claudeCredentialsKeychain
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -31,6 +31,9 @@ public final class RPCRouter: Sendable {
     /// keychain on profile delete. Injected so tests can record the requested
     /// service name instead of touching the real keychain.
     public let claudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting
+    /// Auto-`/login` typing + login-completion watching for profile login
+    /// sessions. Injected so tests can zero out the trigger delays.
+    public let loginSessions: LoginSessionCoordinator
 
     /// Single-flights concurrent `pr.list` RPCs so a poll storm collapses into
     /// one git enumeration + gh fetch instead of N overlapping ones.
@@ -62,7 +65,8 @@ public final class RPCRouter: Sendable {
         pendingQuestions: PendingQuestionStore = PendingQuestionStore(),
         repoSerializer: RepoSerializer = RepoSerializer(),
         configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager(),
-        claudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain()
+        claudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain(),
+        loginSessions: LoginSessionCoordinator = LoginSessionCoordinator()
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -86,6 +90,7 @@ public final class RPCRouter: Sendable {
         self.configDirManager = configDirManager
         self.controlMode = nil
         self.claudeCredentialsKeychain = claudeCredentialsKeychain
+        self.loginSessions = loginSessions
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -327,8 +327,11 @@ public struct TmuxManager: Sendable {
     }
 
     public func sendKeys(server: String, paneID: String, text: String) async throws {
-        if dryRun { return }
         let args = Self.sendKeysCommand(server: server, paneID: paneID, text: text)
+        if dryRun {
+            dryRunRecorder?(args)
+            return
+        }
         try await runTmux(args)
     }
 

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -16,6 +16,10 @@ public struct TmuxManager: Sendable {
     /// Without it, dryRun reports every window as alive, which makes paths
     /// like the pre-session `.paneKilled` short-circuit untestable.
     public let dryRunWindowIsDead: (@Sendable (String) -> Bool)?
+    /// Optional test hook consulted by `capturePaneOutput` in dryRun mode:
+    /// (server, paneID) → pane text. Without it, dryRun captures return "",
+    /// which reads as "pane not ready" to the auto-login pump.
+    public let dryRunCapturePane: (@Sendable (String, String) -> String)?
     /// Optional test hook consulted by `listWindows` in dryRun mode:
     /// `(server, session)` → the window/pane pairs to report. Without it,
     /// dryRun reports no windows, which makes reconcile's orphan-window
@@ -35,12 +39,13 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil) {
         self.dryRun = dryRun
         self.counter = Counter()
         self.dryRunRecorder = dryRunRecorder
         self.dryRunWindowIsDead = dryRunWindowIsDead
         self.dryRunListWindows = dryRunListWindows
+        self.dryRunCapturePane = dryRunCapturePane
     }
 
     // MARK: - Static Command Builders
@@ -345,7 +350,7 @@ public struct TmuxManager: Sendable {
     }
 
     public func capturePaneOutput(server: String, paneID: String) async throws -> String {
-        if dryRun { return "" }
+        if dryRun { return dryRunCapturePane?(server, paneID) ?? "" }
         let args = Self.capturePaneCommand(server: server, paneID: paneID)
         return try await runTmux(args)
     }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -431,9 +431,22 @@ public struct ModelProfileUsage: Codable, Sendable, Equatable {
 public struct ModelProfileWithUsage: Codable, Sendable, Equatable {
     public let profile: ModelProfile
     public let usage: ModelProfileUsage?
-    public init(profile: ModelProfile, usage: ModelProfileUsage? = nil) {
+    /// Computed by the daemon at list time (never persisted): the
+    /// `oauthAccount.emailAddress` from the profile's isolated config dir
+    /// `.claude.json`. Non-nil only for `.oauth` profiles that have completed
+    /// `/login` inside a session. nil = not logged in, non-oauth kind, or an
+    /// older daemon that doesn't send the field.
+    public let loginIdentity: String?
+    /// Absolute path of the profile's isolated `CLAUDE_CONFIG_DIR`
+    /// (`~/tbd/profiles/<lowercased-uuid>/claude`). nil for bedrock profiles
+    /// (no config-dir isolation) or an older daemon that doesn't send the field.
+    public let configDirPath: String?
+    public init(profile: ModelProfile, usage: ModelProfileUsage? = nil,
+                loginIdentity: String? = nil, configDirPath: String? = nil) {
         self.profile = profile
         self.usage = usage
+        self.loginIdentity = loginIdentity
+        self.configDirPath = configDirPath
     }
 }
 

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -1,0 +1,577 @@
+import Foundation
+
+/// Canonical content for the `nightwatch` skill — a quota-lean TBD-fleet
+/// babysitter bundled into the TBD Claude plugin. Repo-agnostic core; each
+/// child repo plugs in policy via <repo>/.nightwatch/policy.json. The scheduler
+/// (scheduler.sh / tick-cron.sh) ships but is opt-in — never auto-loaded.
+/// Single source of truth, written by PluginDirWriter. Generated from the skill files.
+public enum NightwatchSkillContent {
+
+    public static let skillMd: String = #"""
+---
+name: nightwatch
+description: Autonomous TBD-fleet babysitter that runs mostly on scripts + a local model, paging Opus only for genuine judgment. Use to keep ~40 agent worktrees unblocked/gated overnight at a fraction of the Opus quota. Triggers — "babysit the fleet", "nightwatch tick", "drain the decision queue", "keep agents unblocked".
+---
+
+# nightwatch — quota-lean fleet babysitter
+
+Keep a fleet of TBD agent worktrees unblocked, productive, and gated while the human sleeps — and do it **without burning Opus on mechanical work**. Most ticks touch no model at all.
+
+## The tier policy (the whole point)
+
+| Tier | Runs on | Does |
+|---|---|---|
+| **0** | `scripts/tick.py` — pure Python, $0 | sweep all panes (every tmux server), daemon + proxy health, classify every agent, split into auto/judgment/human, write `queue/tick-report.json` |
+| **1** | local model (Ollama) or Haiku — *future* | classify ambiguous panes, triage escalations, draft routine nudges. Off the Opus quota. |
+| **2** | **Opus — rare** | resolve genuinely ambiguous decisions, the deep review, any prod/security/CJI/access call. Wakes only when `queue/decisions.jsonl` has items. |
+| **Human** | Adam | merge PRs, proxy/IAM/prod restarts, Slack pings, access, the capacity (Bedrock) lever. |
+
+**Opus is the exception handler, not the runtime.**
+
+## How a tick runs (cron/launchd calls this — no model)
+
+```
+python3 scripts/tick.py        # exit 0 = silent-ok · exit 10 = judgment queued
+python3 scripts/tick.py --prs  # also gate open PRs (wraps loop_perfect_sweep.py; skip during GitHub-rate crunch)
+```
+
+`tick.py` prints a short human summary AND writes:
+- `queue/tick-report.json` — full structured state (daemon, capacity, every agent, auto_actions, judgment_queue)
+- `queue/decisions.jsonl` — append-only judgment items (decisions to resolve, maybe-archive)
+- `queue/for-adam.md` — human-only items
+
+**Capacity-aware backoff is built in:** when the proxy has `< MIN_ROUTABLE` (2) accounts routable, or is degraded/unreachable, tick.py *holds* all nudges (nudging into a saturated proxy only adds contention) and says so. This is the rule I otherwise have to notice by hand.
+
+## When paged (Tier 2 — Opus drains the queue)
+
+Only when `tick.py` exits 10 (or on the 2-hour deep-review window): read `queue/decisions.jsonl`, resolve each genuine decision (what Adam would decide; sensitive/personal/access → `for-adam.md`, don't auto-fire), then clear the drained lines. This is the only step that should consume Opus.
+
+## The gate (never automate past this)
+
+A PR may only be enqueued when **claude-review = APPROVED on the current SHA + checks clean**. Human approval never substitutes. `gh pr merge` is NOT a safe-wedge — it always escalates. nightwatch's job is to get PRs *ready*; the human merges.
+
+## Config (`config/`)
+- `priorities.txt` — must-keep-moving worktrees (flagged ★, reported first)
+- `safe_wedges.txt` — permission-wedge prefixes the daemon may auto-approve (never `gh pr merge`)
+- `dont_touch.txt` — panes/names nightwatch must never nudge (human-driven, e.g. Adam's own session)
+
+## The durable spine (already on launchd, model-free)
+- `scripts/daemon.py` (babysitter) — auto-approves safe wedges, escalates real ones
+- `scripts/watchdog.sh` — restarts the daemon if its log goes >12min stale (hang/sleep)
+These keep the critical safety net running even when Opus is fully capped. (Currently live as `~/.fleet/babysitter_daemon.py` + `daemon_watchdog.sh`; copy in for a self-contained skill.)
+
+## TBD integration
+- **Read:** `~/tbd/state.db` (worktrees/terminals/`tmuxServer` per pane — pane IDs collide across servers, always read the server, never hardcode)
+- **Act:** `tbd terminal send --submit` (nudge/resolve) · `tbd worktree archive` (prune) · `tbd worktree create` (spawn)
+
+## Durable scheduling (opt-in — never auto-runs)
+
+The skill ships a model-free heartbeat but **does not start it**. Enable it deliberately:
+
+```
+scripts/scheduler.sh enable [interval_seconds]   # default 900 (15m); launchd runs tick.py
+scripts/scheduler.sh disable
+scripts/scheduler.sh status
+```
+
+When enabled, launchd runs `tick.py` on the interval ($0, no model), stays silent on exit 0,
+and on exit 10 (judgment queued) records a marker + fires `tbd notify`. This is the durable,
+quota-free replacement for waking Opus on a timer. It is intentionally NOT loaded by the
+plugin installer — you turn it on only where you want a fleet babysat.
+
+"""#
+
+    public static let tickPy: String = #"""
+#!/usr/bin/env python3
+"""
+nightwatch tick — Tier-0 orchestrator. NO model in the hot path.
+
+Reads the whole TBD fleet across all tmux servers, the babysitter daemon health,
+and the Opus proxy capacity, classifies every agent deterministically, and emits:
+  - a structured tick-report.json  (machine-readable)
+  - a short human summary to stdout
+  - queue/decisions.jsonl   (items that need Tier-2 / Opus judgment)
+  - queue/for-adam.md       (items only a human should do)
+
+Exit code 0 = nothing needs Opus (silent-ok).  Exit code 10 = judgment items queued.
+Run with --prs to also gate open PRs (makes gh calls — skip during GitHub rate crunch).
+"""
+import subprocess, os, re, json, time, sys, urllib.request
+
+HOME = os.path.expanduser("~")
+DB = f"{HOME}/tbd/state.db"
+SKILL = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+QUEUE = f"{SKILL}/queue"
+CFG = f"{SKILL}/config"
+DAEMON_LOG = "/tmp/babysitter.log"
+PROXY_HEALTH = "http://localhost:8080/health"
+
+def sh(args, t=8):
+    try: return subprocess.run(args, capture_output=True, text=True, timeout=t).stdout
+    except Exception: return ""
+
+def load_list(fname):
+    p = f"{CFG}/{fname}"
+    if not os.path.exists(p): return []
+    return [l.strip() for l in open(p) if l.strip() and not l.startswith("#")]
+
+PRIORITIES = load_list("priorities.txt")          # display-name substrings, must-keep-moving
+SAFE_WEDGES = load_list("safe_wedges.txt")         # allowlist prefixes (informational here)
+DONT_TOUCH = load_list("dont_touch.txt")           # panes/names nightwatch must never nudge
+
+def load_policies():
+    """Per-repo HOOKS. Each child repo may ship <repo_root>/.nightwatch/policy.json
+    declaring its own gate, priorities, safe/escalate rules, and SKILL BINDINGS
+    (which of the repo's own skills to invoke to advance/deploy work). nightwatch
+    core stays repo-agnostic and defers repo-specifics to the hook.
+    Returns {repoID: {"name":..., "policy":{...}}}."""
+    out = {}
+    rows = sh(["sqlite3","-separator","\t",DB,"SELECT id,displayName,path FROM repo WHERE status='ok';"])
+    for l in rows.splitlines():
+        p = l.split("\t")
+        if len(p) < 3: continue
+        rid, name, path = p
+        hook = f"{path}/.nightwatch/policy.json"
+        if os.path.exists(hook):
+            try: out[rid] = {"name": name, "policy": json.load(open(hook))}
+            except Exception as e: out[rid] = {"name": name, "policy": {}, "err": str(e)[:50]}
+    return out
+
+POLICIES = load_policies()
+
+DECISION_PAT = re.compile(r"Enter to select|❯ 1\.|Ready to submit|Tab/Arrow keys to navigate|Do you want to proceed")
+ERR_PAT = re.compile(r"API error|rate.?limit|overloaded|529|503|All accounts.*unavailable|ECONNRESET|inference gateway", re.I)
+DONE_PAT = re.compile(r"ready to archive|you're done|nothing (?:open|left)|winding down|wind down|/closeout|all merged", re.I)
+
+def classify(cap):
+    """Return state for a captured pane: WORKING / DECISION / ERROR / STRANDED / DONE / IDLE."""
+    lines = [x for x in cap.splitlines() if x.strip()]
+    if not lines: return "EMPTY", ""
+    tail = "\n".join(lines[-18:])
+    if "esc to interrupt" in tail: return "WORKING", _lastmeaning(lines)
+    if DECISION_PAT.search(tail): return "DECISION", _lastmeaning(lines)
+    comp = _composer(lines)
+    if ERR_PAT.search(tail): return "ERROR", comp or _lastmeaning(lines)
+    if DONE_PAT.search(tail): return "DONE", _lastmeaning(lines)
+    if comp: return "STRANDED", comp
+    return "IDLE", ""
+
+def _lastmeaning(lines):
+    for x in reversed(lines):
+        s = x.strip()
+        if any(k in s for k in ("bypass permissions","esc to interrupt","context used","auto-compact","/model")): continue
+        if s.startswith(("─","✻","✳","✶","⏺","◯")): continue
+        if not s or s == "❯": continue
+        return s[:90]
+    return ""
+
+CTX_PAT = re.compile(r"(\d+)%\s*context used")
+COMPACT_PAT = re.compile(r"(\d+)%\s*until auto-compact")
+def burn_risk(cap):
+    """The dominant quota driver is token WEIGHT per request: a session dragging a
+    near-full context window (esp. 1M Opus) sends up to ~1M input tokens EVERY request.
+    Flag agents at high context — they incinerate the weekly cap fastest. Returns
+    (pct:int|None, is_1m:bool, risk:bool)."""
+    pct = None
+    m = CTX_PAT.search(cap)
+    if m: pct = int(m.group(1))
+    else:
+        c = COMPACT_PAT.search(cap)
+        if c: pct = 100 - int(c.group(1))
+    is_1m = "opus[1m]" in cap or "[1m]" in cap
+    risk = pct is not None and pct >= 85
+    return pct, is_1m, risk
+
+def _composer(lines):
+    for i, x in enumerate(lines):
+        if "bypass permissions" in x and i > 0:
+            for j in range(i-1, -1, -1):
+                s = lines[j].strip()
+                if s.startswith("❯"): return s[1:].strip()[:120]
+                if s.startswith("─"): continue
+            break
+    return ""
+
+def daemon_health():
+    if not os.path.exists(DAEMON_LOG): return {"ok": False, "age_s": None, "reason": "log-missing"}
+    age = int(time.time() - os.path.getmtime(DAEMON_LOG))
+    return {"ok": age <= 720, "age_s": age, "reason": ("stale" if age > 720 else "fresh")}
+
+def proxy_health():
+    # bypass any HTTP(S)_PROXY env — localhost must be direct
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    def parse(raw):
+        d = json.loads(raw); p = d.get("pool", {})
+        return {"ok": d.get("status") == "ok", "status": d.get("status"),
+                "routable": p.get("routable"), "rate_limited": p.get("rate_limited"),
+                "configured": p.get("configured"), "next": p.get("next_available_at")}
+    try:
+        with opener.open(PROXY_HEALTH, timeout=5) as r:
+            return parse(r.read())
+    except urllib.error.HTTPError as e:
+        # ccflare returns 503 when degraded — the body still carries the pool JSON
+        try: return parse(e.read())
+        except Exception: return {"ok": False, "status": f"http{e.code}", "routable": 0}
+    except Exception as e:
+        return {"ok": False, "status": "unreachable", "err": str(e)[:60]}
+
+def fleet():
+    rows = sh(["sqlite3","-separator","\t",DB,
+      "SELECT t.tmuxPaneID, w.displayName, w.tmuxServer, t.id, w.repoID "
+      "FROM worktree w JOIN terminal t ON t.worktreeID=w.id AND t.kind='claude' AND t.suspendedAt IS NULL "
+      "WHERE w.status='active' ORDER BY w.tmuxServer, w.displayName;"])
+    out = []
+    for l in rows.splitlines():
+        p = l.split("\t")
+        if len(p) < 5: continue
+        pane, name, srv, tid, rid = p
+        cap = sh(["tmux","-L",srv,"capture-pane","-p","-t",pane])
+        state, note = classify(cap)
+        ctx_pct, is_1m, burn = burn_risk(cap)
+        hook = POLICIES.get(rid, {})
+        pol = hook.get("policy", {})
+        # priorities/dont-touch are the UNION of global config + the repo's own hook
+        prio = (any(s.lower() in name.lower() for s in PRIORITIES)
+                or any(s.lower() in name.lower() for s in pol.get("priorities", [])))
+        protect = (any(d in pane or d.lower() in name.lower() for d in DONT_TOUCH)
+                   or any(d.lower() in name.lower() for d in pol.get("dont_touch", [])))
+        out.append({"pane": pane, "name": name, "server": srv, "tid": tid,
+                    "state": state, "note": note, "priority": prio, "protected": protect,
+                    "repo": hook.get("name"), "gate": pol.get("gate", {}).get("ready_when"),
+                    "advance_skill": pol.get("advance_skill"), "deploy_skill": pol.get("deploy_skill"),
+                    "ctx_pct": ctx_pct, "is_1m": is_1m, "burn_risk": burn})
+    return out
+
+def main():
+    capacity = proxy_health()
+    rep = {
+        "ts": int(time.time()),
+        "daemon": daemon_health(),
+        "capacity": capacity,
+        "hooks": {v["name"]: {"gate": v["policy"].get("gate",{}).get("ready_when"),
+                              "advance_skill": v["policy"].get("advance_skill"),
+                              "deploy_skill": v["policy"].get("deploy_skill")}
+                  for v in POLICIES.values()},
+        "agents": fleet(),
+    }
+    # ---- deterministic triage (Tier 0): split into auto / judgment / human ----
+    # Don't nudge unless we can confirm healthy spare capacity. Unknown/unreachable/tight => hold.
+    MIN_ROUTABLE = 2   # need >=2 routable accounts before adding nudge contention
+    rt = capacity.get("routable")
+    saturated = (rt is None) or (rt < MIN_ROUTABLE) or (capacity.get("status") not in ("ok",))
+    decisions, stranded, errors, done, working, idle = ([] for _ in range(6))
+    for a in rep["agents"]:
+        s = a["state"]
+        if s == "WORKING": working.append(a)
+        elif s == "DECISION": decisions.append(a)
+        elif s == "STRANDED": stranded.append(a)
+        elif s == "ERROR": errors.append(a)
+        elif s == "DONE": done.append(a)
+        else: idle.append(a)
+
+    rep["summary"] = {
+        "working": len(working), "idle": len(idle), "decisions": len(decisions),
+        "stranded": len(stranded), "errors": len(errors), "done_maybe": len(done),
+        "saturated": saturated,
+    }
+    # Judgment queue = DECISIONS (a model/human must pick) + DONE (archive judgement)
+    judgment = [{"kind":"decision","pane":a["pane"],"server":a["server"],"name":a["name"],
+                 "tid":a["tid"],"note":a["note"]} for a in decisions]
+    judgment += [{"kind":"maybe-archive","pane":a["pane"],"name":a["name"],"note":a["note"]} for a in done]
+    # Auto-handleable (Tier 0/1) = STRANDED + ERROR, BUT suppress when saturated (nudging adds contention)
+    auto = []
+    if not saturated:
+        for a in stranded:
+            if a["protected"]: continue
+            auto.append({"kind":"dispatch","pane":a["pane"],"server":a["server"],"tid":a["tid"],
+                         "name":a["name"],"text":a["note"]})
+        for a in errors:
+            if a["protected"]: continue
+            auto.append({"kind":"nudge-transient","pane":a["pane"],"server":a["server"],"tid":a["tid"],
+                         "name":a["name"]})
+    rep["auto_actions"] = auto
+    rep["judgment_queue"] = judgment
+
+    os.makedirs(QUEUE, exist_ok=True)
+    json.dump(rep, open(f"{QUEUE}/tick-report.json","w"), indent=2)
+    if judgment:
+        with open(f"{QUEUE}/decisions.jsonl","a") as f:
+            for j in judgment: f.write(json.dumps({**j,"ts":rep["ts"]})+"\n")
+
+    # ---- human-readable summary ----
+    d, c = rep["daemon"], capacity
+    print(f"=== nightwatch tick @ {time.strftime('%H:%M:%S')} ===")
+    if rep["hooks"]:
+        print("hooks: " + " · ".join(f"{n}[gate={h['gate'] or '-'},advance={h['advance_skill'] or '-'}]"
+                                      for n,h in rep["hooks"].items()))
+    else:
+        print("hooks: (none — repos can ship .nightwatch/policy.json)")
+    print(f"daemon: {d['reason']} ({d['age_s']}s)   "
+          f"proxy: {c.get('status')} routable={c.get('routable')}/{c.get('configured')} "
+          f"{'⚠ SATURATED — backoff, no nudging' if saturated else ''}")
+    sm = rep["summary"]
+    print(f"agents: {len(rep['agents'])}  working={sm['working']} idle={sm['idle']} "
+          f"decisions={sm['decisions']} stranded={sm['stranded']} errors={sm['errors']} done?={sm['done_maybe']}")
+    for a in working:
+        if a["priority"]: print(f"  ★ PRIORITY {a['name']} ({a['pane']}): WORKING ✓")
+    pr = [a for a in rep["agents"] if a["priority"] and a["state"]!="WORKING"]
+    for a in pr: print(f"  ★ PRIORITY {a['name']} ({a['pane']}): {a['state']} — {a['note'][:60]}")
+    if decisions:
+        print("DECISIONS (need judgment → queued):")
+        for a in decisions: print(f"  ▸ {a['name']} ({a['server']} {a['pane']}): {a['note'][:70]}")
+    burners = sorted([a for a in rep["agents"] if a.get("burn_risk")],
+                     key=lambda a: -(a.get("ctx_pct") or 0))
+    if burners:
+        print(f"🔥 BURN-RISK ({len(burners)} at ctx≥85% — top quota drivers, weight not count):")
+        for a in burners[:8]:
+            print(f"  · {a['name']} ({a['pane']}): {a['ctx_pct']}% ctx{' [1M]' if a['is_1m'] else ''}"
+                  f" — {'compact/clear' if a['ctx_pct']>=95 else 'watch'}")
+    if auto:
+        print(f"AUTO (Tier-0 safe, {len(auto)}):")
+        for x in auto: print(f"  · {x['kind']}: {x['name']} ({x['pane']})")
+    elif saturated and (stranded or errors):
+        print(f"HELD (saturated): {len(stranded)} stranded + {len(errors)} errors — NOT nudging (would add contention)")
+    needs_opus = bool(judgment)
+    print(f"\n→ {'JUDGMENT ITEMS QUEUED — page Opus (nightwatch judge)' if needs_opus else 'nothing needs Opus — silent-ok'}")
+    sys.exit(10 if needs_opus else 0)
+
+if __name__ == "__main__":
+    main()
+
+"""#
+
+    public static let judgePy: String = #"""
+#!/usr/bin/env python3
+"""
+nightwatch judge — the Tier-2 step. Reads what `tick.py` queued + the live fleet
+and ROUTES each item through the owning repo's HOOK (.nightwatch/policy.json):
+  - a not-ready PR  -> dispatch that repo's `advance_skill` to the owner
+  - a deploy        -> that repo's `deploy_skill` (always human-gated)
+  - a stuck menu / archive call -> HUMAN (no hook auto-resolves judgment)
+
+nightwatch core never hardcodes a gate or a drive command — it asks the repo.
+
+Capacity-aware: with `--act` it dispatches via `tbd terminal send`, but REFUSES to
+act when the proxy is saturated (driving into a capped pool only adds contention).
+Default is dry-run (prints the plan, touches nothing). `--prs` also gates open PRs
+(makes gh calls — skip during a GitHub-rate crunch). Dedupes + clears the queue on a
+successful --act drain.
+"""
+import subprocess, os, json, time, sys
+
+HOME = os.path.expanduser("~")
+DB = f"{HOME}/tbd/state.db"
+SKILL = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+QUEUE = f"{SKILL}/queue"
+REPO = "longeye-ai/monorepo"
+
+def sh(args, t=20):
+    try: return subprocess.run(args, capture_output=True, text=True, timeout=t).stdout
+    except Exception: return ""
+
+def gh(*a, t=20):
+    for k in ("HTTPS_PROXY","HTTP_PROXY","https_proxy","http_proxy"): os.environ.pop(k, None)
+    return sh(["gh", *a], t)
+
+def load_report():
+    p = f"{QUEUE}/tick-report.json"
+    return json.load(open(p)) if os.path.exists(p) else None
+
+def saturated(rep):
+    c = (rep or {}).get("capacity", {})
+    rt = c.get("routable")
+    return rt is None or rt < 2 or c.get("status") not in ("ok",)
+
+def dispatch(tid, text, act):
+    """Run the repo's bound skill in the owner's terminal (or describe it in dry-run)."""
+    if not act or not tid: return False
+    sh(["tbd", "terminal", "send", "--terminal", tid, "--submit", "--text", text])
+    return True
+
+def main():
+    act = "--act" in sys.argv
+    do_prs = "--prs" in sys.argv
+    rep = load_report()
+    if not rep:
+        print("no tick-report.json — run `nightwatch tick` first"); sys.exit(1)
+    sat = saturated(rep)
+    agents = {a["pane"]: a for a in rep.get("agents", [])}
+    # branch -> owning agent, for PR routing
+    by_branch = {}
+    for l in sh(["sqlite3","-separator","\t",DB,
+                 "SELECT w.branch,t.tmuxPaneID,t.id,r.displayName FROM worktree w "
+                 "JOIN terminal t ON t.worktreeID=w.id AND t.kind='claude' AND t.suspendedAt IS NULL "
+                 "JOIN repo r ON w.repoID=r.id WHERE w.status='active';"]).splitlines():
+        p = l.split("\t")
+        if len(p) >= 4: by_branch[p[0]] = {"pane": p[1], "tid": p[2], "repo": p[3]}
+
+    print(f"=== nightwatch judge @ {time.strftime('%H:%M:%S')} {'[ACT]' if act else '[dry-run]'} ===")
+    print(f"capacity: {'⚠ SATURATED — will not dispatch (would add contention)' if sat else 'ok'}")
+    hooks = rep.get("hooks", {})
+    print("hooks: " + (" · ".join(f"{n}[gate={h['gate']},advance={h['advance_skill'] or '-'}]"
+                                   for n, h in hooks.items()) or "(none)"))
+
+    plan, for_adam, acted = [], [], 0
+
+    # ---- 1. route the queued judgment items through hooks ----
+    qf = f"{QUEUE}/decisions.jsonl"
+    items, seen = [], set()
+    if os.path.exists(qf):
+        for l in open(qf):
+            l = l.strip()
+            if not l: continue
+            try: it = json.loads(l)
+            except Exception: continue
+            k = (it.get("kind"), it.get("pane"))
+            if k in seen: continue
+            seen.add(k); items.append(it)
+    for it in items:
+        pane, name = it.get("pane"), it.get("name", "")
+        a = agents.get(pane, {})
+        if it["kind"] == "decision":
+            for_adam.append(f"DECISION — {name} ({pane}, repo={a.get('repo')}): sitting on a multi-choice prompt. "
+                            "No hook auto-resolves a menu — resolve in TBD (or Opus).")
+            plan.append(f"  ▸ decision {name} ({pane}) → HUMAN/Opus")
+        elif it["kind"] == "maybe-archive":
+            for_adam.append(f"ARCHIVE? — {name} ({pane}): looks done. Verify no open PR, then `tbd worktree archive`.")
+            plan.append(f"  ▸ archive? {name} ({pane}) → HUMAN (judgment)")
+
+    # ---- 2. (optional) gate open PRs through each repo's hook, drive via advance_skill ----
+    if do_prs:
+        nums = sorted(int(x) for x in gh("api", f"repos/{REPO}/pulls?state=open&per_page=100",
+                      "--jq", '.[]|select(.user.login=="zionts")|.number').split() or [])
+        for pr in nums[:40]:
+            j = gh("api", f"repos/{REPO}/pulls/{pr}",
+                   "--jq", r'"\(.head.ref)\t\(.mergeable_state)\t\(.draft)"').strip().split("\t")
+            if len(j) < 2 or j[2:3] == ["true"]: continue
+            branch, mstate = j[0], j[1]
+            verdict = gh("api", f"repos/{REPO}/pulls/{pr}/reviews",
+                         "--jq", '[.[]|select(.user.login=="longeye-claude-reviewer[bot]")|.state]|last//"NONE"').strip().strip('"')
+            owner = by_branch.get(branch)
+            a = agents.get(owner["pane"], {}) if owner else {}
+            adv = a.get("advance_skill")
+            ready = (verdict == "APPROVED" and mstate == "clean")
+            if ready:
+                for_adam.append(f"READY — #{pr}: claude-APPROVED + clean. Human merge.")
+            elif owner and adv and a.get("state") != "WORKING":
+                txt = f"nightwatch: PR #{pr} not yet claude-APPROVED ({verdict}). Run `/{adv}` to drive it to APPROVED on the current SHA. Do NOT merge."
+                if not sat and dispatch(owner["tid"], txt, act): acted += 1; tag = "DISPATCHED"
+                else: tag = "would dispatch" + (" (saturated-held)" if sat else " (dry-run)")
+                plan.append(f"  ▸ #{pr} not-ready ({verdict}) → {tag}: `/{adv}` to {owner['pane']}")
+            elif not owner:
+                for_adam.append(f"ORPHAN — #{pr} ({verdict}): no live owner. Spawn one or merge.")
+
+    for p in plan: print(p)
+    os.makedirs(QUEUE, exist_ok=True)
+    with open(f"{QUEUE}/for-adam.md", "w") as f:
+        f.write(f"# nightwatch — for Adam ({time.strftime('%Y-%m-%d %H:%M')})\n\n")
+        for x in for_adam: f.write(f"- {x}\n")
+    print(f"\nactions dispatched: {acted}   human items → queue/for-adam.md ({len(for_adam)})")
+    if act and not sat:
+        open(qf, "w").close(); print("drained decisions.jsonl")
+    else:
+        print("(dry-run or saturated — queue left intact)")
+
+if __name__ == "__main__":
+    main()
+
+"""#
+
+    public static let tickCronSh: String = #"""
+#!/bin/bash
+# nightwatch heartbeat — runs the Tier-0 tick ($0, no model). Silent on exit 0;
+# on exit 10 (judgment queued) it records a marker so Opus/human is paged on exception.
+LOG=/tmp/nightwatch-tick.log
+TICK="$HOME/.claude/skills/nightwatch/scripts/tick.py"
+out=$(/usr/bin/env python3 "$TICK" 2>&1); rc=$?
+ts=$(date '+%Y-%m-%d %H:%M:%S')
+echo "[$ts] exit=$rc" >> "$LOG"
+if [ "$rc" = "10" ]; then
+  echo "$out" | grep -E "BURN-RISK|DECISIONS|PRIORITY|SATURATED" >> "$LOG"
+  echo "[$ts] >> JUDGMENT NEEDED — run: nightwatch judge" >> "$LOG"
+  command -v tbd >/dev/null && tbd notify --title "nightwatch" --message "judgment items queued" >/dev/null 2>&1 || true
+fi
+
+"""#
+
+    public static let schedulerSh: String = #"""
+#!/bin/bash
+# nightwatch scheduler — INTENTIONAL enable/disable of the model-free heartbeat.
+#
+# Nothing here auto-runs. The skill ships this script but never loads it; you opt
+# in deliberately. When enabled, a launchd job runs `tick.py` (Tier-0, $0, no model)
+# on an interval, silent on exit 0, paging you (marker + `tbd notify`) only on exit 10.
+#
+#   scheduler.sh enable [interval_seconds]   # default 900 (15m)
+#   scheduler.sh disable
+#   scheduler.sh status
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"            # .../skills/nightwatch/scripts
+LABEL="com.nightwatch-tick"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+case "${1:-}" in
+  enable)
+    INTERVAL="${2:-900}"
+    cat > "$PLIST" <<PL
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key><array>
+    <string>/bin/bash</string><string>$DIR/tick-cron.sh</string>
+  </array>
+  <key>StartInterval</key><integer>$INTERVAL</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardErrorPath</key><string>/tmp/nightwatch-tick.err</string>
+</dict></plist>
+PL
+    launchctl unload "$PLIST" 2>/dev/null || true
+    launchctl load "$PLIST"
+    echo "nightwatch scheduler ENABLED — every ${INTERVAL}s, model-free. Disable: $0 disable"
+    ;;
+  disable)
+    launchctl unload "$PLIST" 2>/dev/null || true
+    rm -f "$PLIST"
+    echo "nightwatch scheduler DISABLED"
+    ;;
+  status)
+    if launchctl list | grep -q "$LABEL"; then
+      echo "ENABLED:"; launchctl list | grep "$LABEL"
+      tail -3 /tmp/nightwatch-tick.log 2>/dev/null
+    else
+      echo "DISABLED (not loaded)"
+    fi
+    ;;
+  *)
+    echo "usage: $0 enable [interval_seconds] | disable | status"; exit 1 ;;
+esac
+
+"""#
+
+    public static let prioritiesTxt: String = #"""
+# Must-keep-moving worktrees (display-name substrings, case-insensitive).
+# tick.py flags these ★ and reports their state first every tick.
+Fix CSV Row Truncation
+
+"""#
+
+    public static let safeWedgesTxt: String = #"""
+# Permission-wedge command prefixes the daemon may AUTO-APPROVE. NEVER include "gh pr merge".
+gh api
+git
+gh pr comment
+gh pr edit
+gh pr review
+gh pr ready
+gh issue
+
+"""#
+
+    public static let dontTouchTxt: String = #"""
+# Panes or name-substrings nightwatch must NEVER nudge/dispatch (human-driven).
+# %352 = Adam's own monitoring session.
+Find Monitor Corrections Issues
+
+"""#
+}

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -134,6 +134,7 @@ public enum RPCMethod {
     public static let modelProfileSetRepoOverride = "modelProfile.setRepoOverride"
     public static let modelProfileFetchUsage = "modelProfile.fetchUsage"
     public static let modelProfileHealthCheck = "modelProfile.healthCheck"
+    public static let modelProfilePrepareConfigDir = "modelProfile.prepareConfigDir"
     public static let terminalSwapProfile = "terminal.swapProfile"
     public static let terminalSessionEvent = "terminal.sessionEvent"
     public static let terminalActivityEvent = "terminal.activityEvent"
@@ -487,6 +488,22 @@ public struct ModelProfileHealthCheckResult: Codable, Sendable {
     public init(reachable: Bool, statusCode: Int?, detail: String?) {
         self.reachable = reachable; self.statusCode = statusCode; self.detail = detail
     }
+}
+
+/// Params for `modelProfile.prepareConfigDir` — ensure an OAuth profile's
+/// isolated `CLAUDE_CONFIG_DIR` exists and is seeded (`.claude.json` +
+/// host-mirror symlinks) so a client can hand it to a `claude` process
+/// (e.g. `tbd profile login`) without reimplementing provisioning.
+public struct ModelProfilePrepareConfigDirParams: Codable, Sendable {
+    public let id: UUID
+    public init(id: UUID) { self.id = id }
+}
+
+public struct ModelProfilePrepareConfigDirResult: Codable, Sendable {
+    /// Absolute path of the profile's isolated `CLAUDE_CONFIG_DIR`
+    /// (`~/tbd/profiles/<lowercased-uuid>/claude`).
+    public let configDirPath: String
+    public init(configDirPath: String) { self.configDirPath = configDirPath }
 }
 
 public struct NotificationsListResult: Codable, Sendable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -819,14 +819,21 @@ public struct TerminalCreateParams: Codable, Sendable {
     public let prompt: String?
     /// Pin a specific profile ID for this terminal, bypassing resolve(repoID:).
     public let overrideProfileID: UUID?
+    /// True for a profile *login session* (Settings → "Open login session"):
+    /// requires `overrideProfileID`; the daemon labels the terminal
+    /// `TerminalLabel.login`, auto-types `/login` once Claude is up, and
+    /// watches the profile's config dir so the UI badge flips on completion.
+    /// Optional so older clients/params decode unchanged (nil = false).
+    public let loginSession: Bool?
     /// Initial tmux window size in cells (see WorktreeCreateParams).
     public let cols: Int?
     public let rows: Int?
     /// COLORFGBG environment variable value computed from active terminal color scheme's
     /// background luminance. Format: "0;15" for light bg or "15;0" for dark bg.
     public let colorFgBg: String?
-    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil, overrideProfileID: UUID? = nil, cols: Int? = nil, rows: Int? = nil, colorFgBg: String? = nil) {
+    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil, overrideProfileID: UUID? = nil, loginSession: Bool? = nil, cols: Int? = nil, rows: Int? = nil, colorFgBg: String? = nil) {
         self.worktreeID = worktreeID; self.cmd = cmd; self.type = type; self.resumeSessionID = resumeSessionID; self.prompt = prompt; self.overrideProfileID = overrideProfileID
+        self.loginSession = loginSession
         self.cols = cols; self.rows = rows; self.colorFgBg = colorFgBg
     }
 }

--- a/Sources/TBDShared/TerminalLabel.swift
+++ b/Sources/TBDShared/TerminalLabel.swift
@@ -12,4 +12,10 @@ public enum TerminalLabel {
     public static let claudeCode = "Claude Code"
     /// Codex agent terminal.
     public static let codex = "Codex"
+    /// Profile login-session terminal (Settings → "Open login session"):
+    /// a Claude session pinned to an OAuth profile, spawned so the user can
+    /// run `/login` into the profile's isolated config dir. The daemon
+    /// auto-types `/login` into terminals carrying this label, and the app
+    /// dedupes "Open login session" clicks against it.
+    public static let login = "login"
 }

--- a/Tests/TBDAppTests/AddTabMenuTests.swift
+++ b/Tests/TBDAppTests/AddTabMenuTests.swift
@@ -7,10 +7,15 @@ import TBDShared
 
 // MARK: - Helpers
 
-private func makeProfile(name: String) -> ModelProfileWithUsage {
+private func makeProfile(
+    name: String,
+    kind: CredentialKind = .oauth,
+    loginIdentity: String? = nil
+) -> ModelProfileWithUsage {
     ModelProfileWithUsage(
-        profile: ModelProfile(id: UUID(), name: name, kind: .oauth),
-        usage: nil
+        profile: ModelProfile(id: UUID(), name: name, kind: kind),
+        usage: nil,
+        loginIdentity: loginIdentity
     )
 }
 
@@ -85,7 +90,7 @@ private func makeExecutable(named name: String, in directory: URL) throws {
 
     #expect(menu.items.contains { $0.title == "Shell" })
     #expect(menu.items.contains { $0.title == "Claude" } == false)
-    #expect(menu.items.contains { $0.title == "Work" } == false)
+    #expect(menu.items.contains { $0.title.hasPrefix("Work") } == false)
     #expect(menu.items.contains { $0.title == "Codex" })
     #expect(menu.items.contains { $0.title == "Note" })
 }
@@ -101,14 +106,15 @@ private func makeExecutable(named name: String, in directory: URL) throws {
 
     #expect(menu.items.contains { $0.title == "Shell" })
     #expect(menu.items.contains { $0.title == "Claude" })
-    #expect(menu.items.contains { $0.title == "Work" })
+    #expect(menu.items.contains { $0.title.hasPrefix("Work") })
     #expect(menu.items.contains { $0.title == "Codex" } == false)
     #expect(menu.items.contains { $0.title == "Note" })
 }
 
 @MainActor
 @Test func addTabMenu_withProfiles_insertsIndentedItemsAfterClaude() {
-    let work = makeProfile(name: "Work")
+    // One logged-in oauth profile, one not — the titles carry the identity suffix.
+    let work = makeProfile(name: "Work", loginIdentity: "zadam@longeye.co")
     let personal = makeProfile(name: "Personal")
     let menu = AddTabMenu.build(profiles: [work, personal], coordinator: makeCoordinator())
 
@@ -116,17 +122,35 @@ private func makeExecutable(named name: String, in directory: URL) throws {
     let first = menu.items[idx + 1]
     let second = menu.items[idx + 2]
 
-    #expect(first.title == "Work")
+    #expect(first.title == "Work — zadam@longeye.co")
     #expect(first.indentationLevel == 0)
     #expect(first.image != nil)
     #expect(first.representedObject as? UUID == work.profile.id)
 
-    #expect(second.title == "Personal")
+    #expect(second.title == "Personal — needs /login")
     #expect(second.indentationLevel == 0)
     #expect(second.image != nil)
     #expect(second.representedObject as? UUID == personal.profile.id)
 
     #expect(menu.items[idx + 3].title == "Codex")
+}
+
+@MainActor
+@Test func addTabMenu_profileItemTitles_reflectLoginIdentityPerKind() {
+    // oauth + email → suffixed with the email; oauth + nil → "needs /login";
+    // non-oauth kinds → bare name regardless of any stray identity.
+    let loggedIn = makeProfile(name: "Work", loginIdentity: "a@b.co")
+    let needsLogin = makeProfile(name: "Spare")
+    let proxy = makeProfile(name: "Router", kind: .apiKey)
+    let menu = AddTabMenu.build(
+        profiles: [loggedIn, needsLogin, proxy],
+        coordinator: makeCoordinator()
+    )
+
+    let idx = claudeIndex(menu)
+    #expect(menu.items[idx + 1].title == "Work — a@b.co")
+    #expect(menu.items[idx + 2].title == "Spare — needs /login")
+    #expect(menu.items[idx + 3].title == "Router")
 }
 
 @MainActor

--- a/Tests/TBDAppTests/DaemonBuildSkewTests.swift
+++ b/Tests/TBDAppTests/DaemonBuildSkewTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+// Identity resolver: paths in these tests are fabricated, so the default
+// (symlink-resolving) resolver would be a no-op anyway; passing an explicit
+// identity keeps the tests hermetic against filesystem state.
+private let identity: @Sendable (String) -> String = { $0 }
+
+@Test func warningMessage_daemonMatchesSourceWorktreeBuild_returnsNil() {
+    // Normal restart.sh topology: app runs from /Applications, daemon runs
+    // from the SAME worktree's .build/debug.
+    let message = DaemonBuildSkew.warningMessage(
+        daemonExecutablePath: "/Users/me/proj/tbd/.build/debug/TBDDaemon",
+        appSiblingDaemonPath: "/Applications/TBD.app/Contents/MacOS/TBDDaemon",
+        sourceWorktreePath: "/Users/me/proj/tbd",
+        resolvePath: identity
+    )
+    #expect(message == nil)
+}
+
+@Test func warningMessage_daemonMatchesAppSibling_returnsNil() {
+    // App-spawned daemon: TBDDaemon sits next to the app executable.
+    let message = DaemonBuildSkew.warningMessage(
+        daemonExecutablePath: "/Users/me/proj/tbd/.build/debug/TBDDaemon",
+        appSiblingDaemonPath: "/Users/me/proj/tbd/.build/debug/TBDDaemon",
+        sourceWorktreePath: nil,
+        resolvePath: identity
+    )
+    #expect(message == nil)
+}
+
+@Test func warningMessage_daemonFromOtherWorktree_returnsWarningNamingDaemonPath() {
+    let otherBuild = "/Users/me/proj/tbd/.claude/worktrees/other-wt/.build/debug/TBDDaemon"
+    let message = DaemonBuildSkew.warningMessage(
+        daemonExecutablePath: otherBuild,
+        appSiblingDaemonPath: "/Applications/TBD.app/Contents/MacOS/TBDDaemon",
+        sourceWorktreePath: "/Users/me/proj/tbd",
+        resolvePath: identity
+    )
+    let unwrapped = try? #require(message)
+    #expect(unwrapped?.contains(otherBuild) == true)
+    #expect(unwrapped?.contains("scripts/restart.sh") == true)
+}
+
+@Test func warningMessage_oldDaemonWithoutField_returnsNil() {
+    // Pre-handshake daemons omit executablePath; decode-compatible clients
+    // must stay quiet rather than false-positive.
+    let message = DaemonBuildSkew.warningMessage(
+        daemonExecutablePath: nil,
+        appSiblingDaemonPath: "/Applications/TBD.app/Contents/MacOS/TBDDaemon",
+        sourceWorktreePath: "/Users/me/proj/tbd",
+        resolvePath: identity
+    )
+    #expect(message == nil)
+}
+
+@Test func warningMessage_emptyDaemonPath_returnsNil() {
+    let message = DaemonBuildSkew.warningMessage(
+        daemonExecutablePath: "",
+        appSiblingDaemonPath: "/Applications/TBD.app/Contents/MacOS/TBDDaemon",
+        sourceWorktreePath: "/Users/me/proj/tbd",
+        resolvePath: identity
+    )
+    #expect(message == nil)
+}
+
+@Test func warningMessage_noExpectedCandidates_returnsNil() {
+    // App identity unknown (no sibling, no source worktree) — can't judge.
+    let message = DaemonBuildSkew.warningMessage(
+        daemonExecutablePath: "/Users/me/proj/tbd/.build/debug/TBDDaemon",
+        appSiblingDaemonPath: nil,
+        sourceWorktreePath: nil,
+        resolvePath: identity
+    )
+    #expect(message == nil)
+}
+
+@Test func warningMessage_resolverUnifiesEquivalentSpellings() {
+    // The resolver seam is what maps /tmp-style symlinked spellings onto one
+    // canonical form; a resolver that unifies them must suppress the warning.
+    let message = DaemonBuildSkew.warningMessage(
+        daemonExecutablePath: "/private/tmp/wt/.build/debug/TBDDaemon",
+        appSiblingDaemonPath: nil,
+        sourceWorktreePath: "/tmp/wt",
+        resolvePath: { path in
+            path.hasPrefix("/private/") ? String(path.dropFirst("/private".count)) : path
+        }
+    )
+    #expect(message == nil)
+}
+
+@Test func defaultResolvePath_standardizesDotComponents() {
+    let resolved = DaemonBuildSkew.defaultResolvePath("/Users/me/proj/tbd/./.build/debug/TBDDaemon")
+    #expect(resolved == "/Users/me/proj/tbd/.build/debug/TBDDaemon")
+}

--- a/Tests/TBDAppTests/DaemonLivenessTests.swift
+++ b/Tests/TBDAppTests/DaemonLivenessTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+// MARK: - isLiveTBDDaemon branches
+
+@Test func isLiveTBDDaemon_deadPid_returnsFalse_withoutResolvingPath() {
+    var resolverCalled = false
+    let result = DaemonLiveness.isLiveTBDDaemon(
+        pid: 98251,
+        isAlive: { _ in false },
+        executablePath: { _ in
+            resolverCalled = true
+            return "/some/worktree/.build/debug/TBDDaemon"
+        }
+    )
+    #expect(result == false)
+    #expect(resolverCalled == false)
+}
+
+@Test func isLiveTBDDaemon_alivePidRunningTBDDaemon_returnsTrue() {
+    let result = DaemonLiveness.isLiveTBDDaemon(
+        pid: 123,
+        isAlive: { _ in true },
+        executablePath: { _ in "/some/worktree/.build/debug/TBDDaemon" }
+    )
+    #expect(result == true)
+}
+
+@Test func isLiveTBDDaemon_recycledPidRunningOtherBinary_returnsFalse() {
+    // The post-reboot failure mode: pid file survives, pid is reused by an
+    // unrelated process — must NOT be treated as a running daemon.
+    let result = DaemonLiveness.isLiveTBDDaemon(
+        pid: 98251,
+        isAlive: { _ in true },
+        executablePath: { _ in "/usr/libexec/somethingelsed" }
+    )
+    #expect(result == false)
+}
+
+@Test func isLiveTBDDaemon_pathResolutionFails_returnsFalse() {
+    // proc_pidpath can fail (e.g. another user's process). Unverifiable pids
+    // are treated as stale rather than trusted.
+    let result = DaemonLiveness.isLiveTBDDaemon(
+        pid: 123,
+        isAlive: { _ in true },
+        executablePath: { _ in nil }
+    )
+    #expect(result == false)
+}
+
+@Test func isLiveTBDDaemon_emptyResolvedPath_returnsFalse() {
+    let result = DaemonLiveness.isLiveTBDDaemon(
+        pid: 123,
+        isAlive: { _ in true },
+        executablePath: { _ in "" }
+    )
+    #expect(result == false)
+}
+
+@Test func isLiveTBDDaemon_similarButDifferentBinaryName_returnsFalse() {
+    let result = DaemonLiveness.isLiveTBDDaemon(
+        pid: 123,
+        isAlive: { _ in true },
+        executablePath: { _ in "/some/worktree/.build/debug/TBDDaemonHelper" }
+    )
+    #expect(result == false)
+}
+
+@Test func isLiveTBDDaemon_nonPositivePid_returnsFalse_withoutSignalling() {
+    // pid 0 would signal the caller's own process group; must short-circuit.
+    var aliveCalled = false
+    let result = DaemonLiveness.isLiveTBDDaemon(
+        pid: 0,
+        isAlive: { _ in
+            aliveCalled = true
+            return true
+        },
+        executablePath: { _ in "/x/TBDDaemon" }
+    )
+    #expect(result == false)
+    #expect(aliveCalled == false)
+}
+
+// MARK: - pid file parsing
+
+@Test func pidFromPidFileContents_parsesTrimmedInteger() {
+    #expect(DaemonLiveness.pid(fromPidFileContents: "  98251\n") == 98251)
+}
+
+@Test func pidFromPidFileContents_malformed_returnsNil() {
+    #expect(DaemonLiveness.pid(fromPidFileContents: "not-a-pid") == nil)
+    #expect(DaemonLiveness.pid(fromPidFileContents: "") == nil)
+}
+
+// MARK: - real libproc resolver
+
+@Test func processExecutablePath_ownPid_returnsOwnBinaryPath() {
+    // Integration sanity check for the default resolver: our own pid must
+    // resolve to a non-empty absolute path (the test runner binary).
+    let path = DaemonLiveness.processExecutablePath(pid: getpid())
+    #expect(path?.hasPrefix("/") == true)
+}
+
+@Test func processExecutablePath_deadPid_returnsNil() {
+    // pid_t.max is far above any real pid on macOS (pid ceiling ~99999).
+    let path = DaemonLiveness.processExecutablePath(pid: pid_t.max)
+    #expect(path == nil)
+}
+
+// MARK: - pid-file-level helper (AppState.pidFilePointsAtLiveDaemon)
+
+@Test func pidFilePointsAtLiveDaemon_missingFile_returnsFalse() {
+    let bogus = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-liveness-\(UUID().uuidString).pid").path
+    #expect(AppState.pidFilePointsAtLiveDaemon(pidFilePath: bogus) == false)
+}
+
+@Test func pidFilePointsAtLiveDaemon_pidOfNonDaemonProcess_returnsFalse() throws {
+    // Our own live pid is real but is the test runner, not TBDDaemon — the
+    // executable-name check must reject it even though kill(pid, 0) == 0.
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-liveness-\(UUID().uuidString).pid")
+    try "\(getpid())\n".write(to: url, atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: url) }
+    #expect(AppState.pidFilePointsAtLiveDaemon(pidFilePath: url.path) == false)
+}

--- a/Tests/TBDAppTests/LoginSessionDedupeTests.swift
+++ b/Tests/TBDAppTests/LoginSessionDedupeTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Unit tests for the "Open login session" duplicate guard: clicking the
+/// button again while a live login session exists for the profile must focus
+/// it instead of spawning another (`AppState.existingLoginSessionTerminal`).
+@Suite("Login session dedupe")
+struct LoginSessionDedupeTests {
+
+    private func makeTerminal(
+        worktreeID: UUID = UUID(),
+        label: String? = TerminalLabel.login,
+        profileID: UUID?,
+        suspendedAt: Date? = nil
+    ) -> Terminal {
+        Terminal(
+            worktreeID: worktreeID,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: label,
+            claudeSessionID: UUID().uuidString,
+            suspendedAt: suspendedAt,
+            profileID: profileID,
+            kind: .claude
+        )
+    }
+
+    @Test("finds a live login session for the profile across worktrees")
+    func findsMatch() {
+        let profileID = UUID()
+        let wtA = UUID(), wtB = UUID()
+        let match = makeTerminal(worktreeID: wtB, profileID: profileID)
+        let terminals: [UUID: [Terminal]] = [
+            wtA: [makeTerminal(worktreeID: wtA, label: TerminalLabel.claudeCode, profileID: nil)],
+            wtB: [match],
+        ]
+        let found = AppState.existingLoginSessionTerminal(profileID: profileID, terminals: terminals)
+        #expect(found?.id == match.id)
+    }
+
+    @Test("ignores login sessions pinned to a different profile")
+    func ignoresOtherProfiles() {
+        let terminals: [UUID: [Terminal]] = [
+            UUID(): [makeTerminal(profileID: UUID())]
+        ]
+        #expect(AppState.existingLoginSessionTerminal(profileID: UUID(), terminals: terminals) == nil)
+    }
+
+    @Test("ignores plain Claude terminals on the same profile (not login sessions)")
+    func ignoresNonLoginTerminals() {
+        let profileID = UUID()
+        let terminals: [UUID: [Terminal]] = [
+            UUID(): [makeTerminal(label: TerminalLabel.claudeCode, profileID: profileID)]
+        ]
+        #expect(AppState.existingLoginSessionTerminal(profileID: profileID, terminals: terminals) == nil)
+    }
+
+    @Test("ignores suspended login sessions")
+    func ignoresSuspended() {
+        let profileID = UUID()
+        let terminals: [UUID: [Terminal]] = [
+            UUID(): [makeTerminal(profileID: profileID, suspendedAt: Date())]
+        ]
+        #expect(AppState.existingLoginSessionTerminal(profileID: profileID, terminals: terminals) == nil)
+    }
+}

--- a/Tests/TBDAppTests/ProfileLoginPresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileLoginPresentationTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// Pure string-composition rules for the login-identity badges (Phase 2a):
+// Settings row captions, and the " — email" / " — needs /login" menu suffix
+// used by both the "+" new-tab menu and the menu-bar profile switcher.
+
+private func makeEntry(
+    kind: CredentialKind = .oauth,
+    baseURL: String? = nil,
+    model: String? = nil,
+    awsRegion: String? = nil,
+    loginIdentity: String? = nil
+) -> ModelProfileWithUsage {
+    ModelProfileWithUsage(
+        profile: ModelProfile(
+            id: UUID(), name: "Work", kind: kind,
+            baseURL: baseURL, model: model, awsRegion: awsRegion
+        ),
+        usage: nil,
+        loginIdentity: loginIdentity
+    )
+}
+
+// MARK: - needsLogin
+
+@Test func needsLogin_oauthWithoutIdentity_isTrue() {
+    #expect(ProfileLoginPresentation.needsLogin(kind: .oauth, loginIdentity: nil))
+    #expect(ProfileLoginPresentation.needsLogin(kind: .oauth, loginIdentity: ""))
+    #expect(ProfileLoginPresentation.needsLogin(kind: .oauth, loginIdentity: "  \n"))
+}
+
+@Test func needsLogin_oauthWithIdentity_isFalse() {
+    #expect(!ProfileLoginPresentation.needsLogin(kind: .oauth, loginIdentity: "a@b.co"))
+}
+
+@Test func needsLogin_nonOAuthKinds_areNeverNeedsLogin() {
+    #expect(!ProfileLoginPresentation.needsLogin(kind: .apiKey, loginIdentity: nil))
+    #expect(!ProfileLoginPresentation.needsLogin(kind: .bedrock, loginIdentity: nil))
+}
+
+// MARK: - menuTitleSuffix / menuItemTitle
+
+@Test func menuTitleSuffix_oauthLoggedIn_showsEmail() {
+    #expect(ProfileLoginPresentation.menuTitleSuffix(kind: .oauth, loginIdentity: "a@b.co")
+            == " — a@b.co")
+}
+
+@Test func menuTitleSuffix_oauthNotLoggedIn_showsNeedsLogin() {
+    #expect(ProfileLoginPresentation.menuTitleSuffix(kind: .oauth, loginIdentity: nil)
+            == " — needs /login")
+    #expect(ProfileLoginPresentation.menuTitleSuffix(kind: .oauth, loginIdentity: "  ")
+            == " — needs /login")
+}
+
+@Test func menuTitleSuffix_nonOAuth_isEmptyEvenWithStrayIdentity() {
+    // loginIdentity should never be set for non-oauth kinds, but even if a
+    // future daemon sends one, menus stay bare for those kinds.
+    #expect(ProfileLoginPresentation.menuTitleSuffix(kind: .apiKey, loginIdentity: "x@y.z") == "")
+    #expect(ProfileLoginPresentation.menuTitleSuffix(kind: .bedrock, loginIdentity: nil) == "")
+}
+
+@Test func menuItemTitle_composesDisplayNameAndSuffix() {
+    let loggedIn = makeEntry(loginIdentity: "zadam@longeye.co")
+    #expect(ProfileLoginPresentation.menuItemTitle(for: loggedIn) == "Work — zadam@longeye.co")
+
+    let needsLogin = makeEntry()
+    #expect(ProfileLoginPresentation.menuItemTitle(for: needsLogin) == "Work — needs /login")
+
+    let bedrock = makeEntry(kind: .bedrock, awsRegion: "us-east-1")
+    #expect(ProfileLoginPresentation.menuItemTitle(for: bedrock) == "Work")
+}
+
+// MARK: - settingsCaption
+
+@Test func settingsCaption_oauthLoggedIn_leadsWithIdentity() {
+    let entry = makeEntry(loginIdentity: "a@b.co")
+    #expect(ProfileLoginPresentation.settingsCaption(for: entry) == "Logged in as a@b.co")
+}
+
+@Test func settingsCaption_oauthLoggedIn_keepsEndpointDetails() {
+    let entry = makeEntry(baseURL: "http://127.0.0.1:8080", model: "opus",
+                          loginIdentity: "a@b.co")
+    #expect(ProfileLoginPresentation.settingsCaption(for: entry)
+            == "Logged in as a@b.co · via http://127.0.0.1:8080 · opus")
+}
+
+@Test func settingsCaption_oauthNotLoggedIn_showsGentleHint() {
+    // nil also covers an older daemon that doesn't send the field, so the
+    // copy is an observation ("no login detected"), not a hard claim.
+    let entry = makeEntry(model: "opus")
+    #expect(ProfileLoginPresentation.settingsCaption(for: entry)
+            == "No login detected — run /login once · opus")
+}
+
+@Test func settingsCaption_nonOAuth_matchesSharedDetailCaption() {
+    let proxy = makeEntry(kind: .apiKey, baseURL: "http://127.0.0.1:3456", model: "gpt-5-codex")
+    #expect(ProfileLoginPresentation.settingsCaption(for: proxy) == proxy.profile.detailCaption)
+    #expect(ProfileLoginPresentation.settingsCaption(for: proxy)
+            == "via http://127.0.0.1:3456 · gpt-5-codex")
+
+    let bedrock = makeEntry(kind: .bedrock, model: "us.anthropic.claude-sonnet-4-5",
+                            awsRegion: "us-west-2")
+    #expect(ProfileLoginPresentation.settingsCaption(for: bedrock)
+            == bedrock.profile.detailCaption)
+
+    // Plain api-key profile with nothing to show stays nil, exactly like
+    // detailCaption — the row simply renders no caption line.
+    let bare = makeEntry(kind: .apiKey)
+    #expect(ProfileLoginPresentation.settingsCaption(for: bare) == nil)
+}

--- a/Tests/TBDCLITests/ProfileCommandsTests.swift
+++ b/Tests/TBDCLITests/ProfileCommandsTests.swift
@@ -1,0 +1,175 @@
+import ArgumentParser
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDCLI
+
+@Suite("ProfileCommands")
+struct ProfileCommandsTests {
+
+    private func entry(
+        name: String,
+        kind: CredentialKind = .oauth,
+        loginIdentity: String? = nil,
+        id: UUID = UUID()
+    ) -> ModelProfileWithUsage {
+        let profile = ModelProfile(id: id, name: name, kind: kind)
+        return ModelProfileWithUsage(profile: profile, loginIdentity: loginIdentity)
+    }
+
+    // MARK: - Identity column rendering
+
+    @Test func identityCell_oauthLoggedIn_showsEmail() {
+        #expect(profileIdentityCell(kind: .oauth, loginIdentity: "zadam@longeye.co") == "zadam@longeye.co")
+    }
+
+    @Test func identityCell_oauthNotLoggedIn_showsNeedsLogin() {
+        #expect(profileIdentityCell(kind: .oauth, loginIdentity: nil) == "needs /login")
+    }
+
+    @Test func identityCell_oauthEmptyIdentity_showsNeedsLogin() {
+        #expect(profileIdentityCell(kind: .oauth, loginIdentity: "") == "needs /login")
+    }
+
+    @Test func identityCell_apiKey_showsDash() {
+        #expect(profileIdentityCell(kind: .apiKey, loginIdentity: nil) == "—")
+    }
+
+    @Test func identityCell_bedrock_showsDash() {
+        // loginIdentity should never be set for non-oauth kinds, but even if a
+        // daemon sent one, the column stays a dash.
+        #expect(profileIdentityCell(kind: .bedrock, loginIdentity: "stray@example.com") == "—")
+    }
+
+    // MARK: - Name resolution
+
+    @Test func resolveProfile_exactName() throws {
+        let profiles = [entry(name: "work"), entry(name: "personal")]
+        let resolved = try resolveProfile(named: "personal", in: profiles)
+        #expect(resolved.profile.name == "personal")
+    }
+
+    @Test func resolveProfile_exactNameWinsOverCaseInsensitive() throws {
+        let profiles = [entry(name: "Work"), entry(name: "work")]
+        let resolved = try resolveProfile(named: "work", in: profiles)
+        #expect(resolved.profile.name == "work")
+    }
+
+    @Test func resolveProfile_uniqueCaseInsensitiveMatch() throws {
+        let profiles = [entry(name: "Work"), entry(name: "personal")]
+        let resolved = try resolveProfile(named: "WORK", in: profiles)
+        #expect(resolved.profile.name == "Work")
+    }
+
+    @Test func resolveProfile_ambiguousCaseInsensitiveThrows() {
+        let profiles = [entry(name: "Work"), entry(name: "work")]
+        #expect(throws: CLIError.self) {
+            _ = try resolveProfile(named: "WORK", in: profiles)
+        }
+    }
+
+    @Test func resolveProfile_byUUID() throws {
+        let id = UUID()
+        let profiles = [entry(name: "work", id: id), entry(name: "personal")]
+        let resolved = try resolveProfile(named: id.uuidString, in: profiles)
+        #expect(resolved.profile.id == id)
+    }
+
+    @Test func resolveProfile_missingListsAvailableNames() {
+        let profiles = [entry(name: "work"), entry(name: "personal")]
+        do {
+            _ = try resolveProfile(named: "nope", in: profiles)
+            Issue.record("expected resolveProfile to throw")
+        } catch {
+            let message = "\(error)"
+            #expect(message.contains("nope"))
+            #expect(message.contains("personal"))
+            #expect(message.contains("work"))
+        }
+    }
+
+    @Test func resolveProfile_emptyListExplains() {
+        do {
+            _ = try resolveProfile(named: "work", in: [])
+            Issue.record("expected resolveProfile to throw")
+        } catch {
+            #expect("\(error)".contains("No model profiles exist"))
+        }
+    }
+
+    // MARK: - Login env scrubbing
+
+    @Test func sanitizedLoginEnvironment_removesPoisonVarsKeepsRest() {
+        let base = [
+            "ANTHROPIC_API_KEY": "sk-ant-api03-xxx",
+            "ANTHROPIC_AUTH_TOKEN": "token",
+            "ANTHROPIC_BASE_URL": "http://localhost:8080",
+            "CLAUDE_CODE_USE_BEDROCK": "1",
+            "PATH": "/usr/bin",
+            "HOME": "/Users/x",
+        ]
+        let sanitized = sanitizedLoginEnvironment(base: base)
+        for key in loginPoisonEnvVars {
+            #expect(sanitized[key] == nil, "expected \(key) to be scrubbed")
+        }
+        #expect(sanitized["PATH"] == "/usr/bin")
+        #expect(sanitized["HOME"] == "/Users/x")
+    }
+
+    // MARK: - Executable lookup
+
+    @Test func findExecutable_findsOnlyExecutableFiles() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory
+            .appendingPathComponent("tbd-find-exec-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        let exec = dir.appendingPathComponent("claude")
+        try Data("#!/bin/sh\n".utf8).write(to: exec)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: exec.path)
+        let plain = dir.appendingPathComponent("not-exec")
+        try Data().write(to: plain)
+
+        let searchPath = "/nonexistent-dir:\(dir.path)"
+        #expect(findExecutable(named: "claude", searchPath: searchPath) == exec.path)
+        #expect(findExecutable(named: "not-exec", searchPath: searchPath) == nil)
+        #expect(findExecutable(named: "missing", searchPath: searchPath) == nil)
+    }
+
+    // MARK: - Command wiring
+
+    @Test func profileCommandRegisteredOnRoot() {
+        let names = TBDCommand.configuration.subcommands.map { String(describing: $0) }
+        #expect(names.contains("ProfileCommand"))
+    }
+
+    @Test func subcommandsRegistered() {
+        let names = ProfileCommand.configuration.subcommands.map { String(describing: $0) }
+        #expect(names == ["ProfileList", "ProfileSetDefault", "ProfileLogin"])
+    }
+
+    @Test func setDefaultParsesClearFlag() throws {
+        let cmd = try ProfileSetDefault.parse(["--clear"])
+        #expect(cmd.clear)
+        #expect(cmd.name == nil)
+    }
+
+    @Test func setDefaultParsesName() throws {
+        let cmd = try ProfileSetDefault.parse(["work"])
+        #expect(!cmd.clear)
+        #expect(cmd.name == "work")
+    }
+
+    @Test func loginRequiresName() {
+        #expect(throws: Error.self) {
+            _ = try ProfileLogin.parse([])
+        }
+    }
+
+    @Test func listParsesJSONFlag() throws {
+        let cmd = try ProfileList.parse(["--json"])
+        #expect(cmd.json)
+    }
+}

--- a/Tests/TBDCLITests/TableRowFormattingTests.swift
+++ b/Tests/TBDCLITests/TableRowFormattingTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import TBDCLI
+
+@Suite("tableRow plain-text list formatting")
+struct TableRowFormattingTests {
+    @Test func padsColumnsToWidthWithTwoSpaceGaps() {
+        let row = tableRow([("ID", 36), ("NAME", 24), ("STATUS", 8), ("BRANCH", 0)])
+        #expect(row == "ID" + String(repeating: " ", count: 34)
+            + "  NAME" + String(repeating: " ", count: 20)
+            + "  STATUS" + String(repeating: " ", count: 2)
+            + "  BRANCH")
+    }
+
+    @Test func doesNotTruncateValuesLongerThanColumnWidth() {
+        let longName = String(repeating: "x", count: 40)
+        let row = tableRow([(longName, 24), ("active", 8), ("main", 0)])
+        #expect(row.hasPrefix(longName + "  "))
+        #expect(row.contains(longName))
+        #expect(row.hasSuffix("active    main"))
+    }
+
+    @Test func exactWidthValueGetsNoPadding() {
+        let value = String(repeating: "a", count: 8)
+        #expect(tableRow([(value, 8), ("end", 0)]) == value + "  end")
+    }
+
+    @Test func zeroWidthFinalColumnIsNotPadded() {
+        #expect(tableRow([("only", 0)]) == "only")
+    }
+
+    /// Regression: `tbd worktree list` (plain text) crashed with SIGSEGV
+    /// because `String(format: "%-36s", ...)` was fed Swift Strings —
+    /// `%s` expects a C string pointer on Darwin. A UUID-shaped row must
+    /// format cleanly and align to the same columns the old format
+    /// string intended.
+    @Test func uuidRowFormatsWithoutCrashingAndAligns() {
+        let id = UUID().uuidString
+        let row = tableRow([(id, 36), ("my-worktree", 24), ("active", 8), ("main", 0)])
+        // UUID strings are exactly 36 chars, so NAME starts at offset 38.
+        #expect(row.count == 36 + 2 + 24 + 2 + 8 + 2 + 4)
+        let nameStart = row.index(row.startIndex, offsetBy: 38)
+        #expect(row[nameStart...].hasPrefix("my-worktree"))
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeCodeCredentialsKeychainTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeCodeCredentialsKeychainTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Recorder stub — captures requested service names without touching the
+/// real login keychain.
+final class RecordingCredentialsKeychain: ClaudeCredentialsKeychainDeleting, @unchecked Sendable {
+    private(set) var deletedServices: [String] = []
+    var statusToReturn: OSStatus = errSecSuccess
+
+    func deleteGenericPassword(service: String) -> OSStatus {
+        deletedServices.append(service)
+        return statusToReturn
+    }
+}
+
+@Suite("ClaudeCodeCredentialsKeychain")
+struct ClaudeCodeCredentialsKeychainTests {
+
+    // MARK: - Suffix computation
+
+    @Test("known vector: sha256 of zadam profile path starts with db64a81f")
+    func knownVector() {
+        let path = "/Users/zionts/.claude-profiles/zadam"
+        #expect(ClaudeCodeCredentialsKeychain.serviceSuffix(forConfigDirPath: path) == "db64a81f")
+        #expect(
+            ClaudeCodeCredentialsKeychain.serviceName(forConfigDirPath: path)
+                == "Claude Code-credentials-db64a81f"
+        )
+    }
+
+    @Test("suffix is always 8 lowercase hex chars")
+    func suffixFormat() {
+        for path in [
+            "/Users/someone/tbd/profiles/abc123/claude",
+            "",
+            "relative/path",
+            "/path/with spaces/and-Ünïcode",
+        ] {
+            let suffix = ClaudeCodeCredentialsKeychain.serviceSuffix(forConfigDirPath: path)
+            #expect(suffix.count == 8)
+            #expect(suffix.allSatisfy { "0123456789abcdef".contains($0) })
+        }
+    }
+
+    @Test("different paths produce different suffixes")
+    func suffixVariesByPath() {
+        let a = ClaudeCodeCredentialsKeychain.serviceSuffix(forConfigDirPath: "/a")
+        let b = ClaudeCodeCredentialsKeychain.serviceSuffix(forConfigDirPath: "/b")
+        #expect(a != b)
+    }
+
+    // MARK: - Safety: never the bare item
+
+    @Test("service name always carries a suffix — never the bare credentials item")
+    func serviceNameNeverBare() {
+        for path in ["", "/", "/Users/x/tbd/profiles/y/claude", "Claude Code-credentials"] {
+            let name = ClaudeCodeCredentialsKeychain.serviceName(forConfigDirPath: path)
+            #expect(name != ClaudeCodeCredentialsKeychain.baseServiceName)
+            #expect(name.hasPrefix("Claude Code-credentials-"))
+            #expect(name.count == "Claude Code-credentials-".count + 8)
+        }
+    }
+
+    // MARK: - deleteCredentials(forConfigDirPath:)
+
+    @Test("deleteCredentials requests the derived, suffixed service name")
+    func deleteRequestsDerivedServiceName() {
+        let recorder = RecordingCredentialsKeychain()
+        let path = "/Users/zionts/.claude-profiles/zadam"
+        let status = recorder.deleteCredentials(forConfigDirPath: path)
+        #expect(status == errSecSuccess)
+        #expect(recorder.deletedServices == ["Claude Code-credentials-db64a81f"])
+    }
+}

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -693,4 +693,109 @@ struct ClaudeSpawnCommandBuilderEnvTests {
             envSettingOverrides: [:])
         #expect(result.sensitiveEnv["CLAUDE_CODE_NO_FLICKER"] == nil)
     }
+
+    // MARK: - Inline re-export of profile routing env (rc-clobber defense)
+
+    /// REGRESSION: tmux `-e CLAUDE_CONFIG_DIR=...` is clobbered by shell rc
+    /// files (`zsh -ic` sources ~/.zshenv BEFORE the -c command — a
+    /// `export CLAUDE_CONFIG_DIR=...` account switcher there silently
+    /// redirected every "isolated" profile session to the rc's config dir).
+    /// The builder must ALSO re-export the routing env inline in the command,
+    /// which runs after rc files and therefore wins.
+    @Test("profile config dir is re-exported inline so rc files cannot clobber it")
+    func configDirInlineExported() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "abc",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            profileKind: .oauth,
+            profileBaseURL: nil,
+            profileModel: nil,
+            profileConfigDir: "/Users/me/tbd/profiles/abc/claude",
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(r.command.hasPrefix("export CLAUDE_CONFIG_DIR='/Users/me/tbd/profiles/abc/claude';"))
+        #expect(r.command.contains("claude --session-id abc"))
+        // Still in -e env too (visible during rc execution).
+        #expect(r.sensitiveEnv["CLAUDE_CONFIG_DIR"] == "/Users/me/tbd/profiles/abc/claude")
+    }
+
+    @Test("proxy routing env (base URL + model) is re-exported inline")
+    func proxyRoutingInlineExported() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "abc",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: "sk-proxy-key",
+            profileKind: .apiKey,
+            profileBaseURL: "http://127.0.0.1:3456",
+            profileModel: "gpt-5-codex",
+            profileConfigDir: "/Users/me/tbd/profiles/abc/claude",
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(r.command.contains("export ANTHROPIC_BASE_URL='http://127.0.0.1:3456';"))
+        #expect(r.command.contains("export ANTHROPIC_MODEL='gpt-5-codex';"))
+        #expect(r.command.contains("export CLAUDE_CONFIG_DIR="))
+    }
+
+    @Test("secrets are NEVER inlined into the command string")
+    func secretNeverInlined() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "abc",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: "sk-super-secret",
+            profileKind: .apiKey,
+            profileBaseURL: "http://127.0.0.1:3456",
+            profileModel: nil,
+            profileConfigDir: "/Users/me/tbd/profiles/abc/claude",
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(!r.command.contains("sk-super-secret"))
+        #expect(!r.command.contains("ANTHROPIC_API_KEY"))
+        #expect(r.sensitiveEnv["ANTHROPIC_API_KEY"] == "sk-super-secret")
+    }
+
+    @Test("bedrock routing env is re-exported inline")
+    func bedrockRoutingInlineExported() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "abc",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            profileKind: .bedrock,
+            profileBaseURL: nil,
+            profileModel: "anthropic.claude-3-7",
+            profileAwsRegion: "us-east-1",
+            profileAwsProfile: "work",
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(r.command.contains("export CLAUDE_CODE_USE_BEDROCK='1';"))
+        #expect(r.command.contains("export AWS_REGION='us-east-1';"))
+        #expect(r.command.contains("export AWS_PROFILE='work';"))
+        #expect(r.command.contains("export ANTHROPIC_MODEL='anthropic.claude-3-7';"))
+    }
+
+    @Test("no profile routing env → command has no inline exports (unchanged shape)")
+    func noRoutingNoInlineExports() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc-123",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(r.command == "claude --resume abc-123 --dangerously-skip-permissions")
+    }
 }

--- a/Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("LoginSessionCoordinator")
+struct LoginSessionCoordinatorTests {
+
+    // MARK: - Auto-login pending set (consume-once)
+
+    @Test("consumePendingAutoLogin returns true exactly once per registration")
+    func consumeOnce() async {
+        let coordinator = LoginSessionCoordinator()
+        let id = UUID()
+        await coordinator.registerPendingAutoLogin(terminalID: id)
+
+        #expect(await coordinator.consumePendingAutoLogin(terminalID: id) == true)
+        // Second trigger (hook vs. spawn-fallback race) must lose.
+        #expect(await coordinator.consumePendingAutoLogin(terminalID: id) == false)
+    }
+
+    @Test("consumePendingAutoLogin for an unregistered terminal is false")
+    func consumeUnregistered() async {
+        let coordinator = LoginSessionCoordinator()
+        #expect(await coordinator.consumePendingAutoLogin(terminalID: UUID()) == false)
+    }
+
+    @Test("cancelPendingAutoLogin drops the pending send")
+    func cancelDropsPending() async {
+        let coordinator = LoginSessionCoordinator()
+        let id = UUID()
+        await coordinator.registerPendingAutoLogin(terminalID: id)
+        await coordinator.cancelPendingAutoLogin(terminalID: id)
+        #expect(await coordinator.consumePendingAutoLogin(terminalID: id) == false)
+    }
+
+    // MARK: - Login-identity watcher
+
+    /// Thread-safe recorder for watcher callbacks.
+    final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _loginCount = 0
+        private var _identity: String?
+        var loginCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _loginCount
+        }
+        func recordLogin() {
+            lock.lock(); defer { lock.unlock() }
+            _loginCount += 1
+        }
+        var identity: String? {
+            lock.lock(); defer { lock.unlock() }
+            return _identity
+        }
+        func setIdentity(_ value: String?) {
+            lock.lock(); defer { lock.unlock() }
+            _identity = value
+        }
+    }
+
+    /// Poll until `condition` is true or `timeout` elapses.
+    private func waitFor(
+        _ condition: @Sendable () -> Bool,
+        timeout: Duration = .seconds(5)
+    ) async -> Bool {
+        var elapsed: Duration = .zero
+        let step: Duration = .milliseconds(10)
+        while elapsed < timeout {
+            if condition() { return true }
+            try? await Task.sleep(for: step)
+            elapsed += step
+        }
+        return condition()
+    }
+
+    @Test("watcher fires onLogin exactly once when identity appears, then stops")
+    func watcherFiresOnLogin() async {
+        let coordinator = LoginSessionCoordinator()
+        let recorder = Recorder()
+        let profileID = UUID()
+
+        await coordinator.watchLoginIdentity(
+            profileID: profileID,
+            interval: .milliseconds(10),
+            timeout: .seconds(5),
+            identity: { recorder.identity },
+            onLogin: { recorder.recordLogin() }
+        )
+
+        // No login yet — give the watcher a few polls.
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(recorder.loginCount == 0)
+
+        recorder.setIdentity("adam@example.com")
+        #expect(await waitFor({ recorder.loginCount == 1 }))
+
+        // Stops after firing: no further callbacks accumulate.
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(recorder.loginCount == 1)
+    }
+
+    @Test("watcher is single-flighted per profile while active")
+    func watcherSingleFlight() async {
+        let coordinator = LoginSessionCoordinator()
+        let recorder = Recorder()
+        let profileID = UUID()
+
+        // Register twice while no login exists — the first watcher stays
+        // alive (polling), so the second registration must hit the
+        // single-flight guard and become a no-op.
+        await coordinator.watchLoginIdentity(
+            profileID: profileID,
+            interval: .milliseconds(10),
+            timeout: .seconds(5),
+            identity: { recorder.identity },
+            onLogin: { recorder.recordLogin() }
+        )
+        await coordinator.watchLoginIdentity(
+            profileID: profileID,
+            interval: .milliseconds(10),
+            timeout: .seconds(5),
+            identity: { recorder.identity },
+            onLogin: { recorder.recordLogin() }
+        )
+
+        recorder.setIdentity("adam@example.com")
+        #expect(await waitFor({ recorder.loginCount >= 1 }))
+        // The duplicate registration must not produce a second callback.
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(recorder.loginCount == 1)
+    }
+
+    @Test("watcher times out without firing, and the profile can be re-watched afterwards")
+    func watcherTimeoutAndRewatch() async {
+        let coordinator = LoginSessionCoordinator()
+        let recorder = Recorder()
+        let profileID = UUID()
+
+        await coordinator.watchLoginIdentity(
+            profileID: profileID,
+            interval: .milliseconds(5),
+            timeout: .milliseconds(20),
+            identity: { recorder.identity },
+            onLogin: { recorder.recordLogin() }
+        )
+        // Let it time out (identity stays nil).
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(recorder.loginCount == 0)
+
+        // A fresh watch after expiry must work (single-flight guard cleared).
+        recorder.setIdentity("adam@example.com")
+        await coordinator.watchLoginIdentity(
+            profileID: profileID,
+            interval: .milliseconds(5),
+            timeout: .seconds(5),
+            identity: { recorder.identity },
+            onLogin: { recorder.recordLogin() }
+        )
+        #expect(await waitFor({ recorder.loginCount == 1 }))
+    }
+}

--- a/Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift
@@ -6,41 +6,22 @@ import Testing
 @Suite("LoginSessionCoordinator")
 struct LoginSessionCoordinatorTests {
 
-    // MARK: - Auto-login pending set (consume-once)
-
-    @Test("consumePendingAutoLogin returns true exactly once per registration")
-    func consumeOnce() async {
-        let coordinator = LoginSessionCoordinator()
-        let id = UUID()
-        await coordinator.registerPendingAutoLogin(terminalID: id)
-
-        #expect(await coordinator.consumePendingAutoLogin(terminalID: id) == true)
-        // Second trigger (hook vs. spawn-fallback race) must lose.
-        #expect(await coordinator.consumePendingAutoLogin(terminalID: id) == false)
-    }
-
-    @Test("consumePendingAutoLogin for an unregistered terminal is false")
-    func consumeUnregistered() async {
-        let coordinator = LoginSessionCoordinator()
-        #expect(await coordinator.consumePendingAutoLogin(terminalID: UUID()) == false)
-    }
-
-    @Test("cancelPendingAutoLogin drops the pending send")
-    func cancelDropsPending() async {
-        let coordinator = LoginSessionCoordinator()
-        let id = UUID()
-        await coordinator.registerPendingAutoLogin(terminalID: id)
-        await coordinator.cancelPendingAutoLogin(terminalID: id)
-        #expect(await coordinator.consumePendingAutoLogin(terminalID: id) == false)
-    }
-
-    // MARK: - Login-identity watcher
-
-    /// Thread-safe recorder for watcher callbacks.
+    /// Thread-safe recorder shared by pump/watcher tests.
     final class Recorder: @unchecked Sendable {
         private let lock = NSLock()
+        private var _sendCount = 0
         private var _loginCount = 0
+        private var _paneText = ""
         private var _identity: String?
+
+        var sendCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _sendCount
+        }
+        func recordSend() {
+            lock.lock(); defer { lock.unlock() }
+            _sendCount += 1
+        }
         var loginCount: Int {
             lock.lock(); defer { lock.unlock() }
             return _loginCount
@@ -48,6 +29,14 @@ struct LoginSessionCoordinatorTests {
         func recordLogin() {
             lock.lock(); defer { lock.unlock() }
             _loginCount += 1
+        }
+        var paneText: String {
+            lock.lock(); defer { lock.unlock() }
+            return _paneText
+        }
+        func setPaneText(_ value: String) {
+            lock.lock(); defer { lock.unlock() }
+            _paneText = value
         }
         var identity: String? {
             lock.lock(); defer { lock.unlock() }
@@ -73,6 +62,186 @@ struct LoginSessionCoordinatorTests {
         }
         return condition()
     }
+
+    /// Fast pump timings for tests.
+    private func fastDelays(timeout: Duration = .seconds(2)) -> LoginSessionCoordinator.Delays {
+        .init(
+            pumpInitialDelay: .zero,
+            pumpPollInterval: .milliseconds(5),
+            pumpPostSendDelay: .milliseconds(5),
+            pumpTimeout: timeout,
+            identityPollInterval: .milliseconds(5),
+            identityPollTimeout: .milliseconds(50)
+        )
+    }
+
+    private static let readyPane = """
+        ⚠ 1 MCP server needs authentication · run /mcp
+        Not logged in · Run /login
+        ❯
+        ⏵⏵ bypass permissions on (shift+tab to cycle)
+        """
+    private static let dialogPane = """
+        Login
+        Select login method:
+        ❯ 1. Claude account with subscription
+        """
+
+    // MARK: - Pane classification
+
+    @Test("classifyPane: boot screen → notReady")
+    func classifyNotReady() {
+        #expect(LoginSessionCoordinator.classifyPane("") == .notReady)
+        #expect(LoginSessionCoordinator.classifyPane("Loading…") == .notReady)
+    }
+
+    @Test("classifyPane: interactive prompt → promptReady")
+    func classifyReady() {
+        #expect(LoginSessionCoordinator.classifyPane(Self.readyPane) == .promptReady)
+        #expect(LoginSessionCoordinator.classifyPane("Not logged in · Run /login") == .promptReady)
+    }
+
+    @Test("classifyPane: login picker → loginDialogVisible")
+    func classifyDialog() {
+        #expect(LoginSessionCoordinator.classifyPane(Self.dialogPane) == .loginDialogVisible)
+    }
+
+    // MARK: - Auto-login pump
+
+    @Test("pump waits for readiness, types /login once, verifies dialog, stops")
+    func pumpHappyPath() async {
+        let coordinator = LoginSessionCoordinator(delays: fastDelays())
+        let recorder = Recorder()
+        let id = UUID()
+        // Pane starts not-ready; typing flips it straight to the dialog.
+        await coordinator.registerPendingAutoLogin(terminalID: id)
+        await coordinator.startAutoLoginPump(
+            terminalID: id,
+            paneText: { recorder.paneText },
+            typeLogin: {
+                recorder.recordSend()
+                recorder.setPaneText(Self.dialogPane)
+            }
+        )
+
+        // Still booting — no sends.
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(recorder.sendCount == 0)
+
+        recorder.setPaneText(Self.readyPane)
+        #expect(await waitFor({ recorder.sendCount == 1 }))
+
+        // Verified done: pending cleared, no extra sends.
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(recorder.sendCount == 1)
+        #expect(await coordinator.isPendingAutoLogin(terminalID: id) == false)
+    }
+
+    @Test("pump re-sends when the first /login is swallowed (unverified)")
+    func pumpRetriesSwallowedSend() async {
+        let coordinator = LoginSessionCoordinator(delays: fastDelays())
+        let recorder = Recorder()
+        let id = UUID()
+        recorder.setPaneText(Self.readyPane)
+        await coordinator.registerPendingAutoLogin(terminalID: id)
+        await coordinator.startAutoLoginPump(
+            terminalID: id,
+            paneText: { recorder.paneText },
+            typeLogin: {
+                recorder.recordSend()
+                // First send vanishes (TUI not consuming input yet);
+                // second send takes.
+                if recorder.sendCount >= 2 {
+                    recorder.setPaneText(Self.dialogPane)
+                }
+            }
+        )
+
+        #expect(await waitFor({ recorder.sendCount == 2 }))
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(recorder.sendCount == 2)
+    }
+
+    @Test("pump caps sends at maxSends even if the dialog never appears")
+    func pumpCapsSends() async {
+        let coordinator = LoginSessionCoordinator(delays: fastDelays(timeout: .milliseconds(200)))
+        let recorder = Recorder()
+        let id = UUID()
+        recorder.setPaneText(Self.readyPane)
+        await coordinator.registerPendingAutoLogin(terminalID: id)
+        await coordinator.startAutoLoginPump(
+            terminalID: id,
+            maxSends: 3,
+            paneText: { recorder.paneText },
+            typeLogin: { recorder.recordSend() }
+        )
+
+        // The pump reaches the cap…
+        #expect(await waitFor({ recorder.sendCount == 3 }))
+        // …then runs to its timeout without ever exceeding it. The pump's
+        // defer clears the registration when it exits, so poll that.
+        var elapsed: Duration = .zero
+        while await coordinator.isPendingAutoLogin(terminalID: id), elapsed < .seconds(5) {
+            try? await Task.sleep(for: .milliseconds(10))
+            elapsed += .milliseconds(10)
+        }
+        #expect(await coordinator.isPendingAutoLogin(terminalID: id) == false)
+        #expect(recorder.sendCount == 3)
+    }
+
+    @Test("pump requires registration and is single-flighted per terminal")
+    func pumpGuards() async {
+        let coordinator = LoginSessionCoordinator(delays: fastDelays())
+        let recorder = Recorder()
+        recorder.setPaneText(Self.readyPane)
+
+        // Unregistered terminal → pump refuses to start.
+        await coordinator.startAutoLoginPump(
+            terminalID: UUID(),
+            paneText: { recorder.paneText },
+            typeLogin: { recorder.recordSend() }
+        )
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(recorder.sendCount == 0)
+
+        // Double-start on the same registered terminal → one pump only.
+        let id = UUID()
+        await coordinator.registerPendingAutoLogin(terminalID: id)
+        let sendAndFinish: @Sendable () async -> Void = {
+            recorder.recordSend()
+            recorder.setPaneText(Self.dialogPane)
+        }
+        await coordinator.startAutoLoginPump(
+            terminalID: id, paneText: { recorder.paneText }, typeLogin: sendAndFinish
+        )
+        await coordinator.startAutoLoginPump(
+            terminalID: id, paneText: { recorder.paneText }, typeLogin: sendAndFinish
+        )
+        #expect(await waitFor({ recorder.sendCount >= 1 }))
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(recorder.sendCount == 1)
+    }
+
+    @Test("cancelPendingAutoLogin stops an active pump before it types")
+    func pumpCancelled() async {
+        let coordinator = LoginSessionCoordinator(delays: fastDelays())
+        let recorder = Recorder()
+        let id = UUID()
+        // Not ready yet — pump idles in the poll loop.
+        await coordinator.registerPendingAutoLogin(terminalID: id)
+        await coordinator.startAutoLoginPump(
+            terminalID: id,
+            paneText: { recorder.paneText },
+            typeLogin: { recorder.recordSend() }
+        )
+        await coordinator.cancelPendingAutoLogin(terminalID: id)
+        // Pane becomes ready AFTER the cancel — the pump must not type.
+        recorder.setPaneText(Self.readyPane)
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(recorder.sendCount == 0)
+    }
+
+    // MARK: - Login-identity watcher
 
     @Test("watcher fires onLogin exactly once when identity appears, then stops")
     func watcherFiresOnLogin() async {

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -954,4 +954,93 @@ struct ModelProfileRPCTests {
         #expect(await router.handle(req).success)
         #expect(try await db.modelProfiles.get(id: row.id)?.fallbackModels == ["anthropic.claude-haiku-4-5"])
     }
+
+    // MARK: - prepareConfigDir
+
+    private func makeTempConfigDirManager() -> (ClaudeProfileConfigDirManager, URL) {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-prepare-configdir-\(UUID().uuidString)", isDirectory: true)
+        let manager = ClaudeProfileConfigDirManager(
+            baseDirectory: base.appendingPathComponent("profiles", isDirectory: true),
+            hostBaseDirectory: base.appendingPathComponent("host-claude", isDirectory: true)
+        )
+        return (manager, base)
+    }
+
+    @Test("prepareConfigDir: oauth profile gets a seeded dir and its path back")
+    func prepareConfigDirOAuth() async throws {
+        let (manager, base) = makeTempConfigDirManager()
+        defer { try? FileManager.default.removeItem(at: base) }
+        let (router, db, _) = makeRouter(configDirManager: manager)
+
+        let profile = try await db.modelProfiles.create(name: "LoginTarget", kind: .oauth)
+        let req = try RPCRequest(
+            method: RPCMethod.modelProfilePrepareConfigDir,
+            params: ModelProfilePrepareConfigDirParams(id: profile.id)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let result = try resp.decodeResult(ModelProfilePrepareConfigDirResult.self)
+        #expect(result.configDirPath == manager.configDirectory(forProfileID: profile.id).path)
+
+        var isDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: result.configDirPath, isDirectory: &isDir))
+        #expect(isDir.boolValue)
+        // Seeded with the minimal OAuth .claude.json (hasCompletedOnboarding).
+        let claudeJSON = result.configDirPath + "/.claude.json"
+        #expect(FileManager.default.fileExists(atPath: claudeJSON))
+    }
+
+    @Test("prepareConfigDir: idempotent — second call returns the same path")
+    func prepareConfigDirIdempotent() async throws {
+        let (manager, base) = makeTempConfigDirManager()
+        defer { try? FileManager.default.removeItem(at: base) }
+        let (router, db, _) = makeRouter(configDirManager: manager)
+
+        let profile = try await db.modelProfiles.create(name: "Twice", kind: .oauth)
+        let req = try RPCRequest(
+            method: RPCMethod.modelProfilePrepareConfigDir,
+            params: ModelProfilePrepareConfigDirParams(id: profile.id)
+        )
+        let first = try (await router.handle(req)).decodeResult(ModelProfilePrepareConfigDirResult.self)
+        let second = try (await router.handle(req)).decodeResult(ModelProfilePrepareConfigDirResult.self)
+        #expect(first.configDirPath == second.configDirPath)
+    }
+
+    @Test("prepareConfigDir: rejects non-oauth kinds with the kind in the error")
+    func prepareConfigDirRejectsNonOAuth() async throws {
+        let (manager, base) = makeTempConfigDirManager()
+        defer { try? FileManager.default.removeItem(at: base) }
+        let (router, db, _) = makeRouter(configDirManager: manager)
+
+        let apiKey = try await db.modelProfiles.create(name: "Keyed", kind: .apiKey)
+        let bedrock = try await db.modelProfiles.create(
+            name: "West", kind: .bedrock, model: "anthropic.claude-sonnet-4-5", awsRegion: "us-west-2"
+        )
+
+        for (profile, kind) in [(apiKey, "apiKey"), (bedrock, "bedrock")] {
+            let req = try RPCRequest(
+                method: RPCMethod.modelProfilePrepareConfigDir,
+                params: ModelProfilePrepareConfigDirParams(id: profile.id)
+            )
+            let resp = await router.handle(req)
+            #expect(!resp.success)
+            #expect(resp.error?.contains(kind) == true)
+            // No config dir was provisioned for the rejected profile.
+            let dir = manager.configDirectory(forProfileID: profile.id)
+            #expect(!FileManager.default.fileExists(atPath: dir.path))
+        }
+    }
+
+    @Test("prepareConfigDir: unknown id fails with profile-not-found")
+    func prepareConfigDirUnknownID() async throws {
+        let (router, _, _) = makeRouter()
+        let req = try RPCRequest(
+            method: RPCMethod.modelProfilePrepareConfigDir,
+            params: ModelProfilePrepareConfigDirParams(id: UUID())
+        )
+        let resp = await router.handle(req)
+        #expect(!resp.success)
+        #expect(resp.error == "Profile not found")
+    }
 }

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -570,15 +570,38 @@ struct ModelProfileSpawnTests {
 
     // MARK: - Login sessions (Settings → "Open login session")
 
-    /// Fixture whose LoginSessionCoordinator delays are test-tuned: the
-    /// session-start trigger is immediate, the spawn fallback is far enough
-    /// out that it never races test assertions, and the identity watcher
-    /// expires quickly so tests don't leave 30-minute poll tasks behind.
-    private func makeLoginFixture(
-        spawnFallback: Duration = .seconds(60)
-    ) -> (RPCRouter, TBDDatabase, TmuxRecorder) {
+    /// Mutable pane-text holder so tests can drive what the auto-login pump
+    /// "sees" in the (dry-run) tmux pane.
+    final class PaneTextBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _text = ""
+        var text: String {
+            lock.lock(); defer { lock.unlock() }
+            return _text
+        }
+        func set(_ value: String) {
+            lock.lock(); defer { lock.unlock() }
+            _text = value
+        }
+    }
+
+    /// Pane text mimicking Claude's interactive, logged-out idle state.
+    static let readyPaneText = "Not logged in · Run /login\n❯"
+    /// Pane text mimicking the /login method picker.
+    static let loginDialogPaneText = "Login\nSelect login method:"
+
+    /// Fixture whose LoginSessionCoordinator delays are test-tuned (fast
+    /// pump, fast-expiring identity watcher so tests don't leave 30-minute
+    /// poll tasks behind) and whose dry-run tmux serves pane text from the
+    /// returned PaneTextBox.
+    private func makeLoginFixture() -> (RPCRouter, TBDDatabase, TmuxRecorder, PaneTextBox) {
         let recorder = TmuxRecorder()
-        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
+        let pane = PaneTextBox()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { args in recorder.record(args) },
+            dryRunCapturePane: { _, _ in pane.text }
+        )
         let db = try! TBDDatabase(inMemory: true)
         let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
         let router = RPCRouter(
@@ -588,13 +611,18 @@ struct ModelProfileSpawnTests {
             startTime: Date(),
             usageFetcher: StubClaudeUsageFetcher(),
             loginSessions: LoginSessionCoordinator(delays: .init(
-                afterSessionStart: .zero,
-                spawnFallback: spawnFallback,
+                pumpInitialDelay: .zero,
+                pumpPollInterval: .milliseconds(5),
+                // Wide enough that a test can observe a send and flip the
+                // pane to the dialog BEFORE the pump's verify re-read —
+                // otherwise the happy path races into a retry.
+                pumpPostSendDelay: .milliseconds(500),
+                pumpTimeout: .seconds(5),
                 identityPollInterval: .milliseconds(5),
                 identityPollTimeout: .milliseconds(50)
             ))
         )
-        return (router, db, recorder)
+        return (router, db, recorder, pane)
     }
 
     /// Poll until `condition` is true or `timeout` elapses.
@@ -619,7 +647,7 @@ struct ModelProfileSpawnTests {
     /// profileID persisted on the DB row.
     @Test("login session: label=login, profileID persisted, config dir inline-exported")
     func loginSessionSpawn() async throws {
-        let (router, db, recorder) = makeLoginFixture()
+        let (router, db, recorder, _) = makeLoginFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
         let profile = try await seedOAuthProfile(db, name: "Login")
@@ -647,13 +675,15 @@ struct ModelProfileSpawnTests {
     }
 
     /// Branch guard: the same spawn WITHOUT the loginSession flag keeps the
-    /// normal Claude Code label and does not auto-type /login.
+    /// normal Claude Code label and does not auto-type /login even when the
+    /// pane looks ready for it.
     @Test("login session flag off: label stays Claude Code, no /login typed")
     func loginSessionFlagOff() async throws {
-        let (router, db, recorder) = makeLoginFixture(spawnFallback: .zero)
+        let (router, db, recorder, pane) = makeLoginFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
         let profile = try await seedOAuthProfile(db, name: "Plain")
+        pane.set(Self.readyPaneText)
 
         let resp = await router.handle(try RPCRequest(
             method: RPCMethod.terminalCreate,
@@ -665,15 +695,14 @@ struct ModelProfileSpawnTests {
         let term = try resp.decodeResult(Terminal.self)
         #expect(term.label == TerminalLabel.claudeCode)
 
-        // Give any (buggy) zero-delay fallback a chance to fire, then assert
-        // no /login was sent.
+        // No pump was armed — nothing may type /login.
         try? await Task.sleep(for: .milliseconds(100))
         #expect(!recorder.joinedAll.contains("/login"))
     }
 
     @Test("login session: missing/unknown profile fails loud, no window spawned")
     func loginSessionUnknownProfile() async throws {
-        let (router, db, recorder) = makeLoginFixture()
+        let (router, db, recorder, _) = makeLoginFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
 
@@ -693,7 +722,7 @@ struct ModelProfileSpawnTests {
 
     @Test("login session: requires overrideProfileID")
     func loginSessionRequiresProfile() async throws {
-        let (router, db, _) = makeLoginFixture()
+        let (router, db, _, _) = makeLoginFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
 
@@ -705,12 +734,13 @@ struct ModelProfileSpawnTests {
         #expect(resp.error?.contains("require a profile") == true)
     }
 
-    /// The SessionStart hook event is the readiness trigger for the
-    /// auto-typed /login: after `terminal.sessionEvent` arrives for a login
-    /// session, the daemon sends `/login` + Enter to the pane (consume-once).
-    @Test("login session: sessionEvent triggers /login + Enter exactly once")
-    func loginSessionAutoTypesOnSessionEvent() async throws {
-        let (router, db, recorder) = makeLoginFixture()
+    /// End-to-end pump behavior through the handler: the spawn arms the
+    /// verified auto-login pump, which waits for the pane to become
+    /// interactive, types `/login` + Enter, and stops once the login dialog
+    /// is visible — exactly one send in the happy path.
+    @Test("login session: pump types /login + Enter once the pane is ready, exactly once")
+    func loginSessionAutoTypesWhenReady() async throws {
+        let (router, db, recorder, pane) = makeLoginFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
         let profile = try await seedOAuthProfile(db, name: "AutoLogin")
@@ -724,49 +754,33 @@ struct ModelProfileSpawnTests {
         ))
         let term = try createResp.decodeResult(Terminal.self)
 
-        let eventResp = await router.handle(try RPCRequest(
-            method: RPCMethod.terminalSessionEvent,
-            params: TerminalSessionEventParams(
-                terminalID: term.id,
-                sessionID: UUID().uuidString,
-                transcriptPath: nil,
-                source: "startup",
-                cwd: wt.path
-            )
-        ))
-        #expect(eventResp.success)
+        // Pane still booting — no sends yet.
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(!recorder.joinedAll.contains("send-keys"))
 
-        // The send is scheduled on a Task (zero delay in this fixture) —
-        // poll the recorder for the send-keys /login + Enter pair.
+        // Claude becomes interactive → the pump types /login + Enter.
+        pane.set(Self.readyPaneText)
         #expect(await waitFor({ recorder.joinedAll.contains("send-keys -l -t \(term.tmuxPaneID) /login") }))
-        #expect(await waitFor({ recorder.joinedAll.contains("Enter") }))
+        #expect(await waitFor({ recorder.joinedAll.contains("send-keys -t \(term.tmuxPaneID) Enter") }))
 
-        // A second sessionEvent (e.g. /clear) must NOT re-type /login.
-        let before = recorder.calls.count
-        _ = await router.handle(try RPCRequest(
-            method: RPCMethod.terminalSessionEvent,
-            params: TerminalSessionEventParams(
-                terminalID: term.id,
-                sessionID: UUID().uuidString,
-                transcriptPath: nil,
-                source: "clear",
-                cwd: wt.path
-            )
-        ))
+        // The dialog appears → verified; the pump must stop at one send.
+        pane.set(Self.loginDialogPaneText)
         try? await Task.sleep(for: .milliseconds(100))
-        let loginSends = recorder.calls.filter { $0.contains("/login") }.count
+        let loginSends = recorder.calls.filter { $0.contains("/login") && $0.contains("send-keys") }.count
         #expect(loginSends == 1)
-        _ = before
     }
 
-    /// Fallback trigger: when the SessionStart hook never arrives, the
-    /// spawn-time fallback still types /login.
-    @Test("login session: spawn fallback types /login when no sessionEvent arrives")
-    func loginSessionFallbackAutoTypes() async throws {
-        let (router, db, recorder) = makeLoginFixture(spawnFallback: .zero)
+    /// If the first /login lands before Claude's input loop consumes pty
+    /// input (send swallowed, dialog never appears), the pump verifies and
+    /// re-sends instead of giving up — the exact failure observed live with
+    /// fixed-delay sends.
+    @Test("login session: pump re-sends when the first /login is swallowed")
+    func loginSessionPumpRetries() async throws {
+        let (router, db, recorder, pane) = makeLoginFixture()
         defer { Task { await cleanup(db) } }
         let (_, wt) = try await seedRepoAndWorktree(db)
-        let profile = try await seedOAuthProfile(db, name: "Fallback")
+        let profile = try await seedOAuthProfile(db, name: "Retry")
+        pane.set(Self.readyPaneText)  // ready, but sends get "swallowed"
 
         let createResp = await router.handle(try RPCRequest(
             method: RPCMethod.terminalCreate,
@@ -776,8 +790,22 @@ struct ModelProfileSpawnTests {
             )
         ))
         let term = try createResp.decodeResult(Terminal.self)
+        let sendMarker = "send-keys -l -t \(term.tmuxPaneID) /login"
 
-        #expect(await waitFor({ recorder.joinedAll.contains("send-keys -l -t \(term.tmuxPaneID) /login") }))
+        // First send happens…
+        #expect(await waitFor({ recorder.joinedAll.contains(sendMarker) }))
+        // …dialog still absent → the pump retries.
+        #expect(await waitFor({
+            recorder.calls.filter { $0.joined(separator: " ").contains(sendMarker) }.count >= 2
+        }))
+
+        // Once the dialog shows, the pump stops retrying.
+        pane.set(Self.loginDialogPaneText)
+        try? await Task.sleep(for: .milliseconds(100))
+        let after = recorder.calls.filter { $0.joined(separator: " ").contains(sendMarker) }.count
+        try? await Task.sleep(for: .milliseconds(100))
+        let final = recorder.calls.filter { $0.joined(separator: " ").contains(sendMarker) }.count
+        #expect(final == after)
     }
 }
 }

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -567,5 +567,217 @@ struct ModelProfileSpawnTests {
         ))
         #expect(!swapResp.success)
     }
+
+    // MARK: - Login sessions (Settings → "Open login session")
+
+    /// Fixture whose LoginSessionCoordinator delays are test-tuned: the
+    /// session-start trigger is immediate, the spawn fallback is far enough
+    /// out that it never races test assertions, and the identity watcher
+    /// expires quickly so tests don't leave 30-minute poll tasks behind.
+    private func makeLoginFixture(
+        spawnFallback: Duration = .seconds(60)
+    ) -> (RPCRouter, TBDDatabase, TmuxRecorder) {
+        let recorder = TmuxRecorder()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
+        let db = try! TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let router = RPCRouter(
+            db: db,
+            lifecycle: lifecycle,
+            tmux: tmux,
+            startTime: Date(),
+            usageFetcher: StubClaudeUsageFetcher(),
+            loginSessions: LoginSessionCoordinator(delays: .init(
+                afterSessionStart: .zero,
+                spawnFallback: spawnFallback,
+                identityPollInterval: .milliseconds(5),
+                identityPollTimeout: .milliseconds(50)
+            ))
+        )
+        return (router, db, recorder)
+    }
+
+    /// Poll until `condition` is true or `timeout` elapses.
+    private func waitFor(
+        _ condition: @Sendable () -> Bool,
+        timeout: Duration = .seconds(5)
+    ) async -> Bool {
+        var elapsed: Duration = .zero
+        let step: Duration = .milliseconds(10)
+        while elapsed < timeout {
+            if condition() { return true }
+            try? await Task.sleep(for: step)
+            elapsed += step
+        }
+        return condition()
+    }
+
+    /// REGRESSION (profile env clobbered by shell rc files): the profile's
+    /// CLAUDE_CONFIG_DIR must ride in the shell command as an inline `export`
+    /// (post-rc, can't be clobbered by ~/.zshenv account switchers), not only
+    /// as tmux `-e` env. Also pins the login-session shape: label=login,
+    /// profileID persisted on the DB row.
+    @Test("login session: label=login, profileID persisted, config dir inline-exported")
+    func loginSessionSpawn() async throws {
+        let (router, db, recorder) = makeLoginFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let profile = try await seedOAuthProfile(db, name: "Login")
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(
+                worktreeID: wt.id, type: .claude,
+                overrideProfileID: profile.id, loginSession: true
+            )
+        ))
+        #expect(resp.success)
+        let term = try resp.decodeResult(Terminal.self)
+        #expect(term.label == TerminalLabel.login)
+        #expect(term.profileID == profile.id)
+
+        // The DB row is persisted with the profile id (no ghost terminals).
+        let row = try #require(try await db.terminals.get(id: term.id))
+        #expect(row.profileID == profile.id)
+        #expect(row.label == TerminalLabel.login)
+
+        // Inline export survives rc files; -e env still present too.
+        #expect(recorder.shellBodies.contains("export CLAUDE_CONFIG_DIR="))
+        #expect(recorder.joinedAll.contains("CLAUDE_CONFIG_DIR="))
+    }
+
+    /// Branch guard: the same spawn WITHOUT the loginSession flag keeps the
+    /// normal Claude Code label and does not auto-type /login.
+    @Test("login session flag off: label stays Claude Code, no /login typed")
+    func loginSessionFlagOff() async throws {
+        let (router, db, recorder) = makeLoginFixture(spawnFallback: .zero)
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let profile = try await seedOAuthProfile(db, name: "Plain")
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(
+                worktreeID: wt.id, type: .claude, overrideProfileID: profile.id
+            )
+        ))
+        #expect(resp.success)
+        let term = try resp.decodeResult(Terminal.self)
+        #expect(term.label == TerminalLabel.claudeCode)
+
+        // Give any (buggy) zero-delay fallback a chance to fire, then assert
+        // no /login was sent.
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(!recorder.joinedAll.contains("/login"))
+    }
+
+    @Test("login session: missing/unknown profile fails loud, no window spawned")
+    func loginSessionUnknownProfile() async throws {
+        let (router, db, recorder) = makeLoginFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(
+                worktreeID: wt.id, type: .claude,
+                overrideProfileID: UUID(), loginSession: true
+            )
+        ))
+        #expect(!resp.success)
+        #expect(resp.error?.contains("Profile not found") == true)
+        // ensureServer may have run, but no window was created and no row inserted.
+        #expect(!recorder.joinedAll.contains("new-window"))
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test("login session: requires overrideProfileID")
+    func loginSessionRequiresProfile() async throws {
+        let (router, db, _) = makeLoginFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude, loginSession: true)
+        ))
+        #expect(!resp.success)
+        #expect(resp.error?.contains("require a profile") == true)
+    }
+
+    /// The SessionStart hook event is the readiness trigger for the
+    /// auto-typed /login: after `terminal.sessionEvent` arrives for a login
+    /// session, the daemon sends `/login` + Enter to the pane (consume-once).
+    @Test("login session: sessionEvent triggers /login + Enter exactly once")
+    func loginSessionAutoTypesOnSessionEvent() async throws {
+        let (router, db, recorder) = makeLoginFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let profile = try await seedOAuthProfile(db, name: "AutoLogin")
+
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(
+                worktreeID: wt.id, type: .claude,
+                overrideProfileID: profile.id, loginSession: true
+            )
+        ))
+        let term = try createResp.decodeResult(Terminal.self)
+
+        let eventResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: term.id,
+                sessionID: UUID().uuidString,
+                transcriptPath: nil,
+                source: "startup",
+                cwd: wt.path
+            )
+        ))
+        #expect(eventResp.success)
+
+        // The send is scheduled on a Task (zero delay in this fixture) —
+        // poll the recorder for the send-keys /login + Enter pair.
+        #expect(await waitFor({ recorder.joinedAll.contains("send-keys -l -t \(term.tmuxPaneID) /login") }))
+        #expect(await waitFor({ recorder.joinedAll.contains("Enter") }))
+
+        // A second sessionEvent (e.g. /clear) must NOT re-type /login.
+        let before = recorder.calls.count
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: term.id,
+                sessionID: UUID().uuidString,
+                transcriptPath: nil,
+                source: "clear",
+                cwd: wt.path
+            )
+        ))
+        try? await Task.sleep(for: .milliseconds(100))
+        let loginSends = recorder.calls.filter { $0.contains("/login") }.count
+        #expect(loginSends == 1)
+        _ = before
+    }
+
+    /// Fallback trigger: when the SessionStart hook never arrives, the
+    /// spawn-time fallback still types /login.
+    @Test("login session: spawn fallback types /login when no sessionEvent arrives")
+    func loginSessionFallbackAutoTypes() async throws {
+        let (router, db, recorder) = makeLoginFixture(spawnFallback: .zero)
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let profile = try await seedOAuthProfile(db, name: "Fallback")
+
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(
+                worktreeID: wt.id, type: .claude,
+                overrideProfileID: profile.id, loginSession: true
+            )
+        ))
+        let term = try createResp.decodeResult(Terminal.self)
+
+        #expect(await waitFor({ recorder.joinedAll.contains("send-keys -l -t \(term.tmuxPaneID) /login") }))
+    }
 }
 }

--- a/Tests/TBDDaemonTests/PluginDirWriterTests.swift
+++ b/Tests/TBDDaemonTests/PluginDirWriterTests.swift
@@ -61,6 +61,38 @@ struct PluginDirWriterTests {
         #expect(written == TBDSkillContent.body)
     }
 
+    @Test("bundles the nightwatch skill — SKILL.md, executable tick.py, configs")
+    func writesNightwatchSkill() throws {
+        let tempRoot = NSTemporaryDirectory() + "tbd-plugin-test-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tempRoot) }
+
+        try PluginDirWriter(applicationSupportRoot: tempRoot).writePlugin()
+
+        let nw = tempRoot + "/TBD/plugin/skills/nightwatch"
+        let tick = nw + "/scripts/tick.py"
+        #expect(FileManager.default.fileExists(atPath: nw + "/SKILL.md"))
+        #expect(FileManager.default.fileExists(atPath: tick))
+        #expect(FileManager.default.fileExists(atPath: nw + "/scripts/judge.py"))
+        #expect(FileManager.default.fileExists(atPath: nw + "/scripts/scheduler.sh"))
+        #expect(FileManager.default.fileExists(atPath: nw + "/scripts/tick-cron.sh"))
+        #expect(FileManager.default.fileExists(atPath: nw + "/config/priorities.txt"))
+        #expect(FileManager.default.fileExists(atPath: nw + "/config/safe_wedges.txt"))
+        #expect(FileManager.default.fileExists(atPath: nw + "/config/dont_touch.txt"))
+
+        // content matches the single source of truth
+        let writtenTick = try String(contentsOfFile: tick, encoding: .utf8)
+        #expect(writtenTick == NightwatchSkillContent.tickPy)
+
+        // tick.py is executable (cron/launchd run it directly)
+        let perms = try FileManager.default.attributesOfItem(atPath: tick)[.posixPermissions] as? NSNumber
+        #expect(perms?.int16Value ?? 0 & 0o111 != 0)
+    }
+
+    @Test("nightwatch SKILL.md has a valid skill name in frontmatter")
+    func nightwatchSkillNamed() {
+        #expect(NightwatchSkillContent.skillMd.contains("name: nightwatch"))
+    }
+
     @Test("pluginDirPath has expected shape")
     func pluginDirPathShape() {
         let writer = PluginDirWriter(applicationSupportRoot: "/var/test")

--- a/Tests/TBDDaemonTests/WorktreeForgetTombstoneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeForgetTombstoneTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import GRDB
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The forget-tombstone feature: `forget` inserts a `forgotten_worktree` row
+/// keyed by path, and reconcile skips tombstoned paths in its re-adopt pass —
+/// so forgetting a worktree under a TBD-managed prefix finally sticks.
+///
+/// Branch coverage for the new gating conditional in reconcile:
+///   - tombstone present  → path NOT re-adopted (the bug this feature fixes).
+///   - tombstone absent   → path IS adopted (ungated behavior intact).
+/// Plus the escape hatch: adopt/create at a tombstoned path clears the
+/// tombstone, restoring normal reconcile behavior.
+///
+/// Uses `createTestRepoResolvingSymlinks` throughout: reconcile compares DB
+/// paths against `git worktree list` output, which reports realpath()-resolved
+/// paths (/private/var/... on macOS).
+
+private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
+    WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+}
+
+/// The bug this feature fixes: a forgotten worktree under a TBD-managed prefix
+/// must NOT be resurrected by the next reconcile pass.
+@Test func testForgetSticksThroughReconcileForManagedPrefix() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = makeLifecycle(db: db)
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // Created under the repo's worktreeRoot override → an acceptable prefix
+    // for reconcile's re-adopt pass.
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    #expect(FileManager.default.fileExists(atPath: wt.path))
+
+    try await lifecycle.forgetWorktree(worktreeID: wt.id)
+    #expect(try await db.forgottenWorktrees.contains(path: wt.path),
+            "forget must insert a tombstone for the worktree path")
+
+    // The directory is still on disk AND still registered with git — exactly
+    // the situation that used to make reconcile resurrect the row.
+    try await lifecycle.reconcile(repoID: repo.id)
+
+    let active = try await db.worktrees.list(repoID: repo.id, status: .active)
+    #expect(!active.contains { $0.path == wt.path },
+            "reconcile must not re-adopt a tombstoned path")
+    let all = try await db.worktrees.list()
+    #expect(!all.contains { $0.path == wt.path },
+            "no row (any status) may be re-created for a tombstoned path")
+}
+
+/// Ungated branch: a plain untracked git worktree under the managed prefix
+/// (no tombstone) must still be adopted by reconcile.
+@Test func testReconcileStillAdoptsUntombstonedWorktree() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = makeLifecycle(db: db)
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // Register a git worktree under the managed prefix WITHOUT any DB row.
+    let base = try #require(repo.worktreeRoot)
+    try FileManager.default.createDirectory(
+        atPath: base, withIntermediateDirectories: true
+    )
+    let wtPath = (base as NSString).appendingPathComponent("stray")
+    try await shell("git worktree add -b stray-branch '\(wtPath)'", at: repoDir)
+
+    try await lifecycle.reconcile(repoID: repo.id)
+
+    let active = try await db.worktrees.list(repoID: repo.id, status: .active)
+    #expect(active.contains { $0.path == wtPath },
+            "reconcile must still adopt untombstoned worktrees under the managed prefix")
+}
+
+/// Escape hatch (adopt): deliberately re-adopting a forgotten path clears the
+/// tombstone, and reconcile treats the path normally again afterwards.
+@Test func testAdoptClearsTombstoneAndReconcileResumes() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = makeLifecycle(db: db)
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.forgetWorktree(worktreeID: wt.id)
+    #expect(try await db.forgottenWorktrees.contains(path: wt.path))
+
+    // Adopt the same path back — the tombstone must be cleared.
+    let outcome = try await lifecycle.adoptWorktree(repoID: repo.id, path: wt.path)
+    #expect(outcome.worktree.path == wt.path)
+    #expect(!(try await db.forgottenWorktrees.contains(path: wt.path)),
+            "adopt must clear the forget tombstone for its path")
+
+    // Back to normal: with the tombstone gone, reconcile re-adopts the path
+    // after its row disappears (proves the skip was tombstone-driven, not
+    // some other latent state).
+    try await db.worktrees.delete(id: outcome.worktree.id)
+    try await lifecycle.reconcile(repoID: repo.id)
+    let active = try await db.worktrees.list(repoID: repo.id, status: .active)
+    #expect(active.contains { $0.path == wt.path },
+            "after the tombstone is cleared, reconcile behavior is back to normal")
+}
+
+/// Escape hatch (create): creating a worktree at a tombstoned path clears the
+/// tombstone.
+@Test func testCreateClearsTombstoneAtItsPath() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = makeLifecycle(db: db)
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // Pre-seed a tombstone at the exact path create will resolve for this
+    // folder name (worktreeRoot override + folder).
+    let base = try #require(repo.worktreeRoot)
+    let expectedPath = (base as NSString).appendingPathComponent("reborn")
+    try await db.forgottenWorktrees.insert(path: expectedPath, repoID: repo.id)
+    #expect(try await db.forgottenWorktrees.contains(path: expectedPath))
+
+    let wt = try await lifecycle.createWorktree(
+        repoID: repo.id, folder: "reborn", skipClaude: true
+    )
+    #expect(wt.path == expectedPath)
+    #expect(!(try await db.forgottenWorktrees.contains(path: expectedPath)),
+            "create must clear the forget tombstone for its path")
+}
+
+/// Forget is idempotent with respect to the tombstone: re-forgetting a path
+/// (forget → adopt → forget) must not throw on the primary-key conflict.
+@Test func testReForgettingSamePathDoesNotThrow() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = makeLifecycle(db: db)
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await lifecycle.forgetWorktree(worktreeID: wt.id)
+    // Seed a second tombstone insert directly (same primary key).
+    try await db.forgottenWorktrees.insert(path: wt.path, repoID: repo.id)
+    #expect(try await db.forgottenWorktrees.contains(path: wt.path))
+}
+
+@Suite struct MigrationForgottenWorktreeTests {
+
+    /// v35 applies on a fresh DB: table + columns + repoID index all present.
+    @Test func forgottenWorktreeTableExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let columns = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(forgotten_worktree)")
+            let names = columns.compactMap { $0["name"] as String? }
+            #expect(names.contains("path"))
+            #expect(names.contains("repoID"))
+            #expect(names.contains("forgottenAt"))
+
+            let indexExists = try Bool.fetchOne(dbConn, sql: """
+                SELECT 1 FROM sqlite_master
+                WHERE type = 'index' AND name = 'idx_forgotten_worktree_repoID'
+                """) ?? false
+            #expect(indexExists, "repoID index must be created by v35")
+        }
+    }
+
+    /// Store round-trip against the fresh schema: insert → contains → delete.
+    @Test func storeRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repoID = UUID()
+        let path = "/tmp/v35-\(UUID().uuidString)"
+
+        #expect(!(try await db.forgottenWorktrees.contains(path: path)))
+        try await db.forgottenWorktrees.insert(path: path, repoID: repoID)
+        #expect(try await db.forgottenWorktrees.contains(path: path))
+        #expect(try await db.forgottenWorktrees.allPaths().contains(path))
+
+        try await db.forgottenWorktrees.delete(path: path)
+        #expect(!(try await db.forgottenWorktrees.contains(path: path)))
+        #expect(!(try await db.forgottenWorktrees.allPaths().contains(path)))
+    }
+}


### PR DESCRIPTION
## What's in here

Seven commits in three groups (all signed, reviewable commit-by-commit):

### Model-profile login UX (the multi-account story)
- **feat(profiles)**: the model-profile list RPC now reports each OAuth profile's logged-in identity (email from its isolated config dir) plus its config-dir path; deleting a profile also removes its Claude Code OAuth credential from the login keychain (service names are always path-hash-suffixed, so the user's default `~/.claude` credential is structurally untouchable).
- **feat(cli)**: `tbd profile list / set-default / login`. `login <name>` provisions the profile's config dir via a new `modelProfile.prepareConfigDir` RPC, scrubs poison env (`ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `CLAUDE_CODE_USE_BEDROCK`…), and execs `claude` under the right `CLAUDE_CONFIG_DIR` — eliminating the logged-into-the-wrong-keychain trap.
- **feat(app)**: Settings rows show "Logged in as <email>" / "No login detected — run /login once" with a one-click "Open login session" action; the "+" tab menu and menu-bar switcher show per-profile identity; creating an OAuth profile ends with an "Open login session" step.

### Daemon lifecycle robustness
- **fix(app)**: after a reboot, a stale pid file whose pid got recycled made the app believe the daemon was alive (never spawning one, connecting to a dead socket forever). Liveness now verifies the pid's executable really is TBDDaemon (proc_pidpath), cleans stale pid/socket files, and the reconnect poll can route into the spawn path. Also: a build-identity handshake — the app compares the daemon's executablePath (already in the status RPC) against its own expected sibling and shows a persistent banner when the running daemon comes from a different build/worktree, instead of silent "Unknown method" weirdness.

### Earlier fixes riding along
- **feat(daemon)**: tombstone forgotten worktrees so reconcile stops re-adopting them.
- **fix(cli)**: replace crashing `%s` String(format:) table rows with a safe padding helper.
- Bundle the nightwatch fleet-babysitter skill into the TBD plugin.

## Testing
`swift test`: 2035 tests / 240 suites, 1 failure — the pre-existing environment-dependent `agentExecutableAvailability_detectsHomeLocalBinFallback` (fails on any machine with `/opt/homebrew/bin/claude` present; fails identically on upstream main here). `swiftlint --strict` clean. Rebased onto current main (one trivial init-order conflict with the new `controlMode` wiring, resolved by keeping both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)