### PR TITLE
Feat: Scratch spaces — talk to Claude outside any repo, promote when it becomes one

### DIFF
--- a/.claude/hooks/guardrails/README.md
+++ b/.claude/hooks/guardrails/README.md
@@ -41,12 +41,14 @@ Python 3, stdlib only (`json`, `re`, `os`, `importlib`, `pkgutil`, `unittest`,
 ```python
 @dataclass
 class Decision:
-    action: str          # "deny" | "allow"
+    action: str          # "deny" | "allow" | "info"
     reason: str = ""
     @staticmethod
     def deny(reason): ...
     @staticmethod
     def allow(): ...
+    @staticmethod
+    def info(reason): ...
 
 class Rule:
     id: str              # stable id, prefixed onto deny reasons, shown by --list
@@ -61,6 +63,12 @@ class Rule:
   via `permissionDecisionReason`, so make it instructive and tell the model how to
   fix the command. Prefix the reason with `[<rule-id>] ` so aggregated denies stay
   attributable.
+- `Decision.info(reason)` — **never blocks.** Surfaces `reason` to the model as
+  non-blocking `additionalContext` (`permissionDecision: "allow"`). Use this for
+  nudges/reminders where blocking would be wrong — e.g. `scratch_git_init.py`
+  reminding the model to offer `tbd scratch promote` after `git init` in a scratch
+  space. Deny always takes precedence: if any rule denies, infos from other rules
+  on the same call are dropped for that call.
 
 `ctx` carries `session_id`, `cwd`, `permission_mode`, and `tool_name`.
 
@@ -99,10 +107,16 @@ class Rule:
   `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"…"}}`
   to stdout and `exit 0`. This blocks the call even under
   `--dangerously-skip-permissions`. (We do NOT use legacy exit-code-2.)
+- **INFORM (non-blocking)**: print
+  `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","additionalContext":"…"}}`
+  to stdout and `exit 0`. The call proceeds; the model just sees `additionalContext`
+  as a reminder. Emitted only when no rule denied the same call.
 - Multiple hooks merge most-restrictive-wins.
 
 When several rules deny the same call, `dispatch.py` emits a single deny whose
 reason concatenates each denying rule's reason (each already prefixed with its id).
+Likewise, when there is no deny but one or more rules return `info`, `dispatch.py`
+emits a single non-blocking `additionalContext` concatenating their reasons.
 
 ## Fail-open
 

--- a/.claude/hooks/guardrails/dispatch.py
+++ b/.claude/hooks/guardrails/dispatch.py
@@ -4,14 +4,19 @@
 Reads the PreToolUse hook JSON on stdin, runs every registered Rule whose `tools`
 set contains the invoked tool, and aggregates the results. If any rule denies, it
 emits a single `deny` hookSpecificOutput whose reason concatenates the denying
-rules' reasons. Otherwise it exits 0 silently (allow).
+rules' reasons. Deny takes precedence and short-circuits — an info decision never
+overrides a deny. Otherwise, if any rule returns an `info` decision, it emits a
+single non-blocking `additionalContext` hookSpecificOutput (`permissionDecision:
+"allow"`) whose text concatenates the info reasons — the call proceeds, but the
+model sees the reminder. If neither, it exits 0 silently (allow).
 
 FAIL-OPEN: every code path is wrapped so that ANY internal error (bad JSON, a rule
 that raises, a discovery failure) logs to decisions.log and exits 0 (allow). A
 buggy guardrail must NEVER block the agent.
 
 `deny` blocks the call even under `--dangerously-skip-permissions`. This uses the
-permissionDecision protocol on stdout + exit 0, NOT legacy exit-code-2.
+permissionDecision protocol on stdout + exit 0, NOT legacy exit-code-2. `info` uses
+the same protocol with `permissionDecision: "allow"` so it can never block.
 
 CLI:
   python3 dispatch.py --list       print active rule ids + descriptions + tools
@@ -65,12 +70,38 @@ def _emit_deny(reason: str) -> None:
     sys.stdout.write(json.dumps(output))
 
 
+def _emit_info(reason: str) -> None:
+    """Print a non-blocking additionalContext hookSpecificOutput JSON to stdout.
+
+    Uses `permissionDecision: "allow"` so this can never block the call — it
+    only surfaces `reason` to the model as additional context.
+    """
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "additionalContext": reason,
+        }
+    }
+    sys.stdout.write(json.dumps(output))
+
+
 def evaluate(payload: dict) -> "str | None":
     """Run applicable rules; return a concatenated deny reason or None (allow).
 
     Each rule is run in its own try/except so one raising rule cannot suppress
     the others or block the agent — its failure is logged and treated as allow.
+
+    Deny reasons take precedence: if any rule denies, this returns only the
+    concatenated deny reasons (info decisions are dropped for this call — see
+    `run_hook`, which re-runs the rule loop's info path only when there is no
+    deny).
     """
+    return _evaluate_with_infos(payload)[0]
+
+
+def _evaluate_with_infos(payload: dict) -> "tuple[str | None, list[str]]":
+    """Run applicable rules; return (deny reason or None, list of info reasons)."""
     tool_name = payload.get("tool_name", "")
     tool_input = payload.get("tool_input", {}) or {}
     ctx = {
@@ -80,7 +111,8 @@ def evaluate(payload: dict) -> "str | None":
         "tool_name": tool_name,
     }
 
-    reasons: list[str] = []
+    deny_reasons: list[str] = []
+    info_reasons: list[str] = []
     for rule in load_rules():
         if tool_name not in getattr(rule, "tools", set()):
             continue
@@ -92,28 +124,41 @@ def evaluate(payload: dict) -> "str | None":
                 f"exception={exc!r} cmd={_snippet(tool_input.get('command', ''))}"
             )
             continue
-        if decision is not None and decision.action == "deny":
-            reasons.append(decision.reason)
+        if decision is None:
+            continue
+        if decision.action == "deny":
+            deny_reasons.append(decision.reason)
             _log(
                 f"DENY tool={tool_name} rule={getattr(rule, 'id', '?')} "
                 f"cmd={_snippet(tool_input.get('command', ''))}"
             )
+        elif decision.action == "info":
+            info_reasons.append(decision.reason)
+            _log(
+                f"INFO tool={tool_name} rule={getattr(rule, 'id', '?')} "
+                f"cmd={_snippet(tool_input.get('command', ''))}"
+            )
 
-    if not reasons:
-        return None
-    return "\n\n".join(reasons)
+    deny = "\n\n".join(deny_reasons) if deny_reasons else None
+    return deny, info_reasons
 
 
 def run_hook() -> int:
-    """Read stdin, evaluate, emit deny if needed. Always returns 0 (fail-open)."""
+    """Read stdin, evaluate, emit deny/info if needed. Always returns 0 (fail-open).
+
+    Deny takes precedence and short-circuits — an info decision is only ever
+    emitted when there is no deny among this call's rules.
+    """
     try:
         raw = sys.stdin.read()
         payload = json.loads(raw) if raw.strip() else {}
         if not isinstance(payload, dict):
             raise ValueError("hook payload was not a JSON object")
-        reason = evaluate(payload)
-        if reason:
-            _emit_deny(reason)
+        deny_reason, info_reasons = _evaluate_with_infos(payload)
+        if deny_reason:
+            _emit_deny(deny_reason)
+        elif info_reasons:
+            _emit_info("\n".join(info_reasons))
     except Exception as exc:  # noqa: BLE001 — fail open: a broken hook must allow
         _log(f"INTERNAL-ERROR fail-open exception={exc!r}")
     return 0

--- a/.claude/hooks/guardrails/lib/rule.py
+++ b/.claude/hooks/guardrails/lib/rule.py
@@ -15,8 +15,11 @@ from dataclasses import dataclass
 class Decision:
     """The outcome of a rule's `check`.
 
-    action is "deny" or "allow". A "deny" carries an instructive `reason` that is
-    fed back to the model (via permissionDecisionReason) so it can self-correct.
+    action is "deny", "allow", or "info". A "deny" carries an instructive
+    `reason` that is fed back to the model (via permissionDecisionReason) so it
+    can self-correct — and blocks the call. An "info" also carries a `reason`
+    but is non-blocking: dispatch.py surfaces it via `additionalContext` while
+    still allowing the call through.
     """
 
     action: str
@@ -29,6 +32,10 @@ class Decision:
     @staticmethod
     def allow() -> "Decision":
         return Decision(action="allow", reason="")
+
+    @staticmethod
+    def info(reason: str) -> "Decision":
+        return Decision(action="info", reason=reason)
 
 
 class Rule:

