### PR TITLE
feat(app): fork session via profile picker

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -367,28 +367,6 @@ extension AppState {
         }
     }
 
-    /// Fork a Claude terminal by resuming from an existing session ID.
-    func forkClaudeTerminal(worktreeID: UUID, sessionID: String, tokenID: UUID? = nil) async {
-        do {
-            let size = mainAreaTerminalSize()
-            let colorFgBg = appearance?.currentColorFgBg
-            let terminal = try await daemonClient.createTerminal(
-                worktreeID: worktreeID,
-                resumeSessionID: sessionID,
-                overrideProfileID: tokenID,
-                cols: size.cols,
-                rows: size.rows,
-                colorFgBg: colorFgBg
-            )
-            terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
-            tabs[worktreeID, default: []].append(tab)
-        } catch {
-            logger.error("Failed to fork Claude terminal: \(error)")
-            handleConnectionError(error)
-        }
-    }
-
     /// Toggle pin state for a terminal.
     func setTerminalPin(id: UUID, pinned: Bool) async {
         // Optimistic local update

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -96,7 +96,6 @@ struct TabBar: View {
     var terminalForTab: (UUID) -> Terminal? = { _ in nil }
     var onSuspendTab: (UUID) -> Void = { _ in }
     var onResumeTab: (UUID) -> Void = { _ in }
-    var onForkTab: (UUID) -> Void = { _ in }
     var isHistorySelected: Bool = false
     var onHistoryTab: () -> Void = {}
 
@@ -119,8 +118,7 @@ struct TabBar: View {
                     onSelect: { activeTabIndex = index },
                     onClose: { onCloseTab(index) },
                     onSuspend: { onSuspendTab(tab.id) },
-                    onResume: { onResumeTab(tab.id) },
-                    onFork: { onForkTab(tab.id) }
+                    onResume: { onResumeTab(tab.id) }
                 )
             }
 
@@ -474,7 +472,6 @@ private struct TabBarItem: View {
     let onClose: () -> Void
     let onSuspend: () -> Void
     let onResume: () -> Void
-    let onFork: () -> Void
 
     @State private var isHovering = false
     @State private var isHoveringClose = false

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -708,6 +708,29 @@ private struct TabBarItem: View {
         entry.profile.name
     }
 
+    @ViewBuilder
+    private func swapProfileMenuItems(mode: TerminalSwapMode) -> some View {
+        Button {
+            guard let terminalID = terminal?.id else { return }
+            Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: nil, mode: mode) }
+        } label: {
+            let prefix = terminal?.profileID == nil ? "● " : "  "
+            Text("\(prefix)Default (logged in)")
+        }
+
+        Divider()
+
+        ForEach(appState.modelProfiles, id: \.profile.id) { entry in
+            Button {
+                guard let terminalID = terminal?.id else { return }
+                Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: entry.profile.id, mode: mode) }
+            } label: {
+                let prefix = terminal?.profileID == entry.profile.id ? "● " : "  "
+                Text("\(prefix)\(formatProfileSubmenuLabel(entry))")
+            }
+        }
+    }
+
     /// Absolute path on disk for tab content that has a backing file
     /// (codeViewer points at the file directly; liveTranscript points at
     /// the resolved Claude session JSONL via the underlying terminal).
