### PR TITLE
fix(app): scratch spaces show "Worktree not found" on first-run selection

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -543,12 +543,17 @@ extension AppState {
             .sorted { $0.sortOrder < $1.sortOrder }
     }
 
-    /// Find a worktree by id across all repos.
+    /// Find a worktree by id across all repos, including repo-less scratch
+    /// spaces. Scratch spaces live only in `scratchWorktrees`, never in the
+    /// repo-grouped `worktrees` dict, so a lookup that consulted `worktrees`
+    /// alone returned nil for a selected scratch space — surfacing as
+    /// "Worktree not found" the instant `createScratch()` auto-selected its
+    /// freshly created row (see `SingleWorktreeView`).
     func findWorktree(id: UUID) -> Worktree? {
         for (_, rows) in worktrees {
             if let wt = rows.first(where: { $0.id == id }) { return wt }
         }
-        return nil
+        return scratchWorktrees.first(where: { $0.id == id })
     }
 
     /// Resolve the effective auto-archive-on-merge setting for a worktree.

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -15,7 +15,8 @@ struct ContentView: View {
 
     private var selectedWorktree: Worktree? {
         guard let id = appState.selectedWorktreeIDs.first else { return nil }
-        return appState.worktrees.values.flatMap { $0 }.first { $0.id == id }
+        // findWorktree also resolves scratch spaces (repo-less worktrees).
+        return appState.findWorktree(id: id)
     }
 
     /// Returns the set of terminal IDs currently rendered anywhere in the

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -98,12 +98,10 @@ struct SingleWorktreeView: View {
     }
 
     private var worktree: Worktree? {
-        for wts in appState.worktrees.values {
-            if let wt = wts.first(where: { $0.id == worktreeID }) {
-                return wt
-            }
-        }
-        return nil
+        // Routes through findWorktree so scratch spaces (which live in
+        // `scratchWorktrees`, not the repo-grouped `worktrees` dict) resolve
+        // too — otherwise selecting a scratch space shows "Worktree not found".
+        appState.findWorktree(id: worktreeID)
     }
 
     private var worktreeTabs: [Tab] {
@@ -387,12 +385,10 @@ private struct MultiWorktreeCell: View {
     @EnvironmentObject var appState: AppState
 
     private var worktree: Worktree? {
-        for wts in appState.worktrees.values {
-            if let wt = wts.first(where: { $0.id == worktreeID }) {
-                return wt
-            }
-        }
-        return nil
+        // Routes through findWorktree so scratch spaces (which live in
+        // `scratchWorktrees`, not the repo-grouped `worktrees` dict) resolve
+        // too — otherwise selecting a scratch space shows "Worktree not found".
+        appState.findWorktree(id: worktreeID)
     }
 
     /// The terminal shown in this cell — derived from the active tab's layout

--- a/Tests/TBDAppTests/FindWorktreeScratchTests.swift
+++ b/Tests/TBDAppTests/FindWorktreeScratchTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Regression tests for `AppState.findWorktree(id:)` resolving repo-less
+/// scratch spaces.
+///
+/// Scratch spaces are stored only in `AppState.scratchWorktrees`, never in the
+/// repo-grouped `worktrees` dict. `createScratch()` appends the new row to
+/// `scratchWorktrees` and immediately sets `selectedWorktreeIDs = [wt.id]`,
+/// which routes the detail pane to `SingleWorktreeView`. That view (and
+/// `ContentView.selectedWorktree`, and the PR toolbar) resolve the selected id
+/// through `findWorktree`. Before the fix, `findWorktree` searched only
+/// `worktrees`, so a freshly created scratch space resolved to nil and the
+/// detail pane rendered "Worktree not found" on first run.
+///
+/// Constructs `AppState(userDefaults:)` against a unique throwaway suite —
+/// `UserDefaults.standard` on this unbundled executable is the developer's real
+/// `TBDApp.plist`.
+@MainActor
+@Suite("findWorktree resolves scratch spaces")
+struct FindWorktreeScratchTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.FindWorktreeScratch.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func makeWorktree(id: UUID, repoID: UUID?) -> Worktree {
+        Worktree(
+            id: id,
+            repoID: repoID,
+            name: "test-\(id.uuidString.prefix(8))",
+            displayName: "Test \(id.uuidString.prefix(8))",
+            branch: "main",
+            path: "/tmp/test",
+            status: .active,
+            tmuxServer: "test-server"
+        )
+    }
+
+    @Test func findsScratchWorktreeNotInReposDict() {
+        withState { state in
+            let scratchID = UUID()
+            state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil)]
+
+            let found = state.findWorktree(id: scratchID)
+
+            #expect(found?.id == scratchID)
+            #expect(found?.isScratch == true)
+        }
+    }
+
+    @Test func stillFindsRepoScopedWorktree() {
+        withState { state in
+            let repoID = UUID()
+            let wtID = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: wtID, repoID: repoID)]]
+
+            #expect(state.findWorktree(id: wtID)?.id == wtID)
+        }
+    }
+
+    @Test func findsScratchEvenWhenReposDictIsPopulated() {
+        withState { state in
+            let repoID = UUID()
+            let repoWtID = UUID()
+            let scratchID = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: repoWtID, repoID: repoID)]]
+            state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil)]
+
+            #expect(state.findWorktree(id: repoWtID)?.id == repoWtID)
+            #expect(state.findWorktree(id: scratchID)?.id == scratchID)
+        }
+    }
+
+    @Test func returnsNilForUnknownID() {
+        withState { state in
+            state.scratchWorktrees = [makeWorktree(id: UUID(), repoID: nil)]
+            #expect(state.findWorktree(id: UUID()) == nil)
+        }
+    }
+}