--- a/.claude/hooks/guardrails/rules/scratch_git_init.py
+++ b/.claude/hooks/guardrails/rules/scratch_git_init.py
@@ -1,0 +1,72 @@
+"""Guardrail: nudge toward `tbd scratch promote` on `git init` in a scratch space.
+
+A TBD scratch space (`~/tbd/scratch/<name>`) is a repo-less workspace. Running
+`git init` inside one is a strong signal the project is taking shape and should
+eventually be promoted to a real TBD repo via `tbd scratch promote <dest-path>`.
+
+This rule is INFORMATIONAL ONLY: it never denies. `git init` in a scratch space
+is exactly what promotion documents as the first step (init + commit, then
+`tbd scratch promote`), so blocking it would break the intended workflow. The
+rule only surfaces a reminder via Decision.info, which dispatch.py emits as a
+non-blocking `additionalContext` — the command always proceeds.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from guardrails.lib.rule import Decision, Rule
+
+# Matches `git init`, `git -C <dir> init`, `git --git-dir=<path> init`, and
+# combinations of those flags before `init` — anything of the form
+# `git [-C <dir> | --flag[=value]]* init`.
+_GIT_INIT = re.compile(r"\bgit\b(?:\s+(?:-C\s+\S+|--[\w-]+(?:=\S+)?))*\s+init\b")
+
+# Match ~/tbd/scratch/ regardless of TBD_HOME override (best-effort: check both).
+_SCRATCH_MARKERS = tuple(
+    marker
+    for marker in (
+        os.path.join(os.path.expanduser("~"), "tbd", "scratch") + os.sep,
+        os.path.join(os.environ.get("TBD_HOME", ""), "scratch") + os.sep
+        if os.environ.get("TBD_HOME")
+        else None,
+    )
+    if marker
+)
+# Fallback markers for scanning the command text itself (e.g. a compound
+# `cd ~/tbd/scratch/x && git init`, where ctx's cwd is still the pre-command
+# directory). Includes the unexpanded `~/tbd/scratch/` form since shell tildes
+# aren't expanded before the hook sees the raw command string.
+_COMMAND_MARKERS = _SCRATCH_MARKERS + ("~" + os.sep + os.path.join("tbd", "scratch") + os.sep,)
+
+_MESSAGE = (
+    "You ran `git init` inside a TBD scratch space. When this project takes "
+    "shape, offer the user promotion: ask for a destination path and run "
+    "`tbd scratch promote <dest-path>` from here to move the folder out and "
+    "register it as a real TBD repo. (This is informational — nothing is blocked.)"
+)
+
+
+class ScratchGitInitRule(Rule):
+    id = "scratch-git-init"
+    description = "Nudge toward `tbd scratch promote` when git init runs in a scratch space."
+    tools = {"Bash"}
+
+    def check(self, tool_input: dict, ctx: dict) -> "Decision | None":
+        command = tool_input.get("command", "") or ""
+        if not _GIT_INIT.search(command):
+            return None
+        cwd = (ctx.get("cwd") or "") + os.sep
+        if any(cwd.startswith(marker) for marker in _SCRATCH_MARKERS):
+            return Decision.info(_MESSAGE)
+        # cwd reflects the directory the command started in, not any `cd` inside
+        # it, so a compound `cd ~/tbd/scratch/x && git init` run from outside the
+        # scratch tree wouldn't otherwise be caught. Fire if the command text
+        # itself references a scratch-space path. Still informational only.
+        if any(marker in command for marker in _COMMAND_MARKERS):
+            return Decision.info(_MESSAGE)
+        return None
+
+
+RULES = [ScratchGitInitRule()]

--- a/.claude/hooks/guardrails/tests/test_dispatch.py
+++ b/.claude/hooks/guardrails/tests/test_dispatch.py
@@ -99,6 +99,24 @@ class _DenyBRule(Rule):
         return Decision.deny("[deny-b] reason B")
 
 
+class _InfoARule(Rule):
+    id = "info-a"
+    description = "always informs A"
+    tools = {"Bash"}
+
+    def check(self, _tool_input, _ctx):
+        return Decision.info("[info-a] reason A")
+
+
+class _InfoBRule(Rule):
+    id = "info-b"
+    description = "always informs B"
+    tools = {"Bash"}
+
+    def check(self, _tool_input, _ctx):
+        return Decision.info("[info-b] reason B")
+
+
 class EvaluateUnitTests(unittest.TestCase):
     """Drive evaluate() directly with injected rule sets via monkeypatch."""
 
@@ -131,6 +149,55 @@ class EvaluateUnitTests(unittest.TestCase):
         )
         assert reason is not None
         self.assertIn("[deny-a] reason A", reason)
+
+
+class InfoEmissionTests(unittest.TestCase):
+    """Pin the non-blocking info path end to end through run_hook()."""
+
+    def setUp(self):
+        self._orig = dispatch.load_rules
+
+    def tearDown(self):
+        dispatch.load_rules = self._orig
+
+    def test_info_only_emits_additional_context_and_allows(self):
+        dispatch.load_rules = lambda: [_InfoARule()]
+        payload = {"tool_name": "Bash", "tool_input": {"command": "echo hi"}}
+        code, out = _run_hook_with_stdin(json.dumps(payload))
+        self.assertEqual(code, 0)
+        parsed = json.loads(out)
+        hso = parsed["hookSpecificOutput"]
+        self.assertEqual(hso["hookEventName"], "PreToolUse")
+        # info must never block: permissionDecision is "allow", not "deny".
+        self.assertEqual(hso["permissionDecision"], "allow")
+        self.assertIn("[info-a] reason A", hso["additionalContext"])
+
+    def test_multiple_infos_concatenate(self):
+        dispatch.load_rules = lambda: [_InfoARule(), _InfoBRule()]
+        payload = {"tool_name": "Bash", "tool_input": {"command": "echo hi"}}
+        code, out = _run_hook_with_stdin(json.dumps(payload))
+        self.assertEqual(code, 0)
+        hso = json.loads(out)["hookSpecificOutput"]
+        self.assertIn("[info-a] reason A", hso["additionalContext"])
+        self.assertIn("[info-b] reason B", hso["additionalContext"])
+
+    def test_deny_takes_precedence_over_info(self):
+        dispatch.load_rules = lambda: [_InfoARule(), _DenyARule()]
+        payload = {"tool_name": "Bash", "tool_input": {"command": "echo hi"}}
+        code, out = _run_hook_with_stdin(json.dumps(payload))
+        self.assertEqual(code, 0)
+        hso = json.loads(out)["hookSpecificOutput"]
+        self.assertEqual(hso["permissionDecision"], "deny")
+        self.assertIn("[deny-a] reason A", hso["permissionDecisionReason"])
+        # The info reason must not leak into the deny output.
+        self.assertNotIn("additionalContext", hso)
+
+    def test_no_decisions_stays_silent(self):
+        dispatch.load_rules = lambda: []
+        payload = {"tool_name": "Bash", "tool_input": {"command": "echo hi"}}
+        code, out = _run_hook_with_stdin(json.dumps(payload))
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/guardrails/tests/test_scratch_git_init.py
+++ b/.claude/hooks/guardrails/tests/test_scratch_git_init.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import unittest
+
+_HOOKS_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+from guardrails.rules.scratch_git_init import ScratchGitInitRule  # noqa: E402
+
+
+def _check(command, cwd):
+    return ScratchGitInitRule().check({"command": command}, {"cwd": cwd})
+
+
+class ScratchGitInitTests(unittest.TestCase):
+    def test_informs_on_git_init_in_scratch(self):
+        d = _check("git init", os.path.expanduser("~/tbd/scratch/my-project"))
+        assert d is not None
+        self.assertEqual(d.action, "info")
+        self.assertIn("tbd scratch promote", d.reason)
+
+    def test_silent_outside_scratch(self):
+        self.assertIsNone(_check("git init", os.path.expanduser("~/projects/foo")))
+
+    def test_silent_for_non_git_init(self):
+        self.assertIsNone(_check("ls -la", os.path.expanduser("~/tbd/scratch/my-project")))
+
+    def test_never_denies(self):
+        d = _check("git init", os.path.expanduser("~/tbd/scratch/x"))
+        self.assertNotEqual(d.action, "deny")
+
+    def test_informs_on_git_dash_c_form(self):
+        d = _check(
+            "git -C ~/tbd/scratch/x init",
+            os.path.expanduser("~/tbd/scratch/x"),
+        )
+        assert d is not None
+        self.assertEqual(d.action, "info")
+
+    def test_informs_on_git_dir_flag_form(self):
+        d = _check(
+            "git --git-dir=~/tbd/scratch/x/.git init",
+            os.path.expanduser("~/tbd/scratch/x"),
+        )
+        assert d is not None
+        self.assertEqual(d.action, "info")
+
+    def test_informs_on_compound_cd_form_from_outside_scratch(self):
+        # cwd is pre-command (outside the scratch tree); the scratch path only
+        # appears in the command text via a leading `cd`.
+        d = _check(
+            "cd ~/tbd/scratch/x && git init",
+            os.path.expanduser("~/projects/foo"),
+        )
+        assert d is not None
+        self.assertEqual(d.action, "info")
+        self.assertIn("tbd scratch promote", d.reason)
+
+    def test_silent_for_git_dash_c_form_outside_scratch(self):
+        self.assertIsNone(
+            _check("git -C ~/projects/foo init", os.path.expanduser("~/projects/foo"))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Sources/TBDApp/AppState+ArchiveTombstones.swift
+++ b/Sources/TBDApp/AppState+ArchiveTombstones.swift
@@ -53,6 +53,7 @@ extension AppState {
         for repoID in worktrees.keys {
             worktrees[repoID]?.removeAll { $0.id == id }
         }
+        scratchWorktrees.removeAll { $0.id == id }
         // If the archived worktree was the *only* selection, dropping it would
         // leave an empty detail pane — instead navigate back through history
         // to the previous still-valid view. Multi-select and not-selected

--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -178,7 +178,9 @@ extension AppState {
             )
             settleReviveState(id: worktreeID, snapshot: snapshot, revived: revived)
             await refreshWorktrees()
-            await refreshArchivedWorktrees(repoID: snapshot.repoID)
+            if let repoID = snapshot.repoID {
+                await refreshArchivedWorktrees(repoID: repoID)
+            }
         } catch {
             revivingArchived.removeValue(forKey: worktreeID)
             logger.error("reviveWithSession failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -53,9 +53,9 @@ extension AppState {
         // If the target is a worktree, expand its containing repo before scrolling.
         if let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == target }),
            let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
+           let repoID = worktree.repoID,
            !repos[repoIdx].expanded {
             repos[repoIdx].expanded = true
-            let repoID = worktree.repoID
             Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
         }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -71,6 +71,34 @@ extension AppState {
         }
     }
 
+    /// Create a repo-less scratch space and select it once the daemon confirms.
+    func createScratch() {
+        Task {
+            do {
+                let wt = try await daemonClient.createScratch()
+                scratchWorktrees.append(wt)
+                selectedWorktreeIDs = [wt.id]
+                editingWorktreeID = wt.id
+            } catch {
+                logger.error("Failed to create scratch space: \(error)")
+                handleConnectionError(error)
+            }
+        }
+    }
+
+    /// Delete a scratch space: closes its terminals and moves its folder to Trash.
+    func deleteScratch(id: UUID) {
+        Task {
+            do {
+                try await daemonClient.deleteScratch(worktreeID: id)
+                scratchWorktrees.removeAll { $0.id == id }
+            } catch {
+                logger.error("Failed to delete scratch space: \(error)")
+                handleConnectionError(error)
+            }
+        }
+    }
+
     /// List local + remote tracking branches for a repo, for the existing-
     /// branch picker on the sidebar `+` button. Rethrows so the picker can
     /// distinguish a fetch failure from a genuinely empty branch list.

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -123,7 +123,9 @@ extension AppState {
             // No refreshWorktrees() here: the sidebar refresh arrives via the
             // `.worktreeRevived` delta handler (AppState.swift handleDelta),
             // same as createWorktree relies on its delta.
-            await refreshArchivedWorktrees(repoID: snapshot.repoID)
+            if let repoID = snapshot.repoID {
+                await refreshArchivedWorktrees(repoID: repoID)
+            }
         } catch {
             revivingArchived.removeValue(forKey: id)
             logger.error("Failed to revive worktree: \(error)")
@@ -197,9 +199,9 @@ extension AppState {
         // synchronously (List rerender + scroll), persist via RPC fire-and-forget.
         if let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),
            let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
+           let repoID = worktree.repoID,
            !repos[repoIdx].expanded {
             repos[repoIdx].expanded = true
-            let repoID = worktree.repoID
             Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
         }
         pendingScrollToWorktreeID = id
@@ -250,11 +252,13 @@ extension AppState {
             logger.warning("Deep link references unknown worktree \(id.uuidString, privacy: .public)")
             return
         }
+        // Archived flows are repo-only — a scratch space has no archived view to deep-link into.
+        guard let rid = wt.repoID else { return }
 
         selectedWorktreeIDs = []
-        selectedRepoID = wt.repoID
-        archivedWorktrees[wt.repoID] = archived.filter { $0.repoID == wt.repoID }
-        archivedWorktreesHasMore[wt.repoID] = false
+        selectedRepoID = rid
+        archivedWorktrees[rid] = archived.filter { $0.repoID == rid }
+        archivedWorktreesHasMore[rid] = false
         highlightedArchivedWorktreeID = id
         if NSApplication.shared.isRunning {
             NSApplication.shared.activate(ignoringOtherApps: true)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1486,6 +1486,16 @@ final class AppState: ObservableObject {
         setting && !spaces.isEmpty
     }
 
+    /// Pure, testable mirror of `WorktreeRowView`'s scratch-row dimming rule:
+    /// a scratch row dims only when its directory is missing AND it was
+    /// never promoted. `tbd scratch promote` MOVES the folder to its
+    /// destination repo, so a promoted row's directory never exists again —
+    /// dimming it as "missing" would contradict the "→ promoted to <repo>"
+    /// caption shown alongside it. Non-scratch worktrees never dim here.
+    nonisolated static func scratchRowIsDimmed(_ worktree: Worktree, directoryExists: Bool) -> Bool {
+        worktree.isScratch && worktree.promotedToRepoID == nil && !directoryExists
+    }
+
     /// Whether the WIP main-area resize broadcast is enabled. Default false.
     private var terminalAutoResizeEnabled: Bool {
         userDefaults.bool(forKey: Self.terminalAutoResizeKey)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1074,9 +1074,9 @@ final class AppState: ObservableObject {
             for id in selectedWorktreeIDs {
                 if let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),
                    let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
+                   let repoID = worktree.repoID,
                    !repos[repoIdx].expanded {
                     repos[repoIdx].expanded = true
-                    let repoID = worktree.repoID
                     Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
                 }
             }
@@ -1246,7 +1246,10 @@ final class AppState: ObservableObject {
             } else {
                 var grouped: [UUID: [Worktree]] = [:]
                 for wt in fetched {
-                    grouped[wt.repoID, default: []].append(wt)
+                    // Scratch spaces (repoID == nil) don't belong to any repo group;
+                    // they're surfaced separately (see the Scratch sidebar section).
+                    guard let rid = wt.repoID else { continue }
+                    grouped[rid, default: []].append(wt)
                 }
                 // Preserve optimistic placeholders the daemon doesn't know about yet
                 for (rid, wts) in worktrees {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -53,6 +53,9 @@ final class AppState: ObservableObject {
 
     @Published var repos: [Repo] = []
     @Published var worktrees: [UUID: [Worktree]] = [:]
+    /// Repo-less scratch spaces (`Worktree.isScratch`), surfaced separately
+    /// in the sidebar's Scratch section rather than under any repo group.
+    @Published var scratchWorktrees: [Worktree] = []
     @Published var terminals: [UUID: [Terminal]] = [:]
     @Published var notes: [UUID: [Note]] = [:]
     @Published var focusedTabCloseContext: TabCloseContext?
@@ -1245,10 +1248,14 @@ final class AppState: ObservableObject {
                 }
             } else {
                 var grouped: [UUID: [Worktree]] = [:]
+                var scratch: [Worktree] = []
                 for wt in fetched {
                     // Scratch spaces (repoID == nil) don't belong to any repo group;
                     // they're surfaced separately (see the Scratch sidebar section).
-                    guard let rid = wt.repoID else { continue }
+                    guard let rid = wt.repoID else {
+                        scratch.append(wt)
+                        continue
+                    }
                     grouped[rid, default: []].append(wt)
                 }
                 // Preserve optimistic placeholders the daemon doesn't know about yet
@@ -1259,6 +1266,10 @@ final class AppState: ObservableObject {
                 }
                 if grouped != worktrees {
                     worktrees = grouped
+                }
+                let sortedScratch = scratch.sorted { $0.sortOrder < $1.sortOrder }
+                if sortedScratch != scratchWorktrees {
+                    scratchWorktrees = sortedScratch
                 }
             }
 
@@ -1464,6 +1475,16 @@ final class AppState: ObservableObject {
     /// for the two enforcement points. Settings UI toggle lives in the
     /// "Experimental" section of the General settings tab.
     static let terminalAutoResizeKey = "enableTerminalAutoResize"
+
+    /// UserDefaults key for showing the sidebar's Scratch section (repo-less
+    /// scratch spaces). Default on.
+    static let showScratchSectionKey = "showScratchSection"
+
+    /// Pure, testable mirror of the sidebar's Scratch-section gate:
+    /// shown only when the setting is on AND there's at least one scratch space.
+    nonisolated static func scratchSectionVisible(setting: Bool, spaces: [Worktree]) -> Bool {
+        setting && !spaces.isEmpty
+    }
 
     /// Whether the WIP main-area resize broadcast is enabled. Default false.
     private var terminalAutoResizeEnabled: Bool {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -478,6 +478,14 @@ actor DaemonClient {
         )
     }
 
+    /// Delete a scratch worktree: closes its terminals and moves its folder to Trash.
+    func deleteScratch(worktreeID: UUID) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.scratchDelete,
+            params: ScratchDeleteParams(worktreeID: worktreeID)
+        )
+    }
+
     /// List local + `origin/*` branches for a repo. Used by the existing-
     /// branch picker on the sidebar `+` button.
     func listBranches(repoID: UUID) async throws -> [BranchInfo] {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -469,6 +469,15 @@ actor DaemonClient {
         )
     }
 
+    /// Create a repo-less scratch worktree.
+    func createScratch(name: String? = nil) async throws -> Worktree {
+        return try await callAsync(
+            method: RPCMethod.scratchCreate,
+            params: ScratchCreateParams(name: name),
+            resultType: Worktree.self
+        )
+    }
+
     /// List local + `origin/*` branches for a repo. Used by the existing-
     /// branch picker on the sidebar `+` button.
     func listBranches(repoID: UUID) async throws -> [BranchInfo] {

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -8,7 +8,7 @@ struct StatusBarView: View {
     /// Transient "Copied" feedback shown after the left label copies a path.
     @State private var didCopy = false
 
-    private var selectedWorktreeInfo: (path: String, repoID: UUID)? {
+    private var selectedWorktreeInfo: (path: String, repoID: UUID?)? {
         guard appState.selectedWorktreeIDs.count == 1,
               let id = appState.selectedWorktreeIDs.first,
               let worktree = appState.worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -37,6 +37,7 @@ struct GeneralSettingsTab: View {
     @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = false
     @AppStorage(AppState.enableTranscriptKey) private var enableTranscript: Bool = false
     @AppStorage(AppState.useTableViewTranscriptKey) private var useTableViewTranscript: Bool = true
+    @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
@@ -132,6 +133,9 @@ struct GeneralSettingsTab: View {
                     set: { newValue in Task { await appState.setAutoArchiveOnMergeDefault(newValue) } }
                 ))
                 .help("Default for new worktrees. Each worktree can override this from its toolbar toggle.")
+
+                Toggle("Show Scratch section", isOn: $showScratchSection)
+                    .help("Hide the repo-less Scratch section. Existing scratch spaces and their terminals keep running.")
             }
 
             Section("Claude") {

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import TBDShared
+
+/// Pinned sidebar section for repo-less scratch spaces (`Worktree.isScratch`).
+/// Modeled on `RepoSectionView`: a header row with a hover `+` to create a new
+/// scratch space, followed by the scratch worktree rows.
+struct ScratchSectionView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var isHeaderHovered = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text("Scratch")
+                .font(.headline).foregroundStyle(.secondary)
+            Spacer()
+            if isHeaderHovered {
+                Button { appState.createScratch() } label: {
+                    Image(systemName: "plus")
+                }
+                .buttonStyle(HoverPressButtonStyle())
+                .help("New scratch space")
+            }
+        }
+        .onHover { isHeaderHovered = $0 }
+        .listRowInsets(EdgeInsets(top: 0, leading: -2, bottom: 0, trailing: 0))
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
+
+        ForEach(appState.scratchWorktrees) { wt in
+            WorktreeRowView(worktree: wt)   // sectionRepoID nil → no (repo) suffix; repo affordances vanish
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+                .tag(wt.id)
+        }
+    }
+}

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -9,7 +9,27 @@ struct SidebarContextMenu: View {
 
     var body: some View {
         Group {
-            if worktree.status == .main || worktree.status == .creating {
+            if worktree.isScratch {
+                Button("Rename...") {
+                    onRename()
+                }
+                if worktree.promotedToRepoID == nil {
+                    Text("To promote: run `tbd scratch promote <dest>` from a session here")
+                        .font(.caption)
+                }
+                Divider()
+                Button("Open in Finder") {
+                    NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.path)
+                }
+                Button("Copy Path") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(worktree.path, forType: .string)
+                }
+                Divider()
+                Button("Delete Scratch Space", role: .destructive) {
+                    appState.deleteScratch(id: worktree.id)
+                }
+            } else if worktree.status == .main || worktree.status == .creating {
                 // Main / creating worktree: only Finder and Copy Path (no rename/archive)
                 if !worktree.path.isEmpty {
                     Button("Open in Finder") {

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -10,6 +10,25 @@ struct SidebarContextMenu: View {
     var body: some View {
         Group {
             if worktree.isScratch {
+                Button("New Claude Terminal") {
+                    let wtID = worktree.id
+                    Task {
+                        await appState.createClaudeTerminal(worktreeID: wtID)
+                    }
+                }
+                Button("New Codex Terminal") {
+                    let wtID = worktree.id
+                    Task {
+                        await appState.createCodexTerminal(worktreeID: wtID)
+                    }
+                }
+                Button("New Shell Terminal") {
+                    let wtID = worktree.id
+                    Task {
+                        await appState.createTerminal(worktreeID: wtID)
+                    }
+                }
+                Divider()
                 Button("Rename...") {
                     onRename()
                 }

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -81,10 +81,11 @@ struct SidebarContextMenu: View {
                     }
                 }
 
-                Button("Create Nested Worktree") {
-                    let parentID = worktree.id
-                    let repoID = worktree.repoID
-                    appState.createWorktree(repoID: repoID, parentWorktreeID: parentID)
+                // Scratch spaces have no repo, so nesting isn't offered for them.
+                if let repoID = worktree.repoID {
+                    Button("Create Nested Worktree") {
+                        appState.createWorktree(repoID: repoID, parentWorktreeID: worktree.id)
+                    }
                 }
 
                 Button("Archive", role: .destructive) {

--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -5,6 +5,7 @@ import TBDShared
 struct SidebarView: View {
     @EnvironmentObject var appState: AppState
     @AppStorage("sidebar.showHiddenRepos") private var showHiddenRepos: Bool = false
+    @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
 
     var filteredRepos: [Repo] {
         let base: [Repo]
@@ -19,6 +20,9 @@ struct SidebarView: View {
     var body: some View {
         ScrollViewReader { proxy in
             List(selection: $appState.selectedWorktreeIDs) {
+                if AppState.scratchSectionVisible(setting: showScratchSection, spaces: appState.scratchWorktrees) {
+                    ScratchSectionView()
+                }
                 ForEach(filteredRepos) { repo in
                     RepoSectionView(repo: repo)
                         .opacity(repo.hidden ? 0.55 : 1.0)

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -191,8 +191,12 @@ struct WorktreeRowView: View {
         .frame(height: 28)
         // Scratch spaces have no repo-level `.missing` status to inherit, so a
         // missing directory is surfaced client-side with a cheap per-row FS stat
-        // (mirrors RepoSectionView dimming a `.missing` repo).
-        .opacity(worktree.isScratch && !FileManager.default.fileExists(atPath: worktree.path) ? 0.5 : 1.0)
+        // (mirrors RepoSectionView dimming a `.missing` repo). Promoted rows are
+        // excluded — promotion MOVES the folder, so their directory is expected
+        // to be gone; see AppState.scratchRowIsDimmed.
+        .opacity(AppState.scratchRowIsDimmed(
+            worktree, directoryExists: FileManager.default.fileExists(atPath: worktree.path)
+        ) ? 0.5 : 1.0)
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(appState.selectedWorktreeIDs.contains(worktree.id) ? Color.accentColor.opacity(0.2) : Color.clear)

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -167,6 +167,11 @@ struct WorktreeRowView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
+                    if let promotedID = worktree.promotedToRepoID,
+                       let name = appState.repoName(for: promotedID) {
+                        Text("→ promoted to \(name)")
+                            .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                    }
                 }
             }
             suffixIcon()

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -168,7 +168,8 @@ struct WorktreeRowView: View {
             }
             suffixIcon()
             if let sectionRepoID, sectionRepoID != worktree.repoID,
-               let homeRepo = appState.repoName(for: worktree.repoID) {
+               let rid = worktree.repoID,
+               let homeRepo = appState.repoName(for: rid) {
                 let short = homeRepo.count > 5 ? String(homeRepo.prefix(5)) + "…" : homeRepo
                 Text("(\(short))")
                     .font(.caption)
@@ -205,7 +206,9 @@ struct WorktreeRowView: View {
             if isRowHovered && !isMain {
                 Button(action: {
                     let parentID = worktree.id
-                    let repoID = worktree.repoID
+                    // Scratch spaces have no repo, so nested-worktree creation
+                    // isn't offered for them — this affordance is repo-only.
+                    guard let repoID = worktree.repoID else { return }
                     appState.createWorktree(repoID: repoID, parentWorktreeID: parentID)
                 }) {
                     Image(systemName: "plus")

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -189,6 +189,10 @@ struct WorktreeRowView: View {
         .padding(.leading, CGFloat(indentLevel) * 16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: 28)
+        // Scratch spaces have no repo-level `.missing` status to inherit, so a
+        // missing directory is surfaced client-side with a cheap per-row FS stat
+        // (mirrors RepoSectionView dimming a `.missing` repo).
+        .opacity(worktree.isScratch && !FileManager.default.fileExists(atPath: worktree.path) ? 0.5 : 1.0)
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(appState.selectedWorktreeIDs.contains(worktree.id) ? Color.accentColor.opacity(0.2) : Color.clear)

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -131,6 +131,9 @@ struct WorktreeRowView: View {
                             appState.worktrees[repoID]?[idx].displayName = newName
                         }
                     }
+                    if let idx = appState.scratchWorktrees.firstIndex(where: { $0.id == worktree.id }) {
+                        appState.scratchWorktrees[idx].displayName = newName
+                    }
                     Task {
                         await appState.renameWorktree(id: worktree.id, displayName: newName)
                     }

--- a/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
+++ b/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
@@ -56,9 +56,13 @@ private func openInEditor(path: String, bundleID: String) {
     NSWorkspace.shared.open([URL(fileURLWithPath: path)], withApplicationAt: appURL, configuration: .init(), completionHandler: nil)
 }
 
-private func recentKey(repoID: UUID) -> String { "openInEditor.recent.\(repoID)" }
+// `repoID` is nil for scratch spaces (repo-less worktrees); the "scratch"
+// sentinel keys their recent-editor list separately from any real repo.
+private func recentKey(repoID: UUID?) -> String {
+    "openInEditor.recent.\(repoID?.uuidString ?? "scratch")"
+}
 
-private func loadRecentBundleIDs(repoID: UUID) -> [String] {
+private func loadRecentBundleIDs(repoID: UUID?) -> [String] {
     guard let data = UserDefaults.standard.data(forKey: recentKey(repoID: repoID)),
           let ids = try? JSONDecoder().decode([String].self, from: data) else {
         return knownEditors.map(\.bundleID)
@@ -66,7 +70,7 @@ private func loadRecentBundleIDs(repoID: UUID) -> [String] {
     return ids
 }
 
-private func recordUsed(bundleID: String, repoID: UUID) {
+private func recordUsed(bundleID: String, repoID: UUID?) {
     var ids = loadRecentBundleIDs(repoID: repoID)
     ids.removeAll { $0 == bundleID }
     ids.insert(bundleID, at: 0)
@@ -77,7 +81,7 @@ private func recordUsed(bundleID: String, repoID: UUID) {
 
 struct OpenInEditorButton: View {
     let path: String
-    let repoID: UUID
+    let repoID: UUID?
 
     @State private var recentBundleIDs: [String] = []
     @State private var hovering: String? = nil

--- a/Sources/TBDCLI/Commands/ScratchCommands.swift
+++ b/Sources/TBDCLI/Commands/ScratchCommands.swift
@@ -6,7 +6,7 @@ struct ScratchCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "scratch",
         abstract: "Manage repo-less scratch spaces",
-        subcommands: [ScratchNew.self, ScratchList.self]
+        subcommands: [ScratchNew.self, ScratchList.self, ScratchPromote.self]
     )
 }
 
@@ -51,6 +51,40 @@ struct ScratchList: AsyncParsableCommand {
         for wt in scratch {
             let promoted = wt.promotedToRepoID != nil ? "  [promoted]" : ""
             print("\(wt.id)  \(wt.displayName)\(promoted)  \(wt.path)")
+        }
+    }
+}
+
+struct ScratchPromote: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "promote",
+        abstract: "Promote the current scratch space into a real TBD repo (move-on-promote)")
+
+    @Argument(help: "Destination path for the new repo (must not exist)")
+    var dest: String
+
+    @Option(name: .long, help: "Repo display name (overrides the scratch name / folder name)")
+    var displayName: String?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        // Prefer TBD_WORKTREE_ID (set in every TBD terminal); else resolve cwd.
+        let worktreeID: UUID
+        if let env = ProcessInfo.processInfo.environment["TBD_WORKTREE_ID"], let id = UUID(uuidString: env) {
+            worktreeID = id
+        } else {
+            worktreeID = try PathResolver(client: client).resolveWorktreeID()
+        }
+        let result: ScratchPromoteResult = try client.call(
+            method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: worktreeID, destPath: resolvePath(dest), displayName: displayName),
+            resultType: ScratchPromoteResult.self)
+        if json { printJSON(result) } else {
+            print("Promoted scratch space to repo: \(result.repoDisplayName)")
+            print("  Repo ID: \(result.repoID)")
+            print("  Path:    \(result.repoPath)")
         }
     }
 }

--- a/Sources/TBDCLI/Commands/ScratchCommands.swift
+++ b/Sources/TBDCLI/Commands/ScratchCommands.swift
@@ -1,0 +1,56 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct ScratchCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "scratch",
+        abstract: "Manage repo-less scratch spaces",
+        subcommands: [ScratchNew.self, ScratchList.self]
+    )
+}
+
+struct ScratchNew: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "new", abstract: "Create a scratch space")
+
+    @Option(name: .long, help: "Optional name (auto-generated if omitted)")
+    var name: String?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let wt: Worktree = try client.call(
+            method: RPCMethod.scratchCreate,
+            params: ScratchCreateParams(name: name),
+            resultType: Worktree.self)
+        if json { printJSON(wt) } else {
+            print("Created scratch space: \(wt.displayName)")
+            print("  ID:   \(wt.id)")
+            print("  Path: \(wt.path)")
+        }
+    }
+}
+
+struct ScratchList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List scratch spaces")
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let all: [Worktree] = try client.call(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(),
+            resultType: [Worktree].self)
+        let scratch = all.filter { $0.isScratch }
+        if json { printJSON(scratch); return }
+        if scratch.isEmpty { print("No scratch spaces. Use 'tbd scratch new' to create one."); return }
+        for wt in scratch {
+            let promoted = wt.promotedToRepoID != nil ? "  [promoted]" : ""
+            print("\(wt.id)  \(wt.displayName)\(promoted)  \(wt.path)")
+        }
+    }
+}

--- a/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
+++ b/Sources/TBDCLI/Commands/StopRenameCheckCommand.swift
@@ -9,9 +9,9 @@ import TBDShared
 /// Behavior (any error path = exit 0 silent so the agent is never wedged):
 /// 1. Read the Stop hook JSON payload from stdin.
 /// 2. Resolve the worktree for `cwd` via the daemon.
-/// 3. Skip if status is .main, displayName != name (already customized),
-///    the current branch can't be resolved, or we've already fired > 2
-///    times this session.
+/// 3. Skip if status is .main, the display name is already customized
+///    (`!hasDefaultDisplayName`), the current branch can't be resolved, or
+///    we've already fired > 2 times this session.
 /// 4. Otherwise emit `{"decision":"block","reason":"<directive>"}` so
 ///    the agent stays in-turn and sees the directive. The directive shape
 ///    depends on the branch: `tbd/*` branches are auto-generated and the
@@ -84,7 +84,8 @@ enum StopRenameCheckCore {
                         return WorktreeSummary(
                             name: wt.name,
                             displayName: wt.displayName,
-                            status: wt.status
+                            status: wt.status,
+                            hasDefaultDisplayName: wt.hasDefaultDisplayName
                         )
                     } catch {
                         return nil
@@ -114,6 +115,12 @@ enum StopRenameCheckCore {
         var name: String
         var displayName: String
         var status: WorktreeStatus
+
+        /// Threaded in from `Worktree.hasDefaultDisplayName` at construction
+        /// (the production call site builds this from a real `Worktree`) —
+        /// stored, not recomputed, so `Worktree.hasDefaultDisplayName` stays
+        /// the single "still default" definition.
+        var hasDefaultDisplayName: Bool
     }
 
     /// Maximum number of times we'll fire the directive in one session
@@ -151,7 +158,7 @@ enum StopRenameCheckCore {
         }
 
         // 3b. Already customized → skip.
-        if worktree.displayName != worktree.name {
+        if !worktree.hasDefaultDisplayName {
             return nil
         }
 

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -240,7 +240,8 @@ struct WorktreeList: AsyncParsableCommand {
                     wt.displayName as NSString,
                     wt.status.rawValue as NSString,
                     wt.branch as NSString)
-                let tag = missingRepoIDs.contains(wt.repoID) ? "  [missing]" : ""
+                // Scratch spaces (repoID == nil) have no repo to be missing.
+                let tag = (wt.repoID.map(missingRepoIDs.contains) ?? false) ? "  [missing]" : ""
                 print(line + tag)
             }
         }

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -10,6 +10,7 @@ struct TBDCommand: AsyncParsableCommand {
         subcommands: [
             RepoCommand.self,
             WorktreeCommand.self,
+            ScratchCommand.self,
             ConfigCommand.self,
             TerminalCommand.self,
             NotifyCommand.self,

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -204,6 +204,19 @@ public final class Daemon: Sendable {
         await healthValidator.validateAll(db: database)
     }
 
+    /// Recreate the base scratch directory if it's missing. Safe to call every startup.
+    static func ensureScratchDir() {
+        let fm = FileManager.default
+        let dir = TBDConstants.scratchDir.path
+        if !fm.fileExists(atPath: dir) {
+            do {
+                try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            } catch {
+                daemonLogger.warning("Failed to recreate scratch dir at \(dir, privacy: .public): \(String(describing: error), privacy: .public)")
+            }
+        }
+    }
+
     /// Start the daemon: create config directory, clean up stale state,
     /// initialize database and all managers, start servers, reconcile worktrees.
     public func start() async throws {
@@ -221,6 +234,7 @@ public final class Daemon: Sendable {
         if !fm.fileExists(atPath: configDir) {
             try fm.createDirectory(atPath: configDir, withIntermediateDirectories: true)
         }
+        Self.ensureScratchDir()
 
         // 2. Clean up stale PID/socket files
         pidFile.cleanupIfStale()

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -559,6 +559,59 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "worktree", column: "prStatus", type: .text)
         }
 
+        // Make worktree.repoID nullable (scratch spaces are repo-less rows) and
+        // add the promotedToRepoID pointer. SQLite cannot drop a NOT NULL
+        // constraint via ALTER, so rebuild the table. Idempotency-guarded:
+        // re-running after the column already went nullable is a no-op.
+        migrator.registerMigration("v35_worktree_nullable_repo") { db in
+            let info = try Row.fetchAll(db, sql: "PRAGMA table_info(worktree)")
+            let repoIDNotNull = (info.first { ($0["name"] as String?) == "repoID" }?["notnull"] as Int?) ?? 1
+            let hasPromoted = info.contains { ($0["name"] as String?) == "promotedToRepoID" }
+            if repoIDNotNull == 0 && hasPromoted { return }  // already applied
+
+            try db.execute(sql: """
+                CREATE TABLE worktree_new (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    repoID TEXT REFERENCES repo(id) ON DELETE CASCADE,
+                    name TEXT NOT NULL,
+                    displayName TEXT NOT NULL,
+                    branch TEXT NOT NULL,
+                    path TEXT NOT NULL UNIQUE,
+                    status TEXT NOT NULL DEFAULT 'active',
+                    createdAt DATETIME NOT NULL,
+                    archivedAt DATETIME,
+                    tmuxServer TEXT NOT NULL,
+                    gitStatus TEXT NOT NULL DEFAULT 'current',
+                    hasConflicts BOOLEAN NOT NULL DEFAULT 0,
+                    pinnedAt DATETIME,
+                    archivedClaudeSessions TEXT,
+                    sortOrder INTEGER NOT NULL DEFAULT 0,
+                    archivedHeadSHA TEXT,
+                    tabOrder TEXT NOT NULL DEFAULT '[]',
+                    activeTabID TEXT,
+                    parentWorktreeID TEXT REFERENCES worktree(id) ON DELETE SET NULL,
+                    autoArchiveOnMerge BOOLEAN,
+                    prStatus TEXT,
+                    promotedToRepoID TEXT
+                )
+                """)
+            try db.execute(sql: """
+                INSERT INTO worktree_new
+                    (id, repoID, name, displayName, branch, path, status, createdAt,
+                     archivedAt, tmuxServer, gitStatus, hasConflicts, pinnedAt,
+                     archivedClaudeSessions, sortOrder, archivedHeadSHA, tabOrder,
+                     activeTabID, parentWorktreeID, autoArchiveOnMerge, prStatus)
+                SELECT
+                     id, repoID, name, displayName, branch, path, status, createdAt,
+                     archivedAt, tmuxServer, gitStatus, hasConflicts, pinnedAt,
+                     archivedClaudeSessions, sortOrder, archivedHeadSHA, tabOrder,
+                     activeTabID, parentWorktreeID, autoArchiveOnMerge, prStatus
+                FROM worktree
+                """)
+            try db.drop(table: "worktree")
+            try db.rename(table: "worktree_new", to: "worktree")
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -7,7 +7,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     static let databaseTableName = "worktree"
 
     var id: String
-    var repoID: String
+    var repoID: String?
     var name: String
     var displayName: String
     var branch: String
@@ -25,10 +25,11 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var parentWorktreeID: String?
     var autoArchiveOnMerge: Bool?
     var prStatus: String?  // JSON-encoded PRStatus, nil when never observed
+    var promotedToRepoID: String?  // set only on promoted scratch rows
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
-        self.repoID = wt.repoID.uuidString
+        self.repoID = wt.repoID?.uuidString
         self.name = wt.name
         self.displayName = wt.displayName
         self.branch = wt.branch
@@ -49,6 +50,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.parentWorktreeID = wt.parentWorktreeID?.uuidString
         self.autoArchiveOnMerge = wt.autoArchiveOnMerge
         self.prStatus = wt.prStatus.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
+        self.promotedToRepoID = wt.promotedToRepoID?.uuidString
     }
 
     func toModel() -> Worktree {
@@ -63,7 +65,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         }
         return Worktree(
             id: UUID(uuidString: id)!,
-            repoID: UUID(uuidString: repoID)!,
+            repoID: repoID.flatMap { UUID(uuidString: $0) },
             name: name,
             displayName: displayName,
             branch: branch,
@@ -78,6 +80,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             archivedHeadSHA: archivedHeadSHA,
             parentWorktreeID: parentWorktreeID.flatMap { UUID(uuidString: $0) },
             autoArchiveOnMerge: autoArchiveOnMerge,
+            promotedToRepoID: promotedToRepoID.flatMap { UUID(uuidString: $0) },
             prStatus: pr
         )
     }
@@ -169,6 +172,40 @@ public struct WorktreeStore: Sendable {
             let record = WorktreeRecord(from: wt)
             try record.insert(db)
             return wt
+        }
+    }
+
+    /// Create a repo-less "scratch" worktree row (repoID == nil). branch is "".
+    public func createScratch(
+        name: String, displayName: String, path: String, tmuxServer: String
+    ) async throws -> Worktree {
+        try await writer.write { db in
+            let maxOrder = try Int.fetchOne(
+                db, sql: "SELECT MAX(sortOrder) FROM worktree WHERE repoID IS NULL"
+            ) ?? 0
+            let wt = Worktree(
+                repoID: nil, name: name, displayName: displayName, branch: "",
+                path: path, status: .active, tmuxServer: tmuxServer, sortOrder: maxOrder + 1)
+            try WorktreeRecord(from: wt).insert(db)
+            return wt
+        }
+    }
+
+    /// Set (or clear) the promotion pointer for a scratch row.
+    public func setPromotedToRepoID(id: UUID, repoID: UUID?) async throws {
+        try await writer.write { db in
+            try db.execute(sql: "UPDATE worktree SET promotedToRepoID = ? WHERE id = ?",
+                           arguments: [repoID?.uuidString, id.uuidString])
+        }
+    }
+
+    /// All repo-less scratch worktree rows.
+    public func listScratch() async throws -> [Worktree] {
+        try await writer.read { db in
+            try WorktreeRecord
+                .filter(Column("repoID") == nil)
+                .order(Column("sortOrder").asc)
+                .fetchAll(db).map { $0.toModel() }
         }
     }
 

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -130,6 +130,11 @@ public struct GitManager: Sendable {
         return trimmed
     }
 
+    /// Returns `true` if the repo at `path` has at least one commit (HEAD resolves).
+    public func hasCommits(path: String) async -> Bool {
+        (try? await run(arguments: ["rev-parse", "--verify", "HEAD"], at: path)) != nil
+    }
+
     /// Returns `true` if there are uncommitted changes (staged or unstaged).
     public func hasUncommittedChanges(repoPath: String) async throws -> Bool {
         let output = try await run(arguments: ["status", "--porcelain"], at: repoPath)

--- a/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/SuspendResumeCoordinator.swift
@@ -223,7 +223,12 @@ public actor SuspendResumeCoordinator {
         let claudeEnvOverrides = resumeConfig?.envSettingOverrides ?? [:]
         // Free-form env overrides (global < repo < profile), layered under the
         // builder's auth/routing env below so resumed sessions keep them too.
-        let resumeRepo = try? await db.repos.get(id: worktree.repoID)
+        let resumeRepo: Repo?
+        if let rid = worktree.repoID {
+            resumeRepo = try? await db.repos.get(id: rid)
+        } else {
+            resumeRepo = nil
+        }
         let mergedEnvOverrides = EnvOverrideResolver.merge(
             global: resumeConfig?.envOverrides,
             repo: resumeRepo?.envOverrides,

--- a/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+++ b/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
@@ -22,6 +22,18 @@ enum SystemPromptBuilder {
         """
     }
 
