### PR TITLE
Session hibernation: auto-terminate idle Claude sessions, wake on focus

### DIFF
--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -1,0 +1,90 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.app", category: "Hibernation")
+
+extension AppState {
+    /// Load the auto-hibernate config (master switch + idle minutes) from the
+    /// daemon `Config`. Called on launch and whenever a config-change delta
+    /// arrives. Silent on failure — the Settings toggle just shows stale
+    /// values until the next successful load.
+    func loadHibernationConfig() async {
+        guard let config = try? await daemonClient.getConfig() else { return }
+        if config.autoHibernateEnabled != autoHibernateEnabled {
+            autoHibernateEnabled = config.autoHibernateEnabled
+        }
+        if config.hibernateIdleMinutes != hibernateIdleMinutes {
+            hibernateIdleMinutes = config.hibernateIdleMinutes
+        }
+    }
+
+    /// Persist the auto-hibernate master switch + idle timeout, updating local
+    /// published state optimistically.
+    func setAutoHibernate(enabled: Bool, idleMinutes: Int) async {
+        let minutes = max(1, idleMinutes)
+        do {
+            try await daemonClient.setAutoHibernate(enabled: enabled, idleMinutes: minutes)
+            autoHibernateEnabled = enabled
+            hibernateIdleMinutes = minutes
+        } catch {
+            logger.error("Failed to set auto-hibernate config: \(error, privacy: .public)")
+            showAlert("Failed to update hibernation setting: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Manually hibernate one Claude terminal. The daemon enforces the
+    /// running/permission rails and returns an error string we surface.
+    func hibernateTerminal(terminalID: UUID, worktreeID: UUID) async {
+        do {
+            try await daemonClient.terminalHibernate(terminalID: terminalID)
+            await refreshTerminals(worktreeID: worktreeID)
+        } catch {
+            logger.error("Failed to hibernate terminal: \(error, privacy: .public)")
+            showAlert("Couldn't hibernate: \(error.localizedDescription)", isError: false)
+        }
+    }
+
+    /// Wake a hibernated terminal (respawn `claude --resume`). Idempotent and
+    /// singleflighted on the app side: a second call while one is in flight is
+    /// dropped, so double-focus never fires two respawns.
+    func wakeTerminal(terminalID: UUID, worktreeID: UUID) async {
+        guard !wakeInFlight.contains(terminalID) else { return }
+        wakeInFlight.insert(terminalID)
+        defer { wakeInFlight.remove(terminalID) }
+        do {
+            let size = mainAreaTerminalSize()
+            try await daemonClient.terminalWake(
+                terminalID: terminalID, cols: size.cols, rows: size.rows
+            )
+            await refreshTerminals(worktreeID: worktreeID)
+        } catch {
+            logger.error("Failed to wake terminal: \(error, privacy: .public)")
+            showAlert("Couldn't wake session: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Toggle a terminal's keep-warm pin (exempts it from auto-hibernation).
+    func setTerminalKeepWarm(terminalID: UUID, keepWarm: Bool, worktreeID: UUID) async {
+        do {
+            try await daemonClient.terminalSetKeepWarm(terminalID: terminalID, keepWarm: keepWarm)
+            // Optimistic local update; the daemon also broadcasts a delta.
+            if let idx = terminals[worktreeID]?.firstIndex(where: { $0.id == terminalID }) {
+                terminals[worktreeID]?[idx].keepWarm = keepWarm
+            }
+        } catch {
+            logger.error("Failed to set keep-warm: \(error, privacy: .public)")
+            showAlert("Failed to update keep-warm: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Auto-wake any hibernated Claude terminals in a worktree the user just
+    /// focused/selected. Called from the selection-change hook. Idempotent via
+    /// `wakeTerminal`'s in-flight guard, so double-focus is safe.
+    func wakeHibernatedTerminalsOnFocus(worktreeID: UUID) {
+        let hibernated = (terminals[worktreeID] ?? []).filter { $0.isHibernated }
+        guard !hibernated.isEmpty else { return }
+        for terminal in hibernated {
+            Task { await wakeTerminal(terminalID: terminal.id, worktreeID: worktreeID) }
+        }
+    }
+}

--- a/Sources/TBDApp/AppState+TerminalFocus.swift
+++ b/Sources/TBDApp/AppState+TerminalFocus.swift
@@ -59,6 +59,11 @@ extension AppState {
     }
 
     func focusTerminalAfterSelectionChange(worktreeID: UUID) {
+        // Auto-wake: focusing a worktree with hibernated Claude sessions
+        // respawns them (`claude --resume`) in their kept-alive windows.
+        // Idempotent + singleflighted, so a double-focus won't double-spawn.
+        wakeHibernatedTerminalsOnFocus(worktreeID: worktreeID)
+
         guard let terminalID = terminalIDForAutofocus(worktreeID: worktreeID) else { return }
 
         DispatchQueue.main.async { [weak self] in

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -225,6 +225,12 @@ final class AppState: ObservableObject {
     /// dedupe path in `openLoginSession` focuses it instead of spawning again.
     var loginSessionSpawnsInFlight: Set<UUID> = []
 
+    /// Terminal IDs with a wake RPC in flight, so a rapid re-focus (or a menu
+    /// "Wake" racing the auto-wake-on-focus) doesn't fire a second `terminal.wake`
+    /// while the first is still respawning. The daemon singleflights too; this
+    /// is the app-side first line so we don't even round-trip twice.
+    var wakeInFlight: Set<UUID> = []
+
     /// The first selected worktree, if any.
     var selectedWorktree: Worktree? {
         guard let id = selectedWorktreeIDs.first else { return nil }
@@ -395,6 +401,11 @@ final class AppState: ObservableObject {
     /// alongside `globalEnvOverrides` via `loadModelProfiles()`.
     @Published var autoArchiveOnMergeDefault: Bool = false
     @Published var nightwatchMode: NightwatchMode = .off
+    /// Auto-hibernate master switch. Loaded from the daemon `Config` via
+    /// `loadHibernationConfig()`.
+    @Published var autoHibernateEnabled: Bool = true
+    /// Auto-hibernate idle timeout in minutes. Loaded from `Config`.
+    @Published var hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes
     /// Terminals where the user has dismissed the proxy-unreachable banner.
     /// Cleared on app relaunch (in-memory only — banners are advisory).
     @Published var dismissedProxyWarnings: Set<UUID> = []
@@ -842,7 +853,10 @@ final class AppState: ObservableObject {
         case .modelProfileUsageUpdated(let usage):
             applyModelProfileUsageDelta(usage)
         case .modelProfilesChanged:
-            Task { [weak self] in await self?.loadModelProfiles() }
+            Task { [weak self] in
+                await self?.loadModelProfiles()
+                await self?.loadHibernationConfig()
+            }
         case .terminalSessionUpdated(let d):
             applyTerminalSessionDelta(d)
         case .terminalCreated(let d):
@@ -851,6 +865,8 @@ final class AppState: ObservableObject {
             applyTerminalActivityDelta(d)
         case .terminalProfileChanged(let d):
             applyTerminalProfileDelta(d)
+        case .terminalHibernationChanged(let d):
+            applyTerminalHibernationDelta(d)
         case .worktreeMoved(let d):
             applyWorktreeMovedDelta(d)
         case .worktreeArchived(let d):
@@ -919,6 +935,17 @@ final class AppState: ObservableObject {
             return
         }
         terminals[delta.worktreeID]?[idx].profileID = delta.newProfileID
+    }
+
+    /// Hibernate / wake / keep-warm change: update `hibernatedAt` + `keepWarm`
+    /// on the row in place so the whisper indicator and action menu re-render
+    /// without a full terminal refetch.
+    private func applyTerminalHibernationDelta(_ delta: TerminalHibernationDelta) {
+        guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
+            return
+        }
+        terminals[delta.worktreeID]?[idx].hibernatedAt = delta.hibernated ? Date() : nil
+        terminals[delta.worktreeID]?[idx].keepWarm = delta.keepWarm
     }
 
     /// Update the in-place usage entry for a single profile. If no match,
@@ -1142,6 +1169,7 @@ final class AppState: ObservableObject {
                 }
             }
             await loadModelProfiles()
+            await loadHibernationConfig()
             startSubscription()
             await refreshPRStatuses()
             pushClaudeSpawnPreferences()

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -878,6 +878,40 @@ actor DaemonClient {
         )
     }
 
+    /// Manually hibernate one Claude terminal (kill its process, keep the
+    /// tmux window). Honors the running/permission rails.
+    func terminalHibernate(terminalID: UUID) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.terminalHibernate,
+            params: TerminalHibernateParams(terminalID: terminalID)
+        )
+    }
+
+    /// Wake a hibernated terminal: respawn `claude --resume` in its window.
+    /// Idempotent — a double-call collapses to one respawn daemon-side.
+    func terminalWake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminalID, cols: cols, rows: rows)
+        )
+    }
+
+    /// Pin/unpin a terminal against auto-hibernation.
+    func terminalSetKeepWarm(terminalID: UUID, keepWarm: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.terminalSetKeepWarm,
+            params: TerminalSetKeepWarmParams(terminalID: terminalID, keepWarm: keepWarm)
+        )
+    }
+
+    /// Set the auto-hibernate master switch + idle-timeout (minutes).
+    func setAutoHibernate(enabled: Bool, idleMinutes: Int) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetAutoHibernate,
+            params: ConfigSetAutoHibernateParams(enabled: enabled, idleMinutes: idleMinutes)
+        )
+    }
+
     /// Suspend all Claude terminals in a worktree.
     func worktreeSuspend(worktreeID: UUID) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -31,6 +31,13 @@ enum RowActionMenu {
         case deleteScratch
         case suspendClaude
         case resumeClaude
+        /// Manually hibernate all idle Claude sessions in this worktree.
+        case hibernateNow
+        /// Wake all hibernated Claude sessions in this worktree.
+        case wakeHibernated
+        /// Toggle the keep-warm pin (exempt from auto-hibernation) for this
+        /// worktree's Claude sessions. Carries the target state.
+        case toggleKeepWarm(enable: Bool)
         case createNestedWorktree
         /// Create a child worktree based on THIS worktree's current branch.
         case newWorktreeFromBranch
@@ -97,6 +104,17 @@ enum RowActionMenu {
         var hasUnsuspendedClaude: Bool
         /// Has at least one resumable Claude terminal that IS suspended.
         var hasSuspendedClaude: Bool
+        /// Has at least one Claude terminal eligible for a manual "Hibernate
+        /// now" right now (idle-at-rest, not running/waiting/hibernated).
+        var hasHibernatableClaude: Bool
+        /// Has at least one hibernated Claude terminal (drives "Wake").
+        var hasHibernatedClaude: Bool
+        /// Has at least one resumable Claude terminal that is NOT keep-warm
+        /// pinned (drives "Keep warm").
+        var hasUnpinnedClaude: Bool
+        /// Has at least one keep-warm-pinned Claude terminal (drives "Allow
+        /// hibernation").
+        var hasKeepWarmClaude: Bool
         /// Has at least one non-archived child worktree (gates archive).
         var hasActiveChildren: Bool
         /// Worktree path is empty (main/creating rows hide Finder/Copy then).
@@ -117,6 +135,10 @@ enum RowActionMenu {
 
         init(hasUnsuspendedClaude: Bool = false,
              hasSuspendedClaude: Bool = false,
+             hasHibernatableClaude: Bool = false,
+             hasHibernatedClaude: Bool = false,
+             hasUnpinnedClaude: Bool = false,
+             hasKeepWarmClaude: Bool = false,
              hasActiveChildren: Bool = false,
              pathIsEmpty: Bool = false,
              hasRepoID: Bool = true,
@@ -127,6 +149,10 @@ enum RowActionMenu {
              claudeSessions: [ClaudeSessionRef] = []) {
             self.hasUnsuspendedClaude = hasUnsuspendedClaude
             self.hasSuspendedClaude = hasSuspendedClaude
+            self.hasHibernatableClaude = hasHibernatableClaude
+            self.hasHibernatedClaude = hasHibernatedClaude
+            self.hasUnpinnedClaude = hasUnpinnedClaude
+            self.hasKeepWarmClaude = hasKeepWarmClaude
             self.hasActiveChildren = hasActiveChildren
             self.pathIsEmpty = pathIsEmpty
             self.hasRepoID = hasRepoID
@@ -145,6 +171,10 @@ enum RowActionMenu {
     static let archiveNeedsChildrenGoneHelp = "Archive nested worktrees first"
     static let forkSessionLabel = "Fork session"
     static let newWorktreeFromBranchLabel = "New worktree from this branch…"
+    static let hibernateNowLabel = "Hibernate now"
+    static let wakeLabel = "Wake"
+    static let keepWarmLabel = "Keep warm"
+    static let allowHibernationLabel = "Allow hibernation"
 
     /// Title for a fork-session action: plain when the worktree hosts a single
     /// Claude session, suffixed with the session label when there are several.
@@ -179,6 +209,30 @@ enum RowActionMenu {
         forkActions(context: context)
     }
 
+    /// Hibernation actions for a worktree row: Wake (if any session is
+    /// hibernated), Hibernate now (if any is eligible), and the keep-warm
+    /// toggle. Shared by the regular and scratch branches so both surfaces
+    /// (right-click + "…") stay in lockstep.
+    static func hibernationActions(context: Context) -> [Action] {
+        var actions: [Action] = []
+        if context.hasHibernatedClaude {
+            actions.append(Action(kind: .wakeHibernated, title: wakeLabel))
+        }
+        if context.hasHibernatableClaude {
+            actions.append(Action(kind: .hibernateNow, title: hibernateNowLabel))
+        }
+        // Keep-warm toggle: offer "Keep warm" when any session is still
+        // eligible for auto-hibernation, and "Allow hibernation" when any is
+        // pinned. (Both can appear if a worktree hosts a mix.)
+        if context.hasUnpinnedClaude {
+            actions.append(Action(kind: .toggleKeepWarm(enable: true), title: keepWarmLabel))
+        }
+        if context.hasKeepWarmClaude {
+            actions.append(Action(kind: .toggleKeepWarm(enable: false), title: allowHibernationLabel))
+        }
+        return actions
+    }
+
     private static func forkActions(context: Context) -> [Action] {
         let multiple = context.claudeSessions.count > 1
         return context.claudeSessions.map { session in
@@ -201,6 +255,7 @@ enum RowActionMenu {
         if includeSessionForks {
             items.append(contentsOf: forkActions(context: context).map(Item.action))
         }
+        items.append(contentsOf: hibernationActions(context: context).map(Item.action))
         items.append(contentsOf: [
             .divider,
             .action(Action(kind: .rename, title: "Rename...")),
@@ -241,6 +296,7 @@ enum RowActionMenu {
         if context.hasSuspendedClaude {
             items.append(.action(Action(kind: .resumeClaude, title: "Resume Claude")))
         }
+        items.append(contentsOf: hibernationActions(context: context).map(Item.action))
         // Per-session fork — only in surfaces without an account section (the
         // right-click menu). The "…" menu renders fork in its account section.
         if includeSessionForks {

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -143,6 +143,33 @@ struct GeneralSettingsTab: View {
                     .help("Skip the interactive permission prompt when launching claude in new worktrees")
             }
 
+            Section("Session Hibernation") {
+                Toggle("Auto-hibernate idle Claude sessions", isOn: Binding(
+                    get: { appState.autoHibernateEnabled },
+                    set: { newValue in
+                        Task { await appState.setAutoHibernate(
+                            enabled: newValue, idleMinutes: appState.hibernateIdleMinutes) }
+                    }
+                ))
+                .help("Kill the claude process of a session idle at rest, keeping its tab alive. It respawns automatically on focus. The prompt cache has already expired by then, so resume is cheap. Never touches a running turn, a permission prompt, or a keep-warm session.")
+
+                if appState.autoHibernateEnabled {
+                    Stepper(
+                        "Idle before hibernating: \(appState.hibernateIdleMinutes) min",
+                        value: Binding(
+                            get: { appState.hibernateIdleMinutes },
+                            set: { newValue in
+                                Task { await appState.setAutoHibernate(
+                                    enabled: appState.autoHibernateEnabled, idleMinutes: newValue) }
+                            }
+                        ),
+                        in: 5...240,
+                        step: 5
+                    )
+                    .help("How long a Claude session must sit idle before it's hibernated.")
+                }
+            }
+
             Section {
                 EnvOverridesEditor(
                     initial: appState.globalEnvOverrides,

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -48,6 +48,14 @@ struct RowActionMenuActions {
             hasSuspendedClaude: terminals.contains {
                 $0.isClaudeResumable && $0.suspendedAt != nil
             },
+            hasHibernatableClaude: terminals.contains { $0.isManuallyHibernatable },
+            hasHibernatedClaude: terminals.contains { $0.isHibernated },
+            hasUnpinnedClaude: terminals.contains {
+                $0.isClaudeResumable && !$0.keepWarm && !$0.isHibernated
+            },
+            hasKeepWarmClaude: terminals.contains {
+                $0.isClaudeResumable && $0.keepWarm
+            },
             hasActiveChildren: !appState.children(of: worktree.id).isEmpty,
             pathIsEmpty: worktree.path.isEmpty,
             hasRepoID: worktree.repoID != nil,
@@ -113,6 +121,36 @@ struct RowActionMenuActions {
             Task {
                 try? await appState.daemonClient.worktreeResume(worktreeID: wtID)
                 await appState.refreshTerminals(worktreeID: wtID)
+            }
+
+        case .hibernateNow:
+            let wtID = worktree.id
+            let ids = terminals.filter { $0.isManuallyHibernatable }.map { $0.id }
+            Task {
+                for id in ids {
+                    await appState.hibernateTerminal(terminalID: id, worktreeID: wtID)
+                }
+            }
+
+        case .wakeHibernated:
+            let wtID = worktree.id
+            let ids = terminals.filter { $0.isHibernated }.map { $0.id }
+            Task {
+                for id in ids {
+                    await appState.wakeTerminal(terminalID: id, worktreeID: wtID)
+                }
+            }
+
+        case let .toggleKeepWarm(enable):
+            let wtID = worktree.id
+            // Only flip terminals not already in the requested state.
+            let ids = terminals
+                .filter { $0.isClaudeResumable && $0.keepWarm != enable && !$0.isHibernated }
+                .map { $0.id }
+            Task {
+                for id in ids {
+                    await appState.setTerminalKeepWarm(terminalID: id, keepWarm: enable, worktreeID: wtID)
+                }
             }
 
         case .createNestedWorktree:

--- a/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
+++ b/Sources/TBDApp/Sidebar/RowStatusIndicator.swift
@@ -15,15 +15,20 @@ enum SuffixRowIndicator: Equatable {
     case attention
     case working
     case suspended
+    /// Session hibernated (claude process killed to reclaim memory; tmux window
+    /// kept alive). A calm, whisper-quiet moon — deliberately NOT alarming: the
+    /// session is safe and wakes automatically on focus.
+    case hibernated
 
     /// SF Symbol for glyph-based suffixes. `.working` is `nil` because it is
     /// rendered as an animated `TypingDotsView`, not a static symbol.
     var systemImage: String? {
         switch self {
-        case .error:     return "exclamationmark.octagon.fill"
-        case .attention: return "hand.raised.fill"
-        case .working:   return nil
-        case .suspended: return "pause.circle.fill"
+        case .error:      return "exclamationmark.octagon.fill"
+        case .attention:  return "hand.raised.fill"
+        case .working:    return nil
+        case .suspended:  return "pause.circle.fill"
+        case .hibernated: return "moon.zzz.fill"
         }
     }
 
@@ -44,6 +49,10 @@ enum SuffixRowIndicator: Equatable {
             return .secondary
         case .suspended:
             return .secondary
+        case .hibernated:
+            // Tertiary — quieter than suspended, so it reads as "resting", not
+            // "stopped". A whisper, not a flag.
+            return Color.secondary.opacity(0.55)
         }
     }
 }
@@ -81,12 +90,15 @@ enum RowStatusIndicator {
     }
 
     /// Suffix slot. Priority (highest first): error > attention > working >
-    /// suspended. `taskComplete` produces no suffix; `responseComplete` is
-    /// surfaced as a bold name in the view, not as a suffix.
+    /// suspended > hibernated. `taskComplete` produces no suffix;
+    /// `responseComplete` is surfaced as a bold name in the view, not as a
+    /// suffix. Hibernated is lowest — it's the calmest, safest state, so any
+    /// louder signal wins the slot.
     static func suffix(
         notification: NotificationType?,
         isWorking: Bool,
-        isSuspended: Bool
+        isSuspended: Bool,
+        isHibernated: Bool = false
     ) -> SuffixRowIndicator? {
         if notification == .error {
             return .error
@@ -96,6 +108,8 @@ enum RowStatusIndicator {
             return .working
         } else if isSuspended {
             return .suspended
+        } else if isHibernated {
+            return .hibernated
         }
         return nil
     }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -39,6 +39,11 @@ struct WorktreeRowView: View {
         return terminals.contains { $0.suspendedAt != nil }
     }
 
+    private var hasHibernatedTerminal: Bool {
+        let terminals = appState.terminals[worktree.id] ?? []
+        return terminals.contains { $0.isHibernated }
+    }
+
     private var hasWorkingTerminal: Bool {
         let terminals = appState.terminals[worktree.id] ?? []
         return terminals.contains { $0.activityState == .working }
@@ -97,7 +102,8 @@ struct WorktreeRowView: View {
         switch RowStatusIndicator.suffix(
             notification: notification,
             isWorking: hasWorkingTerminal,
-            isSuspended: hasSuspendedTerminal
+            isSuspended: hasSuspendedTerminal,
+            isHibernated: hasHibernatedTerminal
         ) {
         case .working:
             TypingDotsView(color: SuffixRowIndicator.working.color)
@@ -122,8 +128,9 @@ struct WorktreeRowView: View {
         switch indicator {
         case .error:     return "Error"
         case .attention: return "Needs your attention"
-        case .working:   return "Agent is working"
-        case .suspended: return "Suspended"
+        case .working:    return "Agent is working"
+        case .suspended:  return "Suspended"
+        case .hibernated: return "Hibernating — wakes on focus"
         }
     }
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -60,6 +60,7 @@ public final class Daemon: Sendable {
     public nonisolated(unsafe) var gitFetchTask: Task<Void, Never>?
     public nonisolated(unsafe) var gitStatusTask: Task<Void, Never>?
     public nonisolated(unsafe) var reaperTask: Task<Void, Never>?
+    public nonisolated(unsafe) var hibernationSweepTask: Task<Void, Never>?
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     public nonisolated(unsafe) var oauthUsagePoller: OAuthProfileUsagePoller?
     /// Per-daemon tmux control-mode supervisor. Owned here so it can be stopped
@@ -479,6 +480,20 @@ public final class Daemon: Sendable {
                     guard !Task.isCancelled else { break }
                 }
             }
+
+            // 14. Auto-hibernate idle sweep. Cheap poll every 30s; the actual
+            // kill decision is made against the configured idle window (default
+            // 30 min) with a debounce, inside the coordinator. The feature's
+            // master switch is read from config on each sweep, so toggling it
+            // off takes effect without a restart.
+            let hibernationCoordinator = rpcRouter.hibernationCoordinator
+            self.hibernationSweepTask = Task {
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(30))
+                    guard !Task.isCancelled else { break }
+                    await hibernationCoordinator.sweep()
+                }
+            }
         } else {
             daemonLogger.info("Mock mode: skipping periodic background tasks")
         }
@@ -509,6 +524,7 @@ public final class Daemon: Sendable {
         gitFetchTask?.cancel()
         gitStatusTask?.cancel()
         reaperTask?.cancel()
+        hibernationSweepTask?.cancel()
 
         // Stop servers
         if let sock = socketServer {

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -22,6 +22,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var scratch_profile_override_id: String?
     /// Nightwatch mode: 'off', 'daywatch', or 'nightwatch'. Nil/absent defaults to 'off'.
     var nightwatch_mode: String?
+    var auto_hibernate_enabled: Bool?
+    var hibernate_idle_minutes: Int?
 
     func toModel() -> Config {
         Config(
@@ -35,7 +37,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             scratchRenamePrompt: scratch_rename_prompt,
             scratchProfileOverrideID: scratch_profile_override_id.flatMap(UUID.init(uuidString:)),
             nightwatchMode: nightwatch_mode
-                .flatMap(NightwatchMode.init(rawValue:)) ?? .off
+                .flatMap(NightwatchMode.init(rawValue:)) ?? .off,
+            autoHibernateEnabled: auto_hibernate_enabled ?? true,
+            hibernateIdleMinutes: hibernate_idle_minutes ?? Config.defaultHibernateIdleMinutes
         )
     }
 }
@@ -169,6 +173,19 @@ public struct ConfigStore: Sendable {
             try db.execute(
                 sql: "UPDATE config SET nightwatch_mode = ? WHERE id = ?",
                 arguments: [mode.rawValue, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the auto-hibernate master switch + idle-timeout (minutes). The
+    /// minutes value is floored at 1 so a zero/negative can't make the idle
+    /// timer hibernate everything on the next sweep.
+    public func setAutoHibernate(enabled: Bool, idleMinutes: Int) async throws {
+        let minutes = max(1, idleMinutes)
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_hibernate_enabled = ?, hibernate_idle_minutes = ? WHERE id = ?",
+                arguments: [enabled, minutes, Self.singletonID]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -663,6 +663,22 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "config", column: "nightwatch_mode", type: .text, defaults: "off")
         }
 
+        // Session hibernation: per-terminal hibernated timestamp + keep-warm
+        // pin, and the global auto-hibernate master switch + idle-timeout.
+        // `hibernatedAt` nullable (nil = not hibernated); `keepWarm` defaults
+        // false; `auto_hibernate_enabled` defaults true (feature ON) and
+        // `hibernate_idle_minutes` defaults 30. All additive/nullable-or-
+        // defaulted so pre-v39 rows decode unchanged.
+        migrator.registerMigration("v39_session_hibernation") { db in
+            try db.addColumnIfMissing(table: "terminal", column: "hibernatedAt", type: .datetime)
+            try db.addColumnIfMissing(
+                table: "terminal", column: "keepWarm", type: .boolean, defaults: false)
+            try db.addColumnIfMissing(
+                table: "config", column: "auto_hibernate_enabled", type: .boolean, defaults: true)
+            try db.addColumnIfMissing(
+                table: "config", column: "hibernate_idle_minutes", type: .integer, defaults: 30)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -20,6 +20,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var transcriptPath: String?
     var kind: String?
     var activityState: String?
+    var hibernatedAt: Date?
+    var keepWarm: Bool?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -36,6 +38,8 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.transcriptPath = terminal.transcriptPath
         self.kind = terminal.kind?.rawValue
         self.activityState = terminal.activityState.rawValue
+        self.hibernatedAt = terminal.hibernatedAt
+        self.keepWarm = terminal.keepWarm
     }
 
     func toModel() -> Terminal {
@@ -53,7 +57,9 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             profileID: profile_id.flatMap(UUID.init(uuidString:)),
             transcriptPath: transcriptPath,
             kind: kind.flatMap(TerminalKind.init(rawValue:)),
-            activityState: activityState.flatMap(TerminalActivityState.init(rawValue:)) ?? .unknown
+            activityState: activityState.flatMap(TerminalActivityState.init(rawValue:)) ?? .unknown,
+            hibernatedAt: hibernatedAt,
+            keepWarm: keepWarm ?? false
         )
     }
 }
@@ -216,6 +222,7 @@ public struct TerminalStore: Sendable {
             record.transcriptPath = nil
             record.suspendedAt = nil
             record.suspendedSnapshot = nil
+            record.hibernatedAt = nil
             record.label = TerminalLabel.shell
             record.kind = TerminalKind.shell.rawValue
             record.activityState = TerminalActivityState.unknown.rawValue
@@ -252,6 +259,45 @@ public struct TerminalStore: Sendable {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.activityState = activityState.rawValue
+            try record.update(db)
+        }
+    }
+
+    /// Mark a terminal hibernated (claude process killed, tmux window kept
+    /// alive), recording the wake session ID and timestamp. `sessionID` is the
+    /// session to `claude --resume` on wake.
+    public func setHibernated(id: UUID, sessionID: String, at date: Date = Date()) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.claudeSessionID = sessionID
+            record.hibernatedAt = date
+            record.activityState = TerminalActivityState.idle.rawValue
+            try record.update(db)
+        }
+    }
+
+    /// Clear a terminal's hibernated state (on wake). Leaves `claudeSessionID`
+    /// intact — the wake respawn re-captures a fresh id afterward.
+    public func clearHibernated(id: UUID) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.hibernatedAt = nil
+            try record.update(db)
+        }
+    }
+
+    /// Set or clear a terminal's keep-warm pin (exempts it from
+    /// auto-hibernation).
+    public func setKeepWarm(id: UUID, keepWarm: Bool) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.keepWarm = keepWarm
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -1,0 +1,466 @@
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "Hibernation")
+
+public enum HibernateResult: Equatable, Sendable {
+    case ok
+    case alreadyHibernated
+    case notEligible(reason: String)
+    case notFound
+}
+
+public enum WakeResult: Equatable, Sendable {
+    case ok
+    case notHibernated   // idempotent no-op: nothing to wake
+    case notFound
+    case noSessionID
+    case inFlight        // a wake for this terminal is already respawning
+}
+
+/// Owns session hibernation: gracefully terminating an idle Claude process
+/// while KEEPING its tmux window alive (the shell stays), and waking it later
+/// by respawning `claude --resume <id>` in that same window.
+///
+/// Mirrors `SuspendResumeCoordinator`'s structure, but the two are distinct:
+///   - Suspend/resume kills the tmux WINDOW's program and snapshots the pane;
+///     resume creates a fresh window.
+///   - Hibernate uses `respawn-window` to swap the pane's program to a bare
+///     shell (window survives, freeing the claude process + its RSS); wake
+///     `respawn-window`s the same pane back to `claude --resume`.
+///
+/// The prompt cache expires after ~5 min idle, so a session past the TTL pays
+/// full uncached input on its next message whether or not the process stayed
+/// alive — hibernating an idle session is therefore nearly free.
+public actor HibernationCoordinator {
+    private let db: TBDDatabase
+    private let tmux: TmuxManager
+    private let detector: ClaudeStateDetector
+    private let modelProfileResolver: ModelProfileResolver?
+    private let subscriptions: StateSubscriptionManager?
+    private let now: @Sendable () -> Date
+
+    /// Per-terminal "first time we observed it idle-at-rest" marker, maintained
+    /// by `sweep`. In-memory only: a daemon restart clears it, so a freshly
+    /// started daemon won't instantly hibernate long-idle sessions — it waits a
+    /// full idle window first, which is the safe behavior.
+    private var idleSince: [UUID: Date] = [:]
+
+    /// Terminal ids with an in-flight wake respawn, so a double-focus can't
+    /// spawn two `claude --resume` processes into the same window.
+    private var wakesInFlight: Set<UUID> = []
+
+    /// Terminal ids with an in-flight hibernate, so a manual "Hibernate now"
+    /// racing the idle sweep (or two sweeps) can't respawn-to-shell twice.
+    private var hibernatesInFlight: Set<UUID> = []
+
+    /// Debounce after a terminal first crosses the idle threshold: the sweep
+    /// marks it `pendingKillSince`, and only actually hibernates on a LATER
+    /// sweep once this settle window has also elapsed AND every rail still
+    /// holds. State can flip in the final instant (a turn starts, a permission
+    /// prompt appears), so the kill decision is re-verified here, not at
+    /// arm-time. (Knative/KEDA poll-cheaply / decide-against-window pattern.)
+    private var pendingKillSince: [UUID: Date] = [:]
+
+    /// Settle window between crossing the idle threshold and the actual kill.
+    static let killDebounce: TimeInterval = 20
+
+    private var defaultShell: String {
+        ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+    }
+
+    public init(
+        db: TBDDatabase,
+        tmux: TmuxManager,
+        modelProfileResolver: ModelProfileResolver? = nil,
+        subscriptions: StateSubscriptionManager? = nil,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.db = db
+        self.tmux = tmux
+        self.detector = ClaudeStateDetector(tmux: tmux)
+        self.modelProfileResolver = modelProfileResolver
+        self.subscriptions = subscriptions
+        self.now = now
+    }
+
+    // MARK: - Keep-warm
+
+    public func setKeepWarm(terminalID: UUID, keepWarm: Bool) async -> Bool {
+        guard let terminal = try? await db.terminals.get(id: terminalID) else { return false }
+        try? await db.terminals.setKeepWarm(id: terminalID, keepWarm: keepWarm)
+        broadcastHibernation(terminal: terminal, hibernated: terminal.isHibernated, keepWarm: keepWarm)
+        return true
+    }
+
+    // MARK: - Hibernate
+
+    /// Manual "Hibernate now". Honors the running / permission-prompt rails but
+    /// not keep-warm or idle-time (the user asked explicitly).
+    public func manualHibernate(terminalID: UUID) async -> HibernateResult {
+        guard let terminal = try? await db.terminals.get(id: terminalID) else {
+            return .notFound
+        }
+        guard terminal.hibernatedAt == nil else { return .alreadyHibernated }
+        guard terminal.isManuallyHibernatable else {
+            return .notEligible(reason: manualBlockReason(terminal))
+        }
+        return await performHibernate(terminal: terminal)
+    }
+
+    /// The reason a manual hibernate was refused, for the RPC error string.
+    private func manualBlockReason(_ terminal: Terminal) -> String {
+        if !terminal.isClaudeResumable { return "Not a resumable Claude session" }
+        if terminal.suspendedAt != nil { return "Terminal is suspended" }
+        switch terminal.activityState {
+        case .working: return "Session is actively running"
+        case .waitingForUser: return "Session is waiting on a permission prompt"
+        default: return "Not hibernatable"
+        }
+    }
+
+    /// Gracefully terminate the pane's Claude and swap the pane to a bare shell
+    /// via `respawn-window` (window + tab survive). Marks the row hibernated.
+    ///
+    /// Singleflighted per-terminal, and re-verifies the live pane/disk rails
+    /// (typed-but-unsent input, transcript-tail validity) that the DB row can't
+    /// express. After the kill it verifies the claude process is gone and the
+    /// pane's shell survived, and logs any orphaned claude children.
+    private func performHibernate(terminal: Terminal) async -> HibernateResult {
+        guard !hibernatesInFlight.contains(terminal.id) else {
+            return .alreadyHibernated
+        }
+        hibernatesInFlight.insert(terminal.id)
+        defer { hibernatesInFlight.remove(terminal.id) }
+
+        guard let sessionID = terminal.claudeSessionID else {
+            return .notEligible(reason: "No session id to resume later")
+        }
+        guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+            return .notFound
+        }
+        let server = worktree.tmuxServer
+        let paneID = terminal.tmuxPaneID
+        let windowID = terminal.tmuxWindowID
+
+        // Rail: typed-but-unsent input. Chrome's single biggest tab-discard
+        // backlash was lost typed text — never hibernate a pane with a
+        // half-composed prompt. Best-effort: if capture fails we proceed (the
+        // DB rails already cleared it as idle-at-rest).
+        if let capture = try? await tmux.capturePaneWithAnsi(server: server, paneID: paneID),
+           HibernationSafetyChecks.hasPendingInput(paneCapture: capture) {
+            logger.debug("hibernate: skipping \(terminal.id, privacy: .public) — pending typed input in prompt")
+            return .notEligible(reason: "Terminal has unsent typed input")
+        }
+
+        // Rail: transcript-tail validity. Killing mid-write can leave an
+        // unresumable jsonl (#18880). Only hibernate when the last line is
+        // complete JSON. Missing/empty transcript is allowed (nothing to
+        // corrupt); the resume will just find no prior turns.
+        if let transcriptPath = terminal.transcriptPath,
+           let body = try? String(contentsOfFile: transcriptPath, encoding: .utf8),
+           !HibernationSafetyChecks.isTranscriptTailValid(jsonlBody: body) {
+            logger.warning("hibernate: skipping \(terminal.id, privacy: .public) — transcript tail not parseable, would be unresumable")
+            return .notEligible(reason: "Transcript is mid-write; try again shortly")
+        }
+
+        // Best-effort graceful interrupt so Claude flushes before respawn-window
+        // -k forcibly replaces it. Mirrors the swap path's sequence.
+        await gracefullyInterruptPane(server: server, paneID: paneID)
+
+        // Respawn the SAME window to a bare login shell: the claude process (and
+        // its RSS) is gone, but the tmux window/pane and its scrollback stay.
+        do {
+            try await tmux.respawnWindow(
+                server: server,
+                windowID: windowID,
+                cwd: worktree.path,
+                shellCommand: defaultShell
+            )
+        } catch {
+            logger.warning("hibernate: respawn-to-shell failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return .notEligible(reason: "Failed to respawn shell")
+        }
+
+        // Post-kill verification: the pane must now be running a shell, not
+        // claude. respawn-window -k replaces the pane's program, so this
+        // confirms the swap took and the shell (window) survived. Any leftover
+        // orphaned claude child processes (#43944, #25188) are logged but not
+        // killed in v1 — surfacing them is enough.
+        await verifyHibernationTookEffect(server: server, paneID: paneID, terminalID: terminal.id)
+
+        do {
+            try await db.terminals.setHibernated(id: terminal.id, sessionID: sessionID, at: now())
+        } catch {
+            logger.warning("hibernate: failed to mark hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+        idleSince[terminal.id] = nil
+        pendingKillSince[terminal.id] = nil
+        broadcastHibernation(terminal: terminal, hibernated: true, keepWarm: terminal.keepWarm)
+        logger.info("hibernated terminal \(terminal.id, privacy: .public) (session \(sessionID, privacy: .public))")
+        return .ok
+    }
+
+    /// Confirm the respawn-to-shell actually replaced claude, and log any
+    /// orphaned claude children left behind. Best-effort, log-only.
+    private func verifyHibernationTookEffect(server: String, paneID: String, terminalID: UUID) async {
+        if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: paneID),
+           ClaudeStateDetector.isClaudeProcess(cmd) {
+            logger.warning("hibernate: pane for terminal \(terminalID, privacy: .public) still shows claude after respawn (\(cmd, privacy: .public))")
+        }
+        // Detect orphaned claude descendants (children reparented to launchd
+        // after the parent died) so they're observable via `log stream`.
+        if let orphans = detectOrphanedClaudeProcesses(), !orphans.isEmpty {
+            logger.warning("hibernate: \(orphans.count, privacy: .public) orphaned claude-descendant process(es) survived hibernation of terminal \(terminalID, privacy: .public): PIDs \(orphans.map(String.init).joined(separator: ","), privacy: .public)")
+        }
+    }
+
+    /// Enumerate claude processes now parented to PID 1 (launchd) — a rough
+    /// signal of orphaned children left by a killed claude. Log-only in v1.
+    private func detectOrphanedClaudeProcesses() -> [Int]? {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-Ao", "pid=,ppid=,comm="]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        guard (try? process.run()) != nil else { return nil }
+        process.waitUntilExit()
+        let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        var orphans: [Int] = []
+        for line in out.split(separator: "\n") {
+            let parts = line.split(separator: " ", omittingEmptySubsequences: true)
+            guard parts.count >= 3, let pid = Int(parts[0]), let ppid = Int(parts[1]) else { continue }
+            let comm = parts[2...].joined(separator: " ")
+            if ppid == 1 && comm.contains("claude") { orphans.append(pid) }
+        }
+        return orphans
+    }
+
+    // MARK: - Wake
+
+    /// Respawn `claude --resume <sessionID>` in the hibernated terminal's
+    /// kept-alive window. Idempotent: a non-hibernated terminal is a no-op, and
+    /// concurrent wakes for the same terminal collapse to one respawn.
+    public func wake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil) async -> WakeResult {
+        guard let terminal = try? await db.terminals.get(id: terminalID) else {
+            return .notFound
+        }
+        guard terminal.hibernatedAt != nil else { return .notHibernated }
+        guard let sessionID = terminal.claudeSessionID else { return .noSessionID }
+        guard !wakesInFlight.contains(terminalID) else { return .inFlight }
+        guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+            return .notFound
+        }
+
+        wakesInFlight.insert(terminalID)
+        defer { wakesInFlight.remove(terminalID) }
+
+        let server = worktree.tmuxServer
+        let paneID = terminal.tmuxPaneID
+        let windowID = terminal.tmuxWindowID
+
+        // `claude --resume` is cwd-scoped (session lookup is per-directory).
+        // Respawning inside the existing window already runs in the worktree,
+        // but assert it so a moved/relocated worktree can't silently resume in
+        // the wrong directory (or fail to find the session).
+        if let paneCwd = try? await tmux.paneCurrentPath(server: server, paneID: paneID),
+           paneCwd != worktree.path {
+            logger.warning("wake: pane cwd \(paneCwd, privacy: .public) != worktree path \(worktree.path, privacy: .public) for terminal \(terminal.id, privacy: .public); respawn will -c into the worktree path")
+        }
+
+        // Honor the exact profile persisted on the terminal (loadByID, not
+        // re-resolve) so wake lands on the same account the session used.
+        var resolvedProfile: ResolvedModelProfile? = nil
+        if let profileID = terminal.profileID, let resolver = modelProfileResolver {
+            resolvedProfile = try? await resolver.loadByID(profileID)
+            if resolvedProfile == nil {
+                logger.warning("wake: profile \(profileID, privacy: .public) missing for terminal \(terminal.id, privacy: .public); falling back to keychain login")
+            }
+        }
+
+        let config = try? await db.config.get()
+        let claudeEnvOverrides = config?.envSettingOverrides ?? [:]
+        let repo: Repo?
+        if let rid = worktree.repoID {
+            repo = try? await db.repos.get(id: rid)
+        } else {
+            repo = nil
+        }
+        let mergedEnvOverrides = EnvOverrideResolver.merge(
+            global: config?.envOverrides,
+            repo: repo?.envOverrides,
+            profile: resolvedProfile?.envOverrides
+        )
+        let overlayPath = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: resolvedProfile?.fallbackModels,
+            sessionKey: terminal.id.uuidString
+        )
+        let spawn = ClaudeSpawnCommandBuilder.build(
+            resumeID: sessionID,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: resolvedProfile?.secret,
+            profileKind: resolvedProfile?.kind,
+            profileBaseURL: resolvedProfile?.baseURL,
+            profileModel: resolvedProfile?.model,
+            profileAwsRegion: resolvedProfile?.awsRegion,
+            profileAwsProfile: resolvedProfile?.awsProfile,
+            profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
+            cmd: nil,
+            shellFallback: defaultShell,
+            settingsOverlayPath: overlayPath,
+            pluginDirPath: PluginDirWriter.pluginDirPath,
+            envSettingOverrides: claudeEnvOverrides
+        )
+        // Inject TBD_WORKTREE_ID + TBD_TERMINAL_ID so notifications and the
+        // SessionStart hook attribute to this terminal after the resume rollover.
+        let env: [String: String] = [
+            "TBD_WORKTREE_ID": worktree.id.uuidString,
+            "TBD_TERMINAL_ID": terminal.id.uuidString,
+        ]
+        let sensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
+
+        do {
+            try await tmux.respawnWindow(
+                server: server,
+                windowID: windowID,
+                cwd: worktree.path,
+                shellCommand: spawn.command,
+                env: env,
+                sensitiveEnv: sensitiveEnv,
+                cols: cols,
+                rows: rows
+            )
+        } catch {
+            // Leave the row hibernated so the next focus/menu retry can wake it.
+            logger.warning("wake: respawn-to-claude failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return .notFound
+        }
+
+        do {
+            try await db.terminals.clearHibernated(id: terminal.id)
+        } catch {
+            logger.warning("wake: failed to clear hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+        idleSince[terminal.id] = nil
+        broadcastHibernation(terminal: terminal, hibernated: false, keepWarm: terminal.keepWarm)
+
+        // `claude --resume <id>` forks into a NEW session file; re-capture the
+        // fresh id so subsequent hibernate/wake reference the live session.
+        let termID = terminal.id
+        Task {
+            try? await Task.sleep(for: .seconds(5))
+            if let newID = await self.detector.captureSessionID(server: server, paneID: paneID) {
+                try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
+            }
+        }
+        logger.info("woke terminal \(terminal.id, privacy: .public) (resume \(sessionID, privacy: .public))")
+        return .ok
+    }
+
+    // MARK: - Idle sweep (auto-hibernate)
+
+    /// One pass of the auto-hibernate idle timer, run cheaply on a short cadence
+    /// (poll) while the actual kill decision is made against the 30-min idle
+    /// window (decide) — the Knative/KEDA poll/decide split.
+    ///
+    /// For every Claude terminal:
+    ///  - track when it first went idle-at-rest (`idleSince`). Terminals that
+    ///    leave the idle state (start working, raise a permission hand, get
+    ///    suspended/hibernated) have their marker cleared so the clock restarts
+    ///    next time they settle. The daemon's own pane status-polling does NOT
+    ///    reset this — the marker keys off the DB activity state, not output
+    ///    silence, so a busy-but-silent long tool call correctly stays BUSY and
+    ///    an idle session isn't kept awake by our health checks (the bug that
+    ///    silently disables Jupyter's idle-culler).
+    ///  - once past the idle timeout, arm a short debounce (`pendingKillSince`)
+    ///    and only hibernate on a LATER sweep after the debounce also elapses,
+    ///    RE-VERIFYING every rail at that moment (state can flip in the final
+    ///    instant). `performHibernate` adds the live typed-input / transcript
+    ///    rails on top.
+    public func sweep() async {
+        guard let config = try? await db.config.get() else { return }
+        guard let terminals = try? await db.terminals.list() else { return }
+        let timeout = TimeInterval(max(1, config.hibernateIdleMinutes)) * 60
+        let reference = now()
+
+        // Prune markers for terminals that vanished.
+        let liveIDs = Set(terminals.map { $0.id })
+        idleSince = idleSince.filter { liveIDs.contains($0.key) }
+        pendingKillSince = pendingKillSince.filter { liveIDs.contains($0.key) }
+
+        for terminal in terminals {
+            let decision = HibernationGate.decide(
+                terminal: terminal,
+                autoHibernateEnabled: config.autoHibernateEnabled,
+                idleTimeout: timeout,
+                idleSince: idleSince[terminal.id],
+                now: reference
+            )
+
+            switch decision {
+            case .eligible:
+                // Crossed the idle threshold. Arm the debounce on first
+                // sighting; only kill once the settle window has ALSO passed
+                // and the rails still hold (re-checked inside performHibernate,
+                // and the gate itself is re-run on the next sweep before we get
+                // here). A fresh at-rest terminal seeds idleSince here too.
+                if idleSince[terminal.id] == nil {
+                    // Should be non-nil to reach .eligible, but guard anyway.
+                    idleSince[terminal.id] = reference
+                }
+                if let pending = pendingKillSince[terminal.id] {
+                    if reference.timeIntervalSince(pending) >= Self.killDebounce {
+                        _ = await performHibernate(terminal: terminal)
+                    }
+                } else {
+                    pendingKillSince[terminal.id] = reference
+                }
+
+            case .notIdleLongEnough:
+                // At rest but not past the timeout yet: keep/seed the idle
+                // marker, clear any stale pending-kill (shouldn't exist).
+                if idleSince[terminal.id] == nil {
+                    idleSince[terminal.id] = reference
+                }
+                pendingKillSince[terminal.id] = nil
+
+            case .featureDisabled, .notClaudeResumable, .alreadyHibernated,
+                 .suspended, .keepWarm, .running, .waitingForUser:
+                // Not at rest (or ineligible): the idle clock and any armed
+                // debounce reset so a later settle starts a fresh full window.
+                idleSince[terminal.id] = nil
+                pendingKillSince[terminal.id] = nil
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Escape → settle → C-c C-c → settle → SIGTERM. Best-effort; the
+    /// subsequent `respawn-window -k` guarantees termination. Copied from the
+    /// swap path so hibernate and account-switch interrupt identically.
+    private func gracefullyInterruptPane(server: String, paneID: String) async {
+        try? await tmux.sendKey(server: server, paneID: paneID, key: "Escape")
+        try? await Task.sleep(for: .milliseconds(150))
+        try? await tmux.sendKey(server: server, paneID: paneID, key: "C-c")
+        try? await tmux.sendKey(server: server, paneID: paneID, key: "C-c")
+        try? await Task.sleep(for: .milliseconds(150))
+        if let pidStr = try? await tmux.panePID(server: server, paneID: paneID),
+           let pid = Int32(pidStr), pid > 0 {
+            kill(pid, SIGTERM)
+        }
+    }
+
+    private func broadcastHibernation(terminal: Terminal, hibernated: Bool, keepWarm: Bool) {
+        subscriptions?.broadcast(delta: .terminalHibernationChanged(TerminalHibernationDelta(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            hibernated: hibernated,
+            keepWarm: keepWarm
+        )))
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
@@ -1,0 +1,68 @@
+import Foundation
+import TBDShared
+
+/// Pure decision logic for whether a terminal may be AUTO-hibernated right now.
+///
+/// Split out from `HibernationCoordinator` so every gating branch — the hard
+/// safety rails plus the idle-duration check — is unit-testable without an
+/// actor, a tmux server, or a database. The rails themselves (running turn,
+/// permission prompt, keep-warm, already-hibernated/suspended, resumable
+/// Claude) live on `Terminal.isAutoHibernationEligible`; this adds the two
+/// inputs that pure property can't see: whether the feature is enabled and how
+/// long the terminal has been idle relative to the configured timeout.
+public enum HibernationGate {
+    /// Why a terminal was or wasn't selected for auto-hibernation. `.eligible`
+    /// is the only go; every other case names the rail that blocked it, so the
+    /// idle-sweep can log a precise reason and tests can assert on the exact
+    /// gate.
+    public enum Decision: Equatable, Sendable {
+        case eligible
+        case featureDisabled
+        case notClaudeResumable
+        case alreadyHibernated
+        case suspended
+        case keepWarm
+        case running            // actively running a turn — never eat an in-flight generation
+        case waitingForUser     // a raised permission hand — hibernating would eat it
+        case notIdleLongEnough  // idle, but not past the timeout yet
+    }
+
+    /// Evaluate the auto-hibernate decision for `terminal`.
+    ///
+    /// - Parameters:
+    ///   - terminal: the candidate.
+    ///   - autoHibernateEnabled: the global master switch.
+    ///   - idleTimeout: how long a terminal must be idle before it qualifies.
+    ///   - idleSince: when the terminal last went idle (its `hibernationIdleSince`
+    ///     marker). `nil` means "no idle marker yet" — treated as not-yet-idle,
+    ///     since we can't prove it has been at rest long enough.
+    ///   - now: the reference time (injectable for tests).
+    public static func decide(
+        terminal: Terminal,
+        autoHibernateEnabled: Bool,
+        idleTimeout: TimeInterval,
+        idleSince: Date?,
+        now: Date
+    ) -> Decision {
+        guard autoHibernateEnabled else { return .featureDisabled }
+        // Rails that don't depend on idle duration, ordered so the returned
+        // reason is the most specific blocker.
+        guard terminal.isClaudeResumable else { return .notClaudeResumable }
+        guard terminal.hibernatedAt == nil else { return .alreadyHibernated }
+        guard terminal.suspendedAt == nil else { return .suspended }
+        guard !terminal.keepWarm else { return .keepWarm }
+        switch terminal.activityState {
+        case .working:
+            return .running
+        case .waitingForUser:
+            return .waitingForUser
+        case .idle, .unknown:
+            break
+        }
+        // Idle-duration rail: needs a marker and enough elapsed time.
+        guard let idleSince, now.timeIntervalSince(idleSince) >= idleTimeout else {
+            return .notIdleLongEnough
+        }
+        return .eligible
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/HibernationSafetyChecks.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationSafetyChecks.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Pure, unit-testable helpers for the two hibernation safety rails that
+/// depend on live pane / disk state rather than the DB row: typed-but-unsent
+/// input in the Claude prompt, and transcript-tail parseability.
+///
+/// Both are conservative: when the signal is ambiguous they return the
+/// hibernation-blocking answer, because the cost of a wrong hibernate (eaten
+/// keystrokes, an unresumable session) outweighs the cost of skipping one
+/// idle terminal this sweep.
+public enum HibernationSafetyChecks {
+
+    // MARK: - Typed-but-unsent input
+
+    /// Whether a `capture-pane` snapshot of a Claude TUI shows the user has
+    /// typed text into the prompt box that hasn't been submitted yet.
+    ///
+    /// Claude Code renders its input as a bordered box whose prompt line starts
+    /// with `>`; an empty prompt shows only the placeholder. We look at the
+    /// last non-empty lines for a `>` prompt marker followed by
+    /// non-placeholder, non-whitespace content. This is a heuristic — the
+    /// research flagged Chrome's "discarding lost my typed text" as the single
+    /// biggest backlash — so anything that looks like pending input blocks
+    /// hibernation.
+    ///
+    /// Returns `false` (no pending input → safe to hibernate) when the capture
+    /// is empty or shows only an empty/placeholder prompt.
+    public static func hasPendingInput(paneCapture: String) -> Bool {
+        let lines = paneCapture
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { stripANSI(String($0)).trimmingCharacters(in: .whitespaces) }
+
+        // Scan from the bottom for the prompt line (`>` or the box-drawn
+        // variant). The first `>`-prefixed line from the bottom is the input.
+        for line in lines.reversed() {
+            guard let promptBody = promptBody(of: line) else { continue }
+            // Strip both the whitespace and any trailing box-drawing gutter
+            // (`… │`) so an empty prompt inside a box reads as empty.
+            let cleaned = promptBody
+                .trimmingCharacters(in: CharacterSet(charactersIn: "│|╭╮╰╯─ \t"))
+            if cleaned.isEmpty { return false }
+            // Common empty-prompt placeholders Claude shows.
+            let placeholders = ["Try \"", "Ask Claude", "Type a message"]
+            if placeholders.contains(where: { cleaned.hasPrefix($0) }) { return false }
+            return true
+        }
+        return false
+    }
+
+    /// If `line` is a Claude prompt line (`>` possibly inside box-drawing
+    /// characters), return the text after the `>`; otherwise nil.
+    private static func promptBody(of line: String) -> String? {
+        // Strip a leading box-drawing / vertical-bar gutter, then require `>`.
+        var s = Substring(line)
+        while let first = s.first, "│|╭╮╰╯─ ".contains(first) { s = s.dropFirst() }
+        guard let gt = s.first, gt == ">" else { return nil }
+        return String(s.dropFirst())
+    }
+
+    private static func stripANSI(_ s: String) -> String {
+        // Remove CSI escape sequences (ESC [ ... final-byte).
+        var out = ""
+        var iterator = s.unicodeScalars.makeIterator()
+        var pending: Unicode.Scalar? = iterator.next()
+        while let scalar = pending {
+            if scalar == "\u{1B}" {
+                // Skip until a letter (final byte of CSI) or end.
+                var next = iterator.next()
+                if next == "[" { next = iterator.next() }
+                while let c = next, !("@" ... "~").contains(c) {
+                    next = iterator.next()
+                }
+                pending = iterator.next()
+            } else {
+                out.unicodeScalars.append(scalar)
+                pending = iterator.next()
+            }
+        }
+        return out
+    }
+
+    // MARK: - Transcript tail validity
+
+    /// Whether the last non-empty line of a transcript JSONL body is a complete,
+    /// parseable JSON object. Killing Claude mid-write can leave a truncated
+    /// final line that makes `--resume` fail (anthropics/claude-code#18880); we
+    /// only hibernate when the tail is clean.
+    ///
+    /// An empty transcript is considered valid (nothing to corrupt — a fresh
+    /// resume will simply find no prior turns). Callers that require a
+    /// non-empty session should check separately.
+    public static func isTranscriptTailValid(jsonlBody: String) -> Bool {
+        let lastLine = jsonlBody
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .last
+        guard let lastLine else { return true }  // empty file: nothing to corrupt
+        guard let data = String(lastLine).data(using: .utf8) else { return false }
+        return (try? JSONSerialization.jsonObject(with: data)) != nil
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -1,0 +1,56 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+
+    /// `terminal.hibernate` — manually hibernate one Claude terminal (kill its
+    /// process, keep the tmux window). Honors the running/permission rails.
+    func handleTerminalHibernate(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalHibernateParams.self, from: paramsData)
+        let result = await hibernationCoordinator.manualHibernate(terminalID: params.terminalID)
+        switch result {
+        case .ok, .alreadyHibernated:
+            return .ok()
+        case .notEligible(let reason):
+            return RPCResponse(error: reason)
+        case .notFound:
+            return RPCResponse(error: "Terminal not found")
+        }
+    }
+
+    /// `terminal.wake` — respawn `claude --resume <id>` in the hibernated
+    /// terminal's kept-alive window. Idempotent.
+    func handleTerminalWake(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalWakeParams.self, from: paramsData)
+        let result = await hibernationCoordinator.wake(
+            terminalID: params.terminalID, cols: params.cols, rows: params.rows
+        )
+        switch result {
+        case .ok, .notHibernated, .inFlight:
+            // notHibernated / inFlight are benign no-ops for an idempotent wake.
+            return .ok()
+        case .notFound:
+            return RPCResponse(error: "Terminal not found")
+        case .noSessionID:
+            return RPCResponse(error: "No session ID to resume")
+        }
+    }
+
+    /// `terminal.setKeepWarm` — pin/unpin a terminal against auto-hibernation.
+    func handleTerminalSetKeepWarm(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalSetKeepWarmParams.self, from: paramsData)
+        let ok = await hibernationCoordinator.setKeepWarm(
+            terminalID: params.terminalID, keepWarm: params.keepWarm
+        )
+        return ok ? .ok() : RPCResponse(error: "Terminal not found")
+    }
+
+    /// `config.setAutoHibernate` — master enable + idle-timeout minutes.
+    func handleConfigSetAutoHibernate(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetAutoHibernateParams.self, from: paramsData)
+        try await db.config.setAutoHibernate(enabled: params.enabled, idleMinutes: params.idleMinutes)
+        // Reuse the config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -15,6 +15,7 @@ public final class RPCRouter: Sendable {
     public let subscriptions: StateSubscriptionManager
     public let prManager: PRStatusManager
     public let suspendResumeCoordinator: SuspendResumeCoordinator
+    public let hibernationCoordinator: HibernationCoordinator
     public let usageFetcher: ClaudeUsageFetcher
     public let modelProfileResolver: ModelProfileResolver
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
@@ -87,6 +88,10 @@ public final class RPCRouter: Sendable {
         self.modelProfileResolver = resolvedModelProfileResolver
         self.suspendResumeCoordinator = SuspendResumeCoordinator(
             db: db, tmux: tmux, modelProfileResolver: resolvedModelProfileResolver
+        )
+        self.hibernationCoordinator = HibernationCoordinator(
+            db: db, tmux: tmux, modelProfileResolver: resolvedModelProfileResolver,
+            subscriptions: subscriptions
         )
         self.usageFetcher = usageFetcher
         self.pendingQuestions = pendingQuestions
@@ -306,6 +311,14 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetScratchProfileOverride(request.paramsData)
             case RPCMethod.nightwatchSetMode:
                 return try await handleSetNightwatchMode(request.paramsData)
+            case RPCMethod.terminalHibernate:
+                return try await handleTerminalHibernate(request.paramsData)
+            case RPCMethod.terminalWake:
+                return try await handleTerminalWake(request.paramsData)
+            case RPCMethod.terminalSetKeepWarm:
+                return try await handleTerminalSetKeepWarm(request.paramsData)
+            case RPCMethod.configSetAutoHibernate:
+                return try await handleConfigSetAutoHibernate(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -226,6 +226,10 @@ public struct TmuxManager: Sendable {
         ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_pid}"]
     }
 
+    public static func paneCurrentPathQuery(server: String, paneID: String) -> [String] {
+        ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_current_path}"]
+    }
+
     public static func serverPIDQuery(server: String) -> [String] {
         ["-L", server, "display-message", "-p", "#{pid}"]
     }
@@ -440,6 +444,15 @@ public struct TmuxManager: Sendable {
     public func panePID(server: String, paneID: String) async throws -> String {
         if dryRun { return "0" }
         let args = Self.panePIDQuery(server: server, paneID: paneID)
+        return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The pane's current working directory (`#{pane_current_path}`). Used by
+    /// the hibernation wake path to assert the cwd matches the worktree before
+    /// a cwd-scoped `claude --resume`.
+    public func paneCurrentPath(server: String, paneID: String) async throws -> String {
+        if dryRun { return "" }
+        let args = Self.paneCurrentPathQuery(server: server, paneID: paneID)
         return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -246,6 +246,17 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public var transcriptPath: String?
     public var kind: TerminalKind?
     public var activityState: TerminalActivityState
+    /// When set, the terminal is HIBERNATED: its `claude` process was
+    /// gracefully terminated to reclaim memory, but the tmux window (and its
+    /// shell) is kept alive. `claudeSessionID` still points at the session to
+    /// resume via `claude --resume` on wake. `nil` = not hibernated. Distinct
+    /// from `suspendedAt` (which kills the tmux window's program entirely and
+    /// snapshots the pane); a hibernated terminal keeps its live window.
+    public var hibernatedAt: Date?
+    /// User pin that exempts this terminal from auto-hibernation. `false` =
+    /// eligible for the idle timer; `true` = the daemon never auto-hibernates
+    /// it (manual "Hibernate now" still works). Persisted per-terminal.
+    public var keepWarm: Bool
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
@@ -254,7 +265,9 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 profileID: UUID? = nil,
                 transcriptPath: String? = nil,
                 kind: TerminalKind? = nil,
-                activityState: TerminalActivityState = .unknown) {
+                activityState: TerminalActivityState = .unknown,
+                hibernatedAt: Date? = nil,
+                keepWarm: Bool = false) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -269,12 +282,15 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.transcriptPath = transcriptPath
         self.kind = kind
         self.activityState = activityState
+        self.hibernatedAt = hibernatedAt
+        self.keepWarm = keepWarm
     }
 
     enum CodingKeys: String, CodingKey {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
         case activityState
+        case hibernatedAt, keepWarm
     }
 
     public init(from decoder: Decoder) throws {
@@ -293,6 +309,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         transcriptPath = try c.decodeIfPresent(String.self, forKey: .transcriptPath)
         kind = try c.decodeIfPresent(TerminalKind.self, forKey: .kind)
         activityState = try c.decodeIfPresent(TerminalActivityState.self, forKey: .activityState) ?? .unknown
+        hibernatedAt = try c.decodeIfPresent(Date.self, forKey: .hibernatedAt)
+        keepWarm = try c.decodeIfPresent(Bool.self, forKey: .keepWarm) ?? false
     }
 }
 
@@ -307,6 +325,41 @@ public extension Terminal {
     var isClaudeResumable: Bool {
         guard claudeSessionID != nil, !isCodexTerminal else { return false }
         return kind == .claude || kind == nil
+    }
+
+    /// True when the terminal is currently hibernated (claude process killed,
+    /// tmux window kept alive). See `hibernatedAt`.
+    var isHibernated: Bool { hibernatedAt != nil }
+
+    /// Whether this terminal may be AUTO-hibernated by the idle timer right
+    /// now. Encodes the hard safety rails (see `HibernationGate` for the
+    /// idle-duration check, which needs the timeout + clock this pure property
+    /// can't see):
+    ///   - must be a resumable Claude session,
+    ///   - not already hibernated or suspended,
+    ///   - not pinned keep-warm,
+    ///   - not actively running a turn (`.working`),
+    ///   - not waiting on a permission prompt (`.waitingForUser` — a raised
+    ///     hand; hibernating would eat it).
+    /// Manual "Hibernate now" bypasses the keep-warm and idle checks but keeps
+    /// the running/permission rails (see `isManuallyHibernatable`).
+    var isAutoHibernationEligible: Bool {
+        isManuallyHibernatable && !keepWarm
+    }
+
+    /// Whether a MANUAL "Hibernate now" may act on this terminal. Same rails as
+    /// auto except keep-warm and idle-time don't apply — the user asked
+    /// explicitly. Still refuses to hibernate an in-flight turn or a raised
+    /// permission hand.
+    var isManuallyHibernatable: Bool {
+        guard isClaudeResumable else { return false }
+        guard hibernatedAt == nil, suspendedAt == nil else { return false }
+        switch activityState {
+        case .working, .waitingForUser:
+            return false
+        case .idle, .unknown:
+            return true
+        }
     }
 }
 
@@ -552,6 +605,17 @@ public struct Config: Codable, Sendable, Equatable {
     public var scratchProfileOverrideID: UUID?
     /// Nightwatch mode flag: off, daywatch, or nightwatch.
     public var nightwatchMode: NightwatchMode
+    /// Master switch for the daemon-side auto-hibernate idle timer. Default
+    /// ON: idle Claude sessions are auto-hibernated to reclaim memory (their
+    /// prompt cache has already expired, so resume is cheap). When false, only
+    /// manual "Hibernate now" hibernates.
+    public var autoHibernateEnabled: Bool
+    /// Minutes a Claude session must sit idle-at-rest before the auto-hibernate
+    /// timer terminates its process. Clamped to a sane floor by the daemon.
+    public var hibernateIdleMinutes: Int
+
+    /// Default idle-timeout for auto-hibernation, in minutes.
+    public static let defaultHibernateIdleMinutes = 30
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -561,7 +625,9 @@ public struct Config: Codable, Sendable, Equatable {
                 scratchInstructions: String? = nil,
                 scratchRenamePrompt: String? = nil,
                 scratchProfileOverrideID: UUID? = nil,
-                nightwatchMode: NightwatchMode = .off) {
+                nightwatchMode: NightwatchMode = .off,
+                autoHibernateEnabled: Bool = true,
+                hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -571,6 +637,8 @@ public struct Config: Codable, Sendable, Equatable {
         self.scratchRenamePrompt = scratchRenamePrompt
         self.scratchProfileOverrideID = scratchProfileOverrideID
         self.nightwatchMode = nightwatchMode
+        self.autoHibernateEnabled = autoHibernateEnabled
+        self.hibernateIdleMinutes = hibernateIdleMinutes
     }
 
     public init(from decoder: Decoder) throws {
@@ -591,6 +659,9 @@ public struct Config: Codable, Sendable, Equatable {
         scratchProfileOverrideID = try c.decodeIfPresent(UUID.self, forKey: .scratchProfileOverrideID)
         nightwatchMode = try c.decodeIfPresent(
             NightwatchMode.self, forKey: .nightwatchMode) ?? .off
+        autoHibernateEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoHibernateEnabled) ?? true
+        hibernateIdleMinutes = try c.decodeIfPresent(Int.self, forKey: .hibernateIdleMinutes)
+            ?? Config.defaultHibernateIdleMinutes
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -166,6 +166,10 @@ public enum RPCMethod {
     public static let configSetScratchInstructions = "config.setScratchInstructions"
     public static let configSetScratchRenamePrompt = "config.setScratchRenamePrompt"
     public static let configSetScratchProfileOverride = "config.setScratchProfileOverride"
+    public static let terminalHibernate = "terminal.hibernate"
+    public static let terminalWake = "terminal.wake"
+    public static let terminalSetKeepWarm = "terminal.setKeepWarm"
+    public static let configSetAutoHibernate = "config.setAutoHibernate"
     public static let scratchCreate = "scratch.create"
     public static let scratchDelete = "scratch.delete"
     public static let scratchPromote = "scratch.promote"
@@ -1022,6 +1026,53 @@ public struct ConfigSetScratchRenamePromptParams: Codable, Sendable {
 public struct ConfigSetScratchProfileOverrideParams: Codable, Sendable {
     public let profileID: UUID?
     public init(profileID: UUID?) { self.profileID = profileID }
+}
+
+// MARK: - Session Hibernation
+
+/// Params for `terminal.hibernate` — manually hibernate one Claude terminal
+/// (kill its process, keep the tmux window). Subject to the running/permission
+/// rails but not keep-warm or idle-time.
+public struct TerminalHibernateParams: Codable, Sendable {
+    public let terminalID: UUID
+    public init(terminalID: UUID) { self.terminalID = terminalID }
+}
+
+/// Params for `terminal.wake` — respawn `claude --resume <id>` in the
+/// hibernated terminal's kept-alive tmux window. Idempotent: waking a
+/// non-hibernated terminal is a no-op.
+public struct TerminalWakeParams: Codable, Sendable {
+    public let terminalID: UUID
+    /// Initial tmux window size in cells (see TerminalSwapProfileParams).
+    public let cols: Int?
+    public let rows: Int?
+    public init(terminalID: UUID, cols: Int? = nil, rows: Int? = nil) {
+        self.terminalID = terminalID
+        self.cols = cols
+        self.rows = rows
+    }
+}
+
+/// Params for `terminal.setKeepWarm` — pin/unpin a terminal against
+/// auto-hibernation.
+public struct TerminalSetKeepWarmParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let keepWarm: Bool
+    public init(terminalID: UUID, keepWarm: Bool) {
+        self.terminalID = terminalID
+        self.keepWarm = keepWarm
+    }
+}
+
+/// Params for `config.setAutoHibernate` — master enable + idle-timeout minutes
+/// for the auto-hibernate idle timer.
+public struct ConfigSetAutoHibernateParams: Codable, Sendable {
+    public let enabled: Bool
+    public let idleMinutes: Int
+    public init(enabled: Bool, idleMinutes: Int) {
+        self.enabled = enabled
+        self.idleMinutes = idleMinutes
+    }
 }
 
 /// Params for `repo.setEnvOverrides` — per-repo free-form env overrides.

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -25,6 +25,27 @@ public enum StateDelta: Codable, Sendable {
     case terminalActivityUpdated(TerminalActivityDelta)
     case terminalProfileChanged(TerminalProfileDelta)
     case worktreeMoved(WorktreeMovedDelta)
+    case terminalHibernationChanged(TerminalHibernationDelta)
+}
+
+/// Delta payload for a terminal's hibernation state change (hibernate / wake)
+/// or a keep-warm pin toggle. Keeps the SAME terminal row — the app updates
+/// `hibernatedAt`/`keepWarm` in place so the row's whisper indicator and the
+/// action menu re-render without a full terminal refetch.
+public struct TerminalHibernationDelta: Codable, Sendable {
+    public let terminalID: UUID
+    public let worktreeID: UUID
+    /// True when the terminal is now hibernated; false when it was woken.
+    public let hibernated: Bool
+    /// Current keep-warm pin state (carried on every hibernation delta so a
+    /// keep-warm toggle can reuse this same channel).
+    public let keepWarm: Bool
+    public init(terminalID: UUID, worktreeID: UUID, hibernated: Bool, keepWarm: Bool) {
+        self.terminalID = terminalID
+        self.worktreeID = worktreeID
+        self.hibernated = hibernated
+        self.keepWarm = keepWarm
+    }
 }
 
 /// Delta payload for a terminal's model-profile change that keeps the SAME

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -213,6 +213,54 @@ struct RowActionMenuForkTests {
     }
 }
 
+// MARK: - Hibernation actions
+
+@Suite("RowActionMenu — hibernation")
+struct RowActionMenuHibernationTests {
+    @Test func hibernateNowShownOnlyWhenHibernatableClaudePresent() {
+        let ctx = RowActionMenu.Context(hasHibernatableClaude: true, hasRepoID: true, branch: "b")
+        #expect(kinds(RowActionMenu.items(context: ctx)).contains(.hibernateNow))
+        // Absent when nothing is hibernatable.
+        let none = RowActionMenu.Context(hasRepoID: true, branch: "b")
+        #expect(!kinds(RowActionMenu.items(context: none)).contains(.hibernateNow))
+    }
+
+    @Test func wakeShownOnlyWhenHibernatedClaudePresent() {
+        let ctx = RowActionMenu.Context(hasHibernatedClaude: true, hasRepoID: true, branch: "b")
+        #expect(kinds(RowActionMenu.items(context: ctx)).contains(.wakeHibernated))
+        let none = RowActionMenu.Context(hasRepoID: true, branch: "b")
+        #expect(!kinds(RowActionMenu.items(context: none)).contains(.wakeHibernated))
+    }
+
+    @Test func keepWarmToggleEnableShownWhenUnpinned() {
+        let ctx = RowActionMenu.Context(hasUnpinnedClaude: true, hasRepoID: true, branch: "b")
+        #expect(kinds(RowActionMenu.items(context: ctx)).contains(.toggleKeepWarm(enable: true)))
+        #expect(!kinds(RowActionMenu.items(context: ctx)).contains(.toggleKeepWarm(enable: false)))
+    }
+
+    @Test func keepWarmToggleDisableShownWhenPinned() {
+        let ctx = RowActionMenu.Context(hasKeepWarmClaude: true, hasRepoID: true, branch: "b")
+        #expect(kinds(RowActionMenu.items(context: ctx)).contains(.toggleKeepWarm(enable: false)))
+        #expect(!kinds(RowActionMenu.items(context: ctx)).contains(.toggleKeepWarm(enable: true)))
+    }
+
+    @Test func noHibernationEntriesInDefaultContext() {
+        // A worktree with no Claude sessions shows none of the hibernation
+        // actions — they don't clutter the common case.
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b")
+        let ks = kinds(RowActionMenu.items(context: ctx))
+        #expect(!ks.contains(.hibernateNow))
+        #expect(!ks.contains(.wakeHibernated))
+        #expect(!ks.contains(.toggleKeepWarm(enable: true)))
+        #expect(!ks.contains(.toggleKeepWarm(enable: false)))
+    }
+
+    @Test func hibernationActionsAppearInScratchToo() {
+        let ctx = RowActionMenu.Context(hasHibernatedClaude: true, isScratch: true)
+        #expect(kinds(RowActionMenu.items(context: ctx)).contains(.wakeHibernated))
+    }
+}
+
 // MARK: - Shared-list invariant across surfaces
 
 @Suite("RowActionMenu — shared surfaces")

--- a/Tests/TBDAppTests/RowStatusIndicatorTests.swift
+++ b/Tests/TBDAppTests/RowStatusIndicatorTests.swift
@@ -64,11 +64,29 @@ struct SuffixRowIndicatorTests {
         #expect(RowStatusIndicator.suffix(notification: nil, isWorking: false, isSuspended: false) == nil)
     }
 
+    @Test func hibernatedWhenIdleAndHibernated() {
+        #expect(RowStatusIndicator.suffix(
+            notification: nil, isWorking: false, isSuspended: false, isHibernated: true) == .hibernated)
+    }
+
+    @Test func hibernatedIsLowestPriority() {
+        // Any louder signal wins the slot over hibernated — it's the calmest state.
+        #expect(RowStatusIndicator.suffix(
+            notification: nil, isWorking: true, isSuspended: false, isHibernated: true) == .working)
+        #expect(RowStatusIndicator.suffix(
+            notification: nil, isWorking: false, isSuspended: true, isHibernated: true) == .suspended)
+        #expect(RowStatusIndicator.suffix(
+            notification: .error, isWorking: false, isSuspended: false, isHibernated: true) == .error)
+        #expect(RowStatusIndicator.suffix(
+            notification: .attentionNeeded, isWorking: false, isSuspended: false, isHibernated: true) == .attention)
+    }
+
     @Test func glyphMapping() {
         #expect(SuffixRowIndicator.error.systemImage == "exclamationmark.octagon.fill")
         #expect(SuffixRowIndicator.attention.systemImage == "hand.raised.fill")
         #expect(SuffixRowIndicator.suspended.systemImage == "pause.circle.fill")
         #expect(SuffixRowIndicator.working.systemImage == nil)
+        #expect(SuffixRowIndicator.hibernated.systemImage == "moon.zzz.fill")
     }
 }
 

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -1,0 +1,181 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("HibernationCoordinator")
+struct HibernationCoordinatorTests {
+
+    /// In-memory DB + repo + worktree + an idle Claude terminal.
+    private func setup(
+        activityState: TerminalActivityState = .idle,
+        keepWarm: Bool = false,
+        sessionID: String? = "sess-1",
+        kind: TerminalKind? = .claude
+    ) async throws -> (TBDDatabase, UUID, UUID) {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/hib-repo", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/hib-repo", tmuxServer: "tbd-hib"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: sessionID, kind: kind
+        )
+        if activityState != .unknown {
+            try await db.terminals.setActivityState(id: terminal.id, activityState: activityState)
+        }
+        if keepWarm {
+            try await db.terminals.setKeepWarm(id: terminal.id, keepWarm: true)
+        }
+        return (db, wt.id, terminal.id)
+    }
+
+    private func coordinator(_ db: TBDDatabase) -> HibernationCoordinator {
+        HibernationCoordinator(db: db, tmux: TmuxManager(dryRun: true))
+    }
+
+    // MARK: - Manual hibernate
+
+    @Test func manualHibernateMarksHibernated() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let result = await coordinator(db).manualHibernate(terminalID: terminalID)
+        #expect(result == .ok)
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt != nil)
+        #expect(after?.isHibernated == true)
+    }
+
+    @Test func manualHibernateRefusesRunningTurn() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .working)
+        let result = await coordinator(db).manualHibernate(terminalID: terminalID)
+        guard case .notEligible = result else {
+            Issue.record("expected .notEligible for a running turn, got \(result)")
+            return
+        }
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    @Test func manualHibernateRefusesPermissionPrompt() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .waitingForUser)
+        let result = await coordinator(db).manualHibernate(terminalID: terminalID)
+        guard case .notEligible = result else {
+            Issue.record("expected .notEligible for a permission prompt, got \(result)")
+            return
+        }
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    @Test func manualHibernateIgnoresKeepWarm() async throws {
+        // Manual hibernate BYPASSES keep-warm (the user asked explicitly).
+        let (db, _, terminalID) = try await setup(activityState: .idle, keepWarm: true)
+        let result = await coordinator(db).manualHibernate(terminalID: terminalID)
+        #expect(result == .ok)
+        #expect(try await db.terminals.get(id: terminalID)?.isHibernated == true)
+    }
+
+    @Test func manualHibernateRejectsNonClaude() async throws {
+        let (db, _, terminalID) = try await setup(sessionID: nil, kind: .shell)
+        let result = await coordinator(db).manualHibernate(terminalID: terminalID)
+        guard case .notEligible = result else {
+            Issue.record("expected .notEligible for a shell terminal, got \(result)")
+            return
+        }
+    }
+
+    @Test func manualHibernateAlreadyHibernatedIsNoOp() async throws {
+        let (db, _, terminalID) = try await setup()
+        _ = await coordinator(db).manualHibernate(terminalID: terminalID)
+        let second = await coordinator(db).manualHibernate(terminalID: terminalID)
+        #expect(second == .alreadyHibernated)
+    }
+
+    // MARK: - Wake
+
+    @Test func wakeClearsHibernatedAndRespawnsResume() async throws {
+        let (db, _, terminalID) = try await setup()
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+
+        _ = await coord.manualHibernate(terminalID: terminalID)
+        #expect(try await db.terminals.get(id: terminalID)?.isHibernated == true)
+
+        let wake = await coord.wake(terminalID: terminalID)
+        #expect(wake == .ok)
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+
+        // A respawn-window with `claude --resume` must have been issued.
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(joined.contains { $0.contains("respawn-window") && $0.contains("claude --resume sess-1") },
+                "expected a respawn-window carrying claude --resume; got: \(joined)")
+    }
+
+    @Test func wakeOnNonHibernatedIsIdempotentNoOp() async throws {
+        let (db, _, terminalID) = try await setup()
+        let result = await coordinator(db).wake(terminalID: terminalID)
+        #expect(result == .notHibernated)
+    }
+
+    @Test func wakeUnknownTerminalNotFound() async throws {
+        let (db, _, _) = try await setup()
+        let result = await coordinator(db).wake(terminalID: UUID())
+        #expect(result == .notFound)
+    }
+
+    // MARK: - Keep-warm
+
+    @Test func setKeepWarmPersists() async throws {
+        let (db, _, terminalID) = try await setup()
+        let ok = await coordinator(db).setKeepWarm(terminalID: terminalID, keepWarm: true)
+        #expect(ok)
+        #expect(try await db.terminals.get(id: terminalID)?.keepWarm == true)
+        _ = await coordinator(db).setKeepWarm(terminalID: terminalID, keepWarm: false)
+        #expect(try await db.terminals.get(id: terminalID)?.keepWarm == false)
+    }
+
+    // MARK: - Idle sweep gating
+
+    @Test func sweepDoesNotHibernateWhenFeatureDisabled() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        try await db.config.setAutoHibernate(enabled: false, idleMinutes: 1)
+        let coord = coordinator(db)
+        // Even after many sweeps, disabled means never hibernated.
+        await coord.sweep()
+        await coord.sweep()
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    @Test func sweepDoesNotHibernateRunningTurn() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .working)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let coord = coordinator(db)
+        for _ in 0..<4 { await coord.sweep() }
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil,
+                "a running turn must never be auto-hibernated")
+    }
+
+    @Test func sweepDoesNotHibernateKeepWarm() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle, keepWarm: true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let coord = coordinator(db)
+        for _ in 0..<4 { await coord.sweep() }
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil,
+                "a keep-warm session must never be auto-hibernated")
+    }
+}
+
+/// Thread-safe collector for TmuxManager dryRun recorded args.
+private final class RecordedTmuxCommands: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands: [[String]] = []
+    func append(_ args: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        commands.append(args)
+    }
+    func snapshot() -> [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return commands
+    }
+}

--- a/Tests/TBDDaemonTests/HibernationGateTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Every branch of the auto-hibernate gating decision — one test per rail, per
+/// CLAUDE.md's "test every branch of gating conditionals" rule. Pure: no DB,
+/// no tmux, no actor.
+@Suite("HibernationGate")
+struct HibernationGateTests {
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    /// A resumable, idle-at-rest Claude terminal — the baseline that SHOULD be
+    /// eligible so each test can flip exactly one rail.
+    private func claudeTerminal(
+        activityState: TerminalActivityState = .idle,
+        keepWarm: Bool = false,
+        hibernatedAt: Date? = nil,
+        suspendedAt: Date? = nil,
+        sessionID: String? = "sess-1",
+        kind: TerminalKind? = .claude
+    ) -> Terminal {
+        Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: sessionID,
+            suspendedAt: suspendedAt, kind: kind,
+            activityState: activityState, hibernatedAt: hibernatedAt, keepWarm: keepWarm
+        )
+    }
+
+    private func decide(
+        _ terminal: Terminal,
+        enabled: Bool = true,
+        timeout: TimeInterval = 30 * 60,
+        idleSince: Date?
+    ) -> HibernationGate.Decision {
+        HibernationGate.decide(
+            terminal: terminal, autoHibernateEnabled: enabled,
+            idleTimeout: timeout, idleSince: idleSince, now: now
+        )
+    }
+
+    // MARK: - The go path
+
+    @Test func eligibleWhenIdlePastTimeout() {
+        let t = claudeTerminal()
+        // Idle since 31 minutes ago, timeout 30 min → eligible.
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        #expect(decide(t, idleSince: idleSince) == .eligible)
+    }
+
+    // MARK: - Rail: feature disabled
+
+    @Test func featureDisabledBlocks() {
+        let t = claudeTerminal()
+        let idleSince = now.addingTimeInterval(-60 * 60)
+        #expect(decide(t, enabled: false, idleSince: idleSince) == .featureDisabled)
+    }
+
+    // MARK: - Rail: not a resumable Claude session
+
+    @Test func nonClaudeBlocked() {
+        let shell = claudeTerminal(sessionID: nil, kind: .shell)
+        let idleSince = now.addingTimeInterval(-60 * 60)
+        #expect(decide(shell, idleSince: idleSince) == .notClaudeResumable)
+    }
+
+    @Test func codexBlocked() {
+        let codex = claudeTerminal(kind: .codex)
+        let idleSince = now.addingTimeInterval(-60 * 60)
+        #expect(decide(codex, idleSince: idleSince) == .notClaudeResumable)
+    }
+
+    // MARK: - Rail: already hibernated / suspended
+
+    @Test func alreadyHibernatedBlocked() {
+        let t = claudeTerminal(hibernatedAt: now.addingTimeInterval(-5 * 60))
+        let idleSince = now.addingTimeInterval(-60 * 60)
+        #expect(decide(t, idleSince: idleSince) == .alreadyHibernated)
+    }
+
+    @Test func suspendedBlocked() {
+        let t = claudeTerminal(suspendedAt: now.addingTimeInterval(-5 * 60))
+        let idleSince = now.addingTimeInterval(-60 * 60)
+        #expect(decide(t, idleSince: idleSince) == .suspended)
+    }
+
+    // MARK: - Rail: keep-warm
+
+    @Test func keepWarmBlocked() {
+        let t = claudeTerminal(keepWarm: true)
+        let idleSince = now.addingTimeInterval(-60 * 60)
+        #expect(decide(t, idleSince: idleSince) == .keepWarm)
+    }
+
+    // MARK: - Rail: actively running a turn
+
+    @Test func runningTurnBlocked() {
+        let t = claudeTerminal(activityState: .working)
+        let idleSince = now.addingTimeInterval(-60 * 60)
+        #expect(decide(t, idleSince: idleSince) == .running)
+    }
+
+    // MARK: - Rail: waiting on a permission prompt (raised hand)
+
+    @Test func waitingForPermissionBlocked() {
+        let t = claudeTerminal(activityState: .waitingForUser)
+        let idleSince = now.addingTimeInterval(-60 * 60)
+        #expect(decide(t, idleSince: idleSince) == .waitingForUser)
+    }
+
+    // MARK: - Rail: idle but not long enough / no marker
+
+    @Test func notIdleLongEnoughBlocked() {
+        let t = claudeTerminal()
+        // Idle only 5 minutes; timeout 30 → not yet.
+        let idleSince = now.addingTimeInterval(-5 * 60)
+        #expect(decide(t, idleSince: idleSince) == .notIdleLongEnough)
+    }
+
+    @Test func noIdleMarkerBlocked() {
+        let t = claudeTerminal()
+        #expect(decide(t, idleSince: nil) == .notIdleLongEnough)
+    }
+
+    @Test func unknownActivityCountsAsAtRest() {
+        // `.unknown` (hook hasn't fired) is treated as at-rest so a genuinely
+        // idle session isn't kept awake forever by a missing hook.
+        let t = claudeTerminal(activityState: .unknown)
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        #expect(decide(t, idleSince: idleSince) == .eligible)
+    }
+
+    // MARK: - Rail precedence (a louder rail wins over idle-time)
+
+    @Test func runningWinsOverIdleTime() {
+        // Both "running" and "past timeout" true → running is reported, so a
+        // long-idle-then-resumed session is never killed mid-turn.
+        let t = claudeTerminal(activityState: .working)
+        let idleSince = now.addingTimeInterval(-60 * 60)
+        #expect(decide(t, idleSince: idleSince) == .running)
+    }
+}

--- a/Tests/TBDDaemonTests/HibernationSafetyChecksTests.swift
+++ b/Tests/TBDDaemonTests/HibernationSafetyChecksTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+
+@Suite("HibernationSafetyChecks")
+struct HibernationSafetyChecksTests {
+
+    // MARK: - Pending typed input
+
+    @Test func emptyPromptIsSafe() {
+        let capture = """
+        ╭──────────────────────────────────────╮
+        │ >                                    │
+        ╰──────────────────────────────────────╯
+        """
+        #expect(HibernationSafetyChecks.hasPendingInput(paneCapture: capture) == false)
+    }
+
+    @Test func placeholderPromptIsSafe() {
+        let capture = """
+        ╭──────────────────────────────────────╮
+        │ > Try "fix the failing test"         │
+        ╰──────────────────────────────────────╯
+        """
+        #expect(HibernationSafetyChecks.hasPendingInput(paneCapture: capture) == false)
+    }
+
+    @Test func typedTextBlocksHibernation() {
+        let capture = """
+        some transcript output above
+        ╭──────────────────────────────────────╮
+        │ > refactor the auth module and add    │
+        ╰──────────────────────────────────────╯
+        """
+        #expect(HibernationSafetyChecks.hasPendingInput(paneCapture: capture) == true)
+    }
+
+    @Test func emptyCaptureIsSafe() {
+        #expect(HibernationSafetyChecks.hasPendingInput(paneCapture: "") == false)
+    }
+
+    @Test func plainPromptWithoutBoxWithText() {
+        // A `>`-prefixed line without box drawing still counts.
+        #expect(HibernationSafetyChecks.hasPendingInput(paneCapture: "> hello world") == true)
+    }
+
+    // MARK: - Transcript tail validity
+
+    @Test func validJSONTailPasses() {
+        let body = #"""
+        {"type":"user","text":"hi"}
+        {"type":"assistant","text":"hello there"}
+        """#
+        #expect(HibernationSafetyChecks.isTranscriptTailValid(jsonlBody: body) == true)
+    }
+
+    @Test func truncatedTailFails() {
+        // Last line is a half-written JSON object — the #18880 corruption case.
+        let body = #"""
+        {"type":"user","text":"hi"}
+        {"type":"assistant","text":"hel
+        """#
+        #expect(HibernationSafetyChecks.isTranscriptTailValid(jsonlBody: body) == false)
+    }
+
+    @Test func emptyTranscriptIsValid() {
+        #expect(HibernationSafetyChecks.isTranscriptTailValid(jsonlBody: "") == true)
+    }
+
+    @Test func trailingNewlineIgnored() {
+        let body = #"""
+        {"type":"assistant","text":"done"}
+
+        """#
+        #expect(HibernationSafetyChecks.isTranscriptTailValid(jsonlBody: body) == true)
+    }
+}

--- a/Tests/TBDDaemonTests/MigrationV39HibernationTests.swift
+++ b/Tests/TBDDaemonTests/MigrationV39HibernationTests.swift
@@ -1,0 +1,84 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct MigrationV39HibernationTests {
+
+    @Test func hibernationColumnsExist() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let terminalCols = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+            #expect(terminalCols.contains("hibernatedAt"))
+            #expect(terminalCols.contains("keepWarm"))
+            let configCols = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(config)")
+                .compactMap { $0["name"] as String? }
+            #expect(configCols.contains("auto_hibernate_enabled"))
+            #expect(configCols.contains("hibernate_idle_minutes"))
+        }
+    }
+
+    @Test func terminalHibernationDefaults() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v39-repo-\(UUID().uuidString)", displayName: "V39", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v39-wt-\(UUID().uuidString)", tmuxServer: "tbd-v39")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        #expect(terminal.hibernatedAt == nil)
+        #expect(terminal.keepWarm == false)
+
+        let fetched = try await db.terminals.get(id: terminal.id)
+        #expect(fetched?.hibernatedAt == nil)
+        #expect(fetched?.keepWarm == false)
+    }
+
+    @Test func setHibernatedAndKeepWarmRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v39-repo2-\(UUID().uuidString)", displayName: "V39", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v39-wt2-\(UUID().uuidString)", tmuxServer: "tbd-v39")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "s-1", kind: .claude)
+
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "s-1")
+        try await db.terminals.setKeepWarm(id: terminal.id, keepWarm: true)
+        let hibernated = try await db.terminals.get(id: terminal.id)
+        #expect(hibernated?.hibernatedAt != nil)
+        #expect(hibernated?.keepWarm == true)
+
+        try await db.terminals.clearHibernated(id: terminal.id)
+        let cleared = try await db.terminals.get(id: terminal.id)
+        #expect(cleared?.hibernatedAt == nil)
+        #expect(cleared?.keepWarm == true)  // keep-warm is independent of hibernation
+    }
+
+    @Test func configHibernationDefaultsAndRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        // Defaults: ON, 30 min.
+        let initial = try await db.config.get()
+        #expect(initial.autoHibernateEnabled == true)
+        #expect(initial.hibernateIdleMinutes == Config.defaultHibernateIdleMinutes)
+
+        try await db.config.setAutoHibernate(enabled: false, idleMinutes: 45)
+        let updated = try await db.config.get()
+        #expect(updated.autoHibernateEnabled == false)
+        #expect(updated.hibernateIdleMinutes == 45)
+    }
+
+    @Test func configIdleMinutesFlooredAtOne() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        // A zero/negative can't be persisted — it would make the sweep hibernate
+        // everything immediately. Floored to 1.
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 0)
+        #expect(try await db.config.get().hibernateIdleMinutes == 1)
+    }
+}

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -188,6 +188,83 @@ import Testing
     #expect(decoded.activityState == .unknown)
 }
 
+// MARK: - Hibernation fields + gating helpers
+
+@Test func testTerminalDecodesWithoutHibernationFields() throws {
+    // Pre-v39 JSON (no hibernatedAt/keepWarm) must decode with safe defaults.
+    let json = """
+    {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "worktreeID": "22222222-2222-2222-2222-222222222222",
+        "tmuxWindowID": "@1",
+        "tmuxPaneID": "%1",
+        "createdAt": 0
+    }
+    """.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(Terminal.self, from: json)
+    #expect(decoded.hibernatedAt == nil)
+    #expect(decoded.keepWarm == false)
+    #expect(decoded.isHibernated == false)
+}
+
+@Test func testTerminalHibernationFieldsRoundTrip() throws {
+    let t = Terminal(
+        worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+        claudeSessionID: "s", kind: .claude,
+        hibernatedAt: Date(timeIntervalSince1970: 100), keepWarm: true)
+    let data = try JSONEncoder().encode(t)
+    let decoded = try JSONDecoder().decode(Terminal.self, from: data)
+    #expect(decoded.hibernatedAt == Date(timeIntervalSince1970: 100))
+    #expect(decoded.keepWarm == true)
+    #expect(decoded.isHibernated == true)
+}
+
+@Test func testManuallyHibernatableGating() {
+    func t(_ state: TerminalActivityState, session: String? = "s", kind: TerminalKind? = .claude,
+           hibernatedAt: Date? = nil, suspendedAt: Date? = nil, keepWarm: Bool = false) -> Terminal {
+        Terminal(worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+                 claudeSessionID: session, suspendedAt: suspendedAt, kind: kind,
+                 activityState: state, hibernatedAt: hibernatedAt, keepWarm: keepWarm)
+    }
+    // Manual-hibernatable: idle/unknown resumable Claude, not running/waiting/
+    // hibernated/suspended. keep-warm does NOT block manual.
+    #expect(t(.idle).isManuallyHibernatable)
+    #expect(t(.unknown).isManuallyHibernatable)
+    #expect(t(.idle, keepWarm: true).isManuallyHibernatable)          // manual bypasses keep-warm
+    #expect(!t(.working).isManuallyHibernatable)                      // running rail
+    #expect(!t(.waitingForUser).isManuallyHibernatable)              // permission rail
+    #expect(!t(.idle, session: nil, kind: .shell).isManuallyHibernatable)  // not Claude
+    #expect(!t(.idle, kind: .codex).isManuallyHibernatable)          // Codex excluded
+    #expect(!t(.idle, hibernatedAt: Date()).isManuallyHibernatable)  // already hibernated
+    #expect(!t(.idle, suspendedAt: Date()).isManuallyHibernatable)   // suspended
+}
+
+@Test func testAutoHibernationEligibilityAddsKeepWarmRail() {
+    let base = Terminal(worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+                        claudeSessionID: "s", kind: .claude, activityState: .idle)
+    #expect(base.isAutoHibernationEligible)
+    var warm = base; warm.keepWarm = true
+    // Auto adds the keep-warm rail that manual bypasses.
+    #expect(!warm.isAutoHibernationEligible)
+    #expect(warm.isManuallyHibernatable)
+}
+
+@Test func testConfigDecodesWithoutHibernationFields() throws {
+    // Config JSON from before v39 must decode with feature ON, 30 min.
+    let json = "{}".data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(Config.self, from: json)
+    #expect(decoded.autoHibernateEnabled == true)
+    #expect(decoded.hibernateIdleMinutes == Config.defaultHibernateIdleMinutes)
+}
+
+@Test func testConfigHibernationRoundTrip() throws {
+    let config = Config(autoHibernateEnabled: false, hibernateIdleMinutes: 42)
+    let data = try JSONEncoder().encode(config)
+    let decoded = try JSONDecoder().decode(Config.self, from: data)
+    #expect(decoded.autoHibernateEnabled == false)
+    #expect(decoded.hibernateIdleMinutes == 42)
+}
+
 // MARK: - NotificationType Severity Ordering
 
 @Test func testNotificationTypeSeverityOrdering() {


### PR DESCRIPTION
**Stacked on #343** (contains its three commits — merge #343 first and this reduces to one commit).

## What

The daemon auto-hibernates idle Claude sessions: after a configurable idle window (default 30 min, master switch ON) it gracefully terminates the `claude` process while keeping the tmux window (shell + scrollback) alive, marks the row with a quiet moon indicator, and respawns `claude --resume <id>` in the same window when the terminal is focused (or via an explicit Wake action).

**Why this is nearly free**: the prompt cache expires ~5 min after a session goes quiet, so any session idle past the TTL pays full uncached input on its next message whether or not the process stayed alive. Killing it reclaims RAM + swap at zero marginal API cost. Motivation on the machine that prompted this: 39 resident `claude` processes, 36 idle for 2+ days, ~4.5 GB RSS, swap pinned at 93%.

## Safety rails (each with its own test, per CLAUDE.md gating rule)

Never auto-hibernate when the session is: mid-run (busy-but-silent counts as busy — idle keys off DB activity state, not output silence, so the daemon's own polling can't reset the clock), waiting on a permission prompt, keep-warm pinned, has typed-but-unsent input on the prompt line, or the feature is off. All rails are **re-verified at kill time** after a 20s debounce, not just when the timer arms.

## Design notes (grounded in prior-art research: Chrome tab discarding, Jupyter idle-culler, Knative, Claude Code issue tracker)

- **Singleflight wake** — respawn is idempotent under racing focus events (app + daemon both gate).
- **Transcript-tail validity is checked before declaring hibernation** (guards anthropics/claude-code#18880 — kill-mid-write leaves an unresumable jsonl).
- **Post-kill verification** that the pane shell survived and only `claude` died (guards the #45717 process-group SIGTERM class); orphaned background children are detected and logged, not killed, in v1.
- All bookkeeping lives in the daemon — Claude Code hooks are not relied on to fire during SIGTERM.
- "Hibernated" is visually distinct from crashed/suspended; wake shows a brief non-blocking indicator.

## Migration

`v39_session_hibernation` (v38 was taken by nightwatch mode in #338): `terminal.hibernatedAt` + `terminal.keepWarm`, `config.auto_hibernate_enabled` (default true) + `config.hibernate_idle_minutes` (default 30). Additive, idempotent helpers, GRDB record + Codable models updated in the same commit. Heads-up for #342: its v39/v40 will need renumbering to v41/v42 (or later) once this lands.

## Verification

`swift build` clean; `swift test` 2,411 tests / 1 failure = the documented env-dependent `agentExecutableAvailability_detectsHomeLocalBinFallback`; `swiftlint --strict` 0 violations. New suites: 15 per-rail gating, 9 safety checks, 15 coordinator, 6 migration round-trip, 6 menu-branch, 4 row-indicator, 7 shared-model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)