### PR TITLE
Fix: Stop scratch-space pins from showing 'Loading...' forever (and 8 sibling scratch-blind lookups)

### DIFF
--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -15,7 +15,8 @@ extension AppState {
     ///
     /// - Exactly one worktree selected → that worktree's ID.
     /// - Multiple selected → the selected worktree whose UUID string sorts
-    ///   first alphabetically among those that still exist in `worktrees`.
+    ///   first alphabetically among those that still exist in `worktrees` or
+    ///   `scratchWorktrees` (scratch spaces live only in the latter).
     ///   Returns `nil` when none of the selected IDs exist (all stale).
     /// - No worktree selected but `selectedRepoID` set → the repo ID (the repo
     ///   header row is tagged with repo.id so scrolling to it works).
@@ -23,13 +24,16 @@ extension AppState {
     nonisolated static func sidebarRevealTarget(
         selectedWorktreeIDs: Set<UUID>,
         worktrees: [UUID: [Worktree]],
+        scratchWorktrees: [Worktree],
         selectedRepoID: UUID?
     ) -> UUID? {
         if selectedWorktreeIDs.count == 1 {
             return selectedWorktreeIDs.first
         } else if selectedWorktreeIDs.count > 1 {
             // Sort by uuidString for a stable, deterministic pick.
-            let allWorktreeIDs = Set(worktrees.values.flatMap { $0 }.map(\.id))
+            let allWorktreeIDs = Set(
+                worktrees.values.flatMap { $0 }.map(\.id) + scratchWorktrees.map(\.id)
+            )
             let candidates = selectedWorktreeIDs.filter { allWorktreeIDs.contains($0) }
             return candidates.min(by: { $0.uuidString < $1.uuidString })
         } else if let repoID = selectedRepoID {
@@ -47,6 +51,7 @@ extension AppState {
         guard let target = Self.sidebarRevealTarget(
             selectedWorktreeIDs: selectedWorktreeIDs,
             worktrees: worktrees,
+            scratchWorktrees: scratchWorktrees,
             selectedRepoID: selectedRepoID
         ) else { return }
 
@@ -168,7 +173,9 @@ extension AppState {
         case .worktrees(let ids):
             guard !ids.isEmpty else { return false }
             if let archivedID, ids.contains(archivedID) { return false }
-            let existing = Set(worktrees.values.flatMap { $0 }.map(\.id))
+            // allWorktrees includes scratch spaces, so back/forward can land
+            // on a live scratch selection instead of skipping it as stale.
+            let existing = Set(allWorktrees.map(\.id))
             return ids.allSatisfy { existing.contains($0) }
         case .repo(let id):
             return repos.contains { $0.id == id }

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -55,16 +55,27 @@ extension AppState {
             selectedRepoID: selectedRepoID
         ) else { return }
 
-        // If the target is a worktree, expand its containing repo before scrolling.
-        if let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == target }),
-           let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
-           let repoID = worktree.repoID,
-           !repos[repoIdx].expanded {
-            repos[repoIdx].expanded = true
-            Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
-        }
+        // If the target is a worktree, expand its containing repo before
+        // scrolling (a repo-ID target matches no worktree row, so this no-ops).
+        expandRepoContaining(worktreeID: target)
 
         pendingScrollToWorktreeID = target
+    }
+
+    /// Expand the repo containing `worktreeID` (if collapsed) so its row is
+    /// part of the rendered sidebar list. Updates local state synchronously
+    /// (List rerender + scroll), persists via RPC fire-and-forget. No-op for
+    /// unknown IDs. Intentionally repo-scoped (dict-only, not `findWorktree`):
+    /// scratch spaces have no repo row to expand.
+    @MainActor
+    func expandRepoContaining(worktreeID: UUID) {
+        guard let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == worktreeID }),
+              let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
+              let repoID = worktree.repoID,
+              !repos[repoIdx].expanded
+        else { return }
+        repos[repoIdx].expanded = true
+        Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
     }
 }
 

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -156,9 +156,18 @@ extension AppState {
         step: Int,
         excluding archivedID: UUID? = nil
     ) -> Int? {
+        // Built ONCE per walk and threaded through isUsableEntry — rebuilding
+        // it per entry made every selection change O(entries × worktrees).
+        // allWorktrees includes scratch spaces, so back/forward can land on a
+        // live scratch selection instead of skipping it as stale.
+        let existingWorktreeIDs = Set(allWorktrees.map(\.id))
         var index = start
         while index >= 0 && index < navigationEntries.count {
-            if isUsableEntry(navigationEntries[index], excluding: archivedID) { return index }
+            if isUsableEntry(
+                navigationEntries[index],
+                excluding: archivedID,
+                existingWorktreeIDs: existingWorktreeIDs
+            ) { return index }
             index += step
         }
         return nil
@@ -166,17 +175,19 @@ extension AppState {
 
     /// Whether a history entry is still a valid landing spot: worktree entries
     /// must not reference `archivedID` (when given) and every referenced
-    /// worktree must still exist; repo entries must reference a repo we still
+    /// worktree must still exist in `existingWorktreeIDs` (built once per walk
+    /// by `usableEntryIndex`); repo entries must reference a repo we still
     /// know about.
-    private func isUsableEntry(_ entry: NavigationEntry, excluding archivedID: UUID? = nil) -> Bool {
+    private func isUsableEntry(
+        _ entry: NavigationEntry,
+        excluding archivedID: UUID? = nil,
+        existingWorktreeIDs: Set<UUID>
+    ) -> Bool {
         switch entry {
         case .worktrees(let ids):
             guard !ids.isEmpty else { return false }
             if let archivedID, ids.contains(archivedID) { return false }
-            // allWorktrees includes scratch spaces, so back/forward can land
-            // on a live scratch selection instead of skipping it as stale.
-            let existing = Set(allWorktrees.map(\.id))
-            return ids.allSatisfy { existing.contains($0) }
+            return ids.allSatisfy { existingWorktreeIDs.contains($0) }
         case .repo(let id):
             return repos.contains { $0.id == id }
         }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -166,7 +166,7 @@ extension AppState {
 
     /// Archive a worktree.
     func archiveWorktree(id: UUID, force: Bool = false) async {
-        let worktreeName = worktrees.values.flatMap { $0 }.first { $0.id == id }?.displayName ?? "worktree"
+        let worktreeName = findWorktree(id: id)?.displayName ?? "worktree"
         do {
             try await daemonClient.archiveWorktree(id: id, force: force)
             removeArchivedWorktreeFromState(id: id)
@@ -363,9 +363,7 @@ extension AppState {
             return
         }
 
-        let activeMatch = worktrees.values
-            .flatMap { $0 }
-            .contains(where: { $0.id == id })
+        let activeMatch = findWorktree(id: id) != nil
         if activeMatch {
             navigateToActiveWorktree(id, terminalID: terminalID)
         } else {

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -238,35 +238,43 @@ extension AppState {
         }
     }
 
-    /// Rename a worktree.
+    /// Rename a worktree (repo-grouped or scratch).
     func renameWorktree(id: UUID, displayName: String) async {
         // For creating worktrees, just update locally — the name will be applied when creation finishes
-        let isCreating = worktrees.values.flatMap({ $0 }).first(where: { $0.id == id })?.status == .creating
+        let isCreating = findWorktree(id: id)?.status == .creating
         if isCreating {
-            for repoID in worktrees.keys {
-                if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == id }) {
-                    worktrees[repoID]?[idx].displayName = displayName
-                }
-            }
+            applyLocalRename(id: id, displayName: displayName)
             return
         }
         do {
             try await daemonClient.renameWorktree(id: id, displayName: displayName)
-            for repoID in worktrees.keys {
-                if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == id }) {
-                    worktrees[repoID]?[idx].displayName = displayName
-                }
-            }
+            applyLocalRename(id: id, displayName: displayName)
         } catch {
             logger.error("Failed to rename worktree: \(error)")
             handleConnectionError(error)
         }
     }
 
+    /// Local rename applied to whichever collection holds the row: the
+    /// repo-grouped `worktrees` dict, or `scratchWorktrees` for repo-less
+    /// scratch spaces (which never appear in the dict). Owned by
+    /// `renameWorktree` so callers don't have to compensate per collection.
+    func applyLocalRename(id: UUID, displayName: String) {
+        for repoID in worktrees.keys {
+            if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == id }) {
+                worktrees[repoID]?[idx].displayName = displayName
+            }
+        }
+        if let idx = scratchWorktrees.firstIndex(where: { $0.id == id }) {
+            scratchWorktrees[idx].displayName = displayName
+        }
+    }
+
     // MARK: - Archived Worktrees
 
     /// Active-worktree path for deep-link navigation. Caller is responsible
-    /// for verifying the id exists in `self.worktrees` first. When
+    /// for verifying the id resolves via `findWorktree(id:)` first (which
+    /// covers both repo-grouped worktrees and scratch spaces). When
     /// `terminalID` is non-nil, also switches the worktree's active tab to
     /// the one rendering that terminal (live transcript or terminal pane);
     /// silently falls back to current selection when no tab matches.
@@ -649,14 +657,49 @@ extension AppState {
         createWorktree(repoID: repoID)
     }
 
-    /// Archive the first selected worktree (refuses main worktrees).
-    func archiveSelectedWorktree() {
-        guard let id = selectedWorktreeIDs.first else { return }
+    /// Which archive path `archiveSelectedWorktree` should take for a
+    /// selection. Scratch spaces live only in `scratchWorktrees` and must go
+    /// through the `scratch.archive` RPC — the repo-worktree `worktree.archive`
+    /// RPC rejects them with `repoNotFound`. Pure so both branches are
+    /// unit-testable without a daemon.
+    enum ArchiveShortcutRoute: Equatable {
+        case scratch(UUID)
+        case worktree(UUID)
+    }
+
+    /// Resolve the archive route for the given selection. Returns `nil` when
+    /// nothing is selected, or when the selected repo worktree is the main
+    /// branch or still creating (those refuse the archive shortcut).
+    nonisolated static func archiveShortcutRoute(
+        selectedID: UUID?,
+        worktrees: [UUID: [Worktree]],
+        scratchWorktrees: [Worktree]
+    ) -> ArchiveShortcutRoute? {
+        guard let id = selectedID else { return nil }
+        if scratchWorktrees.contains(where: { $0.id == id }) {
+            return .scratch(id)
+        }
         // Don't archive the main branch worktree
-        let allWts = worktrees.values.flatMap { $0 }
-        if let wt = allWts.first(where: { $0.id == id }), wt.status == .main || wt.status == .creating { return }
-        Task {
-            await archiveWorktree(id: id)
+        if let wt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),
+           wt.status == .main || wt.status == .creating { return nil }
+        return .worktree(id)
+    }
+
+    /// Archive the first selected worktree (refuses main worktrees). Routes
+    /// scratch spaces to the scratch archive path — same as the row context
+    /// menu's Archive action.
+    func archiveSelectedWorktree() {
+        switch Self.archiveShortcutRoute(
+            selectedID: selectedWorktreeIDs.first,
+            worktrees: worktrees,
+            scratchWorktrees: scratchWorktrees
+        ) {
+        case .scratch(let id):
+            Task { await archiveScratch(id: id) }
+        case .worktree(let id):
+            Task { await archiveWorktree(id: id) }
+        case nil:
+            break
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -49,33 +49,48 @@ extension AppState {
             defer { pendingWorktreeIDs.remove(placeholder.id) }
             do {
                 let size = mainAreaTerminalSize()
+                // Pass the placeholder's name so the daemon row starts with
+                // the same displayName: untouched creations don't flip names
+                // at swap time, and replaceCreationPlaceholder's
+                // string-equality rename inference stays sound.
                 let wt = try await daemonClient.createWorktree(
                     repoID: repoID,
                     branch: existingBranch?.name,
+                    displayName: placeholderName,
                     cols: size.cols, rows: size.rows,
                     parentWorktreeID: parentWorktreeID,
                     useExistingBranch: existingBranch != nil
                 )
                 // Replace the placeholder with the real worktree, carrying
-                // over any rename the user typed while creation was in flight.
-                let typedName = replaceCreationPlaceholder(
+                // over any rename the user typed while creation was in
+                // flight. A nil result means neither the placeholder nor a
+                // poll-merged daemon row exists anymore (e.g. the repo was
+                // removed mid-create) — don't arm selection/editing for a
+                // vanished row.
+                if let swap = replaceCreationPlaceholder(
                     repoID: repoID,
                     placeholderID: placeholder.id,
                     placeholderName: placeholderName,
                     with: wt
-                )
-                selectedWorktreeIDs = [wt.id]
-                editingWorktreeID = wt.id
-                // Persist the carried rename now that a daemon-known row
-                // exists (the placeholder's id never reached the daemon, so
-                // renameWorktree's .creating branch could only apply it
-                // locally).
-                if let typedName {
-                    do {
-                        try await daemonClient.renameWorktree(id: wt.id, displayName: typedName)
-                    } catch {
-                        logger.error("Failed to persist rename typed during creation: \(error)")
-                        handleConnectionError(error)
+                ) {
+                    selectedWorktreeIDs = [wt.id]
+                    editingWorktreeID = wt.id
+                    // Persist the carried rename now that a daemon-known row
+                    // exists (the placeholder's id never reached the daemon,
+                    // so renameWorktree's placeholder branch could only apply
+                    // it locally).
+                    if let typedName = swap.typedName {
+                        do {
+                            try await daemonClient.renameWorktree(id: wt.id, displayName: typedName)
+                            // Re-apply after success: a poll snapshot captured
+                            // before the daemon row updated can land while the
+                            // RPC was in flight and revert the name for a full
+                            // poll interval. Idempotent.
+                            applyLocalRename(id: wt.id, displayName: typedName)
+                        } catch {
+                            logger.error("Failed to persist rename typed during creation: \(error)")
+                            handleConnectionError(error)
+                        }
                     }
                 }
             } catch {
@@ -87,35 +102,66 @@ extension AppState {
         }
     }
 
+    /// Result of a successful creation-placeholder swap. `typedName` carries
+    /// the rename the user typed while creation was in flight (nil when the
+    /// placeholder was never renamed).
+    struct PlaceholderSwapResult {
+        let typedName: String?
+    }
+
     /// Swap the optimistic creation placeholder row for the daemon's worktree.
     /// The daemon row has a different UUID, so a wholesale swap would clobber
     /// a rename the user typed while creation was in flight (renameWorktree's
-    /// `.creating` branch applies such renames locally, onto the placeholder).
-    /// Detects that case by comparing the placeholder row's current
-    /// `displayName` against `placeholderName` (the name it was created with);
-    /// when they differ, the typed name is carried onto the replacement row
-    /// and returned so the caller can persist it via the rename RPC.
-    /// Returns nil when the placeholder was never renamed (or is already gone).
+    /// placeholder branch — gated on `pendingWorktreeIDs` — applies such
+    /// renames locally, onto the placeholder). Detects that case by comparing
+    /// the placeholder row's current `displayName` against `placeholderName`
+    /// (the name it was created with, which `createWorktree` also sends in
+    /// the create RPC so the daemon row starts with the same name); when they
+    /// differ, the typed name is carried onto the replacement row and
+    /// returned so the caller can persist it via the rename RPC.
+    ///
+    /// Exactly one final row ends up in the repo's list: a poll can merge the
+    /// daemon row alongside the still-preserved placeholder, so any existing
+    /// `wt.id` row is deduped, preferring the placeholder's position.
+    /// Returns nil when neither the placeholder nor a `wt.id` row exists
+    /// anymore (e.g. the repo was removed mid-create) — the row is NOT
+    /// resurrected, and the caller must not select/edit the vanished row.
     func replaceCreationPlaceholder(
         repoID: UUID,
         placeholderID: UUID,
         placeholderName: String,
         with wt: Worktree
-    ) -> String? {
-        guard let idx = worktrees[repoID]?.firstIndex(where: { $0.id == placeholderID }) else {
-            return nil
-        }
-        let currentName = worktrees[repoID]?[idx].displayName
-        var replacement = wt
+    ) -> PlaceholderSwapResult? {
+        guard var rows = worktrees[repoID] else { return nil }
+        let placeholderIdx = rows.firstIndex { $0.id == placeholderID }
+        let existingIdx = rows.firstIndex { $0.id == wt.id }
+
         let typedName: String?
-        if let currentName, currentName != placeholderName {
-            replacement.displayName = currentName
-            typedName = currentName
+        if let placeholderIdx, rows[placeholderIdx].displayName != placeholderName {
+            typedName = rows[placeholderIdx].displayName
         } else {
             typedName = nil
         }
-        worktrees[repoID]?[idx] = replacement
-        return typedName
+        var replacement = wt
+        if let typedName {
+            replacement.displayName = typedName
+        }
+
+        switch (placeholderIdx, existingIdx) {
+        case (let pIdx?, let eIdx?):
+            // Poll merged the daemon row alongside the preserved placeholder:
+            // keep the placeholder's position, drop the merged duplicate.
+            rows[pIdx] = replacement
+            rows.remove(at: eIdx)
+        case (let pIdx?, nil):
+            rows[pIdx] = replacement
+        case (nil, let eIdx?):
+            rows[eIdx] = replacement
+        case (nil, nil):
+            return nil
+        }
+        worktrees[repoID] = rows
+        return PlaceholderSwapResult(typedName: typedName)
     }
 
     /// Create a repo-less scratch space and select it once the daemon confirms.
@@ -218,11 +264,12 @@ extension AppState {
     /// `worktree.archive` RPC rejects them with `repoNotFound` — so callers
     /// don't have to route per collection.
     func archiveWorktree(id: UUID, force: Bool = false) async {
-        if findWorktree(id: id)?.isScratch == true {
+        let worktree = findWorktree(id: id)
+        if worktree?.isScratch == true {
             await archiveScratch(id: id)
             return
         }
-        let worktreeName = findWorktree(id: id)?.displayName ?? "worktree"
+        let worktreeName = worktree?.displayName ?? "worktree"
         do {
             try await daemonClient.archiveWorktree(id: id, force: force)
             removeArchivedWorktreeFromState(id: id)
@@ -296,28 +343,60 @@ extension AppState {
 
     /// Rename a worktree (repo-grouped or scratch).
     func renameWorktree(id: UUID, displayName: String) async {
+        // Local-only iff the id is a client-side creation placeholder — the
+        // daemon has never heard of it, so there is nothing to persist yet.
+        // `createWorktree` carries the typed name onto the real daemon row
+        // when it swaps the placeholder out (`replaceCreationPlaceholder`)
+        // and issues the rename RPC for that row's id then. Daemon-known rows
+        // take the RPC path regardless of status: a two-phase create leaves
+        // the daemon row `.creating` for as long as its hooks run, and the
+        // daemon rename handler has no status guard — gating on `.creating`
+        // here would silently drop renames for that whole window.
+        if pendingWorktreeIDs.contains(id) {
+            applyLocalRename(id: id, displayName: displayName)
+            return
+        }
+        // The id resolves nowhere (e.g. the placeholder was just swapped
+        // away, or the row was archived): no-op instead of firing a doomed
+        // RPC for a row that's already gone.
+        guard let previous = findWorktree(id: id) else {
+            logger.debug("renameWorktree: \(id, privacy: .public) resolves nowhere; skipping")
+            return
+        }
         // Optimistic: apply locally before any await so the UI reflects the
         // new name immediately, exactly once (callers must not pre-apply).
         applyLocalRename(id: id, displayName: displayName)
-        // Creating worktrees only exist client-side — their placeholder id is
-        // unknown to the daemon, so there is nothing to persist yet.
-        // `createWorktree` carries the typed name onto the real row when it
-        // swaps the placeholder out (`replaceCreationPlaceholder`) and issues
-        // the rename RPC for the daemon row's id then.
-        if findWorktree(id: id)?.status == .creating { return }
         do {
-            try await daemonClient.renameWorktree(id: id, displayName: displayName)
+            if let override = renameRPCOverride {
+                try await override(id, displayName)
+            } else {
+                try await daemonClient.renameWorktree(id: id, displayName: displayName)
+            }
+            // Re-apply after success: a poll snapshot captured before the
+            // daemon row updated can land while the RPC was in flight and
+            // revert the name for a full poll interval. Idempotent.
+            applyLocalRename(id: id, displayName: displayName)
         } catch {
             logger.error("Failed to rename worktree: \(error)")
+            // Roll back the optimistic apply and surface the failure —
+            // silently reverting on the next poll hides that the daemon
+            // still has the old name. Error handling mirrors
+            // `archiveScratch`: `handleConnectionError` drives the reconnect
+            // UI on a connection drop, the alert covers the rest.
+            applyLocalRename(id: id, displayName: previous.displayName)
             handleConnectionError(error)
+            showAlert("Rename failed: \(error.localizedDescription)", isError: true)
         }
     }
 
     /// Local rename applied to whichever collection holds the row: the
     /// repo-grouped `worktrees` dict, or `scratchWorktrees` for repo-less
-    /// scratch spaces (which never appear in the dict). Owned exclusively by
-    /// `renameWorktree` (the single optimistic pre-RPC application) so callers
-    /// don't have to compensate per collection.
+    /// scratch spaces (which never appear in the dict). Idempotent — the
+    /// rename paths re-apply it after RPC success to clobber any poll
+    /// snapshot that reverted the name mid-flight. Owned by `renameWorktree`
+    /// (optimistic pre-RPC apply + post-RPC re-apply + failure rollback) and
+    /// `createWorktree`'s carried-rename persist block, so callers don't
+    /// have to compensate per collection.
     private func applyLocalRename(id: UUID, displayName: String) {
         for repoID in worktrees.keys {
             if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == id }) {
@@ -342,17 +421,8 @@ extension AppState {
         highlightedArchivedWorktreeID = nil
         selectedWorktreeIDs = [id]
         // Expand the containing repo so the row is part of the rendered list
-        // before we ask the sidebar to scroll to it. Update local state
-        // synchronously (List rerender + scroll), persist via RPC fire-and-forget.
-        // Intentionally repo-scoped (dict-only, not findWorktree): scratch
-        // spaces have no repo row to expand.
-        if let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),
-           let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
-           let repoID = worktree.repoID,
-           !repos[repoIdx].expanded {
-            repos[repoIdx].expanded = true
-            Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
-        }
+        // before we ask the sidebar to scroll to it.
+        expandRepoContaining(worktreeID: id)
         pendingScrollToWorktreeID = id
         // Switch to the originating terminal's tab when one matches. Both
         // `.terminal` and `.liveTranscript` panes count as matches — clicking
@@ -727,48 +797,36 @@ extension AppState {
         createWorktree(repoID: repoID)
     }
 
-    /// Which archive path `archiveSelectedWorktree` should take for a
-    /// selection. Scratch spaces live only in `scratchWorktrees` and must go
-    /// through the `scratch.archive` RPC — the repo-worktree `worktree.archive`
-    /// RPC rejects them with `repoNotFound`. Pure so both branches are
-    /// unit-testable without a daemon.
-    enum ArchiveShortcutRoute: Equatable {
-        case scratch(UUID)
-        case worktree(UUID)
-    }
-
-    /// Resolve the archive route for a pre-resolved selection (the caller
-    /// passes `selectedWorktreeIDs.first.flatMap(findWorktree)`). Returns
-    /// `nil` when:
+    /// Resolve the archive target for a pre-resolved selection (the caller
+    /// passes `selectedWorktreeIDs.first.flatMap(findWorktree)`). This seam
+    /// only decides refuse-vs-proceed — `archiveWorktree(id:)` is
+    /// scratch-aware and self-routes scratch rows to the `scratch.archive`
+    /// RPC. Pure so the branches are unit-testable without a daemon.
+    /// Returns `nil` when:
     /// - nothing is selected, or
     /// - the selected ID is stale/unknown (`findWorktree` returned nil — no
     ///   doomed RPC + error alert for a row that's already gone), or
     /// - the selected repo worktree is the main branch or still creating
-    ///   (those refuse the archive shortcut).
+    ///   (those refuse the archive shortcut; scratch rows always proceed —
+    ///   the daemon creates them `.active`, never `.main`/`.creating`).
     nonisolated static func archiveShortcutRoute(
         selectedWorktree: Worktree?
-    ) -> ArchiveShortcutRoute? {
+    ) -> UUID? {
         guard let wt = selectedWorktree else { return nil }
-        if wt.isScratch { return .scratch(wt.id) }
-        // Don't archive the main branch worktree
+        if wt.isScratch { return wt.id }
+        // Don't archive the main branch worktree (or one still creating)
         if wt.status == .main || wt.status == .creating { return nil }
-        return .worktree(wt.id)
+        return wt.id
     }
 
-    /// Archive the first selected worktree (refuses main worktrees). Routes
-    /// scratch spaces to the scratch archive path — same as the row context
-    /// menu's Archive action.
+    /// Archive the first selected worktree (refuses main worktrees). Scratch
+    /// routing happens inside `archiveWorktree(id:)` — same as the row
+    /// context menu's Archive action.
     func archiveSelectedWorktree() {
-        switch Self.archiveShortcutRoute(
+        guard let id = Self.archiveShortcutRoute(
             selectedWorktree: selectedWorktreeIDs.first.flatMap { findWorktree(id: $0) }
-        ) {
-        case .scratch(let id):
-            Task { await archiveScratch(id: id) }
-        case .worktree(let id):
-            Task { await archiveWorktree(id: id) }
-        case nil:
-            break
-        }
+        ) else { return }
+        Task { await archiveWorktree(id: id) }
     }
 
     /// Select a worktree by its index in the sidebar order.

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -78,19 +78,16 @@ extension AppState {
                     // Persist the carried rename now that a daemon-known row
                     // exists (the placeholder's id never reached the daemon,
                     // so renameWorktree's placeholder branch could only apply
-                    // it locally).
+                    // it locally). Route through renameWorktree rather than an
+                    // inline daemonClient call: wt.id is daemon-known and NOT
+                    // in pendingWorktreeIDs, so it takes the full RPC path —
+                    // optimistic apply (idempotent; the swap already carried
+                    // the name), post-success re-apply to beat an interleaved
+                    // poll revert, and rollback + "Rename failed:" alert on
+                    // failure. The old inline call's catch only logged, so a
+                    // non-connection RPC failure silently lost the name.
                     if let typedName = swap.typedName {
-                        do {
-                            try await daemonClient.renameWorktree(id: wt.id, displayName: typedName)
-                            // Re-apply after success: a poll snapshot captured
-                            // before the daemon row updated can land while the
-                            // RPC was in flight and revert the name for a full
-                            // poll interval. Idempotent.
-                            applyLocalRename(id: wt.id, displayName: typedName)
-                        } catch {
-                            logger.error("Failed to persist rename typed during creation: \(error)")
-                            handleConnectionError(error)
-                        }
+                        await renameWorktree(id: wt.id, displayName: typedName)
                     }
                 }
             } catch {

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -56,12 +56,28 @@ extension AppState {
                     parentWorktreeID: parentWorktreeID,
                     useExistingBranch: existingBranch != nil
                 )
-                // Replace the placeholder with the real worktree
-                if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == placeholder.id }) {
-                    worktrees[repoID]?[idx] = wt
-                }
+                // Replace the placeholder with the real worktree, carrying
+                // over any rename the user typed while creation was in flight.
+                let typedName = replaceCreationPlaceholder(
+                    repoID: repoID,
+                    placeholderID: placeholder.id,
+                    placeholderName: placeholderName,
+                    with: wt
+                )
                 selectedWorktreeIDs = [wt.id]
                 editingWorktreeID = wt.id
+                // Persist the carried rename now that a daemon-known row
+                // exists (the placeholder's id never reached the daemon, so
+                // renameWorktree's .creating branch could only apply it
+                // locally).
+                if let typedName {
+                    do {
+                        try await daemonClient.renameWorktree(id: wt.id, displayName: typedName)
+                    } catch {
+                        logger.error("Failed to persist rename typed during creation: \(error)")
+                        handleConnectionError(error)
+                    }
+                }
             } catch {
                 // Remove the placeholder on failure
                 worktrees[repoID]?.removeAll { $0.id == placeholder.id }
@@ -69,6 +85,37 @@ extension AppState {
                 handleConnectionError(error)
             }
         }
+    }
+
+    /// Swap the optimistic creation placeholder row for the daemon's worktree.
+    /// The daemon row has a different UUID, so a wholesale swap would clobber
+    /// a rename the user typed while creation was in flight (renameWorktree's
+    /// `.creating` branch applies such renames locally, onto the placeholder).
+    /// Detects that case by comparing the placeholder row's current
+    /// `displayName` against `placeholderName` (the name it was created with);
+    /// when they differ, the typed name is carried onto the replacement row
+    /// and returned so the caller can persist it via the rename RPC.
+    /// Returns nil when the placeholder was never renamed (or is already gone).
+    func replaceCreationPlaceholder(
+        repoID: UUID,
+        placeholderID: UUID,
+        placeholderName: String,
+        with wt: Worktree
+    ) -> String? {
+        guard let idx = worktrees[repoID]?.firstIndex(where: { $0.id == placeholderID }) else {
+            return nil
+        }
+        let currentName = worktrees[repoID]?[idx].displayName
+        var replacement = wt
+        let typedName: String?
+        if let currentName, currentName != placeholderName {
+            replacement.displayName = currentName
+            typedName = currentName
+        } else {
+            typedName = nil
+        }
+        worktrees[repoID]?[idx] = replacement
+        return typedName
     }
 
     /// Create a repo-less scratch space and select it once the daemon confirms.
@@ -106,15 +153,17 @@ extension AppState {
     }
 
     /// Archive a scratch space: closes its terminals (folder untouched), moves
-    /// it into the Scratch section's Archived tab. The `.worktreeArchived`
-    /// delta this broadcasts already removes the row from `scratchWorktrees`
-    /// via `removeArchivedWorktreeFromState` (see `AppState+ArchiveTombstones.swift`),
-    /// so the local removal here is belt-and-suspenders for the caller that
-    /// issued the RPC (same pattern as `archiveWorktree`).
+    /// it into the Scratch section's Archived tab. Runs the same synchronous
+    /// cleanup as `archiveWorktree` — `removeArchivedWorktreeFromState` covers
+    /// `scratchWorktrees` removal, selection cleanup (so the detail pane never
+    /// flashes "Worktree not found"), the tombstone (so an in-flight poll can't
+    /// re-append a ghost row), and terminal teardown. The `.worktreeArchived`
+    /// delta repeats the removal for other clients (see
+    /// `AppState+ArchiveTombstones.swift`).
     func archiveScratch(id: UUID) async {
         do {
             try await daemonClient.archiveScratch(worktreeID: id)
-            scratchWorktrees.removeAll { $0.id == id }
+            removeArchivedWorktreeFromState(id: id)
             await refreshArchivedScratch()
         } catch {
             logger.error("Failed to archive scratch space: \(error)")
@@ -164,8 +213,15 @@ extension AppState {
         }
     }
 
-    /// Archive a worktree.
+    /// Archive a worktree. Scratch-aware by construction: repo-less scratch
+    /// spaces are delegated to `archiveScratch(id:)` — the repo-worktree
+    /// `worktree.archive` RPC rejects them with `repoNotFound` — so callers
+    /// don't have to route per collection.
     func archiveWorktree(id: UUID, force: Bool = false) async {
+        if findWorktree(id: id)?.isScratch == true {
+            await archiveScratch(id: id)
+            return
+        }
         let worktreeName = findWorktree(id: id)?.displayName ?? "worktree"
         do {
             try await daemonClient.archiveWorktree(id: id, force: force)
@@ -240,15 +296,17 @@ extension AppState {
 
     /// Rename a worktree (repo-grouped or scratch).
     func renameWorktree(id: UUID, displayName: String) async {
-        // For creating worktrees, just update locally — the name will be applied when creation finishes
-        let isCreating = findWorktree(id: id)?.status == .creating
-        if isCreating {
-            applyLocalRename(id: id, displayName: displayName)
-            return
-        }
+        // Optimistic: apply locally before any await so the UI reflects the
+        // new name immediately, exactly once (callers must not pre-apply).
+        applyLocalRename(id: id, displayName: displayName)
+        // Creating worktrees only exist client-side — their placeholder id is
+        // unknown to the daemon, so there is nothing to persist yet.
+        // `createWorktree` carries the typed name onto the real row when it
+        // swaps the placeholder out (`replaceCreationPlaceholder`) and issues
+        // the rename RPC for the daemon row's id then.
+        if findWorktree(id: id)?.status == .creating { return }
         do {
             try await daemonClient.renameWorktree(id: id, displayName: displayName)
-            applyLocalRename(id: id, displayName: displayName)
         } catch {
             logger.error("Failed to rename worktree: \(error)")
             handleConnectionError(error)
@@ -257,9 +315,10 @@ extension AppState {
 
     /// Local rename applied to whichever collection holds the row: the
     /// repo-grouped `worktrees` dict, or `scratchWorktrees` for repo-less
-    /// scratch spaces (which never appear in the dict). Owned by
-    /// `renameWorktree` so callers don't have to compensate per collection.
-    func applyLocalRename(id: UUID, displayName: String) {
+    /// scratch spaces (which never appear in the dict). Owned exclusively by
+    /// `renameWorktree` (the single optimistic pre-RPC application) so callers
+    /// don't have to compensate per collection.
+    private func applyLocalRename(id: UUID, displayName: String) {
         for repoID in worktrees.keys {
             if let idx = worktrees[repoID]?.firstIndex(where: { $0.id == id }) {
                 worktrees[repoID]?[idx].displayName = displayName
@@ -285,6 +344,8 @@ extension AppState {
         // Expand the containing repo so the row is part of the rendered list
         // before we ask the sidebar to scroll to it. Update local state
         // synchronously (List rerender + scroll), persist via RPC fire-and-forget.
+        // Intentionally repo-scoped (dict-only, not findWorktree): scratch
+        // spaces have no repo row to expand.
         if let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),
            let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
            let repoID = worktree.repoID,
@@ -387,6 +448,11 @@ extension AppState {
         selectedScratchSection = false
         Task { await refreshArchivedWorktrees(repoID: id) }
     }
+
+    /// User-facing label for the repo-less scratch section. Single source for
+    /// the sidebar section header (`ScratchSectionView`) and the jump menu's
+    /// pseudo-repo label (`JumpMenuController.worktreeSnapshots`).
+    nonisolated static let scratchSectionLabel = "Scratch"
 
     /// Select the "Scratch" sidebar section header to show `ScratchDetailView`
     /// (Archived/Instructions/Settings tabs) in the content pane. Mirrors
@@ -542,6 +608,10 @@ extension AppState {
 
     /// All worktrees whose parentWorktreeID == parentID, across all repos, in sortOrder.
     /// Only active or creating worktrees are returned.
+    /// Intentionally repo-scoped (dict-only, not `allWorktrees`): scratch
+    /// spaces can never be children — nesting requires a `repoID`
+    /// (`createNestedWorktree` guards on it), and `createScratch` never sets
+    /// `parentWorktreeID` — so no child ever lives outside the dict.
     func children(of parentID: UUID) -> [Worktree] {
         worktrees.values
             .flatMap { $0 }
@@ -667,22 +737,22 @@ extension AppState {
         case worktree(UUID)
     }
 
-    /// Resolve the archive route for the given selection. Returns `nil` when
-    /// nothing is selected, or when the selected repo worktree is the main
-    /// branch or still creating (those refuse the archive shortcut).
+    /// Resolve the archive route for a pre-resolved selection (the caller
+    /// passes `selectedWorktreeIDs.first.flatMap(findWorktree)`). Returns
+    /// `nil` when:
+    /// - nothing is selected, or
+    /// - the selected ID is stale/unknown (`findWorktree` returned nil — no
+    ///   doomed RPC + error alert for a row that's already gone), or
+    /// - the selected repo worktree is the main branch or still creating
+    ///   (those refuse the archive shortcut).
     nonisolated static func archiveShortcutRoute(
-        selectedID: UUID?,
-        worktrees: [UUID: [Worktree]],
-        scratchWorktrees: [Worktree]
+        selectedWorktree: Worktree?
     ) -> ArchiveShortcutRoute? {
-        guard let id = selectedID else { return nil }
-        if scratchWorktrees.contains(where: { $0.id == id }) {
-            return .scratch(id)
-        }
+        guard let wt = selectedWorktree else { return nil }
+        if wt.isScratch { return .scratch(wt.id) }
         // Don't archive the main branch worktree
-        if let wt = worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),
-           wt.status == .main || wt.status == .creating { return nil }
-        return .worktree(id)
+        if wt.status == .main || wt.status == .creating { return nil }
+        return .worktree(wt.id)
     }
 
     /// Archive the first selected worktree (refuses main worktrees). Routes
@@ -690,9 +760,7 @@ extension AppState {
     /// menu's Archive action.
     func archiveSelectedWorktree() {
         switch Self.archiveShortcutRoute(
-            selectedID: selectedWorktreeIDs.first,
-            worktrees: worktrees,
-            scratchWorktrees: scratchWorktrees
+            selectedWorktree: selectedWorktreeIDs.first.flatMap { findWorktree(id: $0) }
         ) {
         case .scratch(let id):
             Task { await archiveScratch(id: id) }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -242,7 +242,7 @@ final class AppState: ObservableObject {
     /// The first selected worktree, if any.
     var selectedWorktree: Worktree? {
         guard let id = selectedWorktreeIDs.first else { return nil }
-        return worktrees.values.flatMap { $0 }.first { $0.id == id }
+        return findWorktree(id: id)
     }
 
     /// All pinned terminals across all worktrees, sorted by pinnedAt.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1197,7 +1197,9 @@ final class AppState: ObservableObject {
         macNotificationManager.postIfEnabled(
             worktreeID: notification.worktreeID,
             message: notification.message,
-            worktrees: allWorktrees,
+            // Resolve the name here (scratch-aware) instead of handing over
+            // the whole materialized allWorktrees array for one lookup.
+            worktreeName: findWorktree(id: notification.worktreeID)?.displayName,
             type: notification.type,
             terminalID: notification.terminalID
         )

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -208,6 +208,12 @@ final class AppState: ObservableObject {
     /// list.
     var archivedLookupOverride: ((UUID) async -> [Worktree])?
 
+    /// Test seam: when set, replaces the daemon rename RPC in
+    /// `renameWorktree(id:displayName:)`. Production code leaves this nil;
+    /// tests assign a closure to observe the RPC path (or throw from it to
+    /// exercise the rollback branch) without a live daemon.
+    var renameRPCOverride: (@MainActor (UUID, String) async throws -> Void)?
+
     /// True once `connectAndLoadInitialState()` has finished its initial
     /// `refreshAll()` and the worktree list is populated. Used by
     /// `navigateToWorktree(_:)` to detect cold-start clicks that arrive
@@ -1315,13 +1321,7 @@ final class AppState: ObservableObject {
             // Expand any repo whose worktree is now selected but was collapsed,
             // so the restored row is visible in the sidebar.
             for id in selectedWorktreeIDs {
-                if let worktree = worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),
-                   let repoIdx = repos.firstIndex(where: { $0.id == worktree.repoID }),
-                   let repoID = worktree.repoID,
-                   !repos[repoIdx].expanded {
-                    repos[repoIdx].expanded = true
-                    Task { try? await daemonClient.setRepoExpanded(id: repoID, expanded: true) }
-                }
+                expandRepoContaining(worktreeID: id)
             }
             await loadModelProfiles()
             await loadHibernationConfig()

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1203,8 +1203,13 @@ final class AppState: ObservableObject {
         )
     }
 
-    private var allWorktrees: [Worktree] {
-        worktrees.values.flatMap { $0 }
+    /// Every worktree the app knows about: the repo-grouped dict flattened,
+    /// plus repo-less scratch spaces (which live only in `scratchWorktrees`).
+    /// Use this instead of re-flattening `worktrees.values` whenever a lookup
+    /// must also resolve scratch spaces (e.g. notification banner titles,
+    /// startup selection restore).
+    var allWorktrees: [Worktree] {
+        worktrees.values.flatMap { $0 } + scratchWorktrees
     }
 
     /// Runs `body` only if no poll cycle is currently in flight. Returns true if
@@ -1301,9 +1306,10 @@ final class AppState: ObservableObject {
             await refreshAll()
             // Restore persisted selection before notifying the daemon — the RPC
             // below captures `selectedWorktreeIDs` so the daemon learns the real
-            // selection from the previous session.
-            let allWorktreeIDs = worktrees.values.flatMap { $0 }.map(\.id)
-            restoreSavedSelection(validWorktreeIDs: allWorktreeIDs)
+            // selection from the previous session. `allWorktrees` includes
+            // scratch spaces (populated by refreshAll() above), so a persisted
+            // scratch selection survives relaunch instead of being filtered out.
+            restoreSavedSelection(validWorktreeIDs: allWorktrees.map(\.id))
             // Expand any repo whose worktree is now selected but was collapsed,
             // so the restored row is visible in the sidebar.
             for id in selectedWorktreeIDs {
@@ -1833,14 +1839,16 @@ final class AppState: ObservableObject {
     /// Pure target-selection for the pre-sleep suspend hook. Returns the
     /// worktree IDs to best-effort suspend before the machine sleeps:
     /// `[]` when auto-suspend is disabled, otherwise every worktree ID
-    /// (flattened across repos). No I/O — trivially unit-testable for both
-    /// gate branches without a live daemon.
+    /// (flattened across repos, plus repo-less scratch spaces — the daemon's
+    /// suspend handler is worktree-kind agnostic). No I/O — trivially
+    /// unit-testable for both gate branches without a live daemon.
     static func worktreeIDsToSuspendForSleep(
         worktrees: [UUID: [Worktree]],
+        scratchWorktrees: [Worktree],
         autoSuspendEnabled: Bool
     ) -> [UUID] {
         guard autoSuspendEnabled else { return [] }
-        return worktrees.values.flatMap { $0 }.map(\.id)
+        return worktrees.values.flatMap { $0 }.map(\.id) + scratchWorktrees.map(\.id)
     }
 
     /// Best-effort suspend of idle Claude terminals across all worktrees when
@@ -1865,6 +1873,7 @@ final class AppState: ObservableObject {
         let enabled = Self.autoSuspendClaudeEnabled(defaults: defaults)
         let ids = Self.worktreeIDsToSuspendForSleep(
             worktrees: worktrees,
+            scratchWorktrees: scratchWorktrees,
             autoSuspendEnabled: enabled
         )
         guard !ids.isEmpty else {

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -56,14 +56,17 @@ struct StatusBarView: View {
     /// Compute the left-side focus label for the status bar.
     ///
     /// - Single worktree selected: `"<repo name> / <worktree displayName>"`,
-    ///   or just `<worktree displayName>` when the repo lookup fails.
+    ///   or just `<worktree displayName>` when the repo lookup fails (or the
+    ///   worktree is a repo-less scratch space). The caller pre-resolves the
+    ///   selection via `AppState.findWorktree(id:)` — the scratch-aware
+    ///   lookup — and passes it as `selectedWorktree` (same seam
+    ///   `selectedWorktreeInfo` uses); `nil` means the lookup failed.
     /// - Multiple worktrees selected: `"<N> worktrees"`.
     /// - Repo selected, no worktree: the repo's `displayName`.
     /// - Nothing selected: `nil` (renders nothing on the left side).
     nonisolated static func focusLabel(
         selectedWorktreeIDs: Set<UUID>,
-        worktrees: [UUID: [Worktree]],
-        scratchWorktrees: [Worktree],
+        selectedWorktree: Worktree?,
         repos: [Repo],
         selectedRepoID: UUID?
     ) -> String? {
@@ -72,9 +75,8 @@ struct StatusBarView: View {
             guard let repoID = selectedRepoID,
                   let repo = repos.first(where: { $0.id == repoID }) else { return nil }
             return repo.displayName
-        } else if count == 1, let id = selectedWorktreeIDs.first {
-            let allWorktrees = worktrees.values.flatMap { $0 } + scratchWorktrees
-            guard let wt = allWorktrees.first(where: { $0.id == id }) else { return nil }
+        } else if count == 1 {
+            guard let wt = selectedWorktree else { return nil }
             if let repo = repos.first(where: { $0.id == wt.repoID }) {
                 return "\(repo.displayName) / \(wt.displayName)"
             }
@@ -116,8 +118,9 @@ struct StatusBarView: View {
         HStack {
             if let label = Self.focusLabel(
                 selectedWorktreeIDs: appState.selectedWorktreeIDs,
-                worktrees: appState.worktrees,
-                scratchWorktrees: appState.scratchWorktrees,
+                selectedWorktree: appState.selectedWorktreeIDs.count == 1
+                    ? appState.selectedWorktreeIDs.first.flatMap { appState.findWorktree(id: $0) }
+                    : nil,
                 repos: appState.repos,
                 selectedRepoID: appState.selectedRepoID
             ) {

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -8,11 +8,11 @@ struct StatusBarView: View {
     /// Transient "Copied" feedback shown after the left label copies a path.
     @State private var didCopy = false
 
-    private var selectedWorktreeInfo: (path: String, repoID: UUID?)? {
-        guard appState.selectedWorktreeIDs.count == 1,
-              let id = appState.selectedWorktreeIDs.first,
-              let worktree = appState.findWorktree(id: id),
-              !worktree.path.isEmpty else { return nil }
+    /// Path + repo of the resolved single-selected worktree (nil when it has
+    /// no path yet). The caller resolves the selection once per body
+    /// evaluation and passes it in, so this never re-runs `findWorktree`.
+    private static func selectedWorktreeInfo(_ worktree: Worktree?) -> (path: String, repoID: UUID?)? {
+        guard let worktree, !worktree.path.isEmpty else { return nil }
         return (worktree.path, worktree.repoID)
     }
 
@@ -115,16 +115,21 @@ struct StatusBarView: View {
     }
 
     var body: some View {
+        // Resolve the single-selected worktree ONCE per body evaluation —
+        // focusLabel and both selectedWorktreeInfo consumers share it, instead
+        // of each re-running findWorktree per render.
+        let selected = appState.selectedWorktreeIDs.count == 1
+            ? appState.selectedWorktreeIDs.first.flatMap { appState.findWorktree(id: $0) }
+            : nil
+        let selectedInfo = Self.selectedWorktreeInfo(selected)
         HStack {
             if let label = Self.focusLabel(
                 selectedWorktreeIDs: appState.selectedWorktreeIDs,
-                selectedWorktree: appState.selectedWorktreeIDs.count == 1
-                    ? appState.selectedWorktreeIDs.first.flatMap { appState.findWorktree(id: $0) }
-                    : nil,
+                selectedWorktree: selected,
                 repos: appState.repos,
                 selectedRepoID: appState.selectedRepoID
             ) {
-                let behavior = Self.leftLabelBehavior(selectedWorktreePath: selectedWorktreeInfo?.path)
+                let behavior = Self.leftLabelBehavior(selectedWorktreePath: selectedInfo?.path)
                 switch behavior {
                 case .copyPath(let path):
                     Button(action: { copyPath(path) }) {
@@ -143,7 +148,7 @@ struct StatusBarView: View {
                 }
             }
             Spacer()
-            if let info = selectedWorktreeInfo {
+            if let info = selectedInfo {
                 OpenInEditorButton(path: info.path, repoID: info.repoID)
             }
             let footer = footerLabel

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -11,7 +11,7 @@ struct StatusBarView: View {
     private var selectedWorktreeInfo: (path: String, repoID: UUID?)? {
         guard appState.selectedWorktreeIDs.count == 1,
               let id = appState.selectedWorktreeIDs.first,
-              let worktree = appState.worktrees.values.flatMap({ $0 }).first(where: { $0.id == id }),
+              let worktree = appState.findWorktree(id: id),
               !worktree.path.isEmpty else { return nil }
         return (worktree.path, worktree.repoID)
     }
@@ -63,6 +63,7 @@ struct StatusBarView: View {
     nonisolated static func focusLabel(
         selectedWorktreeIDs: Set<UUID>,
         worktrees: [UUID: [Worktree]],
+        scratchWorktrees: [Worktree],
         repos: [Repo],
         selectedRepoID: UUID?
     ) -> String? {
@@ -72,7 +73,7 @@ struct StatusBarView: View {
                   let repo = repos.first(where: { $0.id == repoID }) else { return nil }
             return repo.displayName
         } else if count == 1, let id = selectedWorktreeIDs.first {
-            let allWorktrees = worktrees.values.flatMap { $0 }
+            let allWorktrees = worktrees.values.flatMap { $0 } + scratchWorktrees
             guard let wt = allWorktrees.first(where: { $0.id == id }) else { return nil }
             if let repo = repos.first(where: { $0.id == wt.repoID }) {
                 return "\(repo.displayName) / \(wt.displayName)"
@@ -116,6 +117,7 @@ struct StatusBarView: View {
             if let label = Self.focusLabel(
                 selectedWorktreeIDs: appState.selectedWorktreeIDs,
                 worktrees: appState.worktrees,
+                scratchWorktrees: appState.scratchWorktrees,
                 repos: appState.repos,
                 selectedRepoID: appState.selectedRepoID
             ) {

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -111,11 +111,11 @@ final class JumpMenuController {
     /// Snapshot every live worktree for the jump menu: the repo-grouped dict
     /// flattened, plus repo-less scratch spaces (which live only in
     /// `scratchWorktrees` and would otherwise never be reachable via Cmd-K).
-    /// Scratch rows carry "Scratch" as their repo label.
+    /// Scratch rows carry the Scratch section's label as their repo label.
     static func worktreeSnapshots(appState: AppState) -> [JumpMenuWorktreeSnapshot] {
         appState.allWorktrees.map { wt in
             let repoName = appState.repos.first { $0.id == wt.repoID }?.displayName
-                ?? (wt.isScratch ? "Scratch" : "?")
+                ?? (wt.isScratch ? AppState.scratchSectionLabel : "?")
             return JumpMenuWorktreeSnapshot(
                 id: wt.id,
                 displayName: wt.displayName,

--- a/Sources/TBDApp/JumpMenu/JumpMenuController.swift
+++ b/Sources/TBDApp/JumpMenu/JumpMenuController.swift
@@ -43,16 +43,7 @@ final class JumpMenuController {
         // Snapshot all worktrees + unread + recents at open time. Mutations
         // arriving while the panel is visible don't affect the displayed
         // list — that's the design's "snapshot semantics" rule.
-        let snapshots = appState.worktrees.values
-            .flatMap { $0 }
-            .map { wt -> JumpMenuWorktreeSnapshot in
-                let repoName = appState.repos.first { $0.id == wt.repoID }?.displayName ?? "?"
-                return JumpMenuWorktreeSnapshot(
-                    id: wt.id,
-                    displayName: wt.displayName,
-                    repoName: repoName
-                )
-            }
+        let snapshots = Self.worktreeSnapshots(appState: appState)
 
         let vm = JumpMenuViewModel(
             worktrees: snapshots,
@@ -117,12 +108,28 @@ final class JumpMenuController {
         viewModel = nil
     }
 
+    /// Snapshot every live worktree for the jump menu: the repo-grouped dict
+    /// flattened, plus repo-less scratch spaces (which live only in
+    /// `scratchWorktrees` and would otherwise never be reachable via Cmd-K).
+    /// Scratch rows carry "Scratch" as their repo label.
+    static func worktreeSnapshots(appState: AppState) -> [JumpMenuWorktreeSnapshot] {
+        appState.allWorktrees.map { wt in
+            let repoName = appState.repos.first { $0.id == wt.repoID }?.displayName
+                ?? (wt.isScratch ? "Scratch" : "?")
+            return JumpMenuWorktreeSnapshot(
+                id: wt.id,
+                displayName: wt.displayName,
+                repoName: repoName
+            )
+        }
+    }
+
     private func submit(_ row: JumpMenuRow) {
         guard let appState else { return }
-        // Filter against the live worktree map — the snapshot may be stale
-        // if a worktree was deleted while the panel was open.
-        let liveIDs = Set(appState.worktrees.values.flatMap { $0 }.map(\.id))
-        guard liveIDs.contains(row.id) else {
+        // Filter against live state — the snapshot may be stale if a worktree
+        // was deleted while the panel was open. findWorktree is scratch-aware,
+        // so a scratch row from the snapshot isn't rejected as stale here.
+        guard appState.findWorktree(id: row.id) != nil else {
             logger.debug("Submit on stale worktree id \(row.id, privacy: .public) — closing without jumping")
             close()
             return

--- a/Sources/TBDApp/Services/MacNotificationManager.swift
+++ b/Sources/TBDApp/Services/MacNotificationManager.swift
@@ -78,13 +78,14 @@ final class MacNotificationManager: NSObject, UNUserNotificationCenterDelegate {
         enabled && isAvailable && !mockActive
     }
 
-    func postIfEnabled(worktreeID: UUID, message: String?, worktrees: [Worktree],
+    /// `worktreeName` is the caller-resolved display name (nil when the
+    /// worktree is unknown — the banner falls back to the raw UUID string).
+    func postIfEnabled(worktreeID: UUID, message: String?, worktreeName: String?,
                        type: NotificationType, terminalID: UUID? = nil) {
         guard Self.shouldPost(enabled: enabled, isAvailable: isAvailable, mockActive: MockMode.isActive()) else { return }
         requestPermissionIfNeeded()
 
-        let worktreeName = worktrees.first(where: { $0.id == worktreeID })?.displayName
-            ?? worktreeID.uuidString
+        let worktreeName = worktreeName ?? worktreeID.uuidString
 
         let truncatedMessage = Self.bannerBody(message: message, type: type)
 

--- a/Sources/TBDApp/Sidebar/ScratchSectionView.swift
+++ b/Sources/TBDApp/Sidebar/ScratchSectionView.swift
@@ -12,7 +12,7 @@ struct ScratchSectionView: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            Text("Scratch")
+            Text(AppState.scratchSectionLabel)
                 .font(.headline)
                 .foregroundStyle(appState.selectedScratchSection ? .primary : .secondary)
             Spacer()

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -139,15 +139,10 @@ struct WorktreeRowView: View {
                 text: worktree.displayName,
                 isEditing: $isEditing,
                 onCommit: { newName in
-                    // Optimistic local update so the UI reflects the new name before the RPC returns
-                    for repoID in appState.worktrees.keys {
-                        if let idx = appState.worktrees[repoID]?.firstIndex(where: { $0.id == worktree.id }) {
-                            appState.worktrees[repoID]?[idx].displayName = newName
-                        }
-                    }
-                    if let idx = appState.scratchWorktrees.firstIndex(where: { $0.id == worktree.id }) {
-                        appState.scratchWorktrees[idx].displayName = newName
-                    }
+                    // Optimistic local update so the UI reflects the new name
+                    // before the RPC returns. Scratch-aware: applyLocalRename
+                    // covers both the repo dict and scratchWorktrees.
+                    appState.applyLocalRename(id: worktree.id, displayName: newName)
                     Task {
                         await appState.renameWorktree(id: worktree.id, displayName: newName)
                     }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -139,10 +139,9 @@ struct WorktreeRowView: View {
                 text: worktree.displayName,
                 isEditing: $isEditing,
                 onCommit: { newName in
-                    // Optimistic local update so the UI reflects the new name
-                    // before the RPC returns. Scratch-aware: applyLocalRename
-                    // covers both the repo dict and scratchWorktrees.
-                    appState.applyLocalRename(id: worktree.id, displayName: newName)
+                    // renameWorktree applies the optimistic local update
+                    // itself (scratch-aware, before its RPC) — no caller-side
+                    // pre-apply, or the rename would be applied twice.
                     Task {
                         await appState.renameWorktree(id: worktree.id, displayName: newName)
                     }

--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -112,6 +112,9 @@ private struct PinnedTerminalCell: View {
     }
 
     var body: some View {
+        // Bind ONCE per render — the computed property is a linear scan, and
+        // both the header and the terminal content read it.
+        let worktree = self.worktree
         VStack(spacing: 0) {
             // Header: pin icon + worktree name
             HStack(spacing: 4) {

--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -105,12 +105,7 @@ private struct PinnedTerminalCell: View {
     @EnvironmentObject var appState: AppState
 
     private var worktree: Worktree? {
-        for wts in appState.worktrees.values {
-            if let wt = wts.first(where: { $0.id == terminal.worktreeID }) {
-                return wt
-            }
-        }
-        return nil
+        appState.findWorktree(id: terminal.worktreeID)
     }
 
     var body: some View {

--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -104,6 +104,9 @@ private struct PinnedTerminalCell: View {
     let terminal: Terminal
     @EnvironmentObject var appState: AppState
 
+    // Must stay on findWorktree: scratch spaces live only in
+    // `scratchWorktrees`, never the repo-grouped dict, so a dict-only lookup
+    // leaves scratch pins stuck on "Loading..." forever.
     private var worktree: Worktree? {
         appState.findWorktree(id: terminal.worktreeID)
     }

--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -104,17 +104,13 @@ private struct PinnedTerminalCell: View {
     let terminal: Terminal
     @EnvironmentObject var appState: AppState
 
-    // Must stay on findWorktree: scratch spaces live only in
-    // `scratchWorktrees`, never the repo-grouped dict, so a dict-only lookup
-    // leaves scratch pins stuck on "Loading..." forever.
-    private var worktree: Worktree? {
-        appState.findWorktree(id: terminal.worktreeID)
-    }
-
     var body: some View {
-        // Bind ONCE per render — the computed property is a linear scan, and
-        // both the header and the terminal content read it.
-        let worktree = self.worktree
+        // Bind ONCE per render — findWorktree is a linear scan, and both the
+        // header and the terminal content read it. Must stay on findWorktree:
+        // scratch spaces live only in `scratchWorktrees`, never the
+        // repo-grouped dict, so a dict-only lookup leaves scratch pins stuck
+        // on "Loading..." forever.
+        let worktree = appState.findWorktree(id: terminal.worktreeID)
         VStack(spacing: 0) {
             // Header: pin icon + worktree name
             HStack(spacing: 4) {

--- a/Tests/TBDAppTests/ArchiveNavigateBackTests.swift
+++ b/Tests/TBDAppTests/ArchiveNavigateBackTests.swift
@@ -282,6 +282,31 @@ struct ArchiveNavigateBackTests {
         }
     }
 
+    // MARK: - navigateBack treats live scratch spaces as usable entries
+
+    @Test func navigateBack_landsOnLiveScratchEntry() {
+        withState { state in
+            let repoID = UUID()
+            let scratch = UUID()
+            let b = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: b, repoID: repoID)]]
+            // Scratch spaces live only in `scratchWorktrees`; entry validation
+            // must include them or cmd+[ skips live scratch selections.
+            var scratchWT = makeWorktree(id: scratch, repoID: repoID)
+            scratchWT.repoID = nil
+            state.scratchWorktrees = [scratchWT]
+
+            // History: [scratch], [B].
+            state.selectedWorktreeIDs = [scratch]
+            state.selectedWorktreeIDs = [b]
+
+            state.navigateBack()
+
+            #expect(state.selectedWorktreeIDs == [scratch])
+            #expect(state.selectionOrder == [scratch])
+        }
+    }
+
     // MARK: - navigateForward skips stale entries
 
     @Test func navigateForward_skipsStaleEntries() {

--- a/Tests/TBDAppTests/FindWorktreeScratchTests.swift
+++ b/Tests/TBDAppTests/FindWorktreeScratchTests.swift
@@ -19,7 +19,8 @@ import TBDShared
 /// `PinnedTerminalCell` (PinnedTerminalDock.swift) previously hand-rolled a
 /// worktrees-dict-only lookup, so pins from scratch spaces resolved to nil and
 /// the cell rendered "Loading..." forever. It now resolves through
-/// `findWorktree`, which this suite covers.
+/// `findWorktree`. This suite covers the `findWorktree` helper itself
+/// (including its scratch branch); the SwiftUI cell wiring is not under test.
 ///
 /// Constructs `AppState(userDefaults:)` against a unique throwaway suite —
 /// `UserDefaults.standard` on this unbundled executable is the developer's real

--- a/Tests/TBDAppTests/FindWorktreeScratchTests.swift
+++ b/Tests/TBDAppTests/FindWorktreeScratchTests.swift
@@ -41,8 +41,8 @@ private func withState(_ body: (AppState) -> Void) {
 /// `worktrees`, so a freshly created scratch space resolved to nil and the
 /// detail pane rendered "Worktree not found" on first run.
 ///
-/// The same bug class hit the pinned-terminal dock — see the comment on
-/// `PinnedTerminalCell.worktree` in `PinnedTerminalDock.swift`.
+/// The same bug class hit the pinned-terminal dock — see the comment in
+/// `PinnedTerminalCell.body` in `PinnedTerminalDock.swift`.
 @MainActor
 @Suite("findWorktree resolves scratch spaces")
 struct FindWorktreeScratchTests {
@@ -104,29 +104,32 @@ struct FindWorktreeScratchTests {
     }
 }
 
-/// Cmd+Shift+A routing: scratch spaces must take the scratch-archive path —
-/// the repo-worktree `worktree.archive` RPC rejects them with `repoNotFound`.
-/// `archiveShortcutRoute` takes the caller-resolved selection
-/// (`selectedWorktreeIDs.first.flatMap(findWorktree)`), so a stale/unknown
-/// selected ID resolves to nil and routes nowhere.
+/// Cmd+Shift+A routing: the route seam only decides refuse-vs-proceed —
+/// `archiveWorktree(id:)` is scratch-aware and self-routes scratch rows to
+/// the `scratch.archive` RPC (the repo-worktree `worktree.archive` RPC would
+/// reject them with `repoNotFound`). `archiveShortcutRoute` takes the
+/// caller-resolved selection (`selectedWorktreeIDs.first.flatMap(findWorktree)`),
+/// so a stale/unknown selected ID resolves to nil and routes nowhere.
 @MainActor
-@Suite("archiveSelectedWorktree routes scratch to the scratch path")
+@Suite("archiveSelectedWorktree refuse-vs-proceed routing")
 struct ArchiveShortcutRouteTests {
 
-    @Test func scratchSelectionRoutesToScratchArchive() {
+    @Test func scratchSelectionProceeds() {
+        // Scratch rows always proceed: the daemon creates them `.active`,
+        // never `.main`/`.creating`, so the repo-worktree refusals can't apply.
         let scratchID = UUID()
-        let route = AppState.archiveShortcutRoute(
+        let target = AppState.archiveShortcutRoute(
             selectedWorktree: makeWorktree(id: scratchID, repoID: nil)
         )
-        #expect(route == .scratch(scratchID))
+        #expect(target == scratchID)
     }
 
-    @Test func repoWorktreeSelectionRoutesToWorktreeArchive() {
+    @Test func activeRepoWorktreeSelectionProceeds() {
         let wtID = UUID()
-        let route = AppState.archiveShortcutRoute(
+        let target = AppState.archiveShortcutRoute(
             selectedWorktree: makeWorktree(id: wtID, repoID: UUID())
         )
-        #expect(route == .worktree(wtID))
+        #expect(target == wtID)
     }
 
     @Test func mainAndCreatingRepoWorktreesRefuseArchive() {
@@ -162,39 +165,124 @@ struct ArchiveShortcutRouteTests {
 
 /// `renameWorktree` owns the single optimistic local update (scratch-aware,
 /// applied before its RPC) — callers like `WorktreeRowView` must not
-/// pre-apply. Exercised through the `.creating` branch, which returns before
-/// the daemon RPC so no connection is needed.
+/// pre-apply. The local-only gate keys on `pendingWorktreeIDs` (client-side
+/// creation placeholders the daemon has never heard of), NOT on `.creating`
+/// status: a two-phase create leaves the daemon row `.creating` for as long
+/// as its hooks run, and renames in that window must go through the RPC.
+/// All RPC-path tests inject `renameRPCOverride` — never a live daemon.
 @MainActor
-@Suite("Rename updates scratch spaces locally")
+@Suite("Rename gate, poll-race re-apply, and rollback")
 struct RenameScratchTests {
 
-    @Test func renameCreatingScratchRowUpdatesLocally() async {
+    private func makeState() -> (AppState, () -> Void) {
         let suiteName = "TBDAppTests.RenameScratch.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
         let state = AppState(userDefaults: defaults)
-
-        let scratchID = UUID()
-        state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil, status: .creating)]
-
-        await state.renameWorktree(id: scratchID, displayName: "Renamed Scratch")
-
-        #expect(state.scratchWorktrees.first?.displayName == "Renamed Scratch")
+        return (state, { defaults.removePersistentDomain(forName: suiteName) })
     }
 
-    @Test func renameCreatingWorktreeUpdatesLocallyWithoutRPC() async {
-        let suiteName = "TBDAppTests.RenameScratch.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let state = AppState(userDefaults: defaults)
+    @Test func pendingPlaceholderRenamesLocallyWithoutRPC() async {
+        let (state, teardown) = makeState()
+        defer { teardown() }
 
+        let repoID = UUID()
+        let placeholderID = UUID()
+        state.worktrees = [repoID: [makeWorktree(id: placeholderID, repoID: repoID, status: .creating)]]
+        state.pendingWorktreeIDs = [placeholderID]
+        var rpcCalls = 0
+        state.renameRPCOverride = { _, _ in rpcCalls += 1 }
+
+        await state.renameWorktree(id: placeholderID, displayName: "Renamed Placeholder")
+
+        #expect(state.worktrees[repoID]?.first?.displayName == "Renamed Placeholder")
+        #expect(rpcCalls == 0)
+    }
+
+    @Test func daemonKnownCreatingRowTakesRPCPath() async {
+        let (state, teardown) = makeState()
+        defer { teardown() }
+
+        // Daemon-known row, still `.creating` (hooks running) — NOT pending.
         let repoID = UUID()
         let wtID = UUID()
         state.worktrees = [repoID: [makeWorktree(id: wtID, repoID: repoID, status: .creating)]]
+        var renamed: [(UUID, String)] = []
+        state.renameRPCOverride = { id, name in renamed.append((id, name)) }
 
         await state.renameWorktree(id: wtID, displayName: "Renamed Creating")
 
         #expect(state.worktrees[repoID]?.first?.displayName == "Renamed Creating")
+        #expect(renamed.count == 1)
+        #expect(renamed.first?.0 == wtID)
+        #expect(renamed.first?.1 == "Renamed Creating")
+    }
+
+    @Test func renameScratchRowAppliesLocallyAndSendsRPC() async {
+        let (state, teardown) = makeState()
+        defer { teardown() }
+
+        let scratchID = UUID()
+        state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil)]
+        var rpcCalls = 0
+        state.renameRPCOverride = { _, _ in rpcCalls += 1 }
+
+        await state.renameWorktree(id: scratchID, displayName: "Renamed Scratch")
+
+        #expect(state.scratchWorktrees.first?.displayName == "Renamed Scratch")
+        #expect(rpcCalls == 1)
+    }
+
+    @Test func reappliesAfterRPCSuccessToBeatInterleavedPollRevert() async {
+        let (state, teardown) = makeState()
+        defer { teardown() }
+
+        let repoID = UUID()
+        let wtID = UUID()
+        let original = makeWorktree(id: wtID, repoID: repoID)
+        state.worktrees = [repoID: [original]]
+        // Simulate a poll snapshot captured pre-rename landing while the RPC
+        // is in flight: it reverts the optimistic name, then the RPC succeeds.
+        state.renameRPCOverride = { _, _ in
+            state.worktrees[repoID]?[0].displayName = original.displayName
+        }
+
+        await state.renameWorktree(id: wtID, displayName: "New Name")
+
+        #expect(state.worktrees[repoID]?.first?.displayName == "New Name")
+    }
+
+    @Test func rollsBackAndAlertsOnRPCFailure() async {
+        let (state, teardown) = makeState()
+        defer { teardown() }
+
+        struct RenameError: Error {}
+        let repoID = UUID()
+        let wtID = UUID()
+        let original = makeWorktree(id: wtID, repoID: repoID)
+        state.worktrees = [repoID: [original]]
+        state.renameRPCOverride = { _, _ in throw RenameError() }
+
+        await state.renameWorktree(id: wtID, displayName: "Doomed Name")
+
+        #expect(state.worktrees[repoID]?.first?.displayName == original.displayName)
+        #expect(state.alertMessage?.hasPrefix("Rename failed:") == true)
+        #expect(state.alertIsError == true)
+    }
+
+    @Test func unresolvableIDIsANoOpWithoutRPC() async {
+        let (state, teardown) = makeState()
+        defer { teardown() }
+
+        // The id resolves nowhere and is not a pending placeholder — e.g.
+        // the placeholder was just swapped away. No doomed RPC, no alert.
+        state.worktrees = [UUID(): [makeWorktree(id: UUID(), repoID: UUID())]]
+        var rpcCalls = 0
+        state.renameRPCOverride = { _, _ in rpcCalls += 1 }
+
+        await state.renameWorktree(id: UUID(), displayName: "Ghost")
+
+        #expect(rpcCalls == 0)
+        #expect(state.alertMessage == nil)
     }
 }
 
@@ -202,7 +290,10 @@ struct RenameScratchTests {
 /// (a different UUID) via `replaceCreationPlaceholder`. A rename the user
 /// typed while creation was in flight lives only on the placeholder, so the
 /// swap must carry it onto the replacement row (and report it back so the
-/// caller can persist it via the rename RPC).
+/// caller can persist it via the rename RPC). The swap also dedupes against
+/// a poll that merged the daemon row alongside the preserved placeholder,
+/// and returns nil — no row inserted, caller must not select/edit — when
+/// both rows are gone (e.g. the repo was removed mid-create).
 @MainActor
 @Suite("Rename typed during creation survives the placeholder swap")
 struct CreationPlaceholderRenameTests {
@@ -218,19 +309,21 @@ struct CreationPlaceholderRenameTests {
         var placeholder = makeWorktree(id: placeholderID, repoID: repoID, status: .creating)
         placeholder.displayName = "delicate-coyote"
         state.worktrees = [repoID: [placeholder]]
+        state.pendingWorktreeIDs = [placeholderID]
 
-        // User renames the row mid-creation (renameWorktree's .creating branch).
+        // User renames the row mid-creation (renameWorktree's placeholder
+        // branch — pending id, applied locally only).
         await state.renameWorktree(id: placeholderID, displayName: "typed-name")
 
         let daemonRow = makeWorktree(id: UUID(), repoID: repoID, status: .creating)
-        let typedName = state.replaceCreationPlaceholder(
+        let swap = state.replaceCreationPlaceholder(
             repoID: repoID,
             placeholderID: placeholderID,
             placeholderName: "delicate-coyote",
             with: daemonRow
         )
 
-        #expect(typedName == "typed-name")
+        #expect(swap?.typedName == "typed-name")
         #expect(state.worktrees[repoID]?.count == 1)
         #expect(state.worktrees[repoID]?.first?.id == daemonRow.id)
         #expect(state.worktrees[repoID]?.first?.displayName == "typed-name")
@@ -245,33 +338,105 @@ struct CreationPlaceholderRenameTests {
             state.worktrees = [repoID: [placeholder]]
 
             let daemonRow = makeWorktree(id: UUID(), repoID: repoID, status: .creating)
-            let typedName = state.replaceCreationPlaceholder(
+            let swap = state.replaceCreationPlaceholder(
                 repoID: repoID,
                 placeholderID: placeholderID,
                 placeholderName: "delicate-coyote",
                 with: daemonRow
             )
 
-            #expect(typedName == nil)
+            #expect(swap != nil)
+            #expect(swap?.typedName == nil)
             #expect(state.worktrees[repoID]?.first?.id == daemonRow.id)
             #expect(state.worktrees[repoID]?.first?.displayName == daemonRow.displayName)
         }
     }
 
-    @Test func missingPlaceholderIsANoOp() {
+    @Test func dedupesPollMergedDaemonRowAgainstPreservedPlaceholder() {
+        withState { state in
+            let repoID = UUID()
+            let placeholderID = UUID()
+            var placeholder = makeWorktree(id: placeholderID, repoID: repoID, status: .creating)
+            placeholder.displayName = "typed-name" // renamed mid-creation
+            let other = makeWorktree(id: UUID(), repoID: repoID)
+            let daemonRow = makeWorktree(id: UUID(), repoID: repoID, status: .creating)
+            // A poll merged the daemon row alongside the preserved placeholder.
+            state.worktrees = [repoID: [placeholder, other, daemonRow]]
+
+            let swap = state.replaceCreationPlaceholder(
+                repoID: repoID,
+                placeholderID: placeholderID,
+                placeholderName: "delicate-coyote",
+                with: daemonRow
+            )
+
+            #expect(swap?.typedName == "typed-name")
+            // Exactly one final row, at the placeholder's position.
+            let rows = state.worktrees[repoID] ?? []
+            #expect(rows.count == 2)
+            #expect(rows.first?.id == daemonRow.id)
+            #expect(rows.first?.displayName == "typed-name")
+            #expect(rows.last?.id == other.id)
+        }
+    }
+
+    @Test func placeholderGoneButPollMergedRowPresentUpdatesInPlace() {
+        withState { state in
+            let repoID = UUID()
+            let other = makeWorktree(id: UUID(), repoID: repoID)
+            var daemonRow = makeWorktree(id: UUID(), repoID: repoID, status: .creating)
+            state.worktrees = [repoID: [other, daemonRow]]
+
+            // The RPC result carries fresher fields than the poll-merged row.
+            daemonRow.displayName = "fresher-name"
+            let swap = state.replaceCreationPlaceholder(
+                repoID: repoID,
+                placeholderID: UUID(),
+                placeholderName: "delicate-coyote",
+                with: daemonRow
+            )
+
+            #expect(swap != nil)
+            #expect(swap?.typedName == nil)
+            let rows = state.worktrees[repoID] ?? []
+            #expect(rows.count == 2)
+            #expect(rows.last?.id == daemonRow.id)
+            #expect(rows.last?.displayName == "fresher-name")
+        }
+    }
+
+    @Test func bothRowsAbsentReturnsNilAndResurrectsNothing() {
         withState { state in
             let repoID = UUID()
             state.worktrees = [repoID: []]
 
-            let typedName = state.replaceCreationPlaceholder(
+            let swap = state.replaceCreationPlaceholder(
                 repoID: repoID,
                 placeholderID: UUID(),
                 placeholderName: "delicate-coyote",
                 with: makeWorktree(id: UUID(), repoID: repoID)
             )
 
-            #expect(typedName == nil)
+            // nil tells createWorktree not to arm selection/editing for the
+            // vanished row.
+            #expect(swap == nil)
             #expect(state.worktrees[repoID]?.isEmpty == true)
+        }
+    }
+
+    @Test func removedRepoReturnsNilAndResurrectsNothing() {
+        withState { state in
+            let repoID = UUID()
+            // Repo removed mid-create: no entry in the dict at all.
+            let swap = state.replaceCreationPlaceholder(
+                repoID: repoID,
+                placeholderID: UUID(),
+                placeholderName: "delicate-coyote",
+                with: makeWorktree(id: UUID(), repoID: repoID)
+            )
+
+            #expect(swap == nil)
+            #expect(state.worktrees[repoID] == nil)
         }
     }
 }

--- a/Tests/TBDAppTests/FindWorktreeScratchTests.swift
+++ b/Tests/TBDAppTests/FindWorktreeScratchTests.swift
@@ -3,6 +3,32 @@ import Testing
 @testable import TBDApp
 import TBDShared
 
+/// Shared row builder for every suite in this file. Pass `repoID: nil` for a
+/// repo-less scratch space.
+private func makeWorktree(id: UUID, repoID: UUID?, status: WorktreeStatus = .active) -> Worktree {
+    Worktree(
+        id: id,
+        repoID: repoID,
+        name: "test-\(id.uuidString.prefix(8))",
+        displayName: "Test \(id.uuidString.prefix(8))",
+        branch: "main",
+        path: "/tmp/test",
+        status: status,
+        tmuxServer: "test-server"
+    )
+}
+
+/// Construct `AppState(userDefaults:)` against a unique throwaway suite —
+/// `UserDefaults.standard` on this unbundled executable is the developer's
+/// real `TBDApp.plist`.
+@MainActor
+private func withState(_ body: (AppState) -> Void) {
+    let suiteName = "TBDAppTests.FindWorktreeScratch.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    body(AppState(userDefaults: defaults))
+}
+
 /// Regression tests for `AppState.findWorktree(id:)` resolving repo-less
 /// scratch spaces.
 ///
@@ -17,33 +43,9 @@ import TBDShared
 ///
 /// The same bug class hit the pinned-terminal dock — see the comment on
 /// `PinnedTerminalCell.worktree` in `PinnedTerminalDock.swift`.
-///
-/// Constructs `AppState(userDefaults:)` against a unique throwaway suite —
-/// `UserDefaults.standard` on this unbundled executable is the developer's real
-/// `TBDApp.plist`.
 @MainActor
 @Suite("findWorktree resolves scratch spaces")
 struct FindWorktreeScratchTests {
-
-    private func withState(_ body: (AppState) -> Void) {
-        let suiteName = "TBDAppTests.FindWorktreeScratch.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        body(AppState(userDefaults: defaults))
-    }
-
-    private func makeWorktree(id: UUID, repoID: UUID?) -> Worktree {
-        Worktree(
-            id: id,
-            repoID: repoID,
-            name: "test-\(id.uuidString.prefix(8))",
-            displayName: "Test \(id.uuidString.prefix(8))",
-            branch: "main",
-            path: "/tmp/test",
-            status: .active,
-            tmuxServer: "test-server"
-        )
-    }
 
     @Test func findsScratchWorktreeNotInReposDict() {
         withState { state in
@@ -104,120 +106,83 @@ struct FindWorktreeScratchTests {
 
 /// Cmd+Shift+A routing: scratch spaces must take the scratch-archive path —
 /// the repo-worktree `worktree.archive` RPC rejects them with `repoNotFound`.
+/// `archiveShortcutRoute` takes the caller-resolved selection
+/// (`selectedWorktreeIDs.first.flatMap(findWorktree)`), so a stale/unknown
+/// selected ID resolves to nil and routes nowhere.
 @MainActor
 @Suite("archiveSelectedWorktree routes scratch to the scratch path")
 struct ArchiveShortcutRouteTests {
 
-    private func makeWorktree(id: UUID, repoID: UUID?, status: WorktreeStatus = .active) -> Worktree {
-        Worktree(
-            id: id,
-            repoID: repoID,
-            name: "test-\(id.uuidString.prefix(8))",
-            displayName: "Test \(id.uuidString.prefix(8))",
-            branch: "main",
-            path: "/tmp/test",
-            status: status,
-            tmuxServer: "test-server"
-        )
-    }
-
     @Test func scratchSelectionRoutesToScratchArchive() {
         let scratchID = UUID()
         let route = AppState.archiveShortcutRoute(
-            selectedID: scratchID,
-            worktrees: [:],
-            scratchWorktrees: [makeWorktree(id: scratchID, repoID: nil)]
+            selectedWorktree: makeWorktree(id: scratchID, repoID: nil)
         )
         #expect(route == .scratch(scratchID))
     }
 
     @Test func repoWorktreeSelectionRoutesToWorktreeArchive() {
-        let repoID = UUID()
         let wtID = UUID()
         let route = AppState.archiveShortcutRoute(
-            selectedID: wtID,
-            worktrees: [repoID: [makeWorktree(id: wtID, repoID: repoID)]],
-            scratchWorktrees: []
+            selectedWorktree: makeWorktree(id: wtID, repoID: UUID())
         )
         #expect(route == .worktree(wtID))
     }
 
     @Test func mainAndCreatingRepoWorktreesRefuseArchive() {
-        let repoID = UUID()
         for status: WorktreeStatus in [.main, .creating] {
-            let wtID = UUID()
             let route = AppState.archiveShortcutRoute(
-                selectedID: wtID,
-                worktrees: [repoID: [makeWorktree(id: wtID, repoID: repoID, status: status)]],
-                scratchWorktrees: []
+                selectedWorktree: makeWorktree(id: UUID(), repoID: UUID(), status: status)
             )
             #expect(route == nil)
         }
     }
 
     @Test func emptySelectionRoutesNowhere() {
-        let route = AppState.archiveShortcutRoute(
-            selectedID: nil,
-            worktrees: [:],
-            scratchWorktrees: []
-        )
-        #expect(route == nil)
+        #expect(AppState.archiveShortcutRoute(selectedWorktree: nil) == nil)
+    }
+
+    @Test func staleSelectedIDRoutesNowhere() {
+        withState { state in
+            let repoID = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: UUID(), repoID: repoID)]]
+            state.scratchWorktrees = [makeWorktree(id: UUID(), repoID: nil)]
+            // Selection points at a row that no longer exists anywhere.
+            state.selectedWorktreeIDs = [UUID()]
+
+            // Same resolution wiring archiveSelectedWorktree uses.
+            let route = AppState.archiveShortcutRoute(
+                selectedWorktree: state.selectedWorktreeIDs.first
+                    .flatMap { state.findWorktree(id: $0) }
+            )
+            #expect(route == nil)
+        }
     }
 }
 
-/// `renameWorktree`'s local update is owned by `applyLocalRename`, which must
-/// cover both the repo-grouped dict and `scratchWorktrees` (previously the
-/// scratch update was compensated caller-side in WorktreeRowView).
+/// `renameWorktree` owns the single optimistic local update (scratch-aware,
+/// applied before its RPC) — callers like `WorktreeRowView` must not
+/// pre-apply. Exercised through the `.creating` branch, which returns before
+/// the daemon RPC so no connection is needed.
 @MainActor
 @Suite("Rename updates scratch spaces locally")
 struct RenameScratchTests {
 
-    private func withState(_ body: (AppState) -> Void) {
+    @Test func renameCreatingScratchRowUpdatesLocally() async {
         let suiteName = "TBDAppTests.RenameScratch.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        body(AppState(userDefaults: defaults))
-    }
+        let state = AppState(userDefaults: defaults)
 
-    private func makeWorktree(id: UUID, repoID: UUID?, status: WorktreeStatus = .active) -> Worktree {
-        Worktree(
-            id: id,
-            repoID: repoID,
-            name: "test-\(id.uuidString.prefix(8))",
-            displayName: "Test \(id.uuidString.prefix(8))",
-            branch: "main",
-            path: "/tmp/test",
-            status: status,
-            tmuxServer: "test-server"
-        )
-    }
+        let scratchID = UUID()
+        state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil, status: .creating)]
 
-    @Test func applyLocalRenameUpdatesScratchRow() {
-        withState { state in
-            let scratchID = UUID()
-            state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil)]
+        await state.renameWorktree(id: scratchID, displayName: "Renamed Scratch")
 
-            state.applyLocalRename(id: scratchID, displayName: "Renamed Scratch")
-
-            #expect(state.scratchWorktrees.first?.displayName == "Renamed Scratch")
-        }
-    }
-
-    @Test func applyLocalRenameUpdatesRepoDictRow() {
-        withState { state in
-            let repoID = UUID()
-            let wtID = UUID()
-            state.worktrees = [repoID: [makeWorktree(id: wtID, repoID: repoID)]]
-
-            state.applyLocalRename(id: wtID, displayName: "Renamed WT")
-
-            #expect(state.worktrees[repoID]?.first?.displayName == "Renamed WT")
-        }
+        #expect(state.scratchWorktrees.first?.displayName == "Renamed Scratch")
     }
 
     @Test func renameCreatingWorktreeUpdatesLocallyWithoutRPC() async {
-        // The .creating branch never hits the daemon, so the full async
-        // method is exercisable without a connection.
         let suiteName = "TBDAppTests.RenameScratch.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -230,5 +195,109 @@ struct RenameScratchTests {
         await state.renameWorktree(id: wtID, displayName: "Renamed Creating")
 
         #expect(state.worktrees[repoID]?.first?.displayName == "Renamed Creating")
+    }
+}
+
+/// `createWorktree` replaces its optimistic placeholder with the daemon row
+/// (a different UUID) via `replaceCreationPlaceholder`. A rename the user
+/// typed while creation was in flight lives only on the placeholder, so the
+/// swap must carry it onto the replacement row (and report it back so the
+/// caller can persist it via the rename RPC).
+@MainActor
+@Suite("Rename typed during creation survives the placeholder swap")
+struct CreationPlaceholderRenameTests {
+
+    @Test func renamedPlaceholderCarriesNameOntoDaemonRow() async {
+        let suiteName = "TBDAppTests.CreationPlaceholderRename.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = AppState(userDefaults: defaults)
+
+        let repoID = UUID()
+        let placeholderID = UUID()
+        var placeholder = makeWorktree(id: placeholderID, repoID: repoID, status: .creating)
+        placeholder.displayName = "delicate-coyote"
+        state.worktrees = [repoID: [placeholder]]
+
+        // User renames the row mid-creation (renameWorktree's .creating branch).
+        await state.renameWorktree(id: placeholderID, displayName: "typed-name")
+
+        let daemonRow = makeWorktree(id: UUID(), repoID: repoID, status: .creating)
+        let typedName = state.replaceCreationPlaceholder(
+            repoID: repoID,
+            placeholderID: placeholderID,
+            placeholderName: "delicate-coyote",
+            with: daemonRow
+        )
+
+        #expect(typedName == "typed-name")
+        #expect(state.worktrees[repoID]?.count == 1)
+        #expect(state.worktrees[repoID]?.first?.id == daemonRow.id)
+        #expect(state.worktrees[repoID]?.first?.displayName == "typed-name")
+    }
+
+    @Test func untouchedPlaceholderKeepsDaemonRowName() {
+        withState { state in
+            let repoID = UUID()
+            let placeholderID = UUID()
+            var placeholder = makeWorktree(id: placeholderID, repoID: repoID, status: .creating)
+            placeholder.displayName = "delicate-coyote"
+            state.worktrees = [repoID: [placeholder]]
+
+            let daemonRow = makeWorktree(id: UUID(), repoID: repoID, status: .creating)
+            let typedName = state.replaceCreationPlaceholder(
+                repoID: repoID,
+                placeholderID: placeholderID,
+                placeholderName: "delicate-coyote",
+                with: daemonRow
+            )
+
+            #expect(typedName == nil)
+            #expect(state.worktrees[repoID]?.first?.id == daemonRow.id)
+            #expect(state.worktrees[repoID]?.first?.displayName == daemonRow.displayName)
+        }
+    }
+
+    @Test func missingPlaceholderIsANoOp() {
+        withState { state in
+            let repoID = UUID()
+            state.worktrees = [repoID: []]
+
+            let typedName = state.replaceCreationPlaceholder(
+                repoID: repoID,
+                placeholderID: UUID(),
+                placeholderName: "delicate-coyote",
+                with: makeWorktree(id: UUID(), repoID: repoID)
+            )
+
+            #expect(typedName == nil)
+            #expect(state.worktrees[repoID]?.isEmpty == true)
+        }
+    }
+}
+
+/// `archiveScratch` runs the same synchronous cleanup as `archiveWorktree` —
+/// `removeArchivedWorktreeFromState` — so the Cmd+Shift+A scratch path gets
+/// selection cleanup and a tombstone, not just the daemon delta later. The
+/// RPC itself needs a daemon; this verifies the cleanup helper covers scratch
+/// rows (the piece `archiveScratch` relies on).
+@MainActor
+@Suite("Archive cleanup covers scratch spaces")
+struct ScratchArchiveCleanupTests {
+
+    @Test func removeArchivedWorktreeFromStateClearsScratchRowSelectionAndTombstones() {
+        withState { state in
+            let scratchID = UUID()
+            state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil)]
+            state.selectedWorktreeIDs = [scratchID]
+
+            state.removeArchivedWorktreeFromState(id: scratchID)
+
+            #expect(state.scratchWorktrees.isEmpty)
+            #expect(!state.selectedWorktreeIDs.contains(scratchID))
+            // Synchronous tombstone so an in-flight poll can't re-append a
+            // ghost row before the daemon delta lands.
+            #expect(state.recentlyArchivedWorktreeIDs[scratchID] != nil)
+        }
     }
 }

--- a/Tests/TBDAppTests/FindWorktreeScratchTests.swift
+++ b/Tests/TBDAppTests/FindWorktreeScratchTests.swift
@@ -15,12 +15,8 @@ import TBDShared
 /// `worktrees`, so a freshly created scratch space resolved to nil and the
 /// detail pane rendered "Worktree not found" on first run.
 ///
-/// The same bug class hit a second call site: the pinned-terminal dock.
-/// `PinnedTerminalCell` (PinnedTerminalDock.swift) previously hand-rolled a
-/// worktrees-dict-only lookup, so pins from scratch spaces resolved to nil and
-/// the cell rendered "Loading..." forever. It now resolves through
-/// `findWorktree`. This suite covers the `findWorktree` helper itself
-/// (including its scratch branch); the SwiftUI cell wiring is not under test.
+/// The same bug class hit the pinned-terminal dock — see the comment on
+/// `PinnedTerminalCell.worktree` in `PinnedTerminalDock.swift`.
 ///
 /// Constructs `AppState(userDefaults:)` against a unique throwaway suite —
 /// `UserDefaults.standard` on this unbundled executable is the developer's real
@@ -89,5 +85,150 @@ struct FindWorktreeScratchTests {
             state.scratchWorktrees = [makeWorktree(id: UUID(), repoID: nil)]
             #expect(state.findWorktree(id: UUID()) == nil)
         }
+    }
+
+    // MARK: - allWorktrees (the flat scratch-inclusive accessor)
+
+    @Test func allWorktreesIncludesRepoRowsAndScratch() {
+        withState { state in
+            let repoID = UUID()
+            let repoWtID = UUID()
+            let scratchID = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: repoWtID, repoID: repoID)]]
+            state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil)]
+
+            #expect(Set(state.allWorktrees.map(\.id)) == Set([repoWtID, scratchID]))
+        }
+    }
+}
+
+/// Cmd+Shift+A routing: scratch spaces must take the scratch-archive path —
+/// the repo-worktree `worktree.archive` RPC rejects them with `repoNotFound`.
+@MainActor
+@Suite("archiveSelectedWorktree routes scratch to the scratch path")
+struct ArchiveShortcutRouteTests {
+
+    private func makeWorktree(id: UUID, repoID: UUID?, status: WorktreeStatus = .active) -> Worktree {
+        Worktree(
+            id: id,
+            repoID: repoID,
+            name: "test-\(id.uuidString.prefix(8))",
+            displayName: "Test \(id.uuidString.prefix(8))",
+            branch: "main",
+            path: "/tmp/test",
+            status: status,
+            tmuxServer: "test-server"
+        )
+    }
+
+    @Test func scratchSelectionRoutesToScratchArchive() {
+        let scratchID = UUID()
+        let route = AppState.archiveShortcutRoute(
+            selectedID: scratchID,
+            worktrees: [:],
+            scratchWorktrees: [makeWorktree(id: scratchID, repoID: nil)]
+        )
+        #expect(route == .scratch(scratchID))
+    }
+
+    @Test func repoWorktreeSelectionRoutesToWorktreeArchive() {
+        let repoID = UUID()
+        let wtID = UUID()
+        let route = AppState.archiveShortcutRoute(
+            selectedID: wtID,
+            worktrees: [repoID: [makeWorktree(id: wtID, repoID: repoID)]],
+            scratchWorktrees: []
+        )
+        #expect(route == .worktree(wtID))
+    }
+
+    @Test func mainAndCreatingRepoWorktreesRefuseArchive() {
+        let repoID = UUID()
+        for status: WorktreeStatus in [.main, .creating] {
+            let wtID = UUID()
+            let route = AppState.archiveShortcutRoute(
+                selectedID: wtID,
+                worktrees: [repoID: [makeWorktree(id: wtID, repoID: repoID, status: status)]],
+                scratchWorktrees: []
+            )
+            #expect(route == nil)
+        }
+    }
+
+    @Test func emptySelectionRoutesNowhere() {
+        let route = AppState.archiveShortcutRoute(
+            selectedID: nil,
+            worktrees: [:],
+            scratchWorktrees: []
+        )
+        #expect(route == nil)
+    }
+}
+
+/// `renameWorktree`'s local update is owned by `applyLocalRename`, which must
+/// cover both the repo-grouped dict and `scratchWorktrees` (previously the
+/// scratch update was compensated caller-side in WorktreeRowView).
+@MainActor
+@Suite("Rename updates scratch spaces locally")
+struct RenameScratchTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.RenameScratch.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func makeWorktree(id: UUID, repoID: UUID?, status: WorktreeStatus = .active) -> Worktree {
+        Worktree(
+            id: id,
+            repoID: repoID,
+            name: "test-\(id.uuidString.prefix(8))",
+            displayName: "Test \(id.uuidString.prefix(8))",
+            branch: "main",
+            path: "/tmp/test",
+            status: status,
+            tmuxServer: "test-server"
+        )
+    }
+
+    @Test func applyLocalRenameUpdatesScratchRow() {
+        withState { state in
+            let scratchID = UUID()
+            state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil)]
+
+            state.applyLocalRename(id: scratchID, displayName: "Renamed Scratch")
+
+            #expect(state.scratchWorktrees.first?.displayName == "Renamed Scratch")
+        }
+    }
+
+    @Test func applyLocalRenameUpdatesRepoDictRow() {
+        withState { state in
+            let repoID = UUID()
+            let wtID = UUID()
+            state.worktrees = [repoID: [makeWorktree(id: wtID, repoID: repoID)]]
+
+            state.applyLocalRename(id: wtID, displayName: "Renamed WT")
+
+            #expect(state.worktrees[repoID]?.first?.displayName == "Renamed WT")
+        }
+    }
+
+    @Test func renameCreatingWorktreeUpdatesLocallyWithoutRPC() async {
+        // The .creating branch never hits the daemon, so the full async
+        // method is exercisable without a connection.
+        let suiteName = "TBDAppTests.RenameScratch.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = AppState(userDefaults: defaults)
+
+        let repoID = UUID()
+        let wtID = UUID()
+        state.worktrees = [repoID: [makeWorktree(id: wtID, repoID: repoID, status: .creating)]]
+
+        await state.renameWorktree(id: wtID, displayName: "Renamed Creating")
+
+        #expect(state.worktrees[repoID]?.first?.displayName == "Renamed Creating")
     }
 }

--- a/Tests/TBDAppTests/FindWorktreeScratchTests.swift
+++ b/Tests/TBDAppTests/FindWorktreeScratchTests.swift
@@ -15,6 +15,12 @@ import TBDShared
 /// `worktrees`, so a freshly created scratch space resolved to nil and the
 /// detail pane rendered "Worktree not found" on first run.
 ///
+/// The same bug class hit a second call site: the pinned-terminal dock.
+/// `PinnedTerminalCell` (PinnedTerminalDock.swift) previously hand-rolled a
+/// worktrees-dict-only lookup, so pins from scratch spaces resolved to nil and
+/// the cell rendered "Loading..." forever. It now resolves through
+/// `findWorktree`, which this suite covers.
+///
 /// Constructs `AppState(userDefaults:)` against a unique throwaway suite —
 /// `UserDefaults.standard` on this unbundled executable is the developer's real
 /// `TBDApp.plist`.

--- a/Tests/TBDAppTests/FindWorktreeScratchTests.swift
+++ b/Tests/TBDAppTests/FindWorktreeScratchTests.swift
@@ -329,6 +329,56 @@ struct CreationPlaceholderRenameTests {
         #expect(state.worktrees[repoID]?.first?.displayName == "typed-name")
     }
 
+    /// After the swap carries the typed name onto the daemon row,
+    /// `createWorktree` persists it through `renameWorktree(id:displayName:)`
+    /// (wt.id is daemon-known and non-pending, so it takes the full RPC path).
+    /// A failed persist must surface via the "Rename failed:" alert — the old
+    /// inline `daemonClient.renameWorktree` call's catch only logged, so a
+    /// non-connection RPC failure silently lost the name. Drives the persist
+    /// sub-sequence the create path runs post-swap; the full `createWorktree`
+    /// isn't wired to a seam (its `daemonClient.createWorktree` has no
+    /// override), so this reproduces the post-swap state directly.
+    @Test func createPathPersistRollsBackAndAlertsWhenRenameRPCFails() async {
+        let suiteName = "TBDAppTests.CreationPlaceholderRename.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = AppState(userDefaults: defaults)
+
+        struct RenameError: Error {}
+        let repoID = UUID()
+        let placeholderID = UUID()
+        var placeholder = makeWorktree(id: placeholderID, repoID: repoID, status: .creating)
+        placeholder.displayName = "delicate-coyote"
+        state.worktrees = [repoID: [placeholder]]
+        state.pendingWorktreeIDs = [placeholderID]
+
+        // User renames the row mid-creation (local-only placeholder branch).
+        await state.renameWorktree(id: placeholderID, displayName: "typed-name")
+
+        // Daemon confirms creation: swap carries the typed name onto the real
+        // daemon row and the placeholder leaves `pendingWorktreeIDs` (as
+        // createWorktree's `defer` does).
+        let daemonRow = makeWorktree(id: UUID(), repoID: repoID, status: .creating)
+        state.pendingWorktreeIDs.remove(placeholderID)
+        let swap = state.replaceCreationPlaceholder(
+            repoID: repoID,
+            placeholderID: placeholderID,
+            placeholderName: "delicate-coyote",
+            with: daemonRow
+        )
+        #expect(swap?.typedName == "typed-name")
+
+        // createWorktree now persists the carried rename through renameWorktree.
+        // A failed RPC must alert, not silently log like the old inline call.
+        state.renameRPCOverride = { _, _ in throw RenameError() }
+        if let typedName = swap?.typedName {
+            await state.renameWorktree(id: daemonRow.id, displayName: typedName)
+        }
+
+        #expect(state.alertMessage?.hasPrefix("Rename failed:") == true)
+        #expect(state.alertIsError == true)
+    }
+
     @Test func untouchedPlaceholderKeepsDaemonRowName() {
         withState { state in
             let repoID = UUID()

--- a/Tests/TBDAppTests/JumpMenuViewModelTests.swift
+++ b/Tests/TBDAppTests/JumpMenuViewModelTests.swift
@@ -309,3 +309,84 @@ struct JumpMenuViewModelTests {
         #expect(vm.selectedRow?.id == a)
     }
 }
+
+/// The controller's open-time snapshot must include repo-less scratch spaces
+/// (they live only in `AppState.scratchWorktrees`), otherwise Cmd-K can never
+/// reach them — neither as recents nor as typed matches. Submit-time staleness
+/// is guarded by the scratch-aware `AppState.findWorktree(id:)` (covered in
+/// FindWorktreeScratchTests), so a scratch row surviving into the snapshot is
+/// also accepted on submit.
+@MainActor
+@Suite("JumpMenuController snapshot includes scratch")
+struct JumpMenuSnapshotScratchTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.JumpMenuSnapshot.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func makeWorktree(id: UUID, repoID: UUID?, displayName: String) -> Worktree {
+        Worktree(
+            id: id,
+            repoID: repoID,
+            name: displayName.lowercased(),
+            displayName: displayName,
+            branch: "main",
+            path: "/tmp/\(displayName)",
+            tmuxServer: "tmux-\(id.uuidString)"
+        )
+    }
+
+    @Test func snapshotContainsScratchAndRepoRows() {
+        withState { state in
+            let repoID = UUID()
+            let repoWtID = UUID()
+            let scratchID = UUID()
+            state.repos = [Repo(id: repoID, path: "/tmp/acme", displayName: "acme")]
+            state.worktrees = [repoID: [makeWorktree(id: repoWtID, repoID: repoID, displayName: "feat")]]
+            state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil, displayName: "Scribbles")]
+
+            let snapshots = JumpMenuController.worktreeSnapshots(appState: state)
+
+            #expect(Set(snapshots.map(\.id)) == Set([repoWtID, scratchID]))
+            let scratchSnap = snapshots.first { $0.id == scratchID }
+            #expect(scratchSnap?.repoName == "Scratch")
+            let repoSnap = snapshots.first { $0.id == repoWtID }
+            #expect(repoSnap?.repoName == "acme")
+        }
+    }
+
+    @Test func scratchRecentAppearsInDefaultRows() {
+        withState { state in
+            let scratchID = UUID()
+            state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil, displayName: "Scribbles")]
+
+            let vm = JumpMenuViewModel(
+                worktrees: JumpMenuController.worktreeSnapshots(appState: state),
+                unread: [:],
+                recentIDs: [scratchID]
+            )
+
+            #expect(vm.rows.map(\.id) == [scratchID])
+            #expect(vm.rows.first?.section == .recent)
+        }
+    }
+
+    @Test func scratchRowMatchesTypedQuery() {
+        withState { state in
+            let scratchID = UUID()
+            state.scratchWorktrees = [makeWorktree(id: scratchID, repoID: nil, displayName: "Scribbles")]
+
+            let vm = JumpMenuViewModel(
+                worktrees: JumpMenuController.worktreeSnapshots(appState: state),
+                unread: [:],
+                recentIDs: []
+            )
+            vm.query = "scrib"
+
+            #expect(vm.rows.map(\.id) == [scratchID])
+        }
+    }
+}

--- a/Tests/TBDAppTests/SelectionPersistenceTests.swift
+++ b/Tests/TBDAppTests/SelectionPersistenceTests.swift
@@ -140,6 +140,33 @@ struct SelectionPersistenceTests {
         }
     }
 
+    @Test("persisted scratch-only selection survives relaunch via allWorktrees")
+    func restoreScratchOnlySelection() {
+        withIsolatedDefaults { defaults in
+            let scratchID = UUID()
+            writeSavedSelection([scratchID], to: defaults)
+
+            let state = AppState(userDefaults: defaults)
+            // Scratch spaces live only in `scratchWorktrees`, never the
+            // repo-grouped dict. connectAndLoadInitialState builds its valid-ID
+            // list from `allWorktrees`, exercised here as the same seam.
+            state.scratchWorktrees = [Worktree(
+                id: scratchID,
+                repoID: nil,
+                name: "scratch-1",
+                displayName: "Scratch 1",
+                branch: "main",
+                path: "/tmp/scratch-1",
+                tmuxServer: "tmux-\(scratchID.uuidString)"
+            )]
+
+            state.restoreSavedSelection(validWorktreeIDs: state.allWorktrees.map(\.id))
+
+            #expect(state.selectedWorktreeIDs == [scratchID])
+            #expect(state.selectionOrder == [scratchID])
+        }
+    }
+
     @Test("restoreSavedSelection is no-op when all saved IDs are stale")
     func restoreNoOpWhenAllStale() {
         withIsolatedDefaults { defaults in

--- a/Tests/TBDAppTests/SidebarRevealTargetTests.swift
+++ b/Tests/TBDAppTests/SidebarRevealTargetTests.swift
@@ -31,6 +31,7 @@ struct SidebarRevealTargetTests {
         let target = AppState.sidebarRevealTarget(
             selectedWorktreeIDs: [wtID],
             worktrees: [repoID: [wt]],
+            scratchWorktrees: [],
             selectedRepoID: nil
         )
 
@@ -54,6 +55,7 @@ struct SidebarRevealTargetTests {
         let target = AppState.sidebarRevealTarget(
             selectedWorktreeIDs: [id1, id2, id3],
             worktrees: worktrees,
+            scratchWorktrees: [],
             selectedRepoID: nil
         )
 
@@ -74,11 +76,13 @@ struct SidebarRevealTargetTests {
         let first = AppState.sidebarRevealTarget(
             selectedWorktreeIDs: selectedSet,
             worktrees: worktrees,
+            scratchWorktrees: [],
             selectedRepoID: nil
         )
         let second = AppState.sidebarRevealTarget(
             selectedWorktreeIDs: selectedSet,
             worktrees: worktrees,
+            scratchWorktrees: [],
             selectedRepoID: nil
         )
 
@@ -92,6 +96,7 @@ struct SidebarRevealTargetTests {
         let target = AppState.sidebarRevealTarget(
             selectedWorktreeIDs: [],
             worktrees: [:],
+            scratchWorktrees: [],
             selectedRepoID: repoID
         )
 
@@ -103,10 +108,39 @@ struct SidebarRevealTargetTests {
         let target = AppState.sidebarRevealTarget(
             selectedWorktreeIDs: [],
             worktrees: [:],
+            scratchWorktrees: [],
             selectedRepoID: nil
         )
 
         #expect(target == nil)
+    }
+
+    @Test("all-scratch multi-selection resolves via scratchWorktrees")
+    func multiSelectionAllScratchReturnsCandidate() {
+        // Scratch spaces live only in `scratchWorktrees`, never the repo dict;
+        // a dict-only candidate filter made status-bar reveal a silent no-op
+        // for all-scratch multi-selections.
+        let scratchIDs = [UUID(), UUID()]
+        let scratches = scratchIDs.map { id in
+            Worktree(
+                id: id,
+                repoID: nil,
+                name: "scratch-\(id.uuidString.prefix(4))",
+                displayName: "Scratch \(id.uuidString.prefix(4))",
+                branch: "main",
+                path: "/tmp/scratch",
+                tmuxServer: "tmux-\(id.uuidString)"
+            )
+        }
+
+        let target = AppState.sidebarRevealTarget(
+            selectedWorktreeIDs: Set(scratchIDs),
+            worktrees: [:],
+            scratchWorktrees: scratches,
+            selectedRepoID: nil
+        )
+
+        #expect(target == scratchIDs.min(by: { $0.uuidString < $1.uuidString }))
     }
 
     @Test("multi-selection with all stale IDs returns nil")
@@ -123,6 +157,7 @@ struct SidebarRevealTargetTests {
         let target = AppState.sidebarRevealTarget(
             selectedWorktreeIDs: [staleID1, staleID2],
             worktrees: worktrees,
+            scratchWorktrees: [],
             selectedRepoID: nil
         )
 

--- a/Tests/TBDAppTests/SleepSuspendHookTests.swift
+++ b/Tests/TBDAppTests/SleepSuspendHookTests.swift
@@ -31,6 +31,20 @@ struct SleepSuspendHookTests {
         )
     }
 
+    /// Build a repo-less scratch space (lives only in `scratchWorktrees`).
+    private func makeScratch() -> Worktree {
+        let name = "scratch-\(UUID().uuidString.prefix(4))"
+        return Worktree(
+            id: UUID(),
+            repoID: nil,
+            name: name,
+            displayName: name,
+            branch: "main",
+            path: "/tmp/scratch",
+            tmuxServer: "tbd-test"
+        )
+    }
+
     @Test("gate OFF → returns [] even with worktrees present")
     func gateOffReturnsEmpty() {
         let repoID = UUID()
@@ -39,6 +53,7 @@ struct SleepSuspendHookTests {
         ]
         let ids = AppState.worktreeIDsToSuspendForSleep(
             worktrees: worktrees,
+            scratchWorktrees: [makeScratch()],
             autoSuspendEnabled: false
         )
         #expect(ids.isEmpty)
@@ -58,6 +73,7 @@ struct SleepSuspendHookTests {
 
         let ids = AppState.worktreeIDsToSuspendForSleep(
             worktrees: worktrees,
+            scratchWorktrees: [],
             autoSuspendEnabled: true
         )
 
@@ -66,10 +82,26 @@ struct SleepSuspendHookTests {
         #expect(ids.count == 3)
     }
 
+    @Test("gate ON → scratch spaces are included alongside repo worktrees")
+    func gateOnIncludesScratchSpaces() {
+        let repoID = UUID()
+        let repoWT = makeWorktree(repoID: repoID)
+        let scratch = makeScratch()
+
+        let ids = AppState.worktreeIDsToSuspendForSleep(
+            worktrees: [repoID: [repoWT]],
+            scratchWorktrees: [scratch],
+            autoSuspendEnabled: true
+        )
+
+        #expect(Set(ids) == Set([repoWT.id, scratch.id]))
+    }
+
     @Test("gate ON + empty worktrees → returns []")
     func gateOnEmptyReturnsEmpty() {
         let ids = AppState.worktreeIDsToSuspendForSleep(
             worktrees: [:],
+            scratchWorktrees: [],
             autoSuspendEnabled: true
         )
         #expect(ids.isEmpty)

--- a/Tests/TBDAppTests/StatusBarFocusLabelTests.swift
+++ b/Tests/TBDAppTests/StatusBarFocusLabelTests.swift
@@ -36,6 +36,7 @@ struct StatusBarFocusLabelTests {
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [wtID],
             worktrees: [repoID: [wt]],
+            scratchWorktrees: [],
             repos: [repo],
             selectedRepoID: nil
         )
@@ -52,11 +53,36 @@ struct StatusBarFocusLabelTests {
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [wtID],
             worktrees: [unknownRepoID: [wt]],
+            scratchWorktrees: [],
             repos: [],  // no repos — lookup will fail
             selectedRepoID: nil
         )
 
         #expect(label == "feat-branch")
+    }
+
+    @Test("single scratch-space selection resolves via scratchWorktrees")
+    func singleScratchSelection() {
+        let wtID = UUID()
+        let scratch = Worktree(
+            id: wtID,
+            repoID: nil,
+            name: "scratch-1",
+            displayName: "Scratch 1",
+            branch: "main",
+            path: "/tmp/scratch-1",
+            tmuxServer: "tmux-\(wtID.uuidString)"
+        )
+
+        let label = StatusBarView.focusLabel(
+            selectedWorktreeIDs: [wtID],
+            worktrees: [:],
+            scratchWorktrees: [scratch],
+            repos: [],
+            selectedRepoID: nil
+        )
+
+        #expect(label == "Scratch 1")
     }
 
     @Test("multi-selection shows count label")
@@ -68,6 +94,7 @@ struct StatusBarFocusLabelTests {
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: Set(ids),
             worktrees: [repoID: worktrees],
+            scratchWorktrees: [],
             repos: [],
             selectedRepoID: nil
         )
@@ -83,6 +110,7 @@ struct StatusBarFocusLabelTests {
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [],
             worktrees: [:],
+            scratchWorktrees: [],
             repos: [repo],
             selectedRepoID: repoID
         )
@@ -95,6 +123,7 @@ struct StatusBarFocusLabelTests {
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [],
             worktrees: [:],
+            scratchWorktrees: [],
             repos: [],
             selectedRepoID: nil
         )
@@ -107,6 +136,7 @@ struct StatusBarFocusLabelTests {
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [],
             worktrees: [:],
+            scratchWorktrees: [],
             repos: [],
             selectedRepoID: UUID()  // unknown ID
         )

--- a/Tests/TBDAppTests/StatusBarFocusLabelTests.swift
+++ b/Tests/TBDAppTests/StatusBarFocusLabelTests.swift
@@ -35,8 +35,7 @@ struct StatusBarFocusLabelTests {
 
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [wtID],
-            worktrees: [repoID: [wt]],
-            scratchWorktrees: [],
+            selectedWorktree: wt,
             repos: [repo],
             selectedRepoID: nil
         )
@@ -52,8 +51,7 @@ struct StatusBarFocusLabelTests {
 
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [wtID],
-            worktrees: [unknownRepoID: [wt]],
-            scratchWorktrees: [],
+            selectedWorktree: wt,
             repos: [],  // no repos — lookup will fail
             selectedRepoID: nil
         )
@@ -74,10 +72,11 @@ struct StatusBarFocusLabelTests {
             tmuxServer: "tmux-\(wtID.uuidString)"
         )
 
+        // The caller resolves scratch spaces via the scratch-aware
+        // AppState.findWorktree(id:) and passes the result directly.
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [wtID],
-            worktrees: [:],
-            scratchWorktrees: [scratch],
+            selectedWorktree: scratch,
             repos: [],
             selectedRepoID: nil
         )
@@ -87,19 +86,30 @@ struct StatusBarFocusLabelTests {
 
     @Test("multi-selection shows count label")
     func multiSelectionShowsCount() {
-        let repoID = UUID()
         let ids = [UUID(), UUID(), UUID()]
-        let worktrees = ids.map { makeWorktree(id: $0, repoID: repoID, displayName: "wt-\($0.uuidString.prefix(4))") }
 
+        // Multi-selection ignores selectedWorktree — the caller passes nil.
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: Set(ids),
-            worktrees: [repoID: worktrees],
-            scratchWorktrees: [],
+            selectedWorktree: nil,
             repos: [],
             selectedRepoID: nil
         )
 
         #expect(label == "3 worktrees")
+    }
+
+    @Test("single selection that failed to resolve returns nil")
+    func singleSelectionUnresolvedReturnsNil() {
+        // The caller's findWorktree(id:) lookup came up empty (stale ID).
+        let label = StatusBarView.focusLabel(
+            selectedWorktreeIDs: [UUID()],
+            selectedWorktree: nil,
+            repos: [],
+            selectedRepoID: nil
+        )
+
+        #expect(label == nil)
     }
 
     @Test("repo selected shows repo name")
@@ -109,8 +119,7 @@ struct StatusBarFocusLabelTests {
 
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [],
-            worktrees: [:],
-            scratchWorktrees: [],
+            selectedWorktree: nil,
             repos: [repo],
             selectedRepoID: repoID
         )
@@ -122,8 +131,7 @@ struct StatusBarFocusLabelTests {
     func nothingSelectedReturnsNil() {
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [],
-            worktrees: [:],
-            scratchWorktrees: [],
+            selectedWorktree: nil,
             repos: [],
             selectedRepoID: nil
         )
@@ -135,8 +143,7 @@ struct StatusBarFocusLabelTests {
     func repoSelectedButMissingReturnsNil() {
         let label = StatusBarView.focusLabel(
             selectedWorktreeIDs: [],
-            worktrees: [:],
-            scratchWorktrees: [],
+            selectedWorktree: nil,
             repos: [],
             selectedRepoID: UUID()  // unknown ID
         )


### PR DESCRIPTION
## Summary

Pinning a Claude session that belongs to a scratch space (including the promoted "🩺 Android Health Tracker") rendered `Loading...` forever instead of the terminal.

- **What's broken:** the pinned-terminal dock cell showed a permanent `Loading...` for any pin whose worktree is a scratch space.
- **Why it happens:** scratch worktrees have `repoID == nil` and live only in `AppState.scratchWorktrees`, never in the repo-grouped `worktrees` dict. `PinnedTerminalCell` hand-rolled a lookup over `worktrees` alone, so the worktree resolved to `nil` and the cell fell into its `Text("Loading...")` else-branch. Promotion (pre-#372) didn't change `repoID`, so promoted scratch spaces stayed broken too.
- **What this PR does:** routes the pin cell through the existing `AppState.findWorktree(id:)` helper (which also consults `scratchWorktrees` — it was introduced for exactly this bug class in `SingleWorktreeView`), then fixes the **same dict-only lookup at every sibling call site** surfaced by review: startup selection restore (a persisted scratch selection was silently dropped on relaunch), `Cmd+Shift+A` archive (was sending the repo-worktree RPC the daemon rejects for scratch), the `Cmd-K` jump menu, notification banner titles (raw UUID → display name), back/forward nav history, `renameWorktree`, suspend-before-sleep coverage, and the status-bar reveal target.

Along the way it also makes renames typed **during** worktree creation actually persist (the `.creating` gate was dropping them for the whole hooks-running window; now gated on `pendingWorktreeIDs`, with rollback + alert on RPC failure), unifies a flat all-worktrees accessor, and trims a few per-render lookups on the status bar and pinned dock.

This is app-side only; it composes with the merged #372 (which stops *promoted* scratch spaces from being scratch-parented going forward) — together they cover both the lookup and the promotion side of the "Android Health Tracker" case.

## Test plan

- [x] `swift build` clean; `swift test` green (2980 tests / 371 suites) against current main (post-#372)
- [x] `swiftlint --strict` clean
- [x] New/extended coverage: `FindWorktreeScratchTests` (findWorktree scratch branch, archive-shortcut routing, creation-placeholder rename carry-over + rollback), `SelectionPersistenceTests`, `JumpMenuViewModelTests`, `SidebarRevealTargetTests`, `SleepSuspendHookTests`, `StatusBarFocusLabelTests`, `ArchiveNavigateBackTests`
- [ ] Live smoke: pin a Claude in a scratch space → terminal renders (not `Loading...`); repeat for a promoted scratch space; `Cmd+Shift+A` archives a selected scratch space without error; select a scratch space, quit, relaunch → selection restored

Reviewed via 5 rounds of fresh-context subagent code review; all confirmed findings addressed.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=D3510B91-512B-461B-9605-06B0C4D8C04D)