### PR TITLE
Fix: Scratch section hidden when empty, blocking first-space creation from the UI

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1492,9 +1492,14 @@ final class AppState: ObservableObject {
     static let showScratchSectionKey = "showScratchSection"
 
     /// Pure, testable mirror of the sidebar's Scratch-section gate:
-    /// shown only when the setting is on AND there's at least one scratch space.
+    /// shown whenever the setting is on, regardless of whether any scratch
+    /// spaces exist yet. This keeps the section (and its hover "+" create
+    /// button) reachable for a brand-new user with zero scratch spaces —
+    /// otherwise there'd be no UI path to create the first one.
+    /// `spaces` is currently unused for the visibility decision but is kept
+    /// in the signature for API stability with the existing call site.
     nonisolated static func scratchSectionVisible(setting: Bool, spaces: [Worktree]) -> Bool {
-        setting && !spaces.isEmpty
+        setting
     }
 
     /// Pure, testable mirror of `WorktreeRowView`'s scratch-row dimming rule:

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -41,6 +41,16 @@ struct ScratchSectionView: View {
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
 
+        if appState.scratchWorktrees.isEmpty {
+            Text("No scratch spaces — click + to create one")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .listRowInsets(EdgeInsets(top: 2, leading: 14, bottom: 4, trailing: 0))
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+        }
+
         ForEach(appState.scratchWorktrees) { wt in
             WorktreeRowView(worktree: wt)   // sectionRepoID nil → no (repo) suffix; repo affordances vanish
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Tests/TBDAppTests/ShowScratchSectionSettingTests.swift
+++ b/Tests/TBDAppTests/ShowScratchSectionSettingTests.swift
@@ -45,9 +45,14 @@ struct ScratchSectionVisibleTests {
         #expect(!AppState.scratchSectionVisible(setting: false, spaces: [makeSpace()]))
     }
 
-    @Test("on + no spaces hides the section")
-    func onWithNoSpacesHides() {
-        #expect(!AppState.scratchSectionVisible(setting: true, spaces: []))
+    @Test("on + no spaces still shows the section, so a new user can create the first space")
+    func onWithNoSpacesShows() {
+        #expect(AppState.scratchSectionVisible(setting: true, spaces: []))
+    }
+
+    @Test("off + no spaces hides the section")
+    func offWithNoSpacesHides() {
+        #expect(!AppState.scratchSectionVisible(setting: false, spaces: []))
     }
 
     @Test("toggling the setting never mutates the spaces array")


### PR DESCRIPTION
## Symptom

Fresh users see no Scratch section in the sidebar at all, and have no way to create their first scratch space from the UI. The setting to show the section defaults to on, but the section itself never rendered.

## Root cause

`AppState.scratchSectionVisible(setting:spaces:)` required `setting && !spaces.isEmpty`. This hid the *entire* section — including the hover "+" create button and the selectable header/detail pane — whenever there were zero scratch spaces. Since a new user by definition starts with zero scratch spaces, they had no UI path to create the first one (the CLI was the only way to bootstrap).

## Fix

- `scratchSectionVisible` now returns just `setting`, ignoring the space count for visibility. The section shows whenever the setting is on, regardless of whether any scratch spaces exist yet. The `spaces` parameter is kept in the signature for API stability with the existing call site in `SidebarView.swift`.
- Added a subtle single-line hint row ("No scratch spaces — click + to create one") to `ScratchSectionView` for the empty state, styled consistently with the sidebar's compact row conventions, so new users know to hover the header to find the "+" button.

## Test plan

- Updated `ScratchSectionVisibleTests` to the new truth table:
  - setting=true, spaces=empty → visible=true (changed case)
  - setting=true, spaces=non-empty → visible=true
  - setting=false, spaces=empty → visible=false
  - setting=false, spaces=non-empty → visible=false
- `swift build`: succeeds (pre-existing unrelated warnings only)
- `swift test`: full suite passes — 2063 tests, 0 failures
- `swiftlint --strict`: 0 violations across 273 files, including the two changed Sources files
- Manual review: read `ScratchSectionView.swift` and `RepoSectionView.swift`/`ArchivedWorktreesView.swift` to confirm the empty-state hint row styling matches existing sidebar conventions (secondary caption text, consistent list row insets/separators)