### PR TITLE
Nightwatch Phase 1: clearance ledger + audit log + evaluate-only merge gate

### DIFF
--- a/Sources/TBDCLI/Commands/NightwatchCommand.swift
+++ b/Sources/TBDCLI/Commands/NightwatchCommand.swift
@@ -6,7 +6,7 @@ struct NightwatchCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "nightwatch",
         abstract: "Manage nightwatch mode",
-        subcommands: [NightwatchSet.self, NightwatchStatus.self]
+        subcommands: [NightwatchSet.self, NightwatchStatus.self, NightwatchReport.self]
     )
 }
 
@@ -59,6 +59,79 @@ struct NightwatchStatus: AsyncParsableCommand {
             printJSON(["mode": config.nightwatchMode.rawValue])
         } else {
             print("Nightwatch mode: \(config.nightwatchMode.rawValue)")
+        }
+    }
+}
+
+// MARK: - nightwatch report
+
+struct NightwatchReport: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "report",
+        abstract: "Get the nightwatch audit log report"
+    )
+
+    @Option(name: .long, help: "Start time (ISO8601 format)")
+    var since: String?
+
+    @Option(name: .long, help: "Filter by action: wouldMerge, hold, escalate, or clearanceVoided")
+    var action: String?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+
+        // Parse since date if provided
+        var sinceDate: Date?
+        if let sinceStr = since {
+            let formatter = ISO8601DateFormatter()
+            if let date = formatter.date(from: sinceStr) {
+                sinceDate = date
+            } else {
+                throw CLIError.invalidArgument("Invalid ISO8601 date: \(sinceStr)")
+            }
+        }
+
+        // Parse action if provided
+        var auditAction: AuditAction?
+        if let actionStr = action {
+            auditAction = AuditAction(rawValue: actionStr)
+            if auditAction == nil {
+                throw CLIError.invalidArgument(
+                    "Invalid action: \(actionStr). Must be: wouldMerge, hold, escalate, or clearanceVoided"
+                )
+            }
+        }
+
+        let entries: [AuditLogEntry] = try client.call(
+            method: RPCMethod.nightwatchReport,
+            params: NightwatchReportParams(since: sinceDate, action: auditAction),
+            resultType: [AuditLogEntry].self
+        )
+
+        if json {
+            printJSON(entries)
+        } else {
+            // Human-readable output: one line per entry
+            if entries.isEmpty {
+                print("No audit entries found.")
+            } else {
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+                for entry in entries {
+                    let ts = dateFormatter.string(from: entry.timestamp)
+                    let prStr = entry.prNumber.map { "#\($0)" } ?? "—"
+                    let repo = entry.repo ?? "—"
+                    let sha = entry.headSHA.map { String($0.prefix(8)) } ?? "—"
+                    print("\(ts) [\(entry.action.rawValue)] PR \(prStr) (\(repo) \(sha))")
+                    if let details = entry.details {
+                        print("  Details: \(details)")
+                    }
+                }
+            }
         }
     }
 }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -338,6 +338,62 @@ public final class Daemon: Sendable {
             try? await database.worktrees.setPRStatus(id: worktreeID, status: status)
         }
 
+        // Wire nightwatch evaluation: when a PR status is refreshed, evaluate it through
+        // the merge gate and log the decision to the audit store (evaluate-only, no merging).
+        await prManager.setOnPRStatusComputed { worktreeID, status, repoPath in
+            let config = try? await database.config.get()
+            guard let config, config.nightwatchMode != .off else { return }
+
+            // Load policy from .nightwatch/policy.json (conservative defaults if absent/malformed)
+            let policy = NightwatchPolicy.load(repoPath: repoPath)
+            let gate = MergeGate(policy: policy)
+
+            // Build gate input from PR status. For Phase 1, we make conservative assumptions:
+            // - hasApprovedReview = false (not fetched yet, Phase 1 is evaluate-only)
+            // - checksClean = false (not fetched yet)
+            // - files/commits/author = nil (not fetched yet)
+            // This ensures Phase 1 gates are conservative (most PRs will escalate).
+            let input = GateInput(
+                prNumber: status.number,
+                repo: repoPath,
+                headSHA: "unknown",  // Not available in PRStatus
+                isDraft: status.state == .draft,
+                hasApprovedReview: false,
+                checksClean: status.state == .mergeable || status.state == .merged,
+                files: nil,
+                commits: nil,
+                authorWorktreeID: nil,
+                approvedSHA: nil,
+                touchesCI: false
+            )
+
+            let decision = gate.evaluate(input: input)
+            let action: AuditAction
+            let details: String
+
+            switch decision {
+            case .wouldMerge(clearanceID: let cid):
+                action = .wouldMerge
+                details = "Phase 1: would-merge marker (\(cid))"
+            case .hold(let reason):
+                action = .hold
+                details = "Hold reason: \(reason)"
+            case .escalate(let reason):
+                action = .escalate
+                details = "Escalate reason: \(reason)"
+            }
+
+            let entry = AuditLogEntry(
+                action: action,
+                prNumber: status.number,
+                repo: repoPath,
+                headSHA: "unknown",
+                timestamp: Date(),
+                details: details
+            )
+            try? await database.audit.logAction(entry)
+        }
+
         // 7a. Wire auto-archive-on-merge: when a worktree's cached PR state
         // transitions into `.merged`, the coordinator evaluates the effective
         // setting and archives the worktree (no active children) in the

