### PR TITLE
fix(nightwatch): route v41/v42 migrations through idempotent helpers

### DIFF
--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -686,7 +686,7 @@ public final class TBDDatabase: Sendable {
         }
 
         migrator.registerMigration("v41_clearance_ledger") { db in
-            try db.create(table: "clearance") { t in
+            try db.createTableIfNotExists("clearance") { t in
                 t.primaryKey("id", .text).notNull()
                 t.column("pr_number", .integer).notNull()
                 t.column("repo", .text).notNull()
@@ -698,13 +698,12 @@ public final class TBDDatabase: Sendable {
                 t.column("void_reason", .text)
             }
             // Index for quick lookups by PR and repo
-            try db.execute(sql: """
-                CREATE INDEX idx_clearance_pr_repo ON clearance(pr_number, repo)
-            """)
+            try db.addIndexIfMissing(
+                "idx_clearance_pr_repo", on: "clearance", columns: ["pr_number", "repo"])
         }
 
         migrator.registerMigration("v42_audit_log") { db in
-            try db.create(table: "audit_log") { t in
+            try db.createTableIfNotExists("audit_log") { t in
                 t.primaryKey("id", .text).notNull()
                 t.column("action", .text).notNull()
                 t.column("pr_number", .integer)
@@ -715,9 +714,7 @@ public final class TBDDatabase: Sendable {
                 t.column("details", .text)
             }
             // Index for efficient time-range queries
-            try db.execute(sql: """
-                CREATE INDEX idx_audit_log_ts ON audit_log(ts)
-            """)
+            try db.addIndexIfMissing("idx_audit_log_ts", on: "audit_log", columns: ["ts"])
         }
 
         return migrator


### PR DESCRIPTION
## Follow-up to #342 — addresses the outstanding Medium review finding

PR #342 (Nightwatch Phase 1) merged with one unaddressed review blocker: the Claude reviewer's final verdict was **"Reject — one Medium issue to address"**, and the merge happened anyway.

### The issue
`v41_clearance_ledger` and `v42_audit_log` in `Sources/TBDDaemon/Database/Database.swift` called raw `db.create(table:)` and raw `CREATE INDEX`, violating `Sources/TBDDaemon/Database/CLAUDE.md`, which mandates the idempotent helpers in `MigrationHelpers.swift` for all new migrations.

This isn't hypothetical: these two migrations were **already renumbered once** (v39/v40 → v41/v42) to dodge a collision with #344's `v39_session_hibernation`. If a future rebase lands another branch on the same `v41`/`v42` IDs first, GRDB re-runs the body against an already-migrated schema and crashes with "table already exists" — the exact failure mode (documented daemon bricks on May 6 and May 13) the helpers exist to prevent.

### The fix
Mechanical swap only — schema, migration IDs, and index names are unchanged:
- `db.create(table: "clearance")` → `db.createTableIfNotExists("clearance")`
- raw `CREATE INDEX idx_clearance_pr_repo …` → `db.addIndexIfMissing("idx_clearance_pr_repo", on: "clearance", columns: ["pr_number", "repo"])`
- same pattern for `audit_log` / `idx_audit_log_ts`

### Verification
- `swift build` — clean
- `swift test --filter Migration` — 81 tests / 21 suites pass, including the Nightwatch Migrations suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[🗄 Nightwatch Migration Helpers](https://cheapsteak.github.io/tbd/open/?worktree=1CC34D42-769E-4B31-8B81-0DE33B4DFD23)