### PR TITLE
Fix: Stop sidebar PR icons from blinking en masse on background refresh

### DIFF
--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -52,7 +52,7 @@ struct WorktreeRowView: View {
         ) {
         case .prStatus:
             if let presentation = prPresentation,
-               let nsImage = loadIcon(presentation.iconName),
+               let nsImage = Self.loadIcon(presentation.iconName),
                let status = prStatus {
                 let reasonText = status.reason ?? status.state.displayReason
                 Button(action: openPR) {
@@ -260,10 +260,24 @@ struct WorktreeRowView: View {
         isEditing = true
     }
 
-    private func loadIcon(_ name: String) -> NSImage? {
+    /// Cache for sidebar PR status icons, keyed by icon name. The returned
+    /// NSImage must be identity-stable across body evaluations:
+    /// `Image(nsImage:)` diffs by object identity, so a fresh instance per
+    /// render made every row's icon layer rebuild at once whenever an
+    /// AppState-wide @Published reassignment re-evaluated all rows (visible
+    /// mass flicker). Also skips the disk I/O (`Bundle.module.url` +
+    /// `NSImage(contentsOf:)`) per evaluation. MainActor confinement
+    /// (SwiftUI body runs on main) makes this safe without locks.
+    @MainActor
+    private static var iconCache: [String: NSImage] = [:]
+
+    @MainActor
+    static func loadIcon(_ name: String) -> NSImage? {
+        if let cached = iconCache[name] { return cached }
         guard let url = Bundle.module.url(forResource: name, withExtension: "svg", subdirectory: "Icons"),
               let image = NSImage(contentsOf: url) else { return nil }
         image.isTemplate = true
+        iconCache[name] = image
         return image
     }
 

--- a/Tests/TBDAppTests/WorktreeRowIconCacheTests.swift
+++ b/Tests/TBDAppTests/WorktreeRowIconCacheTests.swift
@@ -1,0 +1,34 @@
+import AppKit
+import Testing
+@testable import TBDApp
+
+/// Tests for `WorktreeRowView.loadIcon` — the cached sidebar PR status icon
+/// loader. The cache exists so the NSImage handed to `Image(nsImage:)` is
+/// identity-stable across body evaluations; a fresh instance per render made
+/// every row's icon layer rebuild simultaneously (visible mass blink).
+@MainActor
+@Suite("WorktreeRowIconCache")
+struct WorktreeRowIconCacheTests {
+
+    @Test("loadIcon returns a non-nil template image for a bundled PR icon")
+    func loadsKnownIcon() {
+        // "git-pull-request" is a real resource in Sources/TBDApp/Resources/Icons
+        // and the name PRStatusPresentation uses for open PRs.
+        let image = WorktreeRowView.loadIcon("git-pull-request")
+        #expect(image != nil)
+        #expect(image?.isTemplate == true)
+    }
+
+    @Test("loadIcon returns the identical instance on repeated calls")
+    func returnsSameInstance() {
+        let first = WorktreeRowView.loadIcon("git-merge")
+        let second = WorktreeRowView.loadIcon("git-merge")
+        #expect(first != nil)
+        #expect(first === second)
+    }
+
+    @Test("loadIcon returns nil for an unknown icon name")
+    func unknownIconIsNil() {
+        #expect(WorktreeRowView.loadIcon("no-such-icon") == nil)
+    }
+}


### PR DESCRIPTION
## Summary

**What's broken:** Every once in a while, all PR status icons in the sidebar worktree list "blink" (flicker out and back) simultaneously.

**Why it happens:** `WorktreeRowView.loadIcon` re-read the SVG from disk and constructed a **brand-new `NSImage` on every body evaluation**. Every row observes `AppState` via `@EnvironmentObject`, so any whole-collection `@Published` reassignment (`prStatuses` on the ~30s PR poll, `worktrees` on the 2s poll) re-evaluates all rows at once — each row hands `Image(nsImage:)` a non-identical image, and since it diffs by object identity, every icon layer rebuilds in the same frame → synchronized mass flicker. The toolbar's PR split button hit the same class of problem and already carries the fix pattern (`bakedIconCache` in `ContentView.swift`).

**What this PR does:** Adds a MainActor-confined static cache keyed by icon name so the returned `NSImage` is identity-stable across renders (and drops the per-render disk I/O). Name-only keying is correct here because the sidebar image stays a template tinted by `.foregroundStyle` — unlike the toolbar cache, no color/appearance is baked in.

## Test plan
- [x] `swift build` passes
- [x] New `WorktreeRowIconCache` suite: non-nil template image for a bundled icon, identical instance (`===`) on repeated calls, nil for unknown names
- [x] Full `swift test` — 2011 tests, all green
- [ ] Live: leave the app running through several PR poll cycles and confirm sidebar icons no longer blink

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B36615BE-FE21-4B17-BAE1-A4F27E66EE68)