### PR TITLE
Perf: Stop re-comparing the whole transcript on the main thread every 1.5s per pane

### DIFF
--- a/Sources/TBDApp/Diagnostics/TranscriptSignposts.swift
+++ b/Sources/TBDApp/Diagnostics/TranscriptSignposts.swift
@@ -9,7 +9,8 @@ import os
 ///
 /// Region names used today (see docs/superpowers/specs/2026-05-11-transcript-render-node-design.md
 /// and docs/diagnostics-strategy.md for capture recipes):
-/// - "transcript.swap"             — LiveTranscriptPaneView.pollOnce mainActor block
+/// - "transcript.swap"             — pollOnce compare+swap phase (compare runs in a
+///                                   detached task; only the publish is on-main)
 /// - "transcript.items.body"       — TranscriptItemsView.body (whole pass)
 /// - "transcript.row.body"         — TranscriptRow.body per row (issue #129 signposts)
 /// - "transcript.markdown.build"   — ChatBubbleView.bubbleBody (split + Markdown view tree)

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -349,8 +349,8 @@ struct LiveTranscriptPaneView: View {
                 TranscriptPollDiff.changed(prev: prev, new: newMessages)
             }.value
             // The detached compare isn't cancellation-linked to the poll task:
-            // if the pane was torn down (tab close / session rollover) while it
-            // ran, skip the publish so a stale snapshot can't resurrect state.
+            // if the pane was torn down (tab close / retry) while it ran, skip
+            // the publish so a stale snapshot can't resurrect state.
             // An interleaved same-key writer during the suspension is tolerable
             // — the publish is a whole fresh daemon snapshot (never derived
             // from `prev`), so the next 1.5s tick converges.

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -348,6 +348,16 @@ struct LiveTranscriptPaneView: View {
             let didChange = await Task.detached(priority: .userInitiated) {
                 TranscriptPollDiff.changed(prev: prev, new: newMessages)
             }.value
+            // The detached compare isn't cancellation-linked to the poll task:
+            // if the pane was torn down (tab close / session rollover) while it
+            // ran, skip the publish so a stale snapshot can't resurrect state.
+            // An interleaved same-key writer during the suspension is tolerable
+            // — the publish is a whole fresh daemon snapshot (never derived
+            // from `prev`), so the next 1.5s tick converges.
+            if Task.isCancelled {
+                TranscriptSignposts.signposter.endInterval("transcript.swap", swapInterval)
+                return
+            }
             let equalElapsed = ContinuousClock.now - equalStart
             let equalMs = Int(equalElapsed.components.seconds * 1000 + equalElapsed.components.attoseconds / 1_000_000_000_000_000)
             let swapStart = ContinuousClock.now

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -336,29 +336,36 @@ struct LiveTranscriptPaneView: View {
             // happened mid-flight; trust the daemon's resolution.
             let resolvedSID = result.sessionID ?? sid
             let swapInterval = TranscriptSignposts.signposter.beginInterval("transcript.swap")
-            let didChange: Bool = await MainActor.run {
-                Self.perfLog.debug("pollOnce.mainActor.start sid=\(sidShort, privacy: .public)")
-                let mainActorStart = ContinuousClock.now
-                let prev = appState.sessionTranscripts[resolvedSID] ?? []
-                let equalStart = ContinuousClock.now
-                let equal = messagesEqual(prev, result.messages)
-                let equalElapsed = ContinuousClock.now - equalStart
-                let equalMs = Int(equalElapsed.components.seconds * 1000 + equalElapsed.components.attoseconds / 1_000_000_000_000_000)
-                let swapStart = ContinuousClock.now
-                if !equal {
-                    appState.sessionTranscripts[resolvedSID] = result.messages
-                    appState.touchSessionTranscript(resolvedSID)
-                }
-                let swapElapsed = ContinuousClock.now - swapStart
-                let swapMs = Int(swapElapsed.components.seconds * 1000 + swapElapsed.components.attoseconds / 1_000_000_000_000_000)
-                if !result.messages.isEmpty {
-                    hasShownInitialMessages = true
-                }
-                let mainActorElapsed = ContinuousClock.now - mainActorStart
-                let mainActorMs = Int(mainActorElapsed.components.seconds * 1000 + mainActorElapsed.components.attoseconds / 1_000_000_000_000_000)
-                Self.perfLog.debug("pollOnce.mainActor.end sid=\(sidShort, privacy: .public) elapsed_ms=\(mainActorMs, privacy: .public) equal_ms=\(equalMs, privacy: .public) swap_ms=\(swapMs, privacy: .public)")
-                return !equal
+            Self.perfLog.debug("pollOnce.mainActor.start sid=\(sidShort, privacy: .public)")
+            let phaseStart = ContinuousClock.now
+            // `prev` is a cheap COW snapshot taken on the main actor; the deep
+            // equality compare then runs in a detached task so a long
+            // transcript never burns main-thread time proving "nothing
+            // changed" on an idle tick (#129 territory).
+            let prev = appState.sessionTranscripts[resolvedSID] ?? []
+            let newMessages = result.messages
+            let equalStart = ContinuousClock.now
+            let didChange = await Task.detached(priority: .userInitiated) {
+                TranscriptPollDiff.changed(prev: prev, new: newMessages)
+            }.value
+            let equalElapsed = ContinuousClock.now - equalStart
+            let equalMs = Int(equalElapsed.components.seconds * 1000 + equalElapsed.components.attoseconds / 1_000_000_000_000_000)
+            let swapStart = ContinuousClock.now
+            if didChange {
+                appState.sessionTranscripts[resolvedSID] = newMessages
+                appState.touchSessionTranscript(resolvedSID)
             }
+            let swapElapsed = ContinuousClock.now - swapStart
+            let swapMs = Int(swapElapsed.components.seconds * 1000 + swapElapsed.components.attoseconds / 1_000_000_000_000_000)
+            if !newMessages.isEmpty {
+                hasShownInitialMessages = true
+            }
+            let phaseElapsed = ContinuousClock.now - phaseStart
+            let phaseMs = Int(phaseElapsed.components.seconds * 1000 + phaseElapsed.components.attoseconds / 1_000_000_000_000_000)
+            // Log event names kept from the MainActor.run era so existing
+            // `log stream` recipes keep matching; equal_ms now measures the
+            // detached compare, swap_ms the on-main publish.
+            Self.perfLog.debug("pollOnce.mainActor.end sid=\(sidShort, privacy: .public) elapsed_ms=\(phaseMs, privacy: .public) equal_ms=\(equalMs, privacy: .public) swap_ms=\(swapMs, privacy: .public)")
             TranscriptSignposts.signposter.endInterval("transcript.swap", swapInterval)
             changed = didChange
         } catch {
@@ -369,17 +376,6 @@ struct LiveTranscriptPaneView: View {
         let pollElapsed = ContinuousClock.now - pollStart
         let pollMs = Int(pollElapsed.components.seconds * 1000 + pollElapsed.components.attoseconds / 1_000_000_000_000_000)
         Self.perfLog.debug("pollOnce.end sid=\(sidShort, privacy: .public) elapsed_ms=\(pollMs, privacy: .public) changed=\(changed, privacy: .public) count=\(finalCount, privacy: .public)")
-    }
-
-    private func messagesEqual(_ a: [TranscriptItem], _ b: [TranscriptItem]) -> Bool {
-        let start = ContinuousClock.now
-        let result = a == b
-        let elapsed = ContinuousClock.now - start
-        if max(a.count, b.count) > 100 {
-            let ms = Int(elapsed.components.seconds * 1000 + elapsed.components.attoseconds / 1_000_000_000_000_000)
-            Self.perfLog.debug("messagesEqual elapsed_ms=\(ms, privacy: .public) count_a=\(a.count, privacy: .public) count_b=\(b.count, privacy: .public) result=\(result, privacy: .public)")
-        }
-        return result
     }
 }
 

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -297,6 +297,13 @@ struct TableTranscriptPaneView: View {
             let didChange = await Task.detached(priority: .userInitiated) {
                 TranscriptPollDiff.changed(prev: prev, new: newMessages)
             }.value
+            // The detached compare isn't cancellation-linked to the poll task:
+            // if the pane was torn down (tab close / session rollover) while it
+            // ran, skip the publish so a stale snapshot can't resurrect state.
+            // An interleaved same-key writer during the suspension is tolerable
+            // — the publish is a whole fresh daemon snapshot (never derived
+            // from `prev`), so the next 1.5s tick converges.
+            if Task.isCancelled { return }
             if didChange {
                 appState.sessionTranscripts[resolvedSID] = newMessages
                 appState.touchSessionTranscript(resolvedSID)

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -288,15 +288,21 @@ struct TableTranscriptPaneView: View {
             let result = try await appState.daemonClient.terminalTranscript(terminalID: terminalID)
             failureCount = 0
             let resolvedSID = result.sessionID ?? sid
-            await MainActor.run {
-                let prev = appState.sessionTranscripts[resolvedSID] ?? []
-                if prev != result.messages {
-                    appState.sessionTranscripts[resolvedSID] = result.messages
-                    appState.touchSessionTranscript(resolvedSID)
-                }
-                if !result.messages.isEmpty {
-                    hasShownInitialMessages = true
-                }
+            // `prev` is a cheap COW snapshot taken on the main actor; the deep
+            // equality compare then runs in a detached task so a long
+            // transcript never burns main-thread time proving "nothing
+            // changed" on an idle tick (#129 territory).
+            let prev = appState.sessionTranscripts[resolvedSID] ?? []
+            let newMessages = result.messages
+            let didChange = await Task.detached(priority: .userInitiated) {
+                TranscriptPollDiff.changed(prev: prev, new: newMessages)
+            }.value
+            if didChange {
+                appState.sessionTranscripts[resolvedSID] = newMessages
+                appState.touchSessionTranscript(resolvedSID)
+            }
+            if !newMessages.isEmpty {
+                hasShownInitialMessages = true
             }
         } catch {
             failureCount += 1

--- a/Sources/TBDApp/Panes/Transcript/TextKit/STTextViewTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TextKit/STTextViewTranscriptPaneView.swift
@@ -370,29 +370,36 @@ struct STTextViewTranscriptPaneView: View {
             finalCount = result.messages.count
             let resolvedSID = result.sessionID ?? sid
             let swapInterval = TranscriptSignposts.signposter.beginInterval("transcript.swap")
-            let didChange: Bool = await MainActor.run {
-                Self.perfLog.debug("textkit.pollOnce.mainActor.start sid=\(sidShort, privacy: .public)")
-                let mainActorStart = ContinuousClock.now
-                let prev = appState.sessionTranscripts[resolvedSID] ?? []
-                let equalStart = ContinuousClock.now
-                let equal = messagesEqual(prev, result.messages)
-                let equalElapsed = ContinuousClock.now - equalStart
-                let equalMs = Int(equalElapsed.components.seconds * 1000 + equalElapsed.components.attoseconds / 1_000_000_000_000_000)
-                let swapStart = ContinuousClock.now
-                if !equal {
-                    appState.sessionTranscripts[resolvedSID] = result.messages
-                    appState.touchSessionTranscript(resolvedSID)
-                }
-                let swapElapsed = ContinuousClock.now - swapStart
-                let swapMs = Int(swapElapsed.components.seconds * 1000 + swapElapsed.components.attoseconds / 1_000_000_000_000_000)
-                if !result.messages.isEmpty {
-                    hasShownInitialMessages = true
-                }
-                let mainActorElapsed = ContinuousClock.now - mainActorStart
-                let mainActorMs = Int(mainActorElapsed.components.seconds * 1000 + mainActorElapsed.components.attoseconds / 1_000_000_000_000_000)
-                Self.perfLog.debug("textkit.pollOnce.mainActor.end sid=\(sidShort, privacy: .public) elapsed_ms=\(mainActorMs, privacy: .public) equal_ms=\(equalMs, privacy: .public) swap_ms=\(swapMs, privacy: .public)")
-                return !equal
+            Self.perfLog.debug("textkit.pollOnce.mainActor.start sid=\(sidShort, privacy: .public)")
+            let phaseStart = ContinuousClock.now
+            // `prev` is a cheap COW snapshot taken on the main actor; the deep
+            // equality compare then runs in a detached task so a long
+            // transcript never burns main-thread time proving "nothing
+            // changed" on an idle tick (#129 territory).
+            let prev = appState.sessionTranscripts[resolvedSID] ?? []
+            let newMessages = result.messages
+            let equalStart = ContinuousClock.now
+            let didChange = await Task.detached(priority: .userInitiated) {
+                TranscriptPollDiff.changed(prev: prev, new: newMessages)
+            }.value
+            let equalElapsed = ContinuousClock.now - equalStart
+            let equalMs = Int(equalElapsed.components.seconds * 1000 + equalElapsed.components.attoseconds / 1_000_000_000_000_000)
+            let swapStart = ContinuousClock.now
+            if didChange {
+                appState.sessionTranscripts[resolvedSID] = newMessages
+                appState.touchSessionTranscript(resolvedSID)
             }
+            let swapElapsed = ContinuousClock.now - swapStart
+            let swapMs = Int(swapElapsed.components.seconds * 1000 + swapElapsed.components.attoseconds / 1_000_000_000_000_000)
+            if !newMessages.isEmpty {
+                hasShownInitialMessages = true
+            }
+            let phaseElapsed = ContinuousClock.now - phaseStart
+            let phaseMs = Int(phaseElapsed.components.seconds * 1000 + phaseElapsed.components.attoseconds / 1_000_000_000_000_000)
+            // Log event names kept from the MainActor.run era so existing
+            // `log stream` recipes keep matching; equal_ms now measures the
+            // detached compare, swap_ms the on-main publish.
+            Self.perfLog.debug("textkit.pollOnce.mainActor.end sid=\(sidShort, privacy: .public) elapsed_ms=\(phaseMs, privacy: .public) equal_ms=\(equalMs, privacy: .public) swap_ms=\(swapMs, privacy: .public)")
             TranscriptSignposts.signposter.endInterval("transcript.swap", swapInterval)
             changed = didChange
             // Diag: log message source, thread resolution, and displayed head/tail
@@ -424,17 +431,6 @@ struct STTextViewTranscriptPaneView: View {
         let pollElapsed = ContinuousClock.now - pollStart
         let pollMs = Int(pollElapsed.components.seconds * 1000 + pollElapsed.components.attoseconds / 1_000_000_000_000_000)
         Self.perfLog.debug("textkit.pollOnce.end sid=\(sidShort, privacy: .public) elapsed_ms=\(pollMs, privacy: .public) changed=\(changed, privacy: .public) count=\(finalCount, privacy: .public)")
-    }
-
-    private func messagesEqual(_ a: [TranscriptItem], _ b: [TranscriptItem]) -> Bool {
-        let start = ContinuousClock.now
-        let result = a == b
-        let elapsed = ContinuousClock.now - start
-        if max(a.count, b.count) > 100 {
-            let ms = Int(elapsed.components.seconds * 1000 + elapsed.components.attoseconds / 1_000_000_000_000_000)
-            Self.perfLog.debug("textkit.messagesEqual elapsed_ms=\(ms, privacy: .public) count_a=\(a.count, privacy: .public) count_b=\(b.count, privacy: .public) result=\(result, privacy: .public)")
-        }
-        return result
     }
 }
 

--- a/Sources/TBDApp/Panes/Transcript/TextKit/STTextViewTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TextKit/STTextViewTranscriptPaneView.swift
@@ -382,6 +382,16 @@ struct STTextViewTranscriptPaneView: View {
             let didChange = await Task.detached(priority: .userInitiated) {
                 TranscriptPollDiff.changed(prev: prev, new: newMessages)
             }.value
+            // The detached compare isn't cancellation-linked to the poll task:
+            // if the pane was torn down (tab close / session rollover) while it
+            // ran, skip the publish so a stale snapshot can't resurrect state.
+            // An interleaved same-key writer during the suspension is tolerable
+            // — the publish is a whole fresh daemon snapshot (never derived
+            // from `prev`), so the next 1.5s tick converges.
+            if Task.isCancelled {
+                TranscriptSignposts.signposter.endInterval("transcript.swap", swapInterval)
+                return
+            }
             let equalElapsed = ContinuousClock.now - equalStart
             let equalMs = Int(equalElapsed.components.seconds * 1000 + equalElapsed.components.attoseconds / 1_000_000_000_000_000)
             let swapStart = ContinuousClock.now

--- a/Sources/TBDApp/Panes/Transcript/TranscriptPollDiff.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptPollDiff.swift
@@ -7,8 +7,10 @@ import TBDShared
 /// array compare of a long transcript never burns main-thread time proving
 /// "nothing changed" on every 1.5s tick (#129 territory).
 enum TranscriptPollDiff {
-    /// O(1)-ish precheck: a count mismatch or a differing last item proves the
-    /// transcript changed without touching the other N-1 elements. Returns
+    /// Cheap precheck: a count mismatch or a differing last item proves the
+    /// transcript changed without touching the other N-1 elements (comparing
+    /// the last item can still recurse into its subagent thread, so this is
+    /// bounded by one item, not strictly O(1)). Returns
     /// `nil` when the cheap signals match — that does NOT prove equality,
     /// because the JSONL parser merges late tool results into earlier
     /// `toolCall` items, so a mid-array item can mutate while the tail stays

--- a/Sources/TBDApp/Panes/Transcript/TranscriptPollDiff.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptPollDiff.swift
@@ -1,0 +1,27 @@
+import TBDShared
+
+/// Pure change-detection for the live-transcript poll loops
+/// (`LiveTranscriptPaneView` / `STTextViewTranscriptPaneView`).
+///
+/// The poll loops call `changed(prev:new:)` from a detached task so the deep
+/// array compare of a long transcript never burns main-thread time proving
+/// "nothing changed" on every 1.5s tick (#129 territory).
+enum TranscriptPollDiff {
+    /// O(1)-ish precheck: a count mismatch or a differing last item proves the
+    /// transcript changed without touching the other N-1 elements. Returns
+    /// `nil` when the cheap signals match — that does NOT prove equality,
+    /// because the JSONL parser merges late tool results into earlier
+    /// `toolCall` items, so a mid-array item can mutate while the tail stays
+    /// identical.
+    static func cheapChangeCheck(prev: [TranscriptItem], new: [TranscriptItem]) -> Bool? {
+        if prev.count != new.count { return true }
+        if prev.last != new.last { return true }
+        return nil
+    }
+
+    /// Full change detection: cheap precheck first, deep compare only when
+    /// the precheck is inconclusive.
+    static func changed(prev: [TranscriptItem], new: [TranscriptItem]) -> Bool {
+        cheapChangeCheck(prev: prev, new: new) ?? (prev != new)
+    }
+}

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -55,8 +55,9 @@ enum TranscriptParser {
         var rawLines: [[String: Any]] = []
         // Parallel to rawLines. Stable per-line identifier used as a fallback
         // when a line is missing the `uuid` field. Using a fresh UUID() here
-        // would make messagesEqual permanently false for that item (forcing a
-        // @Published write on every poll). Line index is process-stable and
+        // would make the poll loops' TranscriptPollDiff.changed permanently
+        // true for that item (forcing a @Published write on every poll). Line
+        // index is process-stable and
         // cheap; in practice every Claude JSONL line carries a `uuid` so this
         // fallback is defensive.
         var stableIDs: [String] = []

--- a/Tests/TBDAppTests/TranscriptPollDiffTests.swift
+++ b/Tests/TBDAppTests/TranscriptPollDiffTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// Verifies the poll-loop change detection: the O(1) precheck may only ever
+/// prove "changed" (count or last-item mismatch) — proving "unchanged"
+/// requires the deep compare, because a late tool result merges into an
+/// EARLIER `toolCall` item without touching the tail.
+@Suite("TranscriptPollDiff")
+struct TranscriptPollDiffTests {
+    private func prompt(_ id: String, _ text: String) -> TranscriptItem {
+        .userPrompt(id: id, text: text, timestamp: nil)
+    }
+
+    private func toolCall(_ id: String, result: ToolResult?) -> TranscriptItem {
+        .toolCall(
+            id: id, name: "Bash", inputJSON: "{}", inputTruncatedTo: nil,
+            result: result, subagent: nil, timestamp: nil, usage: nil)
+    }
+
+    // MARK: cheapChangeCheck
+
+    @Test("count mismatch is a definite change")
+    func countMismatch() {
+        let prev = [prompt("a", "one")]
+        let new = [prompt("a", "one"), prompt("b", "two")]
+        #expect(TranscriptPollDiff.cheapChangeCheck(prev: prev, new: new) == true)
+        #expect(TranscriptPollDiff.changed(prev: prev, new: new))
+    }
+
+    @Test("same count with a differing last item is a definite change")
+    func lastItemMismatch() {
+        let prev = [prompt("a", "one"), prompt("b", "streaming…")]
+        let new = [prompt("a", "one"), prompt("b", "streaming… more")]
+        #expect(TranscriptPollDiff.cheapChangeCheck(prev: prev, new: new) == true)
+        #expect(TranscriptPollDiff.changed(prev: prev, new: new))
+    }
+
+    @Test("matching count and last item is inconclusive, not equal")
+    func inconclusivePrecheck() {
+        let prev = [prompt("a", "one"), prompt("b", "two")]
+        let new = [prompt("a", "CHANGED"), prompt("b", "two")]
+        #expect(TranscriptPollDiff.cheapChangeCheck(prev: prev, new: new) == nil)
+    }
+
+    @Test("identical arrays are inconclusive at the precheck stage")
+    func identicalInconclusive() {
+        let items = [prompt("a", "one"), prompt("b", "two")]
+        #expect(TranscriptPollDiff.cheapChangeCheck(prev: items, new: items) == nil)
+    }
+
+    // MARK: changed (deep fallback)
+
+    @Test("mid-array mutation with an identical tail is detected as changed")
+    func midArrayToolResultMerge() {
+        // Simulates the parser merging a late tool result into an earlier
+        // toolCall item: tail unchanged, middle mutated.
+        let tail = prompt("c", "done")
+        let prev = [prompt("a", "run it"), toolCall("b", result: nil), tail]
+        let new = [
+            prompt("a", "run it"),
+            toolCall("b", result: ToolResult(text: "ok", truncatedTo: nil, isError: false)),
+            tail,
+        ]
+        #expect(TranscriptPollDiff.cheapChangeCheck(prev: prev, new: new) == nil)
+        #expect(TranscriptPollDiff.changed(prev: prev, new: new))
+    }
+
+    @Test("identical non-empty arrays are unchanged")
+    func identicalUnchanged() {
+        let items = [prompt("a", "one"), toolCall("b", result: nil)]
+        #expect(!TranscriptPollDiff.changed(prev: items, new: items))
+    }
+
+    @Test("two empty arrays are unchanged")
+    func bothEmpty() {
+        #expect(!TranscriptPollDiff.changed(prev: [], new: []))
+    }
+
+    @Test("empty to non-empty is changed")
+    func emptyToNonEmpty() {
+        #expect(TranscriptPollDiff.changed(prev: [], new: [prompt("a", "hi")]))
+    }
+}


### PR DESCRIPTION
## Problem

Every visible live transcript pane polls the daemon each 1.5s, and each tick ran a full deep array compare (`prev == result.messages`) of the ENTIRE transcript inside the MainActor context. Main-thread cost per idle tick therefore grew unboundedly with session length x visible panes — #129-class territory.

## Fix (option 2 from the audit: off-main compare + zero-risk precheck)

- New pure helper `TranscriptPollDiff`: cheap precheck (count or last-item mismatch proves "changed" without touching the other N-1 elements) with deep-compare fallback. The fallback is required for correctness: the JSONL parser merges late tool results into EARLIER `toolCall` items, so a mid-array item can mutate while the tail stays identical (covered by a dedicated unit test).
- All three poll loops (`LiveTranscriptPaneView`, the TextKit twin `STTextViewTranscriptPaneView`, and `TableTranscriptPaneView`'s steady-state branch) now take a cheap COW snapshot of `prev` on the main actor, run the compare in a detached task, and hop back only to publish when changed.
- `Task.isCancelled` re-check before publish (the detached compare isn't cancellation-linked), so a pane torn down mid-compare can't publish a stale snapshot.
- 8 unit tests for the pure helper.

## Why not tailLimit / RPC change-detection (option 1)

`TerminalTranscriptResult` carries no mtime/revision, and adding RPC fields was to be avoided. A `tailLimit` fetch is a partial view (it also bypasses the daemon's `TranscriptParseCache`), so using it for the live panes would change full-history rendering semantics — too risky per this file's regression history.

**Known residual**: the full-transcript fetch + JSON decode per tick remains. Both already run off-main on the `DaemonClient` actor and in the daemon (which caches parses by mtime), so this PR removes the growing *main-thread* portion; per-tick bandwidth/CPU off-main still scales with session length. Surfacing an mtime/revision in the RPC is the natural follow-up if that matters.

## Review notes

- The old single `MainActor.run { read prev; compare; write }` block was atomic on the main actor; the detached compare introduces a suspension between read and publish. This is latent, not live: the three pane types are mutually exclusive per terminal, the only other same-key writer (`AppState+History`) is nil-guarded, and the published value is a whole fresh daemon snapshot (never derived from `prev`), so an interleaved write self-heals on the next 1.5s tick. Documented in-code.
- Perf log event names (`pollOnce.mainActor.start/end`, `equal_ms`, `swap_ms`) and the `transcript.swap` signpost are kept so existing `log stream` recipes keep matching; comments and the `TranscriptSignposts` region doc note that `equal_ms` now measures the detached compare.

## Verification

- `swift build`, `swift test` (2031 tests), `swiftlint --strict` all pass.
- Multi-agent code review run; findings addressed in follow-up commits.

**Live verification required before merge** (transcript bugs are live-only per project history): with a streaming Claude session, verify both pane types (SwiftUI live pane and the table/TextKit pane) still render appends, autoscroll, and survive `/clear` rollover; watch `log stream --level debug --predicate 'subsystem BEGINSWITH "com.tbd" AND category == "perf-transcript"'` and confirm `equal_ms`/`swap_ms` stay low and `changed=false` ticks no longer cost main-thread time on a long session.