### PR TITLE
Feat: Put Rename and Archive first in the worktree menu, group hibernation actions

### DIFF
--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -7,9 +7,9 @@ import TBDShared
 ///
 /// Pure composition on top of a small `Context` of live inputs the surfaces read
 /// from `AppState`. No AppKit, no SwiftUI: `role` is our own `ActionRole` and the
-/// view maps it to SwiftUI's `.destructive`. `items(worktree:context:)` is a pure
-/// function of its inputs, so the ordered structure both surfaces render is
-/// directly unit-testable without any `AppState`.
+/// view maps it to SwiftUI's `.destructive`. `items(context:includeSessionForks:)`
+/// is a pure function of its inputs, so the ordered structure both surfaces
+/// render is directly unit-testable without any `AppState`.
 ///
 /// The account section (per-session info + "Switch account") is intentionally
 /// NOT modeled here — it is contributed separately by `RowAccountMenu` and shown
@@ -21,9 +21,6 @@ enum RowActionMenu {
     /// Stable typed identity for each action, so the view can dispatch to the
     /// right side effect without stringly-typed matching on titles.
     enum Kind: Equatable {
-        case newClaudeTerminal
-        case newCodexTerminal
-        case newShellTerminal
         case rename
         case openInFinder
         case copyPath
@@ -159,6 +156,10 @@ enum RowActionMenu {
     static let promoteHint =
         "To promote: run `tbd scratch promote <dest>` from a session here"
     static let archiveNeedsChildrenGoneHelp = "Archive nested worktrees first"
+    /// Archive title when the row still has active nested children: the action
+    /// stays visible (and destructive-styled) but is disabled, and the title
+    /// itself explains why, since menu tooltips are easy to miss.
+    static let archiveHasChildrenLabel = "Archive (has children)"
     static let forkSessionLabel = "Fork session"
     static let newWorktreeFromBranchLabel = "New worktree from this branch…"
     static let hibernateNowLabel = "Hibernate now"
@@ -174,9 +175,21 @@ enum RowActionMenu {
 
     // MARK: - Composition
 
-    /// The ordered action list for a worktree row. Pure function of `context`;
-    /// the three branches map exactly to today's `SidebarContextMenu` branches
-    /// (scratch / main-or-creating / regular), preserving item order within each.
+    /// The ordered action list for a worktree row. Pure function of `context`,
+    /// with three branches (scratch / main-or-creating / regular). The regular
+    /// and scratch branches share a sectioned layout, top to bottom:
+    ///
+    /// 1. Identity — Rename, then Archive (destructive; disabled + retitled
+    ///    "Archive (has children)" for a regular row with active children).
+    /// 2. Hibernation — Wake / Hibernate now / keep-warm toggle (conditional).
+    /// 3. Sessions & spawning — per-session Fork entries, plus (regular only)
+    ///    Create Nested Worktree / New worktree from this branch.
+    /// 4. Filesystem — Open in Finder, Copy Path.
+    /// 5. (scratch only) Delete Scratch Space, with the promote-hint caption
+    ///    beneath it.
+    ///
+    /// Sections are joined with a single divider each; empty sections collapse,
+    /// so the list never renders doubled or dangling dividers.
     ///
     /// `includeSessionForks` controls whether per-session "Fork session" entries
     /// are part of this list. The right-click menu passes `true` (it has no
@@ -233,37 +246,42 @@ enum RowActionMenu {
         }
     }
 
+    /// Join non-empty sections with a single `.divider` between them. Empty
+    /// sections (e.g. no hibernation-eligible sessions, or forks excluded with
+    /// nothing else in that section) collapse entirely, so the rendered list
+    /// never shows doubled dividers or a leading/trailing one.
+    private static func joined(_ sections: [[Item]]) -> [Item] {
+        Array(sections.filter { !$0.isEmpty }.joined(separator: [Item.divider]))
+    }
+
     private static func scratchItems(context: Context, includeSessionForks: Bool) -> [Item] {
-        var items: [Item] = [
-            .action(Action(kind: .newClaudeTerminal, title: "New Claude Terminal")),
-            .action(Action(kind: .newCodexTerminal, title: "New Codex Terminal")),
-            .action(Action(kind: .newShellTerminal, title: "New Shell Terminal")),
-        ]
-        // Scratch spaces host Claude sessions too — same fork parity as the
-        // regular branch (right-click carries fork; the "…" menu's account
-        // section renders it instead).
-        if includeSessionForks {
-            items.append(contentsOf: forkActions(context: context).map(Item.action))
-        }
-        items.append(contentsOf: hibernationActions(context: context).map(Item.action))
-        items.append(contentsOf: [
-            .divider,
-            .action(Action(kind: .rename, title: "Rename...")),
-        ])
-        if !context.isPromoted {
-            items.append(.caption(promoteHint))
-        }
-        items.append(contentsOf: [
-            .divider,
-            .action(Action(kind: .openInFinder, title: "Open in Finder")),
-            .action(Action(kind: .copyPath, title: "Copy Path")),
-            .divider,
-            // `.destructive` for consistency with the repo-worktree Archive even
-            // though scratch archive is recoverable and leaves the folder on disk.
-            .action(Action(kind: .archiveScratch, title: "Archive", role: .destructive)),
+        // Trailing section: Delete stays last among the actions; the
+        // promote-hint caption sits beneath it as the menu's footnote.
+        var trailing: [Item] = [
             .action(Action(kind: .deleteScratch, title: "Delete Scratch Space", role: .destructive)),
+        ]
+        if !context.isPromoted {
+            trailing.append(.caption(promoteHint))
+        }
+        return joined([
+            [
+                .action(Action(kind: .rename, title: "Rename...")),
+                // `.destructive` for consistency with the repo-worktree Archive
+                // even though scratch archive is recoverable and leaves the
+                // folder on disk.
+                .action(Action(kind: .archiveScratch, title: "Archive", role: .destructive)),
+            ],
+            hibernationActions(context: context).map(Item.action),
+            // Scratch spaces host Claude sessions too — same fork parity as the
+            // regular branch (right-click carries fork; the "…" menu's account
+            // section renders it instead).
+            includeSessionForks ? forkActions(context: context).map(Item.action) : [],
+            [
+                .action(Action(kind: .openInFinder, title: "Open in Finder")),
+                .action(Action(kind: .copyPath, title: "Copy Path")),
+            ],
+            trailing,
         ])
-        return items
     }
 
     private static func mainItems(context: Context) -> [Item] {
@@ -277,36 +295,42 @@ enum RowActionMenu {
     }
 
     private static func regularItems(context: Context, includeSessionForks: Bool) -> [Item] {
-        var items: [Item] = [
-            .action(Action(kind: .rename, title: "Rename...")),
-        ]
-        items.append(contentsOf: hibernationActions(context: context).map(Item.action))
-        // Per-session fork — only in surfaces without an account section (the
-        // right-click menu). The "…" menu renders fork in its account section.
+        let archiveBlocked = context.hasActiveChildren
+
+        // Sessions & spawning: per-session fork (only in surfaces without an
+        // account section — the right-click menu; the "…" menu renders fork in
+        // its account section), then the nested-worktree creators.
+        var spawning: [Item] = []
         if includeSessionForks {
-            items.append(contentsOf: forkActions(context: context).map(Item.action))
+            spawning.append(contentsOf: forkActions(context: context).map(Item.action))
         }
-        // Scratch spaces have no repo, so nesting isn't offered for them.
+        // Nested-worktree creation is repo-only.
         if context.hasRepoID {
-            items.append(.action(Action(kind: .createNestedWorktree, title: "Create Nested Worktree")))
+            spawning.append(.action(Action(kind: .createNestedWorktree, title: "Create Nested Worktree")))
             // Base a child worktree on this worktree's current branch. Needs a
             // branch to check out — omitted when empty.
             if !context.branch.isEmpty {
-                items.append(.action(Action(kind: .newWorktreeFromBranch, title: newWorktreeFromBranchLabel)))
+                spawning.append(.action(Action(kind: .newWorktreeFromBranch, title: newWorktreeFromBranchLabel)))
             }
         }
-        items.append(.action(Action(
-            kind: .archive,
-            title: "Archive",
-            role: .destructive,
-            isEnabled: !context.hasActiveChildren,
-            disabledHelp: context.hasActiveChildren ? archiveNeedsChildrenGoneHelp : nil
-        )))
-        items.append(contentsOf: [
-            .divider,
-            .action(Action(kind: .openInFinder, title: "Open in Finder")),
-            .action(Action(kind: .copyPath, title: "Copy Path")),
+
+        return joined([
+            [
+                .action(Action(kind: .rename, title: "Rename...")),
+                .action(Action(
+                    kind: .archive,
+                    title: archiveBlocked ? archiveHasChildrenLabel : "Archive",
+                    role: .destructive,
+                    isEnabled: !archiveBlocked,
+                    disabledHelp: archiveBlocked ? archiveNeedsChildrenGoneHelp : nil
+                )),
+            ],
+            hibernationActions(context: context).map(Item.action),
+            spawning,
+            [
+                .action(Action(kind: .openInFinder, title: "Open in Finder")),
+                .action(Action(kind: .copyPath, title: "Copy Path")),
+            ],
         ])
-        return items
     }
 }

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -79,18 +79,6 @@ struct RowActionMenuActions {
     /// for row-action behavior.
     func run(_ kind: RowActionMenu.Kind) {
         switch kind {
-        case .newClaudeTerminal:
-            let wtID = worktree.id
-            Task { await appState.createClaudeTerminal(worktreeID: wtID) }
-
-        case .newCodexTerminal:
-            let wtID = worktree.id
-            Task { await appState.createCodexTerminal(worktreeID: wtID) }
-
-        case .newShellTerminal:
-            let wtID = worktree.id
-            Task { await appState.createTerminal(worktreeID: wtID) }
-
         case .rename:
             onRename()
 

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -27,25 +27,81 @@ private func session(_ label: String, profileID: UUID? = nil) -> RowActionMenu.C
     RowActionMenu.ClaudeSessionRef(terminalID: UUID(), profileID: profileID, label: label)
 }
 
+/// Indices of the dividers in `items` — for asserting section boundaries.
+private func dividerIndices(_ items: [RowActionMenu.Item]) -> [Int] {
+    items.enumerated().filter { $0.element == .divider }.map(\.offset)
+}
+
+/// Empty sections must collapse: no leading/trailing divider and never two in a row.
+private func expectWellFormedDividers(_ items: [RowActionMenu.Item]) {
+    #expect(items.first != .divider)
+    #expect(items.last != .divider)
+    for (a, b) in zip(items, items.dropFirst()) {
+        #expect(!(a == .divider && b == .divider))
+    }
+}
+
 // MARK: - Regular worktree branch
 
 @Suite("RowActionMenu — regular worktree")
 struct RowActionMenuRegularTests {
-    @Test func baseOrderMatchesLegacyContextMenu() {
-        // No Claude sessions, has repo, non-empty branch: rename → nested →
-        // fromBranch → archive → divider → finder → copy.
+    @Test func fullShapeWithAllSectionsPresent() {
+        // Every conditional on: rename/archive | hibernation | fork/nested |
+        // finder/copy — four sections, three dividers.
+        let s = session("Claude 1")
+        let ctx = RowActionMenu.Context(hasHibernatableClaude: true,
+                                        hasHibernatedClaude: true,
+                                        hasUnpinnedClaude: true,
+                                        hasKeepWarmClaude: true,
+                                        hasRepoID: true,
+                                        branch: "tbd/x",
+                                        claudeSessions: [s])
+        let items = RowActionMenu.items(context: ctx)
+        #expect(kinds(items) == [
+            .rename,
+            .archive,
+            .wakeHibernated,
+            .hibernateNow,
+            .toggleKeepWarm(enable: true),
+            .toggleKeepWarm(enable: false),
+            .forkSession(terminalID: s.terminalID, profileID: s.profileID),
+            .createNestedWorktree,
+            .newWorktreeFromBranch,
+            .openInFinder,
+            .copyPath,
+        ])
+        // Section boundaries: after archive, after the hibernation block, and
+        // after the fork/nested block.
+        #expect(dividerIndices(items) == [2, 7, 11])
+        expectWellFormedDividers(items)
+    }
+
+    @Test func emptyHibernationSectionCollapses() {
+        // No Claude sessions at all: the hibernation and fork sections are
+        // empty, so exactly two dividers remain — rename/archive | nested |
+        // finder/copy — with no doubled or dangling dividers.
         let ctx = RowActionMenu.Context(hasRepoID: true, branch: "tbd/x")
         let items = RowActionMenu.items(context: ctx)
         #expect(kinds(items) == [
             .rename,
+            .archive,
             .createNestedWorktree,
             .newWorktreeFromBranch,
-            .archive,
             .openInFinder,
             .copyPath,
         ])
-        // Divider sits between archive and Open in Finder.
-        #expect(items.contains(.divider))
+        #expect(dividerIndices(items) == [2, 5])
+        expectWellFormedDividers(items)
+    }
+
+    @Test func emptySpawningSectionCollapses() {
+        // No repo, no sessions, no hibernation: only the identity and
+        // filesystem sections remain, joined by a single divider.
+        let ctx = RowActionMenu.Context(hasRepoID: false, branch: "")
+        let items = RowActionMenu.items(context: ctx)
+        #expect(kinds(items) == [.rename, .archive, .openInFinder, .copyPath])
+        #expect(dividerIndices(items) == [2])
+        expectWellFormedDividers(items)
     }
 
     @Test func hibernateShownWhenHibernatableClaudePresent() {
@@ -74,21 +130,31 @@ struct RowActionMenuRegularTests {
         #expect(!ks.contains(.newWorktreeFromBranch))
     }
 
-    @Test func archiveDisabledWithHelpAndDestructiveWhenChildrenActive() {
+    @Test func archiveDisabledRetitledWithHelpWhenChildrenActive() {
         let ctx = RowActionMenu.Context(hasActiveChildren: true, hasRepoID: true, branch: "b")
         let archive = RowActionMenu.items(context: ctx)
             .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.title == RowActionMenu.archiveHasChildrenLabel)
+        #expect(archive?.title == "Archive (has children)")
         #expect(archive?.isEnabled == false)
         #expect(archive?.role == .destructive)
         #expect(archive?.disabledHelp == RowActionMenu.archiveNeedsChildrenGoneHelp)
     }
 
-    @Test func archiveEnabledWithNoHelpWhenNoChildren() {
+    @Test func archiveEnabledPlainTitleWhenNoChildren() {
         let ctx = RowActionMenu.Context(hasActiveChildren: false, hasRepoID: true, branch: "b")
         let archive = RowActionMenu.items(context: ctx)
             .compactMap(\.action).first { $0.kind == .archive }
+        #expect(archive?.title == "Archive")
         #expect(archive?.isEnabled == true)
         #expect(archive?.disabledHelp == nil)
+    }
+
+    @Test func includeSessionForksFalseExcludesForks() {
+        let s = session("Claude 1")
+        let ctx = RowActionMenu.Context(hasRepoID: true, branch: "b", claudeSessions: [s])
+        let ks = kinds(RowActionMenu.items(context: ctx, includeSessionForks: false))
+        #expect(!ks.contains { if case .forkSession = $0 { return true }; return false })
     }
 }
 
@@ -96,41 +162,83 @@ struct RowActionMenuRegularTests {
 
 @Suite("RowActionMenu — scratch")
 struct RowActionMenuScratchTests {
-    @Test func scratchOrderWithPromoteHint() {
+    @Test func fullShapeWithAllSectionsPresent() {
+        // Every conditional on: rename/archive | hibernation | fork |
+        // finder/copy | delete + promote hint — five sections, four dividers,
+        // Delete last among the actions and the caption at the very bottom.
+        let s = session("Claude 1")
+        let ctx = RowActionMenu.Context(hasHibernatableClaude: true,
+                                        hasHibernatedClaude: true,
+                                        hasUnpinnedClaude: true,
+                                        hasKeepWarmClaude: true,
+                                        isScratch: true,
+                                        isPromoted: false,
+                                        claudeSessions: [s])
+        let items = RowActionMenu.items(context: ctx)
+        #expect(kinds(items) == [
+            .rename,
+            .archiveScratch,
+            .wakeHibernated,
+            .hibernateNow,
+            .toggleKeepWarm(enable: true),
+            .toggleKeepWarm(enable: false),
+            .forkSession(terminalID: s.terminalID, profileID: s.profileID),
+            .openInFinder,
+            .copyPath,
+            .deleteScratch,
+        ])
+        #expect(dividerIndices(items) == [2, 7, 9, 12])
+        // Promote hint caption is the very last item, under Delete.
+        #expect(items.last == .caption(RowActionMenu.promoteHint))
+        #expect(kinds(items).last == .deleteScratch)
+        expectWellFormedDividers(items)
+    }
+
+    @Test func emptyMiddleSectionsCollapse() {
+        // No Claude sessions at all: hibernation and fork sections vanish, so
+        // the menu is rename/archive | finder/copy | delete(+caption) with
+        // exactly two dividers — never doubled.
         let ctx = RowActionMenu.Context(isScratch: true, isPromoted: false)
         let items = RowActionMenu.items(context: ctx)
         #expect(kinds(items) == [
-            .newClaudeTerminal,
-            .newCodexTerminal,
-            .newShellTerminal,
             .rename,
+            .archiveScratch,
             .openInFinder,
             .copyPath,
-            .archiveScratch,
             .deleteScratch,
         ])
-        // Promote hint caption present when not yet promoted.
-        #expect(items.contains(.caption(RowActionMenu.promoteHint)))
+        #expect(dividerIndices(items) == [2, 5])
+        #expect(items.last == .caption(RowActionMenu.promoteHint))
+        expectWellFormedDividers(items)
     }
 
     @Test func promoteHintOmittedWhenAlreadyPromoted() {
         let ctx = RowActionMenu.Context(isScratch: true, isPromoted: true)
-        #expect(!RowActionMenu.items(context: ctx).contains(.caption(RowActionMenu.promoteHint)))
+        let items = RowActionMenu.items(context: ctx)
+        #expect(!items.contains(.caption(RowActionMenu.promoteHint)))
+        // Delete then becomes the literal last item.
+        #expect(items.last?.actionKind == .deleteScratch)
     }
 
     @Test func scratchWithClaudeSessionGetsForkParityOnRightClickOnly() {
         // Scratch spaces host Claude sessions too: right-click carries the fork
-        // entries (after the New-Terminal trio); the "…" action block does not
-        // (its account section renders fork instead).
+        // entries (in the middle section); the "…" action block does not (its
+        // account section renders fork instead) — and the emptied fork section
+        // collapses without leaving doubled dividers.
         let s = session("Claude 1")
         let ctx = RowActionMenu.Context(isScratch: true, claudeSessions: [s])
         let rightClick = kinds(RowActionMenu.items(context: ctx, includeSessionForks: true))
-        #expect(rightClick.contains(.forkSession(terminalID: s.terminalID,
-                                                 profileID: s.profileID)))
-        #expect(rightClick[3] == .forkSession(terminalID: s.terminalID,
-                                              profileID: s.profileID))
-        let ellipsis = kinds(RowActionMenu.items(context: ctx, includeSessionForks: false))
-        #expect(!ellipsis.contains { if case .forkSession = $0 { return true }; return false })
+        #expect(rightClick == [
+            .rename,
+            .archiveScratch,
+            .forkSession(terminalID: s.terminalID, profileID: s.profileID),
+            .openInFinder,
+            .copyPath,
+            .deleteScratch,
+        ])
+        let ellipsisItems = RowActionMenu.items(context: ctx, includeSessionForks: false)
+        #expect(!kinds(ellipsisItems).contains { if case .forkSession = $0 { return true }; return false })
+        expectWellFormedDividers(ellipsisItems)
     }
 
     @Test func scratchArchiveAndDeleteAreDestructive() {


### PR DESCRIPTION
## Summary
- Reorders the worktree row action menu (right-click + hover "…" — both render from the shared `RowActionMenu` model): **Rename and Archive now lead**, followed by a divider-fenced **hibernation section** (Wake / Hibernate now / Keep warm / Allow hibernation), then session/spawning actions (Fork session, Create Nested Worktree, New worktree from this branch), then Open in Finder / Copy Path.
- When Archive is disabled because the worktree has active nested children, the item now explains itself inline: it's retitled **"Archive (has children)"** (tooltip kept) — menu tooltips are easy to miss.
- **Scratch spaces** drop the New Claude/Codex/Shell Terminal entries (terminals are created in-worktree via the + button) and follow the same layout; Delete Scratch Space stays last, with the promote hint as a footnote beneath it. The now-unreferenced `Kind.new*Terminal` cases and their dispatch code are deleted.
- Sections are composed as arrays joined by a helper that collapses empty ones, so menus never render doubled or dangling dividers (e.g. a scratch with no Claude sessions is just Rename/Archive | Finder/Copy | Delete).

## Test plan
- [ ] `swift test` — `RowActionMenuTests` updated to assert the new order and cover each conditional branch: archive disabled retitle, hibernation section present/absent, fork inclusion/exclusion per surface, scratch collapse with no sessions, promote-hint gating, main/creating rows unchanged
- [ ] Right-click a regular worktree row: Rename + Archive on top, hibernation actions in their own section
- [ ] Right-click a worktree with nested children: greyed "Archive (has children)"
- [ ] Right-click a scratch space: no terminal-creation entries; Delete Scratch Space last

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=D090F6CB-CFBA-43C1-A578-825D31FBE39A)