### PR TITLE
Fix: Stop promoted scratch spaces from losing their conversations (resume, subagents, and tmux panes now survive promotion)

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSessionScanner.swift
@@ -26,9 +26,14 @@ enum ClaudeProjectDirectory {
     static func resolve(worktreePath: String, projectsBase: URL? = nil) -> URL? {
         let base = projectsBase ?? URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent(".claude/projects")
+        // Key on BOTH the projects base and the worktree path: promote and the
+        // per-profile transcript sync resolve the same worktree path under
+        // different roots, and a path-only key would return the first root's
+        // hit for every subsequent root.
+        let cacheKey = base.path + "|" + worktreePath
 
         lock.lock()
-        if let cached = cache[worktreePath] {
+        if let cached = cache[cacheKey] {
             let now = ContinuousClock.now
             if let url = cached.url {
                 // Positive entry: re-validate against filesystem, then unlock + return
@@ -43,7 +48,7 @@ enum ClaudeProjectDirectory {
                     return nil
                 }
                 // Expired, fall through to re-resolve
-                cache.removeValue(forKey: worktreePath)
+                cache.removeValue(forKey: cacheKey)
             }
         }
         lock.unlock()
@@ -51,7 +56,7 @@ enum ClaudeProjectDirectory {
         let result = resolveUncached(worktreePath: worktreePath, projectsBase: base)
         let entry = CacheEntry(url: result, cachedAt: ContinuousClock.now)
         lock.lock()
-        cache[worktreePath] = entry
+        cache[cacheKey] = entry
         lock.unlock()
         return result
     }

--- a/Sources/TBDDaemon/Claude/TranscriptProjectDirSync.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptProjectDirSync.swift
@@ -1,0 +1,170 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "transcript-sync")
+
+/// Copy-if-newer synchronization of Claude session artifacts between
+/// `projects/<munged-cwd>/` directories.
+///
+/// `claude --resume <id>` is cwd-scoped: it only looks for
+/// `<projects-root>/<munged-current-cwd>/<id>.jsonl`. When a worktree's path
+/// changes after a session's transcript was written — scratch-space promotion
+/// moves the folder; the running session keeps appending to the transcript in
+/// the OLD munged directory — the resume lookup misses. This unit mirrors
+/// transcripts (and their `<id>/subagents/` companions) into the directory
+/// derived from the worktree's CURRENT path.
+///
+/// Invariants:
+/// - COPY, never move: live sessions keep appending to the original file, and
+///   `terminal.transcriptPath` for a live session is never rewritten.
+/// - Copy-if-newer: a destination file that is at least as fresh as the source
+///   is left intact, so a newer forked/rolled-over transcript at the
+///   destination is never clobbered by a stale snapshot.
+/// - Best-effort: all failures are logged and swallowed; callers treat sync as
+///   a freshness hint, not a precondition.
+enum TranscriptProjectDirSync {
+
+    // MARK: - Path derivation
+
+    /// The munged project directory for `worktreePath` under `projectsRoot`,
+    /// using Claude Code's exact encoding (`/` and `.` → `-`). Unlike
+    /// `ClaudeProjectDirectory.resolve`, this does NOT require the directory to
+    /// exist on disk — it names where the directory WOULD live, which is what a
+    /// sync destination needs.
+    static func derivedProjectDir(worktreePath: String, projectsRoot: URL) -> URL {
+        let munged = worktreePath.map { "/.".contains($0) ? "-" : String($0) }.joined()
+        return projectsRoot.appendingPathComponent(munged, isDirectory: true)
+    }
+
+    /// Projects root for a spawn's resolved profile config dir path. `nil` (an
+    /// ambient spawn) falls back to the ambient host claude dir (`~/.claude`,
+    /// honoring the `TBD_CLAUDE_HOST_HOME` test-isolation override). Handler
+    /// code on `RPCRouter` should prefer `claudeProjectsRoot(...)` which routes
+    /// through the router's injectable `configDirManager`.
+    static func projectsRoot(profileConfigDirPath: String?) -> URL {
+        if let path = profileConfigDirPath, !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true)
+                .appendingPathComponent("projects", isDirectory: true)
+        }
+        return ClaudeProfileConfigDirManager().ambientConfigDirectory
+            .appendingPathComponent("projects", isDirectory: true)
+    }
+
+    // MARK: - Copy-if-newer primitives
+
+    private static func modificationDate(_ path: String) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date
+    }
+
+    /// Copy `source` to `destination` unless the destination is already at
+    /// least as fresh (mtime >= source's). Never overwrites a newer or
+    /// equally-fresh destination. No-ops when source and destination resolve to
+    /// the same physical file (symlinked `projects/` roots). Returns true when
+    /// a copy actually happened.
+    @discardableResult
+    static func copyIfNewer(from source: URL, to destination: URL) -> Bool {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: source.path) else { return false }
+        let sourceReal = source.resolvingSymlinksInPath().standardizedFileURL.path
+        let destinationReal = destination.resolvingSymlinksInPath().standardizedFileURL.path
+        guard sourceReal != destinationReal else { return false }
+
+        if fm.fileExists(atPath: destination.path) {
+            let sourceDate = modificationDate(source.path) ?? .distantPast
+            let destinationDate = modificationDate(destination.path) ?? .distantPast
+            guard destinationDate < sourceDate else { return false }  // destination fresh — leave intact
+            do {
+                try fm.removeItem(at: destination)
+            } catch {
+                logger.warning("copyIfNewer: could not replace stale \(destination.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return false
+            }
+        } else {
+            try? fm.createDirectory(
+                at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        }
+        do {
+            try fm.copyItem(at: source, to: destination)
+            logger.debug("copyIfNewer: \(source.path, privacy: .public) -> \(destination.path, privacy: .public)")
+            return true
+        } catch {
+            logger.warning("copyIfNewer: copy failed \(source.path, privacy: .public) -> \(destination.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Recursively sync the CONTENTS of `sourceDir` into `destDir`: files are
+    /// copied with copy-if-newer semantics, subdirectories recurse. Missing or
+    /// non-directory sources are a no-op, as is a destination that resolves to
+    /// the same physical directory.
+    static func syncDirectoryContents(from sourceDir: URL, to destDir: URL) {
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: sourceDir.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else { return }
+        guard sourceDir.resolvingSymlinksInPath().standardizedFileURL.path
+                != destDir.resolvingSymlinksInPath().standardizedFileURL.path else { return }
+
+        let entries = (try? fm.contentsOfDirectory(
+            at: sourceDir, includingPropertiesForKeys: [.isDirectoryKey])) ?? []
+        for entry in entries {
+            let destination = destDir.appendingPathComponent(entry.lastPathComponent)
+            let values = try? entry.resourceValues(forKeys: [.isDirectoryKey])
+            if values?.isDirectory == true {
+                syncDirectoryContents(from: entry, to: destination)
+            } else {
+                copyIfNewer(from: entry, to: destination)
+            }
+        }
+    }
+
+    /// Sync one session's artifacts — the `<id>.jsonl` transcript plus its
+    /// sibling `<id>/subagents/` directory — into `destProjectDir`, each with
+    /// copy-if-newer semantics.
+    static func syncSession(jsonl source: URL, intoProjectDir destProjectDir: URL) {
+        let fileName = source.lastPathComponent                                 // <id>.jsonl
+        let sessionDirName = source.deletingPathExtension().lastPathComponent   // <id>
+        copyIfNewer(from: source, to: destProjectDir.appendingPathComponent(fileName))
+        let sourceSubagents = source.deletingLastPathComponent()
+            .appendingPathComponent(sessionDirName, isDirectory: true)
+            .appendingPathComponent("subagents", isDirectory: true)
+        let destSubagents = destProjectDir
+            .appendingPathComponent(sessionDirName, isDirectory: true)
+            .appendingPathComponent("subagents", isDirectory: true)
+        syncDirectoryContents(from: sourceSubagents, to: destSubagents)
+    }
+
+    /// Before a daemon-driven `claude --resume <sessionID>` spawn with cwd
+    /// `worktreePath`: ensure `<derived-project-dir>/<sessionID>.jsonl` exists
+    /// and is at least as fresh as the best-known source transcript; sync
+    /// (copy-if-newer) when it's missing or stale.
+    ///
+    /// The source is the stored `terminal.transcriptPath` when it still exists
+    /// on disk; otherwise the session file inside the project dir
+    /// `ClaudeProjectDirectory.resolve` finds for the same path (which, when it
+    /// IS the derived dir, makes this a no-op). With no source at all this is a
+    /// no-op — the resume simply starts fresh, exactly as before.
+    static func ensureSessionResumable(
+        sessionID: String,
+        worktreePath: String,
+        projectsRoot: URL,
+        storedTranscriptPath: String?
+    ) {
+        let fm = FileManager.default
+        let destDir = derivedProjectDir(worktreePath: worktreePath, projectsRoot: projectsRoot)
+
+        let source: URL?
+        if let path = storedTranscriptPath, !path.isEmpty, fm.fileExists(atPath: path) {
+            source = URL(fileURLWithPath: path)
+        } else if let resolved = ClaudeProjectDirectory.resolve(
+            worktreePath: worktreePath, projectsBase: projectsRoot
+        ) {
+            let candidate = resolved.appendingPathComponent("\(sessionID).jsonl")
+            source = fm.fileExists(atPath: candidate.path) ? candidate : nil
+        } else {
+            source = nil
+        }
+        guard let source else { return }
+        syncSession(jsonl: source, intoProjectDir: destDir)
+    }
+}

--- a/Sources/TBDDaemon/Claude/TranscriptProjectDirSync.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptProjectDirSync.swift
@@ -36,19 +36,12 @@ enum TranscriptProjectDirSync {
         return projectsRoot.appendingPathComponent(munged, isDirectory: true)
     }
 
-    /// Projects root for a spawn's resolved profile config dir path. `nil` (an
-    /// ambient spawn) falls back to the ambient host claude dir (`~/.claude`,
-    /// honoring the `TBD_CLAUDE_HOST_HOME` test-isolation override). Handler
-    /// code on `RPCRouter` should prefer `claudeProjectsRoot(...)` which routes
-    /// through the router's injectable `configDirManager`.
-    static func projectsRoot(profileConfigDirPath: String?) -> URL {
-        if let path = profileConfigDirPath, !path.isEmpty {
-            return URL(fileURLWithPath: path, isDirectory: true)
-                .appendingPathComponent("projects", isDirectory: true)
-        }
-        return ClaudeProfileConfigDirManager().ambientConfigDirectory
-            .appendingPathComponent("projects", isDirectory: true)
-    }
+    // NOTE: there is deliberately NO `projectsRoot(profileConfigDirPath:)`
+    // helper here. Its nil-profile fallback would have to construct a default
+    // `ClaudeProfileConfigDirManager()` — the real `~/.claude` — which tests
+    // cannot intercept. Callers (`RPCRouter`, `WorktreeLifecycle`,
+    // `HibernationCoordinator`) each expose `claudeProjectsRoot(...)` routed
+    // through their injectable `configDirManager` instead.
 
     // MARK: - Copy-if-newer primitives
 

--- a/Sources/TBDDaemon/Claude/TranscriptProjectDirSync.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptProjectDirSync.swift
@@ -134,16 +134,47 @@ enum TranscriptProjectDirSync {
         syncDirectoryContents(from: sourceSubagents, to: destSubagents)
     }
 
+    /// Locate `<sessionID>.jsonl` anywhere under `projectsRoot` — one shallow
+    /// pass over the munged project directories, `fileExists` per dir. Session
+    /// IDs are UUIDs, so any hit IS this session; when copy-if-newer snapshots
+    /// have left multiple copies, the newest mtime wins. Used as the last
+    /// resort by `ensureSessionResumable` when neither the stored transcript
+    /// path nor the current path's resolved project dir has the file — the
+    /// moved-while-archived case, where the transcript still sits under a slug
+    /// derived from a path that no longer exists.
+    static func locateSessionTranscript(sessionID: String, projectsRoot: URL) -> URL? {
+        let fm = FileManager.default
+        guard let dirs = try? fm.contentsOfDirectory(
+            at: projectsRoot, includingPropertiesForKeys: [.isDirectoryKey]) else { return nil }
+        var best: (url: URL, mtime: Date)?
+        for dir in dirs {
+            let values = try? dir.resourceValues(forKeys: [.isDirectoryKey])
+            guard values?.isDirectory == true else { continue }
+            let candidate = dir.appendingPathComponent("\(sessionID).jsonl")
+            guard fm.fileExists(atPath: candidate.path) else { continue }
+            let mtime = modificationDate(candidate.path) ?? .distantPast
+            if best == nil || mtime > best!.mtime {
+                best = (candidate, mtime)
+            }
+        }
+        return best?.url
+    }
+
     /// Before a daemon-driven `claude --resume <sessionID>` spawn with cwd
     /// `worktreePath`: ensure `<derived-project-dir>/<sessionID>.jsonl` exists
     /// and is at least as fresh as the best-known source transcript; sync
     /// (copy-if-newer) when it's missing or stale.
     ///
-    /// The source is the stored `terminal.transcriptPath` when it still exists
-    /// on disk; otherwise the session file inside the project dir
-    /// `ClaudeProjectDirectory.resolve` finds for the same path (which, when it
-    /// IS the derived dir, makes this a no-op). With no source at all this is a
-    /// no-op — the resume simply starts fresh, exactly as before.
+    /// Source resolution, in order:
+    /// 1. the stored `terminal.transcriptPath`, when it still exists on disk;
+    /// 2. the session file inside the project dir `ClaudeProjectDirectory
+    ///    .resolve` finds for the same path (which, when it IS the derived
+    ///    dir, makes this a no-op);
+    /// 3. a shallow by-session-ID scan across all of `projectsRoot`'s project
+    ///    dirs (`locateSessionTranscript`) — covers archived sessions whose
+    ///    worktree moved while no terminal row survived to store the path.
+    /// With no source at all this is a no-op — the resume simply starts fresh,
+    /// exactly as before.
     static func ensureSessionResumable(
         sessionID: String,
         worktreePath: String,
@@ -153,18 +184,59 @@ enum TranscriptProjectDirSync {
         let fm = FileManager.default
         let destDir = derivedProjectDir(worktreePath: worktreePath, projectsRoot: projectsRoot)
 
-        let source: URL?
+        var source: URL?
         if let path = storedTranscriptPath, !path.isEmpty, fm.fileExists(atPath: path) {
             source = URL(fileURLWithPath: path)
         } else if let resolved = ClaudeProjectDirectory.resolve(
             worktreePath: worktreePath, projectsBase: projectsRoot
-        ) {
-            let candidate = resolved.appendingPathComponent("\(sessionID).jsonl")
-            source = fm.fileExists(atPath: candidate.path) ? candidate : nil
+        ), fm.fileExists(atPath: resolved.appendingPathComponent("\(sessionID).jsonl").path) {
+            source = resolved.appendingPathComponent("\(sessionID).jsonl")
         } else {
-            source = nil
+            source = locateSessionTranscript(sessionID: sessionID, projectsRoot: projectsRoot)
         }
         guard let source else { return }
         syncSession(jsonl: source, intoProjectDir: destDir)
+    }
+
+    // MARK: - Off-executor variants
+
+    /// The synchronous entry points above do unbounded recursive filesystem
+    /// work. Callers running on an actor's serial executor (e.g.
+    /// `HibernationCoordinator.wake`) or inside RPC handler tasks must not
+    /// block their executor on that walk — this repo has shipped two
+    /// hang-class regressions from exactly this pattern. These wrappers hop
+    /// to a detached task; awaiting them preserves per-call ordering (the
+    /// sync completes before the dependent spawn) without monopolizing the
+    /// caller's executor.
+    static func ensureSessionResumableDetached(
+        sessionID: String,
+        worktreePath: String,
+        projectsRoot: URL,
+        storedTranscriptPath: String?
+    ) async {
+        await Task.detached {
+            ensureSessionResumable(
+                sessionID: sessionID,
+                worktreePath: worktreePath,
+                projectsRoot: projectsRoot,
+                storedTranscriptPath: storedTranscriptPath
+            )
+        }.value
+    }
+
+    /// Detached-task variant of `syncDirectoryContents` — see
+    /// `ensureSessionResumableDetached`.
+    static func syncDirectoryContentsDetached(from sourceDir: URL, to destDir: URL) async {
+        await Task.detached {
+            syncDirectoryContents(from: sourceDir, to: destDir)
+        }.value
+    }
+
+    /// Detached-task variant of `syncSession` — see
+    /// `ensureSessionResumableDetached`.
+    static func syncSessionDetached(jsonl source: URL, intoProjectDir destProjectDir: URL) async {
+        await Task.detached {
+            syncSession(jsonl: source, intoProjectDir: destProjectDir)
+        }.value
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -148,6 +148,20 @@ public struct TerminalStore: Sendable {
         }
     }
 
+    /// Re-parent every terminal from one worktree to another in a single
+    /// UPDATE. DB-only: tmux windows and the processes inside them are left
+    /// completely untouched, so this is safe to run while sessions are live —
+    /// scratch-promote uses it to move a promoted scratch space's terminals
+    /// onto the new repo's main worktree row.
+    public func reparentTerminals(from oldWorktreeID: UUID, to newWorktreeID: UUID) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE terminal SET worktreeID = ? WHERE worktreeID = ?",
+                arguments: [newWorktreeID.uuidString, oldWorktreeID.uuidString]
+            )
+        }
+    }
+
     /// Delete all terminals for a worktree.
     public func deleteForWorktree(worktreeID: UUID) async throws {
         _ = try await writer.write { db in

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -166,20 +166,6 @@ public struct TerminalStore: Sendable {
         }
     }
 
-    /// Re-parent every terminal from one worktree to another in a single
-    /// UPDATE. DB-only: tmux windows and the processes inside them are left
-    /// completely untouched, so this is safe to run while sessions are live —
-    /// scratch-promote uses it to move a promoted scratch space's terminals
-    /// onto the new repo's main worktree row.
-    public func reparentTerminals(from oldWorktreeID: UUID, to newWorktreeID: UUID) async throws {
-        try await writer.write { db in
-            try db.execute(
-                sql: "UPDATE terminal SET worktreeID = ? WHERE worktreeID = ?",
-                arguments: [newWorktreeID.uuidString, oldWorktreeID.uuidString]
-            )
-        }
-    }
-
     /// Delete all terminals for a worktree.
     public func deleteForWorktree(worktreeID: UUID) async throws {
         _ = try await writer.write { db in

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -95,6 +95,19 @@ public struct TerminalStore: Sendable {
     /// the tmux window is spawned (so it can be injected as `TBD_TERMINAL_ID`
     /// in the spawned env, used by the SessionStart hook bridge) can pre-mint
     /// a UUID and pass it here. Defaults to a fresh UUID otherwise.
+    ///
+    /// Refuses (throws) when the parent worktree row is a PROMOTED scratch
+    /// row (archived + `promotedToRepoID`) — re-validated inside the same
+    /// write transaction as the insert, so a concurrent `scratch.promote`
+    /// (which retires the row atomically with its terminal migration) can
+    /// never race a new terminal row onto it. Such an orphan row would
+    /// parent a live session to a retired worktree whose sessions moved —
+    /// the SessionStart-hook foreign-session class. Plain archived rows are
+    /// NOT rejected here: the revive flow legitimately spawns terminals
+    /// while the row is still `.archived` (it flips `.active`/`.creating`
+    /// only after the spawn succeeds, for crash consistency); the RPC
+    /// handler rejects user-driven creates on archived rows before spawn.
+    /// Promoted rows have no such flow — they are never revived.
     public func create(
         id: UUID = UUID(),
         worktreeID: UUID,
@@ -117,6 +130,11 @@ public struct TerminalStore: Sendable {
         )
         let record = TerminalRecord(from: terminal)
         try await writer.write { db in
+            if let worktree = try WorktreeRecord.fetchOne(db, key: worktreeID.uuidString),
+               worktree.status == WorktreeStatus.archived.rawValue,
+               worktree.promotedToRepoID != nil {
+                throw DatabaseError(message: "Worktree \(worktreeID) was promoted to a repo; create the terminal on that repo's main worktree instead")
+            }
             try record.insert(db)
         }
         return terminal

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -735,6 +735,58 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// The entire scratch-promote row migration in ONE write transaction:
+    /// terminals re-parented, tab rows re-pointed, the main worktree inherits
+    /// the scratch tmux server + tab order/selection, and the scratch row is
+    /// retired (archived + `promotedToRepoID`). Any failure rolls the whole
+    /// thing back, leaving the pre-promote state intact — in particular the
+    /// scratch row stays un-promoted (retryable) and its terminals stay
+    /// parented to it, so a later `scratch.delete` can never tmux-kill live
+    /// windows that a half-migration left behind. DB-only: tmux windows and
+    /// the processes inside them are never touched — live sessions keep
+    /// running throughout. File copies (Claude project-dir snapshot) are the
+    /// caller's job, outside this transaction (idempotent copy-if-newer).
+    public func promoteScratchMigration(
+        scratchID: UUID,
+        mainWorktreeID: UUID,
+        repoID: UUID,
+        tmuxServer: String
+    ) async throws {
+        try await writer.write { db in
+            // Re-parent terminal + tab rows first, guards after: a missing row
+            // then exercises the rollback of these UPDATEs (and tests assert
+            // exactly that), rather than short-circuiting before any mutation.
+            try db.execute(
+                sql: "UPDATE terminal SET worktreeID = ? WHERE worktreeID = ?",
+                arguments: [mainWorktreeID.uuidString, scratchID.uuidString]
+            )
+            try db.execute(
+                sql: "UPDATE tab SET worktreeID = ? WHERE worktreeID = ?",
+                arguments: [mainWorktreeID.uuidString, scratchID.uuidString]
+            )
+            guard let scratch = try WorktreeRecord.fetchOne(db, key: scratchID.uuidString) else {
+                throw DatabaseError(message: "Scratch worktree not found: \(scratchID)")
+            }
+            guard var main = try WorktreeRecord.fetchOne(db, key: mainWorktreeID.uuidString) else {
+                throw DatabaseError(message: "Main worktree not found: \(mainWorktreeID)")
+            }
+            // Main worktree inherits the tmux server the live panes run on,
+            // plus the scratch row's tab order and selection.
+            main.tmuxServer = tmuxServer
+            main.tabOrder = scratch.tabOrder
+            main.activeTabID = scratch.activeTabID
+            try main.update(db)
+            // Retire the scratch row: archived + promotion pointer together,
+            // so nothing can resolve its stale path as active again and the
+            // skip-trash guard in scratch.delete sees the pointer atomically.
+            var retired = scratch
+            retired.status = WorktreeStatus.archived.rawValue
+            retired.archivedAt = Date()
+            retired.promotedToRepoID = repoID.uuidString
+            try retired.update(db)
+        }
+    }
+
     private static func decodeTabOrder(_ json: String) -> [UUID] {
         guard let data = json.data(using: .utf8) else { return [] }
         guard let strings = try? JSONDecoder().decode([String].self, from: data) else { return [] }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -712,29 +712,6 @@ public struct WorktreeStore: Sendable {
         }
     }
 
-    /// Move all tab state from one worktree row to another in one transaction:
-    /// re-points `tab` rows (the table has no FK to `worktree`; see TabStore's
-    /// cleanup note) and copies the source row's `tabOrder` + `activeTabID`
-    /// columns onto the destination row. Used by scratch-promote to carry tab
-    /// labels, order, and selection onto the new repo's main worktree. Lives
-    /// here rather than TabStore because `tabOrder`/`activeTabID` are worktree
-    /// columns and the `tab` UPDATE must ride the same transaction.
-    public func migrateTabState(from sourceWorktreeID: UUID, to destWorktreeID: UUID) async throws {
-        try await writer.write { db in
-            try db.execute(
-                sql: "UPDATE tab SET worktreeID = ? WHERE worktreeID = ?",
-                arguments: [destWorktreeID.uuidString, sourceWorktreeID.uuidString]
-            )
-            guard let source = try WorktreeRecord.fetchOne(db, key: sourceWorktreeID.uuidString),
-                  var dest = try WorktreeRecord.fetchOne(db, key: destWorktreeID.uuidString) else {
-                return
-            }
-            dest.tabOrder = source.tabOrder
-            dest.activeTabID = source.activeTabID
-            try dest.update(db)
-        }
-    }
-
     /// The entire scratch-promote row migration in ONE write transaction:
     /// terminals re-parented, tab rows re-pointed, the main worktree inherits
     /// the scratch tmux server + tab order/selection, and the scratch row is

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -712,6 +712,29 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// Move all tab state from one worktree row to another in one transaction:
+    /// re-points `tab` rows (the table has no FK to `worktree`; see TabStore's
+    /// cleanup note) and copies the source row's `tabOrder` + `activeTabID`
+    /// columns onto the destination row. Used by scratch-promote to carry tab
+    /// labels, order, and selection onto the new repo's main worktree. Lives
+    /// here rather than TabStore because `tabOrder`/`activeTabID` are worktree
+    /// columns and the `tab` UPDATE must ride the same transaction.
+    public func migrateTabState(from sourceWorktreeID: UUID, to destWorktreeID: UUID) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE tab SET worktreeID = ? WHERE worktreeID = ?",
+                arguments: [destWorktreeID.uuidString, sourceWorktreeID.uuidString]
+            )
+            guard let source = try WorktreeRecord.fetchOne(db, key: sourceWorktreeID.uuidString),
+                  var dest = try WorktreeRecord.fetchOne(db, key: destWorktreeID.uuidString) else {
+                return
+            }
+            dest.tabOrder = source.tabOrder
+            dest.activeTabID = source.activeTabID
+            try dest.update(db)
+        }
+    }
+
     private static func decodeTabOrder(_ json: String) -> [UUID] {
         guard let data = json.data(using: .utf8) else { return [] }
         guard let strings = try? JSONDecoder().decode([String].self, from: data) else { return [] }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -64,6 +64,10 @@ public actor HibernationCoordinator {
     private let detector: ClaudeStateDetector
     private let modelProfileResolver: ModelProfileResolver?
     private let subscriptions: StateSubscriptionManager?
+    /// Routes ambient claude-projects-root resolution for the wake transcript
+    /// sync — injectable (mirroring `RPCRouter.configDirManager`) so tests
+    /// point it at a temp dir instead of falling back to the real `~/.claude`.
+    private let configDirManager: ClaudeProfileConfigDirManager
     private let now: @Sendable () -> Date
 
     /// Per-terminal "first time we observed it idle-at-rest" marker, maintained
@@ -124,6 +128,7 @@ public actor HibernationCoordinator {
         tmux: TmuxManager,
         modelProfileResolver: ModelProfileResolver? = nil,
         subscriptions: StateSubscriptionManager? = nil,
+        configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.db = db
@@ -131,7 +136,23 @@ public actor HibernationCoordinator {
         self.detector = ClaudeStateDetector(tmux: tmux)
         self.modelProfileResolver = modelProfileResolver
         self.subscriptions = subscriptions
+        self.configDirManager = configDirManager
         self.now = now
+    }
+
+    /// Projects root for a wake spawn's resolved profile config dir path,
+    /// falling back to the coordinator's (injectable) ambient claude dir.
+    /// Mirrors `RPCRouter.claudeProjectsRoot(profileConfigDirPath:)`: unlike
+    /// `TranscriptProjectDirSync.projectsRoot`, whose nil-profile fallback
+    /// constructs a default manager (real `~/.claude`), this routes through
+    /// `configDirManager` so tests isolate via the injection seam.
+    private func claudeProjectsRoot(profileConfigDirPath: String?) -> URL {
+        if let path = profileConfigDirPath, !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true)
+                .appendingPathComponent("projects", isDirectory: true)
+        }
+        return configDirManager.ambientConfigDirectory
+            .appendingPathComponent("projects", isDirectory: true)
     }
 
     /// Wire the post-`ensureServer` hook (see `onServerCreated`). Set once by
@@ -415,8 +436,7 @@ public actor HibernationCoordinator {
         await TranscriptProjectDirSync.ensureSessionResumableDetached(
             sessionID: sessionID,
             worktreePath: worktree.path,
-            projectsRoot: TranscriptProjectDirSync.projectsRoot(
-                profileConfigDirPath: profileConfigDir),
+            projectsRoot: claudeProjectsRoot(profileConfigDirPath: profileConfigDir),
             storedTranscriptPath: terminal.transcriptPath
         )
         let spawn = ClaudeSpawnCommandBuilder.build(

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -347,6 +347,16 @@ public actor HibernationCoordinator {
         guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
             return .notFound
         }
+        // Never respawn into a missing directory: tmux's `-c` silently falls
+        // back to $HOME, and the resumed claude would neither find its session
+        // (resume is cwd-scoped) nor belong to this worktree. Leave the row
+        // parked so a retry after the path is restored can still wake it.
+        // (WakeResult's consumers switch exhaustively outside this change's
+        // scope, so reuse .notFound rather than adding a dedicated case.)
+        guard FileManager.default.fileExists(atPath: worktree.path) else {
+            logger.error("wake: worktree path missing on disk for terminal \(terminal.id, privacy: .public): \(worktree.path, privacy: .public) — refusing respawn (would fall back to $HOME)")
+            return .notFound
+        }
 
         wakesInFlight.insert(terminalID)
         defer { wakesInFlight.remove(terminalID) }
@@ -391,6 +401,20 @@ public actor HibernationCoordinator {
             fallbackModels: resolvedProfile?.fallbackModels,
             sessionKey: terminal.id.uuidString
         )
+        let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
+        // Pre-resume freshness: if the worktree was moved/promoted while this
+        // session was parked, its transcript still lives under the OLD munged
+        // project dir; the cwd-scoped `claude --resume` below only checks the
+        // dir derived from the CURRENT path. Mirror the jsonl (+ subagents)
+        // there first — copy-if-newer, best-effort, never rewrites the row's
+        // transcriptPath.
+        TranscriptProjectDirSync.ensureSessionResumable(
+            sessionID: sessionID,
+            worktreePath: worktree.path,
+            projectsRoot: TranscriptProjectDirSync.projectsRoot(
+                profileConfigDirPath: profileConfigDir),
+            storedTranscriptPath: terminal.transcriptPath
+        )
         let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: sessionID,
             freshSessionID: nil,
@@ -402,7 +426,7 @@ public actor HibernationCoordinator {
             profileModel: resolvedProfile?.model,
             profileAwsRegion: resolvedProfile?.awsRegion,
             profileAwsProfile: resolvedProfile?.awsProfile,
-            profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
+            profileConfigDir: profileConfigDir,
             cmd: nil,
             shellFallback: defaultShell,
             settingsOverlayPath: overlayPath,

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -21,6 +21,10 @@ public enum WakeResult: Equatable, Sendable {
     /// so a later retry can wake it; `reason` names the real failure instead
     /// of the misleading "Terminal not found".
     case respawnFailed(reason: String)
+    /// The worktree row exists but its directory is gone from disk — respawn
+    /// would silently land in $HOME. Carries the missing path so callers can
+    /// surface an actionable message instead of a generic "not found".
+    case worktreeMissing(path: String)
 }
 
 /// Owns session PARKING — the single unified "park a Claude session" feature
@@ -351,11 +355,9 @@ public actor HibernationCoordinator {
         // back to $HOME, and the resumed claude would neither find its session
         // (resume is cwd-scoped) nor belong to this worktree. Leave the row
         // parked so a retry after the path is restored can still wake it.
-        // (WakeResult's consumers switch exhaustively outside this change's
-        // scope, so reuse .notFound rather than adding a dedicated case.)
         guard FileManager.default.fileExists(atPath: worktree.path) else {
             logger.error("wake: worktree path missing on disk for terminal \(terminal.id, privacy: .public): \(worktree.path, privacy: .public) — refusing respawn (would fall back to $HOME)")
-            return .notFound
+            return .worktreeMissing(path: worktree.path)
         }
 
         wakesInFlight.insert(terminalID)
@@ -407,8 +409,10 @@ public actor HibernationCoordinator {
         // project dir; the cwd-scoped `claude --resume` below only checks the
         // dir derived from the CURRENT path. Mirror the jsonl (+ subagents)
         // there first — copy-if-newer, best-effort, never rewrites the row's
-        // transcriptPath.
-        TranscriptProjectDirSync.ensureSessionResumable(
+        // transcriptPath. Detached variant: the recursive copy must not run on
+        // this actor's serial executor; the await still completes before the
+        // respawn below.
+        await TranscriptProjectDirSync.ensureSessionResumableDetached(
             sessionID: sessionID,
             worktreePath: worktree.path,
             projectsRoot: TranscriptProjectDirSync.projectsRoot(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -530,8 +530,7 @@ extension WorktreeLifecycle {
                 await TranscriptProjectDirSync.ensureSessionResumableDetached(
                     sessionID: sessionUUID,
                     worktreePath: worktreePath,
-                    projectsRoot: TranscriptProjectDirSync.projectsRoot(
-                        profileConfigDirPath: profileConfigDir),
+                    projectsRoot: claudeProjectsRoot(profileConfigDirPath: profileConfigDir),
                     storedTranscriptPath: nil
                 )
             }
@@ -658,8 +657,7 @@ extension WorktreeLifecycle {
                 await TranscriptProjectDirSync.ensureSessionResumableDetached(
                     sessionID: sessionID,
                     worktreePath: worktreePath,
-                    projectsRoot: TranscriptProjectDirSync.projectsRoot(
-                        profileConfigDirPath: restoreProfileConfigDir),
+                    projectsRoot: claudeProjectsRoot(profileConfigDirPath: restoreProfileConfigDir),
                     storedTranscriptPath: nil
                 )
                 let spawn = ClaudeSpawnCommandBuilder.build(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -522,8 +522,12 @@ extension WorktreeLifecycle {
                 // project dir derived from the current cwd. If the archived
                 // session's transcript lives elsewhere (worktree moved or
                 // promoted since it was written), mirror it in first
-                // (copy-if-newer, best-effort).
-                TranscriptProjectDirSync.ensureSessionResumable(
+                // (copy-if-newer, best-effort). No stored transcript path
+                // survives archival (archive deletes terminal rows), so the
+                // sync falls back to locating the jsonl by session ID across
+                // the projects root. Detached: the copy is synchronous
+                // filesystem work; the await keeps it ordered before spawn.
+                await TranscriptProjectDirSync.ensureSessionResumableDetached(
                     sessionID: sessionUUID,
                     worktreePath: worktreePath,
                     projectsRoot: TranscriptProjectDirSync.projectsRoot(
@@ -651,7 +655,7 @@ extension WorktreeLifecycle {
                 createdTerminalIDs.append(plannedID)
                 let restoreProfileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
                 // Same pre-resume freshness sync as the primary terminal above.
-                TranscriptProjectDirSync.ensureSessionResumable(
+                await TranscriptProjectDirSync.ensureSessionResumableDetached(
                     sessionID: sessionID,
                     worktreePath: worktreePath,
                     projectsRoot: TranscriptProjectDirSync.projectsRoot(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -516,6 +516,21 @@ extension WorktreeLifecycle {
                     repo: repo, worktree: worktree, isResume: false,
                     scratchInstructions: config.scratchInstructions,
                     scratchRenamePrompt: config.scratchRenamePrompt)
+            let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
+            if isResume {
+                // Pre-resume freshness: `claude --resume` only looks in the
+                // project dir derived from the current cwd. If the archived
+                // session's transcript lives elsewhere (worktree moved or
+                // promoted since it was written), mirror it in first
+                // (copy-if-newer, best-effort).
+                TranscriptProjectDirSync.ensureSessionResumable(
+                    sessionID: sessionUUID,
+                    worktreePath: worktreePath,
+                    projectsRoot: TranscriptProjectDirSync.projectsRoot(
+                        profileConfigDirPath: profileConfigDir),
+                    storedTranscriptPath: nil
+                )
+            }
             let spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: isResume ? sessionUUID : nil,
                 freshSessionID: isResume ? nil : sessionUUID,
@@ -527,7 +542,7 @@ extension WorktreeLifecycle {
                 profileModel: resolvedProfile?.model,
                 profileAwsRegion: resolvedProfile?.awsRegion,
                 profileAwsProfile: resolvedProfile?.awsProfile,
-                profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
+                profileConfigDir: profileConfigDir,
                 cmd: nil,
                 shellFallback: defaultShell,
                 settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
@@ -634,6 +649,15 @@ extension WorktreeLifecycle {
             for sessionID in additionalArchivedClaudeSessions {
                 let plannedID = UUID()
                 createdTerminalIDs.append(plannedID)
+                let restoreProfileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
+                // Same pre-resume freshness sync as the primary terminal above.
+                TranscriptProjectDirSync.ensureSessionResumable(
+                    sessionID: sessionID,
+                    worktreePath: worktreePath,
+                    projectsRoot: TranscriptProjectDirSync.projectsRoot(
+                        profileConfigDirPath: restoreProfileConfigDir),
+                    storedTranscriptPath: nil
+                )
                 let spawn = ClaudeSpawnCommandBuilder.build(
                     resumeID: sessionID,
                     freshSessionID: nil,
@@ -645,7 +669,7 @@ extension WorktreeLifecycle {
                     profileModel: resolvedProfile?.model,
                     profileAwsRegion: resolvedProfile?.awsRegion,
                     profileAwsProfile: resolvedProfile?.awsProfile,
-                    profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile),
+                    profileConfigDir: restoreProfileConfigDir,
                     cmd: nil,
                     shellFallback: defaultShell,
                     settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -316,6 +316,20 @@ extension WorktreeLifecycle {
         let repoRows = try await db.worktrees.list(repoID: repoID)
         var referencedServers = Set(repoRows.map(\.tmuxServer))
         referencedServers.insert(correctTmuxServer)
+        // Also visit every server referenced by scratch rows (repoID nil,
+        // archived included — the retired promoted-scratch row is often the
+        // LAST pointer). Scratch spaces belong to no repo, so no per-repo
+        // visit set would otherwise ever include their shared server once the
+        // repo-side pointer is gone: `repo.remove` on a promoted repo
+        // hard-deletes its main worktree row (deleteForRepo) — the only repo
+        // row referencing the inherited scratch server — leaving that
+        // server, and the removed repo's still-running windows on it,
+        // reachable by no reconcile at all (#325-class leak). Folding scratch
+        // servers into every repo's reconcile makes whichever repo reconciles
+        // next sweep those orphans; the live-row checks below already span
+        // all repos + scratch spaces, so live scratch windows stay safe.
+        let scratchRows = try await db.worktrees.list(scratchOnly: true)
+        referencedServers.formUnion(scratchRows.map(\.tmuxServer))
         let globalLiveRows = try await db.worktrees.list(excludeArchived: true)
 
         for server in referencedServers.sorted() {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -251,7 +251,12 @@ extension WorktreeLifecycle {
                 serverAliveByName[wt.tmuxServer] = serverAlive
             }
             let terminals = try await db.terminals.list(worktreeID: wt.id)
-            for terminal in terminals where terminal.suspendedAt == nil {
+            // Parked rows (`hibernatedAt` OR legacy `suspendedAt` — see
+            // `isParked`) are skipped: a parked terminal's window being gone
+            // is expected (post-reboot), the row is already exactly what this
+            // pass would produce, and re-evaluating it would refresh the park
+            // timestamp or, worse, DELETE a parked non-Claude-resumable row.
+            for terminal in terminals where !terminal.isParked {
                 // After a reboot the server is gone, so every window is dead;
                 // otherwise probe the specific window. (Split across statements
                 // because `&&` builds an autoclosure that can't contain `await`.)
@@ -278,53 +283,78 @@ extension WorktreeLifecycle {
             }
         }
 
-        // Clean up orphaned tmux windows — windows not tracked by any terminal
-        // (active, main, or creating). `.creating` worktrees count as live: a
-        // pre-session hook wait that's still in flight (or just resumed by the
-        // startup recovery sweep) owns a real tmux window, and phase 3 spawns
-        // primary/setup windows before the row flips `.active`. Treating those
-        // rows as dead would kill the hook mid-run (interrupting e.g. a running
-        // npm install), fire a spurious `.paneKilled` notification, and spawn
-        // the agent prematurely.
-        let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
-        let activeWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
-        let mainWorktreesForCleanup = try await db.worktrees.list(repoID: repoID, status: .main)
-        let creatingWorktreesForCleanup = try await db.worktrees.list(repoID: repoID, status: .creating)
-        let allLiveWorktreesForCleanup = activeWorktrees + mainWorktreesForCleanup + creatingWorktreesForCleanup
-        if allLiveWorktreesForCleanup.isEmpty {
-            // No live worktrees (including `.creating` ones) — reap the
-            // server's agent processes first so a wedged one doesn't reparent
-            // to launchd, then kill the entire tmux server. A repo whose only
-            // live row is mid-pre-session must NOT land here, or the hook's
-            // window dies with the server.
-            await reaper.reapServerChildren(server: tmuxServer)
-            do {
-                try await tmux.killServer(server: tmuxServer)
-            } catch {
-                logger.warning("reconcile: failed to kill tmux server \(tmuxServer, privacy: .public): \(error, privacy: .public)")
-            }
-        } else {
-            // Collect all tracked window IDs (active + main + creating worktrees)
-            var trackedWindowIDs: Set<String> = []
-            for wt in allLiveWorktreesForCleanup {
-                let terminals = try await db.terminals.list(worktreeID: wt.id)
-                for t in terminals {
-                    trackedWindowIDs.insert(t.tmuxWindowID)
-                }
-            }
+        // Clean up orphaned tmux windows and dead servers. This must cover
+        // every server actually referenced by the repo's worktree rows, not
+        // just the canonical name for the repo path: a promoted scratch
+        // space's main worktree deliberately inherits the shared scratch
+        // server (see the self-heal caution above), and after such a worktree
+        // is archived its row is the only remaining pointer to that server —
+        // so archived rows are included when collecting servers to visit.
+        //
+        // A server can be SHARED beyond this repo: every scratch space runs
+        // on the one server derived from the scratch base dir, and a promoted
+        // repo's main worktree keeps using it. Both decisions below are
+        // therefore made against live rows across ALL repos and scratch
+        // spaces, not just this repo's:
+        //   - kill a server only when NO live worktree row anywhere still
+        //     references it (reaping its agent processes first so a wedged
+        //     one doesn't reparent to launchd);
+        //   - otherwise sweep only windows untracked by any live row on that
+        //     server, so other worktrees' live windows survive.
+        //
+        // "Live" includes `.creating`: a pre-session hook wait that's still
+        // in flight (or just resumed by the startup recovery sweep) owns a
+        // real tmux window, and phase 3 spawns primary/setup windows before
+        // the row flips `.active`. Treating those rows as dead would kill the
+        // hook mid-run (interrupting e.g. a running npm install), fire a
+        // spurious `.paneKilled` notification, and spawn the agent
+        // prematurely.
+        //
+        // For the canonical per-repo server — referenced by nothing outside
+        // this repo — this reduces to the previous behavior: killed when the
+        // repo has no live worktrees, orphan-swept otherwise.
+        let repoRows = try await db.worktrees.list(repoID: repoID)
+        var referencedServers = Set(repoRows.map(\.tmuxServer))
+        referencedServers.insert(correctTmuxServer)
+        let globalLiveRows = try await db.worktrees.list(excludeArchived: true)
 
-            // List actual tmux windows and kill any that aren't tracked
-            do {
-                let tmuxWindows = try await tmux.listWindows(server: tmuxServer, session: "main")
-                for window in tmuxWindows where !trackedWindowIDs.contains(window.windowID) {
-                    await killWindowAndReap(
-                        server: tmuxServer,
-                        windowID: window.windowID,
-                        paneID: window.paneID
-                    )
+        for server in referencedServers.sorted() {
+            let liveRowsOnServer = globalLiveRows.filter { $0.tmuxServer == server }
+            if liveRowsOnServer.isEmpty {
+                // Nothing references this server anymore. Skip silently when
+                // it isn't running (nothing to reap or kill — and archived
+                // rows keep pointing here forever, so this is the steady
+                // state on every later reconcile).
+                guard await tmux.serverExists(server: server) else { continue }
+                await reaper.reapServerChildren(server: server)
+                do {
+                    try await tmux.killServer(server: server)
+                } catch {
+                    logger.warning("reconcile: failed to kill tmux server \(server, privacy: .public): \(error, privacy: .public)")
                 }
-            } catch {
-                logger.warning("reconcile: failed to list tmux windows for server \(tmuxServer, privacy: .public): \(error, privacy: .public)")
+            } else {
+                // Collect window IDs tracked by ANY live worktree row on this
+                // server (all repos + scratch), then kill the untracked rest.
+                var trackedWindowIDs: Set<String> = []
+                for wt in liveRowsOnServer {
+                    let terminals = try await db.terminals.list(worktreeID: wt.id)
+                    for t in terminals {
+                        trackedWindowIDs.insert(t.tmuxWindowID)
+                    }
+                }
+
+                do {
+                    let tmuxWindows = try await tmux.listWindows(server: server, session: "main")
+                    for window in tmuxWindows where !trackedWindowIDs.contains(window.windowID) {
+                        await killWindowAndReap(
+                            server: server,
+                            windowID: window.windowID,
+                            paneID: window.paneID
+                        )
+                    }
+                } catch {
+                    logger.warning("reconcile: failed to list tmux windows for server \(server, privacy: .public): \(error, privacy: .public)")
+                }
             }
         }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -131,9 +131,22 @@ extension WorktreeLifecycle {
         let correctTmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
         var dbWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
 
-        // Fix stale tmux server names (e.g. after migration from UUID-based to path-based naming)
+        // Fix stale tmux server names (e.g. after migration from UUID-based to
+        // path-based naming). CAUTION: a non-canonical stored server is NOT
+        // automatically stale — a promoted scratch space's main worktree
+        // deliberately inherits the scratch tmux server its live sessions run
+        // on. Rewriting such a row would orphan those live windows: the next
+        // pass below probes the (empty) canonical server, concludes every
+        // window is dead, and parks/deletes terminals that are actually alive.
+        // So: canonicalize ONLY when the stored server has no live window for
+        // this worktree's terminals — the genuinely-stale case the self-heal
+        // was built for.
         let mainWorktrees = try await db.worktrees.list(repoID: repoID, status: .main)
         for wt in (dbWorktrees + mainWorktrees) where wt.tmuxServer != correctTmuxServer {
+            if await hasLiveWindow(server: wt.tmuxServer, worktreeID: wt.id) {
+                logger.info("reconcile: keeping non-canonical tmux server \(wt.tmuxServer, privacy: .public) for worktree \(wt.id, privacy: .public) — it has live windows (promoted-scratch inheritance)")
+                continue
+            }
             do {
                 try await db.worktrees.updateTmuxServer(id: wt.id, tmuxServer: correctTmuxServer)
             } catch {
@@ -223,8 +236,20 @@ extension WorktreeLifecycle {
         // Lazy recreate-on-demand keeps idle worktrees as cheap suspended rows.
         let allLiveWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
             + (try await db.worktrees.list(repoID: repoID, status: .main))
-        let serverAlive = await tmux.serverExists(server: correctTmuxServer)
+        // Probe the server each worktree row actually STORES, not the
+        // canonical name: after a scratch promote the main worktree's windows
+        // live on the inherited scratch server, and probing the canonical
+        // (empty) server would declare every live window dead. Cached per
+        // server name — rows overwhelmingly share one server.
+        var serverAliveByName: [String: Bool] = [:]
         for wt in allLiveWorktrees {
+            let serverAlive: Bool
+            if let cached = serverAliveByName[wt.tmuxServer] {
+                serverAlive = cached
+            } else {
+                serverAlive = await tmux.serverExists(server: wt.tmuxServer)
+                serverAliveByName[wt.tmuxServer] = serverAlive
+            }
             let terminals = try await db.terminals.list(worktreeID: wt.id)
             for terminal in terminals where terminal.suspendedAt == nil {
                 // After a reboot the server is gone, so every window is dead;
@@ -318,5 +343,21 @@ extension WorktreeLifecycle {
                 repoID: repo.id, path: repo.path, displayName: repo.displayName
             )))
         }
+    }
+
+    /// True when `server` is up AND hosts a live tmux window for at least one
+    /// of `worktreeID`'s terminal rows. Used by the stale-server self-heal to
+    /// distinguish a genuinely dead/renamed server (safe to canonicalize)
+    /// from a deliberately inherited one whose sessions are still running
+    /// (promoted scratch space). Early-exits on the first live window.
+    private func hasLiveWindow(server: String, worktreeID: UUID) async -> Bool {
+        guard await tmux.serverExists(server: server) else { return false }
+        let terminals = (try? await db.terminals.list(worktreeID: worktreeID)) ?? []
+        for terminal in terminals {
+            if await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -56,6 +56,11 @@ public struct WorktreeLifecycle: Sendable {
     public let subscriptions: StateSubscriptionManager?
     public let modelProfileResolver: ModelProfileResolver?
     public let pendingQuestions: PendingQuestionStore
+    /// Routes ambient claude-projects-root resolution for the revive
+    /// transcript sync — injectable (mirroring `RPCRouter.configDirManager`)
+    /// so tests point it at a temp dir instead of falling back to the real
+    /// `~/.claude`.
+    public let configDirManager: ClaudeProfileConfigDirManager
     /// How long to wait for a blocking `preSession` hook before giving up and
     /// spawning the primary terminals anyway. Injectable for tests.
     public let preSessionTimeout: TimeInterval
@@ -94,6 +99,7 @@ public struct WorktreeLifecycle: Sendable {
         subscriptions: StateSubscriptionManager? = nil,
         modelProfileResolver: ModelProfileResolver? = nil,
         pendingQuestions: PendingQuestionStore = PendingQuestionStore(),
+        configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager(),
         preSessionTimeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout,
         preSessionPollInterval: TimeInterval = 0.5,
         processSignaller: ProcessSignaller = ProductionProcessSignaller(),
@@ -107,12 +113,28 @@ public struct WorktreeLifecycle: Sendable {
         self.subscriptions = subscriptions
         self.modelProfileResolver = modelProfileResolver
         self.pendingQuestions = pendingQuestions
+        self.configDirManager = configDirManager
         self.controlMode = nil
         self.preSessionTimeout = preSessionTimeout
         self.preSessionPollInterval = preSessionPollInterval
         self.processSignaller = processSignaller
         self.reaperGraceAttempts = reaperGraceAttempts
         self.reaperPollInterval = reaperPollInterval
+    }
+
+    /// Projects root for a revive spawn's resolved profile config dir path,
+    /// falling back to the lifecycle's (injectable) ambient claude dir.
+    /// Mirrors `RPCRouter.claudeProjectsRoot(profileConfigDirPath:)`: unlike
+    /// `TranscriptProjectDirSync.projectsRoot`, whose nil-profile fallback
+    /// constructs a default manager (real `~/.claude`), this routes through
+    /// `configDirManager` so tests isolate via the injection seam.
+    func claudeProjectsRoot(profileConfigDirPath: String?) -> URL {
+        if let path = profileConfigDirPath, !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true)
+                .appendingPathComponent("projects", isDirectory: true)
+        }
+        return configDirManager.ambientConfigDirectory
+            .appendingPathComponent("projects", isDirectory: true)
     }
 
     /// The agent reaper composed from the injected tmux + signaller seams.

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -43,6 +43,8 @@ extension RPCRouter {
             // The terminal row exists — the tmux respawn/recreate failed.
             // Surface the real failure, never "Terminal not found".
             return RPCResponse(error: reason)
+        case .worktreeMissing(let path):
+            return RPCResponse(error: "Worktree directory missing on disk: \(path). Restore the directory (or relocate the repo), then retry — the session stays parked and resumable.")
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -52,6 +52,8 @@ extension RPCRouter {
             // The terminal row exists — the tmux respawn/recreate failed.
             // Surface the real failure, never "Terminal not found".
             return RPCResponse(error: reason)
+        case .worktreeMissing(let path):
+            return RPCResponse(error: "Worktree directory missing on disk: \(path). Restore the directory (or relocate the repo), then retry — the session stays parked and resumable.")
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -237,6 +237,7 @@ extension RPCRouter {
             // half-migrated state can leave `scratch.delete` free to tmux-kill
             // live un-reparented terminals.
             do {
+                if let failureHook = scratchPromoteMigrationFailureHook { try await failureHook() }
                 try await db.worktrees.promoteScratchMigration(
                     scratchID: wt.id,
                     mainWorktreeID: mainWorktree.id,
@@ -245,7 +246,38 @@ extension RPCRouter {
                 )
             } catch {
                 scratchLogger.error("scratch.promote: row migration failed for \(wt.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                return RPCResponse(error: "Registered \(dest) as a repo, but migrating the scratch space's sessions failed: \(error.localizedDescription). The scratch row and its terminals were left unchanged — live sessions keep running under the scratch space; the repo at \(dest) is registered and usable.")
+                // The migration transaction itself rolled back atomically (the
+                // scratch row is still active + un-promoted, terminals still
+                // parented to it — see promoteScratchMigration). But two non-DB
+                // side effects already happened: the folder moved to `dest` and
+                // addRepo registered it. Mirror the addRepo-failure branch
+                // above and undo both — otherwise a retry trips the
+                // "Destination already exists" guard against a half-promoted
+                // repo whose scratch row points at a dead path.
+                //
+                // Unregister first: addRepo created exactly a repo row plus its
+                // synthetic main worktree row, so tear down both (the same
+                // store calls handleRepoRemove uses) before touching the
+                // filesystem.
+                var unregisterError: (any Error)?
+                do {
+                    try await db.worktrees.deleteForRepo(repoID: repo.id)
+                    try await db.repos.remove(id: repo.id)
+                    subscriptions.broadcast(delta: .repoRemoved(RepoIDDelta(repoID: repo.id)))
+                } catch let repoRemoveError {
+                    unregisterError = repoRemoveError
+                    scratchLogger.error("scratch.promote: could not unregister repo \(repo.id, privacy: .public) after migration failure: \(repoRemoveError.localizedDescription, privacy: .public)")
+                }
+                let repoNote = unregisterError.map {
+                    " The repo registration at \(dest) could NOT be removed (\($0.localizedDescription)) — remove it manually with `tbd repo remove`."
+                } ?? " Unregistered the repo again."
+                do {
+                    try fm.moveItem(atPath: dest, toPath: wt.path)
+                    return RPCResponse(error: "Migrating the scratch space's sessions failed: \(error.localizedDescription).\(repoNote) Moved the folder back to \(wt.path); the scratch row and its terminals were left unchanged, so promoting again is safe.")
+                } catch let moveBackError {
+                    scratchLogger.error("scratch.promote: move-back failed after migration failure for \(wt.id, privacy: .public): \(moveBackError.localizedDescription, privacy: .public)")
+                    return RPCResponse(error: "Migrating the scratch space's sessions failed: \(error.localizedDescription).\(repoNote) The folder could NOT be moved back to \(wt.path) (\(moveBackError.localizedDescription)) — it currently still lives at \(dest); the scratch row was not marked promoted.")
+                }
             }
             // File copies stay OUTSIDE the transaction: idempotent
             // copy-if-newer snapshots, safe to redo and useless to roll back.

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -218,10 +218,77 @@ extension RPCRouter {
             }
         }
         try await db.worktrees.setPromotedToRepoID(id: wt.id, repoID: repo.id)
-        // .repoAdded (broadcast by addRepo) prompts the app to refresh state; the
-        // scratch row's promotedToRepoID surfaces on the next worktree poll.
+
+        // ---- Metadata migration (DB rows + project-dir snapshot only) ----
+        // The promote RPC is typically issued BY a live Claude session running
+        // in one of this scratch space's panes; the folder move above is a
+        // same-volume rename so those processes keep working. Everything below
+        // must therefore never suspend/kill/respawn a session and never
+        // rewrite a live terminal's transcriptPath — it only re-points DB rows
+        // and copies files.
+        let migratedTerminals = try await db.terminals.list(worktreeID: wt.id)
+        // addRepo just created the repo's main worktree; fetch it. Defensive
+        // guard only — addRepo unconditionally calls createMain, so the else
+        // branch is unreachable short of DB corruption.
+        if let mainWorktree = try await db.worktrees.list(repoID: repo.id, status: .main).first {
+            // Live panes live on the scratch tmux server — carry it over so
+            // they stay reachable from the new main worktree row. (Cosmetic
+            // that it's the shared scratch server; connectivity is what matters.)
+            try await db.worktrees.updateTmuxServer(id: mainWorktree.id, tmuxServer: wt.tmuxServer)
+            try await db.terminals.reparentTerminals(from: wt.id, to: mainWorktree.id)
+            try await db.worktrees.migrateTabState(from: wt.id, to: mainWorktree.id)
+            migrateClaudeProjectDirs(oldPath: wt.path, newPath: repo.path, terminals: migratedTerminals)
+
+            // Retire the scratch row: archived + promotedToRepoID (set above),
+            // so nothing can resolve its stale path as active again.
+            try await db.worktrees.archive(id: wt.id)
+
+            // .repoAdded was already broadcast by addRepo. Announce the moved
+            // terminals under their new worktree, then the scratch row's exit
+            // from the active section — same delta scratch.archive/delete use.
+            for terminal in migratedTerminals {
+                subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
+                    terminalID: terminal.id, worktreeID: mainWorktree.id, label: terminal.label)))
+            }
+            subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: wt.id)))
+        } else {
+            scratchLogger.error("scratch.promote: no main worktree found for repo \(repo.id, privacy: .public) — terminals left on scratch row \(wt.id, privacy: .public)")
+        }
+
         scratchLogger.info("scratch.promote: \(wt.id, privacy: .public) -> repo \(repo.id, privacy: .public) at \(dest, privacy: .public)")
         return try RPCResponse(result: ScratchPromoteResult(
             worktreeID: wt.id, repoID: repo.id, repoPath: repo.path, repoDisplayName: repo.displayName))
+    }
+
+    /// Snapshot the promoted scratch space's Claude project directories into
+    /// the new path's derived directories. For every projects root involved —
+    /// the ambient host claude dir plus each distinct terminal profile's config
+    /// dir — copy the OLD munged dir's contents (session JSONLs,
+    /// `<id>/subagents/`, `memory/`, …) into the NEW munged dir with
+    /// copy-if-newer semantics, so `claude --resume` under the new cwd finds
+    /// the conversations. Best-effort by design: live sessions keep appending
+    /// to their old transcript files, and the lazy Stop-hook / pre-resume sync
+    /// converges anything written after this snapshot.
+    private func migrateClaudeProjectDirs(oldPath: String, newPath: String, terminals: [Terminal]) {
+        var roots: [URL] = []
+        var seen = Set<String>()
+        func addRoot(_ url: URL) {
+            if seen.insert(url.standardizedFileURL.path).inserted { roots.append(url) }
+        }
+        addRoot(configDirManager.ambientConfigDirectory
+            .appendingPathComponent("projects", isDirectory: true))
+        for terminal in terminals {
+            guard let profileID = terminal.profileID else { continue }
+            addRoot(configDirManager.configDirectory(forProfileID: profileID)
+                .appendingPathComponent("projects", isDirectory: true))
+        }
+        for root in roots {
+            guard let oldDir = ClaudeProjectDirectory.resolve(
+                worktreePath: oldPath, projectsBase: root) else { continue }
+            let newDir = TranscriptProjectDirSync.derivedProjectDir(
+                worktreePath: newPath, projectsRoot: root)
+            TranscriptProjectDirSync.syncDirectoryContents(from: oldDir, to: newDir)
+            scratchLogger.info("scratch.promote: snapshotted Claude project dir \(oldDir.path, privacy: .public) -> \(newDir.path, privacy: .public)")
+        }
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -84,10 +84,10 @@ extension RPCRouter {
         try await closeScratchTerminals(wt)
 
         // Move the folder to Trash — never rm -rf. Promoted rows already had
-        // their folder moved by promotion, so skip when promotedToRepoID != nil.
-        // (promotedToRepoID is nil for every row today — Task 8 introduces
-        // `scratch promote`, which will start setting it — so this branch is
-        // currently dead but load-bearing once promotion lands.)
+        // their folder moved by promotion (handleScratchPromote sets
+        // promotedToRepoID when it retires the row), so skip the trash for
+        // them: `wt.path` now names the promoted repo's location and trashing
+        // it would delete the user's real repo.
         if wt.promotedToRepoID == nil, FileManager.default.fileExists(atPath: wt.path) {
             var resulting: NSURL?
             do {
@@ -217,8 +217,6 @@ extension RPCRouter {
                 return RPCResponse(error: "Failed to register \(dest) as a repo: \(error.localizedDescription). The folder could NOT be moved back to \(wt.path) (\(moveBackError.localizedDescription)) — it currently still lives at \(dest); the scratch row was not marked promoted.")
             }
         }
-        try await db.worktrees.setPromotedToRepoID(id: wt.id, repoID: repo.id)
-
         // ---- Metadata migration (DB rows + project-dir snapshot only) ----
         // The promote RPC is typically issued BY a live Claude session running
         // in one of this scratch space's panes; the folder move above is a
@@ -231,17 +229,28 @@ extension RPCRouter {
         // guard only — addRepo unconditionally calls createMain, so the else
         // branch is unreachable short of DB corruption.
         if let mainWorktree = try await db.worktrees.list(repoID: repo.id, status: .main).first {
-            // Live panes live on the scratch tmux server — carry it over so
-            // they stay reachable from the new main worktree row. (Cosmetic
-            // that it's the shared scratch server; connectivity is what matters.)
-            try await db.worktrees.updateTmuxServer(id: mainWorktree.id, tmuxServer: wt.tmuxServer)
-            try await db.terminals.reparentTerminals(from: wt.id, to: mainWorktree.id)
-            try await db.worktrees.migrateTabState(from: wt.id, to: mainWorktree.id)
-            migrateClaudeProjectDirs(oldPath: wt.path, newPath: repo.path, terminals: migratedTerminals)
-
-            // Retire the scratch row: archived + promotedToRepoID (set above),
-            // so nothing can resolve its stale path as active again.
-            try await db.worktrees.archive(id: wt.id)
+            // ALL row mutations in ONE transaction (terminals re-parented, tab
+            // state migrated, main worktree inheriting the scratch tmux server
+            // so the live panes stay reachable, scratch row retired with its
+            // promotion pointer). A mid-sequence failure rolls everything back
+            // — the scratch row stays un-promoted and retryable, and no
+            // half-migrated state can leave `scratch.delete` free to tmux-kill
+            // live un-reparented terminals.
+            do {
+                try await db.worktrees.promoteScratchMigration(
+                    scratchID: wt.id,
+                    mainWorktreeID: mainWorktree.id,
+                    repoID: repo.id,
+                    tmuxServer: wt.tmuxServer
+                )
+            } catch {
+                scratchLogger.error("scratch.promote: row migration failed for \(wt.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return RPCResponse(error: "Registered \(dest) as a repo, but migrating the scratch space's sessions failed: \(error.localizedDescription). The scratch row and its terminals were left unchanged — live sessions keep running under the scratch space; the repo at \(dest) is registered and usable.")
+            }
+            // File copies stay OUTSIDE the transaction: idempotent
+            // copy-if-newer snapshots, safe to redo and useless to roll back.
+            await migrateClaudeProjectDirs(
+                oldPath: wt.path, newPath: repo.path, terminals: migratedTerminals)
 
             // .repoAdded was already broadcast by addRepo. Announce the moved
             // terminals under their new worktree, then the scratch row's exit
@@ -252,6 +261,11 @@ extension RPCRouter {
             }
             subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: wt.id)))
         } else {
+            // Set the promotion pointer even though nothing migrated: the
+            // folder DID move and the repo IS registered, so the row must not
+            // be promotable again (and scratch.delete must not trash the
+            // moved folder).
+            try await db.worktrees.setPromotedToRepoID(id: wt.id, repoID: repo.id)
             scratchLogger.error("scratch.promote: no main worktree found for repo \(repo.id, privacy: .public) — terminals left on scratch row \(wt.id, privacy: .public)")
         }
 
@@ -269,7 +283,9 @@ extension RPCRouter {
     /// the conversations. Best-effort by design: live sessions keep appending
     /// to their old transcript files, and the lazy Stop-hook / pre-resume sync
     /// converges anything written after this snapshot.
-    private func migrateClaudeProjectDirs(oldPath: String, newPath: String, terminals: [Terminal]) {
+    private func migrateClaudeProjectDirs(
+        oldPath: String, newPath: String, terminals: [Terminal]
+    ) async {
         var roots: [URL] = []
         var seen = Set<String>()
         func addRoot(_ url: URL) {
@@ -282,13 +298,18 @@ extension RPCRouter {
             addRoot(configDirManager.configDirectory(forProfileID: profileID)
                 .appendingPathComponent("projects", isDirectory: true))
         }
-        for root in roots {
-            guard let oldDir = ClaudeProjectDirectory.resolve(
-                worktreePath: oldPath, projectsBase: root) else { continue }
-            let newDir = TranscriptProjectDirSync.derivedProjectDir(
-                worktreePath: newPath, projectsRoot: root)
-            TranscriptProjectDirSync.syncDirectoryContents(from: oldDir, to: newDir)
-            scratchLogger.info("scratch.promote: snapshotted Claude project dir \(oldDir.path, privacy: .public) -> \(newDir.path, privacy: .public)")
-        }
+        // Detached: both the resolve (content scans) and the recursive copy
+        // are synchronous filesystem walks that must not block this handler's
+        // executor; the await preserves ordering for the caller.
+        await Task.detached {
+            for root in roots {
+                guard let oldDir = ClaudeProjectDirectory.resolve(
+                    worktreePath: oldPath, projectsBase: root) else { continue }
+                let newDir = TranscriptProjectDirSync.derivedProjectDir(
+                    worktreePath: newPath, projectsRoot: root)
+                TranscriptProjectDirSync.syncDirectoryContents(from: oldDir, to: newDir)
+                scratchLogger.info("scratch.promote: snapshotted Claude project dir \(oldDir.path, privacy: .public) -> \(newDir.path, privacy: .public)")
+            }
+        }.value
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -72,6 +72,14 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
         }
 
+        // Never spawn into a missing directory: tmux's `-c` silently falls
+        // back to $HOME when the cwd doesn't exist, producing a terminal that
+        // looks alive but runs in the wrong place (classic after a stale
+        // worktree row, e.g. an un-migrated promoted scratch path). Fail loud.
+        guard FileManager.default.fileExists(atPath: worktree.path) else {
+            return RPCResponse(error: "Worktree directory missing on disk: \(worktree.path). Cannot create a terminal there.")
+        }
+
         // Resolve initial size: caller-supplied → TmuxManager defaults to avoid
         // tmux's 80x24 default producing un-reflowable hard-wrapped scrollback.
         let resolvedCols = params.cols ?? TmuxManager.defaultCols
@@ -251,6 +259,26 @@ extension RPCRouter {
         }
 
         let claudeEnvOverrides = createConfig?.envSettingOverrides ?? [:]
+        let profileConfigDir = isClaudeType
+            ? ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
+            : nil
+
+        // Pre-resume freshness: `claude --resume` only looks in the project
+        // dir derived from the CURRENT cwd. If this session's transcript lives
+        // elsewhere (worktree moved/promoted since it was written), mirror it
+        // into the derived dir first (copy-if-newer; best-effort). The stored
+        // path, when a sibling terminal row owns this session, is authoritative.
+        if let resumeID = params.resumeSessionID {
+            let storedTranscriptPath = (try? await db.terminals.list(worktreeID: params.worktreeID))?
+                .first(where: { $0.claudeSessionID == resumeID })?.transcriptPath
+            TranscriptProjectDirSync.ensureSessionResumable(
+                sessionID: resumeID,
+                worktreePath: worktree.path,
+                projectsRoot: claudeProjectsRoot(profileConfigDirPath: profileConfigDir),
+                storedTranscriptPath: storedTranscriptPath
+            )
+        }
+
         let spawn = ClaudeSpawnCommandBuilder.build(
             resumeID: params.resumeSessionID,
             freshSessionID: freshSessionID,
@@ -262,7 +290,7 @@ extension RPCRouter {
             profileModel: resolvedProfile?.model,
             profileAwsRegion: resolvedProfile?.awsRegion,
             profileAwsProfile: resolvedProfile?.awsProfile,
-            profileConfigDir: isClaudeType ? ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile) : nil,
+            profileConfigDir: profileConfigDir,
             cmd: params.cmd,
             shellFallback: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
             settingsOverlayPath: isClaudeType
@@ -464,6 +492,13 @@ extension RPCRouter {
             }
             logger.info("recreateWindow: parked claude terminal \(terminal.id, privacy: .public) as suspended — window \(terminal.tmuxWindowID, privacy: .public) gone, session \(sessionID, privacy: .public) preserved")
             return try RPCResponse(result: updated)
+        }
+
+        // Never respawn into a missing directory — tmux's `-c` silently falls
+        // back to $HOME, leaving a live-looking pane in the wrong place. (The
+        // park branch above is fine: it doesn't spawn anything.) Fail loud.
+        guard FileManager.default.fileExists(atPath: worktree.path) else {
+            return RPCResponse(error: "Worktree directory missing on disk: \(worktree.path). Cannot recreate the terminal window.")
         }
 
         // Kill the old window if it still exists (avoids orphans)
@@ -961,6 +996,18 @@ extension RPCRouter {
             } else {
                 logger.warning("swap transcript carry: no source transcript found for session \(sessionID, privacy: .public) — fork will start fresh")
             }
+
+            // ensureTranscriptReachable preserves the transcript's ORIGINAL
+            // cwd slug. If the worktree's path changed since the transcript
+            // was written (scratch promotion), the resumed claude — cwd-scoped
+            // — looks in the dir derived from the CURRENT path instead. Make
+            // sure the session is fresh there too (copy-if-newer, best-effort).
+            TranscriptProjectDirSync.ensureSessionResumable(
+                sessionID: sessionID,
+                worktreePath: worktree.path,
+                projectsRoot: destConfigDir.appendingPathComponent("projects", isDirectory: true),
+                storedTranscriptPath: oldTerminal.transcriptPath
+            )
         }
 
         let claudeEnvOverrides = swapConfig?.envSettingOverrides ?? [:]
@@ -1472,6 +1519,31 @@ extension RPCRouter {
         return nil
     }
 
+    // MARK: - Claude projects roots (transcript sync)
+
+    /// Projects root for a spawn's resolved profile config dir path, falling
+    /// back to the router's (injectable) ambient claude dir. Handler-side
+    /// counterpart of `TranscriptProjectDirSync.projectsRoot`, routed through
+    /// `configDirManager` so tests can isolate via the injection seam.
+    func claudeProjectsRoot(profileConfigDirPath: String?) -> URL {
+        if let path = profileConfigDirPath, !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true)
+                .appendingPathComponent("projects", isDirectory: true)
+        }
+        return configDirManager.ambientConfigDirectory
+            .appendingPathComponent("projects", isDirectory: true)
+    }
+
+    /// Projects root for a terminal's stored profile id (nil = ambient).
+    func claudeProjectsRoot(forProfileID profileID: UUID?) -> URL {
+        if let profileID {
+            return configDirManager.configDirectory(forProfileID: profileID)
+                .appendingPathComponent("projects", isDirectory: true)
+        }
+        return configDirManager.ambientConfigDirectory
+            .appendingPathComponent("projects", isDirectory: true)
+    }
+
     /// Bridge for the Claude SessionStart hook. The CLI relays the hook
     /// payload (session_id, transcript_path, source) plus the spawn-time
     /// `TBD_TERMINAL_ID` env to this method. We persist both fields and
@@ -1506,7 +1578,24 @@ extension RPCRouter {
         // absent we cannot validate, so we fall back to the old behavior.
         if let cwd = params.cwd, !cwd.isEmpty {
             let resolved = try await resolvePathToRepoOrWorktree(cwd)
-            if resolved?.worktreeID != terminal.worktreeID {
+            var accepted = resolved?.worktreeID == terminal.worktreeID
+            // Promotion follow-up: when the terminal's worktree is a promoted
+            // scratch row (promotedToRepoID set), its live session now runs in
+            // the moved folder — whose path resolves to the NEW repo's main
+            // worktree, not the scratch row. That's the same session, not a
+            // foreign one: accept when the cwd resolves to the main worktree
+            // of the promoted-to repo.
+            if !accepted,
+               let resolvedWorktreeID = resolved?.worktreeID,
+               let ownerWorktree = try await db.worktrees.get(id: terminal.worktreeID),
+               let promotedRepoID = ownerWorktree.promotedToRepoID,
+               let resolvedWorktree = try await db.worktrees.get(id: resolvedWorktreeID),
+               resolvedWorktree.repoID == promotedRepoID,
+               resolvedWorktree.status == .main {
+                accepted = true
+                logger.info("sessionEvent: accepted post-promote session for terminal \(terminal.id.uuidString, privacy: .public) — cwd resolves to main worktree of promoted repo \(promotedRepoID.uuidString, privacy: .public)")
+            }
+            if !accepted {
                 logger.info(
                     """
                     sessionEvent: REJECTED foreign session for terminal \
@@ -1585,6 +1674,32 @@ extension RPCRouter {
         if params.activityState == .working, terminal.pendingResumeAt != nil {
             if (try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)) == true {
                 await limitResumeScheduler?.wake()
+            }
+        }
+
+        // Stop-hook transcript sync (Stop/StopFailure reach the daemon as
+        // activity=idle): when a session finishes a turn and its recorded
+        // transcript lives OUTSIDE the project dir derived from the worktree's
+        // CURRENT path — the worktree moved/was promoted after the session
+        // started — mirror the jsonl + its subagents into the derived dir so
+        // a later cwd-scoped `claude --resume` finds the conversation. Runs
+        // BEFORE the unchanged-state guard so repeated Stops keep converging.
+        // Never rewrites terminal.transcriptPath: the live session keeps
+        // appending to the original file; we only copy.
+        if params.activityState == .idle,
+           let storedPath = terminal.transcriptPath, !storedPath.isEmpty,
+           FileManager.default.fileExists(atPath: storedPath),
+           let worktree = try? await db.worktrees.get(id: terminal.worktreeID) {
+            let derivedDir = TranscriptProjectDirSync.derivedProjectDir(
+                worktreePath: worktree.path,
+                projectsRoot: claudeProjectsRoot(forProfileID: terminal.profileID)
+            )
+            let source = URL(fileURLWithPath: storedPath)
+            let sourceDirReal = source.deletingLastPathComponent()
+                .resolvingSymlinksInPath().standardizedFileURL.path
+            let derivedReal = derivedDir.resolvingSymlinksInPath().standardizedFileURL.path
+            if sourceDirReal != derivedReal {
+                TranscriptProjectDirSync.syncSession(jsonl: source, intoProjectDir: derivedDir)
             }
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -72,6 +72,20 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
         }
 
+        // Never parent a new terminal to an archived worktree row — its tmux
+        // state is torn down and nothing will ever show the tab. The promoted
+        // scratch case gets a pointer to where the sessions actually went.
+        // This early check gives a clear RPC error; the authoritative,
+        // race-proof guard lives inside `db.terminals.create` (same write
+        // transaction as the row insert), closing the window where a promote
+        // archives the row between this check and the insert below.
+        if worktree.status == .archived {
+            if let promotedRepoID = worktree.promotedToRepoID {
+                return RPCResponse(error: "This scratch space was promoted to a repo (\(promotedRepoID)). Its sessions moved to that repo's main worktree — create the terminal there instead.")
+            }
+            return RPCResponse(error: "Worktree is archived: \(worktree.displayName). Revive it before creating terminals.")
+        }
+
         // Never spawn into a missing directory: tmux's `-c` silently falls
         // back to $HOME when the cwd doesn't exist, producing a terminal that
         // looks alive but runs in the wrong place (classic after a stale
@@ -266,12 +280,13 @@ extension RPCRouter {
         // Pre-resume freshness: `claude --resume` only looks in the project
         // dir derived from the CURRENT cwd. If this session's transcript lives
         // elsewhere (worktree moved/promoted since it was written), mirror it
-        // into the derived dir first (copy-if-newer; best-effort). The stored
+        // into the derived dir first (copy-if-newer; best-effort; detached so
+        // the recursive copy never blocks this handler's executor). The stored
         // path, when a sibling terminal row owns this session, is authoritative.
         if let resumeID = params.resumeSessionID {
             let storedTranscriptPath = (try? await db.terminals.list(worktreeID: params.worktreeID))?
                 .first(where: { $0.claudeSessionID == resumeID })?.transcriptPath
-            TranscriptProjectDirSync.ensureSessionResumable(
+            await TranscriptProjectDirSync.ensureSessionResumableDetached(
                 sessionID: resumeID,
                 worktreePath: worktree.path,
                 projectsRoot: claudeProjectsRoot(profileConfigDirPath: profileConfigDir),
@@ -1001,8 +1016,9 @@ extension RPCRouter {
             // cwd slug. If the worktree's path changed since the transcript
             // was written (scratch promotion), the resumed claude — cwd-scoped
             // — looks in the dir derived from the CURRENT path instead. Make
-            // sure the session is fresh there too (copy-if-newer, best-effort).
-            TranscriptProjectDirSync.ensureSessionResumable(
+            // sure the session is fresh there too (copy-if-newer, best-effort,
+            // detached off this handler's executor).
+            await TranscriptProjectDirSync.ensureSessionResumableDetached(
                 sessionID: sessionID,
                 worktreePath: worktree.path,
                 projectsRoot: destConfigDir.appendingPathComponent("projects", isDirectory: true),
@@ -1699,7 +1715,8 @@ extension RPCRouter {
                 .resolvingSymlinksInPath().standardizedFileURL.path
             let derivedReal = derivedDir.resolvingSymlinksInPath().standardizedFileURL.path
             if sourceDirReal != derivedReal {
-                TranscriptProjectDirSync.syncSession(jsonl: source, intoProjectDir: derivedDir)
+                await TranscriptProjectDirSync.syncSessionDetached(
+                    jsonl: source, intoProjectDir: derivedDir)
             }
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -35,6 +35,14 @@ public final class RPCRouter: Sendable {
     /// post-construction wiring. `nil` for unit tests / HTTP-only paths, which
     /// report 0.
     public nonisolated(unsafe) var connectedClientsProvider: (@Sendable () -> Int)?
+    /// Test-only injection seam: when set, `handleScratchPromote` awaits this
+    /// immediately before the row migration (`promoteScratchMigration`). A
+    /// throw simulates a mid-promote migration failure at the worst moment —
+    /// AFTER the folder move and repo registration succeeded — so RPC-level
+    /// tests can drive the full handler path and assert that both non-DB side
+    /// effects get rolled back. Never set in production; when nil (always,
+    /// outside tests) the promote path is unchanged.
+    nonisolated(unsafe) var scratchPromoteMigrationFailureHook: (@Sendable () async throws -> Void)?
     public let pendingQuestions: PendingQuestionStore
     public let repoSerializer: RepoSerializer
     public let configDirManager: ClaudeProfileConfigDirManager

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -102,7 +102,7 @@ public final class RPCRouter: Sendable {
         self.modelProfileResolver = resolvedModelProfileResolver
         self.hibernationCoordinator = HibernationCoordinator(
             db: db, tmux: tmux, modelProfileResolver: resolvedModelProfileResolver,
-            subscriptions: subscriptions
+            subscriptions: subscriptions, configDirManager: configDirManager
         )
         self.usageFetcher = usageFetcher
         self.pendingQuestions = pendingQuestions

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -14,6 +14,10 @@ struct HibernationCoordinatorTests {
         kind: TerminalKind? = .claude
     ) async throws -> (TBDDatabase, UUID, UUID) {
         let db = try TBDDatabase(inMemory: true)
+        // wake() refuses to respawn into a missing directory, so the (shared,
+        // idempotently created) fixture path must exist on disk.
+        try FileManager.default.createDirectory(
+            atPath: "/tmp/hib-repo", withIntermediateDirectories: true)
         let repo = try await db.repos.create(path: "/tmp/hib-repo", displayName: "test", defaultBranch: "main")
         let wt = try await db.worktrees.create(
             repoID: repo.id, name: "wt", branch: "main",

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -472,6 +472,11 @@ struct HibernationCoordinatorTests {
     /// each server saw its own new-window.
     @Test func concurrentWakesOnDifferentServersDoNotSerialize() async throws {
         let db = try TBDDatabase(inMemory: true)
+        // wake() refuses to respawn into a missing directory, so the (shared,
+        // idempotently created) fixture paths must exist on disk.
+        for path in ["/tmp/hib-repo", "/tmp/hib-repo-a", "/tmp/hib-repo-b"] {
+            try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        }
         let repo = try await db.repos.create(path: "/tmp/hib-repo", displayName: "test", defaultBranch: "main")
         let wtA = try await db.worktrees.create(
             repoID: repo.id, name: "wt-a", branch: "a",

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -3,6 +3,20 @@ import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
 
+/// A `ClaudeProfileConfigDirManager` pointed at fresh temp dirs, so wake()'s
+/// transcript-sync ambient fallback lists a sandbox — never the developer's
+/// real `~/.claude/projects` (the tier-3 resolve there opens the first jsonl
+/// in every project dir). Every `HibernationCoordinator`/`RPCRouter`
+/// construction in this file must pass one.
+private func isolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
+    let home = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-hib-claude-\(UUID().uuidString)", isDirectory: true)
+    return ClaudeProfileConfigDirManager(
+        baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+        hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
+    )
+}
+
 @Suite("HibernationCoordinator")
 struct HibernationCoordinatorTests {
 
@@ -37,7 +51,9 @@ struct HibernationCoordinatorTests {
     }
 
     private func coordinator(_ db: TBDDatabase) -> HibernationCoordinator {
-        HibernationCoordinator(db: db, tmux: TmuxManager(dryRun: true))
+        HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            configDirManager: isolatedConfigDirManager())
     }
 
     // MARK: - Manual hibernate
@@ -111,7 +127,7 @@ struct HibernationCoordinatorTests {
         // dryRun default paneCurrentCommand is "zsh" (not claude) → poll sees the
         // process leave immediately after `/exit`.
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         let result = await coord.manualHibernate(terminalID: terminalID)
         #expect(result == .ok)
@@ -139,7 +155,7 @@ struct HibernationCoordinatorTests {
             dryRunRecorder: { recorded.append($0) },
             dryRunPaneCurrentCommand: { _, _ in "1.2.3" }  // claude reports its version as pane_current_command
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         let result = await coord.manualHibernate(terminalID: terminalID)
         #expect(result == .ok)
@@ -195,7 +211,7 @@ struct HibernationCoordinatorTests {
         let (db, _, terminalID) = try await setup()
         let recorded = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         _ = await coord.manualHibernate(terminalID: terminalID)
         #expect(try await db.terminals.get(id: terminalID)?.isHibernated == true)
@@ -214,7 +230,7 @@ struct HibernationCoordinatorTests {
         let (db, _, terminalID) = try await setup()
         let recorded = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
         let result = await coord.wake(terminalID: terminalID)
         #expect(result == .notHibernated)
         #expect(recorded.snapshot().isEmpty,
@@ -258,7 +274,7 @@ struct HibernationCoordinatorTests {
         let (db, _, terminalID) = try await setup()
         let recorded = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         // Legacy park: only suspendedAt set, hibernatedAt nil.
         try await db.terminals.setSuspended(id: terminalID, sessionID: "sess-1")
@@ -293,7 +309,7 @@ struct HibernationCoordinatorTests {
         let recorded = RecordedTmuxCommands()
         let serverHookCalls = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
         await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
 
         let wake = await coord.wake(terminalID: terminalID)
@@ -327,7 +343,7 @@ struct HibernationCoordinatorTests {
             dryRunRecorder: { recorded.append($0) },
             dryRunWindowIsDead: { $0 == "@0" }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
         await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
 
         let wake = await coord.wake(terminalID: terminalID)
@@ -373,7 +389,7 @@ struct HibernationCoordinatorTests {
         let recorded = RecordedTmuxCommands()
         // No dryRunWindowIsDead: the window EXISTS — ownership must win.
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         let wake = await coord.wake(terminalID: terminalID)
         #expect(wake == .ok)
@@ -402,7 +418,7 @@ struct HibernationCoordinatorTests {
         )
         let recorded = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         let wake = await coord.wake(terminalID: terminalID)
         #expect(wake == .ok)
@@ -442,7 +458,7 @@ struct HibernationCoordinatorTests {
             dryRunRecorder: { recorded.append($0) },
             dryRunWindowIsDead: { _ in true }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         async let wakeA = coord.wake(terminalID: terminalA)
         async let wakeB = coord.wake(terminalID: terminalB.id)
@@ -502,7 +518,7 @@ struct HibernationCoordinatorTests {
             dryRunRecorder: { recorded.append($0) },
             dryRunWindowIsDead: { _ in true }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         async let wakeA = coord.wake(terminalID: terminalA.id)
         async let wakeB = coord.wake(terminalID: terminalB.id)
@@ -575,7 +591,7 @@ struct HibernationCoordinatorTests {
             dryRunWindowIsDead: { $0 == "@0" },
             dryRunCreateWindowError: { _ in TmuxError.unexpectedOutput("no server running") }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         let wake = await coord.wake(terminalID: terminalID)
         guard case .respawnFailed(let reason) = wake else {
@@ -598,7 +614,7 @@ struct HibernationCoordinatorTests {
             dryRun: true,
             dryRunRespawnWindowError: { $0 == "@0" ? TmuxError.unexpectedOutput("pane died") : nil }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
 
         let wake = await coord.wake(terminalID: terminalID)
         guard case .respawnFailed(let reason) = wake else {
@@ -609,6 +625,41 @@ struct HibernationCoordinatorTests {
         #expect(reason.contains("@0"), "reason must name the window; got: \(reason)")
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.isParked == true, "a failed wake must leave the row parked for retry")
+    }
+
+    /// The wake transcript sync must resolve the ambient (nil-profile)
+    /// projects root through the INJECTED `configDirManager` — the seam this
+    /// suite relies on to stay out of the real `~/.claude`. A transcript
+    /// parked under an old munged dir inside the injected root gets mirrored
+    /// into the dir derived from the worktree's current path.
+    @Test func wakeSyncsTranscriptViaInjectedConfigDirManager() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-hib-seam-\(UUID().uuidString)", isDirectory: true)
+        let host = home.appendingPathComponent("claude-host", isDirectory: true)
+        let projects = host.appendingPathComponent("projects", isDirectory: true)
+        let oldDir = projects.appendingPathComponent("-old-moved-path", isDirectory: true)
+        try FileManager.default.createDirectory(at: oldDir, withIntermediateDirectories: true)
+        try "{}".write(
+            to: oldDir.appendingPathComponent("sess-1.jsonl"), atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let coord = HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            configDirManager: ClaudeProfileConfigDirManager(
+                baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+                hostBaseDirectory: host
+            )
+        )
+        let wake = await coord.wake(terminalID: terminalID)
+        #expect(wake == .ok)
+
+        // `/tmp/hib-repo` munges to `-tmp-hib-repo` under the injected root.
+        let derived = projects.appendingPathComponent("-tmp-hib-repo/sess-1.jsonl")
+        #expect(FileManager.default.fileExists(atPath: derived.path),
+                "wake must mirror the parked transcript into the derived dir under the injected projects root")
     }
 
     // MARK: - Startup reconciliation
@@ -626,7 +677,7 @@ struct HibernationCoordinatorTests {
         // Pane still runs claude (reported as its version string) → the parked
         // state is stale and must be cleared.
         let tmux = TmuxManager(dryRun: true, dryRunPaneCurrentCommand: { _, _ in "1.2.3" })
-        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
         await coord.reconcileOnStartup()
 
         #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil,
@@ -708,8 +759,11 @@ struct RPCRouterWakeErrorMappingTests {
         )
         let router = RPCRouter(
             db: db,
-            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
-            tmux: tmux
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: isolatedConfigDirManager()),
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager()
         )
         let repo = try await db.repos.create(path: "/tmp/hib-repo", displayName: "test", defaultBranch: "main")
         let wt = try await db.worktrees.create(

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -53,11 +53,18 @@ struct ModelProfileSpawnTests {
             displayName: "r",
             defaultBranch: "main"
         )
+        // terminal.create / recreate refuse to spawn into a missing directory
+        // (tmux would silently fall back to $HOME), so the worktree path must
+        // actually exist on disk.
+        let wtPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wt-\(UUID().uuidString)").path
+        try FileManager.default.createDirectory(
+            atPath: wtPath, withIntermediateDirectories: true)
         let wt = try await db.worktrees.create(
             repoID: repo.id,
             name: "wt",
             branch: "main",
-            path: "/tmp/wt-\(UUID().uuidString)",
+            path: wtPath,
             tmuxServer: "tbd-test"
         )
         return (repo, wt)

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -3,6 +3,19 @@ import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
 
+/// A `ClaudeProfileConfigDirManager` pointed at fresh temp dirs, so the
+/// wake/revive transcript-sync ambient fallback lists a sandbox — never the
+/// developer's real `~/.claude/projects`. Every `WorktreeLifecycle`/`RPCRouter`
+/// construction in this file must pass one.
+private func isolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
+    let home = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-spawn-claude-\(UUID().uuidString)", isDirectory: true)
+    return ClaudeProfileConfigDirManager(
+        baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+        hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
+    )
+}
+
 // Nested under TBDHomeSerialized: several tests mutate the process-global
 // `TBD_HOME` env var (via setenv/unsetenv) to isolate the overlay/runtime dir.
 // Nesting prevents cross-suite races with the other TBD_HOME-mutating suites.
@@ -36,13 +49,16 @@ struct ModelProfileSpawnTests {
         let recorder = TmuxRecorder()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
         let db = try! TBDDatabase(inMemory: true)
-        let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+            configDirManager: isolatedConfigDirManager())
         let router = RPCRouter(
             db: db,
             lifecycle: lifecycle,
             tmux: tmux,
             startTime: Date(),
-            usageFetcher: StubClaudeUsageFetcher()
+            usageFetcher: StubClaudeUsageFetcher(),
+            configDirManager: isolatedConfigDirManager()
         )
         return (router, db, recorder)
     }
@@ -188,7 +204,8 @@ struct ModelProfileSpawnTests {
         )
         let lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
-            modelProfileResolver: resolver
+            modelProfileResolver: resolver,
+            configDirManager: isolatedConfigDirManager()
         )
         return (lifecycle, db, recorder)
     }
@@ -795,13 +812,16 @@ struct ModelProfileSpawnTests {
             dryRunCapturePane: { _, _ in pane.text }
         )
         let db = try! TBDDatabase(inMemory: true)
-        let lifecycle = WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+            configDirManager: isolatedConfigDirManager())
         let router = RPCRouter(
             db: db,
             lifecycle: lifecycle,
             tmux: tmux,
             startTime: Date(),
             usageFetcher: StubClaudeUsageFetcher(),
+            configDirManager: isolatedConfigDirManager(),
             loginSessions: LoginSessionCoordinator(delays: .init(
                 pumpInitialDelay: .zero,
                 pumpPollInterval: .milliseconds(5),

--- a/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
@@ -16,11 +16,16 @@ extension RPCRouterTests {
             displayName: "test-repo",
             defaultBranch: "main"
         )
+        // terminal.create refuses to spawn into a missing directory, so the
+        // worktree path must actually exist on disk.
+        let wtPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-wt-\(UUID().uuidString)").path
+        try FileManager.default.createDirectory(atPath: wtPath, withIntermediateDirectories: true)
         let wt = try await db.worktrees.create(
             repoID: repo.id,
             name: "test-wt",
             branch: "tbd/test-wt",
-            path: "/tmp/test-wt-\(UUID().uuidString)",
+            path: wtPath,
             tmuxServer: "tbd-test"
         )
 
@@ -86,11 +91,16 @@ extension RPCRouterTests {
             displayName: "test-repo",
             defaultBranch: "main"
         )
+        // terminal.create refuses to spawn into a missing directory, so the
+        // worktree path must actually exist on disk.
+        let wtPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-wt-\(UUID().uuidString)").path
+        try FileManager.default.createDirectory(atPath: wtPath, withIntermediateDirectories: true)
         let wt = try await db.worktrees.create(
             repoID: repo.id,
             name: "test-wt",
             branch: "tbd/test-wt",
-            path: "/tmp/test-wt-\(UUID().uuidString)",
+            path: wtPath,
             tmuxServer: "tbd-test"
         )
 

--- a/Tests/TBDDaemonTests/ScratchPromoteAtomicityTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteAtomicityTests.swift
@@ -1,0 +1,196 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// `WorktreeStore.promoteScratchMigration` — the single-transaction row
+/// migration behind `scratch.promote`. Pure in-memory-DB tests: no TBD_HOME,
+/// no filesystem, no tmux.
+@Suite("promoteScratchMigration atomicity")
+struct ScratchPromoteAtomicityTests {
+
+    @Test func midMigrationFailureLeavesPrePromoteStateIntact() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: "/tmp/tbd-atomicity-\(UUID())",
+            tmuxServer: "tbd-scratch")
+        let t1 = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        try await db.tabs.setLabel(tabID: t1.id, worktreeID: wt.id, label: "My Tab")
+        try await db.worktrees.setTabOrder(worktreeID: wt.id, tabIDs: [t1.id])
+        try await db.worktrees.setActiveTabID(worktreeID: wt.id, tabID: t1.id)
+
+        // A bogus main-worktree ID fails inside the transaction (either the
+        // terminal FK re-point or the main-row guard, depending on FK
+        // enforcement) — the rollback must restore the full pre-promote state.
+        await #expect(throws: (any Error).self) {
+            try await db.worktrees.promoteScratchMigration(
+                scratchID: wt.id, mainWorktreeID: UUID(), repoID: UUID(),
+                tmuxServer: wt.tmuxServer)
+        }
+
+        // Scratch row un-promoted and still active — retryable.
+        let scratchAfter = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(scratchAfter.status == .active)
+        #expect(scratchAfter.promotedToRepoID == nil)
+        // Terminals + tab state untouched (still parented to the scratch row,
+        // so a later scratch.delete tears down exactly what it owns).
+        #expect(try await db.terminals.list(worktreeID: wt.id).map(\.id) == [t1.id])
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).map(\.label) == ["My Tab"])
+        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [t1.id])
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: wt.id) == t1.id)
+    }
+
+    @Test func successAppliesAllRowMutationsTogether() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/tbd-atomicity-repo-\(UUID())", displayName: "r", defaultBranch: "main")
+        let repoID = repo.id
+        let wt = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: "/tmp/tbd-atomicity-\(UUID())",
+            tmuxServer: "tbd-scratch")
+        let main = try await db.worktrees.createMain(
+            repoID: repoID, name: "main", branch: "main",
+            path: "/tmp/tbd-atomicity-main-\(UUID())", tmuxServer: "tbd-canonical")
+        let t1 = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        try await db.tabs.setLabel(tabID: t1.id, worktreeID: wt.id, label: "My Tab")
+        try await db.worktrees.setTabOrder(worktreeID: wt.id, tabIDs: [t1.id])
+        try await db.worktrees.setActiveTabID(worktreeID: wt.id, tabID: t1.id)
+
+        try await db.worktrees.promoteScratchMigration(
+            scratchID: wt.id, mainWorktreeID: main.id, repoID: repoID,
+            tmuxServer: wt.tmuxServer)
+
+        let mainAfter = try #require(try await db.worktrees.get(id: main.id))
+        #expect(mainAfter.tmuxServer == wt.tmuxServer)
+        #expect(try await db.terminals.list(worktreeID: main.id).map(\.id) == [t1.id])
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+        #expect(try await db.tabs.listForWorktree(worktreeID: main.id).map(\.label) == ["My Tab"])
+        #expect(try await db.worktrees.getTabOrder(worktreeID: main.id) == [t1.id])
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: main.id) == t1.id)
+        let scratchAfter = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(scratchAfter.status == .archived)
+        #expect(scratchAfter.promotedToRepoID == repoID)
+    }
+}
+
+/// `terminal.create` must never parent a new terminal row to an archived
+/// worktree — the orphan class behind the SessionStart-hook foreign-session
+/// window. Store-level tests cover the race-proof in-transaction guard;
+/// RPC-level tests cover each early-check branch.
+@Suite("terminal.create archived-worktree guard")
+struct TerminalCreateArchivedWorktreeGuardTests {
+
+    private func makeRouter(_ db: TBDDatabase) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+    }
+
+    private func makeScratchDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-termguard-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: Store-level (in-transaction) guard
+
+    @Test func storeAllowsInsertOnPlainArchivedWorktree() async throws {
+        // The revive flow spawns terminals while the row is still `.archived`
+        // (it flips `.active`/`.creating` only after the spawn succeeds), so
+        // the store-level guard must reject ONLY promoted rows, never plain
+        // archived ones.
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: "/tmp/x-\(UUID())", tmuxServer: "t")
+        try await db.worktrees.archive(id: wt.id)
+
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        #expect(try await db.terminals.get(id: terminal.id) != nil)
+    }
+
+    @Test func storeRejectsInsertOnPromotedArchivedWorktree() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: "/tmp/x-\(UUID())", tmuxServer: "t")
+        try await db.worktrees.setPromotedToRepoID(id: wt.id, repoID: UUID())
+        try await db.worktrees.archive(id: wt.id)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await db.terminals.create(
+                worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        }
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test func storeAllowsInsertOnActiveWorktree() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wt = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: "/tmp/x-\(UUID())", tmuxServer: "t")
+
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        #expect(try await db.terminals.list(worktreeID: wt.id).map(\.id) == [terminal.id])
+    }
+
+    // MARK: RPC-level early checks
+
+    @Test func rpcRejectsArchivedWorktree() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let dir = try makeScratchDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let wt = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: dir.path, tmuxServer: "t")
+        try await db.worktrees.archive(id: wt.id)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id)))
+        #expect(!resp.success)
+        #expect(resp.error?.contains("archived") == true)
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test func rpcRejectsPromotedWorktreeWithGuidance() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let dir = try makeScratchDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let promotedRepoID = UUID()
+        let wt = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: dir.path, tmuxServer: "t")
+        try await db.worktrees.setPromotedToRepoID(id: wt.id, repoID: promotedRepoID)
+        try await db.worktrees.archive(id: wt.id)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id)))
+        #expect(!resp.success)
+        #expect(resp.error?.contains("promoted") == true)
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test func rpcCreatesShellTerminalOnActiveWorktree() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let dir = try makeScratchDir(); defer { try? FileManager.default.removeItem(at: dir) }
+        let wt = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: dir.path, tmuxServer: "t")
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id)))
+        #expect(resp.success)
+        let terminal = try resp.decodeResult(Terminal.self)
+        #expect(terminal.worktreeID == wt.id)
+        #expect(try await db.terminals.get(id: terminal.id) != nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
@@ -1,0 +1,270 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: scratch.create/promote resolve
+// TBDConstants.scratchDir from the process-global TBD_HOME, and the wake tests
+// set TBD_CLAUDE_HOST_HOME so the ambient projects root never points at the
+// developer's real ~/.claude. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+
+/// scratch.promote metadata migration: terminals re-parented, tmux server
+/// carried, tab state migrated, scratch row archived, Claude project dirs
+/// snapshotted (copy-if-newer).
+@Suite("scratch.promote metadata migration")
+struct ScratchPromoteMigrationTests {
+    private func isolate() -> (URL, () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-promote-mig-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        setenv("TBD_CLAUDE_HOST_HOME", home.appendingPathComponent("claude-host").path, 1)
+        return (home, {
+            unsetenv("TBD_HOME")
+            unsetenv("TBD_CLAUDE_HOST_HOME")
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    /// Router with a fully isolated Claude config-dir manager: profile config
+    /// dirs under `<home>/profiles/`, ambient host dir `<home>/claude-host/`.
+    private func makeRouter(_ db: TBDDatabase, home: URL) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            configDirManager: ClaudeProfileConfigDirManager(
+                baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+                hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
+            )
+        )
+    }
+
+    private func gitInitCommit(at path: String) throws {
+        for args in [["init"], ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"]] {
+            let p = Process(); p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = ["-C", path] + args; try p.run(); p.waitUntilExit()
+        }
+    }
+
+    private func writeFile(_ text: String, to url: URL, mtime: Date? = nil) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        if let mtime {
+            try FileManager.default.setAttributes([.modificationDate: mtime], ofItemAtPath: url.path)
+        }
+    }
+
+    @Test func promoteMigratesTerminalsTabsAndTmuxServerAndArchivesScratchRow() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db, home: home)
+
+        let created = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)
+        try gitInitCommit(at: wt.path)
+
+        // Two live-ish terminals, a labeled tab, an order, and a selection.
+        let t1 = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        let t2 = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: "shell", kind: .shell)
+        try await db.tabs.setLabel(tabID: t1.id, worktreeID: wt.id, label: "My Tab")
+        try await db.worktrees.setTabOrder(worktreeID: wt.id, tabIDs: [t2.id, t1.id])
+        try await db.worktrees.setActiveTabID(worktreeID: wt.id, tabID: t2.id)
+
+        let dest = home.appendingPathComponent("projects/promoted-app").path
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(resp.success)
+        let result = try resp.decodeResult(ScratchPromoteResult.self)
+
+        // The new repo's main worktree exists and inherited the scratch tmux server.
+        let mainWt = try #require(
+            try await db.worktrees.list(repoID: result.repoID, status: .main).first)
+        #expect(mainWt.tmuxServer == wt.tmuxServer)
+
+        // Terminals re-parented; none left on the scratch row.
+        let migrated = try await db.terminals.list(worktreeID: mainWt.id)
+        #expect(Set(migrated.map(\.id)) == [t1.id, t2.id])
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+
+        // Live-session invariant: identity untouched — same session id and no
+        // transcriptPath rewrite (it was nil and must stay nil).
+        let migratedT1 = try #require(migrated.first(where: { $0.id == t1.id }))
+        #expect(migratedT1.claudeSessionID == "sess-1")
+        #expect(migratedT1.transcriptPath == nil)
+
+        // Tab state carried: rows re-pointed, order + selection copied.
+        let tabs = try await db.tabs.listForWorktree(worktreeID: mainWt.id)
+        #expect(tabs.map(\.label) == ["My Tab"])
+        #expect(try await db.tabs.listForWorktree(worktreeID: wt.id).isEmpty)
+        #expect(try await db.worktrees.getTabOrder(worktreeID: mainWt.id) == [t2.id, t1.id])
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: mainWt.id) == t2.id)
+
+        // Scratch row retired: archived AND still pointing at the repo.
+        let scratchRow = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(scratchRow.status == .archived)
+        #expect(scratchRow.promotedToRepoID == result.repoID)
+    }
+
+    @Test func promoteSnapshotsClaudeProjectDirsPerRootWithCopyIfNewer() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db, home: home)
+
+        let created = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)
+        try gitInitCommit(at: wt.path)
+
+        // One ambient terminal and one profile-pinned terminal.
+        let profileID = UUID()
+        _ = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "amb-1", kind: .claude)
+        _ = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: "claude", claudeSessionID: "prof-1", profileID: profileID, kind: .claude)
+
+        // Seed the OLD munged dirs under both projects roots.
+        let ambientRoot = home.appendingPathComponent("claude-host/projects", isDirectory: true)
+        let profileRoot = home.appendingPathComponent(
+            "profiles/\(profileID.uuidString.lowercased())/claude/projects", isDirectory: true)
+        let oldAmbient = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: wt.path, projectsRoot: ambientRoot)
+        let oldProfile = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: wt.path, projectsRoot: profileRoot)
+        try writeFile("ambient transcript", to: oldAmbient.appendingPathComponent("amb-1.jsonl"))
+        try writeFile("sub", to: oldAmbient.appendingPathComponent("amb-1/subagents/agent-a.jsonl"))
+        try writeFile("remember me", to: oldAmbient.appendingPathComponent("memory/MEMORY.md"))
+        // Copy-if-newer: a second session already has FRESHER content at the
+        // destination — the snapshot must not clobber it.
+        try writeFile("stale old", to: oldAmbient.appendingPathComponent("amb-2.jsonl"),
+                      mtime: Date(timeIntervalSinceNow: -600))
+        try writeFile("profile transcript", to: oldProfile.appendingPathComponent("prof-1.jsonl"))
+        ClaudeProjectDirectory.clearCache()
+
+        let dest = home.appendingPathComponent("projects/promoted-app").path
+        let newAmbient = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: dest, projectsRoot: ambientRoot)
+        let newProfile = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: dest, projectsRoot: profileRoot)
+        try writeFile("fresh forked", to: newAmbient.appendingPathComponent("amb-2.jsonl"),
+                      mtime: Date())
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(resp.success)
+
+        // Session JSONLs, subagents contents, and memory/ appear under the new
+        // munged dirs for BOTH roots; the fresher destination file survives.
+        #expect(try String(
+            contentsOf: newAmbient.appendingPathComponent("amb-1.jsonl"), encoding: .utf8)
+            == "ambient transcript")
+        #expect(try String(
+            contentsOf: newAmbient.appendingPathComponent("amb-1/subagents/agent-a.jsonl"),
+            encoding: .utf8) == "sub")
+        #expect(try String(
+            contentsOf: newAmbient.appendingPathComponent("memory/MEMORY.md"), encoding: .utf8)
+            == "remember me")
+        #expect(try String(
+            contentsOf: newAmbient.appendingPathComponent("amb-2.jsonl"), encoding: .utf8)
+            == "fresh forked")
+        #expect(try String(
+            contentsOf: newProfile.appendingPathComponent("prof-1.jsonl"), encoding: .utf8)
+            == "profile transcript")
+    }
+}
+
+/// Wake path guard + pre-resume transcript sync (HibernationCoordinator).
+@Suite("wake path guard and pre-resume sync")
+struct WakePathGuardTests {
+    private func isolate() -> (URL, () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-wake-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        setenv("TBD_CLAUDE_HOST_HOME", home.appendingPathComponent("claude-host").path, 1)
+        return (home, {
+            unsetenv("TBD_HOME")
+            unsetenv("TBD_CLAUDE_HOST_HOME")
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    private func makeRouter(_ db: TBDDatabase) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+    }
+
+    @Test func wakeRefusesWhenWorktreePathMissingOnDisk() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+
+        let missingPath = home.appendingPathComponent("never-created").path
+        let wt = try await db.worktrees.createScratch(
+            name: "gone", displayName: "gone", path: missingPath, tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "sess-1")
+
+        let result = await router.hibernationCoordinator.wake(terminalID: terminal.id)
+
+        #expect(result == .notFound)
+        // Row stays parked so a later retry (after the path is restored) works.
+        #expect(try await db.terminals.get(id: terminal.id)?.hibernatedAt != nil)
+    }
+
+    @Test func wakeSucceedsAndSyncsTranscriptIntoDerivedDirForExistingPath() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+
+        let wtDir = home.appendingPathComponent("wt", isDirectory: true)
+        try FileManager.default.createDirectory(at: wtDir, withIntermediateDirectories: true)
+        let wt = try await db.worktrees.createScratch(
+            name: "wt", displayName: "wt", path: wtDir.path, tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+
+        // Stored transcript lives under an OLD slug (as after a promote).
+        let ambientRoot = home.appendingPathComponent("claude-host/projects", isDirectory: true)
+        let oldSlugFile = ambientRoot.appendingPathComponent("-old-slug/sess-1.jsonl")
+        try FileManager.default.createDirectory(
+            at: oldSlugFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "parked transcript".write(to: oldSlugFile, atomically: true, encoding: .utf8)
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "sess-1", transcriptPath: oldSlugFile.path)
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "sess-1")
+
+        let result = await router.hibernationCoordinator.wake(terminalID: terminal.id)
+
+        #expect(result == .ok)
+        #expect(try await db.terminals.get(id: terminal.id)?.hibernatedAt == nil)
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: wtDir.path, projectsRoot: ambientRoot)
+        #expect(try String(
+            contentsOf: derived.appendingPathComponent("sess-1.jsonl"), encoding: .utf8)
+            == "parked transcript")
+    }
+}
+
+}

--- a/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
@@ -227,7 +227,9 @@ struct WakePathGuardTests {
 
         let result = await router.hibernationCoordinator.wake(terminalID: terminal.id)
 
-        #expect(result == .notFound)
+        // Dedicated case carrying the missing path — the RPC layer surfaces it
+        // as an actionable message instead of a generic "Terminal not found".
+        #expect(result == .worktreeMissing(path: missingPath))
         // Row stays parked so a later retry (after the path is restored) works.
         #expect(try await db.terminals.get(id: terminal.id)?.hibernatedAt != nil)
     }
@@ -264,6 +266,76 @@ struct WakePathGuardTests {
         #expect(try String(
             contentsOf: derived.appendingPathComponent("sess-1.jsonl"), encoding: .utf8)
             == "parked transcript")
+    }
+}
+
+/// Wiring test for the `terminal.create` resume path: the handler must call
+/// `ensureSessionResumable` with the resumed session's STORED transcript path
+/// (from the sibling terminal row that owns the session) and the worktree's
+/// CURRENT path, so a wrong-argument regression can't stay green.
+@Suite("terminal.create pre-resume sync wiring")
+struct TerminalCreateResumeSyncWiringTests {
+    private func isolate() -> (URL, () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-create-resume-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        setenv("TBD_CLAUDE_HOST_HOME", home.appendingPathComponent("claude-host").path, 1)
+        return (home, {
+            unsetenv("TBD_HOME")
+            unsetenv("TBD_CLAUDE_HOST_HOME")
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    @Test func terminalCreateResumeSyncsStoredTranscriptIntoDerivedDir() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            configDirManager: ClaudeProfileConfigDirManager(
+                baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+                hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
+            )
+        )
+
+        let wtDir = home.appendingPathComponent("wt", isDirectory: true)
+        try FileManager.default.createDirectory(at: wtDir, withIntermediateDirectories: true)
+        let wt = try await db.worktrees.createScratch(
+            name: "wt", displayName: "wt", path: wtDir.path, tmuxServer: "tbd-test")
+
+        // Sibling terminal owns the session; its stored transcript lives under
+        // an OLD slug (as after a promote/move).
+        let sibling = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-w", kind: .claude)
+        let ambientRoot = home.appendingPathComponent("claude-host/projects", isDirectory: true)
+        let oldSlugFile = ambientRoot.appendingPathComponent("-old-slug/sess-w.jsonl")
+        try FileManager.default.createDirectory(
+            at: oldSlugFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "moved transcript".write(to: oldSlugFile, atomically: true, encoding: .utf8)
+        try await db.terminals.updateSession(
+            id: sibling.id, sessionID: "sess-w", transcriptPath: oldSlugFile.path)
+        ClaudeProjectDirectory.clearCache()
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, resumeSessionID: "sess-w")))
+        #expect(resp.success)
+
+        // The stored transcript was mirrored into the dir derived from the
+        // worktree's CURRENT path, where the cwd-scoped resume will look.
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: wtDir.path, projectsRoot: ambientRoot)
+        #expect(try String(
+            contentsOf: derived.appendingPathComponent("sess-w.jsonl"), encoding: .utf8)
+            == "moved transcript")
+        // Live-session invariant: the sibling's stored path was NOT rewritten.
+        #expect(try await db.terminals.get(id: sibling.id)?.transcriptPath == oldSlugFile.path)
     }
 }
 

--- a/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
@@ -199,5 +199,66 @@ struct ScratchPromoteRPCTests {
         #expect(row?.promotedToRepoID == nil)
         #expect(try await db.repos.list().count == repoCountBefore)
     }
+
+    /// A row-migration failure strikes at the worst moment: the folder has
+    /// already moved to `dest` and addRepo has already registered it. The
+    /// handler must roll BOTH side effects back — un-register the repo (repo
+    /// row + synthetic main worktree row) and move the folder home — leaving
+    /// the scratch row active, un-promoted, and retryable. Forced through the
+    /// full RPC path via the router's test-only migration failure hook; a
+    /// second promote with the hook cleared exercises the hook-nil branch and
+    /// proves the rollback left a cleanly retryable state.
+    @Test func migrationFailureRollsBackRepoRegistrationAndFolderMove() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db)
+        let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)
+        try gitInitCommit(at: wt.path)
+        let claude = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        let shell = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: "shell", kind: .shell)
+
+        struct MigrationBoom: Error {}
+        router.scratchPromoteMigrationFailureHook = { throw MigrationBoom() }
+
+        let dest = home.appendingPathComponent("projects/rolled-back").path
+        let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(!resp.success)
+        // The error tells the truth about the rollback outcome.
+        #expect(resp.error?.contains("Unregistered the repo again") == true)
+        #expect(resp.error?.contains("Moved the folder back") == true)
+
+        // Folder is back home; dest is gone.
+        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(!FileManager.default.fileExists(atPath: dest))
+        // Scratch row still active and un-promoted — retryable.
+        let row = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(row.status == .active)
+        #expect(row.promotedToRepoID == nil)
+        // Terminals untouched, still parented to the scratch row.
+        #expect(Set(try await db.terminals.list(worktreeID: wt.id).map(\.id)) == [claude.id, shell.id])
+        // No half-registered repo left behind: the repo row and its synthetic
+        // main worktree row are both gone.
+        #expect(try await db.repos.findByPath(path: dest) == nil)
+        #expect(try await db.repos.list().isEmpty)
+        #expect(try await db.worktrees.list(status: .main).isEmpty)
+
+        // With the injected failure cleared, retrying the same promote
+        // succeeds — no "Destination already exists" trap, terminals migrate.
+        router.scratchPromoteMigrationFailureHook = nil
+        let retry = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(retry.success)
+        let result = try retry.decodeResult(ScratchPromoteResult.self)
+        #expect(FileManager.default.fileExists(atPath: dest))
+        #expect(try await db.worktrees.get(id: wt.id)?.promotedToRepoID == result.repoID)
+        let mainWt = try #require(try await db.worktrees.list(repoID: result.repoID, status: .main).first)
+        #expect(Set(try await db.terminals.list(worktreeID: mainWt.id).map(\.id)) == [claude.id, shell.id])
+    }
 }
 }

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -110,26 +110,50 @@ struct ScratchPromoteReconcileTests {
         #expect(claudeAfter.suspendedAt == nil)
     }
 
-    /// After the promoted main worktree is archived, its row is the only
-    /// remaining pointer to the inherited scratch server. With nothing live
-    /// referencing that server anywhere (the scratch row was archived by the
-    /// promote itself), reconcile's cleanup pass must kill it — before this,
-    /// the pass only ever considered the canonical per-repo server, so the
-    /// inherited server lingered forever.
+    /// Register a plain git repo through the real `repo.add` RPC, giving the
+    /// harness a surviving repo whose reconcile can janitor shared servers
+    /// after the promoted repo itself is removed.
+    private func addSurvivorRepo(router: RPCRouter, home: URL) async throws -> Repo {
+        let dir = home.appendingPathComponent("projects/survivor-\(UUID().uuidString)").path
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try gitInitCommit(at: dir)
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.repoAdd, params: RepoAddParams(path: dir)))
+        return try resp.decodeResult(Repo.self)
+    }
+
+    /// The reachable trigger for "nothing references the inherited server
+    /// anymore" is REMOVING the promoted repo: `repo.remove` hard-deletes its
+    /// main worktree row via `deleteForRepo` (a `.main` row can never be
+    /// merely archived — `WorktreeStore.archive` refuses `.main`). That row
+    /// was the only repo-side pointer to the inherited scratch server, so
+    /// afterwards only the retired scratch row (repoID nil, archived) still
+    /// references it — and scratch rows belong to no repo, so no per-repo
+    /// reconcile visited that server before scratch-referenced servers were
+    /// folded into every reconcile's visit set. With nothing live on the
+    /// server anywhere, the next reconcile of ANY surviving repo must kill it.
     @Test func reconcileKillsInheritedServerOnceNothingReferencesIt() async throws {
         let (home, cleanup) = isolate(); defer { cleanup() }
         let db = try TBDDatabase(inMemory: true)
         let router = makeRouter(db, home: home)
         let promoted = try await promoteScratchWithTerminals(db: db, router: router, home: home)
 
-        try await db.worktrees.updateStatus(id: promoted.mainWorktree.id, status: .archived)
+        let removeResp = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: promoted.repoID, force: false)))
+        #expect(removeResp.success)
+        // Hard-deleted, not archived: no row of any repo references the
+        // inherited server anymore.
+        #expect(try await db.worktrees.list(repoID: promoted.repoID).isEmpty)
+
+        let survivor = try await addSurvivorRepo(router: router, home: home)
 
         let recorder = RecordedTmux()
         let lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(),
             tmux: TmuxManager(dryRun: true, dryRunRecorder: { recorder.append($0) }),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: promoted.repoID)
+        try await lifecycle.reconcile(repoID: survivor.id)
 
         let serverKills = recorder.snapshot().filter { $0.contains("kill-server") }
         #expect(serverKills.contains { $0.contains(promoted.scratch.tmuxServer) },
@@ -138,11 +162,13 @@ struct ScratchPromoteReconcileTests {
 
     /// The scratch server is SHARED: every scratch space (and every promoted
     /// repo's main worktree) runs on the one server derived from the scratch
-    /// base dir. When the archived promoted main's windows linger there but
-    /// another scratch space is still live on it, reconcile must sweep only
-    /// the untracked windows and leave the server — and the other space's
-    /// live window — alone.
-    @Test func reconcileSweepsArchivedMainWindowsButSparesSharedScratchServer() async throws {
+    /// base dir. After the promoted repo is removed through the real flow
+    /// (`repo.remove` hard-deletes the main worktree row), its windows linger
+    /// untracked on that server while another scratch space is still live on
+    /// it. The next reconcile of a surviving repo must sweep only the
+    /// untracked windows and leave the server — and the other space's live
+    /// window — alone.
+    @Test func reconcileSweepsRemovedPromotedRepoWindowsButSparesSharedScratchServer() async throws {
         let (home, cleanup) = isolate(); defer { cleanup() }
         let db = try TBDDatabase(inMemory: true)
         let router = makeRouter(db, home: home)
@@ -158,7 +184,14 @@ struct ScratchPromoteReconcileTests {
             worktreeID: otherScratch.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
             label: "shell", kind: .shell)
 
-        try await db.worktrees.updateStatus(id: promoted.mainWorktree.id, status: .archived)
+        // Real trigger: remove the promoted repo; its main worktree row (and
+        // with it the tracking for windows @1/@2) is hard-deleted.
+        let removeResp = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: promoted.repoID, force: false)))
+        #expect(removeResp.success)
+
+        let survivor = try await addSurvivorRepo(router: router, home: home)
 
         let scratchServer = promoted.scratch.tmuxServer
         let recorder = RecordedTmux()
@@ -175,14 +208,14 @@ struct ScratchPromoteReconcileTests {
                         : []
                 }),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: promoted.repoID)
+        try await lifecycle.reconcile(repoID: survivor.id)
 
         let cmds = recorder.snapshot()
         #expect(!cmds.contains { $0.contains("kill-server") && $0.contains(scratchServer) },
                 "a shared server still referenced by a live scratch space must survive")
         let windowKills = cmds.filter { $0.contains("kill-window") }
         #expect(windowKills.contains { $0.contains("@1") && $0.contains(scratchServer) },
-                "the archived promoted main's orphaned windows must be swept")
+                "the removed promoted repo's orphaned windows must be swept")
         #expect(windowKills.contains { $0.contains("@2") })
         #expect(!windowKills.contains { $0.contains("@9") },
                 "the live scratch space's tracked window must be spared")

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -110,6 +110,86 @@ struct ScratchPromoteReconcileTests {
         #expect(claudeAfter.suspendedAt == nil)
     }
 
+    /// After the promoted main worktree is archived, its row is the only
+    /// remaining pointer to the inherited scratch server. With nothing live
+    /// referencing that server anywhere (the scratch row was archived by the
+    /// promote itself), reconcile's cleanup pass must kill it — before this,
+    /// the pass only ever considered the canonical per-repo server, so the
+    /// inherited server lingered forever.
+    @Test func reconcileKillsInheritedServerOnceNothingReferencesIt() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db, home: home)
+        let promoted = try await promoteScratchWithTerminals(db: db, router: router, home: home)
+
+        try await db.worktrees.updateStatus(id: promoted.mainWorktree.id, status: .archived)
+
+        let recorder = RecordedTmux()
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(),
+            tmux: TmuxManager(dryRun: true, dryRunRecorder: { recorder.append($0) }),
+            hooks: HookResolver())
+        try await lifecycle.reconcile(repoID: promoted.repoID)
+
+        let serverKills = recorder.snapshot().filter { $0.contains("kill-server") }
+        #expect(serverKills.contains { $0.contains(promoted.scratch.tmuxServer) },
+                "the inherited scratch server must be killed once no live worktree row references it")
+    }
+
+    /// The scratch server is SHARED: every scratch space (and every promoted
+    /// repo's main worktree) runs on the one server derived from the scratch
+    /// base dir. When the archived promoted main's windows linger there but
+    /// another scratch space is still live on it, reconcile must sweep only
+    /// the untracked windows and leave the server — and the other space's
+    /// live window — alone.
+    @Test func reconcileSweepsArchivedMainWindowsButSparesSharedScratchServer() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db, home: home)
+        let promoted = try await promoteScratchWithTerminals(db: db, router: router, home: home)
+
+        // A second scratch space, still live on the same shared server.
+        let created = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let otherScratch = try created.decodeResult(Worktree.self)
+        #expect(otherScratch.tmuxServer == promoted.scratch.tmuxServer,
+                "sanity: scratch spaces share one tmux server")
+        let liveTerminal = try await db.terminals.create(
+            worktreeID: otherScratch.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
+            label: "shell", kind: .shell)
+
+        try await db.worktrees.updateStatus(id: promoted.mainWorktree.id, status: .archived)
+
+        let scratchServer = promoted.scratch.tmuxServer
+        let recorder = RecordedTmux()
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunRecorder: { recorder.append($0) },
+                dryRunListWindows: { server, _ in
+                    server == scratchServer
+                        ? [(windowID: "@1", paneID: "%1"),
+                           (windowID: "@2", paneID: "%2"),
+                           (windowID: "@9", paneID: "%9")]
+                        : []
+                }),
+            hooks: HookResolver())
+        try await lifecycle.reconcile(repoID: promoted.repoID)
+
+        let cmds = recorder.snapshot()
+        #expect(!cmds.contains { $0.contains("kill-server") && $0.contains(scratchServer) },
+                "a shared server still referenced by a live scratch space must survive")
+        let windowKills = cmds.filter { $0.contains("kill-window") }
+        #expect(windowKills.contains { $0.contains("@1") && $0.contains(scratchServer) },
+                "the archived promoted main's orphaned windows must be swept")
+        #expect(windowKills.contains { $0.contains("@2") })
+        #expect(!windowKills.contains { $0.contains("@9") },
+                "the live scratch space's tracked window must be spared")
+        // And the live scratch space's terminal row is untouched.
+        #expect(try await db.terminals.get(id: liveTerminal.id) != nil)
+    }
+
     @Test func reconcileStillCanonicalizesWhenStoredServerHasNoLiveWindows() async throws {
         let (home, cleanup) = isolate(); defer { cleanup() }
         let db = try TBDDatabase(inMemory: true)
@@ -133,6 +213,22 @@ struct ScratchPromoteReconcileTests {
         #expect(claudeAfter.hibernatedAt != nil)          // parked, session preserved
         #expect(claudeAfter.claudeSessionID == "sess-1")
         #expect(try await db.terminals.get(id: promoted.shell.id) == nil)  // nothing to preserve
+    }
+
+    /// Thread-safe collector for TmuxManager dryRun recorded argv.
+    private final class RecordedTmux: @unchecked Sendable {
+        private let lock = NSLock()
+        private var commands: [[String]] = []
+
+        func append(_ args: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            commands.append(args)
+        }
+
+        func snapshot() -> [[String]] {
+            lock.lock(); defer { lock.unlock() }
+            return commands
+        }
     }
 }
 

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -1,0 +1,139 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: scratch.create resolves
+// TBDConstants.scratchDir from the process-global TBD_HOME, and
+// TBD_CLAUDE_HOST_HOME keeps the ambient projects root off the developer's
+// real ~/.claude. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+
+/// Regression suite for the promote → reconcile interaction: reconcile's
+/// stale-tmux-server self-heal must NOT revert a promoted-main worktree's
+/// deliberately inherited scratch server while its windows are live (doing so
+/// probed the empty canonical server, declared every window dead, parked the
+/// Claude terminals and deleted the shell rows). The self-heal must still
+/// canonicalize when the stored server genuinely has no live windows.
+@Suite("scratch.promote + reconcile interaction")
+struct ScratchPromoteReconcileTests {
+    private func isolate() -> (URL, () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-promote-rec-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        setenv("TBD_CLAUDE_HOST_HOME", home.appendingPathComponent("claude-host").path, 1)
+        return (home, {
+            unsetenv("TBD_HOME")
+            unsetenv("TBD_CLAUDE_HOST_HOME")
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    private func makeRouter(_ db: TBDDatabase, home: URL) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            configDirManager: ClaudeProfileConfigDirManager(
+                baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+                hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
+            )
+        )
+    }
+
+    private func gitInitCommit(at path: String) throws {
+        for args in [["init"], ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"]] {
+            let p = Process(); p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = ["-C", path] + args; try p.run(); p.waitUntilExit()
+        }
+    }
+
+    /// Promote a scratch space carrying two live-ish terminals, returning
+    /// everything the reconcile assertions need.
+    private func promoteScratchWithTerminals(
+        db: TBDDatabase, router: RPCRouter, home: URL
+    ) async throws -> (scratch: Worktree, repoID: UUID, dest: String,
+                       mainWorktree: Worktree, claude: Terminal, shell: Terminal) {
+        let created = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        let wt = try created.decodeResult(Worktree.self)
+        try gitInitCommit(at: wt.path)
+
+        let claude = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        let shell = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: "shell", kind: .shell)
+
+        let dest = home.appendingPathComponent("projects/promoted-app").path
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchPromote,
+            params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
+        #expect(resp.success)
+        let result = try resp.decodeResult(ScratchPromoteResult.self)
+        let mainWt = try #require(
+            try await db.worktrees.list(repoID: result.repoID, status: .main).first)
+        return (wt, result.repoID, dest, mainWt, claude, shell)
+    }
+
+    @Test func reconcilePreservesInheritedServerAndTerminalsWhenWindowsLive() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db, home: home)
+        let promoted = try await promoteScratchWithTerminals(db: db, router: router, home: home)
+
+        // Sanity: the inherited scratch server is NOT the canonical name for
+        // the promoted repo path — otherwise this test proves nothing.
+        let canonical = TmuxManager.serverName(forRepoPath: promoted.dest)
+        #expect(promoted.mainWorktree.tmuxServer != canonical)
+        #expect(promoted.mainWorktree.tmuxServer == promoted.scratch.tmuxServer)
+
+        // dryRun tmux without dryRunWindowIsDead reports every window ALIVE —
+        // the live-session case reconcile must leave alone.
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver())
+        try await lifecycle.reconcile(repoID: promoted.repoID)
+
+        // The inherited tmux server survives reconcile.
+        let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
+        #expect(mainAfter.tmuxServer == promoted.scratch.tmuxServer)
+
+        // Terminal rows intact: nothing parked, nothing deleted.
+        let terminals = try await db.terminals.list(worktreeID: promoted.mainWorktree.id)
+        #expect(Set(terminals.map(\.id)) == [promoted.claude.id, promoted.shell.id])
+        let claudeAfter = try #require(terminals.first(where: { $0.id == promoted.claude.id }))
+        #expect(claudeAfter.hibernatedAt == nil)
+        #expect(claudeAfter.suspendedAt == nil)
+    }
+
+    @Test func reconcileStillCanonicalizesWhenStoredServerHasNoLiveWindows() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db, home: home)
+        let promoted = try await promoteScratchWithTerminals(db: db, router: router, home: home)
+
+        // Every window dead — the genuinely-stale case the self-heal was
+        // built for: reconcile must canonicalize the server name, park the
+        // resumable Claude terminal, and delete the shell row.
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(),
+            tmux: TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true }),
+            hooks: HookResolver())
+        try await lifecycle.reconcile(repoID: promoted.repoID)
+
+        let canonical = TmuxManager.serverName(forRepoPath: promoted.dest)
+        let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
+        #expect(mainAfter.tmuxServer == canonical)
+
+        let claudeAfter = try #require(try await db.terminals.get(id: promoted.claude.id))
+        #expect(claudeAfter.hibernatedAt != nil)          // parked, session preserved
+        #expect(claudeAfter.claudeSessionID == "sess-1")
+        #expect(try await db.terminals.get(id: promoted.shell.id) == nil)  // nothing to preserve
+    }
+}
+
+}

--- a/Tests/TBDDaemonTests/SessionEventPromoteGuardTests.swift
+++ b/Tests/TBDDaemonTests/SessionEventPromoteGuardTests.swift
@@ -1,0 +1,111 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// SessionStart ownership guard after scratch promotion: the promoted
+/// session's own events (cwd now resolves to the new repo's main worktree)
+/// must be accepted, while genuinely foreign sessions stay rejected.
+/// DB-only — no paths need to exist on disk. One test per branch of the
+/// promoted-main acceptance conditional.
+extension RPCRouterTests {
+
+    private func sessionEvent(terminalID: UUID, cwd: String) throws -> RPCRequest {
+        try RPCRequest(
+            method: RPCMethod.terminalSessionEvent,
+            params: TerminalSessionEventParams(
+                terminalID: terminalID, sessionID: "new-session",
+                transcriptPath: "/abs/new-session.jsonl", source: "startup", cwd: cwd))
+    }
+
+    /// Scratch row (with a terminal) promoted to a repo whose main worktree
+    /// lives at `repoPath`.
+    private func makePromotedFixture() async throws
+        -> (terminal: Terminal, repoID: UUID, repoPath: String, scratchPath: String) {
+        let scratchPath = "/tmp/fake-scratch-\(UUID().uuidString)"
+        let scratch = try await db.worktrees.createScratch(
+            name: "s", displayName: "s", path: scratchPath, tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: scratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "old-session", kind: .claude)
+        let repoPath = "/tmp/fake-repo-\(UUID().uuidString)"
+        let repo = try await db.repos.create(
+            path: repoPath, displayName: "r", defaultBranch: "main")
+        _ = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main", path: repoPath, tmuxServer: "tbd-r")
+        try await db.worktrees.setPromotedToRepoID(id: scratch.id, repoID: repo.id)
+        return (terminal, repo.id, repoPath, scratchPath)
+    }
+
+    @Test func sessionEventAcceptsCwdResolvingToPromotedRepoMainWorktree() async throws {
+        let fx = try await makePromotedFixture()
+
+        let resp = await router.handle(try sessionEvent(terminalID: fx.terminal.id, cwd: fx.repoPath))
+
+        #expect(resp.success)
+        let updated = try await db.terminals.get(id: fx.terminal.id)
+        #expect(updated?.claudeSessionID == "new-session")
+        #expect(updated?.transcriptPath == "/abs/new-session.jsonl")
+    }
+
+    @Test func sessionEventStillAcceptsOwnWorktreeCwd() async throws {
+        let fx = try await makePromotedFixture()
+
+        let resp = await router.handle(try sessionEvent(terminalID: fx.terminal.id, cwd: fx.scratchPath))
+
+        #expect(resp.success)
+        #expect(try await db.terminals.get(id: fx.terminal.id)?.claudeSessionID == "new-session")
+    }
+
+    @Test func sessionEventRejectsCwdOfUnrelatedRepo() async throws {
+        let fx = try await makePromotedFixture()
+        // A different repo with its own main worktree — repoID doesn't match
+        // the terminal's worktree's promotedToRepoID.
+        let otherPath = "/tmp/fake-other-repo-\(UUID().uuidString)"
+        let other = try await db.repos.create(
+            path: otherPath, displayName: "o", defaultBranch: "main")
+        _ = try await db.worktrees.createMain(
+            repoID: other.id, name: "main", branch: "main", path: otherPath, tmuxServer: "tbd-o")
+
+        let resp = await router.handle(try sessionEvent(terminalID: fx.terminal.id, cwd: otherPath))
+
+        #expect(resp.success)  // soft no-op, but the pointer must not move
+        #expect(try await db.terminals.get(id: fx.terminal.id)?.claudeSessionID == "old-session")
+    }
+
+    @Test func sessionEventRejectsNonMainWorktreeOfPromotedRepo() async throws {
+        let fx = try await makePromotedFixture()
+        // An ACTIVE (non-main) worktree of the promoted repo: repoID matches
+        // but status != .main — must still be rejected.
+        let branchPath = "/tmp/fake-branch-wt-\(UUID().uuidString)"
+        _ = try await db.worktrees.create(
+            repoID: fx.repoID, name: "feature", branch: "feature",
+            path: branchPath, tmuxServer: "tbd-r")
+
+        let resp = await router.handle(try sessionEvent(terminalID: fx.terminal.id, cwd: branchPath))
+
+        #expect(resp.success)
+        #expect(try await db.terminals.get(id: fx.terminal.id)?.claudeSessionID == "old-session")
+    }
+
+    @Test func sessionEventRejectsForeignCwdWhenWorktreeNotPromoted() async throws {
+        // Terminal under a PLAIN scratch row (no promotedToRepoID): the
+        // acceptance never engages and foreign cwds stay rejected.
+        let scratch = try await db.worktrees.createScratch(
+            name: "plain", displayName: "plain",
+            path: "/tmp/fake-plain-\(UUID().uuidString)", tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: scratch.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "old-session", kind: .claude)
+        let repoPath = "/tmp/fake-repo-\(UUID().uuidString)"
+        let repo = try await db.repos.create(
+            path: repoPath, displayName: "r", defaultBranch: "main")
+        _ = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main", path: repoPath, tmuxServer: "tbd-r")
+
+        let resp = await router.handle(try sessionEvent(terminalID: terminal.id, cwd: repoPath))
+
+        #expect(resp.success)
+        #expect(try await db.terminals.get(id: terminal.id)?.claudeSessionID == "old-session")
+    }
+}

--- a/Tests/TBDDaemonTests/StopHookTranscriptSyncTests.swift
+++ b/Tests/TBDDaemonTests/StopHookTranscriptSyncTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Stop-hook (activity → idle) lazy transcript sync: when a terminal's stored
+/// transcriptPath lies outside the project dir derived from the worktree's
+/// CURRENT path, the jsonl (+ subagents) is mirrored into the derived dir.
+/// Isolated entirely via the injectable ClaudeProfileConfigDirManager seam —
+/// no TBD_HOME, no ~/.claude. One test per branch of the sync conditional.
+@Suite("Stop-hook transcript sync")
+struct StopHookTranscriptSyncTests {
+    let home: URL
+    let db: TBDDatabase
+    let router: RPCRouter
+
+    init() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-stopsync-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        self.home = home
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            configDirManager: ClaudeProfileConfigDirManager(
+                baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+                hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
+            )
+        )
+    }
+
+    private var ambientProjectsRoot: URL {
+        home.appendingPathComponent("claude-host/projects", isDirectory: true)
+    }
+
+    private func writeFile(_ text: String, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try text.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// Worktree + terminal whose stored transcript lives under `slug` (an
+    /// arbitrary project-dir name that differs from the derived one when
+    /// `outsideDerivedDir` is true).
+    private func makeFixture(outsideDerivedDir: Bool) async throws
+        -> (terminal: Terminal, worktreePath: String, transcript: URL, derived: URL) {
+        let worktreePath = home.appendingPathComponent("wt-\(UUID().uuidString)").path
+        let wt = try await db.worktrees.createScratch(
+            name: "w", displayName: "w", path: worktreePath, tmuxServer: "tbd-test")
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: worktreePath, projectsRoot: ambientProjectsRoot)
+        let transcript = outsideDerivedDir
+            ? ambientProjectsRoot.appendingPathComponent("-old-slug-\(UUID().uuidString)/sess-1.jsonl")
+            : derived.appendingPathComponent("sess-1.jsonl")
+        try writeFile("live transcript", to: transcript)
+        try writeFile(
+            "sub", to: transcript.deletingLastPathComponent()
+                .appendingPathComponent("sess-1/subagents/agent-a.jsonl"))
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: "sess-1", transcriptPath: transcript.path)
+        return (terminal, worktreePath, transcript, derived)
+    }
+
+    private func send(_ terminalID: UUID, _ state: TerminalActivityState) async throws -> RPCResponse {
+        await router.handle(try RPCRequest(
+            method: RPCMethod.terminalActivityEvent,
+            params: TerminalActivityEventParams(terminalID: terminalID, activityState: state)))
+    }
+
+    @Test func idleSyncsTranscriptStoredOutsideDerivedDir() async throws {
+        defer { try? FileManager.default.removeItem(at: home) }
+        let fx = try await makeFixture(outsideDerivedDir: true)
+
+        let resp = try await send(fx.terminal.id, .idle)
+
+        #expect(resp.success)
+        #expect(try String(
+            contentsOf: fx.derived.appendingPathComponent("sess-1.jsonl"), encoding: .utf8)
+            == "live transcript")
+        #expect(try String(
+            contentsOf: fx.derived.appendingPathComponent("sess-1/subagents/agent-a.jsonl"),
+            encoding: .utf8) == "sub")
+        // The live session's stored pointer is never rewritten.
+        #expect(try await db.terminals.get(id: fx.terminal.id)?.transcriptPath == fx.transcript.path)
+    }
+
+    @Test func idleWithTranscriptAlreadyInDerivedDirIsNoop() async throws {
+        defer { try? FileManager.default.removeItem(at: home) }
+        let fx = try await makeFixture(outsideDerivedDir: false)
+
+        let resp = try await send(fx.terminal.id, .idle)
+
+        #expect(resp.success)
+        // Only the original artifacts exist in the derived dir — no self-copy.
+        let entries = try FileManager.default.contentsOfDirectory(atPath: fx.derived.path).sorted()
+        #expect(entries == ["sess-1", "sess-1.jsonl"])
+        #expect(try String(contentsOf: fx.transcript, encoding: .utf8) == "live transcript")
+    }
+
+    @Test func nonIdleActivityDoesNotSync() async throws {
+        defer { try? FileManager.default.removeItem(at: home) }
+        let fx = try await makeFixture(outsideDerivedDir: true)
+
+        let resp = try await send(fx.terminal.id, .working)
+
+        #expect(resp.success)
+        #expect(!FileManager.default.fileExists(
+            atPath: fx.derived.appendingPathComponent("sess-1.jsonl").path))
+    }
+
+    @Test func idleWithoutStoredTranscriptPathIsNoop() async throws {
+        defer { try? FileManager.default.removeItem(at: home) }
+        let worktreePath = home.appendingPathComponent("wt-\(UUID().uuidString)").path
+        let wt = try await db.worktrees.createScratch(
+            name: "w", displayName: "w", path: worktreePath, tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+
+        let resp = try await send(terminal.id, .idle)
+
+        #expect(resp.success)
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: worktreePath, projectsRoot: ambientProjectsRoot)
+        #expect(!FileManager.default.fileExists(atPath: derived.path))
+    }
+}

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -58,6 +58,13 @@ private func installCodexTestHomeOverride() {
     _ = codexTestHomePath
 }
 
+/// terminal.create / terminal.recreateWindow refuse to spawn into a missing
+/// directory (tmux would silently fall back to $HOME), so fixtures must
+/// materialize their fake worktree paths on disk. Idempotent.
+private func ensureWorktreeDir(_ path: String) throws {
+    try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+}
+
 // MARK: - Fix 1: Daemon scrubInheritedTBDEnv
 
 @Test("Daemon.scrubInheritedTBDEnv clears inherited routing vars")
@@ -124,6 +131,7 @@ func testHandleTerminalRecreateWindowSetsWorktreeID() async throws {
     let repo = try await db.repos.create(
         path: "/tmp/fake-repo-recreate", displayName: "test", defaultBranch: "main"
     )
+    try ensureWorktreeDir("/tmp/fake-repo-recreate/wt-recreate")
     let wt = try await db.worktrees.create(
         repoID: repo.id,
         name: "wt-recreate",
@@ -175,6 +183,7 @@ func testHandleTerminalRecreateWindowCodexLaunchCommand() async throws {
     let repo = try await db.repos.create(
         path: "/tmp/fake-repo-recreate-codex", displayName: "test", defaultBranch: "main"
     )
+    try ensureWorktreeDir("/tmp/fake-repo-recreate-codex/wt-recreate-codex")
     let wt = try await db.worktrees.create(
         repoID: repo.id,
         name: "wt-recreate-codex",
@@ -351,6 +360,7 @@ func testHandleTerminalRecreateWindowRebuildsShellAsShell() async throws {
     let repo = try await db.repos.create(
         path: "/tmp/fake-repo-recreate-shell", displayName: "test", defaultBranch: "main"
     )
+    try ensureWorktreeDir("/tmp/fake-repo-recreate-shell/wt-recreate-shell")
     let wt = try await db.worktrees.create(
         repoID: repo.id,
         name: "wt-recreate-shell",
@@ -479,6 +489,7 @@ func testHandleTerminalCreateRegressionWorktreeID() async throws {
     let repo = try await db.repos.create(
         path: "/tmp/fake-repo-create", displayName: "test", defaultBranch: "main"
     )
+    try ensureWorktreeDir("/tmp/fake-repo-create/wt-create")
     let wt = try await db.worktrees.create(
         repoID: repo.id,
         name: "wt-create",
@@ -525,6 +536,7 @@ func testHandleTerminalCreateCodexLaunchCommand() async throws {
     let repo = try await db.repos.create(
         path: "/tmp/fake-repo-create-codex", displayName: "test", defaultBranch: "main"
     )
+    try ensureWorktreeDir("/tmp/fake-repo-create-codex/wt-create-codex")
     let wt = try await db.worktrees.create(
         repoID: repo.id,
         name: "wt-create-codex",
@@ -578,6 +590,7 @@ func testHandleTerminalCreateCodexInitialPrompt() async throws {
     let repo = try await db.repos.create(
         path: "/tmp/fake-repo-create-codex-prompt", displayName: "test", defaultBranch: "main"
     )
+    try ensureWorktreeDir("/tmp/fake-repo-create-codex-prompt/wt-create-codex-prompt")
     let wt = try await db.worktrees.create(
         repoID: repo.id,
         name: "wt-create-codex-prompt",

--- a/Tests/TBDDaemonTests/TerminalSpawnPathGuardTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSpawnPathGuardTests.swift
@@ -1,0 +1,79 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// terminal.create / terminal.recreateWindow must fail loudly when the
+/// worktree's directory is missing on disk — tmux's `-c` would otherwise
+/// silently fall back to $HOME. One test per branch of the new guards.
+extension RPCRouterTests {
+
+    private func makeExistingDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-spawn-guard-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func terminalCreateFailsWhenWorktreePathMissing() async throws {
+        let missingPath = "/tmp/tbd-missing-\(UUID().uuidString)"
+        let wt = try await db.worktrees.createScratch(
+            name: "gone", displayName: "gone", path: missingPath, tmuxServer: "tbd-test")
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id)))
+
+        #expect(!resp.success)
+        #expect(resp.error?.contains(missingPath) == true)
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test func terminalCreateSucceedsWhenWorktreePathExists() async throws {
+        let dir = try makeExistingDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let wt = try await db.worktrees.createScratch(
+            name: "here", displayName: "here", path: dir.path, tmuxServer: "tbd-test")
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id)))
+
+        #expect(resp.success)
+        #expect(try await db.terminals.list(worktreeID: wt.id).count == 1)
+    }
+
+    @Test func recreateWindowFailsWhenWorktreePathMissing() async throws {
+        let missingPath = "/tmp/tbd-missing-\(UUID().uuidString)"
+        let wt = try await db.worktrees.createScratch(
+            name: "gone", displayName: "gone", path: missingPath, tmuxServer: "tbd-test")
+        // Shell terminal: reaches the spawn path (Claude-resumable terminals
+        // take the non-spawning park branch instead).
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "shell", kind: .shell)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalRecreateWindow,
+            params: TerminalRecreateWindowParams(terminalID: terminal.id)))
+
+        #expect(!resp.success)
+        #expect(resp.error?.contains(missingPath) == true)
+    }
+
+    @Test func recreateWindowSucceedsWhenWorktreePathExists() async throws {
+        let dir = try makeExistingDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let wt = try await db.worktrees.createScratch(
+            name: "here", displayName: "here", path: dir.path, tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "shell", kind: .shell)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalRecreateWindow,
+            params: TerminalRecreateWindowParams(terminalID: terminal.id)))
+
+        #expect(resp.success)
+    }
+}

--- a/Tests/TBDDaemonTests/TranscriptProjectDirSyncTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptProjectDirSyncTests.swift
@@ -204,6 +204,53 @@ struct TranscriptProjectDirSyncTests {
         #expect(contents(derived.appendingPathComponent("sess-1.jsonl")) == "newer derived")
     }
 
+    // MARK: - locateSessionTranscript
+
+    @Test func locateSessionTranscriptFindsNewestCopyAcrossProjectDirs() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let root = dir.appendingPathComponent("projects", isDirectory: true)
+        try write("stale copy", to: root.appendingPathComponent("-old-slug-a/sess-1.jsonl"),
+                  mtime: Date(timeIntervalSinceNow: -600))
+        try write("fresh copy", to: root.appendingPathComponent("-old-slug-b/sess-1.jsonl"),
+                  mtime: Date())
+        try write("other session", to: root.appendingPathComponent("-old-slug-b/sess-2.jsonl"))
+
+        let located = TranscriptProjectDirSync.locateSessionTranscript(
+            sessionID: "sess-1", projectsRoot: root)
+        #expect(contents(try #require(located)) == "fresh copy")
+    }
+
+    @Test func locateSessionTranscriptReturnsNilWhenSessionAbsent() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let root = dir.appendingPathComponent("projects", isDirectory: true)
+        try write("other session", to: root.appendingPathComponent("-slug/sess-2.jsonl"))
+
+        #expect(TranscriptProjectDirSync.locateSessionTranscript(
+            sessionID: "sess-1", projectsRoot: root) == nil)
+    }
+
+    /// The moved-while-archived revive case: no terminal row survived to
+    /// store a transcript path, and the OLD munged dir doesn't resolve from
+    /// the worktree's CURRENT path — the by-session-ID scan must still find
+    /// and mirror the transcript.
+    @Test func ensureSessionResumableFallsBackToByIDScanWithoutStoredPath() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let root = dir.appendingPathComponent("projects", isDirectory: true)
+        let worktreePath = dir.appendingPathComponent("wt-new-location").path
+        try write("archived transcript", to: root.appendingPathComponent("-old-slug/sess-1.jsonl"))
+
+        TranscriptProjectDirSync.ensureSessionResumable(
+            sessionID: "sess-1", worktreePath: worktreePath,
+            projectsRoot: root, storedTranscriptPath: nil)
+
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: worktreePath, projectsRoot: root)
+        #expect(contents(derived.appendingPathComponent("sess-1.jsonl")) == "archived transcript")
+    }
+
     @Test func ensureSessionResumableNoopsWithoutAnySource() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/TBDDaemonTests/TranscriptProjectDirSyncTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptProjectDirSyncTests.swift
@@ -1,0 +1,223 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+
+/// Unit tests for the copy-if-newer transcript sync unit. Pure temp-dir
+/// filesystem tests — no TBD_HOME, no ~/.claude, no daemon state.
+@Suite("TranscriptProjectDirSync")
+struct TranscriptProjectDirSyncTests {
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-sync-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func write(_ text: String, to url: URL, mtime: Date? = nil) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        if let mtime {
+            try FileManager.default.setAttributes(
+                [.modificationDate: mtime], ofItemAtPath: url.path)
+        }
+    }
+
+    private func contents(_ url: URL) -> String? {
+        try? String(contentsOf: url, encoding: .utf8)
+    }
+
+    // MARK: - derivedProjectDir
+
+    @Test func derivedProjectDirMungesSlashesAndDots() throws {
+        let root = URL(fileURLWithPath: "/tmp/projects", isDirectory: true)
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: "/Users/dev/my.app/wt", projectsRoot: root)
+        #expect(derived.lastPathComponent == "-Users-dev-my-app-wt")
+        #expect(derived.deletingLastPathComponent().path == "/tmp/projects")
+    }
+
+    // MARK: - copyIfNewer
+
+    @Test func copyIfNewerCopiesWhenDestinationMissing() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let source = dir.appendingPathComponent("src/a.jsonl")
+        let dest = dir.appendingPathComponent("dst/a.jsonl")
+        try write("hello", to: source)
+
+        let copied = TranscriptProjectDirSync.copyIfNewer(from: source, to: dest)
+
+        #expect(copied)
+        #expect(contents(dest) == "hello")
+    }
+
+    @Test func copyIfNewerOverwritesStaleDestination() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let source = dir.appendingPathComponent("src/a.jsonl")
+        let dest = dir.appendingPathComponent("dst/a.jsonl")
+        try write("new content", to: source, mtime: Date())
+        try write("old content", to: dest, mtime: Date(timeIntervalSinceNow: -600))
+
+        let copied = TranscriptProjectDirSync.copyIfNewer(from: source, to: dest)
+
+        #expect(copied)
+        #expect(contents(dest) == "new content")
+    }
+
+    @Test func copyIfNewerLeavesFresherDestinationIntact() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let source = dir.appendingPathComponent("src/a.jsonl")
+        let dest = dir.appendingPathComponent("dst/a.jsonl")
+        try write("stale snapshot", to: source, mtime: Date(timeIntervalSinceNow: -600))
+        try write("fresher work", to: dest, mtime: Date())
+
+        let copied = TranscriptProjectDirSync.copyIfNewer(from: source, to: dest)
+
+        #expect(!copied)
+        #expect(contents(dest) == "fresher work")
+    }
+
+    @Test func copyIfNewerLeavesEquallyFreshDestinationIntact() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let stamp = Date(timeIntervalSinceNow: -60)
+        let source = dir.appendingPathComponent("src/a.jsonl")
+        let dest = dir.appendingPathComponent("dst/a.jsonl")
+        try write("source", to: source, mtime: stamp)
+        try write("destination", to: dest, mtime: stamp)
+
+        let copied = TranscriptProjectDirSync.copyIfNewer(from: source, to: dest)
+
+        #expect(!copied)
+        #expect(contents(dest) == "destination")
+    }
+
+    @Test func copyIfNewerNoopsOnMissingSource() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let source = dir.appendingPathComponent("src/missing.jsonl")
+        let dest = dir.appendingPathComponent("dst/missing.jsonl")
+
+        let copied = TranscriptProjectDirSync.copyIfNewer(from: source, to: dest)
+
+        #expect(!copied)
+        #expect(!FileManager.default.fileExists(atPath: dest.path))
+    }
+
+    // MARK: - syncDirectoryContents
+
+    @Test func syncDirectoryContentsRecursesAndPreservesNewerDestination() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sourceDir = dir.appendingPathComponent("src", isDirectory: true)
+        let destDir = dir.appendingPathComponent("dst", isDirectory: true)
+        try write("s1", to: sourceDir.appendingPathComponent("s1.jsonl"))
+        try write("memory", to: sourceDir.appendingPathComponent("memory/MEMORY.md"))
+        try write("agent", to: sourceDir.appendingPathComponent("s1/subagents/agent-a.jsonl"))
+        // Destination already has fresher work for one file.
+        try write("stale s2", to: sourceDir.appendingPathComponent("s2.jsonl"),
+                  mtime: Date(timeIntervalSinceNow: -600))
+        try write("fresh s2", to: destDir.appendingPathComponent("s2.jsonl"), mtime: Date())
+
+        TranscriptProjectDirSync.syncDirectoryContents(from: sourceDir, to: destDir)
+
+        #expect(contents(destDir.appendingPathComponent("s1.jsonl")) == "s1")
+        #expect(contents(destDir.appendingPathComponent("memory/MEMORY.md")) == "memory")
+        #expect(contents(destDir.appendingPathComponent("s1/subagents/agent-a.jsonl")) == "agent")
+        #expect(contents(destDir.appendingPathComponent("s2.jsonl")) == "fresh s2")
+    }
+
+    // MARK: - syncSession
+
+    @Test func syncSessionCopiesJsonlAndSubagents() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sourceDir = dir.appendingPathComponent("old-slug", isDirectory: true)
+        let destDir = dir.appendingPathComponent("new-slug", isDirectory: true)
+        let jsonl = sourceDir.appendingPathComponent("sess-1.jsonl")
+        try write("transcript", to: jsonl)
+        try write("sub", to: sourceDir.appendingPathComponent("sess-1/subagents/agent-x.jsonl"))
+
+        TranscriptProjectDirSync.syncSession(jsonl: jsonl, intoProjectDir: destDir)
+
+        #expect(contents(destDir.appendingPathComponent("sess-1.jsonl")) == "transcript")
+        #expect(contents(destDir.appendingPathComponent("sess-1/subagents/agent-x.jsonl")) == "sub")
+    }
+
+    // MARK: - ensureSessionResumable
+
+    @Test func ensureSessionResumableCopiesFromStoredPathWhenDestinationMissing() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let root = dir.appendingPathComponent("projects", isDirectory: true)
+        let worktreePath = dir.appendingPathComponent("wt").path
+        let stored = dir.appendingPathComponent("elsewhere/sess-1.jsonl")
+        try write("stored transcript", to: stored)
+
+        TranscriptProjectDirSync.ensureSessionResumable(
+            sessionID: "sess-1", worktreePath: worktreePath,
+            projectsRoot: root, storedTranscriptPath: stored.path)
+
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: worktreePath, projectsRoot: root)
+        #expect(contents(derived.appendingPathComponent("sess-1.jsonl")) == "stored transcript")
+    }
+
+    @Test func ensureSessionResumableOverwritesStaleDestination() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let root = dir.appendingPathComponent("projects", isDirectory: true)
+        let worktreePath = dir.appendingPathComponent("wt").path
+        let stored = dir.appendingPathComponent("elsewhere/sess-1.jsonl")
+        try write("live latest", to: stored, mtime: Date())
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: worktreePath, projectsRoot: root)
+        try write("old snapshot", to: derived.appendingPathComponent("sess-1.jsonl"),
+                  mtime: Date(timeIntervalSinceNow: -600))
+
+        TranscriptProjectDirSync.ensureSessionResumable(
+            sessionID: "sess-1", worktreePath: worktreePath,
+            projectsRoot: root, storedTranscriptPath: stored.path)
+
+        #expect(contents(derived.appendingPathComponent("sess-1.jsonl")) == "live latest")
+    }
+
+    @Test func ensureSessionResumableLeavesFresherDestinationIntact() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let root = dir.appendingPathComponent("projects", isDirectory: true)
+        let worktreePath = dir.appendingPathComponent("wt").path
+        let stored = dir.appendingPathComponent("elsewhere/sess-1.jsonl")
+        try write("older stored", to: stored, mtime: Date(timeIntervalSinceNow: -600))
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: worktreePath, projectsRoot: root)
+        try write("newer derived", to: derived.appendingPathComponent("sess-1.jsonl"), mtime: Date())
+
+        TranscriptProjectDirSync.ensureSessionResumable(
+            sessionID: "sess-1", worktreePath: worktreePath,
+            projectsRoot: root, storedTranscriptPath: stored.path)
+
+        #expect(contents(derived.appendingPathComponent("sess-1.jsonl")) == "newer derived")
+    }
+
+    @Test func ensureSessionResumableNoopsWithoutAnySource() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let root = dir.appendingPathComponent("projects", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let worktreePath = dir.appendingPathComponent("wt").path
+
+        TranscriptProjectDirSync.ensureSessionResumable(
+            sessionID: "sess-1", worktreePath: worktreePath,
+            projectsRoot: root, storedTranscriptPath: nil)
+
+        let derived = TranscriptProjectDirSync.derivedProjectDir(
+            worktreePath: worktreePath, projectsRoot: root)
+        #expect(!FileManager.default.fileExists(
+            atPath: derived.appendingPathComponent("sess-1.jsonl").path))
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -769,6 +769,62 @@ import Testing
     #expect(suspendedAfter?.claudeSessionID == fakeSessionID, "claudeSessionID must be preserved for suspended terminal")
 }
 
+/// Hibernated-but-not-legacy-suspended terminals (`hibernatedAt` set,
+/// `suspendedAt` nil) are parked and must be skipped by the dead-window pass
+/// exactly like legacy-suspended ones: a parked row's window being gone is
+/// expected, and the row is already what the pass would produce.
+///
+/// Regression guard for the old `suspendedAt == nil` filter, which passed
+/// hibernated rows through — refreshing the park timestamp on resumable rows
+/// and DELETING parked rows that aren't Claude-resumable.
+@Test func testReconcileHibernatedTerminalSkippedOnDeadWindow() async throws {
+    let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    // Every window reads as dead — the exact scenario the parking pass acts on.
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true }),
+        hooks: HookResolver()
+    )
+
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let serverName = TmuxManager.serverName(forRepoPath: repo.path)
+    // A worktree at the repo path so `git worktree list` reports it and
+    // reconcile doesn't archive it as missing.
+    let wt = try await db.worktrees.create(
+        repoID: repo.id, name: "wt", branch: "main",
+        path: repoDir.path, tmuxServer: serverName
+    )
+
+    let claude = try await db.terminals.create(
+        worktreeID: wt.id, tmuxWindowID: "@hib-claude", tmuxPaneID: "%hib-claude",
+        label: "claude", claudeSessionID: "sess-hib", kind: .claude
+    )
+    try await db.terminals.setHibernated(id: claude.id, sessionID: "sess-hib")
+    // A parked row that is NOT Claude-resumable: under the old filter this
+    // fell through to the delete branch and the parked row vanished.
+    let codex = try await db.terminals.create(
+        worktreeID: wt.id, tmuxWindowID: "@hib-codex", tmuxPaneID: "%hib-codex",
+        label: "Codex", claudeSessionID: "sess-codex", kind: .codex
+    )
+    try await db.terminals.setHibernated(id: codex.id, sessionID: "sess-codex")
+
+    try await lifecycle.reconcile(repoID: repo.id)
+
+    let claudeAfter = try await db.terminals.get(id: claude.id)
+    #expect(claudeAfter != nil, "hibernated claude terminal must survive reconcile")
+    #expect(claudeAfter?.hibernatedAt != nil, "hibernated claude must stay parked")
+    #expect(claudeAfter?.suspendedAt == nil, "hibernated-only row must not gain legacy suspendedAt")
+    #expect(claudeAfter?.claudeSessionID == "sess-hib")
+
+    let codexAfter = try await db.terminals.get(id: codex.id)
+    #expect(codexAfter != nil, "a parked non-Claude-resumable row must be skipped, not deleted")
+    #expect(codexAfter?.hibernatedAt != nil)
+}
+
 /// Server gone path (reboot): in dryRun mode serverExists → true, so this path
 /// cannot be directly triggered. Instead, this test seeds a stale windowID and
 /// verifies that when the server IS alive (dryRun), the stale window is treated


### PR DESCRIPTION
## Summary

**What's broken:** promoting a scratch space (`tbd scratch promote`) moves the folder and registers the new repo — and nothing else. The scratch worktree row keeps its dead path with terminals still parented to it, so `claude --resume` can't find the transcripts (Claude keys its project dir off the cwd, which just changed), new spawns into the dead path silently fall back to `$HOME` and scatter transcripts into wrong project dirs, and the SessionStart ownership guard rejects the promoted session's own events forever — the pointers can never self-heal. Verified live on the "Android Health Tracker" promotion: two post-promotion sessions ran with cwd=`$HOME` and lost their transcripts.

**Why the fix is shaped this way:** the promote RPC is issued *by* the live Claude session in its own pane, and the folder move is a same-volume rename (live processes' cwd follows the inode). So promote must never suspend/kill/respawn anything — this PR migrates metadata atomically and heals transcripts lazily instead:

- **Atomic promote migration** (one write transaction): terminals re-parented to the new repo's main worktree, tab state carried over, the main worktree inherits the scratch tmux server so live panes stay reachable, scratch row archived keeping `promotedToRepoID`. Claude project dirs (session JSONLs, `subagents/`, `memory/`) are snapshotted old-munged→new-munged per profile root, copy-if-newer.
- **Lazy transcript sync** (`TranscriptProjectDirSync`, all copies off-executor via awaited detached tasks): Stop hook mirrors a diverged transcript into the cwd-derived dir; every daemon-driven `claude --resume` pre-syncs the session JSONL (with a by-session-ID scan fallback for moved-while-archived revives) so resume always finds it.
- **Fail loud, not sideways:** terminal create/recreate/wake refuse a missing worktree path instead of tmux's silent `$HOME` fallback; `terminal.create` can't insert onto a promoted worktree (race-proofed inside the insert transaction); the SessionStart guard accepts the promoted repo's main worktree cwd while still rejecting foreign sessions.
- **Reconcile taught about inherited servers:** probes each row's *stored* tmux server before canonicalizing/parking (else the next daemon restart would have reverted the migration and deleted the terminals), and the sweep/kill pass now covers inherited servers — killing only when no live row anywhere references them, which also unsticks the pre-existing scratch-server leak (#325).

Two adversarial review rounds (4 significant findings found and fixed, closures re-verified); 46 new tests; suite 2669/2669 green, `swiftlint --strict` clean.

## Test plan
- [ ] `swift test` — full suite green (2669 tests), including `ScratchPromoteMigrationTests`, `ScratchPromoteAtomicityTests`, `ScratchPromoteReconcileTests`, `TranscriptProjectDirSyncTests`, `TerminalSpawnPathGuardTests`, `SessionEventPromoteGuardTests`, `StopHookTranscriptSyncTests`
- [ ] Live smoke: create a scratch space, start a Claude session, `tbd scratch promote ~/projects/<name>` from inside it → session keeps running; new tabs open in the new path; restart the daemon → terminals survive reconcile; hibernate + wake → `claude --resume` restores the conversation

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=C102EB28-C814-4067-A4C8-FDBED6149242)