### PR TITLE
docs: link the review-gate doc from the workflow and CLAUDE.md

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,11 @@
+# ⚠️  Before changing this workflow, read docs/pr-review-gate.md — it documents the
+# merge-gate design (trust model, verdict token + Stop hook, exact-match enforce) and
+# two gotchas that cost real debugging time:
+#   • Runs on pull_request_target and MUST pass github_token: the OIDC app-token
+#     exchange 401s on this trigger (anthropics/claude-code-action#1017).
+#   • Changing the *trigger event* here needs a one-time admin merge — a PR that
+#     changes the trigger matches neither the old nor the new event, so no review runs
+#     and the required check never reports.
 name: Claude Code Review
 
 on:

--- a/.github/workflows/claude-review-hooks/verdict-gate.sh
+++ b/.github/workflows/claude-review-hooks/verdict-gate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Stop hook for the Claude PR-review session.
+# Part of the merge gate documented in docs/pr-review-gate.md.
 #
 # Refuses to let the review session end until it has recorded a clean,
 # machine-readable verdict in claude-verdict.txt. The workflow's merge gate reads

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,9 @@ Use `os.Logger` (`import os`) with one of the established subsystems (`com.tbd.a
 
 This rule is enforced mechanically by SwiftLint (custom rule `no_print_in_sources`) in the dedicated `lint` CI job and the pre-push git hook, both invoking a Homebrew-installed `swiftlint --strict` directly. To lint manually: `swiftlint --strict`. Prerequisite: `brew install swiftlint`. See `.swiftlint.yml`.
 
+### Changing the PR-review merge gate
+`claude-review` is a required check on `main`, produced by `.github/workflows/claude-code-review.yml`. Before touching that workflow or its `claude-review-hooks/`, read [`docs/pr-review-gate.md`](docs/pr-review-gate.md). Two traps it documents: the workflow runs on `pull_request_target` and **must** pass `github_token` (the OIDC app-token exchange 401s on that trigger), and changing the workflow's *trigger event* requires a one-time **admin merge** (such a PR matches neither the old nor new event, so no review runs and the required check never reports).
+
 ## Quick Reference
 
 - **Build**: `swift build`


### PR DESCRIPTION
`docs/pr-review-gate.md` (added in #352) wasn't referenced anywhere, so an LLM editing the review workflow would never find it. Adds pointers where they'll actually be seen:

- a header comment at the top of `.github/workflows/claude-code-review.yml` flagging the two gotchas (pull_request_target needs `github_token`; trigger changes need an admin merge);
- a one-line pointer in `claude-review-hooks/verdict-gate.sh`;
- a "Changing the PR-review merge gate" note under Critical Rules in `CLAUDE.md`.

No behavior change. Also a second live pass through the gate — should auto-`APPROVE` and merge normally.

[🧌 Require Claude Review](https://cheapsteak.github.io/tbd/open/?worktree=19C987C4-58D6-4264-A770-92A8470AA07F)