### PR TITLE
Feat: Customizable scratch-space system prompt, seeded with the default

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -167,6 +167,27 @@ extension AppState {
         }
     }
 
+    /// Set the global scratch-space system-prompt override. Nil or blank resets to the built-in default.
+    func setScratchInstructions(_ instructions: String?) async {
+        do {
+            try await daemonClient.setScratchInstructions(instructions)
+        } catch {
+            logger.error("Failed to set scratch instructions: \(error, privacy: .public)")
+            handleConnectionError(error)
+        }
+    }
+
+    /// Fetch the current global Config (used by the scratch-instructions editor to show the effective text).
+    func fetchConfig() async -> Config? {
+        do {
+            return try await daemonClient.getConfig()
+        } catch {
+            logger.error("Failed to fetch config: \(error, privacy: .public)")
+            handleConnectionError(error)
+            return nil
+        }
+    }
+
     /// Set or clear a per-repo model profile override.
     func setRepoProfileOverride(repoID: UUID, profileID: UUID?) async {
         do {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -736,6 +736,19 @@ actor DaemonClient {
         )
     }
 
+    /// Set the global scratch-space system-prompt override. Nil or blank resets to the built-in default.
+    func setScratchInstructions(_ instructions: String?) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetScratchInstructions,
+            params: ConfigSetScratchInstructionsParams(instructions: instructions)
+        )
+    }
+
+    /// Fetch the global daemon config (used to read the current effective scratch-instructions override).
+    func getConfig() async throws -> Config {
+        try await callNoParamsAsync(method: RPCMethod.configGet, resultType: Config.self)
+    }
+
     /// Set or clear a repo's free-form env overrides.
     func setRepoEnvOverrides(repoID: UUID, overrides: [String: String]) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/ScratchInstructionsView.swift