@@ -743,49 +766,13 @@ private struct TabBarItem: View {
                 .disabled(true)
 
             Menu("Swap profile") {
-                Button {
-                    guard let terminalID = terminal?.id else { return }
-                    Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: nil) }
-                } label: {
-                    let prefix = terminal?.profileID == nil ? "● " : "  "
-                    Text("\(prefix)Default (logged in)")
-                }
-
-                Divider()
-
-                ForEach(appState.modelProfiles, id: \.profile.id) { entry in
-                    Button {
-                        guard let terminalID = terminal?.id else { return }
-                        Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: entry.profile.id) }
-                    } label: {
-                        let prefix = terminal?.profileID == entry.profile.id ? "● " : "  "
-                        Text("\(prefix)\(formatProfileSubmenuLabel(entry))")
-                    }
-                }
+                swapProfileMenuItems(mode: .inPlace)
             }
 
             Divider()
 
             Menu {
-                Button {
-                    guard let terminalID = terminal?.id else { return }
-                    Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: nil, mode: .fork) }
-                } label: {
-                    let prefix = terminal?.profileID == nil ? "● " : "  "
-                    Text("\(prefix)Default (logged in)")
-                }
-
-                Divider()
-
-                ForEach(appState.modelProfiles, id: \.profile.id) { entry in
-                    Button {
-                        guard let terminalID = terminal?.id else { return }
-                        Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: entry.profile.id, mode: .fork) }
-                    } label: {
-                        let prefix = terminal?.profileID == entry.profile.id ? "● " : "  "
-                        Text("\(prefix)\(formatProfileSubmenuLabel(entry))")
-                    }
-                }
+                swapProfileMenuItems(mode: .fork)
             } label: {
                 Label("Fork Session", systemImage: "arrow.triangle.branch")
             }

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -769,7 +769,27 @@ private struct TabBarItem: View {
 
             Divider()
 
-            Button(action: onFork) {
+            Menu {
+                Button {
+                    guard let terminalID = terminal?.id else { return }
+                    Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: nil, mode: .fork) }
+                } label: {
+                    let prefix = terminal?.profileID == nil ? "● " : "  "
+                    Text("\(prefix)Default (logged in)")
+                }
+
+                Divider()
+
+                ForEach(appState.modelProfiles, id: \.profile.id) { entry in
+                    Button {
+                        guard let terminalID = terminal?.id else { return }
+                        Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: entry.profile.id, mode: .fork) }
+                    } label: {
+                        let prefix = terminal?.profileID == entry.profile.id ? "● " : "  "
+                        Text("\(prefix)\(formatProfileSubmenuLabel(entry))")
+                    }
+                }
+            } label: {
                 Label("Fork Session", systemImage: "arrow.triangle.branch")
             }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -192,15 +192,6 @@ struct SingleWorktreeView: View {
                             await appState.refreshTerminals(worktreeID: worktreeID)
                         }
                     },
