### PR TITLE
Fix: Recreate a parked session's tmux window on wake when it's gone (reboot recovery) + stop focus-wake alert spam

### DIFF
--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -47,8 +47,17 @@ extension AppState {
     /// Wake a hibernated terminal (respawn `claude --resume`). Idempotent and
     /// singleflighted on the app side: a second call while one is in flight is
     /// dropped, so double-focus never fires two respawns.
-    func wakeTerminal(terminalID: UUID, worktreeID: UUID) async {
-        guard !wakeInFlight.contains(terminalID) else { return }
+    ///
+    /// Never shows an alert itself — it returns the failure message (nil on
+    /// success) so CALL SITES decide how to surface it: the explicit Wake menu
+    /// action shows ONE coalesced alert for its whole batch (see
+    /// `coalescedWakeFailureMessage`), while automatic focus-wakes stay silent
+    /// — otherwise every worktree focus after a reboot (which kills all tmux
+    /// windows) fired a modal per parked terminal. `userInitiated` drives the
+    /// failure log level (explicit action → error; background → warning).
+    @discardableResult
+    func wakeTerminal(terminalID: UUID, worktreeID: UUID, userInitiated: Bool) async -> String? {
+        guard !wakeInFlight.contains(terminalID) else { return nil }
         wakeInFlight.insert(terminalID)
         defer { wakeInFlight.remove(terminalID) }
         do {
@@ -57,10 +66,29 @@ extension AppState {
                 terminalID: terminalID, cols: size.cols, rows: size.rows
             )
             await refreshTerminals(worktreeID: worktreeID)
+            return nil
         } catch {
-            logger.error("Failed to wake terminal: \(error, privacy: .public)")
-            showAlert("Couldn't wake session: \(error.localizedDescription)", isError: true)
+            if userInitiated {
+                logger.error("Failed to wake terminal \(terminalID, privacy: .public): \(error, privacy: .public)")
+            } else {
+                logger.warning("Automatic wake failed for terminal \(terminalID, privacy: .public) (alert suppressed): \(error, privacy: .public)")
+            }
+            return error.localizedDescription
         }
+    }
+
+    /// Pure decision/formatting seam behind the explicit Wake menu action's
+    /// COALESCED failure alert: `nil` for no failures (no alert), the bare
+    /// message for a single failure, and a count-prefixed message when several
+    /// wakes failed — one modal per user action, never one per terminal.
+    /// Extracted as a pure function so every branch is unit-tested without a
+    /// live `DaemonClient` (same pattern as `terminalIDToWakeOnFocus`).
+    static func coalescedWakeFailureMessage(failures: [String]) -> String? {
+        guard let first = failures.first else { return nil }
+        if failures.count == 1 {
+            return "Couldn't wake session: \(first)"
+        }
+        return "Couldn't wake \(failures.count) sessions: \(first)"
     }
 
     /// Toggle a terminal's keep-warm pin (exempts it from auto-hibernation).
@@ -98,7 +126,7 @@ extension AppState {
     func wakeHibernatedTerminalsOnFocus(worktreeID: UUID) {
         guard let target = terminalIDToWakeOnFocus(worktreeID: worktreeID) else { return }
         // Wake exactly one; never a parallel fan-out (see the storm rationale above).
-        Task { await wakeTerminal(terminalID: target, worktreeID: worktreeID) }
+        Task { await wakeTerminal(terminalID: target, worktreeID: worktreeID, userInitiated: false) }
     }
 
     /// Pure decision behind `wakeHibernatedTerminalsOnFocus`: the single parked

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -949,6 +949,17 @@ final class AppState: ObservableObject {
         guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
             return
         }
+        // Apply fresh tmux ids (carried on wake, especially after a window
+        // RECREATE) together with the un-park flip. The terminal view keys on
+        // `id-tmuxWindowID-isParked`; flipping isParked while the cached row
+        // still points at the dead window would rebuild the view against that
+        // dead window, and its failed attach re-parks the row (wake flap).
+        if let windowID = delta.tmuxWindowID {
+            terminals[delta.worktreeID]?[idx].tmuxWindowID = windowID
+        }
+        if let paneID = delta.tmuxPaneID {
+            terminals[delta.worktreeID]?[idx].tmuxPaneID = paneID
+        }
         terminals[delta.worktreeID]?[idx].hibernatedAt = delta.hibernated ? Date() : nil
         terminals[delta.worktreeID]?[idx].keepWarm = delta.keepWarm
     }

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -111,8 +111,19 @@ struct RowActionMenuActions {
             // Wake every PARKED session (hibernated or legacy-suspended).
             let ids = terminals.filter { $0.isParked }.map { $0.id }
             Task {
+                // Collect failures and show ONE coalesced alert after the
+                // loop — never a modal per terminal (post-reboot every window
+                // is dead, and a per-terminal alert becomes a modal storm).
+                var failures: [String] = []
                 for id in ids {
-                    await appState.wakeTerminal(terminalID: id, worktreeID: wtID)
+                    if let failure = await appState.wakeTerminal(
+                        terminalID: id, worktreeID: wtID, userInitiated: true
+                    ) {
+                        failures.append(failure)
+                    }
+                }
+                if let message = AppState.coalescedWakeFailureMessage(failures: failures) {
+                    appState.showAlert(message, isError: true)
                 }
             }
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -421,6 +421,13 @@ public final class Daemon: Sendable {
             pendingQuestions: pendingQuestions
         )
         rpcRouter.controlMode = controlModeBridge
+        // The wake path recreates a terminal's tmux server/window when the
+        // window is gone (e.g. post-reboot); give the recreated server the
+        // same gated control-mode connection as every other ensureServer
+        // call site.
+        await rpcRouter.hibernationCoordinator.setOnServerCreated { server in
+            await controlModeBridge.enableIfGated(serverName: server)
+        }
         self.router = rpcRouter
 
         // Shared foreground gate: the app reports its active/inactive state via

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -466,14 +466,6 @@ public actor HibernationCoordinator {
                     rows: resolvedRows
                 )
                 await onServerCreated?(server)
-                // Clean up the old window if it somehow still exists (a
-                // transient windowExists misclassification must not leak a
-                // live window; usually it's already dead so this no-ops).
-                // Skip when another terminal owns the id — killing it would
-                // tear down THEIR live window.
-                if !claimedByOther {
-                    try? await tmux.killWindow(server: server, windowID: windowID)
-                }
                 let window = try await tmux.createWindow(
                     server: server,
                     session: "main",
@@ -484,6 +476,19 @@ public actor HibernationCoordinator {
                     cols: resolvedCols,
                     rows: resolvedRows
                 )
+                // Clean up the old window if it somehow still exists (a
+                // transient windowExists misclassification must not leak a
+                // live window; usually it's already dead so this no-ops).
+                // Skip when another terminal owns the id — killing it would
+                // tear down THEIR live window. This must happen AFTER
+                // createWindow: if the row ever held the session's only
+                // remaining window (e.g. the bootstrap window id), killing
+                // it first would destroy the session and make createWindow
+                // fail on every retry; killing after the new window exists
+                // can never leave the session windowless.
+                if !claimedByOther {
+                    try? await tmux.killWindow(server: server, windowID: windowID)
+                }
                 // ensureServer returns the untracked bootstrap window id when
                 // it just created the server; kill it now that the real
                 // window exists (mirrors WorktreeLifecycle+PreSession).

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -72,11 +72,12 @@ public actor HibernationCoordinator {
     /// spawn two `claude --resume` processes into the same window.
     private var wakesInFlight: Set<UUID> = []
 
-    /// Invoked after the wake path recreates a tmux server via `ensureServer`
-    /// for a terminal whose window vanished (e.g. a machine reboot destroyed
-    /// every tmux server). Daemon.swift wires this to the control-mode
-    /// bridge's `enableIfGated` so a recreated server gets the same gated
-    /// `tmux -CC` connection as every other `ensureServer()` call site.
+    /// Invoked after EVERY `ensureServer` on the wake-recreate path (whether or
+    /// not a server was actually created — the downstream control-mode
+    /// `enableIfGated` is idempotent, so firing on an existing server is a
+    /// no-op). Daemon.swift wires this to the control-mode bridge so a freshly
+    /// recreated server gets the same gated `tmux -CC` connection as every
+    /// other `ensureServer()` call site.
     private var onServerCreated: (@Sendable (String) async -> Void)?
 
     /// Terminal ids with an in-flight hibernate, so a manual "Hibernate now"
@@ -407,12 +408,26 @@ public actor HibernationCoordinator {
         ]
         let sensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
 
-        // The pane the delayed session-ID recapture below must poll: the
-        // original pane when the window survived, or the recreated window's
-        // fresh pane when it didn't.
+        // The window/pane the rest of wake must reference: the original ones
+        // when the window survived, or the recreated window's fresh ones.
         let livePaneID: String
+        let liveWindowID: String
 
-        if await tmux.windowExists(server: server, windowID: windowID) {
+        // Post-reboot a fresh tmux server reissues window ids from @1 again,
+        // so a stale parked row's window id can equal a window that ANOTHER
+        // terminal's wake just created on the same server. `windowExists`
+        // alone is therefore not ownership: if any other terminal currently
+        // claims this id, ours is necessarily the stale claim (it predates
+        // the reboot) and respawning in place would hijack that terminal's
+        // live session. Treat the window as gone and recreate instead.
+        let claimedByOther = await windowClaimedByAnotherTerminal(
+            server: server, windowID: windowID, excluding: terminal.id
+        )
+        if claimedByOther {
+            logger.info("wake: window \(windowID, privacy: .public) on \(server, privacy: .public) is claimed by another terminal — recreating instead of respawning in place for terminal \(terminal.id, privacy: .public)")
+        }
+
+        if !claimedByOther, await tmux.windowExists(server: server, windowID: windowID) {
             do {
                 try await tmux.respawnWindow(
                     server: server,
@@ -425,23 +440,25 @@ public actor HibernationCoordinator {
                     rows: rows
                 )
                 livePaneID = paneID
+                liveWindowID = windowID
             } catch {
                 // Leave the row hibernated so the next focus/menu retry can wake it.
                 logger.warning("wake: respawn-to-claude failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 return .respawnFailed(reason: "failed to respawn claude in window \(windowID): \(error.localizedDescription)")
             }
         } else {
-            // The window is GONE — killed, or the whole tmux server died (a
+            // The window is GONE — killed, the whole tmux server died (a
             // machine reboot destroys every server; `windowExists` returns
-            // false on any tmux error, covering both). Recreate the window and
-            // spawn the same `claude --resume` there: transcripts live on
-            // disk, so resume works fine in a fresh window. Mirrors
+            // false on any tmux error, covering both), or its id is owned by
+            // another terminal (see above). Recreate the window and spawn the
+            // same `claude --resume` there: transcripts live on disk, so
+            // resume works fine in a fresh window. Mirrors
             // `handleTerminalRecreateWindow`. Tabs are keyed by terminal id,
             // so keeping the same terminal row preserves the tab.
             do {
                 let resolvedCols = cols ?? TmuxManager.defaultCols
                 let resolvedRows = rows ?? TmuxManager.defaultRows
-                _ = try await tmux.ensureServer(
+                let bootstrapWindowID = try await tmux.ensureServer(
                     server: server,
                     session: "main",
                     cwd: worktree.path,
@@ -449,6 +466,14 @@ public actor HibernationCoordinator {
                     rows: resolvedRows
                 )
                 await onServerCreated?(server)
+                // Clean up the old window if it somehow still exists (a
+                // transient windowExists misclassification must not leak a
+                // live window; usually it's already dead so this no-ops).
+                // Skip when another terminal owns the id — killing it would
+                // tear down THEIR live window.
+                if !claimedByOther {
+                    try? await tmux.killWindow(server: server, windowID: windowID)
+                }
                 let window = try await tmux.createWindow(
                     server: server,
                     session: "main",
@@ -459,10 +484,27 @@ public actor HibernationCoordinator {
                     cols: resolvedCols,
                     rows: resolvedRows
                 )
-                try await db.terminals.updateTmuxIDs(
-                    id: terminal.id, windowID: window.windowID, paneID: window.paneID
-                )
+                // ensureServer returns the untracked bootstrap window id when
+                // it just created the server; kill it now that the real
+                // window exists (mirrors WorktreeLifecycle+PreSession).
+                if let bootstrapWindowID, !bootstrapWindowID.isEmpty {
+                    try? await tmux.killWindow(server: server, windowID: bootstrapWindowID)
+                }
+                do {
+                    try await db.terminals.updateTmuxIDs(
+                        id: terminal.id, windowID: window.windowID, paneID: window.paneID
+                    )
+                } catch {
+                    // Don't leave an orphaned claude the DB doesn't know
+                    // about: best-effort kill of the just-created window,
+                    // and a reason that names the REAL failure (the window
+                    // was created fine; persisting the ids failed).
+                    try? await tmux.killWindow(server: server, windowID: window.windowID)
+                    logger.warning("wake: created window \(window.windowID, privacy: .public) but failed to persist tmux ids for terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    return .respawnFailed(reason: "recreated tmux window \(window.windowID), but persisting the new tmux ids failed: \(error.localizedDescription)")
+                }
                 livePaneID = window.paneID
+                liveWindowID = window.windowID
                 logger.info("wake: window \(windowID, privacy: .public) was gone for terminal \(terminal.id, privacy: .public); recreated as \(window.windowID, privacy: .public) (pane \(window.paneID, privacy: .public))")
             } catch {
                 // Leave the row hibernated so the next focus/menu retry can wake it.
@@ -477,7 +519,14 @@ public actor HibernationCoordinator {
             logger.warning("wake: failed to clear hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
         idleSince[terminal.id] = nil
-        broadcastHibernation(terminal: terminal, hibernated: false, keepWarm: terminal.keepWarm)
+        // Carry the LIVE window/pane ids on the un-park broadcast so the app
+        // updates its cached row before (together with) the hibernated flip —
+        // otherwise the terminal view rebuilds keyed on the dead window and
+        // its failed attach re-parks the row (wake flap).
+        broadcastHibernation(
+            terminal: terminal, hibernated: false, keepWarm: terminal.keepWarm,
+            tmuxWindowID: liveWindowID, tmuxPaneID: livePaneID
+        )
 
         // `claude --resume <id>` forks into a NEW session file; re-capture the
         // fresh id so subsequent hibernate/wake reference the live session.
@@ -636,12 +685,37 @@ public actor HibernationCoordinator {
         }
     }
 
-    private func broadcastHibernation(terminal: Terminal, hibernated: Bool, keepWarm: Bool) {
+    /// True when any OTHER terminal row whose worktree lives on the same tmux
+    /// server currently claims `windowID`. A fresh (post-reboot) server
+    /// reissues window ids from @1, so a stale parked row can collide with a
+    /// window a different terminal's wake just created — and the other row's
+    /// claim is necessarily the fresher one. Worktrees can share a per-repo
+    /// server, so ownership is resolved across all worktrees with the same
+    /// `tmuxServer` string, not just this terminal's worktree.
+    private func windowClaimedByAnotherTerminal(
+        server: String, windowID: String, excluding terminalID: UUID
+    ) async -> Bool {
+        guard let terminals = try? await db.terminals.list(),
+              let worktrees = try? await db.worktrees.list() else { return false }
+        let serverWorktreeIDs = Set(worktrees.filter { $0.tmuxServer == server }.map(\.id))
+        return terminals.contains {
+            $0.id != terminalID
+                && $0.tmuxWindowID == windowID
+                && serverWorktreeIDs.contains($0.worktreeID)
+        }
+    }
+
+    private func broadcastHibernation(
+        terminal: Terminal, hibernated: Bool, keepWarm: Bool,
+        tmuxWindowID: String? = nil, tmuxPaneID: String? = nil
+    ) {
         subscriptions?.broadcast(delta: .terminalHibernationChanged(TerminalHibernationDelta(
             terminalID: terminal.id,
             worktreeID: terminal.worktreeID,
             hibernated: hibernated,
-            keepWarm: keepWarm
+            keepWarm: keepWarm,
+            tmuxWindowID: tmuxWindowID,
+            tmuxPaneID: tmuxPaneID
         )))
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -14,9 +14,13 @@ public enum HibernateResult: Equatable, Sendable {
 public enum WakeResult: Equatable, Sendable {
     case ok
     case notHibernated   // idempotent no-op: nothing to wake
-    case notFound
+    case notFound        // terminal/worktree DB row missing — NOT tmux failures
     case noSessionID
     case inFlight        // a wake for this terminal is already respawning
+    /// The respawn (or window recreate) failed in tmux. The row stays parked
+    /// so a later retry can wake it; `reason` names the real failure instead
+    /// of the misleading "Terminal not found".
+    case respawnFailed(reason: String)
 }
 
 /// Owns session PARKING — the single unified "park a Claude session" feature
@@ -68,6 +72,13 @@ public actor HibernationCoordinator {
     /// spawn two `claude --resume` processes into the same window.
     private var wakesInFlight: Set<UUID> = []
 
+    /// Invoked after the wake path recreates a tmux server via `ensureServer`
+    /// for a terminal whose window vanished (e.g. a machine reboot destroyed
+    /// every tmux server). Daemon.swift wires this to the control-mode
+    /// bridge's `enableIfGated` so a recreated server gets the same gated
+    /// `tmux -CC` connection as every other `ensureServer()` call site.
+    private var onServerCreated: (@Sendable (String) async -> Void)?
+
     /// Terminal ids with an in-flight hibernate, so a manual "Hibernate now"
     /// racing the idle sweep (or two sweeps) can't respawn-to-shell twice.
     private var hibernatesInFlight: Set<UUID> = []
@@ -107,6 +118,13 @@ public actor HibernationCoordinator {
         self.modelProfileResolver = modelProfileResolver
         self.subscriptions = subscriptions
         self.now = now
+    }
+
+    /// Wire the post-`ensureServer` hook (see `onServerCreated`). Set once by
+    /// Daemon.swift right after construction, mirroring how the RPC router's
+    /// `controlMode` is wired post-construction.
+    public func setOnServerCreated(_ hook: (@Sendable (String) async -> Void)?) {
+        onServerCreated = hook
     }
 
     // MARK: - Keep-warm
@@ -301,6 +319,11 @@ public actor HibernationCoordinator {
     /// Respawn `claude --resume <sessionID>` in the hibernated terminal's
     /// kept-alive window. Idempotent: a non-hibernated terminal is a no-op, and
     /// concurrent wakes for the same terminal collapse to one respawn.
+    ///
+    /// If the window is GONE (killed, or the whole tmux server died — e.g. a
+    /// machine reboot), the window is recreated (ensureServer + createWindow)
+    /// and the same resume command spawned there; the terminal row keeps its
+    /// identity and gets the new window/pane ids persisted.
     public func wake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil) async -> WakeResult {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
@@ -384,21 +407,68 @@ public actor HibernationCoordinator {
         ]
         let sensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
 
-        do {
-            try await tmux.respawnWindow(
-                server: server,
-                windowID: windowID,
-                cwd: worktree.path,
-                shellCommand: spawn.command,
-                env: env,
-                sensitiveEnv: sensitiveEnv,
-                cols: cols,
-                rows: rows
-            )
-        } catch {
-            // Leave the row hibernated so the next focus/menu retry can wake it.
-            logger.warning("wake: respawn-to-claude failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
-            return .notFound
+        // The pane the delayed session-ID recapture below must poll: the
+        // original pane when the window survived, or the recreated window's
+        // fresh pane when it didn't.
+        let livePaneID: String
+
+        if await tmux.windowExists(server: server, windowID: windowID) {
+            do {
+                try await tmux.respawnWindow(
+                    server: server,
+                    windowID: windowID,
+                    cwd: worktree.path,
+                    shellCommand: spawn.command,
+                    env: env,
+                    sensitiveEnv: sensitiveEnv,
+                    cols: cols,
+                    rows: rows
+                )
+                livePaneID = paneID
+            } catch {
+                // Leave the row hibernated so the next focus/menu retry can wake it.
+                logger.warning("wake: respawn-to-claude failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return .respawnFailed(reason: "failed to respawn claude in window \(windowID): \(error.localizedDescription)")
+            }
+        } else {
+            // The window is GONE — killed, or the whole tmux server died (a
+            // machine reboot destroys every server; `windowExists` returns
+            // false on any tmux error, covering both). Recreate the window and
+            // spawn the same `claude --resume` there: transcripts live on
+            // disk, so resume works fine in a fresh window. Mirrors
+            // `handleTerminalRecreateWindow`. Tabs are keyed by terminal id,
+            // so keeping the same terminal row preserves the tab.
+            do {
+                let resolvedCols = cols ?? TmuxManager.defaultCols
+                let resolvedRows = rows ?? TmuxManager.defaultRows
+                _ = try await tmux.ensureServer(
+                    server: server,
+                    session: "main",
+                    cwd: worktree.path,
+                    cols: resolvedCols,
+                    rows: resolvedRows
+                )
+                await onServerCreated?(server)
+                let window = try await tmux.createWindow(
+                    server: server,
+                    session: "main",
+                    cwd: worktree.path,
+                    shellCommand: spawn.command,
+                    env: env,
+                    sensitiveEnv: sensitiveEnv,
+                    cols: resolvedCols,
+                    rows: resolvedRows
+                )
+                try await db.terminals.updateTmuxIDs(
+                    id: terminal.id, windowID: window.windowID, paneID: window.paneID
+                )
+                livePaneID = window.paneID
+                logger.info("wake: window \(windowID, privacy: .public) was gone for terminal \(terminal.id, privacy: .public); recreated as \(window.windowID, privacy: .public) (pane \(window.paneID, privacy: .public))")
+            } catch {
+                // Leave the row hibernated so the next focus/menu retry can wake it.
+                logger.warning("wake: recreate-window failed for terminal \(terminal.id, privacy: .public) (old window \(windowID, privacy: .public)): \(error.localizedDescription, privacy: .public)")
+                return .respawnFailed(reason: "tmux window \(windowID) is gone and could not be recreated: \(error.localizedDescription)")
+            }
         }
 
         do {
@@ -414,7 +484,7 @@ public actor HibernationCoordinator {
         let termID = terminal.id
         Task {
             try? await Task.sleep(for: .seconds(5))
-            if let newID = await self.detector.captureSessionID(server: server, paneID: paneID) {
+            if let newID = await self.detector.captureSessionID(server: server, paneID: livePaneID) {
                 try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
             }
         }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -72,6 +72,15 @@ public actor HibernationCoordinator {
     /// spawn two `claude --resume` processes into the same window.
     private var wakesInFlight: Set<UUID> = []
 
+    /// Tmux servers whose wake tmux-section currently holds the per-server
+    /// lock (see `withServerLock`). `wakesInFlight` only dedupes SAME-terminal
+    /// wakes; this serializes DIFFERENT terminals on the same server.
+    private var lockedServers: Set<String> = []
+
+    /// FIFO waiters per server, resumed one at a time on release so lock
+    /// ownership transfers in arrival order (no starvation, no thundering herd).
+    private var serverLockWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
     /// Invoked after EVERY `ensureServer` on the wake-recreate path (whether or
     /// not a server was actually created — the downstream control-mode
     /// `enableIfGated` is idempotent, so firing on an existing server is a
@@ -413,6 +422,79 @@ public actor HibernationCoordinator {
         let livePaneID: String
         let liveWindowID: String
 
+        // The whole decide-then-mutate tmux section (ownership check +
+        // windowExists + respawn/create/kill/persist) runs under the
+        // per-server lock: `wakesInFlight` above only dedupes wakes for the
+        // SAME terminal, while this closes the cross-terminal TOCTOU on a
+        // shared server (see `withServerLock`). The lock is NOT held around
+        // the delayed session-recapture Task below.
+        let outcome = await withServerLock(server) {
+            await self.wakeTmuxSection(
+                terminal: terminal, worktree: worktree, server: server,
+                windowID: windowID, paneID: paneID, spawnCommand: spawn.command,
+                env: env, sensitiveEnv: sensitiveEnv, cols: cols, rows: rows
+            )
+        }
+        switch outcome {
+        case .failed(let result):
+            return result
+        case .respawned(let newPaneID, let newWindowID):
+            livePaneID = newPaneID
+            liveWindowID = newWindowID
+        }
+
+        do {
+            try await db.terminals.clearHibernated(id: terminal.id)
+        } catch {
+            logger.warning("wake: failed to clear hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+        idleSince[terminal.id] = nil
+        // Carry the LIVE window/pane ids on the un-park broadcast so the app
+        // updates its cached row before (together with) the hibernated flip —
+        // otherwise the terminal view rebuilds keyed on the dead window and
+        // its failed attach re-parks the row (wake flap).
+        broadcastHibernation(
+            terminal: terminal, hibernated: false, keepWarm: terminal.keepWarm,
+            tmuxWindowID: liveWindowID, tmuxPaneID: livePaneID
+        )
+
+        // `claude --resume <id>` forks into a NEW session file; re-capture the
+        // fresh id so subsequent hibernate/wake reference the live session.
+        let termID = terminal.id
+        Task {
+            try? await Task.sleep(for: .seconds(5))
+            if let newID = await self.detector.captureSessionID(server: server, paneID: livePaneID) {
+                try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
+            }
+        }
+        logger.info("woke terminal \(terminal.id, privacy: .public) (resume \(sessionID, privacy: .public))")
+        return .ok
+    }
+
+    /// Outcome of `wakeTmuxSection`: the live pane/window ids the rest of
+    /// `wake()` should reference, or the `WakeResult` to return verbatim.
+    private enum WakeTmuxOutcome {
+        case respawned(paneID: String, windowID: String)
+        case failed(WakeResult)
+    }
+
+    /// The decide-then-mutate tmux section of `wake()` — ownership check,
+    /// `windowExists`, and the in-place respawn OR recreate mutations. Must
+    /// only be entered under `withServerLock(server:)` (see the call site in
+    /// `wake()`), otherwise two concurrent wakes on the same server can
+    /// interleave across the awaits below and hijack each other's windows.
+    private func wakeTmuxSection(
+        terminal: Terminal,
+        worktree: Worktree,
+        server: String,
+        windowID: String,
+        paneID: String,
+        spawnCommand: String,
+        env: [String: String],
+        sensitiveEnv: [String: String],
+        cols: Int?,
+        rows: Int?
+    ) async -> WakeTmuxOutcome {
         // Post-reboot a fresh tmux server reissues window ids from @1 again,
         // so a stale parked row's window id can equal a window that ANOTHER
         // terminal's wake just created on the same server. `windowExists`
@@ -433,18 +515,17 @@ public actor HibernationCoordinator {
                     server: server,
                     windowID: windowID,
                     cwd: worktree.path,
-                    shellCommand: spawn.command,
+                    shellCommand: spawnCommand,
                     env: env,
                     sensitiveEnv: sensitiveEnv,
                     cols: cols,
                     rows: rows
                 )
-                livePaneID = paneID
-                liveWindowID = windowID
+                return .respawned(paneID: paneID, windowID: windowID)
             } catch {
                 // Leave the row hibernated so the next focus/menu retry can wake it.
                 logger.warning("wake: respawn-to-claude failed for terminal \(terminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                return .respawnFailed(reason: "failed to respawn claude in window \(windowID): \(error.localizedDescription)")
+                return .failed(.respawnFailed(reason: "failed to respawn claude in window \(windowID): \(error.localizedDescription)"))
             }
         } else {
             // The window is GONE — killed, the whole tmux server died (a
@@ -470,7 +551,7 @@ public actor HibernationCoordinator {
                     server: server,
                     session: "main",
                     cwd: worktree.path,
-                    shellCommand: spawn.command,
+                    shellCommand: spawnCommand,
                     env: env,
                     sensitiveEnv: sensitiveEnv,
                     cols: resolvedCols,
@@ -506,44 +587,16 @@ public actor HibernationCoordinator {
                     // was created fine; persisting the ids failed).
                     try? await tmux.killWindow(server: server, windowID: window.windowID)
                     logger.warning("wake: created window \(window.windowID, privacy: .public) but failed to persist tmux ids for terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
-                    return .respawnFailed(reason: "recreated tmux window \(window.windowID), but persisting the new tmux ids failed: \(error.localizedDescription)")
+                    return .failed(.respawnFailed(reason: "recreated tmux window \(window.windowID), but persisting the new tmux ids failed: \(error.localizedDescription)"))
                 }
-                livePaneID = window.paneID
-                liveWindowID = window.windowID
                 logger.info("wake: window \(windowID, privacy: .public) was gone for terminal \(terminal.id, privacy: .public); recreated as \(window.windowID, privacy: .public) (pane \(window.paneID, privacy: .public))")
+                return .respawned(paneID: window.paneID, windowID: window.windowID)
             } catch {
                 // Leave the row hibernated so the next focus/menu retry can wake it.
                 logger.warning("wake: recreate-window failed for terminal \(terminal.id, privacy: .public) (old window \(windowID, privacy: .public)): \(error.localizedDescription, privacy: .public)")
-                return .respawnFailed(reason: "tmux window \(windowID) is gone and could not be recreated: \(error.localizedDescription)")
+                return .failed(.respawnFailed(reason: "tmux window \(windowID) is gone and could not be recreated: \(error.localizedDescription)"))
             }
         }
-
-        do {
-            try await db.terminals.clearHibernated(id: terminal.id)
-        } catch {
-            logger.warning("wake: failed to clear hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
-        }
-        idleSince[terminal.id] = nil
-        // Carry the LIVE window/pane ids on the un-park broadcast so the app
-        // updates its cached row before (together with) the hibernated flip —
-        // otherwise the terminal view rebuilds keyed on the dead window and
-        // its failed attach re-parks the row (wake flap).
-        broadcastHibernation(
-            terminal: terminal, hibernated: false, keepWarm: terminal.keepWarm,
-            tmuxWindowID: liveWindowID, tmuxPaneID: livePaneID
-        )
-
-        // `claude --resume <id>` forks into a NEW session file; re-capture the
-        // fresh id so subsequent hibernate/wake reference the live session.
-        let termID = terminal.id
-        Task {
-            try? await Task.sleep(for: .seconds(5))
-            if let newID = await self.detector.captureSessionID(server: server, paneID: livePaneID) {
-                try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
-            }
-        }
-        logger.info("woke terminal \(terminal.id, privacy: .public) (resume \(sessionID, privacy: .public))")
-        return .ok
     }
 
     // MARK: - Idle sweep (auto-hibernate)
@@ -697,6 +750,50 @@ public actor HibernationCoordinator {
     /// claim is necessarily the fresher one. Worktrees can share a per-repo
     /// server, so ownership is resolved across all worktrees with the same
     /// `tmuxServer` string, not just this terminal's worktree.
+    /// Run `body` while holding an exclusive async lock keyed by tmux server.
+    ///
+    /// Actors are reentrant across `await` points, and SocketServer dispatches
+    /// each RPC as its own Task (up to 8 in flight), so two concurrent wakes
+    /// for DIFFERENT terminals on the SAME server can interleave between the
+    /// ownership check, `windowExists`, and the respawn/create mutations —
+    /// e.g. terminal B's recreate mints a fresh post-reboot id equal to A's
+    /// stale one, then A's `windowExists` sees B's just-spawned window as
+    /// alive and the in-place respawn hijacks B's live session. A bare Set
+    /// could only REJECT a concurrent entrant; the FIFO waiter queue makes
+    /// this a true mutex that SERIALIZES them. Different servers never
+    /// serialize against each other.
+    ///
+    /// Release is structural (defer), so every path — success, error return,
+    /// or a throw out of `body` — unlocks. On release, ownership transfers to
+    /// the first waiter WITHOUT clearing `lockedServers`, so no third task can
+    /// barge in between resume and the waiter actually running.
+    ///
+    /// Package-internal (not `private`) so tests can drive the FIFO
+    /// mutual-exclusion semantics directly (mirrors `runExternalCommand`).
+    func withServerLock<T>(_ server: String, _ body: () async -> T) async -> T {
+        if lockedServers.contains(server) {
+            await withCheckedContinuation { continuation in
+                serverLockWaiters[server, default: []].append(continuation)
+            }
+            // Resumed by releaseServerLock: we now OWN the lock.
+        } else {
+            lockedServers.insert(server)
+        }
+        defer { releaseServerLock(server) }
+        return await body()
+    }
+
+    /// Hand the lock to the oldest waiter, or unlock if none are queued.
+    private func releaseServerLock(_ server: String) {
+        if var waiters = serverLockWaiters[server], !waiters.isEmpty {
+            let next = waiters.removeFirst()
+            serverLockWaiters[server] = waiters.isEmpty ? nil : waiters
+            next.resume() // lock ownership transfers; lockedServers stays set
+        } else {
+            lockedServers.remove(server)
+        }
+    }
+
     private func windowClaimedByAnotherTerminal(
         server: String, windowID: String, excluding terminalID: UUID
     ) async -> Bool {

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -39,6 +39,10 @@ extension RPCRouter {
             return RPCResponse(error: "Terminal not found")
         case .noSessionID:
             return RPCResponse(error: "No session ID to resume")
+        case .respawnFailed(let reason):
+            // The terminal row exists — the tmux respawn/recreate failed.
+            // Surface the real failure, never "Terminal not found".
+            return RPCResponse(error: reason)
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -48,6 +48,10 @@ extension RPCRouter {
             return RPCResponse(error: "Terminal not found")
         case .noSessionID:
             return RPCResponse(error: "No session ID to resume")
+        case .respawnFailed(let reason):
+            // The terminal row exists — the tmux respawn/recreate failed.
+            // Surface the real failure, never "Terminal not found".
+            return RPCResponse(error: reason)
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -442,6 +442,16 @@ extension RPCRouter {
         // ID on demand, so this is non-destructive even if the window were somehow
         // still alive.
         if terminal.isClaudeResumable, let sessionID = terminal.claudeSessionID {
+            // Stale-caller gate: if the row's CURRENT window is actually
+            // alive, the caller acted on stale state — e.g. the app's
+            // dead-window path racing a wake that just RECREATED the window
+            // and updated the row's ids. Killing it here would tear down the
+            // freshly-spawned claude and re-park the row (wake flap). Leave
+            // the row untouched.
+            if await tmux.windowExists(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID) {
+                logger.info("recreateWindow: window \(terminal.tmuxWindowID, privacy: .public) for claude terminal \(terminal.id, privacy: .public) is alive — ignoring stale recreate request")
+                return try RPCResponse(result: terminal)
+            }
             // Clean up any lingering (almost always already-dead) window to avoid orphans.
             try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
             // Authoritative `hibernatedAt` column so the unified `wake()` can resume it.

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -46,6 +46,17 @@ public struct TmuxManager: Sendable {
     /// poll always see an immediate polite `/exit` — untestable for the
     /// SIGTERM-fallback branch where claude is still running after the poll.
     public let dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)?
+    /// Optional test hook consulted by `createWindow` in dryRun mode: return a
+    /// non-nil error for a server name to simulate window creation failing
+    /// (tmux refused the new-window, server wedged, …). Without it, dryRun
+    /// createWindow always succeeds, which makes the wake path's
+    /// recreate-failure branch (`WakeResult.respawnFailed`) untestable.
+    public let dryRunCreateWindowError: (@Sendable (String) -> Error?)?
+    /// Optional test hook consulted by `respawnWindow` in dryRun mode: return a
+    /// non-nil error for a window ID to simulate the respawn failing. Without
+    /// it, dryRun respawnWindow always succeeds, which makes the wake path's
+    /// respawn-failure branch (`WakeResult.respawnFailed`) untestable.
+    public let dryRunRespawnWindowError: (@Sendable (String) -> Error?)?
 
     // Thread-safe counter for generating unique mock IDs
     private final class Counter: Sendable {
@@ -60,7 +71,7 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
@@ -69,6 +80,8 @@ public struct TmuxManager: Sendable {
         self.dryRunListWindows = dryRunListWindows
         self.dryRunCapturePane = dryRunCapturePane
         self.dryRunPaneCurrentCommand = dryRunPaneCurrentCommand
+        self.dryRunCreateWindowError = dryRunCreateWindowError
+        self.dryRunRespawnWindowError = dryRunRespawnWindowError
     }
 
     // MARK: - Static Command Builders
@@ -336,6 +349,7 @@ public struct TmuxManager: Sendable {
         if dryRun {
             let args = Self.newWindowCommand(server: server, session: session, cwd: cwd, shellCommand: shellCommand, env: env, sensitiveEnv: sensitiveEnv, cols: cols, rows: rows)
             dryRunRecorder?(args)
+            if let error = dryRunCreateWindowError?(server) { throw error }
             let n = counter.next()
             result = (windowID: "@mock-\(n)", paneID: "%mock-\(n)")
         } else {
@@ -387,6 +401,7 @@ public struct TmuxManager: Sendable {
         )
         if dryRun {
             dryRunRecorder?(args)
+            if let error = dryRunRespawnWindowError?(windowID) { throw error }
             return
         }
         try await runTmux(args)

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -40,11 +40,25 @@ public struct TerminalHibernationDelta: Codable, Sendable {
     /// Current keep-warm pin state (carried on every hibernation delta so a
     /// keep-warm toggle can reuse this same channel).
     public let keepWarm: Bool
-    public init(terminalID: UUID, worktreeID: UUID, hibernated: Bool, keepWarm: Bool) {
+    /// The terminal's CURRENT tmux window/pane ids, carried on wake so the app
+    /// updates its cached row together with the un-park flag. Without them, a
+    /// wake that RECREATED the window (post-reboot) flips `hibernated` first
+    /// and the terminal view rebuilds keyed on the DEAD window id — the failed
+    /// attach then triggers the dead-window recreate path, which kills the
+    /// just-spawned claude and re-parks the row (wake flap). Optional with a
+    /// nil default so payloads from older daemons still decode.
+    public let tmuxWindowID: String?
+    public let tmuxPaneID: String?
+    public init(
+        terminalID: UUID, worktreeID: UUID, hibernated: Bool, keepWarm: Bool,
+        tmuxWindowID: String? = nil, tmuxPaneID: String? = nil
+    ) {
         self.terminalID = terminalID
         self.worktreeID = worktreeID
         self.hibernated = hibernated
         self.keepWarm = keepWarm
+        self.tmuxWindowID = tmuxWindowID
+        self.tmuxPaneID = tmuxPaneID
     }
 }
 

--- a/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
+++ b/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
@@ -55,4 +55,33 @@ struct WakeOnFocusDecisionTests {
 
         #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == nil)
     }
+
+    // MARK: - Wake-failure alert coalescing (modal-spam fix)
+    //
+    // After a reboot kills every tmux server, each wake failure used to fire
+    // its own modal — alert spam. `wakeTerminal` no longer alerts at all; it
+    // RETURNS the failure message. The automatic focus path ignores it
+    // (silent — its "no alert" branch is structural), and the explicit Wake
+    // menu action folds its batch of failures through this pure function
+    // into at most ONE modal per user action. All three branches covered.
+
+    /// No failures → nil → no alert shown.
+    @Test func noWakeFailuresProducesNoAlert() {
+        #expect(AppState.coalescedWakeFailureMessage(failures: []) == nil)
+    }
+
+    /// A single failure → the bare message, no count prefix.
+    @Test func singleWakeFailureShowsBareMessage() {
+        #expect(AppState.coalescedWakeFailureMessage(failures: ["tmux window @1 is gone"])
+                == "Couldn't wake session: tmux window @1 is gone")
+    }
+
+    /// Multiple failures → ONE message carrying the count and the first
+    /// failure — never one modal per terminal.
+    @Test func multipleWakeFailuresCoalesceIntoOneMessage() {
+        let message = AppState.coalescedWakeFailureMessage(
+            failures: ["window @1 gone", "window @2 gone", "window @3 gone"]
+        )
+        #expect(message == "Couldn't wake 3 sessions: window @1 gone")
+    }
 }

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -413,6 +413,148 @@ struct HibernationCoordinatorTests {
                 "a non-colliding live window must not be recreated; got: \(joined)")
     }
 
+    // MARK: - Wake: cross-terminal serialization (per-server lock)
+    //
+    // Actors are reentrant across awaits and SocketServer runs RPCs
+    // concurrently, so two wakes for DIFFERENT terminals on the SAME server
+    // must be serialized by `withServerLock` — `wakesInFlight` only dedupes
+    // the same terminal. Both branches of the lock gate are covered: same
+    // server serializes (and loses no wake), different servers don't.
+
+    /// Two concurrent wakes, two parked terminals, SAME server, both windows
+    /// dead: both must succeed with DISTINCT fresh window ids and exactly two
+    /// new-window commands — no lost wake, no hijack, no deadlock.
+    @Test func concurrentWakesOnSameServerBothRecreateDistinctWindows() async throws {
+        let (db, wtID, terminalA) = try await setup()
+        try await db.terminals.setHibernated(id: terminalA, sessionID: "sess-1")
+        let terminalB = try await db.terminals.create(
+            worktreeID: wtID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "sess-2", kind: .claude
+        )
+        try await db.terminals.setHibernated(id: terminalB.id, sessionID: "sess-2")
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorded.append($0) },
+            dryRunWindowIsDead: { _ in true }
+        )
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+
+        async let wakeA = coord.wake(terminalID: terminalA)
+        async let wakeB = coord.wake(terminalID: terminalB.id)
+        let (resultA, resultB) = await (wakeA, wakeB)
+        #expect(resultA == .ok)
+        #expect(resultB == .ok)
+
+        let afterA = try await db.terminals.get(id: terminalA)
+        let afterB = try await db.terminals.get(id: terminalB.id)
+        #expect(afterA?.isParked == false)
+        #expect(afterB?.isParked == false)
+        #expect(afterA?.tmuxWindowID.hasPrefix("@mock-") == true)
+        #expect(afterB?.tmuxWindowID.hasPrefix("@mock-") == true)
+        #expect(afterA?.tmuxWindowID != afterB?.tmuxWindowID,
+                "serialized wakes must mint DISTINCT windows; got \(String(describing: afterA?.tmuxWindowID)) and \(String(describing: afterB?.tmuxWindowID))")
+
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        let newWindowCount = joined.filter { $0.contains("new-window") }.count
+        #expect(newWindowCount == 2,
+                "expected exactly two new-window commands (one per wake); got \(newWindowCount) in: \(joined)")
+        #expect(!joined.contains { $0.contains("respawn-window") },
+                "dead windows must never be respawned into; got: \(joined)")
+    }
+
+    /// Two concurrent wakes on DIFFERENT servers: the per-server lock must
+    /// not serialize (or deadlock) across servers — both complete `.ok` and
+    /// each server saw its own new-window.
+    @Test func concurrentWakesOnDifferentServersDoNotSerialize() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/hib-repo", displayName: "test", defaultBranch: "main")
+        let wtA = try await db.worktrees.create(
+            repoID: repo.id, name: "wt-a", branch: "a",
+            path: "/tmp/hib-repo-a", tmuxServer: "tbd-hib-a"
+        )
+        let wtB = try await db.worktrees.create(
+            repoID: repo.id, name: "wt-b", branch: "b",
+            path: "/tmp/hib-repo-b", tmuxServer: "tbd-hib-b"
+        )
+        let terminalA = try await db.terminals.create(
+            worktreeID: wtA.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude
+        )
+        let terminalB = try await db.terminals.create(
+            worktreeID: wtB.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: "sess-2", kind: .claude
+        )
+        try await db.terminals.setHibernated(id: terminalA.id, sessionID: "sess-1")
+        try await db.terminals.setHibernated(id: terminalB.id, sessionID: "sess-2")
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorded.append($0) },
+            dryRunWindowIsDead: { _ in true }
+        )
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+
+        async let wakeA = coord.wake(terminalID: terminalA.id)
+        async let wakeB = coord.wake(terminalID: terminalB.id)
+        let (resultA, resultB) = await (wakeA, wakeB)
+        #expect(resultA == .ok, "different servers must not serialize/deadlock each other")
+        #expect(resultB == .ok, "different servers must not serialize/deadlock each other")
+
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(joined.contains { $0.contains("new-window") && $0.contains("-L tbd-hib-a") },
+                "server A must have recorded its own recreate; got: \(joined)")
+        #expect(joined.contains { $0.contains("new-window") && $0.contains("-L tbd-hib-b") },
+                "server B must have recorded its own recreate; got: \(joined)")
+    }
+
+    /// Focused lock-helper semantics: a second acquirer of the SAME key waits
+    /// until the holder releases; a DIFFERENT key proceeds immediately. Driven
+    /// by AsyncStream handshakes (no sleeps): A provably holds the lock, C
+    /// (other key) completes while A holds it, B (same key) only runs after A.
+    @Test func withServerLockSerializesSameKeyAndNotDifferentKeys() async throws {
+        let (db, _, _) = try await setup()
+        let coord = coordinator(db)
+        let events = RecordedTmuxCommands()
+        let (enteredStream, enteredCont) = AsyncStream.makeStream(of: Void.self)
+        let (releaseStream, releaseCont) = AsyncStream.makeStream(of: Void.self)
+
+        let taskA = Task {
+            await coord.withServerLock("s1") {
+                enteredCont.yield()
+                var it = releaseStream.makeAsyncIterator()
+                _ = await it.next()
+                events.append(["A-end"])
+            }
+        }
+        // Wait until A provably HOLDS the s1 lock.
+        var enteredIt = enteredStream.makeAsyncIterator()
+        _ = await enteredIt.next()
+
+        let taskB = Task {
+            await coord.withServerLock("s1") { events.append(["B-ran"]) }
+        }
+        let taskC = Task {
+            await coord.withServerLock("s2") { events.append(["C-ran"]) }
+        }
+        // A different key must proceed while s1 is held...
+        _ = await taskC.value
+        // ...and the same key must still be waiting.
+        #expect(!events.snapshot().contains(["B-ran"]),
+                "same-key acquirer must wait for the holder to release")
+
+        releaseCont.yield()
+        _ = await taskB.value
+        _ = await taskA.value
+        let snapshot = events.snapshot()
+        guard let aEnd = snapshot.firstIndex(of: ["A-end"]),
+              let bRan = snapshot.firstIndex(of: ["B-ran"]) else {
+            Issue.record("expected both A-end and B-ran to have run; got \(snapshot)")
+            return
+        }
+        #expect(aEnd < bRan, "B must only run after A releases; got \(snapshot)")
+    }
+
     /// Recreate FAILS (window dead + createWindow errors): result is
     /// `.respawnFailed` with a reason naming the dead window, the row STAYS
     /// parked for a later retry, and the tmux ids are unchanged.

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -338,8 +338,79 @@ struct HibernationCoordinatorTests {
                 "expected new-window in the worktree cwd carrying claude --resume; got: \(joined)")
         #expect(!joined.contains { $0.contains("respawn-window") },
                 "a dead window must NOT be respawned into; got: \(joined)")
+        // Old-window cleanup: a transient windowExists misclassification must
+        // not leak a live old window (usually already dead — kill no-ops).
+        #expect(joined.contains { $0.contains("kill-window") && $0.contains("@0") },
+                "expected a best-effort kill of the old window; got: \(joined)")
         #expect(serverHookCalls.snapshot() == [["tbd-hib"]],
                 "onServerCreated must fire once with the recreated server name")
+    }
+
+    // MARK: - Wake: window-id ownership (post-reboot id recycling)
+    //
+    // A fresh tmux server reissues window ids from @1, so a stale parked
+    // row's id can equal a window ANOTHER terminal's wake just created.
+    // `windowExists` alone is not ownership — both sides of the claim gate
+    // are covered.
+
+    /// Collision + windowExists true: another terminal on the same server
+    /// claims this row's window id, so respawning in place would hijack that
+    /// terminal's live session. Wake must take the RECREATE branch — and must
+    /// NOT kill the other terminal's window.
+    @Test func wakeRecreatesWhenWindowIDClaimedByAnotherTerminal() async throws {
+        let (db, wtID, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        // The OTHER terminal (fresher claim — e.g. its wake just created @0
+        // on the rebooted server). Same worktree → same tmux server.
+        _ = try await db.terminals.create(
+            worktreeID: wtID, tmuxWindowID: "@0", tmuxPaneID: "%9",
+            label: "claude", claudeSessionID: "sess-2", kind: .claude
+        )
+        let recorded = RecordedTmuxCommands()
+        // No dryRunWindowIsDead: the window EXISTS — ownership must win.
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+
+        let wake = await coord.wake(terminalID: terminalID)
+        #expect(wake == .ok)
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.isParked == false)
+        #expect(after?.tmuxWindowID == "@mock-0", "collision must force a recreate with fresh ids")
+        #expect(after?.tmuxPaneID == "%mock-0")
+
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(joined.contains { $0.contains("new-window") },
+                "expected the recreate branch (new-window); got: \(joined)")
+        #expect(!joined.contains { $0.contains("respawn-window") },
+                "must never respawn into a window another terminal owns; got: \(joined)")
+        #expect(!joined.contains { $0.contains("kill-window") && $0.contains("@0") },
+                "must never kill the other terminal's live window; got: \(joined)")
+    }
+
+    /// No collision: another terminal exists on the same server but claims a
+    /// DIFFERENT window id — the respawn-in-place branch runs unchanged.
+    @Test func wakeRespawnsInPlaceWhenOtherTerminalHoldsDifferentWindow() async throws {
+        let (db, wtID, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        _ = try await db.terminals.create(
+            worktreeID: wtID, tmuxWindowID: "@7", tmuxPaneID: "%7",
+            label: "claude", claudeSessionID: "sess-2", kind: .claude
+        )
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+
+        let wake = await coord.wake(terminalID: terminalID)
+        #expect(wake == .ok)
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.tmuxWindowID == "@0", "no collision → in-place respawn keeps the ids")
+        #expect(after?.tmuxPaneID == "%0")
+
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(joined.contains { $0.contains("respawn-window") },
+                "expected the in-place respawn branch; got: \(joined)")
+        #expect(!joined.contains { $0.contains("new-window") },
+                "a non-colliding live window must not be recreated; got: \(joined)")
     }
 
     /// Recreate FAILS (window dead + createWindow errors): result is

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -208,8 +208,13 @@ struct HibernationCoordinatorTests {
 
     @Test func wakeOnNonHibernatedIsIdempotentNoOp() async throws {
         let (db, _, terminalID) = try await setup()
-        let result = await coordinator(db).wake(terminalID: terminalID)
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        let result = await coord.wake(terminalID: terminalID)
         #expect(result == .notHibernated)
+        #expect(recorded.snapshot().isEmpty,
+                "a non-parked wake must not touch tmux; got: \(recorded.snapshot())")
     }
 
     @Test func wakeUnknownTerminalNotFound() async throws {
@@ -266,6 +271,122 @@ struct HibernationCoordinatorTests {
         let joined = recorded.snapshot().map { $0.joined(separator: " ") }
         #expect(joined.contains { $0.contains("respawn-window") && $0.contains("claude --resume sess-1") },
                 "expected a respawn-window carrying claude --resume; got: \(joined)")
+    }
+
+    // MARK: - Wake: window-gone recreate branch
+    //
+    // A reboot destroys every tmux server, leaving parked rows pointing at
+    // dead windows. Wake must detect the dead window and RECREATE it (server +
+    // window) instead of failing "Terminal not found". Both sides of the
+    // `windowExists` gate are covered.
+
+    /// Window ALIVE (dryRun default): the existing respawn-in-place path runs
+    /// unchanged — same window/pane ids, `respawn-window` issued, never
+    /// `new-window` — and the recreate-only server hook does NOT fire.
+    @Test func wakeWithLiveWindowRespawnsInPlaceKeepingIDs() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let recorded = RecordedTmuxCommands()
+        let serverHookCalls = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
+
+        let wake = await coord.wake(terminalID: terminalID)
+        #expect(wake == .ok)
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.isParked == false, "row must be un-parked")
+        #expect(after?.tmuxWindowID == "@0", "live-window wake must keep the window id")
+        #expect(after?.tmuxPaneID == "%0", "live-window wake must keep the pane id")
+
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(joined.contains { $0.contains("respawn-window") },
+                "expected respawn-window; got: \(joined)")
+        #expect(!joined.contains { $0.contains("new-window") },
+                "a live window must NOT be recreated; got: \(joined)")
+        #expect(serverHookCalls.snapshot().isEmpty,
+                "onServerCreated must only fire on the recreate branch")
+    }
+
+    /// Window DEAD (post-reboot / killed): wake recreates the server + window,
+    /// persists the NEW window/pane ids, un-parks the row, and spawns the same
+    /// `claude --resume` via `new-window -c <worktree path>` — no
+    /// `respawn-window` into the dead window. The server hook fires so a
+    /// recreated server gets its gated control-mode connection.
+    @Test func wakeRecreatesDeadWindowAndPersistsNewIDs() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let recorded = RecordedTmuxCommands()
+        let serverHookCalls = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorded.append($0) },
+            dryRunWindowIsDead: { $0 == "@0" }
+        )
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+        await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
+
+        let wake = await coord.wake(terminalID: terminalID)
+        #expect(wake == .ok)
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.isParked == false, "row must be un-parked")
+        #expect(after?.tmuxWindowID == "@mock-0", "recreate must persist the new window id")
+        #expect(after?.tmuxPaneID == "%mock-0", "recreate must persist the new pane id")
+
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(joined.contains { $0.contains("new-window") && $0.contains("-c /tmp/hib-repo") && $0.contains("--resume sess-1") },
+                "expected new-window in the worktree cwd carrying claude --resume; got: \(joined)")
+        #expect(!joined.contains { $0.contains("respawn-window") },
+                "a dead window must NOT be respawned into; got: \(joined)")
+        #expect(serverHookCalls.snapshot() == [["tbd-hib"]],
+                "onServerCreated must fire once with the recreated server name")
+    }
+
+    /// Recreate FAILS (window dead + createWindow errors): result is
+    /// `.respawnFailed` with a reason naming the dead window, the row STAYS
+    /// parked for a later retry, and the tmux ids are unchanged.
+    @Test func wakeReturnsRespawnFailedWhenRecreateFails() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunWindowIsDead: { $0 == "@0" },
+            dryRunCreateWindowError: { _ in TmuxError.unexpectedOutput("no server running") }
+        )
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+
+        let wake = await coord.wake(terminalID: terminalID)
+        guard case .respawnFailed(let reason) = wake else {
+            Issue.record("expected .respawnFailed, got \(wake)")
+            return
+        }
+        #expect(reason.contains("@0"), "reason must name the gone window; got: \(reason)")
+        #expect(reason.contains("could not be recreated"), "reason must say recreate failed; got: \(reason)")
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.isParked == true, "a failed wake must leave the row parked for retry")
+        #expect(after?.tmuxWindowID == "@0", "tmux ids must be unchanged on failure")
+    }
+
+    /// Respawn FAILS (window alive but respawn-window errors): result is
+    /// `.respawnFailed` naming the respawn, and the row stays parked.
+    @Test func wakeReturnsRespawnFailedWhenRespawnFails() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRespawnWindowError: { $0 == "@0" ? TmuxError.unexpectedOutput("pane died") : nil }
+        )
+        let coord = HibernationCoordinator(db: db, tmux: tmux)
+
+        let wake = await coord.wake(terminalID: terminalID)
+        guard case .respawnFailed(let reason) = wake else {
+            Issue.record("expected .respawnFailed, got \(wake)")
+            return
+        }
+        #expect(reason.contains("respawn"), "reason must name the respawn failure; got: \(reason)")
+        #expect(reason.contains("@0"), "reason must name the window; got: \(reason)")
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.isParked == true, "a failed wake must leave the row parked for retry")
     }
 
     // MARK: - Startup reconciliation
@@ -343,6 +464,54 @@ struct HibernationCoordinatorTests {
         for _ in 0..<4 { await coord.sweep() }
         #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil,
                 "a keep-warm session must never be auto-hibernated")
+    }
+}
+
+/// `terminal.wake` RPC error mapping. The shared `RPCRouterTests` harness pins
+/// a plain dry-run TmuxManager, so this suite builds its own router with a
+/// failing tmux to drive the `.respawnFailed` path end-to-end.
+@Suite("RPCRouter terminal.wake error mapping")
+struct RPCRouterWakeErrorMappingTests {
+
+    /// A wake whose tmux window is gone AND cannot be recreated must surface
+    /// the REAL failure over RPC — naming the window — and never the
+    /// misleading "Terminal not found" (the terminal row exists; the WINDOW
+    /// is gone).
+    @Test func wakeRespawnFailureIsNotReportedAsTerminalNotFound() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunWindowIsDead: { $0 == "@0" },
+            dryRunCreateWindowError: { _ in TmuxError.unexpectedOutput("no server running") }
+        )
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux
+        )
+        let repo = try await db.repos.create(path: "/tmp/hib-repo", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/hib-repo", tmuxServer: "tbd-hib"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude
+        )
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "sess-1")
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id)
+        )
+        let resp = await router.handle(req)
+        #expect(!resp.success)
+        #expect(resp.error != "Terminal not found",
+                "a tmux failure must not masquerade as a missing terminal row")
+        #expect(resp.error?.contains("@0") == true,
+                "the RPC error must name the gone window; got: \(resp.error ?? "nil")")
+        #expect(try await db.terminals.get(id: terminal.id)?.isParked == true,
+                "the row must stay parked so a retry can wake it")
     }
 }
 

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -216,7 +216,9 @@ func testHandleTerminalRecreateWindowCodexLaunchCommand() async throws {
 @Test("handleTerminalRecreateWindow parks a resumable Claude terminal as suspended")
 func testHandleTerminalRecreateWindowParksClaudeAsSuspended() async throws {
     let db = try TBDDatabase(inMemory: true)
-    let tmux = TmuxManager(dryRun: true)
+    // The window is genuinely DEAD (the premise of this scenario); the stale-
+    // caller gate must not trip. dryRun default would report it alive.
+    let tmux = TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true })
     let router = RPCRouter(
         db: db,
         lifecycle: WorktreeLifecycle(
@@ -264,6 +266,69 @@ func testHandleTerminalRecreateWindowParksClaudeAsSuspended() async throws {
     #expect(updated.claudeSessionID == sessionID, "claudeSessionID must be preserved")
     #expect(updated.transcriptPath == transcriptPath, "transcriptPath must be preserved")
     #expect(updated.isClaudeResumable, "parked terminal must remain Claude-resumable")
+}
+
+/// Stale-caller gate: when the claude terminal's CURRENT window is actually
+/// ALIVE (the app's dead-window path raced a wake that just recreated the
+/// window and updated the row's ids), `handleTerminalRecreateWindow` must NOT
+/// kill the window or re-park the row — that tears down the freshly-spawned
+/// claude and flaps the wake. It returns the row unchanged.
+@Test("handleTerminalRecreateWindow ignores a stale request when the claude window is alive")
+func testHandleTerminalRecreateWindowIgnoresStaleRequestWhenWindowAlive() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    // dryRun default: every window reports ALIVE.
+    let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: tmux,
+            hooks: HookResolver()
+        ),
+        tmux: tmux
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-recreate-stale", displayName: "test", defaultBranch: "main"
+    )
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-recreate-stale",
+        branch: "tbd/wt-recreate-stale",
+        path: "/tmp/fake-repo-recreate-stale/wt-recreate-stale",
+        tmuxServer: "tbd-51a1e000"
+    )
+    let sessionID = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@live-claude",
+        tmuxPaneID: "%live-claude",
+        label: "claude",
+        claudeSessionID: sessionID,
+        kind: .claude
+    )
+
+    let request = try RPCRequest(
+        method: RPCMethod.terminalRecreateWindow,
+        params: TerminalRecreateWindowParams(terminalID: terminal.id)
+    )
+    let response = await router.handle(request)
+    #expect(response.success, "expected success; error: \(response.error ?? "nil")")
+
+    let updated = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(!updated.isParked, "a live-window claude row must NOT be re-parked by a stale request")
+    #expect(updated.tmuxWindowID == "@live-claude", "tmux ids must be untouched")
+    #expect(updated.tmuxPaneID == "%live-claude")
+
+    let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+    #expect(!joined.contains { $0.contains("kill-window") },
+            "the alive window must NOT be killed; got: \(joined)")
+
+    let returned = try response.decodeResult(Terminal.self)
+    #expect(returned.id == terminal.id)
+    #expect(!returned.isParked, "the returned row must be the current, un-parked one")
 }
 
 /// Regression guard for the OTHER branch: a plain shell terminal whose window


