### PR TITLE
chore(lint): mechanize migration-helper and TBD_HOME test-target guards

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,12 @@
 # Lint scope. These keys take GLOB syntax.
 included:
   - Sources
+  # The two test targets guarded by the no_setenv_tbdhome_wrong_target custom rule.
+  # A custom rule only runs on files already inside the global lint scope, so these
+  # dirs must be listed here for that rule to fire in CI (`swiftlint --strict`).
+  # TBDDaemonTests is intentionally left out — setenv("TBD_HOME") is legitimate there.
+  - Tests/TBDSharedTests
+  - Tests/TBDAppTests
 
 excluded:
   - .build
@@ -66,4 +72,28 @@ custom_rules:
     match_kinds:
       - identifier
     message: "Transcript row cards must not contain a direct ScrollView — see Sources/TBDApp/Panes/Transcript/CLAUDE.md and issue #129."
+    severity: error
+
+  migration_use_helpers:
+    name: "Use idempotent migration helpers"
+    # included/excluded HERE take REGEX (not glob), matched against file path.
+    included:
+      - "Sources/TBDDaemon/Database/Database\\.swift"
+    regex: 'create\(table:|\.add\(column:|CREATE\s+(?:TABLE|INDEX)'
+    match_kinds:
+      - identifier
+      - string
+    message: "New migrations must use createTableIfNotExists / addIndexIfMissing / addColumnIfMissing from MigrationHelpers.swift, not raw DDL. See Sources/TBDDaemon/Database/CLAUDE.md."
+    severity: error
+
+  no_setenv_tbdhome_wrong_target:
+    name: "No setenv(TBD_HOME) outside TBDDaemonTests"
+    # included/excluded HERE take REGEX (not glob), matched against file path.
+    included:
+      - "Tests/(TBDSharedTests|TBDAppTests)/.*\\.swift"
+    regex: 'setenv\(\s*"TBD_HOME"'
+    match_kinds:
+      - identifier
+      - string
+    message: "setenv(\"TBD_HOME\") is only allowed in TBDDaemonTests under TBDHomeSerialized — it races concurrent suites in other targets (see CLAUDE.md, ConstantsTests flake)."
     severity: error

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -125,6 +125,8 @@ public final class TBDDatabase: Sendable {
     private static func buildMigrator() -> DatabaseMigrator {
         var migrator = DatabaseMigrator()
 
+        // v1–v42 predate/are frozen under the helper mandate; new migrations below the enable line must use the helpers (see Database/CLAUDE.md).
+        // swiftlint:disable migration_use_helpers
         migrator.registerMigration("v1") { db in
             try db.create(table: "repo") { t in
                 t.primaryKey("id", .text).notNull()
@@ -716,6 +718,7 @@ public final class TBDDatabase: Sendable {
             // Index for efficient time-range queries
             try db.addIndexIfMissing("idx_audit_log_ts", on: "audit_log", columns: ["ts"])
         }
+        // swiftlint:enable migration_use_helpers
 
         return migrator
     }

--- a/Tests/TBDAppTests/TranscriptCardAttachmentTests.swift
+++ b/Tests/TBDAppTests/TranscriptCardAttachmentTests.swift
@@ -27,6 +27,7 @@ struct TranscriptCardAttachmentTests {
         let provider = TranscriptCardViewProvider(textAttachment: att, parentView: nil, textLayoutManager: nil, location: TestTextLocation(), card: card)
         provider.loadView()
         #expect(provider.view is NSHostingView<AnyView>)
+        // swiftlint:disable:next force_cast
         let h = TranscriptCardSizing.fittingHeight(of: provider.view as! NSHostingView<AnyView>, width: 300)
         #expect(h > 0)
     }

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -461,6 +461,7 @@ import Testing
     repo.worktreeSlot = "r"
     repo.status = .missing
     let data = try JSONEncoder().encode(repo)
+    // swiftlint:disable:next optional_data_string_conversion
     let s = String(decoding: data, as: UTF8.self)
     #expect(s.contains("\"worktreeSlot\":\"r\""))
     #expect(s.contains("\"status\":\"missing\""))


### PR DESCRIPTION
Follow-up to #342/#348. Two of the project's safety invariants were enforced only by prose in CLAUDE.md — and the migration one was flagged by review on #342 yet merged past anyway. This converts both into deterministic `swiftlint --strict` checks (CI + pre-push hook) so they can't be merged past.

## Rule 1 — `migration_use_helpers`
Bans raw `db.create(table:)`, raw `CREATE TABLE`/`CREATE INDEX` SQL, and raw `t.add(column:)` in `Database.swift`, per `Sources/TBDDaemon/Database/CLAUDE.md` (renumbered migrations re-run against an already-migrated schema and crash — the exact hazard `createTableIfNotExists`/`addIndexIfMissing`/`addColumnIfMissing` exist to prevent).

- The existing `v1`–`v42` history uses raw DDL legitimately (frozen migrations) and is **grandfathered** inside a `// swiftlint:disable migration_use_helpers` … `enable` region. Enforcement starts at the **next** migration added below the enable line.
- Scoped to `Database.swift` only; the helpers' own file is unaffected.

## Rule 2 — `no_setenv_tbdhome_wrong_target`
Bans `setenv("TBD_HOME")` in `TBDSharedTests` / `TBDAppTests`. A `setenv` there races every concurrent suite — the documented root cause of the `ConstantsTests.derivedPathsFollowTBDHome` CI flake.

- `TBDDaemonTests` is **exempt** — `setenv("TBD_HOME")` is legitimate there under `TBDHomeSerialized`. All 13 current usages already comply.
- This mechanizes only the cleanly-expressible half of the invariant (wrong-*target*). The "must nest under `TBDHomeSerialized`" half is a structural/suite-nesting property regex can't see, so it stays a semantic guard.

## ⚠️ Reviewer note — one deliberate scope change
The global lint `included:` was `Sources`-only, so `Tests/` was **never linted** — rule 2 would have been inert in CI. Enabling it required adding `Tests/TBDSharedTests` and `Tests/TBDAppTests` to global scope, which also subjects those two dirs to all default lint rules going forward. That surfaced **2 pre-existing violations**, grandfathered with narrow inline `// swiftlint:disable:next` (one `force_cast` in a test assertion, one `optional_data_string_conversion`). `TBDDaemonTests` was deliberately left out (7 further pre-existing violations + heavy legitimate `setenv`). If you'd rather not lint test dirs at all, the fallback is to drop rule 2 — happy to do either.

## Validation
- `swiftlint --strict`: 0 violations across 451 files.
- Rule 1 fires on a planted raw `db.create(table:)` below the enable line; clean after removal.
- Rule 2 fires on a planted `setenv("TBD_HOME")` in a `TBDAppTests` body; clean after removal.
- `swift build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[🗄 Nightwatch Migration Helpers](https://cheapsteak.github.io/tbd/open/?worktree=1CC34D42-769E-4B31-8B81-0DE33B4DFD23)