### PR DESCRIPTION
## Symptom

Creating a scratch space (sidebar **Scratch** section → **+**, or the "Click to
create scratch space" empty-state CTA) immediately renders **"Worktree not
found"** in the detail pane. Selecting an existing scratch row shows the same
error. Hit on first run on a real machine.

## Root cause

Scratch spaces are repo-less worktrees stored **only** in
`AppState.scratchWorktrees` — they are never inserted into the repo-grouped
`AppState.worktrees` dictionary (`AppState.updateState` routes `repoID == nil`
rows into `scratchWorktrees`).

But every worktree resolver on the selection path searched **only**
`worktrees.values`:

- `SingleWorktreeView.worktree` (`Sources/TBDApp/Terminal/TerminalContainerView.swift`) — the one that renders **"Worktree not found"** when it resolves to `nil`
- `MultiWorktreeCell.worktree` (same file)
- `AppState.findWorktree(id:)` (`Sources/TBDApp/AppState+Worktrees.swift`) — used by the PR split-button toolbar and terminal-title resolution
- `ContentView.selectedWorktree` (`Sources/TBDApp/ContentView.swift`) — file panel

`AppState.createScratch()` appends the new row to `scratchWorktrees` and then
sets `selectedWorktreeIDs = [wt.id]`. That selection routes the detail pane to
`SingleWorktreeView`, whose `worktree` lookup misses (the `worktrees` dict has
no scratch rows) → `nil` → **"Worktree not found"**, deterministically, the
instant the scratch space is created and auto-selected.

The daemon side is correct: `scratch.create` inserts a real `repoID = NULL`
worktree row and broadcasts `.worktreeCreated`. The bug is purely client-side
worktree resolution.

## Fix

Make `AppState.findWorktree(id:)` the single source of truth: after checking
the repo-grouped dict, fall back to `scratchWorktrees`. Route the three
view-local resolvers (`SingleWorktreeView`, `MultiWorktreeCell`,
`ContentView.selectedWorktree`) through `findWorktree` instead of each
re-implementing the repo-only loop, so scratch spaces resolve everywhere the
selection is consumed.

## Test

Adds `Tests/TBDAppTests/FindWorktreeScratchTests.swift` (4 cases): a scratch
space resolves when it lives only in `scratchWorktrees`; repo-scoped worktrees
still resolve; both resolve when the repo dict is also populated; an unknown id
returns `nil`. Verified the scratch case **fails** against the pre-fix
`findWorktree` and passes with it.

`swift build` clean; filtered `swift test` green; `swiftlint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
