### PR TITLE
Fix: Un-break main's test job after two green PRs collided (#341 made the "unknown" enum value real)

### DIFF
--- a/Tests/TBDDaemonTests/DatabaseDecodeResilienceTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseDecodeResilienceTests.swift
@@ -5,11 +5,13 @@ import GRDB
 @testable import TBDShared
 
 /// Regression coverage for the 2026-07-06 crash-loop: a `notification` row with
-/// `type = "limit_reached"` (a `NotificationType` case only present on an
-/// unmerged branch) made `toModel()`'s force-unwrap crash the daemon on
-/// startup, because `notifications.list` decodes the whole result set. These
-/// tests assert the failable `toModel()` SKIPS the offending row (no throw/
-/// crash) while valid rows in the same fetch are unaffected.
+/// `type = "limit_reached"` (at the time, a `NotificationType` case only
+/// present on an unmerged branch) made `toModel()`'s force-unwrap crash the
+/// daemon on startup, because `notifications.list` decodes the whole result
+/// set. `limit_reached` has since merged as a real case (PR #341), so these
+/// tests plant a synthetic never-valid rawValue instead. They assert the
+/// failable `toModel()` SKIPS the offending row (no throw/crash) while valid
+/// rows in the same fetch are unaffected.
 @Suite("Database Decode Resilience Tests")
 struct DatabaseDecodeResilienceTests {
 
@@ -75,9 +77,10 @@ struct DatabaseDecodeResilienceTests {
         let wtGood = try await makeWorktree(db, name: "wt-good-type")
 
         let bad = try await db.notifications.create(worktreeID: wtBad.id, type: .responseComplete)
-        // Plant an enum rawValue this build's NotificationType does not have.
+        // Plant an enum rawValue NotificationType can never gain (synthetic,
+        // test-only) so this stays unknown even as real cases are added.
         try await rawUpdate(db, sql: "UPDATE notification SET type = ? WHERE id = ?",
-                            ["limit_reached", bad.id.uuidString])
+                            ["test_only_unknown_type", bad.id.uuidString])
         _ = try await db.notifications.create(worktreeID: wtGood.id, type: .error)
 
         // Must not throw/crash even though one row has an unknown type.


### PR DESCRIPTION
## Summary
- Main's `Test` job fails deterministically (not a flake): `DatabaseDecodeResilienceTests.unknownTypeSkippedInSummary` plants `"limit_reached"` as an *unknown* `NotificationType` rawValue and expects the failable `toModel()` to skip the row.
- Root cause: #341 added `case limitReached = "limit_reached"` as a real case and merged **42 seconds before** #356 (which added the test). Each PR's CI ran against a base without the other, so both were green in isolation but collide on main. First seen on PR #365's test job, which inherited both.
- Fix: plant a synthetic `"test_only_unknown_type"` rawValue that can never become a real case, and update the suite doc comment to record why (`limit_reached` is now a legitimate case).

## Test plan
- [x] `swift test --filter DatabaseDecodeResilienceTests` — all 8 tests pass, including the previously failing one
- [x] Verified the other synthetic sentinels in the file (`"future_type"`, `"future_status"`) are not real rawValues of their enums, so no analogous latent break remains

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=2FD549A6-F58E-42F3-A920-3871A31B4BAC)