### PR TITLE
Accounts follow-ups: dwell-gated hover cards, two-line usage rows, in-place account switch

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -273,15 +273,34 @@ extension AppState {
     }
 
     /// Swap the model profile associated with a running terminal.
-    /// The daemon forks a new tmux tab; this method adds the new terminal and tab to local state
-    /// and selects it so the UI switches immediately.
-    func swapTerminalProfile(terminalID: UUID, newProfileID: UUID?) async {
+    ///
+    /// `.inPlace` (default, "Switch account"): the daemon respawns the SAME
+    /// tmux window/terminal row under the new profile. The row is updated in
+    /// place via the `terminalProfileChanged` delta — no new tab is created, so
+    /// this method just fires the RPC and lets the delta reconcile local state.
+    ///
+    /// `.fork` ("Fork session"): the daemon forks the conversation into a NEW
+    /// tab/terminal row; this method appends it to local state and selects it.
+    func swapTerminalProfile(
+        terminalID: UUID,
+        newProfileID: UUID?,
+        mode: TerminalSwapMode = .inPlace
+    ) async {
         do {
             let size = mainAreaTerminalSize()
-            let newTerminal = try await daemonClient.swapTerminalProfile(terminalID: terminalID, newProfileID: newProfileID, cols: size.cols, rows: size.rows)
-            let worktreeID = newTerminal.worktreeID
-            terminals[worktreeID, default: []].append(newTerminal)
-            let newTab = Tab(id: newTerminal.id, content: .terminal(terminalID: newTerminal.id))
+            let resultTerminal = try await daemonClient.swapTerminalProfile(
+                terminalID: terminalID, newProfileID: newProfileID,
+                mode: mode, cols: size.cols, rows: size.rows
+            )
+            guard mode == .fork else {
+                // In-place: same tab/row. The `terminalProfileChanged` +
+                // `terminalSessionUpdated` deltas already reconciled the row;
+                // nothing to add or re-select here.
+                return
+            }
+            let worktreeID = resultTerminal.worktreeID
+            terminals[worktreeID, default: []].append(resultTerminal)
+            let newTab = Tab(id: resultTerminal.id, content: .terminal(terminalID: resultTerminal.id))
             tabs[worktreeID, default: []].append(newTab)
             setActiveTab(worktreeID: worktreeID, tabIndex: (tabs[worktreeID]?.count ?? 1) - 1)
         } catch {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -849,6 +849,8 @@ final class AppState: ObservableObject {
             applyTerminalCreatedDelta(d)
         case .terminalActivityUpdated(let d):
             applyTerminalActivityDelta(d)
+        case .terminalProfileChanged(let d):
+            applyTerminalProfileDelta(d)
         case .worktreeMoved(let d):
             applyWorktreeMovedDelta(d)
         case .worktreeArchived(let d):
@@ -908,6 +910,15 @@ final class AppState: ObservableObject {
             return
         }
         terminals[delta.worktreeID]?[idx].activityState = delta.activityState
+    }
+
+    /// Seamless in-place "Switch account": the terminal row is unchanged except
+    /// its `profileID`, so update it in place and the account chip re-renders.
+    private func applyTerminalProfileDelta(_ delta: TerminalProfileDelta) {
+        guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
+            return
+        }
+        terminals[delta.worktreeID]?[idx].profileID = delta.newProfileID
     }
 
     /// Update the in-place usage entry for a single profile. If no match,

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -71,35 +71,148 @@ struct HoverCardModel: Equatable {
 
 // MARK: - Timing
 
-/// Hover timing knobs, injectable for tests. The show-delay decision is a
-/// pure function so the "warm" fast-path is testable without a panel.
+/// Hover timing knobs, injectable for tests.
+///
+/// ## Adopted hover-card timing rules (research-backed)
+///
+/// Distilled from Apple HIG "Offering help" (help-tag display speed is a
+/// deliberate, preference-tunable delay — default ~1.5s), Microsoft Fluent
+/// (~300ms entrance delay, reduced for adjacent items), NN/g's hover-reveal
+/// pattern, and the classic "hover intent" / safe-triangle work:
+///
+/// 1. INTENT, NOT PROXIMITY. Show only when the pointer signals it wants the
+///    card — never merely because it crossed the anchor. A cursor sweeping to
+///    another row must show nothing.
+/// 2. DWELL-GATE THE SHOW. Require the pointer to come to REST over the anchor
+///    (movement below a small threshold for a rest window, ~150–250ms) — this
+///    is the "pointer at rest" signal. Any significant movement RESETS the rest
+///    timer (movement-resets-timer / hover-intent).
+/// 3. MINIMUM COLD DELAY. Independently, hold for a floor delay (~0.5s, the
+///    upper end of the 300–500ms consensus) before a cold card can appear, so a
+///    momentary pause mid-traversal is not enough. Show = floor elapsed AND at
+///    rest.
+/// 4. REDUCED (not zero) DELAY FOR ADJACENT ITEMS. Once a card is up, swapping
+///    to a sibling should feel responsive but must NOT chase the cursor: still
+///    require a short at-rest dwell (~150ms) before swapping. Deliberate
+///    row-to-row comparison stays fluid; a sweep reveals nothing.
+/// 5. WARM GRACE. Briefly after a card hides, a re-hover is still "warm" and
+///    uses the short warm dwell instead of the full cold floor — but it, too,
+///    requires the pointer to settle (no instant chase).
+/// 6. QUICK, ASYMMETRIC FADE-OUT. Dismiss faster than we show (fade < show
+///    delay) so leaving feels immediate while entering feels intentional.
+///
+/// The show decision is factored into a pure `HoverDwellReducer` so the whole
+/// state machine (rest gating, floor delay, warm swap) is unit-testable
+/// without a panel or any NSEvent plumbing.
 struct HoverCardTiming: Equatable {
-    /// Delay before a card appears on a cold hover. Snappier than the
-    /// system tooltip default, but slow enough not to flicker on drive-by
-    /// mouse moves.
+    /// Minimum cold-hover floor: a fresh card cannot appear before this
+    /// elapses since the pointer entered, even if it settles sooner. Upper end
+    /// of the 300–500ms industry consensus (rule 3).
     var showDelay: TimeInterval
-    /// After a card hides, hovers within this window skip the show delay —
-    /// moving between sibling rows swaps content instantly (menu-like feel).
+    /// The pointer must stay below `movementThreshold` for this long — "at
+    /// rest" — before a cold card shows (rule 2). Any larger move resets it.
+    var restWindow: TimeInterval
+    /// Per-move distance (in points) under which the pointer counts as "at
+    /// rest". Small jitter does not reset the dwell; a real traversal does.
+    var movementThreshold: CGFloat
+    /// At-rest dwell required before swapping the visible card to a sibling, or
+    /// re-showing during the warm grace. Short enough to feel responsive,
+    /// long enough that a sweep never triggers a swap (rule 4/5).
+    var warmDwell: TimeInterval
+    /// After a card hides, re-hovers within this window are "warm": they use
+    /// `warmDwell` instead of the full cold floor (rule 5).
     var warmGrace: TimeInterval
-    /// Fade-out duration when the pointer leaves.
+    /// Fade-out duration when the pointer leaves. Kept below `showDelay` so
+    /// dismissal feels quicker than appearance (rule 6).
     var fadeOutDuration: TimeInterval
 
-    init(showDelay: TimeInterval = 0.35,
-         warmGrace: TimeInterval = 0.35,
+    init(showDelay: TimeInterval = 0.55,
+         restWindow: TimeInterval = 0.18,
+         movementThreshold: CGFloat = 3,
+         warmDwell: TimeInterval = 0.15,
+         warmGrace: TimeInterval = 0.4,
          fadeOutDuration: TimeInterval = 0.12) {
         self.showDelay = showDelay
+        self.restWindow = restWindow
+        self.movementThreshold = movementThreshold
+        self.warmDwell = warmDwell
         self.warmGrace = warmGrace
         self.fadeOutDuration = fadeOutDuration
     }
 
     static let standard = HoverCardTiming()
+}
 
-    /// 0 when a card is already up (swap instantly) or one hid moments ago
-    /// (warm), otherwise the full show delay.
-    func effectiveShowDelay(now: Date, lastDismissedAt: Date?, isCardVisible: Bool) -> TimeInterval {
-        if isCardVisible { return 0 }
-        if let lastDismissedAt, now.timeIntervalSince(lastDismissedAt) < warmGrace { return 0 }
-        return showDelay
+// MARK: - Dwell reducer
+
+/// Pure, panel-free state machine deciding WHEN a hover card should show for
+/// one anchor. Fed pointer events (enter / move / a periodic tick) plus the
+/// ambient warm-state (is a card already visible, when one last hid); returns
+/// `true` from `shouldShow` exactly once the dwell gate opens.
+///
+/// Two independent gates must both pass before a cold card shows:
+///  - FLOOR: at least `showDelay` has elapsed since the pointer entered.
+///  - REST: the pointer has stayed below `movementThreshold` for `restWindow`.
+///
+/// When a card is already visible (swap) or one hid within `warmGrace` (warm),
+/// the floor collapses to 0 and only a short `warmDwell` at-rest is required —
+/// responsive row-to-row comparison without chasing the cursor.
+///
+/// Entirely value-typed and clock-injected (`now` is passed in), so tests drive
+/// it with synthetic timestamps — no NSEvent, no timers, no AppKit.
+struct HoverDwellReducer: Equatable {
+    private let timing: HoverCardTiming
+    /// When the pointer entered this anchor. nil once exited.
+    private(set) var enteredAt: Date?
+    /// When the pointer last came to rest (last move, or entry). The rest
+    /// window is measured from here; any significant move pushes it forward.
+    private(set) var restingSince: Date?
+    /// Set once we decide to show, so a satisfied gate fires exactly once.
+    private(set) var didShow = false
+
+    init(timing: HoverCardTiming) {
+        self.timing = timing
+    }
+
+    /// Pointer entered the anchor. `now` is the entry timestamp.
+    mutating func entered(now: Date) {
+        enteredAt = now
+        restingSince = now
+        didShow = false
+    }
+
+    /// Pointer moved by `distance` points since the last position. A move at or
+    /// above the threshold resets the rest clock; sub-threshold jitter does not.
+    mutating func moved(distance: CGFloat, now: Date) {
+        guard enteredAt != nil else { return }
+        if distance >= timing.movementThreshold {
+            restingSince = now
+        }
+    }
+
+    /// Pointer left the anchor — clears all state.
+    mutating func exited() {
+        enteredAt = nil
+        restingSince = nil
+        didShow = false
+    }
+
+    /// Evaluate the gates at `now`. Returns true the first tick both the floor
+    /// and rest gates are open (latched via `didShow` so it fires once). The
+    /// caller passes the ambient warm state; the reducer owns only the dwell.
+    mutating func shouldShow(now: Date, lastDismissedAt: Date?, isCardVisible: Bool) -> Bool {
+        guard !didShow, let enteredAt, let restingSince else { return false }
+
+        let isWarm = isCardVisible
+            || (lastDismissedAt.map { now.timeIntervalSince($0) < timing.warmGrace } ?? false)
+        let floor = isWarm ? 0 : timing.showDelay
+        let requiredRest = isWarm ? timing.warmDwell : timing.restWindow
+
+        let floorElapsed = now.timeIntervalSince(enteredAt) >= floor
+        let atRest = now.timeIntervalSince(restingSince) >= requiredRest
+        guard floorElapsed, atRest else { return false }
+        didShow = true
+        return true
     }
 }
 
@@ -237,17 +350,21 @@ private final class HoverCardPanel: NSPanel {
 // MARK: - Controller
 
 /// One shared panel + the timing state machine. Shared so the "warm" state
-/// spans anchors: once any card is up (or just hid), hovering a sibling swaps
-/// content with no re-delay.
+/// spans anchors: once any card is up (or just hid), hovering a sibling can
+/// swap content on a short dwell instead of the full cold floor.
+///
+/// The per-anchor dwell (rest gating + floor delay) lives in each
+/// `HoverCardAnchorNSView`'s `HoverDwellReducer`; the anchor drives it from
+/// real `mouseMoved` events plus a periodic tick, and calls `requestShow`
+/// only once its gate opens. The controller owns the shared warm state
+/// (`lastDismissedAt`, `isCardVisible`) that the reducer reads.
 @MainActor
 final class HoverCardController {
     static let shared = HoverCardController()
 
-    private let timing: HoverCardTiming
+    let timing: HoverCardTiming
     private var panel: HoverCardPanel?
     private weak var currentAnchor: NSView?
-    private weak var pendingAnchor: NSView?
-    private var pendingShow: Task<Void, Never>?
     private var lastDismissedAt: Date?
     private var lastModel: HoverCardModel?
     /// Bumped on every show/hide; an in-flight fade-out completion only
@@ -310,43 +427,34 @@ final class HoverCardController {
         }
     }
 
-    /// Immediately hide the current card and cancel any pending show, then
-    /// suppress the warm instant-reshow briefly so the tooltip does not pop back
-    /// while a menu is open. Central hook: every `.hoverCard` adopter inherits it.
+    /// Immediately hide the current card, then suppress the warm reshow briefly
+    /// so the tooltip does not pop back while a menu is open. Central hook:
+    /// every `.hoverCard` adopter inherits it.
     func dismissForInteraction() {
-        cancelPendingShow()
         suppressUntil = Date().addingTimeInterval(Self.interactionSuppression)
         hide()
     }
 
-    private var isCardVisible: Bool {
+    var isCardVisible: Bool {
         panel?.isVisible == true && currentAnchor != nil
     }
 
-    func hoverBegan(anchor: NSView, model: HoverCardModel) {
-        cancelPendingShow()
-        // Bail while an interaction dismissal is still suppressing reshow, so a
-        // lingering warm hover can't pop the tooltip back over an open menu.
+    /// Ambient state an anchor's `HoverDwellReducer` needs to decide warm vs.
+    /// cold: is a card up, and when did one last hide. `nil` `lastDismissedAt`
+    /// while suppression is active so a warm reshow can't jump an open menu.
+    func warmState(now: Date = Date()) -> (lastDismissedAt: Date?, isCardVisible: Bool, suppressed: Bool) {
+        let suppressed = suppressUntil.map { now < $0 } ?? false
+        return (suppressed ? nil : lastDismissedAt, isCardVisible, suppressed)
+    }
+
+    /// An anchor's dwell gate has opened — show its card now. No-op while an
+    /// interaction dismissal is still suppressing reshow.
+    func requestShow(anchor: NSView, model: HoverCardModel) {
         if let suppressUntil, Date() < suppressUntil { return }
-        let delay = timing.effectiveShowDelay(
-            now: Date(), lastDismissedAt: lastDismissedAt, isCardVisible: isCardVisible
-        )
-        guard delay > 0 else {
-            show(anchor: anchor, model: model)
-            return
-        }
-        pendingAnchor = anchor
-        pendingShow = Task { [weak self, weak anchor] in
-            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            guard !Task.isCancelled, let self, let anchor else { return }
-            self.show(anchor: anchor, model: model)
-        }
+        show(anchor: anchor, model: model)
     }
 
     func hoverEnded(anchor: NSView) {
-        if pendingAnchor === anchor {
-            cancelPendingShow()
-        }
         if currentAnchor === anchor {
             hide()
         }
@@ -364,14 +472,7 @@ final class HoverCardController {
         apply(model: model, to: panel, anchor: anchor)
     }
 
-    private func cancelPendingShow() {
-        pendingShow?.cancel()
-        pendingShow = nil
-        pendingAnchor = nil
-    }
-
     private func show(anchor: NSView, model: HoverCardModel) {
-        cancelPendingShow()
         guard anchor.window != nil else { return }
         fadeGeneration += 1
         let panel = self.panel ?? HoverCardPanel(model: model)
@@ -436,9 +537,21 @@ final class HoverCardController {
 
 /// Invisible tracking view laid under the modified SwiftUI view. `hitTest`
 /// returns nil so clicks pass straight through; the tracking area still
-/// delivers enter/exit (tracking is owner-routed, not hit-test-routed).
+/// delivers enter/exit/moved (tracking is owner-routed, not hit-test-routed).
+///
+/// Owns a per-anchor `HoverDwellReducer`: `mouseMoved` feeds it real cursor
+/// deltas (movement resets the rest clock), and a lightweight repeating timer
+/// polls the gate while the pointer is inside so a card appears the moment the
+/// pointer settles AND the floor delay has passed — never on a drive-by sweep.
 private final class HoverCardAnchorNSView: NSView {
     var model: HoverCardModel?
+
+    private var reducer = HoverDwellReducer(timing: HoverCardController.shared.timing)
+    private var dwellTimer: Timer?
+    private var lastMouseLocation: NSPoint?
+    /// Poll cadence for the dwell gate — fine enough that the rest window and
+    /// floor delay feel crisp, coarse enough to stay cheap while hovering.
+    private static let pollInterval: TimeInterval = 1.0 / 30.0
 
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
@@ -447,26 +560,79 @@ private final class HoverCardAnchorNSView: NSView {
         trackingAreas.forEach(removeTrackingArea)
         addTrackingArea(NSTrackingArea(
             rect: .zero,
-            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            options: [.mouseEnteredAndExited, .mouseMoved, .activeAlways, .inVisibleRect],
             owner: self,
             userInfo: nil
         ))
     }
 
     override func mouseEntered(with event: NSEvent) {
-        guard let model else { return }
-        HoverCardController.shared.hoverBegan(anchor: self, model: model)
+        guard model != nil else { return }
+        lastMouseLocation = event.locationInWindow
+        reducer.entered(now: Date())
+        startDwellTimer()
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        guard model != nil else { return }
+        let location = event.locationInWindow
+        let distance: CGFloat
+        if let last = lastMouseLocation {
+            distance = hypot(location.x - last.x, location.y - last.y)
+        } else {
+            distance = 0
+        }
+        lastMouseLocation = location
+        reducer.moved(distance: distance, now: Date())
     }
 
     override func mouseExited(with event: NSEvent) {
-        HoverCardController.shared.hoverEnded(anchor: self)
+        endHover()
     }
 
     override func viewWillMove(toWindow newWindow: NSWindow?) {
         super.viewWillMove(toWindow: newWindow)
         if newWindow == nil {
-            HoverCardController.shared.hoverEnded(anchor: self)
+            endHover()
         }
+    }
+
+    /// Poll the dwell gate; once it opens, show the card and stop the timer
+    /// (the reducer latches, so it won't re-fire until the next enter).
+    private func startDwellTimer() {
+        dwellTimer?.invalidate()
+        let timer = Timer(timeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.evaluateDwell()
+            }
+        }
+        // Common mode so the poll keeps ticking during scrolls/tracking loops.
+        RunLoop.main.add(timer, forMode: .common)
+        dwellTimer = timer
+    }
+
+    private func evaluateDwell() {
+        guard let model else {
+            endHover()
+            return
+        }
+        let controller = HoverCardController.shared
+        let warm = controller.warmState()
+        if reducer.shouldShow(now: Date(),
+                              lastDismissedAt: warm.lastDismissedAt,
+                              isCardVisible: warm.isCardVisible) {
+            controller.requestShow(anchor: self, model: model)
+            dwellTimer?.invalidate()
+            dwellTimer = nil
+        }
+    }
+
+    private func endHover() {
+        dwellTimer?.invalidate()
+        dwellTimer = nil
+        lastMouseLocation = nil
+        reducer.exited()
+        HoverCardController.shared.hoverEnded(anchor: self)
     }
 }
 
@@ -487,9 +653,12 @@ private struct HoverCardAnchor: NSViewRepresentable {
 
 extension View {
     /// Attach a styled hover card to this view. nil model = no card (mirrors
-    /// the empty-string `.help()` idiom). Fast: ~0.35s cold show delay,
-    /// instant swap while a card is up or just after one hid, quick fade-out.
-    /// Never steals keyboard focus (non-activating borderless panel).
+    /// the empty-string `.help()` idiom). Dwell-gated: a cold card appears only
+    /// once the pointer has settled over the anchor AND the ~0.55s floor delay
+    /// has passed, so a cursor merely sweeping past shows nothing. While a card
+    /// is up (or one hid moments ago), swapping to a sibling needs only a short
+    /// at-rest dwell — fluid comparison without chasing the cursor. Quick
+    /// fade-out; never steals keyboard focus (non-activating borderless panel).
     func hoverCard(_ model: HoverCardModel?) -> some View {
         background(HoverCardAnchor(model: model))
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1191,11 +1191,24 @@ actor DaemonClient {
     }
 
     /// Swap the model profile associated with a running terminal.
-    /// Returns the newly created Terminal (the daemon forks a new tab).
-    func swapTerminalProfile(terminalID: UUID, newProfileID: UUID?, cols: Int? = nil, rows: Int? = nil) async throws -> Terminal {
+    ///
+    /// `.inPlace` (default) — seamless "Switch account": the daemon respawns the
+    /// SAME tmux window/terminal row under the new profile and returns that
+    /// (unchanged-id) row. `.fork` — the daemon forks the conversation into a
+    /// NEW tab/terminal row and returns the new one.
+    func swapTerminalProfile(
+        terminalID: UUID,
+        newProfileID: UUID?,
+        mode: TerminalSwapMode = .inPlace,
+        cols: Int? = nil,
+        rows: Int? = nil
+    ) async throws -> Terminal {
         return try await callAsync(
             method: RPCMethod.terminalSwapProfile,
-            params: TerminalSwapProfileParams(terminalID: terminalID, newProfileID: newProfileID, cols: cols, rows: rows),
+            params: TerminalSwapProfileParams(
+                terminalID: terminalID, newProfileID: newProfileID,
+                cols: cols, rows: rows, mode: mode
+            ),
             resultType: Terminal.self
         )
     }

--- a/Sources/TBDApp/Helpers/AccountHoverCards.swift
+++ b/Sources/TBDApp/Helpers/AccountHoverCards.swift
@@ -1,61 +1,24 @@
 import Foundation
 import TBDShared
 
-/// Structured hover-card content for the two account/usage hover sites: the
-/// sidebar worktree row (which accounts this worktree's Claude sessions run
-/// on) and the Claude tab (account + live usage + spawn time).
+/// Structured hover-card content for the Claude tab hover site: account + live
+/// usage + spawn time. Pure `HoverCardModel` composition on top of
+/// `ProfileUsagePresentation`'s formatting fragments — unit-testable without
+/// any panel/AppKit machinery. The flat-string
+/// `ProfileUsagePresentation.sessionTooltip` helper remains as the plain-text
+/// form; this structured card supersedes it in the UI.
 ///
-/// Pure `HoverCardModel` composition on top of `ProfileUsagePresentation`'s
-/// formatting fragments — unit-testable without any panel/AppKit machinery.
-/// The flat-string `ProfileUsagePresentation.sessionTooltip` /
-/// `worktreeAccountsTooltip` helpers remain as the plain-text form; these
-/// structured cards supersede them in the UI.
+/// NOTE: The sidebar worktree ROW no longer carries an account hover card —
+/// per-session account facts now live in that row's "…" menu (its info header +
+/// "Switch account"), where they're actionable rather than just informational
+/// (see `RowAccountMenu`). The account-descriptor composition strings below are
+/// shared with the tab card and kept here.
 enum AccountHoverCards {
-    static let worktreeCardTitle = "Claude accounts"
     static let ambientAccountLabel = "ambient (terminal login)"
     static let ambientDriftCaption = "May drift to a different account on token refresh"
     static let removedProfileLabel = "Profile removed"
     static let removedProfileCaption = "Session keeps its spawn account"
     static let notLoggedInCaption = "Not logged in"
-
-    // MARK: - Worktree row card
-
-    /// Sidebar worktree-row card aggregating the accounts of its Claude
-    /// sessions, deduped in tab order. nil when the worktree has no Claude
-    /// sessions (no card).
-    static func worktreeCard(terminals: [Terminal],
-                             profiles: [ModelProfileWithUsage]) -> HoverCardModel? {
-        var rows: [HoverCardRow] = []
-        for terminal in terminals where terminal.kind == .claude || terminal.isClaudeResumable {
-            let row = accountRow(profileID: terminal.profileID, profiles: profiles)
-            if !rows.contains(row) {
-                rows.append(row)
-            }
-        }
-        guard !rows.isEmpty else { return nil }
-        return HoverCardModel(title: worktreeCardTitle, rows: rows)
-    }
-
-    /// One account line: email with a profile-name chip for pinned +
-    /// logged-in sessions; muted-italic "ambient (terminal login)" with the
-    /// drift warning as a caption for NULL-profile legacy sessions.
-    static func accountRow(profileID: UUID?,
-                           profiles: [ModelProfileWithUsage]) -> HoverCardRow {
-        guard let profileID else {
-            return HoverCardRow(value: ambientAccountLabel,
-                                valueStyle: .mutedItalic,
-                                caption: ambientDriftCaption)
-        }
-        guard let entry = profiles.first(where: { $0.profile.id == profileID }) else {
-            return HoverCardRow(value: removedProfileLabel,
-                                valueStyle: .mutedItalic,
-                                caption: removedProfileCaption)
-        }
-        if let identity = ProfileLoginPresentation.normalizedIdentity(entry.loginIdentity) {
-            return HoverCardRow(value: identity, chip: entry.profile.name)
-        }
-        return HoverCardRow(value: entry.profile.name, caption: notLoggedInCaption)
-    }
 
     // MARK: - Claude tab card
 

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -78,6 +78,39 @@ enum ProfileUsagePresentation {
         return String(first).uppercased()
     }
 
+    /// Full family name for the roomier two-line menu secondary line, e.g.
+    /// "Fable". Falls back to "?" when the daemon reported no display name.
+    static func familyName(_ displayName: String?) -> String {
+        let trimmed = displayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "?" : trimmed
+    }
+
+    /// Relative "how long until" a reset, at day/hour granularity: "in 2d 5h",
+    /// "in 5h", "in 43m", "now". The weekly window shows this (rather than an
+    /// absolute clock time like the 5h window) because at week scale the useful
+    /// planning question is time-remaining, not the wall-clock instant. nil
+    /// when there's no reset date to format.
+    ///
+    /// Granularity rules: >= 1 day → "Nd Nh" (hours dropped when zero: "2d");
+    /// >= 1 hour but < 1 day → "Nh"; < 1 hour → "Nm"; already past / <1 min →
+    /// "now". `now` is injectable for deterministic tests.
+    static func relativeResetText(_ date: Date?, now: Date = Date()) -> String? {
+        guard let date else { return nil }
+        let seconds = date.timeIntervalSince(now)
+        guard seconds >= 60 else { return "now" }
+        let totalMinutes = Int(seconds / 60)
+        let days = totalMinutes / (60 * 24)
+        let hours = (totalMinutes % (60 * 24)) / 60
+        let minutes = totalMinutes % 60
+        if days >= 1 {
+            return hours > 0 ? "in \(days)d \(hours)h" : "in \(days)d"
+        }
+        if hours >= 1 {
+            return "in \(hours)h"
+        }
+        return "in \(minutes)m"
+    }
+
     /// Compact usage summary without a leading separator:
     /// "5h 0% ↺23:10 · wk 76% · F 100%". nil when there is no snapshot or it
     /// has no buckets (never logged in / poller hasn't fetched yet).
@@ -118,6 +151,99 @@ enum ProfileUsagePresentation {
                               timeZone: TimeZone = .current) -> String {
         ProfileLoginPresentation.menuItemTitle(for: entry)
             + usageSuffix(for: entry.usageSnapshot, timeZone: timeZone)
+    }
+
+    // MARK: - Two-line menu composition
+
+    /// A menu row rendered on two lines: an identity `primary` ("Name — email")
+    /// and an optional `secondary` usage line drawn smaller and indented
+    /// underneath. `secondary` is nil for profiles with no snapshot (never
+    /// logged in / poller hasn't fetched yet), which keeps their single-line
+    /// identity treatment. All surfaces (the "+" NSMenu, the switch-account
+    /// SwiftUI submenu) compose from `menuLine` so the two-line rules live in
+    /// one place; `menuItemTitle`/`usageSuffix` remain for anything still
+    /// single-line.
+    struct MenuLineModel: Equatable {
+        let primary: String
+        let secondary: String?
+    }
+
+    /// Spelled-out usage line for the roomier second row: "5h 16% used ·
+    /// resets 23:09 · week 79% · resets in 2d 5h · Fable 100%". Unlike
+    /// `usageSummary` this drops the ↺ glyph in favor of "resets " and uses
+    /// full family names instead of the single-letter abbreviation — the
+    /// second line has the width. nil when there is no snapshot or it has no
+    /// buckets.
+    static func usageDetailLine(for snapshot: ProfileUsageSnapshot?,
+                                timeZone: TimeZone = .current,
+                                now: Date = Date()) -> String? {
+        guard let snapshot, !snapshot.buckets.isEmpty else { return nil }
+        var parts: [String] = []
+        // Percentages are UTILIZATION ("% used", matching claude.ai's
+        // phrasing). The word rides the FIRST percentage only — it establishes
+        // the reading for the whole line without per-segment repetition.
+        var usedLabelPending = true
+        func percentPart(_ prefix: String, _ percent: Double) -> String {
+            let label = usedLabelPending ? " used" : ""
+            usedLabelPending = false
+            return "\(prefix) \(percentText(percent))\(label)"
+        }
+        if let session = sessionBucket(snapshot) {
+            var part = percentPart("5h", session.percent)
+            // Reset granularity matches window scale: the 5h window resets
+            // today, so absolute clock time reads best.
+            if let resets = session.resetsAt {
+                part += " · resets \(resetTimeText(resets, timeZone: timeZone))"
+            }
+            parts.append(part)
+        }
+        if let weekly = weeklyAllBucket(snapshot) {
+            var part = percentPart("week", weekly.percent)
+            // The weekly window is a planning horizon — "how long until the
+            // week ends" — so it shows a relative countdown. Weekly buckets
+            // share one reset instant, so it appears once, here.
+            if let resets = weekly.resetsAt,
+               let relative = relativeResetText(resets, now: now) {
+                part += " · resets in \(relative)"
+            }
+            parts.append(part)
+        }
+        for scoped in scopedBuckets(snapshot) {
+            parts.append(percentPart(familyName(scoped.modelDisplayName), scoped.percent))
+        }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: " · ")
+    }
+
+    /// Compact relative countdown for planning-scale resets: "2d 5h", "3h",
+    /// "48m". nil when the instant is not in the future (a stale snapshot
+    /// shouldn't render a nonsense countdown). Minutes appear only under an
+    /// hour; hour-scale drops minutes; day-scale carries the hour remainder.
+    static func relativeResetText(_ resetsAt: Date, now: Date = Date()) -> String? {
+        let interval = resetsAt.timeIntervalSince(now)
+        guard interval > 0 else { return nil }
+        let totalMinutes = Int((interval / 60).rounded(.up))
+        let days = totalMinutes / (24 * 60)
+        let hours = (totalMinutes % (24 * 60)) / 60
+        if days > 0 {
+            return hours > 0 ? "\(days)d \(hours)h" : "\(days)d"
+        }
+        if hours > 0 {
+            return "\(hours)h"
+        }
+        return "\(max(totalMinutes % 60, 1))m"
+    }
+
+    /// Two-line menu-row model for a profile: identity on the primary line,
+    /// spelled-out usage on the secondary line (nil when there's no snapshot).
+    static func menuLine(for entry: ModelProfileWithUsage,
+                         timeZone: TimeZone = .current,
+                         now: Date = Date()) -> MenuLineModel {
+        MenuLineModel(
+            primary: ProfileLoginPresentation.menuItemTitle(for: entry),
+            secondary: usageDetailLine(for: entry.usageSnapshot,
+                                       timeZone: timeZone, now: now)
+        )
     }
 
     // MARK: - Picker ordering & row state

--- a/Sources/TBDApp/Helpers/RowAccountMenu.swift
+++ b/Sources/TBDApp/Helpers/RowAccountMenu.swift
@@ -57,8 +57,20 @@ enum RowAccountMenu {
         /// Switch-account destinations, ordered for the picker (healthiest
         /// selectable first, not-logged-in last).
         let switchTargets: [SwitchTarget]
+        /// True when the session is mid-run (activityState == .working). The
+        /// seamless switch interrupts the current run, so the submenu footer
+        /// warns about it. Cheap advisory; no confirm dialog for v1.
+        let isBusy: Bool
 
         var id: UUID { terminalID }
+
+        /// Per-session submenu footer: the shared switch caption, plus an
+        /// interrupt warning when the session is mid-run.
+        var switchFooter: String {
+            isBusy
+                ? "\(RowAccountMenu.switchAccountCaption) \(RowAccountMenu.interruptsRunSuffix)"
+                : RowAccountMenu.switchAccountCaption
+        }
     }
 
     /// Whole-menu model: the worktree's Claude sessions (each with its own
@@ -85,8 +97,14 @@ enum RowAccountMenu {
 
     static let switchAccountLabel = "Switch account"
     static let notLoggedInReason = "run /login first"
+    /// Whole-menu footer under the account section.
     static let footerCaption =
-        "Switching forks the session onto the new account — its context re-reads uncached once."
+        "Switching account resumes this session in place on the new account — its context re-reads uncached once."
+    /// Per-session "Switch account" submenu caption.
+    static let switchAccountCaption =
+        "Resumes in this tab on the new account."
+    /// Appended to the submenu caption when the session is mid-run.
+    static let interruptsRunSuffix = "— interrupts current run"
 
     // MARK: - Composition
 
@@ -121,7 +139,8 @@ enum RowAccountMenu {
             ),
             switchTargets: switchTargets(currentProfileID: terminal.profileID,
                                          profiles: profiles,
-                                         timeZone: timeZone)
+                                         timeZone: timeZone),
+            isBusy: terminal.activityState == .working
         )
     }
 

--- a/Sources/TBDApp/Helpers/RowAccountMenu.swift
+++ b/Sources/TBDApp/Helpers/RowAccountMenu.swift
@@ -21,8 +21,10 @@ enum RowAccountMenu {
         /// concrete profile (ambient is not offered as a switch destination
         /// here; the info header already names it).
         let profileID: UUID
-        /// "Work — a@b.co · 5h 0% ↺23:10 · wk 76% · F 100%".
-        let title: String
+        /// Two-line row content: "Work — a@b.co" over an indented, spelled-out
+        /// usage line ("5h 0% · resets 23:10 · wk 76% · Fable 100%"). The
+        /// secondary line is nil for not-logged-in / snapshotless profiles.
+        let line: ProfileUsagePresentation.MenuLineModel
         /// True when this profile is the session's current account: shown with
         /// a checkmark and disabled (no-op swap).
         let isCurrent: Bool
@@ -144,7 +146,7 @@ enum RowAccountMenu {
             let isCurrent = entry.profile.id == currentProfileID
             return SwitchTarget(
                 profileID: entry.profile.id,
-                title: ProfileUsagePresentation.menuItemTitle(for: entry, timeZone: timeZone),
+                line: ProfileUsagePresentation.menuLine(for: entry, timeZone: timeZone),
                 isCurrent: isCurrent,
                 isSelectable: selectable,
                 disabledReason: selectable ? nil : notLoggedInReason

--- a/Sources/TBDApp/Sidebar/RowAccountMenuView.swift
+++ b/Sources/TBDApp/Sidebar/RowAccountMenuView.swift
@@ -101,15 +101,38 @@ struct RowAccountMenuView: View {
                                     target: RowAccountMenu.SwitchTarget) -> some View {
         if let action = target.action(terminalID: session.terminalID) {
             Button(action: { dispatch(action) }) {
-                Text("  \(target.title)")
+                Text(Self.twoLineLabel(primary: "  \(target.line.primary)",
+                                       secondary: target.line.secondary))
             }
         } else {
             // Disabled: current account (checkmark) or not-logged-in (hint).
             let prefix = target.isCurrent ? "✓ " : "  "
             let suffix = target.disabledReason.map { " — \($0)" } ?? ""
-            Button("\(prefix)\(target.title)\(suffix)") {}
-                .disabled(true)
+            Button {
+            } label: {
+                Text(Self.twoLineLabel(primary: "\(prefix)\(target.line.primary)\(suffix)",
+                                       secondary: target.line.secondary))
+            }
+            .disabled(true)
         }
+    }
+
+    /// Renders a menu row on two lines inside a SwiftUI `Menu`. macOS menus
+    /// flatten a `VStack`-based `Button` label to a single line and drop its
+    /// per-`Text` styling, so we build one `AttributedString` with an embedded
+    /// newline instead: primary line at the default size, a smaller secondary
+    /// line (`.caption`, secondary color, two-space indent) after the break.
+    /// This is the technique that actually renders two styled lines in a Menu.
+    /// When `secondary` is nil we return a plain single-line string so
+    /// snapshotless / not-logged-in rows keep their existing treatment.
+    static func twoLineLabel(primary: String, secondary: String?) -> AttributedString {
+        var result = AttributedString(primary)
+        guard let secondary, !secondary.isEmpty else { return result }
+        var second = AttributedString("\n  " + secondary)
+        second.font = .caption
+        second.foregroundColor = .secondary
+        result.append(second)
+        return result
     }
 
     private func dispatch(_ action: RowAccountMenu.RowAccountMenuAction) {

--- a/Sources/TBDApp/Sidebar/RowAccountMenuView.swift
+++ b/Sources/TBDApp/Sidebar/RowAccountMenuView.swift
@@ -83,6 +83,10 @@ struct RowAccountMenuView: View {
             ForEach(session.switchTargets) { target in
                 switchTargetButton(session: session, target: target)
             }
+            Divider()
+            // Per-session footer: resumes-in-place caption, with an
+            // interrupt warning when the session is mid-run.
+            Text(session.switchFooter).font(.caption)
         }
     }
 

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -134,10 +134,11 @@ struct RowActionMenuActions {
             Task { await appState.archiveWorktree(id: wtID) }
 
         case let .forkSession(terminalID, profileID):
-            // Duplicate the conversation into a new tab on the SAME account —
+            // Duplicate the conversation into a NEW tab on the SAME account —
             // swapTerminalProfile with the session's own profileID (nil = same
-            // ambient login). The daemon resumes/forks the session.
-            Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: profileID) }
+            // ambient login), in `.fork` mode so the daemon forks into a new
+            // tab rather than switching in place.
+            Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: profileID, mode: .fork) }
         }
     }
 

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -44,16 +44,6 @@ struct WorktreeRowView: View {
         return terminals.contains { $0.activityState == .working }
     }
 
-    /// Structured hover card listing which account(s) this worktree's Claude
-    /// sessions run on ("Claude accounts" + one row per account).
-    /// nil = no card (no Claude sessions).
-    private var accountsHoverCard: HoverCardModel? {
-        AccountHoverCards.worktreeCard(
-            terminals: appState.terminals[worktree.id] ?? [],
-            profiles: appState.modelProfiles
-        )
-    }
-
     /// Hover card for the "+" affordance: what the button does, and which
     /// worktree the new child is created under.
     private var newNestedWorktreeHoverCard: HoverCardModel {
@@ -218,10 +208,10 @@ struct WorktreeRowView: View {
         .opacity(AppState.scratchRowIsDimmed(
             worktree, directoryExists: FileManager.default.fileExists(atPath: worktree.path)
         ) ? 0.5 : 1.0)
-        // Which account(s) this worktree's Claude sessions run on. nil = no
-        // card; the PR icon and status icons keep their own more-specific
-        // tooltips.
-        .hoverCard(accountsHoverCard)
+        // The worktree-row hover surface is intentionally reserved: account
+        // facts moved to the "…" menu (info header + Switch account), and this
+        // hover is earmarked for the planned recency-biased work summary
+        // (see tbd-redesign-direction). No `.hoverCard` here for now.
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(appState.selectedWorktreeIDs.contains(worktree.id) ? Color.accentColor.opacity(0.2) : Color.clear)

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -343,20 +343,29 @@ enum AddTabMenu {
             claudeItem.target = coordinator
             menu.addItem(claudeItem)
 
-            // One item per profile, titled with the profile's display name plus
-            // a short login-identity suffix (" — email" / " — needs /login" for
-            // oauth profiles) and a compact usage suffix when the daemon has a
-            // snapshot (" · 5h 0% ↺23:10 · wk 76% · F 100%"). Each gets a
+            // One item per profile. The primary line is the profile's display
+            // name plus a short login-identity suffix (" — email" / " — needs
+            // /login" for oauth profiles); when the daemon has a usage snapshot,
+            // a smaller, indented secondary line underneath spells out the
+            // usage ("5h 0% · resets 23:10 · wk 76% · Fable 100%"). Each gets a
             // transparent placeholder icon the same size as the Claude asterisk
             // so its title lines up in the same title column as "Claude" — the
             // empty icon slot is the visual nesting cue. The profile id rides
             // along in `representedObject` for MenuCoordinator.addClaudeProfile.
             for entry in profiles {
+                let line = ProfileUsagePresentation.menuLine(for: entry)
                 let item = NSMenuItem(
-                    title: ProfileUsagePresentation.menuItemTitle(for: entry),
+                    title: line.primary,
                     action: #selector(MenuCoordinator.addClaudeProfile(_:)),
                     keyEquivalent: ""
                 )
+                if let attributed = twoLineAttributedTitle(line) {
+                    item.attributedTitle = attributed
+                    // Setting attributedTitle syncs `title` to its flattened
+                    // string; restore the identity-only plain title (used by
+                    // accessibility and any title-based lookups).
+                    item.title = line.primary
+                }
                 item.image = blankIcon(size: claudeIcon.size)
                 item.representedObject = entry.profile.id
                 item.target = coordinator
@@ -419,6 +428,37 @@ enum AddTabMenu {
         image.lockFocus()   // empty draw pass — produces a transparent representation
         image.unlockFocus()
         return image
+    }
+
+    /// NSMenu counterpart of `RowAccountMenuView.twoLineLabel`: an attributed
+    /// two-line NSMenuItem title — identity at menu size, the usage line
+    /// smaller, secondary-colored, and indented underneath. nil when there is
+    /// no secondary line, so snapshotless profiles keep the plain single-line
+    /// title set at item creation.
+    static func twoLineAttributedTitle(
+        _ line: ProfileUsagePresentation.MenuLineModel
+    ) -> NSAttributedString? {
+    guard let secondary = line.secondary, !secondary.isEmpty else { return nil }
+    let title = NSMutableAttributedString(
+        string: line.primary,
+        attributes: [
+            .font: NSFont.menuFont(ofSize: 13),
+            .foregroundColor: NSColor.labelColor,
+        ]
+    )
+    let secondaryStyle = NSMutableParagraphStyle()
+    secondaryStyle.firstLineHeadIndent = 10
+    secondaryStyle.headIndent = 10
+    secondaryStyle.paragraphSpacingBefore = 1
+    title.append(NSAttributedString(
+        string: "\n\(secondary)",
+        attributes: [
+            .font: NSFont.menuFont(ofSize: 11),
+            .foregroundColor: NSColor.secondaryLabelColor,
+            .paragraphStyle: secondaryStyle,
+        ]
+    ))
+        return title
     }
 }
 

--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -61,6 +61,15 @@ public struct ClaudeProfileConfigDirManager: Sendable {
             .appendingPathComponent("claude", isDirectory: true)
     }
 
+    /// The ambient (non-profile) claude config dir — i.e. the host base dir
+    /// (`~/.claude` in production, or the injected `hostBaseDirectory`). This is
+    /// the config dir an ambient TBD session resolves to on this machine now
+    /// that the zshenv-era ambient-dir switcher was retired. Used as the
+    /// swap-to-ambient transcript destination.
+    public var ambientConfigDirectory: URL {
+        hostBaseDirectory
+    }
+
     /// Slots that each TBD profile dir mirrors from the host's claude config dir.
     /// Symlinked from <profile>/claude/<slot> to <host-base>/<slot>.
     /// `projects` migrates pre-existing real-dir content into the host store

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -695,6 +695,97 @@ extension RPCRouter {
         return .resume(sessionID: oldSessionID)
     }
 
+    /// Ensure the session transcript at `source` is reachable under the
+    /// DESTINATION config dir's `projects/` tree, so a `claude --resume <id>`
+    /// spawned with `CLAUDE_CONFIG_DIR=<destConfigDir>` can find it.
+    ///
+    /// `claude` resolves resumable conversations at
+    /// `<CLAUDE_CONFIG_DIR>/projects/<cwd-slug>/<sessionID>.jsonl`. Ambient
+    /// sessions write their transcript under the ambient config dir's
+    /// `projects/`, while TBD profile config dirs symlink their `projects/`
+    /// slot from the host claude dir. So an ambient→profile swap resumes under
+    /// the profile (looking in the host `projects/`) while the transcript sits
+    /// in the ambient config dir's `projects/` — "no conversation found".
+    ///
+    /// This copies (never moves — the source session may still be live) the
+    /// transcript into the destination `projects/<same-parent-dir-name>/<file>`,
+    /// preserving the cwd-slug layout by reusing the SOURCE file's parent-dir
+    /// name rather than recomputing the slug. Writing THROUGH the destination
+    /// config dir naturally follows the `projects/` symlink when one exists.
+    ///
+    /// Best-effort and non-throwing: any failure is logged and the swap proceeds
+    /// (the fork simply starts fresh). No-ops when the destination file already
+    /// exists or resolves (via realpath) to the same file as the source — the
+    /// profile→profile case where both dirs share a symlink target.
+    static func ensureTranscriptReachable(from source: URL, inConfigDir destConfigDir: URL) {
+        let fm = FileManager.default
+
+        guard fm.fileExists(atPath: source.path) else {
+            logger.warning("swap transcript carry: source \(source.path, privacy: .public) missing on disk — fork will start fresh")
+            return
+        }
+
+        // Preserve the source's cwd-slug layout: <projects>/<slug>/<file>.
+        // The slug is the source file's PARENT directory name — reuse it
+        // verbatim rather than recomputing from the worktree path, so a
+        // `/clear`/`/compact`-relocated transcript still lands in the right place.
+        let slug = source.deletingLastPathComponent().lastPathComponent
+        let destProjectsDir = destConfigDir
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(slug, isDirectory: true)
+        let dest = destProjectsDir.appendingPathComponent(source.lastPathComponent)
+
+        // Same realpath → source and destination resolve to the same file
+        // (profile→profile swaps sharing a symlinked `projects/` target, or a
+        // no-op ambient→ambient). Nothing to copy.
+        if fm.fileExists(atPath: dest.path) {
+            let srcReal = source.resolvingSymlinksInPath().standardizedFileURL.path
+            let dstReal = dest.resolvingSymlinksInPath().standardizedFileURL.path
+            if srcReal == dstReal {
+                logger.debug("swap transcript carry: destination already resolves to source — no copy")
+            } else {
+                logger.debug("swap transcript carry: destination \(dest.path, privacy: .public) already present — skipping")
+            }
+            return
+        }
+
+        do {
+            try fm.createDirectory(at: destProjectsDir, withIntermediateDirectories: true)
+            try fm.copyItem(at: source, to: dest)
+            logger.info("swap transcript carry: copied session transcript into \(destProjectsDir.path, privacy: .public) so resume finds the conversation")
+        } catch {
+            logger.warning("swap transcript carry: copy failed (\(error.localizedDescription, privacy: .public)) — fork will start fresh")
+        }
+    }
+
+    /// Resolve the on-disk source transcript for a swap: prefer the terminal
+    /// row's `transcriptPath` (authoritative live-session jsonl); if that's
+    /// nil/missing, fall back to locating `<sessionID>.jsonl` under the SOURCE
+    /// config dir's `projects/` tree for `worktreePath`. Returns nil when
+    /// neither is found (the fork will start fresh).
+    static func resolveSwapSourceTranscript(
+        transcriptPath: String?,
+        sessionID: String,
+        worktreePath: String,
+        sourceConfigDir: URL
+    ) -> URL? {
+        let fm = FileManager.default
+        if let p = transcriptPath, !p.isEmpty, fm.fileExists(atPath: p) {
+            return URL(fileURLWithPath: p)
+        }
+        // Fall back to the source config dir's projects/ tree. Resolve the
+        // cwd-slug dir for this worktree, then look for <sessionID>.jsonl.
+        let projectsBase = sourceConfigDir.appendingPathComponent("projects", isDirectory: true)
+        guard let projectDir = ClaudeProjectDirectory.resolve(
+            worktreePath: worktreePath,
+            projectsBase: projectsBase
+        ) else {
+            return nil
+        }
+        let candidate = projectDir.appendingPathComponent("\(sessionID).jsonl")
+        return fm.fileExists(atPath: candidate.path) ? candidate : nil
+    }
+
     func handleTerminalSwapProfile(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSwapProfileParams.self, from: paramsData)
 
@@ -724,19 +815,28 @@ extension RPCRouter {
             resolved = nil
         }
 
-        // Spawn a NEW window in the same worktree. If the existing session has
-        // any conversation content, `claude --resume` forks it into a fresh
-        // session file (we recapture the forked ID below). If the session is
-        // blank — JSONL never written or no real entries — resuming it would
-        // produce "no conversation found" and chaotic behavior, so we instead
-        // spawn a brand-new session and skip the recapture.
+        // Two reshaping modes (see `TerminalSwapMode`):
+        //   .inPlace (default) — SEAMLESS "Switch account": interrupt the
+        //     pane's Claude, respawn `claude --resume <id>` under the new
+        //     profile IN THE SAME window, and update the existing terminal row.
+        //     One tab, no new row.
+        //   .fork — explicit "Fork session": spawn a NEW window + terminal row,
+        //     leaving the source session untouched (the old behavior).
+        //
+        // In both modes, if the existing session has conversation content,
+        // `claude --resume` forks it into a fresh session file (recaptured
+        // below). If the session is blank, resuming would produce "no
+        // conversation found", so we spawn a brand-new session instead.
+        let mode = params.resolvedMode
         let repo: Repo?
         if let rid = worktree.repoID {
             repo = try await db.repos.get(id: rid)
         } else {
             repo = nil
         }
-        let plannedTerminalID = UUID()
+        // In-place respawn keeps the EXISTING terminal id so its `TBD_TERMINAL_ID`
+        // (and thus SessionStart-hook routing) stays stable; fork uses a fresh id.
+        let plannedTerminalID = mode == .inPlace ? oldTerminal.id : UUID()
         let swapConfig = try? await db.config.get()
         var env = SystemPromptBuilder.promptLayers(
             repo: repo, worktree: worktree, scratchInstructions: swapConfig?.scratchInstructions,
@@ -750,6 +850,41 @@ extension RPCRouter {
             transcriptFilePath: oldTerminal.transcriptPath
         )
         let plan = Self.planTerminalSwap(oldSessionID: sessionID, isBlank: blank)
+
+        // Carry the session transcript into the DESTINATION config dir so the
+        // forked `claude --resume <id>` finds the conversation. Only matters on
+        // the resume path — a fresh spawn has no prior transcript to carry.
+        // Best-effort: never blocks the swap.
+        if case .resume = plan {
+            // Source config dir: where the OLD session's transcript lives — the
+            // old terminal's profile config dir, or the ambient (host) config
+            // dir for an ambient session (profileID == nil).
+            let sourceConfigDir: URL
+            if let oldProfileID = oldTerminal.profileID {
+                sourceConfigDir = configDirManager.configDirectory(forProfileID: oldProfileID)
+            } else {
+                sourceConfigDir = configDirManager.ambientConfigDirectory
+            }
+            // Destination config dir: the new profile's config dir, or the
+            // ambient (host) config dir when swapping to ambient (nil profile).
+            let destConfigDir: URL
+            if let newProfileID = resolved?.profileID {
+                destConfigDir = configDirManager.configDirectory(forProfileID: newProfileID)
+            } else {
+                destConfigDir = configDirManager.ambientConfigDirectory
+            }
+
+            if let sourceTranscript = Self.resolveSwapSourceTranscript(
+                transcriptPath: oldTerminal.transcriptPath,
+                sessionID: sessionID,
+                worktreePath: worktree.path,
+                sourceConfigDir: sourceConfigDir
+            ) {
+                Self.ensureTranscriptReachable(from: sourceTranscript, inConfigDir: destConfigDir)
+            } else {
+                logger.warning("swap transcript carry: no source transcript found for session \(sessionID, privacy: .public) — fork will start fresh")
+            }
+        }
 
         let claudeEnvOverrides = swapConfig?.envSettingOverrides ?? [:]
         // Free-form env overrides for the swapped-in Claude pane (global < repo <
@@ -823,16 +958,64 @@ extension RPCRouter {
         // tmux's 80x24 default producing un-reflowable hard-wrapped scrollback.
         let resolvedCols = params.cols ?? TmuxManager.defaultCols
         let resolvedRows = params.rows ?? TmuxManager.defaultRows
+        let sensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
 
+        switch mode {
+        case .fork:
+            return try await forkSwapNewTab(
+                worktree: worktree,
+                plannedTerminalID: plannedTerminalID,
+                spawnCommand: spawn.command,
+                env: env,
+                sensitiveEnv: sensitiveEnv,
+                storedSessionID: storedSessionID,
+                profileID: resolved?.profileID,
+                scheduleRecapture: scheduleRecapture,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+
+        case .inPlace:
+            return try await inPlaceSwapRespawn(
+                oldTerminal: oldTerminal,
+                worktree: worktree,
+                spawnCommand: spawn.command,
+                env: env,
+                sensitiveEnv: sensitiveEnv,
+                storedSessionID: storedSessionID,
+                newProfileID: resolved?.profileID,
+                scheduleRecapture: scheduleRecapture,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+        }
+    }
+
+    /// `.fork` swap: spawn a NEW window + terminal row in the same worktree,
+    /// leaving the source session's tab untouched. Preserves the original
+    /// fork-into-new-tab behavior; now only reached via the explicit "Fork
+    /// session" action.
+    private func forkSwapNewTab(
+        worktree: Worktree,
+        plannedTerminalID: UUID,
+        spawnCommand: String,
+        env: [String: String],
+        sensitiveEnv: [String: String],
+        storedSessionID: String,
+        profileID: UUID?,
+        scheduleRecapture: Bool,
+        cols: Int,
+        rows: Int
+    ) async throws -> RPCResponse {
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
             session: "main",
             cwd: worktree.path,
-            shellCommand: spawn.command,
+            shellCommand: spawnCommand,
             env: env,
-            sensitiveEnv: mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder },
-            cols: resolvedCols,
-            rows: resolvedRows
+            sensitiveEnv: sensitiveEnv,
+            cols: cols,
+            rows: rows
         )
 
         let newTerminal = try await db.terminals.create(
@@ -842,7 +1025,7 @@ extension RPCRouter {
             tmuxPaneID: window.paneID,
             label: "claude",
             claudeSessionID: storedSessionID,
-            profileID: resolved?.profileID,
+            profileID: profileID,
             kind: .claude
         )
 
@@ -850,30 +1033,134 @@ extension RPCRouter {
             terminalID: newTerminal.id, worktreeID: newTerminal.worktreeID, label: newTerminal.label
         )))
 
-        // For the resume path, `claude --resume <oldID>` forks the conversation
-        // into a NEW session file with a fresh UUID. Mirror SuspendResumeCoordinator's
-        // post-resume pattern: wait ~5s for Claude to settle, then capture the
-        // new session ID from the pane and persist it. The fresh path already
-        // stored the correct ID, so no recapture is needed.
         if scheduleRecapture {
-            let newTerminalID = newTerminal.id
-            let newPaneID = window.paneID
-            let server = worktree.tmuxServer
-            let tmuxRef = self.tmux
-            let dbRef = self.db
-            Task {
-                try? await Task.sleep(for: .seconds(5))
-                let detector = ClaudeStateDetector(tmux: tmuxRef)
-                if let recaptured = await detector.captureSessionID(server: server, paneID: newPaneID) {
-                    try? await dbRef.terminals.updateSessionID(id: newTerminalID, sessionID: recaptured)
-                }
-            }
+            scheduleSessionRecapture(
+                terminalID: newTerminal.id, paneID: window.paneID, server: worktree.tmuxServer
+            )
         }
 
         guard let updated = try await db.terminals.get(id: newTerminal.id) else {
             return RPCResponse(error: "Terminal vanished after swap")
         }
         return try RPCResponse(result: updated)
+    }
+
+    /// `.inPlace` swap (seamless "Switch account"): gracefully interrupt the
+    /// pane's current Claude, respawn `claude` under the new profile IN THE SAME
+    /// tmux window, and update the EXISTING terminal row (new profile id, same
+    /// session id + tmux ids). One tab, no new row.
+    ///
+    /// The terminal row's `profile_id` is set to the new profile BEFORE the
+    /// respawn so a respawn failure still leaves the row on the new account
+    /// (the pane shows the error; the user can retry). The transcript was
+    /// already carried into the destination config dir upstream.
+    private func inPlaceSwapRespawn(
+        oldTerminal: Terminal,
+        worktree: Worktree,
+        spawnCommand: String,
+        env: [String: String],
+        sensitiveEnv: [String: String],
+        storedSessionID: String,
+        newProfileID: UUID?,
+        scheduleRecapture: Bool,
+        cols: Int,
+        rows: Int
+    ) async throws -> RPCResponse {
+        let server = worktree.tmuxServer
+        let paneID = oldTerminal.tmuxPaneID
+        let windowID = oldTerminal.tmuxWindowID
+
+        // 1. Gracefully interrupt the pane's current Claude before respawn.
+        //    `respawn-window -k` will forcibly replace it regardless, but a
+        //    graceful stop lets Claude finish flushing and avoids yanking an
+        //    in-flight generation. Best-effort — never blocks the swap.
+        await gracefullyInterruptPane(server: server, paneID: paneID)
+
+        // 2. Update the terminal row to the new profile + session up front, so a
+        //    later respawn failure still leaves the row on the new account.
+        try await db.terminals.setProfileID(id: oldTerminal.id, profileID: newProfileID)
+        try await db.terminals.updateSessionID(id: oldTerminal.id, sessionID: storedSessionID)
+
+        // 3. Respawn IN PLACE — same window id / pane id → the tab and terminal
+        //    row survive.
+        do {
+            try await tmux.respawnWindow(
+                server: server,
+                windowID: windowID,
+                cwd: worktree.path,
+                shellCommand: spawnCommand,
+                env: env,
+                sensitiveEnv: sensitiveEnv,
+                cols: cols,
+                rows: rows
+            )
+        } catch {
+            // Failure path: the row keeps the new profile id (respawn can be
+            // retried); the pane surfaces the error. Log clearly and still
+            // return the updated row so the app reflects the new account.
+            logger.warning("inPlace swap: respawn failed for terminal \(oldTerminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+
+        subscriptions.broadcast(delta: .terminalSessionUpdated(TerminalSessionDelta(
+            terminalID: oldTerminal.id,
+            worktreeID: worktree.id,
+            sessionID: storedSessionID,
+            transcriptPath: oldTerminal.transcriptPath
+        )))
+        // Update the row's account chip in place — same terminal id, new profile.
+        subscriptions.broadcast(delta: .terminalProfileChanged(TerminalProfileDelta(
+            terminalID: oldTerminal.id,
+            worktreeID: worktree.id,
+            newProfileID: newProfileID
+        )))
+
+        if scheduleRecapture {
+            scheduleSessionRecapture(
+                terminalID: oldTerminal.id, paneID: paneID, server: server
+            )
+        }
+
+        guard let updated = try await db.terminals.get(id: oldTerminal.id) else {
+            return RPCResponse(error: "Terminal vanished after swap")
+        }
+        logger.info("inPlace swap: terminal \(oldTerminal.id, privacy: .public) switched to profile \(newProfileID?.uuidString ?? "ambient", privacy: .public) in window \(windowID, privacy: .public)")
+        return try RPCResponse(result: updated)
+    }
+
+    /// Best-effort graceful interrupt of a pane's foreground program before an
+    /// in-place respawn: Escape (stop a Claude generation), a brief settle,
+    /// then C-c C-c, another settle, then a SIGTERM to the pane pid as a
+    /// backstop. Every step is best-effort — failures are logged and ignored,
+    /// since the subsequent `respawn-window -k` guarantees termination.
+    private func gracefullyInterruptPane(server: String, paneID: String) async {
+        // Escape: ask Claude to stop generating.
+        try? await tmux.sendKey(server: server, paneID: paneID, key: "Escape")
+        try? await Task.sleep(for: .milliseconds(150))
+        // C-c C-c: interrupt / exit the TUI.
+        try? await tmux.sendKey(server: server, paneID: paneID, key: "C-c")
+        try? await tmux.sendKey(server: server, paneID: paneID, key: "C-c")
+        try? await Task.sleep(for: .milliseconds(150))
+        // SIGTERM the pane pid as a backstop (respawn -k is the real guarantee).
+        if let pidStr = try? await tmux.panePID(server: server, paneID: paneID),
+           let pid = Int32(pidStr), pid > 0 {
+            kill(pid, SIGTERM)
+        }
+    }
+
+    /// Schedule the post-resume session-id recapture. `claude --resume <id>`
+    /// forks the conversation into a NEW session file with a fresh UUID; mirror
+    /// SuspendResumeCoordinator's pattern — wait ~5s for Claude to settle, then
+    /// capture the new id from the pane and persist it against `terminalID`.
+    private func scheduleSessionRecapture(terminalID: UUID, paneID: String, server: String) {
+        let tmuxRef = self.tmux
+        let dbRef = self.db
+        Task {
+            try? await Task.sleep(for: .seconds(5))
+            let detector = ClaudeStateDetector(tmux: tmuxRef)
+            if let recaptured = await detector.captureSessionID(server: server, paneID: paneID) {
+                try? await dbRef.terminals.updateSessionID(id: terminalID, sessionID: recaptured)
+            }
+        }
     }
 
     func handleTerminalSend(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -141,6 +141,43 @@ public struct TmuxManager: Sendable {
             + ["-PF", "#{window_id} #{pane_id}", userShell, "-ic", fullCommand]
     }
 
+    /// Respawn (replace the running program of) an existing window's pane
+    /// IN PLACE, keeping the same window id and pane id. Mirrors
+    /// `newWindowCommand`'s env handling — the `env` map is inlined as an
+    /// `export …; ` prefix on the shell command (runs AFTER rc files), while
+    /// `sensitiveEnv` is passed via tmux `-e KEY=VALUE` so it's in the process
+    /// environment before the shell starts (kept out of `ps aux`, and visible
+    /// during rc execution). `-k` kills the pane's current program first.
+    ///
+    /// Used by the seamless in-place account switch: same tab, same terminal
+    /// row, new profile's `claude --resume` command. See PR 5222a79 for why the
+    /// env re-export must be re-applied on respawn (the original pane env does
+    /// not carry over to the newly-exec'd program).
+    public static func respawnWindowCommand(
+        server: String,
+        windowID: String,
+        cwd: String,
+        shellCommand: String,
+        env: [String: String] = [:],
+        sensitiveEnv: [String: String] = [:]
+    ) -> [String] {
+        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        var envPrefix = ""
+        for (key, value) in env.sorted(by: { $0.key < $1.key }) {
+            let escaped = value.replacingOccurrences(of: "'", with: "'\\''")
+            envPrefix += "export \(key)='\(escaped)'; "
+        }
+        let fullCommand = envPrefix.isEmpty ? shellCommand : "\(envPrefix)\(shellCommand)"
+        var eFlags: [String] = []
+        for (key, value) in sensitiveEnv.sorted(by: { $0.key < $1.key }) {
+            eFlags.append("-e")
+            eFlags.append("\(key)=\(value)")
+        }
+        return ["-L", server, "respawn-window", "-k", "-t", windowID, "-c", cwd]
+            + eFlags
+            + [userShell, "-ic", fullCommand]
+    }
+
     /// Resize an existing tmux window to the given cell dimensions.
     public static func resizeWindowCommand(server: String, windowID: String, cols: Int, rows: Int) -> [String] {
         ["-L", server, "resize-window", "-t", windowID, "-x", "\(cols)", "-y", "\(rows)"]
@@ -296,6 +333,38 @@ public struct TmuxManager: Sendable {
             }
         }
         return result
+    }
+
+    /// Respawn a window's pane in place (same window id / pane id) with a new
+    /// program. See `respawnWindowCommand` for the env-inlining semantics.
+    /// After respawn, re-issues the size lock (mirrors `createWindow`) so the
+    /// replaced pane keeps the requested cell dimensions.
+    public func respawnWindow(
+        server: String,
+        windowID: String,
+        cwd: String,
+        shellCommand: String,
+        env: [String: String] = [:],
+        sensitiveEnv: [String: String] = [:],
+        cols: Int? = nil,
+        rows: Int? = nil
+    ) async throws {
+        let args = Self.respawnWindowCommand(
+            server: server, windowID: windowID, cwd: cwd,
+            shellCommand: shellCommand, env: env, sensitiveEnv: sensitiveEnv
+        )
+        if dryRun {
+            dryRunRecorder?(args)
+            return
+        }
+        try await runTmux(args)
+        if let cols, let rows, cols >= Self.minCols, rows >= Self.minRows {
+            do {
+                try await resizeWindow(server: server, windowID: windowID, cols: cols, rows: rows)
+            } catch {
+                logger.warning("resize-window after respawnWindow failed for \(windowID, privacy: .public) on server \(server, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
     }
 
     public func killWindow(server: String, windowID: String) async throws {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -272,18 +272,47 @@ public struct NightwatchSetModeParams: Codable, Sendable {
 
 // MARK: - Terminal Swap Profile
 
+/// How `terminal.swapProfile` reshapes the session.
+///
+/// - `inPlace`: SEAMLESS account switch — interrupt the pane's current Claude,
+///   respawn `claude --resume <id>` under the new profile IN THE SAME tmux
+///   window, and update the existing terminal row in place. One tab, no new
+///   row/tab. This is the "Switch account" action.
+/// - `fork`: duplicate the conversation into a NEW tab/terminal row (the old
+///   fork-into-new-tab behavior), leaving the source session untouched. This
+///   is the explicit "Fork session" action.
+public enum TerminalSwapMode: String, Codable, Sendable, Equatable {
+    case inPlace
+    case fork
+}
+
 public struct TerminalSwapProfileParams: Codable, Sendable {
     public let terminalID: UUID
     public let newProfileID: UUID?
     /// Initial tmux window size in cells (see WorktreeCreateParams).
     public let cols: Int?
     public let rows: Int?
-    public init(terminalID: UUID, newProfileID: UUID?, cols: Int? = nil, rows: Int? = nil) {
+    /// Swap reshaping mode. Optional + `decodeIfPresent` so payloads from older
+    /// clients still decode; a missing value defaults to `.inPlace` (seamless
+    /// same-tab switch) — the common "Switch account" path.
+    public let mode: TerminalSwapMode?
+    public init(
+        terminalID: UUID,
+        newProfileID: UUID?,
+        cols: Int? = nil,
+        rows: Int? = nil,
+        mode: TerminalSwapMode? = nil
+    ) {
         self.terminalID = terminalID
         self.newProfileID = newProfileID
         self.cols = cols
         self.rows = rows
+        self.mode = mode
     }
+
+    /// Resolved mode with the default applied — `.inPlace` when the field is
+    /// absent (older clients / the common switch-account path).
+    public var resolvedMode: TerminalSwapMode { mode ?? .inPlace }
 }
 
 // MARK: - Model Profile RPC

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -23,7 +23,24 @@ public enum StateDelta: Codable, Sendable {
     case modelProfilesChanged
     case terminalSessionUpdated(TerminalSessionDelta)
     case terminalActivityUpdated(TerminalActivityDelta)
+    case terminalProfileChanged(TerminalProfileDelta)
     case worktreeMoved(WorktreeMovedDelta)
+}
+
+/// Delta payload for a terminal's model-profile change that keeps the SAME
+/// terminal row (the seamless in-place "Switch account" swap). The app updates
+/// the row's `profileID` in place so its account chip re-renders without a full
+/// terminal refetch. `newProfileID == nil` means the session switched to the
+/// ambient (keychain/host) login.
+public struct TerminalProfileDelta: Codable, Sendable {
+    public let terminalID: UUID
+    public let worktreeID: UUID
+    public let newProfileID: UUID?
+    public init(terminalID: UUID, worktreeID: UUID, newProfileID: UUID?) {
+        self.terminalID = terminalID
+        self.worktreeID = worktreeID
+        self.newProfileID = newProfileID
+    }
 }
 
 /// Delta payload for Claude session ID/transcript path rollover, fired when

--- a/Tests/TBDAppTests/AccountHoverCardsTests.swift
+++ b/Tests/TBDAppTests/AccountHoverCardsTests.swift
@@ -57,71 +57,6 @@ private let gmailSnapshot = snapshot(buckets: [
     bucket(kind: "weekly_scoped", percent: 100, severity: "critical", family: "Fable"),
 ])
 
-// MARK: - Worktree row card
-
-@Suite("AccountHoverCards — worktree row")
-struct WorktreeCardTests {
-    @Test func noClaudeSessionsMeansNoCard() {
-        let shell = claudeTerminal(kind: .shell)
-        #expect(AccountHoverCards.worktreeCard(terminals: [shell], profiles: []) == nil)
-        #expect(AccountHoverCards.worktreeCard(terminals: [], profiles: []) == nil)
-    }
-
-    @Test func titleAndOneRowPerAccount() {
-        let work = entry(name: "Work", loginIdentity: "a@b.co")
-        let personal = entry(name: "Personal", loginIdentity: "p@q.io")
-        let terminals = [
-            claudeTerminal(profileID: work.profile.id),
-            claudeTerminal(profileID: personal.profile.id),
-        ]
-        let card = AccountHoverCards.worktreeCard(terminals: terminals,
-                                                  profiles: [work, personal])
-        #expect(card?.title == "Claude accounts")
-        #expect(card?.rows.count == 2)
-        #expect(card?.rows[0] == HoverCardRow(value: "a@b.co", chip: "Work"))
-        #expect(card?.rows[1] == HoverCardRow(value: "p@q.io", chip: "Personal"))
-    }
-
-    @Test func duplicateAccountsAreDedupedInTabOrder() {
-        let work = entry(name: "Work", loginIdentity: "a@b.co")
-        let terminals = [
-            claudeTerminal(profileID: work.profile.id),
-            claudeTerminal(profileID: work.profile.id),
-            claudeTerminal(profileID: nil),
-            claudeTerminal(profileID: nil),
-        ]
-        let card = AccountHoverCards.worktreeCard(terminals: terminals, profiles: [work])
-        #expect(card?.rows.count == 2)
-        #expect(card?.rows[0].value == "a@b.co")
-        #expect(card?.rows[1].value == AccountHoverCards.ambientAccountLabel)
-    }
-
-    @Test func ambientRowIsMutedItalicWithDriftCaption() {
-        let row = AccountHoverCards.accountRow(profileID: nil, profiles: [])
-        #expect(row.value == "ambient (terminal login)")
-        #expect(row.valueStyle == .mutedItalic)
-        #expect(row.caption == AccountHoverCards.ambientDriftCaption)
-        #expect(row.chip == nil)
-    }
-
-    @Test func removedProfileRowIsMutedItalicWithCaption() {
-        let row = AccountHoverCards.accountRow(profileID: UUID(), profiles: [])
-        #expect(row.value == AccountHoverCards.removedProfileLabel)
-        #expect(row.valueStyle == .mutedItalic)
-        #expect(row.caption == AccountHoverCards.removedProfileCaption)
-    }
-
-    @Test func notLoggedInProfileRowShowsNameWithCaption() {
-        let pending = entry(name: "Staging", loginIdentity: nil)
-        let row = AccountHoverCards.accountRow(profileID: pending.profile.id,
-                                               profiles: [pending])
-        #expect(row.value == "Staging")
-        #expect(row.chip == nil)
-        #expect(row.caption == AccountHoverCards.notLoggedInCaption)
-        #expect(row.valueStyle == .plain)
-    }
-}
-
 // MARK: - Claude tab card
 
 @Suite("AccountHoverCards — Claude tab")
@@ -244,39 +179,175 @@ struct UsageRowsTests {
     }
 }
 
-// MARK: - Hover timing
+// MARK: - Dwell reducer (show-gate state machine)
 
-@Suite("HoverCardTiming — warm-state show delay")
-struct HoverCardTimingTests {
-    private let timing = HoverCardTiming(showDelay: 0.35, warmGrace: 0.35,
-                                         fadeOutDuration: 0.12)
-    private let now = Date(timeIntervalSinceReferenceDate: 1_000)
+@Suite("HoverDwellReducer — dwell-gated show")
+struct HoverDwellReducerTests {
+    // Deliberately round numbers so the arithmetic in each test reads clearly.
+    private let timing = HoverCardTiming(
+        showDelay: 0.50, restWindow: 0.20, movementThreshold: 3,
+        warmDwell: 0.15, warmGrace: 0.40, fadeOutDuration: 0.12
+    )
+    private let t0 = Date(timeIntervalSinceReferenceDate: 1_000)
 
-    @Test func coldHoverWaitsTheFullShowDelay() {
-        #expect(timing.effectiveShowDelay(now: now, lastDismissedAt: nil,
-                                          isCardVisible: false) == 0.35)
+    private func fresh() -> HoverDwellReducer { HoverDwellReducer(timing: timing) }
+    private func at(_ dt: TimeInterval) -> Date { t0.addingTimeInterval(dt) }
+
+    /// Convenience: cold-hover evaluation (no card up, never dismissed).
+    private func cold(_ r: inout HoverDwellReducer, _ dt: TimeInterval) -> Bool {
+        r.shouldShow(now: at(dt), lastDismissedAt: nil, isCardVisible: false)
     }
 
-    @Test func visibleCardSwapsInstantly() {
-        #expect(timing.effectiveShowDelay(now: now, lastDismissedAt: nil,
-                                          isCardVisible: true) == 0)
+    // MARK: Cold path — floor AND rest must both pass
+
+    @Test func coldHoverDoesNotShowBeforeFloorEvenWhenAtRest() {
+        var r = fresh()
+        r.entered(now: t0)
+        // Rest window (0.20) satisfied but floor (0.50) not yet.
+        #expect(cold(&r, 0.30) == false)
     }
 
-    @Test func recentDismissalIsWarmAndSkipsTheDelay() {
-        let justDismissed = now.addingTimeInterval(-0.2)
-        #expect(timing.effectiveShowDelay(now: now, lastDismissedAt: justDismissed,
-                                          isCardVisible: false) == 0)
+    @Test func coldHoverDoesNotShowBeforeRestEvenAfterFloor() {
+        var r = fresh()
+        r.entered(now: t0)
+        // Keep moving right up to just before evaluation: never at rest.
+        r.moved(distance: 10, now: at(0.55))
+        #expect(cold(&r, 0.60) == false) // only 0.05s at rest < 0.20
+    }
+
+    @Test func coldHoverShowsOnceFloorAndRestBothPass() {
+        var r = fresh()
+        r.entered(now: t0)
+        // No movement: resting since entry. At 0.50, floor met and rest (0.50) met.
+        #expect(cold(&r, 0.50) == true)
+    }
+
+    @Test func showLatchesAndFiresExactlyOnce() {
+        var r = fresh()
+        r.entered(now: t0)
+        #expect(cold(&r, 0.50) == true)
+        // Subsequent ticks must not re-fire.
+        #expect(cold(&r, 0.60) == false)
+        #expect(cold(&r, 1.00) == false)
+    }
+
+    // MARK: Movement resets the rest clock (hover intent)
+
+    @Test func aboveThresholdMoveResetsTheRestClock() {
+        var r = fresh()
+        r.entered(now: t0)
+        // A big move at 0.45 (past the floor) restarts rest; at 0.55 only
+        // 0.10s at rest < 0.20 → still hidden.
+        r.moved(distance: 20, now: at(0.45))
+        #expect(cold(&r, 0.55) == false)
+        // By 0.66, >0.20s at rest → shows. (Evaluate a hair past the boundary
+        // so the assertion doesn't hinge on exact Double equality.)
+        #expect(cold(&r, 0.66) == true)
+    }
+
+    @Test func subThresholdJitterDoesNotResetRest() {
+        var r = fresh()
+        r.entered(now: t0)
+        // Tiny jitter below the 3pt threshold must not push the rest clock.
+        r.moved(distance: 1, now: at(0.40))
+        r.moved(distance: 2, now: at(0.48))
+        #expect(cold(&r, 0.50) == true) // rest still measured from entry
+    }
+
+    @Test func sweepThroughNeverShows() {
+        // Cursor crosses the anchor moving the whole time, then leaves before
+        // ever settling — the drive-by case the user complained about.
+        var r = fresh()
+        r.entered(now: t0)
+        for step in stride(from: 0.02, through: 0.30, by: 0.02) {
+            r.moved(distance: 15, now: at(step))
+            #expect(cold(&r, step) == false)
+        }
+        r.exited()
+        #expect(r.enteredAt == nil)
+    }
+
+    // MARK: Warm swap — reduced floor, short dwell, still gated
+
+    @Test func warmSwapNeedsWarmDwellNotInstant() {
+        var r = fresh()
+        r.entered(now: t0)
+        // Card already visible (sibling swap): floor collapses to 0, but the
+        // warm dwell (0.15) still applies. At 0.10 at rest → hidden.
+        #expect(r.shouldShow(now: at(0.10), lastDismissedAt: nil, isCardVisible: true) == false)
+        // Just past 0.15 at rest → shows (a hair past the boundary to avoid
+        // hinging on exact Double equality).
+        #expect(r.shouldShow(now: at(0.16), lastDismissedAt: nil, isCardVisible: true) == true)
+    }
+
+    @Test func warmSweepDoesNotSwap() {
+        var r = fresh()
+        r.entered(now: t0)
+        // Moving the whole time through a sibling while a card is up: never
+        // settles for the warm dwell, so no chase.
+        r.moved(distance: 12, now: at(0.05))
+        r.moved(distance: 12, now: at(0.12))
+        #expect(r.shouldShow(now: at(0.13), lastDismissedAt: nil, isCardVisible: true) == false)
+    }
+
+    @Test func recentDismissalIsWarmAndUsesWarmDwell() {
+        var r = fresh()
+        r.entered(now: t0)
+        let justDismissed = t0.addingTimeInterval(-0.10) // within 0.40 grace
+        // Warm: floor 0, needs only 0.15 at rest.
+        #expect(r.shouldShow(now: at(0.10), lastDismissedAt: justDismissed,
+                             isCardVisible: false) == false)
+        #expect(r.shouldShow(now: at(0.16), lastDismissedAt: justDismissed,
+                             isCardVisible: false) == true)
     }
 
     @Test func staleDismissalIsColdAgain() {
-        let longAgo = now.addingTimeInterval(-1.0)
-        #expect(timing.effectiveShowDelay(now: now, lastDismissedAt: longAgo,
-                                          isCardVisible: false) == 0.35)
+        var r = fresh()
+        r.entered(now: t0)
+        let longAgo = t0.addingTimeInterval(-1.0) // past the 0.40 grace
+        // Cold: still needs the full 0.50 floor.
+        #expect(r.shouldShow(now: at(0.20), lastDismissedAt: longAgo,
+                             isCardVisible: false) == false)
+        #expect(r.shouldShow(now: at(0.50), lastDismissedAt: longAgo,
+                             isCardVisible: false) == true)
     }
 
-    @Test func standardTimingIsFastButNotFlickery() {
-        #expect(HoverCardTiming.standard.showDelay > 0.1)
-        #expect(HoverCardTiming.standard.showDelay <= 0.5)
+    // MARK: Exit clears state
+
+    @Test func exitClearsAndRequiresReentry() {
+        var r = fresh()
+        r.entered(now: t0)
+        r.exited()
+        // No entry → never shows regardless of clock.
+        #expect(cold(&r, 5.0) == false)
+        // Re-entry restarts the cold gate cleanly.
+        r.entered(now: at(5.0))
+        #expect(r.shouldShow(now: at(5.30), lastDismissedAt: nil, isCardVisible: false) == false)
+        #expect(r.shouldShow(now: at(5.50), lastDismissedAt: nil, isCardVisible: false) == true)
+    }
+}
+
+@Suite("HoverCardTiming — standard constants")
+struct HoverCardTimingTests {
+    @Test func coldFloorIsInTheResearchedRange() {
+        // Upper end of the 300–500ms consensus, raised for the "just passing
+        // through" complaint — kept sane (< 1s HIG default).
+        #expect(HoverCardTiming.standard.showDelay >= 0.5)
+        #expect(HoverCardTiming.standard.showDelay < 1.0)
+    }
+
+    @Test func restWindowIsAShortDwell() {
+        #expect(HoverCardTiming.standard.restWindow >= 0.12)
+        #expect(HoverCardTiming.standard.restWindow <= 0.25)
+    }
+
+    @Test func warmDwellIsShorterThanColdFloorButNonZero() {
+        // Responsive swap, but never an instant cursor-chase.
+        #expect(HoverCardTiming.standard.warmDwell > 0)
+        #expect(HoverCardTiming.standard.warmDwell < HoverCardTiming.standard.showDelay)
+    }
+
+    @Test func fadeOutIsQuickerThanShow() {
         #expect(HoverCardTiming.standard.fadeOutDuration < HoverCardTiming.standard.showDelay)
     }
 }

--- a/Tests/TBDAppTests/AddTabMenuTests.swift
+++ b/Tests/TBDAppTests/AddTabMenuTests.swift
@@ -189,10 +189,12 @@ private func makeExecutable(named name: String, in directory: URL) throws {
 }
 
 @MainActor
-@Test func addTabMenu_profileItemTitles_carryCompactUsageSuffix() {
-    // A profile with a usage snapshot gets the compact suffix; one without
-    // keeps its plain identity title. (No resetsAt in the fixture so the
-    // expected string is timezone-independent.)
+@Test func addTabMenu_profileItemTitles_splitIdentityOverUsageOnTwoLines() {
+    // A profile with a usage snapshot renders two lines: identity as the plain
+    // `title` (primary), spelled-out usage in `attributedTitle` (secondary). A
+    // profile without a snapshot keeps a plain single-line title and no
+    // attributedTitle. (No resetsAt in the fixture so the expected string is
+    // timezone-independent.)
     let snapshot = ProfileUsageSnapshot(
         buckets: [
             ClaudeUsageLimitBucket(kind: "session", percent: 0, severity: "normal"),
@@ -207,8 +209,62 @@ private func makeExecutable(named name: String, in directory: URL) throws {
     let menu = AddTabMenu.build(profiles: [gmail, bare], coordinator: makeCoordinator())
 
     let idx = claudeIndex(menu)
-    #expect(menu.items[idx + 1].title == "Gmail — g@x.co · 5h 0% · wk 76% · F 100%")
-    #expect(menu.items[idx + 2].title == "Work — a@b.co")
+    let gmailItem = menu.items[idx + 1]
+    // Primary line = identity only.
+    #expect(gmailItem.title == "Gmail — g@x.co")
+    // Two-line attributed title: identity, then the spelled-out usage line
+    // ("used" once, "week", full "Fable") on a second line.
+    let attributed = gmailItem.attributedTitle
+    #expect(attributed != nil)
+    let flattened = attributed?.string ?? ""
+    #expect(flattened == "Gmail — g@x.co\n5h 0% used · week 76% · Fable 100%")
+    #expect(flattened.contains("\n"))
+    #expect(flattened.contains("used"))
+
+    // Snapshotless profile stays single-line: plain title, no attributedTitle.
+    let bareItem = menu.items[idx + 2]
+    #expect(bareItem.title == "Work — a@b.co")
+    #expect(bareItem.attributedTitle == nil)
+}
+
+@MainActor
+@Test func addTabMenu_twoLineAttributedTitle_labelsPercentAsUsedOnceAndIndentsSecondLine() {
+    let snapshot = ProfileUsageSnapshot(
+        buckets: [
+            ClaudeUsageLimitBucket(kind: "session", percent: 16, severity: "normal"),
+            ClaudeUsageLimitBucket(kind: "weekly_all", percent: 79, severity: "warning"),
+        ],
+        fetchedAt: Date(), lastAttemptAt: Date(), status: "ok"
+    )
+    let entry = makeProfile(name: "Gmail", loginIdentity: "g@x.co", usageSnapshot: snapshot)
+    let line = ProfileUsagePresentation.menuLine(for: entry)
+    let attributed = try! #require(AddTabMenu.twoLineAttributedTitle(line))
+
+    // "used" appears exactly once, on the first percentage segment.
+    let occurrences = attributed.string.components(separatedBy: "used").count - 1
+    #expect(occurrences == 1)
+    #expect(attributed.string == "Gmail — g@x.co\n5h 16% used · week 79%")
+
+    // The second line carries a head-indent paragraph style; the first does not.
+    let firstStyle = attributed.attribute(
+        .paragraphStyle, at: 0, effectiveRange: nil
+    ) as? NSParagraphStyle
+    let newlineIndex = attributed.string.distance(
+        from: attributed.string.startIndex,
+        to: attributed.string.firstIndex(of: "\n")!
+    )
+    let secondStyle = attributed.attribute(
+        .paragraphStyle, at: newlineIndex + 1, effectiveRange: nil
+    ) as? NSParagraphStyle
+    #expect((firstStyle?.headIndent ?? 0) == 0)
+    #expect((secondStyle?.headIndent ?? 0) > 0)
+}
+
+@MainActor
+@Test func addTabMenu_twoLineAttributedTitle_isNilWithoutUsageLine() {
+    let bare = makeProfile(name: "Work", loginIdentity: "a@b.co")
+    let line = ProfileUsagePresentation.menuLine(for: bare)
+    #expect(AddTabMenu.twoLineAttributedTitle(line) == nil)
 }
 
 @MainActor

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -117,6 +117,83 @@ struct UsageSuffixTests {
     }
 }
 
+// MARK: - Two-line menu composition
+
+@Suite("ProfileUsagePresentation — two-line menu")
+struct TwoLineMenuTests {
+    @Test func fullSnapshotSpellsOutUsageWithUsedLabelOnce() {
+        let line = ProfileUsagePresentation.usageDetailLine(for: gmailSnapshot, timeZone: utc)
+        #expect(line == "5h 0% used · resets 23:10 · week 76% · Fable 100%")
+    }
+
+    @Test func usedLabelAppearsExactlyOnceOnTheFirstPercentage() {
+        let line = ProfileUsagePresentation.usageDetailLine(for: gmailSnapshot, timeZone: utc) ?? ""
+        #expect(line.components(separatedBy: "used").count - 1 == 1)
+        // It rides the first (5h) segment, not the weekly/family ones.
+        #expect(line.hasPrefix("5h 0% used"))
+    }
+
+    @Test func missingSnapshotHasNoDetailLine() {
+        #expect(ProfileUsagePresentation.usageDetailLine(for: nil) == nil)
+    }
+
+    @Test func emptyBucketsHaveNoDetailLine() {
+        #expect(ProfileUsagePresentation.usageDetailLine(for: snapshot(buckets: [])) == nil)
+    }
+
+    @Test func withoutScopedFamilyBucketOmitsFamilySegment() {
+        let noFable = snapshot(buckets: [
+            bucket(kind: "session", percent: 16, resetsAt: resetDate),
+            bucket(kind: "weekly_all", percent: 79),
+        ])
+        #expect(ProfileUsagePresentation.usageDetailLine(for: noFable, timeZone: utc)
+                == "5h 16% used · resets 23:10 · week 79%")
+    }
+
+    @Test func sessionWithoutResetOmitsClockFragmentButKeepsUsed() {
+        let noReset = snapshot(buckets: [bucket(kind: "session", percent: 29)])
+        #expect(ProfileUsagePresentation.usageDetailLine(for: noReset, timeZone: utc)
+                == "5h 29% used")
+    }
+
+    @Test func usedLabelRidesWeeklyWhenNoSessionBucket() {
+        // If the session bucket is absent, "used" attaches to the first segment
+        // that does appear (weekly) so the line still disambiguates once.
+        let weeklyOnly = snapshot(buckets: [bucket(kind: "weekly_all", percent: 40)])
+        #expect(ProfileUsagePresentation.usageDetailLine(for: weeklyOnly, timeZone: utc)
+                == "week 40% used")
+    }
+
+    @Test func menuLineSplitsIdentityAndUsage() {
+        let gmail = entry(name: "Gmail", loginIdentity: "g@x.co", usageSnapshot: gmailSnapshot)
+        let line = ProfileUsagePresentation.menuLine(for: gmail, timeZone: utc)
+        #expect(line.primary == "Gmail — g@x.co")
+        #expect(line.secondary == "5h 0% used · resets 23:10 · week 76% · Fable 100%")
+    }
+
+    @Test func menuLineWithoutSnapshotHasNilSecondary() {
+        let bare = entry(name: "Work", loginIdentity: "a@b.co")
+        let line = ProfileUsagePresentation.menuLine(for: bare)
+        #expect(line.primary == "Work — a@b.co")
+        #expect(line.secondary == nil)
+    }
+
+    @Test func menuLineForNotLoggedInProfileKeepsSingleLineTreatment() {
+        // oauth profile, no identity → "needs /login" primary, no usage line.
+        let needsLogin = entry(name: "Spare")
+        let line = ProfileUsagePresentation.menuLine(for: needsLogin)
+        #expect(line.primary == "Spare — needs /login")
+        #expect(line.secondary == nil)
+    }
+
+    @Test func familyNameSpellsOutTheDisplayNameOrFallsBack() {
+        #expect(ProfileUsagePresentation.familyName("Fable") == "Fable")
+        #expect(ProfileUsagePresentation.familyName("  Opus  ") == "Opus")
+        #expect(ProfileUsagePresentation.familyName(nil) == "?")
+        #expect(ProfileUsagePresentation.familyName("  ") == "?")
+    }
+}
+
 // MARK: - Severity mapping
 
 @Suite("ProfileUsagePresentation — severity")
@@ -391,5 +468,52 @@ struct SkipAccountPickerPersistenceTests {
             state.skipAccountPicker = true
             #expect(UserDefaults.standard.object(forKey: key) == nil || prior != nil)
         }
+    }
+}
+
+// MARK: - Relative weekly reset (granularity matches window scale)
+
+@Suite("RelativeResetText")
+struct RelativeResetTextTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test func minutesUnderAnHour() {
+        let resets = now.addingTimeInterval(48 * 60)
+        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == "48m")
+    }
+
+    @Test func hoursDropMinutes() {
+        let resets = now.addingTimeInterval((3 * 60 + 20) * 60)
+        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == "3h")
+    }
+
+    @Test func daysCarryHourRemainder() {
+        let resets = now.addingTimeInterval(((2 * 24 + 5) * 60 + 10) * 60)
+        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == "2d 5h")
+    }
+
+    @Test func exactDaysOmitHours() {
+        let resets = now.addingTimeInterval(3 * 24 * 60 * 60)
+        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == "3d")
+    }
+
+    @Test func pastInstantYieldsNil() {
+        let resets = now.addingTimeInterval(-60)
+        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == nil)
+    }
+
+    @Test func weeklyResetAppearsOnceInDetailLine() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let weeklyReset = now.addingTimeInterval(((2 * 24 + 5) * 60 + 10) * 60)
+        let snap = snapshot(buckets: [
+            bucket(kind: "session", percent: 16, severity: "normal", resetsAt: resetDate),
+            bucket(kind: "weekly_all", percent: 79, severity: "normal", resetsAt: weeklyReset),
+            bucket(kind: "weekly_scoped", percent: 45, severity: "normal",
+                   resetsAt: weeklyReset, family: "Fable"),
+        ])
+        let line = ProfileUsagePresentation.usageDetailLine(for: snap, timeZone: utc, now: now)
+        #expect(line == "5h 16% used · resets 23:10 · week 79% · resets in 2d 5h · Fable 45%")
+        // The shared weekly instant renders once (on the week segment), not per family.
+        #expect(line?.components(separatedBy: "resets in").count == 2)
     }
 }