### PR DESCRIPTION
## Summary

**The incident (2026-07-06).** A machine reboot destroyed every tmux server. The DB still held 88 hibernated + 88 suspended (parked) Claude terminals referencing windows (`@1723`, `@157`, `@10575`, …) that no longer existed. Focusing a worktree fired the auto-wake sweep, each wake respawned `claude --resume` into its dead window, tmux threw, and the daemon surfaced the failure as **"Terminal not found"** — misleading (the terminal row exists; the *window* is gone) — as a **modal alert, once per parked terminal, on every focus**.

**Why it happened.** The park/wake design assumed the tmux window survives between park and wake (park keeps the window alive as a bare shell; wake `respawn-window`s it back to `claude --resume`). There was no branch for the window being gone. Transcripts survive on disk, so `claude --resume <sessionID>` restores each conversation fine — it just needs a live window.

**The fix, part 1 (daemon — lazy window recreate on wake).** `HibernationCoordinator.wake()` now checks whether the window still exists. Alive → the existing in-place respawn, unchanged. Gone (killed, server died, or the id is owned by another terminal — see below) → recreate: `ensureServer` + `createWindow` at the worktree path with the same `claude --resume` spawn command, persist the new window/pane ids onto the terminal row (tab association is keyed by terminal id, so it survives), un-park as before. Failures now return a new `WakeResult.respawnFailed(reason:)` so the RPC error names the real failure (e.g. `tmux window @1723 is gone and could not be recreated: …`) — never "Terminal not found".

