### PR TITLE
Fix: Scratch header + button hitbox parity with repos; clickable empty-state CTA

### DIFF
--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -135,13 +135,10 @@ struct RepoSectionView: View {
 
             Group {
                 if isSectionHovered || showBranchPicker {
-                    Button(action: handlePlusButton) {
-                        Image(systemName: "plus")
-                            .font(.caption)
-                            .frame(width: 20, height: 20)
-                    }
-                    .buttonStyle(HoverPressButtonStyle())
-                    .help("New worktree (\u{2325}-click to pick existing branch)")
+                    SectionHeaderPlusButton(
+                        help: "New worktree (\u{2325}-click to pick existing branch)",
+                        action: handlePlusButton
+                    )
                     .disabled(repo.status == .missing)
                     .popover(isPresented: $showBranchPicker, arrowEdge: .trailing) {
                         BranchPickerView(repoID: repo.id)

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import TBDShared
 
@@ -16,11 +17,7 @@ struct ScratchSectionView: View {
                 .foregroundStyle(appState.selectedScratchSection ? .primary : .secondary)
             Spacer()
             if isHeaderHovered {
-                Button { appState.createScratch() } label: {
-                    Image(systemName: "plus")
-                }
-                .buttonStyle(HoverPressButtonStyle())
-                .help("New scratch space")
+                SectionHeaderPlusButton(help: "New scratch space", action: { appState.createScratch() })
             }
         }
         .background(Color.white.opacity(0.0001))
@@ -42,13 +39,22 @@ struct ScratchSectionView: View {
         .listRowBackground(Color.clear)
 
         if appState.scratchWorktrees.isEmpty {
-            Text("No scratch spaces — click + to create one")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .listRowInsets(EdgeInsets(top: 2, leading: 14, bottom: 4, trailing: 0))
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
+            Button {
+                appState.createScratch()
+            } label: {
+                Text("Click to create scratch space")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+            .listRowInsets(EdgeInsets(top: 2, leading: 14, bottom: 4, trailing: 0))
+            .listRowSeparator(.hidden)
+            .listRowBackground(Color.clear)
         }
 
         ForEach(appState.scratchWorktrees) { wt in

--- a/Sources/TBDApp/Sidebar/SectionHeaderPlusButton.swift
+++ b/Sources/TBDApp/Sidebar/SectionHeaderPlusButton.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// Shared "+" control for sidebar section headers (Repo, Scratch, ...).
+/// Reproduces RepoSectionView's original inline plus button exactly — a
+/// caption-sized glyph in a 20x20 hit target — so every section header gets
+/// the same tap/hover target size.
+struct SectionHeaderPlusButton: View {
+    let help: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "plus")
+                .font(.caption)
+                .frame(width: 20, height: 20)
+        }
+        .buttonStyle(HoverPressButtonStyle())
+        .help(help)
+    }
+}


### PR DESCRIPTION
## Summary
- The Scratch section header's "+" button had a much smaller hitbox than the Repo section's — the repo header gave its plus glyph `.font(.caption)` + `.frame(width: 20, height: 20)` inside a `HoverPressButtonStyle` button, while the scratch header used a bare `Image(systemName: "plus")` with none of that. Extracted a shared `SectionHeaderPlusButton` view (`Sources/TBDApp/Sidebar/SectionHeaderPlusButton.swift`) that reproduces the repo header's exact label modifiers + `HoverPressButtonStyle` + `.help`, and now use it in both `RepoSectionView` and `ScratchSectionView` so both headers get the identical 20x20 hit target.
- The Scratch section's empty state ("No scratch spaces — click + to create one") was inert `Text` despite telling users to click. Replaced it with a real `Button` labeled "Click to create scratch space" that calls `appState.createScratch()`, styled as a plain inline CTA (`.buttonStyle(.plain)`, `.foregroundStyle(.secondary)`, `.font(.caption)`) with a pointing-hand cursor hover affordance (same idiom used for "Click to resume session" in `PanePlaceholder.swift`) and `.contentShape(Rectangle())` so the full row width is clickable. Row insets are unchanged so it still aligns with the other rows.

## Shared component extracted
```swift
struct SectionHeaderPlusButton: View {
    let help: String
    let action: () -> Void

    var body: some View {
        Button(action: action) {
            Image(systemName: "plus")
                .font(.caption)
                .frame(width: 20, height: 20)
        }
        .buttonStyle(HoverPressButtonStyle())
        .help(help)
    }
}
```
`RepoSectionView`'s original `handlePlusButton` action and its conditional rendering / `.disabled(...)` / `.popover(...)` chain are unchanged — only the button's inner label/styling moved into the shared component.

## Test plan
- [x] `swift build` — succeeds, no new warnings
- [x] `swift test` — 2063 tests / 252 suites pass
- [x] `swiftlint --strict` — 0 violations
- [ ] Live UI check: hover both section headers and confirm the "+" hit targets feel the same size; click anywhere on the scratch empty-state row and confirm it creates a scratch space