### PR TITLE
Nightwatch: menu-bar Away/Back toggle (Phase 0 UI)

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -32,6 +32,9 @@ extension AppState {
             if result.autoArchiveOnMergeDefault != autoArchiveOnMergeDefault {
                 autoArchiveOnMergeDefault = result.autoArchiveOnMergeDefault
             }
+            if result.nightwatchMode != nightwatchMode {
+                nightwatchMode = result.nightwatchMode
+            }
         } catch {
             logger.error("Failed to list model profiles: \(error, privacy: .public)")
             handleConnectionError(error)
@@ -353,6 +356,19 @@ extension AppState {
         } catch {
             logger.error("Failed to fetch profile usage: \(error, privacy: .public)")
             showAlert("Failed to fetch profile usage: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    // MARK: - Nightwatch Mode
+
+    /// Set the nightwatch mode (off, daywatch, or nightwatch).
+    func setNightwatchMode(_ mode: NightwatchMode) async {
+        do {
+            try await daemonClient.setNightwatchMode(mode)
+            nightwatchMode = mode
+        } catch {
+            logger.error("Failed to set nightwatch mode: \(error, privacy: .public)")
+            showAlert("Failed to set nightwatch mode: \(error.localizedDescription)", isError: true)
         }
     }
 }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -387,6 +387,7 @@ final class AppState: ObservableObject {
     /// Global default for auto-archive-on-PR-merge. Loaded from the daemon
     /// alongside `globalEnvOverrides` via `loadModelProfiles()`.
     @Published var autoArchiveOnMergeDefault: Bool = false
+    @Published var nightwatchMode: NightwatchMode = .off
     /// Terminals where the user has dismissed the proxy-unreachable banner.
     /// Cleared on app relaunch (in-memory only — banners are advisory).
     @Published var dismissedProxyWarnings: Set<UUID> = []

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1161,6 +1161,14 @@ actor DaemonClient {
         )
     }
 
+    /// Set the nightwatch mode (off, daywatch, or nightwatch).
+    func setNightwatchMode(_ mode: NightwatchMode) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.nightwatchSetMode,
+            params: NightwatchSetModeParams(mode: mode)
+        )
+    }
+
     /// Fetch fresh usage for a single profile (60s server-side dedupe).
     func fetchProfileUsage(id: UUID) async throws -> ModelProfileUsage {
         let result = try await callAsync(

--- a/Sources/TBDApp/MenuBar/NightwatchStatusItem.swift
+++ b/Sources/TBDApp/MenuBar/NightwatchStatusItem.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import AppKit
+import TBDShared
+
+/// Menu bar "Nightwatch" menu. Displays the current nightwatch mode and
+/// allows toggling between off, daywatch, and nightwatch modes. Three
+/// affordances: "Step out" → daywatch, "Go away" → nightwatch, "I'm back" → off.
+///
+/// The menu TITLE carries the active mode (🌙 / ◐) so "am I being watched?"
+/// is answerable at a glance without opening the menu.
+struct NightwatchStatusItem: Commands {
+    @ObservedObject var appState: AppState
+
+    private var title: String {
+        switch appState.nightwatchMode {
+        case .off: return "Nightwatch"
+        case .daywatch: return "Nightwatch ◐"
+        case .nightwatch: return "Nightwatch 🌙"
+        }
+    }
+
+    var body: some Commands {
+        CommandMenu(title) {
+            NightwatchStatusContent()
+                .environmentObject(appState)
+        }
+    }
+}
+
+/// Extracted into a `View` so SwiftUI re-renders the menu body when
+/// `@Published` properties on `AppState` change. `Commands` bodies do not
+/// always observe `@ObservedObject` mutations reliably for nested content.
+private struct NightwatchStatusContent: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        modeButton("I'm back", mode: .off)
+        modeButton("Step out", mode: .daywatch)
+        modeButton("Go away for the night", mode: .nightwatch)
+    }
+
+    @ViewBuilder
+    private func modeButton(_ label: String, mode: NightwatchMode) -> some View {
+        Button(action: {
+            Task { @MainActor in
+                await appState.setNightwatchMode(mode)
+            }
+        }) {
+            if appState.nightwatchMode == mode {
+                Label(label, systemImage: "checkmark")
+            } else {
+                Text(label)
+            }
+        }
+    }
+}

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -484,6 +484,7 @@ struct TBDAppMain: App {
         .commands {
             TBDCommands(appState: appState)
             ModelProfileMenu(appState: appState)
+            NightwatchStatusItem(appState: appState)
         }
 
         Settings {

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -54,7 +54,8 @@ extension RPCRouter {
             defaultID: config.defaultProfileID,
             primaryAgentPreference: config.primaryAgentPreference,
             globalEnvOverrides: config.envOverrides,
-            autoArchiveOnMergeDefault: config.autoArchiveOnMergeDefault
+            autoArchiveOnMergeDefault: config.autoArchiveOnMergeDefault,
+            nightwatchMode: config.nightwatchMode
         ))
     }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -448,18 +448,21 @@ public struct ModelProfileListResult: Codable, Sendable {
     /// other config-derived fields so the app loads it in one round-trip.
     public let globalEnvOverrides: [String: String]
     public let autoArchiveOnMergeDefault: Bool
+    public let nightwatchMode: NightwatchMode
     public init(
         profiles: [ModelProfileWithUsage],
         defaultID: UUID? = nil,
         primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
         globalEnvOverrides: [String: String] = [:],
-        autoArchiveOnMergeDefault: Bool = false
+        autoArchiveOnMergeDefault: Bool = false,
+        nightwatchMode: NightwatchMode = .off
     ) {
         self.profiles = profiles
         self.defaultID = defaultID
         self.primaryAgentPreference = primaryAgentPreference
         self.globalEnvOverrides = globalEnvOverrides
         self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
+        self.nightwatchMode = nightwatchMode
     }
 
     public init(from decoder: Decoder) throws {
@@ -476,6 +479,8 @@ public struct ModelProfileListResult: Codable, Sendable {
         ) ?? [:]
         autoArchiveOnMergeDefault = try c.decodeIfPresent(
             Bool.self, forKey: .autoArchiveOnMergeDefault) ?? false
+        nightwatchMode = try c.decodeIfPresent(
+            NightwatchMode.self, forKey: .nightwatchMode) ?? .off
     }
 }
 


### PR DESCRIPTION
Follow-up to #338 (the UI commit landed just after auto-merge fired, so it gets its own PR).

Adds the Phase 0 UI for the nightwatch mode flag: a **Nightwatch** command menu with *Step out* (daywatch), *Go away for the night* (nightwatch), *I'm back* (off). The menu **title carries the active mode** (◐ / 🌙) as the at-a-glance "am I being watched?" indicator.

- `nightwatchMode` rides the existing config batch (`ModelProfileListResult`) + `modelProfilesChanged` delta — mirrors `autoArchiveOnMergeDefault` exactly
- `AppState.setNightwatchMode`: RPC + published update + alert on error
- `CommandMenu` per the existing `ModelProfileMenu` pattern (unbundled-safe)
- No new tests: no seam for `Commands` menus; persistence covered by `ConfigStoreTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)