### PR TITLE
Fix multi-account usage polling: OAuth refresh, per-profile backoff, honest stale states

### DIFF
--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -234,16 +234,45 @@ enum ProfileUsagePresentation {
         return "\(max(totalMinutes % 60, 1))m"
     }
 
-    /// Two-line menu-row model for a profile: identity on the primary line,
-    /// spelled-out usage on the secondary line (nil when there's no snapshot).
+    /// Two-line menu-row model for a profile: identity on the primary line, and
+    /// a secondary line that is the spelled-out usage when a fresh healthy
+    /// snapshot exists, otherwise an EXPLICIT honest state — "needs re-login",
+    /// "usage unavailable — retrying · last data 2h ago", "updated 6m ago" —
+    /// so a logged-in profile whose fetch is failing never renders a silent
+    /// blank second line. nil only when there is genuinely nothing to say (not
+    /// logged in / no snapshot yet), which keeps the single-line identity
+    /// treatment for those rows.
     static func menuLine(for entry: ModelProfileWithUsage,
                          timeZone: TimeZone = .current,
                          now: Date = Date()) -> MenuLineModel {
         MenuLineModel(
             primary: ProfileLoginPresentation.menuItemTitle(for: entry),
-            secondary: usageDetailLine(for: entry.usageSnapshot,
-                                       timeZone: timeZone, now: now)
+            secondary: secondaryLine(for: entry.usageSnapshot,
+                                     timeZone: timeZone, now: now)
         )
+    }
+
+    /// The secondary menu line: fresh usage numbers when healthy, else the
+    /// honest staleness/failure note (which already appends the last-known age
+    /// when older data exists). Detail line wins when present AND healthy so a
+    /// rate-limited profile with old numbers still shows the retry note rather
+    /// than silently presenting stale figures as current.
+    static func secondaryLine(for snapshot: ProfileUsageSnapshot?,
+                              timeZone: TimeZone = .current,
+                              now: Date = Date()) -> String? {
+        // Healthy + fresh: numbers.
+        if let snapshot, snapshot.isOK,
+           let detail = usageDetailLine(for: snapshot, timeZone: timeZone, now: now) {
+            // A fresh healthy snapshot may still be aging; append the age note
+            // when it crosses the stale threshold so "5h 12% used …" doesn't
+            // masquerade as up-to-the-second.
+            if let note = stalenessNote(for: snapshot, now: now) {
+                return "\(detail) · \(note)"
+            }
+            return detail
+        }
+        // Otherwise the honest note carries the row (nil for no-snapshot rows).
+        return stalenessNote(for: snapshot, now: now)
     }
 
     // MARK: - Picker ordering & row state
@@ -289,17 +318,69 @@ enum ProfileUsagePresentation {
     /// The daemon poller sweeps ~every 90s, so 5 minutes means several misses.
     static let staleAge: TimeInterval = 300
 
-    /// Staleness note for a picker row. nil = data is fresh and healthy (no
-    /// note). A failing snapshot surfaces the daemon's status string verbatim
-    /// (it already reads "stale since …; fetch failed: …").
+    /// Compact "how long ago" for a fetch timestamp: "just now", "3m", "2h",
+    /// "1d". Used to age both fresh-but-old and stale-with-old-data rows.
+    static func ageText(since date: Date, now: Date = Date()) -> String {
+        let seconds = max(0, now.timeIntervalSince(date))
+        if seconds < 60 { return "just now" }
+        let minutes = Int(seconds / 60)
+        if minutes < 60 { return "\(minutes)m" }
+        let hours = minutes / 60
+        if hours < 24 { return "\(hours)h" }
+        return "\(hours / 24)d"
+    }
+
+    /// Staleness / health note for a picker or menu row. Every logged-in
+    /// profile that lacks a fresh, healthy snapshot gets an EXPLICIT note —
+    /// never a silent blank — so the three failure modes read differently:
+    ///
+    /// - fresh & healthy → nil (no note; the usage line speaks for itself)
+    /// - fresh but aging (>= staleAge) → "updated 6m ago"
+    /// - `needsLogin` → "needs re-login" (actionable: the user must `/login`)
+    /// - `noCredentials` → "not logged in"
+    /// - `rateLimited` → "usage unavailable — retrying" (+ "· last data 2h ago"
+    ///   when we still have older numbers to show alongside)
+    /// - network/decode/unknown failure → "usage unavailable — retrying"
+    ///   (again suffixed with the last-known age when present)
+    ///
+    /// The daemon's verbose `status` string is no longer surfaced verbatim
+    /// (it leaked ISO timestamps into the UI); the typed `statusKind` drives
+    /// the copy instead.
     static func stalenessNote(for snapshot: ProfileUsageSnapshot?,
                               now: Date = Date()) -> String? {
         guard let snapshot else { return nil }
-        guard snapshot.isOK else { return snapshot.status }
-        guard let fetchedAt = snapshot.fetchedAt else { return "no usage data yet" }
-        let age = now.timeIntervalSince(fetchedAt)
-        guard age >= staleAge else { return nil }
-        return "updated \(Int(age / 60))m ago"
+
+        if snapshot.isOK {
+            guard let fetchedAt = snapshot.fetchedAt else { return "no usage data yet" }
+            let age = now.timeIntervalSince(fetchedAt)
+            guard age >= staleAge else { return nil }
+            return "updated \(ageText(since: fetchedAt, now: now)) ago"
+        }
+
+        // Failing snapshot: classify by the typed kind.
+        switch snapshot.statusKind {
+        case .ok:
+            // status text says failure but kind says ok — shouldn't happen;
+            // fall through to a generic note.
+            return retryingNote(for: snapshot, now: now)
+        case .needsLogin:
+            return "needs re-login"
+        case .noCredentials:
+            return "not logged in"
+        case .rateLimited, .networkError, .decodeError, .unknown:
+            return retryingNote(for: snapshot, now: now)
+        }
+    }
+
+    /// "usage unavailable — retrying", plus "· last data Nago" when the profile
+    /// has older buckets to show alongside the note.
+    private static func retryingNote(for snapshot: ProfileUsageSnapshot,
+                                     now: Date) -> String {
+        let base = "usage unavailable — retrying"
+        if let fetchedAt = snapshot.fetchedAt, !snapshot.buckets.isEmpty {
+            return "\(base) · last data \(ageText(since: fetchedAt, now: now)) ago"
+        }
+        return base
     }
 
     // MARK: - Per-session tooltips

--- a/Sources/TBDDaemon/Claude/ClaudeCredentialStore.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeCredentialStore.swift
@@ -1,0 +1,104 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeCredentialStore")
+
+/// Reads and writes the full Claude Code credentials blob for a given isolated
+/// `CLAUDE_CONFIG_DIR`, so the daemon can refresh an expired OAuth access token
+/// and persist the rotated pair back where the CLI reads it.
+///
+/// Reads shell out to `/usr/bin/security find-generic-password` (the items are
+/// ACL'd to specific client binaries; a direct Security-framework read would
+/// prompt). Writes use `/usr/bin/security add-generic-password -U`, which
+/// updates the existing item's secret in place while preserving its service and
+/// account attributes. When the keychain item is absent, both fall back to the
+/// on-disk `<configDir>/.credentials.json` file Claude Code writes when the
+/// keychain is unavailable.
+public protocol ClaudeCredentialStoring: Sendable {
+    /// Read the raw credentials blob bytes for the config dir, or nil when none
+    /// is stored (not logged in). Throws only on unexpected read errors.
+    func readBlob(forConfigDirPath path: String) async throws -> Data?
+    /// Persist a new credentials blob for the config dir. Returns true on
+    /// success; false when the write was denied/failed (caller should then treat
+    /// the profile as needing re-login rather than assume the refresh stuck).
+    func writeBlob(_ data: Data, forConfigDirPath path: String) async -> Bool
+}
+
+public struct SecurityCLIClaudeCredentialStore: ClaudeCredentialStoring {
+    /// The keychain account attribute Claude Code stores (the macOS short user
+    /// name). Resolved once from the environment; `add-generic-password`
+    /// requires an account to target the right item.
+    private let account: String
+
+    public init(account: String = NSUserName()) {
+        self.account = account
+    }
+
+    // MARK: Read
+
+    public func readBlob(forConfigDirPath path: String) async throws -> Data? {
+        let service = ClaudeCodeCredentialsKeychain.serviceName(forConfigDirPath: path)
+        let outcome = try await SecurityCLIOAuthTokenReader.runSecurityFindGenericPassword(service: service)
+        switch outcome {
+        case .found(let data):
+            return data
+        case .notFound:
+            let fileURL = URL(fileURLWithPath: path).appendingPathComponent(".credentials.json")
+            return try? Data(contentsOf: fileURL)
+        }
+    }
+
+    // MARK: Write
+
+    public func writeBlob(_ data: Data, forConfigDirPath path: String) async -> Bool {
+        let service = ClaudeCodeCredentialsKeychain.serviceName(forConfigDirPath: path)
+        guard let secret = String(data: data, encoding: .utf8) else {
+            logger.error("refreshed credential blob is not valid UTF-8; refusing to write")
+            return false
+        }
+        let ok = await Self.runSecurityAddGenericPassword(
+            account: account, service: service, secret: secret)
+        if !ok {
+            logger.warning("keychain write-back denied/failed for service \(service, privacy: .public)")
+            // Best-effort: also refresh the on-disk fallback file if it exists,
+            // so a CLI running in file-mode still benefits. Never creates the
+            // file (that would be surprising); only overwrites an existing one.
+            let fileURL = URL(fileURLWithPath: path).appendingPathComponent(".credentials.json")
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                try? data.write(to: fileURL, options: [.atomic])
+            }
+        }
+        return ok
+    }
+
+    /// Run `security add-generic-password -a <acct> -s <svc> -w <secret> -U`.
+    /// `-U` updates the item in place if it exists (preserving attributes),
+    /// creating it otherwise. Passing the secret via `-w <value>` avoids a
+    /// prompt. Never routes through a shell. Returns true on exit 0.
+    static func runSecurityAddGenericPassword(account: String, service: String, secret: String) async -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = [
+            "add-generic-password",
+            "-a", account,
+            "-s", service,
+            "-w", secret,
+            "-U",
+        ]
+        process.environment = [:]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        return await withCheckedContinuation { continuation in
+            process.terminationHandler = { proc in
+                continuation.resume(returning: proc.terminationStatus == 0)
+            }
+            do {
+                try process.run()
+            } catch {
+                continuation.resume(returning: false)
+            }
+        }
+    }
+}

