### PR TITLE
fix(ci): dedicated claude-named App token so sticky review comments work

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -80,16 +80,32 @@ jobs:
           rm -rf "$GITHUB_WORKSPACE/.github/workflows/claude-review-hooks"
           git checkout FETCH_HEAD -- .github/workflows/claude-review-hooks
 
+      - name: Mint reviewer app token
+        id: app-token
+        if: steps.trust.outputs.trusted == 'true'
+        # A dedicated GitHub App whose slug contains "claude" (e.g. tbd-claude-reviewer)
+        # so the action's sticky-comment matcher recognizes its own prior comment and
+        # updates it in place instead of posting a new one every run. The matcher keys
+        # on the Claude App id OR a "Bot" login containing "claude"
+        # (create-initial.ts) — github-actions[bot] matches neither, which is why the
+        # OIDC-fallback GITHUB_TOKEN produced duplicate comments. See docs/pr-review-gate.md.
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_REVIEWER_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_REVIEWER_APP_PRIVATE_KEY }}
+
       - name: Run Claude Code Review
         if: steps.trust.outputs.trusted == 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Use the Actions token for GitHub ops (sticky comment, gh CLI) instead of
-          # the OIDC->GitHub-App exchange, which 401s under pull_request_target
-          # (anthropics/claude-code-action#1017). Comments post as github-actions[bot].
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Post GitHub comments as the dedicated claude-named App (see the mint step
+          # above) so sticky-comment updating works across runs. We can't use the
+          # OIDC->Claude-App token here because that exchange 401s under
+          # pull_request_target (anthropics/claude-code-action#1017), and a plain
+          # GITHUB_TOKEN (github-actions[bot]) isn't recognized by the sticky matcher.
+          github_token: ${{ steps.app-token.outputs.token }}
           show_full_output: true
           use_sticky_comment: true
           track_progress: true

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -41,5 +41,16 @@ merge, after which every subsequent PR is gated normally.
 - The gate is **fail-closed on infrastructure**: if the Anthropic API is down or
   `CLAUDE_CODE_OAUTH_TOKEN` expires, trusted PRs block until it recovers. An admin
   can temporarily drop `claude-review` from the required contexts to override.
-- `github-actions[bot]` approvals do not count toward required reviews, which is
-  why the gate is a **status check** rather than a required-approval count.
+- Reviews post as a **dedicated GitHub App whose slug contains "claude"** (e.g.
+  `tbd-claude-reviewer[bot]`), minted per run via `actions/create-github-app-token`
+  from the `CLAUDE_REVIEWER_APP_ID` / `CLAUDE_REVIEWER_APP_PRIVATE_KEY` secrets. This
+  is required for **sticky comments** to work: the action's sticky-comment matcher
+  (`create-initial.ts`) only recognizes its own prior comment when the author id is
+  the Claude App *or* the author is a `Bot` whose login contains `claude` — and has
+  no config input to change that. A plain `GITHUB_TOKEN` (`github-actions[bot]`)
+  matches neither, so it posts a new comment every run. We can't use the OIDC→Claude
+  App token because that exchange 401s under `pull_request_target`
+  (anthropics/claude-code-action#1017), hence the dedicated App.
+- The gate is a **status check**, not a required-approval count. (The App's approval
+  *could* count toward required reviews if we ever want that, but the verdict-file
+  status check is what enforces High/Medium blocking today.)


### PR DESCRIPTION
## Why

Sticky comments broke when we moved off the Claude App (`claude[bot]`) to `GITHUB_TOKEN` (`github-actions[bot]`) to dodge the `pull_request_target` OIDC 401. Confirmed from the action's source (`create-initial.ts`): the sticky-comment matcher only recognizes its own prior comment when the author **id is the Claude App** *or* the author is a **Bot whose login contains `claude`** — and there's **no config input** to change it. `github-actions[bot]` matches neither, so it posts a fresh comment every run (5 duplicates on #364).

## Fix

Mirror what makes it work elsewhere: post as a **dedicated GitHub App whose slug contains `claude`** (e.g. `tbd-claude-reviewer[bot]`), minted per run via `actions/create-github-app-token@v2` and passed as `github_token`. The `login.includes("claude")` check then matches and sticky updating works across runs.

## ⚠️ Requires new secrets before merge

This won't run until these repo secrets exist (the mint step 401s otherwise):
- `CLAUDE_REVIEWER_APP_ID`
- `CLAUDE_REVIEWER_APP_PRIVATE_KEY`

**Do not merge until the App is created and both secrets are set.** Setup steps are in the PR discussion. This PR itself is reviewed by the *current* (GITHUB_TOKEN) workflow, so it can still go green.

[🧌 Require Claude Review](https://cheapsteak.github.io/tbd/open/?worktree=19C987C4-58D6-4264-A770-92A8470AA07F)