**The fix, part 2 (app — no more modal spam).** `wakeTerminal` no longer shows alerts; it returns the failure. The automatic on-focus wake logs a warning and stays silent. The explicit **Wake** menu action collects failures across its batch and shows at most **one** coalesced modal per user action.

**Race hardening (from adversarial review).**
- The un-park broadcast now carries the fresh tmux ids (`TerminalHibernationDelta.tmuxWindowID/tmuxPaneID`, optional for decode compat) and the app applies them with the un-park flip — otherwise the terminal view rebuilt against the dead window and its failed attach re-parked the row (wake flap).
- `handleTerminalRecreateWindow` gained a stale-caller gate: if the row's current window is alive, it returns the row unchanged instead of killing a freshly-resumed claude.
- Post-reboot servers reissue `@N` window ids, so `windowExists` is not ownership: if another terminal on the same server claims the id, wake recreates instead of hijacking that terminal's live window.
- Cleanup ordering: the old window is killed only after its replacement exists; `ensureServer`'s bootstrap window is killed; a `updateTmuxIDs` failure kills the just-created window rather than orphaning a running claude.

**Rebased on #371.** While verifying this branch we hit the `detectOrphanedClaudeProcesses` 64KB `ps` pipe deadlock live (968s wedged test run) and fixed it here — then found #371 had landed the same fix on main (more thoroughly: 5s timeout, injectable seam, non-blocking tail drain, grandchild-FD hardening) hours after this branch was cut. Rebased onto main and dropped our duplicate commit in favor of #371's version.

**Reconcile scope.** `reconcileOnStartup` only *clears* parked state for still-running processes, which cannot break the new wake path — recreation stays lazy/on-demand at wake time; no startup sweep was added (waking 88 windows at once is exactly the spawn-storm this codebase already guards against).

## Test plan
- [x] `swift build` clean; `swiftlint --strict` 0 violations
- [x] Full `swift test`: all passing post-rebase (exit 0; ~2,600+ tests incl. main's new `HibernationOrphanDetection` suite)
- [x] New daemon tests: wake with window alive → in-place respawn, ids unchanged; window gone → new window created at the worktree path with `claude --resume`, ids persisted, row un-parked; non-parked → `.notHibernated` no-op; create/respawn failures → `.respawnFailed`, row stays parked (via new `dryRun*Error` hooks); window-id claimed by another terminal → recreate, not hijack; stale recreate request with live window → row untouched
- [x] New app tests: coalesced wake-failure message — none → no alert, one → bare message, many → single counted message
- [x] Pipe-drain regression coverage comes from #371 (already on main)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=0E8045E2-FE1C-4998-A66B-AB66FBCE84C2)
