### PR TITLE
Wake-hang fix: bound tmux/git subprocess timeout + stop focus-wake storm

### DIFF
--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -77,16 +77,40 @@ extension AppState {
         }
     }
 
-    /// Auto-wake any PARKED Claude terminals in a worktree the user just
-    /// focused/selected. Covers both hibernated (authoritative) and legacy
-    /// suspended rows — wake is the one resume path. Called from the
-    /// selection-change hook. Idempotent via `wakeTerminal`'s in-flight guard,
-    /// so double-focus is safe.
+    /// Auto-wake the PARKED Claude terminal the user is actually about to look
+    /// at in a worktree they just focused/selected. Covers both hibernated
+    /// (authoritative) and legacy suspended rows — wake is the one resume path.
+    /// Called from the selection-change hook. Idempotent via `wakeTerminal`'s
+    /// in-flight guard, so double-focus is safe.
+    ///
+    /// Deliberately does NOT wake every parked terminal in the worktree. A
+    /// worktree with ~20+ hibernated sessions on ONE tmux server used to fire
+    /// that many simultaneous `respawn-window -k … claude --resume` (heavy Node)
+    /// spawns on focus → a spawn storm that queued respawns past the app's 300s
+    /// RPC ceiling → the "recv timed out after 300s" hang, which then re-fired
+    /// on the next focus (~5-min loop) and re-inflated memory/swap each cycle.
+    ///
+    /// Strategy: wake ONLY the terminal that autofocus will surface (the active
+    /// tab's terminal). The rest stay hibernated until the user actually
+    /// navigates to them (selecting their tab re-invokes this hook). If the
+    /// focused terminal can't be resolved to a parked row, fall back to waking
+    /// at most one parked terminal — never a parallel fan-out.
     func wakeHibernatedTerminalsOnFocus(worktreeID: UUID) {
-        let hibernated = (terminals[worktreeID] ?? []).filter { $0.isParked }
-        guard !hibernated.isEmpty else { return }
-        for terminal in hibernated {
-            Task { await wakeTerminal(terminalID: terminal.id, worktreeID: worktreeID) }
+        let parked = (terminals[worktreeID] ?? []).filter { $0.isParked }
+        guard !parked.isEmpty else { return }
+
+        // Preferred: wake exactly the terminal the user is about to view.
+        if let focusedID = terminalIDForAutofocus(worktreeID: worktreeID),
+           parked.contains(where: { $0.id == focusedID }) {
+            Task { await wakeTerminal(terminalID: focusedID, worktreeID: worktreeID) }
+            return
+        }
+
+        // Fallback (no resolvable focused terminal, e.g. history view active):
+        // wake a single parked terminal rather than storming all N. The others
+        // wake lazily when their tab is selected.
+        if let first = parked.first {
+            Task { await wakeTerminal(terminalID: first.id, worktreeID: worktreeID) }
         }
     }
 }

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -1,4 +1,18 @@
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "GitManager")
+
+/// Error thrown when a git subprocess outlives its timeout and is killed.
+/// Distinct from `GitError` (which represents a clean non-zero exit) so the
+/// exit-code-1 catch sites don't accidentally swallow a wedged-command kill.
+public struct GitTimeoutError: Error, CustomStringConvertible {
+    public let command: String
+    public let timeout: Duration
+    public var description: String {
+        "Git command timed out after \(timeout): \(command)"
+    }
+}
 
 /// A branch reference returned by `GitManager.listBranches`.
 ///
