### PR TITLE
feat: auto-resume Claude sessions when the usage limit resets

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -35,6 +35,9 @@ extension AppState {
             if result.nightwatchMode != nightwatchMode {
                 nightwatchMode = result.nightwatchMode
             }
+            if result.autoResumeOnLimitReset != autoResumeOnLimitReset {
+                autoResumeOnLimitReset = result.autoResumeOnLimitReset
+            }
         } catch {
             logger.error("Failed to list model profiles: \(error, privacy: .public)")
             handleConnectionError(error)
@@ -168,6 +171,18 @@ extension AppState {
         } catch {
             logger.error("Failed to set auto-archive default: \(error, privacy: .public)")
             showAlert("Failed to set default: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set the global session-limit auto-resume gate. Turning it OFF also
+    /// cancels all pending scheduled resumes daemon-side.
+    func setAutoResumeOnLimitReset(_ enabled: Bool) async {
+        do {
+            try await daemonClient.setAutoResumeOnLimitReset(enabled)
+            autoResumeOnLimitReset = enabled
+        } catch {
+            logger.error("Failed to set auto-resume gate: \(error, privacy: .public)")
+            showAlert("Failed to set auto-resume: \(error.localizedDescription)", isError: true)
         }
     }
 

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -405,4 +405,21 @@ extension AppState {
             handleConnectionError(error)
         }
     }
+
+    /// Cancel a pending session-limit auto-resume and clear the badge
+    /// optimistically (the next terminal.list poll would reconcile anyway).
+    func cancelScheduledResume(terminalID: UUID) async {
+        do {
+            try await daemonClient.cancelScheduledResume(terminalID: terminalID)
+            for (worktreeID, rows) in terminals {
+                if let idx = rows.firstIndex(where: { $0.id == terminalID }) {
+                    terminals[worktreeID]?[idx].pendingResumeAt = nil
+                    break
+                }
+            }
+        } catch {
+            showAlert("Failed to cancel scheduled resume: \(error.localizedDescription)",
+                      isError: true)
+        }
+    }
 }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -406,6 +406,10 @@ final class AppState: ObservableObject {
     @Published var autoHibernateEnabled: Bool = true
     /// Auto-hibernate idle timeout in minutes. Loaded from `Config`.
     @Published var hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes
+    /// Daemon-persisted gate for session-limit auto-resume (default OFF).
+    /// Daemon-side (not @AppStorage) because the daemon must act while the
+    /// app is closed.
+    @Published var autoResumeOnLimitReset: Bool = false
     /// Terminals where the user has dismissed the proxy-unreachable banner.
     /// Cleared on app relaunch (in-memory only — banners are advisory).
     @Published var dismissedProxyWarnings: Set<UUID> = []

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -920,6 +920,14 @@ actor DaemonClient {
         )
     }
 
+    /// Cancel a terminal's pending session-limit auto-resume.
+    func cancelScheduledResume(terminalID: UUID) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.terminalCancelScheduledResume,
+            params: CancelScheduledResumeParams(terminalID: terminalID)
+        )
+    }
+
     /// Suspend all Claude terminals in a worktree.
     func worktreeSuspend(worktreeID: UUID) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -757,6 +757,14 @@ actor DaemonClient {
         )
     }
 
+    /// Set the global session-limit auto-resume gate.
+    func setAutoResumeOnLimitReset(_ enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetAutoResumeOnLimitReset,
+            params: ConfigSetAutoResumeOnLimitResetParams(enabled: enabled)
+        )
+    }
+
     /// Set the global scratch-space system-prompt override. Nil or blank resets to the built-in default.
     func setScratchInstructions(_ instructions: String?) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -141,6 +141,12 @@ struct GeneralSettingsTab: View {
             Section("Claude") {
                 Toggle("Launch claude with --dangerously-skip-permissions", isOn: $skipPermissions)
                     .help("Skip the interactive permission prompt when launching claude in new worktrees")
+                Toggle("Auto-resume Claude sessions when the usage limit resets",
+                       isOn: Binding(
+                    get: { appState.autoResumeOnLimitReset },
+                    set: { newValue in Task { await appState.setAutoResumeOnLimitReset(newValue) } }
+                ))
+                .help("When a session hits the usage limit, TBD schedules a resume for the reset time and types \"continue\" into the pane. Off by default; detection and notifications run regardless.")
             }
 
             Section("Session Hibernation") {

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -82,7 +82,7 @@ enum RowStatusIndicator {
     /// they stay consistent.
     static func shouldBoldName(_ notification: NotificationType?) -> Bool {
         switch notification {
-        case .responseComplete, .attentionNeeded, .focusRequest:
+        case .responseComplete, .attentionNeeded, .focusRequest, .limitReached:
             return true
         case .error, .taskComplete, .none:
             return false

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -589,6 +589,16 @@ private struct TabBarItem: View {
                             .fixedSize()
                             .foregroundStyle(isSuspended ? .tertiary : (isSelected ? .primary : .secondary))
                     }
+
+                    if let resumeAt = terminal?.pendingResumeAt {
+                        Text("⏳ resumes \(ResumeTimeFormatter.string(from: resumeAt))")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.orange)
+                            .lineLimit(1)
+                            .fixedSize()
+                            .padding(.leading, 4)
+                            .help("Session limit hit — TBD will type \"continue\" at this time. Right-click to cancel.")
+                    }
                 }
                 .padding(.leading, 8)
                 .frame(minHeight: 28, alignment: .leading)
@@ -778,6 +788,15 @@ private struct TabBarItem: View {
                     isSuspended ? "Resume Claude" : "Suspend Claude",
                     systemImage: isSuspended ? "play.circle" : "pause.circle"
                 )
+            }
+
+            if terminal?.pendingResumeAt != nil {
+                Button {
+                    guard let terminalID = terminal?.id else { return }
+                    Task { await appState.cancelScheduledResume(terminalID: terminalID) }
+                } label: {
+                    Label("Cancel Scheduled Resume", systemImage: "clock.badge.xmark")
+                }
             }
 
             Divider()

--- a/Sources/TBDCLI/Commands/FakeRateLimitCommand.swift
+++ b/Sources/TBDCLI/Commands/FakeRateLimitCommand.swift
@@ -1,0 +1,46 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+/// `tbd hooks fake-rate-limit` — debug/test seam (spec Testing §End-to-end
+/// seam): fabricate a `claude.rateLimitDetected` with a near-future reset so
+/// schedule → actuate → verify can be exercised without burning a real limit.
+/// Run inside a TBD-managed Claude pane (TBD_TERMINAL_ID set) with the
+/// Settings toggle ON, then watch the pane get `continue` typed into it
+/// ~1-2 minutes after the fake reset.
+struct FakeRateLimitCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "fake-rate-limit",
+        abstract: "Debug: fabricate a rate-limit detection with a near-future reset",
+        shouldDisplay: false
+    )
+
+    @Option(name: .long, help: "Seconds until the fake reset (default 60)")
+    var resetsIn: Int = 60
+
+    @Option(name: .long, help: "Terminal ID (defaults to TBD_TERMINAL_ID)")
+    var terminal: String?
+
+    mutating func run() async throws {
+        let idString = terminal
+            ?? ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"]
+        guard let idString, let terminalID = UUID(uuidString: idString) else {
+            print("fake-rate-limit: no terminal ID (pass --terminal or run inside a TBD pane)")
+            return
+        }
+        let client = SocketClient()
+        guard client.isDaemonRunning else {
+            print("fake-rate-limit: daemon is not running")
+            return
+        }
+        let resetsAt = Date().addingTimeInterval(TimeInterval(resetsIn))
+        try client.callVoid(
+            method: RPCMethod.claudeRateLimitDetected,
+            params: RateLimitDetectedParams(
+                terminalID: terminalID,
+                resetsAt: resetsAt,
+                limitType: "debug",
+                rawMessage: "debug: fake session limit · resets in \(resetsIn)s"))
+        print("fake-rate-limit: reported; resetsAt=\(resetsAt) (fire ≈ +60-90s later)")
+    }
+}

--- a/Sources/TBDCLI/Commands/HooksCommand.swift
+++ b/Sources/TBDCLI/Commands/HooksCommand.swift
@@ -8,7 +8,7 @@ struct HooksCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "hooks",
         abstract: "Inspect and manage TBD's Claude Code hook integration",
-        subcommands: [HooksStatusCommand.self, StopRenameCheckCommand.self, StopFailureCommand.self],
+        subcommands: [HooksStatusCommand.self, StopRenameCheckCommand.self, StopFailureCommand.self, FakeRateLimitCommand.self],
         defaultSubcommand: HooksStatusCommand.self
     )
 }

--- a/Sources/TBDCLI/Commands/StopFailureCommand.swift
+++ b/Sources/TBDCLI/Commands/StopFailureCommand.swift
@@ -1,17 +1,18 @@
 import ArgumentParser
 import Foundation
+import TBDShared
 
-/// `tbd hooks stop-failure` — handler for Claude Code's StopFailure hook,
-/// which fires (unlike Stop) when a turn ends due to an API error. It reads
-/// the verbatim error text Claude wrote to the transcript so the notification
-/// distinguishes a session limit ("You've hit your session limit · resets
-/// 3pm") from a transient rate limit ("Server is temporarily limiting
-/// requests") — both of which arrive as error_type=rate_limit, so the type
-/// alone is not enough.
+/// `tbd hooks stop-failure` — handler for Claude Code's StopFailure hook.
 ///
-/// Prints the message to stdout; the overlay pipes it into `tbd notify
-/// --type error`. Prints nothing when stdin can't be parsed. Every failure is
-/// a silent no-op so the agent is never wedged.
+/// Two jobs:
+/// 1. (existing) Print the verbatim API-error text so the overlay can pipe
+///    it into `tbd notify --type error`.
+/// 2. (auto-resume) When the error is a HARD usage limit, report it to the
+///    daemon via `claude.rateLimitDetected` and print NOTHING — the daemon
+///    emits the richer `limit_reached` notification instead, so the user
+///    never sees a duplicate generic error banner. If the RPC cannot be
+///    delivered (daemon down, no TBD_TERMINAL_ID), fall back to printing —
+///    behavior is then identical to the pre-feature CLI.
 struct StopFailureCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "stop-failure",