-                    onForkTab: { tabID in
-                        guard let tID = terminalID(for: tabID) else { return }
-                        let terminal = appState.terminals[worktreeID]?.first { $0.id == tID }
-                        guard let sessionID = terminal?.claudeSessionID else { return }
-                        Task {
-                            await appState.forkClaudeTerminal(worktreeID: worktreeID, sessionID: sessionID, tokenID: terminal?.profileID)
-                            selectLastTab()
-                        }
-                    },
                     isHistorySelected: appState.historyActiveWorktrees.contains(worktreeID),
                     onHistoryTab: {
                         appState.toggleHistory(worktreeID: worktreeID)

--- a/docs/superpowers/specs/2026-07-06-fork-profile-picker-design.md
+++ b/docs/superpowers/specs/2026-07-06-fork-profile-picker-design.md
@@ -1,0 +1,146 @@
+# Fork profile picker — design
+
+**Date:** 2026-07-06
+**Branch:** `fork-profile-picker`
+**Status:** Approved (brainstorming)
+
+## Problem
+
+PR #343 changed "Swap profile" to swap **in place** — the intuitive default. But a
+common need was actually *fork + switch profile* (open a new tab resuming the session
+under a different profile), which now takes two clicks (Fork Session, then Swap). The
+tab-bar **"Fork Session"** action is a single button that forks only onto the terminal's
+*current* profile, so there is no one-gesture "fork into profile X".
+
+## Goal
+
+Expand the tab-bar "Fork Session" action into a submenu — matching the "Swap profile"
+menu directly above it — that lets the user choose which Claude profile to fork the
+session into. Forking onto the current profile remains available.
+
+## Decisions (from brainstorming)
+
+- **No model-family filter for now.** Every profile in the picker is already
+  Claude-compatible (OAuth / Proxy / Bedrock all run Claude), and swap/fork are already
+  gated to Claude terminals (`isClaudeTerminal`). The picker lists the same profiles as
+  the Swap menu. There is no such thing as a "gemini" or "codex" *profile* today (codex
+  is a separate `TerminalKind`), so a model-family filter would be a no-op. Revisit only
+  if gemini/codex profiles ever exist. (YAGNI.)
+- **Codex/non-Claude terminals unchanged.** Fork is Claude-only today (no fork button on
+  codex terminals); it stays that way. No new fork surface is added.
+- **Menu label stays "Fork Session"** (keeps the `arrow.triangle.branch` icon). Accurate:
+  you fork the *session*; the profile is the target.
+- **Unify on the swap-fork path and remove the old fork path.** Single fork code path.
+
+## The change (client-side only)
+
+Everything below is in `Sources/TBDApp`. No daemon / RPC / CLI changes — the daemon
+already supports "fork into an arbitrary profile" via `terminal.swapProfile` with
+`mode: .fork` (the sidebar row menu already uses it).
+
+### 1. `TabBar.swift` — replace the Fork button with a Fork menu
+
+Currently (`TabBar.swift:772-774`), inside the `if isClaudeTerminal` block:
+
+```swift
+Button(action: onFork) {
+    Label("Fork Session", systemImage: "arrow.triangle.branch")
+}
+```
+
+Replace with a `Menu` mirroring the "Swap profile" menu (`TabBar.swift:748-768`), but
+dispatching `mode: .fork`:
+
+```swift
+Menu {
+    Button {
+        guard let terminalID = terminal?.id else { return }
+        Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: nil, mode: .fork) }
+    } label: {
+        let prefix = terminal?.profileID == nil ? "● " : "  "
+        Text("\(prefix)Default (logged in)")
+    }
+
+    Divider()
+
+    ForEach(appState.modelProfiles, id: \.profile.id) { entry in
+        Button {
+            guard let terminalID = terminal?.id else { return }
+            Task { await appState.swapTerminalProfile(terminalID: terminalID, newProfileID: entry.profile.id, mode: .fork) }
+        } label: {
+            let prefix = terminal?.profileID == entry.profile.id ? "● " : "  "
+            Text("\(prefix)\(formatProfileSubmenuLabel(entry))")
+        }
+    }
+} label: {
+    Label("Fork Session", systemImage: "arrow.triangle.branch")
+}
+```
+
+Notes:
+- The `●` marks the terminal's *current* profile (parity with Swap), signalling
+  "fork here = duplicate as-is".
+- Reuses the existing `formatProfileSubmenuLabel(_:)` helper (`TabBar.swift:710`).
+- The `Default (logged in)` item forks under the ambient keychain login (nil profile),
+  matching the Swap menu and the sidebar fork's nil-profile support.
+
+### 2. Remove the now-dead old fork path
+
+With the tab bar routing through `swapTerminalProfile(mode: .fork)`, these have no
+remaining callers and are removed:
+
+- `AppState+Terminals.swift:371` — `func forkClaudeTerminal(worktreeID:sessionID:tokenID:)`
+- `TerminalContainerView.swift:195-203` — the `onForkTab:` closure
+- `TabBar.swift` — the `onForkTab` (line 99) / `onFork` (line 477) closure plumbing and
+  the `onFork: { onForkTab(tab.id) }` wiring (line 123)
+
+**Behavior change to note:** same-profile fork now resumes via the swap RPC
+(`terminal.swapProfile`, `mode: .fork`) instead of `terminal.create` with a resume
+session id. Net effect is the same — a new tab resuming the session — plus the swap
+path's blank-session planning and transcript-carry (harmless / no-op when the target
+config dir equals the source).
+
+## Why the swap path (not `terminal.create`)
+
+`terminal.swapProfile` with `mode: .fork` (handler at
+`RPCRouter+TerminalHandlers.swift:789+`, fork branch `forkSwapNewTab` ~998) performs
+**transcript-carry**: it copies the session `.jsonl` into the *destination* profile's
+config dir so `claude --resume <id>` finds it. The old `forkClaudeTerminal` path used
+`terminal.create` with `resumeSessionID`, which always keeps the source profile and skips
+transcript-carry — structurally unable to fork into a different profile. Unifying on the
+swap path is what makes the profile picker actually work.
+
+## Preconditions / edge cases
+
+- The swap RPC requires `claudeSessionID` (errors "not a Claude terminal" otherwise). The
+  old fork guarded on the same field (`guard let sessionID = terminal?.claudeSessionID`),
+  and the whole menu lives under `isClaudeTerminal` — so the precondition is unchanged and
+  identical to the existing Swap menu's.
+
+## Non-goals
+
+- No daemon / RPC / CLI changes.
+- No model-family or gemini/codex filtering.
+- No fork surface added for codex/non-Claude terminals.
+- Sidebar row-menu fork (`RowActionMenuActions.swift:174` `.forkSession`) already has a
+  profile chooser via the swap path — untouched.
+
+## Testing
+
+- `swift build` — compiles.
+- `swift test` — confirm removing `forkClaudeTerminal` / `onForkTab` breaks no test
+  (grep tests for the removed symbols first).
+- Live-verify (UI wiring is live-only): from a running Claude terminal's tab context
+  menu, "Fork Session" now opens a submenu; forking into (a) the current profile,
+  (b) another OAuth/Proxy profile, and (c) "Default (logged in)" each opens a **new tab**
+  resuming the session under the chosen profile. Confirm the `●` marks the current
+  profile.
+
+No new behavior-gating conditional is introduced (the change replaces a button with a
+menu routing to an existing gated RPC), so no new unit-test branch is required.
+
+## Files touched
+
+- `Sources/TBDApp/TabBar.swift` — Fork button → Fork menu; remove `onFork`/`onForkTab` plumbing.
+- `Sources/TBDApp/Terminal/TerminalContainerView.swift` — remove `onForkTab:` closure.
+- `Sources/TBDApp/AppState+Terminals.swift` — remove `forkClaudeTerminal`.


