### PR TITLE
Fix: Stop sidebar rows from stat()ing disk on every render (plus editor-button and notification-RPC waste)

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1448,7 +1448,7 @@ final class AppState: ObservableObject {
 
             // Auto-mark-as-read for worktrees the user is currently looking at
             let visible = visibleWorktreeIDs
-            let toMarkRead = fetched.keys.filter { visible.contains($0) }
+            let toMarkRead = Self.worktreeIDsToAutoMarkRead(unreadSummaries: fetched, visible: visible)
             for worktreeID in toMarkRead {
                 do {
                     try await daemonClient.markNotificationsRead(worktreeID: worktreeID)
@@ -1466,6 +1466,23 @@ final class AppState: ObservableObject {
             logger.error("Failed to list notifications: \(error)")
             handleConnectionError(error)
         }
+    }
+
+    /// Pure mirror of `refreshNotifications`' auto-mark-read reconcile: a
+    /// `notifications.markRead` RPC is due only for worktrees that BOTH have
+    /// unread rows (present in the daemon's unread-only summary) AND are
+    /// currently visible. Keying off the fetched summary is load-bearing in
+    /// two directions: idle poll ticks (no unread anywhere) fire zero RPCs,
+    /// and a notification arriving while its worktree is already visible is
+    /// still marked read on the next tick. A guard on `unreadByWorktree`
+    /// would break the latter — it excludes visible worktrees by
+    /// construction, so an arrive-while-visible notification would never
+    /// qualify and would resurface as unread once the worktree left view.
+    nonisolated static func worktreeIDsToAutoMarkRead(
+        unreadSummaries: [UUID: UnreadSummary],
+        visible: Set<UUID>
+    ) -> [UUID] {
+        unreadSummaries.keys.filter { visible.contains($0) }
     }
 
     /// UserDefaults key for the WIP terminal-auto-resize feature. Off by

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1492,8 +1492,17 @@ final class AppState: ObservableObject {
     /// destination repo, so a promoted row's directory never exists again —
     /// dimming it as "missing" would contradict the "→ promoted to <repo>"
     /// caption shown alongside it. Non-scratch worktrees never dim here.
-    nonisolated static func scratchRowIsDimmed(_ worktree: Worktree, directoryExists: Bool) -> Bool {
-        worktree.isScratch && worktree.promotedToRepoID == nil && !directoryExists
+    ///
+    /// `directoryExists` is an autoclosure so the caller's `stat()` is only
+    /// paid for un-promoted scratch rows: every sidebar row re-evaluates its
+    /// body on any AppState `@Published` change, and an eager argument would
+    /// charge every regular row a synchronous disk hit per render for a flag
+    /// this rule ignores.
+    nonisolated static func scratchRowIsDimmed(
+        _ worktree: Worktree,
+        directoryExists: @autoclosure () -> Bool
+    ) -> Bool {
+        worktree.isScratch && worktree.promotedToRepoID == nil && !directoryExists()
     }
 
     /// Whether the WIP main-area resize broadcast is enabled. Default false.

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -190,8 +190,10 @@ struct WorktreeRowView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: 28)
         // Scratch spaces have no repo-level `.missing` status to inherit, so a
-        // missing directory is surfaced client-side with a cheap per-row FS stat
-        // (mirrors RepoSectionView dimming a `.missing` repo). Promoted rows are
+        // missing directory is surfaced client-side with a per-row FS stat
+        // (mirrors RepoSectionView dimming a `.missing` repo). The stat is an
+        // autoclosure argument, so only un-promoted scratch rows pay it — not
+        // every sidebar row on every body evaluation. Promoted rows are
         // excluded — promotion MOVES the folder, so their directory is expected
         // to be gone; see AppState.scratchRowIsDimmed.
         .opacity(AppState.scratchRowIsDimmed(

--- a/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
+++ b/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
@@ -100,8 +100,10 @@ struct OpenInEditorButton: View {
     @MainActor
     private static var iconCache: [String: NSImage] = [:]
 
+    // Internal (not private) so OpenInEditorIconCacheTests can assert the
+    // identity-stability invariant, mirroring WorktreeRowView.loadIcon.
     @MainActor
-    private static func appIcon(forPath path: String) -> NSImage {
+    static func appIcon(forPath path: String) -> NSImage {
         if let cached = iconCache[path] { return cached }
         let icon = NSWorkspace.shared.icon(forFile: path)
         iconCache[path] = icon

--- a/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
+++ b/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
@@ -19,11 +19,14 @@ private let knownEditors: [ExternalEditor] = [
     ExternalEditor(name: "Finder",          bundleID: "com.apple.finder"),
 ]
 
-private func installedEditors() -> [(editor: ExternalEditor, appURL: URL)] {
-    knownEditors.compactMap { editor in
-        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: editor.bundleID) else { return nil }
-        return (editor, url)
-    }
+// Resolved once per process: each lookup is a Launch Services round-trip
+// (~10 `urlForApplication` calls for the full list), and the installed-app
+// set is process-stable — paying it per body evaluation made every hover
+// toggle re-query Launch Services. An editor installed mid-session appears
+// after the next app launch.
+private let installedEditors: [(editor: ExternalEditor, appURL: URL)] = knownEditors.compactMap { editor in
+    guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: editor.bundleID) else { return nil }
+    return (editor, url)
 }
 
 private let intelliJBundleIDs: Set<String> = ["com.jetbrains.intellij", "com.jetbrains.intellij.ce"]
@@ -86,7 +89,24 @@ struct OpenInEditorButton: View {
     @State private var recentBundleIDs: [String] = []
     @State private var hovering: String? = nil
 
-    private var available: [(editor: ExternalEditor, appURL: URL)] { installedEditors() }
+    private var available: [(editor: ExternalEditor, appURL: URL)] { installedEditors }
+
+    /// App icons keyed by app path. The NSImage must be identity-stable
+    /// across body evaluations — `Image(nsImage:)` diffs by object identity,
+    /// so a fresh `NSWorkspace.icon(forFile:)` per render rebuilt every
+    /// pinned editor's icon layer on each hover toggle. Same rationale as
+    /// `WorktreeRowView.iconCache`. MainActor confinement (SwiftUI body runs
+    /// on main) makes this safe without locks.
+    @MainActor
+    private static var iconCache: [String: NSImage] = [:]
+
+    @MainActor
+    private static func appIcon(forPath path: String) -> NSImage {
+        if let cached = iconCache[path] { return cached }
+        let icon = NSWorkspace.shared.icon(forFile: path)
+        iconCache[path] = icon
+        return icon
+    }
 
     private var pinnedEditors: [(editor: ExternalEditor, appURL: URL)] {
         let byID = Dictionary(uniqueKeysWithValues: available.map { ($0.editor.bundleID, $0) })
@@ -115,7 +135,7 @@ struct OpenInEditorButton: View {
     var body: some View {
         HStack(spacing: 2) {
             ForEach(pinnedEditors, id: \.editor.bundleID) { entry in
-                Image(nsImage: NSWorkspace.shared.icon(forFile: entry.appURL.path))
+                Image(nsImage: Self.appIcon(forPath: entry.appURL.path))
                     .resizable()
                     .scaledToFit()
                     .frame(width: 16, height: 16)

--- a/Tests/TBDAppTests/NotificationAutoMarkReadTests.swift
+++ b/Tests/TBDAppTests/NotificationAutoMarkReadTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Foundation
+@testable import TBDApp
+@testable import TBDShared
+
+/// Direct proof of `AppState.worktreeIDsToAutoMarkRead`, the pure decision
+/// behind `refreshNotifications`' auto-mark-read reconcile. The invariant
+/// under test: the `notifications.markRead` RPC fires only when a visible
+/// worktree actually has unread rows — never as a blanket per-visible-worktree
+/// call on every poll tick — while a notification that arrives WHILE its
+/// worktree is visible still gets marked read.
+@MainActor
+@Suite("refreshNotifications auto-mark-read guard")
+struct NotificationAutoMarkReadTests {
+    private func summary() -> UnreadSummary {
+        UnreadSummary(type: .taskComplete, mostRecentAt: Date())
+    }
+
+    @Test("no unread state fires zero RPCs, however many worktrees are visible")
+    func idleTickFiresNothing() {
+        let visible: Set<UUID> = [UUID(), UUID(), UUID()]
+        let result = AppState.worktreeIDsToAutoMarkRead(unreadSummaries: [:], visible: visible)
+        #expect(result.isEmpty)
+    }
+
+    @Test("a notification arriving while its worktree is visible is marked read")
+    func arriveWhileVisibleIsMarkedRead() {
+        let visibleID = UUID()
+        let result = AppState.worktreeIDsToAutoMarkRead(
+            unreadSummaries: [visibleID: summary()],
+            visible: [visibleID]
+        )
+        #expect(result == [visibleID])
+    }
+
+    @Test("unread on a non-visible worktree is left unread")
+    func nonVisibleUnreadIsNotMarkedRead() {
+        let hiddenID = UUID()
+        let result = AppState.worktreeIDsToAutoMarkRead(
+            unreadSummaries: [hiddenID: summary()],
+            visible: [UUID()]
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test("mixed state marks only the visible worktree with unread rows")
+    func mixedStateMarksOnlyVisibleUnread() {
+        let visibleUnread = UUID()
+        let hiddenUnread = UUID()
+        let visibleWithoutUnread = UUID()
+        let result = AppState.worktreeIDsToAutoMarkRead(
+            unreadSummaries: [visibleUnread: summary(), hiddenUnread: summary()],
+            visible: [visibleUnread, visibleWithoutUnread]
+        )
+        #expect(result == [visibleUnread])
+    }
+}

--- a/Tests/TBDAppTests/OpenInEditorIconCacheTests.swift
+++ b/Tests/TBDAppTests/OpenInEditorIconCacheTests.swift
@@ -1,0 +1,30 @@
+import AppKit
+import Testing
+@testable import TBDApp
+
+/// Tests for `OpenInEditorButton.appIcon(forPath:)` — the cached editor app
+/// icon loader. Mirrors `WorktreeRowIconCacheTests`: the cache exists so the
+/// NSImage handed to `Image(nsImage:)` is identity-stable across body
+/// evaluations; a fresh `NSWorkspace.icon(forFile:)` instance per render
+/// rebuilt every pinned editor's icon layer on each hover toggle.
+@MainActor
+@Suite("OpenInEditorIconCache")
+struct OpenInEditorIconCacheTests {
+
+    @Test("appIcon returns the identical instance on repeated calls")
+    func returnsSameInstance() {
+        // NSWorkspace.icon(forFile:) never returns nil — unknown paths get the
+        // generic document icon — so any stable path exercises the cache.
+        let path = "/System/Library/CoreServices/Finder.app"
+        let first = OpenInEditorButton.appIcon(forPath: path)
+        let second = OpenInEditorButton.appIcon(forPath: path)
+        #expect(first === second)
+    }
+
+    @Test("appIcon caches per path, not one image for all paths")
+    func distinctPathsGetDistinctEntries() {
+        let finder = OpenInEditorButton.appIcon(forPath: "/System/Library/CoreServices/Finder.app")
+        let bin = OpenInEditorButton.appIcon(forPath: "/bin")
+        #expect(finder !== bin)
+    }
+}

--- a/Tests/TBDAppTests/ScratchRowDimmingTests.swift
+++ b/Tests/TBDAppTests/ScratchRowDimmingTests.swift
@@ -50,4 +50,24 @@ struct ScratchRowDimmingTests {
         let promotedButNonScratch = makeWorktree(repoID: UUID(), promotedToRepoID: UUID())
         #expect(!AppState.scratchRowIsDimmed(promotedButNonScratch, directoryExists: false))
     }
+
+    // `directoryExists` backs a synchronous stat() at the call site, and every
+    // sidebar row re-evaluates on any AppState @Published change — so rows the
+    // rule ignores must never evaluate it.
+    @Test("directoryExists is only evaluated for un-promoted scratch rows")
+    func directoryExistsEvaluatedLazily() {
+        var evaluated = false
+
+        let nonScratch = makeWorktree(repoID: UUID())
+        _ = AppState.scratchRowIsDimmed(nonScratch, directoryExists: { evaluated = true; return false }())
+        #expect(!evaluated)
+
+        let promotedScratch = makeWorktree(repoID: nil, promotedToRepoID: UUID())
+        _ = AppState.scratchRowIsDimmed(promotedScratch, directoryExists: { evaluated = true; return false }())
+        #expect(!evaluated)
+
+        let unpromotedScratch = makeWorktree(repoID: nil)
+        _ = AppState.scratchRowIsDimmed(unpromotedScratch, directoryExists: { evaluated = true; return false }())
+        #expect(evaluated)
+    }
 }


### PR DESCRIPTION
Sibling cleanups to PR #327's per-render NSImage fix — three render-path/poll waste spots flagged by the same audit.

## 1. Every sidebar row paid a synchronous stat() per body evaluation

`scratchRowIsDimmed`'s `directoryExists:` argument was evaluated eagerly at the `WorktreeRowView` call site, so every row — scratch or not — hit `FileManager.fileExists` on each body evaluation, and rows re-evaluate on any AppState `@Published` change. The rule only reads the flag for un-promoted scratch rows.

**Fix:** the parameter is now `@autoclosure`, and `&&` short-circuiting skips the stat for non-scratch and promoted rows. Scratch-row behavior is identical (they still stat on their own renders, preserving mid-session missing-dir detection — the stored-property alternative from PR #325's review remains a possible follow-up). `ScratchRowDimmingTests` gains a laziness proof for all three row kinds.

## 2. OpenInEditorButton re-queried Launch Services and rebuilt icons per render

`available`/`pinnedEditors`/`overflowEditors` each re-ran `installedEditors()` (~10 `NSWorkspace.urlForApplication` lookups) per body evaluation, and body created a fresh `NSWorkspace.icon(forFile:)` NSImage per pinned editor per render — `Image(nsImage:)` diffs by object identity, so every hover toggle rebuilt every icon layer (same class as #327).

**Fix:** installed editors resolve once per process (top-level `let`; the set is process-stable, new installs appear on next launch), and icons are cached in a `@MainActor` static keyed by app path, mirroring `WorktreeRowView.iconCache`. The overflow `NSMenu` path keeps its direct lookup — click-driven, and it mutates the image's `size`, which must not touch cached instances. `OpenInEditorIconCacheTests` pins the `===` identity invariant, mirroring #327's regression guard.

## 3. Notification auto-mark-read RPC — audit claim verified as already guarded

The audit flagged `refreshNotifications` as firing `markNotificationsRead` for every visible worktree on every 2s tick. Verified against the daemon: `listNotifications` maps to `unreadSummaryByWorktree()` (unread rows only), and the loop already iterates `fetched.keys` filtered by visibility — idle ticks fire zero RPCs, and marked worktrees drop out of the next fetch. The guard has existed since #51, but only implicitly; the suggested `unreadByWorktree[id] != nil` check would have broken arrive-while-visible (it excludes visible worktrees by construction).

**Change:** extracted the decision into pure `AppState.worktreeIDsToAutoMarkRead` with a doc comment recording why it keys off the fetched summary, plus unit tests pinning both properties (idle → zero RPCs; arrive-while-visible → still marked read). No behavior change.

## Verification

- `swift build` clean, `swift test` — 2030 tests, 251 suites, all pass
- `swiftlint --strict` clean
- 5-agent code-review pass + convergence re-review: clean (one finding — missing icon-cache identity test — addressed in the last commit)

🤖 Generated with [Claude Code](https://claude.ai/code)