### PR TITLE
Show per-account usage in the Model Profiles settings pane

### DIFF
--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -98,7 +98,6 @@ struct ModelProfileRow: View {
     @State private var showEditClaudeDirect = false
 
     private var profile: ModelProfile { entry.profile }
-    private var usage: ModelProfileUsage? { entry.usage }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -184,10 +183,13 @@ struct ModelProfileRow: View {
     }
 
     /// Per-account usage summary shown under the identity/endpoint caption,
-    /// reusing `ModelProfileUsage.usageLine` so the format matches everywhere
-    /// usage is rendered. `nil` (no line) for profiles that carry no usage
-    /// snapshot — e.g. Bedrock/proxy profiles, which have no usage concept.
-    private var usageLine: String? { usage?.usageLine() }
+    /// reusing `ProfileUsagePresentation.usageSummary` over the daemon poller's
+    /// `usageSnapshot` — the SAME source the account menus render, so the pane
+    /// stays in sync with them. `nil` (no line) for profiles with no snapshot
+    /// (Bedrock/proxy profiles, or not-yet-polled), which keep a plain identity.
+    private var usageLine: String? {
+        ProfileUsagePresentation.usageSummary(for: entry.usageSnapshot)
+    }
 
     @ViewBuilder
     private var nameView: some View {

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -146,6 +146,11 @@ struct ModelProfileRow: View {
                         .foregroundStyle(.secondary)
                 }
             }
+            if let usageLine {
+                Text(usageLine)
+                    .font(.caption)
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+            }
         }
         .contentShape(Rectangle())
         .confirmationDialog("Delete profile?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
@@ -177,6 +182,12 @@ struct ModelProfileRow: View {
     private var needsLogin: Bool {
         ProfileLoginPresentation.needsLogin(kind: profile.kind, loginIdentity: entry.loginIdentity)
     }
+
+    /// Per-account usage summary shown under the identity/endpoint caption,
+    /// reusing `ModelProfileUsage.usageLine` so the format matches everywhere
+    /// usage is rendered. `nil` (no line) for profiles that carry no usage
+    /// snapshot — e.g. Bedrock/proxy profiles, which have no usage concept.
+    private var usageLine: String? { usage?.usageLine() }
 
     @ViewBuilder
     private var nameView: some View {

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1050,6 +1050,133 @@ extension ModelProfile {
     public var tabDisplayName: String { name }
 }
 
+// MARK: - ModelProfileUsage display
+
+extension ModelProfileUsage {
+    /// Age past which a cached usage reading is considered stale and we
+    /// annotate the line with how old it is rather than presenting it as live.
+    /// Slightly above the poller's 30-min cadence so a single skipped poll
+    /// doesn't flip every row to "stale".
+    static let staleAfter: TimeInterval = 45 * 60
+
+    /// Single-line usage summary for a profile row, e.g.
+    /// `5h 27% · resets 20:20 · week 84% · resets in 2d 5h`.
+    ///
+    /// Returns `nil` when there is nothing honest to show — i.e. we have never
+    /// fetched anything (no `fetchedAt`) and hold no cached percentages. Callers
+    /// render nothing in that case rather than a fake zero or an empty line.
+    ///
+    /// Honest fallback states (from the poller's `lastStatus`):
+    /// - `http_401` → "usage unavailable — needs re-login"
+    /// - `http_429` → cached numbers (if any) suffixed with "· rate-limited",
+    ///   else "usage unavailable — rate-limited, retrying"
+    /// - `network_error` → cached numbers suffixed with "· retrying", else
+    ///   "usage unavailable — retrying"
+    /// A successful-but-stale reading is suffixed with the age, e.g.
+    /// "· 52m ago".
+    public func usageLine(now: Date = Date()) -> String? {
+        // Nothing ever fetched and nothing cached: caller shows nothing.
+        if fetchedAt == nil && fiveHourPct == nil && sevenDayPct == nil {
+            return nil
+        }
+
+        switch lastStatus {
+        case "http_401":
+            return "usage unavailable — needs re-login"
+
+        case "http_429":
+            if let core = Self.coreUsageText(
+                fiveHourPct: fiveHourPct, sevenDayPct: sevenDayPct,
+                fiveHourResetsAt: fiveHourResetsAt, sevenDayResetsAt: sevenDayResetsAt,
+                now: now
+            ) {
+                return core + " · rate-limited"
+            }
+            return "usage unavailable — rate-limited, retrying"
+
+        case "network_error":
+            if let core = Self.coreUsageText(
+                fiveHourPct: fiveHourPct, sevenDayPct: sevenDayPct,
+                fiveHourResetsAt: fiveHourResetsAt, sevenDayResetsAt: sevenDayResetsAt,
+                now: now
+            ) {
+                return core + " · retrying"
+            }
+            return "usage unavailable — retrying"
+
+        default:
+            // "ok" or any unknown status: present cached numbers, annotating age
+            // if the reading is stale.
+            guard let core = Self.coreUsageText(
+                fiveHourPct: fiveHourPct, sevenDayPct: sevenDayPct,
+                fiveHourResetsAt: fiveHourResetsAt, sevenDayResetsAt: sevenDayResetsAt,
+                now: now
+            ) else {
+                return "usage unavailable — retrying"
+            }
+            if let fetchedAt, now.timeIntervalSince(fetchedAt) > Self.staleAfter {
+                return core + " · \(Self.compactAge(now.timeIntervalSince(fetchedAt))) ago"
+            }
+            return core
+        }
+    }
+
+    /// The percentage/reset portion shared by all states. `nil` when neither
+    /// window has a percentage to show.
+    private static func coreUsageText(
+        fiveHourPct: Double?, sevenDayPct: Double?,
+        fiveHourResetsAt: Date?, sevenDayResetsAt: Date?,
+        now: Date
+    ) -> String? {
+        var parts: [String] = []
+        if let five = fiveHourPct {
+            parts.append("5h \(Int(five.rounded()))%")
+            if let reset = fiveHourResetsAt {
+                parts.append("resets \(clockText(reset))")
+            }
+        }
+        if let week = sevenDayPct {
+            parts.append("week \(Int(week.rounded()))%")
+            if let reset = sevenDayResetsAt {
+                parts.append("resets in \(relativeText(reset, now: now))")
+            }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// Wall-clock "HH:mm" for a same-day 5h reset.
+    private static func clockText(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f.string(from: date)
+    }
+
+    /// Coarse "in 2d 5h" / "3h" / "40m" text for a weekly reset. Clamps to
+    /// "soon" once the reset is in the past.
+    private static func relativeText(_ date: Date, now: Date) -> String {
+        let seconds = date.timeIntervalSince(now)
+        if seconds <= 0 { return "soon" }
+        let days = Int(seconds) / 86_400
+        let hours = (Int(seconds) % 86_400) / 3_600
+        let minutes = (Int(seconds) % 3_600) / 60
+        if days > 0 {
+            return hours > 0 ? "\(days)d \(hours)h" : "\(days)d"
+        }
+        if hours > 0 {
+            return "\(hours)h"
+        }
+        return "\(minutes)m"
+    }
+
+    /// Compact age string for a stale reading: "52m", "3h", "2d".
+    private static func compactAge(_ seconds: TimeInterval) -> String {
+        let s = Int(seconds)
+        if s >= 86_400 { return "\(s / 86_400)d" }
+        if s >= 3_600 { return "\(s / 3_600)h" }
+        return "\(max(1, s / 60))m"
+    }
+}
+
 // MARK: - Tab Metadata
 
 /// Per-tab metadata persisted in the daemon DB. A row exists only when

--- a/Tests/TBDSharedTests/ModelProfileUsageLineTests.swift
+++ b/Tests/TBDSharedTests/ModelProfileUsageLineTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("ModelProfileUsage.usageLine")
+struct ModelProfileUsageLineTests {
+
+    private let profileID = UUID()
+
+    // Fixed reference "now": 2026-01-01 20:00:00 UTC.
+    private var now: Date { Date(timeIntervalSince1970: 1_767_297_600) }
+
+    // MARK: - No data → nil
+
+    @Test("no fetch and no cached numbers → nil (renders nothing)")
+    func emptyReturnsNil() {
+        let u = ModelProfileUsage(profileID: profileID)
+        #expect(u.usageLine(now: now) == nil)
+    }
+
+    // MARK: - Fresh "ok" reading
+
+    @Test("fresh ok reading renders 5h % and week %")
+    func freshOkFullLine() {
+        let u = ModelProfileUsage(
+            profileID: profileID,
+            fiveHourPct: 27,
+            sevenDayPct: 84,
+            fiveHourResetsAt: now.addingTimeInterval(20 * 60),
+            sevenDayResetsAt: now.addingTimeInterval((2 * 86_400) + (5 * 3_600)),
+            fetchedAt: now,
+            lastStatus: "ok"
+        )
+        let line = u.usageLine(now: now)
+        #expect(line?.contains("5h 27%") == true)
+        #expect(line?.contains("week 84%") == true)
+        #expect(line?.contains("resets in 2d 5h") == true)
+        // No staleness / retry suffix on a fresh ok reading.
+        #expect(line?.contains("ago") == false)
+        #expect(line?.contains("retrying") == false)
+    }
+
+    @Test("ok reading rounds fractional percentages")
+    func okRoundsPercent() {
+        let u = ModelProfileUsage(
+            profileID: profileID,
+            fiveHourPct: 26.6,
+            sevenDayPct: nil,
+            fetchedAt: now,
+            lastStatus: "ok"
+        )
+        #expect(u.usageLine(now: now) == "5h 27%")
+    }
+
+    // MARK: - Staleness
+
+    @Test("stale ok reading is annotated with age")
+    func staleOkAnnotatedWithAge() {
+        let u = ModelProfileUsage(
+            profileID: profileID,
+            fiveHourPct: 10,
+            sevenDayPct: nil,
+            fetchedAt: now.addingTimeInterval(-52 * 60),  // 52m ago > 45m threshold
+            lastStatus: "ok"
+        )
+        #expect(u.usageLine(now: now) == "5h 10% · 52m ago")
+    }
+
+    @Test("reading just under the stale threshold is not annotated")
+    func freshEnoughNotAnnotated() {
+        let u = ModelProfileUsage(
+            profileID: profileID,
+            fiveHourPct: 10,
+            sevenDayPct: nil,
+            fetchedAt: now.addingTimeInterval(-40 * 60),  // under 45m
+            lastStatus: "ok"
+        )
+        #expect(u.usageLine(now: now) == "5h 10%")
+    }
+
+    // MARK: - Honest fallback states
+
+    @Test("http_401 → needs re-login (even with stale cached numbers)")
+    func unauthorizedNeedsRelogin() {
+        let u = ModelProfileUsage(
+            profileID: profileID,
+            fiveHourPct: 10,
+            sevenDayPct: 20,
+            fetchedAt: now,
+            lastStatus: "http_401"
+        )
+        #expect(u.usageLine(now: now) == "usage unavailable — needs re-login")
+    }
+
+    @Test("http_429 with cached numbers → numbers + rate-limited")
+    func rateLimitedWithCache() {
+        let u = ModelProfileUsage(
+            profileID: profileID,
+            fiveHourPct: 55,
+            sevenDayPct: nil,
+            fetchedAt: now,
+            lastStatus: "http_429"
+        )
+        #expect(u.usageLine(now: now) == "5h 55% · rate-limited")
+    }
+
+    @Test("http_429 without cached numbers → unavailable, rate-limited")
+    func rateLimitedNoCache() {
+        let u = ModelProfileUsage(
+            profileID: profileID,
+            fetchedAt: now,
+            lastStatus: "http_429"
+        )
+        #expect(u.usageLine(now: now) == "usage unavailable — rate-limited, retrying")
+    }
+
+    @Test("network_error with cached numbers → numbers + retrying")
+    func networkErrorWithCache() {
+        let u = ModelProfileUsage(
+            profileID: profileID,
+            fiveHourPct: 42,
+            sevenDayPct: nil,
+            fetchedAt: now,
+            lastStatus: "network_error"
+        )
+        #expect(u.usageLine(now: now) == "5h 42% · retrying")
+    }
+
+    @Test("network_error without cached numbers → unavailable, retrying")
+    func networkErrorNoCache() {
+        let u = ModelProfileUsage(
+            profileID: profileID,
+            fetchedAt: now,
+            lastStatus: "network_error"
+        )
+        #expect(u.usageLine(now: now) == "usage unavailable — retrying")
+    }
+}


### PR DESCRIPTION
Each profile row in Settings → Model Profiles showed only "Logged in as <email>". This adds the usage line the account menus already render — 5h %, weekly %, Fable %, reset times — under each row, reusing `ProfileUsagePresentation` (the same formatter the menus use), including the honest stale / needs-re-login / unavailable states from the #346 poller fix. Non-OAuth profiles show nothing.

Independent of the hibernation stack; based directly on main.

Verified in the combined integration build (`swift build` clean, `swiftlint --strict` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)