### PR TITLE
Accounts: per-profile usage snapshots + spawn-time account picker with session tooltips

### DIFF
--- a/Sources/TBDApp/AccountPickerSheet.swift
+++ b/Sources/TBDApp/AccountPickerSheet.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+import TBDShared
+
+/// Spawn-time account picker: the sheet shown when the user clicks the plain
+/// "Claude" action (unless "Use default without asking" is on) or the
+/// "Choose account…" item in the "+" menu.
+///
+/// Lists every model profile with full usage data — identity, 5h window bar +
+/// reset time, weekly-all bar, per-family bars — sorted
+/// healthiest-session-window first (display order only; nothing is
+/// auto-picked). Cached snapshots render immediately; a forced daemon-side
+/// usage sweep runs on open and updates rows in place ("refreshing…", never a
+/// blocking spinner). Selecting a row spawns a Claude session pinned to that
+/// profile for life.
+struct AccountPickerSheet: View {
+    @EnvironmentObject var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    /// Called with the chosen profile id; the caller owns the actual spawn.
+    let onPick: (UUID) -> Void
+
+    @State private var isRefreshing = false
+
+    private var sortedEntries: [ModelProfileWithUsage] {
+        ProfileUsagePresentation.sortedForPicker(appState.modelProfiles)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+
+            if sortedEntries.isEmpty {
+                Text("No model profiles configured — add one in Settings → Model Profiles.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 80)
+            } else {
+                ScrollView {
+                    VStack(spacing: 4) {
+                        ForEach(sortedEntries, id: \.profile.id) { entry in
+                            AccountPickerRow(
+                                entry: entry,
+                                isDefault: entry.profile.id == appState.defaultProfileID,
+                                onPick: {
+                                    onPick(entry.profile.id)
+                                    dismiss()
+                                }
+                            )
+                        }
+                    }
+                }
+                .frame(maxHeight: 380)
+            }
+
+            Divider()
+
+            HStack {
+                Toggle("Use default without asking", isOn: $appState.skipAccountPicker)
+                    .font(.caption)
+                    .help("Skip this dialog: plain Claude spawns on the global default profile. Toggle back here or in Settings → Model Profiles.")
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 480)
+        .task {
+            // Decision-grade data: force a sweep on open. Cached rows are
+            // already on screen; fresh snapshots merge in when they land.
+            isRefreshing = true
+            await appState.refreshUsageSnapshots()
+            isRefreshing = false
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Choose account for Claude")
+                .font(.headline)
+            Spacer()
+            if isRefreshing {
+                HStack(spacing: 5) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("refreshing…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct AccountPickerRow: View {
+    let entry: ModelProfileWithUsage
+    let isDefault: Bool
+    let onPick: () -> Void
+
+    @State private var isHovering = false
+
+    private var isSelectable: Bool {
+        ProfileUsagePresentation.isSelectable(entry)
+    }
+
+    private var identityText: String? {
+        if ProfileLoginPresentation.needsLogin(kind: entry.profile.kind,
+                                               loginIdentity: entry.loginIdentity) {
+            return "not logged in — run /login first"
+        }
+        return ProfileLoginPresentation.normalizedIdentity(entry.loginIdentity)
+    }
+
+    var body: some View {
+        Button(action: onPick) {
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 6) {
+                    Text(entry.profile.name)
+                        .font(.system(size: 13, weight: .medium))
+                    if isDefault {
+                        Text("default")
+                            .font(.caption2)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(Color.accentColor.opacity(0.18)))
+                    }
+                    if let identityText {
+                        Text(identityText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                }
+
+                if let snapshot = entry.usageSnapshot, !snapshot.buckets.isEmpty {
+                    bucketRows(snapshot)
+                } else if isSelectable {
+                    Text("No usage data")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+
+                if let note = ProfileUsagePresentation.stalenessNote(for: entry.usageSnapshot) {
+                    Text(note)
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovering && isSelectable
+                          ? Color.primary.opacity(0.06)
+                          : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isSelectable)
+        .opacity(isSelectable ? 1 : 0.5)
+        .onHover { isHovering = $0 }
+    }
+
+    @ViewBuilder
+    private func bucketRows(_ snapshot: ProfileUsageSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            if let session = ProfileUsagePresentation.sessionBucket(snapshot) {
+                bucketRow(label: "5h", bucket: session, showsReset: true)
+            }
+            if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot) {
+                bucketRow(label: "week", bucket: weekly, showsReset: false)
+            }
+            ForEach(Array(ProfileUsagePresentation.scopedBuckets(snapshot).enumerated()),
+                    id: \.offset) { _, scoped in
+                bucketRow(label: scoped.modelDisplayName ?? "model",
+                          bucket: scoped, showsReset: false)
+            }
+        }
+    }
+
+    private func bucketRow(label: String, bucket: ClaudeUsageLimitBucket,
+                           showsReset: Bool) -> some View {
+        let level = ProfileUsagePresentation.severityLevel(
+            severity: bucket.severity, percent: bucket.percent
+        )
+        return HStack(spacing: 6) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 40, alignment: .leading)
+            ProgressView(value: min(max(bucket.percent, 0), 100), total: 100)
+                .progressViewStyle(.linear)
+                .tint(level.color)
+                .frame(width: 140)
+            Text(ProfileUsagePresentation.percentText(bucket.percent))
+                .font(.caption)
+                .monospacedDigit()
+                .foregroundStyle(level == .normal ? AnyShapeStyle(.secondary) : AnyShapeStyle(level.color))
+                .frame(width: 38, alignment: .trailing)
+            if showsReset, let resets = bucket.resetsAt {
+                Text("resets \(ProfileUsagePresentation.resetTimeText(resets))")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+// MARK: - Severity color
+
+extension ProfileUsagePresentation.SeverityLevel {
+    /// Bar/percent tint per severity tier.
+    var color: Color {
+        switch self {
+        case .normal: return .green
+        case .warning: return .orange
+        case .critical: return .red
+        }
+    }
+}

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -342,6 +342,46 @@ extension AppState {
             }
     }
 
+    /// Force an immediate daemon-side OAuth usage sweep and merge the returned
+    /// snapshots into local state. The account picker calls this on open —
+    /// cached snapshots stay on screen and update in place when fresh data
+    /// lands. Failures are logged but never surfaced as a blocking alert
+    /// (the picker degrades to cached data).
+    func refreshUsageSnapshots(profileID: UUID? = nil) async {
+        do {
+            let result = try await daemonClient.refreshProfileUsage(id: profileID)
+            let merged = Self.mergingUsageSnapshots(into: modelProfiles, entries: result.snapshots)
+            if merged != modelProfiles {
+                modelProfiles = merged
+            }
+        } catch {
+            logger.warning("Usage snapshot refresh failed: \(error, privacy: .public)")
+        }
+    }
+
+    /// Merge freshly swept snapshots into the current profile list, preserving
+    /// every other field. Profiles without a returned snapshot keep whatever
+    /// snapshot they had (the sweep only reports eligible logged-in OAuth
+    /// profiles). Static + pure for unit testing.
+    nonisolated static func mergingUsageSnapshots(
+        into profiles: [ModelProfileWithUsage],
+        entries: [ModelProfileUsageSnapshotEntry]
+    ) -> [ModelProfileWithUsage] {
+        guard !entries.isEmpty else { return profiles }
+        let snapshotsByID = Dictionary(entries.map { ($0.profileID, $0.snapshot) },
+                                       uniquingKeysWith: { _, last in last })
+        return profiles.map { entry in
+            guard let snapshot = snapshotsByID[entry.profile.id] else { return entry }
+            return ModelProfileWithUsage(
+                profile: entry.profile,
+                usage: entry.usage,
+                loginIdentity: entry.loginIdentity,
+                configDirPath: entry.configDirPath,
+                usageSnapshot: snapshot
+            )
+        }
+    }
+
     /// Fetch fresh usage for a single profile and merge it into local state.
     func fetchProfileUsage(id: UUID) async {
         do {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -321,6 +321,13 @@ final class AppState: ObservableObject {
     @Published var dockRatio: CGFloat = 0.3 {
         didSet { userDefaults.set(Double(dockRatio), forKey: Self.dockRatioKey) }
     }
+    /// "Use default without asking": when true, the plain "Claude" action
+    /// spawns silently on the global default profile instead of opening the
+    /// spawn-time account picker. Toggleable from the picker itself and
+    /// Settings → Model Profiles. Persisted per-user.
+    @Published var skipAccountPicker: Bool = false {
+        didSet { userDefaults.set(skipAccountPicker, forKey: Self.skipAccountPickerKey) }
+    }
     /// Pixel size of the main terminal area (the SingleWorktreeView slot
     /// inside DockSplitView, excluding the pinned dock and file panel).
     /// Default matches the typical window: 1200 wide window − sidebar (~280) ≈ 920;
@@ -562,6 +569,7 @@ final class AppState: ObservableObject {
     private static let layoutsKey = "com.tbd.app.layouts"
     private static let dockRatioKey = "com.tbd.app.dockRatio"
     private static let selectionOrderKey = "com.tbd.app.selectionOrder"
+    private static let skipAccountPickerKey = "com.tbd.app.accountPicker.useDefaultWithoutAsking"
 
     private var memoryPressureSource: DispatchSourceMemoryPressure?
     private var focusObservers: [NSObjectProtocol] = []
@@ -577,6 +585,7 @@ final class AppState: ObservableObject {
         if let saved = userDefaults.object(forKey: Self.dockRatioKey) as? Double {
             dockRatio = max(0.1, min(0.6, CGFloat(saved)))
         }
+        skipAccountPicker = userDefaults.bool(forKey: Self.skipAccountPickerKey)
         startMemoryPressureMonitor()
         registerFocusObservers()
         // Give the notification manager a back-reference so banner clicks

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -253,12 +253,70 @@ final class HoverCardController {
     /// Bumped on every show/hide; an in-flight fade-out completion only
     /// orders the panel out if no newer show/hide superseded it.
     private var fadeGeneration = 0
+    /// After an interaction dismissal (a menu opened, or the row/buttons were
+    /// clicked), suppress the warm instant-reshow until this instant so the
+    /// tooltip can't pop back over an open menu.
+    private var suppressUntil: Date?
+    /// Guards `installInteractionHooks()` so the notification observer and local
+    /// event monitor register exactly once for the app lifetime.
+    private var interactionHooksInstalled = false
+    private var menuObserver: NSObjectProtocol?
+    private var mouseMonitor: Any?
+
+    /// How long a click / menu-open suppresses the tooltip's warm reshow.
+    /// Comfortably longer than the warm-grace window so a click can't be
+    /// immediately undone by a lingering warm hover.
+    private static let interactionSuppression: TimeInterval = 0.4
 
     /// Gap between the anchor's edge and the card.
     private static let anchorGap: CGFloat = 5
 
     init(timing: HoverCardTiming = .standard) {
         self.timing = timing
+        installInteractionHooks()
+    }
+
+    /// Register the global dismissal hooks once. `NSMenu.didBeginTracking`
+    /// covers every menu (right-click contextMenu, the "…" Menu, the "Switch
+    /// account" submenu). A local mouse-down monitor covers plain row-selection
+    /// and button clicks, which post no menu notification. Both hop to the main
+    /// actor and dismiss the card immediately.
+    private func installInteractionHooks() {
+        guard !interactionHooksInstalled else { return }
+        interactionHooksInstalled = true
+
+        menuObserver = NotificationCenter.default.addObserver(
+            forName: NSMenu.didBeginTrackingNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.dismissForInteraction()
+            }
+        }
+
+        // Local monitor fires on the main thread for clicks inside the app.
+        // Only act when a card is up to avoid per-click overhead; return the
+        // event unchanged so selection/button clicks still work.
+        mouseMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            MainActor.assumeIsolated {
+                if let self, self.isCardVisible {
+                    self.dismissForInteraction()
+                }
+            }
+            return event
+        }
+    }
+
+    /// Immediately hide the current card and cancel any pending show, then
+    /// suppress the warm instant-reshow briefly so the tooltip does not pop back
+    /// while a menu is open. Central hook: every `.hoverCard` adopter inherits it.
+    func dismissForInteraction() {
+        cancelPendingShow()
+        suppressUntil = Date().addingTimeInterval(Self.interactionSuppression)
+        hide()
     }
 
     private var isCardVisible: Bool {
@@ -267,6 +325,9 @@ final class HoverCardController {
 
     func hoverBegan(anchor: NSView, model: HoverCardModel) {
         cancelPendingShow()
+        // Bail while an interaction dismissal is still suppressing reshow, so a
+        // lingering warm hover can't pop the tooltip back over an open menu.
+        if let suppressUntil, Date() < suppressUntil { return }
         let delay = timing.effectiveShowDelay(
             now: Date(), lastDismissedAt: lastDismissedAt, isCardVisible: isCardVisible
         )

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -1,0 +1,435 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Content model
+
+/// Text treatment for a hover-card title or row value.
+enum HoverCardTextStyle: Equatable {
+    case plain
+    /// Muted + italic — for "ambient (terminal login)" style de-emphasis.
+    case mutedItalic
+}
+
+/// Color treatment for a row value. Calm by default: color appears ONLY for
+/// warning/critical states, never as decoration.
+enum HoverCardTint: Equatable {
+    case normal
+    case warning
+    case critical
+}
+
+/// One structured line in a hover card: an optional muted label column and a
+/// value, with optional profile-name chip and a small caption underneath.
+struct HoverCardRow: Equatable {
+    var label: String?
+    var value: String
+    /// Small rounded chip rendered after the value (e.g. the profile name).
+    var chip: String?
+    var valueStyle: HoverCardTextStyle
+    /// Render the value with monospaced digits (usage percentages, timestamps).
+    var monospacedDigits: Bool
+    var tint: HoverCardTint
+    /// Muted caption line under the value (drift warnings, staleness notes).
+    var caption: String?
+
+    init(label: String? = nil,
+         value: String,
+         chip: String? = nil,
+         valueStyle: HoverCardTextStyle = .plain,
+         monospacedDigits: Bool = false,
+         tint: HoverCardTint = .normal,
+         caption: String? = nil) {
+        self.label = label
+        self.value = value
+        self.chip = chip
+        self.valueStyle = valueStyle
+        self.monospacedDigits = monospacedDigits
+        self.tint = tint
+        self.caption = caption
+    }
+}
+
+/// The full content of a hover card: a title slot plus structured rows.
+/// Pure data — composition is unit-testable without any AppKit machinery.
+struct HoverCardModel: Equatable {
+    var title: String?
+    var titleStyle: HoverCardTextStyle
+    /// Muted caption line directly under the title.
+    var titleCaption: String?
+    var rows: [HoverCardRow]
+
+    init(title: String? = nil,
+         titleStyle: HoverCardTextStyle = .plain,
+         titleCaption: String? = nil,
+         rows: [HoverCardRow] = []) {
+        self.title = title
+        self.titleStyle = titleStyle
+        self.titleCaption = titleCaption
+        self.rows = rows
+    }
+}
+
+// MARK: - Timing
+
+/// Hover timing knobs, injectable for tests. The show-delay decision is a
+/// pure function so the "warm" fast-path is testable without a panel.
+struct HoverCardTiming: Equatable {
+    /// Delay before a card appears on a cold hover. Snappier than the
+    /// system tooltip default, but slow enough not to flicker on drive-by
+    /// mouse moves.
+    var showDelay: TimeInterval
+    /// After a card hides, hovers within this window skip the show delay —
+    /// moving between sibling rows swaps content instantly (menu-like feel).
+    var warmGrace: TimeInterval
+    /// Fade-out duration when the pointer leaves.
+    var fadeOutDuration: TimeInterval
+
+    init(showDelay: TimeInterval = 0.35,
+         warmGrace: TimeInterval = 0.35,
+         fadeOutDuration: TimeInterval = 0.12) {
+        self.showDelay = showDelay
+        self.warmGrace = warmGrace
+        self.fadeOutDuration = fadeOutDuration
+    }
+
+    static let standard = HoverCardTiming()
+
+    /// 0 when a card is already up (swap instantly) or one hid moments ago
+    /// (warm), otherwise the full show delay.
+    func effectiveShowDelay(now: Date, lastDismissedAt: Date?, isCardVisible: Bool) -> TimeInterval {
+        if isCardVisible { return 0 }
+        if let lastDismissedAt, now.timeIntervalSince(lastDismissedAt) < warmGrace { return 0 }
+        return showDelay
+    }
+}
+
+// MARK: - Card view
+
+/// Renders a `HoverCardModel`: calm neutrals, type hierarchy, color only for
+/// state. Material background + hairline border; the hosting panel's window
+/// shadow provides the elevation.
+struct HoverCardView: View {
+    let model: HoverCardModel
+
+    private static let maxWidth: CGFloat = 320
+    private static let cornerRadius: CGFloat = 9
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let title = model.title {
+                VStack(alignment: .leading, spacing: 2) {
+                    styledText(title,
+                               style: model.titleStyle,
+                               monospacedDigits: false)
+                        .font(.system(size: 12,
+                                      weight: model.titleStyle == .mutedItalic ? .regular : .semibold))
+                        .foregroundStyle(model.titleStyle == .mutedItalic ? Color.secondary : Color.primary)
+                    if let caption = model.titleCaption {
+                        captionText(caption)
+                    }
+                }
+            }
+            if !model.rows.isEmpty {
+                Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 10, verticalSpacing: 5) {
+                    ForEach(Array(model.rows.enumerated()), id: \.offset) { _, row in
+                        GridRow {
+                            if let label = row.label {
+                                Text(label)
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.secondary)
+                                    .gridColumnAlignment(.leading)
+                                valueCell(row)
+                            } else {
+                                valueCell(row)
+                                    .gridCellColumns(2)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: Self.maxWidth, alignment: .leading)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func valueCell(_ row: HoverCardRow) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                styledText(row.value, style: row.valueStyle, monospacedDigits: row.monospacedDigits)
+                    .font(.system(size: 12))
+                    .foregroundStyle(valueColor(row))
+                if let chip = row.chip {
+                    Text(chip)
+                        .font(.system(size: 10, weight: .medium))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Capsule().fill(Color.primary.opacity(0.08)))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if let caption = row.caption {
+                captionText(caption)
+            }
+        }
+    }
+
+    private func styledText(_ string: String, style: HoverCardTextStyle, monospacedDigits: Bool) -> Text {
+        var text = Text(string)
+        if style == .mutedItalic { text = text.italic() }
+        if monospacedDigits { text = text.monospacedDigit() }
+        return text
+    }
+
+    private func valueColor(_ row: HoverCardRow) -> Color {
+        switch row.tint {
+        case .warning: return .orange
+        case .critical: return .red
+        case .normal: return row.valueStyle == .mutedItalic ? Color.secondary : Color.primary
+        }
+    }
+
+    private func captionText(_ string: String) -> some View {
+        Text(string)
+            .font(.system(size: 10))
+            .foregroundStyle(.tertiary)
+    }
+}
+
+// MARK: - Panel
+
+/// Borderless, non-activating panel hosting the card. Never becomes key or
+/// main (the terminal keeps keyboard focus) and ignores mouse events so the
+/// views underneath keep receiving hover/clicks.
+private final class HoverCardPanel: NSPanel {
+    let hostingView: NSHostingView<HoverCardView>
+
+    init(model: HoverCardModel) {
+        hostingView = NSHostingView(rootView: HoverCardView(model: model))
+        super.init(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        isOpaque = false
+        backgroundColor = .clear
+        level = .popUpMenu
+        hasShadow = true
+        ignoresMouseEvents = true
+        isMovableByWindowBackground = false
+        isReleasedWhenClosed = false
+        animationBehavior = .none
+        contentView = hostingView
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
+// MARK: - Controller
+
+/// One shared panel + the timing state machine. Shared so the "warm" state
+/// spans anchors: once any card is up (or just hid), hovering a sibling swaps
+/// content with no re-delay.
+@MainActor
+final class HoverCardController {
+    static let shared = HoverCardController()
+
+    private let timing: HoverCardTiming
+    private var panel: HoverCardPanel?
+    private weak var currentAnchor: NSView?
+    private weak var pendingAnchor: NSView?
+    private var pendingShow: Task<Void, Never>?
+    private var lastDismissedAt: Date?
+    private var lastModel: HoverCardModel?
+    /// Bumped on every show/hide; an in-flight fade-out completion only
+    /// orders the panel out if no newer show/hide superseded it.
+    private var fadeGeneration = 0
+
+    /// Gap between the anchor's edge and the card.
+    private static let anchorGap: CGFloat = 5
+
+    init(timing: HoverCardTiming = .standard) {
+        self.timing = timing
+    }
+
+    private var isCardVisible: Bool {
+        panel?.isVisible == true && currentAnchor != nil
+    }
+
+    func hoverBegan(anchor: NSView, model: HoverCardModel) {
+        cancelPendingShow()
+        let delay = timing.effectiveShowDelay(
+            now: Date(), lastDismissedAt: lastDismissedAt, isCardVisible: isCardVisible
+        )
+        guard delay > 0 else {
+            show(anchor: anchor, model: model)
+            return
+        }
+        pendingAnchor = anchor
+        pendingShow = Task { [weak self, weak anchor] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled, let self, let anchor else { return }
+            self.show(anchor: anchor, model: model)
+        }
+    }
+
+    func hoverEnded(anchor: NSView) {
+        if pendingAnchor === anchor {
+            cancelPendingShow()
+        }
+        if currentAnchor === anchor {
+            hide()
+        }
+    }
+
+    /// Live content refresh: if the card is up for this anchor, re-render (and
+    /// re-fit) in place — usage numbers stay current while the card is shown.
+    func modelChanged(anchor: NSView, model: HoverCardModel?) {
+        guard currentAnchor === anchor, let panel, panel.isVisible else { return }
+        guard let model else {
+            hide()
+            return
+        }
+        guard model != lastModel else { return }
+        apply(model: model, to: panel, anchor: anchor)
+    }
+
+    private func cancelPendingShow() {
+        pendingShow?.cancel()
+        pendingShow = nil
+        pendingAnchor = nil
+    }
+
+    private func show(anchor: NSView, model: HoverCardModel) {
+        cancelPendingShow()
+        guard anchor.window != nil else { return }
+        fadeGeneration += 1
+        let panel = self.panel ?? HoverCardPanel(model: model)
+        self.panel = panel
+        currentAnchor = anchor
+        panel.alphaValue = 1
+        apply(model: model, to: panel, anchor: anchor)
+        if !panel.isVisible {
+            panel.orderFrontRegardless()
+        }
+    }
+
+    private func apply(model: HoverCardModel, to panel: HoverCardPanel, anchor: NSView) {
+        lastModel = model
+        panel.appearance = anchor.effectiveAppearance
+        panel.hostingView.rootView = HoverCardView(model: model)
+        panel.hostingView.invalidateIntrinsicContentSize()
+        position(panel: panel, relativeTo: anchor)
+    }
+
+    /// Below the anchor, leading-aligned; flips above when there is no room
+    /// underneath, and clamps horizontally into the screen's visible frame.
+    private func position(panel: HoverCardPanel, relativeTo anchor: NSView) {
+        guard let window = anchor.window else { return }
+        let anchorFrameInWindow = anchor.convert(anchor.bounds, to: nil)
+        let anchorFrame = window.convertToScreen(anchorFrameInWindow)
+        let size = panel.hostingView.fittingSize
+
+        var origin = NSPoint(
+            x: anchorFrame.minX,
+            y: anchorFrame.minY - size.height - Self.anchorGap
+        )
+        if let screen = window.screen ?? NSScreen.main {
+            let visible = screen.visibleFrame
+            if origin.y < visible.minY {
+                origin.y = anchorFrame.maxY + Self.anchorGap
+            }
+            origin.x = min(max(origin.x, visible.minX + 4), visible.maxX - size.width - 4)
+        }
+        panel.setFrame(NSRect(origin: origin, size: size), display: true)
+    }
+
+    private func hide() {
+        currentAnchor = nil
+        lastModel = nil
+        lastDismissedAt = Date()
+        guard let panel, panel.isVisible else { return }
+        fadeGeneration += 1
+        let generation = fadeGeneration
+        NSAnimationContext.runAnimationGroup { [timing] context in
+            context.duration = timing.fadeOutDuration
+            panel.animator().alphaValue = 0
+        } completionHandler: { [weak self] in
+            guard let self, self.fadeGeneration == generation else { return }
+            panel.orderOut(nil)
+            panel.alphaValue = 1
+        }
+    }
+}
+
+// MARK: - Anchor plumbing
+
+/// Invisible tracking view laid under the modified SwiftUI view. `hitTest`
+/// returns nil so clicks pass straight through; the tracking area still
+/// delivers enter/exit (tracking is owner-routed, not hit-test-routed).
+private final class HoverCardAnchorNSView: NSView {
+    var model: HoverCardModel?
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        trackingAreas.forEach(removeTrackingArea)
+        addTrackingArea(NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        ))
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        guard let model else { return }
+        HoverCardController.shared.hoverBegan(anchor: self, model: model)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        HoverCardController.shared.hoverEnded(anchor: self)
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        if newWindow == nil {
+            HoverCardController.shared.hoverEnded(anchor: self)
+        }
+    }
+}
+
+private struct HoverCardAnchor: NSViewRepresentable {
+    let model: HoverCardModel?
+
+    func makeNSView(context: Context) -> HoverCardAnchorNSView {
+        let view = HoverCardAnchorNSView()
+        view.model = model
+        return view
+    }
+
+    func updateNSView(_ nsView: HoverCardAnchorNSView, context: Context) {
+        nsView.model = model
+        HoverCardController.shared.modelChanged(anchor: nsView, model: model)
+    }
+}
+
+extension View {
+    /// Attach a styled hover card to this view. nil model = no card (mirrors
+    /// the empty-string `.help()` idiom). Fast: ~0.35s cold show delay,
+    /// instant swap while a card is up or just after one hid, quick fade-out.
+    /// Never steals keyboard focus (non-activating borderless panel).
+    func hoverCard(_ model: HoverCardModel?) -> some View {
+        background(HoverCardAnchor(model: model))
+    }
+}

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1171,6 +1171,17 @@ actor DaemonClient {
         return result.usage
     }
 
+    /// Force an immediate usage sweep of the daemon's in-memory OAuth usage
+    /// poller and return the post-sweep snapshots. `id == nil` sweeps every
+    /// logged-in OAuth profile (the account picker's open-time refresh).
+    func refreshProfileUsage(id: UUID? = nil) async throws -> ModelProfileUsageRefreshResult {
+        return try await callAsync(
+            method: RPCMethod.modelProfileUsageRefresh,
+            params: ModelProfileUsageRefreshParams(id: id),
+            resultType: ModelProfileUsageRefreshResult.self
+        )
+    }
+
     /// Swap the model profile associated with a running terminal.
     /// Returns the newly created Terminal (the daemon forks a new tab).
     func swapTerminalProfile(terminalID: UUID, newProfileID: UUID?, cols: Int? = nil, rows: Int? = nil) async throws -> Terminal {

--- a/Sources/TBDApp/Helpers/AccountHoverCards.swift
+++ b/Sources/TBDApp/Helpers/AccountHoverCards.swift
@@ -1,0 +1,138 @@
+import Foundation
+import TBDShared
+
+/// Structured hover-card content for the two account/usage hover sites: the
+/// sidebar worktree row (which accounts this worktree's Claude sessions run
+/// on) and the Claude tab (account + live usage + spawn time).
+///
+/// Pure `HoverCardModel` composition on top of `ProfileUsagePresentation`'s
+/// formatting fragments — unit-testable without any panel/AppKit machinery.
+/// The flat-string `ProfileUsagePresentation.sessionTooltip` /
+/// `worktreeAccountsTooltip` helpers remain as the plain-text form; these
+/// structured cards supersede them in the UI.
+enum AccountHoverCards {
+    static let worktreeCardTitle = "Claude accounts"
+    static let ambientAccountLabel = "ambient (terminal login)"
+    static let ambientDriftCaption = "May drift to a different account on token refresh"
+    static let removedProfileLabel = "Profile removed"
+    static let removedProfileCaption = "Session keeps its spawn account"
+    static let notLoggedInCaption = "Not logged in"
+
+    // MARK: - Worktree row card
+
+    /// Sidebar worktree-row card aggregating the accounts of its Claude
+    /// sessions, deduped in tab order. nil when the worktree has no Claude
+    /// sessions (no card).
+    static func worktreeCard(terminals: [Terminal],
+                             profiles: [ModelProfileWithUsage]) -> HoverCardModel? {
+        var rows: [HoverCardRow] = []
+        for terminal in terminals where terminal.kind == .claude || terminal.isClaudeResumable {
+            let row = accountRow(profileID: terminal.profileID, profiles: profiles)
+            if !rows.contains(row) {
+                rows.append(row)
+            }
+        }
+        guard !rows.isEmpty else { return nil }
+        return HoverCardModel(title: worktreeCardTitle, rows: rows)
+    }
+
+    /// One account line: email with a profile-name chip for pinned +
+    /// logged-in sessions; muted-italic "ambient (terminal login)" with the
+    /// drift warning as a caption for NULL-profile legacy sessions.
+    static func accountRow(profileID: UUID?,
+                           profiles: [ModelProfileWithUsage]) -> HoverCardRow {
+        guard let profileID else {
+            return HoverCardRow(value: ambientAccountLabel,
+                                valueStyle: .mutedItalic,
+                                caption: ambientDriftCaption)
+        }
+        guard let entry = profiles.first(where: { $0.profile.id == profileID }) else {
+            return HoverCardRow(value: removedProfileLabel,
+                                valueStyle: .mutedItalic,
+                                caption: removedProfileCaption)
+        }
+        if let identity = ProfileLoginPresentation.normalizedIdentity(entry.loginIdentity) {
+            return HoverCardRow(value: identity, chip: entry.profile.name)
+        }
+        return HoverCardRow(value: entry.profile.name, caption: notLoggedInCaption)
+    }
+
+    // MARK: - Claude tab card
+
+    /// Per-session tab card: title = account email (or the ambient/removed
+    /// note), rows for profile, live usage windows, and spawn time. nil for
+    /// non-Claude terminals (shells, Codex — no account concept).
+    static func claudeTabCard(terminal: Terminal,
+                              profiles: [ModelProfileWithUsage],
+                              timeZone: TimeZone = .current) -> HoverCardModel? {
+        guard terminal.kind == .claude || terminal.isClaudeResumable else { return nil }
+        var model = HoverCardModel()
+        if let profileID = terminal.profileID {
+            if let entry = profiles.first(where: { $0.profile.id == profileID }) {
+                if let identity = ProfileLoginPresentation.normalizedIdentity(entry.loginIdentity) {
+                    model.title = identity
+                    model.rows.append(HoverCardRow(label: "Profile", value: entry.profile.name))
+                } else {
+                    model.title = entry.profile.name
+                    model.titleCaption = notLoggedInCaption
+                }
+                model.rows.append(contentsOf: usageRows(for: entry.usageSnapshot,
+                                                        timeZone: timeZone))
+            } else {
+                model.title = removedProfileLabel
+                model.titleStyle = .mutedItalic
+                model.titleCaption = removedProfileCaption
+            }
+        } else {
+            model.title = ambientAccountLabel
+            model.titleStyle = .mutedItalic
+            model.titleCaption = ambientDriftCaption
+        }
+        model.rows.append(HoverCardRow(
+            label: "Spawned",
+            value: ProfileUsagePresentation.spawnTimeText(terminal.createdAt, timeZone: timeZone),
+            monospacedDigits: true
+        ))
+        return model
+    }
+
+    /// Usage rows for a snapshot: 5h window (with reset time), weekly, and
+    /// per-family scoped buckets. Numbers are monospaced digits; tinted only
+    /// when the bucket is warning/critical — calm otherwise. Empty when the
+    /// profile has no usage data.
+    static func usageRows(for snapshot: ProfileUsageSnapshot?,
+                          timeZone: TimeZone = .current) -> [HoverCardRow] {
+        guard let snapshot, !snapshot.buckets.isEmpty else { return [] }
+        var rows: [HoverCardRow] = []
+        if let session = ProfileUsagePresentation.sessionBucket(snapshot) {
+            var value = ProfileUsagePresentation.percentText(session.percent)
+            if let resets = session.resetsAt {
+                value += " · resets \(ProfileUsagePresentation.resetTimeText(resets, timeZone: timeZone))"
+            }
+            rows.append(HoverCardRow(label: "5h window", value: value,
+                                     monospacedDigits: true, tint: tint(for: session)))
+        }
+        if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot) {
+            rows.append(HoverCardRow(label: "Week",
+                                     value: ProfileUsagePresentation.percentText(weekly.percent),
+                                     monospacedDigits: true, tint: tint(for: weekly)))
+        }
+        for scoped in ProfileUsagePresentation.scopedBuckets(snapshot) {
+            rows.append(HoverCardRow(label: scoped.modelDisplayName ?? "Model",
+                                     value: ProfileUsagePresentation.percentText(scoped.percent),
+                                     monospacedDigits: true, tint: tint(for: scoped)))
+        }
+        return rows
+    }
+
+    /// Map a bucket's severity to the card tint. `.normal` renders in the
+    /// calm primary color — color appears only for warning/critical.
+    static func tint(for bucket: ClaudeUsageLimitBucket) -> HoverCardTint {
+        switch ProfileUsagePresentation.severityLevel(severity: bucket.severity,
+                                                      percent: bucket.percent) {
+        case .normal: return .normal
+        case .warning: return .warning
+        case .critical: return .critical
+        }
+    }
+}

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -1,0 +1,242 @@
+import Foundation
+import TBDShared
+
+/// App-side presentation of a model profile's OAuth usage snapshot — the
+/// `ModelProfileWithUsage.usageSnapshot` buckets the daemon's poller maintains.
+///
+/// Pure string/ordering composition, extracted from the views (the "+" new-tab
+/// menu, the spawn-time account picker, the per-session tab tooltips) so the
+/// suffix/sort/severity rules are unit-testable without UI. Companion to
+/// `ProfileLoginPresentation`, which owns the identity ("— email") fragments.
+enum ProfileUsagePresentation {
+    // Bucket kinds as the Claude OAuth usage API names them.
+    static let sessionKind = "session"
+    static let weeklyAllKind = "weekly_all"
+    static let weeklyScopedKind = "weekly_scoped"
+
+    // MARK: - Bucket access
+
+    /// The 5-hour rolling window bucket, if present.
+    static func sessionBucket(_ snapshot: ProfileUsageSnapshot?) -> ClaudeUsageLimitBucket? {
+        snapshot?.buckets.first { $0.kind == sessionKind }
+    }
+
+    /// The weekly all-models bucket, if present.
+    static func weeklyAllBucket(_ snapshot: ProfileUsageSnapshot?) -> ClaudeUsageLimitBucket? {
+        snapshot?.buckets.first { $0.kind == weeklyAllKind }
+    }
+
+    /// Per-model-family weekly buckets (e.g. "Fable"), in API order. A family
+    /// absent from this list simply has no data for that account — render nothing.
+    static func scopedBuckets(_ snapshot: ProfileUsageSnapshot?) -> [ClaudeUsageLimitBucket] {
+        snapshot?.buckets.filter { $0.kind == weeklyScopedKind } ?? []
+    }
+
+    // MARK: - Severity
+
+    /// Severity tiers for coloring usage bars/percentages.
+    enum SeverityLevel {
+        case normal
+        case warning
+        case critical
+    }
+
+    /// Map the API's severity label to a tier. When the API omits severity,
+    /// fall back to percent thresholds (>=90 critical, >=75 warning) so
+    /// exhausted buckets never render as healthy.
+    static func severityLevel(severity: String?, percent: Double) -> SeverityLevel {
+        switch severity {
+        case "critical": return .critical
+        case "warning": return .warning
+        case "normal": return .normal
+        default:
+            if percent >= 90 { return .critical }
+            if percent >= 75 { return .warning }
+            return .normal
+        }
+    }
+
+    // MARK: - Formatting fragments
+
+    /// "76%" — usage percents render as whole numbers everywhere.
+    static func percentText(_ percent: Double) -> String {
+        "\(Int(percent.rounded()))%"
+    }
+
+    /// "23:10" — reset times are compact 24h clock times (menu width is precious).
+    static func resetTimeText(_ date: Date, timeZone: TimeZone = .current) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        formatter.timeZone = timeZone
+        return formatter.string(from: date)
+    }
+
+    /// "F" for "Fable" — single-letter family abbreviation for menu rows.
+    static func familyAbbreviation(_ displayName: String?) -> String {
+        let trimmed = displayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard let first = trimmed.first else { return "?" }
+        return String(first).uppercased()
+    }
+
+    /// Compact usage summary without a leading separator:
+    /// "5h 0% ↺23:10 · wk 76% · F 100%". nil when there is no snapshot or it
+    /// has no buckets (never logged in / poller hasn't fetched yet).
+    static func usageSummary(for snapshot: ProfileUsageSnapshot?,
+                             timeZone: TimeZone = .current) -> String? {
+        guard let snapshot, !snapshot.buckets.isEmpty else { return nil }
+        var parts: [String] = []
+        if let session = sessionBucket(snapshot) {
+            var part = "5h \(percentText(session.percent))"
+            if let resets = session.resetsAt {
+                part += " ↺\(resetTimeText(resets, timeZone: timeZone))"
+            }
+            parts.append(part)
+        }
+        if let weekly = weeklyAllBucket(snapshot) {
+            parts.append("wk \(percentText(weekly.percent))")
+        }
+        for scoped in scopedBuckets(snapshot) {
+            parts.append("\(familyAbbreviation(scoped.modelDisplayName)) \(percentText(scoped.percent))")
+        }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: " · ")
+    }
+
+    /// "+"-menu suffix form of `usageSummary` — " · 5h 0% ↺23:10 · …", or ""
+    /// when there is nothing to show (profiles without a snapshot keep their
+    /// plain identity title).
+    static func usageSuffix(for snapshot: ProfileUsageSnapshot?,
+                            timeZone: TimeZone = .current) -> String {
+        guard let summary = usageSummary(for: snapshot, timeZone: timeZone) else { return "" }
+        return " · " + summary
+    }
+
+    /// Full "+"-menu row title: `ProfileLoginPresentation.menuItemTitle` plus
+    /// the compact usage suffix, e.g.
+    /// "Gmail — gmail@… · 5h 0% ↺23:10 · wk 76% · F 100%".
+    static func menuItemTitle(for entry: ModelProfileWithUsage,
+                              timeZone: TimeZone = .current) -> String {
+        ProfileLoginPresentation.menuItemTitle(for: entry)
+            + usageSuffix(for: entry.usageSnapshot, timeZone: timeZone)
+    }
+
+    // MARK: - Picker ordering & row state
+
+    /// oauth profiles with no detected login render as disabled "not logged in"
+    /// rows in the picker — they cannot be spawned onto meaningfully.
+    static func isSelectable(_ entry: ModelProfileWithUsage) -> Bool {
+        !ProfileLoginPresentation.needsLogin(kind: entry.profile.kind,
+                                             loginIdentity: entry.loginIdentity)
+    }
+
+    /// Display order for the account picker: selectable profiles with session
+    /// data first — healthiest (lowest 5h percent) first, ties broken by the
+    /// window that resets soonest — then selectable profiles without usage
+    /// data, then not-logged-in rows last. Display-only heuristic: the picker
+    /// never auto-selects.
+    static func sortedForPicker(_ entries: [ModelProfileWithUsage]) -> [ModelProfileWithUsage] {
+        func rank(_ entry: ModelProfileWithUsage) -> (Int, Double, TimeInterval) {
+            guard isSelectable(entry) else {
+                return (2, 0, .greatestFiniteMagnitude)
+            }
+            guard let session = sessionBucket(entry.usageSnapshot) else {
+                return (1, 0, .greatestFiniteMagnitude)
+            }
+            let reset = session.resetsAt?.timeIntervalSinceReferenceDate
+                ?? .greatestFiniteMagnitude
+            return (0, session.percent, reset)
+        }
+        return entries
+            .enumerated()
+            .sorted { lhs, rhs in
+                let (lg, lp, lr) = rank(lhs.element)
+                let (rg, rp, rr) = rank(rhs.element)
+                if lg != rg { return lg < rg }
+                if lp != rp { return lp < rp }
+                if lr != rr { return lr < rr }
+                return lhs.offset < rhs.offset   // stable
+            }
+            .map(\.element)
+    }
+
+    /// Threshold past which snapshot data is called out as stale in the picker.
+    /// The daemon poller sweeps ~every 90s, so 5 minutes means several misses.
+    static let staleAge: TimeInterval = 300
+
+    /// Staleness note for a picker row. nil = data is fresh and healthy (no
+    /// note). A failing snapshot surfaces the daemon's status string verbatim
+    /// (it already reads "stale since …; fetch failed: …").
+    static func stalenessNote(for snapshot: ProfileUsageSnapshot?,
+                              now: Date = Date()) -> String? {
+        guard let snapshot else { return nil }
+        guard snapshot.isOK else { return snapshot.status }
+        guard let fetchedAt = snapshot.fetchedAt else { return "no usage data yet" }
+        let age = now.timeIntervalSince(fetchedAt)
+        guard age >= staleAge else { return nil }
+        return "updated \(Int(age / 60))m ago"
+    }
+
+    // MARK: - Per-session tooltips
+
+    /// "2026-07-03 14:05" — fixed format so tooltips are locale-stable.
+    static func spawnTimeText(_ date: Date, timeZone: TimeZone = .current) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        formatter.timeZone = timeZone
+        return formatter.string(from: date)
+    }
+
+    /// Human account descriptor for a Claude terminal, resolved against the
+    /// current profile list: "email (Profile)" for pinned + logged-in,
+    /// "Profile (not logged in)" for pinned pre-login, "ambient (terminal
+    /// login)" for NULL-profile legacy sessions, and a removed-profile note
+    /// when the id no longer resolves.
+    static func accountDescriptor(profileID: UUID?,
+                                  profiles: [ModelProfileWithUsage]) -> String {
+        guard let profileID else { return "ambient (terminal login)" }
+        guard let entry = profiles.first(where: { $0.profile.id == profileID }) else {
+            return "profile removed — session keeps its spawn account"
+        }
+        if let identity = ProfileLoginPresentation.normalizedIdentity(entry.loginIdentity) {
+            return "\(identity) (\(entry.profile.name))"
+        }
+        return "\(entry.profile.name) (not logged in)"
+    }
+
+    /// Hover tooltip for a terminal tab. nil for non-Claude terminals (shells,
+    /// Codex — no account concept). Multi-line: account, drift note (ambient
+    /// only), current usage numbers (when the pinned account has a snapshot),
+    /// spawn time. Sessions are pinned to their spawn account for life, so
+    /// this reflects what the session is actually consuming.
+    static func sessionTooltip(terminal: Terminal,
+                               profiles: [ModelProfileWithUsage],
+                               timeZone: TimeZone = .current) -> String? {
+        guard terminal.kind == .claude || terminal.isClaudeResumable else { return nil }
+        var lines = ["Account: \(accountDescriptor(profileID: terminal.profileID, profiles: profiles))"]
+        if terminal.profileID == nil {
+            lines.append("May drift to a different account on token refresh")
+        } else if let entry = profiles.first(where: { $0.profile.id == terminal.profileID }),
+                  let summary = usageSummary(for: entry.usageSnapshot, timeZone: timeZone) {
+            lines.append("Usage: \(summary)")
+        }
+        lines.append("Spawned: \(spawnTimeText(terminal.createdAt, timeZone: timeZone))")
+        return lines.joined(separator: "\n")
+    }
+
+    /// Sidebar worktree-row tooltip aggregating the accounts of its Claude
+    /// sessions, deduped in tab order: "Claude accounts: a@b.co (Work),
+    /// ambient (terminal login)". nil when the worktree has no Claude sessions.
+    static func worktreeAccountsTooltip(terminals: [Terminal],
+                                        profiles: [ModelProfileWithUsage]) -> String? {
+        var seen = Set<String>()
+        var descriptors: [String] = []
+        for terminal in terminals where terminal.kind == .claude || terminal.isClaudeResumable {
+            let descriptor = accountDescriptor(profileID: terminal.profileID, profiles: profiles)
+            if seen.insert(descriptor).inserted {
+                descriptors.append(descriptor)
+            }
+        }
+        guard !descriptors.isEmpty else { return nil }
+        return "Claude accounts: " + descriptors.joined(separator: ", ")
+    }
+}

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -177,6 +177,11 @@ enum ProfileUsagePresentation {
     }
 
     // MARK: - Per-session tooltips
+    //
+    // NOTE: `sessionTooltip` / `worktreeAccountsTooltip` are the flat-string
+    // form. The UI now renders these two sites as structured `HoverCardModel`s
+    // (see `AccountHoverCards`); the string form is kept as the plain-text
+    // fallback/composition reference.
 
     /// "2026-07-03 14:05" — fixed format so tooltips are locale-stable.
     static func spawnTimeText(_ date: Date, timeZone: TimeZone = .current) -> String {

--- a/Sources/TBDApp/Helpers/RowAccountMenu.swift
+++ b/Sources/TBDApp/Helpers/RowAccountMenu.swift
@@ -1,0 +1,154 @@
+import Foundation
+import TBDShared
+
+/// Typed presentation model for the hover-revealed "…" worktree-row menu,
+/// headlined by per-session account switching.
+///
+/// Pure composition on top of `ProfileUsagePresentation` /
+/// `ProfileLoginPresentation` — no AppKit, no strings past the boundary. The
+/// view (`RowAccountMenuView`) lowers this model to a SwiftUI `Menu`; the swap
+/// itself is a typed `RowAccountMenuAction` carrying the terminal + target
+/// profile, dispatched by the view to `AppState.swapTerminalProfile`. Nothing
+/// string-typed crosses back.
+enum RowAccountMenu {
+    // MARK: - Typed model
+
+    /// One switch-target row inside a session's "Switch account" submenu: a
+    /// logged-in profile the session could be forked onto, or a disabled
+    /// not-logged-in / current-account row.
+    struct SwitchTarget: Equatable, Identifiable {
+        /// Profile this row targets. `nil` is never used — every target is a
+        /// concrete profile (ambient is not offered as a switch destination
+        /// here; the info header already names it).
+        let profileID: UUID
+        /// "Work — a@b.co · 5h 0% ↺23:10 · wk 76% · F 100%".
+        let title: String
+        /// True when this profile is the session's current account: shown with
+        /// a checkmark and disabled (no-op swap).
+        let isCurrent: Bool
+        /// True when the profile has a detected login and can be forked onto.
+        /// Not-logged-in profiles render disabled with `disabledReason`.
+        let isSelectable: Bool
+        /// Disabled-row explainer, e.g. "run /login first". nil when selectable
+        /// (and not the current account).
+        let disabledReason: String?
+
+        var id: UUID { profileID }
+
+        /// The action a click emits — nil for disabled rows (current account or
+        /// not-logged-in), so the view can render them non-interactive.
+        func action(terminalID: UUID) -> RowAccountMenuAction? {
+            guard isSelectable, !isCurrent else { return nil }
+            return RowAccountMenuAction(terminalID: terminalID, newProfileID: profileID)
+        }
+    }
+
+    /// One Claude session in the worktree: an info header line plus the
+    /// switch-account targets for that session's terminal.
+    struct Session: Equatable, Identifiable {
+        let terminalID: UUID
+        /// "Claude 1", the tab label, etc. — human handle for the session.
+        let label: String
+        /// Account descriptor for the info header: "a@b.co (Work)",
+        /// "ambient (terminal login)", "profile removed — …".
+        let accountDescriptor: String
+        /// Switch-account destinations, ordered for the picker (healthiest
+        /// selectable first, not-logged-in last).
+        let switchTargets: [SwitchTarget]
+
+        var id: UUID { terminalID }
+    }
+
+    /// Whole-menu model: the worktree's Claude sessions (each with its own
+    /// switch submenu) plus the shared footer caption. `nil` when the worktree
+    /// has no Claude sessions (the "…" menu still exists for non-account items,
+    /// but `RowAccountMenu` contributes nothing).
+    struct Model: Equatable {
+        let sessions: [Session]
+        /// Static explainer shown once at the bottom of the account section.
+        let footer: String
+
+        var isEmpty: Bool { sessions.isEmpty }
+    }
+
+    /// A resolved switch request: fork `terminalID`'s session onto
+    /// `newProfileID`. Dispatched by the view to
+    /// `AppState.swapTerminalProfile(terminalID:newProfileID:)`.
+    struct RowAccountMenuAction: Equatable {
+        let terminalID: UUID
+        let newProfileID: UUID
+    }
+
+    // MARK: - Copy
+
+    static let switchAccountLabel = "Switch account"
+    static let notLoggedInReason = "run /login first"
+    static let footerCaption =
+        "Switching forks the session onto the new account — its context re-reads uncached once."
+
+    // MARK: - Composition
+
+    /// Build the account section for a worktree's "…" menu. Claude sessions in
+    /// tab order; each carries its current-account descriptor and a full list of
+    /// switch targets (current checkmarked+disabled, not-logged-in disabled).
+    static func model(terminals: [Terminal],
+                      profiles: [ModelProfileWithUsage],
+                      timeZone: TimeZone = .current) -> Model {
+        let claudeTerminals = terminals.filter { $0.kind == .claude || $0.isClaudeResumable }
+        var claudeIndex = 0
+        let sessions: [Session] = claudeTerminals.map { terminal in
+            claudeIndex += 1
+            return session(terminal: terminal,
+                           fallbackIndex: claudeIndex,
+                           profiles: profiles,
+                           timeZone: timeZone)
+        }
+        return Model(sessions: sessions, footer: footerCaption)
+    }
+
+    /// One session's row: label, current-account descriptor, and switch targets.
+    static func session(terminal: Terminal,
+                        fallbackIndex: Int,
+                        profiles: [ModelProfileWithUsage],
+                        timeZone: TimeZone = .current) -> Session {
+        Session(
+            terminalID: terminal.id,
+            label: sessionLabel(terminal: terminal, fallbackIndex: fallbackIndex),
+            accountDescriptor: ProfileUsagePresentation.accountDescriptor(
+                profileID: terminal.profileID, profiles: profiles
+            ),
+            switchTargets: switchTargets(currentProfileID: terminal.profileID,
+                                         profiles: profiles,
+                                         timeZone: timeZone)
+        )
+    }
+
+    /// Human handle for a session. Prefers the terminal's own label; falls back
+    /// to "Claude N" using the caller's Claude-session index.
+    static func sessionLabel(terminal: Terminal, fallbackIndex: Int) -> String {
+        if let label = terminal.label?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !label.isEmpty {
+            return label
+        }
+        return "Claude \(fallbackIndex)"
+    }
+
+    /// Switch destinations for a session, in picker order. Every logged-in
+    /// profile is a row: the current account is checkmarked + disabled, others
+    /// are selectable; not-logged-in profiles are disabled with the /login hint.
+    static func switchTargets(currentProfileID: UUID?,
+                              profiles: [ModelProfileWithUsage],
+                              timeZone: TimeZone = .current) -> [SwitchTarget] {
+        ProfileUsagePresentation.sortedForPicker(profiles).map { entry in
+            let selectable = ProfileUsagePresentation.isSelectable(entry)
+            let isCurrent = entry.profile.id == currentProfileID
+            return SwitchTarget(
+                profileID: entry.profile.id,
+                title: ProfileUsagePresentation.menuItemTitle(for: entry, timeZone: timeZone),
+                isCurrent: isCurrent,
+                isSelectable: selectable,
+                disabledReason: selectable ? nil : notLoggedInReason
+            )
+        }
+    }
+}

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -1,0 +1,272 @@
+import Foundation
+import TBDShared
+
+/// Typed, ordered action model for a worktree row's action list — the single
+/// source of truth shared by BOTH the right-click context menu
+/// (`SidebarContextMenu`) and the hover-revealed "…" menu (`RowAccountMenuView`).
+///
+/// Pure composition on top of a small `Context` of live inputs the surfaces read
+/// from `AppState`. No AppKit, no SwiftUI: `role` is our own `ActionRole` and the
+/// view maps it to SwiftUI's `.destructive`. `items(worktree:context:)` is a pure
+/// function of its inputs, so the ordered structure both surfaces render is
+/// directly unit-testable without any `AppState`.
+///
+/// The account section (per-session info + "Switch account") is intentionally
+/// NOT modeled here — it is contributed separately by `RowAccountMenu` and shown
+/// only in the "…" menu, above these items. This model is exactly what the
+/// right-click menu shows, and exactly the tail of what the "…" menu shows.
+enum RowActionMenu {
+    // MARK: - Typed model
+
+    /// Stable typed identity for each action, so the view can dispatch to the
+    /// right side effect without stringly-typed matching on titles.
+    enum Kind: Equatable {
+        case newClaudeTerminal
+        case newCodexTerminal
+        case newShellTerminal
+        case rename
+        case openInFinder
+        case copyPath
+        case archiveScratch
+        case deleteScratch
+        case suspendClaude
+        case resumeClaude
+        case createNestedWorktree
+        /// Create a child worktree based on THIS worktree's current branch.
+        case newWorktreeFromBranch
+        case archive
+        /// Fork a specific Claude session into a new tab on the same account.
+        /// Carries the session's terminal and its own (possibly ambient/nil)
+        /// profile, so the dispatcher can resume+fork it.
+        case forkSession(terminalID: UUID, profileID: UUID?)
+    }
+
+    /// Whether an action reads as destructive. Mapped by the view to SwiftUI's
+    /// `ButtonRole.destructive`; kept AppKit/SwiftUI-free so the helper is pure.
+    enum ActionRole: Equatable {
+        case normal
+        case destructive
+    }
+
+    /// One selectable action: its typed identity, display title, role, enabled
+    /// flag, and an optional disabled-help string (the archive-with-children
+    /// explainer).
+    struct Action: Equatable {
+        let kind: Kind
+        let title: String
+        let role: ActionRole
+        let isEnabled: Bool
+        let disabledHelp: String?
+
+        init(kind: Kind,
+             title: String,
+             role: ActionRole = .normal,
+             isEnabled: Bool = true,
+             disabledHelp: String? = nil) {
+            self.kind = kind
+            self.title = title
+            self.role = role
+            self.isEnabled = isEnabled
+            self.disabledHelp = disabledHelp
+        }
+    }
+
+    /// A single line in the rendered list. Dividers and captions are modeled so
+    /// BOTH surfaces render the exact same visual structure.
+    enum Item: Equatable {
+        case action(Action)
+        case divider
+        /// A muted caption note (the "To promote: run `tbd scratch promote …`"
+        /// line in the scratch branch).
+        case caption(String)
+    }
+
+    /// A forkable Claude session in this worktree: the terminal to resume, its
+    /// own account (nil = ambient), and a human label for disambiguation when a
+    /// worktree hosts more than one session.
+    struct ClaudeSessionRef: Equatable {
+        let terminalID: UUID
+        let profileID: UUID?
+        let label: String
+    }
+
+    /// The small set of live inputs the current `SidebarContextMenu` reads from
+    /// `AppState`, lifted into a value type so `items(...)` is a pure function.
+    struct Context: Equatable {
+        /// Has at least one resumable Claude terminal that is NOT suspended.
+        var hasUnsuspendedClaude: Bool
+        /// Has at least one resumable Claude terminal that IS suspended.
+        var hasSuspendedClaude: Bool
+        /// Has at least one non-archived child worktree (gates archive).
+        var hasActiveChildren: Bool
+        /// Worktree path is empty (main/creating rows hide Finder/Copy then).
+        var pathIsEmpty: Bool
+        /// Backing repo present — nested-worktree creation is repo-only.
+        var hasRepoID: Bool
+        var isScratch: Bool
+        var status: WorktreeStatus
+        /// Whether the scratch space has already been promoted (hides the
+        /// promote-hint caption).
+        var isPromoted: Bool
+        /// This worktree's current branch. Empty → "New worktree from this
+        /// branch…" is omitted (nothing to base it on).
+        var branch: String
+        /// Forkable Claude sessions in tab order. Drives the per-session
+        /// "Fork session" entries (empty → none).
+        var claudeSessions: [ClaudeSessionRef]
+
+        init(hasUnsuspendedClaude: Bool = false,
+             hasSuspendedClaude: Bool = false,
+             hasActiveChildren: Bool = false,
+             pathIsEmpty: Bool = false,
+             hasRepoID: Bool = true,
+             isScratch: Bool = false,
+             status: WorktreeStatus = .active,
+             isPromoted: Bool = false,
+             branch: String = "",
+             claudeSessions: [ClaudeSessionRef] = []) {
+            self.hasUnsuspendedClaude = hasUnsuspendedClaude
+            self.hasSuspendedClaude = hasSuspendedClaude
+            self.hasActiveChildren = hasActiveChildren
+            self.pathIsEmpty = pathIsEmpty
+            self.hasRepoID = hasRepoID
+            self.isScratch = isScratch
+            self.status = status
+            self.isPromoted = isPromoted
+            self.branch = branch
+            self.claudeSessions = claudeSessions
+        }
+    }
+
+    // MARK: - Copy
+
+    static let promoteHint =
+        "To promote: run `tbd scratch promote <dest>` from a session here"
+    static let archiveNeedsChildrenGoneHelp = "Archive nested worktrees first"
+    static let forkSessionLabel = "Fork session"
+    static let newWorktreeFromBranchLabel = "New worktree from this branch…"
+
+    /// Title for a fork-session action: plain when the worktree hosts a single
+    /// Claude session, suffixed with the session label when there are several.
+    static func forkSessionTitle(label: String, multiple: Bool) -> String {
+        multiple ? "\(forkSessionLabel) — \(label)" : forkSessionLabel
+    }
+
+    // MARK: - Composition
+
+    /// The ordered action list for a worktree row. Pure function of `context`;
+    /// the three branches map exactly to today's `SidebarContextMenu` branches
+    /// (scratch / main-or-creating / regular), preserving item order within each.
+    ///
+    /// `includeSessionForks` controls whether per-session "Fork session" entries
+    /// are part of this list. The right-click menu passes `true` (it has no
+    /// account section, so fork lives here); the "…" menu passes `false` and
+    /// renders fork inside each account section instead, so it isn't duplicated.
+    static func items(context: Context, includeSessionForks: Bool = true) -> [Item] {
+        if context.isScratch {
+            return scratchItems(context: context, includeSessionForks: includeSessionForks)
+        } else if context.status == .main || context.status == .creating {
+            return mainItems(context: context)
+        } else {
+            return regularItems(context: context, includeSessionForks: includeSessionForks)
+        }
+    }
+
+    /// The per-session fork actions for this worktree, used by the "…" menu's
+    /// account section (which renders fork alongside each session's switch
+    /// submenu rather than in the shared action block).
+    static func sessionForkActions(context: Context) -> [Action] {
+        forkActions(context: context)
+    }
+
+    private static func forkActions(context: Context) -> [Action] {
+        let multiple = context.claudeSessions.count > 1
+        return context.claudeSessions.map { session in
+            Action(
+                kind: .forkSession(terminalID: session.terminalID, profileID: session.profileID),
+                title: forkSessionTitle(label: session.label, multiple: multiple)
+            )
+        }
+    }
+
+    private static func scratchItems(context: Context, includeSessionForks: Bool) -> [Item] {
+        var items: [Item] = [
+            .action(Action(kind: .newClaudeTerminal, title: "New Claude Terminal")),
+            .action(Action(kind: .newCodexTerminal, title: "New Codex Terminal")),
+            .action(Action(kind: .newShellTerminal, title: "New Shell Terminal")),
+        ]
+        // Scratch spaces host Claude sessions too — same fork parity as the
+        // regular branch (right-click carries fork; the "…" menu's account
+        // section renders it instead).
+        if includeSessionForks {
+            items.append(contentsOf: forkActions(context: context).map(Item.action))
+        }
+        items.append(contentsOf: [
+            .divider,
+            .action(Action(kind: .rename, title: "Rename...")),
+        ])
+        if !context.isPromoted {
+            items.append(.caption(promoteHint))
+        }
+        items.append(contentsOf: [
+            .divider,
+            .action(Action(kind: .openInFinder, title: "Open in Finder")),
+            .action(Action(kind: .copyPath, title: "Copy Path")),
+            .divider,
+            // `.destructive` for consistency with the repo-worktree Archive even
+            // though scratch archive is recoverable and leaves the folder on disk.
+            .action(Action(kind: .archiveScratch, title: "Archive", role: .destructive)),
+            .action(Action(kind: .deleteScratch, title: "Delete Scratch Space", role: .destructive)),
+        ])
+        return items
+    }
+
+    private static func mainItems(context: Context) -> [Item] {
+        // Main / creating worktree: only Finder and Copy Path, and only when a
+        // path exists (no rename/archive).
+        guard !context.pathIsEmpty else { return [] }
+        return [
+            .action(Action(kind: .openInFinder, title: "Open in Finder")),
+            .action(Action(kind: .copyPath, title: "Copy Path")),
+        ]
+    }
+
+    private static func regularItems(context: Context, includeSessionForks: Bool) -> [Item] {
+        var items: [Item] = [
+            .action(Action(kind: .rename, title: "Rename...")),
+        ]
+        if context.hasUnsuspendedClaude {
+            items.append(.action(Action(kind: .suspendClaude, title: "Suspend Claude")))
+        }
+        if context.hasSuspendedClaude {
+            items.append(.action(Action(kind: .resumeClaude, title: "Resume Claude")))
+        }
+        // Per-session fork — only in surfaces without an account section (the
+        // right-click menu). The "…" menu renders fork in its account section.
+        if includeSessionForks {
+            items.append(contentsOf: forkActions(context: context).map(Item.action))
+        }
+        // Scratch spaces have no repo, so nesting isn't offered for them.
+        if context.hasRepoID {
+            items.append(.action(Action(kind: .createNestedWorktree, title: "Create Nested Worktree")))
+            // Base a child worktree on this worktree's current branch. Needs a
+            // branch to check out — omitted when empty.
+            if !context.branch.isEmpty {
+                items.append(.action(Action(kind: .newWorktreeFromBranch, title: newWorktreeFromBranchLabel)))
+            }
+        }
+        items.append(.action(Action(
+            kind: .archive,
+            title: "Archive",
+            role: .destructive,
+            isEnabled: !context.hasActiveChildren,
+            disabledHelp: context.hasActiveChildren ? archiveNeedsChildrenGoneHelp : nil
+        )))
+        items.append(contentsOf: [
+            .divider,
+            .action(Action(kind: .openInFinder, title: "Open in Finder")),
+            .action(Action(kind: .copyPath, title: "Copy Path")),
+        ])
+        return items
+    }
+}

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -25,6 +25,11 @@ struct ModelProfilesSettingsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             globalDefaultHeader
+            // Same persisted flag the spawn-time account picker's checkbox
+            // writes — discoverable/toggleable from either surface.
+            Toggle("Use default without asking (skip the account picker when starting Claude)",
+                   isOn: $appState.skipAccountPicker)
+                .font(.caption)
             Divider()
             profileList
             Spacer()

--- a/Sources/TBDApp/Sidebar/RowAccountMenuView.swift
+++ b/Sources/TBDApp/Sidebar/RowAccountMenuView.swift
@@ -1,15 +1,28 @@
 import SwiftUI
 import TBDShared
 
-/// Hover-revealed "…" menu for a worktree row. Headlined by per-session account
-/// info + switch-account (fork the session onto another logged-in profile).
+/// Hover-revealed "…" menu for a worktree row — the shared action list.
 ///
-/// Pure lowering of `RowAccountMenu.Model` — the composition lives in the
-/// testable helper; this file only maps typed rows to SwiftUI `Menu`/`Button`
-/// and dispatches the typed `RowAccountMenuAction` to `AppState`.
+/// Structure, top to bottom:
+///   [account section: per-session info + "Switch account" submenu]
+///   Divider
+///   [the shared `RowActionMenu` actions — identical to the right-click menu]
+///
+/// The account section lowers `RowAccountMenu.Model` (composition in the
+/// testable helper); the action tail renders the shared `RowActionMenu` items
+/// through `RowActionMenuActions`, so the "…" menu and the right-click
+/// `SidebarContextMenu` can never drift.
 struct RowAccountMenuView: View {
     let worktree: Worktree
+    var onRename: () -> Void
     @EnvironmentObject var appState: AppState
+
+    /// Subtle hover fill on the ellipsis label. A `Menu` with
+    /// `.menuStyle(.borderlessButton)` does not apply the outer
+    /// `HoverPressButtonStyle` fill to its label, so we drive the same look
+    /// (cornerRadius 4, `Color.primary.opacity(0.08)` on hover) here directly to
+    /// match the sibling "+" button.
+    @State private var isHovering = false
 
     private var menuModel: RowAccountMenu.Model {
         RowAccountMenu.model(
@@ -18,17 +31,29 @@ struct RowAccountMenuView: View {
         )
     }
 
+    private var actions: RowActionMenuActions {
+        RowActionMenuActions(appState: appState, worktree: worktree, onRename: onRename)
+    }
+
     var body: some View {
         Menu {
             menuContent(menuModel)
+            Divider()
+            RowActionMenuItemsView(actions: actions, includeSessionForks: false)
         } label: {
             Image(systemName: "ellipsis")
                 .font(.caption)
+                .foregroundStyle(.secondary)
                 .frame(width: 20, height: 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isHovering ? Color.primary.opacity(0.08) : Color.clear)
+                )
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()
+        .onHover { isHovering = $0 }
         .help("Session actions")
     }
 
@@ -50,10 +75,24 @@ struct RowAccountMenuView: View {
         // Info header: session label + its current account.
         Button("\(session.label) — \(session.accountDescriptor)") {}
             .disabled(true)
+        // Fork this conversation into a new tab on the same account.
+        if let fork = forkAction(for: session.terminalID) {
+            Button(fork.title) { actions.run(fork.kind) }
+        }
         Menu(RowAccountMenu.switchAccountLabel) {
             ForEach(session.switchTargets) { target in
                 switchTargetButton(session: session, target: target)
             }
+        }
+    }
+
+    /// The fork-session action for a given terminal (matched from the shared
+    /// per-session fork list), so the "…" menu renders fork alongside the
+    /// session's switch submenu.
+    private func forkAction(for terminalID: UUID) -> RowActionMenu.Action? {
+        actions.sessionForkActions().first {
+            if case let .forkSession(id, _) = $0.kind { return id == terminalID }
+            return false
         }
     }
 

--- a/Sources/TBDApp/Sidebar/RowAccountMenuView.swift
+++ b/Sources/TBDApp/Sidebar/RowAccountMenuView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import TBDShared
+
+/// Hover-revealed "…" menu for a worktree row. Headlined by per-session account
+/// info + switch-account (fork the session onto another logged-in profile).
+///
+/// Pure lowering of `RowAccountMenu.Model` — the composition lives in the
+/// testable helper; this file only maps typed rows to SwiftUI `Menu`/`Button`
+/// and dispatches the typed `RowAccountMenuAction` to `AppState`.
+struct RowAccountMenuView: View {
+    let worktree: Worktree
+    @EnvironmentObject var appState: AppState
+
+    private var menuModel: RowAccountMenu.Model {
+        RowAccountMenu.model(
+            terminals: appState.terminals[worktree.id] ?? [],
+            profiles: appState.modelProfiles
+        )
+    }
+
+    var body: some View {
+        Menu {
+            menuContent(menuModel)
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.caption)
+                .frame(width: 20, height: 20)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Session actions")
+    }
+
+    @ViewBuilder
+    private func menuContent(_ model: RowAccountMenu.Model) -> some View {
+        if model.isEmpty {
+            Button("No Claude sessions") {}.disabled(true)
+        } else {
+            ForEach(model.sessions) { session in
+                sessionSection(session)
+            }
+            Divider()
+            Text(model.footer).font(.caption)
+        }
+    }
+
+    @ViewBuilder
+    private func sessionSection(_ session: RowAccountMenu.Session) -> some View {
+        // Info header: session label + its current account.
+        Button("\(session.label) — \(session.accountDescriptor)") {}
+            .disabled(true)
+        Menu(RowAccountMenu.switchAccountLabel) {
+            ForEach(session.switchTargets) { target in
+                switchTargetButton(session: session, target: target)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func switchTargetButton(session: RowAccountMenu.Session,
+                                    target: RowAccountMenu.SwitchTarget) -> some View {
+        if let action = target.action(terminalID: session.terminalID) {
+            Button(action: { dispatch(action) }) {
+                Text("  \(target.title)")
+            }
+        } else {
+            // Disabled: current account (checkmark) or not-logged-in (hint).
+            let prefix = target.isCurrent ? "✓ " : "  "
+            let suffix = target.disabledReason.map { " — \($0)" } ?? ""
+            Button("\(prefix)\(target.title)\(suffix)") {}
+                .disabled(true)
+        }
+    }
+
+    private func dispatch(_ action: RowAccountMenu.RowAccountMenuAction) {
+        Task {
+            await appState.swapTerminalProfile(
+                terminalID: action.terminalID,
+                newProfileID: action.newProfileID
+            )
+        }
+    }
+}

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -1,0 +1,217 @@
+import AppKit
+import SwiftUI
+import TBDShared
+
+/// The shared dispatcher behind BOTH worktree-row action surfaces (the
+/// right-click `SidebarContextMenu` and the hover "…" menu in
+/// `RowAccountMenuView`). Holding `appState + worktree + onRename`, it exposes:
+///
+/// - `context()` — build the pure `RowActionMenu.Context` from live `AppState`.
+/// - `run(_:)` — the single place every side-effecting closure lives, keyed by
+///   the typed `RowActionMenu.Kind`, so behavior can never drift between the two
+///   surfaces.
+///
+/// `@MainActor` because it reads/mutates `AppState` and touches AppKit
+/// (`NSWorkspace`, `NSPasteboard`).
+@MainActor
+struct RowActionMenuActions {
+    let appState: AppState
+    let worktree: Worktree
+    let onRename: () -> Void
+
+    private var terminals: [Terminal] {
+        appState.terminals[worktree.id] ?? []
+    }
+
+    /// Forkable Claude sessions in tab order, labeled with the same helper the
+    /// account section uses so a session's fork entry matches its header.
+    private var claudeSessions: [RowActionMenu.ClaudeSessionRef] {
+        let claudeTerminals = terminals.filter { $0.kind == .claude || $0.isClaudeResumable }
+        var index = 0
+        return claudeTerminals.map { terminal in
+            index += 1
+            return RowActionMenu.ClaudeSessionRef(
+                terminalID: terminal.id,
+                profileID: terminal.profileID,
+                label: RowAccountMenu.sessionLabel(terminal: terminal, fallbackIndex: index)
+            )
+        }
+    }
+
+    /// Build the pure model context from live `AppState`. Mirrors exactly the
+    /// inputs the old `SidebarContextMenu` read inline.
+    func context() -> RowActionMenu.Context {
+        RowActionMenu.Context(
+            hasUnsuspendedClaude: terminals.contains {
+                $0.isClaudeResumable && $0.suspendedAt == nil
+            },
+            hasSuspendedClaude: terminals.contains {
+                $0.isClaudeResumable && $0.suspendedAt != nil
+            },
+            hasActiveChildren: !appState.children(of: worktree.id).isEmpty,
+            pathIsEmpty: worktree.path.isEmpty,
+            hasRepoID: worktree.repoID != nil,
+            isScratch: worktree.isScratch,
+            status: worktree.status,
+            isPromoted: worktree.promotedToRepoID != nil,
+            branch: worktree.branch,
+            claudeSessions: claudeSessions
+        )
+    }
+
+    /// The ordered items to render. `includeSessionForks` is `true` for the
+    /// right-click menu (fork lives in the shared list) and `false` for the "…"
+    /// menu (fork lives in its account section, so it isn't duplicated here).
+    func items(includeSessionForks: Bool = true) -> [RowActionMenu.Item] {
+        RowActionMenu.items(context: context(), includeSessionForks: includeSessionForks)
+    }
+
+    /// Per-session fork actions for the "…" menu's account section.
+    func sessionForkActions() -> [RowActionMenu.Action] {
+        RowActionMenu.sessionForkActions(context: context())
+    }
+
+    /// Run the side effect for a typed action `kind`. The single source of truth
+    /// for row-action behavior.
+    func run(_ kind: RowActionMenu.Kind) {
+        switch kind {
+        case .newClaudeTerminal:
+            let wtID = worktree.id
+            Task { await appState.createClaudeTerminal(worktreeID: wtID) }
+
+        case .newCodexTerminal:
+            let wtID = worktree.id
+            Task { await appState.createCodexTerminal(worktreeID: wtID) }
+
+        case .newShellTerminal:
+            let wtID = worktree.id
+            Task { await appState.createTerminal(worktreeID: wtID) }
+
+        case .rename:
+            onRename()
+
+        case .openInFinder:
+            NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.path)
+
+        case .copyPath:
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(worktree.path, forType: .string)
+
+        case .archiveScratch:
+            let wtID = worktree.id
+            Task { await appState.archiveScratch(id: wtID) }
+
+        case .deleteScratch:
+            let wtID = worktree.id
+            Task { await appState.deleteScratch(id: wtID) }
+
+        case .suspendClaude:
+            suspendClaude()
+
+        case .resumeClaude:
+            let wtID = worktree.id
+            Task {
+                try? await appState.daemonClient.worktreeResume(worktreeID: wtID)
+                await appState.refreshTerminals(worktreeID: wtID)
+            }
+
+        case .createNestedWorktree:
+            guard let repoID = worktree.repoID else { return }
+            appState.createWorktree(repoID: repoID, parentWorktreeID: worktree.id)
+
+        case .newWorktreeFromBranch:
+            guard let repoID = worktree.repoID, !worktree.branch.isEmpty else { return }
+            appState.createWorktree(
+                repoID: repoID,
+                parentWorktreeID: worktree.id,
+                existingBranch: BranchInfo(name: worktree.branch,
+                                           localName: worktree.branch,
+                                           isRemote: false)
+            )
+
+        case .archive:
+            let wtID = worktree.id
+            Task { await appState.archiveWorktree(id: wtID) }
+
+        case let .forkSession(terminalID, profileID):
+            // Duplicate the conversation into a new tab on the SAME account —
+            // swapTerminalProfile with the session's own profileID (nil = same
+            // ambient login). The daemon resumes/forks the session.
+            Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: profileID) }
+        }
+    }
+
+    /// Suspend all unsuspended resumable Claude terminals. Screenshot-capture +
+    /// suspending-state + poll-until-suspended loop preserved byte-for-byte from
+    /// the original `SidebarContextMenu` implementation.
+    private func suspendClaude() {
+        let wtID = worktree.id
+        let claudeTerminalIDs = terminals
+            .filter { $0.isClaudeResumable && $0.suspendedAt == nil }
+            .map { $0.id }
+        // Capture screenshot synchronously before any state change
+        for id in claudeTerminalIDs {
+            if let screenshot = appState.snapshotProviders[id]?() {
+                appState.setSuspendingSnapshot(screenshot, for: id)
+            }
+        }
+        // Now set suspending state (removes TerminalPanelView, shows screenshot)
+        claudeTerminalIDs.forEach { appState.suspendingTerminalIDs.insert($0) }
+        Task {
+            try? await appState.daemonClient.worktreeSuspend(worktreeID: wtID)
+            // Poll until all Claude terminals are suspended (daemon now async)
+            // 200ms intervals for first 2s, 500ms after — up to 15s total
+            for i in 0..<30 {
+                await appState.refreshTerminals(worktreeID: wtID)
+                let updated = appState.terminals[wtID] ?? []
+                if claudeTerminalIDs.allSatisfy({ id in
+                    updated.first(where: { $0.id == id })?.suspendedAt != nil
+                }) {
+                    break
+                }
+                try? await Task.sleep(for: .milliseconds(i < 10 ? 200 : 500))
+            }
+            claudeTerminalIDs.forEach {
+                appState.suspendingTerminalIDs.remove($0)
+                appState.removeSuspendingSnapshot(for: $0)
+            }
+        }
+    }
+}
+
+// MARK: - Rendering
+
+/// Shared SwiftUI rendering of `RowActionMenu.Item`s into `Button`/`Divider`/
+/// `Text`, dispatching each action through the shared `RowActionMenuActions`.
+/// Used by both the right-click menu and the "…" menu so the two surfaces render
+/// an identical structure.
+struct RowActionMenuItemsView: View {
+    let actions: RowActionMenuActions
+    /// See `RowActionMenuActions.items(includeSessionForks:)`. Right-click passes
+    /// `true`; the "…" menu passes `false` (fork lives in its account section).
+    var includeSessionForks: Bool = true
+
+    var body: some View {
+        ForEach(Array(actions.items(includeSessionForks: includeSessionForks).enumerated()), id: \.offset) { _, item in
+            switch item {
+            case let .action(action):
+                actionButton(action)
+            case .divider:
+                Divider()
+            case let .caption(text):
+                Text(text).font(.caption)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func actionButton(_ action: RowActionMenu.Action) -> some View {
+        Button(role: action.role == .destructive ? .destructive : nil) {
+            actions.run(action.kind)
+        } label: {
+            Text(action.title)
+        }
+        .disabled(!action.isEnabled)
+        .help(action.disabledHelp ?? "")
+    }
+}

--- a/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
+++ b/Sources/TBDApp/Sidebar/SidebarContextMenu.swift
@@ -1,160 +1,22 @@
-import AppKit
 import SwiftUI
 import TBDShared
 
+/// Right-click menu for a worktree row. Renders exactly the shared
+/// `RowActionMenu` action list (via `RowActionMenuItemsView`) — the SAME items,
+/// order, and behavior as the hover "…" menu's action tail. The account section
+/// is contributed only by the "…" menu, never here.
 struct SidebarContextMenu: View {
     let worktree: Worktree
     var onRename: () -> Void
     @EnvironmentObject var appState: AppState
 
     var body: some View {
-        Group {
-            if worktree.isScratch {
-                Button("New Claude Terminal") {
-                    let wtID = worktree.id
-                    Task {
-                        await appState.createClaudeTerminal(worktreeID: wtID)
-                    }
-                }
-                Button("New Codex Terminal") {
-                    let wtID = worktree.id
-                    Task {
-                        await appState.createCodexTerminal(worktreeID: wtID)
-                    }
-                }
-                Button("New Shell Terminal") {
-                    let wtID = worktree.id
-                    Task {
-                        await appState.createTerminal(worktreeID: wtID)
-                    }
-                }
-                Divider()
-                Button("Rename...") {
-                    onRename()
-                }
-                if worktree.promotedToRepoID == nil {
-                    Text("To promote: run `tbd scratch promote <dest>` from a session here")
-                        .font(.caption)
-                }
-                Divider()
-                Button("Open in Finder") {
-                    NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.path)
-                }
-                Button("Copy Path") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(worktree.path, forType: .string)
-                }
-                Divider()
-                // `.destructive` role for consistency with the non-scratch
-                // "Archive" button below, even though scratch archive is
-                // recoverable (revive exists) and leaves the folder untouched
-                // on disk — the repo-worktree Archive button is styled the
-                // same way despite being recoverable too.
-                Button("Archive", role: .destructive) {
-                    Task { await appState.archiveScratch(id: worktree.id) }
-                }
-                Button("Delete Scratch Space", role: .destructive) {
-                    Task { await appState.deleteScratch(id: worktree.id) }
-                }
-            } else if worktree.status == .main || worktree.status == .creating {
-                // Main / creating worktree: only Finder and Copy Path (no rename/archive)
-                if !worktree.path.isEmpty {
-                    Button("Open in Finder") {
-                        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.path)
-                    }
-
-                    Button("Copy Path") {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(worktree.path, forType: .string)
-                    }
-                }
-            } else {
-                Button("Rename...") {
-                    onRename()
-                }
-
-                let terminals = appState.terminals[worktree.id] ?? []
-                let hasUnsuspendedClaude = terminals.contains {
-                    $0.isClaudeResumable && $0.suspendedAt == nil
-                }
-                let hasSuspendedClaude = terminals.contains {
-                    $0.isClaudeResumable && $0.suspendedAt != nil
-                }
-                let hasActiveChildren = !appState.children(of: worktree.id).isEmpty
-
-                if hasUnsuspendedClaude {
-                    Button("Suspend Claude") {
-                        let wtID = worktree.id
-                        let claudeTerminalIDs = terminals
-                            .filter { $0.isClaudeResumable && $0.suspendedAt == nil }
-                            .map { $0.id }
-                        // Capture screenshot synchronously before any state change
-                        for id in claudeTerminalIDs {
-                            if let screenshot = appState.snapshotProviders[id]?() {
-                                appState.setSuspendingSnapshot(screenshot, for: id)
-                            }
-                        }
-                        // Now set suspending state (removes TerminalPanelView, shows screenshot)
-                        claudeTerminalIDs.forEach { appState.suspendingTerminalIDs.insert($0) }
-                        Task {
-                            try? await appState.daemonClient.worktreeSuspend(worktreeID: wtID)
-                            // Poll until all Claude terminals are suspended (daemon now async)
-                            // 200ms intervals for first 2s, 500ms after — up to 15s total
-                            for i in 0..<30 {
-                                await appState.refreshTerminals(worktreeID: wtID)
-                                let updated = appState.terminals[wtID] ?? []
-                                if claudeTerminalIDs.allSatisfy({ id in
-                                    updated.first(where: { $0.id == id })?.suspendedAt != nil
-                                }) {
-                                    break
-                                }
-                                try? await Task.sleep(for: .milliseconds(i < 10 ? 200 : 500))
-                            }
-                            claudeTerminalIDs.forEach {
-                                appState.suspendingTerminalIDs.remove($0)
-                                appState.removeSuspendingSnapshot(for: $0)
-                            }
-                        }
-                    }
-                }
-
-                if hasSuspendedClaude {
-                    Button("Resume Claude") {
-                        let wtID = worktree.id
-                        Task {
-                            try? await appState.daemonClient.worktreeResume(worktreeID: wtID)
-                            await appState.refreshTerminals(worktreeID: wtID)
-                        }
-                    }
-                }
-
-                // Scratch spaces have no repo, so nesting isn't offered for them.
-                if let repoID = worktree.repoID {
-                    Button("Create Nested Worktree") {
-                        appState.createWorktree(repoID: repoID, parentWorktreeID: worktree.id)
-                    }
-                }
-
-                Button("Archive", role: .destructive) {
-                    let wtID = worktree.id
-                    Task {
-                        await appState.archiveWorktree(id: wtID)
-                    }
-                }
-                .disabled(hasActiveChildren)
-                .help(hasActiveChildren ? "Archive nested worktrees first" : "")
-
-                Divider()
-
-                Button("Open in Finder") {
-                    NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.path)
-                }
-
-                Button("Copy Path") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(worktree.path, forType: .string)
-                }
-            }
-        }
+        RowActionMenuItemsView(
+            actions: RowActionMenuActions(
+                appState: appState,
+                worktree: worktree,
+                onRename: onRename
+            )
+        )
     }
 }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -54,6 +54,15 @@ struct WorktreeRowView: View {
         )
     }
 
+    /// Hover card for the "+" affordance: what the button does, and which
+    /// worktree the new child is created under.
+    private var newNestedWorktreeHoverCard: HoverCardModel {
+        HoverCardModel(
+            title: "New nested worktree",
+            titleCaption: "Creates a child worktree under \(worktree.displayName)"
+        )
+    }
+
     @ViewBuilder
     private func leadingIcon() -> some View {
         switch RowStatusIndicator.leading(
@@ -235,10 +244,10 @@ struct WorktreeRowView: View {
         .overlay(alignment: .trailing) {
             if isRowHovered && !isMain {
                 HStack(spacing: 2) {
-                    // Per-session account info + switch-account. Hidden until
-                    // hover, calm styling matching the "+" affordance.
-                    RowAccountMenuView(worktree: worktree)
-                        .buttonStyle(HoverPressButtonStyle())
+                    // The action list ("…") — account section + the
+                    // shared RowActionMenu actions. Hidden until hover, calm
+                    // styling matching the "+" affordance.
+                    RowAccountMenuView(worktree: worktree, onRename: startRename)
                     Button(action: {
                         let parentID = worktree.id
                         // Scratch spaces have no repo, so nested-worktree creation
@@ -251,7 +260,7 @@ struct WorktreeRowView: View {
                             .frame(width: 20, height: 20)
                     }
                     .buttonStyle(HoverPressButtonStyle())
-                    .help("New nested worktree")
+                    .hoverCard(newNestedWorktreeHoverCard)
                 }
                 .padding(.trailing, 4)
             }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -234,19 +234,25 @@ struct WorktreeRowView: View {
         }
         .overlay(alignment: .trailing) {
             if isRowHovered && !isMain {
-                Button(action: {
-                    let parentID = worktree.id
-                    // Scratch spaces have no repo, so nested-worktree creation
-                    // isn't offered for them — this affordance is repo-only.
-                    guard let repoID = worktree.repoID else { return }
-                    appState.createWorktree(repoID: repoID, parentWorktreeID: parentID)
-                }) {
-                    Image(systemName: "plus")
-                        .font(.caption)
-                        .frame(width: 20, height: 20)
+                HStack(spacing: 2) {
+                    // Per-session account info + switch-account. Hidden until
+                    // hover, calm styling matching the "+" affordance.
+                    RowAccountMenuView(worktree: worktree)
+                        .buttonStyle(HoverPressButtonStyle())
+                    Button(action: {
+                        let parentID = worktree.id
+                        // Scratch spaces have no repo, so nested-worktree creation
+                        // isn't offered for them — this affordance is repo-only.
+                        guard let repoID = worktree.repoID else { return }
+                        appState.createWorktree(repoID: repoID, parentWorktreeID: parentID)
+                    }) {
+                        Image(systemName: "plus")
+                            .font(.caption)
+                            .frame(width: 20, height: 20)
+                    }
+                    .buttonStyle(HoverPressButtonStyle())
+                    .help("New nested worktree")
                 }
-                .buttonStyle(HoverPressButtonStyle())
-                .help("New nested worktree")
                 .padding(.trailing, 4)
             }
         }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -44,6 +44,16 @@ struct WorktreeRowView: View {
         return terminals.contains { $0.activityState == .working }
     }
 
+    /// Aggregate account tooltip for this worktree's Claude sessions
+    /// ("Claude accounts: a@b.co (Work), ambient (terminal login)").
+    /// Empty string = no tooltip (no Claude sessions).
+    private var accountsTooltip: String {
+        ProfileUsagePresentation.worktreeAccountsTooltip(
+            terminals: appState.terminals[worktree.id] ?? [],
+            profiles: appState.modelProfiles
+        ) ?? ""
+    }
+
     @ViewBuilder
     private func leadingIcon() -> some View {
         switch RowStatusIndicator.leading(
@@ -197,6 +207,10 @@ struct WorktreeRowView: View {
         .opacity(AppState.scratchRowIsDimmed(
             worktree, directoryExists: FileManager.default.fileExists(atPath: worktree.path)
         ) ? 0.5 : 1.0)
+        // Which account(s) this worktree's Claude sessions run on. Empty
+        // string = no tooltip (same idiom as SidebarContextMenu); the PR icon
+        // and status icons keep their own more-specific tooltips.
+        .help(accountsTooltip)
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(appState.selectedWorktreeIDs.contains(worktree.id) ? Color.accentColor.opacity(0.2) : Color.clear)

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -44,14 +44,14 @@ struct WorktreeRowView: View {
         return terminals.contains { $0.activityState == .working }
     }
 
-    /// Aggregate account tooltip for this worktree's Claude sessions
-    /// ("Claude accounts: a@b.co (Work), ambient (terminal login)").
-    /// Empty string = no tooltip (no Claude sessions).
-    private var accountsTooltip: String {
-        ProfileUsagePresentation.worktreeAccountsTooltip(
+    /// Structured hover card listing which account(s) this worktree's Claude
+    /// sessions run on ("Claude accounts" + one row per account).
+    /// nil = no card (no Claude sessions).
+    private var accountsHoverCard: HoverCardModel? {
+        AccountHoverCards.worktreeCard(
             terminals: appState.terminals[worktree.id] ?? [],
             profiles: appState.modelProfiles
-        ) ?? ""
+        )
     }
 
     @ViewBuilder
@@ -207,10 +207,10 @@ struct WorktreeRowView: View {
         .opacity(AppState.scratchRowIsDimmed(
             worktree, directoryExists: FileManager.default.fileExists(atPath: worktree.path)
         ) ? 0.5 : 1.0)
-        // Which account(s) this worktree's Claude sessions run on. Empty
-        // string = no tooltip (same idiom as SidebarContextMenu); the PR icon
-        // and status icons keep their own more-specific tooltips.
-        .help(accountsTooltip)
+        // Which account(s) this worktree's Claude sessions run on. nil = no
+        // card; the PR icon and status icons keep their own more-specific
+        // tooltips.
+        .hoverCard(accountsHoverCard)
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(appState.selectedWorktreeIDs.contains(worktree.id) ? Color.accentColor.opacity(0.2) : Color.clear)

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -89,6 +89,7 @@ struct TabBar: View {
     var onAddShell: () -> Void = {}
     var onAddClaude: () -> Void = {}
     var onAddClaudeProfile: (UUID) -> Void = { _ in }
+    var onChooseAccount: () -> Void = {}
     var onAddCodex: () -> Void = {}
     var onAddNote: () -> Void = {}
     var onCloseTab: (Int) -> Void
@@ -133,6 +134,7 @@ struct TabBar: View {
                 onAddShell: onAddShell,
                 onAddClaude: onAddClaude,
                 onAddClaudeProfile: onAddClaudeProfile,
+                onChooseAccount: onChooseAccount,
                 onAddCodex: onAddCodex,
                 onAddNote: onAddNote
             )
@@ -167,6 +169,7 @@ private struct AddTabButton: View {
     let onAddShell: () -> Void
     let onAddClaude: () -> Void
     let onAddClaudeProfile: (UUID) -> Void
+    let onChooseAccount: () -> Void
     let onAddCodex: () -> Void
     let onAddNote: () -> Void
     @State private var isHovering = false
@@ -197,6 +200,7 @@ private struct AddTabButton: View {
             onShell: onAddShell,
             onClaude: onAddClaude,
             onClaudeProfile: onAddClaudeProfile,
+            onChooseAccount: onChooseAccount,
             onCodex: onAddCodex,
             onNote: onAddNote
         )
@@ -272,6 +276,7 @@ final class MenuCoordinator: NSObject {
     let onShell: () -> Void
     let onClaude: () -> Void
     let onClaudeProfile: (UUID) -> Void
+    let onChooseAccount: () -> Void
     let onCodex: () -> Void
     let onNote: () -> Void
 
@@ -279,18 +284,21 @@ final class MenuCoordinator: NSObject {
         onShell: @escaping () -> Void,
         onClaude: @escaping () -> Void,
         onClaudeProfile: @escaping (UUID) -> Void,
+        onChooseAccount: @escaping () -> Void = {},
         onCodex: @escaping () -> Void,
         onNote: @escaping () -> Void
     ) {
         self.onShell = onShell
         self.onClaude = onClaude
         self.onClaudeProfile = onClaudeProfile
+        self.onChooseAccount = onChooseAccount
         self.onCodex = onCodex
         self.onNote = onNote
     }
 
     @objc func addShell() { onShell() }
     @objc func addClaude() { onClaude() }
+    @objc func chooseAccount() { onChooseAccount() }
     @objc func addCodex() { onCodex() }
     @objc func addNote() { onNote() }
 
@@ -337,14 +345,15 @@ enum AddTabMenu {
 
             // One item per profile, titled with the profile's display name plus
             // a short login-identity suffix (" — email" / " — needs /login" for
-            // oauth profiles). Each gets a transparent placeholder icon the same
-            // size as the Claude asterisk so its title lines up in the same
-            // title column as "Claude" — the empty icon slot is the visual
-            // nesting cue. The profile id rides along in `representedObject`
-            // for MenuCoordinator.addClaudeProfile.
+            // oauth profiles) and a compact usage suffix when the daemon has a
+            // snapshot (" · 5h 0% ↺23:10 · wk 76% · F 100%"). Each gets a
+            // transparent placeholder icon the same size as the Claude asterisk
+            // so its title lines up in the same title column as "Claude" — the
+            // empty icon slot is the visual nesting cue. The profile id rides
+            // along in `representedObject` for MenuCoordinator.addClaudeProfile.
             for entry in profiles {
                 let item = NSMenuItem(
-                    title: ProfileLoginPresentation.menuItemTitle(for: entry),
+                    title: ProfileUsagePresentation.menuItemTitle(for: entry),
                     action: #selector(MenuCoordinator.addClaudeProfile(_:)),
                     keyEquivalent: ""
                 )
@@ -353,6 +362,17 @@ enum AddTabMenu {
                 item.target = coordinator
                 menu.addItem(item)
             }
+
+            // Full account picker dialog — richer data (bars, reset times,
+            // staleness) than the compact suffixes above can carry.
+            let chooseItem = NSMenuItem(
+                title: "Choose account…",
+                action: #selector(MenuCoordinator.chooseAccount),
+                keyEquivalent: ""
+            )
+            chooseItem.image = blankIcon(size: claudeIcon.size)
+            chooseItem.target = coordinator
+            menu.addItem(chooseItem)
         }
 
         if availability.codex {
@@ -448,6 +468,18 @@ private struct TabBarItem: View {
 
     private var isSuspended: Bool {
         terminal?.suspendedAt != nil
+    }
+
+    /// Hover tooltip describing which account this session runs on: pinned
+    /// email + profile name (or the ambient-drift note for NULL-profile legacy
+    /// sessions), current 5h/weekly usage, and spawn time. nil (no tooltip)
+    /// for non-Claude tabs.
+    private var accountTooltip: String? {
+        guard let terminal else { return nil }
+        return ProfileUsagePresentation.sessionTooltip(
+            terminal: terminal,
+            profiles: appState.modelProfiles
+        )
     }
 
     /// Bold this tab's label when its terminal fired a `.responseComplete`
@@ -557,6 +589,8 @@ private struct TabBarItem: View {
         )
         .onPreferenceChange(TabWidthPreference.self) { measuredWidth = $0 }
         .animation(.easeInOut(duration: 0.1), value: isHovering)
+        // Empty string = no tooltip (same idiom as SidebarContextMenu).
+        .help(accountTooltip ?? "")
         .contextMenu { contextMenuContent }
         .onHover { hovering in
             isHovering = hovering

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -470,13 +470,13 @@ private struct TabBarItem: View {
         terminal?.suspendedAt != nil
     }
 
-    /// Hover tooltip describing which account this session runs on: pinned
+    /// Hover card describing which account this session runs on: pinned
     /// email + profile name (or the ambient-drift note for NULL-profile legacy
-    /// sessions), current 5h/weekly usage, and spawn time. nil (no tooltip)
+    /// sessions), current 5h/weekly usage, and spawn time. nil (no card)
     /// for non-Claude tabs.
-    private var accountTooltip: String? {
+    private var accountHoverCard: HoverCardModel? {
         guard let terminal else { return nil }
-        return ProfileUsagePresentation.sessionTooltip(
+        return AccountHoverCards.claudeTabCard(
             terminal: terminal,
             profiles: appState.modelProfiles
         )
@@ -589,8 +589,8 @@ private struct TabBarItem: View {
         )
         .onPreferenceChange(TabWidthPreference.self) { measuredWidth = $0 }
         .animation(.easeInOut(duration: 0.1), value: isHovering)
-        // Empty string = no tooltip (same idiom as SidebarContextMenu).
-        .help(accountTooltip ?? "")
+        // nil = no card (non-Claude tabs).
+        .hoverCard(accountHoverCard)
         .contextMenu { contextMenuContent }
         .onHover { hovering in
             isHovering = hovering

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -88,6 +88,10 @@ struct TerminalContainerView: View {
 struct SingleWorktreeView: View {
     let worktreeID: UUID
     @EnvironmentObject var appState: AppState
+    /// Spawn-time account picker (AccountPickerSheet). Opened by the plain
+    /// "Claude" action (unless "Use default without asking" is on) and by the
+    /// "+"-menu "Choose account…" item.
+    @State private var showAccountPicker = false
 
     private var activeTabIndex: Int {
         get { appState.activeTabIndices[worktreeID] ?? 0 }
@@ -137,9 +141,15 @@ struct SingleWorktreeView: View {
                         }
                     },
                     onAddClaude: {
-                        Task {
-                            await appState.createClaudeTerminal(worktreeID: worktreeID)
-                            selectLastTab()
+                        // "I get the data and I pick": plain Claude opens the
+                        // account picker unless the user opted out.
+                        if appState.skipAccountPicker {
+                            Task {
+                                await appState.createClaudeTerminal(worktreeID: worktreeID)
+                                selectLastTab()
+                            }
+                        } else {
+                            showAccountPicker = true
                         }
                     },
                     onAddClaudeProfile: { profileID in
@@ -150,6 +160,7 @@ struct SingleWorktreeView: View {
                             selectLastTab()
                         }
                     },
+                    onChooseAccount: { showAccountPicker = true },
                     onAddCodex: {
                         Task {
                             await appState.createCodexTerminal(worktreeID: worktreeID)
@@ -216,6 +227,17 @@ struct SingleWorktreeView: View {
                     .background(GeometryReader { geometry in
                         Color.clear.preference(key: MainAreaSizeKey.self, value: geometry.size)
                     })
+            }
+            .sheet(isPresented: $showAccountPicker) {
+                AccountPickerSheet { profileID in
+                    Task {
+                        await appState.createClaudeTerminal(
+                            worktreeID: worktreeID, profileID: profileID
+                        )
+                        selectLastTab()
+                    }
+                }
+                .environmentObject(appState)
             }
             // TmuxBridge sessions are created on-demand by TerminalPanelView
             .task(id: worktreeID) {

--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -31,6 +31,48 @@ func profileIdentityCell(kind: CredentialKind, loginIdentity: String?) -> String
     return "needs /login"
 }
 
+/// First bucket in the snapshot matching `kind` (and, for scoped buckets,
+/// the given model display name). nil when the snapshot is missing or the
+/// account doesn't have that bucket.
+func usageBucket(
+    in snapshot: ProfileUsageSnapshot?,
+    kind: String,
+    modelDisplayName: String? = nil
+) -> ClaudeUsageLimitBucket? {
+    snapshot?.buckets.first {
+        $0.kind == kind && (modelDisplayName == nil || $0.modelDisplayName == modelDisplayName)
+    }
+}
+
+/// Union of model display names across all profiles' `weekly_scoped` buckets,
+/// sorted for stable column order. Drives the dynamic per-model-family
+/// weekly columns in `tbd profile list` (e.g. "Fable").
+func scopedWeeklyModelNames(in profiles: [ModelProfileWithUsage]) -> [String] {
+    var names: Set<String> = []
+    for entry in profiles {
+        for bucket in entry.usageSnapshot?.buckets ?? []
+        where bucket.kind == "weekly_scoped" {
+            if let name = bucket.modelDisplayName { names.insert(name) }
+        }
+    }
+    return names.sorted()
+}
+
+/// Render a percent cell like "96%", or an em dash when the bucket is absent.
+func usagePercentCell(_ bucket: ClaudeUsageLimitBucket?) -> String {
+    guard let bucket else { return "—" }
+    return "\(Int(bucket.percent.rounded()))%"
+}
+
+/// Render a reset timestamp in compact local time: "18:10" when it lands
+/// within the next 24 h, otherwise "7/7 18:00". Em dash when absent.
+func usageResetCell(_ date: Date?, now: Date = Date()) -> String {
+    guard let date else { return "—" }
+    let formatter = DateFormatter()
+    formatter.dateFormat = date.timeIntervalSince(now) < 24 * 3600 ? "HH:mm" : "M/d HH:mm"
+    return formatter.string(from: date)
+}
+
 /// Resolve a user-supplied profile reference against the daemon's profile
 /// list. Accepts an exact name, a unique case-insensitive name, or a profile
 /// UUID (escape hatch for scripting). Throws a `CLIError` with actionable
@@ -131,8 +173,20 @@ struct ProfileList: AsyncParsableCommand {
     @Flag(name: .long, help: "Output JSON")
     var json = false
 
+    @Flag(name: .long, help: "Force a fresh usage fetch for all logged-in OAuth profiles before listing")
+    var refresh = false
+
     mutating func run() async throws {
         let client = SocketClient()
+
+        if refresh {
+            _ = try client.call(
+                method: RPCMethod.modelProfileUsageRefresh,
+                params: ModelProfileUsageRefreshParams(id: nil),
+                resultType: ModelProfileUsageRefreshResult.self
+            )
+        }
+
         let result = try client.call(
             method: RPCMethod.modelProfileList,
             resultType: ModelProfileListResult.self
@@ -146,24 +200,54 @@ struct ProfileList: AsyncParsableCommand {
             print("No model profiles configured. Create one in TBD Settings → Model Profiles.")
             return
         }
-        print(tableRow([("NAME", 24), ("KIND", 8), ("IDENTITY", 0)]))
-        print(String(repeating: "-", count: 78))
+
+        // Dynamic per-model-family weekly columns ("WK FABLE", ...) driven by
+        // whatever scoped buckets the usage API actually returned.
+        let scopedModels = scopedWeeklyModelNames(in: result.profiles)
+
+        var header: [(String, Int)] = [
+            ("NAME", 24), ("KIND", 6), ("IDENTITY", 26),
+            ("5H", 4), ("RESET", 10), ("WK", 4),
+        ]
+        header.append(contentsOf: scopedModels.map { ("WK \($0.uppercased())", max($0.count + 3, 8)) })
+        header.append(("", 0))
+        print(tableRow(header))
+        let width = header.reduce(0) { $0 + max($1.1, $1.0.count) + 2 }
+        print(String(repeating: "-", count: max(width, 78)))
+
+        var staleNotes: [String] = []
         for entry in result.profiles {
             let identity = profileIdentityCell(
                 kind: entry.profile.kind,
                 loginIdentity: entry.loginIdentity
             )
-            let isDefault = entry.profile.id == result.defaultID
-            // The [default] marker gets its own zero-width trailing cell so
-            // non-default rows end at the identity column with no trailing
-            // padding.
-            let cells: [(String, Int)] = isDefault
-                ? [(entry.profile.name, 24), (entry.profile.kind.rawValue, 8),
-                   (identity, 32), ("[default]", 0)]
-                : [(entry.profile.name, 24), (entry.profile.kind.rawValue, 8),
-                   (identity, 0)]
+            let snapshot = entry.usageSnapshot
+            let session = usageBucket(in: snapshot, kind: "session")
+            let weeklyAll = usageBucket(in: snapshot, kind: "weekly_all")
+
+            var cells: [(String, Int)] = [
+                (entry.profile.name, 24),
+                (entry.profile.kind.rawValue, 6),
+                (identity, 26),
+                (usagePercentCell(session), 4),
+                (usageResetCell(session?.resetsAt), 10),
+                (usagePercentCell(weeklyAll), 4),
+            ]
+            for model in scopedModels {
+                let bucket = usageBucket(in: snapshot, kind: "weekly_scoped", modelDisplayName: model)
+                cells.append((usagePercentCell(bucket), max(model.count + 3, 8)))
+            }
+
+            var trailing: [String] = []
+            if entry.profile.id == result.defaultID { trailing.append("[default]") }
+            if let snapshot, !snapshot.isOK {
+                trailing.append("[stale*]")
+                staleNotes.append("  * \(entry.profile.name): \(snapshot.status)")
+            }
+            cells.append((trailing.joined(separator: " "), 0))
             print(tableRow(cells))
         }
+        for note in staleNotes { print(note) }
     }
 }
 

--- a/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
@@ -1,0 +1,204 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "oauthUsagePoller")
+
+/// Background poller for per-profile OAuth usage snapshots.
+///
+/// Complements `ClaudeUsagePoller` (which serves API-key profiles from
+/// TBD-stored secrets on a 30-min cadence, persisted in the DB): this one
+/// sweeps every logged-in OAuth profile roughly every 90 seconds using
+/// CLI-mediated credentials (`LiveProfileUsageFetcher`), holding results
+/// purely in memory — the spawn-time account picker renders instantly from
+/// this cache and can force a fresh sweep via `modelProfile.usageRefresh`.
+///
+/// Rules:
+/// - Eligible profiles: `kind == .oauth` with a non-nil login identity
+///   (someone has completed `/login` in the profile's isolated config dir).
+/// - Per-profile calls within one sweep are staggered slightly.
+/// - A failing profile records a status ("stale since X; fetch failed: …")
+///   without poisoning the rest of the sweep; previously fetched buckets are
+///   retained so the picker can show stale-but-real numbers.
+/// - `broadcast` fires (once per sweep) only when snapshot data actually
+///   changed — `lastAttemptAt` alone doesn't count, so a persistently failing
+///   profile doesn't emit a delta every 90 s.
+public actor OAuthProfileUsagePoller {
+
+    // MARK: - Constants
+
+    public static let cadence: TimeInterval = 90
+    public static let interProfileStagger: TimeInterval = 2
+
+    // MARK: - Dependencies (closures so tests need no DB or filesystem)
+
+    public typealias ProfilesProvider = @Sendable () async throws -> [ModelProfile]
+
+    private let profilesProvider: ProfilesProvider
+    private let loginIdentity: @Sendable (UUID) -> String?
+    private let configDirPath: @Sendable (UUID) -> String
+    private let fetcher: ProfileUsageFetching
+    private let broadcast: @Sendable () -> Void
+    private let sleeper: @Sendable (TimeInterval) async throws -> Void
+    private let now: @Sendable () -> Date
+
+    // MARK: - State
+
+    private var snapshots: [UUID: ProfileUsageSnapshot] = [:]
+    private var loopTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    public init(
+        profilesProvider: @escaping ProfilesProvider,
+        loginIdentity: @escaping @Sendable (UUID) -> String?,
+        configDirPath: @escaping @Sendable (UUID) -> String,
+        fetcher: ProfileUsageFetching,
+        broadcast: @escaping @Sendable () -> Void,
+        sleeper: (@Sendable (TimeInterval) async throws -> Void)? = nil,
+        now: (@Sendable () -> Date)? = nil
+    ) {
+        self.profilesProvider = profilesProvider
+        self.loginIdentity = loginIdentity
+        self.configDirPath = configDirPath
+        self.fetcher = fetcher
+        self.broadcast = broadcast
+        self.sleeper = sleeper ?? { try await Task.sleep(for: .seconds($0)) }
+        self.now = now ?? { Date() }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Launches the sweep loop. Idempotent.
+    public func start() {
+        guard loopTask == nil else { return }
+        loopTask = Task { [weak self] in
+            await self?.runLoop()
+        }
+    }
+
+    /// Cancels the loop. Idempotent. Cached snapshots remain readable.
+    public func stop() {
+        loopTask?.cancel()
+        loopTask = nil
+    }
+
+    private func runLoop() async {
+        while !Task.isCancelled {
+            await sweep(only: nil)
+            try? await sleeper(Self.cadence)
+        }
+    }
+
+    // MARK: - Reads
+
+    public func allSnapshots() -> [UUID: ProfileUsageSnapshot] { snapshots }
+
+    public func snapshot(for profileID: UUID) -> ProfileUsageSnapshot? {
+        snapshots[profileID]
+    }
+
+    // MARK: - Forced sweep (RPC `modelProfile.usageRefresh`)
+
+    /// Fetch fresh usage now — all logged-in OAuth profiles when `profileID`
+    /// is nil, or just the one profile. Returns the post-sweep snapshots
+    /// (filtered to the requested profile when one was given).
+    @discardableResult
+    public func sweepNow(profileID: UUID? = nil) async -> [UUID: ProfileUsageSnapshot] {
+        await sweep(only: profileID)
+        if let profileID {
+            return snapshots.filter { $0.key == profileID }
+        }
+        return snapshots
+    }
+
+    // MARK: - Sweep
+
+    private func sweep(only: UUID?) async {
+        let allProfiles: [ModelProfile]
+        do {
+            allProfiles = try await profilesProvider()
+        } catch {
+            logger.warning("profile list failed; skipping usage sweep: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        let eligible = allProfiles.filter { $0.kind == .oauth && loginIdentity($0.id) != nil }
+        let eligibleIDs = Set(eligible.map(\.id))
+
+        let before = snapshots
+
+        // Full sweeps prune snapshots for profiles that were deleted, logged
+        // out, or changed kind, so the RPC surface never leaks ghosts.
+        if only == nil {
+            snapshots = snapshots.filter { eligibleIDs.contains($0.key) }
+        }
+
+        let targets = only.map { id in eligible.filter { $0.id == id } } ?? eligible
+
+        for (index, profile) in targets.enumerated() {
+            if index > 0 {
+                try? await sleeper(Self.interProfileStagger)
+            }
+            if Task.isCancelled { break }
+            let status = await fetcher.fetchUsage(configDirPath: configDirPath(profile.id))
+            record(status, for: profile.id)
+        }
+
+        if hasMeaningfulChange(from: before, to: snapshots) {
+            broadcast()
+        }
+    }
+
+    private func record(_ status: ProfileUsageFetchStatus, for profileID: UUID) {
+        let timestamp = now()
+        switch status {
+        case .ok(let buckets):
+            snapshots[profileID] = ProfileUsageSnapshot(
+                buckets: buckets,
+                fetchedAt: timestamp,
+                lastAttemptAt: timestamp,
+                status: "ok"
+            )
+            logger.debug("usage sweep ok for profile \(profileID, privacy: .public): \(buckets.count, privacy: .public) buckets")
+        default:
+            let reason = status.failureReason ?? "unknown"
+            let previous = snapshots[profileID]
+            let statusText: String
+            if let fetchedAt = previous?.fetchedAt {
+                statusText = "stale since \(Self.iso8601String(from: fetchedAt)); fetch failed: \(reason)"
+            } else {
+                statusText = "fetch failed: \(reason)"
+            }
+            snapshots[profileID] = ProfileUsageSnapshot(
+                buckets: previous?.buckets ?? [],
+                fetchedAt: previous?.fetchedAt,
+                lastAttemptAt: timestamp,
+                status: statusText
+            )
+            logger.warning("usage sweep failed for profile \(profileID, privacy: .public): \(reason, privacy: .public)")
+        }
+    }
+
+    /// Snapshot change comparison ignoring `lastAttemptAt`, so repeated
+    /// identical failures don't re-broadcast every sweep.
+    private func hasMeaningfulChange(
+        from before: [UUID: ProfileUsageSnapshot],
+        to after: [UUID: ProfileUsageSnapshot]
+    ) -> Bool {
+        guard before.count == after.count else { return true }
+        for (id, new) in after {
+            guard let old = before[id] else { return true }
+            if old.buckets != new.buckets || old.fetchedAt != new.fetchedAt || old.status != new.status {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func iso8601String(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+}

--- a/Sources/TBDDaemon/Claude/ProfileUsageFetcher.swift
+++ b/Sources/TBDDaemon/Claude/ProfileUsageFetcher.swift
@@ -1,0 +1,300 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "profileUsageFetcher")
+
+// MARK: - OAuth token reading (per profile config dir)
+
+/// Reads the Claude Code OAuth access token that `/login` stored for a given
+/// isolated `CLAUDE_CONFIG_DIR`.
+///
+/// The daemon must NOT read the credential item via `SecItemCopyMatching`:
+/// Claude Code's keychain items are ACL'd to specific client binaries and a
+/// direct Security-framework read from TBDDaemon would trigger a blocking
+/// keychain prompt (or fail outright). Instead the live implementation shells
+/// out to `/usr/bin/security find-generic-password`, which is authorized for
+/// these items (verified empirically against all three live profiles on
+/// 2026-07-03), with the profile dir's `.credentials.json` file as a fallback
+/// (Claude Code writes that file when the keychain is unavailable).
+public protocol ClaudeOAuthTokenReading: Sendable {
+    /// Returns the OAuth access token for the credentials belonging to the
+    /// given config dir path, or nil when no credential is stored (not logged
+    /// in). Throws only on unexpected read errors (tool failure, bad JSON).
+    func accessToken(forConfigDirPath path: String) async throws -> String?
+}
+
+public struct ClaudeOAuthTokenReadError: Error, CustomStringConvertible {
+    public let description: String
+    public init(_ description: String) { self.description = description }
+}
+
+/// Parse the `claudeAiOauth.accessToken` field out of a Claude Code
+/// credentials JSON blob (the keychain item / `.credentials.json` payload).
+/// Pure and static for testability. Returns nil when the shape is missing.
+public func parseClaudeCredentialsAccessToken(_ data: Data) -> String? {
+    guard let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let oauth = parsed["claudeAiOauth"] as? [String: Any],
+          let token = oauth["accessToken"] as? String,
+          !token.isEmpty
+    else { return nil }
+    return token
+}
+
+/// Live token reader: `/usr/bin/security find-generic-password -s <service> -w`
+/// with the service name derived from the config dir path (same derivation
+/// Claude Code uses — see `ClaudeCodeCredentialsKeychain`). Falls back to
+/// `<configDir>/.credentials.json` when the keychain item is absent.
+public struct SecurityCLIOAuthTokenReader: ClaudeOAuthTokenReading {
+    public init() {}
+
+    public func accessToken(forConfigDirPath path: String) async throws -> String? {
+        let service = ClaudeCodeCredentialsKeychain.serviceName(forConfigDirPath: path)
+        let outcome = try await Self.runSecurityFindGenericPassword(service: service)
+        switch outcome {
+        case .found(let data):
+            guard let token = parseClaudeCredentialsAccessToken(data) else {
+                throw ClaudeOAuthTokenReadError("keychain item present but has no claudeAiOauth.accessToken")
+            }
+            return token
+        case .notFound:
+            // Fall back to the on-disk credentials file (Claude Code writes it
+            // when the keychain is unavailable).
+            let fileURL = URL(fileURLWithPath: path).appendingPathComponent(".credentials.json")
+            guard let data = try? Data(contentsOf: fileURL) else { return nil }
+            return parseClaudeCredentialsAccessToken(data)
+        }
+    }
+
+    enum SecurityOutcome {
+        case found(Data)
+        case notFound
+    }
+
+    /// Run `security find-generic-password -s <service> -w` and capture the
+    /// secret bytes from stdout. Exit code 44 (errSecItemNotFound) maps to
+    /// `.notFound`; other non-zero exits throw. Never routes through a shell.
+    static func runSecurityFindGenericPassword(service: String) async throws -> SecurityOutcome {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = ["find-generic-password", "-s", service, "-w"]
+        process.environment = [:]  // no env needed; never inherit shell state
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()  // swallow; may echo item metadata
+
+        return try await withCheckedThrowingContinuation { continuation in
+            process.terminationHandler = { proc in
+                let data = stdout.fileHandleForReading.readDataToEndOfFile()
+                switch proc.terminationStatus {
+                case 0:
+                    // stdout is the secret followed by a trailing newline.
+                    var bytes = data
+                    if bytes.last == UInt8(ascii: "\n") { bytes.removeLast() }
+                    continuation.resume(returning: .found(bytes))
+                case 44:  // errSecItemNotFound
+                    continuation.resume(returning: .notFound)
+                default:
+                    continuation.resume(throwing: ClaudeOAuthTokenReadError(
+                        "security find-generic-password exited \(proc.terminationStatus)"))
+                }
+            }
+            do {
+                try process.run()
+            } catch {
+                continuation.resume(throwing: ClaudeOAuthTokenReadError(
+                    "failed to launch /usr/bin/security: \(error.localizedDescription)"))
+            }
+        }
+    }
+}
+
+// MARK: - Per-profile usage fetch
+
+public enum ProfileUsageFetchStatus: Equatable, Sendable {
+    case ok([ClaudeUsageLimitBucket])
+    /// No stored credential for this profile (not logged in), or the
+    /// credential could not be read. The reason is human-readable and MUST
+    /// NOT contain token bytes.
+    case noCredentials(String)
+    case httpError(Int)  // 401 = token invalid/expired, 429 = rate limited, ...
+    case networkError(String)
+    case decodeError(String)
+
+    /// Short human-readable reason for non-ok statuses, used in snapshot
+    /// status strings. nil for `.ok`.
+    public var failureReason: String? {
+        switch self {
+        case .ok: return nil
+        case .noCredentials(let reason): return "no credentials (\(reason))"
+        case .httpError(let code): return "HTTP \(code)"
+        case .networkError(let msg): return "network error: \(msg)"
+        case .decodeError(let msg): return "decode error: \(msg)"
+        }
+    }
+}
+
+public protocol ProfileUsageFetching: Sendable {
+    /// Fetch the usage buckets for the OAuth account logged into the given
+    /// isolated `CLAUDE_CONFIG_DIR`. Never throws — failures come back as
+    /// non-ok statuses so a poller sweep can record them per profile.
+    func fetchUsage(configDirPath: String) async -> ProfileUsageFetchStatus
+}
+
+/// Live fetcher: resolve the profile's OAuth access token, then GET
+/// `https://api.anthropic.com/api/oauth/usage` with it — the same endpoint
+/// `LiveClaudeUsageFetcher` uses for API-key profiles, but with CLI-mediated
+/// (keychain) credentials and the richer `limits[]` parse.
+public struct LiveProfileUsageFetcher: ProfileUsageFetching {
+    public let tokenReader: ClaudeOAuthTokenReading
+    public let session: URLSession
+
+    public init(
+        tokenReader: ClaudeOAuthTokenReading = SecurityCLIOAuthTokenReader(),
+        session: URLSession = .shared
+    ) {
+        self.tokenReader = tokenReader
+        self.session = session
+    }
+
+    public func fetchUsage(configDirPath: String) async -> ProfileUsageFetchStatus {
+        let token: String?
+        do {
+            token = try await tokenReader.accessToken(forConfigDirPath: configDirPath)
+        } catch {
+            return .noCredentials("credential read failed: \(error)")
+        }
+        guard let token else {
+            return .noCredentials("no stored credential — needs /login")
+        }
+
+        guard let url = URL(string: "https://api.anthropic.com/api/oauth/usage") else {
+            return .networkError("invalid URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            return .networkError(error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            return .networkError("non-HTTP response")
+        }
+        guard http.statusCode == 200 else {
+            return .httpError(http.statusCode)
+        }
+        do {
+            return .ok(try ClaudeUsagePayloadParser.parseBuckets(from: data))
+        } catch {
+            return .decodeError("\(error)")
+        }
+    }
+}
+
+// MARK: - Payload parsing
+
+/// Defensive parser for the `/api/oauth/usage` response. The primary source
+/// is the `limits[]` array (each entry a `ClaudeUsageLimitBucket`); when the
+/// API omits it, the top-level `five_hour` / `seven_day` windows are
+/// synthesized into `session` / `weekly_all` buckets so older response shapes
+/// still yield data. Malformed individual entries are skipped, unknown kinds
+/// flow through, absent buckets simply don't appear.
+public enum ClaudeUsagePayloadParser {
+
+    public struct ParseError: Error, CustomStringConvertible {
+        public let description: String
+    }
+
+    public static func parseBuckets(from data: Data) throws -> [ClaudeUsageLimitBucket] {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let payload: RawPayload
+        do {
+            payload = try decoder.decode(RawPayload.self, from: data)
+        } catch {
+            throw ParseError(description: "usage payload not decodable: \(error)")
+        }
+
+        if let limits = payload.limits, !limits.isEmpty {
+            let buckets = limits.compactMap { raw -> ClaudeUsageLimitBucket? in
+                guard let kind = raw.kind, let percent = raw.percent else { return nil }
+                return ClaudeUsageLimitBucket(
+                    kind: kind,
+                    group: raw.group,
+                    percent: percent,
+                    severity: raw.severity,
+                    resetsAt: parseResetDate(raw.resetsAt),
+                    modelDisplayName: raw.scope?.model?.displayName,
+                    isActive: raw.isActive
+                )
+            }
+            if !buckets.isEmpty { return buckets }
+        }
+
+        // Fallback: synthesize from the legacy top-level windows. Utilization
+        // is passed through on the API's own scale (0–100 on current
+        // responses).
+        var fallback: [ClaudeUsageLimitBucket] = []
+        if let window = payload.fiveHour, let pct = window.utilization {
+            fallback.append(ClaudeUsageLimitBucket(
+                kind: "session", group: "session", percent: pct,
+                resetsAt: parseResetDate(window.resetsAt)))
+        }
+        if let window = payload.sevenDay, let pct = window.utilization {
+            fallback.append(ClaudeUsageLimitBucket(
+                kind: "weekly_all", group: "weekly", percent: pct,
+                resetsAt: parseResetDate(window.resetsAt)))
+        }
+        guard !fallback.isEmpty else {
+            throw ParseError(description: "usage payload contains no limits and no five_hour/seven_day windows")
+        }
+        return fallback
+    }
+
+    /// Parse an API timestamp like "2026-07-04T01:10:00.245613+00:00".
+    /// Tries fractional-second ISO 8601 first, then plain ISO 8601.
+    /// nil in / unparseable → nil out (bucket keeps a nil reset).
+    public static func parseResetDate(_ string: String?) -> Date? {
+        guard let string else { return nil }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: string) { return date }
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        return plain.date(from: string)
+    }
+
+    // MARK: Raw decodable shapes (everything optional — parse defensively)
+
+    private struct RawPayload: Decodable {
+        struct RawWindow: Decodable {
+            let utilization: Double?
+            let resetsAt: String?
+        }
+        struct RawModel: Decodable {
+            let displayName: String?
+        }
+        struct RawScope: Decodable {
+            let model: RawModel?
+        }
+        struct RawLimit: Decodable {
+            let kind: String?
+            let group: String?
+            let percent: Double?
+            let severity: String?
+            let resetsAt: String?
+            let scope: RawScope?
+            let isActive: Bool?
+        }
+        let fiveHour: RawWindow?
+        let sevenDay: RawWindow?
+        let limits: [RawLimit]?
+    }
+}

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -61,6 +61,7 @@ public final class Daemon: Sendable {
     public nonisolated(unsafe) var gitStatusTask: Task<Void, Never>?
     public nonisolated(unsafe) var reaperTask: Task<Void, Never>?
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
+    public nonisolated(unsafe) var oauthUsagePoller: OAuthProfileUsagePoller?
     /// Per-daemon tmux control-mode supervisor. Owned here so it can be stopped
     /// on shutdown; the gate (`ControlModeGate.shouldEnable`) keeps it dormant
     /// unless `TBD_TMUX_CONTROL_MODE` is opted in and tmux is ≥ 3.2.
@@ -450,6 +451,20 @@ public final class Daemon: Sendable {
             rpcRouter.claudeUsagePoller = poller
             await poller.start()
 
+            // 12c. Start per-profile OAuth usage poller (90s cadence,
+            // in-memory snapshots for the spawn-time account picker).
+            let configDirManager = rpcRouter.configDirManager
+            let oauthPoller = OAuthProfileUsagePoller(
+                profilesProvider: { [database] in try await database.modelProfiles.list() },
+                loginIdentity: { id in configDirManager.loginIdentity(forProfileID: id) },
+                configDirPath: { id in configDirManager.configDirectory(forProfileID: id).path },
+                fetcher: LiveProfileUsageFetcher(),
+                broadcast: { [weak subs] in subs?.broadcast(delta: .modelProfilesChanged) }
+            )
+            self.oauthUsagePoller = oauthPoller
+            rpcRouter.oauthUsagePoller = oauthPoller
+            await oauthPoller.start()
+
             // 13. Periodic git status refresh (branch sync, conflict detection)
             self.gitStatusTask = Task {
                 // Run once immediately (cold recovery), then every 10s
@@ -475,8 +490,11 @@ public final class Daemon: Sendable {
     public func stop() async {
         daemonLogger.info("Shutting down...")
 
-        // Stop Claude usage poller before other background tasks.
+        // Stop Claude usage pollers before other background tasks.
         if let poller = claudeUsagePoller {
+            await poller.stop()
+        }
+        if let poller = oauthUsagePoller {
             await poller.stop()
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -29,6 +29,7 @@ extension RPCRouter {
     func handleModelProfileList() async throws -> RPCResponse {
         let profiles = try await db.modelProfiles.list()
         let usageByID = try await db.modelProfileUsage.fetchAll()
+        let oauthSnapshots = await oauthUsagePoller?.allSnapshots() ?? [:]
         let result = profiles.map { profile -> ModelProfileWithUsage in
             // Bedrock profiles have no isolated config dir; everything else
             // gets one at ~/tbd/profiles/<uuid>/claude. loginIdentity is only
@@ -45,7 +46,8 @@ extension RPCRouter {
                 profile: profile,
                 usage: usageByID[profile.id],
                 loginIdentity: loginIdentity,
-                configDirPath: configDirPath
+                configDirPath: configDirPath,
+                usageSnapshot: oauthSnapshots[profile.id]
             )
         }
         let config = try await db.config.get()
@@ -398,6 +400,25 @@ extension RPCRouter {
         case .decodeError(let msg):
             return RPCResponse(error: "Decode error: \(msg)")
         }
+    }
+
+    // MARK: - Usage Refresh (forced sweep of the in-memory OAuth usage poller)
+
+    /// `modelProfile.usageRefresh` — force a fresh usage sweep for all
+    /// logged-in OAuth profiles (params.id == nil) or one profile, and return
+    /// the post-sweep snapshots. The spawn-time account picker calls this on
+    /// open; background staleness is otherwise bounded by the poller cadence.
+    /// The poller broadcasts `.modelProfilesChanged` itself when data changes.
+    func handleModelProfileUsageRefresh(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ModelProfileUsageRefreshParams.self, from: paramsData)
+        guard let poller = oauthUsagePoller else {
+            return RPCResponse(error: "OAuth usage poller is not running (mock mode or startup)")
+        }
+        let snapshots = await poller.sweepNow(profileID: params.id)
+        let entries = snapshots
+            .map { ModelProfileUsageSnapshotEntry(profileID: $0.key, snapshot: $0.value) }
+            .sorted { $0.profileID.uuidString < $1.profileID.uuidString }
+        return try RPCResponse(result: ModelProfileUsageRefreshResult(snapshots: entries))
     }
 
     // MARK: - Health Check

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -18,6 +18,10 @@ public final class RPCRouter: Sendable {
     public let usageFetcher: ClaudeUsageFetcher
     public let modelProfileResolver: ModelProfileResolver
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
+    /// In-memory per-profile OAuth usage poller. Wired post-construction by
+    /// Daemon.swift (mirrors `claudeUsagePoller`); nil in unit tests / mock
+    /// mode, where usage snapshots are simply absent.
+    public nonisolated(unsafe) var oauthUsagePoller: OAuthProfileUsagePoller?
     /// Live connected-client count, supplied by the SocketServer after it is
     /// constructed (the router is built first in Daemon.swift, so it cannot
     /// take the server as an init dependency). Mirrors `claudeUsagePoller`
@@ -256,6 +260,8 @@ public final class RPCRouter: Sendable {
                 return try await handleModelProfileSetEnvOverrides(request.paramsData)
             case RPCMethod.modelProfileFetchUsage:
                 return try await handleModelProfileFetchUsage(request.paramsData)
+            case RPCMethod.modelProfileUsageRefresh:
+                return try await handleModelProfileUsageRefresh(request.paramsData)
             case RPCMethod.modelProfileHealthCheck:
                 return try await handleModelProfileHealthCheck(request.paramsData)
             case RPCMethod.modelProfilePrepareConfigDir:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -428,6 +428,70 @@ public struct ModelProfileUsage: Codable, Sendable, Equatable {
     }
 }
 
+/// One rate-limit bucket from the Claude OAuth usage API's `limits[]` array
+/// (`GET https://api.anthropic.com/api/oauth/usage`). Captured as data —
+/// unknown `kind` values flow through untouched so new API buckets appear
+/// without a code change.
+///
+/// Observed kinds (2026-07): `session` (5-hour window), `weekly_all`
+/// (weekly, all models), `weekly_scoped` (weekly, one model family —
+/// `modelDisplayName` carries the family label, e.g. "Fable").
+public struct ClaudeUsageLimitBucket: Codable, Sendable, Equatable {
+    /// Bucket identifier as the API names it (`session`, `weekly_all`,
+    /// `weekly_scoped`, or a future kind).
+    public var kind: String
+    /// Grouping label from the API (`session`, `weekly`). nil if absent.
+    public var group: String?
+    /// Utilization percent on a 0–100 scale.
+    public var percent: Double
+    /// Severity label from the API (`normal`, `warning`, `critical`). nil if absent.
+    public var severity: String?
+    /// When this window resets. nil when the API sends null (e.g. an unused
+    /// scoped bucket).
+    public var resetsAt: Date?
+    /// For scoped buckets: `scope.model.display_name` (e.g. "Fable").
+    /// nil = bucket is not model-scoped.
+    public var modelDisplayName: String?
+    /// The API's `is_active` flag (which limit is currently binding). nil if absent.
+    public var isActive: Bool?
+
+    public init(kind: String, group: String? = nil, percent: Double,
+                severity: String? = nil, resetsAt: Date? = nil,
+                modelDisplayName: String? = nil, isActive: Bool? = nil) {
+        self.kind = kind
+        self.group = group
+        self.percent = percent
+        self.severity = severity
+        self.resetsAt = resetsAt
+        self.modelDisplayName = modelDisplayName
+        self.isActive = isActive
+    }
+}
+
+/// In-memory per-profile usage snapshot for logged-in OAuth profiles,
+/// maintained by the daemon's background poller (never persisted).
+public struct ProfileUsageSnapshot: Codable, Sendable, Equatable {
+    /// Buckets from the last successful fetch (empty if none succeeded yet).
+    public var buckets: [ClaudeUsageLimitBucket]
+    /// When the buckets were last successfully fetched. nil = never.
+    public var fetchedAt: Date?
+    /// When a fetch was last attempted (success or failure).
+    public var lastAttemptAt: Date
+    /// "ok", or a failure description like
+    /// "stale since 2026-07-03T18:00:00Z; fetch failed: HTTP 401".
+    public var status: String
+
+    public init(buckets: [ClaudeUsageLimitBucket], fetchedAt: Date? = nil,
+                lastAttemptAt: Date, status: String) {
+        self.buckets = buckets
+        self.fetchedAt = fetchedAt
+        self.lastAttemptAt = lastAttemptAt
+        self.status = status
+    }
+
+    public var isOK: Bool { status == "ok" }
+}
+
 public struct ModelProfileWithUsage: Codable, Sendable, Equatable {
     public let profile: ModelProfile
     public let usage: ModelProfileUsage?
@@ -441,12 +505,19 @@ public struct ModelProfileWithUsage: Codable, Sendable, Equatable {
     /// (`~/tbd/profiles/<lowercased-uuid>/claude`). nil for bedrock profiles
     /// (no config-dir isolation) or an older daemon that doesn't send the field.
     public let configDirPath: String?
+    /// Cached per-profile usage snapshot from the daemon's in-memory OAuth
+    /// usage poller. Non-nil only for logged-in `.oauth` profiles once the
+    /// poller has attempted a fetch. nil = non-oauth kind, not logged in, or
+    /// an older daemon that doesn't send the field.
+    public let usageSnapshot: ProfileUsageSnapshot?
     public init(profile: ModelProfile, usage: ModelProfileUsage? = nil,
-                loginIdentity: String? = nil, configDirPath: String? = nil) {
+                loginIdentity: String? = nil, configDirPath: String? = nil,
+                usageSnapshot: ProfileUsageSnapshot? = nil) {
         self.profile = profile
         self.usage = usage
         self.loginIdentity = loginIdentity
         self.configDirPath = configDirPath
+        self.usageSnapshot = usageSnapshot
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -133,6 +133,7 @@ public enum RPCMethod {
     public static let modelProfileSetPrimaryAgentPreference = "modelProfile.setPrimaryAgentPreference"
     public static let modelProfileSetRepoOverride = "modelProfile.setRepoOverride"
     public static let modelProfileFetchUsage = "modelProfile.fetchUsage"
+    public static let modelProfileUsageRefresh = "modelProfile.usageRefresh"
     public static let modelProfileHealthCheck = "modelProfile.healthCheck"
     public static let modelProfilePrepareConfigDir = "modelProfile.prepareConfigDir"
     public static let terminalSwapProfile = "terminal.swapProfile"
@@ -474,6 +475,34 @@ public struct ModelProfileListResult: Codable, Sendable {
 public struct ModelProfileFetchUsageResult: Codable, Sendable {
     public let usage: ModelProfileUsage
     public init(usage: ModelProfileUsage) { self.usage = usage }
+}
+
+/// Params for `modelProfile.usageRefresh` — force an immediate usage sweep of
+/// the daemon's in-memory OAuth usage poller (the picker dialog calls this on
+/// open). `id == nil` refreshes every logged-in OAuth profile; a non-nil id
+/// refreshes just that profile.
+public struct ModelProfileUsageRefreshParams: Codable, Sendable {
+    public let id: UUID?
+    public init(id: UUID? = nil) { self.id = id }
+}
+
+public struct ModelProfileUsageSnapshotEntry: Codable, Sendable, Equatable {
+    public let profileID: UUID
+    public let snapshot: ProfileUsageSnapshot
+    public init(profileID: UUID, snapshot: ProfileUsageSnapshot) {
+        self.profileID = profileID
+        self.snapshot = snapshot
+    }
+}
+
+public struct ModelProfileUsageRefreshResult: Codable, Sendable {
+    /// Post-sweep snapshots. All logged-in OAuth profiles when params.id was
+    /// nil; at most the one requested profile otherwise (empty when that
+    /// profile is not an eligible logged-in OAuth profile).
+    public let snapshots: [ModelProfileUsageSnapshotEntry]
+    public init(snapshots: [ModelProfileUsageSnapshotEntry]) {
+        self.snapshots = snapshots
+    }
 }
 
 public struct ModelProfileHealthCheckParams: Codable, Sendable {

--- a/Tests/TBDAppTests/AccountHoverCardsTests.swift
+++ b/Tests/TBDAppTests/AccountHoverCardsTests.swift
@@ -1,0 +1,282 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// MARK: - Fixtures
+
+private let utc = TimeZone(identifier: "UTC")!
+
+/// 2026-07-03 23:10:00 UTC — renders as "23:10" in the UTC fixtures below.
+private let resetDate: Date = {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 7
+    components.day = 3
+    components.hour = 23
+    components.minute = 10
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = utc
+    return calendar.date(from: components)!
+}()
+
+private func bucket(kind: String, percent: Double, severity: String? = nil,
+                    resetsAt: Date? = nil, family: String? = nil) -> ClaudeUsageLimitBucket {
+    ClaudeUsageLimitBucket(kind: kind, percent: percent, severity: severity,
+                           resetsAt: resetsAt, modelDisplayName: family)
+}
+
+private func snapshot(buckets: [ClaudeUsageLimitBucket]) -> ProfileUsageSnapshot {
+    ProfileUsageSnapshot(buckets: buckets, fetchedAt: Date(),
+                         lastAttemptAt: Date(), status: "ok")
+}
+
+private func entry(id: UUID = UUID(),
+                   name: String,
+                   loginIdentity: String? = nil,
+                   usageSnapshot: ProfileUsageSnapshot? = nil) -> ModelProfileWithUsage {
+    ModelProfileWithUsage(
+        profile: ModelProfile(id: id, name: name, kind: .oauth),
+        usage: nil,
+        loginIdentity: loginIdentity,
+        usageSnapshot: usageSnapshot
+    )
+}
+
+private func claudeTerminal(profileID: UUID? = nil,
+                            createdAt: Date = Date(timeIntervalSince1970: 0),
+                            kind: TerminalKind? = .claude) -> Terminal {
+    Terminal(worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+             createdAt: createdAt, profileID: profileID, kind: kind)
+}
+
+/// The live-verified Gmail shape: 5h 0% resetting 23:10, weekly 76%, Fable 100%.
+private let gmailSnapshot = snapshot(buckets: [
+    bucket(kind: "session", percent: 0, severity: "normal", resetsAt: resetDate),
+    bucket(kind: "weekly_all", percent: 76, severity: "warning"),
+    bucket(kind: "weekly_scoped", percent: 100, severity: "critical", family: "Fable"),
+])
+
+// MARK: - Worktree row card
+
+@Suite("AccountHoverCards — worktree row")
+struct WorktreeCardTests {
+    @Test func noClaudeSessionsMeansNoCard() {
+        let shell = claudeTerminal(kind: .shell)
+        #expect(AccountHoverCards.worktreeCard(terminals: [shell], profiles: []) == nil)
+        #expect(AccountHoverCards.worktreeCard(terminals: [], profiles: []) == nil)
+    }
+
+    @Test func titleAndOneRowPerAccount() {
+        let work = entry(name: "Work", loginIdentity: "a@b.co")
+        let personal = entry(name: "Personal", loginIdentity: "p@q.io")
+        let terminals = [
+            claudeTerminal(profileID: work.profile.id),
+            claudeTerminal(profileID: personal.profile.id),
+        ]
+        let card = AccountHoverCards.worktreeCard(terminals: terminals,
+                                                  profiles: [work, personal])
+        #expect(card?.title == "Claude accounts")
+        #expect(card?.rows.count == 2)
+        #expect(card?.rows[0] == HoverCardRow(value: "a@b.co", chip: "Work"))
+        #expect(card?.rows[1] == HoverCardRow(value: "p@q.io", chip: "Personal"))
+    }
+
+    @Test func duplicateAccountsAreDedupedInTabOrder() {
+        let work = entry(name: "Work", loginIdentity: "a@b.co")
+        let terminals = [
+            claudeTerminal(profileID: work.profile.id),
+            claudeTerminal(profileID: work.profile.id),
+            claudeTerminal(profileID: nil),
+            claudeTerminal(profileID: nil),
+        ]
+        let card = AccountHoverCards.worktreeCard(terminals: terminals, profiles: [work])
+        #expect(card?.rows.count == 2)
+        #expect(card?.rows[0].value == "a@b.co")
+        #expect(card?.rows[1].value == AccountHoverCards.ambientAccountLabel)
+    }
+
+    @Test func ambientRowIsMutedItalicWithDriftCaption() {
+        let row = AccountHoverCards.accountRow(profileID: nil, profiles: [])
+        #expect(row.value == "ambient (terminal login)")
+        #expect(row.valueStyle == .mutedItalic)
+        #expect(row.caption == AccountHoverCards.ambientDriftCaption)
+        #expect(row.chip == nil)
+    }
+
+    @Test func removedProfileRowIsMutedItalicWithCaption() {
+        let row = AccountHoverCards.accountRow(profileID: UUID(), profiles: [])
+        #expect(row.value == AccountHoverCards.removedProfileLabel)
+        #expect(row.valueStyle == .mutedItalic)
+        #expect(row.caption == AccountHoverCards.removedProfileCaption)
+    }
+
+    @Test func notLoggedInProfileRowShowsNameWithCaption() {
+        let pending = entry(name: "Staging", loginIdentity: nil)
+        let row = AccountHoverCards.accountRow(profileID: pending.profile.id,
+                                               profiles: [pending])
+        #expect(row.value == "Staging")
+        #expect(row.chip == nil)
+        #expect(row.caption == AccountHoverCards.notLoggedInCaption)
+        #expect(row.valueStyle == .plain)
+    }
+}
+
+// MARK: - Claude tab card
+
+@Suite("AccountHoverCards — Claude tab")
+struct ClaudeTabCardTests {
+    @Test func nonClaudeTerminalsGetNoCard() {
+        #expect(AccountHoverCards.claudeTabCard(terminal: claudeTerminal(kind: .shell),
+                                                profiles: []) == nil)
+        #expect(AccountHoverCards.claudeTabCard(terminal: claudeTerminal(kind: .codex),
+                                                profiles: []) == nil)
+    }
+
+    @Test func pinnedLoggedInCardHasEmailTitleProfileUsageAndSpawnRows() {
+        let gmail = entry(name: "Gmail", loginIdentity: "g@gmail.com",
+                          usageSnapshot: gmailSnapshot)
+        let terminal = claudeTerminal(profileID: gmail.profile.id,
+                                      createdAt: resetDate)
+        let card = AccountHoverCards.claudeTabCard(terminal: terminal,
+                                                   profiles: [gmail], timeZone: utc)
+        #expect(card?.title == "g@gmail.com")
+        #expect(card?.titleStyle == .plain)
+        let rows = card?.rows ?? []
+        #expect(rows.count == 5)
+        #expect(rows[0] == HoverCardRow(label: "Profile", value: "Gmail"))
+        #expect(rows[1] == HoverCardRow(label: "5h window", value: "0% · resets 23:10",
+                                        monospacedDigits: true, tint: .normal))
+        #expect(rows[2] == HoverCardRow(label: "Week", value: "76%",
+                                        monospacedDigits: true, tint: .warning))
+        #expect(rows[3] == HoverCardRow(label: "Fable", value: "100%",
+                                        monospacedDigits: true, tint: .critical))
+        #expect(rows[4] == HoverCardRow(label: "Spawned", value: "2026-07-03 23:10",
+                                        monospacedDigits: true))
+    }
+
+    @Test func ambientCardHasMutedTitleAndDriftCaptionAndNoUsage() {
+        let card = AccountHoverCards.claudeTabCard(terminal: claudeTerminal(),
+                                                   profiles: [], timeZone: utc)
+        #expect(card?.title == AccountHoverCards.ambientAccountLabel)
+        #expect(card?.titleStyle == .mutedItalic)
+        #expect(card?.titleCaption == AccountHoverCards.ambientDriftCaption)
+        // Only the spawn row — ambient sessions have no pinned usage to show.
+        #expect(card?.rows.count == 1)
+        #expect(card?.rows.first?.label == "Spawned")
+        #expect(card?.rows.first?.value == "1970-01-01 00:00")
+    }
+
+    @Test func removedProfileCardKeepsSpawnRow() {
+        let card = AccountHoverCards.claudeTabCard(terminal: claudeTerminal(profileID: UUID()),
+                                                   profiles: [], timeZone: utc)
+        #expect(card?.title == AccountHoverCards.removedProfileLabel)
+        #expect(card?.titleStyle == .mutedItalic)
+        #expect(card?.titleCaption == AccountHoverCards.removedProfileCaption)
+        #expect(card?.rows.count == 1)
+        #expect(card?.rows.first?.label == "Spawned")
+    }
+
+    @Test func notLoggedInPinnedProfileTitlesByProfileName() {
+        let pending = entry(name: "Staging", loginIdentity: "  ")
+        let card = AccountHoverCards.claudeTabCard(
+            terminal: claudeTerminal(profileID: pending.profile.id),
+            profiles: [pending], timeZone: utc
+        )
+        #expect(card?.title == "Staging")
+        #expect(card?.titleCaption == AccountHoverCards.notLoggedInCaption)
+        // No Profile row (the title IS the profile), no usage rows.
+        #expect(card?.rows.map(\.label) == ["Spawned"])
+    }
+
+    @Test func profileWithoutSnapshotGetsNoUsageRows() {
+        let work = entry(name: "Work", loginIdentity: "a@b.co", usageSnapshot: nil)
+        let card = AccountHoverCards.claudeTabCard(
+            terminal: claudeTerminal(profileID: work.profile.id),
+            profiles: [work], timeZone: utc
+        )
+        #expect(card?.rows.map(\.label) == ["Profile", "Spawned"])
+    }
+}
+
+// MARK: - Usage rows
+
+@Suite("AccountHoverCards — usage rows")
+struct UsageRowsTests {
+    @Test func emptySnapshotYieldsNoRows() {
+        #expect(AccountHoverCards.usageRows(for: nil).isEmpty)
+        #expect(AccountHoverCards.usageRows(for: snapshot(buckets: [])).isEmpty)
+    }
+
+    @Test func sessionRowOmitsResetWhenAbsent() {
+        let rows = AccountHoverCards.usageRows(
+            for: snapshot(buckets: [bucket(kind: "session", percent: 42)]),
+            timeZone: utc
+        )
+        #expect(rows == [HoverCardRow(label: "5h window", value: "42%",
+                                      monospacedDigits: true, tint: .normal)])
+    }
+
+    @Test func allUsageValuesUseMonospacedDigits() {
+        let rows = AccountHoverCards.usageRows(for: gmailSnapshot, timeZone: utc)
+        #expect(!rows.isEmpty)
+        #expect(rows.allSatisfy { $0.monospacedDigits })
+    }
+
+    @Test func tintIsCalmForNormalAndColoredOnlyForWarningCritical() {
+        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 10,
+                                                   severity: "normal")) == .normal)
+        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 80,
+                                                   severity: "warning")) == .warning)
+        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 99,
+                                                   severity: "critical")) == .critical)
+        // API omitted severity: falls back to percent thresholds.
+        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 10)) == .normal)
+        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 92)) == .critical)
+    }
+
+    @Test func scopedBucketWithoutFamilyNameFallsBackToModelLabel() {
+        let rows = AccountHoverCards.usageRows(
+            for: snapshot(buckets: [bucket(kind: "weekly_scoped", percent: 50)]),
+            timeZone: utc
+        )
+        #expect(rows.first?.label == "Model")
+    }
+}
+
+// MARK: - Hover timing
+
+@Suite("HoverCardTiming — warm-state show delay")
+struct HoverCardTimingTests {
+    private let timing = HoverCardTiming(showDelay: 0.35, warmGrace: 0.35,
+                                         fadeOutDuration: 0.12)
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000)
+
+    @Test func coldHoverWaitsTheFullShowDelay() {
+        #expect(timing.effectiveShowDelay(now: now, lastDismissedAt: nil,
+                                          isCardVisible: false) == 0.35)
+    }
+
+    @Test func visibleCardSwapsInstantly() {
+        #expect(timing.effectiveShowDelay(now: now, lastDismissedAt: nil,
+                                          isCardVisible: true) == 0)
+    }
+
+    @Test func recentDismissalIsWarmAndSkipsTheDelay() {
+        let justDismissed = now.addingTimeInterval(-0.2)
+        #expect(timing.effectiveShowDelay(now: now, lastDismissedAt: justDismissed,
+                                          isCardVisible: false) == 0)
+    }
+
+    @Test func staleDismissalIsColdAgain() {
+        let longAgo = now.addingTimeInterval(-1.0)
+        #expect(timing.effectiveShowDelay(now: now, lastDismissedAt: longAgo,
+                                          isCardVisible: false) == 0.35)
+    }
+
+    @Test func standardTimingIsFastButNotFlickery() {
+        #expect(HoverCardTiming.standard.showDelay > 0.1)
+        #expect(HoverCardTiming.standard.showDelay <= 0.5)
+        #expect(HoverCardTiming.standard.fadeOutDuration < HoverCardTiming.standard.showDelay)
+    }
+}

--- a/Tests/TBDAppTests/AddTabMenuTests.swift
+++ b/Tests/TBDAppTests/AddTabMenuTests.swift
@@ -10,22 +10,26 @@ import TBDShared
 private func makeProfile(
     name: String,
     kind: CredentialKind = .oauth,
-    loginIdentity: String? = nil
+    loginIdentity: String? = nil,
+    usageSnapshot: ProfileUsageSnapshot? = nil
 ) -> ModelProfileWithUsage {
     ModelProfileWithUsage(
         profile: ModelProfile(id: UUID(), name: name, kind: kind),
         usage: nil,
-        loginIdentity: loginIdentity
+        loginIdentity: loginIdentity,
+        usageSnapshot: usageSnapshot
     )
 }
 
 private func makeCoordinator(
-    onClaudeProfile: @escaping (UUID) -> Void = { _ in }
+    onClaudeProfile: @escaping (UUID) -> Void = { _ in },
+    onChooseAccount: @escaping () -> Void = {}
 ) -> MenuCoordinator {
     MenuCoordinator(
         onShell: {},
         onClaude: {},
         onClaudeProfile: onClaudeProfile,
+        onChooseAccount: onChooseAccount,
         onCodex: {},
         onNote: {}
     )
@@ -75,7 +79,9 @@ private func makeExecutable(named name: String, in directory: URL) throws {
     let menu = AddTabMenu.build(profiles: [], coordinator: makeCoordinator())
 
     let idx = claudeIndex(menu)
-    #expect(menu.items[idx + 1].title == "Codex")
+    // "Choose account…" always follows the (empty) profile block.
+    #expect(menu.items[idx + 1].title == "Choose account…")
+    #expect(menu.items[idx + 2].title == "Codex")
     #expect(menu.items.allSatisfy { $0.indentationLevel == 0 })
 }
 
@@ -132,7 +138,8 @@ private func makeExecutable(named name: String, in directory: URL) throws {
     #expect(second.image != nil)
     #expect(second.representedObject as? UUID == personal.profile.id)
 
-    #expect(menu.items[idx + 3].title == "Codex")
+    #expect(menu.items[idx + 3].title == "Choose account…")
+    #expect(menu.items[idx + 4].title == "Codex")
 }
 
 @MainActor
@@ -179,6 +186,58 @@ private func makeExecutable(named name: String, in directory: URL) throws {
 
     let item = menu.items[claudeIndex(menu) + 1]
     #expect(item.action == #selector(MenuCoordinator.addClaudeProfile(_:)))
+}
+
+@MainActor
+@Test func addTabMenu_profileItemTitles_carryCompactUsageSuffix() {
+    // A profile with a usage snapshot gets the compact suffix; one without
+    // keeps its plain identity title. (No resetsAt in the fixture so the
+    // expected string is timezone-independent.)
+    let snapshot = ProfileUsageSnapshot(
+        buckets: [
+            ClaudeUsageLimitBucket(kind: "session", percent: 0, severity: "normal"),
+            ClaudeUsageLimitBucket(kind: "weekly_all", percent: 76, severity: "warning"),
+            ClaudeUsageLimitBucket(kind: "weekly_scoped", percent: 100,
+                                   severity: "critical", modelDisplayName: "Fable"),
+        ],
+        fetchedAt: Date(), lastAttemptAt: Date(), status: "ok"
+    )
+    let gmail = makeProfile(name: "Gmail", loginIdentity: "g@x.co", usageSnapshot: snapshot)
+    let bare = makeProfile(name: "Work", loginIdentity: "a@b.co")
+    let menu = AddTabMenu.build(profiles: [gmail, bare], coordinator: makeCoordinator())
+
+    let idx = claudeIndex(menu)
+    #expect(menu.items[idx + 1].title == "Gmail — g@x.co · 5h 0% · wk 76% · F 100%")
+    #expect(menu.items[idx + 2].title == "Work — a@b.co")
+}
+
+@MainActor
+@Test func addTabMenu_whenClaudeUnavailable_omitsChooseAccount() {
+    let menu = AddTabMenu.build(
+        profiles: [makeProfile(name: "Work")],
+        availability: AgentExecutableAvailability(claude: false, codex: true),
+        coordinator: makeCoordinator()
+    )
+    #expect(menu.items.contains { $0.title == "Choose account…" } == false)
+}
+
+@MainActor
+@Test func addTabMenu_chooseAccountItem_isWiredToCoordinator() {
+    let coordinator = makeCoordinator()
+    let menu = AddTabMenu.build(profiles: [], coordinator: coordinator)
+
+    let item = menu.items.first { $0.title == "Choose account…" }!
+    #expect(item.action == #selector(MenuCoordinator.chooseAccount))
+    #expect(item.target as? MenuCoordinator === coordinator)
+    #expect(item.image != nil)   // blank icon keeps title-column alignment
+}
+
+@MainActor
+@Test func menuCoordinator_chooseAccount_forwardsToClosure() {
+    var called = false
+    let coordinator = makeCoordinator(onChooseAccount: { called = true })
+    coordinator.chooseAccount()
+    #expect(called)
 }
 
 // MARK: - MenuCoordinator.addClaudeProfile

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -1,0 +1,395 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// MARK: - Fixtures
+
+private let utc = TimeZone(identifier: "UTC")!
+
+/// 2026-07-03 23:10:00 UTC — renders as "23:10" in the UTC fixtures below.
+private let resetDate: Date = {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 7
+    components.day = 3
+    components.hour = 23
+    components.minute = 10
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = utc
+    return calendar.date(from: components)!
+}()
+
+private func bucket(kind: String, percent: Double, severity: String? = nil,
+                    resetsAt: Date? = nil, family: String? = nil) -> ClaudeUsageLimitBucket {
+    ClaudeUsageLimitBucket(kind: kind, percent: percent, severity: severity,
+                           resetsAt: resetsAt, modelDisplayName: family)
+}
+
+private func snapshot(buckets: [ClaudeUsageLimitBucket],
+                      fetchedAt: Date? = Date(),
+                      status: String = "ok") -> ProfileUsageSnapshot {
+    ProfileUsageSnapshot(buckets: buckets, fetchedAt: fetchedAt,
+                         lastAttemptAt: Date(), status: status)
+}
+
+private func entry(name: String,
+                   kind: CredentialKind = .oauth,
+                   loginIdentity: String? = nil,
+                   usageSnapshot: ProfileUsageSnapshot? = nil) -> ModelProfileWithUsage {
+    ModelProfileWithUsage(
+        profile: ModelProfile(id: UUID(), name: name, kind: kind),
+        usage: nil,
+        loginIdentity: loginIdentity,
+        usageSnapshot: usageSnapshot
+    )
+}
+
+/// The live-verified Gmail shape: 5h 0% resetting 23:10, weekly 76%, Fable 100%.
+private let gmailSnapshot = snapshot(buckets: [
+    bucket(kind: "session", percent: 0, severity: "normal", resetsAt: resetDate),
+    bucket(kind: "weekly_all", percent: 76, severity: "warning"),
+    bucket(kind: "weekly_scoped", percent: 100, severity: "critical", family: "Fable"),
+])
+
+private func claudeTerminal(profileID: UUID? = nil,
+                            createdAt: Date = Date(timeIntervalSince1970: 0),
+                            kind: TerminalKind? = .claude,
+                            claudeSessionID: String? = nil) -> Terminal {
+    Terminal(worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+             createdAt: createdAt, claudeSessionID: claudeSessionID,
+             profileID: profileID, kind: kind)
+}
+
+// MARK: - Usage suffix composition
+
+@Suite("ProfileUsagePresentation — menu suffix")
+struct UsageSuffixTests {
+    @Test func fullSnapshotComposesCompactSuffix() {
+        let suffix = ProfileUsagePresentation.usageSuffix(for: gmailSnapshot, timeZone: utc)
+        #expect(suffix == " · 5h 0% ↺23:10 · wk 76% · F 100%")
+    }
+
+    @Test func missingSnapshotProducesEmptySuffix() {
+        #expect(ProfileUsagePresentation.usageSuffix(for: nil) == "")
+    }
+
+    @Test func emptyBucketsProduceEmptySuffix() {
+        #expect(ProfileUsagePresentation.usageSuffix(for: snapshot(buckets: [])) == "")
+    }
+
+    @Test func missingScopedBucketOmitsFamilySegment() {
+        // No data for the family on this account → segment absent, not "F 0%".
+        let noFable = snapshot(buckets: [
+            bucket(kind: "session", percent: 19),
+            bucket(kind: "weekly_all", percent: 24),
+        ])
+        #expect(ProfileUsagePresentation.usageSuffix(for: noFable, timeZone: utc)
+                == " · 5h 19% · wk 24%")
+    }
+
+    @Test func sessionWithoutResetOmitsClockFragment() {
+        let noReset = snapshot(buckets: [bucket(kind: "session", percent: 29)])
+        #expect(ProfileUsagePresentation.usageSuffix(for: noReset, timeZone: utc) == " · 5h 29%")
+    }
+
+    @Test func percentsRoundToWholeNumbers() {
+        let fractional = snapshot(buckets: [bucket(kind: "session", percent: 75.6)])
+        #expect(ProfileUsagePresentation.usageSuffix(for: fractional, timeZone: utc) == " · 5h 76%")
+    }
+
+    @Test func menuItemTitleCombinesIdentityAndUsage() {
+        let gmail = entry(name: "Gmail", loginIdentity: "g@x.co", usageSnapshot: gmailSnapshot)
+        #expect(ProfileUsagePresentation.menuItemTitle(for: gmail, timeZone: utc)
+                == "Gmail — g@x.co · 5h 0% ↺23:10 · wk 76% · F 100%")
+    }
+
+    @Test func menuItemTitleWithoutSnapshotIsIdentityOnly() {
+        let bare = entry(name: "Work", loginIdentity: "a@b.co")
+        #expect(ProfileUsagePresentation.menuItemTitle(for: bare) == "Work — a@b.co")
+    }
+
+    @Test func familyAbbreviationTakesFirstLetterUppercased() {
+        #expect(ProfileUsagePresentation.familyAbbreviation("Fable") == "F")
+        #expect(ProfileUsagePresentation.familyAbbreviation("opus") == "O")
+        #expect(ProfileUsagePresentation.familyAbbreviation(nil) == "?")
+        #expect(ProfileUsagePresentation.familyAbbreviation("  ") == "?")
+    }
+}
+
+// MARK: - Severity mapping
+
+@Suite("ProfileUsagePresentation — severity")
+struct SeverityLevelTests {
+    @Test func apiSeverityLabelsMapDirectly() {
+        #expect(ProfileUsagePresentation.severityLevel(severity: "normal", percent: 99) == .normal)
+        #expect(ProfileUsagePresentation.severityLevel(severity: "warning", percent: 0) == .warning)
+        #expect(ProfileUsagePresentation.severityLevel(severity: "critical", percent: 0) == .critical)
+    }
+
+    @Test func missingSeverityFallsBackToPercentThresholds() {
+        #expect(ProfileUsagePresentation.severityLevel(severity: nil, percent: 10) == .normal)
+        #expect(ProfileUsagePresentation.severityLevel(severity: nil, percent: 75) == .warning)
+        #expect(ProfileUsagePresentation.severityLevel(severity: nil, percent: 90) == .critical)
+        // Unknown future label also falls through to percent.
+        #expect(ProfileUsagePresentation.severityLevel(severity: "exotic", percent: 100) == .critical)
+    }
+}
+
+// MARK: - Picker sort ordering
+
+@Suite("ProfileUsagePresentation — picker sort")
+struct PickerSortTests {
+    @Test func healthiestSessionWindowSortsFirst() {
+        let busy = entry(name: "Busy", loginIdentity: "b@x.co", usageSnapshot: snapshot(
+            buckets: [bucket(kind: "session", percent: 80)]))
+        let idle = entry(name: "Idle", loginIdentity: "i@x.co", usageSnapshot: snapshot(
+            buckets: [bucket(kind: "session", percent: 5)]))
+
+        let sorted = ProfileUsagePresentation.sortedForPicker([busy, idle])
+        #expect(sorted.map(\.profile.name) == ["Idle", "Busy"])
+    }
+
+    @Test func equalPercentTieBreaksOnSoonestReset() {
+        let later = entry(name: "Later", loginIdentity: "l@x.co", usageSnapshot: snapshot(
+            buckets: [bucket(kind: "session", percent: 20, resetsAt: resetDate.addingTimeInterval(3600))]))
+        let sooner = entry(name: "Sooner", loginIdentity: "s@x.co", usageSnapshot: snapshot(
+            buckets: [bucket(kind: "session", percent: 20, resetsAt: resetDate)]))
+
+        let sorted = ProfileUsagePresentation.sortedForPicker([later, sooner])
+        #expect(sorted.map(\.profile.name) == ["Sooner", "Later"])
+    }
+
+    @Test func snapshotlessLoggedInProfilesFollowDataBackedOnes() {
+        let noData = entry(name: "NoData", loginIdentity: "n@x.co")
+        let withData = entry(name: "WithData", loginIdentity: "w@x.co", usageSnapshot: snapshot(
+            buckets: [bucket(kind: "session", percent: 99)]))
+
+        let sorted = ProfileUsagePresentation.sortedForPicker([noData, withData])
+        #expect(sorted.map(\.profile.name) == ["WithData", "NoData"])
+    }
+
+    @Test func notLoggedInProfilesSortLastAndAreNotSelectable() {
+        let needsLogin = entry(name: "Spare")   // oauth, no identity
+        let loggedIn = entry(name: "Work", loginIdentity: "a@b.co")
+
+        let sorted = ProfileUsagePresentation.sortedForPicker([needsLogin, loggedIn])
+        #expect(sorted.map(\.profile.name) == ["Work", "Spare"])
+        #expect(ProfileUsagePresentation.isSelectable(needsLogin) == false)
+        #expect(ProfileUsagePresentation.isSelectable(loggedIn))
+    }
+
+    @Test func nonOAuthProfilesAreSelectableWithoutIdentity() {
+        // apiKey/bedrock profiles have no login concept — never disabled.
+        let proxy = entry(name: "Router", kind: .apiKey)
+        #expect(ProfileUsagePresentation.isSelectable(proxy))
+    }
+
+    @Test func equalRanksPreserveOriginalOrder() {
+        let first = entry(name: "First", loginIdentity: "f@x.co")
+        let second = entry(name: "Second", loginIdentity: "s@x.co")
+        let sorted = ProfileUsagePresentation.sortedForPicker([first, second])
+        #expect(sorted.map(\.profile.name) == ["First", "Second"])
+    }
+}
+
+// MARK: - Staleness
+
+@Suite("ProfileUsagePresentation — staleness")
+struct StalenessNoteTests {
+    @Test func freshHealthySnapshotHasNoNote() {
+        let now = Date()
+        let fresh = snapshot(buckets: [], fetchedAt: now.addingTimeInterval(-30))
+        #expect(ProfileUsagePresentation.stalenessNote(for: fresh, now: now) == nil)
+    }
+
+    @Test func failingSnapshotSurfacesDaemonStatusVerbatim() {
+        let status = "stale since 2026-07-03T18:00:00Z; fetch failed: HTTP 401"
+        let failing = snapshot(buckets: [], status: status)
+        #expect(ProfileUsagePresentation.stalenessNote(for: failing) == status)
+    }
+
+    @Test func neverFetchedSnapshotSaysNoDataYet() {
+        let never = snapshot(buckets: [], fetchedAt: nil)
+        #expect(ProfileUsagePresentation.stalenessNote(for: never) == "no usage data yet")
+    }
+
+    @Test func oldSnapshotReportsAgeInMinutes() {
+        let now = Date()
+        let old = snapshot(buckets: [], fetchedAt: now.addingTimeInterval(-600))
+        #expect(ProfileUsagePresentation.stalenessNote(for: old, now: now) == "updated 10m ago")
+    }
+
+    @Test func missingSnapshotHasNoNote() {
+        #expect(ProfileUsagePresentation.stalenessNote(for: nil) == nil)
+    }
+}
+
+// MARK: - Session tooltips
+
+@Suite("ProfileUsagePresentation — session tooltip")
+struct SessionTooltipTests {
+    @Test func pinnedLoggedInSessionShowsAccountUsageAndSpawnTime() {
+        let gmail = entry(name: "Gmail", loginIdentity: "g@x.co", usageSnapshot: gmailSnapshot)
+        let terminal = claudeTerminal(profileID: gmail.profile.id,
+                                      createdAt: resetDate)
+
+        let tooltip = ProfileUsagePresentation.sessionTooltip(
+            terminal: terminal, profiles: [gmail], timeZone: utc
+        )
+        #expect(tooltip == """
+        Account: g@x.co (Gmail)
+        Usage: 5h 0% ↺23:10 · wk 76% · F 100%
+        Spawned: 2026-07-03 23:10
+        """)
+    }
+
+    @Test func ambientSessionShowsDriftWarning() {
+        let terminal = claudeTerminal(profileID: nil, createdAt: resetDate,
+                                      kind: nil, claudeSessionID: "abc")
+        let tooltip = ProfileUsagePresentation.sessionTooltip(
+            terminal: terminal, profiles: [], timeZone: utc
+        )
+        #expect(tooltip == """
+        Account: ambient (terminal login)
+        May drift to a different account on token refresh
+        Spawned: 2026-07-03 23:10
+        """)
+    }
+
+    @Test func pinnedSessionWithoutSnapshotOmitsUsageLine() {
+        let work = entry(name: "Work", loginIdentity: "a@b.co")
+        let terminal = claudeTerminal(profileID: work.profile.id, createdAt: resetDate)
+        let tooltip = ProfileUsagePresentation.sessionTooltip(
+            terminal: terminal, profiles: [work], timeZone: utc
+        )
+        #expect(tooltip == "Account: a@b.co (Work)\nSpawned: 2026-07-03 23:10")
+    }
+
+    @Test func removedProfileIsCalledOut() {
+        let terminal = claudeTerminal(profileID: UUID())
+        let tooltip = ProfileUsagePresentation.sessionTooltip(terminal: terminal, profiles: [])
+        #expect(tooltip?.contains("profile removed — session keeps its spawn account") == true)
+    }
+
+    @Test func nonClaudeTerminalsHaveNoTooltip() {
+        let shell = claudeTerminal(kind: .shell)
+        let codex = claudeTerminal(kind: .codex, claudeSessionID: "x")
+        #expect(ProfileUsagePresentation.sessionTooltip(terminal: shell, profiles: []) == nil)
+        #expect(ProfileUsagePresentation.sessionTooltip(terminal: codex, profiles: []) == nil)
+    }
+
+    @Test func pinnedButNotLoggedInShowsProfileNameWithLoginState() {
+        let spare = entry(name: "Spare")   // oauth, nil identity
+        let terminal = claudeTerminal(profileID: spare.profile.id)
+        let tooltip = ProfileUsagePresentation.sessionTooltip(terminal: terminal, profiles: [spare])
+        #expect(tooltip?.contains("Account: Spare (not logged in)") == true)
+    }
+}
+
+// MARK: - Worktree row tooltip
+
+@Suite("ProfileUsagePresentation — worktree accounts tooltip")
+struct WorktreeAccountsTooltipTests {
+    @Test func aggregatesAndDedupesClaudeAccountsInOrder() {
+        let work = entry(name: "Work", loginIdentity: "a@b.co")
+        let terminals = [
+            claudeTerminal(profileID: work.profile.id),
+            claudeTerminal(profileID: nil, kind: nil, claudeSessionID: "legacy"),
+            claudeTerminal(profileID: work.profile.id),   // duplicate account
+            claudeTerminal(kind: .shell),                 // ignored
+        ]
+        let tooltip = ProfileUsagePresentation.worktreeAccountsTooltip(
+            terminals: terminals, profiles: [work]
+        )
+        #expect(tooltip == "Claude accounts: a@b.co (Work), ambient (terminal login)")
+    }
+
+    @Test func noClaudeSessionsMeansNoTooltip() {
+        let terminals = [claudeTerminal(kind: .shell)]
+        #expect(ProfileUsagePresentation.worktreeAccountsTooltip(terminals: terminals, profiles: []) == nil)
+    }
+}
+
+// MARK: - Snapshot merge (AppState)
+
+@Suite("AppState.mergingUsageSnapshots")
+struct MergingUsageSnapshotsTests {
+    @Test func mergesReturnedSnapshotsAndPreservesOtherFields() {
+        let gmail = entry(name: "Gmail", loginIdentity: "g@x.co")
+        let work = entry(name: "Work", loginIdentity: "a@b.co", usageSnapshot: gmailSnapshot)
+
+        let fresh = snapshot(buckets: [bucket(kind: "session", percent: 42)])
+        let merged = AppState.mergingUsageSnapshots(
+            into: [gmail, work],
+            entries: [ModelProfileUsageSnapshotEntry(profileID: gmail.profile.id, snapshot: fresh)]
+        )
+
+        #expect(merged[0].usageSnapshot == fresh)
+        #expect(merged[0].loginIdentity == "g@x.co")
+        #expect(merged[0].profile == gmail.profile)
+        // Untouched profile keeps its cached snapshot.
+        #expect(merged[1].usageSnapshot == gmailSnapshot)
+    }
+
+    @Test func emptySweepLeavesProfilesUntouched() {
+        let work = entry(name: "Work", usageSnapshot: gmailSnapshot)
+        let merged = AppState.mergingUsageSnapshots(into: [work], entries: [])
+        #expect(merged == [work])
+    }
+}
+
+// MARK: - "Use default without asking" persistence
+
+@MainActor
+@Suite("AppState skipAccountPicker persistence")
+struct SkipAccountPickerPersistenceTests {
+    private func withIsolatedDefaults(_ body: (UserDefaults) -> Void) {
+        let suiteName = "TBDAppTests.SkipAccountPicker.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(defaults)
+    }
+
+    @Test func defaultsToAskingEveryTime() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            #expect(state.skipAccountPicker == false)
+        }
+    }
+
+    @Test func togglePersistsToInjectedSuiteAndReloadsOnInit() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            state.skipAccountPicker = true
+
+            #expect(defaults.bool(forKey: "com.tbd.app.accountPicker.useDefaultWithoutAsking"))
+            // A fresh AppState over the same suite reads the persisted value.
+            let reloaded = AppState(userDefaults: defaults)
+            #expect(reloaded.skipAccountPicker)
+
+            // Toggling back off round-trips too (both branches of the gate).
+            reloaded.skipAccountPicker = false
+            #expect(defaults.bool(forKey: "com.tbd.app.accountPicker.useDefaultWithoutAsking") == false)
+            #expect(AppState(userDefaults: defaults).skipAccountPicker == false)
+        }
+    }
+
+    @Test func writesDoNotTouchStandardDefaults() {
+        withIsolatedDefaults { defaults in
+            let key = "com.tbd.app.accountPicker.useDefaultWithoutAsking"
+            let prior = UserDefaults.standard.object(forKey: key)
+            defer {
+                if let prior {
+                    UserDefaults.standard.set(prior, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+
+            let state = AppState(userDefaults: defaults)
+            state.skipAccountPicker = true
+            #expect(UserDefaults.standard.object(forKey: key) == nil || prior != nil)
+        }
+    }
+}

--- a/Tests/TBDAppTests/RowAccountMenuTests.swift
+++ b/Tests/TBDAppTests/RowAccountMenuTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// MARK: - Fixtures
+
+private let utc = TimeZone(identifier: "UTC")!
+
+/// 2026-07-03 23:10:00 UTC — renders as "23:10" in the UTC fixtures below.
+private let resetDate: Date = {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 7
+    components.day = 3
+    components.hour = 23
+    components.minute = 10
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = utc
+    return calendar.date(from: components)!
+}()
+
+private func bucket(kind: String, percent: Double, severity: String? = nil,
+                    resetsAt: Date? = nil, family: String? = nil) -> ClaudeUsageLimitBucket {
+    ClaudeUsageLimitBucket(kind: kind, percent: percent, severity: severity,
+                           resetsAt: resetsAt, modelDisplayName: family)
+}
+
+private func snapshot(buckets: [ClaudeUsageLimitBucket]) -> ProfileUsageSnapshot {
+    ProfileUsageSnapshot(buckets: buckets, fetchedAt: Date(),
+                         lastAttemptAt: Date(), status: "ok")
+}
+
+private func entry(id: UUID = UUID(),
+                   name: String,
+                   loginIdentity: String? = nil,
+                   usageSnapshot: ProfileUsageSnapshot? = nil) -> ModelProfileWithUsage {
+    ModelProfileWithUsage(
+        profile: ModelProfile(id: id, name: name, kind: .oauth),
+        usage: nil,
+        loginIdentity: loginIdentity,
+        usageSnapshot: usageSnapshot
+    )
+}
+
+private func claudeTerminal(id: UUID = UUID(),
+                            label: String? = nil,
+                            profileID: UUID? = nil,
+                            createdAt: Date = Date(timeIntervalSince1970: 0),
+                            kind: TerminalKind? = .claude) -> Terminal {
+    Terminal(id: id, worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+             label: label, createdAt: createdAt, profileID: profileID, kind: kind)
+}
+
+/// Live-verified Gmail shape: 5h 0% resetting 23:10, weekly 76%, Fable 100%.
+private let fableSnapshot = snapshot(buckets: [
+    bucket(kind: "session", percent: 0, severity: "normal", resetsAt: resetDate),
+    bucket(kind: "weekly_all", percent: 76, severity: "warning"),
+    bucket(kind: "weekly_scoped", percent: 100, severity: "critical", family: "Fable"),
+])
+
+// MARK: - Model composition
+
+@Suite("RowAccountMenu — model")
+struct RowAccountMenuModelTests {
+    @Test func noClaudeSessionsYieldsEmptyModel() {
+        let shell = claudeTerminal(kind: .shell)
+        let model = RowAccountMenu.model(terminals: [shell], profiles: [])
+        #expect(model.isEmpty)
+        #expect(model.sessions.isEmpty)
+        #expect(RowAccountMenu.model(terminals: [], profiles: []).isEmpty)
+    }
+
+    @Test func oneSessionPerClaudeTerminalInTabOrder() {
+        let work = entry(name: "Work", loginIdentity: "a@b.co")
+        let t1 = claudeTerminal(label: "Claude 1", profileID: work.profile.id)
+        let t2 = claudeTerminal(label: nil, profileID: nil)
+        let model = RowAccountMenu.model(terminals: [t1, t2], profiles: [work])
+        #expect(model.sessions.count == 2)
+        #expect(model.sessions[0].terminalID == t1.id)
+        #expect(model.sessions[1].terminalID == t2.id)
+    }
+
+    @Test func footerIsTheForkExplainer() {
+        let model = RowAccountMenu.model(
+            terminals: [claudeTerminal()], profiles: []
+        )
+        #expect(model.footer == RowAccountMenu.footerCaption)
+        #expect(model.footer.contains("re-reads uncached once"))
+    }
+}
+
+// MARK: - Session info header
+
+@Suite("RowAccountMenu — session header")
+struct RowAccountMenuSessionTests {
+    @Test func pinnedLoggedInSessionDescribesEmailAndProfile() {
+        let work = entry(name: "Work", loginIdentity: "a@b.co")
+        let session = RowAccountMenu.session(
+            terminal: claudeTerminal(label: "Agent", profileID: work.profile.id),
+            fallbackIndex: 1, profiles: [work], timeZone: utc
+        )
+        #expect(session.label == "Agent")
+        #expect(session.accountDescriptor == "a@b.co (Work)")
+    }
+
+    @Test func ambientSessionDescribesTerminalLogin() {
+        let session = RowAccountMenu.session(
+            terminal: claudeTerminal(profileID: nil),
+            fallbackIndex: 2, profiles: [], timeZone: utc
+        )
+        #expect(session.accountDescriptor == "ambient (terminal login)")
+    }
+
+    @Test func removedProfileSessionKeepsNote() {
+        let session = RowAccountMenu.session(
+            terminal: claudeTerminal(profileID: UUID()),
+            fallbackIndex: 1, profiles: [], timeZone: utc
+        )
+        #expect(session.accountDescriptor == "profile removed — session keeps its spawn account")
+    }
+
+    @Test func labelFallsBackToClaudeIndexWhenTerminalHasNoLabel() {
+        #expect(RowAccountMenu.sessionLabel(terminal: claudeTerminal(label: nil),
+                                            fallbackIndex: 3) == "Claude 3")
+        #expect(RowAccountMenu.sessionLabel(terminal: claudeTerminal(label: "   "),
+                                            fallbackIndex: 1) == "Claude 1")
+        #expect(RowAccountMenu.sessionLabel(terminal: claudeTerminal(label: "Reviewer"),
+                                            fallbackIndex: 1) == "Reviewer")
+    }
+}
+
+// MARK: - Switch targets
+
+@Suite("RowAccountMenu — switch targets")
+struct RowAccountMenuSwitchTargetTests {
+    @Test func currentAccountIsCheckmarkedDisabledAndEmitsNoAction() {
+        let current = entry(name: "Work", loginIdentity: "a@b.co", usageSnapshot: fableSnapshot)
+        let other = entry(name: "Personal", loginIdentity: "p@q.io", usageSnapshot: fableSnapshot)
+        let targets = RowAccountMenu.switchTargets(
+            currentProfileID: current.profile.id,
+            profiles: [current, other], timeZone: utc
+        )
+        let currentTarget = targets.first { $0.profileID == current.profile.id }
+        #expect(currentTarget?.isCurrent == true)
+        // Current account is not a swap destination — no action emitted.
+        #expect(currentTarget?.action(terminalID: UUID()) == nil)
+    }
+
+    @Test func loggedInNonCurrentProfileIsSelectableAndEmitsSwapAction() {
+        let current = entry(name: "Work", loginIdentity: "a@b.co")
+        let target = entry(name: "Personal", loginIdentity: "p@q.io")
+        let terminalID = UUID()
+        let targets = RowAccountMenu.switchTargets(
+            currentProfileID: current.profile.id,
+            profiles: [current, target], timeZone: utc
+        )
+        let row = targets.first { $0.profileID == target.profile.id }
+        #expect(row?.isSelectable == true)
+        #expect(row?.isCurrent == false)
+        #expect(row?.disabledReason == nil)
+        #expect(row?.action(terminalID: terminalID)
+                == RowAccountMenu.RowAccountMenuAction(terminalID: terminalID,
+                                                       newProfileID: target.profile.id))
+    }
+
+    @Test func notLoggedInProfileIsDisabledWithLoginHintAndNoAction() {
+        let current = entry(name: "Work", loginIdentity: "a@b.co")
+        let pending = entry(name: "Staging", loginIdentity: nil)
+        let targets = RowAccountMenu.switchTargets(
+            currentProfileID: current.profile.id,
+            profiles: [current, pending], timeZone: utc
+        )
+        let row = targets.first { $0.profileID == pending.profile.id }
+        #expect(row?.isSelectable == false)
+        #expect(row?.disabledReason == RowAccountMenu.notLoggedInReason)
+        #expect(row?.action(terminalID: UUID()) == nil)
+    }
+
+    @Test func switchTargetTitleCarriesCompactPerFamilyUsageSuffix() {
+        let target = entry(name: "Fablework", loginIdentity: "f@x.co", usageSnapshot: fableSnapshot)
+        let targets = RowAccountMenu.switchTargets(
+            currentProfileID: nil, profiles: [target], timeZone: utc
+        )
+        let title = targets.first?.title ?? ""
+        #expect(title.contains("f@x.co"))
+        // Compact usage from ProfileUsagePresentation, incl. the per-family "F 100%".
+        #expect(title.contains("5h 0% ↺23:10"))
+        #expect(title.contains("wk 76%"))
+        #expect(title.contains("F 100%"))
+    }
+
+    @Test func ambientSessionOffersEveryLoggedInProfileAsSelectable() {
+        // An ambient session (nil profileID) has no current account, so every
+        // logged-in profile is a live switch destination.
+        let work = entry(name: "Work", loginIdentity: "a@b.co")
+        let personal = entry(name: "Personal", loginIdentity: "p@q.io")
+        let targets = RowAccountMenu.switchTargets(
+            currentProfileID: nil, profiles: [work, personal], timeZone: utc
+        )
+        #expect(targets.count == 2)
+        #expect(targets.allSatisfy { $0.isSelectable && !$0.isCurrent })
+        #expect(targets.allSatisfy { $0.action(terminalID: UUID()) != nil })
+    }
+}

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -1,0 +1,254 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// MARK: - Helpers
+
+private extension RowActionMenu.Item {
+    /// The action kind when this item is an `.action`, else nil — for terse
+    /// ordered-kind assertions.
+    var actionKind: RowActionMenu.Kind? {
+        if case let .action(action) = self { return action.kind }
+        return nil
+    }
+
+    var action: RowActionMenu.Action? {
+        if case let .action(action) = self { return action }
+        return nil
+    }
+}
+
+private func kinds(_ items: [RowActionMenu.Item]) -> [RowActionMenu.Kind] {
+    items.compactMap(\.actionKind)
+}
+
+private func session(_ label: String, profileID: UUID? = nil) -> RowActionMenu.ClaudeSessionRef {
+    RowActionMenu.ClaudeSessionRef(terminalID: UUID(), profileID: profileID, label: label)
+}
+
+// MARK: - Regular worktree branch
+
+@Suite("RowActionMenu — regular worktree")
+struct RowActionMenuRegularTests {
+    @Test func baseOrderMatchesLegacyContextMenu() {
+        // No Claude sessions, has repo, non-empty branch: rename → nested →
+        // fromBranch → archive → divider → finder → copy.
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "tbd/x")
+        let items = RowActionMenu.items(context: ctx)
+        #expect(kinds(items) == [
+            .rename,
+            .createNestedWorktree,
+            .newWorktreeFromBranch,
+            .archive,
+            .openInFinder,
+            .copyPath,
+        ])
+        // Divider sits between archive and Open in Finder.
+        #expect(items.contains(.divider))
+    }
+
+    @Test func suspendShownOnlyWhenUnsuspendedClaudePresent() {
+        let ctx = RowActionMenu.Context(hasUnsuspendedClaude: true, hasRepoID: true, branch: "b")
+        #expect(kinds(RowActionMenu.items(context: ctx)).contains(.suspendClaude))
+        #expect(!kinds(RowActionMenu.items(context: ctx)).contains(.resumeClaude))
+    }
+
+    @Test func resumeShownOnlyWhenSuspendedClaudePresent() {
+        let ctx = RowActionMenu.Context(hasSuspendedClaude: true, hasRepoID: true, branch: "b")
+        #expect(kinds(RowActionMenu.items(context: ctx)).contains(.resumeClaude))
+        #expect(!kinds(RowActionMenu.items(context: ctx)).contains(.suspendClaude))
+    }
+
+    @Test func nestedWorktreeOnlyWhenRepoPresent() {
+        let noRepo = RowActionMenu.Context(hasRepoID: false, branch: "b")
+        #expect(!kinds(RowActionMenu.items(context: noRepo)).contains(.createNestedWorktree))
+        #expect(!kinds(RowActionMenu.items(context: noRepo)).contains(.newWorktreeFromBranch))
+    }
+
+    @Test func newWorktreeFromBranchOmittedWhenBranchEmpty() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "")
+        let ks = kinds(RowActionMenu.items(context: ctx))
+        #expect(ks.contains(.createNestedWorktree))
+        #expect(!ks.contains(.newWorktreeFromBranch))
+    }
+
+    @Test func archiveDisabledWithHelpAndDestructiveWhenChildrenActive() {
+        let ctx = RowActionMenu.Context(hasActiveChildren: true, hasRepoID: true, branch: "b")
+        let archive = RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.isEnabled == false)
+        #expect(archive?.role == .destructive)
+        #expect(archive?.disabledHelp == RowActionMenu.archiveNeedsChildrenGoneHelp)
+    }
+
+    @Test func archiveEnabledWithNoHelpWhenNoChildren() {
+        let ctx = RowActionMenu.Context(hasActiveChildren: false, hasRepoID: true, branch: "b")
+        let archive = RowActionMenu.items(context: ctx)
+            .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.isEnabled == true)
+        #expect(archive?.disabledHelp == nil)
+    }
+}
+
+// MARK: - Scratch branch
+
+@Suite("RowActionMenu — scratch")
+struct RowActionMenuScratchTests {
+    @Test func scratchOrderWithPromoteHint() {
+        let ctx = RowActionMenu.Context(isScratch: true, isPromoted: false)
+        let items = RowActionMenu.items(context: ctx)
+        #expect(kinds(items) == [
+            .newClaudeTerminal,
+            .newCodexTerminal,
+            .newShellTerminal,
+            .rename,
+            .openInFinder,
+            .copyPath,
+            .archiveScratch,
+            .deleteScratch,
+        ])
+        // Promote hint caption present when not yet promoted.
+        #expect(items.contains(.caption(RowActionMenu.promoteHint)))
+    }
+
+    @Test func promoteHintOmittedWhenAlreadyPromoted() {
+        let ctx = RowActionMenu.Context(isScratch: true, isPromoted: true)
+        #expect(!RowActionMenu.items(context: ctx).contains(.caption(RowActionMenu.promoteHint)))
+    }
+
+    @Test func scratchWithClaudeSessionGetsForkParityOnRightClickOnly() {
+        // Scratch spaces host Claude sessions too: right-click carries the fork
+        // entries (after the New-Terminal trio); the "…" action block does not
+        // (its account section renders fork instead).
+        let s = session("Claude 1")
+        let ctx = RowActionMenu.Context(isScratch: true, claudeSessions: [s])
+        let rightClick = kinds(RowActionMenu.items(context: ctx, includeSessionForks: true))
+        #expect(rightClick.contains(.forkSession(terminalID: s.terminalID,
+                                                 profileID: s.profileID)))
+        #expect(rightClick[3] == .forkSession(terminalID: s.terminalID,
+                                              profileID: s.profileID))
+        let ellipsis = kinds(RowActionMenu.items(context: ctx, includeSessionForks: false))
+        #expect(!ellipsis.contains { if case .forkSession = $0 { return true }; return false })
+    }
+
+    @Test func scratchArchiveAndDeleteAreDestructive() {
+        let ctx = RowActionMenu.Context(isScratch: true)
+        let actions = RowActionMenu.items(context: ctx).compactMap(\.action)
+        #expect(actions.first { $0.kind == .archiveScratch }?.role == .destructive)
+        #expect(actions.first { $0.kind == .deleteScratch }?.role == .destructive)
+    }
+}
+
+// MARK: - Main / creating branch
+
+@Suite("RowActionMenu — main/creating")
+struct RowActionMenuMainTests {
+    @Test func mainShowsOnlyFinderAndCopyWhenPathPresent() {
+        let ctx = RowActionMenu.Context(pathIsEmpty: false, status: .main)
+        #expect(kinds(RowActionMenu.items(context: ctx)) == [.openInFinder, .copyPath])
+    }
+
+    @Test func creatingBehavesLikeMain() {
+        let ctx = RowActionMenu.Context(pathIsEmpty: false, status: .creating)
+        #expect(kinds(RowActionMenu.items(context: ctx)) == [.openInFinder, .copyPath])
+    }
+
+    @Test func emptyPathMainYieldsNoItems() {
+        let ctx = RowActionMenu.Context(pathIsEmpty: true, status: .main)
+        #expect(RowActionMenu.items(context: ctx).isEmpty)
+    }
+}
+
+// MARK: - Fork session
+
+@Suite("RowActionMenu — fork session")
+struct RowActionMenuForkTests {
+    @Test func noForkEntriesWhenNoClaudeSessions() {
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b", claudeSessions: [])
+        #expect(!kinds(RowActionMenu.items(context: ctx)).contains {
+            if case .forkSession = $0 { return true }; return false
+        })
+    }
+
+    @Test func singleSessionForkHasPlainTitle() {
+        let s = session("Claude 1", profileID: UUID())
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b", claudeSessions: [s])
+        let fork = RowActionMenu.items(context: ctx).compactMap(\.action).first {
+            if case .forkSession = $0.kind { return true }; return false
+        }
+        #expect(fork?.title == RowActionMenu.forkSessionLabel)
+        if case let .forkSession(id, profileID)? = fork?.kind {
+            #expect(id == s.terminalID)
+            #expect(profileID == s.profileID)
+        } else {
+            Issue.record("expected a forkSession action")
+        }
+    }
+
+    @Test func multipleSessionsForkTitlesCarryLabels() {
+        let a = session("Reviewer")
+        let b = session("Builder")
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b", claudeSessions: [a, b])
+        let forks = RowActionMenu.items(context: ctx).compactMap(\.action).filter {
+            if case .forkSession = $0.kind { return true }; return false
+        }
+        #expect(forks.count == 2)
+        #expect(forks.map(\.title) == [
+            "\(RowActionMenu.forkSessionLabel) — Reviewer",
+            "\(RowActionMenu.forkSessionLabel) — Builder",
+        ])
+    }
+
+    @Test func forkAmbientSessionCarriesNilProfile() {
+        let s = session("Claude 1", profileID: nil)
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b", claudeSessions: [s])
+        let forks = RowActionMenu.sessionForkActions(context: ctx)
+        #expect(forks.count == 1)
+        if case let .forkSession(_, profileID) = forks[0].kind {
+            #expect(profileID == nil)
+        } else {
+            Issue.record("expected forkSession")
+        }
+    }
+}
+
+// MARK: - Shared-list invariant across surfaces
+
+@Suite("RowActionMenu — shared surfaces")
+struct RowActionMenuSurfaceInvariantTests {
+    /// The "…" action block (includeSessionForks: false) is the right-click list
+    /// with the per-session fork entries removed — everything else identical.
+    @Test func ellipsisActionBlockOmitsForksButOtherwiseMatchesRightClick() {
+        let s = session("Claude 1")
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b", claudeSessions: [s])
+
+        let rightClick = RowActionMenu.items(context: ctx, includeSessionForks: true)
+        let ellipsis = RowActionMenu.items(context: ctx, includeSessionForks: false)
+
+        // Right-click includes the fork; the "…" action block does not.
+        #expect(kinds(rightClick).contains { if case .forkSession = $0 { return true }; return false })
+        #expect(!kinds(ellipsis).contains { if case .forkSession = $0 { return true }; return false })
+
+        // Removing the fork entries from the right-click list yields the "…" list.
+        let rightClickSansForks = rightClick.filter {
+            if case let .action(a) = $0, case .forkSession = a.kind { return false }
+            return true
+        }
+        #expect(rightClickSansForks == ellipsis)
+    }
+
+    /// The account section is contributed by `RowAccountMenu`, never
+    /// `RowActionMenu`: no action item is an account/switch entry.
+    @Test func actionItemsContainNoAccountOrSwitchEntries() {
+        let s = session("Claude 1")
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b", claudeSessions: [s])
+        for item in RowActionMenu.items(context: ctx) {
+            if case let .action(action) = item {
+                // No switch-account kinds exist in RowActionMenu.Kind at all;
+                // assert titles don't leak the account section's copy either.
+                #expect(action.title != RowAccountMenu.switchAccountLabel)
+            }
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
+++ b/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
@@ -1,0 +1,339 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// MARK: - Test doubles
+
+/// Scriptable fetcher: per-configDir queue of statuses, falling back to a
+/// default. Records call order.
+private final class ScriptedProfileUsageFetcher: ProfileUsageFetching, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "ScriptedProfileUsageFetcher")
+    private var scripted: [String: [ProfileUsageFetchStatus]] = [:]
+    private var fallback: ProfileUsageFetchStatus
+    private var _calls: [String] = []
+
+    init(default fallback: ProfileUsageFetchStatus) {
+        self.fallback = fallback
+    }
+
+    func enqueue(configDirPath: String, _ status: ProfileUsageFetchStatus) {
+        queue.sync { scripted[configDirPath, default: []].append(status) }
+    }
+
+    var calls: [String] { queue.sync { _calls } }
+
+    func fetchUsage(configDirPath: String) async -> ProfileUsageFetchStatus {
+        queue.sync {
+            _calls.append(configDirPath)
+            if var statuses = scripted[configDirPath], !statuses.isEmpty {
+                let next = statuses.removeFirst()
+                scripted[configDirPath] = statuses
+                return next
+            }
+            return fallback
+        }
+    }
+}
+
+private final class BroadcastCounter: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "BroadcastCounter")
+    private var _count = 0
+    var count: Int { queue.sync { _count } }
+    func bump() { queue.sync { _count += 1 } }
+}
+
+private func oauthProfile(named name: String) -> ModelProfile {
+    ModelProfile(name: name, kind: .oauth)
+}
+
+private let okBuckets = [
+    ClaudeUsageLimitBucket(kind: "session", group: "session", percent: 12,
+                           resetsAt: Date(timeIntervalSince1970: 1_800_000_000)),
+    ClaudeUsageLimitBucket(kind: "weekly_all", group: "weekly", percent: 34),
+    ClaudeUsageLimitBucket(kind: "weekly_scoped", group: "weekly", percent: 56,
+                           modelDisplayName: "Fable"),
+]
+
+/// Build a poller over in-memory fixtures. `loggedIn` controls which profile
+/// ids report a login identity. The sleeper is a no-op so sweeps are instant.
+private func makePoller(
+    profiles: [ModelProfile],
+    loggedIn: Set<UUID>,
+    fetcher: ScriptedProfileUsageFetcher,
+    broadcasts: BroadcastCounter,
+    now: Date = Date(timeIntervalSince1970: 1_750_000_000)
+) -> OAuthProfileUsagePoller {
+    OAuthProfileUsagePoller(
+        profilesProvider: { profiles },
+        loginIdentity: { id in loggedIn.contains(id) ? "someone@example.com" : nil },
+        configDirPath: { id in "/profiles/\(id.uuidString.lowercased())/claude" },
+        fetcher: fetcher,
+        broadcast: { broadcasts.bump() },
+        sleeper: { _ in },
+        now: { now }
+    )
+}
+
+// MARK: - Tests
+
+struct OAuthProfileUsagePollerTests {
+
+    @Test func sweepPopulatesSnapshotsForLoggedInOAuthProfilesOnly() async {
+        let loggedIn = oauthProfile(named: "A")
+        let notLoggedIn = oauthProfile(named: "B")
+        let apiKey = ModelProfile(name: "C", kind: .apiKey)
+        let bedrock = ModelProfile(name: "D", kind: .bedrock, awsRegion: "us-west-2")
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [loggedIn, notLoggedIn, apiKey, bedrock],
+            loggedIn: [loggedIn.id, apiKey.id],  // apiKey id "logged in" must still be skipped
+            fetcher: fetcher,
+            broadcasts: broadcasts
+        )
+
+        let snapshots = await poller.sweepNow()
+
+        #expect(snapshots.count == 1)
+        let snapshot = snapshots[loggedIn.id]
+        #expect(snapshot?.buckets == okBuckets)
+        #expect(snapshot?.status == "ok")
+        #expect(snapshot?.fetchedAt != nil)
+        #expect(fetcher.calls.count == 1)
+        #expect(broadcasts.count == 1)
+    }
+
+    @Test func perProfileFailureDoesNotPoisonTheSweep() async {
+        let good = oauthProfile(named: "Good")
+        let bad = oauthProfile(named: "Bad")
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        fetcher.enqueue(
+            configDirPath: "/profiles/\(bad.id.uuidString.lowercased())/claude",
+            .httpError(401)
+        )
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [good, bad],
+            loggedIn: [good.id, bad.id],
+            fetcher: fetcher,
+            broadcasts: broadcasts
+        )
+
+        let snapshots = await poller.sweepNow()
+
+        #expect(snapshots[good.id]?.status == "ok")
+        #expect(snapshots[good.id]?.buckets == okBuckets)
+        let failed = snapshots[bad.id]
+        #expect(failed?.status == "fetch failed: HTTP 401")
+        #expect(failed?.buckets == [])
+        #expect(failed?.fetchedAt == nil)
+        #expect(failed?.lastAttemptAt != nil)
+    }
+
+    @Test func failureAfterSuccessKeepsOldBucketsAndMarksStale() async {
+        let profile = oauthProfile(named: "Flaky")
+        let dir = "/profiles/\(profile.id.uuidString.lowercased())/claude"
+        let fetcher = ScriptedProfileUsageFetcher(default: .networkError("timed out"))
+        fetcher.enqueue(configDirPath: dir, .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [profile], loggedIn: [profile.id],
+            fetcher: fetcher, broadcasts: broadcasts
+        )
+
+        let first = await poller.sweepNow()
+        let successFetchedAt = first[profile.id]?.fetchedAt
+        #expect(first[profile.id]?.status == "ok")
+
+        let second = await poller.sweepNow()
+        let stale = second[profile.id]
+        #expect(stale?.buckets == okBuckets)             // old data retained
+        #expect(stale?.fetchedAt == successFetchedAt)    // success timestamp preserved
+        #expect(stale?.status.hasPrefix("stale since ") == true)
+        #expect(stale?.status.contains("network error: timed out") == true)
+    }
+
+    @Test func noLoggedInProfilesYieldsEmptySweepAndNoBroadcast() async {
+        let profile = oauthProfile(named: "LoggedOut")
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [profile], loggedIn: [],
+            fetcher: fetcher, broadcasts: broadcasts
+        )
+
+        let snapshots = await poller.sweepNow()
+
+        #expect(snapshots.isEmpty)
+        #expect(fetcher.calls.isEmpty)
+        #expect(broadcasts.count == 0)
+    }
+
+    @Test func repeatedIdenticalFailuresBroadcastOnlyOnce() async {
+        let profile = oauthProfile(named: "Dead")
+        let fetcher = ScriptedProfileUsageFetcher(default: .httpError(401))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [profile], loggedIn: [profile.id],
+            fetcher: fetcher, broadcasts: broadcasts
+        )
+
+        await poller.sweepNow()
+        #expect(broadcasts.count == 1)  // nil → failed is a change
+        await poller.sweepNow()
+        await poller.sweepNow()
+        #expect(broadcasts.count == 1)  // same failure text: no re-broadcast
+    }
+
+    @Test func targetedSweepFetchesOnlyThatProfile() async {
+        let one = oauthProfile(named: "One")
+        let two = oauthProfile(named: "Two")
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [one, two], loggedIn: [one.id, two.id],
+            fetcher: fetcher, broadcasts: broadcasts
+        )
+
+        let snapshots = await poller.sweepNow(profileID: two.id)
+
+        #expect(fetcher.calls == ["/profiles/\(two.id.uuidString.lowercased())/claude"])
+        #expect(snapshots.count == 1)
+        #expect(snapshots[two.id]?.status == "ok")
+        // Untargeted profile is untouched (no snapshot yet).
+        #expect(await poller.snapshot(for: one.id) == nil)
+    }
+
+    @Test func fullSweepPrunesProfilesNoLongerEligible() async {
+        let keep = oauthProfile(named: "Keep")
+        let drop = oauthProfile(named: "Drop")
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+
+        // First poller sees both profiles logged in.
+        let both = makePoller(
+            profiles: [keep, drop], loggedIn: [keep.id, drop.id],
+            fetcher: fetcher, broadcasts: broadcasts
+        )
+        let first = await both.sweepNow()
+        #expect(first.count == 2)
+
+        // Simulate "drop logged out" by sweeping a poller whose identity
+        // provider no longer reports it. (Same actor instance can't swap
+        // closures, so verify prune semantics through sweep(only: nil) on a
+        // fresh sweep of the same instance is not possible — instead assert
+        // that a full sweep never returns ineligible ghosts.)
+        let after = makePoller(
+            profiles: [keep, drop], loggedIn: [keep.id],
+            fetcher: fetcher, broadcasts: broadcasts
+        )
+        let snapshots = await after.sweepNow()
+        #expect(snapshots.count == 1)
+        #expect(snapshots[keep.id] != nil)
+        #expect(snapshots[drop.id] == nil)
+    }
+
+    @Test func profilesProviderErrorLeavesExistingSnapshotsIntact() async {
+        let profile = oauthProfile(named: "Sticky")
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let flag = BroadcastCounter()  // reuse as a thread-safe toggle
+        let poller = OAuthProfileUsagePoller(
+            profilesProvider: {
+                if flag.count > 0 {
+                    throw ClaudeOAuthTokenReadError("db unavailable")
+                }
+                flag.bump()
+                return [profile]
+            },
+            loginIdentity: { _ in "someone@example.com" },
+            configDirPath: { _ in "/profiles/x/claude" },
+            fetcher: fetcher,
+            broadcast: { broadcasts.bump() },
+            sleeper: { _ in },
+            now: { Date(timeIntervalSince1970: 1_750_000_000) }
+        )
+
+        let first = await poller.sweepNow()
+        #expect(first[profile.id]?.status == "ok")
+
+        // Second sweep: provider throws — snapshots stay as-is.
+        let second = await poller.sweepNow()
+        #expect(second[profile.id]?.status == "ok")
+        #expect(broadcasts.count == 1)
+    }
+}
+
+// MARK: - RPC decode-compat
+
+struct ProfileUsageRPCCompatTests {
+
+    /// JSON from an older daemon (no `usageSnapshot` key) must still decode.
+    @Test func modelProfileWithUsageDecodesWithoutSnapshotField() throws {
+        let profile = ModelProfile(name: "Old", kind: .oauth)
+        // Encode with the OLD shape by round-tripping a value with nil
+        // snapshot and stripping nothing — synthesized Codable omits... it
+        // actually encodes nil as absent only with encodeIfPresent; verify by
+        // constructing raw JSON instead.
+        let encoder = JSONEncoder()
+        let profileJSON = String(data: try encoder.encode(profile), encoding: .utf8)!
+        let old = """
+        {"profile": \(profileJSON), "loginIdentity": "a@b.c"}
+        """
+        let decoded = try JSONDecoder().decode(ModelProfileWithUsage.self, from: Data(old.utf8))
+        #expect(decoded.usageSnapshot == nil)
+        #expect(decoded.loginIdentity == "a@b.c")
+    }
+
+    @Test func modelProfileWithUsageRoundTripsSnapshot() throws {
+        let snapshot = ProfileUsageSnapshot(
+            buckets: okBuckets,
+            fetchedAt: Date(timeIntervalSince1970: 1_750_000_000),
+            lastAttemptAt: Date(timeIntervalSince1970: 1_750_000_090),
+            status: "ok"
+        )
+        let value = ModelProfileWithUsage(
+            profile: ModelProfile(name: "New", kind: .oauth),
+            usageSnapshot: snapshot
+        )
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(ModelProfileWithUsage.self, from: data)
+        #expect(decoded.usageSnapshot == snapshot)
+        #expect(decoded.usageSnapshot?.buckets.first?.modelDisplayName == nil)
+        #expect(decoded.usageSnapshot?.buckets.last?.modelDisplayName == "Fable")
+    }
+
+    /// Old clients decode new payloads by ignoring unknown keys; simulate by
+    /// decoding a payload with an extra unknown top-level field.
+    @Test func unknownExtraFieldsAreIgnoredOnDecode() throws {
+        let profile = ModelProfile(name: "P", kind: .oauth)
+        let profileJSON = String(data: try JSONEncoder().encode(profile), encoding: .utf8)!
+        let futuristic = """
+        {"profile": \(profileJSON), "someFutureField": {"x": 1}}
+        """
+        let decoded = try JSONDecoder().decode(ModelProfileWithUsage.self, from: Data(futuristic.utf8))
+        #expect(decoded.profile.name == "P")
+    }
+
+    @Test func usageRefreshParamsDecodeFromEmptyObject() throws {
+        // The CLI/app may send "{}" (RPCRequest's default params) for
+        // refresh-all; the id must decode as nil.
+        let params = try JSONDecoder().decode(
+            ModelProfileUsageRefreshParams.self, from: Data("{}".utf8))
+        #expect(params.id == nil)
+    }
+
+    @Test func usageRefreshResultRoundTrips() throws {
+        let entry = ModelProfileUsageSnapshotEntry(
+            profileID: UUID(),
+            snapshot: ProfileUsageSnapshot(
+                buckets: okBuckets, fetchedAt: Date(timeIntervalSince1970: 1),
+                lastAttemptAt: Date(timeIntervalSince1970: 2), status: "ok")
+        )
+        let result = ModelProfileUsageRefreshResult(snapshots: [entry])
+        let data = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(ModelProfileUsageRefreshResult.self, from: data)
+        #expect(decoded.snapshots == [entry])
+    }
+}

--- a/Tests/TBDDaemonTests/ProfileUsageFetcherTests.swift
+++ b/Tests/TBDDaemonTests/ProfileUsageFetcherTests.swift
@@ -1,0 +1,375 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// MARK: - Fixtures
+
+/// Real response captured from `GET https://api.anthropic.com/api/oauth/usage`
+/// on 2026-07-03 (Claude Max account, trimmed of the `extra_usage`/`spend`
+/// blocks we don't parse — top-level unknown keys are exercised by keeping
+/// several of the null experiment fields verbatim).
+private let capturedUsageJSON = """
+{
+    "five_hour": {
+        "utilization": 96.0,
+        "resets_at": "2026-07-04T01:10:00.245613+00:00",
+        "limit_dollars": null,
+        "used_dollars": null,
+        "remaining_dollars": null
+    },
+    "seven_day": {
+        "utilization": 76.0,
+        "resets_at": "2026-07-07T22:00:00.245628+00:00",
+        "limit_dollars": null,
+        "used_dollars": null,
+        "remaining_dollars": null
+    },
+    "seven_day_oauth_apps": null,
+    "seven_day_opus": null,
+    "seven_day_sonnet": null,
+    "tangelo": null,
+    "iguana_necktie": null,
+    "extra_usage": {
+        "is_enabled": false,
+        "monthly_limit": 40000,
+        "used_credits": 0.0,
+        "utilization": 0.0,
+        "currency": "USD",
+        "decimal_places": 2,
+        "disabled_reason": "out_of_credits",
+        "daily": null,
+        "weekly": null
+    },
+    "limits": [
+        {
+            "kind": "session",
+            "group": "session",
+            "percent": 96,
+            "severity": "critical",
+            "resets_at": "2026-07-04T01:10:00.245613+00:00",
+            "scope": null,
+            "is_active": false
+        },
+        {
+            "kind": "weekly_all",
+            "group": "weekly",
+            "percent": 76,
+            "severity": "warning",
+            "resets_at": "2026-07-07T22:00:00.245628+00:00",
+            "scope": null,
+            "is_active": false
+        },
+        {
+            "kind": "weekly_scoped",
+            "group": "weekly",
+            "percent": 100,
+            "severity": "critical",
+            "resets_at": "2026-07-07T22:00:00.245838+00:00",
+            "scope": {
+                "model": {
+                    "id": null,
+                    "display_name": "Fable"
+                },
+                "surface": null
+            },
+            "is_active": true
+        }
+    ],
+    "member_dashboard_available": false
+}
+""".data(using: .utf8)!
+
+// MARK: - Payload parser
+
+struct ClaudeUsagePayloadParserTests {
+
+    @Test func capturedResponseParsesAllBuckets() throws {
+        let buckets = try ClaudeUsagePayloadParser.parseBuckets(from: capturedUsageJSON)
+        #expect(buckets.count == 3)
+
+        let session = try #require(buckets.first { $0.kind == "session" })
+        #expect(session.percent == 96)
+        #expect(session.group == "session")
+        #expect(session.severity == "critical")
+        #expect(session.modelDisplayName == nil)
+        #expect(session.isActive == false)
+        let sessionReset = try #require(session.resetsAt)
+        // 2026-07-04T01:10:00.245613+00:00
+        #expect(abs(sessionReset.timeIntervalSince1970 - 1783127400.245613) < 0.01)
+
+        let weeklyAll = try #require(buckets.first { $0.kind == "weekly_all" })
+        #expect(weeklyAll.percent == 76)
+        #expect(weeklyAll.group == "weekly")
+
+        let scoped = try #require(buckets.first { $0.kind == "weekly_scoped" })
+        #expect(scoped.percent == 100)
+        #expect(scoped.modelDisplayName == "Fable")
+        #expect(scoped.isActive == true)
+    }
+
+    @Test func unknownBucketKindsFlowThroughAsData() throws {
+        let json = """
+        { "limits": [
+            { "kind": "monthly_lunar", "group": "lunar", "percent": 7,
+              "resets_at": null, "scope": null, "is_active": false }
+        ] }
+        """.data(using: .utf8)!
+        let buckets = try ClaudeUsagePayloadParser.parseBuckets(from: json)
+        #expect(buckets == [ClaudeUsageLimitBucket(
+            kind: "monthly_lunar", group: "lunar", percent: 7, isActive: false)])
+    }
+
+    @Test func nullResetsAtYieldsNilDate() throws {
+        let json = """
+        { "limits": [
+            { "kind": "weekly_scoped", "group": "weekly", "percent": 0,
+              "severity": "normal", "resets_at": null,
+              "scope": { "model": { "id": null, "display_name": "Fable" } },
+              "is_active": false }
+        ] }
+        """.data(using: .utf8)!
+        let buckets = try ClaudeUsagePayloadParser.parseBuckets(from: json)
+        #expect(buckets.count == 1)
+        #expect(buckets[0].resetsAt == nil)
+        #expect(buckets[0].modelDisplayName == "Fable")
+    }
+
+    @Test func malformedLimitEntriesAreSkipped() throws {
+        // First entry has no kind, second no percent — both dropped; the
+        // valid third survives.
+        let json = """
+        { "limits": [
+            { "percent": 50 },
+            { "kind": "session" },
+            { "kind": "weekly_all", "percent": 10 }
+        ] }
+        """.data(using: .utf8)!
+        let buckets = try ClaudeUsagePayloadParser.parseBuckets(from: json)
+        #expect(buckets.map(\.kind) == ["weekly_all"])
+    }
+
+    @Test func missingLimitsFallsBackToLegacyWindows() throws {
+        let json = """
+        {
+            "five_hour": { "utilization": 42.0, "resets_at": "2026-04-06T15:00:00Z" },
+            "seven_day": { "utilization": 18.0, "resets_at": "2026-04-13T00:00:00Z" }
+        }
+        """.data(using: .utf8)!
+        let buckets = try ClaudeUsagePayloadParser.parseBuckets(from: json)
+        #expect(buckets.count == 2)
+        #expect(buckets[0].kind == "session")
+        #expect(buckets[0].percent == 42.0)
+        #expect(buckets[0].resetsAt != nil)
+        #expect(buckets[1].kind == "weekly_all")
+        #expect(buckets[1].percent == 18.0)
+    }
+
+    @Test func absentBucketsSimplyDoNotAppear() throws {
+        // Account without any scoped weekly bucket: only what the API sent.
+        let json = """
+        { "limits": [ { "kind": "session", "group": "session", "percent": 5 } ] }
+        """.data(using: .utf8)!
+        let buckets = try ClaudeUsagePayloadParser.parseBuckets(from: json)
+        #expect(buckets.map(\.kind) == ["session"])
+        #expect(buckets.first { $0.kind == "weekly_scoped" } == nil)
+    }
+
+    @Test func garbageJSONThrows() {
+        let garbage = Data("not json at all".utf8)
+        #expect(throws: ClaudeUsagePayloadParser.ParseError.self) {
+            try ClaudeUsagePayloadParser.parseBuckets(from: garbage)
+        }
+    }
+
+    @Test func emptyPayloadThrows() {
+        let empty = Data("{}".utf8)
+        #expect(throws: ClaudeUsagePayloadParser.ParseError.self) {
+            try ClaudeUsagePayloadParser.parseBuckets(from: empty)
+        }
+    }
+
+    @Test func fractionalAndPlainISO8601DatesBothParse() {
+        #expect(ClaudeUsagePayloadParser.parseResetDate("2026-07-04T01:10:00.245613+00:00") != nil)
+        #expect(ClaudeUsagePayloadParser.parseResetDate("2026-07-04T01:10:00Z") != nil)
+        #expect(ClaudeUsagePayloadParser.parseResetDate("yesterday-ish") == nil)
+        #expect(ClaudeUsagePayloadParser.parseResetDate(nil) == nil)
+    }
+}
+
+// MARK: - Credentials JSON parsing
+
+struct ClaudeCredentialsParsingTests {
+
+    @Test func extractsAccessTokenFromCredentialsJSON() {
+        // Same shape as the "Claude Code-credentials-<hash>" keychain item /
+        // .credentials.json file (token value is fake).
+        let json = """
+        {
+            "mcpOAuth": { "some-server": { "accessToken": "not-this-one" } },
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-oat01-FAKEFAKEFAKE",
+                "refreshToken": "sk-ant-ort01-FAKEFAKEFAKE",
+                "expiresAt": 1783155405362,
+                "scopes": ["user:inference", "user:profile"],
+                "subscriptionType": "max",
+                "rateLimitTier": "default_claude_max_20x"
+            }
+        }
+        """.data(using: .utf8)!
+        #expect(parseClaudeCredentialsAccessToken(json) == "sk-ant-oat01-FAKEFAKEFAKE")
+    }
+
+    @Test func missingOAuthSectionYieldsNil() {
+        #expect(parseClaudeCredentialsAccessToken(Data("{\"mcpOAuth\":{}}".utf8)) == nil)
+        #expect(parseClaudeCredentialsAccessToken(Data("{}".utf8)) == nil)
+        #expect(parseClaudeCredentialsAccessToken(Data("garbage".utf8)) == nil)
+        #expect(parseClaudeCredentialsAccessToken(
+            Data("{\"claudeAiOauth\":{\"accessToken\":\"\"}}".utf8)) == nil)
+    }
+}
+
+// MARK: - Live fetcher over a mocked HTTP session
+
+/// Private mock URLProtocol (not the shared `MockURLProtocol` from
+/// ClaudeUsageFetcherTests — suites run in parallel across the module, and
+/// sharing its static handler would race).
+private final class ProfileUsageMockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var lastRequest: URLRequest?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lastRequest = request
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+/// Token reader stub — never touches the keychain.
+private struct StubTokenReader: ClaudeOAuthTokenReading {
+    enum Behavior {
+        case token(String)
+        case absent
+        case failure(String)
+    }
+    let behavior: Behavior
+
+    func accessToken(forConfigDirPath path: String) async throws -> String? {
+        switch behavior {
+        case .token(let token): return token
+        case .absent: return nil
+        case .failure(let message): throw ClaudeOAuthTokenReadError(message)
+        }
+    }
+}
+
+private func makeProfileFetcher(_ behavior: StubTokenReader.Behavior) -> LiveProfileUsageFetcher {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [ProfileUsageMockURLProtocol.self]
+    return LiveProfileUsageFetcher(
+        tokenReader: StubTokenReader(behavior: behavior),
+        session: URLSession(configuration: config)
+    )
+}
+
+@Suite(.serialized)
+struct LiveProfileUsageFetcherTests {
+    init() {
+        ProfileUsageMockURLProtocol.handler = nil
+        ProfileUsageMockURLProtocol.lastRequest = nil
+    }
+
+    @Test func happyPathSendsBearerTokenAndParsesBuckets() async throws {
+        ProfileUsageMockURLProtocol.handler = { req in
+            (HTTPURLResponse(url: req.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!,
+             capturedUsageJSON)
+        }
+        let status = await makeProfileFetcher(.token("sk-ant-oat01-TEST")).fetchUsage(configDirPath: "/tmp/x")
+        guard case .ok(let buckets) = status else {
+            Issue.record("expected .ok, got \(status)")
+            return
+        }
+        #expect(buckets.count == 3)
+        let request = try #require(ProfileUsageMockURLProtocol.lastRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-ant-oat01-TEST")
+        #expect(request.value(forHTTPHeaderField: "anthropic-beta") == "oauth-2025-04-20")
+        #expect(request.url?.absoluteString == "https://api.anthropic.com/api/oauth/usage")
+    }
+
+    @Test func missingCredentialShortCircuitsWithoutHTTP() async {
+        ProfileUsageMockURLProtocol.handler = { _ in
+            Issue.record("no HTTP call expected when credentials are absent")
+            throw URLError(.badServerResponse)
+        }
+        let status = await makeProfileFetcher(.absent).fetchUsage(configDirPath: "/tmp/x")
+        guard case .noCredentials = status else {
+            Issue.record("expected .noCredentials, got \(status)")
+            return
+        }
+    }
+
+    @Test func tokenReadErrorMapsToNoCredentials() async {
+        let status = await makeProfileFetcher(.failure("security exited 51")).fetchUsage(configDirPath: "/tmp/x")
+        guard case .noCredentials(let reason) = status else {
+            Issue.record("expected .noCredentials, got \(status)")
+            return
+        }
+        #expect(reason.contains("security exited 51"))
+    }
+
+    @Test func http401MapsToHTTPError() async {
+        ProfileUsageMockURLProtocol.handler = { req in
+            (HTTPURLResponse(url: req.url!, statusCode: 401, httpVersion: "HTTP/1.1", headerFields: nil)!,
+             Data())
+        }
+        let status = await makeProfileFetcher(.token("sk-ant-oat01-TEST")).fetchUsage(configDirPath: "/tmp/x")
+        #expect(status == .httpError(401))
+    }
+
+    @Test func malformedBodyMapsToDecodeError() async {
+        ProfileUsageMockURLProtocol.handler = { req in
+            (HTTPURLResponse(url: req.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!,
+             Data("<!doctype html>".utf8))
+        }
+        let status = await makeProfileFetcher(.token("sk-ant-oat01-TEST")).fetchUsage(configDirPath: "/tmp/x")
+        guard case .decodeError = status else {
+            Issue.record("expected .decodeError, got \(status)")
+            return
+        }
+    }
+}
+
+// MARK: - Keychain service derivation (per-profile isolation sanity)
+
+struct ProfileUsageKeychainDerivationTests {
+
+    /// The token reader must target the config-dir-derived item, never the
+    /// bare "Claude Code-credentials" item of the user's default ~/.claude.
+    @Test func serviceNameIsAlwaysSuffixed() {
+        let service = ClaudeCodeCredentialsKeychain.serviceName(
+            forConfigDirPath: "/Users/zionts/tbd/profiles/abc/claude")
+        #expect(service.hasPrefix("Claude Code-credentials-"))
+        #expect(service != "Claude Code-credentials")
+    }
+
+    /// Known vector from the class doc comment, verified empirically.
+    @Test func knownSHA256Vector() {
+        #expect(ClaudeCodeCredentialsKeychain.serviceSuffix(
+            forConfigDirPath: "/Users/zionts/.claude-profiles/zadam") == "db64a81f")
+    }
+}


### PR DESCRIPTION
Builds on #324 (merged). Two commits:

**feat(daemon): per-profile OAuth usage snapshots** — the daemon polls every logged-in profile's usage (~90s sweep, staggered) via the oauth usage endpoint (token read per profile through the security CLI; the daemon can't SecItemCopyMatching Claude Code's ACL'd items). Parses the `limits[]` buckets generically: `session` (5h window), `weekly_all`, `weekly_scoped` per model family (e.g. Fable) — unknown kinds flow through as data. Snapshots ride the model-profile list RPC (decode-compatible optional field) + a `modelProfile.usageRefresh` RPC for on-demand freshness. `tbd profile list` grows 5H/RESET/WK columns + dynamic per-family columns + `--refresh`.

**feat(app): spawn-time account picker** — the account is chosen per session, with the data in view, and each session stays pinned to its account for life (no more one-account clobbering → mass restart → uncached-cost burst):
- "+" menu profile items show compact usage (`Gmail — g@x.co · 5h 0% ↺23:10 · wk 76% · F 100%`) + a "Choose account…" dialog item
- plain Claude opens the picker (severity-colored bars per bucket, healthiest-window-expiring-soonest sort, refresh-on-open, "use default without asking" escape persisted in defaults)
- hover tooltips: Claude tabs show account/usage/spawn-time (ambient legacy sessions marked "may drift on token refresh"), worktree rows show a deduped account list

Testing: full suite 2,235 tests green locally (one known env-dependent failure, `agentExecutableAvailability_detectsHomeLocalBinFallback`, fails on machines with /opt/homebrew/bin/claude — also fails on main). swiftlint --strict clean. Live-verified on a 3-account setup: distinct per-account numbers, picker spawn pins correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)