### PR TITLE
Wake-hang fix: bound tmux/git subprocess timeout + stop focus-wake storm

### DIFF
--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -96,21 +96,23 @@ extension AppState {
     /// focused terminal can't be resolved to a parked row, fall back to waking
     /// at most one parked terminal — never a parallel fan-out.
     func wakeHibernatedTerminalsOnFocus(worktreeID: UUID) {
-        let parked = (terminals[worktreeID] ?? []).filter { $0.isParked }
-        guard !parked.isEmpty else { return }
+        guard let target = terminalIDToWakeOnFocus(worktreeID: worktreeID) else { return }
+        // Wake exactly one; never a parallel fan-out (see the storm rationale above).
+        Task { await wakeTerminal(terminalID: target, worktreeID: worktreeID) }
+    }
 
-        // Preferred: wake exactly the terminal the user is about to view.
+    /// Pure decision behind `wakeHibernatedTerminalsOnFocus`: the single parked
+    /// terminal (if any) to wake on focus. Three branches — (1) the focused
+    /// terminal when it is itself parked; (2) otherwise the first parked
+    /// terminal; (3) nil when none are parked. Extracted as a pure function so
+    /// the fan-out choice is unit-tested without a live `DaemonClient`.
+    func terminalIDToWakeOnFocus(worktreeID: UUID) -> UUID? {
+        let parked = (terminals[worktreeID] ?? []).filter { $0.isParked }
+        guard !parked.isEmpty else { return nil }
         if let focusedID = terminalIDForAutofocus(worktreeID: worktreeID),
            parked.contains(where: { $0.id == focusedID }) {
-            Task { await wakeTerminal(terminalID: focusedID, worktreeID: worktreeID) }
-            return
+            return focusedID
         }
-
-        // Fallback (no resolvable focused terminal, e.g. history view active):
-        // wake a single parked terminal rather than storming all N. The others
-        // wake lazily when their tab is selected.
-        if let first = parked.first {
-            Task { await wakeTerminal(terminalID: first.id, worktreeID: worktreeID) }
-        }
+        return parked.first?.id
     }
 }

--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -77,16 +77,40 @@ extension AppState {
         }
     }
 
-    /// Auto-wake any PARKED Claude terminals in a worktree the user just
-    /// focused/selected. Covers both hibernated (authoritative) and legacy
-    /// suspended rows — wake is the one resume path. Called from the
-    /// selection-change hook. Idempotent via `wakeTerminal`'s in-flight guard,
-    /// so double-focus is safe.
+    /// Auto-wake the PARKED Claude terminal the user is actually about to look
+    /// at in a worktree they just focused/selected. Covers both hibernated
+    /// (authoritative) and legacy suspended rows — wake is the one resume path.
+    /// Called from the selection-change hook. Idempotent via `wakeTerminal`'s
+    /// in-flight guard, so double-focus is safe.
+    ///
+    /// Deliberately does NOT wake every parked terminal in the worktree. A
+    /// worktree with ~20+ hibernated sessions on ONE tmux server used to fire
+    /// that many simultaneous `respawn-window -k … claude --resume` (heavy Node)
+    /// spawns on focus → a spawn storm that queued respawns past the app's 300s
+    /// RPC ceiling → the "recv timed out after 300s" hang, which then re-fired
+    /// on the next focus (~5-min loop) and re-inflated memory/swap each cycle.
+    ///
+    /// Strategy: wake ONLY the terminal that autofocus will surface (the active
+    /// tab's terminal). The rest stay hibernated until the user actually
+    /// navigates to them (selecting their tab re-invokes this hook). If the
+    /// focused terminal can't be resolved to a parked row, fall back to waking
+    /// at most one parked terminal — never a parallel fan-out.
     func wakeHibernatedTerminalsOnFocus(worktreeID: UUID) {
-        let hibernated = (terminals[worktreeID] ?? []).filter { $0.isParked }
-        guard !hibernated.isEmpty else { return }
-        for terminal in hibernated {
-            Task { await wakeTerminal(terminalID: terminal.id, worktreeID: worktreeID) }
+        let parked = (terminals[worktreeID] ?? []).filter { $0.isParked }
+        guard !parked.isEmpty else { return }
+
+        // Preferred: wake exactly the terminal the user is about to view.
+        if let focusedID = terminalIDForAutofocus(worktreeID: worktreeID),
+           parked.contains(where: { $0.id == focusedID }) {
+            Task { await wakeTerminal(terminalID: focusedID, worktreeID: worktreeID) }
+            return
+        }
+
+        // Fallback (no resolvable focused terminal, e.g. history view active):
+        // wake a single parked terminal rather than storming all N. The others
+        // wake lazily when their tab is selected.
+        if let first = parked.first {
+            Task { await wakeTerminal(terminalID: first.id, worktreeID: worktreeID) }
         }
     }
 }

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -1,4 +1,18 @@
 import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "GitManager")
