### PR TITLE
Ops: Stop the daemon spawning git subprocesses for every worktree every 10s

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -621,7 +621,8 @@ final class AppState: ObservableObject {
     // nonisolated deinit, and the leak is bounded by app lifetime.
 
     /// Forward macOS app focus changes to the daemon. The daemon uses this to
-    /// pause/resume the Claude usage poller while the app is in the background.
+    /// pause/resume the Claude usage poller and to pick the git polling
+    /// cadence (fast foreground / slow background) while the app is inactive.
     /// `NotificationCenter.addObserver` does not require a bundle ID, so this
     /// is safe to call from an unbundled SPM executable.
     private func registerFocusObservers() {
@@ -1735,7 +1736,11 @@ final class AppState: ObservableObject {
     func pushForegroundState() {
         let isForeground = NSApp?.isActive ?? false
         Task { [daemonClient] in
-            try? await daemonClient.setAppForegroundState(isForeground: isForeground)
+            do {
+                try await daemonClient.setAppForegroundState(isForeground: isForeground)
+            } catch {
+                logger.warning("pushForegroundState(\(isForeground)) failed: \(error)")
+            }
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1066,6 +1066,7 @@ final class AppState: ObservableObject {
                         self.isConnected = didConnect
                         if didConnect {
                             self.pushClaudeSpawnPreferences()
+                            self.pushForegroundState()
                         } else if !AppState.pidFilePointsAtLiveDaemon() {
                             // The socket file exists but nothing accepted the
                             // connection, and the pid file doesn't name a live
@@ -1134,6 +1135,7 @@ final class AppState: ObservableObject {
             startSubscription()
             await refreshPRStatuses()
             pushClaudeSpawnPreferences()
+            pushForegroundState()
         } else {
             logger.warning("Could not connect to daemon — is tbdd running?")
         }
@@ -1723,6 +1725,17 @@ final class AppState: ObservableObject {
         Task { [daemonClient] in
             try? await daemonClient.setClaudeSpawnPreferences(
                 ClaudeSpawnPreferences(settingOverrides: overrides))
+        }
+    }
+
+    /// Push the app's current foreground state to the daemon. Called on every
+    /// (re)connect: the daemon defaults to background git-polling cadence at
+    /// startup, and only the focus notifications would otherwise correct it —
+    /// which never fire if the app was already active when the daemon started.
+    func pushForegroundState() {
+        let isForeground = NSApp?.isActive ?? false
+        Task { [daemonClient] in
+            try? await daemonClient.setAppForegroundState(isForeground: isForeground)
         }
     }
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -420,10 +420,20 @@ public final class Daemon: Sendable {
                 daemonLogger.warning("Failed to prune orphaned per-session overlays: \(error.localizedDescription, privacy: .public)")
             }
 
-            // 12. Start periodic git fetch for all repos (every 60s)
+            // Shared foreground gate: the app reports its active/inactive state
+            // via `app.setForegroundState`; the periodic git tasks below slow
+            // their cadence when no app is foreground (see GitPollCadence).
+            let appForeground = AppForegroundState()
+            rpcRouter.appForegroundState = appForeground
+
+            // 12. Start periodic git fetch for all repos (60s foreground,
+            // 5min background — GitPollCadence.fetchInterval).
             self.gitFetchTask = Task {
                 while !Task.isCancelled {
-                    try? await Task.sleep(for: .seconds(60))
+                    let interval = GitPollCadence.fetchInterval(
+                        isForeground: await appForeground.isForeground
+                    )
+                    try? await Task.sleep(for: interval)
                     guard !Task.isCancelled else { break }
                     let allRepos = (try? await database.repos.list()) ?? []
                     // Skip .missing repos so we don't spam errors against stale paths
@@ -465,9 +475,12 @@ public final class Daemon: Sendable {
             rpcRouter.oauthUsagePoller = oauthPoller
             await oauthPoller.start()
 
-            // 13. Periodic git status refresh (branch sync, conflict detection)
+            // 13. Periodic git status refresh (branch sync, conflict detection).
+            // 10s foreground, 60s background (GitPollCadence.statusInterval);
+            // per-worktree conflict checks are additionally dirty-gated inside
+            // refreshGitStatuses so an unchanged worktree costs no subprocess.
             self.gitStatusTask = Task {
-                // Run once immediately (cold recovery), then every 10s
+                // Run once immediately (cold recovery), then at the gated cadence
                 while !Task.isCancelled {
                     let allRepos = (try? await database.repos.list()) ?? []
                     // Skip .missing repos to match gitFetchTask — running git
@@ -475,7 +488,10 @@ public final class Daemon: Sendable {
                     for repo in allRepos where repo.status != .missing {
                         await lifecycle.refreshGitStatuses(repoID: repo.id)
                     }
-                    try? await Task.sleep(for: .seconds(10))
+                    let interval = GitPollCadence.statusInterval(
+                        isForeground: await appForeground.isForeground
+                    )
+                    try? await Task.sleep(for: interval)
                     guard !Task.isCancelled else { break }
                 }
             }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -363,6 +363,15 @@ public final class Daemon: Sendable {
         rpcRouter.controlMode = controlModeBridge
         self.router = rpcRouter
 
+        // Shared foreground gate: the app reports its active/inactive state via
+        // `app.setForegroundState`; the periodic git tasks below slow their
+        // cadence when no app is foreground (see GitPollCadence). MUST be wired
+        // before the socket starts serving — the app pushes its state once per
+        // (re)connect, and a push landing on a nil gate would be silently
+        // dropped, leaving a foreground app at background cadence.
+        let appForeground = AppForegroundState()
+        rpcRouter.appForegroundState = appForeground
+
         // 9. Start socket server
         let sock = SocketServer(router: rpcRouter)
         self.socketServer = sock
@@ -420,20 +429,25 @@ public final class Daemon: Sendable {
                 daemonLogger.warning("Failed to prune orphaned per-session overlays: \(error.localizedDescription, privacy: .public)")
             }
 
-            // Shared foreground gate: the app reports its active/inactive state
-            // via `app.setForegroundState`; the periodic git tasks below slow
-            // their cadence when no app is foreground (see GitPollCadence).
-            let appForeground = AppForegroundState()
-            rpcRouter.appForegroundState = appForeground
+            // Effective foreground for the git cadence gates: the app-reported
+            // state AND at least one live client connection, so a crashed or
+            // force-quit app (which never reports `false`) can't pin the fast
+            // cadence forever. See GitPollCadence.isEffectivelyForeground.
+            let connectedClients = rpcRouter.connectedClientsProvider
+            let effectivelyForeground: @Sendable () async -> Bool = {
+                GitPollCadence.isEffectivelyForeground(
+                    reportedForeground: await appForeground.isForeground,
+                    connectedClients: connectedClients?() ?? 0
+                )
+            }
 
             // 12. Start periodic git fetch for all repos (60s foreground,
             // 5min background — GitPollCadence.fetchInterval).
             self.gitFetchTask = Task {
                 while !Task.isCancelled {
-                    let interval = GitPollCadence.fetchInterval(
-                        isForeground: await appForeground.isForeground
-                    )
-                    try? await Task.sleep(for: interval)
+                    await Daemon.sleepThroughGatedInterval {
+                        GitPollCadence.fetchInterval(isForeground: await effectivelyForeground())
+                    }
                     guard !Task.isCancelled else { break }
                     let allRepos = (try? await database.repos.list()) ?? []
                     // Skip .missing repos so we don't spam errors against stale paths
@@ -488,11 +502,9 @@ public final class Daemon: Sendable {
                     for repo in allRepos where repo.status != .missing {
                         await lifecycle.refreshGitStatuses(repoID: repo.id)
                     }
-                    let interval = GitPollCadence.statusInterval(
-                        isForeground: await appForeground.isForeground
-                    )
-                    try? await Task.sleep(for: interval)
-                    guard !Task.isCancelled else { break }
+                    await Daemon.sleepThroughGatedInterval {
+                        GitPollCadence.statusInterval(isForeground: await effectivelyForeground())
+                    }
                 }
             }
         } else {
@@ -500,6 +512,23 @@ public final class Daemon: Sendable {
         }
 
         daemonLogger.info("Started successfully (PID \(ProcessInfo.processInfo.processIdentifier, privacy: .public))")
+    }
+
+    /// Sleep in `GitPollCadence.pollTick` ticks until the gated interval has
+    /// elapsed. `interval` is re-evaluated every tick, so a foreground
+    /// transition or app disconnect changes the effective cadence within one
+    /// tick instead of one full background interval (e.g. after a daemon
+    /// restart under a foregrounded app, the first fetch still lands at ~60s
+    /// rather than the 5min sampled before the app reconnected). Returns
+    /// promptly on task cancellation.
+    static func sleepThroughGatedInterval(_ interval: @Sendable () async -> Duration) async {
+        var waited = Duration.zero
+        while !Task.isCancelled {
+            try? await Task.sleep(for: GitPollCadence.pollTick)
+            waited += GitPollCadence.pollTick
+            let due = await interval()
+            if waited >= due { return }
+        }
     }
 
     /// Stop the daemon: shut down servers, remove PID and socket files.

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -141,6 +141,37 @@ public struct GitManager: Sendable {
         return !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// Returns a map of short ref name → tip SHA covering all local branches
+    /// and `origin/*` remote-tracking branches, in a single subprocess.
+    ///
+    /// Used by the periodic conflict sweep's dirty gate: one `for-each-ref`
+    /// per repo resolves every worktree branch tip plus the
+    /// `origin/<defaultBranch>` tip, replacing per-worktree probes.
+    public func refTips(repoPath: String) async throws -> [String: String] {
+        let output = try await run(
+            arguments: [
+                "for-each-ref",
+                "--format=%(objectname) %(refname:short)",
+                "refs/heads",
+                "refs/remotes/origin",
+            ],
+            at: repoPath
+        )
+        var tips: [String: String] = [:]
+        for line in output.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            // "<sha> <short-name>" — the SHA can't contain spaces, so split on
+            // the first space and keep the remainder as the name.
+            guard let sep = trimmed.firstIndex(of: " ") else { continue }
+            let sha = String(trimmed[..<sep])
+            let name = String(trimmed[trimmed.index(after: sep)...])
+            guard !sha.isEmpty, !name.isEmpty else { continue }
+            tips[name] = sha
+        }
+        return tips
+    }
+
     /// Returns true if `base` is an ancestor of `branch` (i.e., branch is ahead or equal, no divergence).
     /// Returns nil if the git command fails for reasons other than "not an ancestor" (e.g., unknown ref).
     public func isMergeBaseAncestor(repoPath: String, base: String, branch: String) async -> Bool? {

--- a/Sources/TBDDaemon/Lifecycle/ConflictSweepCache.swift
+++ b/Sources/TBDDaemon/Lifecycle/ConflictSweepCache.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Dirty gate for the periodic conflict sweep (`refreshGitStatuses`).
+///
+/// The conflict answer for a worktree depends on exactly two commits: the tip
+/// of the worktree's branch and the tip of `origin/<defaultBranch>`. If that
+/// pair is unchanged since the last successful check, re-running
+/// `git merge-base --is-ancestor` (and on divergence `git merge-tree`) cannot
+/// produce a different answer — so the sweep skips those subprocesses entirely.
+/// Resolving the pair costs one `git for-each-ref` per repo per sweep, instead
+/// of 1-2 subprocesses per worktree per sweep.
+///
+/// Only successful (non-nil) checks are recorded: a transient git failure
+/// leaves no cache entry, so the next sweep retries instead of freezing on a
+/// never-computed result.
+public actor ConflictSweepCache {
+    /// The pair of commits a conflict check was computed against.
+    public struct Key: Hashable, Sendable {
+        /// Tip SHA of the worktree's branch.
+        public let branchTip: String
+        /// Tip SHA of `origin/<defaultBranch>`.
+        public let baseTip: String
+
+        public init(branchTip: String, baseTip: String) {
+            self.branchTip = branchTip
+            self.baseTip = baseTip
+        }
+    }
+
+    private var lastChecked: [UUID: Key] = [:]
+
+    public init() {}
+
+    /// True when the worktree has no recorded successful check for `key`
+    /// (first sighting, either tip moved, or the entry was pruned).
+    public func shouldCheck(worktreeID: UUID, key: Key) -> Bool {
+        lastChecked[worktreeID] != key
+    }
+
+    /// Record a successful conflict check computed against `key`.
+    public func markChecked(worktreeID: UUID, key: Key) {
+        lastChecked[worktreeID] = key
+    }
+
+    /// Drop entries for worktrees no longer in the sweep (archived/removed),
+    /// so the cache tracks only live rows.
+    public func retain(worktreeIDs: Set<UUID>) {
+        lastChecked = lastChecked.filter { worktreeIDs.contains($0.key) }
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/ConflictSweepCache.swift
+++ b/Sources/TBDDaemon/Lifecycle/ConflictSweepCache.swift
@@ -10,9 +10,14 @@ import Foundation
 /// Resolving the pair costs one `git for-each-ref` per repo per sweep, instead
 /// of 1-2 subprocesses per worktree per sweep.
 ///
-/// Only successful (non-nil) checks are recorded: a transient git failure
-/// leaves no cache entry, so the next sweep retries instead of freezing on a
-/// never-computed result.
+/// Entries are scoped by repo because the sweep runs per repo in a loop over
+/// all repos: pruning must only ever touch the repo being swept, or repo B's
+/// sweep would evict repo A's fresh entries and the gate would never engage
+/// on multi-repo installs.
+///
+/// Only successful (non-nil) checks whose result was persisted are recorded: a
+/// transient git or DB failure leaves no cache entry, so the next sweep
+/// retries instead of freezing on a never-stored result.
 public actor ConflictSweepCache {
     /// The pair of commits a conflict check was computed against.
     public struct Key: Hashable, Sendable {
@@ -27,24 +32,25 @@ public actor ConflictSweepCache {
         }
     }
 
-    private var lastChecked: [UUID: Key] = [:]
+    /// repoID → (worktreeID → last successfully checked pair).
+    private var lastChecked: [UUID: [UUID: Key]] = [:]
 
     public init() {}
 
     /// True when the worktree has no recorded successful check for `key`
     /// (first sighting, either tip moved, or the entry was pruned).
-    public func shouldCheck(worktreeID: UUID, key: Key) -> Bool {
-        lastChecked[worktreeID] != key
+    public func shouldCheck(repoID: UUID, worktreeID: UUID, key: Key) -> Bool {
+        lastChecked[repoID]?[worktreeID] != key
     }
 
-    /// Record a successful conflict check computed against `key`.
-    public func markChecked(worktreeID: UUID, key: Key) {
-        lastChecked[worktreeID] = key
+    /// Record a successful, persisted conflict check computed against `key`.
+    public func markChecked(repoID: UUID, worktreeID: UUID, key: Key) {
+        lastChecked[repoID, default: [:]][worktreeID] = key
     }
 
-    /// Drop entries for worktrees no longer in the sweep (archived/removed),
-    /// so the cache tracks only live rows.
-    public func retain(worktreeIDs: Set<UUID>) {
-        lastChecked = lastChecked.filter { worktreeIDs.contains($0.key) }
+    /// Drop this repo's entries for worktrees no longer in its sweep
+    /// (archived/removed). Other repos' entries are untouched.
+    public func retain(repoID: UUID, worktreeIDs: Set<UUID>) {
+        lastChecked[repoID] = lastChecked[repoID]?.filter { worktreeIDs.contains($0.key) }
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -26,14 +26,40 @@ extension WorktreeLifecycle {
             }
         }
 
+        // Dirty gate: resolve every branch tip plus the origin/<defaultBranch>
+        // tip in ONE `for-each-ref` subprocess. The conflict answer depends
+        // only on that (branch tip, base tip) pair, so a worktree whose pair is
+        // unchanged since its last successful check is skipped — no merge-base,
+        // no merge-tree. On failure (e.g. no origin remote yet) `tips` is empty
+        // and every worktree falls through to the ungated legacy path.
+        let tips = (try? await git.refTips(repoPath: repo.path)) ?? [:]
+        let baseTip = tips["origin/\(repo.defaultBranch)"]
+        await conflictSweepCache.retain(worktreeIDs: Set(worktrees.map(\.id)))
+
         await withTaskGroup(of: Void.self) { group in
             for wt in worktrees {
                 group.addTask {
+                    // Both tips known → gate on the cached pair. Unknown refs
+                    // (deleted branch, missing origin) → check unconditionally,
+                    // matching pre-gate behavior.
+                    var key: ConflictSweepCache.Key?
+                    if let baseTip, let branchTip = tips[wt.branch] {
+                        key = ConflictSweepCache.Key(branchTip: branchTip, baseTip: baseTip)
+                    }
+                    if let key {
+                        guard await self.conflictSweepCache.shouldCheck(worktreeID: wt.id, key: key) else { return }
+                    }
                     guard let newHasConflicts = await self.checkHasConflicts(
                         repoPath: repo.path,
                         defaultBranch: repo.defaultBranch,
                         branch: wt.branch
-                    ), newHasConflicts != wt.hasConflicts else { return }
+                    ) else { return }
+                    // Record only successful checks so transient git failures
+                    // retry next sweep instead of caching a non-answer.
+                    if let key {
+                        await self.conflictSweepCache.markChecked(worktreeID: wt.id, key: key)
+                    }
+                    guard newHasConflicts != wt.hasConflicts else { return }
                     try? await self.db.worktrees.updateHasConflicts(id: wt.id, hasConflicts: newHasConflicts)
                     self.subscriptions?.broadcast(delta: .worktreeConflictsChanged(
                         WorktreeConflictDelta(worktreeID: wt.id, hasConflicts: newHasConflicts)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -34,7 +34,7 @@ extension WorktreeLifecycle {
         // and every worktree falls through to the ungated legacy path.
         let tips = (try? await git.refTips(repoPath: repo.path)) ?? [:]
         let baseTip = tips["origin/\(repo.defaultBranch)"]
-        await conflictSweepCache.retain(worktreeIDs: Set(worktrees.map(\.id)))
+        await conflictSweepCache.retain(repoID: repoID, worktreeIDs: Set(worktrees.map(\.id)))
 
         await withTaskGroup(of: Void.self) { group in
             for wt in worktrees {
@@ -47,23 +47,35 @@ extension WorktreeLifecycle {
                         key = ConflictSweepCache.Key(branchTip: branchTip, baseTip: baseTip)
                     }
                     if let key {
-                        guard await self.conflictSweepCache.shouldCheck(worktreeID: wt.id, key: key) else { return }
+                        guard await self.conflictSweepCache.shouldCheck(
+                            repoID: repoID, worktreeID: wt.id, key: key
+                        ) else { return }
                     }
                     guard let newHasConflicts = await self.checkHasConflicts(
                         repoPath: repo.path,
                         defaultBranch: repo.defaultBranch,
                         branch: wt.branch
                     ) else { return }
-                    // Record only successful checks so transient git failures
-                    // retry next sweep instead of caching a non-answer.
-                    if let key {
-                        await self.conflictSweepCache.markChecked(worktreeID: wt.id, key: key)
+                    if newHasConflicts != wt.hasConflicts {
+                        do {
+                            try await self.db.worktrees.updateHasConflicts(id: wt.id, hasConflicts: newHasConflicts)
+                        } catch {
+                            // Persist failed — don't mark the pair checked, so
+                            // the next sweep recomputes and retries the write
+                            // (pre-gate behavior was self-healing on the next
+                            // sweep; the gate must not cache over a lost write).
+                            return
+                        }
+                        self.subscriptions?.broadcast(delta: .worktreeConflictsChanged(
+                            WorktreeConflictDelta(worktreeID: wt.id, hasConflicts: newHasConflicts)
+                        ))
                     }
-                    guard newHasConflicts != wt.hasConflicts else { return }
-                    try? await self.db.worktrees.updateHasConflicts(id: wt.id, hasConflicts: newHasConflicts)
-                    self.subscriptions?.broadcast(delta: .worktreeConflictsChanged(
-                        WorktreeConflictDelta(worktreeID: wt.id, hasConflicts: newHasConflicts)
-                    ))
+                    // Record only successful checks whose result is persisted,
+                    // so transient git/DB failures retry next sweep instead of
+                    // caching a non-answer.
+                    if let key {
+                        await self.conflictSweepCache.markChecked(repoID: repoID, worktreeID: wt.id, key: key)
+                    }
                 }
             }
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -66,6 +66,9 @@ public struct WorktreeLifecycle: Sendable {
     /// Reaper grace knobs (kept small in tests to avoid real sleeps).
     public let reaperGraceAttempts: Int
     public let reaperPollInterval: Duration
+    /// Dirty gate for the periodic conflict sweep (see `refreshGitStatuses`).
+    /// An actor reference, so every copy of this struct shares one cache.
+    public let conflictSweepCache = ConflictSweepCache()
 
     /// Default `preSession` hook timeout (production value).
     public static let defaultPreSessionTimeout: TimeInterval = 600

--- a/Sources/TBDDaemon/Server/GitPollingPolicy.swift
+++ b/Sources/TBDDaemon/Server/GitPollingPolicy.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Cadence policy for the daemon's always-on periodic git tasks.
+///
+/// The daemon sweeps every repo forever — conflict/branch status every tick,
+/// plus a per-repo `git fetch`. When no TBD app is in the foreground nobody is
+/// looking at conflict badges or branch freshness, so we trade latency for
+/// subprocess count instead of spawning git at full speed around the clock.
+///
+/// Cadence choice: background is a plain multiple of foreground (6x for the
+/// status sweep, 5x for fetch) — slow enough to stop the constant churn, fast
+/// enough that notification-driving state (merge conflicts, remote tips) is at
+/// most a minute or five stale while the app is closed or backgrounded. We
+/// deliberately never stop the loops entirely: notifications must keep working
+/// with no app running.
+///
+/// These are pure decision functions so each branch is directly testable; the
+/// timer loops in `Daemon.start()` just ask for the next interval each tick.
+public enum GitPollCadence {
+    /// Conflict/branch status sweep interval: 10s foregrounded, 60s backgrounded.
+    public static func statusInterval(isForeground: Bool) -> Duration {
+        isForeground ? .seconds(10) : .seconds(60)
+    }
+
+    /// Per-repo `git fetch` interval: 60s foregrounded, 5min backgrounded.
+    public static func fetchInterval(isForeground: Bool) -> Duration {
+        isForeground ? .seconds(60) : .seconds(300)
+    }
+}
+
+/// Last app-reported foreground state (via the `app.setForegroundState` RPC).
+///
+/// Defaults to background (`false`): a freshly started daemon has no app
+/// attached, so it should idle at the background cadence until an app says
+/// otherwise. The app pushes its current state on every (re)connect and on
+/// each `didBecomeActive`/`didResignActive` notification, so the daemon
+/// converges to the right cadence as soon as an app is talking to it.
+///
+/// Note the timer loops sample this once per tick, before sleeping — a
+/// foreground transition that lands mid-sleep takes effect on the next tick,
+/// so the worst-case extra latency after foregrounding is one background
+/// interval. That is acceptable for status freshness and keeps the loops
+/// trivially simple (no sleep cancellation plumbing).
+public actor AppForegroundState {
+    public private(set) var isForeground: Bool
+
+    public init(isForeground: Bool = false) {
+        self.isForeground = isForeground
+    }
+
+    public func set(isForeground: Bool) {
+        self.isForeground = isForeground
+    }
+}

--- a/Sources/TBDDaemon/Server/GitPollingPolicy.swift
+++ b/Sources/TBDDaemon/Server/GitPollingPolicy.swift
@@ -26,6 +26,23 @@ public enum GitPollCadence {
     public static func fetchInterval(isForeground: Bool) -> Duration {
         isForeground ? .seconds(60) : .seconds(300)
     }
+
+    /// How often the timer loops wake to re-evaluate the gated interval.
+    /// Short enough that a foreground transition (or the app disappearing)
+    /// changes the effective cadence within ~10s instead of one full
+    /// background interval.
+    public static let pollTick: Duration = .seconds(10)
+
+    /// The daemon treats the app as foreground only while at least one client
+    /// is actually connected. The reported flag alone is not trustworthy: a
+    /// crashed or force-quit app never sends `isForeground: false` (the
+    /// resign-active push is a fire-and-forget Task that dies with the
+    /// process), which would pin the fast cadence forever with nobody
+    /// watching. The app holds a long-lived state-subscription socket while
+    /// running, so `connectedClients == 0` reliably means "no app".
+    public static func isEffectivelyForeground(reportedForeground: Bool, connectedClients: Int) -> Bool {
+        reportedForeground && connectedClients > 0
+    }
 }
 
 /// Last app-reported foreground state (via the `app.setForegroundState` RPC).
@@ -36,11 +53,9 @@ public enum GitPollCadence {
 /// each `didBecomeActive`/`didResignActive` notification, so the daemon
 /// converges to the right cadence as soon as an app is talking to it.
 ///
-/// Note the timer loops sample this once per tick, before sleeping — a
-/// foreground transition that lands mid-sleep takes effect on the next tick,
-/// so the worst-case extra latency after foregrounding is one background
-/// interval. That is acceptable for status freshness and keeps the loops
-/// trivially simple (no sleep cancellation plumbing).
+/// The timer loops re-evaluate this every `GitPollCadence.pollTick` while
+/// waiting (see `Daemon.sleepThroughGatedInterval`), so a transition takes
+/// effect within ~one tick — no sleep-cancellation plumbing needed.
 public actor AppForegroundState {
     public private(set) var isForeground: Bool
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -22,6 +22,10 @@ public final class RPCRouter: Sendable {
     /// Daemon.swift (mirrors `claudeUsagePoller`); nil in unit tests / mock
     /// mode, where usage snapshots are simply absent.
     public nonisolated(unsafe) var oauthUsagePoller: OAuthProfileUsagePoller?
+    /// Shared app-foreground gate for the daemon's periodic git tasks. Wired
+    /// post-construction by Daemon.swift (mirrors `claudeUsagePoller`); `nil`
+    /// in unit tests that don't exercise the foreground RPC.
+    public nonisolated(unsafe) var appForegroundState: AppForegroundState?
     /// Live connected-client count, supplied by the SocketServer after it is
     /// constructed (the router is built first in Daemon.swift, so it cannot
     /// take the server as an init dependency). Mirrors `claudeUsagePoller`
@@ -269,6 +273,7 @@ public final class RPCRouter: Sendable {
             case RPCMethod.appSetForegroundState:
                 let params = try decoder.decode(AppSetForegroundStateParams.self, from: request.paramsData)
                 await claudeUsagePoller?.onFocusChanged(isForeground: params.isForeground)
+                await appForegroundState?.set(isForeground: params.isForeground)
                 return .ok()
             case RPCMethod.appearanceUpdateColorFgBg:
                 return try await handleAppearanceUpdateColorFgBg(request.paramsData)

--- a/Tests/TBDDaemonTests/GitPollingPolicyTests.swift
+++ b/Tests/TBDDaemonTests/GitPollingPolicyTests.swift
@@ -23,6 +23,20 @@ struct GitPollCadenceTests {
     @Test func fetchIntervalBackgroundIsSlow() {
         #expect(GitPollCadence.fetchInterval(isForeground: false) == .seconds(300))
     }
+
+    @Test func effectiveForegroundRequiresReportAndClient() {
+        #expect(GitPollCadence.isEffectivelyForeground(reportedForeground: true, connectedClients: 1) == true)
+    }
+
+    @Test func reportedForegroundWithoutClientsIsBackground() {
+        // A crashed/force-quit app never reports false — zero connected
+        // clients must override a stale foreground report.
+        #expect(GitPollCadence.isEffectivelyForeground(reportedForeground: true, connectedClients: 0) == false)
+    }
+
+    @Test func connectedClientWithoutForegroundReportIsBackground() {
+        #expect(GitPollCadence.isEffectivelyForeground(reportedForeground: false, connectedClients: 3) == false)
+    }
 }
 
 // MARK: - AppForegroundState
@@ -51,53 +65,73 @@ struct AppForegroundStateTests {
 @Suite("ConflictSweepCache Tests")
 struct ConflictSweepCacheTests {
 
+    private let repoID = UUID()
     private let id = UUID()
     private let key = ConflictSweepCache.Key(branchTip: "aaa", baseTip: "bbb")
 
     @Test func firstSightingRequiresCheck() async {
         let cache = ConflictSweepCache()
-        #expect(await cache.shouldCheck(worktreeID: id, key: key) == true)
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: id, key: key) == true)
     }
 
     @Test func unchangedPairSkipsCheck() async {
         let cache = ConflictSweepCache()
-        await cache.markChecked(worktreeID: id, key: key)
-        #expect(await cache.shouldCheck(worktreeID: id, key: key) == false)
+        await cache.markChecked(repoID: repoID, worktreeID: id, key: key)
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: id, key: key) == false)
     }
 
     @Test func movedBranchTipInvalidates() async {
         let cache = ConflictSweepCache()
-        await cache.markChecked(worktreeID: id, key: key)
+        await cache.markChecked(repoID: repoID, worktreeID: id, key: key)
         let moved = ConflictSweepCache.Key(branchTip: "ccc", baseTip: "bbb")
-        #expect(await cache.shouldCheck(worktreeID: id, key: moved) == true)
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: id, key: moved) == true)
     }
 
     @Test func movedBaseTipInvalidates() async {
         let cache = ConflictSweepCache()
-        await cache.markChecked(worktreeID: id, key: key)
+        await cache.markChecked(repoID: repoID, worktreeID: id, key: key)
         let moved = ConflictSweepCache.Key(branchTip: "aaa", baseTip: "ddd")
-        #expect(await cache.shouldCheck(worktreeID: id, key: moved) == true)
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: id, key: moved) == true)
     }
 
     @Test func invalidationIsPerWorktree() async {
         let cache = ConflictSweepCache()
         let otherID = UUID()
-        await cache.markChecked(worktreeID: id, key: key)
+        await cache.markChecked(repoID: repoID, worktreeID: id, key: key)
         // A different worktree with the same pair still needs its own check.
-        #expect(await cache.shouldCheck(worktreeID: otherID, key: key) == true)
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: otherID, key: key) == true)
         // ...and checking it doesn't disturb the first worktree's entry.
-        await cache.markChecked(worktreeID: otherID, key: key)
-        #expect(await cache.shouldCheck(worktreeID: id, key: key) == false)
+        await cache.markChecked(repoID: repoID, worktreeID: otherID, key: key)
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: id, key: key) == false)
     }
 
     @Test func retainPrunesRemovedWorktrees() async {
         let cache = ConflictSweepCache()
         let keptID = UUID()
-        await cache.markChecked(worktreeID: id, key: key)
-        await cache.markChecked(worktreeID: keptID, key: key)
-        await cache.retain(worktreeIDs: [keptID])
-        #expect(await cache.shouldCheck(worktreeID: id, key: key) == true)
-        #expect(await cache.shouldCheck(worktreeID: keptID, key: key) == false)
+        await cache.markChecked(repoID: repoID, worktreeID: id, key: key)
+        await cache.markChecked(repoID: repoID, worktreeID: keptID, key: key)
+        await cache.retain(repoID: repoID, worktreeIDs: [keptID])
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: id, key: key) == true)
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: keptID, key: key) == false)
+    }
+
+    @Test func retainIsScopedToOneRepo() async {
+        // The sweep runs per repo in a loop over all repos — repo B's retain
+        // must never evict repo A's entries, or the gate would be inert on
+        // multi-repo installs (every sweep would evict the other repos).
+        let cache = ConflictSweepCache()
+        let repoB = UUID()
+        let wtInB = UUID()
+        await cache.markChecked(repoID: repoID, worktreeID: id, key: key)
+        await cache.markChecked(repoID: repoB, worktreeID: wtInB, key: key)
+        // Sweeping repo B (its own worktrees) leaves repo A untouched.
+        await cache.retain(repoID: repoB, worktreeIDs: [wtInB])
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: id, key: key) == false)
+        #expect(await cache.shouldCheck(repoID: repoB, worktreeID: wtInB, key: key) == false)
+        // And pruning everything from repo B still leaves repo A intact.
+        await cache.retain(repoID: repoB, worktreeIDs: [])
+        #expect(await cache.shouldCheck(repoID: repoID, worktreeID: id, key: key) == false)
+        #expect(await cache.shouldCheck(repoID: repoB, worktreeID: wtInB, key: key) == true)
     }
 }
 

--- a/Tests/TBDDaemonTests/GitPollingPolicyTests.swift
+++ b/Tests/TBDDaemonTests/GitPollingPolicyTests.swift
@@ -1,0 +1,128 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// MARK: - Cadence selection (foreground gate)
+
+@Suite("GitPollCadence Tests")
+struct GitPollCadenceTests {
+
+    @Test func statusIntervalForegroundIsFast() {
+        #expect(GitPollCadence.statusInterval(isForeground: true) == .seconds(10))
+    }
+
+    @Test func statusIntervalBackgroundIsSlow() {
+        #expect(GitPollCadence.statusInterval(isForeground: false) == .seconds(60))
+    }
+
+    @Test func fetchIntervalForegroundIsFast() {
+        #expect(GitPollCadence.fetchInterval(isForeground: true) == .seconds(60))
+    }
+
+    @Test func fetchIntervalBackgroundIsSlow() {
+        #expect(GitPollCadence.fetchInterval(isForeground: false) == .seconds(300))
+    }
+}
+
+// MARK: - AppForegroundState
+
+@Suite("AppForegroundState Tests")
+struct AppForegroundStateTests {
+
+    @Test func defaultsToBackground() async {
+        // A freshly started daemon has no app attached — it must idle at the
+        // background cadence until an app reports otherwise.
+        let state = AppForegroundState()
+        #expect(await state.isForeground == false)
+    }
+
+    @Test func setForegroundThenBackground() async {
+        let state = AppForegroundState()
+        await state.set(isForeground: true)
+        #expect(await state.isForeground == true)
+        await state.set(isForeground: false)
+        #expect(await state.isForeground == false)
+    }
+}
+
+// MARK: - ConflictSweepCache (dirty gate)
+
+@Suite("ConflictSweepCache Tests")
+struct ConflictSweepCacheTests {
+
+    private let id = UUID()
+    private let key = ConflictSweepCache.Key(branchTip: "aaa", baseTip: "bbb")
+
+    @Test func firstSightingRequiresCheck() async {
+        let cache = ConflictSweepCache()
+        #expect(await cache.shouldCheck(worktreeID: id, key: key) == true)
+    }
+
+    @Test func unchangedPairSkipsCheck() async {
+        let cache = ConflictSweepCache()
+        await cache.markChecked(worktreeID: id, key: key)
+        #expect(await cache.shouldCheck(worktreeID: id, key: key) == false)
+    }
+
+    @Test func movedBranchTipInvalidates() async {
+        let cache = ConflictSweepCache()
+        await cache.markChecked(worktreeID: id, key: key)
+        let moved = ConflictSweepCache.Key(branchTip: "ccc", baseTip: "bbb")
+        #expect(await cache.shouldCheck(worktreeID: id, key: moved) == true)
+    }
+
+    @Test func movedBaseTipInvalidates() async {
+        let cache = ConflictSweepCache()
+        await cache.markChecked(worktreeID: id, key: key)
+        let moved = ConflictSweepCache.Key(branchTip: "aaa", baseTip: "ddd")
+        #expect(await cache.shouldCheck(worktreeID: id, key: moved) == true)
+    }
+
+    @Test func invalidationIsPerWorktree() async {
+        let cache = ConflictSweepCache()
+        let otherID = UUID()
+        await cache.markChecked(worktreeID: id, key: key)
+        // A different worktree with the same pair still needs its own check.
+        #expect(await cache.shouldCheck(worktreeID: otherID, key: key) == true)
+        // ...and checking it doesn't disturb the first worktree's entry.
+        await cache.markChecked(worktreeID: otherID, key: key)
+        #expect(await cache.shouldCheck(worktreeID: id, key: key) == false)
+    }
+
+    @Test func retainPrunesRemovedWorktrees() async {
+        let cache = ConflictSweepCache()
+        let keptID = UUID()
+        await cache.markChecked(worktreeID: id, key: key)
+        await cache.markChecked(worktreeID: keptID, key: key)
+        await cache.retain(worktreeIDs: [keptID])
+        #expect(await cache.shouldCheck(worktreeID: id, key: key) == true)
+        #expect(await cache.shouldCheck(worktreeID: keptID, key: key) == false)
+    }
+}
+
+// MARK: - RPC wiring
+
+extension RPCRouterTests {
+
+    @Test("app.setForegroundState updates the shared foreground gate")
+    func appSetForegroundStateUpdatesGate() async throws {
+        let gate = AppForegroundState()
+        router.appForegroundState = gate
+        #expect(await gate.isForeground == false)
+
+        let toForeground = try RPCRequest(
+            method: RPCMethod.appSetForegroundState,
+            params: AppSetForegroundStateParams(isForeground: true)
+        )
+        #expect(await router.handle(toForeground).success)
+        #expect(await gate.isForeground == true)
+
+        let toBackground = try RPCRequest(
+            method: RPCMethod.appSetForegroundState,
+            params: AppSetForegroundStateParams(isForeground: false)
+        )
+        #expect(await router.handle(toBackground).success)
+        #expect(await gate.isForeground == false)
+    }
+}

--- a/Tests/TBDDaemonTests/GitStatusTests.swift
+++ b/Tests/TBDDaemonTests/GitStatusTests.swift
@@ -192,4 +192,111 @@ struct GitStatusTests {
         let updated = try await db.worktrees.get(id: wt.id)
         #expect(updated?.hasConflicts == false)
     }
+
+    @Test func refTipsResolvesLocalAndOriginBranches() async throws {
+        let tempBase = URL(fileURLWithPath: NSTemporaryDirectory())
+        let suffix = UUID().uuidString
+        let repoDir = tempBase.appendingPathComponent("tbd-test-\(suffix)")
+        let originDir = tempBase.appendingPathComponent("tbd-test-origin-\(suffix).git")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: repoDir)
+            try? FileManager.default.removeItem(at: originDir)
+        }
+
+        try await runShell("git init -b main", at: repoDir)
+        try await runShell("git config commit.gpgSign false", at: repoDir)
+        try await runShell("git config user.email 'test@test.com'", at: repoDir)
+        try await runShell("git config user.name 'Test'", at: repoDir)
+        try await runShell("touch README.md && git add . && git commit -m 'initial'", at: repoDir)
+        try await runShell("git init --bare '\(originDir.path)'", at: repoDir)
+        try await runShell("git remote add origin '\(originDir.path)'", at: repoDir)
+        try await runShell("git push -u origin main", at: repoDir)
+        try await runShell("git checkout -b feature", at: repoDir)
+        try await runShell("touch feature.txt && git add . && git commit -m 'feature'", at: repoDir)
+
+        let git = GitManager()
+        let tips = try await git.refTips(repoPath: repoDir.path)
+        let mainSHA = try await git.headSHA(repoPath: repoDir.path, ref: "main")
+        let featureSHA = try await git.headSHA(repoPath: repoDir.path, ref: "feature")
+
+        #expect(tips["main"] == mainSHA)
+        #expect(tips["origin/main"] == mainSHA)
+        #expect(tips["feature"] == featureSHA)
+        #expect(featureSHA != mainSHA)
+    }
+
+    /// Dirty gate: a sweep whose (branch tip, base tip) pair is unchanged must
+    /// NOT re-run the conflict check; moving either tip must re-run it.
+    ///
+    /// Skip is observed by tampering with the DB value between sweeps: a gated
+    /// sweep leaves the tampered value in place (no check ran), while an
+    /// invalidated sweep recomputes and corrects it.
+    @Test func refreshGitStatusesDirtyGateSkipsAndInvalidates() async throws {
+        let tempBase = URL(fileURLWithPath: NSTemporaryDirectory())
+        let suffix = UUID().uuidString
+        let repoDir = tempBase.appendingPathComponent("tbd-test-\(suffix)")
+        let originDir = tempBase.appendingPathComponent("tbd-test-origin-\(suffix).git")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: repoDir)
+            try? FileManager.default.removeItem(at: originDir)
+        }
+
+        // Same conflict scenario as refreshGitStatusesDetectsConflicts:
+        // feature edits shared.txt, origin/main diverges with a conflicting edit.
+        try await runShell("git init -b main", at: repoDir)
+        try await runShell("git config commit.gpgSign false", at: repoDir)
+        try await runShell("git config user.email 'test@test.com'", at: repoDir)
+        try await runShell("git config user.name 'Test'", at: repoDir)
+        try await runShell("echo 'line1' > shared.txt && git add . && git commit -m 'initial'", at: repoDir)
+        try await runShell("git init --bare '\(originDir.path)'", at: repoDir)
+        try await runShell("git remote add origin '\(originDir.path)'", at: repoDir)
+        try await runShell("git push -u origin main", at: repoDir)
+        try await runShell("git checkout -b tbd/feature-wt", at: repoDir)
+        try await runShell("echo 'feature-change' > shared.txt && git add . && git commit -m 'feature change'", at: repoDir)
+        try await runShell("git checkout main", at: repoDir)
+        try await runShell("echo 'main-change' > shared.txt && git add . && git commit -m 'main change'", at: repoDir)
+        try await runShell("git push origin main", at: repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: repoDir.path, displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "feature-wt", branch: "tbd/feature-wt",
+            path: repoDir.path + "/.tbd/worktrees/feature-wt", tmuxServer: "tbd-test"
+        )
+
+        // The cache lives on the lifecycle instance — reuse ONE instance across
+        // sweeps, like the daemon's periodic task does.
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver(), subscriptions: StateSubscriptionManager()
+        )
+
+        // Sweep 1: computes and stores the real answer (conflicts).
+        await lifecycle.refreshGitStatuses(repoID: repo.id)
+        #expect(try await db.worktrees.get(id: wt.id)?.hasConflicts == true)
+
+        // Tamper, then sweep with unchanged tips: the gate must skip the
+        // check, leaving the tampered value untouched.
+        try await db.worktrees.updateHasConflicts(id: wt.id, hasConflicts: false)
+        await lifecycle.refreshGitStatuses(repoID: repo.id)
+        #expect(try await db.worktrees.get(id: wt.id)?.hasConflicts == false)
+
+        // Move the branch tip: gate invalidates, the check re-runs and
+        // corrects the tampered value.
+        try await runShell("git checkout tbd/feature-wt", at: repoDir)
+        try await runShell("echo 'more' >> shared.txt && git add . && git commit -m 'feature again'", at: repoDir)
+        try await runShell("git checkout main", at: repoDir)
+        await lifecycle.refreshGitStatuses(repoID: repo.id)
+        #expect(try await db.worktrees.get(id: wt.id)?.hasConflicts == true)
+
+        // Tamper again, then move the BASE tip (push a new commit to
+        // origin/main): gate invalidates on the other half of the pair.
+        try await db.worktrees.updateHasConflicts(id: wt.id, hasConflicts: false)
+        try await runShell("echo 'base-moves' > other.txt && git add . && git commit -m 'base moves'", at: repoDir)
+        try await runShell("git push origin main", at: repoDir)
+        await lifecycle.refreshGitStatuses(repoID: repo.id)
+        #expect(try await db.worktrees.get(id: wt.id)?.hasConflicts == true)
+    }
 }

--- a/Tests/TBDDaemonTests/GitStatusTests.swift
+++ b/Tests/TBDDaemonTests/GitStatusTests.swift
@@ -299,4 +299,61 @@ struct GitStatusTests {
         await lifecycle.refreshGitStatuses(repoID: repo.id)
         #expect(try await db.worktrees.get(id: wt.id)?.hasConflicts == true)
     }
+
+    /// Ungated fallback: when the worktree's ref is not resolvable from the
+    /// `for-each-ref` tips (here: a tag, which lives outside refs/heads and
+    /// refs/remotes/origin), the dirty gate must fall through to checking
+    /// unconditionally every sweep — fail-open, matching pre-gate behavior —
+    /// rather than skipping (which would freeze hasConflicts forever).
+    @Test func refreshGitStatusesChecksUnconditionallyWhenTipsUnresolvable() async throws {
+        let tempBase = URL(fileURLWithPath: NSTemporaryDirectory())
+        let suffix = UUID().uuidString
+        let repoDir = tempBase.appendingPathComponent("tbd-test-\(suffix)")
+        let originDir = tempBase.appendingPathComponent("tbd-test-origin-\(suffix).git")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: repoDir)
+            try? FileManager.default.removeItem(at: originDir)
+        }
+
+        // Conflict scenario as above, but the worktree row's "branch" is a TAG
+        // pointing at the conflicting commit.
+        try await runShell("git init -b main", at: repoDir)
+        try await runShell("git config commit.gpgSign false", at: repoDir)
+        try await runShell("git config user.email 'test@test.com'", at: repoDir)
+        try await runShell("git config user.name 'Test'", at: repoDir)
+        try await runShell("echo 'line1' > shared.txt && git add . && git commit -m 'initial'", at: repoDir)
+        try await runShell("git init --bare '\(originDir.path)'", at: repoDir)
+        try await runShell("git remote add origin '\(originDir.path)'", at: repoDir)
+        try await runShell("git push -u origin main", at: repoDir)
+        try await runShell("git checkout -b tbd/feature-wt", at: repoDir)
+        try await runShell("echo 'feature-change' > shared.txt && git add . && git commit -m 'feature change'", at: repoDir)
+        try await runShell("git tag feature-tag", at: repoDir)
+        try await runShell("git checkout main", at: repoDir)
+        try await runShell("echo 'main-change' > shared.txt && git add . && git commit -m 'main change'", at: repoDir)
+        try await runShell("git push origin main", at: repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: repoDir.path, displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "feature-wt", branch: "feature-tag",
+            path: repoDir.path + "/.tbd/worktrees/feature-wt", tmuxServer: "tbd-test"
+        )
+
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver(), subscriptions: StateSubscriptionManager()
+        )
+
+        // Sweep 1 computes the real answer through the ungated path.
+        await lifecycle.refreshGitStatuses(repoID: repo.id)
+        #expect(try await db.worktrees.get(id: wt.id)?.hasConflicts == true)
+
+        // Tamper, then sweep again with nothing changed: because the ref isn't
+        // gateable, the check re-runs and corrects the value (a gated worktree
+        // would have skipped and left the tamper in place).
+        try await db.worktrees.updateHasConflicts(id: wt.id, hasConflicts: false)
+        await lifecycle.refreshGitStatuses(repoID: repo.id)
+        #expect(try await db.worktrees.get(id: wt.id)?.hasConflicts == true)
+    }
 }


### PR DESCRIPTION
## Problem

The always-on daemon burns git subprocesses forever, even when nothing changed and no app is running:

- `gitStatusTask` sweeps every repo every 10s, and `refreshGitStatuses` fans out over every active worktree — each spawning `git merge-base --is-ancestor`, plus `git merge-tree` on divergence. That's **1-2 subprocesses per active worktree per 10s, unconditionally, around the clock**.
- `gitFetchTask` runs one `git fetch` per repo per 60s, same story.

This is the surviving analog of the old `handlePRList` RPC storm (fixed in #310 with single-flighting + caching via `PRListCoordinator`).

## Fix: two gates

### Dirty gate (`ConflictSweepCache`)

The conflict answer for a worktree depends on exactly two commits: its branch tip and the `origin/<defaultBranch>` tip. One `git for-each-ref` per repo per sweep resolves every branch tip plus the base tip; worktrees whose (branch tip, base tip) pair is unchanged since their last successful check skip merge-base/merge-tree entirely.

- Cache is **repo-scoped** (the sweep loops repos, so pruning must never evict other repos' entries)
- Unknown refs (deleted branch, no origin, `for-each-ref` failure) **fail open** to the ungated pre-gate path
- `markChecked` only after the check succeeded **and** the DB write persisted — transient git/DB failures retry next sweep instead of being cached over

### Foreground gate (`AppForegroundState` + `GitPollCadence`)

The app already reports focus via `app.setForegroundState` (previously it only paused `ClaudeUsagePoller`). Now it also drives sweep cadence:

| task | foreground | background |
|---|---|---|
| status sweep | 10s | 60s |
| git fetch | 60s | 5min |

- Effective foreground = reported foreground **AND** `connectedClients > 0`, so a crashed/force-quit app (which never sends `false`) can't pin the fast cadence
- Loops wait in 10s ticks re-evaluating the gated interval, so transitions apply within ~one tick (and the first post-restart fetch isn't delayed to 5min)
- Daemon defaults to background cadence; the app pushes its state on every (re)connect (gate is wired before the socket starts so the push can't be dropped) and on active/resign notifications
- Never stops entirely — notification-driving state stays roughly fresh with no app running

## Steady-state cost (app closed, nothing changing)

From ~6-12 subprocesses per worktree per minute to one `for-each-ref` + one `worktree list` per repo per minute, plus one fetch per repo per 5 minutes.

## Tests

Per-branch coverage for every new gate: cadence selection (fg/bg × status/fetch), effective-foreground (reported×clients), cache skip/invalidate (branch tip, base tip, per-worktree, repo-scoped retention), RPC wiring, plus live-git integration tests for gate skip, both invalidation directions, and the ungated fallback when a worktree ref isn't resolvable from tips. Full suite: 2043 tests pass. `swiftlint --strict` clean.