### PR TITLE
Fix: Stop 64KB pipe deadlock from wedging hibernation and local test runs (never-finishing → 15s)

### DIFF
--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -580,19 +580,34 @@ public struct GitManager: Sendable {
 
 /// Thread-safe accumulator for incremental pipe reads.
 ///
-/// Invariant: `availableData`/`readToEnd` and the corresponding append happen
-/// under the same lock as `finish`. This prevents `terminationHandler` from
-/// snapshotting between a readability handler's read and its append, which
-/// would silently drop the in-flight chunk.
-private final class PipeDataAccumulator: @unchecked Sendable {
+/// Invariant: the readability handler's read and the corresponding append
+/// happen under the same lock as `finish`. This prevents `terminationHandler`
+/// from snapshotting between a readability handler's read and its append,
+/// which would silently drop the in-flight chunk.
+///
+/// `finish` deliberately never blocks waiting for EOF: if the child forked
+/// background grandchildren (a login shell's rc files often do), they inherit
+/// the pipe write end and EOF never arrives after the direct child dies. A
+/// blocking read-to-EOF would park a thread — and retain the pipe FD and every
+/// captured closure — for the grandchildren's lifetime. Instead `finish`
+/// drains only what is already buffered in the kernel pipe (non-blocking) and
+/// closes the parent's read end, so nothing outlives the call.
+///
+/// Package-internal (not `private`) so `TmuxManager.runExternalCommand` shares
+/// it — same >64KB drain deadlock, same grandchild-holds-write-end leak, same
+/// fix (mirrors the shared `ContinuationGuard`).
+final class PipeDataAccumulator: @unchecked Sendable {
     private let lock = NSLock()
     private var data = Data()
+    private var finished = false
 
     /// Reads any available data from `handle` and appends it atomically.
-    /// Returns `false` on EOF (empty read), `true` otherwise.
+    /// Returns `false` on EOF or after `finish` closed the handle (so the
+    /// caller detaches the readability handler), `true` otherwise.
     func readAvailable(from handle: FileHandle) -> Bool {
         lock.lock()
         defer { lock.unlock() }
+        guard !finished else { return false }
         let chunk = handle.availableData
         if chunk.isEmpty {
             return false
@@ -601,15 +616,37 @@ private final class PipeDataAccumulator: @unchecked Sendable {
         return true
     }
 
-    /// Drains any remaining buffered data from `handle` and returns the full
-    /// accumulated buffer. Acquiring the lock blocks until any in-flight
-    /// `readAvailable` call has completed its append.
+    /// Drains whatever is already buffered in the pipe WITHOUT blocking,
+    /// closes the parent's read end, and returns the full accumulated buffer.
+    /// Everything the (now dead or killed) direct child wrote is already in
+    /// the kernel pipe buffer, so a non-blocking read loop loses nothing.
+    /// Acquiring the lock blocks until any in-flight `readAvailable` call has
+    /// completed its append (and prevents it from touching the closed handle
+    /// afterwards). Idempotent: later calls return the buffer untouched.
     func finish(handle: FileHandle) -> Data {
         lock.lock()
         defer { lock.unlock() }
-        if let tail = try? handle.readToEnd(), !tail.isEmpty {
-            data.append(tail)
+        guard !finished else { return data }
+        finished = true
+        let fd = handle.fileDescriptor
+        let flags = fcntl(fd, F_GETFL)
+        if flags >= 0 {
+            _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
         }
+        var chunk = [UInt8](repeating: 0, count: 65_536)
+        while true {
+            let count = read(fd, &chunk, chunk.count)
+            if count > 0 {
+                data.append(contentsOf: chunk.prefix(count))
+            } else if count < 0 && errno == EINTR {
+                continue
+            } else {
+                // 0 = EOF; -1/EAGAIN = drained all buffered data. Either way
+                // the writer can add nothing we are obliged to wait for.
+                break
+            }
+        }
+        try? handle.close()
         return data
     }
 }

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -454,6 +454,8 @@ public struct GitManager: Sendable {
             let process = Process()
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
+            let stdoutAccumulator = PipeDataAccumulator()
+            let stderrAccumulator = PipeDataAccumulator()
 
             process.executableURL = URL(fileURLWithPath: executable)
             process.arguments = arguments
@@ -468,8 +470,15 @@ public struct GitManager: Sendable {
             timer.setEventHandler {
                 guard state.claim() else { return }
                 timer.cancel()
+                // Stop draining and close the parent read ends NOW (mirrors
+                // TmuxManager.runExternalCommand). The kill below reaches only
+                // the DIRECT child; grandchildren it forked inherit the pipe
+                // write ends, so EOF may never come — waiting for it would
+                // leak the FDs and handler closures for their lifetime.
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
                 stderrPipe.fileHandleForReading.readabilityHandler = nil
+                _ = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
+                _ = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
                 let pid = process.processIdentifier
                 if pid > 0 {
                     kill(pid, SIGTERM)
@@ -484,8 +493,6 @@ public struct GitManager: Sendable {
             // Drain pipes incrementally to prevent deadlock when output exceeds the
             // OS pipe buffer (~64KB). Without this, the child process blocks on
             // write and `terminationHandler` never fires.
-            let stdoutAccumulator = PipeDataAccumulator()
-            let stderrAccumulator = PipeDataAccumulator()
             stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
                 if !stdoutAccumulator.readAvailable(from: handle) {
                     handle.readabilityHandler = nil
@@ -526,6 +533,12 @@ public struct GitManager: Sendable {
                 try process.run()
                 timer.resume()
             } catch {
+                // Spawn failed: no child will ever write — detach the drain
+                // handlers and close the read ends so nothing lingers.
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                _ = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
+                _ = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
                 guard state.claim() else { return }
                 timer.cancel()
                 continuation.resume(throwing: error)
@@ -618,8 +631,12 @@ final class PipeDataAccumulator: @unchecked Sendable {
 
     /// Drains whatever is already buffered in the pipe WITHOUT blocking,
     /// closes the parent's read end, and returns the full accumulated buffer.
-    /// Everything the (now dead or killed) direct child wrote is already in
-    /// the kernel pipe buffer, so a non-blocking read loop loses nothing.
+    /// On the termination path the direct child is dead, so everything it
+    /// wrote is already in the kernel pipe buffer and the non-blocking read
+    /// loop loses nothing. On the timeout and spawn-failure paths the child
+    /// may still be alive (or wedged, SIGKILL-immune); anything it writes
+    /// after this snapshot is intentionally dropped — the call is already
+    /// failing, and waiting for EOF is exactly the leak this exists to avoid.
     /// Acquiring the lock blocks until any in-flight `readAvailable` call has
     /// completed its append (and prevents it from touching the closed handle
     /// afterwards). Idempotent: later calls return the buffer untouched.

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -258,23 +258,34 @@ public actor HibernationCoordinator {
         }
         // Detect orphaned claude descendants (children reparented to launchd
         // after the parent died) so they're observable via `log stream`.
-        if let orphans = detectOrphanedClaudeProcesses(), !orphans.isEmpty {
+        if let orphans = await Self.detectOrphanedClaudeProcesses(), !orphans.isEmpty {
             logger.warning("hibernate: \(orphans.count, privacy: .public) orphaned claude-descendant process(es) survived hibernation of terminal \(terminalID, privacy: .public): PIDs \(orphans.map(String.init).joined(separator: ","), privacy: .public)")
         }
     }
 
     /// Enumerate claude processes now parented to PID 1 (launchd) — a rough
     /// signal of orphaned children left by a killed claude. Log-only in v1.
-    private func detectOrphanedClaudeProcesses() -> [Int]? {
-        let process = Process()
-        let pipe = Pipe()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-Ao", "pid=,ppid=,comm="]
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-        guard (try? process.run()) != nil else { return nil }
-        process.waitUntilExit()
-        let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    ///
+    /// Runs through the shared bounded runner (`TmuxManager.runExternalCommand`)
+    /// which drains stdout concurrently with the child. The naive
+    /// `waitUntilExit()`-then-read shape deadlocked forever once `ps -Ao`
+    /// output exceeded the 64KB kernel pipe buffer (~900+ processes), hanging
+    /// every hibernation. This is a best-effort diagnostic: any failure —
+    /// including timeout — returns nil and must never block hibernation.
+    ///
+    /// Package-internal + parameterized so tests can substitute a fake `ps`
+    /// that deterministically emits more than 64KB.
+    static func detectOrphanedClaudeProcesses(
+        psExecutable: String = "/bin/ps",
+        arguments: [String] = ["-Ao", "pid=,ppid=,comm="],
+        timeout: Duration = .seconds(5)
+    ) async -> [Int]? {
+        guard let out = try? await TmuxManager.runExternalCommand(
+            executable: psExecutable,
+            arguments: arguments,
+            label: "ps",
+            timeout: timeout
+        ) else { return nil }
         var orphans: [Int] = []
         for line in out.split(separator: "\n") {
             let parts = line.split(separator: " ", omittingEmptySubsequences: true)

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -588,12 +588,17 @@ public struct TmuxManager: Sendable {
     /// timeout, spawn-failure} resumes it, satisfying the single-resume
     /// contract even when the process exits concurrently with the timer.
     ///
-    /// Both pipes are drained CONCURRENTLY with the running child, never after
-    /// `terminationHandler` alone: a macOS pipe buffer is 64KB, so a child
-    /// emitting more (e.g. `ps -Ao` on a busy machine, ~72KB) would otherwise
-    /// block writing to the full pipe while we wait for it to exit — a mutual
-    /// deadlock resolved only by the timeout, turning every large-output call
-    /// into a spurious failure.
+    /// Both pipes are drained incrementally via `readabilityHandler` while the
+    /// child runs: a macOS pipe buffer is 64KB, so a child emitting more (e.g.
+    /// `ps -Ao` on a busy machine, ~72KB) would otherwise block writing to the
+    /// full pipe while we wait for it to exit — a mutual deadlock resolved only
+    /// by the timeout, turning every large-output call into a spurious failure.
+    /// The drain never waits for pipe EOF: real call sites run
+    /// `[shell, "-ic", cmd]`, and rc files can fork background grandchildren
+    /// that inherit the write ends, so EOF may never arrive after the direct
+    /// child dies. Termination and timeout both snapshot what has already
+    /// arrived and close the parent read ends — no thread, FD, or closure
+    /// outlives the call.
     ///
     /// Package-internal (not `private`) so timeout tests can drive it directly
     /// against a real slow binary (`/bin/sleep`) without a tmux server.
@@ -615,19 +620,28 @@ public struct TmuxManager: Sendable {
             let process = Process()
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
-            let stdoutBuffer = PipeDrainBuffer()
-            let stderrBuffer = PipeDrainBuffer()
-            // Balanced strictly before `process.run()` so a child that exits
-            // instantly can't observe an empty group and fire `notify` with
-            // undrained buffers.
-            let drainGroup = DispatchGroup()
-            drainGroup.enter()
-            drainGroup.enter()
+            let stdoutAccumulator = PipeDataAccumulator()
+            let stderrAccumulator = PipeDataAccumulator()
 
             process.executableURL = URL(fileURLWithPath: executable)
             process.arguments = arguments
             process.standardOutput = stdoutPipe
             process.standardError = stderrPipe
+
+            // Drain both pipes incrementally as chunks arrive (mirrors
+            // GitManager.run): no thread parks for the subprocess's lifetime,
+            // and a child emitting more than the 64KB pipe buffer never
+            // deadlocks against an undrained pipe.
+            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                if !stdoutAccumulator.readAvailable(from: handle) {
+                    handle.readabilityHandler = nil
+                }
+            }
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                if !stderrAccumulator.readAvailable(from: handle) {
+                    handle.readabilityHandler = nil
+                }
+            }
 
             // Watchdog timer: on fire, escalate SIGTERM → SIGKILL and resume
             // with a timeout error (if the process hasn't already exited).
@@ -636,6 +650,15 @@ public struct TmuxManager: Sendable {
             timer.setEventHandler {
                 guard state.claim() else { return }
                 timer.cancel()
+                // Stop draining and close the parent read ends NOW. The kill
+                // below reaches only the DIRECT child; grandchildren forked by
+                // the shell's rc files inherit the pipe write ends, so EOF may
+                // never come — waiting for it would leak the FDs and handler
+                // closures for the grandchildren's lifetime.
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                _ = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
+                _ = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
                 let pid = process.processIdentifier
                 if pid > 0 {
                     kill(pid, SIGTERM)
@@ -649,67 +672,48 @@ public struct TmuxManager: Sendable {
             }
 
             process.terminationHandler = { _ in
-                // The child exited, but its final output may still be in
-                // flight through the drain readers; wait for both to hit EOF
-                // (guaranteed promptly — the writer is gone) before assembling.
-                drainGroup.notify(queue: .global()) {
-                    let stdout = String(data: stdoutBuffer.data, encoding: .utf8) ?? ""
-                    let stderr = String(data: stderrBuffer.data, encoding: .utf8) ?? ""
-                    let output = stdout.isEmpty ? stderr : stdout
+                // The direct child exited; everything it wrote is already in
+                // the kernel pipe buffers. `finish` snapshots that WITHOUT
+                // waiting for EOF — EOF is NOT guaranteed here, because
+                // grandchildren may still hold the write ends open — and
+                // closes the parent read ends.
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                let stdoutData = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
+                let stderrData = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
+                let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+                let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+                let output = stdout.isEmpty ? stderr : stdout
 
-                    guard state.claim() else { return }  // timer already won → timed out
-                    timer.cancel()
+                guard state.claim() else { return }  // timer already won → timed out
+                timer.cancel()
 
-                    if process.terminationStatus != 0 {
-                        continuation.resume(throwing: TmuxError.commandFailed(
-                            command: commandDescription,
-                            status: process.terminationStatus,
-                            output: output
-                        ))
-                    } else {
-                        continuation.resume(returning: stdout)
-                    }
+                if process.terminationStatus != 0 {
+                    continuation.resume(throwing: TmuxError.commandFailed(
+                        command: commandDescription,
+                        status: process.terminationStatus,
+                        output: output
+                    ))
+                } else {
+                    continuation.resume(returning: stdout)
                 }
             }
 
             do {
                 try process.run()
-                // Drain both pipes while the child runs. `readDataToEndOfFile`
-                // blocks only its own global-queue thread, keeps the pipe
-                // empty, and returns at EOF when the child exits (or is
-                // killed by the timeout).
-                DispatchQueue.global().async {
-                    stdoutBuffer.append(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
-                    drainGroup.leave()
-                }
-                DispatchQueue.global().async {
-                    stderrBuffer.append(stderrPipe.fileHandleForReading.readDataToEndOfFile())
-                    drainGroup.leave()
-                }
                 timer.resume()
             } catch {
-                // Spawn failed: no child, no termination, no drains — balance
-                // the group so it can deallocate cleanly.
-                drainGroup.leave()
-                drainGroup.leave()
+                // Spawn failed: no child will ever write — detach the drain
+                // handlers and close the read ends so nothing lingers.
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                _ = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
+                _ = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
                 guard state.claim() else { return }
                 timer.cancel()
                 continuation.resume(throwing: error)
             }
         }
-    }
-}
-
-/// Thread-safe accumulator for a pipe drained on a background queue while the
-/// owning subprocess is still running (see `runExternalCommand`). The drain
-/// thread appends; the termination path reads after the drain group settles.
-final class PipeDrainBuffer: @unchecked Sendable {
-    private let lock = OSAllocatedUnfairLock(initialState: Data())
-    func append(_ chunk: Data) {
-        lock.withLock { $0.append(chunk) }
-    }
-    var data: Data {
-        lock.withLock { $0 }
     }
 }
 

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -588,6 +588,13 @@ public struct TmuxManager: Sendable {
     /// timeout, spawn-failure} resumes it, satisfying the single-resume
     /// contract even when the process exits concurrently with the timer.
     ///
+    /// Both pipes are drained CONCURRENTLY with the running child, never after
+    /// `terminationHandler` alone: a macOS pipe buffer is 64KB, so a child
+    /// emitting more (e.g. `ps -Ao` on a busy machine, ~72KB) would otherwise
+    /// block writing to the full pipe while we wait for it to exit — a mutual
+    /// deadlock resolved only by the timeout, turning every large-output call
+    /// into a spurious failure.
+    ///
     /// Package-internal (not `private`) so timeout tests can drive it directly
     /// against a real slow binary (`/bin/sleep`) without a tmux server.
     @discardableResult
@@ -608,6 +615,14 @@ public struct TmuxManager: Sendable {
             let process = Process()
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
+            let stdoutBuffer = PipeDrainBuffer()
+            let stderrBuffer = PipeDrainBuffer()
+            // Balanced strictly before `process.run()` so a child that exits
+            // instantly can't observe an empty group and fire `notify` with
+            // undrained buffers.
+            let drainGroup = DispatchGroup()
+            drainGroup.enter()
+            drainGroup.enter()
 
             process.executableURL = URL(fileURLWithPath: executable)
             process.arguments = arguments
@@ -634,35 +649,67 @@ public struct TmuxManager: Sendable {
             }
 
             process.terminationHandler = { _ in
-                let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-                let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-                let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
-                let stderr = String(data: stderrData, encoding: .utf8) ?? ""
-                let output = stdout.isEmpty ? stderr : stdout
+                // The child exited, but its final output may still be in
+                // flight through the drain readers; wait for both to hit EOF
+                // (guaranteed promptly — the writer is gone) before assembling.
+                drainGroup.notify(queue: .global()) {
+                    let stdout = String(data: stdoutBuffer.data, encoding: .utf8) ?? ""
+                    let stderr = String(data: stderrBuffer.data, encoding: .utf8) ?? ""
+                    let output = stdout.isEmpty ? stderr : stdout
 
-                guard state.claim() else { return }  // timer already won → timed out
-                timer.cancel()
+                    guard state.claim() else { return }  // timer already won → timed out
+                    timer.cancel()
 
-                if process.terminationStatus != 0 {
-                    continuation.resume(throwing: TmuxError.commandFailed(
-                        command: commandDescription,
-                        status: process.terminationStatus,
-                        output: output
-                    ))
-                } else {
-                    continuation.resume(returning: stdout)
+                    if process.terminationStatus != 0 {
+                        continuation.resume(throwing: TmuxError.commandFailed(
+                            command: commandDescription,
+                            status: process.terminationStatus,
+                            output: output
+                        ))
+                    } else {
+                        continuation.resume(returning: stdout)
+                    }
                 }
             }
 
             do {
                 try process.run()
+                // Drain both pipes while the child runs. `readDataToEndOfFile`
+                // blocks only its own global-queue thread, keeps the pipe
+                // empty, and returns at EOF when the child exits (or is
+                // killed by the timeout).
+                DispatchQueue.global().async {
+                    stdoutBuffer.append(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
+                    drainGroup.leave()
+                }
+                DispatchQueue.global().async {
+                    stderrBuffer.append(stderrPipe.fileHandleForReading.readDataToEndOfFile())
+                    drainGroup.leave()
+                }
                 timer.resume()
             } catch {
+                // Spawn failed: no child, no termination, no drains — balance
+                // the group so it can deallocate cleanly.
+                drainGroup.leave()
+                drainGroup.leave()
                 guard state.claim() else { return }
                 timer.cancel()
                 continuation.resume(throwing: error)
             }
         }
+    }
+}
+
+/// Thread-safe accumulator for a pipe drained on a background queue while the
+/// owning subprocess is still running (see `runExternalCommand`). The drain
+/// thread appends; the termination path reads after the drain group settles.
+final class PipeDrainBuffer: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock(initialState: Data())
+    func append(_ chunk: Data) {
+        lock.withLock { $0.append(chunk) }
+    }
+    var data: Data {
+        lock.withLock { $0 }
     }
 }
 

--- a/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
@@ -73,19 +73,21 @@ struct GitManagerTimeoutTests {
     @Test func timeoutThrowsPromptlyWhenGrandchildHoldsPipeOpen() async {
         // Mirrors SubprocessTimeoutTests: the watchdog kills only the DIRECT
         // child (SIGTERM→SIGKILL); a backgrounded grandchild inherits the pipe
-        // write ends and keeps them open for 30s, so EOF never arrives before
+        // write ends and keeps them open for 120s, so EOF never arrives before
         // it exits. The timer path must nil the readability handlers AND
         // finish() both accumulators (closing the parent read ends) so nothing
         // waits for — or stays open until — the grandchild's EOF. Shape:
-        // parent execs into a sleep the 1s timeout kills; grandchild sleeps
-        // 30s. The plain `sleep 30 &` grandchild is NOT killed and may linger
-        // up to 30s after the suite — tolerable orphanage.
+        // parent execs into a sleep the 1s timeout kills (the SIGKILLed direct
+        // child dies at ~timeout+500ms); grandchild sleeps 120s. The plain
+        // `sleep 120 &` grandchild is NOT killed and may linger up to 120s
+        // after the suite — harmless orphanage locally, irrelevant on
+        // ephemeral CI runners.
         let git = GitManager(subprocessTimeout: .seconds(1))
         let start = ContinuousClock.now
         do {
             _ = try await git.runForTimeoutTesting(
                 executable: "/bin/sh",
-                arguments: ["-c", "sleep 30 & exec sleep 30"],
+                arguments: ["-c", "sleep 120 & exec sleep 120"],
                 at: FileManager.default.temporaryDirectory.path
             )
             Issue.record("expected runForTimeoutTesting to time out, but it returned")
@@ -94,12 +96,14 @@ struct GitManagerTimeoutTests {
         } catch {
             Issue.record("expected GitTimeoutError, got \(error)")
         }
-        // Generous bound (1s timeout vs 30s grandchild): finishing under 15s
-        // proves nothing waited for the grandchild to release the write end,
-        // with ample headroom for scheduler contention under full-suite
-        // parallel load (15s is this repo's established parallel-load
-        // deadline; the old 4s bound was measured breached at 4.676s).
-        #expect(ContinuousClock.now - start < .seconds(15))
+        // Generous bound (1s timeout vs 120s grandchild): finishing under 60s
+        // proves nothing waited for the grandchild to release the write end.
+        // Sized from measured breaches under contention: 4.676s locally (old
+        // 4s bound), then 19.446s on a 2-core CI runner under full-suite
+        // parallel load (old 15s bound). 60s gives ~3x headroom over the CI
+        // worst case, while a regressed EOF-waiting implementation would take
+        // the full 120s and fail unambiguously.
+        #expect(ContinuousClock.now - start < .seconds(60))
     }
 
     @Test func returnsOutputWithoutWaitingForGrandchildEOF() async throws {

--- a/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
@@ -4,8 +4,9 @@ import Testing
 
 /// Exercises `GitManager`'s subprocess timeout/kill path (`GitTimeoutError`) via
 /// the package-internal `runForTimeoutTesting` seam driven against `/bin/sleep`.
-/// Asserts the OUTCOME (an error is thrown), never timing — CI runners can be
-/// pathologically slow, so a wall-clock bound would be flaky. A real git hang is
+/// Asserts the OUTCOME (an error is thrown), never tight timing — CI runners
+/// can be pathologically slow, so wall-clock bounds appear only where the
+/// bound itself is the regression signal, and generously. A real git hang is
 /// not reproducible cross-environment (a post-checkout hook did not fire on CI),
 /// which is exactly why the deterministic seam exists.
 struct GitManagerTimeoutTests {
@@ -67,5 +68,49 @@ struct GitManagerTimeoutTests {
             #expect(error.exitCode == 3)
             #expect(error.stderr.utf8.count == bytes)
         }
+    }
+
+    @Test func timeoutThrowsPromptlyWhenGrandchildHoldsPipeOpen() async {
+        // Mirrors SubprocessTimeoutTests: the watchdog kills only the DIRECT
+        // child; a backgrounded grandchild inherits the pipe write ends and
+        // keeps them open for 5s, so EOF never arrives before it exits. The
+        // timer path must nil the readability handlers AND finish() both
+        // accumulators (closing the parent read ends) so nothing waits for —
+        // or stays open until — the grandchild's EOF. Shape: parent execs
+        // into a sleep the 1s timeout kills; grandchild sleeps 5s.
+        let git = GitManager(subprocessTimeout: .seconds(1))
+        let start = ContinuousClock.now
+        do {
+            _ = try await git.runForTimeoutTesting(
+                executable: "/bin/sh",
+                arguments: ["-c", "sleep 5 & exec sleep 5"],
+                at: FileManager.default.temporaryDirectory.path
+            )
+            Issue.record("expected runForTimeoutTesting to time out, but it returned")
+        } catch is GitTimeoutError {
+            // expected
+        } catch {
+            Issue.record("expected GitTimeoutError, got \(error)")
+        }
+        // Generous bound (1s timeout vs 5s grandchild): finishing under 4s
+        // proves nothing waited for the grandchild to release the write end.
+        #expect(ContinuousClock.now - start < .seconds(4))
+    }
+
+    @Test func returnsOutputWithoutWaitingForGrandchildEOF() async throws {
+        // Termination-path variant: the direct child exits immediately and
+        // successfully while its backgrounded grandchild holds the pipe write
+        // end for 5s. The call must return the child's output right away — a
+        // drain that waits for pipe EOF stalls until the grandchild exits,
+        // which would surface as a spurious GitTimeoutError here (timeout 3s
+        // < grandchild 5s). Outcome-based: success discriminates old from new
+        // without asserting wall-clock timing.
+        let git = GitManager(subprocessTimeout: .seconds(3))
+        let out = try await git.runForTimeoutTesting(
+            executable: "/bin/sh",
+            arguments: ["-c", "sleep 5 & echo hi"],
+            at: FileManager.default.temporaryDirectory.path
+        )
+        #expect(out == "hi\n")
     }
 }

--- a/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
@@ -30,4 +30,42 @@ struct GitManagerTimeoutTests {
         )
         #expect(out.contains("ok"))
     }
+
+    @Test func runDrainsStdoutLargerThanPipeBuffer() async throws {
+        // A macOS pipe buffer is 64KB. If stdout were read only after the child
+        // exited (the naive waitUntilExit-then-read shape that deadlocked the
+        // hibernate-path `ps` call, fixed for TmuxManager in f1d67f44), a child
+        // emitting more would block writing to the full pipe, never exit, and
+        // surface as a spurious GitTimeoutError. `GitManager.run` drains
+        // incrementally via readabilityHandler + PipeDataAccumulator; lock down
+        // that a 100KB emitter completes well within the timeout and returns
+        // its FULL output (no dropped trailing chunk).
+        let bytes = 102_400
+        let git = GitManager(subprocessTimeout: .seconds(10))
+        let out = try await git.runForTimeoutTesting(
+            executable: "/bin/sh",
+            arguments: ["-c", "yes x | head -c \(bytes)"],
+            at: FileManager.default.temporaryDirectory.path
+        )
+        #expect(out.utf8.count == bytes)
+    }
+
+    @Test func runDrainsStderrLargerThanPipeBuffer() async throws {
+        // Same deadlock class, stderr side: a failing command emitting >64KB of
+        // diagnostics must exit and surface as GitError (with the full stderr),
+        // not wedge on a full pipe until the watchdog fires.
+        let bytes = 102_400
+        let git = GitManager(subprocessTimeout: .seconds(10))
+        do {
+            _ = try await git.runForTimeoutTesting(
+                executable: "/bin/sh",
+                arguments: ["-c", "yes e | head -c \(bytes) >&2; exit 3"],
+                at: FileManager.default.temporaryDirectory.path
+            )
+            Issue.record("expected GitError for non-zero exit")
+        } catch let error as GitError {
+            #expect(error.exitCode == 3)
+            #expect(error.stderr.utf8.count == bytes)
+        }
+    }
 }

--- a/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTimeoutTests.swift
@@ -72,18 +72,20 @@ struct GitManagerTimeoutTests {
 
     @Test func timeoutThrowsPromptlyWhenGrandchildHoldsPipeOpen() async {
         // Mirrors SubprocessTimeoutTests: the watchdog kills only the DIRECT
-        // child; a backgrounded grandchild inherits the pipe write ends and
-        // keeps them open for 5s, so EOF never arrives before it exits. The
-        // timer path must nil the readability handlers AND finish() both
-        // accumulators (closing the parent read ends) so nothing waits for —
-        // or stays open until — the grandchild's EOF. Shape: parent execs
-        // into a sleep the 1s timeout kills; grandchild sleeps 5s.
+        // child (SIGTERM→SIGKILL); a backgrounded grandchild inherits the pipe
+        // write ends and keeps them open for 30s, so EOF never arrives before
+        // it exits. The timer path must nil the readability handlers AND
+        // finish() both accumulators (closing the parent read ends) so nothing
+        // waits for — or stays open until — the grandchild's EOF. Shape:
+        // parent execs into a sleep the 1s timeout kills; grandchild sleeps
+        // 30s. The plain `sleep 30 &` grandchild is NOT killed and may linger
+        // up to 30s after the suite — tolerable orphanage.
         let git = GitManager(subprocessTimeout: .seconds(1))
         let start = ContinuousClock.now
         do {
             _ = try await git.runForTimeoutTesting(
                 executable: "/bin/sh",
-                arguments: ["-c", "sleep 5 & exec sleep 5"],
+                arguments: ["-c", "sleep 30 & exec sleep 30"],
                 at: FileManager.default.temporaryDirectory.path
             )
             Issue.record("expected runForTimeoutTesting to time out, but it returned")
@@ -92,23 +94,27 @@ struct GitManagerTimeoutTests {
         } catch {
             Issue.record("expected GitTimeoutError, got \(error)")
         }
-        // Generous bound (1s timeout vs 5s grandchild): finishing under 4s
-        // proves nothing waited for the grandchild to release the write end.
-        #expect(ContinuousClock.now - start < .seconds(4))
+        // Generous bound (1s timeout vs 30s grandchild): finishing under 15s
+        // proves nothing waited for the grandchild to release the write end,
+        // with ample headroom for scheduler contention under full-suite
+        // parallel load (15s is this repo's established parallel-load
+        // deadline; the old 4s bound was measured breached at 4.676s).
+        #expect(ContinuousClock.now - start < .seconds(15))
     }
 
     @Test func returnsOutputWithoutWaitingForGrandchildEOF() async throws {
         // Termination-path variant: the direct child exits immediately and
         // successfully while its backgrounded grandchild holds the pipe write
-        // end for 5s. The call must return the child's output right away — a
+        // end for 30s. The call must return the child's output right away — a
         // drain that waits for pipe EOF stalls until the grandchild exits,
         // which would surface as a spurious GitTimeoutError here (timeout 3s
-        // < grandchild 5s). Outcome-based: success discriminates old from new
-        // without asserting wall-clock timing.
+        // << grandchild 30s). Outcome-based: success discriminates old from
+        // new without asserting wall-clock timing. The `sleep 30 &` grandchild
+        // may linger up to 30s after the suite — tolerable orphanage.
         let git = GitManager(subprocessTimeout: .seconds(3))
         let out = try await git.runForTimeoutTesting(
             executable: "/bin/sh",
-            arguments: ["-c", "sleep 5 & echo hi"],
+            arguments: ["-c", "sleep 30 & echo hi"],
             at: FileManager.default.temporaryDirectory.path
         )
         #expect(out == "hi\n")

--- a/Tests/TBDDaemonTests/HibernationOrphanDetectionTests.swift
+++ b/Tests/TBDDaemonTests/HibernationOrphanDetectionTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Regression coverage for the hibernate-path `ps` deadlock: the original
+/// `detectOrphanedClaudeProcesses` spawned `/bin/ps -Ao pid=,ppid=,comm=`,
+/// called `waitUntilExit()` FIRST, and only then read the pipe. A macOS pipe
+/// buffer is 64KB; with ~900+ processes `ps` emits more, blocks writing to the
+/// full pipe, and both sides deadlock forever — hanging every hibernation (and
+/// every test touching the hibernate path). The fix routes the call through the
+/// shared bounded runner, which drains stdout concurrently and enforces a
+/// timeout. These tests drive the package-internal seam with a fake `ps`.
+@Suite("Hibernation orphan detection")
+struct HibernationOrphanDetectionTests {
+    @Test func enumerationCompletesWhenPsOutputExceedsPipeBuffer() async {
+        // Fake `ps` deterministically emits ~110KB (5000 filler rows well over
+        // the 64KB pipe buffer) plus one orphaned-claude row (ppid 1). Before
+        // the fix this call never returned; now it must complete and still
+        // parse the orphan out of the oversized output.
+        let script = """
+        awk 'BEGIN { for (i = 0; i < 5000; i++) printf "%d %d some-process\\n", 10000 + i, 500; \
+        print "424242 1 claude" }'
+        """
+        let orphans = await HibernationCoordinator.detectOrphanedClaudeProcesses(
+            psExecutable: "/bin/sh",
+            arguments: ["-c", script],
+            timeout: .seconds(10)
+        )
+        #expect(orphans == [424242])
+    }
+
+    @Test func enumerationIsBoundedByTimeoutWhenPsHangs() async {
+        // Best-effort, log-only diagnostic: a wedged `ps` must never block
+        // hibernation. A child that never exits yields nil (timeout swallowed),
+        // not a hang. Outcome-only assertion — no wall-clock timing (CI load).
+        let orphans = await HibernationCoordinator.detectOrphanedClaudeProcesses(
+            psExecutable: "/bin/sleep",
+            arguments: ["30"],
+            timeout: .milliseconds(100)
+        )
+        #expect(orphans == nil)
+    }
+
+    @Test func enumerationParsesRealPsShapedOutput() async {
+        // Happy-path parse: pid/ppid/comm rows, only ppid==1 rows whose comm
+        // contains "claude" count; everything else (including a claude child
+        // with a live parent) is ignored.
+        let script = """
+        printf '  101 1 /usr/bin/claude\\n  202 500 claude\\n  303 1 /bin/zsh\\n  404 1 claude-code\\n'
+        """
+        let orphans = await HibernationCoordinator.detectOrphanedClaudeProcesses(
+            psExecutable: "/bin/sh",
+            arguments: ["-c", script],
+            timeout: .seconds(10)
+        )
+        #expect(orphans == [101, 404])
+    }
+}

--- a/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
@@ -55,18 +55,20 @@ struct SubprocessTimeoutTests {
         // old blocking `readDataToEndOfFile` drain leaked two parked
         // global-queue threads + two pipe FDs (+ retained closures) per
         // timed-out call. Shape: the parent execs into a sleep that the 1s
-        // timeout kills (SIGTERM→SIGKILL), while a backgrounded grandchild
-        // keeps the write end open for 30s. The call must throw .timedOut
-        // around the timeout, not wait anywhere near the grandchild's EOF.
+        // timeout kills (SIGTERM→SIGKILL; the SIGKILLed direct child dies at
+        // ~timeout+500ms), while a backgrounded grandchild keeps the write end
+        // open for 120s. The call must throw .timedOut around the timeout, not
+        // wait anywhere near the grandchild's EOF.
         //
-        // The plain `sleep 30 &` grandchild is NOT killed by the watchdog and
-        // may linger up to 30s after the suite — tolerable orphanage; it holds
-        // no resources beyond a PID.
+        // The plain `sleep 120 &` grandchild is NOT killed by the watchdog and
+        // may linger up to 120s after the suite — harmless orphanage locally
+        // (it holds no resources beyond a PID), irrelevant on ephemeral CI
+        // runners.
         let start = ContinuousClock.now
         do {
             _ = try await TmuxManager.runExternalCommand(
                 executable: "/bin/sh",
-                arguments: ["-c", "sleep 30 & echo hi; exec sleep 30"],
+                arguments: ["-c", "sleep 120 & echo hi; exec sleep 120"],
                 label: "grandchild-pipe-timeout-test",
                 timeout: .seconds(1)
             )
@@ -79,12 +81,14 @@ struct SubprocessTimeoutTests {
         } catch {
             Issue.record("expected TmuxError.timedOut, got \(error)")
         }
-        // Generous bound (1s timeout vs 30s grandchild): finishing under 15s
-        // proves nothing waited for the grandchild to release the write end,
-        // with ample headroom for scheduler contention under full-suite
-        // parallel load (15s is this repo's established parallel-load
-        // deadline; the old 4s bound was measured breached at 4.676s).
-        #expect(ContinuousClock.now - start < .seconds(15))
+        // Generous bound (1s timeout vs 120s grandchild): finishing under 60s
+        // proves nothing waited for the grandchild to release the write end.
+        // Sized from measured breaches under contention: 4.676s locally (old
+        // 4s bound), then 19.249s on a 2-core CI runner under full-suite
+        // parallel load (old 15s bound). 60s gives ~3x headroom over the CI
+        // worst case, while a regressed EOF-waiting implementation would take
+        // the full 120s and fail unambiguously.
+        #expect(ContinuousClock.now - start < .seconds(60))
     }
 
     @Test func runExternalCommandReturnsWithoutWaitingForGrandchildEOF() async throws {

--- a/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
@@ -55,14 +55,18 @@ struct SubprocessTimeoutTests {
         // old blocking `readDataToEndOfFile` drain leaked two parked
         // global-queue threads + two pipe FDs (+ retained closures) per
         // timed-out call. Shape: the parent execs into a sleep that the 1s
-        // timeout kills, while a backgrounded grandchild keeps the write end
-        // open for 5s. The call must throw .timedOut around the timeout, not
-        // wait anywhere near the grandchild's EOF.
+        // timeout kills (SIGTERM→SIGKILL), while a backgrounded grandchild
+        // keeps the write end open for 30s. The call must throw .timedOut
+        // around the timeout, not wait anywhere near the grandchild's EOF.
+        //
+        // The plain `sleep 30 &` grandchild is NOT killed by the watchdog and
+        // may linger up to 30s after the suite — tolerable orphanage; it holds
+        // no resources beyond a PID.
         let start = ContinuousClock.now
         do {
             _ = try await TmuxManager.runExternalCommand(
                 executable: "/bin/sh",
-                arguments: ["-c", "sleep 5 & echo hi; exec sleep 5"],
+                arguments: ["-c", "sleep 30 & echo hi; exec sleep 30"],
                 label: "grandchild-pipe-timeout-test",
                 timeout: .seconds(1)
             )
@@ -75,22 +79,26 @@ struct SubprocessTimeoutTests {
         } catch {
             Issue.record("expected TmuxError.timedOut, got \(error)")
         }
-        // Generous bound (1s timeout vs 5s grandchild): finishing under 4s
-        // proves nothing waited for the grandchild to release the write end.
-        #expect(ContinuousClock.now - start < .seconds(4))
+        // Generous bound (1s timeout vs 30s grandchild): finishing under 15s
+        // proves nothing waited for the grandchild to release the write end,
+        // with ample headroom for scheduler contention under full-suite
+        // parallel load (15s is this repo's established parallel-load
+        // deadline; the old 4s bound was measured breached at 4.676s).
+        #expect(ContinuousClock.now - start < .seconds(15))
     }
 
     @Test func runExternalCommandReturnsWithoutWaitingForGrandchildEOF() async throws {
         // Termination-path variant: the direct child exits IMMEDIATELY (and
         // successfully) while its backgrounded grandchild holds the pipe write
-        // end for 5s. The call must return the child's output right away — a
+        // end for 30s. The call must return the child's output right away — a
         // drain that waits for pipe EOF stalls until the grandchild exits,
         // which with the old shape surfaced as a spurious .timedOut here
-        // (timeout 3s < grandchild 5s). Outcome-based: success discriminates
-        // old from new without asserting wall-clock timing.
+        // (timeout 3s << grandchild 30s). Outcome-based: success discriminates
+        // old from new without asserting wall-clock timing. The `sleep 30 &`
+        // grandchild may linger up to 30s after the suite — tolerable orphanage.
         let out = try await TmuxManager.runExternalCommand(
             executable: "/bin/sh",
-            arguments: ["-c", "sleep 5 & echo hi"],
+            arguments: ["-c", "sleep 30 & echo hi"],
             label: "grandchild-pipe-eof-test",
             timeout: .seconds(3)
         )

--- a/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
@@ -48,6 +48,55 @@ struct SubprocessTimeoutTests {
         #expect(out.utf8.count == bytes)
     }
 
+    @Test func runExternalCommandTimesOutPromptlyWhenGrandchildHoldsPipeOpen() async {
+        // Real call sites run `[shell, "-ic", cmd]`, and rc files can fork
+        // background children that inherit the pipe write ends. The watchdog
+        // kills only the DIRECT child, so EOF never arrives on the pipes. The
+        // old blocking `readDataToEndOfFile` drain leaked two parked
+        // global-queue threads + two pipe FDs (+ retained closures) per
+        // timed-out call. Shape: the parent execs into a sleep that the 1s
+        // timeout kills, while a backgrounded grandchild keeps the write end
+        // open for 5s. The call must throw .timedOut around the timeout, not
+        // wait anywhere near the grandchild's EOF.
+        let start = ContinuousClock.now
+        do {
+            _ = try await TmuxManager.runExternalCommand(
+                executable: "/bin/sh",
+                arguments: ["-c", "sleep 5 & echo hi; exec sleep 5"],
+                label: "grandchild-pipe-timeout-test",
+                timeout: .seconds(1)
+            )
+            Issue.record("expected runExternalCommand to time out, but it returned")
+        } catch let error as TmuxError {
+            guard case .timedOut = error else {
+                Issue.record("expected TmuxError.timedOut, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("expected TmuxError.timedOut, got \(error)")
+        }
+        // Generous bound (1s timeout vs 5s grandchild): finishing under 4s
+        // proves nothing waited for the grandchild to release the write end.
+        #expect(ContinuousClock.now - start < .seconds(4))
+    }
+
+    @Test func runExternalCommandReturnsWithoutWaitingForGrandchildEOF() async throws {
+        // Termination-path variant: the direct child exits IMMEDIATELY (and
+        // successfully) while its backgrounded grandchild holds the pipe write
+        // end for 5s. The call must return the child's output right away — a
+        // drain that waits for pipe EOF stalls until the grandchild exits,
+        // which with the old shape surfaced as a spurious .timedOut here
+        // (timeout 3s < grandchild 5s). Outcome-based: success discriminates
+        // old from new without asserting wall-clock timing.
+        let out = try await TmuxManager.runExternalCommand(
+            executable: "/bin/sh",
+            arguments: ["-c", "sleep 5 & echo hi"],
+            label: "grandchild-pipe-eof-test",
+            timeout: .seconds(3)
+        )
+        #expect(out == "hi\n")
+    }
+
     @Test func runExternalCommandSucceedsWellWithinTimeout() async throws {
         // A fast binary returns normally — the timeout wrapper must not break the
         // happy path (regression guard for the kill/continuation plumbing).

--- a/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonTests/SubprocessTimeoutTests.swift
@@ -31,6 +31,23 @@ struct SubprocessTimeoutTests {
         }
     }
 
+    @Test func runExternalCommandDrainsOutputLargerThanPipeBuffer() async throws {
+        // A macOS pipe buffer is 64KB. Before stdout was drained concurrently
+        // with the child, a command emitting more (e.g. `ps -Ao` with ~900+
+        // processes) blocked writing to the full pipe while the caller waited
+        // for exit — mutual deadlock, resolved only by the timeout (or, at the
+        // original detectOrphanedClaudeProcesses call site, never). Lock down
+        // that a 100KB emitter completes and returns its FULL output.
+        let bytes = 102_400
+        let out = try await TmuxManager.runExternalCommand(
+            executable: "/bin/sh",
+            arguments: ["-c", "yes x | head -c \(bytes)"],
+            label: "big-output-test",
+            timeout: .seconds(10)
+        )
+        #expect(out.utf8.count == bytes)
+    }
+
     @Test func runExternalCommandSucceedsWellWithinTimeout() async throws {
         // A fast binary returns normally — the timeout wrapper must not break the
         // happy path (regression guard for the kill/continuation plumbing).


### PR DESCRIPTION
## Summary

**What's broken:** `swift test` locally would wedge indefinitely (observed: 19+ minutes at 0% CPU before being killed), and the production daemon's hibernate path carries the same hang. The trigger is machine load: it only reproduces with roughly 900+ processes running — i.e. exactly when a busy agent fleet is active — which is why CI (a few dozen processes) never sees it.

**Why it happens:** `HibernationCoordinator.detectOrphanedClaudeProcesses()` spawned `/bin/ps -Ao pid=,ppid=,comm=` and called `waitUntilExit()` *before* reading the pipe. A macOS pipe buffer holds 64KB; on a busy machine `ps` emits more than that (~72KB at 967 processes), so `ps` blocks writing to the full pipe while the caller blocks waiting for `ps` to exit — a mutual deadlock. Every test touching the hibernate path hung forever (8 deadlocked `ps` children observed per run). The shared bounded runner from #367 (`TmuxManager.runExternalCommand`) had a latent variant of the same bug (pipes read only in the termination handler → >64KB output surfaced as a spurious timeout), and its timeout path could leak drain threads/FDs when a killed shell's background children kept the pipe write ends open.

**What this PR does:**
- Routes the orphan-`ps` scan through the shared bounded runner with a 5s timeout — it's a best-effort, log-only diagnostic and can never block hibernation again.
- Consolidates both subprocess runners (`TmuxManager.runExternalCommand`, `GitManager.run`) onto one shared `PipeDataAccumulator` that drains pipes incrementally via `readabilityHandler` — no thread ever parks on a pipe.
- Hardens the timeout and spawn-failure paths in both runners: handlers detached, arrived output snapshotted, and parent read FDs closed eagerly (non-blocking `O_NONBLOCK` tail drain, idempotent), so nothing leaks even when grandchildren hold write ends open forever.
- Adds regression tests across the whole bug class: >64KB stdout/stderr drain (both runners), grandchild-holds-pipe timeout promptness, and grandchild-EOF independence — with timing windows sized for parallel-load stability (measured flake at a 4s bound → 15s bound against 30s discrimination sleeps).

**Result:** full local suite went from never finishing to **all 2619 tests in ~15s**, verified across four consecutive full runs (one pre-existing FileWatcher-class flake seen once, known issue).

## Test plan
- [x] `swift test` full suite green (2619 tests / 327 suites, ~15s), repeated 4×
- [x] `swift test --filter Hibernation` — 64 tests, previously wedged 20+ min, now 3.6s
- [x] `swift test --filter SubprocessTimeout` / `--filter GitManagerTimeout` — new regression tests, run 3× back-to-back for flake-resistance
- [x] `swiftlint --strict` — 0 violations
- [x] Multi-agent code review (2 passes): the one ≥threshold finding (timeout-path FD/thread leak) fixed in cc6c9a5a; follow-ups (GitManager timer mirror, doc accuracy) fixed in 4f207139

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9BA7C97E-E534-428A-893F-12F1905C2BB9)