--- a/Sources/TBDDaemon/Claude/ClaudeOAuthTokenRefresher.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeOAuthTokenRefresher.swift
@@ -1,0 +1,206 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "oauthTokenRefresh")
+
+// MARK: - Parsed credential blob
+
+/// The subset of a Claude Code credentials blob the daemon needs to reason
+/// about token freshness and drive a refresh. The raw JSON is preserved as
+/// `rawObject` so a refresh can write the file back byte-compatibly (only the
+/// four rotating fields under `claudeAiOauth` change).
+public struct ClaudeOAuthCredentials: Sendable, Equatable {
+    public var accessToken: String
+    public var refreshToken: String?
+    /// Unix epoch milliseconds (Claude Code stores `expiresAt` in ms).
+    public var expiresAtMillis: Double?
+    public var scopes: [String]
+
+    public init(accessToken: String, refreshToken: String?,
+                expiresAtMillis: Double?, scopes: [String]) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.expiresAtMillis = expiresAtMillis
+        self.scopes = scopes
+    }
+
+    /// True when `expiresAtMillis` is in the past (with a small skew margin so
+    /// we refresh slightly ahead of the hard boundary). nil expiry → never
+    /// considered expired (we let the server be the judge).
+    public func isExpired(now: Date, skew: TimeInterval = 60) -> Bool {
+        guard let expiresAtMillis else { return false }
+        let nowMillis = now.timeIntervalSince1970 * 1000 + skew * 1000
+        return expiresAtMillis < nowMillis
+    }
+}
+
+/// Parse the `claudeAiOauth` object out of a credentials blob into the typed
+/// fields the refresher needs. Pure/static for testability. nil when the shape
+/// is missing its access token.
+public func parseClaudeCredentials(_ data: Data) -> ClaudeOAuthCredentials? {
+    guard let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let oauth = parsed["claudeAiOauth"] as? [String: Any],
+          let token = oauth["accessToken"] as? String, !token.isEmpty
+    else { return nil }
+    let scopes = (oauth["scopes"] as? [String]) ?? []
+    return ClaudeOAuthCredentials(
+        accessToken: token,
+        refreshToken: oauth["refreshToken"] as? String,
+        expiresAtMillis: (oauth["expiresAt"] as? NSNumber)?.doubleValue,
+        scopes: scopes
+    )
+}
+
+/// Produce an updated credentials blob JSON by overwriting only the rotating
+/// OAuth fields (`accessToken`, `refreshToken`, `expiresAt`) inside the
+/// original blob's `claudeAiOauth` object, leaving every other key — including
+/// sibling top-level keys like `mcpOAuth` and other `claudeAiOauth` fields
+/// (`subscriptionType`, `rateLimitTier`, …) — byte-for-byte intact. This is
+/// the round-trip-fidelity contract: the CLI must still read what we write.
+///
+/// Returns nil if the original blob isn't the expected object-with-claudeAiOauth
+/// shape (caller should then not write anything back).
+public func rewriteClaudeCredentials(
+    original: Data,
+    newAccessToken: String,
+    newRefreshToken: String,
+    newExpiresAtMillis: Double
+) -> Data? {
+    guard var root = try? JSONSerialization.jsonObject(with: original) as? [String: Any],
+          var oauth = root["claudeAiOauth"] as? [String: Any]
+    else { return nil }
+    oauth["accessToken"] = newAccessToken
+    oauth["refreshToken"] = newRefreshToken
+    // Claude Code stores `expiresAt` as an integer millisecond epoch.
+    oauth["expiresAt"] = Int(newExpiresAtMillis)
+    root["claudeAiOauth"] = oauth
+    // `.sortedKeys` gives deterministic output for the round-trip test; the CLI
+    // parses by key so ordering is irrelevant to it.
+    return try? JSONSerialization.data(withJSONObject: root, options: [.sortedKeys])
+}
+
+// MARK: - Token endpoint client
+
+/// Result of a successful OAuth refresh_token grant.
+public struct RefreshedOAuthToken: Sendable, Equatable {
+    public let accessToken: String
+    /// The rotated refresh token. Anthropic rotates refresh tokens on every
+    /// grant (verified empirically 2026-07-05: the old token becomes
+    /// `invalid_grant` immediately), so this MUST be persisted or the login
+    /// breaks. Falls back to the caller's old token only when the server omits
+    /// it (it never has in practice).
+    public let refreshToken: String
+    /// Absolute expiry as unix epoch milliseconds (= now + expires_in).
+    public let expiresAtMillis: Double
+}
+
+public enum ClaudeOAuthRefreshError: Error, CustomStringConvertible, Equatable {
+    /// The refresh token itself is dead (400 invalid_grant) — only a re-login
+    /// recovers. Distinct from transient failures so callers can surface
+    /// "needs re-login" rather than retrying forever.
+    case invalidGrant
+    case rateLimited(retryAfter: TimeInterval?)
+    case http(Int)
+    case network(String)
+    case badResponse(String)
+
+    public var description: String {
+        switch self {
+        case .invalidGrant: return "refresh token invalid (needs re-login)"
+        case .rateLimited(let ra): return "refresh rate limited\(ra.map { " (retry \(Int($0))s)" } ?? "")"
+        case .http(let code): return "refresh HTTP \(code)"
+        case .network(let msg): return "refresh network error: \(msg)"
+        case .badResponse(let msg): return "refresh bad response: \(msg)"
+        }
+    }
+}
+
+/// Performs the Anthropic OAuth `refresh_token` grant. Isolated behind a
+/// protocol so the fetcher can be tested without a live token endpoint.
+public protocol ClaudeOAuthRefreshing: Sendable {
+    func refresh(refreshToken: String, scopes: [String]) async -> Result<RefreshedOAuthToken, ClaudeOAuthRefreshError>
+}
+
+/// Live refresher against `https://platform.claude.com/v1/oauth/token`, using
+/// the same client id, body shape, and grant the Claude Code CLI uses (see
+/// `w10` in the bundled cli.js — verified 2026-07-05). A browser/axios-style
+/// User-Agent is required: Cloudflare returns 403 (error 1010) to requests
+/// without one.
+public struct LiveClaudeOAuthRefresher: ClaudeOAuthRefreshing {
+    /// Public Claude Code OAuth client id (from cli.js `CLIENT_ID`).
+    public static let clientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+    public static let tokenURL = "https://platform.claude.com/v1/oauth/token"
+    /// UA that clears the Cloudflare edge check (verified 2026-07-05).
+    public static let userAgent = "axios/1.7.9"
+
+    public let session: URLSession
+    private let now: @Sendable () -> Date
+
+    public init(session: URLSession = .shared, now: (@Sendable () -> Date)? = nil) {
+        self.session = session
+        self.now = now ?? { Date() }
+    }
+
+    public func refresh(refreshToken: String, scopes: [String])
+        async -> Result<RefreshedOAuthToken, ClaudeOAuthRefreshError> {
+        guard let url = URL(string: Self.tokenURL) else {
+            return .failure(.network("invalid token URL"))
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(Self.userAgent, forHTTPHeaderField: "User-Agent")
+        let body: [String: Any] = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": Self.clientID,
+            "scope": scopes.joined(separator: " "),
+        ]
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            return .failure(.badResponse("could not encode refresh body"))
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            return .failure(.network(error.localizedDescription))
+        }
+        guard let http = response as? HTTPURLResponse else {
+            return .failure(.network("non-HTTP response"))
+        }
+        switch http.statusCode {
+        case 200:
+            return Self.parseSuccess(data: data, refreshTokenFallback: refreshToken, now: now())
+        case 400:
+            // invalid_grant → the refresh token is dead.
+            return .failure(.invalidGrant)
+        case 429:
+            let ra = (http.value(forHTTPHeaderField: "Retry-After")).flatMap(TimeInterval.init)
+            return .failure(.rateLimited(retryAfter: ra))
+        default:
+            return .failure(.http(http.statusCode))
+        }
+    }
+
+    static func parseSuccess(data: Data, refreshTokenFallback: String, now: Date)
+        -> Result<RefreshedOAuthToken, ClaudeOAuthRefreshError> {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let access = obj["access_token"] as? String, !access.isEmpty
+        else {
+            return .failure(.badResponse("no access_token in refresh response"))
+        }
+        let newRefresh = (obj["refresh_token"] as? String) ?? refreshTokenFallback
+        let expiresIn = (obj["expires_in"] as? NSNumber)?.doubleValue ?? 0
+        let expiresAtMillis = (now.timeIntervalSince1970 + expiresIn) * 1000
+        return .success(RefreshedOAuthToken(
+            accessToken: access,
+            refreshToken: newRefresh,
+            expiresAtMillis: expiresAtMillis
+        ))
+    }
+}

