### PR TITLE
In-sidebar Nightwatch/Daywatch toggle, gated behind Settings → Experimental

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1670,6 +1670,20 @@ final class AppState: ObservableObject {
         defaults.object(forKey: autoSuspendClaudeKey) as? Bool ?? false
     }
 
+    /// UserDefaults key mirroring the `@AppStorage` toggle in
+    /// Settings → Experimental that gates the Nightwatch / Daywatch feature.
+    /// When off (the default), the sidebar mode control is hidden entirely —
+    /// the feature is unfinished and evaluate-only, so it stays opt-in.
+    static let nightwatchExperimentalKey = "nightwatchExperimentalEnabled"
+
+    /// Whether the experimental Nightwatch / Daywatch UI is enabled. Fails
+    /// closed: defaults to false so the sidebar control only appears once the
+    /// user opts in from Settings → Experimental. Tests pass a private
+    /// `UserDefaults(suiteName:)` so they never touch live app preferences.
+    static func nightwatchExperimentalEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: nightwatchExperimentalKey) as? Bool ?? false
+    }
+
     /// Pure target-selection for the pre-sleep suspend hook. Returns the
     /// worktree IDs to best-effort suspend before the machine sleeps:
     /// `[]` when auto-suspend is disabled, otherwise every worktree ID