+
+/// Error thrown when a git subprocess outlives its timeout and is killed.
+/// Distinct from `GitError` (which represents a clean non-zero exit) so the
+/// exit-code-1 catch sites don't accidentally swallow a wedged-command kill.
+public struct GitTimeoutError: Error, CustomStringConvertible {
+    public let command: String
+    public let timeout: Duration
+    public var description: String {
+        "Git command timed out after \(timeout): \(command)"
+    }
+}
 
 /// A branch reference returned by `GitManager.listBranches`.
 ///
@@ -34,7 +48,19 @@ public struct GitError: Error, CustomStringConvertible {
 /// Manages git operations by shelling out to the `git` CLI.
 public struct GitManager: Sendable {
 
-    public init() {}
+    /// Hard ceiling on any single `git` subprocess. Network git ops (fetch,
+    /// clone) can legitimately run for tens of seconds, so this is far more
+    /// generous than tmux's ceiling — but it is still bounded. A daemon-child
+    /// `git fetch origin main` was once found stuck for 95 minutes, holding a
+    /// continuation open forever; this converts that into a catchable failure.
+    public static let commandTimeout: Duration = .seconds(120)
+
+    /// Per-instance timeout; tests inject a tiny value to exercise the kill path.
+    let subprocessTimeout: Duration
+
+    public init(subprocessTimeout: Duration = GitManager.commandTimeout) {
+        self.subprocessTimeout = subprocessTimeout
+    }
 
     // MARK: - Public API
 
@@ -402,7 +428,15 @@ public struct GitManager: Sendable {
     /// Runs a git command with the given arguments at the given directory and returns stdout.
     /// Throws `GitError` on non-zero exit.
     private func run(arguments: [String], at directory: String) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
+        let timeout = subprocessTimeout
+        let commandDescription = "git " + arguments.joined(separator: " ")
+        // Single-resume guard shared by the termination handler, the timeout
+        // timer, and the spawn-failure path (mirrors TmuxManager.runExternalCommand).
+        let state = ContinuationGuard()
+        let timeoutNanos = UInt64(max(0, timeout.components.seconds)) * 1_000_000_000
+            + UInt64(max(0, timeout.components.attoseconds / 1_000_000_000))
+
+        return try await withCheckedThrowingContinuation { continuation in
             let process = Process()
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
@@ -413,7 +447,25 @@ public struct GitManager: Sendable {
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
 
-            let commandDescription = "git " + arguments.joined(separator: " ")
+            // Watchdog: a wedged git child (a `git fetch` was once stuck 95 min)
+            // is escalated SIGTERM → SIGKILL and the call throws GitTimeoutError.
+            let timer = DispatchSource.makeTimerSource(queue: .global())
+            timer.schedule(deadline: .now() + .nanoseconds(Int(min(timeoutNanos, UInt64(Int.max)))))
+            timer.setEventHandler {
+                guard state.claim() else { return }
+                timer.cancel()
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                let pid = process.processIdentifier
+                if pid > 0 {
+                    kill(pid, SIGTERM)
+                    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(500)) {
+                        if process.isRunning { kill(pid, SIGKILL) }
+                    }
+                }
+                logger.warning("git subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")
+                continuation.resume(throwing: GitTimeoutError(command: commandDescription, timeout: timeout))
+            }
 
             // Drain pipes incrementally to prevent deadlock when output exceeds the
             // OS pipe buffer (~64KB). Without this, the child process blocks on
@@ -442,6 +494,9 @@ public struct GitManager: Sendable {
                 let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
                 let stderr = String(data: stderrData, encoding: .utf8) ?? ""
 
+                guard state.claim() else { return }  // timer already won → timed out
+                timer.cancel()
+
                 if process.terminationStatus != 0 {
                     continuation.resume(throwing: GitError(
                         command: commandDescription,
@@ -455,7 +510,10 @@ public struct GitManager: Sendable {
 
             do {
                 try process.run()
+                timer.resume()
             } catch {
+                guard state.claim() else { return }
+                timer.cancel()
                 continuation.resume(throwing: error)
             }
         }

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -427,7 +427,21 @@ public struct GitManager: Sendable {
 
     /// Runs a git command with the given arguments at the given directory and returns stdout.
     /// Throws `GitError` on non-zero exit.
-    private func run(arguments: [String], at directory: String) async throws -> String {
+    /// Package-internal test seam: drives `run()`'s timeout/kill wrapper against
+    /// an arbitrary executable so the SIGTERM→SIGKILL path (and `GitTimeoutError`)
+    /// is unit-testable deterministically, without relying on a real git operation
+    /// hanging (which it does not reliably do across environments).
+    func runForTimeoutTesting(executable: String, arguments: [String], at directory: String) async throws -> String {
+        try await run(arguments: arguments, at: directory, executable: executable)
+    }
+
+    /// `executable` defaults to git; it is overridable ONLY so the package-internal
+    /// `runForTimeoutTesting` seam can drive this exact timeout/kill wrapper against
+    /// a slow binary (`/bin/sleep`) deterministically — real git has no reliable
+    /// cross-environment hang to exercise the kill path (a post-checkout hook did
+    /// not fire on CI). Production callers never pass `executable`.
+    private func run(arguments: [String], at directory: String,
+                     executable: String = "/usr/bin/git") async throws -> String {
         let timeout = subprocessTimeout
         let commandDescription = "git " + arguments.joined(separator: " ")
         // Single-resume guard shared by the termination handler, the timeout
@@ -441,7 +455,7 @@ public struct GitManager: Sendable {
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
 
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            process.executableURL = URL(fileURLWithPath: executable)
             process.arguments = arguments
             process.currentDirectoryURL = URL(fileURLWithPath: directory)
             process.standardOutput = stdoutPipe

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -4,7 +4,22 @@ import os
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "TmuxManager")
 
 public struct TmuxManager: Sendable {
+    /// Hard ceiling on any single tmux subprocess. tmux control operations
+    /// (respawn-window, new-session, kill-window, capture-pane, …) normally
+    /// complete in milliseconds; a tmux child still running after this long is
+    /// wedged (spawn storm / heavy `claude --resume` under load / a hung
+    /// server). Bounding it converts an otherwise-infinite `await` — which
+    /// used to hang the wake RPC until the app's 300s ceiling and produced the
+    /// "recv timed out after 300s" loop — into a fast, catchable failure that
+    /// leaves the hibernated row intact for a later retry. 15s is generous
+    /// enough that a merely-slow-but-progressing tmux op still succeeds.
+    public static let commandTimeout: Duration = .seconds(15)
+
     public let dryRun: Bool
+    /// Per-instance timeout applied to every external tmux subprocess. Defaults
+    /// to `commandTimeout`; tests inject a tiny value to exercise the timeout /
+    /// SIGTERM-then-SIGKILL path against a real slow command without waiting 15s.
+    let subprocessTimeout: Duration
     private let counter: Counter
     /// Optional test hook that records every dryRun command invocation. When set,
     /// dry-run paths still no-op, but the recorder receives the argv that would
@@ -45,8 +60,9 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
+        self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
         self.dryRunRecorder = dryRunRecorder
         self.dryRunWindowIsDead = dryRunWindowIsDead
@@ -557,17 +573,65 @@ public struct TmuxManager: Sendable {
 
     @discardableResult
     private func runTmux(_ arguments: [String]) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
+        try await Self.runExternalCommand(
+            executable: Self.tmuxPath(),
+            arguments: arguments,
+            label: "tmux",
+            timeout: subprocessTimeout
+        )
+    }
+
+    /// Runs an external command with a hard timeout, draining stdout/stderr.
+    /// On timeout the child is signalled SIGTERM, then SIGKILL after a short
+    /// grace, and the call throws `TmuxError.timedOut` — never hangs. The
+    /// continuation is guarded by a lock so exactly one of {termination,
+    /// timeout, spawn-failure} resumes it, satisfying the single-resume
+    /// contract even when the process exits concurrently with the timer.
+    ///
+    /// Package-internal (not `private`) so timeout tests can drive it directly
+    /// against a real slow binary (`/bin/sleep`) without a tmux server.
+    @discardableResult
+    static func runExternalCommand(
+        executable: String,
+        arguments: [String],
+        label: String,
+        timeout: Duration
+    ) async throws -> String {
+        // Single-resume guard shared between the termination handler and the
+        // timeout timer. Whichever fires first wins; the loser is a no-op.
+        let state = ContinuationGuard()
+        let commandDescription = "\(label) " + arguments.joined(separator: " ")
+        let timeoutNanos = UInt64(max(0, timeout.components.seconds)) * 1_000_000_000
+            + UInt64(max(0, timeout.components.attoseconds / 1_000_000_000))
+
+        return try await withCheckedThrowingContinuation { continuation in
             let process = Process()
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
 
-            process.executableURL = URL(fileURLWithPath: Self.tmuxPath())
+            process.executableURL = URL(fileURLWithPath: executable)
             process.arguments = arguments
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
 
-            let commandDescription = "tmux " + arguments.joined(separator: " ")
+            // Watchdog timer: on fire, escalate SIGTERM → SIGKILL and resume
+            // with a timeout error (if the process hasn't already exited).
+            let timer = DispatchSource.makeTimerSource(queue: .global())
+            timer.schedule(deadline: .now() + .nanoseconds(Int(min(timeoutNanos, UInt64(Int.max)))))
+            timer.setEventHandler {
+                guard state.claim() else { return }
+                timer.cancel()
+                let pid = process.processIdentifier
+                if pid > 0 {
+                    kill(pid, SIGTERM)
+                    // Give it a brief grace to exit on SIGTERM, then SIGKILL.
+                    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(500)) {
+                        if process.isRunning { kill(pid, SIGKILL) }
+                    }
+                }
+                logger.warning("subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")
+                continuation.resume(throwing: TmuxError.timedOut(command: commandDescription, timeout: timeout))
+            }
 
             process.terminationHandler = { _ in
                 let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
@@ -575,6 +639,9 @@ public struct TmuxManager: Sendable {
                 let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
                 let stderr = String(data: stderrData, encoding: .utf8) ?? ""
                 let output = stdout.isEmpty ? stderr : stdout
+
+                guard state.claim() else { return }  // timer already won → timed out
+                timer.cancel()
 
                 if process.terminationStatus != 0 {
                     continuation.resume(throwing: TmuxError.commandFailed(
@@ -589,9 +656,28 @@ public struct TmuxManager: Sendable {
 
             do {
                 try process.run()
+                timer.resume()
             } catch {
+                guard state.claim() else { return }
+                timer.cancel()
                 continuation.resume(throwing: error)
             }
+        }
+    }
+}
+
+/// One-shot claim used to enforce the single-resume contract of a
+/// `CheckedContinuation` shared across a termination handler, a timeout timer,
+/// and a spawn-failure path. `claim()` returns `true` exactly once.
+/// Package-internal so the git runner reuses it for the same purpose.
+final class ContinuationGuard: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock(initialState: false)
+    /// Returns true the first time it is called, false thereafter.
+    func claim() -> Bool {
+        lock.withLock { resumed in
+            if resumed { return false }
+            resumed = true
+            return true
         }
     }
 }
@@ -599,4 +685,8 @@ public struct TmuxManager: Sendable {
 public enum TmuxError: Error, Sendable {
     case commandFailed(command: String, status: Int32, output: String)
     case unexpectedOutput(String)
+    /// The subprocess outlived its timeout and was killed. Callers on the wake
+    /// path catch this and leave the row hibernated for retry rather than
+    /// hanging until the app's 300s RPC ceiling.
+    case timedOut(command: String, timeout: Duration)
 }

--- a/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
+++ b/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// The spawn-storm fix: on focus, wake EXACTLY ONE parked terminal, never fan
+/// out to all N (which queued respawns past the 300s ceiling and hung the
+/// daemon). Tests the pure decision `terminalIDToWakeOnFocus` across its three
+/// branches without needing a live `DaemonClient`.
+@MainActor
+@Suite("Wake-on-focus decision (spawn-storm fix)")
+struct WakeOnFocusDecisionTests {
+    private func terminal(_ id: UUID, parked: Bool) -> Terminal {
+        Terminal(id: id, worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+                 hibernatedAt: parked ? Date() : nil)
+    }
+
+    /// Branch 1: the focused terminal is itself parked → wake exactly it (not
+    /// merely the first parked row).
+    @Test func wakesTheFocusedParkedTerminal() {
+        let state = AppState()
+        let wt = UUID()
+        let other = UUID()
+        let focused = UUID()
+        // `focused` is SECOND so a naive "first parked" would wrongly pick `other`.
+        state.terminals[wt] = [terminal(other, parked: true), terminal(focused, parked: true)]
+        let tabID = UUID()
+        state.tabs[wt] = [Tab(id: tabID, content: .terminal(terminalID: focused), label: nil)]
+        state.activeTabIndices[wt] = 0
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == focused)
+    }
+
+    /// Branch 2: no resolvable focused terminal (history view active) → fall back
+    /// to the FIRST parked terminal — one, not a fan-out.
+    @Test func fallsBackToFirstParkedWhenNoFocusResolvable() {
+        let state = AppState()
+        let wt = UUID()
+        let firstParked = UUID()
+        let secondParked = UUID()
+        state.terminals[wt] = [terminal(firstParked, parked: true), terminal(secondParked, parked: true)]
+        let tabID = UUID()
+        state.tabs[wt] = [Tab(id: tabID, content: .terminal(terminalID: firstParked), label: nil)]
+        // History view active → terminalIDForAutofocus returns nil.
+        state.historyActiveWorktrees.insert(wt)
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == firstParked)
+    }
+
+    /// Branch 3: nothing parked → nil (nothing to wake).
+    @Test func returnsNilWhenNoParkedTerminals() {
+        let state = AppState()
+        let wt = UUID()
+        state.terminals[wt] = [terminal(UUID(), parked: false), terminal(UUID(), parked: false)]
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Exercises `GitManager`'s subprocess timeout/kill path directly, per the
+/// review request: a real temp repo with a slow `post-checkout` hook makes a
+/// git operation hang, and `GitManager(subprocessTimeout:)` must SIGTERM/SIGKILL
+/// it and throw `GitTimeoutError` fast rather than block indefinitely.
+struct GitManagerTimeoutTests {
+    private static func shell(_ command: String, at dir: URL) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/bin/bash")
+            p.arguments = ["-c", command]
+            p.currentDirectoryURL = dir
+            p.terminationHandler = { proc in
+                proc.terminationStatus == 0
+                    ? cont.resume()
+                    : cont.resume(throwing: NSError(domain: "shell", code: Int(proc.terminationStatus)))
+            }
+            do { try p.run() } catch { cont.resume(throwing: error) }
+        }
+    }
+
+    @Test func worktreeAddTimesOutWhenAHookHangs() async throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let repoDir = tempDir.appendingPathComponent("repo")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        try await Self.shell("git init", at: repoDir)
+        try await Self.shell("git config user.email 'test@test.com'", at: repoDir)
+        try await Self.shell("git config user.name 'Test'", at: repoDir)
+        try await Self.shell("git commit --allow-empty -m init", at: repoDir)
+
+        // A post-checkout hook that hangs — `git worktree add` runs it after the
+        // checkout, so the git child blocks far longer than the timeout.
+        let hooksDir = repoDir.appendingPathComponent(".git/hooks")
+        try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+        let hook = hooksDir.appendingPathComponent("post-checkout")
+        try "#!/bin/sh\nsleep 10\n".write(to: hook, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hook.path)
+
+        let base = try await GitManager().detectDefaultBranch(repoPath: repoDir.path)
+        let slowGit = GitManager(subprocessTimeout: .milliseconds(250))
+        let wtPath = tempDir.appendingPathComponent("wt-timeout").path
+
+        let start = Date()
+        await #expect(throws: GitTimeoutError.self) {
+            try await slowGit.worktreeAdd(
+                repoPath: repoDir.path,
+                worktreePath: wtPath,
+                branch: "feature-timeout",
+                baseBranch: base
+            )
+        }
+        // Must fail fast — nowhere near the hook's 10s sleep.
+        #expect(Date().timeIntervalSince(start) < 5.0,
+                "GitManager must kill the hung git child and throw promptly")
+    }
+}

--- a/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
@@ -2,60 +2,32 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 
-/// Exercises `GitManager`'s subprocess timeout/kill path directly, per the
-/// review request: a real temp repo with a slow `post-checkout` hook makes a
-/// git operation hang, and `GitManager(subprocessTimeout:)` must SIGTERM/SIGKILL
-/// it and throw `GitTimeoutError` fast rather than block indefinitely.
+/// Exercises `GitManager`'s subprocess timeout/kill path (`GitTimeoutError`) via
+/// the package-internal `runForTimeoutTesting` seam driven against `/bin/sleep`.
+/// Asserts the OUTCOME (an error is thrown), never timing — CI runners can be
+/// pathologically slow, so a wall-clock bound would be flaky. A real git hang is
+/// not reproducible cross-environment (a post-checkout hook did not fire on CI),
+/// which is exactly why the deterministic seam exists.
 struct GitManagerTimeoutTests {
-    private static func shell(_ command: String, at dir: URL) async throws {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            let p = Process()
-            p.executableURL = URL(fileURLWithPath: "/bin/bash")
-            p.arguments = ["-c", command]
-            p.currentDirectoryURL = dir
-            p.terminationHandler = { proc in
-                proc.terminationStatus == 0
-                    ? cont.resume()
-                    : cont.resume(throwing: NSError(domain: "shell", code: Int(proc.terminationStatus)))
-            }
-            do { try p.run() } catch { cont.resume(throwing: error) }
+    @Test func subprocessTimeoutThrowsGitTimeoutError() async {
+        let git = GitManager(subprocessTimeout: .milliseconds(100))
+        await #expect(throws: GitTimeoutError.self) {
+            _ = try await git.runForTimeoutTesting(
+                executable: "/bin/sleep",
+                arguments: ["30"],
+                at: FileManager.default.temporaryDirectory.path
+            )
         }
     }
 
-    @Test func worktreeAddTimesOutWhenAHookHangs() async throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let repoDir = tempDir.appendingPathComponent("repo")
-        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
-        try await Self.shell("git init", at: repoDir)
-        try await Self.shell("git config user.email 'test@test.com'", at: repoDir)
-        try await Self.shell("git config user.name 'Test'", at: repoDir)
-        try await Self.shell("git commit --allow-empty -m init", at: repoDir)
-
-        // A post-checkout hook that hangs — `git worktree add` runs it after the
-        // checkout, so the git child blocks far longer than the timeout.
-        let hooksDir = repoDir.appendingPathComponent(".git/hooks")
-        try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
-        let hook = hooksDir.appendingPathComponent("post-checkout")
-        try "#!/bin/sh\nsleep 10\n".write(to: hook, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hook.path)
-
-        let base = try await GitManager().detectDefaultBranch(repoPath: repoDir.path)
-        let slowGit = GitManager(subprocessTimeout: .milliseconds(250))
-        let wtPath = tempDir.appendingPathComponent("wt-timeout").path
-
-        let start = Date()
-        await #expect(throws: GitTimeoutError.self) {
-            try await slowGit.worktreeAdd(
-                repoPath: repoDir.path,
-                worktreePath: wtPath,
-                branch: "feature-timeout",
-                baseBranch: base
-            )
-        }
-        // Must fail fast — nowhere near the hook's 10s sleep.
-        #expect(Date().timeIntervalSince(start) < 5.0,
-                "GitManager must kill the hung git child and throw promptly")
+    @Test func fastCommandSucceedsWithinTimeout() async throws {
+        // The timeout wrapper must not break the happy path.
+        let git = GitManager(subprocessTimeout: .seconds(30))
+        let out = try await git.runForTimeoutTesting(
+            executable: "/bin/echo",
+            arguments: ["ok"],
+            at: FileManager.default.temporaryDirectory.path
+        )
+        #expect(out.contains("ok"))
     }
 }

--- a/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Covers the wake-hang fix's core mechanism: an external subprocess that never
+/// returns must be killed and the call must throw a timeout error FAST, rather
+/// than hanging the RPC to the app's 300s ceiling. Drives the package-internal
+/// `runExternalCommand` seam against `/bin/sleep` so no tmux server is needed.
+@Suite("Subprocess timeout / kill path")
+struct SubprocessTimeoutTests {
+    @Test func runExternalCommandThrowsTimedOutOnSlowBinary() async {
+        let start = Date()
+        do {
+            _ = try await TmuxManager.runExternalCommand(
+                executable: "/bin/sleep",
+                arguments: ["5"],
+                label: "timeout-test",
+                timeout: .milliseconds(100)
+            )
+            Issue.record("expected runExternalCommand to time out, but it returned")
+        } catch let error as TmuxError {
+            guard case .timedOut = error else {
+                Issue.record("expected TmuxError.timedOut, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("expected TmuxError.timedOut, got \(error)")
+        }
+        // The whole point: it fails fast, nowhere near the 5s the child would sleep.
+        #expect(Date().timeIntervalSince(start) < 3.0,
+                "timed-out call must return promptly, not wait for the child")
+    }
+
+    @Test func runExternalCommandSucceedsWellWithinTimeout() async throws {
+        // A fast binary returns normally — the timeout wrapper must not break the
+        // happy path (regression guard for the kill/continuation plumbing).
+        let out = try await TmuxManager.runExternalCommand(
+            executable: "/bin/echo",
+            arguments: ["ok"],
+            label: "fast",
+            timeout: .seconds(5)
+        )
+        #expect(out.contains("ok"))
+    }
+}

--- a/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
@@ -9,11 +9,14 @@ import Testing
 @Suite("Subprocess timeout / kill path")
 struct SubprocessTimeoutTests {
     @Test func runExternalCommandThrowsTimedOutOnSlowBinary() async {
-        let start = Date()
+        // Assert the OUTCOME (throws .timedOut), never wall-clock timing — a
+        // loaded CI runner can be arbitrarily slow to schedule the kill, and a
+        // timing bound would flake. The `sleep 30` guarantees the child never
+        // finishes on its own, so a thrown error can only mean the timeout fired.
         do {
             _ = try await TmuxManager.runExternalCommand(
                 executable: "/bin/sleep",
-                arguments: ["5"],
+                arguments: ["30"],
                 label: "timeout-test",
                 timeout: .milliseconds(100)
             )
@@ -26,9 +29,6 @@ struct SubprocessTimeoutTests {
         } catch {
             Issue.record("expected TmuxError.timedOut, got \(error)")
         }
-        // The whole point: it fails fast, nowhere near the 5s the child would sleep.
-        #expect(Date().timeIntervalSince(start) < 3.0,
-                "timed-out call must return promptly, not wait for the child")
     }
 
     @Test func runExternalCommandSucceedsWellWithinTimeout() async throws {


### PR DESCRIPTION
Same-repo re-open of #353 (now that the unify base #362 is merged, this rebases to just its own commit).

Fixes the "recv timed out after 300s (daemon unresponsive)" wake error that looped every ~5 min: bounds `runTmux`/git subprocesses with a timeout (a stalled respawn-window hung the wake RPC to the 300s ceiling), and stops `wakeHibernatedTerminalsOnFocus` from firing N simultaneous respawns on one tmux server.

Verified in the integration build + running live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)