--- a/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
@@ -30,6 +30,14 @@ public actor OAuthProfileUsagePoller {
     public static let cadence: TimeInterval = 90
     public static let interProfileStagger: TimeInterval = 2
 
+    /// Backoff schedule for a profile whose fetch failed. Doubles per
+    /// consecutive failure, jittered, capped. A 429 with a `Retry-After`
+    /// overrides this with the server's own value. Kept below the picker's
+    /// stale threshold at the low end so a single hiccup doesn't visibly stall
+    /// a profile.
+    public static let baseBackoff: TimeInterval = 30
+    public static let maxBackoff: TimeInterval = 15 * 60
+
     // MARK: - Dependencies (closures so tests need no DB or filesystem)
 
     public typealias ProfilesProvider = @Sendable () async throws -> [ModelProfile]
@@ -41,11 +49,23 @@ public actor OAuthProfileUsagePoller {
     private let broadcast: @Sendable () -> Void
     private let sleeper: @Sendable (TimeInterval) async throws -> Void
     private let now: @Sendable () -> Date
+    private let jitter: @Sendable (TimeInterval) -> TimeInterval
 
     // MARK: - State
 
     private var snapshots: [UUID: ProfileUsageSnapshot] = [:]
     private var loopTask: Task<Void, Never>?
+
+    /// Per-profile backoff bookkeeping. `consecutiveFailures` drives the
+    /// exponential schedule; `nextEligibleAt` is when a scheduled sweep may try
+    /// this profile again. Isolated per profile so one account's rate limit
+    /// never delays another's polling. A forced sweep (`sweepNow`) ignores this
+    /// gate — the user explicitly asked.
+    private struct BackoffState {
+        var consecutiveFailures: Int = 0
+        var nextEligibleAt: Date?
+    }
+    private var backoff: [UUID: BackoffState] = [:]
 
     // MARK: - Init
 
@@ -56,7 +76,8 @@ public actor OAuthProfileUsagePoller {
         fetcher: ProfileUsageFetching,
         broadcast: @escaping @Sendable () -> Void,
         sleeper: (@Sendable (TimeInterval) async throws -> Void)? = nil,
-        now: (@Sendable () -> Date)? = nil
+        now: (@Sendable () -> Date)? = nil,
+        jitter: (@Sendable (TimeInterval) -> TimeInterval)? = nil
     ) {
         self.profilesProvider = profilesProvider
         self.loginIdentity = loginIdentity
@@ -65,6 +86,10 @@ public actor OAuthProfileUsagePoller {
         self.broadcast = broadcast
         self.sleeper = sleeper ?? { try await Task.sleep(for: .seconds($0)) }
         self.now = now ?? { Date() }
+        // Default jitter: uniform in [0, span). Injectable for deterministic
+        // tests. Applied additively to the base backoff so synchronized
+        // failures across profiles don't retry in lockstep.
+        self.jitter = jitter ?? { span in span <= 0 ? 0 : Double.random(in: 0..<span) }
     }
 
     // MARK: - Lifecycle
@@ -85,7 +110,8 @@ public actor OAuthProfileUsagePoller {
 
     private func runLoop() async {
         while !Task.isCancelled {
-            await sweep(only: nil)
+            // Scheduled sweeps honor per-profile backoff windows.
+            await sweep(only: nil, forced: false)
             try? await sleeper(Self.cadence)
         }
     }
@@ -103,18 +129,30 @@ public actor OAuthProfileUsagePoller {
     /// Fetch fresh usage now — all logged-in OAuth profiles when `profileID`
     /// is nil, or just the one profile. Returns the post-sweep snapshots
     /// (filtered to the requested profile when one was given).
+    ///
+    /// This is the user-explicit path (RPC `modelProfile.usageRefresh`), so it
+    /// bypasses per-profile backoff windows — the user asked, so we try even a
+    /// rate-limited profile.
     @discardableResult
     public func sweepNow(profileID: UUID? = nil) async -> [UUID: ProfileUsageSnapshot] {
-        await sweep(only: profileID)
+        await sweep(only: profileID, forced: true)
         if let profileID {
             return snapshots.filter { $0.key == profileID }
         }
         return snapshots
     }
 
+    /// Test seam: run the SCHEDULED sweep path (honoring backoff) synchronously,
+    /// as the background loop would. Not part of the public runtime API.
+    @discardableResult
+    func sweepNow(profileID: UUID?, forcedForTest: Bool) async -> [UUID: ProfileUsageSnapshot] {
+        await sweep(only: profileID, forced: forcedForTest)
+        return snapshots
+    }
+
     // MARK: - Sweep
 
-    private func sweep(only: UUID?) async {
+    private func sweep(only: UUID?, forced: Bool) async {
         let allProfiles: [ModelProfile]
         do {
             allProfiles = try await profilesProvider()
@@ -132,15 +170,26 @@ public actor OAuthProfileUsagePoller {
         // out, or changed kind, so the RPC surface never leaks ghosts.
         if only == nil {
             snapshots = snapshots.filter { eligibleIDs.contains($0.key) }
+            backoff = backoff.filter { eligibleIDs.contains($0.key) }
         }
 
-        let targets = only.map { id in eligible.filter { $0.id == id } } ?? eligible
+        // A forced sweep (only != nil) always tries the requested profile.
+        // A scheduled sweep skips any profile still inside its backoff window,
+        // so a rate-limited account isn't hammered every cadence tick — but the
+        // stagger + isolation mean the others still poll normally.
+        let candidates = only.map { id in eligible.filter { $0.id == id } } ?? eligible
+        let currentTime = now()
+        let targets = candidates.filter { profile in
+            forced || isEligibleNow(profile.id, at: currentTime)
+        }
 
-        for (index, profile) in targets.enumerated() {
-            if index > 0 {
+        var didFetch = false
+        for profile in targets {
+            if didFetch {
                 try? await sleeper(Self.interProfileStagger)
             }
             if Task.isCancelled { break }
+            didFetch = true
             let status = await fetcher.fetchUsage(configDirPath: configDirPath(profile.id))
             record(status, for: profile.id)
         }
@@ -150,15 +199,24 @@ public actor OAuthProfileUsagePoller {
         }
     }
 
+    /// Whether a scheduled sweep may attempt this profile now (its backoff
+    /// window, if any, has elapsed).
+    private func isEligibleNow(_ profileID: UUID, at time: Date) -> Bool {
+        guard let next = backoff[profileID]?.nextEligibleAt else { return true }
+        return time >= next
+    }
+
     private func record(_ status: ProfileUsageFetchStatus, for profileID: UUID) {
         let timestamp = now()
         switch status {
         case .ok(let buckets):
+            backoff[profileID] = BackoffState()  // reset schedule on success
             snapshots[profileID] = ProfileUsageSnapshot(
                 buckets: buckets,
                 fetchedAt: timestamp,
                 lastAttemptAt: timestamp,
-                status: "ok"
+                status: "ok",
+                statusKind: .ok
             )
             logger.debug("usage sweep ok for profile \(profileID, privacy: .public): \(buckets.count, privacy: .public) buckets")
         default:
@@ -170,14 +228,37 @@ public actor OAuthProfileUsagePoller {
             } else {
                 statusText = "fetch failed: \(reason)"
             }
+            scheduleBackoff(for: profileID, status: status, at: timestamp)
             snapshots[profileID] = ProfileUsageSnapshot(
                 buckets: previous?.buckets ?? [],
                 fetchedAt: previous?.fetchedAt,
                 lastAttemptAt: timestamp,
-                status: statusText
+                status: statusText,
+                statusKind: status.kind
             )
             logger.warning("usage sweep failed for profile \(profileID, privacy: .public): \(reason, privacy: .public)")
         }
+    }
+
+    /// Advance a profile's backoff after a failure. Honors a 429 `Retry-After`
+    /// verbatim; otherwise uses exponential backoff (base·2^failures) plus
+    /// additive jitter, capped at `maxBackoff`. `needsLogin`/`noCredentials`
+    /// aren't retry-worthy at high frequency, so they also back off (they'll
+    /// clear when the user re-logs in and the identity/credential reappears).
+    private func scheduleBackoff(for profileID: UUID, status: ProfileUsageFetchStatus, at time: Date) {
+        var state = backoff[profileID] ?? BackoffState()
+        state.consecutiveFailures += 1
+        let delay: TimeInterval
+        if let retryAfter = status.retryAfter, retryAfter > 0 {
+            delay = min(retryAfter, Self.maxBackoff)
+        } else {
+            let exponent = Double(min(state.consecutiveFailures - 1, 10))
+            let raw = Self.baseBackoff * pow(2, exponent)
+            let capped = min(raw, Self.maxBackoff)
+            delay = min(capped + jitter(Self.baseBackoff), Self.maxBackoff)
+        }
+        state.nextEligibleAt = time.addingTimeInterval(delay)
+        backoff[profileID] = state
     }
 
     /// Snapshot change comparison ignoring `lastAttemptAt`, so repeated

--- a/Sources/TBDDaemon/Claude/ProfileUsageFetcher.swift
+++ b/Sources/TBDDaemon/Claude/ProfileUsageFetcher.swift
@@ -117,7 +117,15 @@ public enum ProfileUsageFetchStatus: Equatable, Sendable {
     /// credential could not be read. The reason is human-readable and MUST
     /// NOT contain token bytes.
     case noCredentials(String)
-    case httpError(Int)  // 401 = token invalid/expired, 429 = rate limited, ...
+    /// The stored credential is present but the account needs the user to
+    /// re-run `/login`: either the access token was rejected (401/403) and
+    /// automatic refresh could not recover it, or the refresh token itself is
+    /// dead (`invalid_grant`).
+    case needsLogin(String)
+    /// HTTP 429. `retryAfter` carries the server's `Retry-After` (seconds) when
+    /// present, so the poller can honor it instead of guessing a backoff.
+    case rateLimited(retryAfter: TimeInterval?)
+    case httpError(Int)
     case networkError(String)
     case decodeError(String)
 
@@ -127,10 +135,32 @@ public enum ProfileUsageFetchStatus: Equatable, Sendable {
         switch self {
         case .ok: return nil
         case .noCredentials(let reason): return "no credentials (\(reason))"
+        case .needsLogin(let reason): return "needs re-login (\(reason))"
+        case .rateLimited(let ra):
+            return ra.map { "rate limited (retry \(Int($0))s)" } ?? "rate limited"
         case .httpError(let code): return "HTTP \(code)"
         case .networkError(let msg): return "network error: \(msg)"
         case .decodeError(let msg): return "decode error: \(msg)"
         }
+    }
+
+    /// Machine-readable classification for the snapshot / UI.
+    public var kind: ProfileUsageStatusKind {
+        switch self {
+        case .ok: return .ok
+        case .noCredentials: return .noCredentials
+        case .needsLogin: return .needsLogin
+        case .rateLimited: return .rateLimited
+        case .httpError: return .unknown
+        case .networkError: return .networkError
+        case .decodeError: return .decodeError
+        }
+    }
+
+    /// The `Retry-After` the server asked for, if any (429 only).
+    public var retryAfter: TimeInterval? {
+        if case .rateLimited(let ra) = self { return ra }
+        return nil
     }
 }
 
@@ -145,35 +175,134 @@ public protocol ProfileUsageFetching: Sendable {
 /// `https://api.anthropic.com/api/oauth/usage` with it — the same endpoint
 /// `LiveClaudeUsageFetcher` uses for API-key profiles, but with CLI-mediated
 /// (keychain) credentials and the richer `limits[]` parse.
+///
+/// Token freshness is handled here so a profile whose access token has expired
+/// (nothing running a Claude session on it to refresh it) recovers on its own:
+/// before the GET, an expired credential is refreshed via the OAuth
+/// `refresh_token` grant and the rotated pair written back to the keychain (so
+/// the CLI benefits too); a 401/403 on the GET triggers one refresh-and-retry.
+/// When refresh fails because the refresh token is dead, the profile is
+/// classified `.needsLogin` rather than an eternal auth error.
 public struct LiveProfileUsageFetcher: ProfileUsageFetching {
-    public let tokenReader: ClaudeOAuthTokenReading
+    public let credentialStore: ClaudeCredentialStoring
+    public let refresher: ClaudeOAuthRefreshing
     public let session: URLSession
+    private let now: @Sendable () -> Date
 
     public init(
-        tokenReader: ClaudeOAuthTokenReading = SecurityCLIOAuthTokenReader(),
-        session: URLSession = .shared
+        credentialStore: ClaudeCredentialStoring = SecurityCLIClaudeCredentialStore(),
+        refresher: ClaudeOAuthRefreshing = LiveClaudeOAuthRefresher(),
+        session: URLSession = .shared,
+        now: (@Sendable () -> Date)? = nil
     ) {
-        self.tokenReader = tokenReader
+        self.credentialStore = credentialStore
+        self.refresher = refresher
         self.session = session
+        self.now = now ?? { Date() }
     }
 
     public func fetchUsage(configDirPath: String) async -> ProfileUsageFetchStatus {
-        let token: String?
+        // 1. Read the full credential blob.
+        let blob: Data?
         do {
-            token = try await tokenReader.accessToken(forConfigDirPath: configDirPath)
+            blob = try await credentialStore.readBlob(forConfigDirPath: configDirPath)
         } catch {
             return .noCredentials("credential read failed: \(error)")
         }
-        guard let token else {
+        guard let blob, var creds = parseClaudeCredentials(blob) else {
             return .noCredentials("no stored credential — needs /login")
         }
 
+        // 2. Proactively refresh an already-expired access token before the
+        //    request (avoids a guaranteed 401 round-trip).
+        if creds.isExpired(now: now()) {
+            switch await refreshAndPersist(creds, blob: blob, configDirPath: configDirPath) {
+            case .refreshed(let updated):
+                creds = updated
+            case .needsLogin(let reason):
+                return .needsLogin(reason)
+            case .transient(let status):
+                return status
+            }
+        }
+
+        // 3. Fetch usage. On 401/403, refresh once and retry.
+        let firstAttempt = await requestUsage(accessToken: creds.accessToken)
+        if case .httpError(let code) = firstAttempt, code == 401 || code == 403 {
+            switch await refreshAndPersist(creds, blob: blob, configDirPath: configDirPath) {
+            case .refreshed(let updated):
+                return await requestUsage(accessToken: updated.accessToken)
+            case .needsLogin(let reason):
+                return .needsLogin(reason)
+            case .transient(let status):
+                return status
+            }
+        }
+        return firstAttempt
+    }
+
+    // MARK: Refresh + persist
+
+    private enum RefreshOutcome {
+        case refreshed(ClaudeOAuthCredentials)
+        case needsLogin(String)
+        case transient(ProfileUsageFetchStatus)
+    }
+
+    /// Refresh the access token and write the rotated pair back to the
+    /// keychain. A failed write-back is treated as `.needsLogin`: we must not
+    /// report success against a token the CLI can't see (the refresh token has
+    /// already rotated server-side, so the un-persisted old one is now dead).
+    private func refreshAndPersist(_ creds: ClaudeOAuthCredentials, blob: Data,
+                                   configDirPath: String) async -> RefreshOutcome {
+        guard let refreshToken = creds.refreshToken else {
+            return .needsLogin("no refresh token stored")
+        }
+        let result = await refresher.refresh(refreshToken: refreshToken, scopes: creds.scopes)
+        switch result {
+        case .success(let token):
+            guard let rewritten = rewriteClaudeCredentials(
+                original: blob,
+                newAccessToken: token.accessToken,
+                newRefreshToken: token.refreshToken,
+                newExpiresAtMillis: token.expiresAtMillis
+            ) else {
+                return .needsLogin("could not rewrite credential blob")
+            }
+            let wrote = await credentialStore.writeBlob(rewritten, forConfigDirPath: configDirPath)
+            guard wrote else {
+                return .needsLogin("token refreshed but keychain write-back was denied")
+            }
+            var updated = creds
+            updated.accessToken = token.accessToken
+            updated.refreshToken = token.refreshToken
+            updated.expiresAtMillis = token.expiresAtMillis
+            return .refreshed(updated)
+        case .failure(let error):
+            switch error {
+            case .invalidGrant:
+                return .needsLogin("refresh token expired")
+            case .rateLimited(let ra):
+                return .transient(.rateLimited(retryAfter: ra))
+            case .network(let msg):
+                return .transient(.networkError("refresh: \(msg)"))
+            case .http(let code):
+                return .transient(.httpError(code))
+            case .badResponse(let msg):
+                return .transient(.networkError("refresh: \(msg)"))
+            }
+        }
+    }
+
+    // MARK: Usage request
+
+    private func requestUsage(accessToken: String) async -> ProfileUsageFetchStatus {
         guard let url = URL(string: "https://api.anthropic.com/api/oauth/usage") else {
             return .networkError("invalid URL")
         }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
@@ -187,13 +316,18 @@ public struct LiveProfileUsageFetcher: ProfileUsageFetching {
         guard let http = response as? HTTPURLResponse else {
             return .networkError("non-HTTP response")
         }
-        guard http.statusCode == 200 else {
+        switch http.statusCode {
+        case 200:
+            do {
+                return .ok(try ClaudeUsagePayloadParser.parseBuckets(from: data))
+            } catch {
+                return .decodeError("\(error)")
+            }
+        case 429:
+            let ra = (http.value(forHTTPHeaderField: "Retry-After")).flatMap(TimeInterval.init)
+            return .rateLimited(retryAfter: ra)
+        default:
             return .httpError(http.statusCode)
-        }
-        do {
-            return .ok(try ClaudeUsagePayloadParser.parseBuckets(from: data))
-        } catch {
-            return .decodeError("\(error)")
         }
     }
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -527,6 +527,36 @@ public struct ClaudeUsageLimitBucket: Codable, Sendable, Equatable {
     }
 }
 
+/// Machine-readable classification of a profile's last usage-fetch outcome,
+/// so the UI can render honest, distinct states instead of parsing the
+/// free-form `status` string. Separates auth failures from rate limits from
+/// network errors — the three demand different user affordances ("needs
+/// re-login" vs "retrying" vs "temporarily unavailable").
+///
+/// New field: `statusKind` is optional on `ProfileUsageSnapshot` with an
+/// `.unknown` default so payloads from an older daemon (which only sent the
+/// `status` string) still decode.
+public enum ProfileUsageStatusKind: String, Codable, Sendable, Equatable {
+    /// Last fetch succeeded; `buckets` are current.
+    case ok
+    /// HTTP 429 — rate limited. The poller is backing off and will retry.
+    case rateLimited
+    /// HTTP 401/403 with a credential the daemon believes is present but the
+    /// server rejected, AND automatic token refresh could not recover it. The
+    /// profile needs the user to re-run `/login`.
+    case needsLogin
+    /// No stored credential at all for this profile (never logged in, or the
+    /// keychain item is gone).
+    case noCredentials
+    /// A transport-level failure (DNS, timeout, offline). Transient; retried.
+    case networkError
+    /// The server replied 200 but the body didn't parse. Retried.
+    case decodeError
+    /// Some other HTTP status, or a snapshot from an older daemon that didn't
+    /// classify. Treated as a generic retryable failure by the UI.
+    case unknown
+}
+
 /// In-memory per-profile usage snapshot for logged-in OAuth profiles,
 /// maintained by the daemon's background poller (never persisted).
 public struct ProfileUsageSnapshot: Codable, Sendable, Equatable {
@@ -539,13 +569,31 @@ public struct ProfileUsageSnapshot: Codable, Sendable, Equatable {
     /// "ok", or a failure description like
     /// "stale since 2026-07-03T18:00:00Z; fetch failed: HTTP 401".
     public var status: String
+    /// Machine-readable classification of the last fetch outcome. Optional for
+    /// decode-compat with older daemons; defaults to `.unknown` when absent.
+    public var statusKind: ProfileUsageStatusKind
 
     public init(buckets: [ClaudeUsageLimitBucket], fetchedAt: Date? = nil,
-                lastAttemptAt: Date, status: String) {
+                lastAttemptAt: Date, status: String,
+                statusKind: ProfileUsageStatusKind = .unknown) {
         self.buckets = buckets
         self.fetchedAt = fetchedAt
         self.lastAttemptAt = lastAttemptAt
         self.status = status
+        self.statusKind = statusKind
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.buckets = try container.decode([ClaudeUsageLimitBucket].self, forKey: .buckets)
+        self.fetchedAt = try container.decodeIfPresent(Date.self, forKey: .fetchedAt)
+        self.lastAttemptAt = try container.decode(Date.self, forKey: .lastAttemptAt)
+        self.status = try container.decode(String.self, forKey: .status)
+        // Absent (older daemon) → infer from the legacy string so callers still
+        // get a usable classification: "ok" → .ok, else .unknown.
+        self.statusKind = try container.decodeIfPresent(
+            ProfileUsageStatusKind.self, forKey: .statusKind)
+            ?? (self.status == "ok" ? .ok : .unknown)
     }
 
     public var isOK: Bool { status == "ok" }

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -28,9 +28,11 @@ private func bucket(kind: String, percent: Double, severity: String? = nil,
 
 private func snapshot(buckets: [ClaudeUsageLimitBucket],
                       fetchedAt: Date? = Date(),
-                      status: String = "ok") -> ProfileUsageSnapshot {
+                      status: String = "ok",
+                      statusKind: ProfileUsageStatusKind = .ok) -> ProfileUsageSnapshot {
     ProfileUsageSnapshot(buckets: buckets, fetchedAt: fetchedAt,
-                         lastAttemptAt: Date(), status: status)
+                         lastAttemptAt: Date(), status: status,
+                         statusKind: statusKind)
 }
 
 private func entry(name: String,
@@ -272,18 +274,12 @@ struct PickerSortTests {
 
 // MARK: - Staleness
 
-@Suite("ProfileUsagePresentation — staleness")
+@Suite("ProfileUsagePresentation — staleness / honest states")
 struct StalenessNoteTests {
     @Test func freshHealthySnapshotHasNoNote() {
         let now = Date()
         let fresh = snapshot(buckets: [], fetchedAt: now.addingTimeInterval(-30))
         #expect(ProfileUsagePresentation.stalenessNote(for: fresh, now: now) == nil)
-    }
-
-    @Test func failingSnapshotSurfacesDaemonStatusVerbatim() {
-        let status = "stale since 2026-07-03T18:00:00Z; fetch failed: HTTP 401"
-        let failing = snapshot(buckets: [], status: status)
-        #expect(ProfileUsagePresentation.stalenessNote(for: failing) == status)
     }
 
     @Test func neverFetchedSnapshotSaysNoDataYet() {
@@ -299,6 +295,118 @@ struct StalenessNoteTests {
 
     @Test func missingSnapshotHasNoNote() {
         #expect(ProfileUsagePresentation.stalenessNote(for: nil) == nil)
+    }
+
+    // MARK: Typed failure states — each renders distinct, explicit copy.
+
+    @Test func needsLoginRendersActionableNote() {
+        let failing = snapshot(buckets: [], fetchedAt: nil,
+                               status: "fetch failed: needs re-login (refresh token expired)",
+                               statusKind: .needsLogin)
+        #expect(ProfileUsagePresentation.stalenessNote(for: failing) == "needs re-login")
+    }
+
+    @Test func noCredentialsRendersNotLoggedIn() {
+        let failing = snapshot(buckets: [], fetchedAt: nil,
+                               status: "fetch failed: no credentials", statusKind: .noCredentials)
+        #expect(ProfileUsagePresentation.stalenessNote(for: failing) == "not logged in")
+    }
+
+    @Test func rateLimitedWithoutPriorDataSaysRetrying() {
+        let failing = snapshot(buckets: [], fetchedAt: nil,
+                               status: "fetch failed: rate limited", statusKind: .rateLimited)
+        #expect(ProfileUsagePresentation.stalenessNote(for: failing)
+                == "usage unavailable — retrying")
+    }
+
+    @Test func rateLimitedWithPriorDataAppendsLastKnownAge() {
+        let now = Date()
+        // Older successful buckets exist; status now reflects a 429.
+        let failing = snapshot(buckets: [bucket(kind: "session", percent: 20)],
+                               fetchedAt: now.addingTimeInterval(-7200),
+                               status: "stale since …; fetch failed: rate limited",
+                               statusKind: .rateLimited)
+        #expect(ProfileUsagePresentation.stalenessNote(for: failing, now: now)
+                == "usage unavailable — retrying · last data 2h ago")
+    }
+
+    @Test func networkErrorSaysRetrying() {
+        let failing = snapshot(buckets: [], fetchedAt: nil,
+                               status: "fetch failed: network error: timed out",
+                               statusKind: .networkError)
+        #expect(ProfileUsagePresentation.stalenessNote(for: failing)
+                == "usage unavailable — retrying")
+    }
+
+    @Test func unknownStatusFromOlderDaemonSaysRetrying() {
+        // Older daemon: no statusKind field → inferred .unknown on decode.
+        let failing = snapshot(buckets: [], fetchedAt: nil,
+                               status: "fetch failed: HTTP 503", statusKind: .unknown)
+        #expect(ProfileUsagePresentation.stalenessNote(for: failing)
+                == "usage unavailable — retrying")
+    }
+
+    @Test func ageTextGranularity() {
+        let now = Date()
+        #expect(ProfileUsagePresentation.ageText(since: now.addingTimeInterval(-30), now: now) == "just now")
+        #expect(ProfileUsagePresentation.ageText(since: now.addingTimeInterval(-180), now: now) == "3m")
+        #expect(ProfileUsagePresentation.ageText(since: now.addingTimeInterval(-7200), now: now) == "2h")
+        #expect(ProfileUsagePresentation.ageText(since: now.addingTimeInterval(-172800), now: now) == "2d")
+    }
+}
+
+// MARK: - Secondary menu line honesty (menuLine composition)
+
+@Suite("ProfileUsagePresentation — secondary line honesty")
+struct SecondaryLineHonestyTests {
+    @Test func healthyFreshShowsUsageNumbers() {
+        let line = ProfileUsagePresentation.secondaryLine(for: gmailSnapshot, timeZone: utc)
+        #expect(line == "5h 0% used · resets 23:10 · week 76% · Fable 100%")
+    }
+
+    @Test func rateLimitedProfileShowsRetryNoteNotStaleNumbers() {
+        // Even though old buckets exist, a 429 snapshot must not present them as
+        // current — the retry note carries the row.
+        let now = Date()
+        let stale = ProfileUsageSnapshot(
+            buckets: gmailSnapshot.buckets,
+            fetchedAt: now.addingTimeInterval(-3600),
+            lastAttemptAt: now,
+            status: "stale since …; fetch failed: rate limited",
+            statusKind: .rateLimited)
+        let line = ProfileUsagePresentation.secondaryLine(for: stale, timeZone: utc, now: now)
+        #expect(line == "usage unavailable — retrying · last data 1h ago")
+    }
+
+    @Test func needsLoginProfileShowsReloginNote() {
+        let needs = ProfileUsageSnapshot(
+            buckets: [], fetchedAt: nil, lastAttemptAt: Date(),
+            status: "fetch failed: needs re-login", statusKind: .needsLogin)
+        #expect(ProfileUsagePresentation.secondaryLine(for: needs) == "needs re-login")
+    }
+
+    @Test func noSnapshotHasNoSecondaryLine() {
+        #expect(ProfileUsagePresentation.secondaryLine(for: nil) == nil)
+    }
+
+    @Test func healthyButAgingAppendsAgeNote() {
+        let now = Date()
+        let aging = ProfileUsageSnapshot(
+            buckets: [bucket(kind: "session", percent: 12)],
+            fetchedAt: now.addingTimeInterval(-600),
+            lastAttemptAt: now, status: "ok", statusKind: .ok)
+        #expect(ProfileUsagePresentation.secondaryLine(for: aging, timeZone: utc, now: now)
+                == "5h 12% used · updated 10m ago")
+    }
+
+    @Test func menuLineForFailingProfileHasHonestSecondary() {
+        let entry = entry(name: "Gmail", loginIdentity: "g@x.co",
+                          usageSnapshot: ProfileUsageSnapshot(
+                            buckets: [], fetchedAt: nil, lastAttemptAt: Date(),
+                            status: "fetch failed: needs re-login", statusKind: .needsLogin))
+        let line = ProfileUsagePresentation.menuLine(for: entry)
+        #expect(line.primary == "Gmail — g@x.co")
+        #expect(line.secondary == "needs re-login")
     }
 }
 

--- a/Tests/TBDDaemonTests/ClaudeOAuthTokenRefresherTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeOAuthTokenRefresherTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// MARK: - Credential blob parse + rewrite round-trip
+
+@Suite("ClaudeOAuthCredentials parse")
+struct ClaudeCredentialsParseTests {
+    /// The live-verified blob shape (top-level mcpOAuth + claudeAiOauth with the
+    /// six oauth fields).
+    private let blob = """
+    {
+      "mcpOAuth": {"some": "thing"},
+      "claudeAiOauth": {
+        "accessToken": "at-abc",
+        "refreshToken": "rt-xyz",
+        "expiresAt": 1783155405362,
+        "scopes": ["user:inference", "user:profile"],
+        "subscriptionType": "max",
+        "rateLimitTier": "default_claude_max_20x"
+      }
+    }
+    """.data(using: .utf8)!
+
+    @Test func parsesAllFields() throws {
+        let creds = try #require(parseClaudeCredentials(blob))
+        #expect(creds.accessToken == "at-abc")
+        #expect(creds.refreshToken == "rt-xyz")
+        #expect(creds.expiresAtMillis == 1783155405362)
+        #expect(creds.scopes == ["user:inference", "user:profile"])
+    }
+
+    @Test func missingAccessTokenYieldsNil() {
+        let bad = #"{"claudeAiOauth": {"refreshToken": "x"}}"#.data(using: .utf8)!
+        #expect(parseClaudeCredentials(bad) == nil)
+    }
+
+    @Test func expiryDetection() throws {
+        let creds = try #require(parseClaudeCredentials(blob))
+        // expiresAt = 1783155405362 ms → 2026-07-03ish.
+        let after = Date(timeIntervalSince1970: 1783155405362 / 1000 + 3600)
+        let before = Date(timeIntervalSince1970: 1783155405362 / 1000 - 3600)
+        #expect(creds.isExpired(now: after))
+        #expect(creds.isExpired(now: before) == false)
+    }
+
+    @Test func nilExpiryIsNeverExpired() {
+        let creds = ClaudeOAuthCredentials(accessToken: "a", refreshToken: "r",
+                                           expiresAtMillis: nil, scopes: [])
+        #expect(creds.isExpired(now: Date()) == false)
+    }
+}
+
+@Suite("rewriteClaudeCredentials round-trip fidelity")
+struct RewriteCredentialsTests {
+    private let original = """
+    {
+      "mcpOAuth": {"server": {"token": "keep-me"}},
+      "claudeAiOauth": {
+        "accessToken": "old-at",
+        "refreshToken": "old-rt",
+        "expiresAt": 1000,
+        "scopes": ["user:inference"],
+        "subscriptionType": "max",
+        "rateLimitTier": "default_claude_max_20x"
+      }
+    }
+    """.data(using: .utf8)!
+
+    @Test func rewritesOnlyRotatingFieldsAndPreservesEverythingElse() throws {
+        let rewritten = try #require(rewriteClaudeCredentials(
+            original: original,
+            newAccessToken: "new-at",
+            newRefreshToken: "new-rt",
+            newExpiresAtMillis: 2_000_000
+        ))
+        let root = try #require(
+            try JSONSerialization.jsonObject(with: rewritten) as? [String: Any])
+        let oauth = try #require(root["claudeAiOauth"] as? [String: Any])
+
+        // Rotated fields updated.
+        #expect(oauth["accessToken"] as? String == "new-at")
+        #expect(oauth["refreshToken"] as? String == "new-rt")
+        #expect((oauth["expiresAt"] as? NSNumber)?.intValue == 2_000_000)
+
+        // Sibling oauth fields preserved verbatim.
+        #expect(oauth["subscriptionType"] as? String == "max")
+        #expect(oauth["rateLimitTier"] as? String == "default_claude_max_20x")
+        #expect(oauth["scopes"] as? [String] == ["user:inference"])
+
+        // Top-level siblings preserved (mcpOAuth untouched).
+        let mcp = try #require(root["mcpOAuth"] as? [String: Any])
+        let server = try #require(mcp["server"] as? [String: Any])
+        #expect(server["token"] as? String == "keep-me")
+    }
+
+    @Test func rewrittenBlobParsesBackToTheNewCredentials() throws {
+        // Full round-trip: rewrite, then re-parse with the fetcher's own parser.
+        let rewritten = try #require(rewriteClaudeCredentials(
+            original: original, newAccessToken: "at2", newRefreshToken: "rt2",
+            newExpiresAtMillis: 5_000_000))
+        let reparsed = try #require(parseClaudeCredentials(rewritten))
+        #expect(reparsed.accessToken == "at2")
+        #expect(reparsed.refreshToken == "rt2")
+        #expect(reparsed.expiresAtMillis == 5_000_000)
+    }
+
+    @Test func nonMatchingShapeYieldsNil() {
+        let noOauth = #"{"something": 1}"#.data(using: .utf8)!
+        #expect(rewriteClaudeCredentials(original: noOauth, newAccessToken: "a",
+                                         newRefreshToken: "b", newExpiresAtMillis: 1) == nil)
+    }
+}
+
+// MARK: - Refresh response parsing
+
+@Suite("LiveClaudeOAuthRefresher.parseSuccess")
+struct RefreshSuccessParseTests {
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    @Test func extractsRotatedPairAndComputesExpiry() {
+        let body = """
+        {"token_type":"Bearer","access_token":"new-at","refresh_token":"new-rt","expires_in":28800}
+        """.data(using: .utf8)!
+        let result = LiveClaudeOAuthRefresher.parseSuccess(
+            data: body, refreshTokenFallback: "old-rt", now: now)
+        guard case .success(let token) = result else {
+            Issue.record("expected success"); return
+        }
+        #expect(token.accessToken == "new-at")
+        #expect(token.refreshToken == "new-rt")
+        // now (1_000_000s) + 28800s → millis
+        #expect(token.expiresAtMillis == (1_000_000 + 28800) * 1000)
+    }
+
+    @Test func fallsBackToOldRefreshTokenWhenServerOmitsIt() {
+        let body = #"{"access_token":"a","expires_in":100}"#.data(using: .utf8)!
+        let result = LiveClaudeOAuthRefresher.parseSuccess(
+            data: body, refreshTokenFallback: "old-rt", now: now)
+        guard case .success(let token) = result else {
+            Issue.record("expected success"); return
+        }
+        #expect(token.refreshToken == "old-rt")
+    }
+
+    @Test func missingAccessTokenIsBadResponse() {
+        let body = #"{"expires_in":100}"#.data(using: .utf8)!
+        let result = LiveClaudeOAuthRefresher.parseSuccess(
+            data: body, refreshTokenFallback: "old", now: now)
+        guard case .failure(.badResponse) = result else {
+            Issue.record("expected badResponse"); return
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
+++ b/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
@@ -234,6 +234,31 @@ struct OAuthProfileUsagePollerTests {
         #expect(snapshots[drop.id] == nil)
     }
 
+    @Test func failedFetchSetsTypedStatusKind() async {
+        let profile = oauthProfile(named: "Rate")
+        let fetcher = ScriptedProfileUsageFetcher(default: .rateLimited(retryAfter: 60))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [profile], loggedIn: [profile.id],
+            fetcher: fetcher, broadcasts: broadcasts
+        )
+        let snapshots = await poller.sweepNow()
+        #expect(snapshots[profile.id]?.statusKind == .rateLimited)
+    }
+
+    @Test func needsLoginStatusFlowsThroughToSnapshot() async {
+        let profile = oauthProfile(named: "Expired")
+        let fetcher = ScriptedProfileUsageFetcher(default: .needsLogin("refresh token expired"))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [profile], loggedIn: [profile.id],
+            fetcher: fetcher, broadcasts: broadcasts
+        )
+        let snapshots = await poller.sweepNow()
+        #expect(snapshots[profile.id]?.statusKind == .needsLogin)
+        #expect(snapshots[profile.id]?.status.contains("needs re-login") == true)
+    }
+
     @Test func profilesProviderErrorLeavesExistingSnapshotsIntact() async {
         let profile = oauthProfile(named: "Sticky")
         let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
@@ -262,6 +287,145 @@ struct OAuthProfileUsagePollerTests {
         let second = await poller.sweepNow()
         #expect(second[profile.id]?.status == "ok")
         #expect(broadcasts.count == 1)
+    }
+}
+
+// MARK: - Backoff scheduling
+
+/// Thread-safe mutable clock for backoff tests.
+private final class MutableClock: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "MutableClock")
+    private var _now: Date
+    init(_ start: Date) { _now = start }
+    var now: Date { queue.sync { _now } }
+    func advance(_ interval: TimeInterval) { queue.sync { _now = _now.addingTimeInterval(interval) } }
+}
+
+@Suite struct OAuthProfileUsagePollerBackoffTests {
+
+    /// Build a poller whose scheduled loop runs exactly one sweep (the cadence
+    /// sleeper throws to stop the loop), with a deterministic clock and zero
+    /// jitter.
+    private func scheduledPoller(
+        profile: ModelProfile,
+        fetcher: ScriptedProfileUsageFetcher,
+        clock: MutableClock
+    ) -> OAuthProfileUsagePoller {
+        OAuthProfileUsagePoller(
+            profilesProvider: { [profile] },
+            loginIdentity: { _ in "someone@example.com" },
+            configDirPath: { id in "/profiles/\(id.uuidString.lowercased())/claude" },
+            fetcher: fetcher,
+            broadcast: {},
+            sleeper: { _ in },  // instant staggers
+            now: { clock.now },
+            jitter: { _ in 0 }
+        )
+    }
+
+    @Test func retryAfterGatesTheNextScheduledSweep() async {
+        let profile = oauthProfile(named: "Limited")
+        let dir = "/profiles/\(profile.id.uuidString.lowercased())/claude"
+        // First fetch: 429 Retry-After 300s. Second (if it happened): ok.
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        fetcher.enqueue(configDirPath: dir, .rateLimited(retryAfter: 300))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = scheduledPoller(profile: profile, fetcher: fetcher, clock: clock)
+
+        // Forced sweep records the 429 and arms the 300s backoff.
+        _ = await poller.sweepNow()
+        #expect(fetcher.calls.count == 1)
+        #expect(await poller.snapshot(for: profile.id)?.statusKind == .rateLimited)
+
+        // A scheduled sweep only 100s later must SKIP this profile (still inside
+        // the 300s Retry-After window).
+        clock.advance(100)
+        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        #expect(fetcher.calls.count == 1)  // no new fetch
+
+        // Past the window: scheduled sweep tries again and recovers.
+        clock.advance(300)
+        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        #expect(fetcher.calls.count == 2)
+        #expect(await poller.snapshot(for: profile.id)?.statusKind == .ok)
+    }
+
+    @Test func forcedSweepIgnoresBackoffWindow() async {
+        let profile = oauthProfile(named: "Limited")
+        let dir = "/profiles/\(profile.id.uuidString.lowercased())/claude"
+        let fetcher = ScriptedProfileUsageFetcher(default: .rateLimited(retryAfter: 600))
+        fetcher.enqueue(configDirPath: dir, .rateLimited(retryAfter: 600))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = scheduledPoller(profile: profile, fetcher: fetcher, clock: clock)
+
+        _ = await poller.sweepNow()               // arms 600s backoff
+        #expect(fetcher.calls.count == 1)
+        // A user-forced refresh 1s later still fetches (explicit intent).
+        clock.advance(1)
+        _ = await poller.sweepNow()
+        #expect(fetcher.calls.count == 2)
+    }
+
+    @Test func exponentialBackoffGrowsWithConsecutiveFailures() async {
+        let profile = oauthProfile(named: "Flaky")
+        // Always fails with a network error (no Retry-After) → exponential path.
+        let fetcher = ScriptedProfileUsageFetcher(default: .networkError("down"))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = scheduledPoller(profile: profile, fetcher: fetcher, clock: clock)
+
+        // Failure 1 → base backoff (30s). A scheduled sweep at +29s is skipped,
+        // at +31s it runs (failure 2), which arms ~60s.
+        _ = await poller.sweepNow()  // forced; failure 1, arms 30s
+        #expect(fetcher.calls.count == 1)
+
+        clock.advance(29)
+        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        #expect(fetcher.calls.count == 1)  // still gated
+
+        clock.advance(2)  // now +31s
+        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        #expect(fetcher.calls.count == 2)  // failure 2, arms ~60s
+
+        // +31s from failure-2 is NOT enough now (window doubled to 60s).
+        clock.advance(31)
+        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        #expect(fetcher.calls.count == 2)  // still gated by the longer window
+
+        clock.advance(30)  // +61s total from failure 2
+        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        #expect(fetcher.calls.count == 3)
+    }
+
+    @Test func oneProfileBackoffDoesNotBlockAnother() async {
+        let limited = oauthProfile(named: "Limited")
+        let healthy = oauthProfile(named: "Healthy")
+        let limitedDir = "/profiles/\(limited.id.uuidString.lowercased())/claude"
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        fetcher.enqueue(configDirPath: limitedDir, .rateLimited(retryAfter: 600))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = OAuthProfileUsagePoller(
+            profilesProvider: { [limited, healthy] },
+            loginIdentity: { _ in "someone@example.com" },
+            configDirPath: { id in "/profiles/\(id.uuidString.lowercased())/claude" },
+            fetcher: fetcher,
+            broadcast: {},
+            sleeper: { _ in },
+            now: { clock.now },
+            jitter: { _ in 0 }
+        )
+
+        _ = await poller.sweepNow()  // limited → 429 (backoff), healthy → ok
+        let firstCalls = fetcher.calls.count
+        #expect(firstCalls == 2)
+
+        // Scheduled sweep shortly after: limited is gated, but healthy still
+        // polls — proving isolation.
+        clock.advance(10)
+        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        // Only the healthy profile fetched again.
+        #expect(fetcher.calls.count == firstCalls + 1)
+        #expect(await poller.snapshot(for: healthy.id)?.statusKind == .ok)
+        #expect(await poller.snapshot(for: limited.id)?.statusKind == .rateLimited)
     }
 }
 

--- a/Tests/TBDDaemonTests/ProfileUsageFetcherTests.swift
+++ b/Tests/TBDDaemonTests/ProfileUsageFetcherTests.swift
@@ -260,31 +260,89 @@ private final class ProfileUsageMockURLProtocol: URLProtocol {
     override func stopLoading() {}
 }
 
-/// Token reader stub — never touches the keychain.
-private struct StubTokenReader: ClaudeOAuthTokenReading {
-    enum Behavior {
-        case token(String)
+/// Credential-store stub — never touches the keychain. Serves a blob and
+/// records write-backs.
+private final class StubCredentialStore: ClaudeCredentialStoring, @unchecked Sendable {
+    enum ReadBehavior {
+        case blob(Data)
         case absent
         case failure(String)
     }
-    let behavior: Behavior
+    private let queue = DispatchQueue(label: "StubCredentialStore")
+    private var read: ReadBehavior
+    private var writeSucceeds: Bool
+    private var _writes: [Data] = []
 
-    func accessToken(forConfigDirPath path: String) async throws -> String? {
-        switch behavior {
-        case .token(let token): return token
+    init(read: ReadBehavior, writeSucceeds: Bool = true) {
+        self.read = read
+        self.writeSucceeds = writeSucceeds
+    }
+
+    var writes: [Data] { queue.sync { _writes } }
+
+    func readBlob(forConfigDirPath path: String) async throws -> Data? {
+        switch queue.sync(execute: { read }) {
+        case .blob(let data): return data
         case .absent: return nil
-        case .failure(let message): throw ClaudeOAuthTokenReadError(message)
+        case .failure(let msg): throw ClaudeOAuthTokenReadError(msg)
+        }
+    }
+
+    func writeBlob(_ data: Data, forConfigDirPath path: String) async -> Bool {
+        queue.sync {
+            _writes.append(data)
+            return writeSucceeds
         }
     }
 }
 
-private func makeProfileFetcher(_ behavior: StubTokenReader.Behavior) -> LiveProfileUsageFetcher {
+/// Refresher stub returning a scripted result.
+private struct StubRefresher: ClaudeOAuthRefreshing {
+    let result: Result<RefreshedOAuthToken, ClaudeOAuthRefreshError>
+    func refresh(refreshToken: String, scopes: [String])
+        async -> Result<RefreshedOAuthToken, ClaudeOAuthRefreshError> { result }
+}
+
+/// A valid credential blob. `expiresAtMillis` defaults far in the future so the
+/// fetcher doesn't preemptively refresh unless a test asks for expiry.
+private func credentialBlob(accessToken: String = "at-live",
+                            refreshToken: String = "rt-live",
+                            expiresAtMillis: Double = 9_999_999_999_999) -> Data {
+    """
+    {
+      "mcpOAuth": {},
+      "claudeAiOauth": {
+        "accessToken": "\(accessToken)",
+        "refreshToken": "\(refreshToken)",
+        "expiresAt": \(Int(expiresAtMillis)),
+        "scopes": ["user:inference"],
+        "subscriptionType": "max"
+      }
+    }
+    """.data(using: .utf8)!
+}
+
+private func mockSession() -> URLSession {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [ProfileUsageMockURLProtocol.self]
-    return LiveProfileUsageFetcher(
-        tokenReader: StubTokenReader(behavior: behavior),
-        session: URLSession(configuration: config)
+    return URLSession(configuration: config)
+}
+
+private func makeProfileFetcher(
+    store: StubCredentialStore,
+    refresher: ClaudeOAuthRefreshing = StubRefresher(result: .failure(.invalidGrant)),
+    now: @escaping @Sendable () -> Date = { Date() }
+) -> LiveProfileUsageFetcher {
+    LiveProfileUsageFetcher(
+        credentialStore: store,
+        refresher: refresher,
+        session: mockSession(),
+        now: now
     )
+}
+
+private func okResponse(_ req: URLRequest, body: Data) -> (HTTPURLResponse, Data) {
+    (HTTPURLResponse(url: req.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!, body)
 }
 
 @Suite(.serialized)
@@ -295,11 +353,9 @@ struct LiveProfileUsageFetcherTests {
     }
 
     @Test func happyPathSendsBearerTokenAndParsesBuckets() async throws {
-        ProfileUsageMockURLProtocol.handler = { req in
-            (HTTPURLResponse(url: req.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!,
-             capturedUsageJSON)
-        }
-        let status = await makeProfileFetcher(.token("sk-ant-oat01-TEST")).fetchUsage(configDirPath: "/tmp/x")
+        ProfileUsageMockURLProtocol.handler = { req in okResponse(req, body: capturedUsageJSON) }
+        let store = StubCredentialStore(read: .blob(credentialBlob(accessToken: "sk-ant-oat01-TEST")))
+        let status = await makeProfileFetcher(store: store).fetchUsage(configDirPath: "/tmp/x")
         guard case .ok(let buckets) = status else {
             Issue.record("expected .ok, got \(status)")
             return
@@ -309,6 +365,7 @@ struct LiveProfileUsageFetcherTests {
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-ant-oat01-TEST")
         #expect(request.value(forHTTPHeaderField: "anthropic-beta") == "oauth-2025-04-20")
         #expect(request.url?.absoluteString == "https://api.anthropic.com/api/oauth/usage")
+        #expect(store.writes.isEmpty)  // fresh token → no refresh/write
     }
 
     @Test func missingCredentialShortCircuitsWithoutHTTP() async {
@@ -316,15 +373,17 @@ struct LiveProfileUsageFetcherTests {
             Issue.record("no HTTP call expected when credentials are absent")
             throw URLError(.badServerResponse)
         }
-        let status = await makeProfileFetcher(.absent).fetchUsage(configDirPath: "/tmp/x")
+        let store = StubCredentialStore(read: .absent)
+        let status = await makeProfileFetcher(store: store).fetchUsage(configDirPath: "/tmp/x")
         guard case .noCredentials = status else {
             Issue.record("expected .noCredentials, got \(status)")
             return
         }
     }
 
-    @Test func tokenReadErrorMapsToNoCredentials() async {
-        let status = await makeProfileFetcher(.failure("security exited 51")).fetchUsage(configDirPath: "/tmp/x")
+    @Test func credentialReadErrorMapsToNoCredentials() async {
+        let store = StubCredentialStore(read: .failure("security exited 51"))
+        let status = await makeProfileFetcher(store: store).fetchUsage(configDirPath: "/tmp/x")
         guard case .noCredentials(let reason) = status else {
             Issue.record("expected .noCredentials, got \(status)")
             return
@@ -332,25 +391,118 @@ struct LiveProfileUsageFetcherTests {
         #expect(reason.contains("security exited 51"))
     }
 
-    @Test func http401MapsToHTTPError() async {
+    @Test func rateLimitedResponseMapsToRateLimitedWithRetryAfter() async {
         ProfileUsageMockURLProtocol.handler = { req in
-            (HTTPURLResponse(url: req.url!, statusCode: 401, httpVersion: "HTTP/1.1", headerFields: nil)!,
-             Data())
+            (HTTPURLResponse(url: req.url!, statusCode: 429, httpVersion: "HTTP/1.1",
+                             headerFields: ["Retry-After": "120"])!, Data())
         }
-        let status = await makeProfileFetcher(.token("sk-ant-oat01-TEST")).fetchUsage(configDirPath: "/tmp/x")
-        #expect(status == .httpError(401))
+        let store = StubCredentialStore(read: .blob(credentialBlob()))
+        let status = await makeProfileFetcher(store: store).fetchUsage(configDirPath: "/tmp/x")
+        #expect(status == .rateLimited(retryAfter: 120))
     }
 
     @Test func malformedBodyMapsToDecodeError() async {
         ProfileUsageMockURLProtocol.handler = { req in
-            (HTTPURLResponse(url: req.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)!,
-             Data("<!doctype html>".utf8))
+            okResponse(req, body: Data("<!doctype html>".utf8))
         }
-        let status = await makeProfileFetcher(.token("sk-ant-oat01-TEST")).fetchUsage(configDirPath: "/tmp/x")
+        let store = StubCredentialStore(read: .blob(credentialBlob()))
+        let status = await makeProfileFetcher(store: store).fetchUsage(configDirPath: "/tmp/x")
         guard case .decodeError = status else {
             Issue.record("expected .decodeError, got \(status)")
             return
         }
+    }
+
+    // MARK: Token refresh paths
+
+    @Test func expiredTokenIsRefreshedAndWrittenBackBeforeFetch() async throws {
+        // First (and only) HTTP call should carry the REFRESHED token, proving
+        // the preemptive refresh happened before the usage GET.
+        ProfileUsageMockURLProtocol.handler = { req in okResponse(req, body: capturedUsageJSON) }
+        let store = StubCredentialStore(
+            read: .blob(credentialBlob(accessToken: "old-at", expiresAtMillis: 1000)))
+        let refresher = StubRefresher(result: .success(RefreshedOAuthToken(
+            accessToken: "fresh-at", refreshToken: "fresh-rt", expiresAtMillis: 9_999_999_999_999)))
+        // now well past the 1000ms expiry.
+        let status = await makeProfileFetcher(
+            store: store, refresher: refresher, now: { Date(timeIntervalSince1970: 2_000_000) }
+        ).fetchUsage(configDirPath: "/tmp/x")
+
+        guard case .ok = status else { Issue.record("expected .ok, got \(status)"); return }
+        let request = try #require(ProfileUsageMockURLProtocol.lastRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer fresh-at")
+        // Rotated pair persisted.
+        #expect(store.writes.count == 1)
+        let written = try #require(parseClaudeCredentials(store.writes[0]))
+        #expect(written.accessToken == "fresh-at")
+        #expect(written.refreshToken == "fresh-rt")
+    }
+
+    @Test func deadRefreshTokenSurfacesNeedsLogin() async {
+        // Expired access token, refresh returns invalid_grant → needs re-login.
+        let store = StubCredentialStore(
+            read: .blob(credentialBlob(expiresAtMillis: 1000)))
+        let refresher = StubRefresher(result: .failure(.invalidGrant))
+        let status = await makeProfileFetcher(
+            store: store, refresher: refresher, now: { Date(timeIntervalSince1970: 2_000_000) }
+        ).fetchUsage(configDirPath: "/tmp/x")
+        guard case .needsLogin = status else {
+            Issue.record("expected .needsLogin, got \(status)"); return
+        }
+    }
+
+    @Test func refreshWriteBackDenialSurfacesNeedsLogin() async {
+        // Refresh succeeds server-side but the keychain write is denied; we must
+        // NOT report success against a token the CLI can't see.
+        ProfileUsageMockURLProtocol.handler = { req in okResponse(req, body: capturedUsageJSON) }
+        let store = StubCredentialStore(
+            read: .blob(credentialBlob(expiresAtMillis: 1000)), writeSucceeds: false)
+        let refresher = StubRefresher(result: .success(RefreshedOAuthToken(
+            accessToken: "fresh-at", refreshToken: "fresh-rt", expiresAtMillis: 9_999_999_999_999)))
+        let status = await makeProfileFetcher(
+            store: store, refresher: refresher, now: { Date(timeIntervalSince1970: 2_000_000) }
+        ).fetchUsage(configDirPath: "/tmp/x")
+        guard case .needsLogin = status else {
+            Issue.record("expected .needsLogin, got \(status)"); return
+        }
+    }
+
+    @Test func http401TriggersRefreshAndRetry() async {
+        // Fresh (non-expired) token, but the server rejects it 401 → refresh
+        // once and retry; the retry sees 200.
+        let responder = ResponseScript(responses: [401, 200])
+        ProfileUsageMockURLProtocol.handler = { req in responder.next(req, okBody: capturedUsageJSON) }
+        let store = StubCredentialStore(read: .blob(credentialBlob(accessToken: "stale-at")))
+        let refresher = StubRefresher(result: .success(RefreshedOAuthToken(
+            accessToken: "fresh-at", refreshToken: "fresh-rt", expiresAtMillis: 9_999_999_999_999)))
+        let status = await makeProfileFetcher(store: store, refresher: refresher)
+            .fetchUsage(configDirPath: "/tmp/x")
+        guard case .ok = status else { Issue.record("expected .ok, got \(status)"); return }
+        #expect(store.writes.count == 1)  // refresh persisted
+    }
+
+    @Test func rateLimitedDoesNotTriggerRefresh() async {
+        // 429 is not an auth failure — must NOT refresh (that would waste the
+        // single-use refresh token and could compound the rate limit).
+        ProfileUsageMockURLProtocol.handler = { req in
+            (HTTPURLResponse(url: req.url!, statusCode: 429, httpVersion: "HTTP/1.1", headerFields: nil)!, Data())
+        }
+        let store = StubCredentialStore(read: .blob(credentialBlob()))
+        let status = await makeProfileFetcher(store: store).fetchUsage(configDirPath: "/tmp/x")
+        #expect(status == .rateLimited(retryAfter: nil))
+        #expect(store.writes.isEmpty)
+    }
+}
+
+/// Ordered HTTP status responder for multi-call tests.
+private final class ResponseScript: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "ResponseScript")
+    private var statuses: [Int]
+    init(responses: [Int]) { self.statuses = responses }
+    func next(_ req: URLRequest, okBody: Data) -> (HTTPURLResponse, Data) {
+        let code = queue.sync { statuses.isEmpty ? 200 : statuses.removeFirst() }
+        let body = code == 200 ? okBody : Data()
+        return (HTTPURLResponse(url: req.url!, statusCode: code, httpVersion: "HTTP/1.1", headerFields: nil)!, body)
     }
 }
 


### PR DESCRIPTION
Non-default accounts showed no usage data at all — the Switch-account submenu, add-tab menu, and picker rendered a blank second line for every profile except the default, and `tbd profile list` showed them permanently `fetch failed: HTTP 429 [stale]`.

## Root cause (verified with live curl against all three accounts)
- **The real bug**: an OAuth **access token expired ~40h ago with nothing refreshing it**, and the usage endpoint returns **429 for an expired token, not 401** — so an expired-token account looked like a permanent rate limit forever, with no path to recovery.
- The default account only ever showed data because its valid token intermittently squeaked past aggressive rate-limiting (~1 success then 429).
- A third account was actually healthy the whole time (HTTP 200) but rendered blank because the UI had no "we have data" vs "we have nothing" distinction.

## Fix
- **OAuth token refresh**: use the refresh token from the same keychain blob (single-use rotating token; refreshed blob written back in Claude Code's exact format so the CLI benefits too, with a round-trip fidelity test). On refused refresh → explicit "needs re-login" state, not an eternal 429 lie.
- **Per-profile 429 handling**: honor Retry-After, exponential backoff with jitter, staggered fetches — one profile's failure never blocks or delays another's.
- **Typed status classification**: auth (401-ish) vs rate (429) vs network, so the UI renders the right thing.
- **Honest UI states**: last-known usage with a stale age, "usage unavailable — retrying", or "needs re-login" — never a silent blank. Routed through the existing `ProfileUsagePresentation` composition points; no structural row-menu changes (avoids collision with #345).

## Verification
`swift build` clean; new tests pass (39 daemon + 65 app); full suite green except the documented env-dependent `agentExecutableAvailability` test; `swiftlint --strict` 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)