### PR TITLE
fix(ci): use GITHUB_TOKEN for review under pull_request_target (OIDC 401)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
       actions: read
       checks: read
 
@@ -66,6 +65,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the Actions token for GitHub ops (sticky comment, gh CLI) instead of
+          # the OIDC->GitHub-App exchange, which 401s under pull_request_target
+          # (anthropics/claude-code-action#1017). Comments post as github-actions[bot].
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
           use_sticky_comment: true
           track_progress: true


### PR DESCRIPTION
The review workflow merged in #350 fails on its first `pull_request_target` run:

```
App token exchange failed: 401 Unauthorized - Invalid OIDC token
Action failed with error: Invalid OIDC token
```

`claude-code-action`'s OIDC → GitHub App token exchange 401s under `pull_request_target` (works under `pull_request`) — see anthropics/claude-code-action#1017. The trust gate, PR-head checkout, and verdict-file reset all ran correctly; only the action's GitHub-App auth failed.

**Fix:** pass `github_token: ${{ secrets.GITHUB_TOKEN }}` so GitHub operations skip the OIDC exchange (the review still auths to Anthropic via `CLAUDE_CODE_OAUTH_TOKEN`). Drops the now-unused `id-token: write`. The sticky comment now posts as `github-actions[bot]`.

> Needs an admin merge for the same reason #350 did: `pull_request_target` always runs the workflow from `main`, which still has the broken version — so this fix can't review itself. After it lands, #352 will be re-run against fixed `main` to demonstrate a normal (non-admin) pass.

[🧌 Require Claude Review](https://cheapsteak.github.io/tbd/open/?worktree=19C987C4-58D6-4264-A770-92A8470AA07F)