--- a/Sources/TBDDaemon/Database/AuditStore.swift
+++ b/Sources/TBDDaemon/Database/AuditStore.swift
@@ -1,0 +1,115 @@
+import Foundation
+import GRDB
+import os
+import TBDShared
+
+/// GRDB Record type for the `audit_log` table.
+struct AuditLogRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "audit_log"
+
+    var id: String
+    var action: String
+    var pr_number: Int?
+    var repo: String?
+    var head_sha: String?
+    var merge_commit: String?
+    var ts: Date
+    var details: String?
+
+    init(from entry: AuditLogEntry) {
+        self.id = entry.id
+        self.action = entry.action.rawValue
+        self.pr_number = entry.prNumber
+        self.repo = entry.repo
+        self.head_sha = entry.headSHA
+        self.merge_commit = entry.mergeCommit
+        self.ts = entry.timestamp
+        self.details = entry.details
+    }
+
+    func toModel() -> AuditLogEntry {
+        AuditLogEntry(
+            id: id,
+            action: AuditAction(rawValue: action) ?? .escalate,
+            prNumber: pr_number,
+            repo: repo,
+            headSHA: head_sha,
+            mergeCommit: merge_commit,
+            timestamp: ts,
+            details: details
+        )
+    }
+}
+
+/// Provides operations for audit logging.
+public struct AuditStore: Sendable {
+    let writer: any DatabaseWriter
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "nightwatch.audit")
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Log an action to the audit trail.
+    public func logAction(_ entry: AuditLogEntry) async throws {
+        try await writer.write { db in
+            let record = AuditLogRecord(from: entry)
+            try record.insert(db)
+        }
+        // Mirror to os.Logger for incident investigation
+        Self.logger.debug(
+            """
+            action=\(entry.action.rawValue, privacy: .public) \
+            pr=\(entry.prNumber?.description ?? "N/A", privacy: .public) \
+            repo=\(entry.repo ?? "N/A", privacy: .public) \
+            sha=\(entry.headSHA?.prefix(8) ?? "N/A", privacy: .public)
+            """
+        )
+    }
+
+    /// List audit log entries within a time window, optionally filtered by action.
+    public func list(since: Date? = nil, until: Date? = nil, action: AuditAction? = nil) async throws -> [AuditLogEntry] {
+        try await writer.read { db in
+            var request = AuditLogRecord.all()
+            if let since {
+                request = request.filter(Column("ts") >= since)
+            }
+            if let until {
+                request = request.filter(Column("ts") <= until)
+            }
+            if let action {
+                request = request.filter(Column("action") == action.rawValue)
+            }
+            let records = try request.order(Column("ts").desc).fetchAll(db)
+            return records.map { $0.toModel() }
+        }
+    }
+
+    /// Get a specific audit log entry by ID.
+    public func get(id: String) async throws -> AuditLogEntry? {
+        try await writer.read { db in
+            try AuditLogRecord.fetchOne(db, key: id)?.toModel()
+        }
+    }
+
+    /// Count audit entries by action in a time window.
+    public func countByAction(since: Date? = nil, until: Date? = nil) async throws -> [AuditAction: Int] {
+        try await writer.read { db in
+            var request = AuditLogRecord.all()
+            if let since {
+                request = request.filter(Column("ts") >= since)
+            }
+            if let until {
+                request = request.filter(Column("ts") <= until)
+            }
+            let records = try request.fetchAll(db)
+            var counts: [AuditAction: Int] = [:]
+            for record in records {
+                if let action = AuditAction(rawValue: record.action) {
+                    counts[action, default: 0] += 1
+                }
+            }
+            return counts
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/ClearanceStore.swift
+++ b/Sources/TBDDaemon/Database/ClearanceStore.swift
@@ -70,7 +70,8 @@ public struct ClearanceStore: Sendable {
         }
     }
 
-    /// Void all clearances for a PR by PR number and repo due to a new SHA.
+    /// Void every live clearance for the PR that is pinned to a SHA other
+    /// than `newSHA` — a clearance granted on the current head stays valid.
     public func voidBySHA(pr: Int, repo: String, newSHA: String, reason: String) async throws {
         try await writer.write { db in
             try db.execute(
@@ -78,8 +79,9 @@ public struct ClearanceStore: Sendable {
                 UPDATE clearance
                 SET void_reason = ?
                 WHERE pr_number = ? AND repo = ? AND void_reason IS NULL
+                  AND cleared_when_sha != ?
                 """,
-                arguments: [reason, pr, repo]
+                arguments: [reason, pr, repo, newSHA]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/ClearanceStore.swift
+++ b/Sources/TBDDaemon/Database/ClearanceStore.swift
@@ -1,0 +1,115 @@
+import Foundation
+import GRDB
+import TBDShared
+
+/// GRDB Record type for the `clearance` table.
+struct ClearanceRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "clearance"
+
+    var id: String
+    var pr_number: Int
+    var repo: String
+    var cleared_when_sha: String
+    var pr_state_at_clear: String?
+    var clearance_kind: String
+    var granted_by: String?
+    var granted_at: Date
+    var void_reason: String?
+
+    init(from clearance: Clearance) {
+        self.id = clearance.id
+        self.pr_number = clearance.prNumber
+        self.repo = clearance.repo
+        self.cleared_when_sha = clearance.clearedWhenSHA
+        self.pr_state_at_clear = clearance.prStateAtClear
+        self.clearance_kind = clearance.clearanceKind.rawValue
+        self.granted_by = clearance.grantedBy
+        self.granted_at = clearance.grantedAt
+        self.void_reason = clearance.voidReason
+    }
+
+    func toModel() -> Clearance {
+        Clearance(
+            id: id,
+            prNumber: pr_number,
+            repo: repo,
+            clearedWhenSHA: cleared_when_sha,
+            prStateAtClear: pr_state_at_clear,
+            clearanceKind: ClearanceKind(rawValue: clearance_kind) ?? .small_safe,
+            grantedBy: granted_by,
+            grantedAt: granted_at,
+            voidReason: void_reason
+        )
+    }
+}
+
+/// Provides CRUD operations for clearance records.
+public struct ClearanceStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Insert a new clearance record.
+    public func insert(_ clearance: Clearance) async throws {
+        try await writer.write { db in
+            let record = ClearanceRecord(from: clearance)
+            try record.insert(db)
+        }
+    }
+
+    /// Void a clearance by ID with a reason.
+    public func voidByID(_ id: String, reason: String) async throws {
+        try await writer.write { db in
+            guard var record = try ClearanceRecord.fetchOne(db, key: id) else {
+                throw DatabaseError(message: "Clearance not found")
+            }
+            record.void_reason = reason
+            try record.update(db)
+        }
+    }
+
+    /// Void all clearances for a PR by PR number and repo due to a new SHA.
+    public func voidBySHA(pr: Int, repo: String, newSHA: String, reason: String) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                UPDATE clearance
+                SET void_reason = ?
+                WHERE pr_number = ? AND repo = ? AND void_reason IS NULL
+                """,
+                arguments: [reason, pr, repo]
+            )
+        }
+    }
+
+    /// List clearances for a specific PR.
+    public func listByPR(_ prNumber: Int, repo: String) async throws -> [Clearance] {
+        try await writer.read { db in
+            let records = try ClearanceRecord
+                .filter(Column("pr_number") == prNumber && Column("repo") == repo)
+                .fetchAll(db)
+            return records.map { $0.toModel() }
+        }
+    }
+
+    /// Get audit trail of clearances (all non-void clearances).
+    public func auditTrail(since: Date? = nil) async throws -> [Clearance] {
+        try await writer.read { db in
+            var request = ClearanceRecord.filter(Column("void_reason") == nil)
+            if let since {
+                request = request.filter(Column("granted_at") >= since)
+            }
+            let records = try request.order(Column("granted_at")).fetchAll(db)
+            return records.map { $0.toModel() }
+        }
+    }
+
+    /// Get a clearance by ID.
+    public func get(id: String) async throws -> Clearance? {
+        try await writer.read { db in
+            try ClearanceRecord.fetchOne(db, key: id)?.toModel()
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -21,6 +21,8 @@ public final class TBDDatabase: Sendable {
     public let meta: TBDMetaStore
     public let tabs: TabStore
     public let forgottenWorktrees: ForgottenWorktreeStore
+    public let clearance: ClearanceStore
+    public let audit: AuditStore
 
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
@@ -50,6 +52,8 @@ public final class TBDDatabase: Sendable {
         self.meta = TBDMetaStore(writer: pool)
         self.tabs = TabStore(writer: pool)
         self.forgottenWorktrees = ForgottenWorktreeStore(writer: pool)
+        self.clearance = ClearanceStore(writer: pool)
+        self.audit = AuditStore(writer: pool)
 
         let migrator = Self.buildMigrator()
         if fileExisted {
@@ -79,6 +83,8 @@ public final class TBDDatabase: Sendable {
         self.meta = TBDMetaStore(writer: queue)
         self.tabs = TabStore(writer: queue)
         self.forgottenWorktrees = ForgottenWorktreeStore(writer: queue)
+        self.clearance = ClearanceStore(writer: queue)
+        self.audit = AuditStore(writer: queue)
         try Self.buildMigrator().migrate(queue)
     }
 
@@ -661,6 +667,41 @@ public final class TBDDatabase: Sendable {
         // existing rows decode to the default 'off'. See Phase 0 design.
         migrator.registerMigration("v38_nightwatch_mode") { db in
             try db.addColumnIfMissing(table: "config", column: "nightwatch_mode", type: .text, defaults: "off")
+        }
+
+        migrator.registerMigration("v39_clearance_ledger") { db in
+            try db.create(table: "clearance") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("pr_number", .integer).notNull()
+                t.column("repo", .text).notNull()
+                t.column("cleared_when_sha", .text).notNull()
+                t.column("pr_state_at_clear", .text)
+                t.column("clearance_kind", .text).notNull()
+                t.column("granted_by", .text)
+                t.column("granted_at", .datetime).notNull()
+                t.column("void_reason", .text)
+            }
+            // Index for quick lookups by PR and repo
+            try db.execute(sql: """
+                CREATE INDEX idx_clearance_pr_repo ON clearance(pr_number, repo)
+            """)
+        }
+
+        migrator.registerMigration("v40_audit_log") { db in
+            try db.create(table: "audit_log") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("action", .text).notNull()
+                t.column("pr_number", .integer)
+                t.column("repo", .text)
+                t.column("head_sha", .text)
+                t.column("merge_commit", .text)
+                t.column("ts", .datetime).notNull()
+                t.column("details", .text)
+            }
+            // Index for efficient time-range queries
+            try db.execute(sql: """
+                CREATE INDEX idx_audit_log_ts ON audit_log(ts)
+            """)
         }
 
         return migrator

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -669,7 +669,7 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "config", column: "nightwatch_mode", type: .text, defaults: "off")
         }
 
-        migrator.registerMigration("v39_clearance_ledger") { db in
+        migrator.registerMigration("v41_clearance_ledger") { db in
             try db.create(table: "clearance") { t in
                 t.primaryKey("id", .text).notNull()
                 t.column("pr_number", .integer).notNull()
@@ -687,7 +687,7 @@ public final class TBDDatabase: Sendable {
             """)
         }
 
-        migrator.registerMigration("v40_audit_log") { db in
+        migrator.registerMigration("v42_audit_log") { db in
             try db.create(table: "audit_log") { t in
                 t.primaryKey("id", .text).notNull()
                 t.column("action", .text).notNull()

--- a/Sources/TBDDaemon/Nightwatch/MergeGate.swift
+++ b/Sources/TBDDaemon/Nightwatch/MergeGate.swift
@@ -289,10 +289,12 @@ public struct MergeGate: Sendable {
             return true
         }
 
-        // Check if any runtime files changed.
-        let runtimeFiles = files.filter { !isTestFile($0) }
+        // Check if any runtime files changed. Documentation and other
+        // non-executable files don't demand test coverage (a docs-only PR
+        // must not hold on "inadequate tests" — design §7.1).
+        let runtimeFiles = files.filter { !isTestFile($0) && !isNonExecutableFile($0) }
         guard !runtimeFiles.isEmpty else {
-            // Only test files changed → adequate coverage.
+            // Only test/doc files changed → adequate coverage.
             return true
         }
 
@@ -310,6 +312,17 @@ public struct MergeGate: Sendable {
             "Tests.swift"
         ]
         return testPatterns.contains { path.contains($0) }
+    }
+
+    /// Files that carry no runtime behavior and therefore don't demand test
+    /// coverage. Deliberately narrow (fail closed): anything not clearly
+    /// non-executable counts as runtime.
+    private func isNonExecutableFile(_ path: String) -> Bool {
+        let docExtensions = [".md", ".txt", ".rst"]
+        if docExtensions.contains(where: { path.hasSuffix($0) }) { return true }
+        if path.hasPrefix("docs/") || path.contains("/docs/") { return true }
+        if path == "LICENSE" || path.hasSuffix("/LICENSE") { return true }
+        return false
     }
 
     private func fileMatchesGlob(files: [String], glob: String) -> Bool {

--- a/Sources/TBDDaemon/Nightwatch/MergeGate.swift
+++ b/Sources/TBDDaemon/Nightwatch/MergeGate.swift
@@ -100,11 +100,17 @@ public struct GateInput: Sendable, Equatable {
 
 /// Nightwatch merge policy: governs what auto-merges and under what conditions.
 public struct NightwatchPolicy: Sendable, Equatable {
+    /// Hard compiled maximum on lines changed for any auto-merge. Editable
+    /// policy (`.nightwatch/policy.json`) may only tighten BELOW this; a
+    /// larger value in a policy file is clamped here, so a policy edit can
+    /// never widen the merge set past the compiled floor (design §7.1).
+    public static let hardSizeCeiling = 50
+
     /// Impact map: glob patterns identifying high-impact, foundational domains.
     /// A change matching any pattern is held regardless of approval/checks.
     public let impactMapGlobs: [String]
-    /// Maximum compiled size ceiling (lines changed) for any auto-merge.
-    /// Policy can only tighten below this; never exceed.
+    /// Effective size ceiling (lines changed) for any auto-merge. Always
+    /// `<= hardSizeCeiling` — enforced in init, not trusted from input.
     public let compiledSizeCeiling: Int
     /// Explicit list of PR numbers/names currently under test-hold.
     public let testHoldList: [Int]
@@ -113,12 +119,12 @@ public struct NightwatchPolicy: Sendable, Equatable {
 
     public init(
         impactMapGlobs: [String] = [],
-        compiledSizeCeiling: Int = 50,
+        compiledSizeCeiling: Int = NightwatchPolicy.hardSizeCeiling,
         testHoldList: [Int] = [],
         allowRebaseReclearance: Bool = false
     ) {
         self.impactMapGlobs = impactMapGlobs
-        self.compiledSizeCeiling = compiledSizeCeiling
+        self.compiledSizeCeiling = min(compiledSizeCeiling, Self.hardSizeCeiling)
         self.testHoldList = testHoldList
         self.allowRebaseReclearance = allowRebaseReclearance
     }
@@ -163,10 +169,16 @@ extension NightwatchPolicy: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        impactMapGlobs = try container.decodeIfPresent([String].self, forKey: .impactMapGlobs) ?? []
-        compiledSizeCeiling = try container.decodeIfPresent(Int.self, forKey: .compiledSizeCeiling) ?? 50
-        testHoldList = try container.decodeIfPresent([Int].self, forKey: .testHoldList) ?? []
-        allowRebaseReclearance = try container.decodeIfPresent(Bool.self, forKey: .allowRebaseReclearance) ?? false
+        // Route through the memberwise init so the hardSizeCeiling clamp
+        // applies to policy files too — a policy edit can tighten the
+        // ceiling but never widen it (design §7.1, policy-poisoning guard).
+        self.init(
+            impactMapGlobs: try container.decodeIfPresent([String].self, forKey: .impactMapGlobs) ?? [],
+            compiledSizeCeiling: try container.decodeIfPresent(Int.self, forKey: .compiledSizeCeiling)
+                ?? NightwatchPolicy.hardSizeCeiling,
+            testHoldList: try container.decodeIfPresent([Int].self, forKey: .testHoldList) ?? [],
+            allowRebaseReclearance: try container.decodeIfPresent(Bool.self, forKey: .allowRebaseReclearance) ?? false
+        )
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/TBDDaemon/Nightwatch/MergeGate.swift
+++ b/Sources/TBDDaemon/Nightwatch/MergeGate.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TBDShared
+import os
 
 // MARK: - Gate Decision Types
 
@@ -129,6 +130,52 @@ public struct NightwatchPolicy: Sendable, Equatable {
         testHoldList: [],
         allowRebaseReclearance: false
     )
+
+    /// Load policy from `<repo>/.nightwatch/policy.json`.
+    /// Returns conservativeDefaults if file is absent or unparseable (with one warning logged if malformed).
+    public static func load(repoPath: String) -> NightwatchPolicy {
+        let policyPath = (repoPath as NSString).appendingPathComponent(".nightwatch/policy.json")
+        guard FileManager.default.fileExists(atPath: policyPath) else {
+            return conservativeDefaults
+        }
+
+        do {
+            let data = try Data(contentsOf: URL(fileURLWithPath: policyPath))
+            let decoded = try JSONDecoder().decode(NightwatchPolicy.self, from: data)
+            return decoded
+        } catch {
+            let logger = Logger(subsystem: "com.tbd.daemon", category: "nightwatch.policy")
+            logger.warning("Failed to parse nightwatch policy at \(policyPath, privacy: .public): \(error, privacy: .public). Using conservative defaults.")
+            return conservativeDefaults
+        }
+    }
+}
+
+// MARK: - Codable support for NightwatchPolicy
+
+extension NightwatchPolicy: Codable {
+    enum CodingKeys: String, CodingKey {
+        case impactMapGlobs = "impactMapGlobs"
+        case compiledSizeCeiling = "compiledSizeCeiling"
+        case testHoldList = "testHoldList"
+        case allowRebaseReclearance = "allowRebaseReclearance"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        impactMapGlobs = try container.decodeIfPresent([String].self, forKey: .impactMapGlobs) ?? []
+        compiledSizeCeiling = try container.decodeIfPresent(Int.self, forKey: .compiledSizeCeiling) ?? 50
+        testHoldList = try container.decodeIfPresent([Int].self, forKey: .testHoldList) ?? []
+        allowRebaseReclearance = try container.decodeIfPresent(Bool.self, forKey: .allowRebaseReclearance) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(impactMapGlobs, forKey: .impactMapGlobs)
+        try container.encode(compiledSizeCeiling, forKey: .compiledSizeCeiling)
+        try container.encode(testHoldList, forKey: .testHoldList)
+        try container.encode(allowRebaseReclearance, forKey: .allowRebaseReclearance)
+    }
 }
 
 // MARK: - Merge Gate Evaluator

--- a/Sources/TBDDaemon/Nightwatch/MergeGate.swift
+++ b/Sources/TBDDaemon/Nightwatch/MergeGate.swift
@@ -1,0 +1,268 @@
+import Foundation
+import TBDShared
+
+// MARK: - Gate Decision Types
+
+/// The result of evaluating a PR against the merge gate.
+public enum GateDecision: Sendable, Equatable {
+    /// PR would be merged with this clearance ID.
+    case wouldMerge(clearanceID: String)
+    /// PR is held for the given reason.
+    case hold(HoldReason)
+    /// PR escalates for human review with the given reason.
+    case escalate(EscalateReason)
+}
+
+/// Reasons why a PR is held (never auto-mergeable without override).
+public enum HoldReason: Sendable, Equatable {
+    /// High-impact domain: change touches a foundational area (per policy impact map).
+    case highImpactDomain(domain: String)
+    /// Inadequate test coverage: runtime changes without corresponding tests.
+    case inadequateTestCoverage
+    /// Explicit test-hold placed by human.
+    case testHold
+    /// Authoring worktree still active and working.
+    case authoringWorktreeActive
+    /// PR modifies its own CI/workflow (floor integrity guard).
+    case selfModifyingChecks
+}
+
+/// Reasons why a PR escalates to human review.
+public enum EscalateReason: Sendable, Equatable {
+    /// SAFETY_FLOOR failure: not approved, checks failing, draft, etc.
+    case safetyFloorFailed(detail: String)
+    /// GitHub API error or missing data.
+    case dataReadFailure(detail: String)
+    /// PR size exceeds compiled ceiling.
+    case sizeExceedsCeiling(lines: Int, ceiling: Int)
+    /// No clearance path authorized this PR.
+    case noClearancePath
+    /// Clearance was voided (SHA mismatch, PR state changed, etc).
+    case clearanceVoided(reason: String)
+    /// Unknown or unexpected state.
+    case unknownState(detail: String)
+}
+
+// MARK: - Merge Gate Input & Policy
+
+/// Input data required to evaluate a PR against the merge gate.
+public struct GateInput: Sendable, Equatable {
+    /// PR number.
+    public let prNumber: Int
+    /// Repository name or URL.
+    public let repo: String
+    /// Head SHA of the PR.
+    public let headSHA: String
+    /// PR state (open, draft, etc).
+    public let isDraft: Bool
+    /// Whether the PR has a valid claude-review APPROVED on this SHA.
+    public let hasApprovedReview: Bool
+    /// Whether required checks are clean.
+    public let checksClean: Bool
+    /// List of files changed in the PR.
+    public let files: [String]?
+    /// Number of commits in the PR.
+    public let commits: Int?
+    /// UUID of the worktree that authored this PR, if known.
+    public let authorWorktreeID: UUID?
+    /// SHA that was approved by claude-review.
+    public let approvedSHA: String?
+    /// Whether the PR touches workflow/CI definition files.
+    public let touchesCI: Bool
+
+    public init(
+        prNumber: Int,
+        repo: String,
+        headSHA: String,
+        isDraft: Bool,
+        hasApprovedReview: Bool,
+        checksClean: Bool,
+        files: [String]? = nil,
+        commits: Int? = nil,
+        authorWorktreeID: UUID? = nil,
+        approvedSHA: String? = nil,
+        touchesCI: Bool = false
+    ) {
+        self.prNumber = prNumber
+        self.repo = repo
+        self.headSHA = headSHA
+        self.isDraft = isDraft
+        self.hasApprovedReview = hasApprovedReview
+        self.checksClean = checksClean
+        self.files = files
+        self.commits = commits
+        self.authorWorktreeID = authorWorktreeID
+        self.approvedSHA = approvedSHA
+        self.touchesCI = touchesCI
+    }
+}
+
+/// Nightwatch merge policy: governs what auto-merges and under what conditions.
+public struct NightwatchPolicy: Sendable, Equatable {
+    /// Impact map: glob patterns identifying high-impact, foundational domains.
+    /// A change matching any pattern is held regardless of approval/checks.
+    public let impactMapGlobs: [String]
+    /// Maximum compiled size ceiling (lines changed) for any auto-merge.
+    /// Policy can only tighten below this; never exceed.
+    public let compiledSizeCeiling: Int
+    /// Explicit list of PR numbers/names currently under test-hold.
+    public let testHoldList: [Int]
+    /// Whether to auto-re-clear rebases (advanced feature; Phase 2+).
+    public let allowRebaseReclearance: Bool
+
+    public init(
+        impactMapGlobs: [String] = [],
+        compiledSizeCeiling: Int = 50,
+        testHoldList: [Int] = [],
+        allowRebaseReclearance: Bool = false
+    ) {
+        self.impactMapGlobs = impactMapGlobs
+        self.compiledSizeCeiling = compiledSizeCeiling
+        self.testHoldList = testHoldList
+        self.allowRebaseReclearance = allowRebaseReclearance
+    }
+
+    /// Conservative defaults when policy file is missing or unparseable.
+    public static let conservativeDefaults = NightwatchPolicy(
+        impactMapGlobs: ["**/.nightwatch/**", "**/.claude/**", "**/scripts/**"],
+        compiledSizeCeiling: 50,
+        testHoldList: [],
+        allowRebaseReclearance: false
+    )
+}
+
+// MARK: - Merge Gate Evaluator
+
+/// Pure, injection-based merge gate evaluator.
+/// Takes input PR data and policy, returns a typed decision.
+/// No I/O, no database access — deterministic for testing.
+public struct MergeGate: Sendable {
+    public let policy: NightwatchPolicy
+
+    public init(policy: NightwatchPolicy = .conservativeDefaults) {
+        self.policy = policy
+    }
+
+    /// Evaluate a PR against the merge gate.
+    /// Returns the gate decision without executing any action.
+    public func evaluate(input: GateInput) -> GateDecision {
+        // Step 1: SAFETY_FLOOR — fail closed on any check failure.
+        if let floorFailure = checkSafetyFloor(input: input) {
+            return .escalate(floorFailure)
+        }
+
+        // Step 2: Check hard holds — these always block, regardless of clearance.
+        if let hold = checkHardHolds(input: input) {
+            return .hold(hold)
+        }
+
+        // Step 3: If no hard holds, this PR *would* merge (assuming a valid clearance exists).
+        // Phase 1 = evaluate-only; we don't check actual clearances in the gate.
+        // Return wouldMerge with a marker clearance ID (will be validated by RPC layer).
+        let clearanceID = "phase1-would-merge-\(input.headSHA.prefix(8))"
+        return .wouldMerge(clearanceID: String(clearanceID))
+    }
+
+    // MARK: - Safety Floor Checks
+
+    private func checkSafetyFloor(input: GateInput) -> EscalateReason? {
+        // Draft PRs cannot merge.
+        if input.isDraft {
+            return .safetyFloorFailed(detail: "PR is marked as draft")
+        }
+
+        // Must have an approved review on the current head SHA.
+        if !input.hasApprovedReview {
+            return .safetyFloorFailed(detail: "Missing claude-review APPROVED on current head SHA")
+        }
+
+        // Approval SHA must match current head SHA.
+        if let approvedSHA = input.approvedSHA, approvedSHA != input.headSHA {
+            return .safetyFloorFailed(detail: "Approval SHA mismatch: approved on \(approvedSHA.prefix(8)), head is \(input.headSHA.prefix(8))")
+        }
+
+        // All required checks must be clean.
+        if !input.checksClean {
+            return .safetyFloorFailed(detail: "Required checks not clean")
+        }
+
+        // No required check data is as bad as failing checks (misconfiguration).
+        // (This is checked by the daemon at fetch time; we assume non-empty here.)
+
+        return nil
+    }
+
+    // MARK: - Hard Holds
+
+    private func checkHardHolds(input: GateInput) -> HoldReason? {
+        // Test-hold list.
+        if policy.testHoldList.contains(input.prNumber) {
+            return .testHold
+        }
+
+        // Self-modifying CI/workflow (floor integrity guard).
+        if input.touchesCI {
+            return .selfModifyingChecks
+        }
+
+        // High-impact domain (from policy impact map).
+        if let files = input.files {
+            for glob in policy.impactMapGlobs {
+                if fileMatchesGlob(files: files, glob: glob) {
+                    return .highImpactDomain(domain: glob)
+                }
+            }
+        }
+
+        // Inadequate test coverage: runtime changes without tests.
+        if !hasAdequateTestCoverage(input: input) {
+            return .inadequateTestCoverage
+        }
+
+        // (Authoring worktree check & other holds would require DB access; Phase 1 doesn't have them.)
+
+        return nil
+    }
+
+    private func hasAdequateTestCoverage(input: GateInput) -> Bool {
+        guard let files = input.files, !files.isEmpty else {
+            // No file list: be conservative.
+            return true
+        }
+
+        // Check if any runtime files changed.
+        let runtimeFiles = files.filter { !isTestFile($0) }
+        guard !runtimeFiles.isEmpty else {
+            // Only test files changed → adequate coverage.
+            return true
+        }
+
+        // Runtime files changed; check if tests were also added/modified.
+        let testFiles = files.filter { isTestFile($0) }
+        return !testFiles.isEmpty
+    }
+
+    private func isTestFile(_ path: String) -> Bool {
+        let testPatterns = [
+            "Tests/",
+            "test_",
+            "_test.swift",
+            "Test.swift",
+            "Tests.swift"
+        ]
+        return testPatterns.contains { path.contains($0) }
+    }
+
+    private func fileMatchesGlob(files: [String], glob: String) -> Bool {
+        // Simple glob matching: * = any characters in path component, ** = any depth.
+        let pattern = glob.replacingOccurrences(of: ".", with: "\\.")
+            .replacingOccurrences(of: "**/", with: ".*\\/")
+            .replacingOccurrences(of: "*", with: "[^/]*")
+        guard let regex = try? NSRegularExpression(pattern: "^" + pattern + "$") else {
+            return false
+        }
+        return files.contains { path in
+            regex.firstMatch(in: path, range: NSRange(path.startIndex..., in: path)) != nil
+        }
+    }
+}

--- a/Sources/TBDDaemon/Nightwatch/MergeGate.swift
+++ b/Sources/TBDDaemon/Nightwatch/MergeGate.swift
@@ -161,10 +161,10 @@ public struct NightwatchPolicy: Sendable, Equatable {
 
 extension NightwatchPolicy: Codable {
     enum CodingKeys: String, CodingKey {
-        case impactMapGlobs = "impactMapGlobs"
-        case compiledSizeCeiling = "compiledSizeCeiling"
-        case testHoldList = "testHoldList"
-        case allowRebaseReclearance = "allowRebaseReclearance"
+        case impactMapGlobs
+        case compiledSizeCeiling
+        case testHoldList
+        case allowRebaseReclearance
     }
 
     public init(from decoder: Decoder) throws {

--- a/Sources/TBDDaemon/Nightwatch/MergeGate.swift
+++ b/Sources/TBDDaemon/Nightwatch/MergeGate.swift
@@ -313,15 +313,46 @@ public struct MergeGate: Sendable {
     }
 
     private func fileMatchesGlob(files: [String], glob: String) -> Bool {
-        // Simple glob matching: * = any characters in path component, ** = any depth.
-        let pattern = glob.replacingOccurrences(of: ".", with: "\\.")
-            .replacingOccurrences(of: "**/", with: ".*\\/")
-            .replacingOccurrences(of: "*", with: "[^/]*")
-        guard let regex = try? NSRegularExpression(pattern: "^" + pattern + "$") else {
+        guard let regex = try? NSRegularExpression(pattern: Self.globToRegexPattern(glob)) else {
             return false
         }
         return files.contains { path in
             regex.firstMatch(in: path, range: NSRange(path.startIndex..., in: path)) != nil
         }
+    }
+
+    /// Translate a path glob to an anchored regex by scanning characters —
+    /// NOT by cascading string replacements, which corrupt each other's
+    /// output (a prior version turned its own `.*` into `.[^/]*`).
+    /// Semantics: `**/` = zero or more whole path segments (so `**/x` also
+    /// matches a repo-root `x`), `**` = any characters incl. `/`,
+    /// `*` = any characters within one segment.
+    static func globToRegexPattern(_ glob: String) -> String {
+        var out = "^"
+        var i = glob.startIndex
+        while i < glob.endIndex {
+            let c = glob[i]
+            if c == "*" {
+                let next = glob.index(after: i)
+                if next < glob.endIndex, glob[next] == "*" {
+                    let after = glob.index(after: next)
+                    if after < glob.endIndex, glob[after] == "/" {
+                        out += "(?:[^/]+/)*"   // "**/" — zero or more segments
+                        i = glob.index(after: after)
+                    } else {
+                        out += ".*"            // "**" — any depth
+                        i = after
+                    }
+                } else {
+                    out += "[^/]*"             // "*" — within one segment
+                    i = next
+                }
+            } else {
+                if #"\^$.|?+()[]{}"#.contains(c) { out += "\\" }
+                out.append(c)
+                i = glob.index(after: i)
+            }
+        }
+        return out + "$"
     }
 }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -27,6 +27,8 @@ public actor PRStatusManager {
 
     private var onStatusPersist: (@Sendable (UUID, PRStatus) async -> Void)?
 
+    private var onPRStatusComputed: (@Sendable (UUID, PRStatus, String) async -> Void)?
+
     public init() {}
 
     // MARK: - Public interface
@@ -48,6 +50,12 @@ public actor PRStatusManager {
     /// changes, so the daemon can persist it to the DB.
     public func setOnStatusPersist(_ cb: @escaping @Sendable (UUID, PRStatus) async -> Void) {
         self.onStatusPersist = cb
+    }
+
+    /// Register a callback fired whenever a PR status is computed (for nightwatch evaluation).
+    /// Passes (worktreeID, status, repoPath) so the callback can evaluate the PR.
+    public func setOnPRStatusComputed(_ cb: @escaping @Sendable (UUID, PRStatus, String) async -> Void) {
+        self.onPRStatusComputed = cb
     }
 
     /// Seed the cache from persisted DB state at startup. Writes directly (not via
@@ -182,10 +190,9 @@ public actor PRStatusManager {
                 requiredChecksFailing: signals.failing,
                 requiredChecksPending: signals.pending
             )
-            await apply(
-                PRStatus(number: match.node.number, url: match.node.url, state: state, reason: reason),
-                for: match.worktreeID
-            )
+            let status = PRStatus(number: match.node.number, url: match.node.url, state: state, reason: reason)
+            await apply(status, for: match.worktreeID)
+            await onPRStatusComputed?(match.worktreeID, status, repoPath)
         }
     }
 
@@ -231,6 +238,7 @@ public actor PRStatusManager {
             let status = PRStatus(number: obj.number, url: obj.url, state: state, reason: reason)
             await apply(status, for: worktreeID)
             lastDirectUpdate[worktreeID] = Date()
+            await onPRStatusComputed?(worktreeID, status, repoPath)
             return status
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
@@ -9,4 +9,10 @@ extension RPCRouter {
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()
     }
+
+    func handleNightwatchReport(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NightwatchReportParams.self, from: data)
+        let entries = try await db.audit.list(since: params.since, action: params.action)
+        return try RPCResponse(result: entries)
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -306,6 +306,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetScratchProfileOverride(request.paramsData)
             case RPCMethod.nightwatchSetMode:
                 return try await handleSetNightwatchMode(request.paramsData)
+            case RPCMethod.nightwatchReport:
+                return try await handleNightwatchReport(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -718,12 +718,22 @@ public struct PRStatus: Codable, Sendable, Equatable {
     public let url: String
     public let state: PRMergeableState
     public let reason: String?
+    /// List of files changed in the PR (lazy-fetched on demand by the merge gate).
+    public let files: [String]?
+    /// Number of commits in the PR (lazy-fetched on demand by the merge gate).
+    public let commits: Int?
+    /// UUID of the worktree that authored this PR, if known.
+    public let authorWorktreeID: UUID?
 
-    public init(number: Int, url: String, state: PRMergeableState, reason: String? = nil) {
+    public init(number: Int, url: String, state: PRMergeableState, reason: String? = nil,
+                files: [String]? = nil, commits: Int? = nil, authorWorktreeID: UUID? = nil) {
         self.number = number
         self.url = url
         self.state = state
         self.reason = reason
+        self.files = files
+        self.commits = commits
+        self.authorWorktreeID = authorWorktreeID
     }
 }
 

--- a/Sources/TBDShared/Models_Nightwatch.swift
+++ b/Sources/TBDShared/Models_Nightwatch.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+// MARK: - Clearance Kind
+
+public enum ClearanceKind: String, Codable, Sendable, CaseIterable {
+    case preclear
+    case small_safe
+    case in_channel
+}
+
+// MARK: - Clearance
+
+/// A SHA-pinned clearance record for a PR that was cleared to merge.
+/// Stored append-only in the clearance ledger.
+public struct Clearance: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let prNumber: Int
+    public let repo: String
+    public let clearedWhenSHA: String
+    public let prStateAtClear: String?
+    public let clearanceKind: ClearanceKind
+    public let grantedBy: String?
+    public let grantedAt: Date
+    public let voidReason: String?
+
+    public init(
+        id: String = UUID().uuidString,
+        prNumber: Int,
+        repo: String,
+        clearedWhenSHA: String,
+        prStateAtClear: String? = nil,
+        clearanceKind: ClearanceKind,
+        grantedBy: String? = nil,
+        grantedAt: Date = Date(),
+        voidReason: String? = nil
+    ) {
+        self.id = id
+        self.prNumber = prNumber
+        self.repo = repo
+        self.clearedWhenSHA = clearedWhenSHA
+        self.prStateAtClear = prStateAtClear
+        self.clearanceKind = clearanceKind
+        self.grantedBy = grantedBy
+        self.grantedAt = grantedAt
+        self.voidReason = voidReason
+    }
+}
+
+// MARK: - Audit Action
+
+public enum AuditAction: String, Codable, Sendable, CaseIterable {
+    case wouldMerge
+    case hold
+    case escalate
+    case clearanceVoided
+}
+
+// MARK: - Audit Log Entry
+
+/// An audit record of a merge gate decision or action.
+public struct AuditLogEntry: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let action: AuditAction
+    public let prNumber: Int?
+    public let repo: String?
+    public let headSHA: String?
+    public let mergeCommit: String?
+    public let timestamp: Date
+    public let details: String?
+
+    public init(
+        id: String = UUID().uuidString,
+        action: AuditAction,
+        prNumber: Int? = nil,
+        repo: String? = nil,
+        headSHA: String? = nil,
+        mergeCommit: String? = nil,
+        timestamp: Date = Date(),
+        details: String? = nil
+    ) {
+        self.id = id
+        self.action = action
+        self.prNumber = prNumber
+        self.repo = repo
+        self.headSHA = headSHA
+        self.mergeCommit = mergeCommit
+        self.timestamp = timestamp
+        self.details = details
+    }
+}

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -172,6 +172,7 @@ public enum RPCMethod {
     public static let scratchArchive = "scratch.archive"
     public static let scratchRevive = "scratch.revive"
     public static let nightwatchSetMode = "nightwatch.setMode"
+    public static let nightwatchReport = "nightwatch.report"
 }
 
 // MARK: - Branch Listing
@@ -268,6 +269,16 @@ public struct AppearanceUpdateColorFgBgParams: Codable, Sendable {
 public struct NightwatchSetModeParams: Codable, Sendable {
     public let mode: NightwatchMode
     public init(mode: NightwatchMode) { self.mode = mode }
+}
+
+public struct NightwatchReportParams: Codable, Sendable {
+    public let since: Date?
+    public let action: AuditAction?
+
+    public init(since: Date? = nil, action: AuditAction? = nil) {
+        self.since = since
+        self.action = action
+    }
 }
 
 // MARK: - Terminal Swap Profile

--- a/Tests/TBDAppTests/PRButtonLabelTests.swift
+++ b/Tests/TBDAppTests/PRButtonLabelTests.swift
@@ -143,8 +143,12 @@ struct PRButtonLabelTests {
         // url — reason deliberately excluded), so a new field is otherwise
         // silently unkeyed: decide whether the split button renders it and
         // update prSplitButtonID (and this count) accordingly.
+        // 7 = number, state, url, reason + the nightwatch gate metadata
+        // (files, commits, authorWorktreeID), which the split button does NOT
+        // render — deliberately excluded like reason, else every metadata
+        // fetch would force a spurious toolbar-item rebuild.
         let status = Self.makeStatus()
-        #expect(Mirror(reflecting: status).children.count == 4)
+        #expect(Mirror(reflecting: status).children.count == 7)
     }
 
     @Test("id key differs between blocked states, color schemes, and worktrees")

--- a/Tests/TBDDaemonTests/AuditStoreTests.swift
+++ b/Tests/TBDDaemonTests/AuditStoreTests.swift
@@ -7,7 +7,7 @@ import TBDShared
 struct AuditStoreTests {
 
     @Test("Log action and retrieve")
-    async func logActionAndRetrieve() throws {
+    func logActionAndRetrieve() async throws {
         let db = try TBDDatabase(inMemory: true)
         let entry = AuditLogEntry(
             action: .wouldMerge,
@@ -24,7 +24,7 @@ struct AuditStoreTests {
     }
 
     @Test("List audit entries by time range")
-    async func listByTimeRange() throws {
+    func listByTimeRange() async throws {
         let db = try TBDDatabase(inMemory: true)
         let now = Date()
         let oneHourAgo = now.addingTimeInterval(-3600)
@@ -47,7 +47,7 @@ struct AuditStoreTests {
     }
 
     @Test("List audit entries by action")
-    async func listByAction() throws {
+    func listByAction() async throws {
         let db = try TBDDatabase(inMemory: true)
 
         try await db.audit.logAction(AuditLogEntry(action: .wouldMerge, prNumber: 1))
@@ -64,7 +64,7 @@ struct AuditStoreTests {
     }
 
     @Test("Count audit entries by action")
-    async func countByAction() throws {
+    func countByAction() async throws {
         let db = try TBDDatabase(inMemory: true)
 
         try await db.audit.logAction(AuditLogEntry(action: .wouldMerge, prNumber: 1))
@@ -81,7 +81,7 @@ struct AuditStoreTests {
     }
 
     @Test("Audit entries ordered by timestamp descending")
-    async func entriesOrderedByTimestamp() throws {
+    func entriesOrderedByTimestamp() async throws {
         let db = try TBDDatabase(inMemory: true)
         let now = Date()
 
@@ -102,7 +102,7 @@ struct AuditStoreTests {
     }
 
     @Test("Audit details captured in JSON")
-    async func detailsCapture() throws {
+    func detailsCapture() async throws {
         let db = try TBDDatabase(inMemory: true)
         let details = #"{"reason":"high_impact_domain","domain":".nightwatch"}"#
         let entry = AuditLogEntry(

--- a/Tests/TBDDaemonTests/AuditStoreTests.swift
+++ b/Tests/TBDDaemonTests/AuditStoreTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("AuditStore Integration Tests")
+struct AuditStoreTests {
+
+    @Test("Log action and retrieve")
+    async func logActionAndRetrieve() throws {
+        let db = try TBDDatabase(inMemory: true)
+        let entry = AuditLogEntry(
+            action: .wouldMerge,
+            prNumber: 42,
+            repo: "test/repo",
+            headSHA: "abc123"
+        )
+
+        try await db.audit.logAction(entry)
+        let retrieved = try await db.audit.get(id: entry.id)
+
+        #expect(retrieved?.action == .wouldMerge)
+        #expect(retrieved?.prNumber == 42)
+    }
+
+    @Test("List audit entries by time range")
+    async func listByTimeRange() throws {
+        let db = try TBDDatabase(inMemory: true)
+        let now = Date()
+        let oneHourAgo = now.addingTimeInterval(-3600)
+        let oneHourFromNow = now.addingTimeInterval(3600)
+
+        let e1 = AuditLogEntry(action: .wouldMerge, prNumber: 42, timestamp: oneHourAgo)
+        let e2 = AuditLogEntry(action: .hold, prNumber: 43, timestamp: now)
+        let e3 = AuditLogEntry(action: .escalate, prNumber: 44, timestamp: oneHourFromNow)
+
+        try await db.audit.logAction(e1)
+        try await db.audit.logAction(e2)
+        try await db.audit.logAction(e3)
+
+        let recent = try await db.audit.list(since: now, until: oneHourFromNow)
+
+        #expect(recent.count == 2)
+        #expect(recent.contains(where: { $0.action == .hold }))
+        #expect(recent.contains(where: { $0.action == .escalate }))
+        #expect(!recent.contains(where: { $0.action == .wouldMerge }))
+    }
+
+    @Test("List audit entries by action")
+    async func listByAction() throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        try await db.audit.logAction(AuditLogEntry(action: .wouldMerge, prNumber: 1))
+        try await db.audit.logAction(AuditLogEntry(action: .wouldMerge, prNumber: 2))
+        try await db.audit.logAction(AuditLogEntry(action: .hold, prNumber: 3))
+        try await db.audit.logAction(AuditLogEntry(action: .escalate, prNumber: 4))
+
+        let merges = try await db.audit.list(action: .wouldMerge)
+        let holds = try await db.audit.list(action: .hold)
+
+        #expect(merges.count == 2)
+        #expect(holds.count == 1)
+        #expect(merges.allSatisfy { $0.action == .wouldMerge })
+    }
+
+    @Test("Count audit entries by action")
+    async func countByAction() throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        try await db.audit.logAction(AuditLogEntry(action: .wouldMerge, prNumber: 1))
+        try await db.audit.logAction(AuditLogEntry(action: .wouldMerge, prNumber: 2))
+        try await db.audit.logAction(AuditLogEntry(action: .hold, prNumber: 3))
+        try await db.audit.logAction(AuditLogEntry(action: .escalate, prNumber: 4))
+
+        let counts = try await db.audit.countByAction()
+
+        #expect(counts[.wouldMerge] == 2)
+        #expect(counts[.hold] == 1)
+        #expect(counts[.escalate] == 1)
+        #expect(counts[.clearanceVoided] == nil)
+    }
+
+    @Test("Audit entries ordered by timestamp descending")
+    async func entriesOrderedByTimestamp() throws {
+        let db = try TBDDatabase(inMemory: true)
+        let now = Date()
+
+        let e1 = AuditLogEntry(action: .wouldMerge, prNumber: 1, timestamp: now.addingTimeInterval(-10))
+        let e2 = AuditLogEntry(action: .hold, prNumber: 2, timestamp: now)
+        let e3 = AuditLogEntry(action: .escalate, prNumber: 3, timestamp: now.addingTimeInterval(10))
+
+        try await db.audit.logAction(e1)
+        try await db.audit.logAction(e2)
+        try await db.audit.logAction(e3)
+
+        let entries = try await db.audit.list()
+
+        #expect(entries.count == 3)
+        #expect(entries[0].prNumber == 3)  // Most recent first
+        #expect(entries[1].prNumber == 2)
+        #expect(entries[2].prNumber == 1)  // Oldest last
+    }
+
+    @Test("Audit details captured in JSON")
+    async func detailsCapture() throws {
+        let db = try TBDDatabase(inMemory: true)
+        let details = #"{"reason":"high_impact_domain","domain":".nightwatch"}"#
+        let entry = AuditLogEntry(
+            action: .hold,
+            prNumber: 42,
+            repo: "test/repo",
+            details: details
+        )
+
+        try await db.audit.logAction(entry)
+        let retrieved = try await db.audit.get(id: entry.id)
+
+        #expect(retrieved?.details == details)
+    }
+}

--- a/Tests/TBDDaemonTests/ClearanceStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClearanceStoreTests.swift
@@ -7,7 +7,7 @@ import TBDShared
 struct ClearanceStoreTests {
 
     @Test("Insert and retrieve clearance")
-    async func insertAndRetrieve() throws {
+    func insertAndRetrieve() async throws {
         let db = try TBDDatabase(inMemory: true)
         let clearance = Clearance(
             prNumber: 42,
@@ -25,7 +25,7 @@ struct ClearanceStoreTests {
     }
 
     @Test("Void clearance by ID")
-    async func voidByID() throws {
+    func voidByID() async throws {
         let db = try TBDDatabase(inMemory: true)
         let clearance = Clearance(
             prNumber: 42,
@@ -42,7 +42,7 @@ struct ClearanceStoreTests {
     }
 
     @Test("List clearances by PR")
-    async func listByPR() throws {
+    func listByPR() async throws {
         let db = try TBDDatabase(inMemory: true)
 
         let c1 = Clearance(id: "id1", prNumber: 42, repo: "test/repo", clearedWhenSHA: "abc123", clearanceKind: .small_safe)
@@ -62,7 +62,7 @@ struct ClearanceStoreTests {
     }
 
     @Test("Audit trail excludes voided clearances")
-    async func auditTrailExcludesVoided() throws {
+    func auditTrailExcludesVoided() async throws {
         let db = try TBDDatabase(inMemory: true)
 
         let c1 = Clearance(id: "id1", prNumber: 42, repo: "test/repo", clearedWhenSHA: "abc123", clearanceKind: .small_safe)
@@ -78,7 +78,7 @@ struct ClearanceStoreTests {
     }
 
     @Test("Void by SHA affects multiple clearances")
-    async func voidBySHAMultiple() throws {
+    func voidBySHAMultiple() async throws {
         let db = try TBDDatabase(inMemory: true)
 
         let c1 = Clearance(id: "id1", prNumber: 42, repo: "test/repo", clearedWhenSHA: "abc123", clearanceKind: .small_safe)

--- a/Tests/TBDDaemonTests/ClearanceStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClearanceStoreTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("ClearanceStore Integration Tests")
+struct ClearanceStoreTests {
+
+    @Test("Insert and retrieve clearance")
+    async func insertAndRetrieve() throws {
+        let db = try TBDDatabase(inMemory: true)
+        let clearance = Clearance(
+            prNumber: 42,
+            repo: "test/repo",
+            clearedWhenSHA: "abc123",
+            clearanceKind: .small_safe
+        )
+
+        try await db.clearance.insert(clearance)
+        let retrieved = try await db.clearance.get(id: clearance.id)
+
+        #expect(retrieved?.prNumber == 42)
+        #expect(retrieved?.repo == "test/repo")
+        #expect(retrieved?.clearedWhenSHA == "abc123")
+    }
+
+    @Test("Void clearance by ID")
+    async func voidByID() throws {
+        let db = try TBDDatabase(inMemory: true)
+        let clearance = Clearance(
+            prNumber: 42,
+            repo: "test/repo",
+            clearedWhenSHA: "abc123",
+            clearanceKind: .small_safe
+        )
+
+        try await db.clearance.insert(clearance)
+        try await db.clearance.voidByID(clearance.id, reason: "sha_mismatch")
+        let voided = try await db.clearance.get(id: clearance.id)
+
+        #expect(voided?.voidReason == "sha_mismatch")
+    }
+
+    @Test("List clearances by PR")
+    async func listByPR() throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let c1 = Clearance(id: "id1", prNumber: 42, repo: "test/repo", clearedWhenSHA: "abc123", clearanceKind: .small_safe)
+        let c2 = Clearance(id: "id2", prNumber: 42, repo: "test/repo", clearedWhenSHA: "def456", clearanceKind: .preclear)
+        let c3 = Clearance(id: "id3", prNumber: 99, repo: "test/repo", clearedWhenSHA: "xyz789", clearanceKind: .in_channel)
+
+        try await db.clearance.insert(c1)
+        try await db.clearance.insert(c2)
+        try await db.clearance.insert(c3)
+
+        let forPR42 = try await db.clearance.listByPR(42, repo: "test/repo")
+        let forPR99 = try await db.clearance.listByPR(99, repo: "test/repo")
+
+        #expect(forPR42.count == 2)
+        #expect(forPR99.count == 1)
+        #expect(forPR99.first?.prNumber == 99)
+    }
+
+    @Test("Audit trail excludes voided clearances")
+    async func auditTrailExcludesVoided() throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let c1 = Clearance(id: "id1", prNumber: 42, repo: "test/repo", clearedWhenSHA: "abc123", clearanceKind: .small_safe)
+        let c2 = Clearance(id: "id2", prNumber: 43, repo: "test/repo", clearedWhenSHA: "def456", clearanceKind: .preclear, voidReason: "rebased")
+
+        try await db.clearance.insert(c1)
+        try await db.clearance.insert(c2)
+
+        let trail = try await db.clearance.auditTrail()
+
+        #expect(trail.count == 1)
+        #expect(trail.first?.id == "id1")
+    }
+
+    @Test("Void by SHA affects multiple clearances")
+    async func voidBySHAMultiple() throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        let c1 = Clearance(id: "id1", prNumber: 42, repo: "test/repo", clearedWhenSHA: "abc123", clearanceKind: .small_safe)
+        let c2 = Clearance(id: "id2", prNumber: 42, repo: "test/repo", clearedWhenSHA: "abc123", clearanceKind: .preclear)
+        let c3 = Clearance(id: "id3", prNumber: 42, repo: "test/repo", clearedWhenSHA: "def456", clearanceKind: .in_channel)
+
+        try await db.clearance.insert(c1)
+        try await db.clearance.insert(c2)
+        try await db.clearance.insert(c3)
+
+        try await db.clearance.voidBySHA(pr: 42, repo: "test/repo", newSHA: "new999", reason: "rebased")
+
+        let current = try await db.clearance.listByPR(42, repo: "test/repo")
+        let voided = current.filter { $0.voidReason != nil }
+
+        #expect(voided.count == 2, "Expected 2 voided (matching old SHA)")
+        #expect(current.first(where: { $0.id == "id3" })?.voidReason == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ClearanceStoreTests.swift
+++ b/Tests/TBDDaemonTests/ClearanceStoreTests.swift
@@ -89,12 +89,15 @@ struct ClearanceStoreTests {
         try await db.clearance.insert(c2)
         try await db.clearance.insert(c3)
 
-        try await db.clearance.voidBySHA(pr: 42, repo: "test/repo", newSHA: "new999", reason: "rebased")
+        // Head is now def456: clearances pinned to abc123 void; the clearance
+        // granted on the current head (id3) survives — design §7.3.
+        try await db.clearance.voidBySHA(pr: 42, repo: "test/repo", newSHA: "def456", reason: "rebased")
 
         let current = try await db.clearance.listByPR(42, repo: "test/repo")
         let voided = current.filter { $0.voidReason != nil }
 
-        #expect(voided.count == 2, "Expected 2 voided (matching old SHA)")
-        #expect(current.first(where: { $0.id == "id3" })?.voidReason == nil)
+        #expect(voided.count == 2, "Expected 2 voided (pinned to the old SHA)")
+        #expect(current.first(where: { $0.id == "id3" })?.voidReason == nil,
+                "Clearance granted on the current head must survive")
     }
 }

--- a/Tests/TBDDaemonTests/MergeGateTests.swift
+++ b/Tests/TBDDaemonTests/MergeGateTests.swift
@@ -412,4 +412,34 @@ struct NightwatchPolicyTests {
         #expect(policy.testHoldList == [], "Should use default testHoldList")
         #expect(policy.allowRebaseReclearance == false, "Should use default allowRebaseReclearance")
     }
+
+    @Test("Policy file can tighten the size ceiling but never widen past the compiled hard ceiling")
+    func policySizeCeilingClampsToHardCeiling() throws {
+        let tmpDir = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: URL(fileURLWithPath: "/"),
+            create: true
+        ).path
+        defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+
+        let nightwatchDir = (tmpDir as NSString).appendingPathComponent(".nightwatch")
+        try FileManager.default.createDirectory(atPath: nightwatchDir, withIntermediateDirectories: true)
+        let policyPath = (nightwatchDir as NSString).appendingPathComponent("policy.json")
+
+        // Widening attempt (the policy-poisoning vector): clamped to the hard ceiling.
+        try #"{"compiledSizeCeiling": 5000}"#.write(toFile: policyPath, atomically: true, encoding: .utf8)
+        let widened = NightwatchPolicy.load(repoPath: tmpDir)
+        #expect(widened.compiledSizeCeiling == NightwatchPolicy.hardSizeCeiling,
+                "A policy file must never widen the size ceiling past the compiled maximum")
+
+        // Tightening is allowed.
+        try #"{"compiledSizeCeiling": 10}"#.write(toFile: policyPath, atomically: true, encoding: .utf8)
+        let tightened = NightwatchPolicy.load(repoPath: tmpDir)
+        #expect(tightened.compiledSizeCeiling == 10, "A policy file may tighten the ceiling")
+
+        // The memberwise init clamps too (not just the decoder path).
+        let direct = NightwatchPolicy(compiledSizeCeiling: 9999)
+        #expect(direct.compiledSizeCeiling == NightwatchPolicy.hardSizeCeiling)
+    }
 }

--- a/Tests/TBDDaemonTests/MergeGateTests.swift
+++ b/Tests/TBDDaemonTests/MergeGateTests.swift
@@ -293,3 +293,123 @@ struct MergeGateTests {
         #expect(Bool(false), "Expected wouldMerge decision")
     }
 }
+
+@Suite("NightwatchPolicy Unit Tests")
+struct NightwatchPolicyTests {
+
+    @Test("Policy loader: returns conservative defaults when file is absent")
+    func policyLoaderAbsentFile() throws {
+        let tmpDir = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: URL(fileURLWithPath: "/"),
+            create: true
+        ).path
+
+        defer {
+            try? FileManager.default.removeItem(atPath: tmpDir)
+        }
+
+        let policy = NightwatchPolicy.load(repoPath: tmpDir)
+
+        #expect(policy == .conservativeDefaults, "Should return conservative defaults when policy file is absent")
+    }
+
+    @Test("Policy loader: loads valid policy file")
+    func policyLoaderValidFile() throws {
+        let tmpDir = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: URL(fileURLWithPath: "/"),
+            create: true
+        ).path
+
+        defer {
+            try? FileManager.default.removeItem(atPath: tmpDir)
+        }
+
+        // Create .nightwatch directory and policy.json
+        let nightwatchDir = (tmpDir as NSString).appendingPathComponent(".nightwatch")
+        try FileManager.default.createDirectory(atPath: nightwatchDir, withIntermediateDirectories: true)
+
+        let policyJSON = """
+        {
+            "impactMapGlobs": ["**/dangerous/**", "**/critical/**"],
+            "compiledSizeCeiling": 100,
+            "testHoldList": [42, 99],
+            "allowRebaseReclearance": true
+        }
+        """
+
+        let policyPath = (nightwatchDir as NSString).appendingPathComponent("policy.json")
+        try policyJSON.write(toFile: policyPath, atomically: true, encoding: .utf8)
+
+        let policy = NightwatchPolicy.load(repoPath: tmpDir)
+
+        #expect(policy.impactMapGlobs == ["**/dangerous/**", "**/critical/**"], "Should load impactMapGlobs")
+        #expect(policy.compiledSizeCeiling == 100, "Should load compiledSizeCeiling")
+        #expect(policy.testHoldList == [42, 99], "Should load testHoldList")
+        #expect(policy.allowRebaseReclearance == true, "Should load allowRebaseReclearance")
+    }
+
+    @Test("Policy loader: returns conservative defaults on malformed JSON")
+    func policyLoaderMalformedFile() throws {
+        let tmpDir = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: URL(fileURLWithPath: "/"),
+            create: true
+        ).path
+
+        defer {
+            try? FileManager.default.removeItem(atPath: tmpDir)
+        }
+
+        // Create .nightwatch directory with malformed policy.json
+        let nightwatchDir = (tmpDir as NSString).appendingPathComponent(".nightwatch")
+        try FileManager.default.createDirectory(atPath: nightwatchDir, withIntermediateDirectories: true)
+
+        let malformedJSON = "{ invalid json ]"
+        let policyPath = (nightwatchDir as NSString).appendingPathComponent("policy.json")
+        try malformedJSON.write(toFile: policyPath, atomically: true, encoding: .utf8)
+
+        let policy = NightwatchPolicy.load(repoPath: tmpDir)
+
+        #expect(policy == .conservativeDefaults, "Should return conservative defaults on malformed JSON")
+    }
+
+    @Test("Policy loader: handles partial policy file with defaults")
+    func policyLoaderPartialFile() throws {
+        let tmpDir = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: URL(fileURLWithPath: "/"),
+            create: true
+        ).path
+
+        defer {
+            try? FileManager.default.removeItem(atPath: tmpDir)
+        }
+
+        // Create .nightwatch directory with partial policy.json
+        let nightwatchDir = (tmpDir as NSString).appendingPathComponent(".nightwatch")
+        try FileManager.default.createDirectory(atPath: nightwatchDir, withIntermediateDirectories: true)
+
+        // Only provide impactMapGlobs; let other fields use defaults
+        let partialJSON = """
+        {
+            "impactMapGlobs": ["**/custom/**"]
+        }
+        """
+
+        let policyPath = (nightwatchDir as NSString).appendingPathComponent("policy.json")
+        try partialJSON.write(toFile: policyPath, atomically: true, encoding: .utf8)
+
+        let policy = NightwatchPolicy.load(repoPath: tmpDir)
+
+        #expect(policy.impactMapGlobs == ["**/custom/**"], "Should load custom impactMapGlobs")
+        #expect(policy.compiledSizeCeiling == 50, "Should use default compiledSizeCeiling")
+        #expect(policy.testHoldList == [], "Should use default testHoldList")
+        #expect(policy.allowRebaseReclearance == false, "Should use default allowRebaseReclearance")
+    }
+}

--- a/Tests/TBDDaemonTests/MergeGateTests.swift
+++ b/Tests/TBDDaemonTests/MergeGateTests.swift
@@ -271,6 +271,30 @@ struct MergeGateTests {
         #expect(Bool(false), "Expected conservative policy to hold scripts/**")
     }
 
+    @Test("Glob translation: **/ matches repo-root paths and nesting; * stays within a segment")
+    func globTranslationSemantics() {
+        // The regression: cascading replacements meant "**/x/**" could NEVER
+        // match a repo-root "x/..." path, silently no-opping the default holds.
+        let cases: [(glob: String, path: String, matches: Bool)] = [
+            ("**/.nightwatch/**", ".nightwatch/policy.json", true),   // root-level
+            ("**/.nightwatch/**", "a/b/.nightwatch/policy.json", true),
+            ("**/scripts/**", "scripts/ci/deploy.sh", true),          // root-level
+            ("**/scripts/**", "tools/scripts/x.sh", true),
+            ("**/scripts/**", "Sources/main.swift", false),
+            ("**/.claude/**", ".claude/settings.json", true),
+            ("src/*.swift", "src/main.swift", true),
+            ("src/*.swift", "src/nested/main.swift", false),          // * ≠ cross-segment
+        ]
+        for c in cases {
+            let pattern = MergeGate.globToRegexPattern(c.glob)
+            let regex = try? NSRegularExpression(pattern: pattern)
+            let hit = regex.map {
+                $0.firstMatch(in: c.path, range: NSRange(c.path.startIndex..., in: c.path)) != nil
+            } ?? false
+            #expect(hit == c.matches, "\(c.glob) vs \(c.path): expected \(c.matches), got \(hit) (pattern: \(pattern))")
+        }
+    }
+
     // MARK: - Decision Type Tests
 
     @Test("wouldMerge decision includes clearance ID")
@@ -347,7 +371,9 @@ struct NightwatchPolicyTests {
         let policy = NightwatchPolicy.load(repoPath: tmpDir)
 
         #expect(policy.impactMapGlobs == ["**/dangerous/**", "**/critical/**"], "Should load impactMapGlobs")
-        #expect(policy.compiledSizeCeiling == 100, "Should load compiledSizeCeiling")
+        // 100 in the file exceeds the compiled hard ceiling → clamped to 50.
+        #expect(policy.compiledSizeCeiling == NightwatchPolicy.hardSizeCeiling,
+                "Ceiling above the compiled max must clamp, never widen")
         #expect(policy.testHoldList == [42, 99], "Should load testHoldList")
         #expect(policy.allowRebaseReclearance == true, "Should load allowRebaseReclearance")
     }

--- a/Tests/TBDDaemonTests/MergeGateTests.swift
+++ b/Tests/TBDDaemonTests/MergeGateTests.swift
@@ -1,0 +1,295 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("MergeGate Unit Tests")
+struct MergeGateTests {
+
+    // MARK: - Safety Floor Tests
+
+    @Test("Safety floor: passes with valid approval and clean checks")
+    func safetyFloorPass() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true,
+            approvedSHA: "abc123"
+        )
+        let decision = gate.evaluate(input: input)
+
+        #expect(
+            if case .wouldMerge = decision { true } else { false },
+            "Expected wouldMerge decision for valid input"
+        )
+    }
+
+    @Test("Safety floor: fails for draft PR")
+    func safetyFloorFailsDraft() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: true,
+            hasApprovedReview: true,
+            checksClean: true
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .escalate(let reason) = decision {
+            if case .safetyFloorFailed = reason {
+                return
+            }
+        }
+        #expect(Bool(false), "Expected escalate due to draft status")
+    }
+
+    @Test("Safety floor: fails without approved review")
+    func safetyFloorFailsNoApproval() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: false,
+            checksClean: true
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .escalate(let reason) = decision {
+            if case .safetyFloorFailed(let detail) = reason {
+                #expect(detail.contains("claude-review"), "Expected approval error")
+                return
+            }
+        }
+        #expect(Bool(false), "Expected escalate due to missing approval")
+    }
+
+    @Test("Safety floor: fails with mismatched approval SHA")
+    func safetyFloorFailsSHAMismatch() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true,
+            approvedSHA: "def456"
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .escalate(let reason) = decision {
+            if case .safetyFloorFailed = reason {
+                return
+            }
+        }
+        #expect(Bool(false), "Expected escalate due to SHA mismatch")
+    }
+
+    @Test("Safety floor: fails when checks not clean")
+    func safetyFloorFailsChecks() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: false
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .escalate(let reason) = decision {
+            if case .safetyFloorFailed = reason {
+                return
+            }
+        }
+        #expect(Bool(false), "Expected escalate due to failing checks")
+    }
+
+    // MARK: - Hard Holds Tests
+
+    @Test("Hard hold: test-hold list")
+    func hardHoldTestHoldList() {
+        let policy = NightwatchPolicy(testHoldList: [42, 100, 200])
+        let gate = MergeGate(policy: policy)
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .hold(let reason) = decision {
+            if case .testHold = reason {
+                return
+            }
+        }
+        #expect(Bool(false), "Expected hold for PR on test-hold list")
+    }
+
+    @Test("Hard hold: self-modifying CI")
+    func hardHoldSelfModifyingCI() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true,
+            touchesCI: true
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .hold(let reason) = decision {
+            if case .selfModifyingChecks = reason {
+                return
+            }
+        }
+        #expect(Bool(false), "Expected hold for self-modifying CI")
+    }
+
+    @Test("Hard hold: high-impact domain (glob matching)")
+    func hardHoldHighImpactDomain() {
+        let policy = NightwatchPolicy(
+            impactMapGlobs: ["**/.nightwatch/**", "**/.claude/**"]
+        )
+        let gate = MergeGate(policy: policy)
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true,
+            files: ["sources/main.swift", ".nightwatch/policy.json", "README.md"]
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .hold(let reason) = decision {
+            if case .highImpactDomain = reason {
+                return
+            }
+        }
+        #expect(Bool(false), "Expected hold for high-impact domain")
+    }
+
+    @Test("Hard hold: inadequate test coverage (runtime without tests)")
+    func hardHoldInadequateTestCoverage() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true,
+            files: ["Sources/main.swift", "README.md"]  // Runtime changes, no tests
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .hold(let reason) = decision {
+            if case .inadequateTestCoverage = reason {
+                return
+            }
+        }
+        #expect(Bool(false), "Expected hold for inadequate test coverage")
+    }
+
+    @Test("Hard hold: adequate test coverage (runtime with tests)")
+    func noHoldWithAdequateTestCoverage() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true,
+            files: ["Sources/main.swift", "Tests/mainTests.swift"]
+        )
+        let decision = gate.evaluate(input: input)
+
+        #expect(
+            if case .wouldMerge = decision { true } else { false },
+            "Expected wouldMerge when test coverage is adequate"
+        )
+    }
+
+    @Test("Hard hold: doc-only changes (no test requirement)")
+    func noHoldDocOnlyChanges() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true,
+            files: ["README.md", "docs/guide.md"]
+        )
+        let decision = gate.evaluate(input: input)
+
+        #expect(
+            if case .wouldMerge = decision { true } else { false },
+            "Expected wouldMerge for doc-only changes"
+        )
+    }
+
+    // MARK: - Policy Tests
+
+    @Test("Conservative defaults applied when using default policy")
+    func conservativePolicyDefaults() {
+        let gate = MergeGate()  // Uses conservativeDefaults
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true,
+            files: ["scripts/deploy.sh"]  // Matches conservative default impact map
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .hold(let reason) = decision {
+            if case .highImpactDomain = reason {
+                return
+            }
+        }
+        #expect(Bool(false), "Expected conservative policy to hold scripts/**")
+    }
+
+    // MARK: - Decision Type Tests
+
+    @Test("wouldMerge decision includes clearance ID")
+    func wouldMergeDecision() {
+        let gate = MergeGate()
+        let input = GateInput(
+            prNumber: 100,
+            repo: "test/repo",
+            headSHA: "abc123",
+            isDraft: false,
+            hasApprovedReview: true,
+            checksClean: true
+        )
+        let decision = gate.evaluate(input: input)
+
+        if case .wouldMerge(let clearanceID) = decision {
+            #expect(!clearanceID.isEmpty, "Clearance ID should not be empty")
+            return
+        }
+        #expect(Bool(false), "Expected wouldMerge decision")
+    }
+}

--- a/Tests/TBDDaemonTests/MergeGateTests.swift
+++ b/Tests/TBDDaemonTests/MergeGateTests.swift
@@ -22,10 +22,10 @@ struct MergeGateTests {
         )
         let decision = gate.evaluate(input: input)
 
-        #expect(
-            if case .wouldMerge = decision { true } else { false },
-            "Expected wouldMerge decision for valid input"
-        )
+        guard case .wouldMerge = decision else {
+            Issue.record("Expected wouldMerge decision for valid input, got \(decision)")
+            return
+        }
     }
 
     @Test("Safety floor: fails for draft PR")
@@ -221,10 +221,10 @@ struct MergeGateTests {
         )
         let decision = gate.evaluate(input: input)
 
-        #expect(
-            if case .wouldMerge = decision { true } else { false },
-            "Expected wouldMerge when test coverage is adequate"
-        )
+        guard case .wouldMerge = decision else {
+            Issue.record("Expected wouldMerge when test coverage is adequate, got \(decision)")
+            return
+        }
     }
 
     @Test("Hard hold: doc-only changes (no test requirement)")
@@ -241,10 +241,10 @@ struct MergeGateTests {
         )
         let decision = gate.evaluate(input: input)
 
-        #expect(
-            if case .wouldMerge = decision { true } else { false },
-            "Expected wouldMerge for doc-only changes"
-        )
+        guard case .wouldMerge = decision else {
+            Issue.record("Expected wouldMerge for doc-only changes, got \(decision)")
+            return
+        }
     }
 
     // MARK: - Policy Tests

--- a/Tests/TBDDaemonTests/MigrationTests_Nightwatch.swift
+++ b/Tests/TBDDaemonTests/MigrationTests_Nightwatch.swift
@@ -61,7 +61,7 @@ struct MigrationTests_Nightwatch {
     }
 
     @Test("Clearance table has correct primary key")
-    func clearancePrimaryKey() throws {
+    func clearancePrimaryKey() async throws {
         let db = try TBDDatabase(inMemory: true)
 
         // Insert a record
@@ -93,7 +93,7 @@ struct MigrationTests_Nightwatch {
     }
 
     @Test("Audit log table allows multiple entries")
-    func auditLogAllowsMultiple() throws {
+    func auditLogAllowsMultiple() async throws {
         let db = try TBDDatabase(inMemory: true)
 
         try await db.audit.logAction(AuditLogEntry(action: .wouldMerge, prNumber: 1))

--- a/Tests/TBDDaemonTests/MigrationTests_Nightwatch.swift
+++ b/Tests/TBDDaemonTests/MigrationTests_Nightwatch.swift
@@ -34,7 +34,7 @@ struct MigrationTests_Nightwatch {
         #expect(columnNames.contains("void_reason"))
     }
 
-    @Test("v40_audit_log migration creates table with correct schema")
+    @Test("v42_audit_log migration creates table with correct schema")
     func v40AuditLogSchema() throws {
         let db = try TBDDatabase(inMemory: true)
 

--- a/Tests/TBDDaemonTests/MigrationTests_Nightwatch.swift
+++ b/Tests/TBDDaemonTests/MigrationTests_Nightwatch.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import GRDB
+import TBDShared
+
+@Suite("Nightwatch Migrations")
+struct MigrationTests_Nightwatch {
+
+    @Test("v39_clearance migration creates table with correct schema")
+    func v39ClearanceSchema() throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        // Verify table exists
+        let tableExists = try db.writerForTests.read { db in
+            try db.tableExists("clearance")
+        }
+        #expect(tableExists, "clearance table should exist after migration")
+
+        // Verify columns exist
+        let columns = try db.writerForTests.read { db in
+            try db.columns(in: "clearance")
+        }
+        let columnNames = Set(columns.map { $0.name })
+
+        #expect(columnNames.contains("id"))
+        #expect(columnNames.contains("pr_number"))
+        #expect(columnNames.contains("repo"))
+        #expect(columnNames.contains("cleared_when_sha"))
+        #expect(columnNames.contains("pr_state_at_clear"))
+        #expect(columnNames.contains("clearance_kind"))
+        #expect(columnNames.contains("granted_by"))
+        #expect(columnNames.contains("granted_at"))
+        #expect(columnNames.contains("void_reason"))
+    }
+
+    @Test("v40_audit_log migration creates table with correct schema")
+    func v40AuditLogSchema() throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        // Verify table exists
+        let tableExists = try db.writerForTests.read { db in
+            try db.tableExists("audit_log")
+        }
+        #expect(tableExists, "audit_log table should exist after migration")
+
+        // Verify columns exist
+        let columns = try db.writerForTests.read { db in
+            try db.columns(in: "audit_log")
+        }
+        let columnNames = Set(columns.map { $0.name })
+
+        #expect(columnNames.contains("id"))
+        #expect(columnNames.contains("action"))
+        #expect(columnNames.contains("pr_number"))
+        #expect(columnNames.contains("repo"))
+        #expect(columnNames.contains("head_sha"))
+        #expect(columnNames.contains("merge_commit"))
+        #expect(columnNames.contains("ts"))
+        #expect(columnNames.contains("details"))
+    }
+
+    @Test("Clearance table has correct primary key")
+    func clearancePrimaryKey() throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        // Insert a record
+        let clearance = Clearance(
+            id: "test-id",
+            prNumber: 1,
+            repo: "test/repo",
+            clearedWhenSHA: "abc123",
+            clearanceKind: .small_safe
+        )
+        try await db.clearance.insert(clearance)
+
+        // Attempt to insert duplicate - should fail due to PK constraint
+        let duplicate = Clearance(
+            id: "test-id",
+            prNumber: 2,
+            repo: "test/repo",
+            clearedWhenSHA: "def456",
+            clearanceKind: .preclear
+        )
+
+        var threwError = false
+        do {
+            try await db.clearance.insert(duplicate)
+        } catch {
+            threwError = true
+        }
+        #expect(threwError, "Inserting duplicate ID should fail")
+    }
+
+    @Test("Audit log table allows multiple entries")
+    func auditLogAllowsMultiple() throws {
+        let db = try TBDDatabase(inMemory: true)
+
+        try await db.audit.logAction(AuditLogEntry(action: .wouldMerge, prNumber: 1))
+        try await db.audit.logAction(AuditLogEntry(action: .hold, prNumber: 2))
+        try await db.audit.logAction(AuditLogEntry(action: .escalate, prNumber: 3))
+
+        let entries = try await db.audit.list()
+        #expect(entries.count == 3)
+    }
+}


### PR DESCRIPTION
Phase 1 of the Nightwatch/Daywatch design (#338): the daemon can now **evaluate** the merge gate and **record** what it would do — while merging **nothing**. No code path calls `gh pr merge`. This is the observe-only trust period from design §11/§17.

- **PR metadata**: `PRStatus` gains optional `files`/`commits`/`authorWorktreeID`
- **Clearance ledger** (v39): SHA-pinned clearances with typed `ClearanceKind`, void tracking (`voidBySHA`)
- **Audit log** (v40): typed `AuditAction` entries, mirrored to os.Logger (`nightwatch.audit`)
- **MergeGate**: pure evaluator — fail-closed safety floor (approved-on-head, checks clean+non-empty, not draft), hard holds on **impact + test-adequacy** (impact-map globs, no-tests-with-runtime-changes, test-holds, self-modifying CI), typed `GateDecision/HoldReason/EscalateReason`
- **Policy loader**: `.nightwatch/policy.json` → typed `NightwatchPolicy`; absent → conservative defaults, malformed → defaults + one warning; **size ceiling clamped to a compiled hard max** — a policy edit can tighten but never widen the merge set (§7.1 policy-poisoning guard, with tests)
- **Surfacing**: gate evaluation hooks the existing PR-refresh path (no new poller) when mode ≠ off; `nightwatch.report` RPC + `tbd nightwatch report [--since] [--action] [--json]`
- Tests: every gate branch, stores (in-memory DB), migrations, policy load/clamp

Phase 1 inputs are deliberately conservative (approval/checks not yet deep-fetched → most PRs escalate); Phase 1.5 enriches inputs before any real merge path exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)