### PR TITLE
feat(nightwatch): daywatch autonomous runner

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -592,7 +592,6 @@ public final class Daemon: Sendable {
             rpcRouter.oauthUsagePoller = oauthPoller
             await oauthPoller.start()
 
-<<<<<<< HEAD
             // 12d. Session-limit auto-resume scheduler (spec 2026-07-03).
             // Pending rows reload on start; past-due rows fire immediately
             // (covers Mac sleep and multi-day weekly-limit waits).
@@ -631,12 +630,7 @@ public final class Daemon: Sendable {
             rpcRouter.limitResumeScheduler = resumeScheduler
             await resumeScheduler.start()
 
-            // 13. Periodic git status refresh (branch sync, conflict detection).
-            // 10s foreground, 60s background (GitPollCadence.statusInterval);
-            // per-worktree conflict checks are additionally dirty-gated inside
-            // refreshGitStatuses so an unchanged worktree costs no subprocess.
-=======
-            // 12d. Start daywatch runner (autonomous fleet babysitter loop).
+            // 12e. Start daywatch runner (autonomous fleet babysitter loop).
             let skillDir = PluginDirWriter.pluginDirPath + "/skills/nightwatch"
             let executor = ProcessDaywatchExecutor(skillDir: skillDir)
             let runner = DaywatchRunner(executor: executor)
@@ -647,8 +641,10 @@ public final class Daemon: Sendable {
                 await runner.apply(mode: config.nightwatchMode)
             }
 
-            // 13. Periodic git status refresh (branch sync, conflict detection)
->>>>>>> f4356e5 (feat(nightwatch): daywatch autonomous runner — toggle starts/stops a tick+Sonnet-judge loop)
+            // 13. Periodic git status refresh (branch sync, conflict detection).
+            // 10s foreground, 60s background (GitPollCadence.statusInterval);
+            // per-worktree conflict checks are additionally dirty-gated inside
+            // refreshGitStatuses so an unchanged worktree costs no subprocess.
             self.gitStatusTask = Task {
                 // Run once immediately (cold recovery), then at the gated cadence
                 while !Task.isCancelled {
@@ -713,14 +709,13 @@ public final class Daemon: Sendable {
             await poller.stop()
         }
 
-<<<<<<< HEAD
         if let resumeScheduler = limitResumeScheduler {
             await resumeScheduler.stop()
-=======
+        }
+
         // Stop daywatch runner.
         if let runner = daywatchRunner {
             await runner.apply(mode: .off)
->>>>>>> f4356e5 (feat(nightwatch): daywatch autonomous runner — toggle starts/stops a tick+Sonnet-judge loop)
         }
 
         // Stop any tmux control-mode connections (no-op when the gate is off).

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -66,6 +66,7 @@ public final class Daemon: Sendable {
     /// Session-limit auto-resume scheduler. Owned here so it can be stopped
     /// on shutdown; `nil` in mock mode.
     public nonisolated(unsafe) var limitResumeScheduler: LimitResumeScheduler?
+    public nonisolated(unsafe) var daywatchRunner: DaywatchRunner?
     /// Per-daemon tmux control-mode supervisor. Owned here so it can be stopped
     /// on shutdown; the gate (`ControlModeGate.shouldEnable`) keeps it dormant
     /// unless `TBD_TMUX_CONTROL_MODE` is opted in and tmux is ≥ 3.2.
@@ -591,6 +592,7 @@ public final class Daemon: Sendable {
             rpcRouter.oauthUsagePoller = oauthPoller
             await oauthPoller.start()
 
+<<<<<<< HEAD
             // 12d. Session-limit auto-resume scheduler (spec 2026-07-03).
             // Pending rows reload on start; past-due rows fire immediately
             // (covers Mac sleep and multi-day weekly-limit waits).
@@ -633,6 +635,20 @@ public final class Daemon: Sendable {
             // 10s foreground, 60s background (GitPollCadence.statusInterval);
             // per-worktree conflict checks are additionally dirty-gated inside
             // refreshGitStatuses so an unchanged worktree costs no subprocess.
+=======
+            // 12d. Start daywatch runner (autonomous fleet babysitter loop).
+            let skillDir = PluginDirWriter.pluginDirPath + "/skills/nightwatch"
+            let executor = ProcessDaywatchExecutor(skillDir: skillDir)
+            let runner = DaywatchRunner(executor: executor)
+            self.daywatchRunner = runner
+            rpcRouter.daywatchRunner = runner
+            // Boot-reconcile: if nightwatch mode was persisted, restart the loop.
+            if let config = try? await database.config.get() {
+                await runner.apply(mode: config.nightwatchMode)
+            }
+
+            // 13. Periodic git status refresh (branch sync, conflict detection)
+>>>>>>> f4356e5 (feat(nightwatch): daywatch autonomous runner — toggle starts/stops a tick+Sonnet-judge loop)
             self.gitStatusTask = Task {
                 // Run once immediately (cold recovery), then at the gated cadence
                 while !Task.isCancelled {
@@ -697,8 +713,14 @@ public final class Daemon: Sendable {
             await poller.stop()
         }
 
+<<<<<<< HEAD
         if let resumeScheduler = limitResumeScheduler {
             await resumeScheduler.stop()
+=======
+        // Stop daywatch runner.
+        if let runner = daywatchRunner {
+            await runner.apply(mode: .off)
+>>>>>>> f4356e5 (feat(nightwatch): daywatch autonomous runner — toggle starts/stops a tick+Sonnet-judge loop)
         }
 
         // Stop any tmux control-mode connections (no-op when the gate is off).

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -637,8 +637,11 @@ public final class Daemon: Sendable {
             self.daywatchRunner = runner
             rpcRouter.daywatchRunner = runner
             // Boot-reconcile: if nightwatch mode was persisted, restart the loop.
-            if let config = try? await database.config.get() {
+            do {
+                let config = try await database.config.get()
                 await runner.apply(mode: config.nightwatchMode)
+            } catch {
+                reconcileLogger.error("Failed to restore daywatch mode on boot: \(String(describing: error), privacy: .public)")
             }
 
             // 13. Periodic git status refresh (branch sync, conflict detection).

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -744,12 +744,26 @@ public actor HibernationCoordinator {
         for terminal in allTerminals where terminal.isParked {
             guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else { continue }
             let server = worktree.tmuxServer
-            let alive = await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID)
-            if alive,
-               let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
-               ClaudeStateDetector.isClaudeProcess(cmd) {
-                try? await db.terminals.clearHibernated(id: terminal.id)
-                logger.info("startup: cleared stale parked state for still-running terminal \(terminal.id, privacy: .public)")
+
+            // Check if the window still exists AND is running claude
+            let serverAlive = await tmux.serverExists(server: server)
+            guard serverAlive else { continue }
+
+            let windowAlive = await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID)
+            guard windowAlive else { continue }
+
+            // Verify the pane is still running a Claude process
+            guard let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: terminal.tmuxPaneID),
+                  ClaudeStateDetector.isClaudeProcess(cmd) else {
+                continue
+            }
+
+            // Window and process are alive — clear the parked state
+            do {
+                try await db.terminals.clearHibernated(id: terminal.id)
+                logger.info("startup: cleared stale parked state for still-running terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public), process alive")
+            } catch {
+                logger.warning("startup: failed to clear parked state for terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -266,6 +266,19 @@ extension WorktreeLifecycle {
                 }
                 guard !windowAlive else { continue }
 
+                // Extra safety: If this is a Claude-resumable terminal, double-check
+                // that the process is truly gone before parking. If Claude is still
+                // running, leave the terminal active — the next reconcile can reassess.
+                if terminal.isClaudeResumable {
+                    if let cmd = try? await tmux.paneCurrentCommand(server: wt.tmuxServer, paneID: terminal.tmuxPaneID),
+                       ClaudeStateDetector.isClaudeProcess(cmd) {
+                        // Claude is still running in this pane despite windowExists returning false.
+                        // This shouldn't happen, but don't park if it's true.
+                        logger.warning("reconcile: terminal \(terminal.id, privacy: .public) window marked dead but claude process still running — skipping park")
+                        continue
+                    }
+                }
+
                 if terminal.isClaudeResumable, let sessionID = terminal.claudeSessionID {
                     // Resumable Claude session: park it. The unified park/wake
                     // machinery rebuilds a window from the session ID on demand.

--- a/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
+++ b/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
@@ -1,0 +1,167 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "nightwatch.daywatch")
+
+/// Protocol for injecting executor behavior (tick + judge wake).
+/// Allows tests to stub out real subprocess execution.
+public protocol DaywatchExecuting: Sendable {
+    /// Run one tick cycle; return exit code (0 = silent-ok, 10 = judgment queued).
+    func runTick() async -> Int32
+    /// Wake the judge to process queued decisions.
+    /// `act` = true: auto-fire actions (nightwatch mode); false: batch/surface only (daywatch mode).
+    func wakeJudge(act: Bool) async
+}
+
+/// Real executor: runs tick.py and judge.py via Process.
+public struct ProcessDaywatchExecutor: DaywatchExecuting {
+    private let skillDir: String
+
+    public init(skillDir: String) {
+        self.skillDir = skillDir
+    }
+
+    /// Run tick.py; return exit code.
+    public func runTick() async -> Int32 {
+        let tickPath = skillDir + "/scripts/tick.py"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [tickPath]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus
+        } catch {
+            logger.error("Failed to run tick.py: \(error.localizedDescription, privacy: .public)")
+            return -1
+        }
+    }
+
+    /// Wake the judge: spawn `claude --model claude-sonnet-5 <prompt>`.
+    /// Safe no-op if `claude` binary is not found.
+    public func wakeJudge(act: Bool) async {
+        let prompt = act
+            ? "Run the nightwatch judge: process queue/decisions.jsonl and fire approved actions."
+            : "Run the nightwatch judge: process queue/decisions.jsonl and batch to for-adam.md (act=false)."
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        process.arguments = ["claude"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            guard let claudePath = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !claudePath.isEmpty else {
+                logger.debug("claude binary not found; judge wake is a no-op")
+                return
+            }
+
+            let judge = Process()
+            judge.executableURL = URL(fileURLWithPath: claudePath)
+            judge.arguments = ["-p", prompt, "--model", "claude-sonnet-5"]
+            judge.standardOutput = FileHandle.nullDevice
+            judge.standardError = FileHandle.nullDevice
+
+            try judge.run()
+            // Don't wait — let it run detached.
+        } catch {
+            logger.debug("Failed to wake judge: \(error.localizedDescription, privacy: .public)")
+            // Best-effort; don't crash.
+        }
+    }
+}
+
+/// Autonomous background loop that runs nightwatch ticks and wakes the judge
+/// when a judgment is needed. Mirrors the poller pattern (ClaudeUsagePoller).
+public actor DaywatchRunner {
+
+    // MARK: - Constants
+
+    /// Default tick interval (15 minutes in production, overrideable for tests).
+    public static let defaultInterval: TimeInterval = 15 * 60
+
+    // MARK: - Dependencies
+
+    private let executor: DaywatchExecuting
+    private let interval: TimeInterval
+    private let now: @Sendable () -> Date
+
+    // MARK: - State
+
+    private var currentMode: NightwatchMode = .off
+    private var loopTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    public init(
+        executor: DaywatchExecuting,
+        interval: TimeInterval = 15 * 60,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.executor = executor
+        self.interval = interval
+        self.now = now
+    }
+
+    // MARK: - Public API
+
+    /// Apply a mode change: start the loop for .daywatch/.nightwatch, stop for .off.
+    /// Idempotent.
+    public func apply(mode: NightwatchMode) async {
+        let wasRunning = currentMode != .off
+        let shouldRun = mode != .off
+
+        currentMode = mode
+
+        if shouldRun && !wasRunning {
+            // Start the loop
+            loopTask = Task { [weak self] in
+                await self?.runLoop()
+            }
+            logger.info("Started daywatch runner in mode \(mode.rawValue, privacy: .public)")
+        } else if !shouldRun && wasRunning {
+            // Stop the loop
+            loopTask?.cancel()
+            loopTask = nil
+            logger.info("Stopped daywatch runner (was in mode \(self.currentMode.rawValue, privacy: .public))")
+        }
+        // else: no-op (already in desired state)
+    }
+
+    // MARK: - Private loop
+
+    private func runLoop() async {
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(for: .seconds(interval))
+            } catch {
+                // Cancelled during sleep
+                return
+            }
+
+            if Task.isCancelled { return }
+
+            // Run one tick
+            let exitCode = await executor.runTick()
+
+            // If exit code is 10, judgment is queued — wake the judge
+            if exitCode == 10 {
+                let act = (currentMode == .nightwatch)
+                await executor.wakeJudge(act: act)
+                logger.debug("Tick queued judgment; woke judge (act=\(act))")
+            } else if exitCode == 0 {
+                logger.debug("Tick completed (no judgment queued)")
+            } else {
+                logger.warning("Tick failed with exit code \(exitCode, privacy: .public)")
+            }
+        }
+    }
+}

--- a/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
+++ b/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
@@ -125,6 +125,7 @@ public actor DaywatchRunner {
     public func apply(mode: NightwatchMode) async {
         let wasRunning = currentMode != .off
         let shouldRun = mode != .off
+        let previousMode = currentMode
 
         currentMode = mode
 
@@ -138,7 +139,7 @@ public actor DaywatchRunner {
             // Stop the loop
             loopTask?.cancel()
             loopTask = nil
-            logger.info("Stopped daywatch runner (was in mode \(self.currentMode.rawValue, privacy: .public))")
+            logger.info("Stopped daywatch runner (was in mode \(previousMode.rawValue, privacy: .public))")
         }
         // else: no-op (already in desired state)
     }

--- a/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
+++ b/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
@@ -22,7 +22,8 @@ public struct ProcessDaywatchExecutor: DaywatchExecuting {
         self.skillDir = skillDir
     }
 
-    /// Run tick.py; return exit code.
+    /// Run tick.py with a 5-minute timeout; return exit code.
+    /// Uses terminationHandler to avoid blocking a Swift-concurrency thread indefinitely.
     public func runTick() async -> Int32 {
         let tickPath = skillDir + "/scripts/tick.py"
         let process = Process()
@@ -31,56 +32,60 @@ public struct ProcessDaywatchExecutor: DaywatchExecuting {
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
 
-        do {
-            try process.run()
-            process.waitUntilExit()
-            return process.terminationStatus
-        } catch {
-            logger.error("Failed to run tick.py: \(error.localizedDescription, privacy: .public)")
-            return -1
-        }
-    }
+        let exitCode = await withCheckedContinuation { continuation in
+            // Use a final class to hold the mutable state safely across async boundaries.
+            // The lock protects the check-and-set of `finished` so that exactly one
+            // of {terminationHandler, timeout} resumes the continuation (no double-resume).
+            struct LockState {
+                var finished = false
+            }
+            final class State: @unchecked Sendable {
+                let lock = os.OSAllocatedUnfairLock(initialState: LockState())
+            }
+            let state = State()
 
-    /// Wake the judge: spawn `claude --model claude-sonnet-5 <prompt>`.
-    /// Sets up working directory to the skill dir and provides absolute queue paths.
-    /// Safe no-op if `claude` binary is not found.
-    public func wakeJudge(act: Bool) async {
-        let prompt = act
-            ? "Run the nightwatch judge: process \(skillDir)/queue/decisions.jsonl and fire approved actions."
-            : "Run the nightwatch judge: process \(skillDir)/queue/decisions.jsonl and batch to \(skillDir)/queue/for-adam.md (act=false)."
+            process.terminationHandler = { p in
+                state.lock.withLock { s in
+                    if !s.finished {
+                        s.finished = true
+                        continuation.resume(returning: p.terminationStatus)
+                    }
+                }
+            }
 
-        // Find claude binary in standard locations
-        let claudePath = findExecutable("claude")
-        guard !claudePath.isEmpty && claudePath != "/usr/bin/env" else {
-            logger.warning("claude binary not found; judge wake is a no-op")
-            return
-        }
+            do {
+                try process.run()
+            } catch {
+                logger.error("Failed to run tick.py: \(error.localizedDescription, privacy: .public)")
+                continuation.resume(returning: -1)
+                return
+            }
 
-        let judge = Process()
-        judge.executableURL = URL(fileURLWithPath: claudePath)
-        judge.arguments = ["-p", prompt, "--model", "claude-sonnet-5"]
-        judge.currentDirectoryURL = URL(fileURLWithPath: skillDir)
-        judge.standardOutput = FileHandle.nullDevice
-        judge.standardError = FileHandle.nullDevice
-
-        do {
-            try judge.run()
-            // Don't wait — let it run detached.
-        } catch {
-            logger.warning("Failed to wake judge: \(error.localizedDescription, privacy: .public)")
-            // Best-effort; don't crash.
-        }
-    }
-
-    /// Helper: find an executable in standard locations.
-    /// Returns the full path if found, or an empty string otherwise.
-    private func findExecutable(_ name: String) -> String {
-        for path in ["/opt/homebrew/bin/\(name)", "/usr/local/bin/\(name)", "/usr/bin/\(name)"] {
-            if FileManager.default.isExecutableFile(atPath: path) {
-                return path
+            // Set up a 5-minute deadline. The timeout Task's check-and-set is also protected
+            // by the lock, so only one of {termination, timeout} will successfully resume.
+            Task {
+                try await Task.sleep(for: .seconds(5 * 60))
+                state.lock.withLock { s in
+                    if !s.finished {
+                        s.finished = true
+                        logger.warning("tick.py exceeded 5-minute deadline; killed")
+                        process.terminate()
+                        continuation.resume(returning: -2)
+                    }
+                }
             }
         }
-        return ""
+
+        return exitCode
+    }
+
+    /// Judgment queuing intentional interim no-op: ticks detect and record judgment requirements (exit 10),
+    /// but daemon does NOT spawn a judge subprocess yet. Actuation is deferred to Phase A visible-worker
+    /// rewrite, which will spawn TBD workers through the daemon's real primitives (ClaudeSpawnCommandBuilder,
+    /// WorktreeLifecycle), providing proper plugin-dir, cwd, and permission posture instead of this interim
+    /// headless approach. Removes token-burn loop and hardcoded prompt/model/policy-in-mechanism.
+    public func wakeJudge(act: Bool) async {
+        logger.notice("Judgment queued (act=\(act, privacy: .public)); actuation deferred to Phase A visible-worker rewrite.")
     }
 }
 

--- a/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
+++ b/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
@@ -42,40 +42,45 @@ public struct ProcessDaywatchExecutor: DaywatchExecuting {
     }
 
     /// Wake the judge: spawn `claude --model claude-sonnet-5 <prompt>`.
+    /// Sets up working directory to the skill dir and provides absolute queue paths.
     /// Safe no-op if `claude` binary is not found.
     public func wakeJudge(act: Bool) async {
         let prompt = act
-            ? "Run the nightwatch judge: process queue/decisions.jsonl and fire approved actions."
-            : "Run the nightwatch judge: process queue/decisions.jsonl and batch to for-adam.md (act=false)."
+            ? "Run the nightwatch judge: process \(skillDir)/queue/decisions.jsonl and fire approved actions."
+            : "Run the nightwatch judge: process \(skillDir)/queue/decisions.jsonl and batch to \(skillDir)/queue/for-adam.md (act=false)."
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-        process.arguments = ["claude"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
+        // Find claude binary in standard locations
+        let claudePath = findExecutable("claude")
+        guard !claudePath.isEmpty && claudePath != "/usr/bin/env" else {
+            logger.warning("claude binary not found; judge wake is a no-op")
+            return
+        }
+
+        let judge = Process()
+        judge.executableURL = URL(fileURLWithPath: claudePath)
+        judge.arguments = ["-p", prompt, "--model", "claude-sonnet-5"]
+        judge.currentDirectoryURL = URL(fileURLWithPath: skillDir)
+        judge.standardOutput = FileHandle.nullDevice
+        judge.standardError = FileHandle.nullDevice
 
         do {
-            try process.run()
-            process.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard let claudePath = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !claudePath.isEmpty else {
-                logger.debug("claude binary not found; judge wake is a no-op")
-                return
-            }
-
-            let judge = Process()
-            judge.executableURL = URL(fileURLWithPath: claudePath)
-            judge.arguments = ["-p", prompt, "--model", "claude-sonnet-5"]
-            judge.standardOutput = FileHandle.nullDevice
-            judge.standardError = FileHandle.nullDevice
-
             try judge.run()
             // Don't wait — let it run detached.
         } catch {
-            logger.debug("Failed to wake judge: \(error.localizedDescription, privacy: .public)")
+            logger.warning("Failed to wake judge: \(error.localizedDescription, privacy: .public)")
             // Best-effort; don't crash.
         }
+    }
+
+    /// Helper: find an executable in standard locations.
+    /// Returns the full path if found, or an empty string otherwise.
+    private func findExecutable(_ name: String) -> String {
+        for path in ["/opt/homebrew/bin/\(name)", "/usr/local/bin/\(name)", "/usr/bin/\(name)"] {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return ""
     }
 }
 
@@ -92,7 +97,6 @@ public actor DaywatchRunner {
 
     private let executor: DaywatchExecuting
     private let interval: TimeInterval
-    private let now: @Sendable () -> Date
 
     // MARK: - State
 
@@ -103,12 +107,10 @@ public actor DaywatchRunner {
 
     public init(
         executor: DaywatchExecuting,
-        interval: TimeInterval = 15 * 60,
-        now: @escaping @Sendable () -> Date = { Date() }
+        interval: TimeInterval = 15 * 60
     ) {
         self.executor = executor
         self.interval = interval
-        self.now = now
     }
 
     // MARK: - Public API
@@ -136,9 +138,39 @@ public actor DaywatchRunner {
         // else: no-op (already in desired state)
     }
 
+    // MARK: - Testable single tick
+
+    /// Run one tick cycle: execute tick.py and conditionally wake the judge.
+    /// This method contains the core logic that the background loop drives repeatedly.
+    /// - Parameter mode: If provided, use this mode instead of the actor's currentMode.
+    ///   Useful for testing without starting the background loop.
+    public func runOnce(mode: NightwatchMode? = nil) async {
+        let effectiveMode = mode ?? currentMode
+
+        // Run one tick
+        let exitCode = await executor.runTick()
+
+        // If exit code is 10, judgment is queued — wake the judge
+        if exitCode == 10 {
+            let act = (effectiveMode == .nightwatch)
+            await executor.wakeJudge(act: act)
+            logger.debug("Tick queued judgment; woke judge (act=\(act))")
+        } else if exitCode == 0 {
+            logger.debug("Tick completed (no judgment queued)")
+        } else {
+            logger.warning("Tick failed with exit code \(exitCode, privacy: .public)")
+        }
+    }
+
     // MARK: - Private loop
 
     private func runLoop() async {
+        // Run one tick immediately on start (don't wait for the first interval)
+        if !Task.isCancelled {
+            await runOnce()
+        }
+
+        // Then sleep and loop
         while !Task.isCancelled {
             do {
                 try await Task.sleep(for: .seconds(interval))
@@ -149,19 +181,7 @@ public actor DaywatchRunner {
 
             if Task.isCancelled { return }
 
-            // Run one tick
-            let exitCode = await executor.runTick()
-
-            // If exit code is 10, judgment is queued — wake the judge
-            if exitCode == 10 {
-                let act = (currentMode == .nightwatch)
-                await executor.wakeJudge(act: act)
-                logger.debug("Tick queued judgment; woke judge (act=\(act))")
-            } else if exitCode == 0 {
-                logger.debug("Tick completed (no judgment queued)")
-            } else {
-                logger.warning("Tick failed with exit code \(exitCode, privacy: .public)")
-            }
+            await runOnce()
         }
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
@@ -5,6 +5,10 @@ extension RPCRouter {
     func handleSetNightwatchMode(_ data: Data) async throws -> RPCResponse {
         let params = try decoder.decode(NightwatchSetModeParams.self, from: data)
         try await db.config.setNightwatchMode(params.mode)
+        // Apply the mode to the runner (start/stop the loop).
+        if let runner = daywatchRunner {
+            await runner.apply(mode: params.mode)
+        }
         // Reuse the existing config-change channel so the app reloads Config.
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -17,6 +17,7 @@ public final class RPCRouter: Sendable {
     public let hibernationCoordinator: HibernationCoordinator
     public let usageFetcher: ClaudeUsageFetcher
     public let modelProfileResolver: ModelProfileResolver
+    public nonisolated(unsafe) var daywatchRunner: DaywatchRunner?
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     /// In-memory per-profile OAuth usage poller. Wired post-construction by
     /// Daemon.swift (mirrors `claudeUsagePoller`); nil in unit tests / mock

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -235,6 +235,11 @@ def fleet():
     return out
 
 def main():
+    # Create the queue dir BEFORE opening the lock file. On a fresh install queue/
+    # does not exist yet (PluginDirWriter only makes scripts/ + config/), so opening
+    # the lock would raise FileNotFoundError — caught below as "lock held" — and tick.py
+    # would silently exit 0 forever, never reaching the later makedirs. Create it first.
+    os.makedirs(QUEUE, exist_ok=True)
     # Prevent concurrent tick runs (e.g. DaywatchRunner loop + launchd scheduler both active).
     # Acquire an exclusive lock on a lock file; if already held, another tick is running — exit silently.
     lock_path = f"{SKILL}/queue/tick.lock"

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -235,14 +235,12 @@ def fleet():
     return out
 
 def main():
-    # Create the queue dir BEFORE opening the lock file. On a fresh install queue/
-    # does not exist yet (PluginDirWriter only makes scripts/ + config/), so opening
-    # the lock would raise FileNotFoundError — caught below as "lock held" — and tick.py
-    # would silently exit 0 forever, never reaching the later makedirs. Create it first.
-    os.makedirs(QUEUE, exist_ok=True)
-    # Prevent concurrent tick runs (e.g. DaywatchRunner loop + launchd scheduler both active).
-    # Acquire an exclusive lock on a lock file; if already held, another tick is running — exit silently.
-    lock_path = f"{SKILL}/queue/tick.lock"
+    # Prevent concurrent tick runs across BOTH schedulers — the in-daemon DaywatchRunner
+    # loop and the launchd scheduler.sh heartbeat. They execute DIFFERENT tick.py copies
+    # from different install trees (AppSupport plugin dir vs ~/.claude), so a lock under
+    # each copy's own queue/ dir would never contend. Use a single machine-global lock path
+    # that every copy computes identically; /tmp always exists, so no bootstrap dir is needed.
+    lock_path = "/tmp/nightwatch-tick.lock"
     try:
         lock_file = open(lock_path, 'w')
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -95,7 +95,7 @@ and fleet-derived capacity, classifies every agent deterministically, and emits:
 Exit code 0 = nothing needs Opus (silent-ok).  Exit code 10 = judgment items queued.
 Run with --prs to also gate open PRs (makes gh calls — skip during GitHub rate crunch).
 """
-import subprocess, os, re, json, time, sys
+import subprocess, os, re, json, time, sys, fcntl
 
 HOME = os.path.expanduser("~")
 DB = f"{HOME}/tbd/state.db"
@@ -235,6 +235,16 @@ def fleet():
     return out
 
 def main():
+    # Prevent concurrent tick runs (e.g. DaywatchRunner loop + launchd scheduler both active).
+    # Acquire an exclusive lock on a lock file; if already held, another tick is running — exit silently.
+    lock_path = f"{SKILL}/queue/tick.lock"
+    try:
+        lock_file = open(lock_path, 'w')
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (IOError, OSError):
+        # Lock is already held by another tick — exit 0 silently (another instance is active).
+        sys.exit(0)
+
     rep = {
         "ts": int(time.time()),
         "daemon": daemon_health(),

--- a/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
+++ b/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
@@ -13,18 +13,13 @@ actor FakeDaywatchExecutor: DaywatchExecuting {
 
     private(set) var tickCallCount: Int = 0
     private(set) var judgeWakeCalls: [JudgeWakeCall] = []
-    private var tickExitCode: Int32 = 0
-    private var shouldDelayTick: Bool = false
+    private(set) var tickExitCode: Int32 = 0
 
-    init(tickExitCode: Int32 = 0, shouldDelayTick: Bool = false) {
+    init(tickExitCode: Int32 = 0) {
         self.tickExitCode = tickExitCode
-        self.shouldDelayTick = shouldDelayTick
     }
 
     func runTick() async -> Int32 {
-        if shouldDelayTick {
-            try? await Task.sleep(for: .milliseconds(10))
-        }
         tickCallCount += 1
         return tickExitCode
     }
@@ -33,9 +28,8 @@ actor FakeDaywatchExecutor: DaywatchExecuting {
         judgeWakeCalls.append(JudgeWakeCall(act: act))
     }
 
-    nonisolated func setTickExitCode(_ code: Int32) {
-        // Note: in real code we'd use a mutable reference or a separate state holder,
-        // but for tests we'll just reinit the executor or accept this limitation.
+    func setTickExitCode(_ code: Int32) {
+        self.tickExitCode = code
     }
 }
 
@@ -43,47 +37,60 @@ actor FakeDaywatchExecutor: DaywatchExecuting {
 
 struct DaywatchRunnerTests {
 
-    // MARK: - Test: apply(.daywatch) starts the loop
+    // MARK: - Test: runOnce() with exit code 0 does not wake judge
 
-    @Test("apply(.daywatch) starts the loop")
-    func testApplyDaywatchStartsLoop() async {
+    @Test("runOnce with exit code 0 → tick counted, judge not woken")
+    func testRunOnceExitCode0() async {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+        let runner = DaywatchRunner(executor: executor, interval: 60)
 
-        // Initially no ticks
-        #expect(await executor.tickCallCount == 0)
+        await runner.runOnce(mode: .daywatch)
 
-        // Apply daywatch mode
-        await runner.apply(mode: .daywatch)
-
-        // Wait for at least one tick
-        try? await Task.sleep(for: .milliseconds(50))
-
-        // Tick should have been called at least once
-        #expect(await executor.tickCallCount >= 1)
+        #expect(await executor.tickCallCount == 1)
+        #expect(await executor.judgeWakeCalls.isEmpty)
     }
 
-    // MARK: - Test: apply(.off) stops the loop
+    // MARK: - Test: runOnce() with exit code 10 in daywatch mode wakes judge with act=false
 
-    @Test("apply(.off) stops the loop")
-    func testApplyOffStopsLoop() async {
-        let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+    @Test("runOnce with exit code 10 in daywatch → wakeJudge(act: false)")
+    func testRunOnceExitCode10Daywatch() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 10)
+        let runner = DaywatchRunner(executor: executor, interval: 60)
 
-        // Start the loop
-        await runner.apply(mode: .daywatch)
-        try? await Task.sleep(for: .milliseconds(40))
+        await runner.runOnce(mode: .daywatch)
 
-        let countBefore = await executor.tickCallCount
-        #expect(countBefore >= 1)
+        #expect(await executor.tickCallCount == 1)
+        let wakeCalls = await executor.judgeWakeCalls
+        #expect(wakeCalls.count == 1)
+        #expect(wakeCalls[0].act == false)
+    }
 
-        // Stop the loop
-        await runner.apply(mode: .off)
-        try? await Task.sleep(for: .milliseconds(40))
+    // MARK: - Test: runOnce() with exit code 10 in nightwatch mode wakes judge with act=true
 
-        let countAfter = await executor.tickCallCount
-        // Should not have increased (or increased minimally)
-        #expect(countAfter <= countBefore + 1)
+    @Test("runOnce with exit code 10 in nightwatch → wakeJudge(act: true)")
+    func testRunOnceExitCode10Nightwatch() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 10)
+        let runner = DaywatchRunner(executor: executor, interval: 60)
+
+        await runner.runOnce(mode: .nightwatch)
+
+        #expect(await executor.tickCallCount == 1)
+        let wakeCalls = await executor.judgeWakeCalls
+        #expect(wakeCalls.count == 1)
+        #expect(wakeCalls[0].act == true)
+    }
+
+    // MARK: - Test: runOnce() with other exit codes does not wake judge
+
+    @Test("runOnce with non-zero, non-10 exit code → tick counted, judge not woken")
+    func testRunOnceOtherExitCode() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 1)
+        let runner = DaywatchRunner(executor: executor, interval: 60)
+
+        await runner.runOnce(mode: .daywatch)
+
+        #expect(await executor.tickCallCount == 1)
+        #expect(await executor.judgeWakeCalls.isEmpty)
     }
 
     // MARK: - Test: apply(.off) when never started is idempotent
@@ -91,118 +98,95 @@ struct DaywatchRunnerTests {
     @Test("apply(.off) when never started is idempotent")
     func testApplyOffWhenNeverStartedIsIdempotent() async {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+        let runner = DaywatchRunner(executor: executor, interval: 60)
 
         // Apply off immediately (never started)
         await runner.apply(mode: .off)
-
-        try? await Task.sleep(for: .milliseconds(30))
 
         // No ticks should have been called
         #expect(await executor.tickCallCount == 0)
         #expect(await executor.judgeWakeCalls.isEmpty)
     }
 
-    // MARK: - Test: apply idempotency (calling apply(.daywatch) twice = one loop)
+    // MARK: - Test: apply(.daywatch) twice is idempotent (one loop)
 
     @Test("apply(.daywatch) twice is idempotent (one loop)")
     func testApplyIdempotency() async {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+        let runner = DaywatchRunner(executor: executor, interval: 1000)
 
-        // Apply daywatch twice
+        // Apply daywatch twice — should not start two loops
         await runner.apply(mode: .daywatch)
         await runner.apply(mode: .daywatch)
 
-        try? await Task.sleep(for: .milliseconds(40))
+        // Give a tiny bit of time for the loop to run its first tick
+        try? await Task.sleep(for: .milliseconds(50))
 
-        // Should still have ticks (loop is running)
-        #expect(await executor.tickCallCount >= 1)
+        // Should have exactly one tick from the initial immediate tick
+        let count = await executor.tickCallCount
+        #expect(count == 1)
     }
 
-    // MARK: - Test: tick returns 10 → wakeJudge called with act=false in daywatch
+    // MARK: - Test: loop runs first tick immediately (no wait)
 
-    @Test("tick returns 10 in daywatch mode → wakeJudge(act: false)")
-    func testTickReturns10InDaywatch() async {
-        let executor = FakeDaywatchExecutor(tickExitCode: 10)
-        let runner = DaywatchRunner(executor: executor, interval: 0.01)
-
-        await runner.apply(mode: .daywatch)
-        try? await Task.sleep(for: .milliseconds(40))
-
-        // Judge should have been woken with act=false
-        let wakeCalls = await executor.judgeWakeCalls
-        #expect(wakeCalls.count >= 1)
-        #expect(wakeCalls.last?.act == false)
-    }
-
-    // MARK: - Test: tick returns 10 → wakeJudge called with act=true in nightwatch
-
-    @Test("tick returns 10 in nightwatch mode → wakeJudge(act: true)")
-    func testTickReturns10InNightwatch() async {
-        let executor = FakeDaywatchExecutor(tickExitCode: 10)
-        let runner = DaywatchRunner(executor: executor, interval: 0.01)
-
-        await runner.apply(mode: .nightwatch)
-        try? await Task.sleep(for: .milliseconds(40))
-
-        // Judge should have been woken with act=true
-        let wakeCalls = await executor.judgeWakeCalls
-        #expect(wakeCalls.count >= 1)
-        #expect(wakeCalls.last?.act == true)
-    }
-
-    // MARK: - Test: tick returns 0 → judge NOT woken
-
-    @Test("tick returns 0 → judge NOT woken")
-    func testTickReturns0NoJudgeWake() async {
+    @Test("loop runs first tick immediately (no wait for full interval)")
+    func testLoopRunsFirstTickImmediately() async {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+        // Use a large interval so we can be sure the immediate tick happens before the sleep
+        let runner = DaywatchRunner(executor: executor, interval: 1000)
 
         await runner.apply(mode: .daywatch)
-        try? await Task.sleep(for: .milliseconds(40))
 
-        // Judge should NOT have been woken
-        let wakeCalls = await executor.judgeWakeCalls
-        #expect(wakeCalls.isEmpty)
+        // Small sleep to let the loop start and run first tick
+        try? await Task.sleep(for: .milliseconds(100))
 
-        // But tick should have been called
-        #expect(await executor.tickCallCount >= 1)
+        // First tick should have been called immediately
+        let count = await executor.tickCallCount
+        #expect(count >= 1)
     }
 
-    // MARK: - Test: mode switching (daywatch → nightwatch → off)
+    // MARK: - Test: apply(.off) cancels the loop
 
-    @Test("mode switching: daywatch → nightwatch → off")
+    @Test("apply(.off) cancels the loop")
+    func testApplyOffCancelsLoop() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let runner = DaywatchRunner(executor: executor, interval: 0.05)
+
+        // Start the loop
+        await runner.apply(mode: .daywatch)
+        try? await Task.sleep(for: .milliseconds(100))
+
+        let countBefore = await executor.tickCallCount
+        #expect(countBefore >= 1)
+
+        // Stop the loop
+        await runner.apply(mode: .off)
+        try? await Task.sleep(for: .milliseconds(50))
+
+        let countAfter = await executor.tickCallCount
+        // Should not have increased much (at most one more tick if one was in progress)
+        #expect(countAfter <= countBefore + 1)
+    }
+
+    // MARK: - Test: mode switching (daywatch → nightwatch)
+
+    @Test("mode switching: daywatch → nightwatch changes judge behavior")
     func testModeSwitching() async {
         let executor = FakeDaywatchExecutor(tickExitCode: 10)
-        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+        let runner = DaywatchRunner(executor: executor, interval: 1000)
 
-        // Start in daywatch
-        await runner.apply(mode: .daywatch)
-        try? await Task.sleep(for: .milliseconds(30))
+        // Run one tick in daywatch mode
+        await runner.runOnce(mode: .daywatch)
 
         var wakeCalls = await executor.judgeWakeCalls
-        let daywatchWakesCount = wakeCalls.filter { !$0.act }.count
-        #expect(daywatchWakesCount >= 1)
+        #expect(wakeCalls.count == 1)
+        #expect(wakeCalls[0].act == false, "daywatch should pass act=false")
 
-        // Clear calls by reiniting executor
-        let executor2 = FakeDaywatchExecutor(tickExitCode: 10)
-        let runner2 = DaywatchRunner(executor: executor2, interval: 0.01)
+        // Run another tick in nightwatch mode
+        await runner.runOnce(mode: .nightwatch)
 
-        // Switch to nightwatch
-        await runner2.apply(mode: .nightwatch)
-        try? await Task.sleep(for: .milliseconds(30))
-
-        wakeCalls = await executor2.judgeWakeCalls
-        let nightwatchWakesCount = wakeCalls.filter { $0.act }.count
-        #expect(nightwatchWakesCount >= 1)
-
-        // Stop
-        await runner2.apply(mode: .off)
-        try? await Task.sleep(for: .milliseconds(30))
-
-        let finalTickCount = await executor2.tickCallCount
-        // Shouldn't increase much after stopping
-        #expect(finalTickCount >= 1)
+        wakeCalls = await executor.judgeWakeCalls
+        #expect(wakeCalls.count == 2)
+        #expect(wakeCalls[1].act == true, "nightwatch should pass act=true")
     }
 }

--- a/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
+++ b/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+// MARK: - Fake Executor for Testing
+
+/// Fake executor that captures calls and allows stubbing exit codes and behavior.
+actor FakeDaywatchExecutor: DaywatchExecuting {
+    struct JudgeWakeCall: Sendable {
+        let act: Bool
+    }
+
+    private(set) var tickCallCount: Int = 0
+    private(set) var judgeWakeCalls: [JudgeWakeCall] = []
+    private var tickExitCode: Int32 = 0
+    private var shouldDelayTick: Bool = false
+
+    init(tickExitCode: Int32 = 0, shouldDelayTick: Bool = false) {
+        self.tickExitCode = tickExitCode
+        self.shouldDelayTick = shouldDelayTick
+    }
+
+    func runTick() async -> Int32 {
+        if shouldDelayTick {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        tickCallCount += 1
+        return tickExitCode
+    }
+
+    func wakeJudge(act: Bool) async {
+        judgeWakeCalls.append(JudgeWakeCall(act: act))
+    }
+
+    nonisolated func setTickExitCode(_ code: Int32) {
+        // Note: in real code we'd use a mutable reference or a separate state holder,
+        // but for tests we'll just reinit the executor or accept this limitation.
+    }
+}
+
+// MARK: - Tests
+
+struct DaywatchRunnerTests {
+
+    // MARK: - Test: apply(.daywatch) starts the loop
+
+    @Test("apply(.daywatch) starts the loop")
+    func testApplyDaywatchStartsLoop() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+
+        // Initially no ticks
+        #expect(await executor.tickCallCount == 0)
+
+        // Apply daywatch mode
+        await runner.apply(mode: .daywatch)
+
+        // Wait for at least one tick
+        try? await Task.sleep(for: .milliseconds(50))
+
+        // Tick should have been called at least once
+        #expect(await executor.tickCallCount >= 1)
+    }
+
+    // MARK: - Test: apply(.off) stops the loop
+
+    @Test("apply(.off) stops the loop")
+    func testApplyOffStopsLoop() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+
+        // Start the loop
+        await runner.apply(mode: .daywatch)
+        try? await Task.sleep(for: .milliseconds(40))
+
+        let countBefore = await executor.tickCallCount
+        #expect(countBefore >= 1)
+
+        // Stop the loop
+        await runner.apply(mode: .off)
+        try? await Task.sleep(for: .milliseconds(40))
+
+        let countAfter = await executor.tickCallCount
+        // Should not have increased (or increased minimally)
+        #expect(countAfter <= countBefore + 1)
+    }
+
+    // MARK: - Test: apply(.off) when never started is idempotent
+
+    @Test("apply(.off) when never started is idempotent")
+    func testApplyOffWhenNeverStartedIsIdempotent() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+
+        // Apply off immediately (never started)
+        await runner.apply(mode: .off)
+
+        try? await Task.sleep(for: .milliseconds(30))
+
+        // No ticks should have been called
+        #expect(await executor.tickCallCount == 0)
+        #expect(await executor.judgeWakeCalls.isEmpty)
+    }
+
+    // MARK: - Test: apply idempotency (calling apply(.daywatch) twice = one loop)
+
+    @Test("apply(.daywatch) twice is idempotent (one loop)")
+    func testApplyIdempotency() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+
+        // Apply daywatch twice
+        await runner.apply(mode: .daywatch)
+        await runner.apply(mode: .daywatch)
+
+        try? await Task.sleep(for: .milliseconds(40))
+
+        // Should still have ticks (loop is running)
+        #expect(await executor.tickCallCount >= 1)
+    }
+
+    // MARK: - Test: tick returns 10 → wakeJudge called with act=false in daywatch
+
+    @Test("tick returns 10 in daywatch mode → wakeJudge(act: false)")
+    func testTickReturns10InDaywatch() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 10)
+        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+
+        await runner.apply(mode: .daywatch)
+        try? await Task.sleep(for: .milliseconds(40))
+
+        // Judge should have been woken with act=false
+        let wakeCalls = await executor.judgeWakeCalls
+        #expect(wakeCalls.count >= 1)
+        #expect(wakeCalls.last?.act == false)
+    }
+
+    // MARK: - Test: tick returns 10 → wakeJudge called with act=true in nightwatch
+
+    @Test("tick returns 10 in nightwatch mode → wakeJudge(act: true)")
+    func testTickReturns10InNightwatch() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 10)
+        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+
+        await runner.apply(mode: .nightwatch)
+        try? await Task.sleep(for: .milliseconds(40))
+
+        // Judge should have been woken with act=true
+        let wakeCalls = await executor.judgeWakeCalls
+        #expect(wakeCalls.count >= 1)
+        #expect(wakeCalls.last?.act == true)
+    }
+
+    // MARK: - Test: tick returns 0 → judge NOT woken
+
+    @Test("tick returns 0 → judge NOT woken")
+    func testTickReturns0NoJudgeWake() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+
+        await runner.apply(mode: .daywatch)
+        try? await Task.sleep(for: .milliseconds(40))
+
+        // Judge should NOT have been woken
+        let wakeCalls = await executor.judgeWakeCalls
+        #expect(wakeCalls.isEmpty)
+
+        // But tick should have been called
+        #expect(await executor.tickCallCount >= 1)
+    }
+
+    // MARK: - Test: mode switching (daywatch → nightwatch → off)
+
+    @Test("mode switching: daywatch → nightwatch → off")
+    func testModeSwitching() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 10)
+        let runner = DaywatchRunner(executor: executor, interval: 0.01)
+
+        // Start in daywatch
+        await runner.apply(mode: .daywatch)
+        try? await Task.sleep(for: .milliseconds(30))
+
+        var wakeCalls = await executor.judgeWakeCalls
+        let daywatchWakesCount = wakeCalls.filter { !$0.act }.count
+        #expect(daywatchWakesCount >= 1)
+
+        // Clear calls by reiniting executor
+        let executor2 = FakeDaywatchExecutor(tickExitCode: 10)
+        let runner2 = DaywatchRunner(executor: executor2, interval: 0.01)
+
+        // Switch to nightwatch
+        await runner2.apply(mode: .nightwatch)
+        try? await Task.sleep(for: .milliseconds(30))
+
+        wakeCalls = await executor2.judgeWakeCalls
+        let nightwatchWakesCount = wakeCalls.filter { $0.act }.count
+        #expect(nightwatchWakesCount >= 1)
+
+        // Stop
+        await runner2.apply(mode: .off)
+        try? await Task.sleep(for: .milliseconds(30))
+
+        let finalTickCount = await executor2.tickCallCount
+        // Shouldn't increase much after stopping
+        #expect(finalTickCount >= 1)
+    }
+}

--- a/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
+++ b/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
@@ -27,10 +27,6 @@ actor FakeDaywatchExecutor: DaywatchExecuting {
     func wakeJudge(act: Bool) async {
         judgeWakeCalls.append(JudgeWakeCall(act: act))
     }
-
-    func setTickExitCode(_ code: Int32) {
-        self.tickExitCode = code
-    }
 }
 
 // MARK: - Tests


### PR DESCRIPTION
## What this ships

The **plumbing foundation** for daywatch/nightwatch: a `DaywatchRunner` actor (mode→loop, idempotent `apply`, boot-reconcile, shutdown), the `DaywatchExecuting` protocol seam, DB-persisted `nightwatchMode`, and RPC wiring.

## ⚠️ Actuation is DEFERRED (not live in this PR)

`ProcessDaywatchExecutor.wakeJudge(act:)` is an **intentional no-op** that only logs — it does **not** spawn a judge or fire actions. The tick loop sweeps + records; judgment actuation (the visible watchable worker: Sonnet for daywatch, Opus for nightwatch) lands in **Phase A**. So today this is a *tick-sweep + logging loop*, not autonomous actuation. The `act` flag is plumbed through for Phase A but currently only changes a log line.

## Notes
- `tick.py` guards against concurrent runs across both the in-daemon loop and the legacy `scheduler.sh` launchd heartbeat via a machine-global `/tmp/nightwatch-tick.lock`.
- `runTick` has a 5-minute deadline; boot-reconcile logs on failure.
- Also carries reconcile-safety so a daemon restart re-adopts live sessions instead of parking them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)