--- a/Tests/TBDAppTests/RowAccountMenuTests.swift
+++ b/Tests/TBDAppTests/RowAccountMenuTests.swift
@@ -47,9 +47,11 @@ private func claudeTerminal(id: UUID = UUID(),
                             label: String? = nil,
                             profileID: UUID? = nil,
                             createdAt: Date = Date(timeIntervalSince1970: 0),
-                            kind: TerminalKind? = .claude) -> Terminal {
+                            kind: TerminalKind? = .claude,
+                            activityState: TerminalActivityState = .unknown) -> Terminal {
     Terminal(id: id, worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
-             label: label, createdAt: createdAt, profileID: profileID, kind: kind)
+             label: label, createdAt: createdAt, profileID: profileID, kind: kind,
+             activityState: activityState)
 }
 
 /// Live-verified Gmail shape: 5h 0% resetting 23:10, weekly 76%, Fable 100%.
@@ -210,5 +212,29 @@ struct RowAccountMenuSwitchTargetTests {
         #expect(targets.count == 2)
         #expect(targets.allSatisfy { $0.isSelectable && !$0.isCurrent })
         #expect(targets.allSatisfy { $0.action(terminalID: UUID()) != nil })
+    }
+
+    // MARK: - Busy-aware switch footer
+
+    @Test func idleSessionFooterHasNoInterruptWarning() {
+        let work = entry(name: "Work", loginIdentity: "a@b.co")
+        let term = claudeTerminal(profileID: nil, activityState: .idle)
+        let session = RowAccountMenu.session(
+            terminal: term, fallbackIndex: 1, profiles: [work], timeZone: utc
+        )
+        #expect(session.isBusy == false)
+        #expect(session.switchFooter == RowAccountMenu.switchAccountCaption)
+        #expect(!session.switchFooter.contains(RowAccountMenu.interruptsRunSuffix))
+    }
+
+    @Test func busySessionFooterWarnsAboutInterrupt() {
+        let work = entry(name: "Work", loginIdentity: "a@b.co")
+        let term = claudeTerminal(profileID: nil, activityState: .working)
+        let session = RowAccountMenu.session(
+            terminal: term, fallbackIndex: 1, profiles: [work], timeZone: utc
+        )
+        #expect(session.isBusy == true)
+        #expect(session.switchFooter.hasPrefix(RowAccountMenu.switchAccountCaption))
+        #expect(session.switchFooter.hasSuffix(RowAccountMenu.interruptsRunSuffix))
     }
 }

