### PR TITLE
Feat: Let users turn off the Claude tab usage tooltip (default on)

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1621,6 +1621,11 @@ final class AppState: ObservableObject {
     /// scratch spaces). Default on.
     static let showScratchSectionKey = "showScratchSection"
 
+    /// UserDefaults key for the Claude tab hover card (account email, profile,
+    /// 5h/weekly usage, spawn time). Default on; the Settings → Claude toggle
+    /// turns it off for users who find the hover card noisy.
+    static let showClaudeTabUsageTooltipKey = "showClaudeTabUsageTooltip"
+
     /// Pure, testable mirror of the sidebar's Scratch-section gate:
     /// shown whenever the setting is on, regardless of whether any scratch
     /// spaces exist yet. This keeps the section (and its hover "+" create

--- a/Sources/TBDApp/Helpers/AccountHoverCards.swift
+++ b/Sources/TBDApp/Helpers/AccountHoverCards.swift
@@ -24,10 +24,18 @@ enum AccountHoverCards {
 
     /// Per-session tab card: title = account email (or the ambient/removed
     /// note), rows for profile, live usage windows, and spawn time. nil for
-    /// non-Claude terminals (shells, Codex — no account concept).
+    /// non-Claude terminals (shells, Codex — no account concept), and nil when
+    /// `enabled` is false (the "Show usage tooltip on Claude tabs" setting,
+    /// `AppState.showClaudeTabUsageTooltipKey`) — the setting gate lives here
+    /// so both branches are unit-testable without UserDefaults.
+    ///
+    /// For future iterations: https://github.com/hamed-elfayome/Claude-Usage-Tracker
+    /// is a feature-rich, easy-to-skim take on session-usage display.
     static func claudeTabCard(terminal: Terminal,
                               profiles: [ModelProfileWithUsage],
-                              timeZone: TimeZone = .current) -> HoverCardModel? {
+                              timeZone: TimeZone = .current,
+                              enabled: Bool = true) -> HoverCardModel? {
+        guard enabled else { return nil }
         guard terminal.kind == .claude || terminal.isClaudeResumable else { return nil }
         var model = HoverCardModel()
         if let profileID = terminal.profileID {

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -39,6 +39,7 @@ struct GeneralSettingsTab: View {
     @AppStorage(AppState.useTableViewTranscriptKey) private var useTableViewTranscript: Bool = true
     @AppStorage(AppState.nightwatchExperimentalKey) private var nightwatchExperimental: Bool = false
     @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
+    @AppStorage(AppState.showClaudeTabUsageTooltipKey) private var showClaudeTabUsageTooltip: Bool = true
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
@@ -148,6 +149,8 @@ struct GeneralSettingsTab: View {
                     set: { newValue in Task { await appState.setAutoResumeOnLimitReset(newValue) } }
                 ))
                 .help("When a session hits the usage limit, TBD schedules a resume for the reset time and types \"continue\" into the pane. Off by default; detection and notifications run regardless.")
+                Toggle("Show usage tooltip on Claude tabs", isOn: $showClaudeTabUsageTooltip)
+                    .help("Show a hover card on Claude tabs with the session's account, profile, 5h/weekly usage, and spawn time.")
             }
 
             Section("Session Hibernation") {

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -475,6 +475,8 @@ private struct TabBarItem: View {
     @State private var dropEdge: DropEdge? = nil
     @State private var measuredWidth: CGFloat = 100
     @AppStorage("codeViewer.showSidebar") private var showSidebar = false
+    @AppStorage(AppState.showClaudeTabUsageTooltipKey)
+    private var showClaudeTabUsageTooltip: Bool = true
     @EnvironmentObject private var appState: AppState
 
     private var showClose: Bool {
@@ -509,12 +511,14 @@ private struct TabBarItem: View {
     /// Hover card describing which account this session runs on: pinned
     /// email + profile name (or the ambient-drift note for NULL-profile legacy
     /// sessions), current 5h/weekly usage, and spawn time. nil (no card)
-    /// for non-Claude tabs.
+    /// for non-Claude tabs, or when the "Show usage tooltip on Claude tabs"
+    /// setting is off.
     private var accountHoverCard: HoverCardModel? {
         guard let terminal else { return nil }
         return AccountHoverCards.claudeTabCard(
             terminal: terminal,
-            profiles: appState.modelProfiles
+            profiles: appState.modelProfiles,
+            enabled: showClaudeTabUsageTooltip
         )
     }
 

--- a/Tests/TBDAppTests/AccountHoverCardsTests.swift
+++ b/Tests/TBDAppTests/AccountHoverCardsTests.swift
@@ -124,6 +124,31 @@ struct ClaudeTabCardTests {
         #expect(card?.rows.map(\.label) == ["Spawned"])
     }
 
+    // The "Show usage tooltip on Claude tabs" setting gate
+    // (AppState.showClaudeTabUsageTooltipKey), both branches. Pure `enabled:`
+    // parameter — no UserDefaults involved.
+    @Test func settingEnabledProducesCardForClaudeTerminal() {
+        let card = AccountHoverCards.claudeTabCard(terminal: claudeTerminal(),
+                                                   profiles: [], timeZone: utc,
+                                                   enabled: true)
+        #expect(card != nil)
+        // Ungated behavior is unchanged: same content as the default-argument path.
+        #expect(card == AccountHoverCards.claudeTabCard(terminal: claudeTerminal(),
+                                                        profiles: [], timeZone: utc))
+    }
+
+    @Test func settingDisabledSuppressesCardEvenForClaudeTerminal() {
+        let gmail = entry(name: "Gmail", loginIdentity: "g@gmail.com",
+                          usageSnapshot: gmailSnapshot)
+        let terminal = claudeTerminal(profileID: gmail.profile.id)
+        #expect(AccountHoverCards.claudeTabCard(terminal: terminal,
+                                                profiles: [gmail], timeZone: utc,
+                                                enabled: false) == nil)
+        #expect(AccountHoverCards.claudeTabCard(terminal: claudeTerminal(),
+                                                profiles: [], timeZone: utc,
+                                                enabled: false) == nil)
+    }
+
     @Test func profileWithoutSnapshotGetsNoUsageRows() {
         let work = entry(name: "Work", loginIdentity: "a@b.co", usageSnapshot: nil)
         let card = AccountHoverCards.claudeTabCard(


### PR DESCRIPTION
## Summary
- Hovering a Claude tab shows a session-usage hover card (account email, profile, 5h/weekly usage, spawn time) since #337/#343. Some users find it noisy, so this adds a **"Show usage tooltip on Claude tabs"** toggle in Settings → General → Claude. Default **on** — existing behavior is unchanged until a user opts out.
- The gate is a pure `enabled:` parameter on `AccountHoverCards.claudeTabCard` (defaulting to `true`), so both branches are unit-tested without touching UserDefaults; `TabBarItem` feeds it from `@AppStorage(AppState.showClaudeTabUsageTooltipKey)`.
- Also leaves a doc-comment breadcrumb pointing at [Claude-Usage-Tracker](https://github.com/hamed-elfayome/Claude-Usage-Tracker) as a feature-rich, easy-to-skim reference for future iterations of the usage display.

## Test plan
- [ ] `swift test` — full suite passes (2625 tests), including new `settingEnabledProducesCardForClaudeTerminal` / `settingDisabledSuppressesCardEvenForClaudeTerminal`
- [ ] Live: hover a Claude tab → card appears; turn off the toggle in Settings → General → Claude → hover again → no card; non-Claude tabs unaffected either way

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=D689F07F-AC4F-4159-A773-C57D0B6691B1)