+    /// Layer injected for repo-less scratch sessions. Explains the space and
+    /// nudges agent-driven promotion.
+    static var scratchContext: String {
+        """
+        You are in a TBD **scratch space** — a repo-less workspace with no git repo yet.
+        Use it to bootstrap a new project or hold a general-purpose chat.
+        When the project takes shape, offer the user promotion: ask them for a \
+        destination path, then run `tbd scratch promote <dest-path>` from this \
+        session. That moves the folder and registers it as a real TBD repo.
+        """
+    }
+
     /// Returns the individual prompt layers as env-var-name → value pairs.
     /// Used both to set env vars in terminals and to build the combined `--append-system-prompt`.
     static func promptLayers(repo: Repo?, worktree: Worktree) -> [String: String] {
@@ -29,7 +41,11 @@ enum SystemPromptBuilder {
 
         layers["TBD_PROMPT_CONTEXT"] = builtInTBDContext
 
-        if worktree.status != .main && worktree.displayName == worktree.name {
+        if worktree.isScratch {
+            layers["TBD_PROMPT_SCRATCH"] = scratchContext
+        }
+
+        if !worktree.isScratch && worktree.status != .main && worktree.displayName == worktree.name {
             let renamePrompt = repo?.renamePrompt ?? defaultRenamePrompt
             if !renamePrompt.isEmpty {
                 layers["TBD_PROMPT_RENAME"] = renamePrompt
@@ -46,13 +62,14 @@ enum SystemPromptBuilder {
 
     /// Build the combined system prompt for a Claude session.
     /// Returns nil if there's nothing to append (e.g., resume session).
-    static func build(repo: Repo, worktree: Worktree, isResume: Bool) -> String? {
+    static func build(repo: Repo?, worktree: Worktree, isResume: Bool) -> String? {
         if isResume { return nil }
 
         let layers = promptLayers(repo: repo, worktree: worktree)
         var parts: [String] = []
 
-        // Order: rename prompt, TBD context, custom instructions
+        // Order: scratch layer, rename prompt, TBD context, custom instructions
+        if let scratch = layers["TBD_PROMPT_SCRATCH"] { parts.append(scratch) }
         if let rename = layers["TBD_PROMPT_RENAME"] { parts.append(rename) }
         parts.append(builtInTBDContext)
         if let instructions = layers["TBD_PROMPT_INSTRUCTIONS"] { parts.append(instructions) }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -60,8 +60,8 @@ extension WorktreeLifecycle {
             try await db.worktrees.assertArchivable(id: worktreeID)
         }
 
-        guard let repo = try await db.repos.get(id: worktree.repoID) else {
-            throw WorktreeLifecycleError.repoNotFound(worktree.repoID)
+        guard let rid = worktree.repoID, let repo = try await db.repos.get(id: rid) else {
+            throw WorktreeLifecycleError.repoNotFound(worktree.repoID ?? worktreeID)
         }
 
         // Collect Claude session IDs before archiving so they survive terminal deletion
@@ -140,7 +140,9 @@ extension WorktreeLifecycle {
             let archiveHookPath = hooks.resolve(
                 event: .archive,
                 repoPath: worktree.path,
-                appHookPath: TBDConstants.hookPath(repoID: worktree.repoID, eventName: HookEvent.archive.rawValue)
+                appHookPath: worktree.repoID.map {
+                    TBDConstants.hookPath(repoID: $0, eventName: HookEvent.archive.rawValue)
+                }
             )
             if let hookPath = archiveHookPath {
                 _ = try? await hooks.execute(
@@ -225,8 +227,8 @@ extension WorktreeLifecycle {
             throw WorktreeLifecycleError.worktreeAlreadyActive(worktreeID)
         }
 
-        guard let repo = try await db.repos.get(id: worktree.repoID) else {
-            throw WorktreeLifecycleError.repoNotFound(worktree.repoID)
+        guard let rid = worktree.repoID, let repo = try await db.repos.get(id: rid) else {
+            throw WorktreeLifecycleError.repoNotFound(worktree.repoID ?? worktreeID)
         }
 
         // Create parent directory if needed

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -179,9 +179,9 @@ extension WorktreeLifecycle {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
-        guard let repo = try await db.repos.get(id: worktree.repoID) else {
+        guard let rid = worktree.repoID, let repo = try await db.repos.get(id: rid) else {
             try? await db.worktrees.delete(id: worktreeID)
-            throw WorktreeLifecycleError.repoNotFound(worktree.repoID)
+            throw WorktreeLifecycleError.repoNotFound(worktree.repoID ?? worktreeID)
         }
 
         do {
@@ -570,7 +570,9 @@ extension WorktreeLifecycle {
         let setupHookPath = hooks.resolve(
             event: .setup,
             repoPath: worktreePath,
-            appHookPath: TBDConstants.hookPath(repoID: worktree.repoID, eventName: HookEvent.setup.rawValue)
+            appHookPath: worktree.repoID.map {
+                TBDConstants.hookPath(repoID: $0, eventName: HookEvent.setup.rawValue)
+            }
         )
         let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
         // Suppress the omz update prompt only when a setup hook actually

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
@@ -47,7 +47,7 @@ extension WorktreeLifecycle {
         // Warn (best-effort) when the path is under a TBD-managed prefix, since
         // reconcile would re-adopt it. Repo lookup is best-effort — a missing
         // repo row doesn't block forget (we still want the row gone).
-        if let repo = try? await db.repos.get(id: worktree.repoID) {
+        if let rid = worktree.repoID, let repo = try? await db.repos.get(id: rid) {
             let acceptablePrefixes = WorktreeLayout().legacyAndCanonicalPrefixes(for: repo)
                 .map { $0.hasSuffix("/") ? $0 : $0 + "/" }
             if acceptablePrefixes.contains(where: { worktree.path.hasPrefix($0) }) {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -102,9 +102,9 @@ extension WorktreeLifecycle {
         guard let hookPath = hooks.resolve(
             event: .preSession,
             repoPath: worktreePath,
-            appHookPath: TBDConstants.hookPath(
-                repoID: worktree.repoID, eventName: HookEvent.preSession.rawValue
-            )
+            appHookPath: worktree.repoID.map {
+                TBDConstants.hookPath(repoID: $0, eventName: HookEvent.preSession.rawValue)
+            }
         ) else {
             return nil
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -86,8 +86,8 @@ extension WorktreeLifecycle {
                 continue
             }
 
-            guard let repo = (try? await db.repos.get(id: worktree.repoID)) ?? nil else {
-                logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — repo \(worktree.repoID, privacy: .public) row is missing, so the pre-session wait can never be resumed")
+            guard let rid = worktree.repoID, let repo = (try? await db.repos.get(id: rid)) ?? nil else {
+                logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — repo \(String(describing: worktree.repoID), privacy: .public) row is missing, so the pre-session wait can never be resumed")
                 do {
                     try await db.terminals.deleteForWorktree(worktreeID: worktree.id)
                     try await db.tabs.deleteForWorktree(worktreeID: worktree.id)
@@ -111,7 +111,7 @@ extension WorktreeLifecycle {
                     event: .preSession,
                     repoPath: worktree.path,
                     appHookPath: TBDConstants.hookPath(
-                        repoID: worktree.repoID,
+                        repoID: rid,
                         eventName: HookEvent.preSession.rawValue
                     )
                 ) ?? ""

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -42,44 +42,25 @@ extension RPCRouter {
             return try RPCResponse(result: existing)
         }
 
-        // Detect default branch and remote URL
-        let defaultBranch: String
-        do {
-            defaultBranch = try await git.detectDefaultBranch(repoPath: path)
-        } catch {
-            defaultBranch = "main"
-        }
+        return try RPCResponse(result: try await addRepo(path: path, displayNameOverride: nil))
+    }
 
+    /// Register `path` as a repo (default-branch detect, create row, synthetic
+    /// main worktree, reconcile, broadcast). `displayNameOverride` wins over the
+    /// folder-name default. Assumes `path` is already a git repo.
+    func addRepo(path: String, displayNameOverride: String?) async throws -> Repo {
+        let defaultBranch = (try? await git.detectDefaultBranch(repoPath: path)) ?? "main"
         let remoteURL = await git.getRemoteURL(repoPath: path)
-
-        // Derive display name from last path component
-        let displayName = (path as NSString).lastPathComponent
-
-        let repo = try await db.repos.create(
-            path: path,
-            displayName: displayName,
-            defaultBranch: defaultBranch,
-            remoteURL: remoteURL
-        )
-
-        // Create synthetic "main" worktree entry pointing at repo root
+        let displayName = displayNameOverride ?? (path as NSString).lastPathComponent
+        let repo = try await db.repos.create(path: path, displayName: displayName,
+                                             defaultBranch: defaultBranch, remoteURL: remoteURL)
         let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
-        _ = try await db.worktrees.createMain(
-            repoID: repo.id,
-            name: defaultBranch,
-            branch: defaultBranch,
-            path: path,
-            tmuxServer: tmuxServer
-        )
-
-        // Reconcile existing git worktrees into the DB
+        _ = try await db.worktrees.createMain(repoID: repo.id, name: defaultBranch,
+                                              branch: defaultBranch, path: path, tmuxServer: tmuxServer)
         try? await lifecycle.reconcile(repoID: repo.id)
-
         subscriptions.broadcast(delta: .repoAdded(RepoDelta(
-            repoID: repo.id, path: repo.path, displayName: repo.displayName
-        )))
-
-        return try RPCResponse(result: repo)
+            repoID: repo.id, path: repo.path, displayName: repo.displayName)))
+        return repo
     }
 
     func handleRepoRemove(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -11,6 +11,15 @@ extension RPCRouter {
         // Resolve to absolute path
         let path = (params.path as NSString).standardizingPath
 
+        // Reject paths inside TBD's scratch area — those must go through
+        // `tbd scratch promote`, which moves the folder out first.
+        // Canonicalize both paths to resolve symlinks (e.g., /tmp → /private/tmp on macOS)
+        let canonPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+        let canonScratchBase = URL(fileURLWithPath: TBDConstants.scratchDir.path).resolvingSymlinksInPath().path
+        if canonPath == canonScratchBase || canonPath.hasPrefix(canonScratchBase + "/") {
+            return RPCResponse(error: "That path is inside TBD's scratch area. Use `tbd scratch promote <dest-path>` to move it out and register it as a repo.")
+        }
+
         // Validate it's a git repo
         guard await git.isGitRepo(path: path) else {
             return RPCResponse(error: "Not a git repository: \(path)")

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -1,0 +1,56 @@
+import Foundation
+import os
+import TBDShared
+
+private let scratchLogger = Logger(subsystem: "com.tbd.daemon", category: "scratchHandlers")
+
+extension RPCRouter {
+
+    func handleScratchCreate(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ScratchCreateParams.self, from: paramsData)
+        let fm = FileManager.default
+        let base = TBDConstants.scratchDir
+        try fm.createDirectory(at: base, withIntermediateDirectories: true)
+
+        var name = (params.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if name.isEmpty { name = NameGenerator.generate() }
+        var dir = base.appendingPathComponent(name)
+        var attempts = 0
+        // Regenerate on filesystem or DB-path collision.
+        while true {
+            let existsOnDisk = fm.fileExists(atPath: dir.path)
+            let existsInDB = try await db.worktrees.findByPath(path: dir.path) != nil
+            if !existsOnDisk && !existsInDB { break }
+            name = NameGenerator.generate()
+            dir = base.appendingPathComponent(name)
+            attempts += 1
+            if attempts > 50 { return RPCResponse(error: "Could not allocate a unique scratch name") }
+        }
+        // withIntermediateDirectories: false is deliberate: it makes this mkdir
+        // fail (rather than silently no-op) if `dir` already exists, which is
+        // exactly the case when a concurrent scratch.create raced us to the
+        // same name — the base directory above is already guaranteed to exist,
+        // so `false` here is safe. That failure surfaces before the DB insert,
+        // so the loser never reaches the orphan-cleanup catch below and can
+        // never delete a directory it didn't create (i.e. the race winner's).
+        try fm.createDirectory(at: dir, withIntermediateDirectories: false)
+
+        let tmuxServer = TmuxManager.serverName(forRepoPath: base.path)
+        let wt: Worktree
+        do {
+            wt = try await db.worktrees.createScratch(
+                name: name, displayName: name, path: dir.path, tmuxServer: tmuxServer)
+        } catch {
+            // Don't leave an orphan directory with no DB row behind — it
+            // would permanently block this name via the existsOnDisk check
+            // above with nothing to show for it.
+            try? fm.removeItem(at: dir)
+            throw error
+        }
+
+        subscriptions.broadcast(delta: .worktreeCreated(WorktreeDelta(
+            worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.path, status: wt.status)))
+        scratchLogger.info("scratch.create: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
+        return try RPCResponse(result: wt)
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -95,4 +95,76 @@ extension RPCRouter {
         subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: wt.id)))
         return .ok()
     }
+
+    func handleScratchPromote(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ScratchPromoteParams.self, from: paramsData)
+        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+            return RPCResponse(error: "Scratch space not found")
+        }
+        guard wt.isScratch else { return RPCResponse(error: "Not a scratch space") }
+        guard wt.promotedToRepoID == nil else { return RPCResponse(error: "Scratch space already promoted") }
+
+        let fm = FileManager.default
+        let dest = (params.destPath as NSString).standardizingPath
+
+        // Reject a dest inside TBD's own scratch area — same canonicalization
+        // + boundary check as the repo.add scratch guard (Task 7), so a
+        // symlink can't be used to bypass it either.
+        let canonDest = URL(fileURLWithPath: dest).resolvingSymlinksInPath().path
+        let canonScratchBase = URL(fileURLWithPath: TBDConstants.scratchDir.path).resolvingSymlinksInPath().path
+        guard canonDest != canonScratchBase, !canonDest.hasPrefix(canonScratchBase + "/") else {
+            return RPCResponse(error: "Destination is inside TBD's scratch area. Choose a location outside \(TBDConstants.scratchDir.path).")
+        }
+
+        guard !fm.fileExists(atPath: dest) else { return RPCResponse(error: "Destination already exists: \(dest)") }
+        guard fm.fileExists(atPath: wt.path) else { return RPCResponse(error: "Scratch directory missing on disk: \(wt.path)") }
+        guard await git.isGitRepo(path: wt.path) else {
+            return RPCResponse(error: "Scratch space is not a git repository. Run `git init` and commit before promoting.")
+        }
+        guard await git.hasCommits(path: wt.path) else {
+            return RPCResponse(error: "Scratch space has no commits. Commit your work before promoting.")
+        }
+
+        // Move the folder (same-volume rename keeps the running cwd valid).
+        do {
+            try fm.createDirectory(at: URL(fileURLWithPath: dest).deletingLastPathComponent(),
+                                   withIntermediateDirectories: true)
+            try fm.moveItem(atPath: wt.path, toPath: dest)
+        } catch {
+            return RPCResponse(error: "Failed to move scratch space to \(dest): \(error.localizedDescription)")
+        }
+
+        // Display-name priority: explicit flag > renamed-scratch-name > folder name.
+        let displayNameOverride: String?
+        if let explicit = params.displayName?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
+            displayNameOverride = explicit
+        } else if !wt.hasDefaultDisplayName {   // reuse stop-rename-check's default detection
+            displayNameOverride = wt.displayName
+        } else {
+            displayNameOverride = nil
+        }
+
+        let repo: Repo
+        do {
+            repo = try await addRepo(path: dest, displayNameOverride: displayNameOverride)
+        } catch {
+            // The folder already moved but registration failed — best-effort
+            // move it back so the row (still un-promoted) and the filesystem
+            // agree on where the scratch space lives. If even that fails, the
+            // error says exactly where the folder ended up so it isn't lost.
+            do {
+                try fm.moveItem(atPath: dest, toPath: wt.path)
+                return RPCResponse(error: "Failed to register \(dest) as a repo: \(error.localizedDescription). Moved the folder back to \(wt.path); nothing was promoted.")
+            } catch let moveBackError {
+                scratchLogger.error("scratch.promote: move-back failed after addRepo failure for \(wt.id, privacy: .public): \(moveBackError.localizedDescription, privacy: .public)")
+                return RPCResponse(error: "Failed to register \(dest) as a repo: \(error.localizedDescription). The folder could NOT be moved back to \(wt.path) (\(moveBackError.localizedDescription)) — it currently still lives at \(dest); the scratch row was not marked promoted.")
+            }
+        }
+        try await db.worktrees.setPromotedToRepoID(id: wt.id, repoID: repo.id)
+        // .repoAdded (broadcast by addRepo) prompts the app to refresh state; the
+        // scratch row's promotedToRepoID surfaces on the next worktree poll.
+        scratchLogger.info("scratch.promote: \(wt.id, privacy: .public) -> repo \(repo.id, privacy: .public) at \(dest, privacy: .public)")
+        return try RPCResponse(result: ScratchPromoteResult(
+            worktreeID: wt.id, repoID: repo.id, repoPath: repo.path, repoDisplayName: repo.displayName))
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -53,4 +53,46 @@ extension RPCRouter {
         scratchLogger.info("scratch.create: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
         return try RPCResponse(result: wt)
     }
+
+    func handleScratchDelete(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ScratchDeleteParams.self, from: paramsData)
+        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+            return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
+        }
+        guard wt.isScratch else {
+            return RPCResponse(error: "Not a scratch space: \(params.worktreeID)")
+        }
+
+        // Close terminals: kill tmux windows, delete terminals + tabs, clear
+        // pending questions + per-session overlays (mirrors forgetWorktree).
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        for t in terminals {
+            try? await tmux.killWindow(server: wt.tmuxServer, windowID: t.tmuxWindowID)
+        }
+        try await db.terminals.deleteForWorktree(worktreeID: wt.id)
+        try await db.tabs.deleteForWorktree(worktreeID: wt.id)
+        for t in terminals {
+            await pendingQuestions.clear(terminalID: t.id)
+            ClaudeHookOverlay.removePerSessionOverlay(sessionKey: t.id.uuidString)
+        }
+
+        // Move the folder to Trash — never rm -rf. Promoted rows already had
+        // their folder moved by promotion, so skip when promotedToRepoID != nil.
+        // (promotedToRepoID is nil for every row today — Task 8 introduces
+        // `scratch promote`, which will start setting it — so this branch is
+        // currently dead but load-bearing once promotion lands.)
+        if wt.promotedToRepoID == nil, FileManager.default.fileExists(atPath: wt.path) {
+            var resulting: NSURL?
+            do {
+                try FileManager.default.trashItem(at: URL(fileURLWithPath: wt.path), resultingItemURL: &resulting)
+            } catch {
+                scratchLogger.warning("scratch.delete: trashItem failed for \(wt.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return RPCResponse(error: "Could not move folder to Trash: \(error.localizedDescription)")
+            }
+        }
+
+        try await db.worktrees.delete(id: wt.id)
+        subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: wt.id)))
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -211,12 +211,7 @@ extension RPCRouter {
             let sessionID = UUID().uuidString
             claudeSessionID = sessionID
             freshSessionID = sessionID
-            if let repo,
-               let prompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false) {
-                appendSystemPrompt = prompt
-            } else {
-                appendSystemPrompt = nil
-            }
+            appendSystemPrompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false)
             label = TerminalLabel.claudeCode
         } else if let cmd = params.cmd {
             claudeSessionID = nil
@@ -715,9 +710,7 @@ extension RPCRouter {
             scheduleRecapture = true
         case .fresh(let newSessionID):
             logger.debug("swap: blank session — spawning fresh \(newSessionID, privacy: .public)")
-            let appendPrompt = repo.flatMap {
-                SystemPromptBuilder.build(repo: $0, worktree: worktree, isResume: false)
-            }
+            let appendPrompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false)
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,
                 freshSessionID: newSessionID,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -88,7 +88,12 @@ extension RPCRouter {
         await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
 
         // Look up repo once for system prompt env vars and Claude session setup
-        let repo = try await db.repos.get(id: worktree.repoID)
+        let repo: Repo?
+        if let rid = worktree.repoID {
+            repo = try await db.repos.get(id: rid)
+        } else {
+            repo = nil
+        }
 
         // Fetch config once for both the typed Claude env overrides and the
         // free-form env overrides (global < repo < profile). The profile scope
@@ -405,7 +410,12 @@ extension RPCRouter {
             // recreated Codex pane keeps them. No profile is resolved here, so the
             // profile scope is nil.
             let recreateConfig = try? await db.config.get()
-            let recreateRepo = try? await db.repos.get(id: worktree.repoID)
+            let recreateRepo: Repo?
+            if let rid = worktree.repoID {
+                recreateRepo = try? await db.repos.get(id: rid)
+            } else {
+                recreateRepo = nil
+            }
             let codexEnvOverrides = EnvOverrideResolver.merge(
                 global: recreateConfig?.envOverrides,
                 repo: recreateRepo?.envOverrides,
@@ -647,7 +657,12 @@ extension RPCRouter {
         // blank — JSONL never written or no real entries — resuming it would
         // produce "no conversation found" and chaotic behavior, so we instead
         // spawn a brand-new session and skip the recapture.
-        let repo = try await db.repos.get(id: worktree.repoID)
+        let repo: Repo?
+        if let rid = worktree.repoID {
+            repo = try await db.repos.get(id: rid)
+        } else {
+            repo = nil
+        }
         let plannedTerminalID = UUID()
         var env = SystemPromptBuilder.promptLayers(repo: repo, worktree: worktree)
         env["TBD_WORKTREE_ID"] = worktree.id.uuidString

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -37,7 +37,10 @@ extension RPCRouter {
         // Pass the raw branch ref (possibly `origin/...`) to phase 2 so it
         // can dispatch to the right git command.
         let existingBranchRef = useExistingBranch ? params.branch : nil
-        await repoSerializer.submit(repoID: pending.repoID) {
+        // handleWorktreeCreate is always repo-scoped (scratch creation uses a
+        // separate RPC), so params.repoID is the reliable non-optional source
+        // — pending.repoID mirrors it but is now UUID? on the shared model.
+        await repoSerializer.submit(repoID: params.repoID) {
             do {
                 let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef)
                 switch completion {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -103,6 +103,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRepoRemove(request.paramsData)
             case RPCMethod.repoList:
                 return try await handleRepoList()
+            case RPCMethod.scratchCreate:
+                return try await handleScratchCreate(request.paramsData)
             case RPCMethod.repoUpdateInstructions:
                 return try await handleRepoUpdateInstructions(request.paramsData)
             case RPCMethod.repoRelocate:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -105,6 +105,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRepoList()
             case RPCMethod.scratchCreate:
                 return try await handleScratchCreate(request.paramsData)
+            case RPCMethod.scratchDelete:
+                return try await handleScratchDelete(request.paramsData)
             case RPCMethod.repoUpdateInstructions:
                 return try await handleRepoUpdateInstructions(request.paramsData)
             case RPCMethod.repoRelocate:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -314,7 +314,7 @@ public final class RPCRouter: Sendable {
     /// `PRListCoordinator` propagates the error to every concurrent caller.
     private func computePRList() async throws -> PRListResult {
         // Fetch fresh PR data for all active worktrees before returning the cache.
-        let worktrees = try await db.worktrees.list(status: .active)
+        let worktrees = Self.pollableWorktrees(try await db.worktrees.list(status: .active))
         var infos: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String)] = []
         infos.reserveCapacity(worktrees.count)
         for wt in worktrees {
@@ -337,6 +337,14 @@ public final class RPCRouter: Sendable {
         // Prune at the END so we never drop an entry this pass just populated.
         await upstreamBranchCache.retain(active: infos.map { (worktreePath: $0.worktreePath, branch: $0.branch) })
         return PRListResult(statuses: await prManager.allStatuses())
+    }
+
+    /// Scratch spaces are repo-less and have no PR — exclude them so the
+    /// poller's "all worktrees share one repo" assumption holds. Pulled out
+    /// as a pure function (rather than inlined `.filter` in `computePRList`)
+    /// so it's directly unit-testable without spinning up git/gh machinery.
+    static func pollableWorktrees(_ worktrees: [Worktree]) -> [Worktree] {
+        worktrees.filter { !$0.isScratch }
     }
 
     private func handlePRRefresh(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -107,6 +107,8 @@ public final class RPCRouter: Sendable {
                 return try await handleScratchCreate(request.paramsData)
             case RPCMethod.scratchDelete:
                 return try await handleScratchDelete(request.paramsData)
+            case RPCMethod.scratchPromote:
+                return try await handleScratchPromote(request.paramsData)
             case RPCMethod.repoUpdateInstructions:
                 return try await handleRepoUpdateInstructions(request.paramsData)
             case RPCMethod.repoRelocate:

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -65,6 +65,12 @@ public enum TBDConstants {
     }
     public static var reposDir: URL { reposDir(environment: ProcessInfo.processInfo.environment) }
 
+    /// Base directory holding all scratch spaces: `~/tbd/scratch`. Honors TBD_HOME.
+    public static func scratchDir(environment: [String: String]) -> URL {
+        configDir(environment: environment).appendingPathComponent("scratch")
+    }
+    public static var scratchDir: URL { scratchDir(environment: ProcessInfo.processInfo.environment) }
+
     public static func hookPath(repoID: UUID, eventName: String, environment: [String: String]) -> String {
         reposDir(environment: environment)
             .appendingPathComponent(repoID.uuidString)

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -105,7 +105,8 @@ public enum PrimaryAgentPreference: String, Codable, Sendable, Equatable, CaseIt
 
 public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
-    public var repoID: UUID
+    /// nil for scratch spaces (repo-less worktrees).
+    public var repoID: UUID?
     public var name: String
     public var displayName: String
     public var branch: String
@@ -137,7 +138,13 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// PR poll; the app seeds from this only when it has no fresher live value.
     public var prStatus: PRStatus?
 
-    public init(id: UUID = UUID(), repoID: UUID, name: String, displayName: String,
+    /// Set only on promoted scratch rows: the repo created by `tbd scratch promote`.
+    public var promotedToRepoID: UUID?
+
+    /// A scratch space is a repo-less worktree. Derived — no separate column.
+    public var isScratch: Bool { repoID == nil }
+
+    public init(id: UUID = UUID(), repoID: UUID?, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
                 hasConflicts: Bool = false,
                 createdAt: Date = Date(), archivedAt: Date? = nil, tmuxServer: String,
@@ -146,6 +153,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 liveClaudeSessionCount: Int? = nil,
                 parentWorktreeID: UUID? = nil,
                 autoArchiveOnMerge: Bool? = nil,
+                promotedToRepoID: UUID? = nil,
                 prStatus: PRStatus? = nil) {
         self.id = id
         self.repoID = repoID
@@ -164,6 +172,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.liveClaudeSessionCount = liveClaudeSessionCount
         self.parentWorktreeID = parentWorktreeID
         self.autoArchiveOnMerge = autoArchiveOnMerge
+        self.promotedToRepoID = promotedToRepoID
         self.prStatus = prStatus
     }
 
@@ -171,13 +180,14 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         case id, repoID, name, displayName, branch, path, status
         case hasConflicts, createdAt, archivedAt, tmuxServer
         case archivedClaudeSessions, sortOrder, archivedHeadSHA
-        case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge, prStatus
+        case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge
+        case promotedToRepoID, prStatus
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(UUID.self, forKey: .id)
-        repoID = try c.decode(UUID.self, forKey: .repoID)
+        repoID = try c.decodeIfPresent(UUID.self, forKey: .repoID)
         name = try c.decode(String.self, forKey: .name)
         displayName = try c.decode(String.self, forKey: .displayName)
         branch = try c.decode(String.self, forKey: .branch)
@@ -193,6 +203,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         liveClaudeSessionCount = try c.decodeIfPresent(Int.self, forKey: .liveClaudeSessionCount)
         parentWorktreeID = try c.decodeIfPresent(UUID.self, forKey: .parentWorktreeID)
         autoArchiveOnMerge = try c.decodeIfPresent(Bool.self, forKey: .autoArchiveOnMerge)
+        promotedToRepoID = try c.decodeIfPresent(UUID.self, forKey: .promotedToRepoID)
         prStatus = try c.decodeIfPresent(PRStatus.self, forKey: .prStatus)
     }
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -144,6 +144,12 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// A scratch space is a repo-less worktree. Derived — no separate column.
     public var isScratch: Bool { repoID == nil }
 
+    /// True when `displayName` has never been customized away from the
+    /// auto-generated `name`. Single source of truth for "still default"
+    /// shared by the `stop-rename-check` hook (skip firing when already
+    /// customized) and `scratch promote` (display-name fallback priority).
+    public var hasDefaultDisplayName: Bool { displayName == name }
+
     public init(id: UUID = UUID(), repoID: UUID?, name: String, displayName: String,
                 branch: String, path: String, status: WorktreeStatus = .active,
                 hasConflicts: Bool = false,

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -161,6 +161,9 @@ public enum RPCMethod {
     public static let worktreeSetAutoArchive = "worktree.setAutoArchive"
     public static let configGet = "config.get"
     public static let configSetAutoArchiveOnMergeDefault = "config.setAutoArchiveOnMergeDefault"
+    public static let scratchCreate = "scratch.create"
+    public static let scratchDelete = "scratch.delete"
+    public static let scratchPromote = "scratch.promote"
 }
 
 // MARK: - Branch Listing
@@ -529,6 +532,36 @@ public struct PRRefreshResult: Codable, Sendable {
 public struct RepoAddParams: Codable, Sendable {
     public let path: String
     public init(path: String) { self.path = path }
+}
+
+public struct ScratchCreateParams: Codable, Sendable {
+    public let name: String?
+    public init(name: String? = nil) { self.name = name }
+}
+
+public struct ScratchDeleteParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public init(worktreeID: UUID) { self.worktreeID = worktreeID }
+}
+
+public struct ScratchPromoteParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let destPath: String
+    public let displayName: String?
+    public init(worktreeID: UUID, destPath: String, displayName: String? = nil) {
+        self.worktreeID = worktreeID; self.destPath = destPath; self.displayName = displayName
+    }
+}
+
+public struct ScratchPromoteResult: Codable, Sendable {
+    public let worktreeID: UUID
+    public let repoID: UUID
+    public let repoPath: String
+    public let repoDisplayName: String
+    public init(worktreeID: UUID, repoID: UUID, repoPath: String, repoDisplayName: String) {
+        self.worktreeID = worktreeID; self.repoID = repoID
+        self.repoPath = repoPath; self.repoDisplayName = repoDisplayName
+    }
 }
 
 public struct RepoRemoveParams: Codable, Sendable {

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -56,11 +56,11 @@ public struct TerminalActivityDelta: Codable, Sendable {
 /// Delta payload for worktree creation/revival.
 public struct WorktreeDelta: Codable, Sendable {
     public let worktreeID: UUID
-    public let repoID: UUID
+    public let repoID: UUID?
     public let name: String
     public let path: String
     public let status: WorktreeStatus?
-    public init(worktreeID: UUID, repoID: UUID, name: String, path: String, status: WorktreeStatus? = nil) {
+    public init(worktreeID: UUID, repoID: UUID?, name: String, path: String, status: WorktreeStatus? = nil) {
         self.worktreeID = worktreeID; self.repoID = repoID
         self.name = name; self.path = path; self.status = status
     }

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -142,6 +142,20 @@ tbd notify --type {response_complete|error|task_complete|attention_needed} --mes
 tbd link [<worktree>]   # no arg = current
 ```
 
+## Scratch spaces & promotion
+
+A **scratch space** is a repo-less TBD workspace (`~/tbd/scratch/<name>`) with no
+git repo. Use `tbd scratch new` to make one, `tbd scratch list` to list them.
+
+When a scratch project takes shape, offer the user promotion: ask for a
+destination path, then run `tbd scratch promote <dest-path>` from a session
+inside the scratch space. Promotion requires the scratch directory to be a git
+repository with at least one commit — run `git init` and make an initial commit
+before promoting. Promotion then moves the folder to the destination and
+registers it as a real TBD repo. Add `--display-name <name>` to override the
+repo name. Do not `git init` and leave it a scratch space forever — promotion
+is the graduation path.
+
 ## Briefing requirements when spawning sessions
 
 Always include:

--- a/Tests/TBDAppTests/PreSessionAppStateTests.swift
+++ b/Tests/TBDAppTests/PreSessionAppStateTests.swift
@@ -56,7 +56,8 @@ struct PreSessionAppStateTests {
     @discardableResult
     private func seedWorktree(_ state: AppState, status: WorktreeStatus) -> Worktree {
         let wt = makeWorktree(status: status)
-        state.worktrees[wt.repoID] = [wt]
+        // makeWorktree() always assigns a real repoID (never a scratch space).
+        state.worktrees[wt.repoID!] = [wt]
         return wt
     }
 

--- a/Tests/TBDAppTests/ScratchRowDimmingTests.swift
+++ b/Tests/TBDAppTests/ScratchRowDimmingTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+@testable import TBDApp
+@testable import TBDShared
+
+/// Direct, falsifiable proof of `WorktreeRowView`'s scratch-row dimming rule,
+/// mirroring `ScratchSectionVisibleTests`'s pattern of testing the extracted
+/// pure function instead of live view behavior. Exercises
+/// `AppState.scratchRowIsDimmed` in isolation — no SwiftUI render, no
+/// `FileManager` I/O — so a regression in the promoted/missing-dir interplay
+/// fails this test immediately instead of surfacing as a silently-wrong
+/// opacity in the sidebar.
+@MainActor
+@Suite("scratchRowIsDimmed gate")
+struct ScratchRowDimmingTests {
+    private func makeWorktree(
+        repoID: UUID?,
+        promotedToRepoID: UUID? = nil
+    ) -> Worktree {
+        Worktree(
+            repoID: repoID, name: "s", displayName: "s", branch: "",
+            path: "/tmp/scratch-\(UUID().uuidString)", tmuxServer: "tbd-scratch",
+            promotedToRepoID: promotedToRepoID)
+    }
+
+    @Test("un-promoted scratch with a missing directory dims")
+    func unpromotedScratchMissingDirDims() {
+        let worktree = makeWorktree(repoID: nil)
+        #expect(AppState.scratchRowIsDimmed(worktree, directoryExists: false))
+    }
+
+    @Test("promoted scratch with a missing directory does NOT dim")
+    func promotedScratchMissingDirDoesNotDim() {
+        let worktree = makeWorktree(repoID: nil, promotedToRepoID: UUID())
+        #expect(!AppState.scratchRowIsDimmed(worktree, directoryExists: false))
+    }
+
+    @Test("un-promoted scratch with its directory present does NOT dim")
+    func unpromotedScratchDirPresentDoesNotDim() {
+        let worktree = makeWorktree(repoID: nil)
+        #expect(!AppState.scratchRowIsDimmed(worktree, directoryExists: true))
+    }
+
+    @Test("non-scratch worktree never dims, regardless of promoted/dir state")
+    func nonScratchWorktreeNeverDims() {
+        let worktree = makeWorktree(repoID: UUID(), promotedToRepoID: nil)
+        #expect(!AppState.scratchRowIsDimmed(worktree, directoryExists: false))
+        #expect(!AppState.scratchRowIsDimmed(worktree, directoryExists: true))
+
+        let promotedButNonScratch = makeWorktree(repoID: UUID(), promotedToRepoID: UUID())
+        #expect(!AppState.scratchRowIsDimmed(promotedButNonScratch, directoryExists: false))
+    }
+}

--- a/Tests/TBDAppTests/ShowScratchSectionSettingTests.swift
+++ b/Tests/TBDAppTests/ShowScratchSectionSettingTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import Foundation
+@testable import TBDApp
+@testable import TBDShared
+
+@MainActor
+@Suite("showScratchSection setting")
+struct ShowScratchSectionSettingTests {
+    @Test func defaultsToOn() {
+        let suiteName = "scratch-\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: suiteName)!
+        defer { d.removePersistentDomain(forName: suiteName) }
+        // No stored value → @AppStorage default (true) applies at the view; assert
+        // the key convention and both explicit branches persist as written.
+        #expect(d.object(forKey: AppState.showScratchSectionKey) == nil)
+        d.set(false, forKey: AppState.showScratchSectionKey)
+        #expect(d.bool(forKey: AppState.showScratchSectionKey) == false)
+        d.set(true, forKey: AppState.showScratchSectionKey)
+        #expect(d.bool(forKey: AppState.showScratchSectionKey) == true)
+    }
+}
+
+/// Direct, falsifiable proof of the sidebar's Scratch-section gate, mirroring
+/// `ScratchExclusionTests.pollableWorktreesDiscriminatesScratchFromRegular`'s
+/// pattern of testing the extracted pure function instead of live view
+/// behavior. Exercises `AppState.scratchSectionVisible` in isolation — no
+/// SwiftUI render, no `@EnvironmentObject` — so an inverted or dropped gate
+/// fails this test immediately.
+@MainActor
+@Suite("scratchSectionVisible gate")
+struct ScratchSectionVisibleTests {
+    private func makeSpace() -> Worktree {
+        Worktree(
+            repoID: nil, name: "s", displayName: "s", branch: "",
+            path: "/tmp/scratch-\(UUID().uuidString)", tmuxServer: "tbd-scratch")
+    }
+
+    @Test("on + spaces present shows the section")
+    func onWithSpacesShows() {
+        #expect(AppState.scratchSectionVisible(setting: true, spaces: [makeSpace()]))
+    }
+
+    @Test("off + spaces present hides the section")
+    func offWithSpacesHides() {
+        #expect(!AppState.scratchSectionVisible(setting: false, spaces: [makeSpace()]))
+    }
+
+    @Test("on + no spaces hides the section")
+    func onWithNoSpacesHides() {
+        #expect(!AppState.scratchSectionVisible(setting: true, spaces: []))
+    }
+
+    @Test("toggling the setting never mutates the spaces array")
+    func toggleDoesNotMutateData() {
+        let spaces = [makeSpace(), makeSpace()]
+        let originalCount = spaces.count
+        _ = AppState.scratchSectionVisible(setting: true, spaces: spaces)
+        _ = AppState.scratchSectionVisible(setting: false, spaces: spaces)
+        #expect(spaces.count == originalCount)
+    }
+}

--- a/Tests/TBDCLITests/StopRenameCheckCommandTests.swift
+++ b/Tests/TBDCLITests/StopRenameCheckCommandTests.swift
@@ -43,7 +43,8 @@ struct StopRenameCheckCommandTests {
         worktree: StopRenameCheckCore.WorktreeSummary? = .init(
             name: "20260515-surprised-giraffe",
             displayName: "20260515-surprised-giraffe",
-            status: .active
+            status: .active,
+            hasDefaultDisplayName: true
         ),
         branch: String? = "tbd/20260515-surprised-giraffe",
         folder: String? = "20260515-surprised-giraffe",
@@ -104,7 +105,7 @@ struct StopRenameCheckCommandTests {
         let out = StopRenameCheckCore.decide(
             stdinData: Self.payload(),
             dependencies: Self.deps(
-                worktree: .init(name: "main", displayName: "main", status: .main),
+                worktree: .init(name: "main", displayName: "main", status: .main, hasDefaultDisplayName: true),
                 counterDirectory: dir
             )
         )
@@ -117,7 +118,7 @@ struct StopRenameCheckCommandTests {
         let out = StopRenameCheckCore.decide(
             stdinData: Self.payload(),
             dependencies: Self.deps(
-                worktree: .init(name: "raw-folder", displayName: "🦒 My Cool Feature", status: .active),
+                worktree: .init(name: "raw-folder", displayName: "🦒 My Cool Feature", status: .active, hasDefaultDisplayName: false),
                 counterDirectory: dir
             )
         )

--- a/Tests/TBDDaemonTests/MigrationV35Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV35Tests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct MigrationV35Tests {
+
+    @Test func repoIDBecomesNullableAndPromotedColumnAdded() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v34_worktree_pr_status")
+
+        // Seed a pre-v35 repo + worktree row via raw SQL (repoID NOT NULL era).
+        let repoID = "11111111-1111-1111-1111-111111111111"
+        let wtID = "22222222-2222-2222-2222-222222222222"
+        try queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                VALUES (?, '/tmp/v35-repo', 'V35', 'main', ?)
+                """, arguments: [repoID, Date()])
+            try db.execute(sql: """
+                INSERT INTO worktree (id, repoID, name, displayName, branch, path, status, createdAt, tmuxServer)
+                VALUES (?, ?, 'w', 'w', 'main', '/tmp/v35-wt', 'active', ?, 'tbd-v35')
+                """, arguments: [wtID, repoID, Date()])
+        }
+
+        // Run v35.
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let cols = try Row.fetchAll(db, sql: "PRAGMA table_info(worktree)")
+            let repoIDCol = cols.first { ($0["name"] as String?) == "repoID" }
+            #expect((repoIDCol?["notnull"] as Int?) == 0, "repoID must be nullable after v35")
+            let names = cols.compactMap { $0["name"] as String? }
+            #expect(names.contains("promotedToRepoID"))
+            // Old row survived the rebuild.
+            let count = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM worktree WHERE id = ?", arguments: [wtID]) ?? -1
+            #expect(count == 1)
+        }
+    }
+
+    @Test func scratchRowWithNullRepoIDRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await db.worktrees.createScratch(
+            name: "20260702-worrying-pike", displayName: "20260702-worrying-pike",
+            path: "/tmp/scratch-\(UUID().uuidString)", tmuxServer: "tbd-scratch")
+        #expect(wt.repoID == nil)
+        #expect(wt.isScratch)
+        let fetched = try await db.worktrees.get(id: wt.id)
+        #expect(fetched?.repoID == nil)
+        #expect(fetched?.isScratch == true)
+        #expect(fetched?.branch == "")
+    }
+}

--- a/Tests/TBDDaemonTests/RepoAddScratchGuardTests.swift
+++ b/Tests/TBDDaemonTests/RepoAddScratchGuardTests.swift
@@ -1,0 +1,117 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+extension TBDHomeSerialized {
+@Suite("repo.add scratch guard")
+struct RepoAddScratchGuardTests {
+    @Test func rejectsPathUnderScratchDir() async throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("tbd-addguard-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: home) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+
+        let scratchChild = TBDConstants.scratchDir.appendingPathComponent("some-project").path
+        try FileManager.default.createDirectory(atPath: scratchChild, withIntermediateDirectories: true)
+
+        let response = await router.handle(try RPCRequest(method: RPCMethod.repoAdd, params: RepoAddParams(path: scratchChild)))
+        #expect(!response.success)
+        #expect(response.error?.contains("tbd scratch promote") == true)
+    }
+
+    @Test func acceptsPathOutsideScratchDir() async throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("tbd-addguard-normal-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: home) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+
+        // Create a temporary git repo outside the scratch directory
+        let repoPath = FileManager.default.temporaryDirectory.appendingPathComponent("normal-repo-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repoPath, withIntermediateDirectories: true)
+
+        // Initialize a git repo
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "init"]
+        process.currentDirectoryURL = repoPath
+        try process.run()
+        process.waitUntilExit()
+
+        // Set git config
+        let configProcess = Process()
+        configProcess.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        configProcess.arguments = ["git", "config", "user.email", "test@test.com"]
+        configProcess.currentDirectoryURL = repoPath
+        try configProcess.run()
+        configProcess.waitUntilExit()
+
+        let nameProcess = Process()
+        nameProcess.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        nameProcess.arguments = ["git", "config", "user.name", "Test"]
+        nameProcess.currentDirectoryURL = repoPath
+        try nameProcess.run()
+        nameProcess.waitUntilExit()
+
+        // Create initial commit
+        try "# Test".write(to: repoPath.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        let addProcess = Process()
+        addProcess.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        addProcess.arguments = ["git", "add", "README.md"]
+        addProcess.currentDirectoryURL = repoPath
+        try addProcess.run()
+        addProcess.waitUntilExit()
+
+        let commitProcess = Process()
+        commitProcess.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        commitProcess.arguments = ["git", "commit", "-m", "initial commit"]
+        commitProcess.currentDirectoryURL = repoPath
+        try commitProcess.run()
+        commitProcess.waitUntilExit()
+
+        let response = await router.handle(try RPCRequest(method: RPCMethod.repoAdd, params: RepoAddParams(path: repoPath.path)))
+        #expect(response.success)
+        #expect(response.error == nil)
+    }
+
+    @Test func rejectsSymlinkBypassToScratchDir() async throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("tbd-addguard-symlink-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: home) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+
+        // Create a scratch child directory
+        let scratchChild = TBDConstants.scratchDir.appendingPathComponent("symlink-test-project")
+        try FileManager.default.createDirectory(at: scratchChild, withIntermediateDirectories: true)
+
+        // Create a symlink elsewhere that points to the scratch child
+        let symlinkParent = FileManager.default.temporaryDirectory.appendingPathComponent("symlink-parent-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: symlinkParent, withIntermediateDirectories: true)
+        let symlinkPath = symlinkParent.appendingPathComponent("link-to-scratch")
+        try FileManager.default.createSymbolicLink(at: symlinkPath, withDestinationURL: scratchChild)
+
+        // Try to add via the symlink path - should still be rejected
+        let response = await router.handle(try RPCRequest(method: RPCMethod.repoAdd, params: RepoAddParams(path: symlinkPath.path)))
+        #expect(!response.success)
+        #expect(response.error?.contains("tbd scratch promote") == true)
+    }
+}
+}

--- a/Tests/TBDDaemonTests/ScratchCreateRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchCreateRPCTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+extension TBDHomeSerialized {
+@Suite("scratch.create RPC")
+struct ScratchCreateRPCTests {
+    private func isolateTBDHome() -> (home: URL, cleanup: () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-scratchcreate-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        return (home, { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: home) })
+    }
+
+    @Test func createsRepoLessWorktreeRowAndDirectory() async throws {
+        let iso = isolateTBDHome(); defer { iso.cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+
+        let request = try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil))
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let wt = try response.decodeResult(Worktree.self)
+        #expect(wt.repoID == nil)
+        #expect(wt.isScratch)
+        #expect(wt.path.hasPrefix(TBDConstants.scratchDir.path))
+        #expect(FileManager.default.fileExists(atPath: wt.path))
+        let all = try await db.worktrees.listScratch()
+        #expect(all.count == 1)
+    }
+
+    @Test func honorsExplicitNameAndRegeneratesOnCollision() async throws {
+        let iso = isolateTBDHome(); defer { iso.cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+
+        let r1 = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "notes")))
+        let w1 = try r1.decodeResult(Worktree.self)
+        #expect(w1.name == "notes")
+        // Second create with the same name must not collide on the unique path.
+        let r2 = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "notes")))
+        let w2 = try r2.decodeResult(Worktree.self)
+        #expect(w2.path != w1.path)
+    }
+}
+}

--- a/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
@@ -1,0 +1,99 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+extension TBDHomeSerialized {
+@Suite("scratch.delete RPC")
+struct ScratchDeleteRPCTests {
+    private func isolateTBDHome() -> (URL, () -> Void) {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("tbd-scratchdel-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        return (home, { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: home) })
+    }
+
+    @Test func deletesRowAndTrashesFolder() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "gone")))
+        let wt = try created.decodeResult(Worktree.self)
+        #expect(FileManager.default.fileExists(atPath: wt.path))
+
+        let del = await router.handle(try RPCRequest(method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: wt.id)))
+        #expect(del.success)
+        #expect(try await db.worktrees.get(id: wt.id) == nil)
+        #expect(!FileManager.default.fileExists(atPath: wt.path))  // moved to Trash
+    }
+
+    @Test func closesTerminalsAndTabsBeforeDeleting() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "with-terminal")))
+        let wt = try created.decodeResult(Worktree.self)
+
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        try await db.tabs.setLabel(tabID: terminal.id, worktreeID: wt.id, label: "my tab")
+
+        #expect(try await db.terminals.list(worktreeID: wt.id).count == 1)
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).count == 1)
+
+        let del = await router.handle(try RPCRequest(method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: wt.id)))
+        #expect(del.success)
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).isEmpty)
+        #expect(try await db.worktrees.get(id: wt.id) == nil)
+    }
+
+    /// Forces `FileManager.trashItem` to fail deterministically by stripping
+    /// write permission from the scratch space's *parent* directory (trashItem
+    /// must remove the entry from its containing directory, so a read-only
+    /// parent reliably yields NSCocoaErrorDomain 513 "couldn't be moved to the
+    /// trash"). Verifies the finding-1 fix: on trash failure the row survives
+    /// and an error is returned, instead of silently deleting the row while
+    /// orphaning the folder.
+    @Test func keepsRowWhenTrashFails() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "undeletable")))
+        let wt = try created.decodeResult(Worktree.self)
+
+        let parent = TBDConstants.scratchDir
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: parent.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: parent.path) }
+
+        let del = await router.handle(try RPCRequest(method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: wt.id)))
+        #expect(!del.success)
+        #expect(del.error != nil)
+        #expect(try await db.worktrees.get(id: wt.id) != nil)  // row survives so a retry is possible
+        #expect(FileManager.default.fileExists(atPath: wt.path))  // folder untouched
+    }
+
+    @Test func rejectsNonScratchWorktree() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let wt = try await db.worktrees.create(repoID: repo.id, name: "w", branch: "b",
+                                               path: "/tmp/w-\(UUID().uuidString)", tmuxServer: "tbd-x")
+        let del = await router.handle(try RPCRequest(method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: wt.id)))
+        #expect(!del.success)
+    }
+}
+}

--- a/Tests/TBDDaemonTests/ScratchExclusionTests.swift
+++ b/Tests/TBDDaemonTests/ScratchExclusionTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import Foundation
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("Scratch exclusion by construction")
+struct ScratchExclusionTests {
+
+    /// Direct, falsifiable proof of the poller guard: a scratch worktree is
+    /// dropped and a regular (repo-scoped) worktree is kept. Exercises
+    /// `RPCRouter.pollableWorktrees` in isolation — no git/gh machinery, no
+    /// dependence on `PRStatusManager`'s incidental empty-branch behavior —
+    /// so an inverted or deleted filter fails this test immediately.
+    @Test("pollableWorktrees drops scratch rows and keeps regular rows")
+    func pollableWorktreesDiscriminatesScratchFromRegular() {
+        let regular = Worktree(
+            repoID: UUID(), name: "r", displayName: "r", branch: "tbd/r",
+            path: "/tmp/regular", tmuxServer: "tbd-r")
+        let scratch = Worktree(
+            repoID: nil, name: "s", displayName: "s", branch: "",
+            path: "/tmp/scratch", tmuxServer: "tbd-scratch")
+
+        let pollable = RPCRouter.pollableWorktrees([regular, scratch])
+
+        #expect(pollable.map(\.id) == [regular.id])
+        #expect(!pollable.contains { $0.id == scratch.id })
+    }
+
+    @Test("pr.list never includes a scratch worktree")
+    func prListExcludesScratch() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+        let scratch = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: "/tmp/scr-\(UUID().uuidString)", tmuxServer: "tbd-scratch")
+
+        let response = await router.handle(RPCRequest(method: RPCMethod.prList))
+        #expect(response.success)
+        let result = try response.decodeResult(PRListResult.self)
+        #expect(result.statuses[scratch.id] == nil)
+    }
+
+    @Test("reconcile only ever lists worktrees scoped to a repoID")
+    func reconcileIsRepoScoped() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver())
+        let scratch = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: "/tmp/scr-\(UUID().uuidString)", tmuxServer: "tbd-scratch")
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Reconcile is entered per repo and scopes its worktree lookups to
+        // that repoID — a scratch row (repoID == nil) can never be in scope,
+        // even when the repo itself is real and reconcile runs to completion.
+        try await lifecycle.reconcile(repoID: repo.id)
+        let after = try await db.worktrees.get(id: scratch.id)
+        #expect(after != nil)               // untouched
+        #expect(after?.status == .active)   // not archived
+        #expect(after?.repoID == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
@@ -1,0 +1,203 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+extension TBDHomeSerialized {
+@Suite("scratch.promote RPC")
+struct ScratchPromoteRPCTests {
+    private func isolate() -> (URL, () -> Void) {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("tbd-promote-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        return (home, { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: home) })
+    }
+
+    private func makeRouter(_ db: TBDDatabase) -> RPCRouter {
+        RPCRouter(db: db,
+                  lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+                  tmux: TmuxManager(dryRun: true), startTime: Date())
+    }
+
+    private func gitInitCommit(at path: String) throws {
+        for args in [["init"], ["-c","user.email=t@t","-c","user.name=t","commit","--allow-empty","-m","init"]] {
+            let p = Process(); p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = ["-C", path] + args; try p.run(); p.waitUntilExit()
+        }
+    }
+
+    @Test func happyPathMovesRegistersAndMarksPromoted() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)
+        try gitInitCommit(at: wt.path)
+
+        let dest = home.appendingPathComponent("projects/myapp").path
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(resp.success)
+        let result = try resp.decodeResult(ScratchPromoteResult.self)
+        #expect(FileManager.default.fileExists(atPath: dest))
+        #expect(!FileManager.default.fileExists(atPath: wt.path))
+        let row = try await db.worktrees.get(id: wt.id)
+        #expect(row?.promotedToRepoID == result.repoID)
+        #expect(try await db.repos.get(id: result.repoID) != nil)
+    }
+
+    @Test func noGitLeavesEverythingUntouched() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)   // no git init
+
+        let dest = home.appendingPathComponent("projects/nope").path
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(!resp.success)
+        #expect(FileManager.default.fileExists(atPath: wt.path))       // not moved
+        #expect(!FileManager.default.fileExists(atPath: dest))         // dest not created
+        #expect(try await db.worktrees.get(id: wt.id)?.promotedToRepoID == nil)
+    }
+
+    @Test func displayNamePriority_renamedScratchWins() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        var wt = try created.decodeResult(Worktree.self)
+        try await db.worktrees.rename(id: wt.id, displayName: "My Cool App")  // displayName != name now
+        wt = try await db.worktrees.get(id: wt.id)!
+        try gitInitCommit(at: wt.path)
+
+        let dest = home.appendingPathComponent("projects/folder-name").path
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        let result = try resp.decodeResult(ScratchPromoteResult.self)
+        #expect(result.repoDisplayName == "My Cool App")   // renamed scratch name inherited
+    }
+
+    @Test func displayNamePriority_explicitFlagOverridesEverything() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        var wt = try created.decodeResult(Worktree.self)
+        try await db.worktrees.rename(id: wt.id, displayName: "Renamed Scratch")
+        wt = try await db.worktrees.get(id: wt.id)!
+        try gitInitCommit(at: wt.path)
+
+        let dest = home.appendingPathComponent("projects/folder-name").path
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: "Explicit Name")))
+        let result = try resp.decodeResult(ScratchPromoteResult.self)
+        #expect(result.repoDisplayName == "Explicit Name")
+    }
+
+    @Test func displayNamePriority_defaultScratchFallsBackToFolderName() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)   // displayName == name (still default)
+        try gitInitCommit(at: wt.path)
+
+        let dest = home.appendingPathComponent("projects/coolfolder").path
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        let result = try resp.decodeResult(ScratchPromoteResult.self)
+        #expect(result.repoDisplayName == "coolfolder")   // repo.add's folder-name default
+    }
+
+    @Test func rejectsNonScratchWorktree() async throws {
+        let (_, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let wt = try await db.worktrees.create(repoID: repo.id, name: "w", branch: "b",
+                                               path: "/tmp/w-\(UUID().uuidString)", tmuxServer: "tbd-x")
+        let repoCountBefore = try await db.repos.list().count
+
+        let dest = FileManager.default.temporaryDirectory.appendingPathComponent("promote-dest-\(UUID().uuidString)").path
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(!resp.success)
+        #expect(!FileManager.default.fileExists(atPath: dest))
+        let row = try await db.worktrees.get(id: wt.id)
+        #expect(row?.path == wt.path)
+        #expect(row?.promotedToRepoID == nil)
+        #expect(try await db.repos.list().count == repoCountBefore)
+    }
+
+    @Test func rejectsExistingDestination() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)
+        try gitInitCommit(at: wt.path)
+        let repoCountBefore = try await db.repos.list().count
+
+        let dest = home.appendingPathComponent("projects/already-here").path
+        try FileManager.default.createDirectory(at: URL(fileURLWithPath: dest), withIntermediateDirectories: true)
+
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(!resp.success)
+        #expect(FileManager.default.fileExists(atPath: wt.path))          // scratch folder untouched
+        let row = try await db.worktrees.get(id: wt.id)
+        #expect(row?.path == wt.path)
+        #expect(row?.promotedToRepoID == nil)
+        #expect(try await db.repos.list().count == repoCountBefore)       // no repo row created
+    }
+
+    @Test func rejectsGitRepoWithZeroCommits() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)
+        // git init WITHOUT a commit — distinct from the no-git-at-all case,
+        // exercises the hasCommits guard specifically.
+        let p = Process(); p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        p.arguments = ["-C", wt.path, "init"]; try p.run(); p.waitUntilExit()
+        let repoCountBefore = try await db.repos.list().count
+
+        let dest = home.appendingPathComponent("projects/no-commits-yet").path
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(!resp.success)
+        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(!FileManager.default.fileExists(atPath: dest))
+        let row = try await db.worktrees.get(id: wt.id)
+        #expect(row?.path == wt.path)
+        #expect(row?.promotedToRepoID == nil)
+        #expect(try await db.repos.list().count == repoCountBefore)
+    }
+
+    @Test func rejectsDestInsideScratchDir() async throws {
+        let (_, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)
+        try gitInitCommit(at: wt.path)
+        let repoCountBefore = try await db.repos.list().count
+
+        // Dest is another path under the scratch base — must be rejected
+        // before any mutation, same boundary check as the repo.add guard.
+        let dest = TBDConstants.scratchDir.appendingPathComponent("sneaky-dest").path
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(!resp.success)
+        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(!FileManager.default.fileExists(atPath: dest))
+        let row = try await db.worktrees.get(id: wt.id)
+        #expect(row?.path == wt.path)
+        #expect(row?.promotedToRepoID == nil)
+        #expect(try await db.repos.list().count == repoCountBefore)
+    }
+}
+}

--- a/Tests/TBDDaemonTests/ScratchStartupTests.swift
+++ b/Tests/TBDDaemonTests/ScratchStartupTests.swift
@@ -1,0 +1,21 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+extension TBDHomeSerialized {
+@Suite("scratch startup")
+struct ScratchStartupTests {
+    @Test func ensureScratchDirCreatesBaseWhenMissing() throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("tbd-startup-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: home) }
+
+        let scratch = TBDConstants.scratchDir.path
+        #expect(!FileManager.default.fileExists(atPath: scratch))
+        Daemon.ensureScratchDir()   // pure static helper, no server needed
+        #expect(FileManager.default.fileExists(atPath: scratch))
+    }
+}
+}

--- a/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
+++ b/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
@@ -185,4 +185,27 @@ struct SystemPromptBuilderTests {
         #expect(prompt != nil)
         #expect(prompt?.contains("`tbd` skill") == true)
     }
+
+    // MARK: - Scratch layer
+
+    @Test("build injects scratch layer and no repo/rename layer for scratch worktree")
+    func buildScratchLayer() {
+        let wt = Worktree(repoID: nil, name: "20260702-worrying-pike", displayName: "20260702-worrying-pike",
+                          branch: "", path: "/tmp/scratch/x", tmuxServer: "tbd-scratch")
+        let result = SystemPromptBuilder.build(repo: nil, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("scratch space"))
+        #expect(result!.contains("tbd scratch promote"))
+        #expect(!result!.contains("Rename the git branch"))
+    }
+
+    @Test("scratch layer absent for a normal repo worktree")
+    func buildNoScratchLayerForRepoWorktree() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "gorgeous-panda",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda", tmuxServer: "tbd-test")
+        let result = SystemPromptBuilder.build(repo: repo, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(!result!.contains("tbd scratch promote"))
+    }
 }

--- a/Tests/TBDSharedTests/ConstantsTests.swift
+++ b/Tests/TBDSharedTests/ConstantsTests.swift
@@ -68,6 +68,16 @@ import Foundation
         // Other paths still resolve to ~/tbd.
         #expect(TBDConstants.databasePath(environment: env).hasSuffix("/tbd/state.db"))
     }
+
+    @Test func scratchDirFollowsTBDHome() {
+        let env = ["TBD_HOME": "/tmp/tbd-scratch-test"]
+        #expect(TBDConstants.scratchDir(environment: env).path == "/tmp/tbd-scratch-test/scratch")
+    }
+
+    @Test func scratchDirFallsBackToHomeTbdScratch() {
+        let path = TBDConstants.scratchDir(environment: [:]).path
+        #expect(path.hasSuffix("/tbd/scratch"))
+    }
 }
 
 /// Smoke-tests that the production computed vars are correctly wired to the

--- a/Tests/TBDSharedTests/TBDSkillContentTests.swift
+++ b/Tests/TBDSharedTests/TBDSkillContentTests.swift
@@ -35,3 +35,12 @@ import Foundation
     // Versioning-drift mitigation: instruct the model to use --help for current flags.
     #expect(body.contains("--help"))
 }
+
+@Test func bodyContainsScratchPromotionSection() {
+    let body = TBDSkillContent.body
+    #expect(body.contains("## Scratch spaces & promotion"))
+    #expect(body.contains("tbd scratch new"))
+    #expect(body.contains("tbd scratch list"))
+    #expect(body.contains("tbd scratch promote <dest-path>"))
+    #expect(body.contains("--display-name"))
+}

--- a/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
+++ b/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
@@ -1,0 +1,199 @@
+# Scratch Spaces — repo-less Claude/Codex sessions
+
+**Date:** 2026-07-02
+**Status:** Approved design, pre-implementation
+
+## Problem
+
+Every TBD session today lives under `Repo → Worktree → Terminal`. There is no
+place to talk to Claude or Codex outside a repo context — e.g. to bootstrap a
+brand-new project (which has no repo yet) or to hold a general-purpose chat
+that belongs to no codebase. Starting that conversation inside an unrelated
+project's worktree pollutes both contexts.
+
+## Goals
+
+- A "Scratch" area in the sidebar holding repo-less workspaces, each with its
+  own folder and Claude/Codex/shell terminals.
+- Serves both use cases: persistent general-purpose chat spaces, and
+  incubators for new projects.
+- Agent-driven promotion: when a scratch project takes shape, Claude moves it
+  to a permanent location and registers it as a real TBD repo
+  (move-on-promote). No promotion UI.
+- Scratch spaces are excluded from all repo-driven behavior (PR polling,
+  reconcile, merge flows) **by construction**, not by remembered guards.
+
+## Non-goals
+
+- No new window/tab UI; scratch lives in the existing sidebar.
+- No migration of live terminals across tmux servers at promotion time.
+- No UI-driven promotion flow.
+- Scratch spaces are not git repos and get no git affordances until promoted.
+
+## Approach decision
+
+Three approaches were considered:
+
+- **A — synthetic "Scratch" pseudo-repo row**: smallest diff, but scratch is
+  *included by default* in every repo-driven behavior (each needs an opt-out
+  guard, forever), and `state.db` carries a permanent fake `Repo` row.
+- **B — nullable `Worktree.repoID` (chosen)**: scratch spaces are `Worktree`
+  rows with `repoID = nil`. Excluded-by-default polarity; the compiler forces
+  an explicit decision at every daemon site that resolves the repo; no false
+  rows in persistent state.
+- **C — hidden anchor git repo**: rejected. Nested-git confusion lands exactly
+  on the bootstrap path, and promotion would require detaching worktrees from
+  the anchor.
+
+`Worktree` already stretches beyond "a git worktree" (the `.main` row is a
+plain directory), so B extends an existing precedent: a Worktree is a
+directory TBD manages terminals in, with *optional* git parentage.
+
+## 1. Data model & migration
+
+- `Worktree.repoID: UUID?` in `Sources/TBDShared/Models.swift`. Scratch-ness
+  is derived — `var isScratch: Bool { repoID == nil }` — no separate `kind`
+  column that could disagree with the FK.
+- Regular statuses apply to scratch rows (`.active`, `.archived` unused for
+  now; `.main` never applies).
+- `branch` stays non-optional and holds `""` for scratch rows; the UI hides
+  it. (Deliberate compromise: making `branch` optional would double call-site
+  churn with no behavioral gain.)
+- `promotedToRepoID: UUID?` on `Worktree` (nil except for promoted scratch
+  rows — see §5.1).
+- Migration (house 3-file rule, one commit):
+  1. New sequential `vN` migration rebuilds `worktrees` to drop the
+     `NOT NULL` on `repo_id` and adds the nullable `promoted_to_repo_id`
+     column (SQLite table-rebuild via GRDB).
+  2. `WorktreeRecord.repoID` becomes optional
+     (`Sources/TBDDaemon/Database/WorktreeStore.swift`).
+  3. `Models.swift` field becomes `UUID?` — old JSON/rows still decode.
+- Every daemon site doing `db.repos.get(id: worktree.repoID)` stops compiling;
+  each gets an explicit nil decision (this audit is the point of approach B).
+  App-side `repos.first(where: { $0.id == worktree.repoID })` comparisons keep
+  compiling and correctly no-match for scratch.
+
+## 2. Scratch space lifecycle
+
+- **Location:** `~/tbd/scratch/<name>` via a new `TBDConstants.scratchDir`
+  (honors `TBD_HOME`). Created as a plain empty directory — no `git init`.
+- **Naming:** same `YYYYMMDD-adjective-animal` generator as worktrees;
+  display name renameable through the existing rename flow.
+- **tmux:** one shared server for all scratch spaces, named via the existing
+  per-repo derivation with the scratch base dir in the repo-path role
+  (`TmuxManager.serverName(forRepoPath: scratchDir)`), stored in
+  `worktree.tmuxServer` as usual.
+- **RPC:** new `scratch.create` method (mkdir + insert row + `StateDelta`
+  broadcast). Deliberately not overloading `worktree.create`, which is
+  entangled with `git worktree add` phases.
+- **CLI:** `tbd scratch new [--name <n>]`, `tbd scratch list`,
+  `tbd scratch promote <dest-path>` (§5).
+- **Deletion:** closes terminals, moves the folder to Trash (never `rm -rf`),
+  deletes the row. No archive machinery — there is no branch to preserve;
+  Claude transcripts survive on disk as today.
+- **Reconcile/recovery:** repo reconcile never sees scratch rows (it walks
+  repos). Startup recreates `~/tbd/scratch/` if missing; a space whose dir is
+  missing is flagged the same way missing worktrees are today.
+
+## 3. Terminal spawning in a scratch space
+
+`terminal.create` operates on the worktree row exactly as today (path,
+tmuxServer, `TBD_WORKTREE_ID`). Where the handler currently resolves the
+repo, `repoID == nil` means:
+
+- **System prompt:** `SystemPromptBuilder.promptLayers(repo: nil, worktree:)`
+  substitutes a scratch layer (content in §5.3) for the repo layer.
+- **Model profiles:** `modelProfileResolver.resolve(repoID: nil)` → global
+  default profile.
+- **Env overrides:** scopes collapse to `global < profile` (no repo scope).
+- **Claude instrumentation unchanged:** plugin dir (`tbd` skill), settings
+  overlay hooks, session-event relay all apply to scratch sessions.
+- **Codex:** `CodexHomeManager` provides one scratch `CODEX_HOME` keyed off
+  the scratch base dir (same role a repo plays today).
+
+## 4. Sidebar & UI
+
+- The Scratch section is **synthesized client-side** from
+  `worktrees.filter { $0.repoID == nil }` — no repo row backs it. Pinned at
+  the top of the sidebar, titled "Scratch", with a `+ New scratch space`
+  affordance.
+- **Setting:** `showScratchSection` (app-side, default **on**). Gates
+  presentation only: turning it off hides the section; existing spaces and
+  live terminals keep running.
+- Rows reuse `WorktreeRowView`. Repo-derived affordances (branch label, PR
+  icon, merge/archive menu items) disappear because the repo lookup returns
+  nil — verify this falls out naturally before adding special cases.
+- Context menu: new Claude/Codex/shell terminal, rename, reveal in Finder,
+  a "Promote…" hint that explains the agent-driven flow, and delete.
+- Jump menu, notes, and notifications work unchanged (keyed off
+  `worktreeID`).
+
+## 5. Promotion (agent-driven, move-on-promote)
+
+### 5.1 `tbd scratch promote <dest-path>`
+
+The single real mechanism, run by Claude from inside a scratch session:
+
+1. Validate: cwd is a scratch space; dest does not exist; the scratch dir is
+   a git repo (the agent must have `git init`-ed and committed) — clear error
+   otherwise, nothing moved.
+2. Move the folder to dest. Same-volume rename keeps the running session's
+   cwd valid (inode-based). Cross-volume dest is allowed with a warning that
+   running processes may lose their cwd.
+3. Run the existing `repo.add` path on the new location (creates the Repo
+   row + its synthetic main worktree, reconciles, broadcasts).
+4. Mark the scratch row **promoted**: store a pointer to the new repo
+   (`promotedToRepoID: UUID?` on `Worktree`, nil for everything else). The
+   row remains; its live terminals keep working on the scratch tmux server
+   until closed. Sidebar shows "→ promoted to <repo>". Deleting a promoted
+   row removes only the row (the folder already moved).
+
+This deliberately avoids migrating live terminals to the new repo's tmux
+server.
+
+### 5.2 `repo.add` guard
+
+`repo.add` rejects any path under `~/tbd/scratch/` with an error directing to
+`tbd scratch promote`. Prevents the unguided path from creating a repo that
+lives inside TBD's scratch area.
+
+### 5.3 The nudge
+
+- The scratch system-prompt layer and a section in the bundled `tbd` skill
+  explain: this is a scratch space; when the project takes shape, offer the
+  user promotion via `tbd scratch promote` (Claude asks the user for the
+  destination path).
+- A guardrail rule in the existing PreToolUse hook framework fires on
+  `git init` inside a scratch workspace and injects a reminder to consider
+  offering promotion. It informs; it never blocks.
+
+## 6. Error handling
+
+- Scratch name collision on create → regenerate name.
+- `~/tbd/scratch/` missing at startup → recreate; individual space dir
+  missing → flag as missing (existing worktree pattern).
+- Promote with no git repo / dirty validation failure → CLI error, no move.
+- Deletion always goes to Trash.
+
+## 7. Testing
+
+Per the gated-branch rule (a test per branch of any new toggle):
+
+- Migration: old rows decode; nil `repoID` round-trips; existing worktrees
+  unaffected.
+- `terminal.create` on a nil-repo worktree: default profile resolved,
+  global-only env scopes, scratch prompt layer present, repo layer absent.
+- PR poller and reconcile provably never touch scratch rows.
+- `repo.add` rejects paths under the scratch dir.
+- `scratch promote`: happy path (move + repo.add + promoted marker), and
+  no-git failure leaves everything untouched.
+- `showScratchSection` on/off: section renders/hides; spaces and terminals
+  intact in both states.
+- All tests isolate via `TBD_HOME` / injection seams per CLAUDE.md.
+
+## Open follow-ups (explicitly out of scope)
+
+- Archiving (vs deleting) scratch spaces.
+- Converting a promoted scratch row's live terminals into terminals of the
+  new repo's main worktree.
+- UI-driven promotion.

--- a/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
+++ b/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
@@ -130,7 +130,7 @@ repo, `repoID == nil` means:
 
 ## 5. Promotion (agent-driven, move-on-promote)
 
-### 5.1 `tbd scratch promote <dest-path>`
+### 5.1 `tbd scratch promote <dest-path> [--display-name <name>]`
 
 The single real mechanism, run by Claude from inside a scratch session:
 
@@ -141,7 +141,13 @@ The single real mechanism, run by Claude from inside a scratch session:
    cwd valid (inode-based). Cross-volume dest is allowed with a warning that
    running processes may lose their cwd.
 3. Run the existing `repo.add` path on the new location (creates the Repo
-   row + its synthetic main worktree, reconciles, broadcasts).
+   row + its synthetic main worktree, reconciles, broadcasts). The repo's
+   display name is resolved in priority order:
+   1. `--display-name <name>` if given;
+   2. the scratch space's display name, if the user renamed it from its
+      auto-generated default (reuse the same default-name detection the
+      `stop-rename-check` hook uses);
+   3. the destination folder name (`repo.add`'s existing behavior).
 4. Mark the scratch row **promoted**: store a pointer to the new repo
    (`promotedToRepoID: UUID?` on `Worktree`, nil for everything else). The
    row remains; its live terminals keep working on the scratch tmux server
@@ -187,6 +193,9 @@ Per the gated-branch rule (a test per branch of any new toggle):
 - `repo.add` rejects paths under the scratch dir.
 - `scratch promote`: happy path (move + repo.add + promoted marker), and
   no-git failure leaves everything untouched.
+- Promote display-name priority: explicit flag wins; renamed scratch space
+  inherits its display name; still-default scratch name falls back to the
+  destination folder name.
 - `showScratchSection` on/off: section renders/hides; spaces and terminals
   intact in both states.
 - All tests isolate via `TBD_HOME` / injection seams per CLAUDE.md.

--- a/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
+++ b/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
@@ -108,8 +108,9 @@ repo, `repoID == nil` means:
 - **Env overrides:** scopes collapse to `global < profile` (no repo scope).
 - **Claude instrumentation unchanged:** plugin dir (`tbd` skill), settings
   overlay hooks, session-event relay all apply to scratch sessions.
-- **Codex:** `CodexHomeManager` provides one scratch `CODEX_HOME` keyed off
-  the scratch base dir (same role a repo plays today).
+- **Codex:** no change — Codex sessions already share one global
+  `CODEX_HOME` (per-repo isolation was removed by the 2026-05-22 codex
+  global-home redesign), and scratch sessions use it the same way.
 
 ## 4. Sidebar & UI
 


### PR DESCRIPTION
## Summary
- Adds a **Scratch** section to the sidebar: repo-less workspaces under `~/tbd/scratch/` where you can talk to Claude/Codex without polluting an unrelated project's context — for bootstrapping new projects or general-purpose chat. Toggleable via a new `showScratchSection` setting (default on).
- Modeled as approach B from the committed spec (`docs/superpowers/specs/2026-07-02-scratch-spaces-design.md`): `Worktree.repoID` becomes nullable (migration v35, idempotency-guarded table rebuild). Scratch rows are excluded from repo-driven machinery **by construction** — PR polling filters via a unit-tested pure function, reconcile only ever walks repo-scoped queries.
- Agent-driven **move-on-promote**: `tbd scratch promote <dest> [--display-name]` validates (git repo with ≥1 commit, dest outside scratch), moves the folder, registers via the existing `repo.add` path with display-name priority (flag > renamed-scratch-name > folder name), and marks the row `[promoted]`. `repo.add` rejects paths inside the scratch area (symlink-canonicalized) and points at the promote flow instead. A skill section + informational-only `git init` guardrail nudge Claude to offer promotion when a scratch project takes shape.
- New RPCs `scratch.create` / `scratch.delete` / `scratch.promote` + CLI `tbd scratch new/list/promote`; scratch sessions get their own system-prompt layer, the default model profile, and global-only env scopes. Deletion closes terminals and moves the folder to Trash (never `rm -rf`), refusing to report success if the Trash move fails.

## Test plan
- [x] `swift test` — 1975 tests / 240 suites green (incl. migration round-trip, promote validation matrix, exclusion proofs with mutation-verified falsifiability, delete-to-Trash failure injection via chmod)
- [x] `swiftlint --strict` — 0 violations; guardrails self-test 26/26
- [x] Live-verified against a running daemon: v35 migrated the real `state.db` cleanly (all existing repos intact), `scratch new/list`, `repo.add` guard rejection, full promote round-trip (folder moved, repo registered with `--display-name`, `[promoted]` marker), `scratch.delete` on a promoted row
- [ ] Visual pass: sidebar section, settings toggle, scratch context menu, missing-dir dimming

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=4CF864A6-7061-406F-AEEC-1B2830168C6F)