### PR TITLE
Fix: One unknown enum value in state.db no longer crash-loops the daemon on startup

### DIFF
--- a/Sources/TBDDaemon/Database/ModelProfileRecord.swift
+++ b/Sources/TBDDaemon/Database/ModelProfileRecord.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
 
 struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     static let databaseTableName = "model_profiles"
@@ -37,9 +40,16 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
         self.last_used_at = profile.lastUsedAt
     }
 
-    func toModel() -> ModelProfile {
-        ModelProfile(
-            id: UUID(uuidString: id)!,
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when the primary key UUID fails to parse. `kind` already
+    /// decodes safely via `?? .oauth`.
+    func toModel() -> ModelProfile? {
+        guard let uuid = UUID(uuidString: id) else {
+            decodeLogger.warning("Skipping model_profiles row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        return ModelProfile(
+            id: uuid,
             name: name,
             kind: CredentialKind(rawValue: kind) ?? .oauth,
             baseURL: base_url,
@@ -93,7 +103,7 @@ public struct ModelProfileStore: Sendable {
 
     public func list() async throws -> [ModelProfile] {
         try await writer.read { db in
-            try ModelProfileRecord.fetchAll(db).map { $0.toModel() }
+            try ModelProfileRecord.fetchAll(db).compactMap { $0.toModel() }
         }
     }
 

--- a/Sources/TBDDaemon/Database/ModelProfileUsageRecord.swift
+++ b/Sources/TBDDaemon/Database/ModelProfileUsageRecord.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
 
 struct ModelProfileUsageRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     static let databaseTableName = "model_profile_usage"
@@ -23,9 +26,15 @@ struct ModelProfileUsageRecord: Codable, FetchableRecord, PersistableRecord, Sen
         self.last_status = u.lastStatus
     }
 
-    func toModel() -> ModelProfileUsage {
-        ModelProfileUsage(
-            profileID: UUID(uuidString: profile_id)!,
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when the profile_id UUID fails to parse.
+    func toModel() -> ModelProfileUsage? {
+        guard let uuid = UUID(uuidString: profile_id) else {
+            decodeLogger.warning("Skipping model_profile_usage row: malformed profile_id \(profile_id, privacy: .public)")
+            return nil
+        }
+        return ModelProfileUsage(
+            profileID: uuid,
             fiveHourPct: five_hour_pct,
             sevenDayPct: seven_day_pct,
             fiveHourResetsAt: five_hour_resets_at,
@@ -62,7 +71,7 @@ public struct ModelProfileUsageStore: Sendable {
             var byProfileID: [UUID: ModelProfileUsage] = [:]
             byProfileID.reserveCapacity(records.count)
             for record in records {
-                let usage = record.toModel()
+                guard let usage = record.toModel() else { continue }
                 byProfileID[usage.profileID] = usage
             }
             return byProfileID

--- a/Sources/TBDDaemon/Database/NoteStore.swift
+++ b/Sources/TBDDaemon/Database/NoteStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
 
 /// GRDB Record type for the `note` table.
 struct NoteRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
@@ -22,10 +25,20 @@ struct NoteRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.updatedAt = note.updatedAt
     }
 
-    func toModel() -> Note {
-        Note(
-            id: UUID(uuidString: id)!,
-            worktreeID: UUID(uuidString: worktreeID)!,
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when a required UUID fails to parse.
+    func toModel() -> Note? {
+        guard let uuid = UUID(uuidString: id) else {
+            decodeLogger.warning("Skipping note row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        guard let wtID = UUID(uuidString: worktreeID) else {
+            decodeLogger.warning("Skipping note row \(id, privacy: .public): malformed worktreeID \(worktreeID, privacy: .public)")
+            return nil
+        }
+        return Note(
+            id: uuid,
+            worktreeID: wtID,
             title: title,
             content: content,
             createdAt: createdAt,
@@ -75,7 +88,7 @@ public struct NoteStore: Sendable {
             if let worktreeID {
                 request = request.filter(Column("worktreeID") == worktreeID.uuidString)
             }
-            return try request.fetchAll(db).map { $0.toModel() }
+            return try request.fetchAll(db).compactMap { $0.toModel() }
         }
     }
 
@@ -89,7 +102,12 @@ public struct NoteStore: Sendable {
             if let content { record.content = content }
             record.updatedAt = Date()
             try record.update(db)
-            return record.toModel()
+            guard let model = record.toModel() else {
+                // The row we just wrote carries a valid UUID by construction;
+                // a nil here means the id column was corrupted out-of-band.
+                throw DatabaseError(message: "Note row has a malformed id after update")
+            }
+            return model
         }
     }
 

--- a/Sources/TBDDaemon/Database/NotificationStore.swift
+++ b/Sources/TBDDaemon/Database/NotificationStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
 
 /// GRDB Record type for the `notification` table.
 struct NotificationRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
@@ -24,11 +27,28 @@ struct NotificationRecord: Codable, FetchableRecord, PersistableRecord, Sendable
         self.terminalID = notification.terminalID?.uuidString
     }
 
-    func toModel() -> TBDNotification {
-        TBDNotification(
-            id: UUID(uuidString: id)!,
-            worktreeID: UUID(uuidString: worktreeID)!,
-            type: NotificationType(rawValue: type)!,
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when a required UUID or the notification type fails to parse.
+    /// A single unknown `type` rawValue (e.g. a row written by a branch build
+    /// whose enum has a case this build lacks) must not take down the whole
+    /// `notifications.list` fetch — and thus the daemon — on startup.
+    func toModel() -> TBDNotification? {
+        guard let uuid = UUID(uuidString: id) else {
+            decodeLogger.warning("Skipping notification row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        guard let wtID = UUID(uuidString: worktreeID) else {
+            decodeLogger.warning("Skipping notification row \(id, privacy: .public): malformed worktreeID \(worktreeID, privacy: .public)")
+            return nil
+        }
+        guard let notificationType = NotificationType(rawValue: type) else {
+            decodeLogger.warning("Skipping notification row \(id, privacy: .public): unknown type \(type, privacy: .public)")
+            return nil
+        }
+        return TBDNotification(
+            id: uuid,
+            worktreeID: wtID,
+            type: notificationType,
             message: message,
             read: read,
             createdAt: createdAt,
@@ -73,7 +93,7 @@ public struct NotificationStore: Sendable {
                 .filter(Column("read") == false)
                 .order(Column("createdAt").desc)
                 .fetchAll(db)
-                .map { $0.toModel() }
+                .compactMap { $0.toModel() }
         }
     }
 
@@ -106,7 +126,7 @@ public struct NotificationStore: Sendable {
         }
         var result: [UUID: UnreadSummary] = [:]
         for record in records {
-            let model = record.toModel()
+            guard let model = record.toModel() else { continue }
             if let existing = result[model.worktreeID] {
                 let newType = model.type.severity > existing.type.severity
                     ? model.type

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
 
 /// GRDB Record type for the `repo` table.
 struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
@@ -40,9 +43,16 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.env_overrides = EnvOverridesCoding.encode(repo.envOverrides)
     }
 
-    func toModel() -> Repo {
-        Repo(
-            id: UUID(uuidString: id)!,
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when the primary key UUID fails to parse. `status` already
+    /// decodes safely via `?? .ok`.
+    func toModel() -> Repo? {
+        guard let uuid = UUID(uuidString: id) else {
+            decodeLogger.warning("Skipping repo row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        return Repo(
+            id: uuid,
             path: path,
             remoteURL: remoteURL,
             displayName: displayName,
@@ -116,7 +126,7 @@ public struct RepoStore: Sendable {
         try await writer.read { db in
             try RepoRecord
                 .fetchAll(db)
-                .map { $0.toModel() }
+                .compactMap { $0.toModel() }
         }
     }
 

--- a/Sources/TBDDaemon/Database/TabStore.swift
+++ b/Sources/TBDDaemon/Database/TabStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
 
 /// GRDB Record type for the `tab` table.
 struct TabRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
@@ -18,10 +21,20 @@ struct TabRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.createdAt = state.createdAt
     }
 
-    func toModel() -> TabState {
-        TabState(
-            id: UUID(uuidString: id)!,
-            worktreeID: UUID(uuidString: worktreeID)!,
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when a required UUID fails to parse.
+    func toModel() -> TabState? {
+        guard let uuid = UUID(uuidString: id) else {
+            decodeLogger.warning("Skipping tab row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        guard let wtID = UUID(uuidString: worktreeID) else {
+            decodeLogger.warning("Skipping tab row \(id, privacy: .public): malformed worktreeID \(worktreeID, privacy: .public)")
+            return nil
+        }
+        return TabState(
+            id: uuid,
+            worktreeID: wtID,
             label: label,
             createdAt: createdAt
         )
@@ -74,7 +87,7 @@ public struct TabStore: Sendable {
             try TabRecord
                 .filter(Column("worktreeID") == worktreeID.uuidString)
                 .fetchAll(db)
-                .map { $0.toModel() }
+                .compactMap { $0.toModel() }
         }
     }
 

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
 
 /// GRDB Record type for the `terminal` table.
 struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
@@ -42,10 +45,21 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.keepWarm = terminal.keepWarm
     }
 
-    func toModel() -> Terminal {
-        Terminal(
-            id: UUID(uuidString: id)!,
-            worktreeID: UUID(uuidString: worktreeID)!,
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when a required UUID fails to parse. Optional/enum columns
+    /// (`profile_id`, `kind`, `activityState`) already decode safely.
+    func toModel() -> Terminal? {
+        guard let uuid = UUID(uuidString: id) else {
+            decodeLogger.warning("Skipping terminal row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        guard let wtID = UUID(uuidString: worktreeID) else {
+            decodeLogger.warning("Skipping terminal row \(id, privacy: .public): malformed worktreeID \(worktreeID, privacy: .public)")
+            return nil
+        }
+        return Terminal(
+            id: uuid,
+            worktreeID: wtID,
             tmuxWindowID: tmuxWindowID,
             tmuxPaneID: tmuxPaneID,
             label: label,
@@ -113,7 +127,7 @@ public struct TerminalStore: Sendable {
                 request = request.filter(Column("worktreeID") == worktreeID.uuidString)
             }
             request = request.order(Column("createdAt").asc, Column("id").asc)
-            return try request.fetchAll(db).map { $0.toModel() }
+            return try request.fetchAll(db).compactMap { $0.toModel() }
         }
     }
 

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -1,6 +1,9 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
 
 /// GRDB Record type for the `worktree` table.
 struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
@@ -53,7 +56,15 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.promotedToRepoID = wt.promotedToRepoID?.uuidString
     }
 
-    func toModel() -> Worktree {
+    /// Failable decode: skips (returns nil after a logged warning) only when the
+    /// primary key UUID fails to parse — that row is unrecoverable. An unknown
+    /// `status` rawValue instead falls back to `.active` (see below) so the
+    /// worktree is preserved rather than dropped. `worktrees.list` runs
+    /// constantly and on every reconcile, so one row written by a branch build
+    /// whose `WorktreeStatus` enum has a case this build lacks must not crash the
+    /// fetch. `repoID` already decodes safely via `flatMap` and is intentionally
+    /// left as-is.
+    func toModel() -> Worktree? {
         var sessions: [String]?
         if let json = archivedClaudeSessions,
            let data = json.data(using: .utf8) {
@@ -63,14 +74,30 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         if let json = prStatus, let data = json.data(using: .utf8) {
             pr = try? JSONDecoder().decode(PRStatus.self, from: data)
         }
+        guard let uuid = UUID(uuidString: id) else {
+            decodeLogger.warning("Skipping worktree row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        // Unlike a malformed primary-key UUID (genuinely unrecoverable → drop the
+        // row), an unknown status is recoverable: dropping the whole worktree
+        // mid-reconcile could orphan its terminals/tmux, which is worse than the
+        // startup crash we're fixing. Fall back to `.active` (the safe visible/
+        // normal default) — matching sibling stores' `RepoStatus(rawValue:) ?? .ok`.
+        let worktreeStatus: WorktreeStatus
+        if let parsed = WorktreeStatus(rawValue: status) {
+            worktreeStatus = parsed
+        } else {
+            decodeLogger.warning("worktree row \(id, privacy: .public): unknown status \(status, privacy: .public); defaulting to .active")
+            worktreeStatus = .active
+        }
         return Worktree(
-            id: UUID(uuidString: id)!,
+            id: uuid,
             repoID: repoID.flatMap { UUID(uuidString: $0) },
             name: name,
             displayName: displayName,
             branch: branch,
             path: path,
-            status: WorktreeStatus(rawValue: status)!,
+            status: worktreeStatus,
             hasConflicts: hasConflicts,
             createdAt: createdAt,
             archivedAt: archivedAt,
@@ -205,7 +232,7 @@ public struct WorktreeStore: Sendable {
             try WorktreeRecord
                 .filter(Column("repoID") == nil)
                 .order(Column("sortOrder").asc)
-                .fetchAll(db).map { $0.toModel() }
+                .fetchAll(db).compactMap { $0.toModel() }
         }
     }
 
@@ -350,7 +377,7 @@ public struct WorktreeStore: Sendable {
             if let limit {
                 request = request.limit(limit, offset: offset ?? 0)
             }
-            return try request.fetchAll(db).map { $0.toModel() }
+            return try request.fetchAll(db).compactMap { $0.toModel() }
         }
     }
 
@@ -730,7 +757,7 @@ public struct WorktreeStore: Sendable {
             var result: [UUID: PRStatus] = [:]
             for record in try WorktreeRecord.fetchAll(db) {
                 guard let wtID = UUID(uuidString: record.id),
-                      let model = record.toModel().prStatus else { continue }
+                      let model = record.toModel()?.prStatus else { continue }
                 result[wtID] = model
             }
             return result

--- a/Tests/TBDDaemonTests/DatabaseDecodeResilienceTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseDecodeResilienceTests.swift
@@ -1,0 +1,230 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Regression coverage for the 2026-07-06 crash-loop: a `notification` row with
+/// `type = "limit_reached"` (a `NotificationType` case only present on an
+/// unmerged branch) made `toModel()`'s force-unwrap crash the daemon on
+/// startup, because `notifications.list` decodes the whole result set. These
+/// tests assert the failable `toModel()` SKIPS the offending row (no throw/
+/// crash) while valid rows in the same fetch are unaffected.
+@Suite("Database Decode Resilience Tests")
+struct DatabaseDecodeResilienceTests {
+
+    // MARK: - Helpers
+
+    private func makeWorktree(_ db: TBDDatabase, name: String) async throws -> Worktree {
+        let repo = try await db.repos.create(
+            path: "/tmp/decode-test-\(UUID().uuidString)",
+            displayName: "test",
+            defaultBranch: "main"
+        )
+        return try await db.worktrees.create(
+            repoID: repo.id,
+            name: name,
+            branch: "tbd/\(name)",
+            path: "/tmp/decode-test/.tbd/worktrees/\(name)",
+            tmuxServer: "tbd-test"
+        )
+    }
+
+    /// Raw UPDATE bypassing the type-safe insert path so we can plant a value
+    /// the model layer would never write itself.
+    private func rawUpdate(_ db: TBDDatabase, sql: String, _ args: [String]) async throws {
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: sql, arguments: StatementArguments(args))
+        }
+    }
+
+    /// Like `rawUpdate` but with foreign-key enforcement disabled for the plant,
+    /// so we can corrupt an FK column (e.g. `worktreeID`) to a non-UUID string —
+    /// simulating exactly the "out-of-band corruption" (manual sqlite edit / a
+    /// future schema regression) that the failable `toModel()` UUID guards defend
+    /// against. Runs outside a transaction (autocommit) so `PRAGMA foreign_keys`
+    /// takes effect, and restores enforcement afterward.
+    private func rawUpdateNoFK(_ db: TBDDatabase, sql: String, _ args: [String]) async throws {
+        try await db.writerForTests.writeWithoutTransaction { conn in
+            try conn.execute(sql: "PRAGMA foreign_keys = OFF")
+            defer { try? conn.execute(sql: "PRAGMA foreign_keys = ON") }
+            try conn.execute(sql: sql, arguments: StatementArguments(args))
+        }
+    }
+
+    // MARK: - NotificationStore
+
+    @Test("valid notification row decodes and is returned")
+    func validNotificationDecodes() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await makeWorktree(db, name: "wt-valid")
+        _ = try await db.notifications.create(worktreeID: wt.id, type: .error)
+
+        let unread = try await db.notifications.unread(worktreeID: wt.id)
+        #expect(unread.count == 1)
+        #expect(unread.first?.type == .error)
+
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        #expect(summary[wt.id]?.type == .error)
+    }
+
+    @Test("unknown notification type is skipped by unreadSummaryByWorktree (RPC path)")
+    func unknownTypeSkippedInSummary() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtBad = try await makeWorktree(db, name: "wt-bad-type")
+        let wtGood = try await makeWorktree(db, name: "wt-good-type")
+
+        let bad = try await db.notifications.create(worktreeID: wtBad.id, type: .responseComplete)
+        // Plant an enum rawValue this build's NotificationType does not have.
+        try await rawUpdate(db, sql: "UPDATE notification SET type = ? WHERE id = ?",
+                            ["limit_reached", bad.id.uuidString])
+        _ = try await db.notifications.create(worktreeID: wtGood.id, type: .error)
+
+        // Must not throw/crash even though one row has an unknown type.
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        #expect(summary[wtBad.id] == nil)          // bad row skipped
+        #expect(summary[wtGood.id]?.type == .error) // valid row unaffected
+    }
+
+    @Test("unknown notification type is skipped by unread() path")
+    func unknownTypeSkippedInUnread() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await makeWorktree(db, name: "wt-unread-mixed")
+
+        _ = try await db.notifications.create(worktreeID: wt.id, type: .error)
+        let bad = try await db.notifications.create(worktreeID: wt.id, type: .responseComplete)
+        try await rawUpdate(db, sql: "UPDATE notification SET type = ? WHERE id = ?",
+                            ["future_type", bad.id.uuidString])
+
+        let unread = try await db.notifications.unread(worktreeID: wt.id)
+        #expect(unread.count == 1)            // bad row skipped
+        #expect(unread.first?.type == .error) // valid row unaffected
+    }
+
+    @Test("malformed notification id is skipped; valid rows unaffected")
+    func malformedNotificationIDSkipped() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtBad = try await makeWorktree(db, name: "wt-bad-id")
+        let wtGood = try await makeWorktree(db, name: "wt-good-id")
+
+        let bad = try await db.notifications.create(worktreeID: wtBad.id, type: .responseComplete)
+        try await rawUpdate(db, sql: "UPDATE notification SET id = ? WHERE id = ?",
+                            ["not-a-uuid", bad.id.uuidString])
+        _ = try await db.notifications.create(worktreeID: wtGood.id, type: .error)
+
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        #expect(summary[wtBad.id] == nil)           // malformed-id row skipped
+        #expect(summary[wtGood.id]?.type == .error) // valid row unaffected
+    }
+
+    // MARK: - WorktreeStore
+
+    @Test("unknown worktree status falls back to .active; worktree still returned")
+    func unknownWorktreeStatusFallsBackToDefault() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/decode-wt-\(UUID().uuidString)",
+            displayName: "test",
+            defaultBranch: "main"
+        )
+        let good = try await db.worktrees.create(
+            repoID: repo.id, name: "good", branch: "b-good",
+            path: "/tmp/decode-wt/good", tmuxServer: "srv"
+        )
+        let bad = try await db.worktrees.create(
+            repoID: repo.id, name: "bad", branch: "b-bad",
+            path: "/tmp/decode-wt/bad", tmuxServer: "srv"
+        )
+        // Plant a WorktreeStatus rawValue this build does not recognize.
+        try await rawUpdate(db, sql: "UPDATE worktree SET status = ? WHERE id = ?",
+                            ["future_status", bad.id.uuidString])
+
+        // Unknown status must NOT drop the row (dropping could orphan its
+        // terminals/tmux); it falls back to the safe `.active` default.
+        let listed = try await db.worktrees.list(repoID: repo.id)
+        let ids = listed.map(\.id)
+        #expect(ids.contains(bad.id))    // bad row preserved, not dropped
+        #expect(ids.contains(good.id))   // valid row unaffected
+        #expect(listed.first { $0.id == bad.id }?.status == .active) // defaulted
+    }
+
+    @Test("malformed worktree id is skipped by list; valid worktree still returned")
+    func malformedWorktreeIDSkipped() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/decode-wt-\(UUID().uuidString)",
+            displayName: "test",
+            defaultBranch: "main"
+        )
+        let good = try await db.worktrees.create(
+            repoID: repo.id, name: "good-id", branch: "b-good",
+            path: "/tmp/decode-wt/good-id", tmuxServer: "srv"
+        )
+        let bad = try await db.worktrees.create(
+            repoID: repo.id, name: "bad-id", branch: "b-bad",
+            path: "/tmp/decode-wt/bad-id", tmuxServer: "srv"
+        )
+        // A malformed primary-key UUID is genuinely unrecoverable — the row must
+        // be dropped (this is the DROP branch that remains after status now
+        // falls back to a default).
+        try await rawUpdate(db, sql: "UPDATE worktree SET id = ? WHERE id = ?",
+                            ["not-a-uuid", bad.id.uuidString])
+
+        // Must not throw/crash even though one row has a malformed id.
+        let listed = try await db.worktrees.list(repoID: repo.id)
+        let ids = listed.map(\.id)
+        #expect(!ids.contains(bad.id))   // malformed-id row dropped
+        #expect(ids.contains(good.id))   // valid row unaffected
+    }
+
+    // MARK: - NoteStore
+
+    @Test("NoteStore.update throws when its row's id was corrupted out-of-band")
+    func noteUpdateThrowsOnMalformedID() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await makeWorktree(db, name: "wt-note")
+        let note = try await db.notes.create(worktreeID: wt.id)
+
+        // Corrupt the primary key out-of-band, then call update() for the original
+        // id. This exercises update()'s error path: `fetchOne(key:)` no longer
+        // finds the renamed row, so it throws. (`id` has no FK, so a plain raw
+        // UPDATE suffices.)
+        //
+        // Note on the deeper `toModel()`-nil guard inside update(): it is defensive
+        // dead code under the DB's invariants — reaching it needs `fetchOne` to
+        // succeed (valid id) AND `record.update` to commit (FK-valid worktreeID, a
+        // real UUID) yet `toModel()` to still return nil (a non-UUID field), which
+        // is self-contradictory. So the reachable throw here is the "Note not
+        // found" guard; either way update() surfaces the corruption as a throw
+        // rather than returning a bogus model.
+        try await rawUpdate(db, sql: "UPDATE note SET id = ? WHERE id = ?",
+                            ["not-a-uuid", note.id.uuidString])
+
+        await #expect(throws: (any Error).self) {
+            _ = try await db.notes.update(id: note.id, title: "renamed")
+        }
+    }
+
+    // MARK: - NotificationStore (malformed worktreeID)
+
+    @Test("malformed notification worktreeID is skipped; valid rows unaffected")
+    func malformedNotificationWorktreeIDSkipped() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtBad = try await makeWorktree(db, name: "wt-bad-wtid")
+        let wtGood = try await makeWorktree(db, name: "wt-good-wtid")
+
+        let bad = try await db.notifications.create(worktreeID: wtBad.id, type: .responseComplete)
+        // Corrupt the worktreeID column so the second UUID guard in toModel fires.
+        // Needs FK enforcement off — worktreeID references worktree.id.
+        try await rawUpdateNoFK(db, sql: "UPDATE notification SET worktreeID = ? WHERE id = ?",
+                                ["not-a-uuid", bad.id.uuidString])
+        _ = try await db.notifications.create(worktreeID: wtGood.id, type: .error)
+
+        let unreadBad = try await db.notifications.unread(worktreeID: wtBad.id)
+        #expect(unreadBad.isEmpty)                  // malformed-worktreeID row skipped
+
+        let summary = try await db.notifications.unreadSummaryByWorktree()
+        #expect(summary[wtBad.id] == nil)           // absent from summary
+        #expect(summary[wtGood.id]?.type == .error) // valid row unaffected
+    }
+}


### PR DESCRIPTION
## The crash (2026-07-06)
After a reboot the daemon crash-looped on startup at `NotificationStore.swift:31`: `Fatal error: Unexpectedly found nil while unwrapping an Optional value`. The shared `~/tbd/state.db` held `notification` rows with `type = "limit_reached"` — a `NotificationType` case that exists only on the unmerged `session-limit-auto-resume` branch. On any build whose enum lacks that case, `NotificationType(rawValue: type)!` force-unwraps nil and crashes. Because `notifications.list` decodes the whole result set, **one** unknown-type row takes down the entire daemon on startup → the whole app is unusable.

This is the general fix for the **"one bad row poisons the whole list / crashes the daemon"** class (same shape as the earlier NULL `repoID` in `worktree.list`). Force-unwrapping DB-derived values in GRDB Record `toModel()` is the anti-pattern.

## Fix
- Every affected `toModel()` is now **failable** (`toModel() -> Model?`): it **skips + logs** (`os.Logger` `.warning`, category `database.decode`) when a required UUID or enum rawValue fails to parse, instead of force-unwrapping. List/decode call sites use `compactMap` / `guard let … else { continue }`, so an unrecognized row is dropped from the result, never fatal. **No rows are deleted from the DB.**
- Hardened stores: `NotificationStore`, `WorktreeStore`, `RepoStore`, `TerminalStore`, `TabStore`, `NoteStore`, `ModelProfileRecord`, `ModelProfileUsageRecord`.
- **Unknown `WorktreeStatus` falls back to `.active`** (not dropped) — a worktree written by a build with a newer status enum must not silently vanish from `worktrees.list` and orphan its terminals during reconcile. A malformed primary-key UUID (genuinely unrecoverable) still drops that one row.
- `NoteStore.update()` **throws** instead of returning a bogus model on a nil decode (the row was just written with a valid id, so nil is a real invariant violation).

## Known trade-off
An unknown enum / malformed row is **invisible** to the daemon until a build that understands it reads it back (e.g. a missing unread badge). This is by design — keeping the daemon alive beats crashing on non-critical display data.

## Sibling audit
Swept all GRDB Record `toModel()` in `Sources/TBDDaemon/Database/` for `SomeEnum(rawValue:)!` and `UUID(uuidString:)!` on DB-read paths and fixed every one on a startup / list-RPC path. Enum columns already using safe defaults (`RepoStatus ?? .ok`, `CredentialKind ?? .oauth`) and optional UUIDs already decoded via `flatMap(UUID.init)` were left as-is (already safe). No remaining DB-derived force-unwraps in the directory.

## Tests (`DatabaseDecodeResilienceTests`, in-memory DB seam, no `~/tbd` touch)
- Valid notification row decodes and appears in the list.
- Unknown notification `type` skipped on **both** the `unread()` and `unreadSummaryByWorktree()` (the `notifications.list` RPC) paths; valid rows in the same fetch unaffected.
- Malformed notification `id` / `worktreeID` skipped; valid rows unaffected.
- Unknown `WorktreeStatus` falls back to `.active` with the worktree still returned by `list()`; malformed worktree `id` dropped while a valid sibling is returned.
- `NoteStore.update()` throws on a corrupted id.

`swift build` clean; `swift test --filter DatabaseDecodeResilienceTests` → 8/8 green.

[defensive-decode](https://cheapsteak.github.io/tbd/open/?worktree=7C1A4C42-9911-4944-95EE-C60576138271)