### PR TITLE
fix(ci): restore review Stop-hook from base branch, not the PR checkout

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -67,6 +67,19 @@ jobs:
         # killed or timed out before writing its own, sail through the gate.
         run: rm -f "$GITHUB_WORKSPACE/claude-verdict.txt"
 
+      - name: Restore review hooks from the base branch
+        if: steps.trust.outputs.trusted == 'true'
+        # The Stop hook + its settings.json must come from the BASE branch, not the PR
+        # head. Two reasons: (1) a PR branch created before the hooks existed doesn't
+        # contain them, and the action then hard-errors on a missing `settings:` file
+        # (ENOENT) — this blocked pre-existing fork PRs; (2) a PR must not be able to
+        # neuter the gate that reviews it. github.event.pull_request.base.ref is the
+        # base branch under pull_request_target; FETCH_HEAD is its tip after the fetch.
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+          rm -rf "$GITHUB_WORKSPACE/.github/workflows/claude-review-hooks"
+          git checkout FETCH_HEAD -- .github/workflows/claude-review-hooks
+
       - name: Run Claude Code Review
         if: steps.trust.outputs.trusted == 'true'
         id: claude-review


### PR DESCRIPTION
Pre-existing fork PRs (#351, #353) fail the required `claude-review` check. Root cause: the `settings:` input pointed at `.github/workflows/claude-review-hooks/settings.json` inside the **checked-out PR head**. Fork branches created before the hooks dir landed (#350) don't contain that file, so the action hard-errors:

```
Failed to process settings input: ENOENT ... claude-review-hooks/settings.json
```

**Fix:** after checkout, restore `claude-review-hooks/` from the base branch (`FETCH_HEAD` of `base.ref`). The Stop hook + settings are now always present and always the trusted `main` copy — so a PR can neither be blocked by, nor tamper with, the gate reviewing it. Unblocks every pre-existing PR without a rebase.

No trigger change, so this reviews and merges normally. After it lands I'll re-run #351 and #353.

[🧌 Require Claude Review](https://cheapsteak.github.io/tbd/open/?worktree=19C987C4-58D6-4264-A770-92A8470AA07F)