@@ -20,30 +21,65 @@ struct StopFailureCommand: AsyncParsableCommand {
 
     mutating func run() async throws {
         let stdin = FileHandle.standardInput.readDataToEndOfFile()
-        if let message = StopFailureMessage.compute(
+        let outcome = StopFailureMessage.computeOutcome(
             stdinData: stdin,
             readFile: { path in try? Data(contentsOf: URL(fileURLWithPath: path)) }
-        ) {
+        )
+
+        if let detected = outcome.detectedLimit, reportToDaemon(detected) {
+            return  // daemon owns the limit_reached notification
+        }
+        if let message = outcome.message {
             print(message)
+        }
+    }
+
+    /// Fire the rateLimitDetected RPC. Returns true only when the daemon
+    /// accepted it. Silent on every failure — the hook must never wedge Claude.
+    private func reportToDaemon(_ detected: DetectedRateLimit) -> Bool {
+        guard let terminalIDString = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+              let terminalID = UUID(uuidString: terminalIDString) else {
+            return false
+        }
+        let client = SocketClient()
+        guard client.isDaemonRunning else { return false }
+        do {
+            try client.callVoid(
+                method: RPCMethod.claudeRateLimitDetected,
+                params: RateLimitDetectedParams(
+                    terminalID: terminalID,
+                    resetsAt: detected.resetsAt,
+                    limitType: detected.limitType,
+                    rawMessage: detected.rawMessage))
+            return true
+        } catch {
+            return false
         }
     }
 }
 
 // MARK: - Pure core (testable)
 
-/// Pure message-construction logic for `stop-failure`. Factored out so unit
-/// tests exercise every branch without touching the filesystem.
 enum StopFailureMessage {
 
-    /// Build the notification message for a StopFailure payload.
-    /// - Returns: the verbatim API-error text from the transcript when
-    ///   available; else a generic fallback naming the `error_type`; else nil
-    ///   when the stdin payload can't be parsed (caller prints nothing).
-    static func compute(stdinData: Data, readFile: (String) -> Data?) -> String? {
+    struct Outcome {
+        /// Text for the legacy `tbd notify --type error` pipe (nil = print nothing).
+        let message: String?
+        /// Non-nil when the transcript's last API error is a schedulable hard limit.
+        let detectedLimit: DetectedRateLimit?
+    }
+
+    /// Pure detection + message construction; every branch unit-testable.
+    static func computeOutcome(
+        stdinData: Data,
+        readFile: (String) -> Data?,
+        now: Date = Date(),
+        timeZone: TimeZone = .current
+    ) -> Outcome {
         guard
             let payload = try? JSONSerialization.jsonObject(with: stdinData) as? [String: Any]
         else {
-            return nil
+            return Outcome(message: nil, detectedLimit: nil)
         }
 
         let errorType = (payload["error_type"] as? String) ?? "unknown"
@@ -51,12 +87,20 @@ enum StopFailureMessage {
 
         guard
             let transcriptPath = payload["transcript_path"] as? String,
-            let data = readFile(transcriptPath),
-            let text = lastApiErrorText(in: data)
+            let data = readFile(transcriptPath)
         else {
-            return fallback
+            return Outcome(message: fallback, detectedLimit: nil)
         }
-        return text
+
+        let detected = RateLimitDetection.detect(
+            transcriptData: data, now: now, timeZone: timeZone)
+        let text = lastApiErrorText(in: data)
+        return Outcome(message: text ?? fallback, detectedLimit: detected)
+    }
+
+    /// Legacy entry point — existing tests exercise this shape.
+    static func compute(stdinData: Data, readFile: (String) -> Data?) -> String? {
+        computeOutcome(stdinData: stdinData, readFile: readFile).message
     }
 
     /// Scan transcript JSONL lines from the end; return the first

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -1,0 +1,188 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "limitResume")
+
+/// The tmux surface the actuator needs. `TmuxManager` conforms; tests fake it.
+/// All sends go through the SAME methods `handleTerminalSend` uses — never
+/// raw tmux invocations (spec constraint).
+public protocol ResumeSendingTmux: Sendable {
+    func windowExists(server: String, windowID: String) async -> Bool
+    func paneInMode(server: String, paneID: String) async throws -> Bool
+    func panePID(server: String, paneID: String) async throws -> String
+    func sendKeys(server: String, paneID: String, text: String) async throws
+    func sendKey(server: String, paneID: String, key: String) async throws
+}
+
+extension TmuxManager: ResumeSendingTmux {}
+
+/// Finds the pane's foreground Claude process. `#{pane_current_command}`
+/// reports `zsh` on macOS, so we walk the pane PID's process tree and check
+/// `ps -o stat=` for the `+` (foreground process group) flag instead
+/// (spec §Actuation 1).
+public protocol PaneProcessInspecting: Sendable {
+    /// PID of the Claude process that owns the pane's tty foreground group,
+    /// or nil when Claude is not foreground (bare shell, editor, …).
+    func foregroundClaudePID(panePID: Int32) -> Int32?
+}
+
+public struct ProductionPaneProcessInspector: PaneProcessInspecting {
+    private let signaller: any ProcessSignaller
+
+    public init(signaller: any ProcessSignaller = ProductionProcessSignaller()) {
+        self.signaller = signaller
+    }
+
+    public func foregroundClaudePID(panePID: Int32) -> Int32? {
+        // Candidates: pane PID itself (zsh may have exec'd into Claude),
+        // its children, and grandchildren (wrapper-shell spawns).
+        var candidates: [Int32] = [panePID]
+        let children = signaller.children(ofServerPID: panePID)
+        candidates += children
+        for child in children {
+            candidates += signaller.children(ofServerPID: child)
+        }
+        for pid in candidates {
+            guard let stat = signaller.stat(pid), stat.contains("+"),
+                  let command = signaller.commandLine(pid)?.lowercased(),
+                  command.contains("claude")
+            else { continue }
+            return pid
+        }
+        return nil
+    }
+}
+
+/// Runs one actuation attempt for a scheduled resume: eligibility checks,
+/// the Escape/continue/Enter send sequence, and post-send verification.
+public struct LimitResumeActuator: LimitResumeActuating {
+
+    // MARK: - Timing constants (spec §Actuation 4-5)
+
+    static let interKeyPause: Duration = .milliseconds(150)
+    static let verifyPollInterval: Duration = .seconds(1)
+    static let verifyPolls = 20   // ~20s window
+
+    private let db: TBDDatabase
+    private let tmux: any ResumeSendingTmux
+    private let inspector: any PaneProcessInspecting
+    private let readTranscript: @Sendable (String) -> Data?
+    /// Injectable sleep so unit tests run instantly.
+    private let waiter: @Sendable (Duration) async -> Void
+
+    public init(
+        db: TBDDatabase,
+        tmux: any ResumeSendingTmux,
+        inspector: any PaneProcessInspecting,
+        readTranscript: @escaping @Sendable (String) -> Data?,
+        waiter: @escaping @Sendable (Duration) async -> Void
+    ) {
+        self.db = db
+        self.tmux = tmux
+        self.inspector = inspector
+        self.readTranscript = readTranscript
+        self.waiter = waiter
+    }
+
+    public func actuate(_ resume: ScheduledResume) async -> ResumeActuationOutcome {
+        // 1. Eligibility: terminal alive.
+        guard let terminal = ((try? await db.terminals.get(id: resume.terminalID)) ?? nil),
+              terminal.suspendedAt == nil,
+              let worktree = ((try? await db.worktrees.get(id: terminal.worktreeID)) ?? nil)
+        else { return .terminalGone }
+        let server = worktree.tmuxServer
+        guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
+            return .terminalGone
+        }
+
+        // 2. User already continued? Any transcript record newer than the
+        //    detection instant means yes — send nothing. Keep this read
+        //    around as the pre-send baseline for growth verification below
+        //    (step 6) instead of re-reading — a fresh read here would race
+        //    ahead of the baseline on a fast-growing transcript and make
+        //    growth undetectable.
+        var preSendTranscriptData: Data?
+        if let path = terminal.transcriptPath, !path.isEmpty {
+            preSendTranscriptData = readTranscript(path)
+            if let data = preSendTranscriptData,
+               RateLimitDetection.hasRecord(newerThan: resume.createdAt, in: data) {
+                return .userAlreadyContinued
+            }
+        }
+
+        // 3. Copy-mode: typing would go to the mode; cancelling copy-mode
+        //    would yank the user out of scrollback. Reschedule instead.
+        if (try? await tmux.paneInMode(server: server, paneID: terminal.tmuxPaneID)) == true {
+            return .paneInCopyMode
+        }
+
+        // 4. Claude must be the pane's FOREGROUND process (+ flag). Never
+        //    type into a bare shell.
+        guard let panePIDString = try? await tmux.panePID(server: server, paneID: terminal.tmuxPaneID),
+              let panePID = Int32(panePIDString),
+              inspector.foregroundClaudePID(panePID: panePID) != nil
+        else {
+            return .failed("Claude is not the pane's foreground process")
+        }
+
+        // 5+6. Send, verify; one retry of send+verify, then failed. The
+        // growth baseline is fixed at the pre-send snapshot from step 2 for
+        // both attempts — re-snapshotting per attempt would let a transcript
+        // that grew during a failed first attempt mask itself on the retry.
+        let preSize = preSendTranscriptData?.count ?? 0
+        for attempt in 1...2 {
+            do {
+                try await Self.sendContinueSequence(
+                    tmux: tmux, server: server, paneID: terminal.tmuxPaneID, waiter: waiter)
+            } catch {
+                return .failed("tmux send failed: \(error.localizedDescription)")
+            }
+            if await verifyResumed(terminalID: terminal.id,
+                                   transcriptPath: terminal.transcriptPath,
+                                   preSize: preSize) {
+                return .sent
+            }
+            logger.warning("actuate: no resume signal after attempt \(attempt, privacy: .public) for terminal \(terminal.id.uuidString, privacy: .public)")
+        }
+        return .failed("no activity within the verification window after 2 sends")
+    }
+
+    /// The exact production send sequence (spec §Actuation 4):
+    /// Escape first — at the limit, newer Claude Code opens the
+    /// `/rate-limit-options` menu whose highlighted default can be "Upgrade
+    /// your plan"; a blind Enter can confirm a paid upgrade. Escape
+    /// dismisses and can never select. 150ms pauses — Claude's TUI drops
+    /// keys during UI transitions ("ontinue"). Enter as a separate
+    /// named-key call — text+Enter in one send-keys is treated as a
+    /// bracketed paste (literal newline, nothing submits).
+    ///
+    /// Static + seam-typed so the live tmux test drives this very code path.
+    public static func sendContinueSequence(
+        tmux: any ResumeSendingTmux, server: String, paneID: String,
+        waiter: (Duration) async -> Void
+    ) async throws {
+        try await tmux.sendKey(server: server, paneID: paneID, key: "Escape")
+        await waiter(interKeyPause)
+        try await tmux.sendKeys(server: server, paneID: paneID, text: "continue")
+        await waiter(interKeyPause)
+        try await tmux.sendKey(server: server, paneID: paneID, key: "Enter")
+    }
+
+    /// Success signal within ~20s: the activity hook reports `working`, or
+    /// the transcript file grows (spec §Actuation 5).
+    private func verifyResumed(terminalID: UUID, transcriptPath: String?, preSize: Int) async -> Bool {
+        for _ in 0..<Self.verifyPolls {
+            if let terminal = ((try? await db.terminals.get(id: terminalID)) ?? nil),
+               terminal.activityState == .working {
+                return true
+            }
+            if let path = transcriptPath, !path.isEmpty,
+               let size = readTranscript(path)?.count, size > preSize {
+                return true
+            }
+            await waiter(Self.verifyPollInterval)
+        }
+        return false
+    }
+}

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -20,7 +20,7 @@ extension TmuxManager: ResumeSendingTmux {}
 /// Finds the pane's foreground Claude process. `#{pane_current_command}`
 /// reports `zsh` on macOS, so we walk the pane PID's process tree and check
 /// `ps -o stat=` for the `+` (foreground process group) flag instead
-/// (spec §Actuation 1).
+/// (spec §Actuation 3).
 public protocol PaneProcessInspecting: Sendable {
     /// PID of the Claude process that owns the pane's tty foreground group,
     /// or nil when Claude is not foreground (bare shell, editor, …).
@@ -58,7 +58,7 @@ public struct ProductionPaneProcessInspector: PaneProcessInspecting {
 /// the Escape/continue/Enter send sequence, and post-send verification.
 public struct LimitResumeActuator: LimitResumeActuating {
 
-    // MARK: - Timing constants (spec §Actuation 4-5)
+    // MARK: - Timing constants (spec §Actuation 5-6)
 
     static let interKeyPause: Duration = .milliseconds(150)
     static let verifyPollInterval: Duration = .seconds(1)
@@ -86,69 +86,126 @@ public struct LimitResumeActuator: LimitResumeActuating {
     }
 
     public func actuate(_ resume: ScheduledResume) async -> ResumeActuationOutcome {
-        // 1. Eligibility: terminal alive.
+        // Attempt 1's eligibility pass also captures the pre-send transcript
+        // baseline used for growth verification (see comment at `preSize`
+        // below).
+        let firstContext: EligibilityContext
+        switch await checkEligibility(resume) {
+        case .eligible(let ctx): firstContext = ctx
+        case .notEligible(let outcome): return outcome
+        }
+
+        // The growth baseline is fixed at attempt 1's eligibility snapshot
+        // for BOTH attempts — deliberately not re-baselined on attempt 2.
+        // Re-snapshotting per attempt would let a transcript that grew
+        // during a failed/late-landing attempt 1 mask itself as "no growth"
+        // against attempt 2's fresh (already-grown) baseline; reusing the
+        // original baseline means that growth still counts as resumed.
+        let preSize = firstContext.preSendTranscriptData?.count ?? 0
+
+        var context = firstContext
+        for attempt in 1...2 {
+            // Re-run eligibility (spec §Actuation "one retry of steps 1-5")
+            // on every attempt except the first, which already ran it above.
+            // State can change during a prior attempt's ~20s verify window:
+            // copy-mode entered, the user typed manually, the terminal died.
+            if attempt > 1 {
+                switch await checkEligibility(resume) {
+                case .eligible(let ctx): context = ctx
+                case .notEligible(let outcome): return outcome
+                }
+            }
+
+            do {
+                try await Self.sendContinueSequence(
+                    tmux: tmux, server: context.server, paneID: context.paneID, waiter: waiter)
+            } catch {
+                // Treat a thrown send like a failed verification: retry
+                // (with a fresh eligibility re-check) rather than failing
+                // instantly — only give up after attempt 2 also fails.
+                logger.warning("actuate: send threw on attempt \(attempt, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                continue
+            }
+            if await verifyResumed(terminalID: context.terminalID,
+                                   transcriptPath: context.transcriptPath,
+                                   preSize: preSize) {
+                return .sent
+            }
+            logger.warning("actuate: no resume signal after attempt \(attempt, privacy: .public) for terminal \(context.terminalID.uuidString, privacy: .public)")
+        }
+        return .failed("no activity within the verification window after 2 sends")
+    }
+
+    /// What one eligibility pass (spec §Actuation 1-4) concluded: either all
+    /// checks passed (carrying what the send/verify steps need), or a check
+    /// failed — in which case its outcome IS the actuation outcome.
+    private enum EligibilityCheckResult {
+        case eligible(EligibilityContext)
+        case notEligible(ResumeActuationOutcome)
+    }
+
+    private struct EligibilityContext {
+        let server: String
+        let paneID: String
+        let terminalID: UUID
+        let transcriptPath: String?
+        /// Transcript bytes read during THIS eligibility pass's
+        /// user-already-continued check (step 2) — reused as the growth
+        /// baseline for verification of the send this context leads to.
+        let preSendTranscriptData: Data?
+    }
+
+    /// Runs eligibility steps 1-4 (spec §Actuation), in order: terminal
+    /// alive → user-already-continued → Claude foreground → copy-mode.
+    /// Foreground is checked before copy-mode so a dead/backgrounded shell
+    /// classifies `.failed` rather than endlessly rescheduling on a stale
+    /// copy-mode flag.
+    private func checkEligibility(_ resume: ScheduledResume) async -> EligibilityCheckResult {
+        // 1. Terminal alive.
         guard let terminal = ((try? await db.terminals.get(id: resume.terminalID)) ?? nil),
               terminal.suspendedAt == nil,
               let worktree = ((try? await db.worktrees.get(id: terminal.worktreeID)) ?? nil)
-        else { return .terminalGone }
+        else { return .notEligible(.terminalGone) }
         let server = worktree.tmuxServer
         guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
-            return .terminalGone
+            return .notEligible(.terminalGone)
         }
 
         // 2. User already continued? Any transcript record newer than the
         //    detection instant means yes — send nothing. Keep this read
-        //    around as the pre-send baseline for growth verification below
-        //    (step 6) instead of re-reading — a fresh read here would race
-        //    ahead of the baseline on a fast-growing transcript and make
-        //    growth undetectable.
+        //    around as the pre-send baseline for growth verification — a
+        //    fresh read later would race ahead of the baseline on a
+        //    fast-growing transcript and make growth undetectable.
         var preSendTranscriptData: Data?
         if let path = terminal.transcriptPath, !path.isEmpty {
             preSendTranscriptData = readTranscript(path)
             if let data = preSendTranscriptData,
                RateLimitDetection.hasRecord(newerThan: resume.createdAt, in: data) {
-                return .userAlreadyContinued
+                return .notEligible(.userAlreadyContinued)
             }
         }
 
-        // 3. Copy-mode: typing would go to the mode; cancelling copy-mode
-        //    would yank the user out of scrollback. Reschedule instead.
-        if (try? await tmux.paneInMode(server: server, paneID: terminal.tmuxPaneID)) == true {
-            return .paneInCopyMode
-        }
-
-        // 4. Claude must be the pane's FOREGROUND process (+ flag). Never
+        // 3. Claude must be the pane's FOREGROUND process (+ flag). Never
         //    type into a bare shell.
         guard let panePIDString = try? await tmux.panePID(server: server, paneID: terminal.tmuxPaneID),
               let panePID = Int32(panePIDString),
               inspector.foregroundClaudePID(panePID: panePID) != nil
         else {
-            return .failed("Claude is not the pane's foreground process")
+            return .notEligible(.failed("Claude is not the pane's foreground process"))
         }
 
-        // 5+6. Send, verify; one retry of send+verify, then failed. The
-        // growth baseline is fixed at the pre-send snapshot from step 2 for
-        // both attempts — re-snapshotting per attempt would let a transcript
-        // that grew during a failed first attempt mask itself on the retry.
-        let preSize = preSendTranscriptData?.count ?? 0
-        for attempt in 1...2 {
-            do {
-                try await Self.sendContinueSequence(
-                    tmux: tmux, server: server, paneID: terminal.tmuxPaneID, waiter: waiter)
-            } catch {
-                return .failed("tmux send failed: \(error.localizedDescription)")
-            }
-            if await verifyResumed(terminalID: terminal.id,
-                                   transcriptPath: terminal.transcriptPath,
-                                   preSize: preSize) {
-                return .sent
-            }
-            logger.warning("actuate: no resume signal after attempt \(attempt, privacy: .public) for terminal \(terminal.id.uuidString, privacy: .public)")
+        // 4. Copy-mode: typing would go to the mode; cancelling copy-mode
+        //    would yank the user out of scrollback. Reschedule instead.
+        if (try? await tmux.paneInMode(server: server, paneID: terminal.tmuxPaneID)) == true {
+            return .notEligible(.paneInCopyMode)
         }
-        return .failed("no activity within the verification window after 2 sends")
+
+        return .eligible(EligibilityContext(
+            server: server, paneID: terminal.tmuxPaneID, terminalID: terminal.id,
+            transcriptPath: terminal.transcriptPath, preSendTranscriptData: preSendTranscriptData))
     }
 
-    /// The exact production send sequence (spec §Actuation 4):
+    /// The exact production send sequence (spec §Actuation 5):
     /// Escape first — at the limit, newer Claude Code opens the
     /// `/rate-limit-options` menu whose highlighted default can be "Upgrade
     /// your plan"; a blind Enter can confirm a paid upgrade. Escape
@@ -170,7 +227,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
     }
 
     /// Success signal within ~20s: the activity hook reports `working`, or
-    /// the transcript file grows (spec §Actuation 5).
+    /// the transcript file grows (spec §Actuation 6).
     private func verifyResumed(terminalID: UUID, transcriptPath: String?, preSize: Int) async -> Bool {
         for _ in 0..<Self.verifyPolls {
             if let terminal = ((try? await db.terminals.get(id: terminalID)) ?? nil),

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -159,8 +159,21 @@ public struct LimitResumeActuator: LimitResumeActuating {
     /// alive → user-already-continued → Claude foreground → copy-mode.
     /// Foreground is checked before copy-mode so a dead/backgrounded shell
     /// classifies `.failed` rather than endlessly rescheduling on a stale
-    /// copy-mode flag.
+    /// copy-mode flag. Two additional checks (0a global toggle, 1b row
+    /// status) run on every pass too — they aren't in the spec's numbered
+    /// list but close the same "state changed during a prior attempt's ~20s
+    /// verify window" gap the spec's steps 1-4 already cover for the other
+    /// cancellation reasons.
     private func checkEligibility(_ resume: ScheduledResume) async -> EligibilityCheckResult {
+        // 0a. Toggle-off-mid-flight: the global gate can be switched off
+        //     while a prior attempt's ~20s verify window is running. This
+        //     check runs on EVERY call to `checkEligibility` (the initial
+        //     pass and every attempt>1 re-check in `actuate`), so attempt 2
+        //     never fires after the user turns auto-resume off mid-flight.
+        guard (try? await db.config.get())?.autoResumeOnLimitReset ?? false else {
+            return .notEligible(.cancelledExternally)
+        }
+
         // 1. Terminal alive.
         guard let terminal = ((try? await db.terminals.get(id: resume.terminalID)) ?? nil),
               terminal.suspendedAt == nil,
@@ -169,6 +182,19 @@ public struct LimitResumeActuator: LimitResumeActuating {
         let server = worktree.tmuxServer
         guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
             return .notEligible(.terminalGone)
+        }
+
+        // 1b. Explicit-cancel-mid-flight: the row itself can be cancelled
+        //     (`cancelPending`/`cancelAllPending`) while a prior attempt's
+        //     verify window is running — e.g. the user clicked "Cancel
+        //     scheduled resume". Re-checking the row's own status here
+        //     (same every-call guarantee as 0a) closes that gap too. Placed
+        //     after the terminal-alive check (not at the very top) so a
+        //     terminal/row that was never persisted at all (defensive
+        //     callers, tests) still classifies via step 1's `.terminalGone`
+        //     rather than this row lookup.
+        guard ((try? await db.scheduledResumes.get(id: resume.id)) ?? nil)?.status == .pending else {
+            return .notEligible(.cancelledExternally)
         }
 
         // 2. User already continued? Any transcript record newer than the

--- a/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
@@ -47,7 +47,7 @@ public enum LimitResumeOutcome: Equatable, Sendable {
 /// at once). Spec §Scheduler, §State.
 public actor LimitResumeScheduler {
 
-    // MARK: - Constants (spec §Scheduler / §Actuation 3)
+    // MARK: - Constants (spec §Scheduler / §Actuation 4)
 
     public static let slack: TimeInterval = 60
     public static let jitterMax: TimeInterval = 30
@@ -252,7 +252,7 @@ public actor LimitResumeScheduler {
                 logger.warning("fire: copy-mode retry cap hit for terminal \(row.terminalID.uuidString, privacy: .public)")
                 await onOutcome(row, .failed("pane stayed in copy-mode/scrollback for ~30 minutes"))
             } else {
-                // Don't cancel their scroll — retry in 2 minutes (spec §Actuation 3).
+                // Don't cancel their scroll — retry in 2 minutes (spec §Actuation 4).
                 let nextFire = clock.now().addingTimeInterval(Self.copyModeRetryDelay)
                 if let rescheduled = await rescheduleWithRetry(id: row.id, fireAt: nextFire, attemptCount: attempts, terminalID: row.terminalID) {
                     if rescheduled {

--- a/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
@@ -48,6 +48,13 @@ public actor LimitResumeScheduler {
     public static let copyModeRetryDelay: TimeInterval = 120
     public static let maxCopyModeAttempts = 15
 
+    /// Post-actuation store-write retry (double-fire protection).
+    private static let writeRetryAttempts = 3
+    private static let writeRetryDelay: TimeInterval = 1
+    /// Backoff before retrying a failed `store.pending()` read — keeps the
+    /// loop self-driven instead of parking in `waitIdle()` forever.
+    private static let readErrorRetryDelay: TimeInterval = 5
+
     // MARK: - Dependencies
 
     private let store: ScheduledResumeStore
@@ -62,6 +69,14 @@ public actor LimitResumeScheduler {
     private var loopTask: Task<Void, Never>?
     private var idleWakeContinuation: CheckedContinuation<Void, Never>?
     private var currentSleepTask: Task<Void, Error>?
+
+    /// Row IDs currently being actuated, or whose post-actuation store write
+    /// failed after all retries. Selection skips these IDs so a write
+    /// failure can never cause `actuator.actuate` to run twice for the same
+    /// row. IDs that exhaust write retries stay here for the rest of this
+    /// process's lifetime — a daemon restart re-evaluates from DB truth,
+    /// which is the accepted tradeoff (see `fire`).
+    private var inFlightOrFired: Set<UUID> = []
 
     public init(
         store: ScheduledResumeStore,
@@ -129,10 +144,7 @@ public actor LimitResumeScheduler {
             resetsAt: resetsAt, fireAt: fireAt,
             limitType: limitType, rawMessage: rawMessage,
             createdAt: clock.now())
-        // `try?` on a `-> ScheduledResume?` API yields a double optional:
-        // outer nil = threw, inner nil = latch rejected. Flatten with `?? nil`.
-        let insertResult: ScheduledResume?? = try? await store.insertPending(row)
-        guard let inserted = insertResult ?? nil else {
+        guard let inserted = try? await store.insertPending(row) else {
             logger.info("schedule: no pending row created for terminal \(terminalID.uuidString, privacy: .public) (latch or store error)")
             return nil
         }
@@ -145,8 +157,21 @@ public actor LimitResumeScheduler {
 
     private func runLoop() async {
         while !Task.isCancelled {
-            let rows = (try? await store.pending()) ?? []
-            guard let next = rows.first else {   // pending() is fireAt-ordered
+            let rows: [ScheduledResume]
+            do {
+                rows = try await store.pending()
+            } catch {
+                logger.error("runLoop: pending() read failed: \(String(describing: error), privacy: .public); retrying in \(Self.readErrorRetryDelay, privacy: .public)s")
+                try? await clock.sleep(until: clock.now().addingTimeInterval(Self.readErrorRetryDelay))
+                if Task.isCancelled { return }
+                continue
+            }
+
+            // Skip rows currently being actuated or whose post-actuation
+            // write permanently failed — never re-select them (double-fire
+            // guard; see `inFlightOrFired`).
+            let candidates = rows.filter { !inFlightOrFired.contains($0.id) }   // pending() is fireAt-ordered
+            guard let next = candidates.first else {
                 await waitIdle()
                 if Task.isCancelled { return }
                 continue
@@ -163,7 +188,13 @@ public actor LimitResumeScheduler {
             if Task.isCancelled { return }
 
             let now = clock.now()
-            let due = ((try? await store.pending()) ?? []).filter { $0.fireAt <= now }
+            let due: [ScheduledResume]
+            do {
+                due = try await store.pending().filter { $0.fireAt <= now && !inFlightOrFired.contains($0.id) }
+            } catch {
+                logger.error("runLoop: pending() read failed while collecting due rows: \(String(describing: error), privacy: .public)")
+                due = []
+            }
             for row in due {
                 await fire(row)
             }
@@ -179,42 +210,110 @@ public actor LimitResumeScheduler {
     // MARK: - Fire
 
     private func fire(_ row: ScheduledResume) async {
+        inFlightOrFired.insert(row.id)
+
         // Belt-and-braces gate check: toggle-off should already have
         // cancelled pending rows; if one slipped through, cancel silently.
         let enabled = (try? await config.get())?.autoResumeOnLimitReset ?? false
         guard enabled else {
-            try? await store.setStatus(id: row.id, status: .cancelled)
+            if await setStatusWithRetry(id: row.id, status: .cancelled, terminalID: row.terminalID, context: "toggle-off") {
+                inFlightOrFired.remove(row.id)
+            }
             return
         }
 
         let outcome = await actuator.actuate(row)
         switch outcome {
         case .sent:
-            try? await store.setStatus(id: row.id, status: .sent)
+            if await setStatusWithRetry(id: row.id, status: .sent, terminalID: row.terminalID, context: "sent") {
+                inFlightOrFired.remove(row.id)
+            }
             logger.info("fire: sent continue to terminal \(row.terminalID.uuidString, privacy: .public)")
             await onOutcome(row, .sent)
 
         case .userAlreadyContinued, .terminalGone:
-            try? await store.setStatus(id: row.id, status: .cancelled)
+            if await setStatusWithRetry(id: row.id, status: .cancelled, terminalID: row.terminalID, context: String(describing: outcome)) {
+                inFlightOrFired.remove(row.id)
+            }
             logger.info("fire: cancelled (\(String(describing: outcome), privacy: .public)) for terminal \(row.terminalID.uuidString, privacy: .public)")
 
         case .paneInCopyMode:
             let attempts = row.attemptCount + 1
             if attempts >= Self.maxCopyModeAttempts {
-                try? await store.setStatus(id: row.id, status: .failed)
+                if await setStatusWithRetry(id: row.id, status: .failed, terminalID: row.terminalID, context: "copy-mode cap") {
+                    inFlightOrFired.remove(row.id)
+                }
                 logger.warning("fire: copy-mode retry cap hit for terminal \(row.terminalID.uuidString, privacy: .public)")
                 await onOutcome(row, .failed("pane stayed in copy-mode/scrollback for ~30 minutes"))
             } else {
                 // Don't cancel their scroll — retry in 2 minutes (spec §Actuation 3).
                 let nextFire = clock.now().addingTimeInterval(Self.copyModeRetryDelay)
-                try? await store.reschedule(id: row.id, fireAt: nextFire, attemptCount: attempts)
-                logger.info("fire: pane in copy-mode; rescheduled attempt \(attempts, privacy: .public) for terminal \(row.terminalID.uuidString, privacy: .public)")
+                if let rescheduled = await rescheduleWithRetry(id: row.id, fireAt: nextFire, attemptCount: attempts, terminalID: row.terminalID) {
+                    if rescheduled {
+                        logger.info("fire: pane in copy-mode; rescheduled attempt \(attempts, privacy: .public) for terminal \(row.terminalID.uuidString, privacy: .public)")
+                    } else {
+                        logger.debug("fire: row no longer pending, dropping (terminal \(row.terminalID.uuidString, privacy: .public))")
+                    }
+                    // Either the row is intentionally still pending (future
+                    // fireAt — remove so the future attempt can fire) or it's
+                    // gone for good (also safe to remove). Only a write
+                    // failure (nil) should leave the ID latched.
+                    inFlightOrFired.remove(row.id)
+                }
             }
 
         case .failed(let reason):
-            try? await store.setStatus(id: row.id, status: .failed)
+            if await setStatusWithRetry(id: row.id, status: .failed, terminalID: row.terminalID, context: "failed") {
+                inFlightOrFired.remove(row.id)
+            }
             logger.warning("fire: failed for terminal \(row.terminalID.uuidString, privacy: .public): \(reason, privacy: .public)")
             await onOutcome(row, .failed(reason))
         }
+    }
+
+    /// Retry a `setStatus` write up to `writeRetryAttempts` times, sleeping
+    /// `writeRetryDelay` seconds (via the injected clock) between attempts.
+    /// Returns true once the write succeeds; logs `.error` and returns false
+    /// once retries are exhausted (double-fire protection — see
+    /// `inFlightOrFired`).
+    @discardableResult
+    private func setStatusWithRetry(
+        id: UUID, status: ScheduledResumeStatus, terminalID: UUID, context: String
+    ) async -> Bool {
+        for attempt in 1...Self.writeRetryAttempts {
+            do {
+                try await store.setStatus(id: id, status: status)
+                return true
+            } catch {
+                if attempt < Self.writeRetryAttempts {
+                    try? await clock.sleep(until: clock.now().addingTimeInterval(Self.writeRetryDelay))
+                } else {
+                    logger.error("fire: setStatus(\(status.rawValue, privacy: .public)) [\(context, privacy: .public)] failed after \(Self.writeRetryAttempts, privacy: .public) attempts for terminal \(terminalID.uuidString, privacy: .public), row \(id.uuidString, privacy: .public): \(String(describing: error), privacy: .public). Leaving row marked in-flight for this process lifetime to prevent double-fire; a daemon restart re-evaluates from DB truth.")
+                }
+            }
+        }
+        return false
+    }
+
+    /// Retry a `reschedule` write up to `writeRetryAttempts` times, sleeping
+    /// `writeRetryDelay` seconds (via the injected clock) between attempts.
+    /// Returns the store's own Bool (true = rescheduled, false = row no
+    /// longer pending) once a write succeeds, or nil once retries are
+    /// exhausted (double-fire protection — see `inFlightOrFired`).
+    private func rescheduleWithRetry(
+        id: UUID, fireAt: Date, attemptCount: Int, terminalID: UUID
+    ) async -> Bool? {
+        for attempt in 1...Self.writeRetryAttempts {
+            do {
+                return try await store.reschedule(id: id, fireAt: fireAt, attemptCount: attemptCount)
+            } catch {
+                if attempt < Self.writeRetryAttempts {
+                    try? await clock.sleep(until: clock.now().addingTimeInterval(Self.writeRetryDelay))
+                } else {
+                    logger.error("fire: reschedule failed after \(Self.writeRetryAttempts, privacy: .public) attempts for terminal \(terminalID.uuidString, privacy: .public), row \(id.uuidString, privacy: .public): \(String(describing: error), privacy: .public). Leaving row marked in-flight for this process lifetime to prevent double-fire; a daemon restart re-evaluates from DB truth.")
+                }
+            }
+        }
+        return nil
     }
 }

--- a/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
@@ -15,6 +15,12 @@ public enum ResumeActuationOutcome: Equatable, Sendable {
     /// `#{pane_in_mode}` was set; typing would land in copy-mode and
     /// cancelling copy-mode would yank the user out of scrollback.
     case paneInCopyMode
+    /// The global toggle was switched off, or this row was explicitly
+    /// cancelled (`cancelPending`/`cancelAllPending`), while an actuation
+    /// was in-flight — caught by `checkEligibility`'s toggle/row-status
+    /// re-check between attempts (spec §Cancellation). Cancel silently,
+    /// same handling as `.terminalGone`.
+    case cancelledExternally
     /// Hard failure (Claude not foreground, send verify timed out, …).
     case failed(String)
 }
@@ -231,7 +237,7 @@ public actor LimitResumeScheduler {
             logger.info("fire: sent continue to terminal \(row.terminalID.uuidString, privacy: .public)")
             await onOutcome(row, .sent)
 
-        case .userAlreadyContinued, .terminalGone:
+        case .userAlreadyContinued, .terminalGone, .cancelledExternally:
             if await setStatusWithRetry(id: row.id, status: .cancelled, terminalID: row.terminalID, context: String(describing: outcome)) {
                 inFlightOrFired.remove(row.id)
             }

--- a/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
@@ -1,0 +1,220 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "limitResume")
+
+/// What one actuation attempt concluded (produced by `LimitResumeActuating`).
+public enum ResumeActuationOutcome: Equatable, Sendable {
+    /// Send verified — Claude is working again.
+    case sent
+    /// Transcript grew after the limit record — user continued manually.
+    case userAlreadyContinued
+    /// Terminal deleted/suspended/window dead — cancel silently.
+    case terminalGone
+    /// `#{pane_in_mode}` was set; typing would land in copy-mode and
+    /// cancelling copy-mode would yank the user out of scrollback.
+    case paneInCopyMode
+    /// Hard failure (Claude not foreground, send verify timed out, …).
+    case failed(String)
+}
+
+/// Seam between the scheduler (timing) and the actuator (tmux side effects).
+public protocol LimitResumeActuating: Sendable {
+    func actuate(_ resume: ScheduledResume) async -> ResumeActuationOutcome
+}
+
+/// Terminal outcome surfaced to the user (notification copy lives in the
+/// daemon wiring's onOutcome closure).
+public enum LimitResumeOutcome: Equatable, Sendable {
+    case sent
+    case failed(String)
+}
+
+/// Fires scheduled session-limit resumes. Clone of `ClaudeUsagePoller`'s
+/// loop shape: injected clock, min-deadline cancellable sleep, `wake()` on
+/// insert/cancel, idle continuation when no rows are pending.
+///
+/// Restart-safe by construction: the loop re-reads `store.pending()` every
+/// iteration, so rows inserted before a daemon restart reload automatically
+/// and past-due rows fire immediately (`clock.sleep(until: past)` returns
+/// at once). Spec §Scheduler, §State.
+public actor LimitResumeScheduler {
+
+    // MARK: - Constants (spec §Scheduler / §Actuation 3)
+
+    public static let slack: TimeInterval = 60
+    public static let jitterMax: TimeInterval = 30
+    public static let copyModeRetryDelay: TimeInterval = 120
+    public static let maxCopyModeAttempts = 15
+
+    // MARK: - Dependencies
+
+    private let store: ScheduledResumeStore
+    private let config: ConfigStore
+    private let actuator: any LimitResumeActuating
+    private let clock: PollerClock
+    private let jitterProvider: @Sendable () -> TimeInterval
+    private let onOutcome: @Sendable (ScheduledResume, LimitResumeOutcome) async -> Void
+
+    // MARK: - State
+
+    private var loopTask: Task<Void, Never>?
+    private var idleWakeContinuation: CheckedContinuation<Void, Never>?
+    private var currentSleepTask: Task<Void, Error>?
+
+    public init(
+        store: ScheduledResumeStore,
+        config: ConfigStore,
+        actuator: any LimitResumeActuating,
+        clock: PollerClock,
+        jitterProvider: (@Sendable () -> TimeInterval)? = nil,
+        onOutcome: @escaping @Sendable (ScheduledResume, LimitResumeOutcome) async -> Void
+    ) {
+        self.store = store
+        self.config = config
+        self.actuator = actuator
+        self.clock = clock
+        self.jitterProvider = jitterProvider ?? { Double.random(in: 0..<Self.jitterMax) }
+        self.onOutcome = onOutcome
+    }
+
+    // MARK: - Lifecycle
+
+    /// Launch the loop. Idempotent. Pending rows (including past-due ones)
+    /// are picked up on the first iteration — that IS the startup reload.
+    public func start() async {
+        guard loopTask == nil else { return }
+        loopTask = Task { [weak self] in
+            await self?.runLoop()
+        }
+    }
+
+    public func stop() {
+        loopTask?.cancel()
+        loopTask = nil
+        currentSleepTask?.cancel()
+        currentSleepTask = nil
+        if let cont = idleWakeContinuation {
+            idleWakeContinuation = nil
+            cont.resume()
+        }
+    }
+
+    /// Interrupt the current sleep / idle wait so the loop re-reads pending
+    /// rows. Called on insert, cancel, and toggle changes.
+    public func wake() {
+        if let cont = idleWakeContinuation {
+            idleWakeContinuation = nil
+            cont.resume()
+        }
+        currentSleepTask?.cancel()
+        currentSleepTask = nil
+    }
+
+    // MARK: - Scheduling
+
+    /// Insert a pending row for a detected limit. Computes
+    /// `fireAt = resetsAt + slack + jitter` ONCE (never re-derived from
+    /// display text). Returns nil when the terminal already has a pending
+    /// row (the double-send latch).
+    public func schedule(
+        terminalID: UUID, worktreeID: UUID, claudeSessionID: String?,
+        resetsAt: Date, limitType: String, rawMessage: String
+    ) async -> ScheduledResume? {
+        let fireAt = resetsAt.addingTimeInterval(Self.slack + jitterProvider())
+        let row = ScheduledResume(
+            terminalID: terminalID, worktreeID: worktreeID,
+            claudeSessionID: claudeSessionID,
+            resetsAt: resetsAt, fireAt: fireAt,
+            limitType: limitType, rawMessage: rawMessage,
+            createdAt: clock.now())
+        // `try?` on a `-> ScheduledResume?` API yields a double optional:
+        // outer nil = threw, inner nil = latch rejected. Flatten with `?? nil`.
+        let insertResult: ScheduledResume?? = try? await store.insertPending(row)
+        guard let inserted = insertResult ?? nil else {
+            logger.info("schedule: no pending row created for terminal \(terminalID.uuidString, privacy: .public) (latch or store error)")
+            return nil
+        }
+        logger.info("schedule: resume for terminal \(terminalID.uuidString, privacy: .public) at \(fireAt.description, privacy: .public) (type \(limitType, privacy: .public))")
+        wake()
+        return inserted
+    }
+
+    // MARK: - Loop
+
+    private func runLoop() async {
+        while !Task.isCancelled {
+            let rows = (try? await store.pending()) ?? []
+            guard let next = rows.first else {   // pending() is fireAt-ordered
+                await waitIdle()
+                if Task.isCancelled { return }
+                continue
+            }
+
+            let clock = self.clock
+            let deadline = next.fireAt
+            let sleepTask = Task<Void, Error> {
+                try await clock.sleep(until: deadline)
+            }
+            currentSleepTask = sleepTask
+            _ = try? await sleepTask.value
+            currentSleepTask = nil
+            if Task.isCancelled { return }
+
+            let now = clock.now()
+            let due = ((try? await store.pending()) ?? []).filter { $0.fireAt <= now }
+            for row in due {
+                await fire(row)
+            }
+        }
+    }
+
+    private func waitIdle() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            idleWakeContinuation = cont
+        }
+    }
+
+    // MARK: - Fire
+
+    private func fire(_ row: ScheduledResume) async {
+        // Belt-and-braces gate check: toggle-off should already have
+        // cancelled pending rows; if one slipped through, cancel silently.
+        let enabled = (try? await config.get())?.autoResumeOnLimitReset ?? false
+        guard enabled else {
+            try? await store.setStatus(id: row.id, status: .cancelled)
+            return
+        }
+
+        let outcome = await actuator.actuate(row)
+        switch outcome {
+        case .sent:
+            try? await store.setStatus(id: row.id, status: .sent)
+            logger.info("fire: sent continue to terminal \(row.terminalID.uuidString, privacy: .public)")
+            await onOutcome(row, .sent)
+
+        case .userAlreadyContinued, .terminalGone:
+            try? await store.setStatus(id: row.id, status: .cancelled)
+            logger.info("fire: cancelled (\(String(describing: outcome), privacy: .public)) for terminal \(row.terminalID.uuidString, privacy: .public)")
+
+        case .paneInCopyMode:
+            let attempts = row.attemptCount + 1
+            if attempts >= Self.maxCopyModeAttempts {
+                try? await store.setStatus(id: row.id, status: .failed)
+                logger.warning("fire: copy-mode retry cap hit for terminal \(row.terminalID.uuidString, privacy: .public)")
+                await onOutcome(row, .failed("pane stayed in copy-mode/scrollback for ~30 minutes"))
+            } else {
+                // Don't cancel their scroll — retry in 2 minutes (spec §Actuation 3).
+                let nextFire = clock.now().addingTimeInterval(Self.copyModeRetryDelay)
+                try? await store.reschedule(id: row.id, fireAt: nextFire, attemptCount: attempts)
+                logger.info("fire: pane in copy-mode; rescheduled attempt \(attempts, privacy: .public) for terminal \(row.terminalID.uuidString, privacy: .public)")
+            }
+
+        case .failed(let reason):
+            try? await store.setStatus(id: row.id, status: .failed)
+            logger.warning("fire: failed for terminal \(row.terminalID.uuidString, privacy: .public): \(reason, privacy: .public)")
+            await onOutcome(row, .failed(reason))
+        }
+    }
+}

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -63,6 +63,9 @@ public final class Daemon: Sendable {
     public nonisolated(unsafe) var hibernationSweepTask: Task<Void, Never>?
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     public nonisolated(unsafe) var oauthUsagePoller: OAuthProfileUsagePoller?
+    /// Session-limit auto-resume scheduler. Owned here so it can be stopped
+    /// on shutdown; `nil` in mock mode.
+    public nonisolated(unsafe) var limitResumeScheduler: LimitResumeScheduler?
     /// Per-daemon tmux control-mode supervisor. Owned here so it can be stopped
     /// on shutdown; the gate (`ControlModeGate.shouldEnable`) keeps it dormant
     /// unless `TBD_TMUX_CONTROL_MODE` is opted in and tmux is ≥ 3.2.
@@ -546,6 +549,44 @@ public final class Daemon: Sendable {
             rpcRouter.oauthUsagePoller = oauthPoller
             await oauthPoller.start()
 
+            // 12d. Session-limit auto-resume scheduler (spec 2026-07-03).
+            // Pending rows reload on start; past-due rows fire immediately
+            // (covers Mac sleep and multi-day weekly-limit waits).
+            let resumeActuator = LimitResumeActuator(
+                db: database,
+                tmux: tmux,
+                inspector: ProductionPaneProcessInspector(),
+                readTranscript: { path in FileManager.default.contents(atPath: path) },
+                waiter: { duration in _ = try? await Task.sleep(for: duration) }
+            )
+            let resumeScheduler = LimitResumeScheduler(
+                store: database.scheduledResumes,
+                config: database.config,
+                actuator: resumeActuator,
+                clock: SystemPollerClock(),
+                onOutcome: { [weak subs, database] resume, outcome in
+                    let (type, message): (NotificationType, String)
+                    switch outcome {
+                    case .sent:
+                        (type, message) = (.limitReached, "Auto-resumed Claude after the limit reset")
+                    case .failed(let reason):
+                        (type, message) = (.attentionNeeded,
+                            "Auto-resume failed — \(reason). Claude may still be parked at the limit screen.")
+                    }
+                    guard let notification = try? await database.notifications.create(
+                        worktreeID: resume.worktreeID, type: type,
+                        message: message, terminalID: resume.terminalID)
+                    else { return }
+                    subs?.broadcast(delta: .notificationReceived(NotificationDelta(
+                        notificationID: notification.id, worktreeID: notification.worktreeID,
+                        type: notification.type, message: notification.message,
+                        terminalID: notification.terminalID)))
+                }
+            )
+            self.limitResumeScheduler = resumeScheduler
+            rpcRouter.limitResumeScheduler = resumeScheduler
+            await resumeScheduler.start()
+
             // 13. Periodic git status refresh (branch sync, conflict detection).
             // 10s foreground, 60s background (GitPollCadence.statusInterval);
             // per-worktree conflict checks are additionally dirty-gated inside
@@ -612,6 +653,10 @@ public final class Daemon: Sendable {
         }
         if let poller = oauthUsagePoller {
             await poller.stop()
+        }
+
+        if let resumeScheduler = limitResumeScheduler {
+            await resumeScheduler.stop()
         }
 
         // Stop any tmux control-mode connections (no-op when the gate is off).

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -130,6 +130,16 @@ public struct ConfigStore: Sendable {
         }
     }
 
+    /// Persist the session-limit auto-resume gate (default OFF).
+    public func setAutoResumeOnLimitReset(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_resume_on_limit_reset = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
     /// Persist the global scratch-space system-prompt override. Nil or a
     /// whitespace-only string clears the override, falling back to the
     /// built-in default scratch layer.

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -17,6 +17,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// JSON-encoded `[String: String]` free-form env overrides (global scope).
     var env_overrides: String?
     var auto_archive_on_merge_default: Bool?
+    var auto_resume_on_limit_reset: Bool?
     var scratch_instructions: String?
     var scratch_rename_prompt: String?
     var scratch_profile_override_id: String?
@@ -33,6 +34,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             envSettingOverrides: ConfigStore.decodeOverrides(claude_env_settings),
             envOverrides: EnvOverridesCoding.decode(env_overrides),
             autoArchiveOnMergeDefault: auto_archive_on_merge_default ?? false,
+            autoResumeOnLimitReset: auto_resume_on_limit_reset ?? false,
             scratchInstructions: scratch_instructions,
             scratchRenamePrompt: scratch_rename_prompt,
             scratchProfileOverrideID: scratch_profile_override_id.flatMap(UUID.init(uuidString:)),

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -23,6 +23,7 @@ public final class TBDDatabase: Sendable {
     public let forgottenWorktrees: ForgottenWorktreeStore
     public let clearance: ClearanceStore
     public let audit: AuditStore
+    public let scheduledResumes: ScheduledResumeStore
 
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
@@ -54,6 +55,7 @@ public final class TBDDatabase: Sendable {
         self.forgottenWorktrees = ForgottenWorktreeStore(writer: pool)
         self.clearance = ClearanceStore(writer: pool)
         self.audit = AuditStore(writer: pool)
+        self.scheduledResumes = ScheduledResumeStore(writer: pool)
 
         let migrator = Self.buildMigrator()
         if fileExisted {
@@ -85,6 +87,7 @@ public final class TBDDatabase: Sendable {
         self.forgottenWorktrees = ForgottenWorktreeStore(writer: queue)
         self.clearance = ClearanceStore(writer: queue)
         self.audit = AuditStore(writer: queue)
+        self.scheduledResumes = ScheduledResumeStore(writer: queue)
         try Self.buildMigrator().migrate(queue)
     }
 

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -720,6 +720,34 @@ public final class TBDDatabase: Sendable {
             """)
         }
 
+        // Session-limit auto-resume (spec 2026-07-03). `scheduled_resumes`
+        // rows are the double-send latch (at most one `pending` row per
+        // terminal, enforced by the partial unique index below).
+        // `terminal.pendingResumeAt` mirrors the pending row for UI badges;
+        // `config.auto_resume_on_limit_reset` is the global gate (default OFF).
+        migrator.registerMigration("v43_scheduled_resumes") { db in
+            try db.createTableIfNotExists("scheduled_resumes") { t in
+                t.column("id", .text).primaryKey()
+                t.column("terminalID", .text).notNull()
+                t.column("worktreeID", .text).notNull()
+                t.column("claudeSessionID", .text)
+                t.column("resetsAt", .datetime).notNull()
+                t.column("fireAt", .datetime).notNull()
+                t.column("limitType", .text).notNull()
+                t.column("rawMessage", .text).notNull()
+                t.column("createdAt", .datetime).notNull()
+                t.column("status", .text).notNull()
+                t.column("attemptCount", .integer).notNull().defaults(to: 0)
+            }
+            try db.addIndexIfMissing(
+                "idx_scheduled_resumes_one_pending", on: "scheduled_resumes",
+                columns: ["terminalID"], unique: true, where: "status = 'pending'")
+            try db.addColumnIfMissing(table: "terminal", column: "pendingResumeAt", type: .datetime)
+            try db.addColumnIfMissing(
+                table: "config", column: "auto_resume_on_limit_reset",
+                type: .boolean, defaults: false)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
+++ b/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
@@ -1,0 +1,188 @@
+import Foundation
+import GRDB
+import TBDShared
+
+/// GRDB Record for the `scheduled_resumes` table.
+struct ScheduledResumeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "scheduled_resumes"
+
+    var id: String
+    var terminalID: String
+    var worktreeID: String
+    var claudeSessionID: String?
+    var resetsAt: Date
+    var fireAt: Date
+    var limitType: String
+    var rawMessage: String
+    var createdAt: Date
+    var status: String
+    var attemptCount: Int
+
+    init(from model: ScheduledResume) {
+        self.id = model.id.uuidString
+        self.terminalID = model.terminalID.uuidString
+        self.worktreeID = model.worktreeID.uuidString
+        self.claudeSessionID = model.claudeSessionID
+        self.resetsAt = model.resetsAt
+        self.fireAt = model.fireAt
+        self.limitType = model.limitType
+        self.rawMessage = model.rawMessage
+        self.createdAt = model.createdAt
+        self.status = model.status.rawValue
+        self.attemptCount = model.attemptCount
+    }
+
+    func toModel() -> ScheduledResume {
+        ScheduledResume(
+            id: UUID(uuidString: id)!,
+            terminalID: UUID(uuidString: terminalID)!,
+            worktreeID: UUID(uuidString: worktreeID)!,
+            claudeSessionID: claudeSessionID,
+            resetsAt: resetsAt,
+            fireAt: fireAt,
+            limitType: limitType,
+            rawMessage: rawMessage,
+            createdAt: createdAt,
+            status: ScheduledResumeStatus(rawValue: status) ?? .failed,
+            attemptCount: attemptCount
+        )
+    }
+}
+
+/// CRUD for scheduled session-limit resumes. The single `pending` row per
+/// terminal is the double-send latch (spec §State); every transition that
+/// creates/moves/ends a pending row also syncs `terminal.pendingResumeAt`
+/// inside the SAME write transaction so the UI mirror can never drift.
+public struct ScheduledResumeStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Insert a pending row unless the terminal already has one.
+    /// - Returns: the inserted model, or nil when the latch rejected it.
+    public func insertPending(_ resume: ScheduledResume) async throws -> ScheduledResume? {
+        var toInsert = resume
+        toInsert.status = .pending
+        let record = ScheduledResumeRecord(from: toInsert)
+        let resultModel = toInsert
+        return try await writer.write { db -> ScheduledResume? in
+            let existing = try ScheduledResumeRecord
+                .filter(Column("terminalID") == record.terminalID)
+                .filter(Column("status") == ScheduledResumeStatus.pending.rawValue)
+                .fetchCount(db)
+            guard existing == 0 else { return nil }
+            try record.insert(db)
+            try db.execute(
+                sql: "UPDATE terminal SET pendingResumeAt = ? WHERE id = ?",
+                arguments: [record.fireAt, record.terminalID])
+            return resultModel
+        }
+    }
+
+    /// Insert a non-pending audit row (e.g. toggle-off detection: `.cancelled`).
+    /// Never touches the latch or `terminal.pendingResumeAt`.
+    public func insertAudit(_ resume: ScheduledResume) async throws {
+        precondition(resume.status != .pending, "audit rows must not be pending")
+        let record = ScheduledResumeRecord(from: resume)
+        try await writer.write { db in
+            try record.insert(db)
+        }
+    }
+
+    /// All pending rows ordered by fireAt ascending.
+    public func pending() async throws -> [ScheduledResume] {
+        try await writer.read { db in
+            try ScheduledResumeRecord
+                .filter(Column("status") == ScheduledResumeStatus.pending.rawValue)
+                .order(Column("fireAt").asc)
+                .fetchAll(db)
+                .map { $0.toModel() }
+        }
+    }
+
+    public func pending(terminalID: UUID) async throws -> ScheduledResume? {
+        try await writer.read { db in
+            try ScheduledResumeRecord
+                .filter(Column("terminalID") == terminalID.uuidString)
+                .filter(Column("status") == ScheduledResumeStatus.pending.rawValue)
+                .fetchOne(db)?
+                .toModel()
+        }
+    }
+
+    public func get(id: UUID) async throws -> ScheduledResume? {
+        try await writer.read { db in
+            try ScheduledResumeRecord.fetchOne(db, key: id.uuidString)?.toModel()
+        }
+    }
+
+    /// Transition a row's status. Leaving `.pending` clears the terminal's
+    /// `pendingResumeAt` mirror.
+    public func setStatus(id: UUID, status: ScheduledResumeStatus) async throws {
+        try await writer.write { db in
+            guard var record = try ScheduledResumeRecord.fetchOne(db, key: id.uuidString) else {
+                return
+            }
+            record.status = status.rawValue
+            try record.update(db)
+            if status != .pending {
+                try db.execute(
+                    sql: "UPDATE terminal SET pendingResumeAt = NULL WHERE id = ?",
+                    arguments: [record.terminalID])
+            }
+        }
+    }
+
+    /// Push a pending row's fire time (copy-mode retry) and bump attemptCount.
+    public func reschedule(id: UUID, fireAt: Date, attemptCount: Int) async throws {
+        try await writer.write { db in
+            guard var record = try ScheduledResumeRecord.fetchOne(db, key: id.uuidString) else {
+                return
+            }
+            record.fireAt = fireAt
+            record.attemptCount = attemptCount
+            try record.update(db)
+            try db.execute(
+                sql: "UPDATE terminal SET pendingResumeAt = ? WHERE id = ?",
+                arguments: [fireAt, record.terminalID])
+        }
+    }
+
+    /// Cancel the terminal's pending row, if any. Returns true when one existed.
+    @discardableResult
+    public func cancelPending(terminalID: UUID) async throws -> Bool {
+        try await writer.write { db in
+            guard var record = try ScheduledResumeRecord
+                .filter(Column("terminalID") == terminalID.uuidString)
+                .filter(Column("status") == ScheduledResumeStatus.pending.rawValue)
+                .fetchOne(db)
+            else { return false }
+            record.status = ScheduledResumeStatus.cancelled.rawValue
+            try record.update(db)
+            try db.execute(
+                sql: "UPDATE terminal SET pendingResumeAt = NULL WHERE id = ?",
+                arguments: [terminalID.uuidString])
+            return true
+        }
+    }
+
+    /// Cancel every pending row (global toggle switched off). Returns count.
+    @discardableResult
+    public func cancelAllPending() async throws -> Int {
+        try await writer.write { db in
+            let records = try ScheduledResumeRecord
+                .filter(Column("status") == ScheduledResumeStatus.pending.rawValue)
+                .fetchAll(db)
+            for var record in records {
+                record.status = ScheduledResumeStatus.cancelled.rawValue
+                try record.update(db)
+                try db.execute(
+                    sql: "UPDATE terminal SET pendingResumeAt = NULL WHERE id = ?",
+                    arguments: [record.terminalID])
+            }
+            return records.count
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
+++ b/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
@@ -112,6 +112,21 @@ public struct ScheduledResumeStore: Sendable {
         }
     }
 
+    /// All rows for a terminal regardless of status, ordered by createdAt
+    /// ascending. Unlike `pending(terminalID:)`, this surfaces audit rows
+    /// (e.g. the `.cancelled` row inserted by the toggle-off branch of
+    /// `handleRateLimitDetected`) — useful for tests/diagnostics that need
+    /// to assert on a terminal's full history, not just its latch state.
+    public func all(terminalID: UUID) async throws -> [ScheduledResume] {
+        try await writer.read { db in
+            try ScheduledResumeRecord
+                .filter(Column("terminalID") == terminalID.uuidString)
+                .order(Column("createdAt").asc)
+                .fetchAll(db)
+                .map { $0.toModel() }
+        }
+    }
+
     public func get(id: UUID) async throws -> ScheduledResume? {
         try await writer.read { db in
             try ScheduledResumeRecord.fetchOne(db, key: id.uuidString)?.toModel()

--- a/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
+++ b/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
@@ -119,8 +119,10 @@ public struct ScheduledResumeStore: Sendable {
     }
 
     /// Transition a row's status. Leaving `.pending` clears the terminal's
-    /// `pendingResumeAt` mirror.
+    /// `pendingResumeAt` mirror. Invariant: setStatus never creates or resumes a
+    /// pending row. Use insertPending/reschedule for that.
     public func setStatus(id: UUID, status: ScheduledResumeStatus) async throws {
+        precondition(status != .pending, "use insertPending/reschedule to (re)arm a resume")
         try await writer.write { db in
             guard var record = try ScheduledResumeRecord.fetchOne(db, key: id.uuidString) else {
                 return
@@ -136,10 +138,15 @@ public struct ScheduledResumeStore: Sendable {
     }
 
     /// Push a pending row's fire time (copy-mode retry) and bump attemptCount.
-    public func reschedule(id: UUID, fireAt: Date, attemptCount: Int) async throws {
+    /// - Returns: true if the row was pending and rescheduled, false if row not found or not pending.
+    @discardableResult
+    public func reschedule(id: UUID, fireAt: Date, attemptCount: Int) async throws -> Bool {
         try await writer.write { db in
             guard var record = try ScheduledResumeRecord.fetchOne(db, key: id.uuidString) else {
-                return
+                return false
+            }
+            guard record.status == ScheduledResumeStatus.pending.rawValue else {
+                return false
             }
             record.fireAt = fireAt
             record.attemptCount = attemptCount
@@ -147,6 +154,7 @@ public struct ScheduledResumeStore: Sendable {
             try db.execute(
                 sql: "UPDATE terminal SET pendingResumeAt = ? WHERE id = ?",
                 arguments: [fireAt, record.terminalID])
+            return true
         }
     }
 

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -22,6 +22,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var activityState: String?
     var hibernatedAt: Date?
     var keepWarm: Bool?
+    var pendingResumeAt: Date?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -40,6 +41,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.activityState = terminal.activityState.rawValue
         self.hibernatedAt = terminal.hibernatedAt
         self.keepWarm = terminal.keepWarm
+        self.pendingResumeAt = terminal.pendingResumeAt
     }
 
     func toModel() -> Terminal {
@@ -59,7 +61,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             kind: kind.flatMap(TerminalKind.init(rawValue:)),
             activityState: activityState.flatMap(TerminalActivityState.init(rawValue:)) ?? .unknown,
             hibernatedAt: hibernatedAt,
-            keepWarm: keepWarm ?? false
+            keepWarm: keepWarm ?? false,
+            pendingResumeAt: pendingResumeAt
         )
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -195,6 +195,10 @@ public actor HibernationCoordinator {
         } catch {
             logger.warning("hibernate: failed to mark hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
+        // Hibernation = parking; a parked pane must not receive a scheduled
+        // auto-resume send (spec §Cancellation); fire-time eligibility
+        // re-checks are the backstop.
+        _ = try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)
         idleSince[terminal.id] = nil
         pendingKillSince[terminal.id] = nil
         broadcastHibernation(terminal: terminal, hibernated: true, keepWarm: terminal.keepWarm)

--- a/Sources/TBDDaemon/Process/ProcessSignaller.swift
+++ b/Sources/TBDDaemon/Process/ProcessSignaller.swift
@@ -18,6 +18,9 @@ public protocol ProcessSignaller: Sendable {
     func children(ofServerPID serverPID: Int32) -> [Int32]
     /// Full command line of the pid (for the TBD ownership fingerprint), or nil.
     func commandLine(_ pid: Int32) -> String?
+    /// `ps -o stat=` for the pid (e.g. "S+", "Ss"), or nil when the pid is
+    /// gone. The trailing `+` marks the tty's foreground process group.
+    func stat(_ pid: Int32) -> String?
 }
 
 public struct ProductionProcessSignaller: ProcessSignaller {
@@ -60,6 +63,11 @@ public struct ProductionProcessSignaller: ProcessSignaller {
         // when stdout is a pipe, clipping the TBD fingerprint markers off the
         // tail of a long `claude`/`codex` invocation.
         Self.runPS(["-ww", "-o", "command=", "-p", String(pid)])?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public func stat(_ pid: Int32) -> String? {
+        Self.runPS(["-o", "stat=", "-p", String(pid)])?
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -15,6 +15,23 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the session-limit auto-resume gate. Turning it OFF cancels
+    /// every pending scheduled resume (spec §Cancellation) and wakes the
+    /// scheduler so its in-flight sleep re-evaluates.
+    func handleConfigSetAutoResumeOnLimitReset(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetAutoResumeOnLimitResetParams.self, from: paramsData)
+        try await db.config.setAutoResumeOnLimitReset(params.enabled)
+        if !params.enabled {
+            _ = try await db.scheduledResumes.cancelAllPending()
+        }
+        // NOTE(Task 7): `await limitResumeScheduler?.wake()` is added here in
+        // Task 7 once the router grows that property. Not needed for this
+        // task's tests.
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     func handleConfigSetScratchInstructions(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ConfigSetScratchInstructionsParams.self, from: paramsData)
         try await db.config.setScratchInstructions(params.instructions)

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -20,10 +20,12 @@ extension RPCRouter {
     /// scheduler so its in-flight sleep re-evaluates.
     func handleConfigSetAutoResumeOnLimitReset(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ConfigSetAutoResumeOnLimitResetParams.self, from: paramsData)
-        try await db.config.setAutoResumeOnLimitReset(params.enabled)
         if !params.enabled {
+            // Cancel before persisting the off-state so a cancel failure can never
+            // leave the gate off with live pending rows, violating the feature invariant.
             _ = try await db.scheduledResumes.cancelAllPending()
         }
+        try await db.config.setAutoResumeOnLimitReset(params.enabled)
         // NOTE(Task 7): `await limitResumeScheduler?.wake()` is added here in
         // Task 7 once the router grows that property. Not needed for this
         // task's tests.

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -26,9 +26,7 @@ extension RPCRouter {
             _ = try await db.scheduledResumes.cancelAllPending()
         }
         try await db.config.setAutoResumeOnLimitReset(params.enabled)
-        // NOTE(Task 7): `await limitResumeScheduler?.wake()` is added here in
-        // Task 7 once the router grows that property. Not needed for this
-        // task's tests.
+        await limitResumeScheduler?.wake()
         // Reuse the existing config-change channel so the app reloads Config.
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -9,7 +9,13 @@ extension RPCRouter {
         let params = try decoder.decode(TerminalHibernateParams.self, from: paramsData)
         let result = await hibernationCoordinator.manualHibernate(terminalID: params.terminalID)
         switch result {
-        case .ok, .alreadyHibernated:
+        case .ok:
+            // Hibernating cancels any pending auto-resume inside the
+            // coordinator (spec §Cancellation); wake the scheduler so it
+            // re-reads pending rows instead of sleeping until a stale fire time.
+            await limitResumeScheduler?.wake()
+            return .ok()
+        case .alreadyHibernated:
             return .ok()
         case .notEligible(let reason):
             return RPCResponse(error: reason)

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -5,6 +5,10 @@ extension RPCRouter {
 
     func handleTerminalSuspend(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSuspendParams.self, from: paramsData)
+        // Suspend cancels any pending auto-resume (spec §Cancellation).
+        if (try? await db.scheduledResumes.cancelPending(terminalID: params.terminalID)) == true {
+            await limitResumeScheduler?.wake()
+        }
         let result = await suspendResumeCoordinator.manualSuspend(terminalID: params.terminalID)
         switch result {
         case .ok, .alreadySuspended:
@@ -34,6 +38,12 @@ extension RPCRouter {
         guard let terminals = try? await db.terminals.list(worktreeID: params.worktreeID) else {
             return RPCResponse(error: "Worktree not found")
         }
+
+        // Suspend cancels any pending auto-resume (spec §Cancellation).
+        for terminal in terminals where terminal.pendingResumeAt != nil {
+            _ = try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)
+        }
+        await limitResumeScheduler?.wake()
 
         let claudeTerminals = terminals.filter { $0.isClaudeResumable && $0.suspendedAt == nil }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -57,7 +57,8 @@ extension RPCRouter {
             primaryAgentPreference: config.primaryAgentPreference,
             globalEnvOverrides: config.envOverrides,
             autoArchiveOnMergeDefault: config.autoArchiveOnMergeDefault,
-            nightwatchMode: config.nightwatchMode
+            nightwatchMode: config.nightwatchMode,
+            autoResumeOnLimitReset: config.autoResumeOnLimitReset
         ))
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+RateLimitHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RateLimitHandlers.swift
@@ -44,7 +44,11 @@ extension RPCRouter {
                 fireAt: params.resetsAt.addingTimeInterval(LimitResumeScheduler.slack),
                 limitType: params.limitType, rawMessage: params.rawMessage,
                 status: .cancelled)
-            try? await db.scheduledResumes.insertAudit(audit)
+            do {
+                try await db.scheduledResumes.insertAudit(audit)
+            } catch {
+                logger.warning("handleRateLimitDetected: audit insert failed for terminal \(terminal.id.uuidString, privacy: .public): \(String(describing: error), privacy: .public)")
+            }
             message = "Session limit hit — resets \(ResumeTimeFormatter.string(from: params.resetsAt))"
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+RateLimitHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RateLimitHandlers.swift
@@ -1,0 +1,60 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "limitResume")
+
+extension RPCRouter {
+
+    /// A hard usage limit was detected by the StopFailure hook. Detection and
+    /// notification always run; only the scheduled send is gated on
+    /// `autoResumeOnLimitReset` (spec §Constraints "Gated, default OFF").
+    ///
+    /// Latch: when the terminal already has a pending resume (a repeat
+    /// StopFailure while parked), do nothing — no duplicate notification.
+    func handleRateLimitDetected(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(RateLimitDetectedParams.self, from: paramsData)
+        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+            // Fire-and-forget hook caller — soft no-op like sessionEvent.
+            logger.debug("rateLimitDetected: unknown terminal \(params.terminalID.uuidString, privacy: .public) — ignoring")
+            return .ok()
+        }
+
+        let enabled = (try? await db.config.get())?.autoResumeOnLimitReset ?? false
+        let message: String
+
+        if enabled, let scheduler = limitResumeScheduler {
+            guard let scheduled = await scheduler.schedule(
+                terminalID: terminal.id, worktreeID: terminal.worktreeID,
+                claudeSessionID: terminal.claudeSessionID,
+                resetsAt: params.resetsAt, limitType: params.limitType,
+                rawMessage: params.rawMessage)
+            else {
+                return .ok()   // latch: already pending — no duplicate notification
+            }
+            message = "Session limit hit — auto-resume scheduled for \(ResumeTimeFormatter.string(from: scheduled.fireAt))"
+        } else {
+            // Gate off: record the detection for audit, notify with the reset
+            // time, schedule nothing (spec Testing→Gate: "row recorded +
+            // notification, no send scheduled").
+            let audit = ScheduledResume(
+                terminalID: terminal.id, worktreeID: terminal.worktreeID,
+                claudeSessionID: terminal.claudeSessionID,
+                resetsAt: params.resetsAt,
+                fireAt: params.resetsAt.addingTimeInterval(LimitResumeScheduler.slack),
+                limitType: params.limitType, rawMessage: params.rawMessage,
+                status: .cancelled)
+            try? await db.scheduledResumes.insertAudit(audit)
+            message = "Session limit hit — resets \(ResumeTimeFormatter.string(from: params.resetsAt))"
+        }
+
+        let notification = try await db.notifications.create(
+            worktreeID: terminal.worktreeID, type: .limitReached,
+            message: message, terminalID: terminal.id)
+        subscriptions.broadcast(delta: .notificationReceived(NotificationDelta(
+            notificationID: notification.id, worktreeID: notification.worktreeID,
+            type: notification.type, message: notification.message,
+            terminalID: notification.terminalID)))
+        return .ok()
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+RateLimitHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RateLimitHandlers.swift
@@ -57,4 +57,12 @@ extension RPCRouter {
             terminalID: notification.terminalID)))
         return .ok()
     }
+
+    /// Explicit user cancel ("Cancel scheduled resume" context-menu item).
+    func handleCancelScheduledResume(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(CancelScheduledResumeParams.self, from: paramsData)
+        _ = try await db.scheduledResumes.cancelPending(terminalID: params.terminalID)
+        await limitResumeScheduler?.wake()
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -385,6 +385,11 @@ extension RPCRouter {
             return RPCResponse(error: "Terminal not found: \(params.terminalID)")
         }
 
+        // Terminal close cancels any pending auto-resume (spec §Cancellation).
+        if (try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)) == true {
+            await limitResumeScheduler?.wake()
+        }
+
         // Kill the tmux window
         if let worktree = try await db.worktrees.get(id: terminal.worktreeID) {
             try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
@@ -1501,6 +1506,19 @@ extension RPCRouter {
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
             logger.debug("activityEvent: unknown terminalID=\(params.terminalID.uuidString, privacy: .public) — ignoring")
             return .ok()
+        }
+
+        // UserPromptSubmit reaches the daemon as activity=working. If a
+        // session-limit auto-resume is pending, the user just continued
+        // manually — cancel it (spec §Cancellation). Guarded on the mirror
+        // field so the common case costs nothing. Note: the actuator's own
+        // "continue" also lands here; by then verification usually already
+        // moved the row out of pending, and a cancel-vs-sent race only
+        // affects the audit status, never causes a second send.
+        if params.activityState == .working, terminal.pendingResumeAt != nil {
+            if (try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)) == true {
+                await limitResumeScheduler?.wake()
+            }
         }
 
         guard terminal.activityState != params.activityState else {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -208,6 +208,8 @@ public final class RPCRouter: Sendable {
                 return try await handleSetClaudeSpawnPreferences(request.paramsData)
             case RPCMethod.claudeRateLimitDetected:
                 return try await handleRateLimitDetected(request.paramsData)
+            case RPCMethod.terminalCancelScheduledResume:
+                return try await handleCancelScheduledResume(request.paramsData)
             case RPCMethod.attachRequest:
                 return try await handleAttachRequest(request.paramsData)
             case RPCMethod.attachReady:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -27,6 +27,9 @@ public final class RPCRouter: Sendable {
     /// post-construction by Daemon.swift (mirrors `claudeUsagePoller`); `nil`
     /// in unit tests that don't exercise the foreground RPC.
     public nonisolated(unsafe) var appForegroundState: AppForegroundState?
+    /// Session-limit auto-resume scheduler. `nil` in mock mode / tests that
+    /// don't need it; set post-construction like `claudeUsagePoller`.
+    public nonisolated(unsafe) var limitResumeScheduler: LimitResumeScheduler?
     /// Live connected-client count, supplied by the SocketServer after it is
     /// constructed (the router is built first in Daemon.swift, so it cannot
     /// take the server as an init dependency). Mirrors `claudeUsagePoller`
@@ -203,6 +206,8 @@ public final class RPCRouter: Sendable {
                 return try await handlePRRefresh(request.paramsData)
             case RPCMethod.claudeSetSpawnPreferences:
                 return try await handleSetClaudeSpawnPreferences(request.paramsData)
+            case RPCMethod.claudeRateLimitDetected:
+                return try await handleRateLimitDetected(request.paramsData)
             case RPCMethod.attachRequest:
                 return try await handleAttachRequest(request.paramsData)
             case RPCMethod.attachReady:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -308,6 +308,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigGet()
             case RPCMethod.configSetAutoArchiveOnMergeDefault:
                 return try await handleConfigSetAutoArchiveDefault(request.paramsData)
+            case RPCMethod.configSetAutoResumeOnLimitReset:
+                return try await handleConfigSetAutoResumeOnLimitReset(request.paramsData)
             case RPCMethod.configSetScratchInstructions:
                 return try await handleConfigSetScratchInstructions(request.paramsData)
             case RPCMethod.configSetScratchRenamePrompt:

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -230,6 +230,11 @@ public struct TmuxManager: Sendable {
         ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_current_path}"]
     }
 
+    /// "1" when the pane is in a mode (copy-mode/scrollback), else "0".
+    public static func paneInModeQuery(server: String, paneID: String) -> [String] {
+        ["-L", server, "display-message", "-p", "-t", paneID, "#{pane_in_mode}"]
+    }
+
     public static func serverPIDQuery(server: String) -> [String] {
         ["-L", server, "display-message", "-p", "#{pid}"]
     }
@@ -454,6 +459,14 @@ public struct TmuxManager: Sendable {
         if dryRun { return "" }
         let args = Self.paneCurrentPathQuery(server: server, paneID: paneID)
         return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// True when the pane is in copy-mode/scrollback — keystrokes would go
+    /// to the mode, not the application (spec §Actuation 3).
+    public func paneInMode(server: String, paneID: String) async throws -> Bool {
+        if dryRun { return false }
+        let args = Self.paneInModeQuery(server: server, paneID: paneID)
+        return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines) == "1"
     }
 
     /// The tmux server's own process pid (the parent of every pane process),

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -462,7 +462,7 @@ public struct TmuxManager: Sendable {
     }
 
     /// True when the pane is in copy-mode/scrollback — keystrokes would go
-    /// to the mode, not the application (spec §Actuation 3).
+    /// to the mode, not the application (spec §Actuation 4).
     public func paneInMode(server: String, paneID: String) async throws -> Bool {
         if dryRun { return false }
         let args = Self.paneInModeQuery(server: server, paneID: paneID)

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -257,6 +257,11 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// eligible for the idle timer; `true` = the daemon never auto-hibernates
     /// it (manual "Hibernate now" still works). Persisted per-terminal.
     public var keepWarm: Bool
+    /// When non-nil, a session-limit auto-resume is scheduled to fire at this
+    /// instant (mirrors the terminal's single `pending` scheduled_resumes
+    /// row). Drives the "⏳ resumes 1:01pm" tab badge. Optional for
+    /// decode-compat with pre-v43 rows/JSON.
+    public var pendingResumeAt: Date?
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
@@ -267,7 +272,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 kind: TerminalKind? = nil,
                 activityState: TerminalActivityState = .unknown,
                 hibernatedAt: Date? = nil,
-                keepWarm: Bool = false) {
+                keepWarm: Bool = false,
+                pendingResumeAt: Date? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -284,13 +290,14 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.activityState = activityState
         self.hibernatedAt = hibernatedAt
         self.keepWarm = keepWarm
+        self.pendingResumeAt = pendingResumeAt
     }
 
     enum CodingKeys: String, CodingKey {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
         case activityState
-        case hibernatedAt, keepWarm
+        case hibernatedAt, keepWarm, pendingResumeAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -311,6 +318,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         activityState = try c.decodeIfPresent(TerminalActivityState.self, forKey: .activityState) ?? .unknown
         hibernatedAt = try c.decodeIfPresent(Date.self, forKey: .hibernatedAt)
         keepWarm = try c.decodeIfPresent(Bool.self, forKey: .keepWarm) ?? false
+        pendingResumeAt = try c.decodeIfPresent(Date.self, forKey: .pendingResumeAt)
     }
 }
 
@@ -639,6 +647,9 @@ public struct Config: Codable, Sendable, Equatable {
     /// Global default for auto-archive-on-PR-merge, applied to worktrees whose
     /// per-worktree override is `nil`.
     public var autoArchiveOnMergeDefault: Bool
+    /// Global gate for session-limit auto-resume (spec 2026-07-03). Daemon-
+    /// side because the daemon must act while the app is closed. Default OFF.
+    public var autoResumeOnLimitReset: Bool
     /// Global, user-customizable system-prompt layer for scratch spaces
     /// (repo-less worktrees). `nil` means "use the built-in default"
     /// (`RepoConstants.defaultScratchInstructions`).
@@ -670,6 +681,7 @@ public struct Config: Codable, Sendable, Equatable {
                 envSettingOverrides: [String: ClaudeEnvValue] = [:],
                 envOverrides: [String: String] = [:],
                 autoArchiveOnMergeDefault: Bool = false,
+                autoResumeOnLimitReset: Bool = false,
                 scratchInstructions: String? = nil,
                 scratchRenamePrompt: String? = nil,
                 scratchProfileOverrideID: UUID? = nil,
@@ -681,6 +693,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.envSettingOverrides = envSettingOverrides
         self.envOverrides = envOverrides
         self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
+        self.autoResumeOnLimitReset = autoResumeOnLimitReset
         self.scratchInstructions = scratchInstructions
         self.scratchRenamePrompt = scratchRenamePrompt
         self.scratchProfileOverrideID = scratchProfileOverrideID
@@ -702,6 +715,8 @@ public struct Config: Codable, Sendable, Equatable {
             [String: String].self, forKey: .envOverrides) ?? [:]
         autoArchiveOnMergeDefault = try c.decodeIfPresent(
             Bool.self, forKey: .autoArchiveOnMergeDefault) ?? false
+        autoResumeOnLimitReset = try c.decodeIfPresent(
+            Bool.self, forKey: .autoResumeOnLimitReset) ?? false
         scratchInstructions = try c.decodeIfPresent(String.self, forKey: .scratchInstructions) ?? nil
         scratchRenamePrompt = try c.decodeIfPresent(String.self, forKey: .scratchRenamePrompt) ?? nil
         scratchProfileOverrideID = try c.decodeIfPresent(UUID.self, forKey: .scratchProfileOverrideID)
@@ -710,6 +725,50 @@ public struct Config: Codable, Sendable, Equatable {
         autoHibernateEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoHibernateEnabled) ?? true
         hibernateIdleMinutes = try c.decodeIfPresent(Int.self, forKey: .hibernateIdleMinutes)
             ?? Config.defaultHibernateIdleMinutes
+    }
+}
+
+public enum ScheduledResumeStatus: String, Codable, Sendable {
+    case pending
+    case sent
+    case cancelled
+    case failed
+}
+
+/// One scheduled "type `continue` at reset time" action. At most one
+/// `pending` row exists per terminal — the row IS the double-send latch.
+public struct ScheduledResume: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public let terminalID: UUID
+    public let worktreeID: UUID
+    public let claudeSessionID: String?
+    /// Absolute reset instant (structured epoch or parsed-once display text).
+    public let resetsAt: Date
+    /// Next actuation attempt: resetsAt + 60s slack + jitter(0-30s) at insert;
+    /// pushed +2min per copy-mode retry. Persisted so reschedules survive
+    /// daemon restarts.
+    public var fireAt: Date
+    public let limitType: String
+    public let rawMessage: String
+    public let createdAt: Date
+    public var status: ScheduledResumeStatus
+    public var attemptCount: Int
+
+    public init(id: UUID = UUID(), terminalID: UUID, worktreeID: UUID,
+                claudeSessionID: String? = nil, resetsAt: Date, fireAt: Date,
+                limitType: String, rawMessage: String, createdAt: Date = Date(),
+                status: ScheduledResumeStatus = .pending, attemptCount: Int = 0) {
+        self.id = id
+        self.terminalID = terminalID
+        self.worktreeID = worktreeID
+        self.claudeSessionID = claudeSessionID
+        self.resetsAt = resetsAt
+        self.fireAt = fireAt
+        self.limitType = limitType
+        self.rawMessage = rawMessage
+        self.createdAt = createdAt
+        self.status = status
+        self.attemptCount = attemptCount
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -799,12 +799,16 @@ public enum NotificationType: String, Codable, Sendable {
     /// A focus push from `tbd terminal focus`. Rendered like `.attentionNeeded`
     /// in-app; the macOS banner adds a distinguishing title prefix.
     case focusRequest = "focus_request"
+    /// A session/weekly usage limit was hit. Message carries either the
+    /// scheduled auto-resume time (gate on) or the reset time (gate off).
+    case limitReached = "limit_reached"
 
     public var severity: Int {
         switch self {
         case .error: 4
         case .attentionNeeded: 3
         case .focusRequest: 3
+        case .limitReached: 3
         case .taskComplete: 2
         case .responseComplete: 1
         }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -179,6 +179,7 @@ public enum RPCMethod {
     public static let scratchRevive = "scratch.revive"
     public static let nightwatchSetMode = "nightwatch.setMode"
     public static let nightwatchReport = "nightwatch.report"
+    public static let terminalCancelScheduledResume = "terminal.cancelScheduledResume"
 }
 
 // MARK: - Branch Listing
@@ -1429,6 +1430,13 @@ public struct RateLimitDetectedParams: Codable, Sendable {
         self.limitType = limitType
         self.rawMessage = rawMessage
     }
+}
+
+/// Params for `terminal.cancelScheduledResume` — explicit user cancel from
+/// the tab context menu / notification.
+public struct CancelScheduledResumeParams: Codable, Sendable {
+    public let terminalID: UUID
+    public init(terminalID: UUID) { self.terminalID = terminalID }
 }
 
 /// PreToolUse:AskUserQuestion hook bridge — fires when Claude is about to

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -163,6 +163,7 @@ public enum RPCMethod {
     public static let worktreeSetAutoArchive = "worktree.setAutoArchive"
     public static let configGet = "config.get"
     public static let configSetAutoArchiveOnMergeDefault = "config.setAutoArchiveOnMergeDefault"
+    public static let configSetAutoResumeOnLimitReset = "config.setAutoResumeOnLimitReset"
     public static let configSetScratchInstructions = "config.setScratchInstructions"
     public static let configSetScratchRenamePrompt = "config.setScratchRenamePrompt"
     public static let configSetScratchProfileOverride = "config.setScratchProfileOverride"
@@ -494,13 +495,15 @@ public struct ModelProfileListResult: Codable, Sendable {
     public let globalEnvOverrides: [String: String]
     public let autoArchiveOnMergeDefault: Bool
     public let nightwatchMode: NightwatchMode
+    public let autoResumeOnLimitReset: Bool
     public init(
         profiles: [ModelProfileWithUsage],
         defaultID: UUID? = nil,
         primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
         globalEnvOverrides: [String: String] = [:],
         autoArchiveOnMergeDefault: Bool = false,
-        nightwatchMode: NightwatchMode = .off
+        nightwatchMode: NightwatchMode = .off,
+        autoResumeOnLimitReset: Bool = false
     ) {
         self.profiles = profiles
         self.defaultID = defaultID
@@ -508,6 +511,7 @@ public struct ModelProfileListResult: Codable, Sendable {
         self.globalEnvOverrides = globalEnvOverrides
         self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
         self.nightwatchMode = nightwatchMode
+        self.autoResumeOnLimitReset = autoResumeOnLimitReset
     }
 
     public init(from decoder: Decoder) throws {
@@ -526,6 +530,8 @@ public struct ModelProfileListResult: Codable, Sendable {
             Bool.self, forKey: .autoArchiveOnMergeDefault) ?? false
         nightwatchMode = try c.decodeIfPresent(
             NightwatchMode.self, forKey: .nightwatchMode) ?? .off
+        autoResumeOnLimitReset = try c.decodeIfPresent(
+            Bool.self, forKey: .autoResumeOnLimitReset) ?? false
     }
 }
 
@@ -1014,6 +1020,13 @@ public struct WorktreeSetAutoArchiveParams: Codable, Sendable {
 }
 
 public struct ConfigSetAutoArchiveDefaultParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setAutoResumeOnLimitReset` — the session-limit
+/// auto-resume gate (default OFF). Disabling cancels all pending resumes.
+public struct ConfigSetAutoResumeOnLimitResetParams: Codable, Sendable {
     public let enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -104,6 +104,7 @@ public enum RPCMethod {
     public static let prRefresh = "pr.refresh"
     public static let cleanup = "cleanup"
     public static let claudeSetSpawnPreferences = "claude.setSpawnPreferences"
+    public static let claudeRateLimitDetected = "claude.rateLimitDetected"
     public static let terminalSuspend = "terminal.suspend"
     public static let terminalResume = "terminal.resume"
     public static let worktreeSuspend = "worktree.suspend"
@@ -1411,6 +1412,22 @@ public struct TerminalActivityEventParams: Codable, Sendable {
     public init(terminalID: UUID, activityState: TerminalActivityState) {
         self.terminalID = terminalID
         self.activityState = activityState
+    }
+}
+
+/// Params for `claude.rateLimitDetected` — sent by `tbd hooks stop-failure`
+/// when the transcript's last API error is a HARD usage limit. `resetsAt`
+/// is absolute: parsed once CLI-side, never re-derived from display text.
+public struct RateLimitDetectedParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let resetsAt: Date
+    public let limitType: String
+    public let rawMessage: String
+    public init(terminalID: UUID, resetsAt: Date, limitType: String, rawMessage: String) {
+        self.terminalID = terminalID
+        self.resetsAt = resetsAt
+        self.limitType = limitType
+        self.rawMessage = rawMessage
     }
 }
 

--- a/Sources/TBDShared/RateLimitDetection.swift
+++ b/Sources/TBDShared/RateLimitDetection.swift
@@ -45,9 +45,13 @@ public enum RateLimitDetection {
         if let info = entry.rateLimitInfo,
            (info["status"] as? String) == "rejected" {
             let epoch: Double?
-            if let d = info["resetsAt"] as? Double { epoch = d }
-            else if let i = info["resetsAt"] as? Int { epoch = Double(i) }
-            else { epoch = nil }
+            if let d = info["resetsAt"] as? Double {
+                epoch = d
+            } else if let i = info["resetsAt"] as? Int {
+                epoch = Double(i)
+            } else {
+                epoch = nil
+            }
             if let epoch {
                 return DetectedRateLimit(
                     resetsAt: Date(timeIntervalSince1970: epoch),

--- a/Sources/TBDShared/RateLimitDetection.swift
+++ b/Sources/TBDShared/RateLimitDetection.swift
@@ -1,0 +1,261 @@
+import Foundation
+
+/// A hard usage-limit hit extracted from a Claude Code transcript.
+public struct DetectedRateLimit: Equatable, Sendable {
+    /// Absolute reset instant. Parsed ONCE and persisted — never re-derived
+    /// from display text later (spec: autoclaude's flagship bug).
+    public let resetsAt: Date
+    /// Structured `rateLimitType` when available, else the qualifier words
+    /// captured from "hit your <qualifier> limit", else "unknown".
+    public let limitType: String
+    /// Verbatim display text from the transcript record.
+    public let rawMessage: String
+
+    public init(resetsAt: Date, limitType: String, rawMessage: String) {
+        self.resetsAt = resetsAt
+        self.limitType = limitType
+        self.rawMessage = rawMessage
+    }
+}
+
+/// Pure detection logic shared by the CLI (`tbd hooks stop-failure`), the
+/// daemon (actuator's user-already-continued check), and tests.
+///
+/// Spec: docs/specs/2026-07-03-session-limit-auto-resume-design.md §Detection.
+public enum RateLimitDetection {
+
+    // MARK: - Entry point
+
+    /// Scan transcript JSONL for the last `isApiErrorMessage == true` record
+    /// and decide whether it is a schedulable hard limit.
+    ///
+    /// Order (spec): structured `rate_limit_info` first (`status == "rejected"`
+    /// + epoch `resetsAt` taken verbatim); else text fallback (hard-limit
+    /// wording + parseable reset clause). Transient wordings and unparseable
+    /// times return nil — the caller keeps its plain error notification.
+    public static func detect(
+        transcriptData: Data,
+        now: Date = Date(),
+        timeZone: TimeZone = .current
+    ) -> DetectedRateLimit? {
+        guard let entry = lastApiErrorEntry(in: transcriptData) else { return nil }
+        let text = entry.text ?? ""
+
+        // 1. Structured first.
+        if let info = entry.rateLimitInfo,
+           (info["status"] as? String) == "rejected" {
+            let epoch: Double?
+            if let d = info["resetsAt"] as? Double { epoch = d }
+            else if let i = info["resetsAt"] as? Int { epoch = Double(i) }
+            else { epoch = nil }
+            if let epoch {
+                return DetectedRateLimit(
+                    resetsAt: Date(timeIntervalSince1970: epoch),
+                    limitType: (info["rateLimitType"] as? String) ?? "unknown",
+                    rawMessage: text
+                )
+            }
+        }
+
+        // 2. Text fallback.
+        guard !text.isEmpty,
+              !isTransientMessage(text),
+              isHardLimitMessage(text),
+              let resetsAt = parseResetTime(from: text, now: now, defaultTimeZone: timeZone)
+        else { return nil }
+
+        return DetectedRateLimit(
+            resetsAt: resetsAt,
+            limitType: qualifier(in: text) ?? "unknown",
+            rawMessage: text
+        )
+    }
+
+    // MARK: - Wording discrimination
+
+    /// Transient wordings Claude Code retries itself. Racing its internal
+    /// retry loop was a documented community-tool failure mode — exclude.
+    public static func isTransientMessage(_ text: String) -> Bool {
+        let lower = text.lowercased()
+        if lower.contains("not your usage limit") { return true }
+        if lower.contains("temporarily limiting requests") { return true }
+        // Bare HTTP-status API errors (429/5xx/529) with no limit wording.
+        if lower.range(of: #"api error:?\s*(429|5\d\d)"#, options: .regularExpression) != nil {
+            return true
+        }
+        return false
+    }
+
+    /// Hard-limit wordings. Qualifier drifts (session / weekly / 5-hour /
+    /// future words) — allow up to a few arbitrary words before "limit"
+    /// (spec, per claude-auto-retry issue #15).
+    public static func isHardLimitMessage(_ text: String) -> Bool {
+        let lower = text.lowercased()
+        if lower.range(of: #"hit your(?:\s+\S+){0,5}?\s+limit"#, options: .regularExpression) != nil {
+            return true
+        }
+        if lower.contains("limit reached") { return true }
+        if lower.contains("out of extra usage") { return true }
+        return false
+    }
+
+    /// Qualifier words between "hit your" and "limit", for `limitType`.
+    static func qualifier(in text: String) -> String? {
+        let lower = text.lowercased()
+        guard let regex = try? NSRegularExpression(pattern: #"hit your((?:\s+\S+){0,5}?)\s+limit"#),
+              let m = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower)),
+              m.numberOfRanges > 1,
+              let r = Range(m.range(at: 1), in: lower)
+        else { return nil }
+        let q = lower[r].trimmingCharacters(in: .whitespaces)
+        return q.isEmpty ? nil : q
+    }
+
+    // MARK: - Reset-time text parsing
+
+    /// Parse "resets 3pm (America/Toronto)" / "Resets at 2pm" / "resets 4:50pm"
+    /// into an absolute instant using Foundation Calendar + TimeZone — never
+    /// offset arithmetic (spec: claude-auto-retry's nastiest bug).
+    ///
+    /// Rules (spec):
+    /// - no am/pm and hour 1–12 → compute both candidates, take nearest future;
+    /// - parsed instant already past → add a day;
+    /// - unparseable (incl. unknown IANA zone) → nil.
+    public static func parseResetTime(
+        from text: String, now: Date, defaultTimeZone: TimeZone
+    ) -> Date? {
+        let pattern = #"resets(?:\s+at)?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?(?:\s*\(([^)]+)\))?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+              let m = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text))
+        else { return nil }
+
+        func group(_ i: Int) -> String? {
+            guard m.numberOfRanges > i, let r = Range(m.range(at: i), in: text) else { return nil }
+            return String(text[r])
+        }
+        guard let hourStr = group(1), let hour = Int(hourStr), hour <= 23 else { return nil }
+        let minute = group(2).flatMap(Int.init) ?? 0
+        guard minute <= 59 else { return nil }
+        let ampm = group(3)?.lowercased()
+
+        let zone: TimeZone
+        if let zoneID = group(4) {
+            guard let z = TimeZone(identifier: zoneID.trimmingCharacters(in: .whitespaces)) else {
+                return nil  // unknown zone → unparseable → notify-only
+            }
+            zone = z
+        } else {
+            zone = defaultTimeZone
+        }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = zone
+
+        /// Today's instant at hour24:minute in `zone`, rolled +1 day if past.
+        func futureCandidate(hour24: Int) -> Date? {
+            var comps = calendar.dateComponents([.year, .month, .day], from: now)
+            comps.hour = hour24
+            comps.minute = minute
+            comps.second = 0
+            guard var candidate = calendar.date(from: comps) else { return nil }
+            if candidate <= now {
+                guard let rolled = calendar.date(byAdding: .day, value: 1, to: candidate) else {
+                    return nil
+                }
+                candidate = rolled
+            }
+            return candidate
+        }
+
+        if let ampm {
+            let hour24: Int
+            switch (ampm, hour) {
+            case ("am", 12): hour24 = 0
+            case ("am", _):  hour24 = hour
+            case ("pm", 12): hour24 = 12
+            default:         hour24 = hour + 12
+            }
+            guard hour24 <= 23 else { return nil }
+            return futureCandidate(hour24: hour24)
+        }
+
+        if (1...12).contains(hour) {
+            // Ambiguous: both interpretations, nearest future wins.
+            let candidates = [hour % 12, (hour % 12) + 12].compactMap(futureCandidate(hour24:))
+            return candidates.min()
+        }
+        return futureCandidate(hour24: hour)
+    }
+
+    // MARK: - JSONL scanning
+
+    /// Last `isApiErrorMessage == true` record: first non-empty text block +
+    /// the top-level `rate_limit_info` object when present.
+    static func lastApiErrorEntry(in data: Data) -> (text: String?, rateLimitInfo: [String: Any]?)? {
+        guard let contents = String(data: data, encoding: .utf8) else { return nil }
+        for line in contents.split(separator: "\n", omittingEmptySubsequences: true).reversed() {
+            guard let lineData = line.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  obj["isApiErrorMessage"] as? Bool == true
+            else { continue }
+            var text: String?
+            if let message = obj["message"] as? [String: Any],
+               let content = message["content"] as? [[String: Any]] {
+                for block in content where block["type"] as? String == "text" {
+                    if let t = block["text"] as? String,
+                       !t.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        text = t
+                        break
+                    }
+                }
+            }
+            return (text: text, rateLimitInfo: obj["rate_limit_info"] as? [String: Any])
+        }
+        return nil
+    }
+
+    /// True when the newest timestamped transcript record is newer than
+    /// `cutoff`. Used at fire time: any record after the limit hit means the
+    /// user already continued — cancel, send nothing (spec §Actuation 2).
+    public static func hasRecord(newerThan cutoff: Date, in data: Data) -> Bool {
+        guard let contents = String(data: data, encoding: .utf8) else { return false }
+        let isoFractional = ISO8601DateFormatter()
+        isoFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let isoPlain = ISO8601DateFormatter()
+        isoPlain.formatOptions = [.withInternetDateTime]
+
+        for line in contents.split(separator: "\n", omittingEmptySubsequences: true).reversed() {
+            guard let lineData = line.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let ts = obj["timestamp"] as? String
+            else { continue }
+
+            var date: Date?
+            // Try ISO8601 with fractional seconds first
+            if let parsed = isoFractional.date(from: ts) {
+                date = parsed
+            } else if let parsed = isoPlain.date(from: ts) {
+                date = parsed
+            }
+
+            if let parsedDate = date {
+                return parsedDate > cutoff
+            }
+        }
+        return false
+    }
+}
+
+/// Formats reset/fire instants for notification + badge copy: "1:01pm",
+/// minutes dropped when zero ("1pm"). Locale-pinned so copy is stable.
+public enum ResumeTimeFormatter {
+    public static func string(from date: Date, timeZone: TimeZone = .current) -> String {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = calendar.component(.minute, from: date) == 0 ? "ha" : "h:mma"
+        return formatter.string(from: date).lowercased()
+    }
+}

--- a/Tests/TBDCLITests/StopFailureMessageTests.swift
+++ b/Tests/TBDCLITests/StopFailureMessageTests.swift
@@ -70,4 +70,48 @@ struct StopFailureMessageTests {
         )
         #expect(result == nil)
     }
+
+    // MARK: - computeOutcome (auto-resume detection)
+
+    @Test func hardLimitProducesDetectedLimitAndMessage() {
+        let text = "You've hit your session limit · resets 3pm (UTC)"
+        let outcome = StopFailureMessage.computeOutcome(
+            stdinData: Self.stdin(errorType: "rate_limit", transcriptPath: "/x.jsonl"),
+            readFile: { _ in Self.transcript(text: text) },
+            now: Date(timeIntervalSince1970: 1_783_173_600),  // 14:00 UTC
+            timeZone: TimeZone(identifier: "UTC")!)
+        #expect(outcome.message == text)
+        #expect(outcome.detectedLimit != nil)
+        #expect(outcome.detectedLimit!.rawMessage == text)
+        #expect(outcome.detectedLimit!.resetsAt > Date(timeIntervalSince1970: 1_783_173_600))
+    }
+
+    @Test func transientProducesMessageButNoDetection() {
+        let text = "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited"
+        let outcome = StopFailureMessage.computeOutcome(
+            stdinData: Self.stdin(errorType: "rate_limit", transcriptPath: "/x.jsonl"),
+            readFile: { _ in Self.transcript(text: text) },
+            now: Date(), timeZone: TimeZone(identifier: "UTC")!)
+        #expect(outcome.message == text)         // existing behavior preserved
+        #expect(outcome.detectedLimit == nil)
+    }
+
+    @Test func unparseableResetKeepsErrorNotificationPath() {
+        let text = "You've hit your session limit"
+        let outcome = StopFailureMessage.computeOutcome(
+            stdinData: Self.stdin(errorType: "rate_limit", transcriptPath: "/x.jsonl"),
+            readFile: { _ in Self.transcript(text: text) },
+            now: Date(), timeZone: TimeZone(identifier: "UTC")!)
+        #expect(outcome.message == text)          // notify only, never schedule
+        #expect(outcome.detectedLimit == nil)
+    }
+
+    @Test func missingTranscriptHasFallbackMessageNoDetection() {
+        let outcome = StopFailureMessage.computeOutcome(
+            stdinData: Self.stdin(errorType: "rate_limit", transcriptPath: "/missing.jsonl"),
+            readFile: { _ in nil },
+            now: Date(), timeZone: TimeZone(identifier: "UTC")!)
+        #expect(outcome.message == "Claude stopped: API error (rate_limit)")
+        #expect(outcome.detectedLimit == nil)
+    }
 }

--- a/Tests/TBDDaemonTests/AutoResumeConfigRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoResumeConfigRPCTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct AutoResumeConfigRPCTests {
+    let db: TBDDatabase
+    let router: RPCRouter
+
+    init() throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date())
+    }
+
+    @Test func enablePersistsFlag() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetAutoResumeOnLimitReset,
+            params: ConfigSetAutoResumeOnLimitResetParams(enabled: true))
+        let response = await router.handle(request)
+        #expect(response.success)
+        #expect(try await db.config.get().autoResumeOnLimitReset == true)
+    }
+
+    @Test func disableCancelsAllPendingRows() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        let repo = try await db.repos.create(
+            path: "/tmp/arc-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/arc-wt-\(UUID().uuidString)", tmuxServer: "tbd-arc")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminal.id, worktreeID: wt.id,
+            resetsAt: Date(), fireAt: Date().addingTimeInterval(60),
+            limitType: "session", rawMessage: "m"))
+
+        let request = try RPCRequest(
+            method: RPCMethod.configSetAutoResumeOnLimitReset,
+            params: ConfigSetAutoResumeOnLimitResetParams(enabled: false))
+        let response = await router.handle(request)
+        #expect(response.success)
+        #expect(try await db.config.get().autoResumeOnLimitReset == false)
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+        #expect(try await db.terminals.get(id: terminal.id)?.pendingResumeAt == nil)
+    }
+
+    @Test func modelProfileListCarriesFlag() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        let response = await router.handle(RPCRequest(method: RPCMethod.modelProfileList))
+        #expect(response.success)
+        let result = try response.decodeResult(ModelProfileListResult.self)
+        #expect(result.autoResumeOnLimitReset == true)
+    }
+
+    @Test func oldListResultJSONDecodesWithDefaultFalse() throws {
+        // decode-compat: a pre-feature daemon's result has no such key.
+        let json = #"{"profiles":[],"globalEnvOverrides":{},"autoArchiveOnMergeDefault":false}"#
+        let result = try JSONDecoder().decode(ModelProfileListResult.self, from: Data(json.utf8))
+        #expect(result.autoResumeOnLimitReset == false)
+    }
+}

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -4,22 +4,44 @@ import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
 
+struct FakeTmuxSendError: Error {}
+
 /// Records every tmux call; scriptable pane state.
 final class FakeResumeTmux: ResumeSendingTmux, @unchecked Sendable {
     private let queue = DispatchQueue(label: "FakeResumeTmux")
     var windowAlive = true
     var inMode = false
+    /// When non-empty, `paneInMode` pops values off the front (in call
+    /// order) before falling back to `inMode` — scripts a value that
+    /// changes between an actuation's eligibility passes (e.g. attempt 1
+    /// vs. attempt 2's re-check).
+    var inModeSequence: [Bool] = []
     var panePIDValue = "4242"
+    /// 1-indexed count of `sendKey(key: "Escape")` calls (i.e. actuation
+    /// attempts) on which the send should throw instead of recording.
+    var throwOnEscapeAttempts: Set<Int> = []
     private var _sends: [String] = []
+    private var _escapeCount = 0
     var sends: [String] { queue.sync { _sends } }
 
     func windowExists(server: String, windowID: String) async -> Bool { windowAlive }
-    func paneInMode(server: String, paneID: String) async throws -> Bool { inMode }
+    func paneInMode(server: String, paneID: String) async throws -> Bool {
+        queue.sync {
+            if !inModeSequence.isEmpty { return inModeSequence.removeFirst() }
+            return inMode
+        }
+    }
     func panePID(server: String, paneID: String) async throws -> String { panePIDValue }
     func sendKeys(server: String, paneID: String, text: String) async throws {
         queue.sync { _sends.append("text:\(text)") }
     }
     func sendKey(server: String, paneID: String, key: String) async throws {
+        if key == "Escape" {
+            let attempt = queue.sync { _escapeCount += 1; return _escapeCount }
+            if throwOnEscapeAttempts.contains(attempt) {
+                throw FakeTmuxSendError()
+            }
+        }
         queue.sync { _sends.append("key:\(key)") }
     }
 }
@@ -122,7 +144,7 @@ struct FakeInspector: PaneProcessInspecting {
         try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
         let outcome = await makeActuator().actuate(row)
         if case .failed = outcome {} else { Issue.record("expected .failed, got \(outcome)") }
-        // Sequence sent twice: initial + one retry (spec §Actuation 5).
+        // Sequence sent twice: initial + one retry (spec §Actuation 6).
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter",
                                "key:Escape", "text:continue", "key:Enter"])
     }
@@ -140,5 +162,97 @@ struct FakeInspector: PaneProcessInspecting {
             readTranscript: growing, waiter: { _ in })
         let outcome = await actuator.actuate(row)
         #expect(outcome == .sent)
+    }
+
+    // MARK: - Retry re-runs eligibility (spec §Actuation "one retry of steps 1-5")
+
+    @Test func copyModeEnteredBetweenAttemptsReschedulesAfterOneSend() async throws {
+        // Attempt 1's eligibility pass sees no copy-mode and sends; attempt
+        // 1's verify window times out (idle, flat transcript); attempt 2's
+        // eligibility RE-CHECK sees copy-mode now set and reschedules
+        // instead of blind-Escaping the user's scrollback.
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        tmux.inModeSequence = [false, true]
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .paneInCopyMode)
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func userContinuedBetweenAttemptsCancelsAfterOneSend() async throws {
+        // Attempt 1's eligibility pass reads a transcript with no newer
+        // record and sends; attempt 1's verify window times out; attempt
+        // 2's eligibility RE-CHECK reads a transcript that now has a record
+        // newer than the limit (user typed manually in the window) and
+        // cancels instead of sending again.
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        // Padding is deliberately LARGER than the newer-record line so the
+        // growth check during attempt 1's verify polls (which only compares
+        // byte counts, not content) never mistakes the later reads for
+        // growth.
+        let padding = Data(repeating: 0x20, count: 200)
+        let newerRecordLine = Data(
+            (#"{"type":"user","timestamp":"2099-01-01T00:00:00.000Z"}"# + "\n").utf8)
+        let flipping: @Sendable (String) -> Data? = { _ in
+            let n = counter.withLock { $0 += 1; return $0 }
+            return n == 1 ? padding : newerRecordLine
+        }
+        let actuator = LimitResumeActuator(
+            db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
+            readTranscript: flipping, waiter: { _ in })
+        let outcome = await actuator.actuate(row)
+        #expect(outcome == .userAlreadyContinued)
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    // MARK: - Thrown send retries instead of instant .failed
+
+    @Test func throwingSendOnFirstAttemptRetriesAndSucceeds() async throws {
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        tmux.throwOnEscapeAttempts = [1]
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .sent)
+        // Attempt 1 threw before recording anything; attempt 2 sent in full.
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func throwingSendOnBothAttemptsFails() async throws {
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        tmux.throwOnEscapeAttempts = [1, 2]
+        let outcome = await makeActuator().actuate(row)
+        if case .failed = outcome {} else { Issue.record("expected .failed, got \(outcome)") }
+        #expect(tmux.sends.isEmpty)
+    }
+}
+
+// MARK: - ProductionPaneProcessInspector
+
+@Suite struct ProductionPaneProcessInspectorTests {
+    @Test func paneChildWithForegroundClaudeIsFound() {
+        let signaller = FakeProcessSignaller()
+        signaller.childrenByServer[100] = [200]
+        signaller.cmdlines[200] = "/opt/homebrew/bin/claude"
+        signaller.stats[200] = "S+"
+        let inspector = ProductionPaneProcessInspector(signaller: signaller)
+        #expect(inspector.foregroundClaudePID(panePID: 100) == 200)
+    }
+
+    @Test func childWithoutForegroundFlagIsNotFound() {
+        let signaller = FakeProcessSignaller()
+        signaller.childrenByServer[100] = [200]
+        signaller.cmdlines[200] = "claude"
+        signaller.stats[200] = "Ss"   // no trailing "+"
+        let inspector = ProductionPaneProcessInspector(signaller: signaller)
+        #expect(inspector.foregroundClaudePID(panePID: 100) == nil)
+    }
+
+    @Test func grandchildWithForegroundClaudeIsFound() {
+        let signaller = FakeProcessSignaller()
+        signaller.childrenByServer[100] = [200]     // pane -> wrapper shell
+        signaller.childrenByServer[200] = [300]     // wrapper shell -> claude
+        signaller.cmdlines[300] = "claude"
+        signaller.stats[300] = "S+"
+        let inspector = ProductionPaneProcessInspector(signaller: signaller)
+        #expect(inspector.foregroundClaudePID(panePID: 100) == 300)
     }
 }

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import os
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Records every tmux call; scriptable pane state.
+final class FakeResumeTmux: ResumeSendingTmux, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "FakeResumeTmux")
+    var windowAlive = true
+    var inMode = false
+    var panePIDValue = "4242"
+    private var _sends: [String] = []
+    var sends: [String] { queue.sync { _sends } }
+
+    func windowExists(server: String, windowID: String) async -> Bool { windowAlive }
+    func paneInMode(server: String, paneID: String) async throws -> Bool { inMode }
+    func panePID(server: String, paneID: String) async throws -> String { panePIDValue }
+    func sendKeys(server: String, paneID: String, text: String) async throws {
+        queue.sync { _sends.append("text:\(text)") }
+    }
+    func sendKey(server: String, paneID: String, key: String) async throws {
+        queue.sync { _sends.append("key:\(key)") }
+    }
+}
+
+struct FakeInspector: PaneProcessInspecting {
+    var claudePID: Int32?
+    func foregroundClaudePID(panePID: Int32) -> Int32? { claudePID }
+}
+
+@Suite struct LimitResumeActuatorTests {
+    let db: TBDDatabase
+    let tmux = FakeResumeTmux()
+    let terminalID: UUID
+    let worktreeID: UUID
+    let row: ScheduledResume
+
+    init() async throws {
+        db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/act-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/act-wt-\(UUID().uuidString)", tmuxServer: "tbd-act")
+        worktreeID = wt.id
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        terminalID = terminal.id
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "sess", transcriptPath: "/tmp/act-transcript.jsonl")
+        row = ScheduledResume(
+            terminalID: terminal.id, worktreeID: wt.id, claudeSessionID: "sess",
+            resetsAt: Date().addingTimeInterval(-120), fireAt: Date().addingTimeInterval(-60),
+            limitType: "session", rawMessage: "m", createdAt: Date().addingTimeInterval(-3600))
+    }
+
+    private func makeActuator(
+        inspector: FakeInspector = FakeInspector(claudePID: 4242),
+        transcript: Data? = Data("{}\n".utf8)
+    ) -> LimitResumeActuator {
+        LimitResumeActuator(
+            db: db, tmux: tmux, inspector: inspector,
+            readTranscript: { _ in transcript },
+            waiter: { _ in })   // no real sleeping in unit tests
+    }
+
+    @Test func missingTerminalIsTerminalGone() async throws {
+        let orphan = ScheduledResume(
+            terminalID: UUID(), worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: row.resetsAt, fireAt: row.fireAt,
+            limitType: "session", rawMessage: "m")
+        let outcome = await makeActuator().actuate(orphan)
+        #expect(outcome == .terminalGone)
+        #expect(tmux.sends.isEmpty)
+    }
+
+    @Test func suspendedTerminalIsTerminalGone() async throws {
+        try await db.terminals.setSuspended(id: terminalID, sessionID: "sess", snapshot: nil)
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .terminalGone)
+        #expect(tmux.sends.isEmpty)
+    }
+
+    @Test func deadWindowIsTerminalGone() async throws {
+        tmux.windowAlive = false
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .terminalGone)
+    }
+
+    @Test func newerTranscriptRecordCancels() async throws {
+        // Record timestamped AFTER the limit was detected (createdAt is 1h ago).
+        let line = #"{"type":"user","timestamp":"2099-01-01T00:00:00.000Z"}"#
+        let outcome = await makeActuator(transcript: Data((line + "\n").utf8)).actuate(row)
+        #expect(outcome == .userAlreadyContinued)
+        #expect(tmux.sends.isEmpty)
+    }
+
+    @Test func copyModeReschedules() async throws {
+        tmux.inMode = true
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .paneInCopyMode)
+        #expect(tmux.sends.isEmpty)
+    }
+
+    @Test func claudeNotForegroundFails() async throws {
+        let outcome = await makeActuator(inspector: FakeInspector(claudePID: nil)).actuate(row)
+        if case .failed = outcome {} else { Issue.record("expected .failed, got \(outcome)") }
+        #expect(tmux.sends.isEmpty)   // never type into a bare shell
+    }
+
+    @Test func happyPathSendsEscapeContinueEnterAndVerifiesViaActivity() async throws {
+        // Activity hook already reports working → first verify poll succeeds.
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .sent)
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func verifyTimeoutRetriesOnceThenFails() async throws {
+        // Activity never becomes working and transcript never grows.
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        let outcome = await makeActuator().actuate(row)
+        if case .failed = outcome {} else { Issue.record("expected .failed, got \(outcome)") }
+        // Sequence sent twice: initial + one retry (spec §Actuation 5).
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter",
+                               "key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func transcriptGrowthCountsAsVerification() async throws {
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        // Transcript grows between pre-send snapshot and verify polls.
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        let growing: @Sendable (String) -> Data? = { _ in
+            let n = counter.withLock { $0 += 1; return $0 }
+            return Data(repeating: 0x7b, count: n <= 1 ? 10 : 500)  // grows after first read
+        }
+        let actuator = LimitResumeActuator(
+            db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
+            readTranscript: growing, waiter: { _ in })
+        let outcome = await actuator.actuate(row)
+        #expect(outcome == .sent)
+    }
+}

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -60,6 +60,11 @@ struct FakeInspector: PaneProcessInspecting {
 
     init() async throws {
         db = try TBDDatabase(inMemory: true)
+        // Production only ever calls `actuate` after `fire()`'s own gate
+        // check passed, so the actuator's own re-check (checkEligibility
+        // step 0a) needs the toggle on by default here too — tests that
+        // exercise the toggle-off-mid-flight path flip it explicitly.
+        try await db.config.setAutoResumeOnLimitReset(true)
         let repo = try await db.repos.create(
             path: "/tmp/act-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
         let wt = try await db.worktrees.create(
@@ -75,6 +80,11 @@ struct FakeInspector: PaneProcessInspecting {
             terminalID: terminal.id, worktreeID: wt.id, claudeSessionID: "sess",
             resetsAt: Date().addingTimeInterval(-120), fireAt: Date().addingTimeInterval(-60),
             limitType: "session", rawMessage: "m", createdAt: Date().addingTimeInterval(-3600))
+        // Persist `row` as the terminal's pending row so checkEligibility's
+        // "row still pending" re-check (step 1b) finds it — production only
+        // ever actuates rows that came from `scheduler.schedule()`, which
+        // always inserts first.
+        _ = try await db.scheduledResumes.insertPending(row)
     }
 
     private func makeActuator(
@@ -203,6 +213,63 @@ struct FakeInspector: PaneProcessInspecting {
         let outcome = await actuator.actuate(row)
         #expect(outcome == .userAlreadyContinued)
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func toggleFlippedOffBetweenAttemptsCancelsAfterOneSend() async throws {
+        // Attempt 1's eligibility pass sees the toggle on and sends; attempt
+        // 1's verify window times out (idle, flat transcript, exactly like
+        // `verifyTimeoutRetriesOnceThenFails`). The injected `waiter` — the
+        // same seam `sendContinueSequence`/`verifyResumed` already await on
+        // — flips the toggle off as a side effect of its FIRST call (the
+        // interKeyPause after attempt 1's Escape), so by the time attempt
+        // 2's eligibility RE-CHECK (step 0a) runs, the gate is off and it
+        // cancels instead of sending again.
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        let flippingWaiter: @Sendable (Duration) async -> Void = { _ in
+            let n = counter.withLock { $0 += 1; return $0 }
+            if n == 1 {
+                try? await self.db.config.setAutoResumeOnLimitReset(false)
+            }
+        }
+        let actuator = LimitResumeActuator(
+            db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
+            readTranscript: { _ in Data("{}\n".utf8) },
+            waiter: flippingWaiter)
+        let outcome = await actuator.actuate(row)
+        #expect(outcome == .cancelledExternally)
+        // Only attempt 1's 3 sends — attempt 2 never fires.
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func rowCancelledBetweenAttemptsCancelsAfterOneSend() async throws {
+        // Same timeout setup as above, but instead of the global toggle,
+        // the ROW is cancelled between attempts (mirrors
+        // `LimitResumeSchedulerTests.copyModeRescheduleDropsRowNoLongerPending`'s
+        // `CancellingActuator`, except here the test body — not a fake
+        // actuator — does the cancelling, via the same waiter-side-effect
+        // seam as the toggle test above). Attempt 2's eligibility RE-CHECK
+        // (step 1b) sees the row is no longer `.pending` and cancels
+        // instead of sending again.
+        try await db.terminals.setActivityState(id: terminalID, activityState: .idle)
+        let counter = OSAllocatedUnfairLock(initialState: 0)
+        let cancellingWaiter: @Sendable (Duration) async -> Void = { _ in
+            let n = counter.withLock { $0 += 1; return $0 }
+            if n == 1 {
+                _ = try? await self.db.scheduledResumes.cancelPending(terminalID: self.terminalID)
+            }
+        }
+        let actuator = LimitResumeActuator(
+            db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
+            readTranscript: { _ in Data("{}\n".utf8) },
+            waiter: cancellingWaiter)
+        let outcome = await actuator.actuate(row)
+        #expect(outcome == .cancelledExternally)
+        // Only attempt 1's 3 sends — attempt 2 never fires.
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+        // The row stays cancelled — not resurrected by a stray write.
+        let stored = try await db.scheduledResumes.get(id: row.id)
+        #expect(stored?.status == .cancelled)
     }
 
     // MARK: - Thrown send retries instead of instant .failed

--- a/Tests/TBDDaemonTests/LimitResumeSchedulerTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeSchedulerTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Scripted actuator: returns queued outcomes in order, records calls.
+final class FakeActuator: LimitResumeActuating, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "FakeActuator")
+    private var outcomes: [ResumeActuationOutcome]
+    private var _calls: [ScheduledResume] = []
+    var calls: [ScheduledResume] { queue.sync { _calls } }
+
+    init(_ outcomes: [ResumeActuationOutcome] = [.sent]) {
+        self.outcomes = outcomes
+    }
+
+    func actuate(_ resume: ScheduledResume) async -> ResumeActuationOutcome {
+        queue.sync {
+            _calls.append(resume)
+            return outcomes.count > 1 ? outcomes.removeFirst() : outcomes[0]
+        }
+    }
+}
+
+final class OutcomeCollector: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "OutcomeCollector")
+    private var _events: [(ScheduledResume, LimitResumeOutcome)] = []
+    var events: [(ScheduledResume, LimitResumeOutcome)] { queue.sync { _events } }
+    func record(_ resume: ScheduledResume, _ outcome: LimitResumeOutcome) {
+        queue.sync { _events.append((resume, outcome)) }
+    }
+}
+
+@Suite struct LimitResumeSchedulerTests {
+    let db: TBDDatabase
+    let clock: TestPollerClock
+    let terminalID: UUID
+    let worktreeID: UUID
+
+    init() async throws {
+        db = try TBDDatabase(inMemory: true)
+        clock = TestPollerClock()
+        try await db.config.setAutoResumeOnLimitReset(true)
+        let repo = try await db.repos.create(
+            path: "/tmp/lrs-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/lrs-wt-\(UUID().uuidString)", tmuxServer: "tbd-lrs")
+        worktreeID = wt.id
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        terminalID = terminal.id
+    }
+
+    private func makeScheduler(
+        actuator: FakeActuator,
+        jitter: TimeInterval = 0,
+        onOutcome: @escaping @Sendable (ScheduledResume, LimitResumeOutcome) async -> Void = { _, _ in }
+    ) -> LimitResumeScheduler {
+        LimitResumeScheduler(
+            store: db.scheduledResumes, config: db.config,
+            actuator: actuator, clock: clock,
+            jitterProvider: { jitter }, onOutcome: onOutcome)
+    }
+
+    /// Let the actor loop cross its awaits (GRDB runs on its own threads,
+    /// so pure Task.yield isn't enough — mirror ClaudeUsagePollerTests' pump).
+    private func pump() async {
+        for _ in 0..<10 {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+            await Task.yield()
+        }
+    }
+
+    @Test func scheduleComputesFireAtWithSlackAndJitter() async throws {
+        let scheduler = makeScheduler(actuator: FakeActuator(), jitter: 10)
+        let resetsAt = clock.now().addingTimeInterval(3600)
+        let row = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: resetsAt, limitType: "session", rawMessage: "m")
+        #expect(row != nil)
+        #expect(abs(row!.fireAt.timeIntervalSince(resetsAt) - 70) < 1) // 60 slack + 10 jitter
+    }
+
+    @Test func latchSecondScheduleReturnsNil() async throws {
+        let scheduler = makeScheduler(actuator: FakeActuator())
+        let resetsAt = clock.now().addingTimeInterval(3600)
+        _ = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: resetsAt, limitType: "session", rawMessage: "m")
+        let second = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: resetsAt, limitType: "session", rawMessage: "m")
+        #expect(second == nil)
+    }
+
+    @Test func pastDueRowFiresImmediatelyOnStart() async throws {
+        // Startup reload: a persisted past-due row (Mac slept past reset).
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminalID, worktreeID: worktreeID,
+            resetsAt: clock.now().addingTimeInterval(-120),
+            fireAt: clock.now().addingTimeInterval(-60),
+            limitType: "session", rawMessage: "m"))
+        let actuator = FakeActuator([.sent])
+        let collector = OutcomeCollector()
+        let scheduler = makeScheduler(actuator: actuator) { collector.record($0, $1) }
+        await scheduler.start()
+        await pump()
+        #expect(actuator.calls.count == 1)
+        let rows = try await db.scheduledResumes.pending()
+        #expect(rows.isEmpty)
+        #expect(collector.events.count == 1)
+        if case .sent = collector.events[0].1 {} else { Issue.record("expected .sent") }
+        await scheduler.stop()
+    }
+
+    @Test func sleepsUntilFireAtThenActuates() async throws {
+        let actuator = FakeActuator([.sent])
+        let scheduler = makeScheduler(actuator: actuator)
+        await scheduler.start()
+        _ = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(600),
+            limitType: "session", rawMessage: "m")
+        await pump()
+        #expect(actuator.calls.isEmpty)          // still sleeping
+        await clock.advance(by: 700)             // past resetsAt + slack
+        await pump()
+        #expect(actuator.calls.count == 1)
+        await scheduler.stop()
+    }
+
+    @Test func copyModeReschedulesPlusTwoMinutes() async throws {
+        let actuator = FakeActuator([.paneInCopyMode, .sent])
+        let scheduler = makeScheduler(actuator: actuator)
+        await scheduler.start()
+        _ = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(-120),
+            limitType: "session", rawMessage: "m")
+        await pump()
+        #expect(actuator.calls.count == 1)
+        let row = try await db.scheduledResumes.pending(terminalID: terminalID)
+        #expect(row?.attemptCount == 1)
+        #expect(row!.fireAt.timeIntervalSince(clock.now()) > 100) // ~+120s
+        await clock.advance(by: 130)
+        await pump()
+        #expect(actuator.calls.count == 2)
+        #expect(try await db.scheduledResumes.pending(terminalID: terminalID) == nil)
+        await scheduler.stop()
+    }
+
+    @Test func copyModeCapsAtFifteenAttemptsThenFails() async throws {
+        let actuator = FakeActuator([.paneInCopyMode])
+        let collector = OutcomeCollector()
+        let scheduler = makeScheduler(actuator: actuator) { collector.record($0, $1) }
+        await scheduler.start()
+        _ = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(-120),
+            limitType: "session", rawMessage: "m")
+        for _ in 0..<15 {
+            await pump()
+            await clock.advance(by: 130)
+        }
+        await pump()
+        #expect(actuator.calls.count == LimitResumeScheduler.maxCopyModeAttempts)
+        let rows = try await db.scheduledResumes.pending()
+        #expect(rows.isEmpty)
+        #expect(collector.events.contains { if case .failed = $0.1 { return true }; return false })
+        await scheduler.stop()
+    }
+
+    @Test func toggleOffAtFireTimeCancelsSilently() async throws {
+        let actuator = FakeActuator([.sent])
+        let collector = OutcomeCollector()
+        let scheduler = makeScheduler(actuator: actuator) { collector.record($0, $1) }
+        await scheduler.start()
+        _ = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(-120),
+            limitType: "session", rawMessage: "m")
+        try await db.config.setAutoResumeOnLimitReset(false)
+        await scheduler.wake()
+        await pump()
+        #expect(actuator.calls.isEmpty)
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+        #expect(collector.events.isEmpty)
+        await scheduler.stop()
+    }
+
+    @Test func userAlreadyContinuedCancelsWithoutOutcome() async throws {
+        let actuator = FakeActuator([.userAlreadyContinued])
+        let collector = OutcomeCollector()
+        let scheduler = makeScheduler(actuator: actuator) { collector.record($0, $1) }
+        await scheduler.start()
+        _ = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(-120),
+            limitType: "session", rawMessage: "m")
+        await pump()
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+        #expect(collector.events.isEmpty)
+        await scheduler.stop()
+    }
+}

--- a/Tests/TBDDaemonTests/LimitResumeSchedulerTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeSchedulerTests.swift
@@ -171,20 +171,33 @@ final class OutcomeCollector: @unchecked Sendable {
         await scheduler.stop()
     }
 
+    /// Deterministic toggle-off race: schedule with a FUTURE resetsAt so the
+    /// loop parks sleeping on the virtual clock, write the config change
+    /// (guaranteed to complete before anything else happens), THEN advance
+    /// the clock past fireAt. No real-time dependence, no thread-scheduling
+    /// race between the config write and the fire.
     @Test func toggleOffAtFireTimeCancelsSilently() async throws {
         let actuator = FakeActuator([.sent])
         let collector = OutcomeCollector()
         let scheduler = makeScheduler(actuator: actuator) { collector.record($0, $1) }
         await scheduler.start()
-        _ = await scheduler.schedule(
+        let resetsAt = clock.now().addingTimeInterval(600)
+        let scheduled = await scheduler.schedule(
             terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
-            resetsAt: clock.now().addingTimeInterval(-120),
-            limitType: "session", rawMessage: "m")
-        try await db.config.setAutoResumeOnLimitReset(false)
-        await scheduler.wake()
+            resetsAt: resetsAt, limitType: "session", rawMessage: "m")
+        #expect(scheduled != nil)
         await pump()
+        #expect(actuator.calls.isEmpty)   // still parked, sleeping until fireAt
+
+        // Completes fully before the clock advances below — no race.
+        try await db.config.setAutoResumeOnLimitReset(false)
+
+        await clock.advance(by: 700)      // past resetsAt + slack
+        await pump()
+
         #expect(actuator.calls.isEmpty)
-        #expect(try await db.scheduledResumes.pending().isEmpty)
+        let row = try await db.scheduledResumes.get(id: scheduled!.id)
+        #expect(row?.status == .cancelled)
         #expect(collector.events.isEmpty)
         await scheduler.stop()
     }
@@ -193,6 +206,53 @@ final class OutcomeCollector: @unchecked Sendable {
         let actuator = FakeActuator([.userAlreadyContinued])
         let collector = OutcomeCollector()
         let scheduler = makeScheduler(actuator: actuator) { collector.record($0, $1) }
+        await scheduler.start()
+        _ = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(-120),
+            limitType: "session", rawMessage: "m")
+        await pump()
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+        #expect(collector.events.isEmpty)
+        await scheduler.stop()
+    }
+
+    @Test func terminalGoneCancelsWithoutOutcome() async throws {
+        let actuator = FakeActuator([.terminalGone])
+        let collector = OutcomeCollector()
+        let scheduler = makeScheduler(actuator: actuator) { collector.record($0, $1) }
+        await scheduler.start()
+        let scheduled = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(-120),
+            limitType: "session", rawMessage: "m")
+        await pump()
+        #expect(actuator.calls.count == 1)   // no retry
+        let row = try await db.scheduledResumes.get(id: scheduled!.id)
+        #expect(row?.status == .cancelled)
+        #expect(collector.events.isEmpty)
+        await scheduler.stop()
+    }
+
+    /// If a row is cancelled out from under a copy-mode retry (e.g. by a
+    /// concurrent cancel) between actuation and the reschedule write,
+    /// `store.reschedule` returns false. The scheduler must not resurrect
+    /// the row into pending — it drops it from consideration instead.
+    @Test func copyModeRescheduleDropsRowNoLongerPending() async throws {
+        final class CancellingActuator: LimitResumeActuating, @unchecked Sendable {
+            let store: ScheduledResumeStore
+            init(store: ScheduledResumeStore) { self.store = store }
+            func actuate(_ resume: ScheduledResume) async -> ResumeActuationOutcome {
+                _ = try? await store.cancelPending(terminalID: resume.terminalID)
+                return .paneInCopyMode
+            }
+        }
+        let actuator = CancellingActuator(store: db.scheduledResumes)
+        let collector = OutcomeCollector()
+        let scheduler = LimitResumeScheduler(
+            store: db.scheduledResumes, config: db.config,
+            actuator: actuator, clock: clock,
+            jitterProvider: { 0 }, onOutcome: { collector.record($0, $1) })
         await scheduler.start()
         _ = await scheduler.schedule(
             terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,

--- a/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
@@ -108,23 +108,17 @@ struct LimitResumeSendSequenceLiveTests {
         let outputPath = NSTemporaryDirectory() + "tbd-resume-capture-\(UUID().uuidString).bin"
         // A live `tmux -CC` client on the same server — the "control-mode on"
         // coexistence case. Daemon-initiated send-keys must land identically.
-        let ccClient = Process()
-        ccClient.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        let ccIn = Pipe(); let ccOut = Pipe()
-        ccClient.standardInput = ccIn
-        ccClient.standardOutput = ccOut
-        ccClient.standardError = FileHandle.nullDevice
+        // Uses the production TmuxControlConnection (pty-backed) rather than a
+        // Process/Pipe fake: `tmux -CC` requires a real tty on stdin/stdout and
+        // exits immediately with "tcgetattr failed" when given plain pipes.
+        let connection = TmuxControlConnection(serverName: server)
         defer {
-            ccOut.fileHandleForReading.readabilityHandler = nil  // clear handler before terminate
-            if ccClient.isRunning { ccClient.terminate() }
+            connection.stop()
             tmux(["-L", server, "kill-server"])
             try? FileManager.default.removeItem(atPath: outputPath)
         }
         let paneID = try await startRawCapture(server: server, outputPath: outputPath)
-        ccClient.arguments = ["tmux", "-CC", "-L", server, "attach", "-t", "main"]
-        try ccClient.run()
-        // Drain the -CC client's stdout to prevent 64KB pipe backpressure stalling the observer
-        ccOut.fileHandleForReading.readabilityHandler = { _ in }
+        try connection.start()
 
         // Poll tmux list-clients until exactly 1 client is attached.
         // Use #{client_pid} format so each attached client emits one non-empty

--- a/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
@@ -1,0 +1,127 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Live-tmux proof of the auto-resume send sequence (spec §Actuation 4):
+/// Escape → 150ms → literal "continue" → 150ms → Enter must arrive as the
+/// bytes ESC + "continue" + "\r" — no bracketed-paste wrapping, no dropped
+/// keys. The pane captures its own input under a raw tty via
+/// `head -c N > file` (rc-free bootstrap: the pane command IS the capture,
+/// so no interactive shell startup can race the test under parallel-suite
+/// load). 15s deadlines throughout.
+@Suite("LimitResume send sequence (live tmux)", .serialized)
+struct LimitResumeSendSequenceLiveTests {
+
+    /// ESC + "continue" + CR = 10 bytes.
+    private static let expectedBytes = Data([0x1b]) + Data("continue".utf8) + Data([0x0d])
+
+    @discardableResult
+    private func tmux(_ args: [String]) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["tmux"] + args
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+
+    private func tmuxCapture(_ args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["tmux"] + args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            return String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Bootstrap a raw-capture pane; block (≤15s) until `head` owns the tty.
+    private func startRawCapture(server: String, outputPath: String) async throws -> String {
+        try #require(tmux(["-L", server, "new-session", "-d", "-s", "main", "-x", "80", "-y", "24",
+                           "/bin/sh", "-c",
+                           "stty raw -echo; exec head -c \(Self.expectedBytes.count) > \(outputPath)"]),
+                     "failed to bootstrap raw-capture tmux session")
+        let paneID = try #require(
+            tmuxCapture(["-L", server, "display-message", "-t", "main", "-p", "#{pane_id}"]),
+            "could not resolve pane id")
+        let deadline = ContinuousClock.now + .seconds(15)
+        while ContinuousClock.now < deadline {
+            if tmuxCapture(["-L", server, "list-panes", "-t", paneID,
+                            "-F", "#{pane_current_command}"]) == "head" {
+                return paneID
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        Issue.record("head never became the pane's foreground command")
+        return paneID
+    }
+
+    private func awaitFileBytes(path: String, expected: Data) async throws {
+        let deadline = ContinuousClock.now + .seconds(15)
+        while ContinuousClock.now < deadline {
+            if let data = FileManager.default.contents(atPath: path), data == expected { return }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        let actual = FileManager.default.contents(atPath: path) ?? Data()
+        Issue.record("capture mismatch: expected \(expected.count) bytes, got \(actual.count): \(Array(actual))")
+    }
+
+    private func runSequence(server: String, paneID: String) async throws {
+        let manager = TmuxManager()
+        try await LimitResumeActuator.sendContinueSequence(
+            tmux: manager, server: server, paneID: paneID,
+            waiter: { duration in _ = try? await Task.sleep(for: duration) })
+    }
+
+    @Test func sequenceArrivesVerbatim() async throws {
+        let server = "tbd-test-resume-\(UUID().uuidString.prefix(8))"
+        let outputPath = NSTemporaryDirectory() + "tbd-resume-capture-\(UUID().uuidString).bin"
+        defer {
+            tmux(["-L", server, "kill-server"])
+            try? FileManager.default.removeItem(atPath: outputPath)
+        }
+        let paneID = try await startRawCapture(server: server, outputPath: outputPath)
+        try await runSequence(server: server, paneID: paneID)
+        try await awaitFileBytes(path: outputPath, expected: Self.expectedBytes)
+    }
+
+    @Test func sequenceArrivesVerbatimWithControlModeClientAttached() async throws {
+        let server = "tbd-test-resume-cc-\(UUID().uuidString.prefix(8))"
+        let outputPath = NSTemporaryDirectory() + "tbd-resume-capture-\(UUID().uuidString).bin"
+        // A live `tmux -CC` client on the same server — the "control-mode on"
+        // coexistence case. Daemon-initiated send-keys must land identically.
+        let ccClient = Process()
+        ccClient.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        let ccIn = Pipe(); let ccOut = Pipe()
+        ccClient.standardInput = ccIn
+        ccClient.standardOutput = ccOut
+        ccClient.standardError = FileHandle.nullDevice
+        defer {
+            if ccClient.isRunning { ccClient.terminate() }
+            tmux(["-L", server, "kill-server"])
+            try? FileManager.default.removeItem(atPath: outputPath)
+        }
+        let paneID = try await startRawCapture(server: server, outputPath: outputPath)
+        ccClient.arguments = ["tmux", "-CC", "-L", server, "attach", "-t", "main"]
+        try ccClient.run()
+        try await Task.sleep(for: .milliseconds(300))   // let the client attach
+        try await runSequence(server: server, paneID: paneID)
+        try await awaitFileBytes(path: outputPath, expected: Self.expectedBytes)
+    }
+}

--- a/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
@@ -126,14 +126,20 @@ struct LimitResumeSendSequenceLiveTests {
         // Drain the -CC client's stdout to prevent 64KB pipe backpressure stalling the observer
         ccOut.fileHandleForReading.readabilityHandler = { _ in }
 
-        // Poll tmux list-clients until exactly 1 client is attached
+        // Poll tmux list-clients until exactly 1 client is attached.
+        // Use #{client_pid} format so each attached client emits one non-empty
+        // line — #{client_tty} is empty for -CC control-mode clients.
         let deadline = ContinuousClock.now + .seconds(15)
         while ContinuousClock.now < deadline {
-            if let clientCount = tmuxCapture(["-L", server, "list-clients", "-F", "#{client_tty}"])?
-                .split(separator: "\n").count, clientCount == 1 {
+            if let output = tmuxCapture(["-L", server, "list-clients", "-F", "#{client_pid}"]),
+               output.split(separator: "\n", omittingEmptySubsequences: true).count == 1 {
                 break
             }
             try await Task.sleep(for: .milliseconds(50))
+        }
+        if ContinuousClock.now >= deadline {
+            Issue.record("tmux -CC client never attached within 15s")
+            return
         }
 
         try await runSequence(server: server, paneID: paneID)

--- a/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 
-/// Live-tmux proof of the auto-resume send sequence (spec §Actuation 4):
+/// Live-tmux proof of the auto-resume send sequence (spec §Actuation 5):
 /// Escape → 150ms → literal "continue" → 150ms → Enter must arrive as the
 /// bytes ESC + "continue" + "\r" — no bracketed-paste wrapping, no dropped
 /// keys. The pane captures its own input under a raw tty via

--- a/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeSendSequenceLiveTests.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 import Testing
 @testable import TBDDaemonLib
@@ -90,6 +89,7 @@ struct LimitResumeSendSequenceLiveTests {
     }
 
     @Test func sequenceArrivesVerbatim() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
         let server = "tbd-test-resume-\(UUID().uuidString.prefix(8))"
         let outputPath = NSTemporaryDirectory() + "tbd-resume-capture-\(UUID().uuidString).bin"
         defer {
@@ -102,6 +102,8 @@ struct LimitResumeSendSequenceLiveTests {
     }
 
     @Test func sequenceArrivesVerbatimWithControlModeClientAttached() async throws {
+        guard let version = await TmuxVersion.detect(),
+              version >= TmuxVersion.controlModeMinimum else { return }
         let server = "tbd-test-resume-cc-\(UUID().uuidString.prefix(8))"
         let outputPath = NSTemporaryDirectory() + "tbd-resume-capture-\(UUID().uuidString).bin"
         // A live `tmux -CC` client on the same server — the "control-mode on"
@@ -113,6 +115,7 @@ struct LimitResumeSendSequenceLiveTests {
         ccClient.standardOutput = ccOut
         ccClient.standardError = FileHandle.nullDevice
         defer {
+            ccOut.fileHandleForReading.readabilityHandler = nil  // clear handler before terminate
             if ccClient.isRunning { ccClient.terminate() }
             tmux(["-L", server, "kill-server"])
             try? FileManager.default.removeItem(atPath: outputPath)
@@ -120,7 +123,19 @@ struct LimitResumeSendSequenceLiveTests {
         let paneID = try await startRawCapture(server: server, outputPath: outputPath)
         ccClient.arguments = ["tmux", "-CC", "-L", server, "attach", "-t", "main"]
         try ccClient.run()
-        try await Task.sleep(for: .milliseconds(300))   // let the client attach
+        // Drain the -CC client's stdout to prevent 64KB pipe backpressure stalling the observer
+        ccOut.fileHandleForReading.readabilityHandler = { _ in }
+
+        // Poll tmux list-clients until exactly 1 client is attached
+        let deadline = ContinuousClock.now + .seconds(15)
+        while ContinuousClock.now < deadline {
+            if let clientCount = tmuxCapture(["-L", server, "list-clients", "-F", "#{client_tty}"])?
+                .split(separator: "\n").count, clientCount == 1 {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
         try await runSequence(server: server, paneID: paneID)
         try await awaitFileBytes(path: outputPath, expected: Self.expectedBytes)
     }

--- a/Tests/TBDDaemonTests/Process/FakeProcessSignaller.swift
+++ b/Tests/TBDDaemonTests/Process/FakeProcessSignaller.swift
@@ -13,6 +13,9 @@ final class FakeProcessSignaller: ProcessSignaller, @unchecked Sendable {
     var childrenByServer: [Int32: [Int32]] = [:]
     var cmdlines: [Int32: String] = [:]
     var behaviors: [Int32: Behavior] = [:]
+    /// Scriptable `ps -o stat=` result per pid; a missing entry means the
+    /// pid reports no stat (as if gone) — mirrors `ProcessSignaller.stat`.
+    var stats: [Int32: String] = [:]
     private(set) var terminated: [Int32] = []
     private(set) var killed: [Int32] = []
     private var terminatedSet: Set<Int32> = []
@@ -30,7 +33,7 @@ final class FakeProcessSignaller: ProcessSignaller, @unchecked Sendable {
     func forceKill(_ pid: Int32) { lock.withLock { killed.append(pid); killedSet.insert(pid) } }
     func children(ofServerPID serverPID: Int32) -> [Int32] { lock.withLock { childrenByServer[serverPID] ?? [] } }
     func commandLine(_ pid: Int32) -> String? { lock.withLock { cmdlines[pid] } }
-    func stat(_ pid: Int32) -> String? { nil }
+    func stat(_ pid: Int32) -> String? { lock.withLock { stats[pid] } }
 }
 
 final class FakeTmuxQuerier: TmuxProcessQuerying, @unchecked Sendable {

--- a/Tests/TBDDaemonTests/Process/FakeProcessSignaller.swift
+++ b/Tests/TBDDaemonTests/Process/FakeProcessSignaller.swift
@@ -30,6 +30,7 @@ final class FakeProcessSignaller: ProcessSignaller, @unchecked Sendable {
     func forceKill(_ pid: Int32) { lock.withLock { killed.append(pid); killedSet.insert(pid) } }
     func children(ofServerPID serverPID: Int32) -> [Int32] { lock.withLock { childrenByServer[serverPID] ?? [] } }
     func commandLine(_ pid: Int32) -> String? { lock.withLock { cmdlines[pid] } }
+    func stat(_ pid: Int32) -> String? { nil }
 }
 
 final class FakeTmuxQuerier: TmuxProcessQuerying, @unchecked Sendable {

--- a/Tests/TBDDaemonTests/RateLimitDetectedRPCTests.swift
+++ b/Tests/TBDDaemonTests/RateLimitDetectedRPCTests.swift
@@ -73,6 +73,11 @@ import Testing
         #expect(unread.count == 1)
         #expect(unread[0].type == .limitReached)
         #expect(unread[0].message?.hasPrefix("Session limit hit — resets") == true)
+        // The off-branch's audit row (recorded via insertAudit) must actually
+        // land in the DB, not just be attempted.
+        let rows = try await db.scheduledResumes.all(terminalID: terminalID)
+        #expect(rows.count == 1)
+        #expect(rows[0].status == .cancelled)
     }
 
     @Test func latchSuppressesDuplicateNotification() async throws {

--- a/Tests/TBDDaemonTests/RateLimitDetectedRPCTests.swift
+++ b/Tests/TBDDaemonTests/RateLimitDetectedRPCTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct RateLimitDetectedRPCTests {
+    let db: TBDDatabase
+    let router: RPCRouter
+    let clock = TestPollerClock()
+    let terminalID: UUID
+    let worktreeID: UUID
+
+    init() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date())
+        let repo = try await db.repos.create(
+            path: "/tmp/rld-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/rld-wt-\(UUID().uuidString)", tmuxServer: "tbd-rld")
+        worktreeID = wt.id
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        terminalID = terminal.id
+        // Router-held scheduler, not started (schedule() works without loop).
+        router.limitResumeScheduler = LimitResumeScheduler(
+            store: db.scheduledResumes, config: db.config,
+            actuator: FakeActuator(), clock: clock,
+            jitterProvider: { 0 }, onOutcome: { _, _ in })
+    }
+
+    private func detect() async -> RPCResponse {
+        let request = try! RPCRequest(
+            method: RPCMethod.claudeRateLimitDetected,
+            params: RateLimitDetectedParams(
+                terminalID: terminalID,
+                resetsAt: Date().addingTimeInterval(3600),
+                limitType: "session",
+                rawMessage: "You've hit your session limit · resets 3pm (UTC)"))
+        return await router.handle(request)
+    }
+
+    // GATE BRANCH 1: toggle ON → pending row + scheduled notification.
+    @Test func toggleOnSchedulesAndNotifies() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        let response = await detect()
+        #expect(response.success)
+        let pending = try await db.scheduledResumes.pending(terminalID: terminalID)
+        #expect(pending != nil)
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt != nil)
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(unread.count == 1)
+        #expect(unread[0].type == .limitReached)
+        #expect(unread[0].message?.hasPrefix("Session limit hit — auto-resume scheduled for") == true)
+        #expect(unread[0].terminalID == terminalID)
+    }
+
+    // GATE BRANCH 2: toggle OFF → audit row recorded + notification, NO send scheduled.
+    @Test func toggleOffRecordsAndNotifiesWithoutScheduling() async throws {
+        try await db.config.setAutoResumeOnLimitReset(false)
+        let response = await detect()
+        #expect(response.success)
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil)
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(unread.count == 1)
+        #expect(unread[0].type == .limitReached)
+        #expect(unread[0].message?.hasPrefix("Session limit hit — resets") == true)
+    }
+
+    @Test func latchSuppressesDuplicateNotification() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        _ = await detect()
+        _ = await detect()   // second StopFailure while already parked
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(unread.count == 1)
+        let rows = try await db.scheduledResumes.pending()
+        #expect(rows.count == 1)
+    }
+
+    @Test func unknownTerminalIsSoftNoOp() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        let request = try RPCRequest(
+            method: RPCMethod.claudeRateLimitDetected,
+            params: RateLimitDetectedParams(
+                terminalID: UUID(), resetsAt: Date(), limitType: "session", rawMessage: "m"))
+        let response = await router.handle(request)
+        #expect(response.success)   // fire-and-forget hook caller: never error
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+    }
+
+    @Test func limitReachedSeverityIsAttentionLevel() {
+        #expect(NotificationType.limitReached.severity == 3)
+        #expect(NotificationType(rawValue: "limit_reached") == .limitReached)
+    }
+}

--- a/Tests/TBDDaemonTests/ScheduledResumeCancellationTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumeCancellationTests.swift
@@ -88,6 +88,36 @@ import Testing
         try await assertCancelled()
     }
 
+    @Test func terminalHibernateCancels() async throws {
+        // Hibernation is a parking mechanism just like suspend: a parked pane
+        // must not receive a scheduled auto-resume send (spec §Cancellation).
+        // This terminal needs a claudeSessionID + idle state to actually
+        // complete the hibernate transition (unlike terminalSuspendCancels,
+        // the cancel here is wired inside HibernationCoordinator itself, at
+        // the point of the real state transition — not unconditionally
+        // upfront — so the hibernate must actually succeed to observe it).
+        let hibTerminal = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            claudeSessionID: "sess-hib", kind: .claude)
+        try await db.terminals.setActivityState(id: hibTerminal.id, activityState: .idle)
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: hibTerminal.id, worktreeID: worktreeID,
+            resetsAt: Date().addingTimeInterval(3600),
+            fireAt: Date().addingTimeInterval(3660),
+            limitType: "session", rawMessage: "m"))
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalHibernate,
+            params: TerminalHibernateParams(terminalID: hibTerminal.id))
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        #expect(try await db.scheduledResumes.pending(terminalID: hibTerminal.id) == nil)
+        let terminal = try await db.terminals.get(id: hibTerminal.id)
+        #expect(terminal?.pendingResumeAt == nil)
+        #expect(terminal?.isHibernated == true)
+    }
+
     @Test func explicitCancelRPC() async throws {
         let request = try RPCRequest(
             method: RPCMethod.terminalCancelScheduledResume,

--- a/Tests/TBDDaemonTests/ScheduledResumeCancellationTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumeCancellationTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct ScheduledResumeCancellationTests {
+    let db: TBDDatabase
+    let router: RPCRouter
+    let terminalID: UUID
+    let worktreeID: UUID
+
+    init() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date())
+        try await db.config.setAutoResumeOnLimitReset(true)
+        let repo = try await db.repos.create(
+            path: "/tmp/can-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/can-wt-\(UUID().uuidString)", tmuxServer: "tbd-can")
+        worktreeID = wt.id
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        terminalID = terminal.id
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminal.id, worktreeID: wt.id,
+            resetsAt: Date().addingTimeInterval(3600),
+            fireAt: Date().addingTimeInterval(3660),
+            limitType: "session", rawMessage: "m"))
+    }
+
+    private func assertCancelled() async throws {
+        #expect(try await db.scheduledResumes.pending(terminalID: terminalID) == nil)
+        let terminal = try await db.terminals.get(id: terminalID)
+        #expect(terminal == nil || terminal?.pendingResumeAt == nil)
+    }
+
+    @Test func userPromptSubmitCancels() async throws {
+        // UserPromptSubmit → overlay → `tbd terminal-activity working` →
+        // terminal.activityEvent(working): user continued manually.
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminalID, activityState: .working))
+        let response = await router.handle(request)
+        #expect(response.success)
+        try await assertCancelled()
+    }
+
+    @Test func nonWorkingActivityDoesNotCancel() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminalID, activityState: .idle))
+        _ = await router.handle(request)
+        #expect(try await db.scheduledResumes.pending(terminalID: terminalID) != nil)
+    }
+
+    @Test func terminalDeleteCancels() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: terminalID))
+        let response = await router.handle(request)
+        #expect(response.success)
+        try await assertCancelled()
+    }
+
+    @Test func terminalSuspendCancels() async throws {
+        // manualSuspend returns .notClaudeTerminal for a session-less terminal,
+        // but the cancel must happen regardless of the coordinator's verdict.
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSuspend,
+            params: TerminalSuspendParams(terminalID: terminalID))
+        _ = await router.handle(request)
+        try await assertCancelled()
+    }
+
+    @Test func worktreeSuspendCancelsAllTerminals() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeSuspend,
+            params: WorktreeSuspendParams(worktreeID: worktreeID))
+        _ = await router.handle(request)
+        try await assertCancelled()
+    }
+
+    @Test func explicitCancelRPC() async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.terminalCancelScheduledResume,
+            params: CancelScheduledResumeParams(terminalID: terminalID))
+        let response = await router.handle(request)
+        #expect(response.success)
+        try await assertCancelled()
+    }
+}

--- a/Tests/TBDDaemonTests/ScheduledResumeStoreTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumeStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -39,10 +40,10 @@ import Testing
         #expect(fetched?.terminalID == resume.terminalID)
         #expect(fetched?.worktreeID == resume.worktreeID)
         #expect(fetched?.claudeSessionID == resume.claudeSessionID)
-        // Dates lose subsecond precision in SQLite, so allow 1-second tolerance
-        #expect(abs(fetched!.fireAt.timeIntervalSince(resume.fireAt)) < 1)
-        #expect(abs(fetched!.resetsAt.timeIntervalSince(resume.resetsAt)) < 1)
-        #expect(abs(fetched!.createdAt.timeIntervalSince(resume.createdAt)) < 1)
+        // Dates lose subsecond precision in SQLite (millisecond precision), so allow 0.01s tolerance
+        #expect(abs(fetched!.fireAt.timeIntervalSince(resume.fireAt)) < 0.01)
+        #expect(abs(fetched!.resetsAt.timeIntervalSince(resume.resetsAt)) < 0.01)
+        #expect(abs(fetched!.createdAt.timeIntervalSince(resume.createdAt)) < 0.01)
         #expect(fetched?.limitType == resume.limitType)
         #expect(fetched?.rawMessage == resume.rawMessage)
         #expect(fetched?.status == .pending)
@@ -84,7 +85,8 @@ import Testing
             #expect(Bool(false), "DB unique index did not reject second pending row")
         } catch {
             // Expected: constraint violation when trying to insert second pending row.
-            #expect(error != nil)
+            // Verify it's a constraint error (result code 19 for SQLITE_CONSTRAINT).
+            #expect((error as? DatabaseError)?.resultCode == .SQLITE_CONSTRAINT)
         }
     }
 
@@ -112,12 +114,13 @@ import Testing
         let resume = makeResume()
         _ = try await db.scheduledResumes.insertPending(resume)
         let newFireAt = resume.fireAt.addingTimeInterval(120)
-        try await db.scheduledResumes.reschedule(id: resume.id, fireAt: newFireAt, attemptCount: 3)
+        let rescheduled = try await db.scheduledResumes.reschedule(id: resume.id, fireAt: newFireAt, attemptCount: 3)
+        #expect(rescheduled)
         let row = try await db.scheduledResumes.get(id: resume.id)
-        #expect(abs(row!.fireAt.timeIntervalSince(newFireAt)) < 1)
+        #expect(abs(row!.fireAt.timeIntervalSince(newFireAt)) < 0.01)
         #expect(row?.attemptCount == 3)
         let terminal = try await db.terminals.get(id: terminalID)
-        #expect(abs(terminal!.pendingResumeAt!.timeIntervalSince(newFireAt)) < 1)
+        #expect(abs(terminal!.pendingResumeAt!.timeIntervalSince(newFireAt)) < 0.01)
     }
 
     @Test func cancelPendingByTerminal() async throws {
@@ -156,5 +159,46 @@ import Testing
         _ = try await db.scheduledResumes.insertPending(sooner)
         let rows = try await db.scheduledResumes.pending()
         #expect(rows.map(\.id) == [sooner.id, later.id])
+    }
+
+    @Test func pendingByTerminalIDReturnsOnlyRequestedTerminal() async throws {
+        let terminal2 = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2")
+        let resume1 = makeResume()
+        let resume2 = ScheduledResume(
+            terminalID: terminal2.id, worktreeID: worktreeID,
+            resetsAt: Date(), fireAt: Date().addingTimeInterval(100),
+            limitType: "session", rawMessage: "m2")
+        _ = try await db.scheduledResumes.insertPending(resume1)
+        _ = try await db.scheduledResumes.insertPending(resume2)
+
+        let forTerminal1 = try await db.scheduledResumes.pending(terminalID: terminalID)
+        #expect(forTerminal1?.id == resume1.id)
+        let forTerminal2 = try await db.scheduledResumes.pending(terminalID: terminal2.id)
+        #expect(forTerminal2?.id == resume2.id)
+        let forUnknown = try await db.scheduledResumes.pending(terminalID: UUID())
+        #expect(forUnknown == nil)
+    }
+
+    @Test func rescheduleReturnsFailsForNonPendingAndMissingRows() async throws {
+        let resume = makeResume()
+        _ = try await db.scheduledResumes.insertPending(resume)
+
+        // Cancel the pending row, making it non-pending
+        _ = try await db.scheduledResumes.cancelPending(terminalID: terminalID)
+        let row = try await db.scheduledResumes.get(id: resume.id)
+        #expect(row?.status == .cancelled)
+
+        // Reschedule on the now-cancelled row should return false and not touch the mirror
+        let rescheduled = try await db.scheduledResumes.reschedule(
+            id: resume.id, fireAt: Date(), attemptCount: 5)
+        #expect(rescheduled == false)
+        let terminal = try await db.terminals.get(id: terminalID)
+        #expect(terminal?.pendingResumeAt == nil)
+
+        // Reschedule on a non-existent row should return false
+        let rescheduleUnknown = try await db.scheduledResumes.reschedule(
+            id: UUID(), fireAt: Date(), attemptCount: 1)
+        #expect(rescheduleUnknown == false)
     }
 }

--- a/Tests/TBDDaemonTests/ScheduledResumeStoreTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumeStoreTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct ScheduledResumeStoreTests {
+    let db: TBDDatabase
+    let terminalID: UUID
+    let worktreeID: UUID
+
+    init() async throws {
+        db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/srs-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/srs-wt-\(UUID().uuidString)", tmuxServer: "tbd-srs")
+        worktreeID = wt.id
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        terminalID = terminal.id
+    }
+
+    private func makeResume(fireAt: Date = Date().addingTimeInterval(90)) -> ScheduledResume {
+        ScheduledResume(
+            terminalID: terminalID, worktreeID: worktreeID,
+            claudeSessionID: "sess-1",
+            resetsAt: Date().addingTimeInterval(60), fireAt: fireAt,
+            limitType: "session",
+            rawMessage: "You've hit your session limit · resets 3pm (UTC)")
+    }
+
+    @Test func insertPendingSetsTerminalBadgeAndRoundTrips() async throws {
+        let resume = makeResume()
+        let inserted = try await db.scheduledResumes.insertPending(resume)
+        #expect(inserted == resume)
+        let fetched = try await db.scheduledResumes.get(id: resume.id)
+        #expect(fetched?.id == resume.id)
+        #expect(fetched?.terminalID == resume.terminalID)
+        #expect(fetched?.worktreeID == resume.worktreeID)
+        #expect(fetched?.claudeSessionID == resume.claudeSessionID)
+        // Dates lose subsecond precision in SQLite, so allow 1-second tolerance
+        #expect(abs(fetched!.fireAt.timeIntervalSince(resume.fireAt)) < 1)
+        #expect(abs(fetched!.resetsAt.timeIntervalSince(resume.resetsAt)) < 1)
+        #expect(abs(fetched!.createdAt.timeIntervalSince(resume.createdAt)) < 1)
+        #expect(fetched?.limitType == resume.limitType)
+        #expect(fetched?.rawMessage == resume.rawMessage)
+        #expect(fetched?.status == .pending)
+        #expect(fetched?.attemptCount == 0)
+        let terminal = try await db.terminals.get(id: terminalID)
+        #expect(terminal?.pendingResumeAt != nil)
+    }
+
+    @Test func latchRejectsSecondPendingForSameTerminal() async throws {
+        _ = try await db.scheduledResumes.insertPending(makeResume())
+        let second = try await db.scheduledResumes.insertPending(makeResume())
+        #expect(second == nil)
+        let rows = try await db.scheduledResumes.pending()
+        #expect(rows.count == 1)
+    }
+
+    @Test func dbLevelPartialUniqueIndexEnforcesOnePerTerminal() async throws {
+        let resume = makeResume()
+        _ = try await db.scheduledResumes.insertPending(resume)
+
+        // Try to insert a second pending row for the same terminal via direct SQL,
+        // bypassing the store's guard. The partial unique index should reject it.
+        do {
+            try await db.writerForTests.write { db in
+                try db.execute(
+                    sql: """
+                    INSERT INTO scheduled_resumes
+                    (id, terminalID, worktreeID, claudeSessionID, resetsAt, fireAt,
+                     limitType, rawMessage, createdAt, status, attemptCount)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    arguments: [
+                        UUID().uuidString, terminalID.uuidString, worktreeID.uuidString,
+                        "sess-2", Date().addingTimeInterval(60), Date().addingTimeInterval(120),
+                        "session", "msg", Date(), ScheduledResumeStatus.pending.rawValue, 0
+                    ])
+            }
+            // If we reach here, the constraint was not enforced — fail the test.
+            #expect(Bool(false), "DB unique index did not reject second pending row")
+        } catch {
+            // Expected: constraint violation when trying to insert second pending row.
+            #expect(error != nil)
+        }
+    }
+
+    @Test func insertAuditNeverSetsBadgeOrLatch() async throws {
+        var audit = makeResume()
+        audit.status = .cancelled
+        try await db.scheduledResumes.insertAudit(audit)
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+        let terminal = try await db.terminals.get(id: terminalID)
+        #expect(terminal?.pendingResumeAt == nil)
+        // A real pending insert still succeeds afterwards (audit row ≠ latch).
+        #expect(try await db.scheduledResumes.insertPending(makeResume()) != nil)
+    }
+
+    @Test func setStatusLeavingPendingClearsBadge() async throws {
+        let resume = makeResume()
+        _ = try await db.scheduledResumes.insertPending(resume)
+        try await db.scheduledResumes.setStatus(id: resume.id, status: .sent)
+        #expect(try await db.scheduledResumes.get(id: resume.id)?.status == .sent)
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil)
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+    }
+
+    @Test func rescheduleMovesFireAtAndBadge() async throws {
+        let resume = makeResume()
+        _ = try await db.scheduledResumes.insertPending(resume)
+        let newFireAt = resume.fireAt.addingTimeInterval(120)
+        try await db.scheduledResumes.reschedule(id: resume.id, fireAt: newFireAt, attemptCount: 3)
+        let row = try await db.scheduledResumes.get(id: resume.id)
+        #expect(abs(row!.fireAt.timeIntervalSince(newFireAt)) < 1)
+        #expect(row?.attemptCount == 3)
+        let terminal = try await db.terminals.get(id: terminalID)
+        #expect(abs(terminal!.pendingResumeAt!.timeIntervalSince(newFireAt)) < 1)
+    }
+
+    @Test func cancelPendingByTerminal() async throws {
+        let resume = makeResume()
+        _ = try await db.scheduledResumes.insertPending(resume)
+        #expect(try await db.scheduledResumes.cancelPending(terminalID: terminalID))
+        #expect(try await db.scheduledResumes.get(id: resume.id)?.status == .cancelled)
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil)
+        // Second cancel is a no-op.
+        #expect(try await db.scheduledResumes.cancelPending(terminalID: terminalID) == false)
+    }
+
+    @Test func cancelAllPending() async throws {
+        _ = try await db.scheduledResumes.insertPending(makeResume())
+        let terminal2 = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2")
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminal2.id, worktreeID: worktreeID,
+            resetsAt: Date(), fireAt: Date().addingTimeInterval(60),
+            limitType: "weekly", rawMessage: "m"))
+        let count = try await db.scheduledResumes.cancelAllPending()
+        #expect(count == 2)
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+        #expect(try await db.terminals.get(id: terminal2.id)?.pendingResumeAt == nil)
+    }
+
+    @Test func pendingOrderedByFireAt() async throws {
+        let terminal2 = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2")
+        let later = makeResume(fireAt: Date().addingTimeInterval(500))
+        _ = try await db.scheduledResumes.insertPending(later)
+        let sooner = ScheduledResume(
+            terminalID: terminal2.id, worktreeID: worktreeID,
+            resetsAt: Date(), fireAt: Date().addingTimeInterval(100),
+            limitType: "session", rawMessage: "m")
+        _ = try await db.scheduledResumes.insertPending(sooner)
+        let rows = try await db.scheduledResumes.pending()
+        #expect(rows.map(\.id) == [sooner.id, later.id])
+    }
+}

--- a/Tests/TBDDaemonTests/ScheduledResumesMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumesMigrationTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct ScheduledResumesMigrationTests {
+
+    @Test func scheduledResumesTableExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            #expect(try dbConn.tableExists("scheduled_resumes"))
+            let columns = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(scheduled_resumes)")
+            let names = Set(columns.compactMap { $0["name"] as String? })
+            #expect(names.isSuperset(of: [
+                "id", "terminalID", "worktreeID", "claudeSessionID", "resetsAt",
+                "fireAt", "limitType", "rawMessage", "createdAt", "status", "attemptCount"
+            ]))
+        }
+    }
+
+    @Test func terminalPendingResumeAtColumnExistsAndDefaultsNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let columns = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(terminal)")
+            let names = columns.compactMap { $0["name"] as String? }
+            #expect(names.contains("pendingResumeAt"))
+        }
+        let repo = try await db.repos.create(
+            path: "/tmp/v38-repo-\(UUID().uuidString)", displayName: "V38", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v38-wt-\(UUID().uuidString)", tmuxServer: "tbd-v38")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        #expect(terminal.pendingResumeAt == nil)
+        let fetched = try await db.terminals.get(id: terminal.id)
+        #expect(fetched?.pendingResumeAt == nil)
+    }
+
+    @Test func configAutoResumeDefaultsFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let config = try await db.config.get()
+        #expect(config.autoResumeOnLimitReset == false)
+    }
+
+    @Test func oldTerminalJSONStillDecodes() throws {
+        // decode-compat rule: pre-v38 payloads have no pendingResumeAt.
+        let json = """
+        {"id":"\(UUID().uuidString)","worktreeID":"\(UUID().uuidString)",
+         "tmuxWindowID":"@1","tmuxPaneID":"%1","createdAt":773400000,
+         "activityState":"idle"}
+        """
+        let terminal = try JSONDecoder().decode(Terminal.self, from: Data(json.utf8))
+        #expect(terminal.pendingResumeAt == nil)
+    }
+}

--- a/Tests/TBDSharedTests/RateLimitDetectionTests.swift
+++ b/Tests/TBDSharedTests/RateLimitDetectionTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("RateLimitDetection")
+struct RateLimitDetectionTests {
+
+    // MARK: - Fixture builders
+
+    /// One JSONL line: an API-error assistant record with `text`, optionally
+    /// carrying a top-level `rate_limit_info` object.
+    private static func errorLine(text: String, rateLimitInfo: [String: Any]? = nil,
+                                  timestamp: String = "2026-07-03T14:00:00.123Z") -> String {
+        var obj: [String: Any] = [
+            "type": "assistant",
+            "isApiErrorMessage": true,
+            "timestamp": timestamp,
+            "message": ["role": "assistant",
+                        "content": [["type": "text", "text": text]]]
+        ]
+        if let rateLimitInfo { obj["rate_limit_info"] = rateLimitInfo }
+        let data = try! JSONSerialization.data(withJSONObject: obj)
+        return String(data: data, encoding: .utf8)!
+    }
+
+    private static func transcript(_ lines: [String]) -> Data {
+        Data((lines.joined(separator: "\n") + "\n").utf8)
+    }
+
+    /// Fixed "now": 2026-07-03 14:00:00 UTC.
+    private static let now = Date(timeIntervalSince1970: 1_783_087_200)
+    private static let utc = TimeZone(identifier: "UTC")!
+
+    // MARK: - Structured rate_limit_info
+
+    @Test func structuredRejectedTakesResetsAtVerbatim() {
+        let epoch: Double = 1_783_180_800
+        let data = Self.transcript([Self.errorLine(
+            text: "You've hit your session limit · resets 1pm (America/Toronto)",
+            rateLimitInfo: ["status": "rejected", "resetsAt": epoch, "rateLimitType": "session"])])
+        let hit = RateLimitDetection.detect(transcriptData: data, now: Self.now, timeZone: Self.utc)
+        #expect(hit?.resetsAt == Date(timeIntervalSince1970: epoch))
+        #expect(hit?.limitType == "session")
+        #expect(hit?.rawMessage == "You've hit your session limit · resets 1pm (America/Toronto)")
+    }
+
+    @Test func structuredNonRejectedFallsThroughToTextRules() {
+        // status != rejected and the text is transient → nil.
+        let data = Self.transcript([Self.errorLine(
+            text: "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+            rateLimitInfo: ["status": "allowed_warning", "rateLimitType": "session"])])
+        #expect(RateLimitDetection.detect(transcriptData: data, now: Self.now, timeZone: Self.utc) == nil)
+    }
+
+    // MARK: - Hard-limit wordings (spec fixtures, delimiters · / - / .)
+
+    @Test(arguments: [
+        "You've hit your session limit · resets 4:50pm (Asia/Shanghai)",
+        "You've hit your weekly limit · resets 9am (Europe/London)",
+        "5-hour limit reached - resets 3pm (UTC)",
+        "Claude usage limit reached. Resets at 2pm",
+        "You're out of extra usage · resets 3pm",
+    ])
+    func hardLimitWordingsSchedule(text: String) {
+        let data = Self.transcript([Self.errorLine(text: text)])
+        let hit = RateLimitDetection.detect(transcriptData: data, now: Self.now, timeZone: Self.utc)
+        #expect(hit != nil, "should detect: \(text)")
+        #expect(hit!.resetsAt > Self.now)
+        #expect(hit!.rawMessage == text)
+    }
+
+    @Test(arguments: [
+        "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+        "API Error: 529",
+        "API Error: 500 Internal server error",
+    ])
+    func transientMessagesNeverSchedule(text: String) {
+        let data = Self.transcript([Self.errorLine(text: text)])
+        #expect(RateLimitDetection.detect(transcriptData: data, now: Self.now, timeZone: Self.utc) == nil)
+    }
+
+    @Test func qualifierDriftStillMatches() {
+        // "allow a few arbitrary words" between "hit your" and "limit".
+        let text = "You've hit your shiny new 5-hour usage limit · resets 3pm (UTC)"
+        #expect(RateLimitDetection.isHardLimitMessage(text))
+    }
+
+    // MARK: - Text-fallback time math
+
+    @Test func zoneConversionUsesIANAZone() throws {
+        let text = "You've hit your session limit · resets 4:50pm (Asia/Shanghai)"
+        let hit = try #require(RateLimitDetection.detect(
+            transcriptData: Self.transcript([Self.errorLine(text: text)]),
+            now: Self.now, timeZone: Self.utc))
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Asia/Shanghai")!
+        let comps = cal.dateComponents([.hour, .minute], from: hit.resetsAt)
+        #expect(comps.hour == 16)
+        #expect(comps.minute == 50)
+        #expect(hit.resetsAt > Self.now)
+    }
+
+    @Test func pastInstantRollsToTomorrow() throws {
+        // now is 14:00 UTC; "resets 1pm (UTC)" is in the past → tomorrow 13:00.
+        let hit = try #require(RateLimitDetection.parseResetTime(
+            from: "You've hit your session limit · resets 1pm (UTC)",
+            now: Self.now, defaultTimeZone: Self.utc))
+        #expect(hit.timeIntervalSince(Self.now) > 22 * 3600)
+        #expect(hit.timeIntervalSince(Self.now) < 24 * 3600)
+    }
+
+    @Test func missingAmPmPicksNearestFuture() throws {
+        // now 14:00 UTC, "resets 9" → 9pm today (21:00) is nearer-future than 9am tomorrow.
+        let hit = try #require(RateLimitDetection.parseResetTime(
+            from: "resets 9 (UTC)", now: Self.now, defaultTimeZone: Self.utc))
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = Self.utc
+        #expect(cal.component(.hour, from: hit) == 21)
+    }
+
+    @Test func twelveAmAndPmParseCorrectly() throws {
+        let noon = try #require(RateLimitDetection.parseResetTime(
+            from: "resets 12pm (UTC)", now: Self.now, defaultTimeZone: Self.utc))
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = Self.utc
+        #expect(cal.component(.hour, from: noon) == 12)
+        let midnight = try #require(RateLimitDetection.parseResetTime(
+            from: "resets 12am (UTC)", now: Self.now, defaultTimeZone: Self.utc))
+        #expect(cal.component(.hour, from: midnight) == 0)
+    }
+
+    @Test func invalidZoneIsUnparseable() {
+        #expect(RateLimitDetection.parseResetTime(
+            from: "resets 3pm (Mars/Olympus)", now: Self.now, defaultTimeZone: Self.utc) == nil)
+    }
+
+    @Test func hardLimitWithoutParseableTimeDetectsNothing() {
+        // notify-only path: hard wording but no reset clause → nil (caller keeps
+        // the plain error notification).
+        let data = Self.transcript([Self.errorLine(text: "You've hit your session limit")])
+        #expect(RateLimitDetection.detect(transcriptData: data, now: Self.now, timeZone: Self.utc) == nil)
+    }
+
+    @Test func scansFromEndForLastApiError() {
+        let old = Self.errorLine(text: "API Error: 529")
+        let newer = Self.errorLine(text: "You've hit your session limit · resets 3pm (UTC)")
+        let hit = RateLimitDetection.detect(
+            transcriptData: Self.transcript([old, newer]), now: Self.now, timeZone: Self.utc)
+        #expect(hit != nil)
+    }
+
+    // MARK: - hasRecord(newerThan:)
+
+    @Test func hasRecordNewerThanComparesLastTimestamp() {
+        let line = Self.errorLine(text: "x", timestamp: "2026-07-03T14:05:00.000Z")
+        let data = Self.transcript([line])
+        #expect(RateLimitDetection.hasRecord(newerThan: Self.now, in: data))
+        #expect(!RateLimitDetection.hasRecord(
+            newerThan: Self.now.addingTimeInterval(600), in: data))
+    }
+
+    // MARK: - ResumeTimeFormatter
+
+    @Test func formatterDropsZeroMinutes() {
+        let cal = Calendar(identifier: .gregorian)
+        var comps = DateComponents(); comps.year = 2026; comps.month = 7; comps.day = 3
+        comps.hour = 13; comps.minute = 0
+        var utcCal = cal; utcCal.timeZone = Self.utc
+        let onePM = utcCal.date(from: comps)!
+        #expect(ResumeTimeFormatter.string(from: onePM, timeZone: Self.utc) == "1pm")
+        comps.minute = 1
+        let oneOhOne = utcCal.date(from: comps)!
+        #expect(ResumeTimeFormatter.string(from: oneOhOne, timeZone: Self.utc) == "1:01pm")
+    }
+}

--- a/docs/specs/2026-07-03-session-limit-auto-resume-design.md
+++ b/docs/specs/2026-07-03-session-limit-auto-resume-design.md
@@ -1,0 +1,200 @@
+# Session-Limit Auto-Resume — Design
+
+**Date:** 2026-07-03
+**Status:** Approved design, pre-implementation
+**Branch:** `session-limit-auto-resume`
+
+## Problem
+
+When a Claude Code session hits the subscription usage limit, the TUI parks on
+"You've hit your session limit · resets 1pm (America/Toronto)" and the turn
+dies. Claude Code has no native wait-and-continue (it is one of the
+most-requested open features: anthropics/claude-code #18980, #36320, #38263,
+#47276, #62788), so every affected TBD terminal sits dead until the user
+notices and types `continue` by hand — hours later if they stepped away.
+
+TBD should detect the limit the moment it happens, schedule a resume for the
+reset time, and type `continue` into the still-open pane — unattended, across
+every managed worktree.
+
+## Constraints
+
+- **No screen scraping.** Detection rides Claude Code hooks + the transcript
+  JSONL only. TBD already removed pane-text matching once (see
+  `SuspendResumeCoordinator.swift` history) because CLI display text churns
+  across versions; the two community tools studied (claude-auto-retry,
+  autoclaude) spent most of their bug-fix history on exactly that churn.
+- **Actuation goes through the existing send API** (`handleTerminalSend` /
+  `TmuxManager.sendKeys`/`sendKey`), never raw `tmux` invocations. The
+  in-flight control-mode work (`tbd/control-mode-phase-a`) adds a sidecar path
+  for *app* keystrokes but does not touch daemon-initiated sends; staying
+  behind the API means a future phase that reroutes daemon sends carries this
+  feature along.
+- **Migration-number coordination:** control-mode-phase-a also adds a DB
+  migration (`controlModeEnabled`). Whichever branch lands second renumbers
+  its migration.
+- **Gated, default OFF.** Global toggle, consistent with auto-suspend's
+  opt-in convention. Detection/notification runs regardless; only the
+  scheduled send is gated. Both branches get tests (CLAUDE.md rule).
+
+## Detection
+
+`StopFailure` is the signal: it fires when a turn dies on an API error, and
+TBD's overlay hook (`ClaudeHookOverlay.swift`) already routes it through
+`tbd stop-failure` (`TBDCLI/Commands/StopFailureCommand.swift`), which already
+reads the last `isApiErrorMessage == true` record from the transcript.
+
+Extend that command:
+
+1. **Structured first.** If the last API-error record carries
+   `rate_limit_info` (`status: "rejected"`, `resetsAt` epoch,
+   `rateLimitType`), take `resetsAt` verbatim. No text parsing, no timezone
+   math, weekly limits included for free.
+2. **Text fallback.** If `rate_limit_info` is absent but the message matches a
+   hard-limit pattern, parse the display text
+   (`resets 3pm (America/Toronto)`): hour, optional `:MM`, optional am/pm,
+   optional parenthesized IANA zone. Use Foundation `Calendar` +
+   `TimeZone(identifier:)` for the conversion (not offset arithmetic — that
+   was claude-auto-retry's nastiest bug, off by ~24h in UTC+10). Rules:
+   - no am/pm and hour 1–12 → compute both candidates, take the nearest
+     future one;
+   - parsed instant already past → add a day;
+   - unparseable → notify only, never schedule.
+3. **Parse once, persist the absolute timestamp.** Never re-derive from
+   display text later (autoclaude's flagship bug: re-parsing "resets 3pm"
+   after 3pm rolls the deadline to tomorrow forever).
+
+**Hard-limit vs transient discrimination.** Both arrive as
+`error_type == rate_limit`. Schedule only when the message matches
+`hit your <qualifier> limit` (qualifier drifts: *session* / *weekly* /
+*5-hour* — allow a few arbitrary words, per claude-auto-retry issue #15) or
+structured `rate_limit_info` marks a rejection with a reset. Explicitly
+exclude `temporarily limiting requests (not your usage limit)` and transient
+`429/5xx/529` — Claude Code retries those itself, and racing its internal
+retry loop was a documented community-tool failure mode.
+
+On a hit, the CLI calls a new RPC `rateLimitDetected` with
+`{terminalID, resetsAt, limitType, rawMessage}`. Existing error notification
+behavior is preserved for non-limit StopFailures.
+
+## State
+
+New migration (next free `vN` at land time):
+
+- **`scheduled_resumes` table:** id, terminalID, worktreeID, claudeSessionID,
+  resetsAt, limitType, rawMessage, createdAt, status
+  (`pending` / `sent` / `cancelled` / `failed`), attemptCount.
+  **At most one `pending` row per terminal** — the row is the double-send
+  latch (double-sends were the worst production bug in both mined tools).
+- **Daemon config:** `autoResumeOnLimitReset` (bool, default false), set from
+  the app via RPC. Daemon-side because the daemon must act while the app is
+  closed.
+- **`Terminal.pendingResumeAt: Date?`** in `TBDShared/Models.swift`
+  (optional — decode-compat rule), populated from the pending row and
+  broadcast via delta for UI. Activity state machine is untouched.
+
+Rows survive daemon restarts; on startup, `pending` rows reload into the
+scheduler and past-due rows fire immediately (covers Mac sleep and multi-day
+weekly-limit waits).
+
+## Scheduler
+
+New daemon actor `LimitResumeScheduler`, cloned from `ClaudeUsagePoller`'s
+shape: min-deadline sleep via injected clock, `wake()` on insert/cancel.
+
+Fire time = `resetsAt + 60s slack + jitter(0–30s per terminal)`.
+Slack because server-side resets are not millisecond-precise (claude-auto-retry
+ships 60s; autoclaude dropped its slack in a rewrite and fired too early);
+jitter so N panes on the same account don't stampede the API at the same
+second.
+
+## Actuation
+
+At fire time, in order — every step is a mined landmine:
+
+1. **Eligibility.** Terminal alive; toggle still on; Claude is the pane's
+   foreground process — check `ps -o stat=` for the `+` flag, because tmux
+   `#{pane_current_command}` reports `zsh` on macOS. Never type into a bare
+   shell.
+2. **User-already-continued.** If the transcript has any record newer than
+   the limit record, mark `cancelled`, send nothing.
+3. **Copy-mode.** If `#{pane_in_mode}` is set, the send would go to copy-mode,
+   not Claude — and cancelling copy-mode would yank the user out of scrollback.
+   Reschedule +2min, up to 15 attempts (~30min), then mark `failed` with an
+   attention notification — don't cancel their scroll.
+4. **Send sequence** (via `handleTerminalSend`-level API):
+   `Escape` → sleep 150ms → `send-keys -l "continue"` → sleep 150ms →
+   `Enter` as a separate named-key call.
+   - Escape first: at the limit, newer Claude Code opens the
+     `/rate-limit-options` menu whose *highlighted default can be "Upgrade
+     your plan"* and whose option order varies by version — a blind Enter can
+     confirm a paid upgrade. Escape dismisses and can never select.
+   - The 150ms pauses: Claude's TUI drops keys during UI transitions
+     (autoclaude shipped "ontinue"), and text+Enter in one send-keys call is
+     treated as a bracketed paste — the Enter becomes a literal newline and
+     nothing submits.
+5. **Verify.** Within ~20s expect the activity hook to report `working` (or
+   the transcript to grow). Success → status `sent` + success notification.
+   No signal → one retry of steps 1–4, then status `failed` + attention
+   notification. (autoclaude never verified; a swallowed send was silently
+   lost.)
+
+## Cancellation
+
+A pending row is cancelled by: `UserPromptSubmit` hook firing for that
+terminal (user continued manually), terminal close/suspend, global toggle
+switched off (cancels all pending), or explicit user action ("Cancel
+scheduled resume" in the terminal context menu / notification).
+
+## UI
+
+- New `NotificationType` case `limit_reached`: toggle on → "Session limit hit
+  — auto-resume scheduled for 1:01pm"; toggle off → "Session limit hit —
+  resets 1pm". Outcome notifications on `sent` / `failed`.
+- Terminal row badge with countdown, driven by `pendingResumeAt`
+  ("⏳ resumes 1:01pm").
+- Settings toggle: "Auto-resume Claude sessions when the usage limit resets"
+  (default off).
+
+## Testing
+
+- **Extraction fixtures** from real-world captures: `rate_limit_info`
+  present/absent; delimiters `·` / `-` / `.`; wordings "You've hit your
+  session limit · resets 4:50pm (Asia/Shanghai)", "…weekly limit · resets 9am
+  (Europe/London)", "5-hour limit reached - resets 3pm (UTC)", "Claude usage
+  limit reached. Resets at 2pm", "You're out of extra usage · resets 3pm";
+  transient exclusions ("temporarily limiting requests (not your usage
+  limit)", `API Error: 529`).
+- **Text-fallback parsing:** day rollover, ambiguous am/pm → nearest future,
+  invalid timezone → notify-only.
+- **Scheduler:** injected clock; restart reload; past-due fires immediately;
+  one-pending-per-terminal latch; cancellation paths.
+- **Gate:** toggle off → row recorded + notification, no send scheduled;
+  toggle on → scheduled. (Both branches, per CLAUDE.md.)
+- **End-to-end seam:** debug RPC that fakes a `rateLimitDetected` with
+  `resetsAt = now + 1min`, exercising schedule → actuate → verify without
+  burning a real limit (autoclaude's `--test-pattern`, upgraded).
+- **Live tmux test** for the send sequence (rc-free bootstrap, 15s deadlines),
+  run with the control-mode flag off and on.
+
+## Out of scope (v1)
+
+- Respawning a dead pane at reset via `claude --resume` (the TUI stays alive
+  at the limit screen; a dead pane gets a notification instead).
+- Codex terminals.
+- Per-terminal/per-worktree enable overrides.
+- Cross-checking reset times against the usage API
+  (`ModelProfileUsage.fiveHourResetsAt` — API-key profiles only).
+- Draft-text protection (user's half-typed prompt in the input box when the
+  resume fires; Escape does not clear a draft, so `continue` would append).
+  Accepted risk in v1, noted for follow-up.
+
+## Sources
+
+- Codebase survey: `ClaudeHookOverlay.swift`, `StopFailureCommand.swift`,
+  `ClaudeUsagePoller.swift`, `SuspendResumeCoordinator.swift`,
+  `RPCRouter+TerminalHandlers.swift` (`handleTerminalSend`),
+  `TmuxManager.swift`.
+- Mined: `cheapestinference/claude-auto-retry` (18 commits; DESIGN-NOTES
+  verified StopFailure payload/semantics against a decompiled v2.1.195
+  binary) and `henryaj/autoclaude` (54 commits, tmux actuation lessons).

--- a/docs/specs/2026-07-03-session-limit-auto-resume-design.md
+++ b/docs/specs/2026-07-03-session-limit-auto-resume-design.md
@@ -112,17 +112,19 @@ second.
 
 At fire time, in order — every step is a mined landmine:
 
-1. **Eligibility.** Terminal alive; toggle still on; Claude is the pane's
-   foreground process — check `ps -o stat=` for the `+` flag, because tmux
-   `#{pane_current_command}` reports `zsh` on macOS. Never type into a bare
-   shell.
+1. **Terminal alive.** Terminal alive; toggle still on.
 2. **User-already-continued.** If the transcript has any record newer than
    the limit record, mark `cancelled`, send nothing.
-3. **Copy-mode.** If `#{pane_in_mode}` is set, the send would go to copy-mode,
+3. **Foreground.** Claude is the pane's foreground process — check
+   `ps -o stat=` for the `+` flag, because tmux `#{pane_current_command}`
+   reports `zsh` on macOS. Never type into a bare shell. Checked before
+   copy-mode: a dead/backgrounded shell should classify `failed` rather than
+   endlessly rescheduling on a stale copy-mode flag.
+4. **Copy-mode.** If `#{pane_in_mode}` is set, the send would go to copy-mode,
    not Claude — and cancelling copy-mode would yank the user out of scrollback.
    Reschedule +2min, up to 15 attempts (~30min), then mark `failed` with an
    attention notification — don't cancel their scroll.
-4. **Send sequence** (via `handleTerminalSend`-level API):
+5. **Send sequence** (via `handleTerminalSend`-level API):
    `Escape` → sleep 150ms → `send-keys -l "continue"` → sleep 150ms →
    `Enter` as a separate named-key call.
    - Escape first: at the limit, newer Claude Code opens the
@@ -133,10 +135,13 @@ At fire time, in order — every step is a mined landmine:
      (autoclaude shipped "ontinue"), and text+Enter in one send-keys call is
      treated as a bracketed paste — the Enter becomes a literal newline and
      nothing submits.
-5. **Verify.** Within ~20s expect the activity hook to report `working` (or
+6. **Verify.** Within ~20s expect the activity hook to report `working` (or
    the transcript to grow). Success → status `sent` + success notification.
-   No signal → one retry of steps 1–4, then status `failed` + attention
-   notification. (autoclaude never verified; a swallowed send was silently
+   No signal → one retry of steps 1–5 (eligibility is re-checked fresh on the
+   retry — a copy-mode or user-continued state entered during the first
+   attempt's verify window is caught before blindly resending), then status
+   `failed` + attention notification. (autoclaude never verified; a swallowed
+   send was silently
    lost.)
 
 ## Cancellation


### PR DESCRIPTION
## What

When a Claude Code session dies on a hard usage limit ("You've hit your session limit · resets 1pm"), TBD now detects it the moment it happens, schedules a resume for the reset time, and types `continue` into the still-open pane — unattended, across every managed worktree. Gated behind a **default-OFF** settings toggle ("Auto-resume Claude sessions when the usage limit resets").

Spec: `docs/specs/2026-07-03-session-limit-auto-resume-design.md` (committed, amended once during implementation to reconcile eligibility-check ordering).

## How it works

- **Detection (no screen scraping):** the existing StopFailure hook → `tbd hooks stop-failure` now extracts the structured `rate_limit_info.resetsAt` epoch from the transcript JSONL (text-parse fallback for the display string), distinguishes hard limits from transient 429/529s, and reports via a new `claude.rateLimitDetected` RPC. All non-limit stdout behavior is preserved byte-for-byte.
- **State:** migration `v38_scheduled_resumes` — one-pending-per-terminal latch enforced by a partial unique index; `Terminal.pendingResumeAt` mirror synced transactionally; rows survive daemon restarts (past-due rows fire immediately on boot — covers Mac sleep and multi-day weekly-limit waits).
- **Scheduler:** `LimitResumeScheduler` actor (ClaudeUsagePoller pattern): fires at `resetsAt + 60s slack + 0–30s jitter`, double-fire guard set, bounded post-actuation write retries.
- **Actuation:** per-attempt eligibility (terminal alive → toggle on → row still pending → user-already-continued via transcript → Claude foreground via `ps stat` `+` flag → copy-mode check), then `Escape → 150ms → "continue" → 150ms → Enter` through `TmuxManager` (separate named-key Enter — combined send-keys becomes a bracketed paste and never submits). Verified via activity hook / transcript growth; one retry; every landmine here is mined from claude-auto-retry and autoclaude's bug archaeology (the Escape-first rule exists because Enter can select "Upgrade your plan" in the `/rate-limit-options` menu).
- **Cancellation:** manual continue (UserPromptSubmit), terminal delete/suspend, toggle-off, explicit context-menu cancel, and mid-flight cancellation between actuation attempts.
- **UI:** `limit_reached` notifications ("auto-resume scheduled for 1:01pm" vs "resets 1pm" when off), tab badge "⏳ resumes 1:01pm", context-menu cancel, settings toggle.
- **Testing:** 2140 tests green; deterministic clock-injected scheduler/actuator suites; live tmux byte-level proof of the send sequence, run plain and with a production `TmuxControlConnection` (-CC) client attached; hidden `tbd hooks fake-rate-limit --resets-in 60` seam exercises the full pipeline without burning a real limit.

## Coordination notes

- Migration landed as **v38** (main was at v37). The in-flight `tbd/control-mode-phase-a` branch also registers a v35→(now) migration — whichever lands second renumbers.
- Daemon-initiated sends go through the existing `TmuxManager` API only, so a future control-mode phase that reroutes sends carries this feature along.

## Follow-ups (non-blocking, from the final whole-branch review)

- Unify the CLI's two transcript scanners (message vs detection could read different records in a textless-error edge).
- Unknown-terminal RPC responds `.ok` → CLI suppresses its fallback banner; return a "not handled" signal instead.
- Centralize cancel-on-park at the store/coordinator choke point (3 per-handler call sites today; reconcile-parking and recreate-window paths don't cancel — benign, fire-time `.terminalGone` self-heals).
- Boot-window: an RPC arriving before the scheduler is wired takes the notify-only branch (same idiom as claudeUsagePoller).
- Fault-injection seam for `ScheduledResumeStore` write-retry paths.

https://claude.ai/code/session_01Leu1sJPDm8YrELnTKvPuN3