--- a/Tests/TBDAppTests/RowAccountMenuTests.swift
+++ b/Tests/TBDAppTests/RowAccountMenuTests.swift
@@ -177,17 +177,26 @@ struct RowAccountMenuSwitchTargetTests {
         #expect(row?.action(terminalID: UUID()) == nil)
     }
 
-    @Test func switchTargetTitleCarriesCompactPerFamilyUsageSuffix() {
+    @Test func switchTargetLineSplitsIdentityAndSpelledOutUsage() {
         let target = entry(name: "Fablework", loginIdentity: "f@x.co", usageSnapshot: fableSnapshot)
         let targets = RowAccountMenu.switchTargets(
             currentProfileID: nil, profiles: [target], timeZone: utc
         )
-        let title = targets.first?.title ?? ""
-        #expect(title.contains("f@x.co"))
-        // Compact usage from ProfileUsagePresentation, incl. the per-family "F 100%".
-        #expect(title.contains("5h 0% ↺23:10"))
-        #expect(title.contains("wk 76%"))
-        #expect(title.contains("F 100%"))
+        let line = targets.first?.line
+        // Primary line is identity only — usage moves to the second line.
+        #expect(line?.primary == "Fablework — f@x.co")
+        // Secondary line spells out the roomier form: "used" once, "resets",
+        // "week", full family name "Fable".
+        #expect(line?.secondary == "5h 0% used · resets 23:10 · week 76% · Fable 100%")
+    }
+
+    @Test func switchTargetWithoutSnapshotHasNoSecondaryLine() {
+        let bare = entry(name: "Work", loginIdentity: "a@b.co")   // no usage snapshot
+        let targets = RowAccountMenu.switchTargets(
+            currentProfileID: nil, profiles: [bare], timeZone: utc
+        )
+        #expect(targets.first?.line.primary == "Work — a@b.co")
+        #expect(targets.first?.line.secondary == nil)
     }
 
     @Test func ambientSessionOffersEveryLoggedInProfileAsSelectable() {

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -427,7 +427,7 @@ struct ModelProfileSpawnTests {
 
     // MARK: - Swap: to a different token
 
-    @Test("swap on blank session: forks into a new tab with a fresh session id and new token")
+    @Test("fork on blank session: forks into a new tab with a fresh session id and new token")
     func swapToDifferentToken() async throws {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
@@ -449,10 +449,10 @@ struct ModelProfileSpawnTests {
 
         let beforeSwap = recorder.calls.count
 
-        // Swap to B → returns a NEW terminal row, old one untouched
+        // FORK to B → returns a NEW terminal row, old one untouched.
         let swapResp = await router.handle(try RPCRequest(
             method: RPCMethod.terminalSwapProfile,
-            params: TerminalSwapProfileParams(terminalID: oldTerm.id, newProfileID: b.id)
+            params: TerminalSwapProfileParams(terminalID: oldTerm.id, newProfileID: b.id, mode: .fork)
         ))
         #expect(swapResp.success)
         let newTerm = try swapResp.decodeResult(Terminal.self)
@@ -466,11 +466,13 @@ struct ModelProfileSpawnTests {
         let oldAfter = try await db.terminals.get(id: oldTerm.id)
         #expect(oldAfter?.profileID == a.id)
 
-        // Daemon did NOT send C-c or send-keys to the old pane
+        // Daemon did NOT send C-c or send-keys to the old pane (fork spawns a
+        // brand-new window; it never interrupts the source pane).
         let postSwap = Array(recorder.calls.dropFirst(beforeSwap))
         let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
         #expect(!joined.contains("C-c"))
         #expect(!joined.contains("send-keys"))
+        #expect(!joined.contains("respawn-window"))
         // The new tab was spawned with B's CLAUDE_CONFIG_DIR via tmux -e (NOT inlined),
         // and the shell body contains --session-id <newSessionID> (fresh path),
         // never --resume.
@@ -483,9 +485,55 @@ struct ModelProfileSpawnTests {
         #expect(!postBodies.contains("CLAUDE_CODE_OAUTH_TOKEN"))
     }
 
+    @Test("in-place swap (default): keeps terminal id + tmux window id, updates profile_id")
+    func inPlaceSwapKeepsRowAndWindow() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let a = try await seedOAuthProfile(db, name: "A")
+        let b = try await seedOAuthProfile(db, name: "B")
+        try await db.config.setDefaultProfileID(a.id)
+
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .claude)
+        ))
+        let oldTerm = try createResp.decodeResult(Terminal.self)
+        #expect(oldTerm.profileID == a.id)
+        let originalWindowID = oldTerm.tmuxWindowID
+
+        let beforeSwap = recorder.calls.count
+
+        // Default mode (nil → .inPlace): same tab.
+        let swapResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(terminalID: oldTerm.id, newProfileID: b.id)
+        ))
+        #expect(swapResp.success)
+        let result = try swapResp.decodeResult(Terminal.self)
+        // Same terminal id + same tmux window id — the row and tab survive.
+        #expect(result.id == oldTerm.id)
+        #expect(result.tmuxWindowID == originalWindowID)
+        // profile_id flipped to B, in place.
+        #expect(result.profileID == b.id)
+        // DB reflects the in-place update — no new row was created.
+        let all = try await db.terminals.list(worktreeID: wt.id)
+        #expect(all.count == 1)
+        #expect(all.first?.profileID == b.id)
+
+        // The pane was respawned in place (respawn-window -k on the SAME window),
+        // not spawned as a new window.
+        let postSwap = Array(recorder.calls.dropFirst(beforeSwap))
+        let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
+        #expect(joined.contains("respawn-window"))
+        #expect(joined.contains(originalWindowID))
+        #expect(!joined.contains("new-window"))
+        #expect(joined.contains("CLAUDE_CONFIG_DIR="))
+    }
+
     // MARK: - Swap: to nil
 