@@ -34,7 +48,19 @@ public struct GitError: Error, CustomStringConvertible {
 /// Manages git operations by shelling out to the `git` CLI.
 public struct GitManager: Sendable {
 
-    public init() {}
+    /// Hard ceiling on any single `git` subprocess. Network git ops (fetch,
+    /// clone) can legitimately run for tens of seconds, so this is far more
+    /// generous than tmux's ceiling — but it is still bounded. A daemon-child
+    /// `git fetch origin main` was once found stuck for 95 minutes, holding a
+    /// continuation open forever; this converts that into a catchable failure.
+    public static let commandTimeout: Duration = .seconds(120)
+
+    /// Per-instance timeout; tests inject a tiny value to exercise the kill path.
+    let subprocessTimeout: Duration
+
+    public init(subprocessTimeout: Duration = GitManager.commandTimeout) {
+        self.subprocessTimeout = subprocessTimeout
+    }
 
     // MARK: - Public API
 
@@ -402,7 +428,15 @@ public struct GitManager: Sendable {
     /// Runs a git command with the given arguments at the given directory and returns stdout.
     /// Throws `GitError` on non-zero exit.
     private func run(arguments: [String], at directory: String) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
+        let timeout = subprocessTimeout
+        let commandDescription = "git " + arguments.joined(separator: " ")
+        // Single-resume guard shared by the termination handler, the timeout
+        // timer, and the spawn-failure path (mirrors TmuxManager.runExternalCommand).
+        let state = ContinuationGuard()
+        let timeoutNanos = UInt64(max(0, timeout.components.seconds)) * 1_000_000_000
+            + UInt64(max(0, timeout.components.attoseconds / 1_000_000_000))
+
+        return try await withCheckedThrowingContinuation { continuation in
             let process = Process()
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
@@ -413,7 +447,25 @@ public struct GitManager: Sendable {
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
 
-            let commandDescription = "git " + arguments.joined(separator: " ")
+            // Watchdog: a wedged git child (a `git fetch` was once stuck 95 min)
+            // is escalated SIGTERM → SIGKILL and the call throws GitTimeoutError.
+            let timer = DispatchSource.makeTimerSource(queue: .global())
+            timer.schedule(deadline: .now() + .nanoseconds(Int(min(timeoutNanos, UInt64(Int.max)))))
+            timer.setEventHandler {
+                guard state.claim() else { return }
+                timer.cancel()
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                let pid = process.processIdentifier
+                if pid > 0 {
+                    kill(pid, SIGTERM)
+                    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(500)) {
+                        if process.isRunning { kill(pid, SIGKILL) }
+                    }
+                }
+                logger.warning("git subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")
+                continuation.resume(throwing: GitTimeoutError(command: commandDescription, timeout: timeout))
+            }
 
             // Drain pipes incrementally to prevent deadlock when output exceeds the
             // OS pipe buffer (~64KB). Without this, the child process blocks on
@@ -442,6 +494,9 @@ public struct GitManager: Sendable {
                 let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
                 let stderr = String(data: stderrData, encoding: .utf8) ?? ""
 
+                guard state.claim() else { return }  // timer already won → timed out
+                timer.cancel()
+
                 if process.terminationStatus != 0 {
                     continuation.resume(throwing: GitError(
                         command: commandDescription,
@@ -455,7 +510,10 @@ public struct GitManager: Sendable {
 
             do {
                 try process.run()
+                timer.resume()
             } catch {
+                guard state.claim() else { return }
+                timer.cancel()
                 continuation.resume(throwing: error)
             }
         }

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -4,7 +4,22 @@ import os
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "TmuxManager")
 
 public struct TmuxManager: Sendable {
+    /// Hard ceiling on any single tmux subprocess. tmux control operations
+    /// (respawn-window, new-session, kill-window, capture-pane, …) normally
+    /// complete in milliseconds; a tmux child still running after this long is
+    /// wedged (spawn storm / heavy `claude --resume` under load / a hung
+    /// server). Bounding it converts an otherwise-infinite `await` — which
+    /// used to hang the wake RPC until the app's 300s ceiling and produced the
+    /// "recv timed out after 300s" loop — into a fast, catchable failure that
+    /// leaves the hibernated row intact for a later retry. 15s is generous
+    /// enough that a merely-slow-but-progressing tmux op still succeeds.
+    public static let commandTimeout: Duration = .seconds(15)
+
     public let dryRun: Bool
+    /// Per-instance timeout applied to every external tmux subprocess. Defaults
+    /// to `commandTimeout`; tests inject a tiny value to exercise the timeout /
+    /// SIGTERM-then-SIGKILL path against a real slow command without waiting 15s.
+    let subprocessTimeout: Duration
     private let counter: Counter
     /// Optional test hook that records every dryRun command invocation. When set,
     /// dry-run paths still no-op, but the recorder receives the argv that would
@@ -45,8 +60,9 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
+        self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
         self.dryRunRecorder = dryRunRecorder
         self.dryRunWindowIsDead = dryRunWindowIsDead
@@ -557,17 +573,65 @@ public struct TmuxManager: Sendable {
 
     @discardableResult
     private func runTmux(_ arguments: [String]) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
+        try await Self.runExternalCommand(
+            executable: Self.tmuxPath(),
+            arguments: arguments,
+            label: "tmux",
+            timeout: subprocessTimeout
+        )
+    }
+
+    /// Runs an external command with a hard timeout, draining stdout/stderr.
+    /// On timeout the child is signalled SIGTERM, then SIGKILL after a short
+    /// grace, and the call throws `TmuxError.timedOut` — never hangs. The
+    /// continuation is guarded by a lock so exactly one of {termination,
+    /// timeout, spawn-failure} resumes it, satisfying the single-resume
+    /// contract even when the process exits concurrently with the timer.
+    ///
+    /// Package-internal (not `private`) so timeout tests can drive it directly
+    /// against a real slow binary (`/bin/sleep`) without a tmux server.
+    @discardableResult
+    static func runExternalCommand(
+        executable: String,
+        arguments: [String],
+        label: String,
+        timeout: Duration
+    ) async throws -> String {
+        // Single-resume guard shared between the termination handler and the
+        // timeout timer. Whichever fires first wins; the loser is a no-op.
+        let state = ContinuationGuard()
+        let commandDescription = "\(label) " + arguments.joined(separator: " ")
+        let timeoutNanos = UInt64(max(0, timeout.components.seconds)) * 1_000_000_000
+            + UInt64(max(0, timeout.components.attoseconds / 1_000_000_000))
+
+        return try await withCheckedThrowingContinuation { continuation in
             let process = Process()
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
 
-            process.executableURL = URL(fileURLWithPath: Self.tmuxPath())
+            process.executableURL = URL(fileURLWithPath: executable)
             process.arguments = arguments
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
 
-            let commandDescription = "tmux " + arguments.joined(separator: " ")
+            // Watchdog timer: on fire, escalate SIGTERM → SIGKILL and resume
+            // with a timeout error (if the process hasn't already exited).
+            let timer = DispatchSource.makeTimerSource(queue: .global())
+            timer.schedule(deadline: .now() + .nanoseconds(Int(min(timeoutNanos, UInt64(Int.max)))))
+            timer.setEventHandler {
+                guard state.claim() else { return }
+                timer.cancel()
+                let pid = process.processIdentifier
+                if pid > 0 {
+                    kill(pid, SIGTERM)
+                    // Give it a brief grace to exit on SIGTERM, then SIGKILL.
+                    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(500)) {
+                        if process.isRunning { kill(pid, SIGKILL) }
+                    }
+                }
+                logger.warning("subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")
+                continuation.resume(throwing: TmuxError.timedOut(command: commandDescription, timeout: timeout))
+            }
 
             process.terminationHandler = { _ in
                 let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
@@ -575,6 +639,9 @@ public struct TmuxManager: Sendable {
                 let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
                 let stderr = String(data: stderrData, encoding: .utf8) ?? ""
                 let output = stdout.isEmpty ? stderr : stdout
+
+                guard state.claim() else { return }  // timer already won → timed out
+                timer.cancel()
 
                 if process.terminationStatus != 0 {
                     continuation.resume(throwing: TmuxError.commandFailed(
@@ -589,9 +656,28 @@ public struct TmuxManager: Sendable {
 
             do {
                 try process.run()
+                timer.resume()
             } catch {
+                guard state.claim() else { return }
+                timer.cancel()
                 continuation.resume(throwing: error)
             }
+        }
+    }
+}
+
+/// One-shot claim used to enforce the single-resume contract of a
+/// `CheckedContinuation` shared across a termination handler, a timeout timer,
+/// and a spawn-failure path. `claim()` returns `true` exactly once.
+/// Package-internal so the git runner reuses it for the same purpose.
+final class ContinuationGuard: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock(initialState: false)
+    /// Returns true the first time it is called, false thereafter.
+    func claim() -> Bool {
+        lock.withLock { resumed in
+            if resumed { return false }
+            resumed = true
+            return true
         }
     }
 }
@@ -599,4 +685,8 @@ public struct TmuxManager: Sendable {
 public enum TmuxError: Error, Sendable {
     case commandFailed(command: String, status: Int32, output: String)
     case unexpectedOutput(String)
+    /// The subprocess outlived its timeout and was killed. Callers on the wake
+    /// path catch this and leave the row hibernated for retry rather than
+    /// hanging until the app's 300s RPC ceiling.
+    case timedOut(command: String, timeout: Duration)
 }


### PR DESCRIPTION
> **Stacks on #345** — its commits appear in this diff until #345 merges, after which this rebases to just the wake-fix commit (`01e3994`). Review that top commit.

Fixes the "recv timed out after 300s (daemon unresponsive)" wake error that looped every ~5 min. The daemon was never dead (served other RPCs in ms). Two causes:

1. **Unbounded subprocesses** — `runTmux`/git awaited external commands with no timeout (a `git fetch` was found stuck 95 min); a stalled `respawn-window` hung the wake RPC to the 300s ceiling. Now timeout-bounded → fails fast into the existing retry-safe catch.
2. **Focus-wake storm** — focusing a worktree woke *every* hibernated session in it (~23 on one tmux server) at once. Now wakes only the focused session / throttles.

Verified compiling + running in the combined integration build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)