### PR DESCRIPTION
## What

Expands the tab-bar **Fork Session** action from a single button (which forked onto the *current* profile only) into a profile-picker submenu, mirroring the **Swap profile** menu directly above it. You can now fork a Claude session into a new tab under any profile in one gesture.

Follow-up to #343 (which made Swap swap in place) — restores the easy "fork + switch profile" that otherwise took two clicks.

## How

- **Fork Session** is now a `Menu` listing `Default (logged in)` + all model profiles, with `●` marking the terminal's current profile. Each item routes through the existing `swapTerminalProfile(…, mode: .fork)` daemon path — the same path the sidebar row-menu fork already uses — which performs transcript-carry so forking into a *different* profile actually works.
- Removed the now-dead old fork path (`forkClaudeTerminal` → `terminal.create`, plus the `onFork`/`onForkTab` plumbing), unifying on a single fork path.
- Extracted the shared menu-item list into a `swapProfileMenuItems(mode:)` `@ViewBuilder` used by both the Swap and Fork menus (removes a ~20-line copy-paste).

## Scope / non-goals

- **Client-side only** — no daemon / RPC / CLI / DB changes (the `mode: .fork` plumbing already existed).
- **No model-family filter** — every profile is Claude-compatible (OAuth / Proxy / Bedrock all run Claude), and there is no gemini/codex *profile* (codex is a separate terminal kind). Both menus stay gated to Claude terminals, so codex tabs are unchanged (no fork option).

## Test plan

- `swift build` clean.
- `swift test`: TBDApp suites (appearance / code-highlight / hook-spawn / FileWatcher) green; the change touches no daemon/shared code.
- Live: right-click a Claude tab → **Fork Session** shows the profile submenu; forking into the current profile, a different profile, and *Default (logged in)* each opens a new tab resuming the session.

Design spec: `docs/superpowers/specs/2026-07-06-fork-profile-picker-design.md`

[🍴 Fork Profile Picker](https://cheapsteak.github.io/tbd/open/?worktree=1C2D4037-CE76-4A81-9776-893A39276976)