--- a/Sources/TBDApp/MenuBar/NightwatchStatusItem.swift
+++ b/Sources/TBDApp/MenuBar/NightwatchStatusItem.swift
@@ -10,6 +10,10 @@ import TBDShared
 /// is answerable at a glance without opening the menu.
 struct NightwatchStatusItem: Commands {
     @ObservedObject var appState: AppState
+    /// Gated behind the same Settings → Experimental opt-in as the sidebar
+    /// control, so the whole Nightwatch feature (both entry points) is off by
+    /// default. Fail-closed to hidden when the user has never opted in.
+    @AppStorage(AppState.nightwatchExperimentalKey) private var experimentalEnabled: Bool = false
 
     private var title: String {
         switch appState.nightwatchMode {
@@ -20,9 +24,11 @@ struct NightwatchStatusItem: Commands {
     }
 
     var body: some Commands {
-        CommandMenu(title) {
-            NightwatchStatusContent()
-                .environmentObject(appState)
+        if experimentalEnabled {
+            CommandMenu(title) {
+                NightwatchStatusContent()
+                    .environmentObject(appState)
+            }
         }
     }
 }

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -37,6 +37,7 @@ struct GeneralSettingsTab: View {
     @AppStorage(AppState.autoSuspendClaudeKey) private var autoSuspend: Bool = false
     @AppStorage(AppState.enableTranscriptKey) private var enableTranscript: Bool = false
     @AppStorage(AppState.useTableViewTranscriptKey) private var useTableViewTranscript: Bool = true
+    @AppStorage(AppState.nightwatchExperimentalKey) private var nightwatchExperimental: Bool = false
     @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
@@ -191,6 +192,18 @@ struct GeneralSettingsTab: View {
                 Toggle("New transcript renderer", isOn: $useTableViewTranscript)
                     .help("On by default. Off falls back to the legacy renderer (for comparison).")
                     .disabled(!enableTranscript)
+                Toggle("Nightwatch / Daywatch", isOn: $nightwatchExperimental)
+                    .help("""
+                    Experimental — an autonomous fleet babysitter. It sweeps your \
+                    worktrees, keeps stuck agents unblocked, and gates open PRs, using \
+                    cheap local scripts and only paging a model for genuine judgment \
+                    calls. Daywatch (◐) is a lighter pass for when you're at the \
+                    keyboard; Nightwatch (🌙) is the fuller autonomous mode for when \
+                    you're away. Evaluate-only for now — it records what it would do \
+                    without acting, and its behavior and safety rules are still \
+                    changing. Turning this on shows a mode control in the sidebar; off \
+                    hides it. You still merge PRs and make prod/access calls yourself.
+                    """)
             }
         }
         .formStyle(.grouped)

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -201,8 +201,9 @@ struct GeneralSettingsTab: View {
                     keyboard; Nightwatch (🌙) is the fuller autonomous mode for when \
                     you're away. Evaluate-only for now — it records what it would do \
                     without acting, and its behavior and safety rules are still \
-                    changing. Turning this on shows a mode control in the sidebar; off \
-                    hides it. You still merge PRs and make prod/access calls yourself.
+                    changing. Turning this on reveals the mode controls (sidebar \
+                    footer and menu bar); off hides both. You still merge PRs and \
+                    make prod/access calls yourself.
                     """)
             }
         }

--- a/Sources/TBDApp/Sidebar/NightwatchModeToggle.swift
+++ b/Sources/TBDApp/Sidebar/NightwatchModeToggle.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import TBDShared
+
+/// Pure, view-free presentation model for one Nightwatch mode segment. Extracted
+/// so the label / glyph / help copy and the active-state logic are unit-testable
+/// without instantiating any SwiftUI view. The sidebar control renders one
+/// segment per `NightwatchMode` case and highlights the one matching the active
+/// mode.
+enum NightwatchModePresentation {
+    /// Every mode, in display order (Off · Day · Night).
+    static let ordered: [NightwatchMode] = [.off, .daywatch, .nightwatch]
+
+    /// Short segment label shown in the sidebar control.
+    static func label(_ mode: NightwatchMode) -> String {
+        switch mode {
+        case .off: return "Off"
+        case .daywatch: return "Day"
+        case .nightwatch: return "Night"
+        }
+    }
+
+    /// Glyph prefixed to the label (◐ = daywatch, 🌙 = nightwatch, none = off).
+    /// Matches the menu-bar item's glyph vocabulary.
+    static func glyph(_ mode: NightwatchMode) -> String? {
+        switch mode {
+        case .off: return nil
+        case .daywatch: return "◐"
+        case .nightwatch: return "🌙"
+        }
+    }
+
+    /// Label with the glyph prepended, e.g. "◐ Day". Used for the visible
+    /// segment text and its accessibility label.
+    static func glyphLabel(_ mode: NightwatchMode) -> String {
+        if let glyph = glyph(mode) {
+            return "\(glyph) \(label(mode))"
+        }
+        return label(mode)
+    }
+
+    /// Short help explaining what each mode does. "daywatch"/"nightwatch" are
+    /// not self-evident, so the control carries this as a tooltip.
+    static func help(_ mode: NightwatchMode) -> String {
+        switch mode {
+        case .off: return "Off — not watching"
+        case .daywatch: return "Daywatch — watching while you're around"
+        case .nightwatch: return "Nightwatch — watching while you're away"
+        }
+    }
+
+    /// Whether `segment` is the currently-active mode (drives the filled/tinted
+    /// highlight so a glance answers "what mode am I in?").
+    static func isActive(segment: NightwatchMode, current: NightwatchMode) -> Bool {
+        segment == current
+    }
+}
+
+/// Compact three-state Nightwatch mode control pinned in the sidebar footer.
+/// `Off | ◐ Day | 🌙 Night` — the active mode is filled/tinted; tapping a
+/// segment calls `setNightwatchMode`. Always visible so the mode is never lost
+/// in the menu bar.
+struct NightwatchModeToggle: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(NightwatchModePresentation.ordered, id: \.self) { mode in
+                segment(mode)
+                if mode != NightwatchModePresentation.ordered.last {
+                    Divider()
+                        .frame(height: 14)
+                        .opacity(0.4)
+                }
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Nightwatch mode")
+    }
+
+    @ViewBuilder
+    private func segment(_ mode: NightwatchMode) -> some View {
+        let isActive = NightwatchModePresentation.isActive(
+            segment: mode, current: appState.nightwatchMode)
+        Button {
+            Task { @MainActor in
+                await appState.setNightwatchMode(mode)
+            }
+        } label: {
+            Text(NightwatchModePresentation.glyphLabel(mode))
+                .font(.system(size: 11, weight: isActive ? .semibold : .regular))
+                .foregroundStyle(isActive ? Color.accentColor : Color.secondary)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 3)
+                .contentShape(Rectangle())
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(isActive ? Color.accentColor.opacity(0.14) : Color.clear)
+                        .padding(1)
+                )
+        }
+        .buttonStyle(.plain)
+        .help(NightwatchModePresentation.help(mode))
+        .accessibilityLabel(NightwatchModePresentation.glyphLabel(mode))
+        .accessibilityAddTraits(isActive ? [.isSelected] : [])
+    }
+}

--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -6,6 +6,7 @@ struct SidebarView: View {
     @EnvironmentObject var appState: AppState
     @AppStorage("sidebar.showHiddenRepos") private var showHiddenRepos: Bool = false
     @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
+    @AppStorage(AppState.nightwatchExperimentalKey) private var nightwatchExperimental: Bool = false
 
     var filteredRepos: [Repo] {
         let base: [Repo]
@@ -54,10 +55,12 @@ struct SidebarView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
                 Divider()
-                NightwatchModeToggle()
-                    .padding(.horizontal, 12)
-                    .padding(.top, 8)
-                    .padding(.bottom, 6)
+                if nightwatchExperimental {
+                    NightwatchModeToggle()
+                        .padding(.horizontal, 12)
+                        .padding(.top, 8)
+                        .padding(.bottom, 6)
+                }
                 HStack(spacing: 4) {
                     Button(action: addRepo) {
                         Label("Add Repository", systemImage: "plus.rectangle")

--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -54,6 +54,10 @@ struct SidebarView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             VStack(spacing: 0) {
                 Divider()
+                NightwatchModeToggle()
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+                    .padding(.bottom, 6)
                 HStack(spacing: 4) {
                     Button(action: addRepo) {
                         Label("Add Repository", systemImage: "plus.rectangle")
@@ -65,7 +69,7 @@ struct SidebarView: View {
                     filterMenu
                 }
                 .padding(.horizontal, 12)
-                .padding(.vertical, 8)
+                .padding(.bottom, 8)
             }
             .background(.bar)
         }

--- a/Tests/TBDAppTests/NightwatchExperimentalGateTests.swift
+++ b/Tests/TBDAppTests/NightwatchExperimentalGateTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tests for the `nightwatchExperimentalEnabled` UserDefaults helper that gates
+/// the experimental Nightwatch / Daywatch feature. The sidebar mode control is
+/// hidden unless this opt-in is on, so the gate must fail closed.
+///
+/// Isolation matters: TBDApp ships as an unbundled SPM executable, so its
+/// `UserDefaults.standard` domain is the developer's live `TBDApp.plist`. Each
+/// test drives the helper through a per-test `UserDefaults(suiteName:)` so
+/// `.standard` is never touched (see AutoSuspendPreferenceTests for the full
+/// rationale).
+@MainActor
+@Suite("Nightwatch experimental gate")
+struct NightwatchExperimentalGateTests {
+    private let key = AppState.nightwatchExperimentalKey
+
+    private func withIsolatedDefaults(
+        seed: Bool?,
+        _ body: (UserDefaults) -> Void
+    ) {
+        let suiteName = "TBDAppTests.NightwatchExperimental.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        if let seed {
+            defaults.set(seed, forKey: key)
+        }
+        body(defaults)
+    }
+
+    @Test("enabled when the opt-in toggle is on")
+    func enabledWhenOn() {
+        withIsolatedDefaults(seed: true) { defaults in
+            #expect(AppState.nightwatchExperimentalEnabled(defaults: defaults) == true)
+        }
+    }
+
+    @Test("disabled when the toggle is explicitly off")
+    func disabledWhenOff() {
+        withIsolatedDefaults(seed: false) { defaults in
+            #expect(AppState.nightwatchExperimentalEnabled(defaults: defaults) == false)
+        }
+    }
+
+    @Test("defaults to false when never set — fail-closed, control stays hidden")
+    func defaultsToFalseWhenUnset() {
+        withIsolatedDefaults(seed: nil) { defaults in
+            #expect(AppState.nightwatchExperimentalEnabled(defaults: defaults) == false)
+        }
+    }
+}

--- a/Tests/TBDAppTests/NightwatchModeToggleTests.swift
+++ b/Tests/TBDAppTests/NightwatchModeToggleTests.swift
@@ -1,0 +1,72 @@
+import Testing
+
+@testable import TBDApp
+import TBDShared
+
+@Suite("NightwatchModePresentation")
+struct NightwatchModePresentationTests {
+    @Test func orderedCoversEveryModeInDisplayOrder() {
+        #expect(NightwatchModePresentation.ordered == [.off, .daywatch, .nightwatch])
+        // Guard against a new NightwatchMode case being added without a segment.
+        #expect(Set(NightwatchModePresentation.ordered) == Set(NightwatchMode.allCases))
+    }
+
+    @Test(arguments: [
+        (NightwatchMode.off, "Off"),
+        (.daywatch, "Day"),
+        (.nightwatch, "Night"),
+    ])
+    func labelPerMode(mode: NightwatchMode, expected: String) {
+        #expect(NightwatchModePresentation.label(mode) == expected)
+    }
+
+    @Test func glyphMatchesMenuBarVocabulary() {
+        #expect(NightwatchModePresentation.glyph(.off) == nil)
+        #expect(NightwatchModePresentation.glyph(.daywatch) == "◐")
+        #expect(NightwatchModePresentation.glyph(.nightwatch) == "🌙")
+    }
+
+    @Test func glyphLabelPrependsGlyphWhenPresent() {
+        #expect(NightwatchModePresentation.glyphLabel(.off) == "Off")
+        #expect(NightwatchModePresentation.glyphLabel(.daywatch) == "◐ Day")
+        #expect(NightwatchModePresentation.glyphLabel(.nightwatch) == "🌙 Night")
+    }
+
+    @Test func helpExplainsEachMode() {
+        #expect(NightwatchModePresentation.help(.off).contains("not watching"))
+        #expect(NightwatchModePresentation.help(.daywatch).contains("while you're around"))
+        #expect(NightwatchModePresentation.help(.nightwatch).contains("while you're away"))
+    }
+
+    /// The control highlights exactly the segment matching the active mode — for
+    /// each possible `nightwatchMode` value, only its own segment reads active.
+    @Test(arguments: NightwatchMode.allCases)
+    func exactlyOneSegmentActivePerMode(current: NightwatchMode) {
+        let active = NightwatchModePresentation.ordered.filter {
+            NightwatchModePresentation.isActive(segment: $0, current: current)
+        }
+        #expect(active == [current])
+    }
+}
+
+@Suite("NightwatchModeToggle tap -> setNightwatchMode(mode)")
+@MainActor
+struct NightwatchModeToggleTapTargetTests {
+    /// The toggle wires each segment's tap to `setNightwatchMode(mode)` where
+    /// `mode` is that segment's own `NightwatchMode`. `DaemonClient` is a
+    /// concrete actor with no injection seam (see ModelProfileAppStateTests), so
+    /// we can't observe the RPC directly; instead we lock in the tap-target
+    /// mapping the button closure forwards — segment i taps `ordered[i]`, and
+    /// the active-highlight (verified above) reflects that same mode afterward.
+    @Test func eachSegmentTapTargetsItsOwnMode() {
+        for mode in NightwatchModePresentation.ordered {
+            // The value the segment's button hands to setNightwatchMode is the
+            // segment's mode itself; after that call succeeds, isActive(current:)
+            // for that same mode must read true and no sibling may.
+            let active = NightwatchModePresentation.ordered.filter {
+                NightwatchModePresentation.isActive(segment: $0, current: mode)
+            }
+            #expect(active == [mode])
+        }
+    }
+}

--- a/Tests/TBDAppTests/NightwatchModeToggleTests.swift
+++ b/Tests/TBDAppTests/NightwatchModeToggleTests.swift
@@ -48,25 +48,3 @@ struct NightwatchModePresentationTests {
         #expect(active == [current])
     }
 }
-
-@Suite("NightwatchModeToggle tap -> setNightwatchMode(mode)")
-@MainActor
-struct NightwatchModeToggleTapTargetTests {
-    /// The toggle wires each segment's tap to `setNightwatchMode(mode)` where
-    /// `mode` is that segment's own `NightwatchMode`. `DaemonClient` is a
-    /// concrete actor with no injection seam (see ModelProfileAppStateTests), so
-    /// we can't observe the RPC directly; instead we lock in the tap-target
-    /// mapping the button closure forwards — segment i taps `ordered[i]`, and
-    /// the active-highlight (verified above) reflects that same mode afterward.
-    @Test func eachSegmentTapTargetsItsOwnMode() {
-        for mode in NightwatchModePresentation.ordered {
-            // The value the segment's button hands to setNightwatchMode is the
-            // segment's mode itself; after that call succeeds, isActive(current:)
-            // for that same mode must read true and no sibling may.
-            let active = NightwatchModePresentation.ordered.filter {
-                NightwatchModePresentation.isActive(segment: $0, current: mode)
-            }
-            #expect(active == [mode])
-        }
-    }
-}


### PR DESCRIPTION
Same-repo re-open of #354. Adds a three-state `Off | ◐ Day | 🌙 Night` control in the sidebar footer (active mode highlighted), gated behind a new "Nightwatch / Daywatch" toggle in Settings → Experimental (default off, fail-closed) with a tooltip explaining the evaluate-only feature. Sidebar control hidden until opted in.

Verified in the integration build + running live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)