-    @Test("swap: to nil forks new tab with no env prefix; old tab untouched")
+    @Test("fork: to nil forks new tab with no env prefix; old tab untouched")
     func swapToNil() async throws {
         let (router, db, recorder) = makeFixture()
         defer { Task { await cleanup(db) } }
@@ -504,7 +552,7 @@ struct ModelProfileSpawnTests {
 
         let swapResp = await router.handle(try RPCRequest(
             method: RPCMethod.terminalSwapProfile,
-            params: TerminalSwapProfileParams(terminalID: oldTerm.id, newProfileID: nil)
+            params: TerminalSwapProfileParams(terminalID: oldTerm.id, newProfileID: nil, mode: .fork)
         ))
         #expect(swapResp.success)
         let newTerm = try swapResp.decodeResult(Terminal.self)

--- a/Tests/TBDDaemonTests/SwapTranscriptCarryTests.swift
+++ b/Tests/TBDDaemonTests/SwapTranscriptCarryTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Covers the account-swap transcript carry: when "Switch account" forks a new
+/// `claude --resume <id>` under a DIFFERENT config dir, the session transcript
+/// must be reachable in that destination config dir's `projects/` tree or the
+/// resume fails with "No conversation found with session ID".
+///
+/// These tests exercise the pure filesystem helpers (`ensureTranscriptReachable`,
+/// `resolveSwapSourceTranscript`) plus one end-to-end swap through
+/// `handleTerminalSwapProfile` with an injected `ClaudeProfileConfigDirManager`
+/// pointed at temp dirs — no `TBD_HOME` mutation, so no serialization needed.
+@Suite("Swap Transcript Carry")
+struct SwapTranscriptCarryTests {
+
+    // MARK: - Helpers
+
+    /// A fresh temp directory, removed on `deinit` via the returned token.
+    private func makeTempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-swap-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Write a session jsonl containing a real user message under
+    /// `<configDir>/projects/<slug>/<sessionID>.jsonl`, returning the file URL.
+    @discardableResult
+    private func writeTranscript(
+        configDir: URL,
+        slug: String,
+        sessionID: String,
+        content: String = #"{"type":"user","message":{"role":"user","content":"hello there"}}"#
+    ) throws -> URL {
+        let projectDir = configDir
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(slug, isDirectory: true)
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        let file = projectDir.appendingPathComponent("\(sessionID).jsonl")
+        try content.write(to: file, atomically: true, encoding: .utf8)
+        return file
+    }
+
+    // MARK: - ensureTranscriptReachable
+
+    @Test("copies transcript into destination config dir preserving cwd-slug layout")
+    func copiesIntoDestination() throws {
+        let src = makeTempDir()
+        let dst = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: src); try? FileManager.default.removeItem(at: dst) }
+
+        let sessionID = UUID().uuidString
+        let slug = "-Users-zionts-wt"
+        let sourceFile = try writeTranscript(configDir: src, slug: slug, sessionID: sessionID)
+
+        RPCRouter.ensureTranscriptReachable(from: sourceFile, inConfigDir: dst)
+
+        let expected = dst
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(slug, isDirectory: true)
+            .appendingPathComponent("\(sessionID).jsonl")
+        #expect(FileManager.default.fileExists(atPath: expected.path))
+        // Source is copied, not moved — the live session may still be writing.
+        #expect(FileManager.default.fileExists(atPath: sourceFile.path))
+        // Content matches.
+        let copied = try String(contentsOf: expected, encoding: .utf8)
+        #expect(copied.contains("hello there"))
+    }
+
+    @Test("no-op when destination already has the file (content preserved)")
+    func noOpWhenDestinationExists() throws {
+        let src = makeTempDir()
+        let dst = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: src); try? FileManager.default.removeItem(at: dst) }
+
+        let sessionID = UUID().uuidString
+        let slug = "-Users-zionts-wt"
+        let sourceFile = try writeTranscript(
+            configDir: src, slug: slug, sessionID: sessionID,
+            content: #"{"type":"user","message":{"role":"user","content":"NEW source"}}"#
+        )
+        // Pre-existing destination with DIFFERENT content — must not be clobbered.
+        let destFile = try writeTranscript(
+            configDir: dst, slug: slug, sessionID: sessionID,
+            content: #"{"type":"user","message":{"role":"user","content":"EXISTING dest"}}"#
+        )
+
+        RPCRouter.ensureTranscriptReachable(from: sourceFile, inConfigDir: dst)
+
+        let after = try String(contentsOf: destFile, encoding: .utf8)
+        #expect(after.contains("EXISTING dest"))
+        #expect(!after.contains("NEW source"))
+    }
+
+    @Test("no throw / no crash when source transcript is missing")
+    func missingSourceIsSafe() throws {
+        let dst = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dst) }
+        let bogus = makeTempDir().appendingPathComponent("projects/-slug/\(UUID().uuidString).jsonl")
+
+        // Should simply log and return — never throws.
+        RPCRouter.ensureTranscriptReachable(from: bogus, inConfigDir: dst)
+        // Nothing was created.
+        #expect(!FileManager.default.fileExists(atPath: dst.appendingPathComponent("projects").path))
+    }
+
+    @Test("profile→profile shared symlink target: same realpath → no copy")
+    func sharedSymlinkTargetIsNoOp() throws {
+        // Model the production layout: a host `projects/` dir, and a profile
+        // config dir whose `projects/` slot symlinks to the host. Source and
+        // destination both resolve to the host file — nothing to copy.
+        let host = makeTempDir()
+        let profileConfig = makeTempDir()
+        defer {
+            try? FileManager.default.removeItem(at: host)
+            try? FileManager.default.removeItem(at: profileConfig)
+        }
+
+        let sessionID = UUID().uuidString
+        let slug = "-Users-zionts-wt"
+        // Real transcript lives under host/projects.
+        let hostFile = try writeTranscript(configDir: host, slug: slug, sessionID: sessionID)
+
+        // profileConfig/projects → host/projects (symlink the slot).
+        let profileProjects = profileConfig.appendingPathComponent("projects")
+        try FileManager.default.createSymbolicLink(
+            at: profileProjects,
+            withDestinationURL: host.appendingPathComponent("projects")
+        )
+
+        // Source = the path as seen through the profile symlink; dest config = host.
+        let sourceViaSymlink = profileProjects
+            .appendingPathComponent(slug)
+            .appendingPathComponent("\(sessionID).jsonl")
+
+        RPCRouter.ensureTranscriptReachable(from: sourceViaSymlink, inConfigDir: host)
+
+        // The host file is unchanged and no stray duplicate was made.
+        #expect(FileManager.default.fileExists(atPath: hostFile.path))
+    }
+
+    // MARK: - resolveSwapSourceTranscript
+
+    @Test("prefers terminal transcriptPath when present on disk")
+    func prefersTranscriptPath() throws {
+        let src = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: src) }
+        let sessionID = UUID().uuidString
+        let file = try writeTranscript(configDir: src, slug: "-Users-zionts-wt", sessionID: sessionID)
+
+        let resolved = RPCRouter.resolveSwapSourceTranscript(
+            transcriptPath: file.path,
+            sessionID: sessionID,
+            worktreePath: "/Users/zionts/wt",
+            sourceConfigDir: src
+        )
+        #expect(resolved?.path == file.path)
+    }
+
+    @Test("falls back to source config dir projects scan when transcriptPath nil")
+    func fallsBackToProjectsScan() throws {
+        let src = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: src) }
+        let worktreePath = "/tmp/wt-\(UUID().uuidString)"
+        // Exact slug encoding: / and . → -
+        let slug = worktreePath.map { "/.".contains($0) ? "-" : String($0) }.joined()
+        let sessionID = UUID().uuidString
+        let file = try writeTranscript(configDir: src, slug: slug, sessionID: sessionID)
+
+        ClaudeProjectDirectory.clearCache()
+        let resolved = RPCRouter.resolveSwapSourceTranscript(
+            transcriptPath: nil,
+            sessionID: sessionID,
+            worktreePath: worktreePath,
+            sourceConfigDir: src
+        )
+        #expect(resolved?.resolvingSymlinksInPath().path == file.resolvingSymlinksInPath().path)
+    }
+
+    @Test("returns nil when neither transcriptPath nor projects file exist")
+    func returnsNilWhenAbsent() throws {
+        let src = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: src) }
+        ClaudeProjectDirectory.clearCache()
+        let resolved = RPCRouter.resolveSwapSourceTranscript(
+            transcriptPath: nil,
+            sessionID: UUID().uuidString,
+            worktreePath: "/tmp/wt-\(UUID().uuidString)",
+            sourceConfigDir: src
+        )
+        #expect(resolved == nil)
+    }
+
+    // MARK: - End-to-end: ambient → profile swap carries the transcript
+
+    @Test("ambient→profile swap copies the live transcript into the profile config dir")
+    func ambientToProfileSwapCarriesTranscript() async throws {
+        // Inject a config-dir manager pointed at temp base/host dirs so the
+        // swap's carry writes into a directory we can assert on, without
+        // touching ~/.claude or ~/tbd.
+        let baseDir = makeTempDir()   // stands in for ~/tbd/profiles
+        let hostDir = makeTempDir()   // stands in for ~/.claude (ambient source)
+        defer {
+            try? FileManager.default.removeItem(at: baseDir)
+            try? FileManager.default.removeItem(at: hostDir)
+        }
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: baseDir, hostBaseDirectory: hostDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let tmux = TmuxManager(dryRun: true)
+        let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let router = RPCRouter(
+            db: db,
+            lifecycle: lifecycle,
+            tmux: tmux,
+            startTime: Date(),
+            usageFetcher: StubClaudeUsageFetcher(),
+            configDirManager: manager
+        )
+
+        // Seed repo + worktree.
+        let repo = try await db.repos.create(path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let worktreePath = "/tmp/wt-\(UUID().uuidString)"
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main", path: worktreePath, tmuxServer: "tbd-test"
+        )
+
+        // Destination profile (OAuth).
+        let dest = try await db.modelProfiles.create(name: "Dest", kind: .oauth)
+        defer { try? ModelProfileKeychain.delete(id: dest.id.uuidString) }
+
+        // Seed an AMBIENT claude terminal (profileID nil) with a NON-blank
+        // transcript living under the ambient (host) config dir's projects.
+        let sessionID = UUID().uuidString
+        let slug = "-ambient-slug"
+        let transcript = try writeTranscript(configDir: hostDir, slug: slug, sessionID: sessionID)
+
+        let term = try await db.terminals.create(
+            id: UUID(),
+            worktreeID: wt.id,
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            label: "claude",
+            claudeSessionID: sessionID,
+            profileID: nil,
+            kind: .claude
+        )
+        try await db.terminals.updateSession(id: term.id, sessionID: sessionID, transcriptPath: transcript.path)
+
+        // Swap ambient → Dest profile.
+        let swapResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(terminalID: term.id, newProfileID: dest.id)
+        ))
+        #expect(swapResp.success)
+
+        // The transcript must now be reachable under the DEST profile's config
+        // dir projects tree, at the same slug/file the ambient source used.
+        let destConfig = manager.configDirectory(forProfileID: dest.id)
+        let carried = destConfig
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(slug, isDirectory: true)
+            .appendingPathComponent("\(sessionID).jsonl")
+        #expect(FileManager.default.fileExists(atPath: carried.path))
+        // Source ambient transcript is untouched (copy, not move).
+        #expect(FileManager.default.fileExists(atPath: transcript.path))
+    }
+}


### PR DESCRIPTION
Three commits built as part of the #337 accounts work that landed on the branch after the squash-merge cutoff (merged at 4b93b82; these came later), rebased cleanly onto main:

- **Dwell-gated hover cards** — hover cards wait for a real dwell before appearing (no flicker while navigating the sidebar), and row account info is demoted from the tooltip to the "…" menu.
- **Two-line account menu rows** — identity on the first line, usage on an indented secondary line; percentages explicitly labeled "used"; 5h reset shown as clock time, weekly reset as a relative countdown ("resets in 2d 5h").
- **In-place account switch** — "Switch account" now interrupts the current run gracefully, carries the transcript into the destination profile's config dir (copy, never move; no-op when the path is shared), and respawns `claude --resume` **in the same tmux window / same tab** with the row's account chip updated via a targeted delta. Forking a parallel timeline only happens via the explicit "Fork session" action. Busy sessions get an honest "— interrupts current run" footer.

Tests: SwapTranscriptCarryTests + updated ModelProfileSpawn/RowAccountMenu suites; full run green except the documented env-dependent `agentExecutableAvailability` test. `swiftlint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)