### PR TITLE
Feat: Scratch section detail pane — archive, prompts, and model profile parity with repos

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -177,6 +177,16 @@ extension AppState {
         }
     }
 
+    /// Set the global scratch-space rename-nudge override. Nil or blank resets to the built-in default.
+    func setScratchRenamePrompt(_ value: String?) async {
+        do {
+            try await daemonClient.setScratchRenamePrompt(value)
+        } catch {
+            logger.error("Failed to set scratch rename prompt: \(error, privacy: .public)")
+            handleConnectionError(error)
+        }
+    }
+
     /// Fetch the current global Config (used by the scratch-instructions editor to show the effective text).
     func fetchConfig() async -> Config? {
         do {
@@ -200,6 +210,18 @@ extension AppState {
         } catch {
             logger.error("Failed to set repo profile override: \(error, privacy: .public)")
             showAlert("Failed to set repo profile: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set or clear the global model-profile override applied to scratch terminal
+    /// spawns. Unlike `setRepoProfileOverride`, there's no `Repo` array entry to
+    /// patch afterward — callers refresh their own local `@State` on success.
+    func setScratchProfileOverride(_ profileID: UUID?) async {
+        do {
+            try await daemonClient.setScratchProfileOverride(profileID)
+        } catch {
+            logger.error("Failed to set scratch profile override: \(error, privacy: .public)")
+            showAlert("Failed to set scratch profile override: \(error.localizedDescription)", isError: true)
         }
     }
 

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -191,6 +191,7 @@ extension AppState {
         case .worktrees(let ids):
             if let leavingRepoID { clearRevivingArchived(repoID: leavingRepoID) }
             selectedRepoID = nil
+            selectedScratchSection = false
             selectedWorktreeIDs = Set(ids)
             selectionOrder = ids // must come after; didSet above rebuilds from unordered Set
         case .repo(let id):
@@ -199,6 +200,7 @@ extension AppState {
             }
             selectedWorktreeIDs = []
             selectedRepoID = id
+            selectedScratchSection = false
             Task { await refreshArchivedWorktrees(repoID: id) }
         }
     }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -86,16 +86,22 @@ extension AppState {
         }
     }
 
-    /// Delete a scratch space: closes its terminals and moves its folder to Trash.
-    func deleteScratch(id: UUID) {
-        Task {
-            do {
-                try await daemonClient.deleteScratch(worktreeID: id)
-                scratchWorktrees.removeAll { $0.id == id }
-            } catch {
-                logger.error("Failed to delete scratch space: \(error)")
-                handleConnectionError(error)
-            }
+    /// Delete a scratch space: closes its terminals and moves its folder to
+    /// Trash. Handles both active rows (sidebar context menu) and archived
+    /// rows (the Scratch detail pane's Archived tab) — the daemon-side
+    /// `scratch.delete` works on either, so this clears the row from both
+    /// client-side arrays. Error handling mirrors `archiveScratch`/
+    /// `reviveScratch`: `handleConnectionError` drives the reconnect UI on a
+    /// connection drop, and the alert makes non-connection failures visible.
+    func deleteScratch(id: UUID) async {
+        do {
+            try await daemonClient.deleteScratch(worktreeID: id)
+            scratchWorktrees.removeAll { $0.id == id }
+            archivedScratchWorktrees.removeAll { $0.id == id }
+        } catch {
+            logger.error("Failed to delete scratch space: \(error)")
+            handleConnectionError(error)
+            showAlert("Couldn't delete scratch space: \(error.localizedDescription)", isError: true)
         }
     }
 
@@ -112,6 +118,7 @@ extension AppState {
             await refreshArchivedScratch()
         } catch {
             logger.error("Failed to archive scratch space: \(error)")
+            handleConnectionError(error)
             showAlert("Couldn't archive scratch space: \(error.localizedDescription)", isError: true)
         }
     }
@@ -126,6 +133,7 @@ extension AppState {
             await refreshWorktrees()
         } catch {
             logger.error("Failed to revive scratch space: \(error)")
+            handleConnectionError(error)
             showAlert("Couldn't revive scratch space: \(error.localizedDescription)", isError: true)
         }
     }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -99,6 +99,50 @@ extension AppState {
         }
     }
 
+    /// Archive a scratch space: closes its terminals (folder untouched), moves
+    /// it into the Scratch section's Archived tab. The `.worktreeArchived`
+    /// delta this broadcasts already removes the row from `scratchWorktrees`
+    /// via `removeArchivedWorktreeFromState` (see `AppState+ArchiveTombstones.swift`),
+    /// so the local removal here is belt-and-suspenders for the caller that
+    /// issued the RPC (same pattern as `archiveWorktree`).
+    func archiveScratch(id: UUID) async {
+        do {
+            try await daemonClient.archiveScratch(worktreeID: id)
+            scratchWorktrees.removeAll { $0.id == id }
+            await refreshArchivedScratch()
+        } catch {
+            logger.error("Failed to archive scratch space: \(error)")
+            showAlert("Couldn't archive scratch space: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Revive an archived scratch space. Surfaces a visible alert on failure —
+    /// the daemon returns a real error (e.g. the folder was deleted out from
+    /// under the archived row) that must not fail silently.
+    func reviveScratch(id: UUID) async {
+        do {
+            try await daemonClient.reviveScratch(worktreeID: id)
+            archivedScratchWorktrees.removeAll { $0.id == id }
+            await refreshWorktrees()
+        } catch {
+            logger.error("Failed to revive scratch space: \(error)")
+            showAlert("Couldn't revive scratch space: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Fetch archived scratch spaces (repo-less, `status == .archived`) for
+    /// `ScratchArchivedView`. No pagination for v1 — scratch archive volume is
+    /// expected to be low.
+    func refreshArchivedScratch() async {
+        do {
+            archivedScratchWorktrees = try await daemonClient.listWorktrees(
+                status: .archived, scratchOnly: true
+            )
+        } catch {
+            logger.error("Failed to list archived scratch spaces: \(error)")
+        }
+    }
+
     /// List local + remote tracking branches for a repo, for the existing-
     /// branch picker on the sidebar `+` button. Rethrows so the picker can
     /// distinguish a fetch failure from a genuinely empty branch list.
@@ -285,6 +329,7 @@ extension AppState {
 
         selectedWorktreeIDs = []
         selectedRepoID = rid
+        selectedScratchSection = false
         archivedWorktrees[rid] = archived.filter { $0.repoID == rid }
         archivedWorktreesHasMore[rid] = false
         highlightedArchivedWorktreeID = id
@@ -325,7 +370,21 @@ extension AppState {
         highlightedArchivedWorktreeID = nil
         selectedWorktreeIDs = []
         selectedRepoID = id
+        selectedScratchSection = false
         Task { await refreshArchivedWorktrees(repoID: id) }
+    }
+
+    /// Select the "Scratch" sidebar section header to show `ScratchDetailView`
+    /// (Archived/Instructions/Settings tabs) in the content pane. Mirrors
+    /// `selectRepo(id:)`; no `NavigationEntry`/back-forward integration for v1
+    /// (documented scope cut — the Scratch section header has no natural UUID
+    /// identity for `List`'s native selection or the navigation history's
+    /// worktree/repo entries to key off).
+    func selectScratchSection() {
+        highlightedArchivedWorktreeID = nil
+        selectedWorktreeIDs = []
+        selectedRepoID = nil
+        selectedScratchSection = true
     }
 
     private static let archivedPageSize = 50

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -100,6 +100,7 @@ final class AppState: ObservableObject {
             if !selectedWorktreeIDs.isEmpty {
                 if let leaving = selectedRepoID { clearRevivingArchived(repoID: leaving) }
                 selectedRepoID = nil
+                selectedScratchSection = false
                 recordNavigation(.worktrees(selectionOrder))
                 // Feed the jump menu's Recent section. Insertion-order LRU,
                 // most-recent-first; capped at 32 to bound memory. Only the
@@ -135,6 +136,11 @@ final class AppState: ObservableObject {
             recordNavigation(.repo(id))
         }
     }
+    /// Selected — set when the "Scratch" sidebar section header is clicked,
+    /// shows `ScratchDetailView` (Archived/Instructions/Settings tabs) in the
+    /// content pane. Parallel to `selectedRepoID` but with no `NavigationEntry`
+    /// integration for v1 (documented scope cut — see `selectScratchSection()`).
+    @Published var selectedScratchSection: Bool = false
 
     // MARK: - Navigation history (back/forward)
 
@@ -167,6 +173,11 @@ final class AppState: ObservableObject {
     }
     /// Archived worktrees keyed by repo ID, fetched on demand.
     @Published var archivedWorktrees: [UUID: [Worktree]] = [:]
+
+    /// Archived scratch spaces (repo-less), fetched on demand by
+    /// `ScratchArchivedView`. Unlike `archivedWorktrees`, this is a flat list —
+    /// scratch archive volume is expected to be low, so no pagination for v1.
+    @Published var archivedScratchWorktrees: [Worktree] = []
 
     /// Whether there are more archived worktrees to load beyond what's in `archivedWorktrees`.
     @Published var archivedWorktreesHasMore: [UUID: Bool] = [:]

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -38,6 +38,8 @@ struct ContentView: View {
             } detail: {
                 if !appState.isConnected {
                     disconnectedView
+                } else if appState.selectedScratchSection {
+                    ScratchDetailView()
                 } else if appState.repos.isEmpty {
                     emptyStateView
                 } else if let repoID = appState.selectedRepoID {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -486,6 +486,22 @@ actor DaemonClient {
         )
     }
 
+    /// Archive a scratch worktree: closes its terminals, leaves the folder on disk.
+    func archiveScratch(worktreeID: UUID) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.scratchArchive,
+            params: ScratchArchiveParams(worktreeID: worktreeID)
+        )
+    }
+
+    /// Revive an archived scratch worktree. Errors if its folder no longer exists on disk.
+    func reviveScratch(worktreeID: UUID) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.scratchRevive,
+            params: ScratchReviveParams(worktreeID: worktreeID)
+        )
+    }
+
     /// List local + `origin/*` branches for a repo. Used by the existing-
     /// branch picker on the sidebar `+` button.
     func listBranches(repoID: UUID) async throws -> [BranchInfo] {
@@ -500,12 +516,16 @@ actor DaemonClient {
     /// List worktrees, optionally filtered by repo and/or status, with optional pagination.
     /// Pass `excludeArchived: true` to skip archived rows (used by the 2 s poll so
     /// the 87 % of payload that is immediately dropped client-side never crosses the wire).
+    /// Pass `scratchOnly: true` to restrict the result to repo-less (scratch)
+    /// worktrees — otherwise `repoID: nil` means "no repo filter" (i.e. every
+    /// repo plus scratch), not "scratch only".
     func listWorktrees(
         repoID: UUID? = nil,
         status: WorktreeStatus? = nil,
         limit: Int? = nil,
         offset: Int? = nil,
-        excludeArchived: Bool = false
+        excludeArchived: Bool = false,
+        scratchOnly: Bool = false
     ) async throws -> [Worktree] {
         return try await callAsync(
             method: RPCMethod.worktreeList,
@@ -514,7 +534,8 @@ actor DaemonClient {
                 status: status,
                 limit: limit,
                 offset: offset,
-                excludeArchived: excludeArchived
+                excludeArchived: excludeArchived,
+                scratchOnly: scratchOnly
             ),
             resultType: [Worktree].self
         )
@@ -741,6 +762,14 @@ actor DaemonClient {
         try await callVoidAsync(
             method: RPCMethod.configSetScratchInstructions,
             params: ConfigSetScratchInstructionsParams(instructions: instructions)
+        )
+    }
+
+    /// Set the global scratch-space rename-nudge override. Nil or blank resets to the built-in default.
+    func setScratchRenamePrompt(_ value: String?) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetScratchRenamePrompt,
+            params: ConfigSetScratchRenamePromptParams(renamePrompt: value)
         )
     }
 
@@ -1121,6 +1150,14 @@ actor DaemonClient {
         try await callVoidAsync(
             method: RPCMethod.modelProfileSetRepoOverride,
             params: ModelProfileSetRepoOverrideParams(repoID: repoID, profileID: profileID)
+        )
+    }
+
+    /// Set or clear the global model-profile override applied to scratch terminal spawns.
+    func setScratchProfileOverride(_ id: UUID?) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetScratchProfileOverride,
+            params: ConfigSetScratchProfileOverrideParams(profileID: id)
         )
     }
 

--- a/Sources/TBDApp/ScratchArchivedView.swift
+++ b/Sources/TBDApp/ScratchArchivedView.swift
@@ -41,7 +41,7 @@ struct ScratchArchivedView: View {
         ) {
             Button("Delete", role: .destructive) {
                 if let id = pendingDeleteID {
-                    delete(id: id)
+                    Task { await appState.deleteScratch(id: id) }
                 }
                 pendingDeleteID = nil
             }
@@ -97,17 +97,6 @@ struct ScratchArchivedView: View {
             }
             Button("Delete", role: .destructive) {
                 pendingDeleteID = worktree.id
-            }
-        }
-    }
-
-    private func delete(id: UUID) {
-        Task {
-            do {
-                try await appState.daemonClient.deleteScratch(worktreeID: id)
-                appState.archivedScratchWorktrees.removeAll { $0.id == id }
-            } catch {
-                appState.showAlert("Couldn't delete scratch space: \(error.localizedDescription)", isError: true)
             }
         }
     }

--- a/Sources/TBDApp/ScratchArchivedView.swift
+++ b/Sources/TBDApp/ScratchArchivedView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import TBDShared
+
+/// Archived tab for `ScratchDetailView`: a plain list of archived scratch
+/// spaces. Deliberately NOT `ArchivedWorktreesView` (the rich master-detail
+/// session-history browser built for repo worktrees) — scratch archive
+/// (Stage 2) tears down terminals fully at archive time, exactly like
+/// `scratch.delete`, so there are no Claude sessions to browse. No split
+/// pane, no pagination — scratch archive volume is expected to be low.
+struct ScratchArchivedView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var pendingDeleteID: UUID?
+
+    private var rows: [Worktree] {
+        appState.archivedScratchWorktrees.sorted {
+            ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast)
+        }
+    }
+
+    var body: some View {
+        Group {
+            if rows.isEmpty {
+                emptyState
+            } else {
+                List(rows) { worktree in
+                    row(for: worktree)
+                }
+                .listStyle(.inset)
+            }
+        }
+        .task {
+            await appState.refreshArchivedScratch()
+        }
+        .confirmationDialog(
+            "Delete this scratch space?",
+            isPresented: Binding(
+                get: { pendingDeleteID != nil },
+                set: { if !$0 { pendingDeleteID = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let id = pendingDeleteID {
+                    delete(id: id)
+                }
+                pendingDeleteID = nil
+            }
+            Button("Cancel", role: .cancel) { pendingDeleteID = nil }
+        } message: {
+            Text("This moves the scratch space's folder to Trash. This cannot be undone.")
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "archivebox")
+                .font(.system(size: 36))
+                .foregroundStyle(.secondary)
+            Text("No Archived Scratch Spaces")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func row(for worktree: Worktree) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(worktree.displayName)
+                    .font(.body)
+                if let archivedAt = worktree.archivedAt {
+                    Text(archivedAt, format: .relative(presentation: .named))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(worktree.path)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            Spacer()
+            Button("Revive") {
+                Task { await appState.reviveScratch(id: worktree.id) }
+            }
+            .buttonStyle(.bordered)
+            Button("Delete", role: .destructive) {
+                pendingDeleteID = worktree.id
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(.vertical, 4)
+        .contextMenu {
+            Button("Revive") {
+                Task { await appState.reviveScratch(id: worktree.id) }
+            }
+            Button("Delete", role: .destructive) {
+                pendingDeleteID = worktree.id
+            }
+        }
+    }
+
+    private func delete(id: UUID) {
+        Task {
+            do {
+                try await appState.daemonClient.deleteScratch(worktreeID: id)
+                appState.archivedScratchWorktrees.removeAll { $0.id == id }
+            } catch {
+                appState.showAlert("Couldn't delete scratch space: \(error.localizedDescription)", isError: true)
+            }
+        }
+    }
+}

--- a/Sources/TBDApp/ScratchDetailView.swift
+++ b/Sources/TBDApp/ScratchDetailView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import TBDShared
+
+/// Detail pane shown when the "Scratch" sidebar section header is selected
+/// (`AppState.selectedScratchSection`). Mirrors `RepoDetailView`'s shell —
+/// same segmented-Picker tab bar — but has no `repoID`, since scratch config
+/// is global (`Config.scratchInstructions` / `scratchRenamePrompt` /
+/// `scratchProfileOverrideID`), not per-row.
+struct ScratchDetailView: View {
+    enum Tab: String, CaseIterable {
+        case archived = "Archived"
+        case instructions = "Instructions"
+        case settings = "Settings"
+    }
+
+    @State private var selectedTab: Tab = .archived
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $selectedTab) {
+                ForEach(Tab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 340)
+            .padding(.vertical, 12)
+
+            Divider()
+
+            switch selectedTab {
+            case .archived:
+                ScratchArchivedView()
+            case .instructions:
+                ScratchInstructionsTabView()
+            case .settings:
+                ScratchSettingsView()
+            }
+        }
+    }
+}
+
+/// Settings tab: global model-profile override applied to scratch terminal
+/// spawns. Unlike `RepoSettingsView`, this is GLOBAL config (not a `Repo`
+/// model field kept in sync via deltas), so it's fetched fresh into local
+/// `@State` rather than read from a live in-memory array entry. No env
+/// overrides / hooks sections — out of scope for scratch settings.
+struct ScratchSettingsView: View {
+    @EnvironmentObject var appState: AppState
+
+    @State private var scratchProfileOverrideID: UUID?
+    @State private var isLoaded = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                if isLoaded {
+                    Picker("Model profile override", selection: profileOverrideBinding) {
+                        Text("Inherit global default").tag(UUID?.none)
+                        ForEach(appState.modelProfiles, id: \.profile.id) { entry in
+                            Text(profileLabel(entry: entry)).tag(UUID?.some(entry.profile.id))
+                        }
+                    }
+                    .pickerStyle(.menu)
+
+                    if let caption = profileOverrideCaption {
+                        Text(caption)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    ProgressView()
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .task {
+            guard !isLoaded else { return }
+            let config = await appState.fetchConfig()
+            scratchProfileOverrideID = config?.scratchProfileOverrideID
+            isLoaded = true
+        }
+    }
+
+    private var profileOverrideBinding: Binding<UUID?> {
+        Binding(
+            get: { scratchProfileOverrideID },
+            set: { newValue in
+                scratchProfileOverrideID = newValue
+                Task {
+                    await appState.setScratchProfileOverride(newValue)
+                }
+            }
+        )
+    }
+
+    private func profileLabel(entry: ModelProfileWithUsage) -> String {
+        if let detail = entry.profile.detailCaption {
+            return "\(entry.profile.name) — \(detail)"
+        }
+        return entry.profile.name
+    }
+
+    private var profileOverrideCaption: String? {
+        if let overrideID = scratchProfileOverrideID {
+            let name = appState.modelProfiles.first(where: { $0.profile.id == overrideID })?.profile.name ?? "Unknown profile"
+            return "Overriding with: \(name)"
+        }
+        if let defaultID = appState.defaultProfileID,
+           let name = appState.modelProfiles.first(where: { $0.profile.id == defaultID })?.profile.name {
+            return "Inheriting: \(name)"
+        }
+        return "Inheriting: Default (claude keychain login)"
+    }
+}

--- a/Sources/TBDApp/ScratchInstructionsTabView.swift
+++ b/Sources/TBDApp/ScratchInstructionsTabView.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+import TBDShared
+
+/// Instructions tab for `ScratchDetailView`: two debounced-autosave sections
+/// for the global scratch-space config fields — mirrors `RepoInstructionsView`'s
+/// two-section, 1s-debounce, "Saved" indicator pattern, but for
+/// `Config.scratchRenamePrompt` / `Config.scratchInstructions` instead of a
+/// per-repo `Repo` row.
+///
+/// Deliberately NOT built by refactoring `ScratchInstructionsView` (the
+/// existing sheet, still used from `ScratchSectionView`'s context menu) into a
+/// shared widget: that view's explicit Cancel/Save-then-dismiss flow and this
+/// tab's debounced-autosave-on-change flow have different save triggers and
+/// lifecycles, so extracting a shared "editing widget" would mostly just move
+/// the `TextEditor` + "Reset to Default" markup into a wrapper while leaving
+/// the two views' surrounding save logic duplicated anyway. Writing fresh,
+/// consistent-looking markup here keeps both views simple and leaves the
+/// sheet's existing behavior/tests untouched.
+struct ScratchInstructionsTabView: View {
+    @EnvironmentObject var appState: AppState
+
+    @State private var renamePromptDraft: String = ""
+    @State private var instructionsDraft: String = ""
+    @State private var showSaved = false
+    @State private var saveTask: Task<Void, Never>?
+    @State private var initialized = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // MARK: - Rename Nudge Section
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Rename Nudge")
+                        .font(.title3)
+                        .fontWeight(.medium)
+                    Text("Sent once, nudging the agent to rename the scratch space once its topic is clear (only while it still has its auto-generated name).")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    if initialized {
+                        TextEditor(text: $renamePromptDraft)
+                            .font(.body.monospaced())
+                            .frame(minHeight: 160)
+                            .scrollContentBackground(.hidden)
+                            .padding(8)
+                            .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
+
+                        HStack {
+                            Spacer()
+                            Button("Reset to Default") {
+                                renamePromptDraft = RepoConstants.defaultScratchRenamePrompt
+                                scheduleSave()
+                            }
+                            .buttonStyle(.borderless)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                            Spacer()
+                        }
+                        .frame(minHeight: 160)
+                    }
+                }
+
+                Divider()
+
+                // MARK: - Scratch Instructions Section
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Scratch Instructions")
+                        .font(.title3)
+                        .fontWeight(.medium)
+                    Text("Added to all new Claude sessions in scratch spaces (repo-less worktrees).")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+
+                    if initialized {
+                        TextEditor(text: $instructionsDraft)
+                            .font(.body.monospaced())
+                            .frame(minHeight: 120)
+                            .scrollContentBackground(.hidden)
+                            .padding(8)
+                            .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
+
+                        HStack {
+                            Spacer()
+                            Button("Reset to Default") {
+                                instructionsDraft = RepoConstants.defaultScratchInstructions
+                                scheduleSave()
+                            }
+                            .buttonStyle(.borderless)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                            Spacer()
+                        }
+                        .frame(minHeight: 120)
+                    }
+                }
+
+                // MARK: - Save Indicator
+                HStack {
+                    Spacer()
+                    if showSaved {
+                        Text("Saved")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .transition(.opacity)
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task {
+            guard !initialized else { return }
+            let config = await appState.fetchConfig()
+            renamePromptDraft = config?.scratchRenamePrompt ?? RepoConstants.defaultScratchRenamePrompt
+            instructionsDraft = config?.scratchInstructions ?? RepoConstants.defaultScratchInstructions
+            initialized = true
+        }
+        .onChange(of: renamePromptDraft) { _, _ in
+            guard initialized else { return }
+            scheduleSave()
+        }
+        .onChange(of: instructionsDraft) { _, _ in
+            guard initialized else { return }
+            scheduleSave()
+        }
+        .onDisappear {
+            saveTask?.cancel()
+            guard initialized else { return }
+            let renameToSave = normalizedRenamePrompt
+            let instructionsToSave = normalizedInstructions
+            Task {
+                await appState.setScratchRenamePrompt(renameToSave)
+                await appState.setScratchInstructions(instructionsToSave)
+            }
+        }
+    }
+
+    private var normalizedRenamePrompt: String? {
+        let trimmed = renamePromptDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultTrimmed = RepoConstants.defaultScratchRenamePrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (trimmed.isEmpty || trimmed == defaultTrimmed) ? nil : renamePromptDraft
+    }
+
+    private var normalizedInstructions: String? {
+        let trimmed = instructionsDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultTrimmed = RepoConstants.defaultScratchInstructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (trimmed.isEmpty || trimmed == defaultTrimmed) ? nil : instructionsDraft
+    }
+
+    private func scheduleSave() {
+        saveTask?.cancel()
+        saveTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled else { return }
+
+            let renameToSave = normalizedRenamePrompt
+            let instructionsToSave = normalizedInstructions
+
+            await appState.setScratchRenamePrompt(renameToSave)
+            await appState.setScratchInstructions(instructionsToSave)
+
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }
+        }
+    }
+}

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -12,7 +12,8 @@ struct ScratchSectionView: View {
     var body: some View {
         HStack(spacing: 4) {
             Text("Scratch")
-                .font(.headline).foregroundStyle(.secondary)
+                .font(.headline)
+                .foregroundStyle(appState.selectedScratchSection ? .primary : .secondary)
             Spacer()
             if isHeaderHovered {
                 Button { appState.createScratch() } label: {
@@ -21,6 +22,11 @@ struct ScratchSectionView: View {
                 .buttonStyle(HoverPressButtonStyle())
                 .help("New scratch space")
             }
+        }
+        .background(Color.white.opacity(0.0001))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            appState.selectScratchSection()
         }
         .onHover { isHeaderHovered = $0 }
         .contextMenu {

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -54,7 +54,7 @@ struct SidebarContextMenu: View {
                     Task { await appState.archiveScratch(id: worktree.id) }
                 }
                 Button("Delete Scratch Space", role: .destructive) {
-                    appState.deleteScratch(id: worktree.id)
+                    Task { await appState.deleteScratch(id: worktree.id) }
                 }
             } else if worktree.status == .main || worktree.status == .creating {
                 // Main / creating worktree: only Finder and Copy Path (no rename/archive)

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -45,6 +45,14 @@ struct SidebarContextMenu: View {
                     NSPasteboard.general.setString(worktree.path, forType: .string)
                 }
                 Divider()
+                // `.destructive` role for consistency with the non-scratch
+                // "Archive" button below, even though scratch archive is
+                // recoverable (revive exists) and leaves the folder untouched
+                // on disk — the repo-worktree Archive button is styled the
+                // same way despite being recoverable too.
+                Button("Archive", role: .destructive) {
+                    Task { await appState.archiveScratch(id: worktree.id) }
+                }
                 Button("Delete Scratch Space", role: .destructive) {
                     appState.deleteScratch(id: worktree.id)
                 }

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -18,6 +18,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var env_overrides: String?
     var auto_archive_on_merge_default: Bool?
     var scratch_instructions: String?
+    var scratch_rename_prompt: String?
+    var scratch_profile_override_id: String?
 
     func toModel() -> Config {
         Config(
@@ -27,7 +29,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             envSettingOverrides: ConfigStore.decodeOverrides(claude_env_settings),
             envOverrides: EnvOverridesCoding.decode(env_overrides),
             autoArchiveOnMergeDefault: auto_archive_on_merge_default ?? false,
-            scratchInstructions: scratch_instructions
+            scratchInstructions: scratch_instructions,
+            scratchRenamePrompt: scratch_rename_prompt,
+            scratchProfileOverrideID: scratch_profile_override_id.flatMap(UUID.init(uuidString:))
         )
     }
 }
@@ -126,6 +130,32 @@ public struct ConfigStore: Sendable {
             try db.execute(
                 sql: "UPDATE config SET scratch_instructions = ? WHERE id = ?",
                 arguments: [toStore, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the global scratch-space rename-nudge override. Nil or a
+    /// whitespace-only string clears the override, falling back to the
+    /// built-in default rename-nudge layer.
+    public func setScratchRenamePrompt(_ value: String?) async throws {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let toStore = (trimmed?.isEmpty ?? true) ? nil : value
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET scratch_rename_prompt = ? WHERE id = ?",
+                arguments: [toStore, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the global model-profile override applied to scratch terminal
+    /// spawns. Nil clears the override, falling back to the global default
+    /// profile.
+    public func setScratchProfileOverride(_ id: UUID?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET scratch_profile_override_id = ? WHERE id = ?",
+                arguments: [id?.uuidString, Self.singletonID]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -619,6 +619,15 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "config", column: "scratch_instructions", type: .text)
         }
 
+        // Global, user-customizable rename-nudge override for scratch spaces,
+        // plus a global model-profile override applied to scratch terminal
+        // spawns. Both nullable; nil means "use the built-in default" /
+        // "fall back to the global default profile" respectively.
+        migrator.registerMigration("v37_config_scratch_rename_and_profile") { db in
+            try db.addColumnIfMissing(table: "config", column: "scratch_rename_prompt", type: .text)
+            try db.addColumnIfMissing(table: "config", column: "scratch_profile_override_id", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -315,11 +315,16 @@ public struct WorktreeStore: Sendable {
 
     /// List worktrees, optionally filtered by repo and/or status, with optional pagination.
     /// When `excludeArchived` is true, archived rows are excluded from the result.
-    /// This composes with `status`: both filters are applied when both are given.
+    /// When `scratchOnly` is true, restricts to repo-less (scratch) worktrees —
+    /// note `repoID: nil` alone means "no repo filter" (every repo plus
+    /// scratch), not "scratch only"; `scratchOnly` is the only way to get
+    /// scratch-only rows.
+    /// This composes with `status`: all filters are applied when given together.
     public func list(
         repoID: UUID? = nil,
         status: WorktreeStatus? = nil,
         excludeArchived: Bool = false,
+        scratchOnly: Bool = false,
         limit: Int? = nil,
         offset: Int? = nil
     ) async throws -> [Worktree] {
@@ -327,6 +332,9 @@ public struct WorktreeStore: Sendable {
             var request = WorktreeRecord.all()
             if let repoID {
                 request = request.filter(Column("repoID") == repoID.uuidString)
+            }
+            if scratchOnly {
+                request = request.filter(Column("repoID") == nil)
             }
             if let status {
                 request = request.filter(Column("status") == status.rawValue)

--- a/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
+++ b/Sources/TBDDaemon/Lifecycle/SystemPromptBuilder.swift
@@ -31,8 +31,13 @@ enum SystemPromptBuilder {
     /// Used both to set env vars in terminals and to build the combined `--append-system-prompt`.
     /// `scratchInstructions` is the global user-customizable override for the
     /// scratch layer (`Config.scratchInstructions`); `nil` or blank falls
-    /// back to the built-in default.
-    static func promptLayers(repo: Repo?, worktree: Worktree, scratchInstructions: String? = nil) -> [String: String] {
+    /// back to the built-in default. `scratchRenamePrompt` is the analogous
+    /// global user-customizable override for the scratch rename-nudge layer
+    /// (`Config.scratchRenamePrompt`); `nil` or blank falls back to
+    /// `RepoConstants.defaultScratchRenamePrompt`.
+    static func promptLayers(
+        repo: Repo?, worktree: Worktree, scratchInstructions: String? = nil, scratchRenamePrompt: String? = nil
+    ) -> [String: String] {
         var layers: [String: String] = [:]
 
         layers["TBD_PROMPT_CONTEXT"] = builtInTBDContext
@@ -40,6 +45,16 @@ enum SystemPromptBuilder {
         if worktree.isScratch {
             let trimmedCustom = scratchInstructions?.trimmingCharacters(in: .whitespacesAndNewlines)
             layers["TBD_PROMPT_SCRATCH"] = (trimmedCustom?.isEmpty == false) ? scratchInstructions! : scratchContext
+
+            if worktree.hasDefaultDisplayName {
+                let trimmedRename = scratchRenamePrompt?.trimmingCharacters(in: .whitespacesAndNewlines)
+                let renamePrompt = (trimmedRename?.isEmpty == false)
+                    ? scratchRenamePrompt!
+                    : RepoConstants.defaultScratchRenamePrompt
+                if !renamePrompt.isEmpty {
+                    layers["TBD_PROMPT_RENAME"] = renamePrompt
+                }
+            }
         }
 
         if !worktree.isScratch && worktree.status != .main && worktree.displayName == worktree.name {
@@ -59,10 +74,16 @@ enum SystemPromptBuilder {
 
     /// Build the combined system prompt for a Claude session.
     /// Returns nil if there's nothing to append (e.g., resume session).
-    static func build(repo: Repo?, worktree: Worktree, isResume: Bool, scratchInstructions: String? = nil) -> String? {
+    static func build(
+        repo: Repo?, worktree: Worktree, isResume: Bool, scratchInstructions: String? = nil,
+        scratchRenamePrompt: String? = nil
+    ) -> String? {
         if isResume { return nil }
 
-        let layers = promptLayers(repo: repo, worktree: worktree, scratchInstructions: scratchInstructions)
+        let layers = promptLayers(
+            repo: repo, worktree: worktree, scratchInstructions: scratchInstructions,
+            scratchRenamePrompt: scratchRenamePrompt
+        )
         var parts: [String] = []
 
         // Order: scratch layer, rename prompt, TBD context, custom instructions

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -509,7 +509,8 @@ extension WorktreeLifecycle {
                 ? nil
                 : SystemPromptBuilder.build(
                     repo: repo, worktree: worktree, isResume: false,
-                    scratchInstructions: config.scratchInstructions)
+                    scratchInstructions: config.scratchInstructions,
+                    scratchRenamePrompt: config.scratchRenamePrompt)
             let spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: isResume ? sessionUUID : nil,
                 freshSessionID: isResume ? nil : sessionUUID,

--- a/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
+++ b/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
@@ -84,8 +84,20 @@ public struct ModelProfileResolver: Sendable {
             logger.warning("profile override \(overrideID, privacy: .public) for repo \(repoID, privacy: .public) is missing; falling back to global default")
         }
 
+        let cfg = try await config.get()
+
+        // Step 1.5: scratch override. `repoID == nil` is the sole signal for a
+        // scratch (repo-less) spawn — see resolve(repoID:) call sites. Repo-scoped
+        // calls (repoID != nil) never consult scratchProfileOverrideID.
+        if repoID == nil, let scratchOverrideID = cfg.scratchProfileOverrideID {
+            if let resolved = try await loadResolved(id: scratchOverrideID) {
+                return resolved
+            }
+            logger.warning("scratch profile override \(scratchOverrideID, privacy: .public) is missing; falling back to global default")
+        }
+
         // Step 2: global default.
-        if let defaultID = try await config.get().defaultProfileID {
+        if let defaultID = cfg.defaultProfileID {
             if let resolved = try await loadResolved(id: defaultID) {
                 return resolved
             }

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -23,4 +23,22 @@ extension RPCRouter {
         // config from the DB at spawn time.
         return .ok()
     }
+
+    func handleConfigSetScratchRenamePrompt(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetScratchRenamePromptParams.self, from: paramsData)
+        try await db.config.setScratchRenamePrompt(params.renamePrompt)
+        // No broadcast: nothing in the app consumes a delta for this field —
+        // the editor sheet fetches Config fresh on open, and the daemon reads
+        // config from the DB at spawn time.
+        return .ok()
+    }
+
+    func handleConfigSetScratchProfileOverride(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetScratchProfileOverrideParams.self, from: paramsData)
+        try await db.config.setScratchProfileOverride(params.profileID)
+        // No broadcast: nothing in the app consumes a delta for this field —
+        // the picker fetches Config fresh on open, and the daemon reads
+        // config from the DB at spawn time.
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -54,17 +54,12 @@ extension RPCRouter {
         return try RPCResponse(result: wt)
     }
 
-    func handleScratchDelete(_ paramsData: Data) async throws -> RPCResponse {
-        let params = try decoder.decode(ScratchDeleteParams.self, from: paramsData)
-        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
-            return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
-        }
-        guard wt.isScratch else {
-            return RPCResponse(error: "Not a scratch space: \(params.worktreeID)")
-        }
-
-        // Close terminals: kill tmux windows, delete terminals + tabs, clear
-        // pending questions + per-session overlays (mirrors forgetWorktree).
+    /// Close out a scratch space's terminals: kill tmux windows, delete terminals
+    /// + tabs, clear pending questions + per-session overlays (mirrors
+    /// forgetWorktree). Shared by `scratch.delete` and `scratch.archive` — both
+    /// tear down the terminal/tab state identically before mutating the row
+    /// itself (delete removes it, archive flips its status).
+    private func closeScratchTerminals(_ wt: Worktree) async throws {
         let terminals = try await db.terminals.list(worktreeID: wt.id)
         for t in terminals {
             try? await tmux.killWindow(server: wt.tmuxServer, windowID: t.tmuxWindowID)
@@ -75,6 +70,18 @@ extension RPCRouter {
             await pendingQuestions.clear(terminalID: t.id)
             ClaudeHookOverlay.removePerSessionOverlay(sessionKey: t.id.uuidString)
         }
+    }
+
+    func handleScratchDelete(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ScratchDeleteParams.self, from: paramsData)
+        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+            return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
+        }
+        guard wt.isScratch else {
+            return RPCResponse(error: "Not a scratch space: \(params.worktreeID)")
+        }
+
+        try await closeScratchTerminals(wt)
 
         // Move the folder to Trash — never rm -rf. Promoted rows already had
         // their folder moved by promotion, so skip when promotedToRepoID != nil.
@@ -93,6 +100,56 @@ extension RPCRouter {
 
         try await db.worktrees.delete(id: wt.id)
         subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: wt.id)))
+        return .ok()
+    }
+
+    /// Archive a scratch space: close its terminals (same teardown as delete)
+    /// and flip its status to `.archived`, but leave the folder on disk —
+    /// unlike delete, nothing is moved to Trash.
+    func handleScratchArchive(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ScratchArchiveParams.self, from: paramsData)
+        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+            return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
+        }
+        guard wt.isScratch else {
+            return RPCResponse(error: "Not a scratch space: \(params.worktreeID)")
+        }
+
+        try await closeScratchTerminals(wt)
+        try await db.worktrees.archive(id: wt.id)
+
+        // Same delta `scratch.delete` broadcasts — deliberate: from the
+        // client's perspective the row leaves the active section identically
+        // whether archived or deleted.
+        subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: wt.id)))
+        scratchLogger.info("scratch.archive: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
+        return .ok()
+    }
+
+    /// Revive an archived scratch space: flip its status back to `.active`.
+    /// Requires the folder to still exist on disk — scratch spaces have no
+    /// git-worktree machinery to recreate a missing directory, unlike
+    /// repo-scoped revive.
+    func handleScratchRevive(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ScratchReviveParams.self, from: paramsData)
+        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+            return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
+        }
+        guard wt.isScratch else {
+            return RPCResponse(error: "Not a scratch space: \(params.worktreeID)")
+        }
+        guard wt.status == .archived else {
+            return RPCResponse(error: "Scratch space is already active: \(wt.id)")
+        }
+        guard FileManager.default.fileExists(atPath: wt.path) else {
+            return RPCResponse(error: "Scratch directory missing on disk: \(wt.path)")
+        }
+
+        try await db.worktrees.revive(id: wt.id)
+
+        subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
+            worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.path)))
+        scratchLogger.info("scratch.revive: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
         return .ok()
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -108,7 +108,8 @@ extension RPCRouter {
 
         // Build env vars available in all TBD terminals
         var env = SystemPromptBuilder.promptLayers(
-            repo: repo, worktree: worktree, scratchInstructions: createConfig?.scratchInstructions)
+            repo: repo, worktree: worktree, scratchInstructions: createConfig?.scratchInstructions,
+            scratchRenamePrompt: createConfig?.scratchRenamePrompt)
         env["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
         env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
 
@@ -214,7 +215,8 @@ extension RPCRouter {
             freshSessionID = sessionID
             appendSystemPrompt = SystemPromptBuilder.build(
                 repo: repo, worktree: worktree, isResume: false,
-                scratchInstructions: createConfig?.scratchInstructions)
+                scratchInstructions: createConfig?.scratchInstructions,
+                scratchRenamePrompt: createConfig?.scratchRenamePrompt)
             label = TerminalLabel.claudeCode
         } else if let cmd = params.cmd {
             claudeSessionID = nil
@@ -664,7 +666,8 @@ extension RPCRouter {
         let plannedTerminalID = UUID()
         let swapConfig = try? await db.config.get()
         var env = SystemPromptBuilder.promptLayers(
-            repo: repo, worktree: worktree, scratchInstructions: swapConfig?.scratchInstructions)
+            repo: repo, worktree: worktree, scratchInstructions: swapConfig?.scratchInstructions,
+            scratchRenamePrompt: swapConfig?.scratchRenamePrompt)
         env["TBD_WORKTREE_ID"] = worktree.id.uuidString
         env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
 
@@ -716,7 +719,8 @@ extension RPCRouter {
             logger.debug("swap: blank session — spawning fresh \(newSessionID, privacy: .public)")
             let appendPrompt = SystemPromptBuilder.build(
                 repo: repo, worktree: worktree, isResume: false,
-                scratchInstructions: swapConfig?.scratchInstructions)
+                scratchInstructions: swapConfig?.scratchInstructions,
+                scratchRenamePrompt: swapConfig?.scratchRenamePrompt)
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: nil,
                 freshSessionID: newSessionID,

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -77,6 +77,7 @@ extension RPCRouter {
             repoID: params.repoID,
             status: params.status,
             excludeArchived: params.excludeArchived ?? false,
+            scratchOnly: params.scratchOnly ?? false,
             limit: params.limit,
             offset: params.offset
         )

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -109,6 +109,10 @@ public final class RPCRouter: Sendable {
                 return try await handleScratchDelete(request.paramsData)
             case RPCMethod.scratchPromote:
                 return try await handleScratchPromote(request.paramsData)
+            case RPCMethod.scratchArchive:
+                return try await handleScratchArchive(request.paramsData)
+            case RPCMethod.scratchRevive:
+                return try await handleScratchRevive(request.paramsData)
             case RPCMethod.repoUpdateInstructions:
                 return try await handleRepoUpdateInstructions(request.paramsData)
             case RPCMethod.repoRelocate:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -277,6 +277,10 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetAutoArchiveDefault(request.paramsData)
             case RPCMethod.configSetScratchInstructions:
                 return try await handleConfigSetScratchInstructions(request.paramsData)
+            case RPCMethod.configSetScratchRenamePrompt:
+                return try await handleConfigSetScratchRenamePrompt(request.paramsData)
+            case RPCMethod.configSetScratchProfileOverride:
+                return try await handleConfigSetScratchProfileOverride(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -452,19 +452,31 @@ public struct Config: Codable, Sendable, Equatable {
     /// (repo-less worktrees). `nil` means "use the built-in default"
     /// (`RepoConstants.defaultScratchInstructions`).
     public var scratchInstructions: String?
+    /// Global, user-customizable override for the scratch-space rename-nudge
+    /// system-prompt layer. `nil` means "use the built-in default"
+    /// (`RepoConstants.defaultScratchRenamePrompt`).
+    public var scratchRenamePrompt: String?
+    /// Global model-profile override applied to scratch (repo-less) terminal
+    /// spawns. `nil` means "fall back to the global default profile"
+    /// (`defaultProfileID`).
+    public var scratchProfileOverrideID: UUID?
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
                 envSettingOverrides: [String: ClaudeEnvValue] = [:],
                 envOverrides: [String: String] = [:],
                 autoArchiveOnMergeDefault: Bool = false,
-                scratchInstructions: String? = nil) {
+                scratchInstructions: String? = nil,
+                scratchRenamePrompt: String? = nil,
+                scratchProfileOverrideID: UUID? = nil) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
         self.envOverrides = envOverrides
         self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
         self.scratchInstructions = scratchInstructions
+        self.scratchRenamePrompt = scratchRenamePrompt
+        self.scratchProfileOverrideID = scratchProfileOverrideID
     }
 
     public init(from decoder: Decoder) throws {
@@ -481,6 +493,8 @@ public struct Config: Codable, Sendable, Equatable {
         autoArchiveOnMergeDefault = try c.decodeIfPresent(
             Bool.self, forKey: .autoArchiveOnMergeDefault) ?? false
         scratchInstructions = try c.decodeIfPresent(String.self, forKey: .scratchInstructions) ?? nil
+        scratchRenamePrompt = try c.decodeIfPresent(String.self, forKey: .scratchRenamePrompt) ?? nil
+        scratchProfileOverrideID = try c.decodeIfPresent(UUID.self, forKey: .scratchProfileOverrideID)
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -167,6 +167,8 @@ public enum RPCMethod {
     public static let scratchCreate = "scratch.create"
     public static let scratchDelete = "scratch.delete"
     public static let scratchPromote = "scratch.promote"
+    public static let scratchArchive = "scratch.archive"
+    public static let scratchRevive = "scratch.revive"
 }
 
 // MARK: - Branch Listing
@@ -554,6 +556,16 @@ public struct ScratchPromoteParams: Codable, Sendable {
     public init(worktreeID: UUID, destPath: String, displayName: String? = nil) {
         self.worktreeID = worktreeID; self.destPath = destPath; self.displayName = displayName
     }
+}
+
+public struct ScratchArchiveParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public init(worktreeID: UUID) { self.worktreeID = worktreeID }
+}
+
+public struct ScratchReviveParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public init(worktreeID: UUID) { self.worktreeID = worktreeID }
 }
 
 public struct ScratchPromoteResult: Codable, Sendable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -681,18 +681,26 @@ public struct WorktreeListParams: Codable, Sendable {
     /// Optional (nil == false) for backward compatibility — old daemons
     /// ignore the unknown key and return everything; old clients omit it.
     public let excludeArchived: Bool?
+    /// When true, restrict the result to repo-less (scratch) worktrees.
+    /// Optional (nil == false) for backward compatibility — old daemons
+    /// ignore the unknown key and return everything; old clients omit it.
+    /// Note `repoID: nil` means "no repo filter" (every repo plus scratch),
+    /// NOT "scratch only" — this flag is the only way to get scratch-only rows.
+    public let scratchOnly: Bool?
     public init(
         repoID: UUID? = nil,
         status: WorktreeStatus? = nil,
         limit: Int? = nil,
         offset: Int? = nil,
-        excludeArchived: Bool? = nil
+        excludeArchived: Bool? = nil,
+        scratchOnly: Bool? = nil
     ) {
         self.repoID = repoID
         self.status = status
         self.limit = limit
         self.offset = offset
         self.excludeArchived = excludeArchived
+        self.scratchOnly = scratchOnly
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -162,6 +162,8 @@ public enum RPCMethod {
     public static let configGet = "config.get"
     public static let configSetAutoArchiveOnMergeDefault = "config.setAutoArchiveOnMergeDefault"
     public static let configSetScratchInstructions = "config.setScratchInstructions"
+    public static let configSetScratchRenamePrompt = "config.setScratchRenamePrompt"
+    public static let configSetScratchProfileOverride = "config.setScratchProfileOverride"
     public static let scratchCreate = "scratch.create"
     public static let scratchDelete = "scratch.delete"
     public static let scratchPromote = "scratch.promote"
@@ -891,6 +893,20 @@ public struct ConfigSetAutoArchiveDefaultParams: Codable, Sendable {
 public struct ConfigSetScratchInstructionsParams: Codable, Sendable {
     public let instructions: String?
     public init(instructions: String?) { self.instructions = instructions }
+}
+
+/// Params for `config.setScratchRenamePrompt` — the global scratch-space
+/// rename-nudge override. `nil` (or blank) resets to the built-in default.
+public struct ConfigSetScratchRenamePromptParams: Codable, Sendable {
+    public let renamePrompt: String?
+    public init(renamePrompt: String?) { self.renamePrompt = renamePrompt }
+}
+
+/// Params for `config.setScratchProfileOverride` — the global model-profile
+/// override applied to scratch terminal spawns. `nil` clears the override.
+public struct ConfigSetScratchProfileOverrideParams: Codable, Sendable {
+    public let profileID: UUID?
+    public init(profileID: UUID?) { self.profileID = profileID }
 }
 
 /// Params for `repo.setEnvOverrides` — per-repo free-form env overrides.

--- a/Sources/TBDShared/RepoConstants.swift
+++ b/Sources/TBDShared/RepoConstants.swift
@@ -30,4 +30,26 @@ public enum RepoConstants {
         destination path, then run `tbd scratch promote <dest-path>` from this \
         session. That moves the folder and registers it as a real TBD repo.
         """
+
+    /// Layer injected for repo-less scratch sessions once their default display
+    /// name hasn't been customized yet — nudges the agent to rename the SPACE
+    /// (not a git branch; there is none) once its topic becomes clear. Mirrors
+    /// `defaultRenamePrompt` but scratch-flavored. User-overridable via the
+    /// global `Config.scratchRenamePrompt` setting.
+    public static let defaultScratchRenamePrompt = """
+        Once this scratch space's topic becomes clear, rename it to reflect
+        what it's about:
+
+        tbd worktree rename "$(basename "$PWD")" "<emoji> <Title>"
+
+        This renames the TBD scratch space itself, not a git branch — there is
+        no repo here yet. Pick a relevant emoji, then a short, specific title
+        in title case.
+
+        Examples:
+          Topic: debugging a login timeout  → 🐛 Login Timeout Debug
+          Topic: exploring a CSV exporter   → 📊 CSV Export Exploration
+
+        Do this once the topic is clear — it doesn't need to block other work.
+        """
 }

--- a/Tests/TBDAppTests/ScratchSectionSelectionTests.swift
+++ b/Tests/TBDAppTests/ScratchSectionSelectionTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tests for `AppState.selectScratchSection()` and its mutual exclusivity with
+/// `selectedRepoID` / `selectedWorktreeIDs`. Selecting the "Scratch" sidebar
+/// section header is a third, parallel selection concept alongside the
+/// existing two (`selectedWorktreeIDs` for `List`'s native selection,
+/// `selectedRepoID` for repo headers) — an inconsistent combination (e.g.
+/// both `selectedRepoID` and `selectedScratchSection` true at once) would
+/// make `ContentView`'s if/else detail-pane chain pick the wrong pane.
+///
+/// Constructs `AppState(userDefaults:)` against a unique throwaway suite per
+/// `ArchiveNavigateBackTests`' convention — `UserDefaults.standard` on this
+/// unbundled executable is the developer's real `TBDApp.plist`.
+@MainActor
+@Suite("Scratch section selection")
+struct ScratchSectionSelectionTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.ScratchSectionSelection.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func makeWorktree(id: UUID, repoID: UUID?) -> Worktree {
+        Worktree(
+            id: id,
+            repoID: repoID,
+            name: "test-\(id.uuidString.prefix(8))",
+            displayName: "Test \(id.uuidString.prefix(8))",
+            branch: "main",
+            path: "/tmp/test",
+            status: .active,
+            tmuxServer: "test-server"
+        )
+    }
+
+    @Test func selectScratchSectionSetsFlagAndClearsOtherSelections() {
+        withState { state in
+            let repoID = UUID()
+            let wtID = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: wtID, repoID: repoID)]]
+            state.selectedWorktreeIDs = [wtID]
+
+            state.selectScratchSection()
+
+            #expect(state.selectedScratchSection == true)
+            #expect(state.selectedRepoID == nil)
+            #expect(state.selectedWorktreeIDs.isEmpty)
+        }
+    }
+
+    @Test func selectingRepoClearsScratchSection() {
+        withState { state in
+            let repoID = UUID()
+            state.repos = [Repo(id: repoID, path: "/tmp/r", displayName: "r", defaultBranch: "main")]
+
+            state.selectScratchSection()
+            #expect(state.selectedScratchSection == true)
+
+            state.selectRepo(id: repoID)
+
+            #expect(state.selectedScratchSection == false)
+            #expect(state.selectedRepoID == repoID)
+        }
+    }
+
+    @Test func selectingWorktreeClearsScratchSection() {
+        withState { state in
+            let repoID = UUID()
+            let wtID = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: wtID, repoID: repoID)]]
+
+            state.selectScratchSection()
+            #expect(state.selectedScratchSection == true)
+
+            state.selectedWorktreeIDs = [wtID]
+
+            #expect(state.selectedScratchSection == false)
+            #expect(state.selectedWorktreeIDs == [wtID])
+        }
+    }
+
+    @Test func scratchSectionDefaultsToFalse() {
+        withState { state in
+            #expect(state.selectedScratchSection == false)
+        }
+    }
+
+    /// Back/forward navigation entries never encode `.scratchSection` (a
+    /// documented scope cut for v1), but applying a `.repo` or `.worktrees`
+    /// history entry must still clear a lingering scratch selection so the
+    /// two flags never end up simultaneously true.
+    @Test func navigatingBackToARepoEntryClearsScratchSection() {
+        withState { state in
+            let repoID = UUID()
+            let wtID = UUID()
+            state.repos = [Repo(id: repoID, path: "/tmp/r", displayName: "r", defaultBranch: "main")]
+            state.worktrees = [repoID: [makeWorktree(id: wtID, repoID: repoID)]]
+
+            // History: [.repo(repoID)] (index 0), [.worktrees([wtID])] (index 1, current).
+            state.selectRepo(id: repoID)
+            state.selectedWorktreeIDs = [wtID]
+
+            // Scratch section is selected without going through recordNavigation
+            // (documented scope cut) — history still points at index 1.
+            state.selectScratchSection()
+            #expect(state.selectedScratchSection == true)
+            #expect(state.canGoBack == true)
+
+            state.navigateBack()
+
+            #expect(state.selectedScratchSection == false)
+            #expect(state.selectedRepoID == repoID)
+        }
+    }
+
+    @Test func navigatingBackToAWorktreesEntryClearsScratchSection() {
+        withState { state in
+            let repoID = UUID()
+            let wtID = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: wtID, repoID: repoID)]]
+            state.repos = [Repo(id: repoID, path: "/tmp/r", displayName: "r", defaultBranch: "main")]
+
+            // History: [.worktrees([wtID])] (index 0), [.repo(repoID)] (index 1, current).
+            state.selectedWorktreeIDs = [wtID]
+            state.selectRepo(id: repoID)
+
+            state.selectScratchSection()
+            #expect(state.selectedScratchSection == true)
+            #expect(state.canGoBack == true)
+
+            state.navigateBack()
+
+            #expect(state.selectedScratchSection == false)
+            #expect(state.selectedWorktreeIDs == [wtID])
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -84,4 +84,55 @@ struct ConfigStoreTests {
         let cfg = try await db.config.get()
         #expect(cfg.scratchInstructions == nil)
     }
+
+    @Test func scratchRenamePromptDefaultsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchRenamePrompt == nil)
+    }
+
+    @Test func setAndGetScratchRenamePrompt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setScratchRenamePrompt("Rename it once it has a clear purpose.")
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchRenamePrompt == "Rename it once it has a clear purpose.")
+    }
+
+    @Test func setScratchRenamePromptWhitespaceResetsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setScratchRenamePrompt("   \n  ")
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchRenamePrompt == nil)
+    }
+
+    @Test func setScratchRenamePromptNilResetsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setScratchRenamePrompt("Rename it once it has a clear purpose.")
+        try await db.config.setScratchRenamePrompt(nil)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchRenamePrompt == nil)
+    }
+
+    @Test func scratchProfileOverrideIDDefaultsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchProfileOverrideID == nil)
+    }
+
+    @Test func setAndGetScratchProfileOverride() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.modelProfiles.create(name: "Personal", kind: .oauth)
+        try await db.config.setScratchProfileOverride(tok.id)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchProfileOverrideID == tok.id)
+    }
+
+    @Test func clearScratchProfileOverride() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tok = try await db.modelProfiles.create(name: "Personal", kind: .oauth)
+        try await db.config.setScratchProfileOverride(tok.id)
+        try await db.config.setScratchProfileOverride(nil)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchProfileOverrideID == nil)
+    }
 }

--- a/Tests/TBDDaemonTests/MigrationV37Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV37Tests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+
+@Suite struct MigrationV37Tests {
+
+    @Test func scratchRenamePromptColumnExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let columns = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(config)")
+            let names = columns.compactMap { $0["name"] as String? }
+            #expect(names.contains("scratch_rename_prompt"))
+        }
+    }
+
+    @Test func scratchProfileOverrideIDColumnExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let columns = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(config)")
+            let names = columns.compactMap { $0["name"] as String? }
+            #expect(names.contains("scratch_profile_override_id"))
+        }
+    }
+
+    @Test func scratchRenamePromptDefaultsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchRenamePrompt == nil)
+    }
+
+    @Test func scratchProfileOverrideIDDefaultsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.scratchProfileOverrideID == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ModelProfileResolverTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileResolverTests.swift
@@ -272,4 +272,64 @@ struct ModelProfileResolverTests {
         let result = try await resolver.loadByID(apiKey.id)
         #expect(result == nil)
     }
+
+    // MARK: - Scratch profile override (Config.scratchProfileOverrideID)
+
+    @Test("scratch override set + nilRepo resolves to the override profile")
+    func resolve_nilRepo_scratchOverride_wins() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let scratch = try await db.modelProfiles.create(name: "Scratch", kind: .apiKey)
+        let global = try await db.modelProfiles.create(name: "Global", kind: .apiKey)
+        try await db.config.setDefaultProfileID(global.id)
+        try await db.config.setScratchProfileOverride(scratch.id)
+        box.map[scratch.id.uuidString] = "secret-scratch"
+        box.map[global.id.uuidString] = "secret-global"
+
+        let result = try await resolver.resolve(repoID: nil)
+        #expect(result?.profileID == scratch.id)
+        #expect(result?.secret == "secret-scratch")
+    }
+
+    @Test("scratch override set but profile row missing falls back to global default")
+    func resolve_nilRepo_scratchOverride_rowMissing_fallsBackToGlobal() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let global = try await db.modelProfiles.create(name: "Global", kind: .apiKey)
+        try await db.config.setDefaultProfileID(global.id)
+        // Point the scratch override at a profile ID that doesn't exist in the store.
+        try await db.config.setScratchProfileOverride(UUID())
+        box.map[global.id.uuidString] = "secret-global"
+
+        let result = try await resolver.resolve(repoID: nil)
+        #expect(result?.profileID == global.id)
+        #expect(result?.secret == "secret-global")
+    }
+
+    @Test("scratch override unset + nilRepo falls back to global default (existing behavior)")
+    func resolve_nilRepo_noScratchOverride_usesGlobal() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let global = try await db.modelProfiles.create(name: "Global", kind: .apiKey)
+        try await db.config.setDefaultProfileID(global.id)
+        box.map[global.id.uuidString] = "secret-global"
+
+        let result = try await resolver.resolve(repoID: nil)
+        #expect(result?.profileID == global.id)
+    }
+
+    @Test("scratchProfileOverrideID does not leak into repo-scoped resolution")
+    func resolve_repoScoped_ignoresScratchOverride() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let scratchOverride = try await db.modelProfiles.create(name: "Scratch", kind: .apiKey)
+        let global = try await db.modelProfiles.create(name: "Global", kind: .apiKey)
+        try await db.config.setDefaultProfileID(global.id)
+        try await db.config.setScratchProfileOverride(scratchOverride.id)
+        // Repo has NO per-repo override — should fall through to global default,
+        // never to the scratch override, even though one is globally configured.
+        let repo = try await makeRepo(db)
+        box.map[scratchOverride.id.uuidString] = "secret-scratch"
+        box.map[global.id.uuidString] = "secret-global"
+
+        let result = try await resolver.resolve(repoID: repo.id)
+        #expect(result?.profileID == global.id)
+        #expect(result?.secret == "secret-global")
+    }
 }

--- a/Tests/TBDDaemonTests/RPCRouterConfigScratchRenameAndProfileTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterConfigScratchRenameAndProfileTests.swift
@@ -1,0 +1,69 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// config.setScratchRenamePrompt and config.setScratchProfileOverride RPC
+// handlers, mirroring the round-trip style of
+// RPCRouterConfigScratchInstructionsTests.
+extension RPCRouterTests {
+
+    @Test("config.setScratchRenamePrompt persists the custom rename prompt")
+    func configSetScratchRenamePrompt() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetScratchRenamePrompt,
+            params: ConfigSetScratchRenamePromptParams(renamePrompt: "Rename it once it has a clear purpose.")
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let config = try await db.config.get()
+        #expect(config.scratchRenamePrompt == "Rename it once it has a clear purpose.")
+    }
+
+    @Test("config.setScratchRenamePrompt with whitespace-only value resets to nil")
+    func configSetScratchRenamePromptWhitespaceResetsToNil() async throws {
+        try await db.config.setScratchRenamePrompt("Rename it once it has a clear purpose.")
+
+        let request = try RPCRequest(
+            method: RPCMethod.configSetScratchRenamePrompt,
+            params: ConfigSetScratchRenamePromptParams(renamePrompt: "   \n  ")
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let config = try await db.config.get()
+        #expect(config.scratchRenamePrompt == nil)
+    }
+
+    @Test("config.setScratchProfileOverride persists the profile override")
+    func configSetScratchProfileOverride() async throws {
+        let tok = try await db.modelProfiles.create(name: "Personal", kind: .oauth)
+
+        let request = try RPCRequest(
+            method: RPCMethod.configSetScratchProfileOverride,
+            params: ConfigSetScratchProfileOverrideParams(profileID: tok.id)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let config = try await db.config.get()
+        #expect(config.scratchProfileOverrideID == tok.id)
+    }
+
+    @Test("config.setScratchProfileOverride with nil clears the override")
+    func configSetScratchProfileOverrideNilClears() async throws {
+        let tok = try await db.modelProfiles.create(name: "Personal", kind: .oauth)
+        try await db.config.setScratchProfileOverride(tok.id)
+
+        let request = try RPCRequest(
+            method: RPCMethod.configSetScratchProfileOverride,
+            params: ConfigSetScratchProfileOverrideParams(profileID: nil)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        let config = try await db.config.get()
+        #expect(config.scratchProfileOverrideID == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/RPCRouterWorktreeTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterWorktreeTests.swift
@@ -148,4 +148,38 @@ extension RPCRouterTests {
         // Most recent archive (wt2) should be first
         #expect(page.map(\.id) == [wt2.id])
     }
+
+    @Test("worktree.list with scratchOnly + archived returns only repo-less archived rows")
+    func worktreeListScratchOnlyArchived() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let activeScratch = try await db.worktrees.createScratch(
+            name: "active-scratch", displayName: "active-scratch",
+            path: "/tmp/scratch-active-\(UUID())", tmuxServer: "srv-scratch"
+        )
+        let archivedScratch = try await db.worktrees.createScratch(
+            name: "archived-scratch", displayName: "archived-scratch",
+            path: "/tmp/scratch-archived-\(UUID())", tmuxServer: "srv-scratch"
+        )
+        try await db.worktrees.archive(id: archivedScratch.id)
+        let archivedRepoWorktree = try await db.worktrees.create(
+            repoID: repo.id, name: "repo-wt", branch: "b-repo",
+            path: "/tmp/repo-wt-\(UUID())", tmuxServer: "srv-repo"
+        )
+        try await db.worktrees.archive(id: archivedRepoWorktree.id)
+
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(status: .archived, scratchOnly: true)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        let result = try response.decodeResult([Worktree].self)
+        #expect(result.map(\.id) == [archivedScratch.id])
+        #expect(!result.map(\.id).contains(activeScratch.id))
+        #expect(!result.map(\.id).contains(archivedRepoWorktree.id))
+    }
 }

--- a/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
@@ -1,0 +1,168 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+extension TBDHomeSerialized {
+@Suite("scratch.archive / scratch.revive RPC")
+struct ScratchArchiveReviveRPCTests {
+    private func isolateTBDHome() -> (URL, () -> Void) {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent("tbd-scratcharch-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        return (home, { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: home) })
+    }
+
+    /// Router whose lifecycle and handlers share one StateSubscriptionManager,
+    /// with every broadcast delta captured in `deltas`.
+    private func makeRouter(db: TBDDatabase) -> (router: RPCRouter, deltas: BroadcastDeltas) {
+        let deltas = BroadcastDeltas()
+        let subs = StateSubscriptionManager()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            subscriptions: subs)
+        return (router, deltas)
+    }
+
+    @Test func archiveFlipsStatusSetsArchivedAtAndLeavesFolder() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "to-archive")))
+        let wt = try created.decodeResult(Worktree.self)
+        #expect(FileManager.default.fileExists(atPath: wt.path))
+
+        let archive = await router.handle(try RPCRequest(method: RPCMethod.scratchArchive, params: ScratchArchiveParams(worktreeID: wt.id)))
+        #expect(archive.success)
+
+        let reloaded = try await db.worktrees.get(id: wt.id)
+        #expect(reloaded?.status == .archived)
+        #expect(reloaded?.archivedAt != nil)
+
+        // Folder is left untouched on disk — unlike delete, no Trash move.
+        #expect(FileManager.default.fileExists(atPath: wt.path))
+
+        let archived = deltas.snapshot().filter {
+            if case .worktreeArchived(let d) = $0 { return d.worktreeID == wt.id }
+            return false
+        }
+        #expect(archived.count == 1)
+    }
+
+    @Test func archiveClosesTerminalsAndTabs() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "with-terminal")))
+        let wt = try created.decodeResult(Worktree.self)
+
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        try await db.tabs.setLabel(tabID: terminal.id, worktreeID: wt.id, label: "my tab")
+
+        #expect(try await db.terminals.list(worktreeID: wt.id).count == 1)
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).count == 1)
+
+        let archive = await router.handle(try RPCRequest(method: RPCMethod.scratchArchive, params: ScratchArchiveParams(worktreeID: wt.id)))
+        #expect(archive.success)
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test func archiveRejectsNonScratchWorktree() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let wt = try await db.worktrees.create(repoID: repo.id, name: "w", branch: "b",
+                                               path: "/tmp/w-\(UUID().uuidString)", tmuxServer: "tbd-x")
+        let archive = await router.handle(try RPCRequest(method: RPCMethod.scratchArchive, params: ScratchArchiveParams(worktreeID: wt.id)))
+        #expect(!archive.success)
+    }
+
+    @Test func reviveHappyPathFlipsBackToActiveAndClearsArchivedAt() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "to-revive")))
+        let wt = try created.decodeResult(Worktree.self)
+        let archive = await router.handle(try RPCRequest(method: RPCMethod.scratchArchive, params: ScratchArchiveParams(worktreeID: wt.id)))
+        #expect(archive.success)
+
+        let revive = await router.handle(try RPCRequest(method: RPCMethod.scratchRevive, params: ScratchReviveParams(worktreeID: wt.id)))
+        #expect(revive.success)
+
+        let reloaded = try await db.worktrees.get(id: wt.id)
+        #expect(reloaded?.status == .active)
+        #expect(reloaded?.archivedAt == nil)
+
+        let revived = deltas.snapshot().filter {
+            if case .worktreeRevived(let d) = $0 { return d.worktreeID == wt.id }
+            return false
+        }
+        #expect(revived.count == 1)
+    }
+
+    @Test func reviveWithMissingFolderReturnsErrorAndDoesNotFlipStatus() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "to-vanish")))
+        let wt = try created.decodeResult(Worktree.self)
+        let archive = await router.handle(try RPCRequest(method: RPCMethod.scratchArchive, params: ScratchArchiveParams(worktreeID: wt.id)))
+        #expect(archive.success)
+
+        // Simulate the folder disappearing out from under the archived row.
+        try FileManager.default.removeItem(atPath: wt.path)
+
+        let revive = await router.handle(try RPCRequest(method: RPCMethod.scratchRevive, params: ScratchReviveParams(worktreeID: wt.id)))
+        #expect(!revive.success)
+        #expect(revive.error != nil)
+
+        let reloaded = try await db.worktrees.get(id: wt.id)
+        #expect(reloaded?.status == .archived)
+    }
+
+    @Test func deleteStillWorksOnAnAlreadyArchivedScratchRow() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "archived-then-deleted")))
+        let wt = try created.decodeResult(Worktree.self)
+        let archive = await router.handle(try RPCRequest(method: RPCMethod.scratchArchive, params: ScratchArchiveParams(worktreeID: wt.id)))
+        #expect(archive.success)
+        // Terminals are already gone from the archive step — delete's cleanup
+        // loop must be a no-op over zero terminals, not choke.
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+
+        let del = await router.handle(try RPCRequest(method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: wt.id)))
+        #expect(del.success)
+        #expect(try await db.worktrees.get(id: wt.id) == nil)
+        #expect(!FileManager.default.fileExists(atPath: wt.path))  // moved to Trash
+    }
+}
+}
+
+/// Thread-safe collector for broadcast StateDeltas.
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+}

--- a/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
+++ b/Tests/TBDDaemonTests/SystemPromptBuilderTests.swift
@@ -252,4 +252,62 @@ struct SystemPromptBuilderTests {
         #expect(result != nil)
         #expect(!result!.contains("Always use uv for scratch spaces."))
     }
+
+    // MARK: - Scratch rename-nudge layer
+
+    @Test("build includes default scratch rename prompt for a still-default scratch worktree")
+    func buildIncludesDefaultScratchRenamePromptWhenNotRenamed() {
+        let wt = Worktree(repoID: nil, name: "20260702-worrying-pike", displayName: "20260702-worrying-pike",
+                          branch: "", path: "/tmp/scratch/x", tmuxServer: "tbd-scratch")
+        let result = SystemPromptBuilder.build(repo: nil, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(result!.contains("tbd worktree rename"))
+        #expect(!result!.contains("Rename the git branch"))
+    }
+
+    @Test("build excludes scratch rename prompt once the scratch space has been renamed")
+    func buildExcludesScratchRenamePromptWhenRenamed() {
+        let wt = Worktree(repoID: nil, name: "20260702-worrying-pike", displayName: "🐛 Login Timeout Debug",
+                          branch: "", path: "/tmp/scratch/x", tmuxServer: "tbd-scratch")
+        let result = SystemPromptBuilder.build(repo: nil, worktree: wt, isResume: false)
+        #expect(result != nil)
+        #expect(!result!.contains("tbd worktree rename"))
+    }
+
+    @Test("build uses custom scratchRenamePrompt for a still-default scratch worktree")
+    func buildUsesCustomScratchRenamePrompt() {
+        let wt = Worktree(repoID: nil, name: "20260702-worrying-pike", displayName: "20260702-worrying-pike",
+                          branch: "", path: "/tmp/scratch/x", tmuxServer: "tbd-scratch")
+        let result = SystemPromptBuilder.build(
+            repo: nil, worktree: wt, isResume: false,
+            scratchRenamePrompt: "Name this scratch space something fun.")
+        #expect(result != nil)
+        #expect(result!.contains("Name this scratch space something fun."))
+        #expect(!result!.contains("tbd worktree rename"))
+    }
+
+    @Test("build falls back to default scratch rename prompt when scratchRenamePrompt is whitespace-only")
+    func buildFallsBackToDefaultScratchRenamePromptWhenWhitespace() {
+        let wt = Worktree(repoID: nil, name: "20260702-worrying-pike", displayName: "20260702-worrying-pike",
+                          branch: "", path: "/tmp/scratch/x", tmuxServer: "tbd-scratch")
+        let result = SystemPromptBuilder.build(
+            repo: nil, worktree: wt, isResume: false,
+            scratchRenamePrompt: "   ")
+        #expect(result != nil)
+        #expect(result!.contains("tbd worktree rename"))
+    }
+
+    @Test("scratchRenamePrompt param is ignored for a non-scratch worktree")
+    func buildIgnoresScratchRenamePromptForRepoWorktree() {
+        let repo = Repo(path: "/test", displayName: "test", defaultBranch: "main")
+        let wt = Worktree(repoID: repo.id, name: "gorgeous-panda", displayName: "gorgeous-panda",
+                          branch: "tbd/gorgeous-panda", path: "/test/.tbd/worktrees/gorgeous-panda", tmuxServer: "tbd-test")
+        let result = SystemPromptBuilder.build(
+            repo: repo, worktree: wt, isResume: false,
+            scratchRenamePrompt: "Name this scratch space something fun.")
+        #expect(result != nil)
+        #expect(!result!.contains("Name this scratch space something fun."))
+        // Non-scratch rename gating still applies (worktree not renamed yet).
+        #expect(result!.contains("Rename the git branch"))
+    }
 }

--- a/Tests/TBDDaemonTests/WorktreeStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreTests.swift
@@ -414,4 +414,57 @@ import TBDShared
         #expect(try await db.worktrees.get(id: wt.id)?.prStatus == nil)
         #expect(try await db.worktrees.allPRStatuses()[wt.id] == nil)
     }
+
+    // MARK: - scratchOnly filter
+
+    /// `scratchOnly: true` + `status: .archived` must return exactly the
+    /// repo-less archived rows — excluding both active scratch rows and
+    /// archived repo-worktree rows. This is the filter the Scratch section's
+    /// Archived tab relies on; without it, `repoID: nil` alone would return
+    /// every repo's rows too (nil repoID means "no repo filter").
+    @Test func scratchOnlyArchivedExcludesActiveScratchAndArchivedRepoRows() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let activeScratch = try await db.worktrees.createScratch(
+            name: "active-scratch", displayName: "active-scratch",
+            path: "/tmp/scratch-active-\(UUID())", tmuxServer: "srv-scratch"
+        )
+        let archivedScratch = try await db.worktrees.createScratch(
+            name: "archived-scratch", displayName: "archived-scratch",
+            path: "/tmp/scratch-archived-\(UUID())", tmuxServer: "srv-scratch"
+        )
+        try await db.worktrees.archive(id: archivedScratch.id)
+
+        let archivedRepoWorktree = try await db.worktrees.create(
+            repoID: repo.id, name: "repo-wt", branch: "b-repo",
+            path: "/tmp/repo-wt-\(UUID())", tmuxServer: "srv-repo"
+        )
+        try await db.worktrees.archive(id: archivedRepoWorktree.id)
+
+        let result = try await db.worktrees.list(status: .archived, scratchOnly: true)
+        let ids = Set(result.map(\.id))
+
+        #expect(ids == [archivedScratch.id])
+        #expect(!ids.contains(activeScratch.id))
+        #expect(!ids.contains(archivedRepoWorktree.id))
+    }
+
+    /// `scratchOnly: true` without a status filter still excludes every
+    /// repo-scoped row, active or archived.
+    @Test func scratchOnlyWithoutStatusReturnsOnlyRepolessRows() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        let scratch = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: "/tmp/scratch-\(UUID())", tmuxServer: "srv-scratch"
+        )
+        _ = try await db.worktrees.create(
+            repoID: repo.id, name: "repo-wt", branch: "b-repo",
+            path: "/tmp/repo-wt-\(UUID())", tmuxServer: "srv-repo"
+        )
+
+        let result = try await db.worktrees.list(scratchOnly: true)
+        #expect(result.map(\.id) == [scratch.id])
+    }
 }

--- a/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
+++ b/docs/superpowers/specs/2026-07-02-scratch-spaces-design.md
@@ -54,8 +54,8 @@ directory TBD manages terminals in, with *optional* git parentage.
 - `Worktree.repoID: UUID?` in `Sources/TBDShared/Models.swift`. Scratch-ness
   is derived — `var isScratch: Bool { repoID == nil }` — no separate `kind`
   column that could disagree with the FK.
-- Regular statuses apply to scratch rows (`.active`, `.archived` unused for
-  now; `.main` never applies).
+- Regular statuses apply to scratch rows (`.active`, `.archived` — see §8;
+  `.main` never applies).
 - `branch` stays non-optional and holds `""` for scratch rows; the UI hides
   it. (Deliberate compromise: making `branch` optional would double call-site
   churn with no behavioral gain.)
@@ -89,8 +89,8 @@ directory TBD manages terminals in, with *optional* git parentage.
 - **CLI:** `tbd scratch new [--name <n>]`, `tbd scratch list`,
   `tbd scratch promote <dest-path>` (§5).
 - **Deletion:** closes terminals, moves the folder to Trash (never `rm -rf`),
-  deletes the row. No archive machinery — there is no branch to preserve;
-  Claude transcripts survive on disk as today.
+  deletes the row — irreversible, unlike archiving (§8). Claude transcripts
+  survive on disk as today.
 - **Reconcile/recovery:** repo reconcile never sees scratch rows (it walks
   repos). Startup recreates `~/tbd/scratch/` if missing; a space whose dir is
   missing is flagged the same way missing worktrees are today.
@@ -123,6 +123,27 @@ text. Non-scratch worktrees are unaffected; the terminal-spawn handlers fetch
 the value from config and pass it through to `SystemPromptBuilder`, which
 stays pure.
 
+**Rename-nudge layer (2026-07-03 amendment):** scratch spaces whose display
+name is still auto-generated (`Worktree.hasDefaultDisplayName`) also
+receive a `TBD_PROMPT_RENAME` layer — the scratch-flavored counterpart to
+the repo-worktree rename nudge (§3 above talks about the general prompt
+layers; this one nudges renaming the *scratch space itself* via
+`tbd worktree rename`, since there is no git branch to rename). Global,
+user-customizable via `Config.scratchRenamePrompt` (nullable; `nil`/blank
+falls back to `RepoConstants.defaultScratchRenamePrompt`), set via the
+`config.setScratchRenamePrompt` RPC, and edited from the Scratch section's
+detail-pane Instructions tab.
+
+**Model profile override (2026-07-03 amendment):** `Config.scratchProfileOverrideID`
+(nullable) lets the global default profile be overridden specifically for
+scratch (repo-less) terminal spawns. `ModelProfileResolver.resolve(repoID:)`
+consults it only when `repoID == nil` — the sole nil-repoID caller in the
+codebase is the scratch terminal-spawn path, so this cannot affect
+repo-scoped resolution. Set via `config.setScratchProfileOverride`, edited
+from the Scratch section's detail-pane Settings tab (a picker identical in
+shape to the per-repo "Model profile override" picker, with "Inherit
+global default" as the nil option).
+
 ## 4. Sidebar & UI
 
 - The Scratch section is **synthesized client-side** from
@@ -136,9 +157,13 @@ stays pure.
   icon, merge/archive menu items) disappear because the repo lookup returns
   nil — verify this falls out naturally before adding special cases.
 - Context menu: new Claude/Codex/shell terminal, rename, reveal in Finder,
-  a "Promote…" hint that explains the agent-driven flow, and delete.
+  a "Promote…" hint that explains the agent-driven flow, Archive (§8), and
+  delete.
 - Jump menu, notes, and notifications work unchanged (keyed off
   `worktreeID`).
+- **Detail pane (2026-07-03 amendment):** the Scratch section header itself
+  is selectable and opens `ScratchDetailView`, a detail pane with Archived /
+  Instructions / Settings tabs — mirroring `RepoDetailView`'s per-repo pane.
 
 ## 5. Promotion (agent-driven, move-on-promote)
 
@@ -212,9 +237,36 @@ Per the gated-branch rule (a test per branch of any new toggle):
   intact in both states.
 - All tests isolate via `TBD_HOME` / injection seams per CLAUDE.md.
 
+## 8. Archiving scratch spaces
+
+Unlike deletion (§2), archiving is recoverable and never touches the
+folder:
+
+- **`scratch.archive`:** closes the scratch space's terminals the same way
+  `scratch.delete` does (kill tmux windows, delete terminal + tab rows,
+  clear pending questions and per-session hook overlays) but leaves the
+  folder on disk untouched and flips the row's status to `.archived`
+  (`archivedAt` timestamped) instead of deleting it. Broadcasts the same
+  `.worktreeArchived` delta `scratch.delete` broadcasts, so the row
+  disappears from the sidebar's active Scratch section identically either
+  way.
+- **`scratch.revive`:** flips status back to `.active` and clears
+  `archivedAt`, provided the folder still exists on disk (errors
+  otherwise, without touching the row). Broadcasts `.worktreeRevived`.
+  No terminals are restored — archiving a scratch space, unlike archiving
+  a repo worktree, never preserves session state to resume, since there
+  is no branch/session-file bookkeeping equivalent for repo-less spaces.
+- **UI:** the Scratch section header (sidebar) is now selectable and opens
+  a detail pane (`ScratchDetailView`) with three tabs — Archived,
+  Instructions, Settings — mirroring the per-repo detail pane. The
+  Archived tab lists archived scratch spaces with Revive and Delete
+  actions (a simpler list than the repo-scoped Archived tab: no session
+  history browsing, since scratch archiving captures no session state).
+  The sidebar's context menu on a scratch row gains an "Archive" action
+  alongside the existing "Delete Scratch Space".
+
 ## Open follow-ups (explicitly out of scope)
 
-- Archiving (vs deleting) scratch spaces.
 - Converting a promoted scratch row's live terminals into terminals of the
   new repo's main worktree.
 - UI-driven promotion.


### PR DESCRIPTION
## Summary

Brings the Scratch sidebar section to parity with repo sections: selecting the "Scratch" header now opens a detail pane (`ScratchDetailView`) with three tabs — Archived / Instructions / Settings — mirroring `RepoDetailView`.

- **Archive/revive for scratch spaces** (previously delete-only): new `scratch.archive` / `scratch.revive` RPCs. Archive closes terminals/tabs the same way `scratch.delete` does but leaves the folder on disk and flips status to `.archived` instead of deleting the row; broadcasts the same `.worktreeArchived` delta `scratch.delete` uses. Revive flips back to `.active` (errors if the folder is gone) and broadcasts `.worktreeRevived`. No session state is preserved across archive/revive (scratch terminals are always fully torn down).
- **Rename nudge for scratch spaces**: scratch sessions whose display name is still auto-generated now get a `TBD_PROMPT_RENAME` layer (new `Config.scratchRenamePrompt`, nullable, global-only, mirrors `Config.scratchInstructions`'s nil/blank → default semantics) nudging the agent to rename the *scratch space* (via `tbd worktree rename`), not a git branch.
- **Model profile override for scratch spawns**: new `Config.scratchProfileOverrideID` (nullable UUID). `ModelProfileResolver.resolve(repoID: nil)` — verified to be the sole nil-repoID call site in the codebase, driven by scratch terminal spawns — now consults it before falling back to the global default. Repo-scoped resolution is unaffected.
- **UI**: Scratch section header is now selectable (previously inert); new `ScratchDetailView` with Archived (simple list + Revive/Delete, no session browsing since scratch archive captures no session state), Instructions (debounced-autosave editors for the rename nudge + scratch instructions, plus the existing "Edit Scratch Instructions…" sheet unchanged), and Settings (model-profile-override picker) tabs. Sidebar context menu on scratch rows gains "Archive" alongside "Delete Scratch Space".
- **Migration v37**: adds `scratch_rename_prompt` and `scratch_profile_override_id` nullable columns to `config`.
- **Spec**: `docs/superpowers/specs/2026-07-02-scratch-spaces-design.md` amended — new §8 documents archive/revive (replacing the old "explicitly out of scope" bullet), §3/§4 document the rename-nudge, profile-override, and selectable-header UI.

## Commits

1. `45cc4957` — migration v37 + `Config` fields + `config.setScratchRenamePrompt`/`config.setScratchProfileOverride` RPCs
2. `35a069c8` — rename-nudge layer in `SystemPromptBuilder`, resolver scratch-override, `scratch.archive`/`scratch.revive` RPCs
3. `7ab16b53` — UI: `ScratchDetailView`, selection mechanics, archived list, instructions/settings tabs, context-menu Archive
4. `c61701ae` — spec doc amendment

## Test plan

- [x] `swift build` clean at every commit
- [x] `swift test` green at every commit (2059 tests / 251 suites at HEAD)
- [x] `swiftlint --strict` clean at every commit (0 violations)
- [x] Migration test: both new columns exist, default to nil
- [x] Config round-trip tests for both new fields (nil/blank/whitespace → default, custom replaces)
- [x] `SystemPromptBuilder` rename-layer tests: default emitted for default-named scratch, custom replaces default, absent for renamed scratch, absent/unaffected for non-scratch (existing rename + scratch-layer tests still green)
- [x] `ModelProfileResolver` tests: scratch override used for nil-repoID, missing override profile falls back to global default, repo-scoped resolution unaffected even when a scratch override is set
- [x] `scratch.archive`/`scratch.revive` RPC tests: status flip + terminals/tabs cleaned + folder untouched + delta broadcast; revive happy path + missing-folder error; `scratch.delete` still works on an already-archived row
- [x] New `scratchOnly` `worktree.list` filter test (archived-scratch-only fetch excludes both active scratch and archived repo worktrees)
- [x] `AppState` selection tests: `selectScratchSection()` mutual exclusivity with repo/worktree selection
- [ ] **Live UI verification not performed in this isolated worktree session** — needs a human pass via `scripts/restart.sh`: click the Scratch header, exercise all three tabs, edit both instruction fields, change the model-profile override, and archive→revive a scratch space to confirm it round-trips between the sidebar and the Archived tab. Per this repo's own documented lesson, selection/layout UI bugs are live-only and don't reproduce in headless tests.

## Concerns / deviations from the brief

- No unified `SidebarSelection` enum exists in the codebase (contrary to what the brief implied) — selection is two parallel `@Published` properties (`selectedRepoID`, `selectedWorktreeIDs`). Added a third, `selectedScratchSection: Bool`, following the same pattern rather than a bigger enum refactor.
- Scratch header selection is not wired into back/forward navigation history (`NavigationEntry`) or List keyboard-arrow-nav (`.tag`) — documented, scoped-out follow-ups, not attempted.
- The Instructions tab's two fields (rename nudge, scratch instructions) autosave via two independent RPC calls on one debounce timer rather than a single batched RPC (unlike `RepoInstructionsView`'s single `updateRepoInstructions` call) — there's no combined RPC for these two independent `Config` fields, so this is functionally equivalent but not literally identical in wire-shape.
- Archive's context-menu button uses `role: .destructive` for consistency with the repo-worktree "Archive" button, despite scratch archive being fully recoverable and non-destructive to the folder.