+++ b/Sources/TBDApp/ScratchInstructionsView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import TBDShared
+
+/// Sheet for editing the global, user-customizable system-prompt layer for
+/// scratch spaces (repo-less worktrees). Mirrors `RepoInstructionsView`'s
+/// "General Instructions" section but presented as a sheet (Cancel/Save)
+/// rather than a persistent autosaving tab — see `EditEndpointSheet` in
+/// `Settings/ModelProfilesSettingsView.swift` for the sheet convention.
+struct ScratchInstructionsView: View {
+    @EnvironmentObject var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft: String = ""
+    @State private var isLoaded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Edit Scratch Instructions").font(.headline)
+            Text("Added to all new Claude sessions in scratch spaces (repo-less worktrees).")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            if isLoaded {
+                TextEditor(text: $draft)
+                    .font(.body.monospaced())
+                    .frame(minHeight: 200)
+                    .scrollContentBackground(.hidden)
+                    .padding(8)
+                    .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
+
+                HStack {
+                    Spacer()
+                    Button("Reset to Default") {
+                        draft = RepoConstants.defaultScratchInstructions
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            } else {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .frame(minHeight: 200)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Save") { save() }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!isLoaded)
+            }
+        }
+        .padding(20)
+        .frame(width: 480)
+        .task {
+            guard !isLoaded else { return }
+            let config = await appState.fetchConfig()
+            let effective = config?.scratchInstructions?.trimmingCharacters(in: .whitespacesAndNewlines)
+            draft = (effective?.isEmpty == false ? config?.scratchInstructions : nil)
+                ?? RepoConstants.defaultScratchInstructions
+            isLoaded = true
+        }
+    }
+
+    private func save() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultTrimmed = RepoConstants.defaultScratchInstructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        let toSave: String? = (trimmed.isEmpty || trimmed == defaultTrimmed) ? nil : trimmed
+        Task {
+            await appState.setScratchInstructions(toSave)
+            dismiss()
+        }
+    }
+}

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -7,6 +7,7 @@ import TBDShared
 struct ScratchSectionView: View {
     @EnvironmentObject var appState: AppState
     @State private var isHeaderHovered = false
+    @State private var showingScratchInstructions = false
 
     var body: some View {
         HStack(spacing: 4) {
@@ -22,6 +23,14 @@ struct ScratchSectionView: View {
             }
         }
         .onHover { isHeaderHovered = $0 }
+        .contextMenu {
+            Button("Edit Scratch Instructions…") {
+                showingScratchInstructions = true
+            }
+        }
+        .sheet(isPresented: $showingScratchInstructions) {
+            ScratchInstructionsView().environmentObject(appState)
+        }
         .listRowInsets(EdgeInsets(top: 0, leading: -2, bottom: 0, trailing: 0))
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -17,6 +17,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// JSON-encoded `[String: String]` free-form env overrides (global scope).
     var env_overrides: String?
     var auto_archive_on_merge_default: Bool?
+    var scratch_instructions: String?
 
     func toModel() -> Config {
         Config(
@@ -25,7 +26,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
                 .flatMap(PrimaryAgentPreference.init(rawValue:)) ?? .defaultValue,
             envSettingOverrides: ConfigStore.decodeOverrides(claude_env_settings),
             envOverrides: EnvOverridesCoding.decode(env_overrides),
-            autoArchiveOnMergeDefault: auto_archive_on_merge_default ?? false
+            autoArchiveOnMergeDefault: auto_archive_on_merge_default ?? false,
+            scratchInstructions: scratch_instructions
         )
     }
 }
@@ -110,6 +112,20 @@ public struct ConfigStore: Sendable {
             try db.execute(
                 sql: "UPDATE config SET auto_archive_on_merge_default = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the global scratch-space system-prompt override. Nil or a
+    /// whitespace-only string clears the override, falling back to the
+    /// built-in default scratch layer.
+    public func setScratchInstructions(_ value: String?) async throws {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let toStore = (trimmed?.isEmpty ?? true) ? nil : value
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET scratch_instructions = ? WHERE id = ?",
+                arguments: [toStore, Self.singletonID]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -612,6 +612,13 @@ public final class TBDDatabase: Sendable {
             try db.rename(table: "worktree_new", to: "worktree")
         }
 
+        // Global, user-customizable system-prompt override for scratch spaces
+        // (repo-less worktrees). Nullable text; nil means "use the built-in
+        // default" (RepoConstants.defaultScratchInstructions).
+        migrator.registerMigration("v36_config_scratch_instructions") { db in
+            try db.addColumnIfMissing(table: "config", column: "scratch_instructions", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+++ b/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
@@ -23,26 +23,23 @@ enum SystemPromptBuilder {
     }
 
     /// Layer injected for repo-less scratch sessions. Explains the space and
-    /// nudges agent-driven promotion.
-    static var scratchContext: String {
-        """
-        You are in a TBD **scratch space** — a repo-less workspace with no git repo yet.
-        Use it to bootstrap a new project or hold a general-purpose chat.
-        When the project takes shape, offer the user promotion: ask them for a \
-        destination path, then run `tbd scratch promote <dest-path>` from this \
-        session. That moves the folder and registers it as a real TBD repo.
-        """
-    }
+    /// nudges agent-driven promotion. This is the built-in default; callers
+    /// may override it per-session via `promptLayers(scratchInstructions:)`.
+    static var scratchContext: String { RepoConstants.defaultScratchInstructions }
 
     /// Returns the individual prompt layers as env-var-name → value pairs.
     /// Used both to set env vars in terminals and to build the combined `--append-system-prompt`.
-    static func promptLayers(repo: Repo?, worktree: Worktree) -> [String: String] {
+    /// `scratchInstructions` is the global user-customizable override for the
+    /// scratch layer (`Config.scratchInstructions`); `nil` or blank falls
+    /// back to the built-in default.
+    static func promptLayers(repo: Repo?, worktree: Worktree, scratchInstructions: String? = nil) -> [String: String] {
         var layers: [String: String] = [:]
 
         layers["TBD_PROMPT_CONTEXT"] = builtInTBDContext
 
         if worktree.isScratch {
-            layers["TBD_PROMPT_SCRATCH"] = scratchContext
+            let trimmedCustom = scratchInstructions?.trimmingCharacters(in: .whitespacesAndNewlines)
+            layers["TBD_PROMPT_SCRATCH"] = (trimmedCustom?.isEmpty == false) ? scratchInstructions! : scratchContext
         }
 
         if !worktree.isScratch && worktree.status != .main && worktree.displayName == worktree.name {
@@ -62,10 +59,10 @@ enum SystemPromptBuilder {
 
     /// Build the combined system prompt for a Claude session.
     /// Returns nil if there's nothing to append (e.g., resume session).
-    static func build(repo: Repo?, worktree: Worktree, isResume: Bool) -> String? {
+    static func build(repo: Repo?, worktree: Worktree, isResume: Bool, scratchInstructions: String? = nil) -> String? {
         if isResume { return nil }
 
-        let layers = promptLayers(repo: repo, worktree: worktree)
+        let layers = promptLayers(repo: repo, worktree: worktree, scratchInstructions: scratchInstructions)
         var parts: [String] = []
 
         // Order: scratch layer, rename prompt, TBD context, custom instructions

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -507,7 +507,9 @@ extension WorktreeLifecycle {
             // already-existing session file would lose the transcript.
             let appendPrompt = isResume
                 ? nil
-                : SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false)
+                : SystemPromptBuilder.build(
+                    repo: repo, worktree: worktree, isResume: false,
+                    scratchInstructions: config.scratchInstructions)
             let spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: isResume ? sessionUUID : nil,
                 freshSessionID: isResume ? nil : sessionUUID,

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -14,4 +14,13 @@ extension RPCRouter {
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()
     }
+
+    func handleConfigSetScratchInstructions(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetScratchInstructionsParams.self, from: paramsData)
+        try await db.config.setScratchInstructions(params.instructions)
+        // No broadcast: nothing in the app consumes a delta for this field —
+        // the editor sheet fetches Config fresh on open, and the daemon reads
+        // config from the DB at spawn time.
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -107,7 +107,8 @@ extension RPCRouter {
         let plannedTerminalID = UUID()
 
         // Build env vars available in all TBD terminals
-        var env = SystemPromptBuilder.promptLayers(repo: repo, worktree: worktree)
+        var env = SystemPromptBuilder.promptLayers(
+            repo: repo, worktree: worktree, scratchInstructions: createConfig?.scratchInstructions)
         env["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
         env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
 
@@ -211,7 +212,9 @@ extension RPCRouter {
             let sessionID = UUID().uuidString
             claudeSessionID = sessionID
             freshSessionID = sessionID
-            appendSystemPrompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false)
+            appendSystemPrompt = SystemPromptBuilder.build(
+                repo: repo, worktree: worktree, isResume: false,
+                scratchInstructions: createConfig?.scratchInstructions)
             label = TerminalLabel.claudeCode
         } else if let cmd = params.cmd {
             claudeSessionID = nil
@@ -659,7 +662,9 @@ extension RPCRouter {
             repo = nil
         }
         let plannedTerminalID = UUID()
-        var env = SystemPromptBuilder.promptLayers(repo: repo, worktree: worktree)
+        let swapConfig = try? await db.config.get()
+        var env = SystemPromptBuilder.promptLayers(
+            repo: repo, worktree: worktree, scratchInstructions: swapConfig?.scratchInstructions)
         env["TBD_WORKTREE_ID"] = worktree.id.uuidString
         env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
 
@@ -670,7 +675,6 @@ extension RPCRouter {
         )
         let plan = Self.planTerminalSwap(oldSessionID: sessionID, isBlank: blank)
 
-        let swapConfig = try? await db.config.get()
         let claudeEnvOverrides = swapConfig?.envSettingOverrides ?? [:]
         // Free-form env overrides for the swapped-in Claude pane (global < repo <
         // new profile), layered under the builder's auth/routing env below.
@@ -710,7 +714,9 @@ extension RPCRouter {
             scheduleRecapture = true
         case .fresh(let newSessionID):
             logger.debug("swap: blank session — spawning fresh \(newSessionID, privacy: .public)")
-            let appendPrompt = SystemPromptBuilder.build(repo: repo, worktree: worktree, isResume: false)
+            let appendPrompt = SystemPromptBuilder.build(
+                repo: repo, worktree: worktree, isResume: false,
+                scratchInstructions: swapConfig?.scratchInstructions)
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,
                 freshSessionID: newSessionID,

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -275,6 +275,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigGet()
             case RPCMethod.configSetAutoArchiveOnMergeDefault:
                 return try await handleConfigSetAutoArchiveDefault(request.paramsData)
+            case RPCMethod.configSetScratchInstructions:
+                return try await handleConfigSetScratchInstructions(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -448,17 +448,23 @@ public struct Config: Codable, Sendable, Equatable {
     /// Global default for auto-archive-on-PR-merge, applied to worktrees whose
     /// per-worktree override is `nil`.
     public var autoArchiveOnMergeDefault: Bool
+    /// Global, user-customizable system-prompt layer for scratch spaces
+    /// (repo-less worktrees). `nil` means "use the built-in default"
+    /// (`RepoConstants.defaultScratchInstructions`).
+    public var scratchInstructions: String?
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
                 envSettingOverrides: [String: ClaudeEnvValue] = [:],
                 envOverrides: [String: String] = [:],
-                autoArchiveOnMergeDefault: Bool = false) {
+                autoArchiveOnMergeDefault: Bool = false,
+                scratchInstructions: String? = nil) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
         self.envOverrides = envOverrides
         self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
+        self.scratchInstructions = scratchInstructions
     }
 
     public init(from decoder: Decoder) throws {
@@ -474,6 +480,7 @@ public struct Config: Codable, Sendable, Equatable {
             [String: String].self, forKey: .envOverrides) ?? [:]
         autoArchiveOnMergeDefault = try c.decodeIfPresent(
             Bool.self, forKey: .autoArchiveOnMergeDefault) ?? false
+        scratchInstructions = try c.decodeIfPresent(String.self, forKey: .scratchInstructions) ?? nil
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -161,6 +161,7 @@ public enum RPCMethod {
     public static let worktreeSetAutoArchive = "worktree.setAutoArchive"
     public static let configGet = "config.get"
     public static let configSetAutoArchiveOnMergeDefault = "config.setAutoArchiveOnMergeDefault"
+    public static let configSetScratchInstructions = "config.setScratchInstructions"
     public static let scratchCreate = "scratch.create"
     public static let scratchDelete = "scratch.delete"
     public static let scratchPromote = "scratch.promote"
@@ -883,6 +884,13 @@ public struct WorktreeSetAutoArchiveParams: Codable, Sendable {
 public struct ConfigSetAutoArchiveDefaultParams: Codable, Sendable {
     public let enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setScratchInstructions` — the global scratch-space
+/// system-prompt override. `nil` (or blank) resets to the built-in default.
+public struct ConfigSetScratchInstructionsParams: Codable, Sendable {
+    public let instructions: String?
+    public init(instructions: String?) { self.instructions = instructions }
 }
 
 /// Params for `repo.setEnvOverrides` — per-repo free-form env overrides.

--- a/Sources/TBDShared/RepoConstants.swift
+++ b/Sources/TBDShared/RepoConstants.swift
@@ -19,4 +19,15 @@ public enum RepoConstants {
 
         Do this immediately, before reading files, using skills, or any other tools.
         """
+
+    /// Layer injected for repo-less scratch sessions. Explains the space and
+    /// nudges agent-driven promotion. User-overridable via the global
+    /// `Config.scratchInstructions` setting.
+    public static let defaultScratchInstructions = """
+        You are in a TBD **scratch space** — a repo-less workspace with no git repo yet.
+        Use it to bootstrap a new project or hold a general-purpose chat.
+        When the project takes shape, offer the user promotion: ask them for a \
+        destination path, then run `tbd scratch promote <dest-path>` from this \
+        session. That moves the folder and registers it as a real TBD repo.
+        """
 }

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -56,4 +56,32 @@ struct ConfigStoreTests {
         let cfg = try await db.config.get()
         #expect(cfg.primaryAgentPreference == .codex)
     }
+
+    @Test func scratchInstructionsDefaultsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchInstructions == nil)
+    }
+
+    @Test func setAndGetScratchInstructions() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setScratchInstructions("Always use uv, never pip.")
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchInstructions == "Always use uv, never pip.")
+    }
+
+    @Test func setScratchInstructionsWhitespaceResetsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setScratchInstructions("   \n  ")
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchInstructions == nil)
+    }
+
+    @Test func setScratchInstructionsNilResetsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setScratchInstructions("Always use uv, never pip.")
+        try await db.config.setScratchInstructions(nil)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchInstructions == nil)
+    }
 }

--- a/Tests/TBDDaemonTests/MigrationV36Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV36Tests.swift
@@ -1,0 +1,22 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+
+@Suite struct MigrationV36Tests {
+
+    @Test func scratchInstructionsColumnExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let columns = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(config)")
+            let names = columns.compactMap { $0["name"] as String? }
+            #expect(names.contains("scratch_instructions"))
+        }
+    }
+
+    @Test func scratchInstructionsDefaultsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchInstructions == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/RPCRouterConfigScratchInstructionsTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterConfigScratchInstructionsTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// config.setScratchInstructions RPC handler, mirroring the round-trip style
+// of RPCRouterEnvOverridesTests.
+extension RPCRouterTests {
+
+    @Test("config.setScratchInstructions persists the custom instructions")
+    func configSetScratchInstructions() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetScratchInstructions,
+            params: ConfigSetScratchInstructionsParams(instructions: "Always use uv, never pip.")
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let config = try await db.config.get()
+        #expect(config.scratchInstructions == "Always use uv, never pip.")
+    }
+
+    @Test("config.setScratchInstructions with whitespace-only value resets to nil")
+    func configSetScratchInstructionsWhitespaceResetsToNil() async throws {
+        try await db.config.setScratchInstructions("Always use uv, never pip.")
+
+        let request = try RPCRequest(
+            method: RPCMethod.configSetScratchInstructions,
+            params: ConfigSetScratchInstructionsParams(instructions: "   \n  ")
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let config = try await db.config.get()
+        #expect(config.scratchInstructions == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
+++ b/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
@@ -208,4 +208,48 @@ struct SystemPromptBuilderTests {
         #expect(result != nil)
         #expect(!result!.contains("tbd scratch promote"))
     }
+
+    @Test("build uses custom scratchInstructions for a scratch worktree")
+    func buildUsesCustomScratchInstructions() {
+        let wt = Worktree(repoID: nil, name: "20260702-worrying-pike", displayName: "20260702-worrying-pike",
+                          branch: "", path: "/tmp/scratch/x", tmuxServer: "tbd-scratch")
+        let result = SystemPromptBuilder.build(
+            repo: nil, worktree: wt, isResume: false,
+            scratchInstructions: "Always use uv for scratch spaces.")
+        #expect(result != nil)
+        #expect(result!.contains("Always use uv for scratch spaces."))
+        #expect(!result!.contains("tbd scratch promote"))
+    }
+
+    @Test("build falls back to built-in default when scratchInstructions is nil")
+    func buildFallsBackToDefaultScratchInstructionsWhenNil() {
+        let wt = Worktree(repoID: nil, name: "20260702-worrying-pike", displayName: "20260702-worrying-pike",
+                          branch: "", path: "/tmp/scratch/x", tmuxServer: "tbd-scratch")
+        let result = SystemPromptBuilder.build(repo: nil, worktree: wt, isResume: false, scratchInstructions: nil)
+        #expect(result != nil)
+        #expect(result!.contains("scratch space"))
+        #expect(result!.contains("tbd scratch promote"))
+    }
+
+    @Test("build falls back to built-in default when scratchInstructions is whitespace-only")
+    func buildFallsBackToDefaultScratchInstructionsWhenWhitespace() {
+        let wt = Worktree(repoID: nil, name: "20260702-worrying-pike", displayName: "20260702-worrying-pike",
+                          branch: "", path: "/tmp/scratch/x", tmuxServer: "tbd-scratch")
+        let result = SystemPromptBuilder.build(repo: nil, worktree: wt, isResume: false, scratchInstructions: "   ")
+        #expect(result != nil)
+        #expect(result!.contains("scratch space"))
+        #expect(result!.contains("tbd scratch promote"))
+    }
+
+    @Test("scratchInstructions param is ignored for a non-scratch worktree")
+    func buildIgnoresScratchInstructionsForRepoWorktree() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "gorgeous-panda",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda", tmuxServer: "tbd-test")
+        let result = SystemPromptBuilder.build(
+            repo: repo, worktree: wt, isResume: false,
+            scratchInstructions: "Always use uv for scratch spaces.")
+        #expect(result != nil)
+        #expect(!result!.contains("Always use uv for scratch spaces."))
+    }
 }

--- a/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
+++ b/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
@@ -112,6 +112,17 @@ repo, `repoID == nil` means:
   `CODEX_HOME` (per-repo isolation was removed by the 2026-05-22 codex
   global-home redesign), and scratch sessions use it the same way.
 
+**Customizable scratch layer (2026-07-03 amendment):** the scratch layer is
+user-customizable via a global-only config field, `Config.scratchInstructions`
+(nullable; `nil` or blank = built-in default, exposed as
+`RepoConstants.defaultScratchInstructions`). Set via the
+`config.setScratchInstructions` RPC (whitespace-only normalizes to `nil`) and
+edited from an "Edit Scratch Instructions…" context-menu item on the sidebar's
+Scratch section header, whose editor is seeded with the current effective
+text. Non-scratch worktrees are unaffected; the terminal-spawn handlers fetch
+the value from config and pass it through to `SystemPromptBuilder`, which
+stays pure.
+
 ## 4. Sidebar & UI
 
 - The Scratch section is **synthesized client-side** from


### PR DESCRIPTION
> [!NOTE]
> Originally planned as a stack on #325 (`scratch-session-design`), but #325 squash-merged while this was in flight — so the branch was rebased onto `main` and this PR targets `main` directly.

## Summary

- **Config field**: `Config.scratchInstructions: String?` — a global-only, user-customizable system-prompt layer for scratch spaces. `nil` = use the built-in default. New `v36_config_scratch_instructions` migration (nullable text, idempotent `addColumnIfMissing`), `ConfigRecord` + `ConfigStore.setScratchInstructions` — whitespace-only or `nil` normalizes to `nil` at the store boundary.
- **Shared default**: the built-in scratch layer text moved verbatim from `SystemPromptBuilder.scratchContext` to `RepoConstants.defaultScratchInstructions` (TBDShared) so the app can seed the editor with it; `scratchContext` now aliases it.
- **RPC**: `config.setScratchInstructions` following the `configSetAutoArchiveOnMergeDefault` recipe end to end (method constant + params struct, handler with `.modelProfilesChanged` config broadcast, dispatch case, `DaemonClient.setScratchInstructions` + `getConfig`).
- **Prompt layer**: `SystemPromptBuilder.promptLayers`/`build` gain a `scratchInstructions: String? = nil` parameter — the builder stays pure/testable. Non-blank custom text replaces the scratch layer; `nil`/blank falls back to the built-in default. All four daemon call sites (terminal create ×2, terminal swap ×2, worktree-create spawn) thread the value from the `Config` each handler already fetches — no new DB round-trips.
- **UI**: "Edit Scratch Instructions…" context-menu item on the sidebar Scratch section header, opening a sheet (modeled on the repo instructions editor + existing sheet conventions) pre-populated with the current *effective* text. Save trims; blank or default-equal text resets to `nil`. "Reset to Default" restores the built-in text in the draft.
- **Docs**: §3 of `docs/superpowers/specs/2026-07-02-scratch-spaces-design.md` amended with the customizable-layer paragraph.

## Test plan

- [x] `MigrationV36Tests`: `scratch_instructions` column exists; fresh config decodes with `scratchInstructions == nil`
- [x] `ConfigStoreTests`: defaults to nil; round-trips a custom value; whitespace-only and `nil` both reset to nil
- [x] `RPCRouterConfigScratchInstructionsTests` (existing router harness): set custom → `config.get` returns it; set whitespace → returns nil
- [x] `SystemPromptBuilderTests` (gated-branch rule): custom text replaces the scratch layer (default absent); explicit `nil` and whitespace-only fall back to the default; non-scratch worktrees ignore the value entirely
- [x] `swift build` clean, full `swift test` green (2020 tests / 248 suites, post-rebase on main), `swiftlint --strict` 0 violations